### PR TITLE
Add sheet page type with spreadsheet editing

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -67,6 +67,7 @@
     "framer-motion": "^12.23.10",
     "fuse.js": "^7.1.0",
     "google-auth-library": "^10.2.1",
+    "hot-formula-parser": "^4.0.0",
     "jose": "^6.0.11",
     "lucide-react": "^0.525.0",
     "mammoth": "^1.10.0",

--- a/apps/web/src/app/api/pages/route.ts
+++ b/apps/web/src/app/api/pages/route.ts
@@ -96,7 +96,7 @@ export async function POST(request: Request) {
     const newPage = await db.transaction(async (tx) => {
       interface APIPageInsertData {
         title: string;
-        type: 'FOLDER' | 'DOCUMENT' | 'CHANNEL' | 'AI_CHAT' | 'CANVAS';
+        type: 'FOLDER' | 'DOCUMENT' | 'CHANNEL' | 'AI_CHAT' | 'CANVAS' | 'SHEET';
         parentId: string | null;
         driveId: string;
         content: string;
@@ -110,7 +110,7 @@ export async function POST(request: Request) {
 
       const pageData: APIPageInsertData = {
         title,
-        type: type as 'FOLDER' | 'DOCUMENT' | 'CHANNEL' | 'AI_CHAT' | 'CANVAS',
+        type: type as 'FOLDER' | 'DOCUMENT' | 'CHANNEL' | 'AI_CHAT' | 'CANVAS' | 'SHEET',
         parentId,
         driveId: drive.id,
         content: content || getDefaultContent(type as PageTypeEnum),

--- a/apps/web/src/components/common/PageTypeIcon.tsx
+++ b/apps/web/src/components/common/PageTypeIcon.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { 
-  FileText, 
-  Folder, 
-  MessageSquare, 
-  Sparkles, 
-  Palette, 
-  FileIcon 
+import {
+  FileText,
+  Folder,
+  MessageSquare,
+  Sparkles,
+  Palette,
+  FileIcon,
+  Table
 } from 'lucide-react';
 import { PageType, getPageTypeIconName } from '@pagespace/lib';
 
@@ -22,6 +23,7 @@ const iconMap = {
   Sparkles,
   Palette,
   FileIcon,
+  Table,
 } as const;
 
 export function PageTypeIcon({ type, className }: PageTypeIconProps) {

--- a/apps/web/src/components/layout/left-sidebar/CreatePageDialog.tsx
+++ b/apps/web/src/components/layout/left-sidebar/CreatePageDialog.tsx
@@ -190,6 +190,7 @@ export default function CreatePageDialog({ parentId, isOpen, setIsOpen, onPageCr
                   <SelectItem value="CHANNEL">Channel</SelectItem>
                   <SelectItem value="AI_CHAT">AI Chat</SelectItem>
                   <SelectItem value="CANVAS">Canvas</SelectItem>
+                  <SelectItem value="SHEET">Sheet</SelectItem>
                   <SelectItem value="FILE">File Upload</SelectItem>
                 </SelectContent>
               </Select>

--- a/apps/web/src/components/layout/middle-content/CenterPanel.tsx
+++ b/apps/web/src/components/layout/middle-content/CenterPanel.tsx
@@ -18,6 +18,7 @@ import CanvasPageView from './page-views/canvas/CanvasPageView';
 import GlobalAssistantView from './page-views/dashboard/GlobalAssistantView';
 import { memo } from 'react';
 import { useLayoutStore } from '@/stores/useLayoutStore';
+import SheetView from './page-views/sheet/SheetView';
 
 // Memoized page content component to prevent unnecessary re-renders
 const PageContent = memo(({ pageId }: { pageId: string | null }) => {
@@ -67,6 +68,7 @@ const PageContent = memo(({ pageId }: { pageId: string | null }) => {
     DocumentView,
     CanvasPageView,
     FileViewer,
+    SheetView,
   };
   
   const componentName = getPageTypeComponent(page.type);

--- a/apps/web/src/components/layout/middle-content/index.tsx
+++ b/apps/web/src/components/layout/middle-content/index.tsx
@@ -14,6 +14,7 @@ import { CustomScrollArea } from '@/components/ui/custom-scroll-area';
 import { getPageTypeComponent } from '@pagespace/lib/client';
 import CanvasPageView from './page-views/canvas/CanvasPageView';
 import GlobalAssistantView from './page-views/dashboard/GlobalAssistantView';
+import SheetView from './page-views/sheet/SheetView';
 
 
 const PageContent = ({ pageId }: { pageId: string | null }) => {
@@ -44,6 +45,7 @@ const PageContent = ({ pageId }: { pageId: string | null }) => {
     DocumentView,
     CanvasPageView,
     FileViewer,
+    SheetView,
   };
   
   const componentName = getPageTypeComponent(page.type);

--- a/apps/web/src/components/layout/middle-content/page-views/sheet/SheetView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/sheet/SheetView.tsx
@@ -1,0 +1,590 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { TreePage } from '@/hooks/usePageTree';
+import { useDocument } from '@/hooks/useDocument';
+import { useSocket } from '@/hooks/useSocket';
+import { useAuth } from '@/hooks/use-auth';
+import { PageEventPayload } from '@/lib/socket-utils';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { Parser as FormulaParser } from 'hot-formula-parser';
+
+const MIN_ROWS = 20;
+const MIN_COLS = 10;
+
+interface SheetViewProps {
+  page: TreePage;
+}
+
+type RawGrid = string[][];
+
+interface EvaluatedCell {
+  raw: string;
+  display: string;
+  error?: string;
+  isFormula: boolean;
+}
+
+function columnIndexToLabel(index: number): string {
+  let label = '';
+  let current = index;
+
+  do {
+    label = String.fromCharCode((current % 26) + 65) + label;
+    current = Math.floor(current / 26) - 1;
+  } while (current >= 0);
+
+  return label;
+}
+
+function normalizeGrid(rows: string[][]): RawGrid {
+  const baseRows = rows.length > 0 ? rows : [['']];
+  const maxColumns = Math.max(
+    MIN_COLS,
+    ...baseRows.map((row) => row.length)
+  );
+
+  const normalizedRows = baseRows.map((row) => {
+    const cells = row.slice(0, maxColumns);
+    while (cells.length < maxColumns) {
+      cells.push('');
+    }
+    return cells;
+  });
+
+  while (normalizedRows.length < MIN_ROWS) {
+    normalizedRows.push(new Array(maxColumns).fill(''));
+  }
+
+  return normalizedRows;
+}
+
+function parseSheetContent(content: string): RawGrid {
+  if (!content || content.trim() === '') {
+    return normalizeGrid([['']]);
+  }
+
+  const rows: string[][] = [];
+  let current = '';
+  let row: string[] = [];
+  let inQuotes = false;
+
+  for (let i = 0; i < content.length; i++) {
+    const char = content[i];
+
+    if (char === '"') {
+      if (inQuotes && content[i + 1] === '"') {
+        current += '"';
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (char === ',' && !inQuotes) {
+      row.push(current);
+      current = '';
+    } else if ((char === '\n' || char === '\r') && !inQuotes) {
+      if (char === '\r' && content[i + 1] === '\n') {
+        i++;
+      }
+      row.push(current);
+      rows.push(row);
+      row = [];
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+
+  row.push(current);
+  rows.push(row);
+
+  return normalizeGrid(rows);
+}
+
+function escapeCsvValue(value: string): string {
+  if (value.includes('"')) {
+    value = value.replace(/"/g, '""');
+  }
+  if (/[",\n\r]/.test(value)) {
+    return `"${value}"`;
+  }
+  return value;
+}
+
+function trimGrid(grid: RawGrid): string[][] {
+  let lastRow = -1;
+  let lastColumn = -1;
+
+  for (let r = 0; r < grid.length; r++) {
+    for (let c = 0; c < grid[r].length; c++) {
+      if (grid[r][c].trim() !== '') {
+        lastRow = Math.max(lastRow, r);
+        lastColumn = Math.max(lastColumn, c);
+      }
+    }
+  }
+
+  if (lastRow === -1 || lastColumn === -1) {
+    return [];
+  }
+
+  const trimmed: string[][] = [];
+  for (let r = 0; r <= lastRow; r++) {
+    trimmed.push(grid[r].slice(0, lastColumn + 1));
+  }
+
+  return trimmed;
+}
+
+function serializeSheetContent(grid: RawGrid): string {
+  const trimmed = trimGrid(grid);
+  if (trimmed.length === 0) {
+    return '';
+  }
+
+  return trimmed
+    .map((row) => row.map((cell) => escapeCsvValue(cell ?? '')).join(','))
+    .join('\n');
+}
+
+function formatNumber(value: number): string {
+  if (!Number.isFinite(value)) {
+    return value.toString();
+  }
+  if (Number.isInteger(value)) {
+    return value.toString();
+  }
+  return parseFloat(value.toFixed(6)).toString();
+}
+
+function evaluateSheet(grid: RawGrid): EvaluatedCell[][] {
+  const cache = new Map<string, { value: number | string; display: string; error?: string }>();
+  const evaluating = new Set<string>();
+
+  const safeNumber = (value: number | string): number | string => {
+    if (typeof value === 'number') {
+      return value;
+    }
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : value;
+  };
+
+  const evaluateCell = (rowIndex: number, columnIndex: number): { value: number | string; display: string; error?: string } => {
+    const key = `${rowIndex}:${columnIndex}`;
+    if (cache.has(key)) {
+      return cache.get(key)!;
+    }
+
+    if (rowIndex < 0 || columnIndex < 0 || rowIndex >= grid.length || columnIndex >= grid[rowIndex].length) {
+      const result = { value: '', display: '' };
+      cache.set(key, result);
+      return result;
+    }
+
+    const raw = grid[rowIndex][columnIndex] ?? '';
+    const trimmed = raw.trim();
+
+    if (trimmed.startsWith('=')) {
+      if (evaluating.has(key)) {
+        const cycle = { value: '#CYCLE!', display: '#CYCLE!', error: '#CYCLE!' };
+        cache.set(key, cycle);
+        return cycle;
+      }
+
+      evaluating.add(key);
+      const parser = new FormulaParser();
+
+      parser.on('callCellValue', (cellCoord, done) => {
+        const r = cellCoord.row.index;
+        const c = cellCoord.column.index;
+        const result = evaluateCell(r, c);
+        if (result.error) {
+          done(result.error);
+          return;
+        }
+        const value = safeNumber(result.value);
+        if (typeof value === 'number') {
+          done(value);
+        } else if (value === '') {
+          done(0);
+        } else {
+          const numeric = Number(value);
+          done(Number.isFinite(numeric) ? numeric : value);
+        }
+      });
+
+      parser.on('callRangeValue', (start, end, done) => {
+        const fragment: (number | string)[][] = [];
+        for (let r = start.row.index; r <= end.row.index; r++) {
+          const rowValues: (number | string)[] = [];
+          for (let c = start.column.index; c <= end.column.index; c++) {
+            const result = evaluateCell(r, c);
+            if (result.error) {
+              rowValues.push(result.error);
+            } else {
+              const value = safeNumber(result.value);
+              if (typeof value === 'number') {
+                rowValues.push(value);
+              } else if (value === '') {
+                rowValues.push(0);
+              } else {
+                const numeric = Number(value);
+                rowValues.push(Number.isFinite(numeric) ? numeric : value);
+              }
+            }
+          }
+          fragment.push(rowValues);
+        }
+        done(fragment);
+      });
+
+      let parsed;
+      try {
+        const expression = trimmed.startsWith('=') ? trimmed.slice(1) : trimmed;
+        parsed = parser.parse(expression);
+      } catch (error) {
+        evaluating.delete(key);
+        const message = error instanceof Error ? error.message : '#ERROR';
+        const failure = { value: message, display: message, error: message };
+        cache.set(key, failure);
+        return failure;
+      }
+
+      evaluating.delete(key);
+
+      if (parsed.error) {
+        const errorLabel = typeof parsed.error === 'string' ? parsed.error : '#ERROR';
+        const failure = { value: errorLabel, display: errorLabel, error: errorLabel };
+        cache.set(key, failure);
+        return failure;
+      }
+
+      const resultValue = parsed.result;
+      let display: string;
+      if (typeof resultValue === 'number') {
+        display = formatNumber(resultValue);
+      } else if (resultValue === null || typeof resultValue === 'undefined') {
+        display = '';
+      } else {
+        display = String(resultValue);
+      }
+
+      const success = { value: resultValue as number | string, display };
+      cache.set(key, success);
+      return success;
+    }
+
+    const numeric = Number(trimmed);
+    if (trimmed === '' || Number.isNaN(numeric)) {
+      const result = { value: trimmed, display: trimmed };
+      cache.set(key, result);
+      return result;
+    }
+
+    const numericResult = { value: numeric, display: trimmed };
+    cache.set(key, numericResult);
+    return numericResult;
+  };
+
+  return grid.map((row, rowIndex) =>
+    row.map((cell, columnIndex) => {
+      const evaluation = evaluateCell(rowIndex, columnIndex);
+      return {
+        raw: cell,
+        display: evaluation.display,
+        error: evaluation.error,
+        isFormula: cell.trim().startsWith('='),
+      } satisfies EvaluatedCell;
+    })
+  );
+}
+
+const SheetView = ({ page }: SheetViewProps) => {
+  const initialContent = typeof page.content === 'string' ? page.content : '';
+  const [rawGrid, setRawGrid] = useState<RawGrid>(() => parseSheetContent(initialContent));
+  const [selectedCell, setSelectedCell] = useState<{ row: number; column: number }>({ row: 0, column: 0 });
+  const [isReadOnly, setIsReadOnly] = useState(false);
+  const serializedRef = useRef<string>(initialContent || '');
+  const socket = useSocket();
+  const { user } = useAuth();
+
+  const {
+    document: documentState,
+    initializeAndActivate,
+    updateContent,
+    updateContentFromServer,
+    saveWithDebounce,
+    forceSave,
+  } = useDocument(page.id, initialContent);
+
+  useEffect(() => {
+    initializeAndActivate();
+  }, [initializeAndActivate]);
+
+  useEffect(() => {
+    if (!user?.id) {
+      return;
+    }
+
+    const checkPermissions = async () => {
+      try {
+        const response = await fetch(`/api/pages/${page.id}/permissions/check?userId=${user.id}`);
+        if (response.ok) {
+          const permissions = await response.json();
+          setIsReadOnly(!permissions.canEdit);
+          if (!permissions.canEdit) {
+            toast.info("You don't have permission to edit this sheet", {
+              duration: 4000,
+              position: 'bottom-right',
+            });
+          }
+        }
+      } catch (error) {
+        console.error('Failed to check permissions:', error);
+      }
+    };
+
+    checkPermissions();
+  }, [user?.id, page.id]);
+
+  useEffect(() => {
+    if (!socket) {
+      return;
+    }
+
+    const handleContentUpdate = async (eventData: PageEventPayload) => {
+      if (eventData.pageId === page.id) {
+        try {
+          const response = await fetch(`/api/pages/${page.id}`);
+          if (response.ok) {
+            const updatedPage = await response.json();
+            if (updatedPage.content !== documentState?.content && !documentState?.isDirty) {
+              serializedRef.current = updatedPage.content || '';
+              updateContentFromServer(updatedPage.content || '');
+              setRawGrid(parseSheetContent(updatedPage.content || ''));
+            }
+          }
+        } catch (error) {
+          console.error('Failed to fetch updated content:', error);
+        }
+      }
+    };
+
+    socket.on('page:content-updated', handleContentUpdate);
+
+    return () => {
+      socket.off('page:content-updated', handleContentUpdate);
+    };
+  }, [socket, page.id, documentState, updateContentFromServer]);
+
+  useEffect(() => {
+    const nextContent = typeof documentState?.content === 'string' ? documentState.content : '';
+    if (nextContent !== serializedRef.current) {
+      serializedRef.current = nextContent;
+      setRawGrid(parseSheetContent(nextContent));
+    }
+  }, [documentState?.content]);
+
+  useEffect(() => {
+    return () => {
+      if (documentState?.isDirty) {
+        fetch(`/api/pages/${page.id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ content: documentState.content }),
+        }).catch((error) => {
+          console.error('Failed to save sheet on unmount:', error);
+        });
+      }
+    };
+  }, [documentState, page.id]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.ctrlKey || event.metaKey) && event.key === 's') {
+        event.preventDefault();
+        forceSave().catch((error) => console.error('Force save failed:', error));
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [forceSave]);
+
+  useEffect(() => {
+    const handleBlur = () => {
+      if (documentState?.isDirty) {
+        forceSave().catch((error) => console.error('Auto-save on blur failed:', error));
+      }
+    };
+
+    window.addEventListener('blur', handleBlur);
+    return () => {
+      window.removeEventListener('blur', handleBlur);
+    };
+  }, [documentState?.isDirty, forceSave]);
+
+  useEffect(() => {
+    setSelectedCell((previous) => {
+      const clampedRow = Math.min(previous.row, rawGrid.length - 1);
+      const clampedColumn = Math.min(previous.column, rawGrid[0]?.length - 1);
+      return { row: clampedRow, column: clampedColumn };
+    });
+  }, [rawGrid]);
+
+  const evaluatedGrid = useMemo(() => evaluateSheet(rawGrid), [rawGrid]);
+
+  const updateGrid = useCallback(
+    (updater: (grid: RawGrid) => RawGrid) => {
+      setRawGrid((previous) => {
+        const updated = normalizeGrid(updater(previous));
+        const serialized = serializeSheetContent(updated);
+        serializedRef.current = serialized;
+        updateContent(serialized);
+        saveWithDebounce(serialized);
+        return updated;
+      });
+    },
+    [saveWithDebounce, updateContent]
+  );
+
+  const handleFormulaChange = useCallback(
+    (value: string) => {
+      if (isReadOnly) {
+        toast.error('This sheet is read-only.');
+        return;
+      }
+      updateGrid((grid) => {
+        const next = grid.map((row) => row.slice());
+        next[selectedCell.row][selectedCell.column] = value;
+        return next;
+      });
+    },
+    [isReadOnly, selectedCell, updateGrid]
+  );
+
+  const handleAddRow = () => {
+    if (isReadOnly) {
+      toast.error('This sheet is read-only.');
+      return;
+    }
+    updateGrid((grid) => [...grid, new Array(grid[0]?.length || MIN_COLS).fill('')]);
+  };
+
+  const handleAddColumn = () => {
+    if (isReadOnly) {
+      toast.error('This sheet is read-only.');
+      return;
+    }
+    updateGrid((grid) => grid.map((row) => [...row, '']));
+  };
+
+  const handleClearCell = () => {
+    if (isReadOnly) {
+      toast.error('This sheet is read-only.');
+      return;
+    }
+    updateGrid((grid) => {
+      const next = grid.map((row) => row.slice());
+      next[selectedCell.row][selectedCell.column] = '';
+      return next;
+    });
+  };
+
+  const selectedDisplayLabel = `${columnIndexToLabel(selectedCell.column)}${selectedCell.row + 1}`;
+  const selectedRawValue = rawGrid[selectedCell.row]?.[selectedCell.column] ?? '';
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="border-b px-4 py-3">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h1 className="text-xl font-semibold">{page.title}</h1>
+            <p className="text-sm text-muted-foreground">
+              Enter values or formulas (e.g. =SUM(A2:A5)) directly into the active cell.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button size="sm" variant="outline" onClick={handleAddRow} disabled={isReadOnly}>
+              Add Row
+            </Button>
+            <Button size="sm" variant="outline" onClick={handleAddColumn} disabled={isReadOnly}>
+              Add Column
+            </Button>
+            <Button size="sm" variant="outline" onClick={handleClearCell} disabled={isReadOnly}>
+              Clear Cell
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="border-b px-4 py-3 flex items-center gap-3 bg-muted/30">
+        <span className="text-sm font-medium text-muted-foreground w-16">{selectedDisplayLabel}</span>
+        <input
+          className="flex-1 rounded-md border bg-background px-3 py-2 text-sm outline-none focus-visible:ring"
+          value={selectedRawValue}
+          onChange={(event) => handleFormulaChange(event.target.value)}
+          disabled={isReadOnly}
+          placeholder="Enter a value or formula"
+        />
+      </div>
+
+      <div className="flex-1 overflow-auto">
+        <table className="min-w-full border-collapse">
+          <thead className="sticky top-0 bg-muted/40">
+            <tr>
+              <th className="sticky left-0 z-20 border border-border bg-muted/60 px-2 py-1 text-left text-xs font-semibold text-muted-foreground">
+                &nbsp;
+              </th>
+              {rawGrid[0]?.map((_, columnIndex) => (
+                <th
+                  key={`col-${columnIndex}`}
+                  className="border border-border px-2 py-1 text-left text-xs font-semibold text-muted-foreground"
+                >
+                  {columnIndexToLabel(columnIndex)}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rawGrid.map((row, rowIndex) => (
+              <tr key={`row-${rowIndex}`}>
+                <th className="sticky left-0 z-10 border border-border bg-muted/60 px-2 py-1 text-right text-xs font-semibold text-muted-foreground">
+                  {rowIndex + 1}
+                </th>
+                {row.map((_, columnIndex) => {
+                  const evaluation = evaluatedGrid[rowIndex]?.[columnIndex];
+                  const isActive = selectedCell.row === rowIndex && selectedCell.column === columnIndex;
+                  const displayValue = evaluation?.error ? evaluation.error : evaluation?.display ?? '';
+
+                  return (
+                    <td key={`cell-${rowIndex}-${columnIndex}`} className="border border-border">
+                      <button
+                        type="button"
+                        onClick={() => setSelectedCell({ row: rowIndex, column: columnIndex })}
+                        className={cn(
+                          'block w-full min-h-[2.25rem] px-2 text-left text-sm focus:outline-none focus-visible:ring',
+                          isActive ? 'bg-primary/10 ring-2 ring-primary/60' : 'bg-background'
+                        )}
+                      >
+                        <span className={cn('block truncate', evaluation?.error ? 'text-destructive font-medium' : undefined)}>
+                          {displayValue}
+                        </span>
+                      </button>
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default SheetView;

--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -331,12 +331,12 @@ export const pageWriteTools = {
    * Create new documents, folders, or other content
    */
   create_page: tool({
-    description: 'Create new pages in the workspace. Supports all page types: FOLDER (hierarchical organization), DOCUMENT (text content), AI_CHAT (AI conversation spaces with optional agent configuration), CHANNEL (team discussions), CANVAS (custom HTML/CSS pages), DATABASE (deprecated). Any page type can contain any other page type as children with infinite nesting. For AI_CHAT pages, can optionally configure system prompt and enabled tools.',
+    description: 'Create new pages in the workspace. Supports all page types: FOLDER (hierarchical organization), DOCUMENT (text content), AI_CHAT (AI conversation spaces with optional agent configuration), CHANNEL (team discussions), CANVAS (custom HTML/CSS pages), SHEET (spreadsheet-style grid with formulas), DATABASE (deprecated). Any page type can contain any other page type as children with infinite nesting. For AI_CHAT pages, can optionally configure system prompt and enabled tools.',
     inputSchema: z.object({
       driveId: z.string().describe('The unique ID of the drive to create the page in'),
       parentId: z.string().optional().describe('The unique ID of the parent page from list_pages - REQUIRED when creating inside any page (folder, document, channel, etc). Only omit for root-level pages in the drive.'),
       title: z.string().describe('The title of the new page'),
-      type: z.enum(['FOLDER', 'DOCUMENT', 'CHANNEL', 'AI_CHAT', 'CANVAS']).describe('The type of page to create'),
+      type: z.enum(['FOLDER', 'DOCUMENT', 'CHANNEL', 'AI_CHAT', 'CANVAS', 'SHEET']).describe('The type of page to create'),
       content: z.string().optional().describe('Optional initial content for the page'),
       // Agent configuration fields (only for AI_CHAT type)
       systemPrompt: z.string().optional().describe('System prompt for AI agent behavior (only for AI_CHAT pages). Defines how the agent should behave and respond.'),
@@ -424,7 +424,7 @@ export const pageWriteTools = {
         // Prepare page data with proper typing
         interface PageInsertData {
           title: string;
-          type: 'FOLDER' | 'DOCUMENT' | 'CHANNEL' | 'AI_CHAT' | 'CANVAS';
+        type: 'FOLDER' | 'DOCUMENT' | 'CHANNEL' | 'AI_CHAT' | 'CANVAS' | 'SHEET';
           content: string;
           position: number;
           driveId: string;

--- a/packages/db/drizzle/0013_nimble_sheet.sql
+++ b/packages/db/drizzle/0013_nimble_sheet.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "PageType" ADD VALUE 'SHEET';--> statement-breakpoint

--- a/packages/db/src/schema/core.ts
+++ b/packages/db/src/schema/core.ts
@@ -2,7 +2,7 @@ import { pgTable, text, timestamp, jsonb, real, boolean, pgEnum, primaryKey, ind
 import { relations } from 'drizzle-orm';
 import { users } from './auth';
 import { createId } from '@paralleldrive/cuid2';
-export const pageType = pgEnum('PageType', ['FOLDER', 'DOCUMENT', 'CHANNEL', 'AI_CHAT', 'CANVAS', 'FILE']);
+export const pageType = pgEnum('PageType', ['FOLDER', 'DOCUMENT', 'CHANNEL', 'AI_CHAT', 'CANVAS', 'FILE', 'SHEET']);
 
 export const drives = pgTable('drives', {
   id: text('id').primaryKey().$defaultFn(() => createId()),

--- a/packages/lib/src/enums.ts
+++ b/packages/lib/src/enums.ts
@@ -5,6 +5,7 @@ export enum PageType {
   AI_CHAT = 'AI_CHAT',
   CANVAS = 'CANVAS',
   FILE = 'FILE',
+  SHEET = 'SHEET',
 }
 
 export enum PermissionAction {

--- a/packages/lib/src/page-content-parser.ts
+++ b/packages/lib/src/page-content-parser.ts
@@ -62,6 +62,14 @@ export function getPageContentForAI(page: Page & { channelMessages?: any[], chil
                 contentString += "Folder is empty.\n";
             }
             break;
+        case PageType.SHEET:
+            if (page.content && typeof page.content === 'string' && page.content.trim() !== '') {
+                contentString += "Sheet Data (CSV format):\n";
+                contentString += `${page.content}\n`;
+            } else {
+                contentString += "Sheet is empty.\n";
+            }
+            break;
         default:
             contentString += `Content extraction not implemented for page type: ${page.type}.\n`;
     }

--- a/packages/lib/src/page-type-validators.ts
+++ b/packages/lib/src/page-type-validators.ts
@@ -65,6 +65,9 @@ export function validatePageCreation(
     case PageType.CANVAS:
       // Canvas pages can start empty
       break;
+    case PageType.SHEET:
+      // Sheets initialize from CSV content
+      break;
   }
 
   // Run custom validation if defined
@@ -134,8 +137,9 @@ export function validatePageUpdate(
     switch (type) {
       case PageType.DOCUMENT:
       case PageType.CANVAS:
+      case PageType.SHEET:
         if (typeof data.content !== 'string') {
-          errors.push('Content must be a string for document/canvas pages');
+          errors.push('Content must be a string for document/canvas/sheet pages');
         }
         break;
       

--- a/packages/lib/src/page-types.config.ts
+++ b/packages/lib/src/page-types.config.ts
@@ -20,7 +20,7 @@ export interface PageTypeConfig {
   type: PageType;
   displayName: string;
   description: string;
-  iconName: 'Folder' | 'FileText' | 'MessageSquare' | 'Sparkles' | 'Palette' | 'FileIcon';
+  iconName: 'Folder' | 'FileText' | 'MessageSquare' | 'Sparkles' | 'Palette' | 'FileIcon' | 'Table';
   emoji: string;
   capabilities: PageTypeCapabilities;
   defaultContent: () => any;
@@ -152,6 +152,27 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
     defaultContent: () => '',
     allowedChildTypes: [],
     uiComponent: 'FileViewer',
+    layoutViewType: 'document',
+  },
+  [PageType.SHEET]: {
+    type: PageType.SHEET,
+    displayName: 'Sheet',
+    description: 'Structured grid with formulas and calculations',
+    iconName: 'Table',
+    emoji: '📊',
+    capabilities: {
+      canHaveChildren: false,
+      canAcceptUploads: false,
+      canBeConverted: false,
+      requiresAuth: false,
+      supportsRealtime: false,
+      supportsVersioning: true,
+      supportsAI: false,
+    },
+    defaultContent: () =>
+      ['Item,Quantity,Price,Total', 'Apples,3,1.50,=B2*C2', 'Oranges,2,1.25,=B3*C3', 'Total,,,=SUM(D2:D3)'].join('\n'),
+    allowedChildTypes: [],
+    uiComponent: 'SheetView',
     layoutViewType: 'document',
   },
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,6 +307,9 @@ importers:
       google-auth-library:
         specifier: ^10.2.1
         version: 10.2.1
+      hot-formula-parser:
+        specifier: ^4.0.0
+        version: 4.0.0
       jose:
         specifier: ^6.0.11
         version: 6.0.11
@@ -1098,6 +1101,10 @@ packages:
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
+  '@handsontable/formulajs@2.0.2':
+    resolution: {integrity: sha512-maIyMJtYjA5e/R9nyA22Qd7Yw73MBSxClJvle0a8XWAS/5l6shc/OFpQqrmwMy4IXUCmywJ9ER0gOGz/YA720w==}
+    hasBin: true
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -3002,6 +3009,10 @@ packages:
     resolution: {integrity: sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==}
     hasBin: true
 
+  bessel@1.0.2:
+    resolution: {integrity: sha512-Al3nHGQGqDYqqinXhQzmwmcRToe/3WyBv4N8aZc5Pef8xw2neZlR9VPi84Sa23JtgWcucu18HxVZrnI0fn2etw==}
+    engines: {node: '>=0.8'}
+
   big.js@5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
 
@@ -4178,6 +4189,9 @@ packages:
   header-case@1.0.1:
     resolution: {integrity: sha512-i0q9mkOeSuhXw6bGgiQCCBgY/jlZuV/7dZXyZ9c6LcBrqwvT8eT719E9uxE5LiZftdl+z81Ugbg/VvXV4OJOeQ==}
 
+  hot-formula-parser@4.0.0:
+    resolution: {integrity: sha512-diG1UvuQ3HxtfezVUIpvndk/bVkqZJ9Rfv10MdVF7pJEj8P2Jd4iCZSMJCN3lDhnLegaVlfSYSA6+szYNFQUKg==}
+
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
@@ -4540,6 +4554,9 @@ packages:
 
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
+
+  jstat@1.9.6:
+    resolution: {integrity: sha512-rPBkJbK2TnA8pzs93QcDDPlKcrtZWuuCo2dVR0TFLOJSxhqfWOVCSp8aV3/oSbn+4uY4yw1URtLpHQedtmXfug==}
 
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
@@ -5989,6 +6006,9 @@ packages:
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
+  tiny-emitter@2.1.0:
+    resolution: {integrity: sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==}
+
   tiny-invariant@1.3.1:
     resolution: {integrity: sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==}
 
@@ -6880,6 +6900,11 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
 
   '@floating-ui/utils@0.2.10': {}
+
+  '@handsontable/formulajs@2.0.2':
+    dependencies:
+      bessel: 1.0.2
+      jstat: 1.9.6
 
   '@humanfs/core@0.19.1': {}
 
@@ -8784,6 +8809,8 @@ snapshots:
 
   bcryptjs@3.0.2: {}
 
+  bessel@1.0.2: {}
+
   big.js@5.2.2: {}
 
   bignumber.js@9.3.1: {}
@@ -10196,6 +10223,11 @@ snapshots:
       no-case: 2.3.2
       upper-case: 1.1.3
 
+  hot-formula-parser@4.0.0:
+    dependencies:
+      '@handsontable/formulajs': 2.0.2
+      tiny-emitter: 2.1.0
+
   html-url-attributes@3.0.1: {}
 
   htmlparser2@10.0.0:
@@ -10593,6 +10625,8 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jstat@1.9.6: {}
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -12395,6 +12429,8 @@ snapshots:
   throttleit@2.1.0: {}
 
   through@2.3.8: {}
+
+  tiny-emitter@2.1.0: {}
 
   tiny-invariant@1.3.1: {}
 

--- a/types/hot-formula-parser.d.ts
+++ b/types/hot-formula-parser.d.ts
@@ -1,0 +1,25 @@
+declare module 'hot-formula-parser' {
+  interface CellCoordinate {
+    row: { index: number };
+    column: { index: number };
+    sheet?: string;
+  }
+
+  interface ParserResult {
+    result: any;
+    error: string | null;
+  }
+
+  type CellValueHandler = (cellCoord: CellCoordinate, done: (value: any) => void) => void;
+  type RangeValueHandler = (
+    start: CellCoordinate,
+    end: CellCoordinate,
+    done: (values: any[][]) => void
+  ) => void;
+
+  export class Parser {
+    parse(formula: string): ParserResult;
+    on(event: 'callCellValue', handler: CellValueHandler): void;
+    on(event: 'callRangeValue', handler: RangeValueHandler): void;
+  }
+}


### PR DESCRIPTION
## Summary
- add the SHEET page type across enums, schema/migrations, configuration, validation, and AI formatting alongside the hot-formula-parser dependency
- implement a SheetView React experience that parses CSV content, evaluates formulas, and saves edits with permission-aware autosave and socket refresh handling
- expose sheets throughout the UI and AI tooling, including page creation flows, iconography, and the create_page tool options

## Testing
- pnpm --filter web lint

------
https://chatgpt.com/codex/tasks/task_e_68d39ac7c4308320917e16bd412ff63a