### PR TITLE
Fix AI-generated HTML tab indentation triggering code blocks

### DIFF
--- a/apps/web/src/lib/editor/prettier.ts
+++ b/apps/web/src/lib/editor/prettier.ts
@@ -3,13 +3,34 @@ import * as prettierPluginHtml from 'prettier/plugins/html';
 
 export const formatHtml = async (html: string): Promise<string> => {
   try {
+    // CRITICAL FIX: Strip leading whitespace from lines starting with HTML tags
+    // to prevent Markdown code block interpretation.
+    // In Markdown (used by Tiptap), indenting by 4 spaces or a tab creates a code block.
+    // This causes AI-generated indented HTML like "    <p>text</p>" to render as code.
+    //
+    // We only strip leading whitespace from lines that start with HTML tags (< character),
+    // preserving meaningful indentation inside <pre>, <code>, <textarea>, etc.
+    const normalizedHtml = html
+      .split('\n')
+      .map(line => {
+        // Only strip leading whitespace if the line starts with an HTML tag
+        const trimmed = line.trimStart();
+        if (trimmed.startsWith('<')) {
+          return trimmed;
+        }
+        // Preserve original indentation for non-tag lines (e.g., code inside <pre>)
+        return line;
+      })
+      .join('\n')
+      .trim();
+
     // Detect trailing spaces in text content before closing tags
     // Pattern matches: " </p>", " </h1>", " </li>", etc.
     const trailingSpacePattern = /( )(<\/(?:p|h1|h2|h3|h4|h5|h6|li|td|th|blockquote)>)/g;
     const trailingSpaces: Array<{ tag: string; position: number }> = [];
 
     let match;
-    while ((match = trailingSpacePattern.exec(html)) !== null) {
+    while ((match = trailingSpacePattern.exec(normalizedHtml)) !== null) {
       trailingSpaces.push({
         tag: match[2], // The closing tag like "</p>"
         position: match.index
@@ -17,7 +38,7 @@ export const formatHtml = async (html: string): Promise<string> => {
     }
 
     // Format with Prettier (may remove trailing spaces)
-    let formatted = await format(html, {
+    let formatted = await format(normalizedHtml, {
       parser: 'html',
       plugins: [prettierPluginHtml],
       printWidth: 120,


### PR DESCRIPTION
The Tiptap Markdown extension interprets lines starting with 4 spaces or
tabs as code blocks (standard Markdown behavior). When AI writes HTML with
natural indentation like:
    <p>Hello</p>

It was being rendered as a code block instead of proper HTML.

Solution: Normalize HTML by stripping leading whitespace from all lines
before Prettier formatting. This prevents Markdown code block detection
while still allowing Prettier to properly re-indent the HTML structure.

Nested elements like <li> inside <ul> continue to work correctly as
Prettier handles the re-indentation.