### PR TITLE
feat(ios): Add compacted tool calls matching web app pattern

### DIFF
--- a/apps/ios/PageSpace/Features/Chat/MessageRow.swift
+++ b/apps/ios/PageSpace/Features/Chat/MessageRow.swift
@@ -217,12 +217,13 @@ struct GroupedToolCallsView: View {
 
     private var summaryText: String {
         let stats = summary
-        if stats.inProgress > 0 {
+        // Priority order matches groupStatus: error > inProgress > pending > completed
+        if stats.error > 0 {
+            return "\(stats.error) failed"
+        } else if stats.inProgress > 0 {
             return "\(stats.inProgress) active"
         } else if stats.completed == stats.total {
             return "all done"
-        } else if stats.error > 0 {
-            return "\(stats.error) failed"
         } else {
             return "\(stats.completed)/\(stats.total)"
         }


### PR DESCRIPTION
Implements grouped tool calls functionality for iOS to match the web app:
- Add GroupedToolCallsView that collapses consecutive tool calls of same type
- Show count, tool name, and status summary in collapsed header
- Status icons: spinner (in progress), checkmark (completed), X (error)
- Expandable to show individual tool calls with input/output details
- Active tool highlighting with blue border
- Updated preview with grouped tool call examples