### PR TITLE
fix: restore deletion behavior and update prompts

### DIFF
--- a/apps/web/src/lib/ai/role-prompts.ts
+++ b/apps/web/src/lib/ai/role-prompts.ts
@@ -96,7 +96,7 @@ export const ROLE_PROMPTS: Record<AgentRole, RolePromptTemplate> = {
     behavior: `EXECUTION PRIORITIES:
 1. ACT IMMEDIATELY: Start tool execution within first response
 2. PARALLEL EVERYTHING: Never wait - run independent operations simultaneously
-3. BATCH SIMILAR WORK: Use batch_page_operations for multi-page changes
+3. BATCH SIMILAR WORK: Chain replace_lines/insert_lines for multi-page changes
 4. REPORT PROGRESS: "Creating folders..." → "Created 5 folders" → "What's next?"
 5. CHAIN OPERATIONS: read_page → replace_lines → next task without pause`,
     

--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -68,10 +68,13 @@ export const pageWriteTools = {
           throw new Error(`Invalid line range: ${startLine}-${endLine}. Document has ${lines.length} lines.`);
         }
 
+        const isDeletion = content.length === 0;
+
         // Replace lines (convert to 0-based indexing)
+        const replacementSegment = isDeletion ? [] : [content];
         const newLines = [
           ...lines.slice(0, startLine - 1),
-          content,
+          ...replacementSegment,
           ...lines.slice(endLine),
         ];
 
@@ -99,12 +102,16 @@ export const pageWriteTools = {
           title: page.title,
           linesReplaced: endLine - startLine + 1,
           newLineCount: newLines.length,
-          message: `Successfully replaced lines ${startLine}-${endLine}`,
-          summary: `Updated "${page.title}" by replacing ${endLine - startLine + 1} line${endLine - startLine + 1 === 1 ? '' : 's'}`,
+          message: isDeletion
+            ? `Successfully removed lines ${startLine}-${endLine}`
+            : `Successfully replaced lines ${startLine}-${endLine}`,
+          summary: isDeletion
+            ? `Removed ${endLine - startLine + 1} line${endLine - startLine + 1 === 1 ? '' : 's'} from "${page.title}"`
+            : `Updated "${page.title}" by replacing ${endLine - startLine + 1} line${endLine - startLine + 1 === 1 ? '' : 's'}`,
           stats: {
             linesChanged: endLine - startLine + 1,
             totalLines: newLines.length,
-            changeType: 'replacement'
+            changeType: isDeletion ? 'deletion' : 'replacement'
           },
           nextSteps: [
             'Review the updated content to ensure it meets requirements',

--- a/apps/web/src/lib/ai/tools/task-management-tools.ts
+++ b/apps/web/src/lib/ai/tools/task-management-tools.ts
@@ -246,7 +246,7 @@ export const taskManagementTools = {
           nextSteps: pendingTasks > 0 ? [
             'Continue working through pending tasks',
             'Use update_task_status to mark tasks as you complete them',
-            'Use add_task_note to document progress on specific tasks',
+            'Include notes when using update_task_status to document progress',
           ] : [
             'All tasks are either completed or in progress',
             'Consider adding new tasks if needed',


### PR DESCRIPTION
## Summary
- allow replace_lines to fully remove content when called with empty text and update metadata
- update writer role guidance to reference the current editing tools
- adjust task list follow-up guidance to avoid recommending removed tools

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69189e204fc883209defe3c6694b3cdd)