### PR TITLE
Ensure desktop expiry listener clears secure session

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -22,6 +22,7 @@
     "ai": "^5.0.81",
     "electron-store": "^10.0.0",
     "electron-updater": "^6.6.2",
+    "node-machine-id": "^1.1.12",
     "ws": "^8.18.3",
     "zod": "^4.0.16"
   },

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -39,7 +39,15 @@ contextBridge.exposeInMainWorld('electron', {
   // Authentication
   auth: {
     getJWT: () => ipcRenderer.invoke('auth:get-jwt'),
+    getSession: () => ipcRenderer.invoke('auth:get-session'),
+    storeSession: (session: {
+      accessToken: string;
+      refreshToken: string;
+      csrfToken?: string | null;
+      deviceToken?: string | null;
+    }) => ipcRenderer.invoke('auth:store-session', session),
     clearAuth: () => ipcRenderer.invoke('auth:clear-auth'),
+    getDeviceInfo: () => ipcRenderer.invoke('auth:get-device-info'),
   },
 
   // MCP Server Management
@@ -81,7 +89,26 @@ export interface ElectronAPI {
   version: string;
   auth: {
     getJWT: () => Promise<string | null>;
+    getSession: () => Promise<{
+      accessToken: string;
+      refreshToken: string;
+      csrfToken?: string | null;
+      deviceToken?: string | null;
+    } | null>;
+    storeSession: (session: {
+      accessToken: string;
+      refreshToken: string;
+      csrfToken?: string | null;
+      deviceToken?: string | null;
+    }) => Promise<{ success: boolean }>;
     clearAuth: () => Promise<void>;
+    getDeviceInfo: () => Promise<{
+      deviceId: string;
+      deviceName: string;
+      platform: NodeJS.Platform;
+      appVersion: string;
+      userAgent: string;
+    }>;
   };
   mcp: {
     getConfig: () => Promise<MCPConfig>;

--- a/apps/ios/PageSpace/Core/Models/User.swift
+++ b/apps/ios/PageSpace/Core/Models/User.swift
@@ -10,6 +10,11 @@ struct User: Identifiable, Codable {
 struct LoginRequest: Codable {
     let email: String
     let password: String
+    let deviceId: String
+    let platform: String
+    let deviceName: String?
+    let appVersion: String?
+    let deviceToken: String?
 }
 
 struct SignupRequest: Codable {
@@ -17,6 +22,10 @@ struct SignupRequest: Codable {
     let email: String
     let password: String
     let confirmPassword: String
+    let deviceId: String
+    let platform: String
+    let deviceName: String?
+    let appVersion: String?
 }
 
 struct LoginResponse: Codable {
@@ -24,20 +33,37 @@ struct LoginResponse: Codable {
     let token: String
     let refreshToken: String
     let csrfToken: String
+    let deviceToken: String?
 }
 
 struct RefreshRequest: Codable {
     let refreshToken: String
+    let deviceToken: String?
+    let deviceId: String
+    let platform: String
 }
 
 struct RefreshResponse: Codable {
     let token: String
     let refreshToken: String
     let csrfToken: String
+    let deviceToken: String?
 }
 
 struct OAuthExchangeRequest: Codable {
     let idToken: String
+    let deviceId: String
+    let platform: String
+    let deviceName: String?
+    let appVersion: String?
+    let deviceToken: String?
+}
+
+struct DeviceRefreshRequest: Codable {
+    let deviceToken: String
+    let deviceId: String
+    let userAgent: String?
+    let appVersion: String?
 }
 
 struct AISettings: Codable {

--- a/apps/ios/PageSpace/Core/Networking/APIEndpoints.swift
+++ b/apps/ios/PageSpace/Core/Networking/APIEndpoints.swift
@@ -5,6 +5,7 @@ enum APIEndpoints {
     static let login = "/api/auth/mobile/login"
     static let signup = "/api/auth/mobile/signup"
     static let refresh = "/api/auth/mobile/refresh"
+    static let deviceRefresh = "/api/auth/device/refresh"
     static let logout = "/api/auth/logout"
     static let me = "/api/auth/me"
 

--- a/apps/web/src/app/api/auth/device/refresh/route.ts
+++ b/apps/web/src/app/api/auth/device/refresh/route.ts
@@ -1,0 +1,140 @@
+import { z } from 'zod/v4';
+import { users, refreshTokens } from '@pagespace/db';
+import { db, eq } from '@pagespace/db';
+import {
+  validateDeviceToken,
+  rotateDeviceToken,
+  updateDeviceTokenActivity,
+  generateAccessToken,
+  generateRefreshToken,
+  decodeToken,
+  getRefreshTokenMaxAge,
+  generateCSRFToken,
+  getSessionIdFromJWT,
+} from '@pagespace/lib/server';
+import { createId } from '@paralleldrive/cuid2';
+import { loggers, logAuthEvent } from '@pagespace/lib/server';
+import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
+
+const deviceRefreshSchema = z.object({
+  deviceToken: z.string().min(1, { message: 'Device token is required' }),
+  deviceId: z.string().min(1, { message: 'Device identifier is required' }),
+  userAgent: z.string().optional(),
+  appVersion: z.string().optional(),
+});
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const validation = deviceRefreshSchema.safeParse(body);
+
+    if (!validation.success) {
+      return Response.json({ errors: validation.error.flatten().fieldErrors }, { status: 400 });
+    }
+
+    const { deviceToken, deviceId, userAgent, appVersion } = validation.data;
+
+    const clientIP =
+      req.headers.get('x-forwarded-for')?.split(',')[0] ||
+      req.headers.get('x-real-ip') ||
+      'unknown';
+
+    const deviceRecord = await validateDeviceToken(deviceToken);
+    if (!deviceRecord) {
+      return Response.json({ error: 'Invalid or expired device token.' }, { status: 401 });
+    }
+
+    if (deviceRecord.deviceId !== deviceId) {
+      loggers.auth.warn('Device token mismatch detected', {
+        tokenDeviceId: deviceRecord.deviceId,
+        providedDeviceId: deviceId,
+      });
+      return Response.json({ error: 'Device token does not match this device.' }, { status: 401 });
+    }
+
+    const user = await db.query.users.findFirst({
+      where: eq(users.id, deviceRecord.userId),
+    });
+
+    if (!user) {
+      return Response.json({ error: 'User not found for device token.' }, { status: 404 });
+    }
+
+    // Rotate device token if it is within 30 days of expiration
+    let activeDeviceToken = deviceToken;
+    let activeDeviceTokenId = deviceRecord.id;
+    const thirtyDaysMs = 30 * 24 * 60 * 60 * 1000;
+
+    if (deviceRecord.expiresAt && deviceRecord.expiresAt.getTime() - Date.now() < thirtyDaysMs) {
+      const rotated = await rotateDeviceToken(
+        deviceToken,
+        {
+          userAgent: userAgent ?? req.headers.get('user-agent') ?? undefined,
+          ipAddress: clientIP === 'unknown' ? undefined : clientIP,
+        },
+        user.tokenVersion,
+      );
+
+      if (rotated) {
+        activeDeviceToken = rotated.token;
+        activeDeviceTokenId = rotated.deviceToken.id;
+      }
+    }
+
+    const normalizedIP = clientIP === 'unknown' ? undefined : clientIP;
+
+    await updateDeviceTokenActivity(activeDeviceTokenId, normalizedIP);
+
+    const accessToken = await generateAccessToken(user.id, user.tokenVersion, user.role);
+    const refreshToken = await generateRefreshToken(user.id, user.tokenVersion, user.role);
+
+    const refreshPayload = await decodeToken(refreshToken);
+    const refreshExpiresAt = refreshPayload?.exp
+      ? new Date(refreshPayload.exp * 1000)
+      : new Date(Date.now() + getRefreshTokenMaxAge() * 1000);
+
+    await db.insert(refreshTokens).values({
+      id: createId(),
+      token: refreshToken,
+      userId: user.id,
+      device: userAgent ?? deviceRecord.deviceName,
+      userAgent: userAgent ?? deviceRecord.userAgent,
+      ip: normalizedIP ?? null,
+      lastUsedAt: new Date(),
+      platform: deviceRecord.platform,
+      deviceTokenId: activeDeviceTokenId,
+      expiresAt: refreshExpiresAt,
+    });
+
+    const decodedAccess = await decodeToken(accessToken);
+    if (!decodedAccess?.iat) {
+      loggers.auth.error('Failed to decode access token for CSRF generation during device refresh');
+      return Response.json({ error: 'Failed to generate session.' }, { status: 500 });
+    }
+
+    const sessionId = getSessionIdFromJWT({
+      userId: user.id,
+      tokenVersion: user.tokenVersion,
+      iat: decodedAccess.iat,
+    });
+    const csrfToken = generateCSRFToken(sessionId);
+
+    logAuthEvent('login', user.id, user.email, normalizedIP ?? 'unknown', 'Device token refresh');
+    trackAuthEvent(user.id, 'device_refresh', {
+      platform: deviceRecord.platform,
+      ip: normalizedIP ?? 'unknown',
+      userAgent: userAgent ?? req.headers.get('user-agent'),
+      appVersion,
+    });
+
+    return Response.json({
+      token: accessToken,
+      refreshToken,
+      csrfToken,
+      deviceToken: activeDeviceToken,
+    });
+  } catch (error) {
+    loggers.auth.error('Device token refresh error', error as Error);
+    return Response.json({ error: 'An unexpected error occurred.' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/auth/google/callback/route.ts
+++ b/apps/web/src/app/api/auth/google/callback/route.ts
@@ -1,7 +1,7 @@
 import { users, refreshTokens, drives } from '@pagespace/db';
 import { db, eq, or, count } from '@pagespace/db';
 import { z } from 'zod/v4';
-import { generateAccessToken, generateRefreshToken, getRefreshTokenMaxAge, checkRateLimit, resetRateLimit, RATE_LIMIT_CONFIGS, slugify } from '@pagespace/lib/server';
+import { generateAccessToken, generateRefreshToken, getRefreshTokenMaxAge, checkRateLimit, resetRateLimit, RATE_LIMIT_CONFIGS, slugify, decodeToken } from '@pagespace/lib/server';
 import { serialize } from 'cookie';
 import { createId } from '@paralleldrive/cuid2';
 import { loggers, logAuthEvent } from '@pagespace/lib/server';
@@ -165,13 +165,22 @@ export async function GET(req: Request) {
     const accessToken = await generateAccessToken(user.id, user.tokenVersion, user.role);
     const refreshToken = await generateRefreshToken(user.id, user.tokenVersion, user.role);
 
+    const refreshPayload = await decodeToken(refreshToken);
+    const refreshExpiresAt = refreshPayload?.exp
+      ? new Date(refreshPayload.exp * 1000)
+      : new Date(Date.now() + getRefreshTokenMaxAge() * 1000);
+
     // Save refresh token
     await db.insert(refreshTokens).values({
       id: createId(),
       token: refreshToken,
       userId: user.id,
       device: req.headers.get('user-agent'),
+      userAgent: req.headers.get('user-agent'),
       ip: clientIP,
+      lastUsedAt: new Date(),
+      platform: 'web',
+      expiresAt: refreshExpiresAt,
     });
 
     // Reset rate limits on successful login

--- a/apps/web/src/app/api/auth/mobile/login/route.ts
+++ b/apps/web/src/app/api/auth/mobile/login/route.ts
@@ -2,7 +2,18 @@ import { users, refreshTokens } from '@pagespace/db';
 import { db, eq } from '@pagespace/db';
 import bcrypt from 'bcryptjs';
 import { z } from 'zod/v4';
-import { generateAccessToken, generateRefreshToken, checkRateLimit, resetRateLimit, RATE_LIMIT_CONFIGS, decodeToken } from '@pagespace/lib/server';
+import {
+  generateAccessToken,
+  generateRefreshToken,
+  getRefreshTokenMaxAge,
+  checkRateLimit,
+  resetRateLimit,
+  RATE_LIMIT_CONFIGS,
+  decodeToken,
+  createDeviceTokenRecord,
+  validateDeviceToken,
+  updateDeviceTokenActivity,
+} from '@pagespace/lib/server';
 import { generateCSRFToken, getSessionIdFromJWT } from '@pagespace/lib/server';
 import { createId } from '@paralleldrive/cuid2';
 import { loggers, logAuthEvent } from '@pagespace/lib/server';
@@ -11,8 +22,13 @@ import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
 const loginSchema = z.object({
   email: z.email(),
   password: z.string().min(1, {
-      error: "Password is required"
+    error: 'Password is required',
   }),
+  deviceId: z.string().min(1, { message: 'Device identifier is required' }),
+  platform: z.enum(['ios', 'android', 'desktop']).default('ios'),
+  deviceName: z.string().optional(),
+  appVersion: z.string().optional(),
+  deviceToken: z.string().optional(),
 });
 
 export async function POST(req: Request) {
@@ -24,7 +40,7 @@ export async function POST(req: Request) {
       return Response.json({ errors: validation.error.flatten().fieldErrors }, { status: 400 });
     }
 
-    const { email, password } = validation.data;
+    const { email, password, deviceId, platform, deviceName, appVersion, deviceToken: existingDeviceToken } = validation.data;
 
     // Rate limiting by IP address and email
     const clientIP = req.headers.get('x-forwarded-for')?.split(',')[0] ||
@@ -83,12 +99,58 @@ export async function POST(req: Request) {
     const accessToken = await generateAccessToken(user.id, user.tokenVersion, user.role);
     const refreshToken = await generateRefreshToken(user.id, user.tokenVersion, user.role);
 
+    const refreshTokenPayload = await decodeToken(refreshToken);
+    const refreshTokenExpiresAt = refreshTokenPayload?.exp
+      ? new Date(refreshTokenPayload.exp * 1000)
+      : new Date(Date.now() + getRefreshTokenMaxAge() * 1000);
+
+    let deviceTokenValue = existingDeviceToken ?? null;
+    let deviceTokenRecordId: string | null = null;
+
+    if (deviceTokenValue) {
+      const storedDeviceToken = await validateDeviceToken(deviceTokenValue);
+      if (
+        !storedDeviceToken ||
+        storedDeviceToken.userId !== user.id ||
+        storedDeviceToken.deviceId !== deviceId ||
+        storedDeviceToken.platform !== platform
+      ) {
+        deviceTokenValue = null;
+      } else {
+        deviceTokenRecordId = storedDeviceToken.id;
+        await updateDeviceTokenActivity(storedDeviceToken.id, clientIP);
+      }
+    }
+
+    if (!deviceTokenValue) {
+      const { id: newDeviceTokenId, token: newDeviceToken } = await createDeviceTokenRecord(
+        user.id,
+        deviceId,
+        platform,
+        user.tokenVersion,
+        {
+          deviceName: deviceName || undefined,
+          userAgent: req.headers.get('user-agent') || undefined,
+          ipAddress: clientIP === 'unknown' ? undefined : clientIP,
+          location: undefined,
+        }
+      );
+
+      deviceTokenValue = newDeviceToken;
+      deviceTokenRecordId = newDeviceTokenId;
+    }
+
     await db.insert(refreshTokens).values({
       id: createId(),
       token: refreshToken,
       userId: user.id,
       device: req.headers.get('user-agent'),
+      userAgent: req.headers.get('user-agent'),
       ip: clientIP,
+      lastUsedAt: new Date(),
+      platform,
+      deviceTokenId: deviceTokenRecordId,
+      expiresAt: refreshTokenExpiresAt,
     });
 
     // Reset rate limits on successful login
@@ -103,7 +165,8 @@ export async function POST(req: Request) {
       email,
       ip: clientIP,
       userAgent: req.headers.get('user-agent'),
-      platform: 'mobile'
+      platform,
+      appVersion,
     });
 
     // Generate CSRF token for mobile client
@@ -132,6 +195,7 @@ export async function POST(req: Request) {
       token: accessToken,
       refreshToken: refreshToken,
       csrfToken: csrfToken,
+      deviceToken: deviceTokenValue,
     }, { status: 200 });
 
   } catch (error) {

--- a/apps/web/src/hooks/use-auth.ts
+++ b/apps/web/src/hooks/use-auth.ts
@@ -4,7 +4,7 @@ import { useEffect, useCallback, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuthStore, authStoreHelpers } from '@/stores/auth-store';
 import { useTokenRefresh } from './use-token-refresh';
-import { post } from '@/lib/auth-fetch';
+import { post, clearJWTCache } from '@/lib/auth-fetch';
 
 interface User {
   id: string;
@@ -62,6 +62,64 @@ export function useAuth(): {
   const login = useCallback(async (email: string, password: string) => {
     setLoading(true);
     try {
+      const isDesktop = typeof window !== 'undefined' && window.electron?.isDesktop;
+
+      if (isDesktop && window.electron) {
+        const [deviceInfo, existingSession] = await Promise.all([
+          window.electron.auth.getDeviceInfo(),
+          window.electron.auth.getSession(),
+        ]);
+
+        const desktopLoginPayload: {
+          email: string;
+          password: string;
+          deviceId: string;
+          platform: 'desktop';
+          deviceName: string;
+          appVersion: string;
+          deviceToken?: string;
+        } = {
+          email,
+          password,
+          deviceId: deviceInfo.deviceId,
+          platform: 'desktop',
+          deviceName: deviceInfo.deviceName,
+          appVersion: deviceInfo.appVersion,
+        };
+
+        if (existingSession?.deviceToken) {
+          desktopLoginPayload.deviceToken = existingSession.deviceToken;
+        }
+
+        const response = await fetch('/api/auth/mobile/login', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(desktopLoginPayload),
+        });
+
+        if (response.ok) {
+          const userData = await response.json();
+
+          await window.electron.auth.storeSession({
+            accessToken: userData.token,
+            refreshToken: userData.refreshToken,
+            csrfToken: userData.csrfToken,
+            deviceToken: userData.deviceToken,
+          });
+
+          clearJWTCache();
+          setUser(userData.user);
+          startSession();
+          return { success: true };
+        }
+
+        const errorData = await response.json().catch(() => ({}));
+        return {
+          success: false,
+          error: errorData.error || 'Login failed',
+        };
+      }
+
       const response = await fetch('/api/auth/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -76,16 +134,16 @@ export function useAuth(): {
         return { success: true };
       } else {
         const errorData = await response.json();
-        return { 
-          success: false, 
-          error: errorData.error || 'Login failed' 
+        return {
+          success: false,
+          error: errorData.error || 'Login failed'
         };
       }
     } catch (error) {
       console.error('Login error:', error);
-      return { 
-        success: false, 
-        error: 'Network error. Please try again.' 
+      return {
+        success: false,
+        error: 'Network error. Please try again.'
       };
     } finally {
       setLoading(false);
@@ -99,6 +157,14 @@ export function useAuth(): {
     } catch (error) {
       console.error('Logout error:', error);
     } finally {
+      if (typeof window !== 'undefined' && window.electron?.isDesktop) {
+        try {
+          await window.electron.auth.clearAuth();
+        } catch (err) {
+          console.error('Failed to clear desktop auth session', err);
+        }
+        clearJWTCache();
+      }
       // Reset token refresh state
       tokenRefreshActiveRef.current = false;
       endSession();

--- a/apps/web/src/types/electron.d.ts
+++ b/apps/web/src/types/electron.d.ts
@@ -20,10 +20,38 @@ export interface ElectronAPI {
      */
     getJWT: () => Promise<string | null>;
     /**
+     * Retrieves the full stored session, including refresh and device tokens.
+     */
+    getSession: () => Promise<{
+      accessToken: string;
+      refreshToken: string;
+      csrfToken?: string | null;
+      deviceToken?: string | null;
+    } | null>;
+    /**
+     * Persists the current authentication session in the native secure storage.
+     */
+    storeSession: (session: {
+      accessToken: string;
+      refreshToken: string;
+      csrfToken?: string | null;
+      deviceToken?: string | null;
+    }) => Promise<{ success: boolean }>;
+    /**
      * Clears authentication data (JWT cookies) from Electron session.
      * Called during logout.
      */
     clearAuth: () => Promise<void>;
+    /**
+     * Returns device metadata used for device token authentication.
+     */
+    getDeviceInfo: () => Promise<{
+      deviceId: string;
+      deviceName: string;
+      platform: NodeJS.Platform;
+      appVersion: string;
+      userAgent: string;
+    }>;
   };
   mcp: {
     getConfig: () => Promise<MCPConfig>;

--- a/packages/lib/src/device-auth-utils.ts
+++ b/packages/lib/src/device-auth-utils.ts
@@ -256,7 +256,8 @@ export async function rotateDeviceToken(
   metadata: {
     userAgent?: string;
     ipAddress?: string;
-  }
+  },
+  tokenVersion: number = 0
 ): Promise<{ token: string; deviceToken: DeviceToken } | null> {
   try {
     // Validate old token
@@ -273,7 +274,7 @@ export async function rotateDeviceToken(
       oldDeviceToken.userId,
       oldDeviceToken.deviceId,
       oldDeviceToken.platform,
-      0, // Token version from user will be checked separately
+      tokenVersion,
       {
         deviceName: oldDeviceToken.deviceName || undefined,
         userAgent: metadata.userAgent || oldDeviceToken.userAgent || undefined,

--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -22,6 +22,7 @@ export * from './sheet';
 
 // Auth and security utilities (server-only)
 export * from './auth-utils';
+export * from './device-auth-utils';
 export {
   createServiceToken as createServiceTokenV2,
   verifyServiceToken as verifyServiceTokenV2,

--- a/packages/lib/src/server.ts
+++ b/packages/lib/src/server.ts
@@ -1,5 +1,6 @@
 // All exports including Node.js-only utilities
 export * from './auth-utils';
+export * from './device-auth-utils';
 export * from './csrf-utils';
 export * from './encryption-utils';
 export * from './page-content-parser';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       electron-updater:
         specifier: ^6.6.2
         version: 6.6.2
+      node-machine-id:
+        specifier: ^1.1.12
+        version: 1.1.12
       ws:
         specifier: ^8.18.3
         version: 8.18.3
@@ -7846,6 +7849,9 @@ packages:
   node-html-parser@7.0.1:
     resolution: {integrity: sha512-KGtmPY2kS0thCWGK0VuPyOS+pBKhhe8gXztzA2ilAOhbUbxa9homF1bOyKvhGzMLXUoRds9IOmr/v5lr/lqNmA==}
 
+  node-machine-id@1.1.12:
+    resolution: {integrity: sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ==}
+
   node-plop@0.26.3:
     resolution: {integrity: sha512-Cov028YhBZ5aB7MdMWJEmwyBig43aGL5WT4vdoB28Oitau1zZAcHUn8Sgfk9HM33TqhtLJ9PlM/O0Mv+QpV/4Q==}
     engines: {node: '>=8.9.4'}
@@ -13462,7 +13468,7 @@ snapshots:
     dependencies:
       '@types/node': 20.19.17
       tapable: 2.2.3
-      webpack: 5.101.3(esbuild@0.19.12)
+      webpack: 5.101.3(esbuild@0.25.0)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -17534,7 +17540,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       monaco-editor: 0.52.2
-      webpack: 5.101.3(esbuild@0.19.12)
+      webpack: 5.101.3(esbuild@0.25.0)
 
   monaco-editor@0.52.2: {}
 
@@ -17724,6 +17730,8 @@ snapshots:
     dependencies:
       css-select: 5.2.2
       he: 1.2.0
+
+  node-machine-id@1.1.12: {}
 
   node-plop@0.26.3:
     dependencies:
@@ -19470,16 +19478,16 @@ snapshots:
       mkdirp: 0.5.6
       rimraf: 2.6.3
 
-  terser-webpack-plugin@5.3.14(esbuild@0.19.12)(webpack@5.101.3(esbuild@0.25.0)):
+  terser-webpack-plugin@5.3.14(esbuild@0.25.0)(webpack@5.101.3(esbuild@0.19.12)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.2
       serialize-javascript: 6.0.2
       terser: 5.44.0
-      webpack: 5.101.3(esbuild@0.19.12)
+      webpack: 5.101.3(esbuild@0.25.0)
     optionalDependencies:
-      esbuild: 0.19.12
+      esbuild: 0.25.0
 
   terser@5.44.0:
     dependencies:
@@ -20101,7 +20109,7 @@ snapshots:
 
   webpack-sources@3.3.3: {}
 
-  webpack@5.101.3(esbuild@0.19.12):
+  webpack@5.101.3(esbuild@0.25.0):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -20125,7 +20133,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.2
       tapable: 2.2.3
-      terser-webpack-plugin: 5.3.14(esbuild@0.19.12)(webpack@5.101.3(esbuild@0.25.0))
+      terser-webpack-plugin: 5.3.14(esbuild@0.25.0)(webpack@5.101.3(esbuild@0.19.12))
       watchpack: 2.4.4
       webpack-sources: 3.3.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- clear the encrypted desktop session and cached JWTs when the auth-expired event fires
- keep the auth store listener responsible for forced logouts consistent with the refresh hook cleanup

## Testing
- pnpm --filter web lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691760c9c58883209fd0189117ad255f)