### PR TITLE
Fix JWT awaiting in page resource routes

### DIFF
--- a/apps/web/src/app/api/users/find/route.ts
+++ b/apps/web/src/app/api/users/find/route.ts
@@ -13,8 +13,8 @@ export async function GET(request: Request) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
 
-  const decoded = decodeToken(accessToken);
-  if (!decoded) {
+  const decoded = await decodeToken(accessToken);
+  if (!decoded?.userId) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
 


### PR DESCRIPTION
## Summary
- await JWT decoding in page breadcrumbs, children, trash deletion, and user lookup routes
- enforce page-level permission checks for breadcrumb, child listing, and trash deletion handlers

## Testing
- pnpm --filter web lint

------
https://chatgpt.com/codex/tasks/task_e_68d5dbde60e08320aa8972462cf36f40