### PR TITLE
test: add comprehensive tests for AI system routes

### DIFF
--- a/apps/web/src/app/api/ai/chat/messages/[messageId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/chat/messages/[messageId]/__tests__/route.test.ts
@@ -1,0 +1,410 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+import { PATCH, DELETE } from '../route';
+import type { WebAuthResult, AuthError } from '@/lib/auth';
+
+// Mock dependencies
+vi.mock('@pagespace/db', () => {
+  const whereMock = vi.fn().mockResolvedValue([]);
+  const setMock = vi.fn().mockReturnValue({ where: whereMock });
+  const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+  const selectMock = vi.fn().mockReturnValue({ from: fromMock });
+  const updateMock = vi.fn().mockReturnValue({ set: setMock });
+
+  return {
+    db: {
+      select: selectMock,
+      update: updateMock,
+    },
+    chatMessages: {},
+    eq: vi.fn((field: unknown, value: unknown) => ({ field, value, type: 'eq' })),
+  };
+});
+
+vi.mock('@pagespace/lib/server', () => ({
+  loggers: {
+    api: {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    },
+  },
+  canUserEditPage: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn(),
+}));
+
+vi.mock('@/lib/logging/mask', () => ({
+  maskIdentifier: vi.fn((id: string) => `***${id.slice(-4)}`),
+}));
+
+import { db } from '@pagespace/db';
+import { loggers, canUserEditPage } from '@pagespace/lib/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+
+// Helper to create mock WebAuthResult
+const mockWebAuth = (userId: string, tokenVersion = 0): WebAuthResult => ({
+  userId,
+  tokenVersion,
+  tokenType: 'jwt',
+  source: 'cookie',
+  role: 'user',
+});
+
+// Helper to create mock AuthError
+const mockAuthError = (status = 401): AuthError => ({
+  error: NextResponse.json({ error: 'Unauthorized' }, { status }),
+});
+
+// Helper to create mock chat message
+const mockChatMessage = (overrides: Partial<{
+  id: string;
+  pageId: string;
+  conversationId: string;
+  role: string;
+  content: string;
+  isActive: boolean;
+}> = {}) => ({
+  id: overrides.id || 'msg_123',
+  pageId: overrides.pageId || 'page_123',
+  conversationId: overrides.conversationId || 'conv_123',
+  role: overrides.role || 'user',
+  content: overrides.content || 'Hello, AI!',
+  isActive: overrides.isActive ?? true,
+});
+
+describe('Chat Message Individual Routes', () => {
+  const mockUserId = 'user_123';
+  const mockMessageId = 'msg_123';
+  const mockPageId = 'page_123';
+
+  // Helper to setup select mock for messages
+  const setupMessageSelectMock = (message: ReturnType<typeof mockChatMessage> | undefined) => {
+    const whereMock = vi.fn().mockResolvedValue(message ? [message] : []);
+    const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+    vi.mocked(db.select).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof db.select>);
+  };
+
+  // Helper to setup update mock
+  const setupUpdateMock = () => {
+    const whereMock = vi.fn().mockResolvedValue(undefined);
+    const setMock = vi.fn().mockReturnValue({ where: whereMock });
+    vi.mocked(db.update).mockReturnValue({ set: setMock } as unknown as ReturnType<typeof db.update>);
+    return { setMock, whereMock };
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default auth success
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockWebAuth(mockUserId));
+    vi.mocked(isAuthError).mockReturnValue(false);
+
+    // Default permission granted
+    vi.mocked(canUserEditPage).mockResolvedValue(true);
+
+    // Default message exists
+    setupMessageSelectMock(mockChatMessage());
+    setupUpdateMock();
+  });
+
+  describe('PATCH /api/ai/chat/messages/[messageId]', () => {
+    const createPatchRequest = (messageId: string, body: object) => {
+      return new Request(`https://example.com/api/ai/chat/messages/${messageId}`, {
+        method: 'PATCH',
+        body: JSON.stringify(body),
+      });
+    };
+
+    const createContext = (messageId: string) => ({
+      params: Promise.resolve({ messageId }),
+    });
+
+    describe('authentication', () => {
+      it('should return 401 when not authenticated', async () => {
+        vi.mocked(isAuthError).mockReturnValue(true);
+        vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthError(401));
+
+        const request = createPatchRequest(mockMessageId, { content: 'Updated content' });
+        const context = createContext(mockMessageId);
+
+        const response = await PATCH(request, context);
+        expect(response.status).toBe(401);
+      });
+    });
+
+    describe('validation', () => {
+      it('should return 400 when content is missing', async () => {
+        const request = createPatchRequest(mockMessageId, {});
+        const context = createContext(mockMessageId);
+
+        const response = await PATCH(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(400);
+        expect(body.error).toContain('Content is required');
+      });
+
+      it('should return 400 when content is not a string', async () => {
+        const request = createPatchRequest(mockMessageId, { content: 123 });
+        const context = createContext(mockMessageId);
+
+        const response = await PATCH(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(400);
+        expect(body.error).toContain('must be a string');
+      });
+
+      it('should return 400 when content is empty string', async () => {
+        const request = createPatchRequest(mockMessageId, { content: '' });
+        const context = createContext(mockMessageId);
+
+        const response = await PATCH(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(400);
+        expect(body.error).toContain('Content is required');
+      });
+    });
+
+    describe('message not found', () => {
+      it('should return 404 when message does not exist', async () => {
+        setupMessageSelectMock(undefined);
+
+        const request = createPatchRequest(mockMessageId, { content: 'Updated' });
+        const context = createContext(mockMessageId);
+
+        const response = await PATCH(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(404);
+        expect(body.error).toBe('Message not found');
+      });
+    });
+
+    describe('authorization', () => {
+      it('should return 403 when user lacks edit permission', async () => {
+        vi.mocked(canUserEditPage).mockResolvedValue(false);
+
+        const request = createPatchRequest(mockMessageId, { content: 'Updated' });
+        const context = createContext(mockMessageId);
+
+        const response = await PATCH(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(403);
+        expect(body.error).toContain('permission to edit');
+        expect(canUserEditPage).toHaveBeenCalledWith(mockUserId, mockPageId);
+      });
+
+      it('should log warning when permission denied', async () => {
+        vi.mocked(canUserEditPage).mockResolvedValue(false);
+
+        const request = createPatchRequest(mockMessageId, { content: 'Updated' });
+        const context = createContext(mockMessageId);
+
+        await PATCH(request, context);
+
+        expect(loggers.api.warn).toHaveBeenCalledWith(
+          'Edit message permission denied',
+          expect.any(Object)
+        );
+      });
+    });
+
+    describe('successful message update', () => {
+      it('should update message content successfully', async () => {
+        const { setMock } = setupUpdateMock();
+
+        const request = createPatchRequest(mockMessageId, { content: 'Updated content' });
+        const context = createContext(mockMessageId);
+
+        const response = await PATCH(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.success).toBe(true);
+        expect(body.message).toBe('Message updated successfully');
+        expect(setMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            content: 'Updated content',
+            editedAt: expect.any(Date),
+          })
+        );
+      });
+
+      it('should log successful edit', async () => {
+        const request = createPatchRequest(mockMessageId, { content: 'Updated' });
+        const context = createContext(mockMessageId);
+
+        await PATCH(request, context);
+
+        expect(loggers.api.info).toHaveBeenCalledWith(
+          'Message edited successfully',
+          expect.any(Object)
+        );
+      });
+
+      it('should handle structured content with textParts', async () => {
+        const structuredContent = JSON.stringify({
+          textParts: ['Original text'],
+          partsOrder: ['text'],
+          originalContent: 'Original text',
+        });
+        setupMessageSelectMock(mockChatMessage({ content: structuredContent }));
+        const { setMock } = setupUpdateMock();
+
+        const request = createPatchRequest(mockMessageId, { content: 'New text' });
+        const context = createContext(mockMessageId);
+
+        await PATCH(request, context);
+
+        // Should preserve structure but update textParts
+        expect(setMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            content: expect.stringContaining('New text'),
+          })
+        );
+      });
+    });
+
+    describe('error handling', () => {
+      it('should handle database errors gracefully', async () => {
+        const whereMock = vi.fn().mockRejectedValue(new Error('Database error'));
+        const setMock = vi.fn().mockReturnValue({ where: whereMock });
+        vi.mocked(db.update).mockReturnValue({ set: setMock } as unknown as ReturnType<typeof db.update>);
+
+        const request = createPatchRequest(mockMessageId, { content: 'Updated' });
+        const context = createContext(mockMessageId);
+
+        const response = await PATCH(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(500);
+        expect(body.error).toBe('Failed to edit message');
+        expect(loggers.api.error).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('DELETE /api/ai/chat/messages/[messageId]', () => {
+    const createDeleteRequest = (messageId: string) => {
+      return new Request(`https://example.com/api/ai/chat/messages/${messageId}`, {
+        method: 'DELETE',
+      });
+    };
+
+    const createContext = (messageId: string) => ({
+      params: Promise.resolve({ messageId }),
+    });
+
+    describe('authentication', () => {
+      it('should return 401 when not authenticated', async () => {
+        vi.mocked(isAuthError).mockReturnValue(true);
+        vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthError(401));
+
+        const request = createDeleteRequest(mockMessageId);
+        const context = createContext(mockMessageId);
+
+        const response = await DELETE(request, context);
+        expect(response.status).toBe(401);
+      });
+    });
+
+    describe('message not found', () => {
+      it('should return 404 when message does not exist', async () => {
+        setupMessageSelectMock(undefined);
+
+        const request = createDeleteRequest(mockMessageId);
+        const context = createContext(mockMessageId);
+
+        const response = await DELETE(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(404);
+        expect(body.error).toBe('Message not found');
+      });
+    });
+
+    describe('authorization', () => {
+      it('should return 403 when user lacks edit permission', async () => {
+        vi.mocked(canUserEditPage).mockResolvedValue(false);
+
+        const request = createDeleteRequest(mockMessageId);
+        const context = createContext(mockMessageId);
+
+        const response = await DELETE(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(403);
+        expect(body.error).toContain('permission to delete');
+      });
+
+      it('should log warning when permission denied', async () => {
+        vi.mocked(canUserEditPage).mockResolvedValue(false);
+
+        const request = createDeleteRequest(mockMessageId);
+        const context = createContext(mockMessageId);
+
+        await DELETE(request, context);
+
+        expect(loggers.api.warn).toHaveBeenCalledWith(
+          'Delete message permission denied',
+          expect.any(Object)
+        );
+      });
+    });
+
+    describe('successful message deletion', () => {
+      it('should soft delete message successfully', async () => {
+        const { setMock } = setupUpdateMock();
+
+        const request = createDeleteRequest(mockMessageId);
+        const context = createContext(mockMessageId);
+
+        const response = await DELETE(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.success).toBe(true);
+        expect(body.message).toBe('Message deleted successfully');
+        expect(setMock).toHaveBeenCalledWith({ isActive: false });
+      });
+
+      it('should log successful deletion', async () => {
+        const request = createDeleteRequest(mockMessageId);
+        const context = createContext(mockMessageId);
+
+        await DELETE(request, context);
+
+        expect(loggers.api.info).toHaveBeenCalledWith(
+          'Message deleted successfully',
+          expect.any(Object)
+        );
+      });
+    });
+
+    describe('error handling', () => {
+      it('should handle database errors gracefully', async () => {
+        const whereMock = vi.fn().mockRejectedValue(new Error('Database error'));
+        const setMock = vi.fn().mockReturnValue({ where: whereMock });
+        vi.mocked(db.update).mockReturnValue({ set: setMock } as unknown as ReturnType<typeof db.update>);
+
+        const request = createDeleteRequest(mockMessageId);
+        const context = createContext(mockMessageId);
+
+        const response = await DELETE(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(500);
+        expect(body.error).toBe('Failed to delete message');
+        expect(loggers.api.error).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/apps/web/src/app/api/ai/chat/messages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/chat/messages/__tests__/route.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+import { GET } from '../route';
+import type { WebAuthResult, AuthError } from '@/lib/auth';
+
+// Mock dependencies
+vi.mock('@pagespace/db', () => {
+  const orderByMock = vi.fn().mockResolvedValue([]);
+  const whereMock = vi.fn().mockReturnValue({ orderBy: orderByMock });
+  const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+  const selectMock = vi.fn().mockReturnValue({ from: fromMock });
+
+  return {
+    db: {
+      select: selectMock,
+    },
+    chatMessages: {},
+    eq: vi.fn((field: unknown, value: unknown) => ({ field, value, type: 'eq' })),
+    and: vi.fn((...conditions: unknown[]) => ({ conditions, type: 'and' })),
+  };
+});
+
+vi.mock('@pagespace/lib/server', () => ({
+  loggers: {
+    ai: {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    },
+  },
+  canUserViewPage: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateHybridRequest: vi.fn(),
+  isAuthError: vi.fn(),
+}));
+
+vi.mock('@/lib/ai/core', () => ({
+  convertDbMessageToUIMessage: vi.fn((msg) => ({
+    id: msg.id,
+    role: msg.role,
+    content: msg.content,
+  })),
+}));
+
+import { db } from '@pagespace/db';
+import { loggers, canUserViewPage } from '@pagespace/lib/server';
+import { authenticateHybridRequest, isAuthError } from '@/lib/auth';
+import { convertDbMessageToUIMessage } from '@/lib/ai/core';
+
+// Helper to create mock WebAuthResult
+const mockWebAuth = (userId: string, tokenVersion = 0): WebAuthResult => ({
+  userId,
+  tokenVersion,
+  tokenType: 'jwt',
+  source: 'cookie',
+  role: 'user',
+});
+
+// Helper to create mock AuthError
+const mockAuthError = (status = 401): AuthError => ({
+  error: NextResponse.json({ error: 'Unauthorized' }, { status }),
+});
+
+// Helper to create mock chat message
+const mockChatMessage = (overrides: Partial<{
+  id: string;
+  pageId: string;
+  conversationId: string;
+  role: string;
+  content: string;
+  isActive: boolean;
+  createdAt: Date;
+}> = {}) => ({
+  id: overrides.id || 'msg_123',
+  pageId: overrides.pageId || 'page_123',
+  conversationId: overrides.conversationId || 'conv_123',
+  role: overrides.role || 'user',
+  content: overrides.content || 'Hello, AI!',
+  isActive: overrides.isActive ?? true,
+  createdAt: overrides.createdAt || new Date(),
+});
+
+describe('GET /api/ai/chat/messages', () => {
+  const mockUserId = 'user_123';
+  const mockPageId = 'page_123';
+
+  // Helper to setup select mock for messages
+  const setupMessagesSelectMock = (messages: ReturnType<typeof mockChatMessage>[]) => {
+    const orderByMock = vi.fn().mockResolvedValue(messages);
+    const whereMock = vi.fn().mockReturnValue({ orderBy: orderByMock });
+    const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+    vi.mocked(db.select).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof db.select>);
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default auth success
+    vi.mocked(authenticateHybridRequest).mockResolvedValue(mockWebAuth(mockUserId));
+    vi.mocked(isAuthError).mockReturnValue(false);
+
+    // Default permission granted
+    vi.mocked(canUserViewPage).mockResolvedValue(true);
+
+    // Default empty messages
+    setupMessagesSelectMock([]);
+  });
+
+  describe('authentication', () => {
+    it('should return 401 when not authenticated', async () => {
+      vi.mocked(isAuthError).mockReturnValue(true);
+      vi.mocked(authenticateHybridRequest).mockResolvedValue(mockAuthError(401));
+
+      const request = new Request(`https://example.com/api/ai/chat/messages?pageId=${mockPageId}`, {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe('validation', () => {
+    it('should return 400 when pageId is missing', async () => {
+      const request = new Request('https://example.com/api/ai/chat/messages', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toBe('pageId is required');
+    });
+  });
+
+  describe('authorization', () => {
+    it('should return 403 when user lacks view permission', async () => {
+      vi.mocked(canUserViewPage).mockResolvedValue(false);
+
+      const request = new Request(`https://example.com/api/ai/chat/messages?pageId=${mockPageId}`, {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.error).toContain('view permission');
+      expect(canUserViewPage).toHaveBeenCalledWith(mockUserId, mockPageId);
+    });
+  });
+
+  describe('successful message retrieval', () => {
+    it('should return messages for a page', async () => {
+      const messages = [
+        mockChatMessage({ id: 'msg_1', role: 'user', content: 'Hello' }),
+        mockChatMessage({ id: 'msg_2', role: 'assistant', content: 'Hi there!' }),
+      ];
+      setupMessagesSelectMock(messages);
+
+      const request = new Request(`https://example.com/api/ai/chat/messages?pageId=${mockPageId}`, {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(Array.isArray(body)).toBe(true);
+      expect(body.length).toBe(2);
+      expect(convertDbMessageToUIMessage).toHaveBeenCalledTimes(2);
+    });
+
+    it('should return empty array when no messages exist', async () => {
+      setupMessagesSelectMock([]);
+
+      const request = new Request(`https://example.com/api/ai/chat/messages?pageId=${mockPageId}`, {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body).toEqual([]);
+    });
+
+    it('should filter by conversationId when provided', async () => {
+      const conversationId = 'conv_456';
+      const messages = [
+        mockChatMessage({ id: 'msg_1', conversationId }),
+      ];
+      setupMessagesSelectMock(messages);
+
+      const request = new Request(
+        `https://example.com/api/ai/chat/messages?pageId=${mockPageId}&conversationId=${conversationId}`,
+        { method: 'GET' }
+      );
+
+      const response = await GET(request);
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle database errors gracefully', async () => {
+      const orderByMock = vi.fn().mockRejectedValue(new Error('Database error'));
+      const whereMock = vi.fn().mockReturnValue({ orderBy: orderByMock });
+      const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+      vi.mocked(db.select).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof db.select>);
+
+      const request = new Request(`https://example.com/api/ai/chat/messages?pageId=${mockPageId}`, {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(body.error).toBe('Failed to load messages');
+      expect(loggers.ai.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/app/api/ai/global/[id]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/__tests__/route.test.ts
@@ -1,0 +1,361 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+import { GET, PATCH, DELETE } from '../route';
+import type { WebAuthResult, AuthError } from '@/lib/auth';
+
+// Mock dependencies
+vi.mock('@pagespace/db', () => {
+  const returningMock = vi.fn().mockResolvedValue([]);
+  const whereMock = vi.fn().mockReturnValue({ returning: returningMock });
+  const setMock = vi.fn().mockReturnValue({ where: whereMock });
+  const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+  const selectMock = vi.fn().mockReturnValue({ from: fromMock });
+  const updateMock = vi.fn().mockReturnValue({ set: setMock });
+
+  return {
+    db: {
+      select: selectMock,
+      update: updateMock,
+    },
+    conversations: {},
+    eq: vi.fn((field: unknown, value: unknown) => ({ field, value, type: 'eq' })),
+    and: vi.fn((...conditions: unknown[]) => ({ conditions, type: 'and' })),
+  };
+});
+
+vi.mock('@pagespace/lib/server', () => ({
+  loggers: {
+    api: {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn(),
+}));
+
+import { db } from '@pagespace/db';
+import { loggers } from '@pagespace/lib/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+
+// Helper to create mock WebAuthResult
+const mockWebAuth = (userId: string, tokenVersion = 0): WebAuthResult => ({
+  userId,
+  tokenVersion,
+  tokenType: 'jwt',
+  source: 'cookie',
+  role: 'user',
+});
+
+// Helper to create mock AuthError
+const mockAuthError = (status = 401): AuthError => ({
+  error: NextResponse.json({ error: 'Unauthorized' }, { status }),
+});
+
+// Helper to create mock conversation
+const mockConversation = (overrides: Partial<{
+  id: string;
+  userId: string;
+  title: string;
+  type: string;
+  contextId: string | null;
+  lastMessageAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+  isActive: boolean;
+}> = {}) => ({
+  id: overrides.id || 'conv_123',
+  userId: overrides.userId || 'user_123',
+  title: overrides.title || 'Test Conversation',
+  type: overrides.type || 'global',
+  contextId: overrides.contextId ?? null,
+  lastMessageAt: overrides.lastMessageAt || new Date(),
+  createdAt: overrides.createdAt || new Date(),
+  updatedAt: overrides.updatedAt || new Date(),
+  isActive: overrides.isActive ?? true,
+});
+
+describe('Global Conversation [id] Routes', () => {
+  const mockUserId = 'user_123';
+  const mockConversationId = 'conv_123';
+
+  // Helper to setup select mock
+  const setupConversationSelectMock = (conversation: ReturnType<typeof mockConversation> | undefined) => {
+    const whereMock = vi.fn().mockResolvedValue(conversation ? [conversation] : []);
+    const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+    vi.mocked(db.select).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof db.select>);
+  };
+
+  // Helper to setup update mock
+  const setupUpdateMock = (result: ReturnType<typeof mockConversation> | undefined) => {
+    const returningMock = vi.fn().mockResolvedValue(result ? [result] : []);
+    const whereMock = vi.fn().mockReturnValue({ returning: returningMock });
+    const setMock = vi.fn().mockReturnValue({ where: whereMock });
+    vi.mocked(db.update).mockReturnValue({ set: setMock } as unknown as ReturnType<typeof db.update>);
+    return { setMock, whereMock, returningMock };
+  };
+
+  const createContext = (id: string) => ({
+    params: Promise.resolve({ id }),
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default auth success
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockWebAuth(mockUserId));
+    vi.mocked(isAuthError).mockReturnValue(false);
+
+    // Default conversation exists
+    setupConversationSelectMock(mockConversation());
+  });
+
+  describe('GET /api/ai/global/[id]', () => {
+    describe('authentication', () => {
+      it('should return 401 when not authenticated', async () => {
+        vi.mocked(isAuthError).mockReturnValue(true);
+        vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthError(401));
+
+        const request = new Request(`https://example.com/api/ai/global/${mockConversationId}`, {
+          method: 'GET',
+        });
+        const context = createContext(mockConversationId);
+
+        const response = await GET(request, context);
+        expect(response.status).toBe(401);
+      });
+    });
+
+    describe('conversation not found', () => {
+      it('should return 404 when conversation does not exist', async () => {
+        setupConversationSelectMock(undefined);
+
+        const request = new Request(`https://example.com/api/ai/global/${mockConversationId}`, {
+          method: 'GET',
+        });
+        const context = createContext(mockConversationId);
+
+        const response = await GET(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(404);
+        expect(body.error).toBe('Conversation not found');
+      });
+
+      it('should return 404 for conversation belonging to another user', async () => {
+        // Conversation exists but belongs to different user
+        // This is handled by the where clause checking userId
+        setupConversationSelectMock(undefined);
+
+        const request = new Request(`https://example.com/api/ai/global/${mockConversationId}`, {
+          method: 'GET',
+        });
+        const context = createContext(mockConversationId);
+
+        const response = await GET(request, context);
+        expect(response.status).toBe(404);
+      });
+    });
+
+    describe('successful retrieval', () => {
+      it('should return conversation details', async () => {
+        const conversation = mockConversation({
+          id: mockConversationId,
+          title: 'My Conversation',
+        });
+        setupConversationSelectMock(conversation);
+
+        const request = new Request(`https://example.com/api/ai/global/${mockConversationId}`, {
+          method: 'GET',
+        });
+        const context = createContext(mockConversationId);
+
+        const response = await GET(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.id).toBe(mockConversationId);
+        expect(body.title).toBe('My Conversation');
+      });
+    });
+
+    describe('error handling', () => {
+      it('should handle database errors gracefully', async () => {
+        const whereMock = vi.fn().mockRejectedValue(new Error('Database error'));
+        const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+        vi.mocked(db.select).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof db.select>);
+
+        const request = new Request(`https://example.com/api/ai/global/${mockConversationId}`, {
+          method: 'GET',
+        });
+        const context = createContext(mockConversationId);
+
+        const response = await GET(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(500);
+        expect(body.error).toBe('Failed to fetch conversation');
+        expect(loggers.api.error).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('PATCH /api/ai/global/[id]', () => {
+    const createPatchRequest = (id: string, body: object) => {
+      return new Request(`https://example.com/api/ai/global/${id}`, {
+        method: 'PATCH',
+        body: JSON.stringify(body),
+      });
+    };
+
+    describe('authentication', () => {
+      it('should return 401 when not authenticated', async () => {
+        vi.mocked(isAuthError).mockReturnValue(true);
+        vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthError(401));
+
+        const request = createPatchRequest(mockConversationId, { title: 'Updated' });
+        const context = createContext(mockConversationId);
+
+        const response = await PATCH(request, context);
+        expect(response.status).toBe(401);
+      });
+    });
+
+    describe('conversation not found', () => {
+      it('should return 404 when conversation does not exist', async () => {
+        setupUpdateMock(undefined);
+
+        const request = createPatchRequest(mockConversationId, { title: 'Updated' });
+        const context = createContext(mockConversationId);
+
+        const response = await PATCH(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(404);
+        expect(body.error).toBe('Conversation not found');
+      });
+    });
+
+    describe('successful update', () => {
+      it('should update conversation title', async () => {
+        const updatedConversation = mockConversation({
+          id: mockConversationId,
+          title: 'Updated Title',
+        });
+        setupUpdateMock(updatedConversation);
+
+        const request = createPatchRequest(mockConversationId, { title: 'Updated Title' });
+        const context = createContext(mockConversationId);
+
+        const response = await PATCH(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.title).toBe('Updated Title');
+      });
+    });
+
+    describe('error handling', () => {
+      it('should handle database errors gracefully', async () => {
+        const returningMock = vi.fn().mockRejectedValue(new Error('Database error'));
+        const whereMock = vi.fn().mockReturnValue({ returning: returningMock });
+        const setMock = vi.fn().mockReturnValue({ where: whereMock });
+        vi.mocked(db.update).mockReturnValue({ set: setMock } as unknown as ReturnType<typeof db.update>);
+
+        const request = createPatchRequest(mockConversationId, { title: 'Updated' });
+        const context = createContext(mockConversationId);
+
+        const response = await PATCH(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(500);
+        expect(body.error).toBe('Failed to update conversation');
+        expect(loggers.api.error).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('DELETE /api/ai/global/[id]', () => {
+    const createDeleteRequest = (id: string) => {
+      return new Request(`https://example.com/api/ai/global/${id}`, {
+        method: 'DELETE',
+      });
+    };
+
+    describe('authentication', () => {
+      it('should return 401 when not authenticated', async () => {
+        vi.mocked(isAuthError).mockReturnValue(true);
+        vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthError(401));
+
+        const request = createDeleteRequest(mockConversationId);
+        const context = createContext(mockConversationId);
+
+        const response = await DELETE(request, context);
+        expect(response.status).toBe(401);
+      });
+    });
+
+    describe('conversation not found', () => {
+      it('should return 404 when conversation does not exist', async () => {
+        setupUpdateMock(undefined);
+
+        const request = createDeleteRequest(mockConversationId);
+        const context = createContext(mockConversationId);
+
+        const response = await DELETE(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(404);
+        expect(body.error).toBe('Conversation not found');
+      });
+    });
+
+    describe('successful deletion', () => {
+      it('should soft delete conversation', async () => {
+        const deletedConversation = mockConversation({
+          id: mockConversationId,
+          isActive: false,
+        });
+        const { setMock } = setupUpdateMock(deletedConversation);
+
+        const request = createDeleteRequest(mockConversationId);
+        const context = createContext(mockConversationId);
+
+        const response = await DELETE(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.success).toBe(true);
+        expect(setMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            isActive: false,
+          })
+        );
+      });
+    });
+
+    describe('error handling', () => {
+      it('should handle database errors gracefully', async () => {
+        const returningMock = vi.fn().mockRejectedValue(new Error('Database error'));
+        const whereMock = vi.fn().mockReturnValue({ returning: returningMock });
+        const setMock = vi.fn().mockReturnValue({ where: whereMock });
+        vi.mocked(db.update).mockReturnValue({ set: setMock } as unknown as ReturnType<typeof db.update>);
+
+        const request = createDeleteRequest(mockConversationId);
+        const context = createContext(mockConversationId);
+
+        const response = await DELETE(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(500);
+        expect(body.error).toBe('Failed to delete conversation');
+        expect(loggers.api.error).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/apps/web/src/app/api/ai/global/[id]/messages/[messageId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/[messageId]/__tests__/route.test.ts
@@ -1,0 +1,389 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+import { PATCH, DELETE } from '../route';
+import type { WebAuthResult, AuthError } from '@/lib/auth';
+
+// Mock dependencies
+vi.mock('@pagespace/db', () => {
+  const whereMock = vi.fn().mockResolvedValue([]);
+  const setMock = vi.fn().mockReturnValue({ where: whereMock });
+  const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+  const selectMock = vi.fn().mockReturnValue({ from: fromMock });
+  const updateMock = vi.fn().mockReturnValue({ set: setMock });
+
+  return {
+    db: {
+      select: selectMock,
+      update: updateMock,
+    },
+    conversations: {},
+    messages: {},
+    eq: vi.fn((field: unknown, value: unknown) => ({ field, value, type: 'eq' })),
+    and: vi.fn((...conditions: unknown[]) => ({ conditions, type: 'and' })),
+  };
+});
+
+vi.mock('@pagespace/lib/server', () => ({
+  loggers: {
+    api: {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn(),
+}));
+
+vi.mock('@/lib/logging/mask', () => ({
+  maskIdentifier: vi.fn((id: string) => `***${id.slice(-4)}`),
+}));
+
+import { db } from '@pagespace/db';
+import { loggers } from '@pagespace/lib/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+
+// Helper to create mock WebAuthResult
+const mockWebAuth = (userId: string, tokenVersion = 0): WebAuthResult => ({
+  userId,
+  tokenVersion,
+  tokenType: 'jwt',
+  source: 'cookie',
+  role: 'user',
+});
+
+// Helper to create mock AuthError
+const mockAuthError = (status = 401): AuthError => ({
+  error: NextResponse.json({ error: 'Unauthorized' }, { status }),
+});
+
+// Helper to create mock conversation
+const mockConversation = (overrides: Partial<{
+  id: string;
+  userId: string;
+  isActive: boolean;
+}> = {}) => ({
+  id: overrides.id || 'conv_123',
+  userId: overrides.userId || 'user_123',
+  isActive: overrides.isActive ?? true,
+});
+
+// Helper to create mock message
+const mockMessage = (overrides: Partial<{
+  id: string;
+  conversationId: string;
+  role: string;
+  content: string;
+  isActive: boolean;
+}> = {}) => ({
+  id: overrides.id || 'msg_123',
+  conversationId: overrides.conversationId || 'conv_123',
+  role: overrides.role || 'user',
+  content: overrides.content || 'Hello, AI!',
+  isActive: overrides.isActive ?? true,
+});
+
+describe('Global Conversation Message Routes', () => {
+  const mockUserId = 'user_123';
+  const mockConversationId = 'conv_123';
+  const mockMessageId = 'msg_123';
+
+  // Track which mock call is for conversation vs message
+  let selectCallCount = 0;
+
+  // Helper to setup select mock for conversation and message
+  const setupSelectMocks = (
+    conversation: ReturnType<typeof mockConversation> | undefined,
+    message: ReturnType<typeof mockMessage> | undefined
+  ) => {
+    selectCallCount = 0;
+    const whereMock = vi.fn().mockImplementation(() => {
+      selectCallCount++;
+      if (selectCallCount === 1) {
+        // First call is for conversation
+        return Promise.resolve(conversation ? [conversation] : []);
+      } else {
+        // Second call is for message
+        return Promise.resolve(message ? [message] : []);
+      }
+    });
+    const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+    vi.mocked(db.select).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof db.select>);
+  };
+
+  // Helper to setup update mock
+  const setupUpdateMock = () => {
+    const whereMock = vi.fn().mockResolvedValue(undefined);
+    const setMock = vi.fn().mockReturnValue({ where: whereMock });
+    vi.mocked(db.update).mockReturnValue({ set: setMock } as unknown as ReturnType<typeof db.update>);
+    return { setMock, whereMock };
+  };
+
+  const createContext = (id: string, messageId: string) => ({
+    params: Promise.resolve({ id, messageId }),
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectCallCount = 0;
+
+    // Default auth success
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockWebAuth(mockUserId));
+    vi.mocked(isAuthError).mockReturnValue(false);
+
+    // Default: both conversation and message exist
+    setupSelectMocks(mockConversation(), mockMessage());
+    setupUpdateMock();
+  });
+
+  describe('PATCH /api/ai/global/[id]/messages/[messageId]', () => {
+    const createPatchRequest = (id: string, messageId: string, body: object) => {
+      return new Request(`https://example.com/api/ai/global/${id}/messages/${messageId}`, {
+        method: 'PATCH',
+        body: JSON.stringify(body),
+      });
+    };
+
+    describe('authentication', () => {
+      it('should return 401 when not authenticated', async () => {
+        vi.mocked(isAuthError).mockReturnValue(true);
+        vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthError(401));
+
+        const request = createPatchRequest(mockConversationId, mockMessageId, { content: 'Updated' });
+        const context = createContext(mockConversationId, mockMessageId);
+
+        const response = await PATCH(request, context);
+        expect(response.status).toBe(401);
+      });
+    });
+
+    describe('validation', () => {
+      it('should return 400 when content is missing', async () => {
+        const request = createPatchRequest(mockConversationId, mockMessageId, {});
+        const context = createContext(mockConversationId, mockMessageId);
+
+        const response = await PATCH(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(400);
+        expect(body.error).toContain('Content is required');
+      });
+
+      it('should return 400 when content is not a string', async () => {
+        const request = createPatchRequest(mockConversationId, mockMessageId, { content: 123 });
+        const context = createContext(mockConversationId, mockMessageId);
+
+        const response = await PATCH(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(400);
+        expect(body.error).toContain('must be a string');
+      });
+    });
+
+    describe('conversation not found', () => {
+      it('should return 404 when conversation does not exist', async () => {
+        setupSelectMocks(undefined, mockMessage());
+
+        const request = createPatchRequest(mockConversationId, mockMessageId, { content: 'Updated' });
+        const context = createContext(mockConversationId, mockMessageId);
+
+        const response = await PATCH(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(404);
+        expect(body.error).toBe('Conversation not found');
+      });
+    });
+
+    describe('message not found', () => {
+      it('should return 404 when message does not exist', async () => {
+        setupSelectMocks(mockConversation(), undefined);
+
+        const request = createPatchRequest(mockConversationId, mockMessageId, { content: 'Updated' });
+        const context = createContext(mockConversationId, mockMessageId);
+
+        const response = await PATCH(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(404);
+        expect(body.error).toBe('Message not found');
+      });
+    });
+
+    describe('successful update', () => {
+      it('should update message content', async () => {
+        const { setMock } = setupUpdateMock();
+
+        const request = createPatchRequest(mockConversationId, mockMessageId, { content: 'Updated content' });
+        const context = createContext(mockConversationId, mockMessageId);
+
+        const response = await PATCH(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.success).toBe(true);
+        expect(body.message).toBe('Message updated successfully');
+        expect(setMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            content: 'Updated content',
+            editedAt: expect.any(Date),
+          })
+        );
+      });
+
+      it('should log successful edit', async () => {
+        const request = createPatchRequest(mockConversationId, mockMessageId, { content: 'Updated' });
+        const context = createContext(mockConversationId, mockMessageId);
+
+        await PATCH(request, context);
+
+        expect(loggers.api.info).toHaveBeenCalledWith(
+          'Global Assistant message edited successfully',
+          expect.any(Object)
+        );
+      });
+
+      it('should handle structured content with textParts', async () => {
+        const structuredContent = JSON.stringify({
+          textParts: ['Original text'],
+          partsOrder: ['text'],
+          originalContent: 'Original text',
+        });
+        setupSelectMocks(mockConversation(), mockMessage({ content: structuredContent }));
+        const { setMock } = setupUpdateMock();
+
+        const request = createPatchRequest(mockConversationId, mockMessageId, { content: 'New text' });
+        const context = createContext(mockConversationId, mockMessageId);
+
+        await PATCH(request, context);
+
+        expect(setMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            content: expect.stringContaining('New text'),
+          })
+        );
+      });
+    });
+
+    describe('error handling', () => {
+      it('should handle database errors gracefully', async () => {
+        const whereMock = vi.fn().mockRejectedValue(new Error('Database error'));
+        const setMock = vi.fn().mockReturnValue({ where: whereMock });
+        vi.mocked(db.update).mockReturnValue({ set: setMock } as unknown as ReturnType<typeof db.update>);
+
+        const request = createPatchRequest(mockConversationId, mockMessageId, { content: 'Updated' });
+        const context = createContext(mockConversationId, mockMessageId);
+
+        const response = await PATCH(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(500);
+        expect(body.error).toBe('Failed to edit message');
+        expect(loggers.api.error).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('DELETE /api/ai/global/[id]/messages/[messageId]', () => {
+    const createDeleteRequest = (id: string, messageId: string) => {
+      return new Request(`https://example.com/api/ai/global/${id}/messages/${messageId}`, {
+        method: 'DELETE',
+      });
+    };
+
+    describe('authentication', () => {
+      it('should return 401 when not authenticated', async () => {
+        vi.mocked(isAuthError).mockReturnValue(true);
+        vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthError(401));
+
+        const request = createDeleteRequest(mockConversationId, mockMessageId);
+        const context = createContext(mockConversationId, mockMessageId);
+
+        const response = await DELETE(request, context);
+        expect(response.status).toBe(401);
+      });
+    });
+
+    describe('conversation not found', () => {
+      it('should return 404 when conversation does not exist', async () => {
+        setupSelectMocks(undefined, mockMessage());
+
+        const request = createDeleteRequest(mockConversationId, mockMessageId);
+        const context = createContext(mockConversationId, mockMessageId);
+
+        const response = await DELETE(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(404);
+        expect(body.error).toBe('Conversation not found');
+      });
+    });
+
+    describe('message not found', () => {
+      it('should return 404 when message does not exist', async () => {
+        setupSelectMocks(mockConversation(), undefined);
+
+        const request = createDeleteRequest(mockConversationId, mockMessageId);
+        const context = createContext(mockConversationId, mockMessageId);
+
+        const response = await DELETE(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(404);
+        expect(body.error).toBe('Message not found');
+      });
+    });
+
+    describe('successful deletion', () => {
+      it('should soft delete message', async () => {
+        const { setMock } = setupUpdateMock();
+
+        const request = createDeleteRequest(mockConversationId, mockMessageId);
+        const context = createContext(mockConversationId, mockMessageId);
+
+        const response = await DELETE(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.success).toBe(true);
+        expect(body.message).toBe('Message deleted successfully');
+        expect(setMock).toHaveBeenCalledWith({ isActive: false });
+      });
+
+      it('should log successful deletion', async () => {
+        const request = createDeleteRequest(mockConversationId, mockMessageId);
+        const context = createContext(mockConversationId, mockMessageId);
+
+        await DELETE(request, context);
+
+        expect(loggers.api.info).toHaveBeenCalledWith(
+          'Global Assistant message deleted successfully',
+          expect.any(Object)
+        );
+      });
+    });
+
+    describe('error handling', () => {
+      it('should handle database errors gracefully', async () => {
+        const whereMock = vi.fn().mockRejectedValue(new Error('Database error'));
+        const setMock = vi.fn().mockReturnValue({ where: whereMock });
+        vi.mocked(db.update).mockReturnValue({ set: setMock } as unknown as ReturnType<typeof db.update>);
+
+        const request = createDeleteRequest(mockConversationId, mockMessageId);
+        const context = createContext(mockConversationId, mockMessageId);
+
+        const response = await DELETE(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(500);
+        expect(body.error).toBe('Failed to delete message');
+        expect(loggers.api.error).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/apps/web/src/app/api/ai/global/[id]/usage/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/usage/__tests__/route.test.ts
@@ -1,0 +1,348 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+import { GET } from '../route';
+import type { WebAuthResult, AuthError } from '@/lib/auth';
+
+// Mock dependencies
+vi.mock('@pagespace/db', () => {
+  const orderByMock = vi.fn().mockResolvedValue([]);
+  const whereMock = vi.fn().mockReturnValue({ orderBy: orderByMock });
+  const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+  const selectMock = vi.fn().mockReturnValue({ from: fromMock });
+
+  return {
+    db: {
+      select: selectMock,
+    },
+    conversations: {},
+    aiUsageLogs: {},
+    eq: vi.fn((field: unknown, value: unknown) => ({ field, value, type: 'eq' })),
+    and: vi.fn((...conditions: unknown[]) => ({ conditions, type: 'and' })),
+    desc: vi.fn((field: unknown) => ({ field, type: 'desc' })),
+  };
+});
+
+vi.mock('@pagespace/lib/server', () => ({
+  loggers: {
+    api: {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@pagespace/lib/ai-monitoring', () => ({
+  getContextWindow: vi.fn(() => 200000),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn(),
+}));
+
+import { db } from '@pagespace/db';
+import { loggers } from '@pagespace/lib/server';
+import { getContextWindow } from '@pagespace/lib/ai-monitoring';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+
+// Helper to create mock WebAuthResult
+const mockWebAuth = (userId: string, tokenVersion = 0): WebAuthResult => ({
+  userId,
+  tokenVersion,
+  tokenType: 'jwt',
+  source: 'cookie',
+  role: 'user',
+});
+
+// Helper to create mock AuthError
+const mockAuthError = (status = 401): AuthError => ({
+  error: NextResponse.json({ error: 'Unauthorized' }, { status }),
+});
+
+// Helper to create mock conversation
+const mockConversation = (overrides: Partial<{
+  id: string;
+  userId: string;
+  isActive: boolean;
+}> = {}) => ({
+  id: overrides.id || 'conv_123',
+  userId: overrides.userId || 'user_123',
+  isActive: overrides.isActive ?? true,
+});
+
+// Helper to create mock usage log
+const mockUsageLog = (overrides: Partial<{
+  id: string;
+  timestamp: Date;
+  userId: string;
+  provider: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  cost: number;
+  conversationId: string;
+  messageId: string | null;
+  pageId: string | null;
+  driveId: string | null;
+  success: boolean;
+  error: string | null;
+  contextSize: number;
+  messageCount: number;
+  wasTruncated: boolean;
+}> = {}) => ({
+  id: overrides.id || 'log_123',
+  timestamp: overrides.timestamp || new Date(),
+  userId: overrides.userId || 'user_123',
+  provider: overrides.provider || 'openrouter',
+  model: overrides.model || 'anthropic/claude-3-opus',
+  inputTokens: overrides.inputTokens ?? 1000,
+  outputTokens: overrides.outputTokens ?? 500,
+  totalTokens: overrides.totalTokens ?? 1500,
+  cost: overrides.cost ?? 0.015,
+  conversationId: overrides.conversationId || 'conv_123',
+  messageId: overrides.messageId ?? null,
+  pageId: overrides.pageId ?? null,
+  driveId: overrides.driveId ?? null,
+  success: overrides.success ?? true,
+  error: overrides.error ?? null,
+  contextSize: overrides.contextSize ?? 50000,
+  messageCount: overrides.messageCount ?? 10,
+  wasTruncated: overrides.wasTruncated ?? false,
+});
+
+describe('GET /api/ai/global/[id]/usage', () => {
+  const mockUserId = 'user_123';
+  const mockConversationId = 'conv_123';
+
+  let selectCallCount = 0;
+
+  // Helper to setup select mocks for conversation and usage logs
+  const setupSelectMocks = (
+    conversation: ReturnType<typeof mockConversation> | undefined,
+    usageLogs: ReturnType<typeof mockUsageLog>[]
+  ) => {
+    selectCallCount = 0;
+    const orderByMock = vi.fn().mockImplementation(() => {
+      return Promise.resolve(usageLogs);
+    });
+    const whereMock = vi.fn().mockImplementation(() => {
+      selectCallCount++;
+      if (selectCallCount === 1) {
+        // First call is for conversation
+        return Promise.resolve(conversation ? [conversation] : []);
+      } else {
+        // Second call is for usage logs (returns object with orderBy)
+        return { orderBy: orderByMock };
+      }
+    });
+    const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+    vi.mocked(db.select).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof db.select>);
+  };
+
+  const createContext = (id: string) => ({
+    params: Promise.resolve({ id }),
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectCallCount = 0;
+
+    // Default auth success
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockWebAuth(mockUserId));
+    vi.mocked(isAuthError).mockReturnValue(false);
+
+    // Default context window
+    vi.mocked(getContextWindow).mockReturnValue(200000);
+
+    // Default: conversation exists, no usage logs
+    setupSelectMocks(mockConversation(), []);
+  });
+
+  describe('authentication', () => {
+    it('should return 401 when not authenticated', async () => {
+      vi.mocked(isAuthError).mockReturnValue(true);
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthError(401));
+
+      const request = new Request(`https://example.com/api/ai/global/${mockConversationId}/usage`, {
+        method: 'GET',
+      });
+      const context = createContext(mockConversationId);
+
+      const response = await GET(request, context);
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe('conversation not found', () => {
+    it('should return 404 when conversation does not exist', async () => {
+      setupSelectMocks(undefined, []);
+
+      const request = new Request(`https://example.com/api/ai/global/${mockConversationId}/usage`, {
+        method: 'GET',
+      });
+      const context = createContext(mockConversationId);
+
+      const response = await GET(request, context);
+      const body = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(body.error).toBe('Conversation not found');
+    });
+  });
+
+  describe('successful retrieval', () => {
+    it('should return usage statistics for conversation', async () => {
+      const usageLogs = [
+        mockUsageLog({ inputTokens: 1000, outputTokens: 500, totalTokens: 1500, cost: 0.01 }),
+        mockUsageLog({ inputTokens: 2000, outputTokens: 800, totalTokens: 2800, cost: 0.02 }),
+      ];
+      setupSelectMocks(mockConversation(), usageLogs);
+
+      const request = new Request(`https://example.com/api/ai/global/${mockConversationId}/usage`, {
+        method: 'GET',
+      });
+      const context = createContext(mockConversationId);
+
+      const response = await GET(request, context);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.logs).toBeDefined();
+      expect(body.summary).toBeDefined();
+      expect(body.summary.billing).toBeDefined();
+      expect(body.summary.billing.totalInputTokens).toBe(3000);
+      expect(body.summary.billing.totalOutputTokens).toBe(1300);
+      expect(body.summary.billing.totalTokens).toBe(4300);
+      expect(body.summary.billing.totalCost).toBe(0.03);
+    });
+
+    it('should return empty logs with zero totals when no usage', async () => {
+      setupSelectMocks(mockConversation(), []);
+
+      const request = new Request(`https://example.com/api/ai/global/${mockConversationId}/usage`, {
+        method: 'GET',
+      });
+      const context = createContext(mockConversationId);
+
+      const response = await GET(request, context);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.logs).toEqual([]);
+      expect(body.summary.billing.totalInputTokens).toBe(0);
+      expect(body.summary.billing.totalOutputTokens).toBe(0);
+      expect(body.summary.billing.totalTokens).toBe(0);
+      expect(body.summary.billing.totalCost).toBe(0);
+      expect(body.summary.context).toBeNull();
+    });
+
+    it('should return context metrics from most recent log', async () => {
+      const usageLogs = [
+        mockUsageLog({
+          contextSize: 75000,
+          messageCount: 15,
+          wasTruncated: false,
+          model: 'anthropic/claude-3-opus',
+        }),
+      ];
+      setupSelectMocks(mockConversation(), usageLogs);
+
+      const request = new Request(`https://example.com/api/ai/global/${mockConversationId}/usage`, {
+        method: 'GET',
+      });
+      const context = createContext(mockConversationId);
+
+      const response = await GET(request, context);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.summary.context).toBeDefined();
+      expect(body.summary.context.currentContextSize).toBe(75000);
+      expect(body.summary.context.messagesInContext).toBe(15);
+      expect(body.summary.context.wasTruncated).toBe(false);
+      expect(body.summary.mostRecentModel).toBe('anthropic/claude-3-opus');
+      expect(body.summary.mostRecentProvider).toBe('openrouter');
+    });
+
+    it('should calculate context usage percentage correctly', async () => {
+      const usageLogs = [
+        mockUsageLog({ contextSize: 100000 }),
+      ];
+      vi.mocked(getContextWindow).mockReturnValue(200000);
+      setupSelectMocks(mockConversation(), usageLogs);
+
+      const request = new Request(`https://example.com/api/ai/global/${mockConversationId}/usage`, {
+        method: 'GET',
+      });
+      const context = createContext(mockConversationId);
+
+      const response = await GET(request, context);
+      const body = await response.json();
+
+      expect(body.summary.context.contextUsagePercent).toBe(50);
+      expect(body.summary.context.contextWindowSize).toBe(200000);
+    });
+
+    it('should handle null token values gracefully', async () => {
+      const usageLogs = [
+        mockUsageLog({ inputTokens: 0, outputTokens: 0, totalTokens: 0, cost: 0 }),
+      ];
+      setupSelectMocks(mockConversation(), usageLogs);
+
+      const request = new Request(`https://example.com/api/ai/global/${mockConversationId}/usage`, {
+        method: 'GET',
+      });
+      const context = createContext(mockConversationId);
+
+      const response = await GET(request, context);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.summary.billing.totalInputTokens).toBe(0);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle database errors gracefully', async () => {
+      const whereMock = vi.fn().mockRejectedValue(new Error('Database error'));
+      const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+      vi.mocked(db.select).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof db.select>);
+
+      const request = new Request(`https://example.com/api/ai/global/${mockConversationId}/usage`, {
+        method: 'GET',
+      });
+      const context = createContext(mockConversationId);
+
+      const response = await GET(request, context);
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(body.error).toBe('Failed to fetch AI usage');
+      expect(loggers.api.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should round cost to 6 decimal places', async () => {
+      const usageLogs = [
+        mockUsageLog({ cost: 0.00000123456789 }),
+        mockUsageLog({ cost: 0.00000987654321 }),
+      ];
+      setupSelectMocks(mockConversation(), usageLogs);
+
+      const request = new Request(`https://example.com/api/ai/global/${mockConversationId}/usage`, {
+        method: 'GET',
+      });
+      const context = createContext(mockConversationId);
+
+      const response = await GET(request, context);
+      const body = await response.json();
+
+      // Total should be rounded to 6 decimal places
+      expect(typeof body.summary.billing.totalCost).toBe('number');
+    });
+  });
+});

--- a/apps/web/src/app/api/ai/global/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/global/__tests__/route.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+import { GET, POST } from '../route';
+import type { WebAuthResult, AuthError } from '@/lib/auth';
+
+// Mock dependencies
+vi.mock('@pagespace/db', () => {
+  const orderByMock = vi.fn().mockResolvedValue([]);
+  const whereMock = vi.fn().mockReturnValue({ orderBy: orderByMock });
+  const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+  const selectMock = vi.fn().mockReturnValue({ from: fromMock });
+  const returningMock = vi.fn().mockResolvedValue([]);
+  const valuesMock = vi.fn().mockReturnValue({ returning: returningMock });
+  const insertMock = vi.fn().mockReturnValue({ values: valuesMock });
+
+  return {
+    db: {
+      select: selectMock,
+      insert: insertMock,
+    },
+    conversations: {},
+    eq: vi.fn((field: unknown, value: unknown) => ({ field, value, type: 'eq' })),
+    and: vi.fn((...conditions: unknown[]) => ({ conditions, type: 'and' })),
+    desc: vi.fn((field: unknown) => ({ field, type: 'desc' })),
+  };
+});
+
+vi.mock('@pagespace/lib/server', () => ({
+  loggers: {
+    api: {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn(),
+}));
+
+vi.mock('@paralleldrive/cuid2', () => ({
+  createId: vi.fn(() => 'generated_conv_id'),
+}));
+
+import { db } from '@pagespace/db';
+import { loggers } from '@pagespace/lib/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+
+// Helper to create mock WebAuthResult
+const mockWebAuth = (userId: string, tokenVersion = 0): WebAuthResult => ({
+  userId,
+  tokenVersion,
+  tokenType: 'jwt',
+  source: 'cookie',
+  role: 'user',
+});
+
+// Helper to create mock AuthError
+const mockAuthError = (status = 401): AuthError => ({
+  error: NextResponse.json({ error: 'Unauthorized' }, { status }),
+});
+
+// Helper to create mock conversation
+const mockConversation = (overrides: Partial<{
+  id: string;
+  userId: string;
+  title: string;
+  type: string;
+  contextId: string | null;
+  lastMessageAt: Date;
+  createdAt: Date;
+  isActive: boolean;
+}> = {}) => ({
+  id: overrides.id || 'conv_123',
+  userId: overrides.userId || 'user_123',
+  title: overrides.title || 'Test Conversation',
+  type: overrides.type || 'global',
+  contextId: overrides.contextId ?? null,
+  lastMessageAt: overrides.lastMessageAt || new Date(),
+  createdAt: overrides.createdAt || new Date(),
+  isActive: overrides.isActive ?? true,
+});
+
+describe('Global Conversations API Routes', () => {
+  const mockUserId = 'user_123';
+
+  // Helper to setup select mock for conversations
+  const setupConversationsSelectMock = (conversations: ReturnType<typeof mockConversation>[]) => {
+    const orderByMock = vi.fn().mockResolvedValue(conversations);
+    const whereMock = vi.fn().mockReturnValue({ orderBy: orderByMock });
+    const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+    vi.mocked(db.select).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof db.select>);
+  };
+
+  // Helper to setup insert mock for conversations
+  const setupInsertMock = (conversation: ReturnType<typeof mockConversation>) => {
+    const returningMock = vi.fn().mockResolvedValue([conversation]);
+    const valuesMock = vi.fn().mockReturnValue({ returning: returningMock });
+    vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as unknown as ReturnType<typeof db.insert>);
+    return { valuesMock, returningMock };
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default auth success
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockWebAuth(mockUserId));
+    vi.mocked(isAuthError).mockReturnValue(false);
+
+    // Default empty conversations
+    setupConversationsSelectMock([]);
+  });
+
+  describe('GET /api/ai/global', () => {
+    describe('authentication', () => {
+      it('should return 401 when not authenticated', async () => {
+        vi.mocked(isAuthError).mockReturnValue(true);
+        vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthError(401));
+
+        const request = new Request('https://example.com/api/ai/global', {
+          method: 'GET',
+        });
+
+        const response = await GET(request);
+        expect(response.status).toBe(401);
+      });
+    });
+
+    describe('successful retrieval', () => {
+      it('should return conversations for authenticated user', async () => {
+        const conversations = [
+          mockConversation({ id: 'conv_1', title: 'First conversation' }),
+          mockConversation({ id: 'conv_2', title: 'Second conversation' }),
+        ];
+        setupConversationsSelectMock(conversations);
+
+        const request = new Request('https://example.com/api/ai/global', {
+          method: 'GET',
+        });
+
+        const response = await GET(request);
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(Array.isArray(body)).toBe(true);
+        expect(body.length).toBe(2);
+      });
+
+      it('should return empty array when no conversations exist', async () => {
+        setupConversationsSelectMock([]);
+
+        const request = new Request('https://example.com/api/ai/global', {
+          method: 'GET',
+        });
+
+        const response = await GET(request);
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body).toEqual([]);
+      });
+
+      it('should only return active conversations', async () => {
+        // The route filters by isActive=true
+        const request = new Request('https://example.com/api/ai/global', {
+          method: 'GET',
+        });
+
+        await GET(request);
+        // Verify the select was called (the mock handles the filtering)
+        expect(db.select).toHaveBeenCalled();
+      });
+    });
+
+    describe('error handling', () => {
+      it('should handle database errors gracefully', async () => {
+        const orderByMock = vi.fn().mockRejectedValue(new Error('Database error'));
+        const whereMock = vi.fn().mockReturnValue({ orderBy: orderByMock });
+        const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+        vi.mocked(db.select).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof db.select>);
+
+        const request = new Request('https://example.com/api/ai/global', {
+          method: 'GET',
+        });
+
+        const response = await GET(request);
+        const body = await response.json();
+
+        expect(response.status).toBe(500);
+        expect(body.error).toBe('Failed to fetch conversations');
+        expect(loggers.api.error).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('POST /api/ai/global', () => {
+    describe('authentication', () => {
+      it('should return 401 when not authenticated', async () => {
+        vi.mocked(isAuthError).mockReturnValue(true);
+        vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthError(401));
+
+        const request = new Request('https://example.com/api/ai/global', {
+          method: 'POST',
+          body: JSON.stringify({ title: 'New conversation' }),
+        });
+
+        const response = await POST(request);
+        expect(response.status).toBe(401);
+      });
+    });
+
+    describe('successful creation', () => {
+      it('should create a new conversation', async () => {
+        const newConversation = mockConversation({
+          id: 'generated_conv_id',
+          title: 'My new conversation',
+        });
+        setupInsertMock(newConversation);
+
+        const request = new Request('https://example.com/api/ai/global', {
+          method: 'POST',
+          body: JSON.stringify({ title: 'My new conversation' }),
+        });
+
+        const response = await POST(request);
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.id).toBe('generated_conv_id');
+      });
+
+      it('should create conversation without title', async () => {
+        const newConversation = mockConversation({
+          id: 'generated_conv_id',
+          title: null,
+        });
+        setupInsertMock(newConversation);
+
+        const request = new Request('https://example.com/api/ai/global', {
+          method: 'POST',
+          body: JSON.stringify({}),
+        });
+
+        const response = await POST(request);
+        expect(response.status).toBe(200);
+      });
+
+      it('should create conversation with type and contextId', async () => {
+        const newConversation = mockConversation({
+          id: 'generated_conv_id',
+          type: 'page',
+          contextId: 'page_123',
+        });
+        setupInsertMock(newConversation);
+
+        const request = new Request('https://example.com/api/ai/global', {
+          method: 'POST',
+          body: JSON.stringify({ type: 'page', contextId: 'page_123' }),
+        });
+
+        const response = await POST(request);
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.type).toBe('page');
+        expect(body.contextId).toBe('page_123');
+      });
+
+      it('should default type to global', async () => {
+        const newConversation = mockConversation({ type: 'global' });
+        const { valuesMock } = setupInsertMock(newConversation);
+
+        const request = new Request('https://example.com/api/ai/global', {
+          method: 'POST',
+          body: JSON.stringify({}),
+        });
+
+        await POST(request);
+
+        expect(valuesMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'global',
+          })
+        );
+      });
+    });
+
+    describe('error handling', () => {
+      it('should handle database errors gracefully', async () => {
+        const returningMock = vi.fn().mockRejectedValue(new Error('Database error'));
+        const valuesMock = vi.fn().mockReturnValue({ returning: returningMock });
+        vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as unknown as ReturnType<typeof db.insert>);
+
+        const request = new Request('https://example.com/api/ai/global', {
+          method: 'POST',
+          body: JSON.stringify({ title: 'New conversation' }),
+        });
+
+        const response = await POST(request);
+        const body = await response.json();
+
+        expect(response.status).toBe(500);
+        expect(body.error).toBe('Failed to create conversation');
+        expect(loggers.api.error).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/apps/web/src/app/api/ai/global/active/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/global/active/__tests__/route.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+import { GET } from '../route';
+import type { WebAuthResult, AuthError } from '@/lib/auth';
+
+// Mock dependencies
+vi.mock('@pagespace/db', () => {
+  const limitMock = vi.fn().mockResolvedValue([]);
+  const orderByMock = vi.fn().mockReturnValue({ limit: limitMock });
+  const whereMock = vi.fn().mockReturnValue({ orderBy: orderByMock });
+  const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+  const selectMock = vi.fn().mockReturnValue({ from: fromMock });
+
+  return {
+    db: {
+      select: selectMock,
+    },
+    conversations: {},
+    eq: vi.fn((field: unknown, value: unknown) => ({ field, value, type: 'eq' })),
+    and: vi.fn((...conditions: unknown[]) => ({ conditions, type: 'and' })),
+    desc: vi.fn((field: unknown) => ({ field, type: 'desc' })),
+  };
+});
+
+vi.mock('@pagespace/lib/server', () => ({
+  loggers: {
+    api: {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn(),
+}));
+
+import { db } from '@pagespace/db';
+import { loggers } from '@pagespace/lib/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+
+// Helper to create mock WebAuthResult
+const mockWebAuth = (userId: string, tokenVersion = 0): WebAuthResult => ({
+  userId,
+  tokenVersion,
+  tokenType: 'jwt',
+  source: 'cookie',
+  role: 'user',
+});
+
+// Helper to create mock AuthError
+const mockAuthError = (status = 401): AuthError => ({
+  error: NextResponse.json({ error: 'Unauthorized' }, { status }),
+});
+
+// Helper to create mock conversation
+const mockConversation = (overrides: Partial<{
+  id: string;
+  title: string;
+  type: string;
+  contextId: string | null;
+  lastMessageAt: Date;
+  createdAt: Date;
+}> = {}) => ({
+  id: overrides.id || 'conv_123',
+  title: overrides.title || 'Test Conversation',
+  type: overrides.type || 'global',
+  contextId: overrides.contextId ?? null,
+  lastMessageAt: overrides.lastMessageAt || new Date(),
+  createdAt: overrides.createdAt || new Date(),
+});
+
+describe('GET /api/ai/global/active', () => {
+  const mockUserId = 'user_123';
+
+  // Helper to setup select mock for active conversation
+  const setupActiveConversationMock = (conversation: ReturnType<typeof mockConversation> | null) => {
+    const limitMock = vi.fn().mockResolvedValue(conversation ? [conversation] : []);
+    const orderByMock = vi.fn().mockReturnValue({ limit: limitMock });
+    const whereMock = vi.fn().mockReturnValue({ orderBy: orderByMock });
+    const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+    vi.mocked(db.select).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof db.select>);
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default auth success
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockWebAuth(mockUserId));
+    vi.mocked(isAuthError).mockReturnValue(false);
+
+    // Default no active conversation
+    setupActiveConversationMock(null);
+  });
+
+  describe('authentication', () => {
+    it('should return 401 when not authenticated', async () => {
+      vi.mocked(isAuthError).mockReturnValue(true);
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthError(401));
+
+      const request = new Request('https://example.com/api/ai/global/active', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe('successful retrieval', () => {
+    it('should return the most recent global conversation', async () => {
+      const conversation = mockConversation({
+        id: 'conv_active',
+        title: 'Active Conversation',
+        type: 'global',
+      });
+      setupActiveConversationMock(conversation);
+
+      const request = new Request('https://example.com/api/ai/global/active', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.id).toBe('conv_active');
+      expect(body.title).toBe('Active Conversation');
+      expect(body.type).toBe('global');
+    });
+
+    it('should return null when no global conversation exists', async () => {
+      setupActiveConversationMock(null);
+
+      const request = new Request('https://example.com/api/ai/global/active', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body).toBeNull();
+    });
+
+    it('should only query for global type conversations', async () => {
+      const request = new Request('https://example.com/api/ai/global/active', {
+        method: 'GET',
+      });
+
+      await GET(request);
+      // Verify the select was called
+      expect(db.select).toHaveBeenCalled();
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle database errors gracefully', async () => {
+      const limitMock = vi.fn().mockRejectedValue(new Error('Database error'));
+      const orderByMock = vi.fn().mockReturnValue({ limit: limitMock });
+      const whereMock = vi.fn().mockReturnValue({ orderBy: orderByMock });
+      const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+      vi.mocked(db.select).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof db.select>);
+
+      const request = new Request('https://example.com/api/ai/global/active', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(body.error).toBe('Failed to fetch global conversation');
+      expect(loggers.api.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/app/api/ai/lmstudio/models/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/lmstudio/models/__tests__/route.test.ts
@@ -1,0 +1,415 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+import { GET } from '../route';
+import type { WebAuthResult, AuthError } from '@/lib/auth';
+
+// Mock dependencies
+vi.mock('@pagespace/lib/server', () => ({
+  loggers: {
+    ai: {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateWebRequest: vi.fn(),
+  isAuthError: vi.fn(),
+}));
+
+vi.mock('@/lib/ai/core', () => ({
+  getUserLMStudioSettings: vi.fn(),
+}));
+
+import { loggers } from '@pagespace/lib/server';
+import { authenticateWebRequest, isAuthError } from '@/lib/auth';
+import { getUserLMStudioSettings } from '@/lib/ai/core';
+
+// Helper to create mock WebAuthResult
+const mockWebAuth = (userId: string, tokenVersion = 0): WebAuthResult => ({
+  userId,
+  tokenVersion,
+  tokenType: 'jwt',
+  source: 'cookie',
+  role: 'user',
+});
+
+// Helper to create mock AuthError
+const mockAuthError = (status = 401): AuthError => ({
+  error: NextResponse.json({ error: 'Unauthorized' }, { status }),
+});
+
+describe('GET /api/ai/lmstudio/models', () => {
+  const mockUserId = 'user_123';
+  const mockBaseUrl = 'http://localhost:1234/v1';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default auth success
+    vi.mocked(authenticateWebRequest).mockResolvedValue(mockWebAuth(mockUserId));
+    vi.mocked(isAuthError).mockReturnValue(false);
+
+    // Default: no settings configured
+    vi.mocked(getUserLMStudioSettings).mockResolvedValue(null);
+  });
+
+  describe('authentication', () => {
+    it('should return 401 when not authenticated', async () => {
+      vi.mocked(isAuthError).mockReturnValue(true);
+      vi.mocked(authenticateWebRequest).mockResolvedValue(mockAuthError(401));
+
+      const request = new Request('https://example.com/api/ai/lmstudio/models', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe('configuration validation', () => {
+    it('should return 400 when LM Studio is not configured', async () => {
+      vi.mocked(getUserLMStudioSettings).mockResolvedValue(null);
+
+      const request = new Request('https://example.com/api/ai/lmstudio/models', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.success).toBe(false);
+      expect(body.error).toContain('LM Studio not configured');
+      expect(body.models).toEqual({});
+    });
+
+    it('should return 400 when LM Studio settings exist but baseUrl is missing', async () => {
+      vi.mocked(getUserLMStudioSettings).mockResolvedValue({
+        isConfigured: true,
+        baseUrl: null,
+      });
+
+      const request = new Request('https://example.com/api/ai/lmstudio/models', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.success).toBe(false);
+      expect(body.error).toContain('LM Studio not configured');
+    });
+  });
+
+  describe('successful model discovery', () => {
+    it('should return models from LM Studio instance', async () => {
+      vi.mocked(getUserLMStudioSettings).mockResolvedValue({
+        isConfigured: true,
+        baseUrl: mockBaseUrl,
+      });
+
+      // LM Studio uses OpenAI-compatible API format
+      const mockLMStudioModels = {
+        data: [
+          { id: 'llama-3.2-3b' },
+          { id: 'mistral-7b-instruct' },
+          { id: 'codellama-13b' },
+        ],
+      };
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockLMStudioModels),
+      });
+
+      const request = new Request('https://example.com/api/ai/lmstudio/models', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.models).toHaveProperty('llama-3.2-3b');
+      expect(body.models).toHaveProperty('mistral-7b-instruct');
+      expect(body.models).toHaveProperty('codellama-13b');
+      expect(body.baseUrl).toBe(mockBaseUrl);
+      expect(body.modelCount).toBe(3);
+
+      // LM Studio uses /models endpoint (OpenAI-compatible)
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${mockBaseUrl}/models`,
+        expect.objectContaining({
+          method: 'GET',
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    });
+
+    it('should clean up model display names', async () => {
+      vi.mocked(getUserLMStudioSettings).mockResolvedValue({
+        isConfigured: true,
+        baseUrl: mockBaseUrl,
+      });
+
+      const mockLMStudioModels = {
+        data: [
+          { id: 'llama-3_2-3b_instruct' },
+        ],
+      };
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockLMStudioModels),
+      });
+
+      const request = new Request('https://example.com/api/ai/lmstudio/models', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      // Should replace underscores and hyphens with spaces, capitalize words
+      expect(body.models['llama-3_2-3b_instruct']).toBe('Llama 3 2 3b Instruct');
+    });
+
+    it('should handle empty models array', async () => {
+      vi.mocked(getUserLMStudioSettings).mockResolvedValue({
+        isConfigured: true,
+        baseUrl: mockBaseUrl,
+      });
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ data: [] }),
+      });
+
+      const request = new Request('https://example.com/api/ai/lmstudio/models', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.models).toEqual({});
+      expect(body.modelCount).toBe(0);
+    });
+
+    it('should log successful model fetch', async () => {
+      vi.mocked(getUserLMStudioSettings).mockResolvedValue({
+        isConfigured: true,
+        baseUrl: mockBaseUrl,
+      });
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ data: [{ id: 'test-model' }] }),
+      });
+
+      const request = new Request('https://example.com/api/ai/lmstudio/models', {
+        method: 'GET',
+      });
+
+      await GET(request);
+
+      expect(loggers.ai.info).toHaveBeenCalledWith(
+        'Successfully fetched LM Studio models',
+        expect.objectContaining({
+          userId: mockUserId,
+          baseUrl: mockBaseUrl,
+          modelCount: 1,
+        })
+      );
+    });
+  });
+
+  describe('LM Studio connection failures', () => {
+    it('should return empty models with error when LM Studio is unreachable', async () => {
+      vi.mocked(getUserLMStudioSettings).mockResolvedValue({
+        isConfigured: true,
+        baseUrl: mockBaseUrl,
+      });
+
+      global.fetch = vi.fn().mockRejectedValue(new Error('Connection refused'));
+
+      const request = new Request('https://example.com/api/ai/lmstudio/models', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      // Should return 200 with empty models (no fallbacks per user preference)
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(false);
+      expect(body.error).toContain('Could not connect to LM Studio');
+      expect(body.error).toContain('Please ensure LM Studio server is running');
+      expect(body.models).toEqual({});
+      expect(body.baseUrl).toBe(mockBaseUrl);
+    });
+
+    it('should return empty models when LM Studio returns non-OK status', async () => {
+      vi.mocked(getUserLMStudioSettings).mockResolvedValue({
+        isConfigured: true,
+        baseUrl: mockBaseUrl,
+      });
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+      });
+
+      const request = new Request('https://example.com/api/ai/lmstudio/models', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(false);
+      expect(body.models).toEqual({});
+    });
+
+    it('should log errors when LM Studio fetch fails', async () => {
+      vi.mocked(getUserLMStudioSettings).mockResolvedValue({
+        isConfigured: true,
+        baseUrl: mockBaseUrl,
+      });
+
+      const error = new Error('Network timeout');
+      global.fetch = vi.fn().mockRejectedValue(error);
+
+      const request = new Request('https://example.com/api/ai/lmstudio/models', {
+        method: 'GET',
+      });
+
+      await GET(request);
+
+      expect(loggers.ai.error).toHaveBeenCalledWith(
+        'Failed to fetch models from LM Studio',
+        error,
+        expect.objectContaining({
+          userId: mockUserId,
+          baseUrl: mockBaseUrl,
+        })
+      );
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle unexpected errors gracefully', async () => {
+      vi.mocked(getUserLMStudioSettings).mockRejectedValue(new Error('Database error'));
+
+      const request = new Request('https://example.com/api/ai/lmstudio/models', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(body.success).toBe(false);
+      expect(body.error).toBe('Failed to discover LM Studio models');
+      expect(body.models).toEqual({});
+      expect(loggers.ai.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle models without id property', async () => {
+      vi.mocked(getUserLMStudioSettings).mockResolvedValue({
+        isConfigured: true,
+        baseUrl: mockBaseUrl,
+      });
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          data: [
+            { id: 'valid-model' },
+            { /* missing id */ },
+            { id: '' },
+            { id: 'another-model' },
+          ],
+        }),
+      });
+
+      const request = new Request('https://example.com/api/ai/lmstudio/models', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(Object.keys(body.models).length).toBe(2);
+      expect(body.models).toHaveProperty('valid-model');
+      expect(body.models).toHaveProperty('another-model');
+    });
+
+    it('should handle missing data array in response', async () => {
+      vi.mocked(getUserLMStudioSettings).mockResolvedValue({
+        isConfigured: true,
+        baseUrl: mockBaseUrl,
+      });
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+      const request = new Request('https://example.com/api/ai/lmstudio/models', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.models).toEqual({});
+    });
+
+    it('should handle various base URL formats', async () => {
+      const testCases = [
+        'http://localhost:1234/v1',
+        'http://192.168.1.100:1234/v1',
+        'http://lmstudio.local:1234/v1',
+      ];
+
+      for (const baseUrl of testCases) {
+        vi.mocked(getUserLMStudioSettings).mockResolvedValue({
+          isConfigured: true,
+          baseUrl,
+        });
+
+        global.fetch = vi.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ data: [{ id: 'test-model' }] }),
+        });
+
+        const request = new Request('https://example.com/api/ai/lmstudio/models', {
+          method: 'GET',
+        });
+
+        const response = await GET(request);
+        expect(response.status).toBe(200);
+        expect(global.fetch).toHaveBeenCalledWith(
+          `${baseUrl}/models`,
+          expect.any(Object)
+        );
+      }
+    });
+  });
+});

--- a/apps/web/src/app/api/ai/ollama/models/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/ollama/models/__tests__/route.test.ts
@@ -1,0 +1,383 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+import { GET } from '../route';
+import type { WebAuthResult, AuthError } from '@/lib/auth';
+
+// Mock dependencies
+vi.mock('@pagespace/lib/server', () => ({
+  loggers: {
+    ai: {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateWebRequest: vi.fn(),
+  isAuthError: vi.fn(),
+}));
+
+vi.mock('@/lib/ai/core', () => ({
+  getUserOllamaSettings: vi.fn(),
+}));
+
+import { loggers } from '@pagespace/lib/server';
+import { authenticateWebRequest, isAuthError } from '@/lib/auth';
+import { getUserOllamaSettings } from '@/lib/ai/core';
+
+// Helper to create mock WebAuthResult
+const mockWebAuth = (userId: string, tokenVersion = 0): WebAuthResult => ({
+  userId,
+  tokenVersion,
+  tokenType: 'jwt',
+  source: 'cookie',
+  role: 'user',
+});
+
+// Helper to create mock AuthError
+const mockAuthError = (status = 401): AuthError => ({
+  error: NextResponse.json({ error: 'Unauthorized' }, { status }),
+});
+
+describe('GET /api/ai/ollama/models', () => {
+  const mockUserId = 'user_123';
+  const mockBaseUrl = 'http://localhost:11434';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default auth success
+    vi.mocked(authenticateWebRequest).mockResolvedValue(mockWebAuth(mockUserId));
+    vi.mocked(isAuthError).mockReturnValue(false);
+
+    // Default: no settings configured
+    vi.mocked(getUserOllamaSettings).mockResolvedValue(null);
+  });
+
+  describe('authentication', () => {
+    it('should return 401 when not authenticated', async () => {
+      vi.mocked(isAuthError).mockReturnValue(true);
+      vi.mocked(authenticateWebRequest).mockResolvedValue(mockAuthError(401));
+
+      const request = new Request('https://example.com/api/ai/ollama/models', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe('configuration validation', () => {
+    it('should return 400 when Ollama is not configured', async () => {
+      vi.mocked(getUserOllamaSettings).mockResolvedValue(null);
+
+      const request = new Request('https://example.com/api/ai/ollama/models', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.success).toBe(false);
+      expect(body.error).toContain('Ollama not configured');
+      expect(body.models).toEqual([]);
+    });
+
+    it('should return 400 when Ollama settings exist but baseUrl is missing', async () => {
+      vi.mocked(getUserOllamaSettings).mockResolvedValue({
+        isConfigured: true,
+        baseUrl: null,
+      });
+
+      const request = new Request('https://example.com/api/ai/ollama/models', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.success).toBe(false);
+      expect(body.error).toContain('Ollama not configured');
+    });
+  });
+
+  describe('successful model discovery', () => {
+    it('should return models from Ollama instance', async () => {
+      vi.mocked(getUserOllamaSettings).mockResolvedValue({
+        isConfigured: true,
+        baseUrl: mockBaseUrl,
+      });
+
+      const mockOllamaModels = {
+        models: [
+          { name: 'llama3.2:latest' },
+          { name: 'mistral:7b' },
+          { name: 'codellama:13b' },
+        ],
+      };
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockOllamaModels),
+      });
+
+      const request = new Request('https://example.com/api/ai/ollama/models', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.models).toHaveProperty('llama3.2:latest');
+      expect(body.models).toHaveProperty('mistral:7b');
+      expect(body.models).toHaveProperty('codellama:13b');
+      expect(body.baseUrl).toBe(mockBaseUrl);
+      expect(body.modelCount).toBe(3);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${mockBaseUrl}/api/tags`,
+        expect.objectContaining({
+          method: 'GET',
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    });
+
+    it('should clean up model display names', async () => {
+      vi.mocked(getUserOllamaSettings).mockResolvedValue({
+        isConfigured: true,
+        baseUrl: mockBaseUrl,
+      });
+
+      const mockOllamaModels = {
+        models: [
+          { name: 'llama3.2:latest' },
+        ],
+      };
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockOllamaModels),
+      });
+
+      const request = new Request('https://example.com/api/ai/ollama/models', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      // Should remove :latest suffix and capitalize
+      expect(body.models['llama3.2:latest']).toBe('Llama3.2');
+    });
+
+    it('should handle empty models array', async () => {
+      vi.mocked(getUserOllamaSettings).mockResolvedValue({
+        isConfigured: true,
+        baseUrl: mockBaseUrl,
+      });
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ models: [] }),
+      });
+
+      const request = new Request('https://example.com/api/ai/ollama/models', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.models).toEqual({});
+      expect(body.modelCount).toBe(0);
+    });
+
+    it('should log successful model fetch', async () => {
+      vi.mocked(getUserOllamaSettings).mockResolvedValue({
+        isConfigured: true,
+        baseUrl: mockBaseUrl,
+      });
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ models: [{ name: 'test:model' }] }),
+      });
+
+      const request = new Request('https://example.com/api/ai/ollama/models', {
+        method: 'GET',
+      });
+
+      await GET(request);
+
+      expect(loggers.ai.info).toHaveBeenCalledWith(
+        'Successfully fetched Ollama models',
+        expect.objectContaining({
+          userId: mockUserId,
+          baseUrl: mockBaseUrl,
+          modelCount: 1,
+        })
+      );
+    });
+  });
+
+  describe('Ollama connection failures', () => {
+    it('should return fallback models when Ollama is unreachable', async () => {
+      vi.mocked(getUserOllamaSettings).mockResolvedValue({
+        isConfigured: true,
+        baseUrl: mockBaseUrl,
+      });
+
+      global.fetch = vi.fn().mockRejectedValue(new Error('Connection refused'));
+
+      const request = new Request('https://example.com/api/ai/ollama/models', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      // Should return 200 with fallback models
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(false);
+      expect(body.error).toContain('Could not connect to Ollama');
+      expect(body.isFallback).toBe(true);
+      expect(body.models).toHaveProperty('llama3.2:latest');
+      expect(body.models).toHaveProperty('mistral:latest');
+      expect(body.baseUrl).toBe(mockBaseUrl);
+    });
+
+    it('should return fallback models when Ollama returns non-OK status', async () => {
+      vi.mocked(getUserOllamaSettings).mockResolvedValue({
+        isConfigured: true,
+        baseUrl: mockBaseUrl,
+      });
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+      });
+
+      const request = new Request('https://example.com/api/ai/ollama/models', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(false);
+      expect(body.isFallback).toBe(true);
+    });
+
+    it('should log errors when Ollama fetch fails', async () => {
+      vi.mocked(getUserOllamaSettings).mockResolvedValue({
+        isConfigured: true,
+        baseUrl: mockBaseUrl,
+      });
+
+      const error = new Error('Network timeout');
+      global.fetch = vi.fn().mockRejectedValue(error);
+
+      const request = new Request('https://example.com/api/ai/ollama/models', {
+        method: 'GET',
+      });
+
+      await GET(request);
+
+      expect(loggers.ai.error).toHaveBeenCalledWith(
+        'Failed to fetch models from Ollama',
+        error,
+        expect.objectContaining({
+          userId: mockUserId,
+          baseUrl: mockBaseUrl,
+        })
+      );
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle unexpected errors gracefully', async () => {
+      vi.mocked(getUserOllamaSettings).mockRejectedValue(new Error('Database error'));
+
+      const request = new Request('https://example.com/api/ai/ollama/models', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(body.success).toBe(false);
+      expect(body.error).toBe('Failed to discover Ollama models');
+      expect(body.models).toEqual({});
+      expect(loggers.ai.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle models without name property', async () => {
+      vi.mocked(getUserOllamaSettings).mockResolvedValue({
+        isConfigured: true,
+        baseUrl: mockBaseUrl,
+      });
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          models: [
+            { name: 'valid:model' },
+            { /* missing name */ },
+            { name: '' },
+            { name: 'another:model' },
+          ],
+        }),
+      });
+
+      const request = new Request('https://example.com/api/ai/ollama/models', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(Object.keys(body.models).length).toBe(2);
+      expect(body.models).toHaveProperty('valid:model');
+      expect(body.models).toHaveProperty('another:model');
+    });
+
+    it('should handle missing models array in response', async () => {
+      vi.mocked(getUserOllamaSettings).mockResolvedValue({
+        isConfigured: true,
+        baseUrl: mockBaseUrl,
+      });
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+      const request = new Request('https://example.com/api/ai/ollama/models', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.models).toEqual({});
+    });
+  });
+});

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/config/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/config/__tests__/route.test.ts
@@ -1,0 +1,459 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+import { PUT } from '../route';
+import type { WebAuthResult, AuthError } from '@/lib/auth';
+
+// Mock dependencies
+vi.mock('@pagespace/db', () => {
+  const returningMock = vi.fn().mockResolvedValue([]);
+  const whereMock = vi.fn().mockReturnValue({ returning: returningMock });
+  const setMock = vi.fn().mockReturnValue({ where: whereMock });
+  const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+  const selectMock = vi.fn().mockReturnValue({ from: fromMock });
+  const updateMock = vi.fn().mockReturnValue({ set: setMock });
+
+  return {
+    db: {
+      select: selectMock,
+      update: updateMock,
+    },
+    pages: {},
+    eq: vi.fn((field: unknown, value: unknown) => ({ field, value, type: 'eq' })),
+  };
+});
+
+vi.mock('@pagespace/lib/server', () => ({
+  loggers: {
+    api: {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    },
+  },
+  canUserEditPage: vi.fn(),
+  agentAwarenessCache: {
+    invalidateDriveAgents: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn(),
+}));
+
+vi.mock('@/lib/websocket', () => ({
+  broadcastPageEvent: vi.fn(),
+  createPageEventPayload: vi.fn(() => ({ type: 'updated' })),
+}));
+
+vi.mock('@/lib/ai/core', () => ({
+  pageSpaceTools: {
+    read_page: {},
+    list_pages: {},
+    create_page: {},
+    update_page: {},
+    delete_page: {},
+  },
+}));
+
+import { db } from '@pagespace/db';
+import { loggers, canUserEditPage, agentAwarenessCache } from '@pagespace/lib/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { broadcastPageEvent } from '@/lib/websocket';
+
+// Helper to create mock WebAuthResult
+const mockWebAuth = (userId: string, tokenVersion = 0): WebAuthResult => ({
+  userId,
+  tokenVersion,
+  tokenType: 'jwt',
+  source: 'cookie',
+  role: 'user',
+});
+
+// Helper to create mock AuthError
+const mockAuthError = (status = 401): AuthError => ({
+  error: NextResponse.json({ error: 'Unauthorized' }, { status }),
+});
+
+// Helper to create mock agent page
+const mockAgent = (overrides: Partial<{
+  id: string;
+  title: string;
+  type: string;
+  driveId: string;
+  parentId: string | null;
+  systemPrompt: string | null;
+  enabledTools: string[] | null;
+  aiProvider: string | null;
+  aiModel: string | null;
+}> = {}) => ({
+  id: overrides.id || 'agent_123',
+  title: overrides.title || 'Test Agent',
+  type: overrides.type || 'AI_CHAT',
+  driveId: overrides.driveId || 'drive_123',
+  parentId: overrides.parentId ?? null,
+  systemPrompt: overrides.systemPrompt ?? 'You are a helpful assistant.',
+  enabledTools: overrides.enabledTools ?? [],
+  aiProvider: overrides.aiProvider ?? null,
+  aiModel: overrides.aiModel ?? null,
+});
+
+describe('PUT /api/ai/page-agents/[agentId]/config', () => {
+  const mockUserId = 'user_123';
+  const mockAgentId = 'agent_123';
+
+  // Helper to setup select mock for agent
+  const setupAgentSelectMock = (agent: ReturnType<typeof mockAgent> | undefined) => {
+    const whereMock = vi.fn().mockResolvedValue(agent ? [agent] : []);
+    const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+    vi.mocked(db.select).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof db.select>);
+  };
+
+  // Helper to setup update mock
+  const setupUpdateMock = (updatedAgent: ReturnType<typeof mockAgent>) => {
+    const returningMock = vi.fn().mockResolvedValue([updatedAgent]);
+    const whereMock = vi.fn().mockReturnValue({ returning: returningMock });
+    const setMock = vi.fn().mockReturnValue({ where: whereMock });
+    vi.mocked(db.update).mockReturnValue({ set: setMock } as unknown as ReturnType<typeof db.update>);
+    return { setMock, whereMock, returningMock };
+  };
+
+  const createContext = (agentId: string) => ({
+    params: Promise.resolve({ agentId }),
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default auth success
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockWebAuth(mockUserId));
+    vi.mocked(isAuthError).mockReturnValue(false);
+
+    // Default permission granted
+    vi.mocked(canUserEditPage).mockResolvedValue(true);
+
+    // Default agent exists
+    setupAgentSelectMock(mockAgent());
+    setupUpdateMock(mockAgent());
+  });
+
+  describe('authentication', () => {
+    it('should return 401 when not authenticated', async () => {
+      vi.mocked(isAuthError).mockReturnValue(true);
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthError(401));
+
+      const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/config`, {
+        method: 'PUT',
+        body: JSON.stringify({ systemPrompt: 'Updated prompt' }),
+      });
+      const context = createContext(mockAgentId);
+
+      const response = await PUT(request, context);
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe('agent not found', () => {
+    it('should return 404 when agent does not exist', async () => {
+      setupAgentSelectMock(undefined);
+
+      const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/config`, {
+        method: 'PUT',
+        body: JSON.stringify({ systemPrompt: 'Updated prompt' }),
+      });
+      const context = createContext(mockAgentId);
+
+      const response = await PUT(request, context);
+      const body = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(body.error).toContain('Agent with ID');
+      expect(body.error).toContain('not found');
+    });
+  });
+
+  describe('page type validation', () => {
+    it('should return 400 when page is not AI_CHAT type', async () => {
+      setupAgentSelectMock(mockAgent({ type: 'DOCUMENT' }));
+
+      const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/config`, {
+        method: 'PUT',
+        body: JSON.stringify({ systemPrompt: 'Updated prompt' }),
+      });
+      const context = createContext(mockAgentId);
+
+      const response = await PUT(request, context);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toContain('not an AI agent');
+    });
+  });
+
+  describe('authorization', () => {
+    it('should return 403 when user lacks edit permission', async () => {
+      vi.mocked(canUserEditPage).mockResolvedValue(false);
+
+      const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/config`, {
+        method: 'PUT',
+        body: JSON.stringify({ systemPrompt: 'Updated prompt' }),
+      });
+      const context = createContext(mockAgentId);
+
+      const response = await PUT(request, context);
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.error).toContain('Insufficient permissions');
+    });
+  });
+
+  describe('validation', () => {
+    it('should return 400 when no fields provided for update', async () => {
+      const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/config`, {
+        method: 'PUT',
+        body: JSON.stringify({}),
+      });
+      const context = createContext(mockAgentId);
+
+      const response = await PUT(request, context);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toContain('No valid fields');
+    });
+
+    it('should return 400 when enabledTools contains invalid tools', async () => {
+      const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/config`, {
+        method: 'PUT',
+        body: JSON.stringify({
+          enabledTools: ['invalid_tool', 'read_page'],
+        }),
+      });
+      const context = createContext(mockAgentId);
+
+      const response = await PUT(request, context);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toContain('Invalid tools specified');
+    });
+  });
+
+  describe('successful updates', () => {
+    it('should update systemPrompt', async () => {
+      const { setMock } = setupUpdateMock(mockAgent({ systemPrompt: 'New prompt' }));
+
+      const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/config`, {
+        method: 'PUT',
+        body: JSON.stringify({ systemPrompt: 'New prompt' }),
+      });
+      const context = createContext(mockAgentId);
+
+      const response = await PUT(request, context);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.updatedFields).toContain('systemPrompt');
+      expect(setMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          systemPrompt: 'New prompt',
+        })
+      );
+    });
+
+    it('should update enabledTools', async () => {
+      const { setMock } = setupUpdateMock(mockAgent({ enabledTools: ['read_page', 'list_pages'] }));
+
+      const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/config`, {
+        method: 'PUT',
+        body: JSON.stringify({ enabledTools: ['read_page', 'list_pages'] }),
+      });
+      const context = createContext(mockAgentId);
+
+      const response = await PUT(request, context);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.updatedFields).toContain('enabledTools');
+      expect(setMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enabledTools: ['read_page', 'list_pages'],
+        })
+      );
+    });
+
+    it('should update aiProvider and aiModel', async () => {
+      setupUpdateMock(mockAgent({
+        aiProvider: 'openrouter',
+        aiModel: 'anthropic/claude-3-opus',
+      }));
+
+      const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/config`, {
+        method: 'PUT',
+        body: JSON.stringify({
+          aiProvider: 'openrouter',
+          aiModel: 'anthropic/claude-3-opus',
+        }),
+      });
+      const context = createContext(mockAgentId);
+
+      const response = await PUT(request, context);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.updatedFields).toContain('aiProvider');
+      expect(body.updatedFields).toContain('aiModel');
+    });
+
+    it('should update agentDefinition', async () => {
+      const { setMock } = setupUpdateMock(mockAgent());
+
+      const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/config`, {
+        method: 'PUT',
+        body: JSON.stringify({ agentDefinition: 'A coding assistant' }),
+      });
+      const context = createContext(mockAgentId);
+
+      const response = await PUT(request, context);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.updatedFields).toContain('agentDefinition');
+      expect(setMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentDefinition: 'A coding assistant',
+        })
+      );
+    });
+
+    it('should update visibleToGlobalAssistant', async () => {
+      const { setMock } = setupUpdateMock(mockAgent());
+
+      const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/config`, {
+        method: 'PUT',
+        body: JSON.stringify({ visibleToGlobalAssistant: true }),
+      });
+      const context = createContext(mockAgentId);
+
+      const response = await PUT(request, context);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.updatedFields).toContain('visibleToGlobalAssistant');
+      expect(setMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          visibleToGlobalAssistant: true,
+        })
+      );
+    });
+
+    it('should update multiple fields at once', async () => {
+      setupUpdateMock(mockAgent({
+        systemPrompt: 'New prompt',
+        enabledTools: ['read_page'],
+      }));
+
+      const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/config`, {
+        method: 'PUT',
+        body: JSON.stringify({
+          systemPrompt: 'New prompt',
+          enabledTools: ['read_page'],
+          aiProvider: 'google',
+        }),
+      });
+      const context = createContext(mockAgentId);
+
+      const response = await PUT(request, context);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.updatedFields.length).toBe(3);
+    });
+
+    it('should broadcast page update event', async () => {
+      setupUpdateMock(mockAgent());
+
+      const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/config`, {
+        method: 'PUT',
+        body: JSON.stringify({ systemPrompt: 'New prompt' }),
+      });
+      const context = createContext(mockAgentId);
+
+      await PUT(request, context);
+
+      expect(broadcastPageEvent).toHaveBeenCalled();
+    });
+
+    it('should invalidate agent cache when agentDefinition changes', async () => {
+      setupUpdateMock(mockAgent());
+
+      const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/config`, {
+        method: 'PUT',
+        body: JSON.stringify({ agentDefinition: 'New definition' }),
+      });
+      const context = createContext(mockAgentId);
+
+      await PUT(request, context);
+
+      expect(agentAwarenessCache.invalidateDriveAgents).toHaveBeenCalled();
+    });
+
+    it('should invalidate agent cache when visibleToGlobalAssistant changes', async () => {
+      setupUpdateMock(mockAgent());
+
+      const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/config`, {
+        method: 'PUT',
+        body: JSON.stringify({ visibleToGlobalAssistant: true }),
+      });
+      const context = createContext(mockAgentId);
+
+      await PUT(request, context);
+
+      expect(agentAwarenessCache.invalidateDriveAgents).toHaveBeenCalled();
+    });
+
+    it('should log successful update', async () => {
+      setupUpdateMock(mockAgent());
+
+      const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/config`, {
+        method: 'PUT',
+        body: JSON.stringify({ systemPrompt: 'New prompt' }),
+      });
+      const context = createContext(mockAgentId);
+
+      await PUT(request, context);
+
+      expect(loggers.api.info).toHaveBeenCalledWith(
+        'AI agent configuration updated',
+        expect.objectContaining({
+          agentId: mockAgentId,
+        })
+      );
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle database errors gracefully', async () => {
+      const returningMock = vi.fn().mockRejectedValue(new Error('Database error'));
+      const whereMock = vi.fn().mockReturnValue({ returning: returningMock });
+      const setMock = vi.fn().mockReturnValue({ where: whereMock });
+      vi.mocked(db.update).mockReturnValue({ set: setMock } as unknown as ReturnType<typeof db.update>);
+
+      const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/config`, {
+        method: 'PUT',
+        body: JSON.stringify({ systemPrompt: 'New prompt' }),
+      });
+      const context = createContext(mockAgentId);
+
+      const response = await PUT(request, context);
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(body.error).toContain('Failed to update AI agent');
+      expect(loggers.api.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/__tests__/route.test.ts
@@ -1,0 +1,409 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+import { PATCH, DELETE } from '../route';
+import type { WebAuthResult, AuthError } from '@/lib/auth';
+
+// Mock dependencies
+vi.mock('@pagespace/db', () => {
+  return {
+    db: {
+      query: {
+        pages: {
+          findFirst: vi.fn(),
+        },
+      },
+      select: vi.fn(),
+      update: vi.fn(),
+      insert: vi.fn(),
+    },
+    chatMessages: {},
+    userActivities: {},
+    pages: {},
+    eq: vi.fn((field: unknown, value: unknown) => ({ field, value, type: 'eq' })),
+    and: vi.fn((...conditions: unknown[]) => ({ conditions, type: 'and' })),
+    sql: vi.fn((strings: TemplateStringsArray) => ({
+      sql: strings.join(''),
+      as: vi.fn(() => ({})),
+    })),
+  };
+});
+
+vi.mock('@pagespace/lib/server', () => ({
+  loggers: {
+    ai: {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    },
+  },
+  canUserEditPage: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateHybridRequest: vi.fn(),
+  isAuthError: vi.fn(),
+}));
+
+import { db } from '@pagespace/db';
+import { loggers, canUserEditPage } from '@pagespace/lib/server';
+import { authenticateHybridRequest, isAuthError } from '@/lib/auth';
+
+// Helper to create mock WebAuthResult
+const mockWebAuth = (userId: string, tokenVersion = 0): WebAuthResult => ({
+  userId,
+  tokenVersion,
+  tokenType: 'jwt',
+  source: 'cookie',
+  role: 'user',
+});
+
+// Helper to create mock AuthError
+const mockAuthError = (status = 401): AuthError => ({
+  error: NextResponse.json({ error: 'Unauthorized' }, { status }),
+});
+
+// Helper to create mock agent page
+const mockAgent = (overrides: Partial<{
+  id: string;
+  title: string;
+  type: string;
+  isTrashed: boolean;
+}> = {}) => ({
+  id: overrides.id || 'agent_123',
+  title: overrides.title || 'Test Agent',
+  type: overrides.type || 'AI_CHAT',
+  isTrashed: overrides.isTrashed ?? false,
+});
+
+describe('Page Agent Conversation Routes', () => {
+  const mockUserId = 'user_123';
+  const mockAgentId = 'agent_123';
+  const mockConversationId = 'conv_123';
+
+  const createContext = (agentId: string, conversationId: string) => ({
+    params: Promise.resolve({ agentId, conversationId }),
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default auth success
+    vi.mocked(authenticateHybridRequest).mockResolvedValue(mockWebAuth(mockUserId));
+    vi.mocked(isAuthError).mockReturnValue(false);
+
+    // Default permission granted
+    vi.mocked(canUserEditPage).mockResolvedValue(true);
+
+    // Default agent exists
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue(mockAgent());
+  });
+
+  describe('PATCH /api/ai/page-agents/[agentId]/conversations/[conversationId]', () => {
+    // Helper to setup select mock for conversation messages (uses .limit())
+    const setupConversationMessagesMock = (hasMessages: boolean) => {
+      const result = hasMessages ? [{ count: 'msg_1' }] : [];
+      // Chain: db.select().from().where().limit() -> result
+      const limitMock = vi.fn().mockResolvedValue(result);
+      const whereMock = vi.fn().mockReturnValue({ limit: limitMock });
+      const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+      vi.mocked(db.select).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof db.select>);
+    };
+
+    describe('authentication', () => {
+      it('should return 401 when not authenticated', async () => {
+        vi.mocked(isAuthError).mockReturnValue(true);
+        vi.mocked(authenticateHybridRequest).mockResolvedValue(mockAuthError(401));
+
+        const request = new Request(
+          `https://example.com/api/ai/page-agents/${mockAgentId}/conversations/${mockConversationId}`,
+          {
+            method: 'PATCH',
+            body: JSON.stringify({ title: 'Updated' }),
+          }
+        );
+        const context = createContext(mockAgentId, mockConversationId);
+
+        const response = await PATCH(request, context);
+        expect(response.status).toBe(401);
+      });
+    });
+
+    describe('agent not found', () => {
+      it('should return 404 when agent does not exist', async () => {
+        vi.mocked(db.query.pages.findFirst).mockResolvedValue(undefined);
+
+        const request = new Request(
+          `https://example.com/api/ai/page-agents/${mockAgentId}/conversations/${mockConversationId}`,
+          {
+            method: 'PATCH',
+            body: JSON.stringify({ title: 'Updated' }),
+          }
+        );
+        const context = createContext(mockAgentId, mockConversationId);
+
+        const response = await PATCH(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(404);
+        expect(body.error).toBe('AI agent not found');
+      });
+    });
+
+    describe('authorization', () => {
+      it('should return 403 when user lacks edit permission', async () => {
+        vi.mocked(canUserEditPage).mockResolvedValue(false);
+
+        const request = new Request(
+          `https://example.com/api/ai/page-agents/${mockAgentId}/conversations/${mockConversationId}`,
+          {
+            method: 'PATCH',
+            body: JSON.stringify({ title: 'Updated' }),
+          }
+        );
+        const context = createContext(mockAgentId, mockConversationId);
+
+        const response = await PATCH(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(403);
+        expect(body.error).toContain('Insufficient permissions');
+      });
+    });
+
+    describe('conversation not found', () => {
+      it('should return 404 when conversation does not exist', async () => {
+        setupConversationMessagesMock(false);
+
+        const request = new Request(
+          `https://example.com/api/ai/page-agents/${mockAgentId}/conversations/${mockConversationId}`,
+          {
+            method: 'PATCH',
+            body: JSON.stringify({ title: 'Updated' }),
+          }
+        );
+        const context = createContext(mockAgentId, mockConversationId);
+
+        const response = await PATCH(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(404);
+        expect(body.error).toBe('Conversation not found');
+      });
+    });
+
+    describe('successful update', () => {
+      it('should return success with title update message', async () => {
+        setupConversationMessagesMock(true);
+
+        const request = new Request(
+          `https://example.com/api/ai/page-agents/${mockAgentId}/conversations/${mockConversationId}`,
+          {
+            method: 'PATCH',
+            body: JSON.stringify({ title: 'My Custom Title' }),
+          }
+        );
+        const context = createContext(mockAgentId, mockConversationId);
+
+        const response = await PATCH(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.success).toBe(true);
+        expect(body.conversationId).toBe(mockConversationId);
+        expect(body.title).toBe('My Custom Title');
+        expect(body.message).toContain('Custom titles will be supported');
+      });
+    });
+
+    describe('error handling', () => {
+      it('should handle database errors gracefully', async () => {
+        vi.mocked(db.query.pages.findFirst).mockRejectedValue(new Error('Database error'));
+
+        const request = new Request(
+          `https://example.com/api/ai/page-agents/${mockAgentId}/conversations/${mockConversationId}`,
+          {
+            method: 'PATCH',
+            body: JSON.stringify({ title: 'Updated' }),
+          }
+        );
+        const context = createContext(mockAgentId, mockConversationId);
+
+        const response = await PATCH(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(500);
+        expect(body.error).toBe('Failed to update conversation');
+        expect(loggers.ai.error).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('DELETE /api/ai/page-agents/[agentId]/conversations/[conversationId]', () => {
+    // Helper to setup mocks for DELETE
+    // Chain: db.select().from().where() -> result (no .limit() for DELETE metadata query)
+    const setupDeleteMocks = (metadata: { messageCount: number; firstMessageTime: Date; lastMessageTime: Date } | null) => {
+      const selectWhereMock = vi.fn().mockResolvedValue(metadata ? [metadata] : []);
+      const fromMock = vi.fn().mockReturnValue({ where: selectWhereMock });
+      vi.mocked(db.select).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof db.select>);
+
+      // Chain: db.update().set().where() -> resolved
+      const updateWhereMock = vi.fn().mockResolvedValue(undefined);
+      const setMock = vi.fn().mockReturnValue({ where: updateWhereMock });
+      vi.mocked(db.update).mockReturnValue({ set: setMock } as unknown as ReturnType<typeof db.update>);
+
+      // Chain: db.insert().values() -> resolved
+      const insertValuesMock = vi.fn().mockResolvedValue([]);
+      vi.mocked(db.insert).mockReturnValue({ values: insertValuesMock } as unknown as ReturnType<typeof db.insert>);
+
+      return { updateWhereMock, insertValuesMock };
+    };
+
+    describe('authentication', () => {
+      it('should return 401 when not authenticated', async () => {
+        vi.mocked(isAuthError).mockReturnValue(true);
+        vi.mocked(authenticateHybridRequest).mockResolvedValue(mockAuthError(401));
+
+        const request = new Request(
+          `https://example.com/api/ai/page-agents/${mockAgentId}/conversations/${mockConversationId}`,
+          { method: 'DELETE' }
+        );
+        const context = createContext(mockAgentId, mockConversationId);
+
+        const response = await DELETE(request, context);
+        expect(response.status).toBe(401);
+      });
+    });
+
+    describe('agent not found', () => {
+      it('should return 404 when agent does not exist', async () => {
+        vi.mocked(db.query.pages.findFirst).mockResolvedValue(undefined);
+
+        const request = new Request(
+          `https://example.com/api/ai/page-agents/${mockAgentId}/conversations/${mockConversationId}`,
+          { method: 'DELETE' }
+        );
+        const context = createContext(mockAgentId, mockConversationId);
+
+        const response = await DELETE(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(404);
+        expect(body.error).toBe('AI agent not found');
+      });
+    });
+
+    describe('authorization', () => {
+      it('should return 403 when user lacks edit permission', async () => {
+        vi.mocked(canUserEditPage).mockResolvedValue(false);
+
+        const request = new Request(
+          `https://example.com/api/ai/page-agents/${mockAgentId}/conversations/${mockConversationId}`,
+          { method: 'DELETE' }
+        );
+        const context = createContext(mockAgentId, mockConversationId);
+
+        const response = await DELETE(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(403);
+        expect(body.error).toContain('Insufficient permissions');
+      });
+    });
+
+    describe('successful deletion', () => {
+      it('should soft delete all conversation messages', async () => {
+        const metadata = {
+          messageCount: 5,
+          firstMessageTime: new Date(),
+          lastMessageTime: new Date(),
+        };
+        setupDeleteMocks(metadata);
+
+        const request = new Request(
+          `https://example.com/api/ai/page-agents/${mockAgentId}/conversations/${mockConversationId}`,
+          { method: 'DELETE' }
+        );
+        const context = createContext(mockAgentId, mockConversationId);
+
+        const response = await DELETE(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.success).toBe(true);
+        expect(body.conversationId).toBe(mockConversationId);
+        expect(body.message).toBe('Conversation deleted successfully');
+      });
+
+      it('should create audit log entry', async () => {
+        const metadata = {
+          messageCount: 5,
+          firstMessageTime: new Date(),
+          lastMessageTime: new Date(),
+        };
+        const { insertValuesMock } = setupDeleteMocks(metadata);
+
+        const request = new Request(
+          `https://example.com/api/ai/page-agents/${mockAgentId}/conversations/${mockConversationId}`,
+          { method: 'DELETE' }
+        );
+        const context = createContext(mockAgentId, mockConversationId);
+
+        await DELETE(request, context);
+
+        expect(insertValuesMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            userId: mockUserId,
+            action: 'delete',
+            resource: 'conversation',
+            resourceId: mockConversationId,
+          })
+        );
+      });
+
+      it('should log successful deletion', async () => {
+        const metadata = {
+          messageCount: 5,
+          firstMessageTime: new Date(),
+          lastMessageTime: new Date(),
+        };
+        setupDeleteMocks(metadata);
+
+        const request = new Request(
+          `https://example.com/api/ai/page-agents/${mockAgentId}/conversations/${mockConversationId}`,
+          { method: 'DELETE' }
+        );
+        const context = createContext(mockAgentId, mockConversationId);
+
+        await DELETE(request, context);
+
+        expect(loggers.ai.info).toHaveBeenCalledWith(
+          'Conversation deleted',
+          expect.objectContaining({
+            conversationId: mockConversationId,
+            agentId: mockAgentId,
+          })
+        );
+      });
+    });
+
+    describe('error handling', () => {
+      it('should handle database errors gracefully', async () => {
+        vi.mocked(db.query.pages.findFirst).mockRejectedValue(new Error('Database error'));
+
+        const request = new Request(
+          `https://example.com/api/ai/page-agents/${mockAgentId}/conversations/${mockConversationId}`,
+          { method: 'DELETE' }
+        );
+        const context = createContext(mockAgentId, mockConversationId);
+
+        const response = await DELETE(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(500);
+        expect(body.error).toBe('Failed to delete conversation');
+        expect(loggers.ai.error).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/__tests__/route.test.ts
@@ -1,0 +1,375 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+import { GET, POST } from '../route';
+import type { WebAuthResult, AuthError } from '@/lib/auth';
+
+// Mock dependencies
+vi.mock('@pagespace/db', () => ({
+  db: {
+    query: {
+      pages: {
+        findFirst: vi.fn(),
+      },
+    },
+    select: vi.fn(),
+    execute: vi.fn(),
+  },
+  chatMessages: {},
+  pages: {},
+  eq: vi.fn((field: unknown, value: unknown) => ({ field, value, type: 'eq' })),
+  and: vi.fn((...conditions: unknown[]) => ({ conditions, type: 'and' })),
+  sql: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/server', () => ({
+  loggers: {
+    ai: {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    },
+  },
+  canUserViewPage: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateHybridRequest: vi.fn(),
+  isAuthError: vi.fn(),
+}));
+
+vi.mock('@paralleldrive/cuid2', () => ({
+  createId: vi.fn(() => 'generated_conv_id'),
+}));
+
+import { db } from '@pagespace/db';
+import { loggers, canUserViewPage } from '@pagespace/lib/server';
+import { authenticateHybridRequest, isAuthError } from '@/lib/auth';
+
+// Helper to create mock WebAuthResult
+const mockWebAuth = (userId: string, tokenVersion = 0): WebAuthResult => ({
+  userId,
+  tokenVersion,
+  tokenType: 'jwt',
+  source: 'cookie',
+  role: 'user',
+});
+
+// Helper to create mock AuthError
+const mockAuthError = (status = 401): AuthError => ({
+  error: NextResponse.json({ error: 'Unauthorized' }, { status }),
+});
+
+// Helper to create mock agent page
+const mockAgent = (overrides: Partial<{
+  id: string;
+  title: string;
+  type: string;
+  isTrashed: boolean;
+}> = {}) => ({
+  id: overrides.id || 'agent_123',
+  title: overrides.title || 'Test Agent',
+  type: overrides.type || 'AI_CHAT',
+  isTrashed: overrides.isTrashed ?? false,
+});
+
+describe('Page Agent Conversations Routes', () => {
+  const mockUserId = 'user_123';
+  const mockAgentId = 'agent_123';
+
+  const createContext = (agentId: string) => ({
+    params: Promise.resolve({ agentId }),
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default auth success
+    vi.mocked(authenticateHybridRequest).mockResolvedValue(mockWebAuth(mockUserId));
+    vi.mocked(isAuthError).mockReturnValue(false);
+
+    // Default permission granted
+    vi.mocked(canUserViewPage).mockResolvedValue(true);
+
+    // Default agent exists
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue(mockAgent());
+  });
+
+  describe('GET /api/ai/page-agents/[agentId]/conversations', () => {
+    // Helper to setup mocks for GET
+    const setupGetMocks = (
+      agent: ReturnType<typeof mockAgent> | undefined,
+      conversationsResult: { rows: unknown[] },
+      totalCount: number
+    ) => {
+      vi.mocked(db.query.pages.findFirst).mockResolvedValue(agent);
+      vi.mocked(db.execute).mockResolvedValue(conversationsResult);
+
+      const whereMock = vi.fn().mockResolvedValue([{ count: totalCount }]);
+      const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+      vi.mocked(db.select).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof db.select>);
+    };
+
+    describe('authentication', () => {
+      it('should return 401 when not authenticated', async () => {
+        vi.mocked(isAuthError).mockReturnValue(true);
+        vi.mocked(authenticateHybridRequest).mockResolvedValue(mockAuthError(401));
+
+        const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/conversations`, {
+          method: 'GET',
+        });
+        const context = createContext(mockAgentId);
+
+        const response = await GET(request, context);
+        expect(response.status).toBe(401);
+      });
+    });
+
+    describe('agent not found', () => {
+      it('should return 404 when agent does not exist', async () => {
+        vi.mocked(db.query.pages.findFirst).mockResolvedValue(undefined);
+
+        const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/conversations`, {
+          method: 'GET',
+        });
+        const context = createContext(mockAgentId);
+
+        const response = await GET(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(404);
+        expect(body.error).toBe('AI agent not found');
+      });
+    });
+
+    describe('authorization', () => {
+      it('should return 403 when user lacks view permission', async () => {
+        vi.mocked(canUserViewPage).mockResolvedValue(false);
+
+        const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/conversations`, {
+          method: 'GET',
+        });
+        const context = createContext(mockAgentId);
+
+        const response = await GET(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(403);
+        expect(body.error).toContain('Insufficient permissions');
+      });
+    });
+
+    describe('successful retrieval', () => {
+      it('should return conversations with pagination', async () => {
+        const mockConversations = [
+          {
+            conversationId: 'conv_1',
+            firstMessageTime: new Date(),
+            lastMessageTime: new Date(),
+            messageCount: 5,
+            firstUserMessage: JSON.stringify([{ text: 'Hello' }]),
+            lastMessageRole: 'assistant',
+            lastMessageContent: 'Hi there!',
+          },
+        ];
+        setupGetMocks(mockAgent(), { rows: mockConversations }, 1);
+
+        const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/conversations`, {
+          method: 'GET',
+        });
+        const context = createContext(mockAgentId);
+
+        const response = await GET(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.conversations).toBeDefined();
+        expect(body.pagination).toBeDefined();
+        expect(body.pagination.totalCount).toBe(1);
+      });
+
+      it('should return empty array when no conversations exist', async () => {
+        setupGetMocks(mockAgent(), { rows: [] }, 0);
+
+        const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/conversations`, {
+          method: 'GET',
+        });
+        const context = createContext(mockAgentId);
+
+        const response = await GET(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.conversations).toEqual([]);
+        expect(body.pagination.totalCount).toBe(0);
+      });
+
+      it('should handle pagination parameters', async () => {
+        setupGetMocks(mockAgent(), { rows: [] }, 100);
+
+        const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/conversations?page=2&pageSize=20`, {
+          method: 'GET',
+        });
+        const context = createContext(mockAgentId);
+
+        const response = await GET(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.pagination.page).toBe(2);
+        expect(body.pagination.pageSize).toBe(20);
+        expect(body.pagination.hasMore).toBe(true);
+      });
+    });
+
+    describe('error handling', () => {
+      it('should handle database errors gracefully', async () => {
+        vi.mocked(db.query.pages.findFirst).mockRejectedValue(new Error('Database error'));
+
+        const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/conversations`, {
+          method: 'GET',
+        });
+        const context = createContext(mockAgentId);
+
+        const response = await GET(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(500);
+        expect(body.error).toBe('Failed to list conversations');
+        expect(loggers.ai.error).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('POST /api/ai/page-agents/[agentId]/conversations', () => {
+    describe('authentication', () => {
+      it('should return 401 when not authenticated', async () => {
+        vi.mocked(isAuthError).mockReturnValue(true);
+        vi.mocked(authenticateHybridRequest).mockResolvedValue(mockAuthError(401));
+
+        const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/conversations`, {
+          method: 'POST',
+          body: JSON.stringify({}),
+        });
+        const context = createContext(mockAgentId);
+
+        const response = await POST(request, context);
+        expect(response.status).toBe(401);
+      });
+    });
+
+    describe('agent not found', () => {
+      it('should return 404 when agent does not exist', async () => {
+        vi.mocked(db.query.pages.findFirst).mockResolvedValue(undefined);
+
+        const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/conversations`, {
+          method: 'POST',
+          body: JSON.stringify({}),
+        });
+        const context = createContext(mockAgentId);
+
+        const response = await POST(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(404);
+        expect(body.error).toBe('AI agent not found');
+      });
+    });
+
+    describe('authorization', () => {
+      it('should return 403 when user lacks view permission', async () => {
+        vi.mocked(canUserViewPage).mockResolvedValue(false);
+
+        const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/conversations`, {
+          method: 'POST',
+          body: JSON.stringify({}),
+        });
+        const context = createContext(mockAgentId);
+
+        const response = await POST(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(403);
+        expect(body.error).toContain('Insufficient permissions');
+      });
+    });
+
+    describe('successful creation', () => {
+      it('should create a new conversation', async () => {
+        const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/conversations`, {
+          method: 'POST',
+          body: JSON.stringify({}),
+        });
+        const context = createContext(mockAgentId);
+
+        const response = await POST(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.conversationId).toBe('generated_conv_id');
+        expect(body.createdAt).toBeDefined();
+      });
+
+      it('should use custom title if provided', async () => {
+        const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/conversations`, {
+          method: 'POST',
+          body: JSON.stringify({ title: 'My Custom Conversation' }),
+        });
+        const context = createContext(mockAgentId);
+
+        const response = await POST(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.title).toBe('My Custom Conversation');
+      });
+
+      it('should default to "New conversation" title', async () => {
+        const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/conversations`, {
+          method: 'POST',
+          body: JSON.stringify({}),
+        });
+        const context = createContext(mockAgentId);
+
+        const response = await POST(request, context);
+        const body = await response.json();
+
+        expect(body.title).toBe('New conversation');
+      });
+
+      it('should handle invalid JSON body gracefully', async () => {
+        const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/conversations`, {
+          method: 'POST',
+          body: 'invalid json',
+        });
+        const context = createContext(mockAgentId);
+
+        const response = await POST(request, context);
+        const body = await response.json();
+
+        // Should still succeed with default values
+        expect(response.status).toBe(200);
+        expect(body.title).toBe('New conversation');
+      });
+    });
+
+    describe('error handling', () => {
+      it('should handle database errors gracefully', async () => {
+        vi.mocked(db.query.pages.findFirst).mockRejectedValue(new Error('Database error'));
+
+        const request = new Request(`https://example.com/api/ai/page-agents/${mockAgentId}/conversations`, {
+          method: 'POST',
+          body: JSON.stringify({}),
+        });
+        const context = createContext(mockAgentId);
+
+        const response = await POST(request, context);
+        const body = await response.json();
+
+        expect(response.status).toBe(500);
+        expect(body.error).toBe('Failed to create conversation');
+        expect(loggers.ai.error).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/apps/web/src/app/api/ai/page-agents/create/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/create/__tests__/route.test.ts
@@ -1,0 +1,521 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+import { POST } from '../route';
+import type { WebAuthResult, AuthError } from '@/lib/auth';
+
+// Mock dependencies
+vi.mock('@pagespace/db', () => {
+  const orderByMock = vi.fn().mockResolvedValue([]);
+  const whereMock = vi.fn().mockReturnValue({ orderBy: orderByMock });
+  const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+  const selectMock = vi.fn().mockReturnValue({ from: fromMock });
+  const returningMock = vi.fn().mockResolvedValue([]);
+  const valuesMock = vi.fn().mockReturnValue({ returning: returningMock });
+  const insertMock = vi.fn().mockReturnValue({ values: valuesMock });
+
+  return {
+    db: {
+      select: selectMock,
+      insert: insertMock,
+    },
+    pages: {},
+    drives: {},
+    eq: vi.fn((field: unknown, value: unknown) => ({ field, value, type: 'eq' })),
+    and: vi.fn((...conditions: unknown[]) => ({ conditions, type: 'and' })),
+    desc: vi.fn((field: unknown) => ({ field, type: 'desc' })),
+    isNull: vi.fn((field: unknown) => ({ field, type: 'isNull' })),
+  };
+});
+
+vi.mock('@pagespace/lib/server', () => ({
+  loggers: {
+    api: {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    },
+  },
+  canUserEditPage: vi.fn(),
+  agentAwarenessCache: {
+    invalidateDriveAgents: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn(),
+}));
+
+vi.mock('@/lib/websocket', () => ({
+  broadcastPageEvent: vi.fn(),
+  createPageEventPayload: vi.fn(() => ({ type: 'created' })),
+}));
+
+vi.mock('@/lib/ai/core', () => ({
+  pageSpaceTools: {
+    read_page: {},
+    list_pages: {},
+    create_page: {},
+    update_page: {},
+    delete_page: {},
+  },
+}));
+
+import { db } from '@pagespace/db';
+import { loggers, canUserEditPage, agentAwarenessCache } from '@pagespace/lib/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { broadcastPageEvent } from '@/lib/websocket';
+
+// Helper to create mock WebAuthResult
+const mockWebAuth = (userId: string, tokenVersion = 0): WebAuthResult => ({
+  userId,
+  tokenVersion,
+  tokenType: 'jwt',
+  source: 'cookie',
+  role: 'user',
+});
+
+// Helper to create mock AuthError
+const mockAuthError = (status = 401): AuthError => ({
+  error: NextResponse.json({ error: 'Unauthorized' }, { status }),
+});
+
+// Helper to create mock drive
+const mockDrive = (overrides: Partial<{
+  id: string;
+  ownerId: string;
+}> = {}) => ({
+  id: overrides.id || 'drive_123',
+  ownerId: overrides.ownerId || 'user_123',
+});
+
+// Helper to create mock page
+const mockPage = (overrides: Partial<{
+  id: string;
+  driveId: string;
+  position: number;
+}> = {}) => ({
+  id: overrides.id || 'page_123',
+  driveId: overrides.driveId || 'drive_123',
+  position: overrides.position ?? 1,
+});
+
+describe('POST /api/ai/page-agents/create', () => {
+  const mockUserId = 'user_123';
+  const mockDriveId = 'drive_123';
+
+  let selectCallCount = 0;
+
+  // Helper to setup mocks for drive and parent page
+  // hasParentId: set to true if the test provides a parentId in the request body
+  const setupSelectMocks = (
+    drive: ReturnType<typeof mockDrive> | undefined,
+    parentPage: ReturnType<typeof mockPage> | undefined,
+    siblingPages: ReturnType<typeof mockPage>[] = [],
+    hasParentId: boolean = false
+  ) => {
+    selectCallCount = 0;
+    const whereMock = vi.fn().mockImplementation(() => {
+      selectCallCount++;
+
+      // Determine what result to return based on call order
+      let result: unknown[];
+      if (selectCallCount === 1) {
+        // First call: get drive
+        result = drive ? [drive] : [];
+      } else if (hasParentId && selectCallCount === 2) {
+        // Second call WITH parentId: verify parent page
+        result = parentPage ? [parentPage] : [];
+      } else {
+        // Sibling pages call (call 2 without parentId, or call 3 with parentId)
+        result = siblingPages;
+      }
+
+      // Return a thenable object that also has orderBy for chaining
+      // This allows both patterns: `await db.select().from().where()`
+      // and `await db.select().from().where().orderBy()`
+      return {
+        then: (resolve: (value: unknown[]) => void, reject?: (reason: unknown) => void) =>
+          Promise.resolve(result).then(resolve, reject),
+        orderBy: vi.fn().mockResolvedValue(result),
+      };
+    });
+    const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+    vi.mocked(db.select).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof db.select>);
+  };
+
+  // Helper to setup insert mock
+  const setupInsertMock = (newAgent: { id: string; title: string; type: string }) => {
+    const returningMock = vi.fn().mockResolvedValue([newAgent]);
+    const valuesMock = vi.fn().mockReturnValue({ returning: returningMock });
+    vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as unknown as ReturnType<typeof db.insert>);
+    return { valuesMock, returningMock };
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectCallCount = 0;
+
+    // Default auth success
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockWebAuth(mockUserId));
+    vi.mocked(isAuthError).mockReturnValue(false);
+
+    // Default permission granted
+    vi.mocked(canUserEditPage).mockResolvedValue(true);
+
+    // Default drive exists and user owns it
+    setupSelectMocks(mockDrive({ ownerId: mockUserId }), undefined, []);
+    setupInsertMock({ id: 'agent_123', title: 'Test Agent', type: 'AI_CHAT' });
+  });
+
+  describe('authentication', () => {
+    it('should return 401 when not authenticated', async () => {
+      vi.mocked(isAuthError).mockReturnValue(true);
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthError(401));
+
+      const request = new Request('https://example.com/api/ai/page-agents/create', {
+        method: 'POST',
+        body: JSON.stringify({
+          driveId: mockDriveId,
+          title: 'Test Agent',
+          systemPrompt: 'You are a helpful assistant.',
+        }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe('validation', () => {
+    it('should return 400 when driveId is missing', async () => {
+      const request = new Request('https://example.com/api/ai/page-agents/create', {
+        method: 'POST',
+        body: JSON.stringify({
+          title: 'Test Agent',
+          systemPrompt: 'You are a helpful assistant.',
+        }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toContain('driveId, title, and systemPrompt are required');
+    });
+
+    it('should return 400 when title is missing', async () => {
+      const request = new Request('https://example.com/api/ai/page-agents/create', {
+        method: 'POST',
+        body: JSON.stringify({
+          driveId: mockDriveId,
+          systemPrompt: 'You are a helpful assistant.',
+        }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toContain('driveId, title, and systemPrompt are required');
+    });
+
+    it('should return 400 when systemPrompt is missing', async () => {
+      const request = new Request('https://example.com/api/ai/page-agents/create', {
+        method: 'POST',
+        body: JSON.stringify({
+          driveId: mockDriveId,
+          title: 'Test Agent',
+        }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toContain('driveId, title, and systemPrompt are required');
+    });
+
+    it('should return 400 when enabledTools contains invalid tools', async () => {
+      const request = new Request('https://example.com/api/ai/page-agents/create', {
+        method: 'POST',
+        body: JSON.stringify({
+          driveId: mockDriveId,
+          title: 'Test Agent',
+          systemPrompt: 'You are a helpful assistant.',
+          enabledTools: ['invalid_tool', 'read_page'],
+        }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toContain('Invalid tools specified');
+      expect(body.error).toContain('invalid_tool');
+    });
+  });
+
+  describe('drive not found', () => {
+    it('should return 404 when drive does not exist', async () => {
+      setupSelectMocks(undefined, undefined, []);
+
+      const request = new Request('https://example.com/api/ai/page-agents/create', {
+        method: 'POST',
+        body: JSON.stringify({
+          driveId: mockDriveId,
+          title: 'Test Agent',
+          systemPrompt: 'You are a helpful assistant.',
+        }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(body.error).toContain('Drive with ID');
+      expect(body.error).toContain('not found');
+    });
+  });
+
+  describe('parent page validation', () => {
+    it('should return 404 when parent page does not exist', async () => {
+      setupSelectMocks(mockDrive(), undefined, [], true); // hasParentId = true
+
+      const request = new Request('https://example.com/api/ai/page-agents/create', {
+        method: 'POST',
+        body: JSON.stringify({
+          driveId: mockDriveId,
+          parentId: 'parent_123',
+          title: 'Test Agent',
+          systemPrompt: 'You are a helpful assistant.',
+        }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(body.error).toContain('Parent page');
+      expect(body.error).toContain('not found');
+    });
+  });
+
+  describe('authorization', () => {
+    it('should return 403 when non-owner tries to create at root level', async () => {
+      setupSelectMocks(mockDrive({ ownerId: 'different_user' }), undefined, []);
+
+      const request = new Request('https://example.com/api/ai/page-agents/create', {
+        method: 'POST',
+        body: JSON.stringify({
+          driveId: mockDriveId,
+          title: 'Test Agent',
+          systemPrompt: 'You are a helpful assistant.',
+        }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.error).toContain('Only drive owners');
+    });
+
+    it('should return 403 when user lacks edit permission for parent folder', async () => {
+      setupSelectMocks(mockDrive(), mockPage({ id: 'parent_123' }), [], true); // hasParentId = true
+      vi.mocked(canUserEditPage).mockResolvedValue(false);
+
+      const request = new Request('https://example.com/api/ai/page-agents/create', {
+        method: 'POST',
+        body: JSON.stringify({
+          driveId: mockDriveId,
+          parentId: 'parent_123',
+          title: 'Test Agent',
+          systemPrompt: 'You are a helpful assistant.',
+        }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.error).toContain('Insufficient permissions');
+    });
+  });
+
+  describe('successful creation', () => {
+    it('should create agent at drive root', async () => {
+      setupSelectMocks(mockDrive({ ownerId: mockUserId }), undefined, []);
+      setupInsertMock({ id: 'agent_123', title: 'Test Agent', type: 'AI_CHAT' });
+
+      const request = new Request('https://example.com/api/ai/page-agents/create', {
+        method: 'POST',
+        body: JSON.stringify({
+          driveId: mockDriveId,
+          title: 'Test Agent',
+          systemPrompt: 'You are a helpful assistant.',
+        }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.id).toBe('agent_123');
+      expect(body.title).toBe('Test Agent');
+      expect(body.type).toBe('AI_CHAT');
+    });
+
+    it('should create agent in parent folder', async () => {
+      setupSelectMocks(mockDrive(), mockPage({ id: 'parent_123' }), [], true); // hasParentId = true
+      setupInsertMock({ id: 'agent_123', title: 'Test Agent', type: 'AI_CHAT' });
+
+      const request = new Request('https://example.com/api/ai/page-agents/create', {
+        method: 'POST',
+        body: JSON.stringify({
+          driveId: mockDriveId,
+          parentId: 'parent_123',
+          title: 'Test Agent',
+          systemPrompt: 'You are a helpful assistant.',
+        }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+    });
+
+    it('should accept valid enabledTools', async () => {
+      setupSelectMocks(mockDrive({ ownerId: mockUserId }), undefined, []);
+      setupInsertMock({ id: 'agent_123', title: 'Test Agent', type: 'AI_CHAT' });
+
+      const request = new Request('https://example.com/api/ai/page-agents/create', {
+        method: 'POST',
+        body: JSON.stringify({
+          driveId: mockDriveId,
+          title: 'Test Agent',
+          systemPrompt: 'You are a helpful assistant.',
+          enabledTools: ['read_page', 'list_pages'],
+        }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.agentConfig.enabledTools).toEqual(['read_page', 'list_pages']);
+    });
+
+    it('should accept aiProvider and aiModel', async () => {
+      setupSelectMocks(mockDrive({ ownerId: mockUserId }), undefined, []);
+      setupInsertMock({ id: 'agent_123', title: 'Test Agent', type: 'AI_CHAT' });
+
+      const request = new Request('https://example.com/api/ai/page-agents/create', {
+        method: 'POST',
+        body: JSON.stringify({
+          driveId: mockDriveId,
+          title: 'Test Agent',
+          systemPrompt: 'You are a helpful assistant.',
+          aiProvider: 'openrouter',
+          aiModel: 'anthropic/claude-3-opus',
+        }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.agentConfig.aiProvider).toBe('openrouter');
+      expect(body.agentConfig.aiModel).toBe('anthropic/claude-3-opus');
+    });
+
+    it('should broadcast page creation event', async () => {
+      setupSelectMocks(mockDrive({ ownerId: mockUserId }), undefined, []);
+      setupInsertMock({ id: 'agent_123', title: 'Test Agent', type: 'AI_CHAT' });
+
+      const request = new Request('https://example.com/api/ai/page-agents/create', {
+        method: 'POST',
+        body: JSON.stringify({
+          driveId: mockDriveId,
+          title: 'Test Agent',
+          systemPrompt: 'You are a helpful assistant.',
+        }),
+      });
+
+      await POST(request);
+
+      expect(broadcastPageEvent).toHaveBeenCalled();
+    });
+
+    it('should invalidate agent awareness cache', async () => {
+      setupSelectMocks(mockDrive({ ownerId: mockUserId }), undefined, []);
+      setupInsertMock({ id: 'agent_123', title: 'Test Agent', type: 'AI_CHAT' });
+
+      const request = new Request('https://example.com/api/ai/page-agents/create', {
+        method: 'POST',
+        body: JSON.stringify({
+          driveId: mockDriveId,
+          title: 'Test Agent',
+          systemPrompt: 'You are a helpful assistant.',
+        }),
+      });
+
+      await POST(request);
+
+      expect(agentAwarenessCache.invalidateDriveAgents).toHaveBeenCalledWith(mockDriveId);
+    });
+
+    it('should log agent creation', async () => {
+      setupSelectMocks(mockDrive({ ownerId: mockUserId }), undefined, []);
+      setupInsertMock({ id: 'agent_123', title: 'Test Agent', type: 'AI_CHAT' });
+
+      const request = new Request('https://example.com/api/ai/page-agents/create', {
+        method: 'POST',
+        body: JSON.stringify({
+          driveId: mockDriveId,
+          title: 'Test Agent',
+          systemPrompt: 'You are a helpful assistant.',
+        }),
+      });
+
+      await POST(request);
+
+      expect(loggers.api.info).toHaveBeenCalledWith(
+        'AI agent created',
+        expect.objectContaining({
+          agentId: 'agent_123',
+          title: 'Test Agent',
+        })
+      );
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle database errors gracefully', async () => {
+      setupSelectMocks(mockDrive({ ownerId: mockUserId }), undefined, []);
+      const returningMock = vi.fn().mockRejectedValue(new Error('Database error'));
+      const valuesMock = vi.fn().mockReturnValue({ returning: returningMock });
+      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as unknown as ReturnType<typeof db.insert>);
+
+      const request = new Request('https://example.com/api/ai/page-agents/create', {
+        method: 'POST',
+        body: JSON.stringify({
+          driveId: mockDriveId,
+          title: 'Test Agent',
+          systemPrompt: 'You are a helpful assistant.',
+        }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(body.error).toContain('Failed to create AI agent');
+      expect(loggers.api.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/app/api/ai/settings/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/settings/__tests__/route.test.ts
@@ -1,0 +1,777 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+import { GET, POST, PATCH, DELETE } from '../route';
+import type { WebAuthResult, AuthError } from '@/lib/auth';
+
+// Mock dependencies
+vi.mock('@pagespace/db', () => {
+  const whereMock = vi.fn().mockResolvedValue([]);
+  const setMock = vi.fn().mockReturnValue({ where: whereMock });
+  const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+  const selectMock = vi.fn().mockReturnValue({ from: fromMock });
+  const updateMock = vi.fn().mockReturnValue({ set: setMock });
+
+  return {
+    db: {
+      select: selectMock,
+      update: updateMock,
+    },
+    users: {},
+    eq: vi.fn((field: unknown, value: unknown) => ({ field, value, type: 'eq' })),
+  };
+});
+
+vi.mock('@pagespace/lib/server', () => ({
+  loggers: {
+    ai: {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn(),
+}));
+
+vi.mock('@/lib/ai/core', () => ({
+  getUserOpenRouterSettings: vi.fn(),
+  createOpenRouterSettings: vi.fn(),
+  deleteOpenRouterSettings: vi.fn(),
+  getUserGoogleSettings: vi.fn(),
+  createGoogleSettings: vi.fn(),
+  deleteGoogleSettings: vi.fn(),
+  getDefaultPageSpaceSettings: vi.fn(),
+  getUserOpenAISettings: vi.fn(),
+  createOpenAISettings: vi.fn(),
+  deleteOpenAISettings: vi.fn(),
+  getUserAnthropicSettings: vi.fn(),
+  createAnthropicSettings: vi.fn(),
+  deleteAnthropicSettings: vi.fn(),
+  getUserXAISettings: vi.fn(),
+  createXAISettings: vi.fn(),
+  deleteXAISettings: vi.fn(),
+  getUserOllamaSettings: vi.fn(),
+  createOllamaSettings: vi.fn(),
+  deleteOllamaSettings: vi.fn(),
+  getUserLMStudioSettings: vi.fn(),
+  createLMStudioSettings: vi.fn(),
+  deleteLMStudioSettings: vi.fn(),
+  getUserGLMSettings: vi.fn(),
+  createGLMSettings: vi.fn(),
+  deleteGLMSettings: vi.fn(),
+  getUserMiniMaxSettings: vi.fn(),
+  createMiniMaxSettings: vi.fn(),
+  deleteMiniMaxSettings: vi.fn(),
+}));
+
+vi.mock('@/lib/subscription/rate-limit-middleware', () => ({
+  requiresProSubscription: vi.fn(),
+}));
+
+import { db } from '@pagespace/db';
+import { loggers } from '@pagespace/lib/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import {
+  getUserOpenRouterSettings,
+  createOpenRouterSettings,
+  deleteOpenRouterSettings,
+  getUserGoogleSettings,
+  createGoogleSettings,
+  deleteGoogleSettings,
+  getDefaultPageSpaceSettings,
+  getUserOpenAISettings,
+  createOpenAISettings,
+  deleteOpenAISettings,
+  getUserAnthropicSettings,
+  createAnthropicSettings,
+  deleteAnthropicSettings,
+  getUserXAISettings,
+  createXAISettings,
+  deleteXAISettings,
+  getUserOllamaSettings,
+  createOllamaSettings,
+  deleteOllamaSettings,
+  getUserLMStudioSettings,
+  createLMStudioSettings,
+  deleteLMStudioSettings,
+  getUserGLMSettings,
+  createGLMSettings,
+  deleteGLMSettings,
+  getUserMiniMaxSettings,
+  createMiniMaxSettings,
+  deleteMiniMaxSettings,
+} from '@/lib/ai/core';
+import { requiresProSubscription } from '@/lib/subscription/rate-limit-middleware';
+
+// Helper to create mock WebAuthResult
+const mockWebAuth = (userId: string, tokenVersion = 0): WebAuthResult => ({
+  userId,
+  tokenVersion,
+  tokenType: 'jwt',
+  source: 'cookie',
+  role: 'user',
+});
+
+// Helper to create mock AuthError
+const mockAuthError = (status = 401): AuthError => ({
+  error: NextResponse.json({ error: 'Unauthorized' }, { status }),
+});
+
+// Helper to create mock user
+const mockUser = (overrides: Partial<{
+  id: string;
+  currentAiProvider: string;
+  currentAiModel: string;
+  subscriptionTier: string;
+}> = {}) => ({
+  id: overrides.id || 'user_123',
+  name: 'Test User',
+  email: 'test@example.com',
+  currentAiProvider: overrides.currentAiProvider || 'pagespace',
+  currentAiModel: overrides.currentAiModel || 'glm-4.5-air',
+  subscriptionTier: overrides.subscriptionTier || 'free',
+});
+
+describe('AI Settings API Routes', () => {
+  const mockUserId = 'user_123';
+
+  // Helper to setup select mock for users
+  const setupUserSelectMock = (user: ReturnType<typeof mockUser> | undefined) => {
+    const whereMock = vi.fn().mockResolvedValue(user ? [user] : []);
+    const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+    vi.mocked(db.select).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof db.select>);
+  };
+
+  // Helper to setup update mock for users
+  const setupUpdateMock = () => {
+    const whereMock = vi.fn().mockResolvedValue([mockUser()]);
+    const setMock = vi.fn().mockReturnValue({ where: whereMock });
+    vi.mocked(db.update).mockReturnValue({ set: setMock } as unknown as ReturnType<typeof db.update>);
+    return { setMock, whereMock };
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default auth success
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockWebAuth(mockUserId));
+    vi.mocked(isAuthError).mockReturnValue(false);
+
+    // Default user setup
+    setupUserSelectMock(mockUser());
+
+    // Default provider settings (none configured)
+    vi.mocked(getDefaultPageSpaceSettings).mockResolvedValue(null);
+    vi.mocked(getUserOpenRouterSettings).mockResolvedValue(null);
+    vi.mocked(getUserGoogleSettings).mockResolvedValue(null);
+    vi.mocked(getUserOpenAISettings).mockResolvedValue(null);
+    vi.mocked(getUserAnthropicSettings).mockResolvedValue(null);
+    vi.mocked(getUserXAISettings).mockResolvedValue(null);
+    vi.mocked(getUserOllamaSettings).mockResolvedValue(null);
+    vi.mocked(getUserLMStudioSettings).mockResolvedValue(null);
+    vi.mocked(getUserGLMSettings).mockResolvedValue(null);
+    vi.mocked(getUserMiniMaxSettings).mockResolvedValue(null);
+  });
+
+  describe('GET /api/ai/settings', () => {
+    it('should return 401 when not authenticated', async () => {
+      vi.mocked(isAuthError).mockReturnValue(true);
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthError(401));
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      expect(response.status).toBe(401);
+    });
+
+    it('should return current AI settings for authenticated user', async () => {
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.currentProvider).toBe('pagespace');
+      expect(body.currentModel).toBe('glm-4.5-air');
+      expect(body.userSubscriptionTier).toBe('free');
+      expect(body.providers).toBeDefined();
+      expect(body.isAnyProviderConfigured).toBe(false);
+    });
+
+    it('should return provider configuration status', async () => {
+      vi.mocked(getDefaultPageSpaceSettings).mockResolvedValue({
+        isConfigured: true,
+        apiKey: 'test-key',
+      });
+      vi.mocked(getUserOpenRouterSettings).mockResolvedValue({
+        isConfigured: true,
+        apiKey: 'openrouter-key',
+      });
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.providers.pagespace.isConfigured).toBe(true);
+      expect(body.providers.pagespace.hasApiKey).toBe(true);
+      expect(body.providers.openrouter.isConfigured).toBe(true);
+      expect(body.providers.openrouter.hasApiKey).toBe(true);
+      expect(body.isAnyProviderConfigured).toBe(true);
+    });
+
+    it('should return ollama and lmstudio with baseUrl check', async () => {
+      vi.mocked(getUserOllamaSettings).mockResolvedValue({
+        isConfigured: true,
+        baseUrl: 'http://localhost:11434',
+      });
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(body.providers.ollama.isConfigured).toBe(true);
+      expect(body.providers.ollama.hasBaseUrl).toBe(true);
+    });
+
+    it('should handle database errors gracefully', async () => {
+      const whereMock = vi.fn().mockRejectedValue(new Error('Database connection lost'));
+      const fromMock = vi.fn().mockReturnValue({ where: whereMock });
+      vi.mocked(db.select).mockReturnValue({ from: fromMock } as unknown as ReturnType<typeof db.select>);
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'GET',
+      });
+
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(body.error).toBe('Failed to retrieve settings');
+      expect(loggers.ai.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /api/ai/settings', () => {
+    it('should return 401 when not authenticated', async () => {
+      vi.mocked(isAuthError).mockReturnValue(true);
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthError(401));
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'POST',
+        body: JSON.stringify({ provider: 'openrouter', apiKey: 'test-key' }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(401);
+    });
+
+    it('should reject invalid provider', async () => {
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'POST',
+        body: JSON.stringify({ provider: 'invalid-provider', apiKey: 'test-key' }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toContain('Invalid provider');
+    });
+
+    it('should reject missing API key for API-key providers', async () => {
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'POST',
+        body: JSON.stringify({ provider: 'openrouter', apiKey: '' }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toBe('API key is required');
+    });
+
+    it('should reject missing base URL for Ollama', async () => {
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'POST',
+        body: JSON.stringify({ provider: 'ollama', baseUrl: '' }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toBe('Base URL is required for Ollama');
+    });
+
+    it('should reject missing base URL for LM Studio', async () => {
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'POST',
+        body: JSON.stringify({ provider: 'lmstudio', baseUrl: '' }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toBe('Base URL is required for LM Studio');
+    });
+
+    it('should save OpenRouter API key successfully', async () => {
+      vi.mocked(createOpenRouterSettings).mockResolvedValue(undefined);
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'POST',
+        body: JSON.stringify({ provider: 'openrouter', apiKey: '  test-api-key  ' }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(body.success).toBe(true);
+      expect(body.provider).toBe('openrouter');
+      expect(body.message).toContain('OpenRouter');
+      expect(createOpenRouterSettings).toHaveBeenCalledWith(mockUserId, 'test-api-key');
+    });
+
+    it('should save Google API key successfully', async () => {
+      vi.mocked(createGoogleSettings).mockResolvedValue(undefined);
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'POST',
+        body: JSON.stringify({ provider: 'google', apiKey: 'google-key' }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(body.success).toBe(true);
+      expect(createGoogleSettings).toHaveBeenCalledWith(mockUserId, 'google-key');
+    });
+
+    it('should save OpenAI API key successfully', async () => {
+      vi.mocked(createOpenAISettings).mockResolvedValue(undefined);
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'POST',
+        body: JSON.stringify({ provider: 'openai', apiKey: 'openai-key' }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(201);
+      expect(createOpenAISettings).toHaveBeenCalledWith(mockUserId, 'openai-key');
+    });
+
+    it('should save Anthropic API key successfully', async () => {
+      vi.mocked(createAnthropicSettings).mockResolvedValue(undefined);
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'POST',
+        body: JSON.stringify({ provider: 'anthropic', apiKey: 'anthropic-key' }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(201);
+      expect(createAnthropicSettings).toHaveBeenCalledWith(mockUserId, 'anthropic-key');
+    });
+
+    it('should save xAI API key successfully', async () => {
+      vi.mocked(createXAISettings).mockResolvedValue(undefined);
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'POST',
+        body: JSON.stringify({ provider: 'xai', apiKey: 'xai-key' }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(201);
+      expect(createXAISettings).toHaveBeenCalledWith(mockUserId, 'xai-key');
+    });
+
+    it('should save Ollama base URL successfully', async () => {
+      vi.mocked(createOllamaSettings).mockResolvedValue(undefined);
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'POST',
+        body: JSON.stringify({ provider: 'ollama', baseUrl: 'http://localhost:11434' }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(201);
+      expect(body.success).toBe(true);
+      expect(createOllamaSettings).toHaveBeenCalledWith(mockUserId, 'http://localhost:11434');
+    });
+
+    it('should save LM Studio base URL successfully', async () => {
+      vi.mocked(createLMStudioSettings).mockResolvedValue(undefined);
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'POST',
+        body: JSON.stringify({ provider: 'lmstudio', baseUrl: 'http://localhost:1234/v1' }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(201);
+      expect(createLMStudioSettings).toHaveBeenCalledWith(mockUserId, 'http://localhost:1234/v1');
+    });
+
+    it('should save GLM API key successfully', async () => {
+      vi.mocked(createGLMSettings).mockResolvedValue(undefined);
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'POST',
+        body: JSON.stringify({ provider: 'glm', apiKey: 'glm-key' }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(201);
+      expect(createGLMSettings).toHaveBeenCalledWith(mockUserId, 'glm-key');
+    });
+
+    it('should save MiniMax API key successfully', async () => {
+      vi.mocked(createMiniMaxSettings).mockResolvedValue(undefined);
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'POST',
+        body: JSON.stringify({ provider: 'minimax', apiKey: 'minimax-key' }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(201);
+      expect(createMiniMaxSettings).toHaveBeenCalledWith(mockUserId, 'minimax-key');
+    });
+
+    it('should handle save errors gracefully', async () => {
+      vi.mocked(createOpenRouterSettings).mockRejectedValue(new Error('Save failed'));
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'POST',
+        body: JSON.stringify({ provider: 'openrouter', apiKey: 'test-key' }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(body.error).toContain('Failed to save');
+      expect(loggers.ai.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('PATCH /api/ai/settings', () => {
+    beforeEach(() => {
+      setupUpdateMock();
+    });
+
+    it('should return 401 when not authenticated', async () => {
+      vi.mocked(isAuthError).mockReturnValue(true);
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthError(401));
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'PATCH',
+        body: JSON.stringify({ provider: 'pagespace', model: 'glm-4.5-air' }),
+      });
+
+      const response = await PATCH(request);
+      expect(response.status).toBe(401);
+    });
+
+    it('should reject invalid provider', async () => {
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'PATCH',
+        body: JSON.stringify({ provider: 'invalid', model: 'test-model' }),
+      });
+
+      const response = await PATCH(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toContain('Invalid provider');
+    });
+
+    it('should reject missing model', async () => {
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'PATCH',
+        body: JSON.stringify({ provider: 'pagespace' }),
+      });
+
+      const response = await PATCH(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toBe('Model is required');
+    });
+
+    it('should return 404 when user not found', async () => {
+      setupUserSelectMock(undefined);
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'PATCH',
+        body: JSON.stringify({ provider: 'pagespace', model: 'glm-4.5-air' }),
+      });
+
+      const response = await PATCH(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(404);
+      expect(body.error).toBe('User not found');
+    });
+
+    it('should reject pro model for free tier user', async () => {
+      setupUserSelectMock(mockUser({ subscriptionTier: 'free' }));
+      vi.mocked(requiresProSubscription).mockReturnValue(true);
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'PATCH',
+        body: JSON.stringify({ provider: 'pagespace', model: 'pro-model' }),
+      });
+
+      const response = await PATCH(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.error).toBe('Subscription required');
+      expect(body.upgradeUrl).toBe('/settings/billing');
+    });
+
+    it('should update model selection successfully', async () => {
+      setupUserSelectMock(mockUser({ subscriptionTier: 'pro' }));
+      vi.mocked(requiresProSubscription).mockReturnValue(false);
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'PATCH',
+        body: JSON.stringify({ provider: 'openrouter', model: 'anthropic/claude-3-opus' }),
+      });
+
+      const response = await PATCH(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.provider).toBe('openrouter');
+      expect(body.model).toBe('anthropic/claude-3-opus');
+    });
+
+    it('should accept pagespace provider', async () => {
+      vi.mocked(requiresProSubscription).mockReturnValue(false);
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'PATCH',
+        body: JSON.stringify({ provider: 'pagespace', model: 'glm-4.5-air' }),
+      });
+
+      const response = await PATCH(request);
+      expect(response.status).toBe(200);
+    });
+
+    it('should accept openrouter_free provider', async () => {
+      vi.mocked(requiresProSubscription).mockReturnValue(false);
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'PATCH',
+        body: JSON.stringify({ provider: 'openrouter_free', model: 'meta-llama/llama-3.2-3b' }),
+      });
+
+      const response = await PATCH(request);
+      expect(response.status).toBe(200);
+    });
+
+    it('should handle update errors gracefully', async () => {
+      vi.mocked(requiresProSubscription).mockReturnValue(false);
+      const whereMock = vi.fn().mockRejectedValue(new Error('Update failed'));
+      const setMock = vi.fn().mockReturnValue({ where: whereMock });
+      vi.mocked(db.update).mockReturnValue({ set: setMock } as unknown as ReturnType<typeof db.update>);
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'PATCH',
+        body: JSON.stringify({ provider: 'pagespace', model: 'glm-4.5-air' }),
+      });
+
+      const response = await PATCH(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(body.error).toBe('Failed to update model selection');
+    });
+  });
+
+  describe('DELETE /api/ai/settings', () => {
+    it('should return 401 when not authenticated', async () => {
+      vi.mocked(isAuthError).mockReturnValue(true);
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthError(401));
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'DELETE',
+        body: JSON.stringify({ provider: 'openrouter' }),
+      });
+
+      const response = await DELETE(request);
+      expect(response.status).toBe(401);
+    });
+
+    it('should reject invalid provider', async () => {
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'DELETE',
+        body: JSON.stringify({ provider: 'invalid' }),
+      });
+
+      const response = await DELETE(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toContain('Invalid provider');
+    });
+
+    it('should delete OpenRouter settings successfully', async () => {
+      vi.mocked(deleteOpenRouterSettings).mockResolvedValue(undefined);
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'DELETE',
+        body: JSON.stringify({ provider: 'openrouter' }),
+      });
+
+      const response = await DELETE(request);
+      expect(response.status).toBe(204);
+      expect(deleteOpenRouterSettings).toHaveBeenCalledWith(mockUserId);
+    });
+
+    it('should delete Google settings successfully', async () => {
+      vi.mocked(deleteGoogleSettings).mockResolvedValue(undefined);
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'DELETE',
+        body: JSON.stringify({ provider: 'google' }),
+      });
+
+      const response = await DELETE(request);
+      expect(response.status).toBe(204);
+      expect(deleteGoogleSettings).toHaveBeenCalledWith(mockUserId);
+    });
+
+    it('should delete OpenAI settings successfully', async () => {
+      vi.mocked(deleteOpenAISettings).mockResolvedValue(undefined);
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'DELETE',
+        body: JSON.stringify({ provider: 'openai' }),
+      });
+
+      const response = await DELETE(request);
+      expect(response.status).toBe(204);
+      expect(deleteOpenAISettings).toHaveBeenCalledWith(mockUserId);
+    });
+
+    it('should delete Anthropic settings successfully', async () => {
+      vi.mocked(deleteAnthropicSettings).mockResolvedValue(undefined);
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'DELETE',
+        body: JSON.stringify({ provider: 'anthropic' }),
+      });
+
+      const response = await DELETE(request);
+      expect(response.status).toBe(204);
+      expect(deleteAnthropicSettings).toHaveBeenCalledWith(mockUserId);
+    });
+
+    it('should delete xAI settings successfully', async () => {
+      vi.mocked(deleteXAISettings).mockResolvedValue(undefined);
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'DELETE',
+        body: JSON.stringify({ provider: 'xai' }),
+      });
+
+      const response = await DELETE(request);
+      expect(response.status).toBe(204);
+      expect(deleteXAISettings).toHaveBeenCalledWith(mockUserId);
+    });
+
+    it('should delete Ollama settings successfully', async () => {
+      vi.mocked(deleteOllamaSettings).mockResolvedValue(undefined);
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'DELETE',
+        body: JSON.stringify({ provider: 'ollama' }),
+      });
+
+      const response = await DELETE(request);
+      expect(response.status).toBe(204);
+      expect(deleteOllamaSettings).toHaveBeenCalledWith(mockUserId);
+    });
+
+    it('should delete LM Studio settings successfully', async () => {
+      vi.mocked(deleteLMStudioSettings).mockResolvedValue(undefined);
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'DELETE',
+        body: JSON.stringify({ provider: 'lmstudio' }),
+      });
+
+      const response = await DELETE(request);
+      expect(response.status).toBe(204);
+      expect(deleteLMStudioSettings).toHaveBeenCalledWith(mockUserId);
+    });
+
+    it('should delete GLM settings successfully', async () => {
+      vi.mocked(deleteGLMSettings).mockResolvedValue(undefined);
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'DELETE',
+        body: JSON.stringify({ provider: 'glm' }),
+      });
+
+      const response = await DELETE(request);
+      expect(response.status).toBe(204);
+      expect(deleteGLMSettings).toHaveBeenCalledWith(mockUserId);
+    });
+
+    it('should delete MiniMax settings successfully', async () => {
+      vi.mocked(deleteMiniMaxSettings).mockResolvedValue(undefined);
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'DELETE',
+        body: JSON.stringify({ provider: 'minimax' }),
+      });
+
+      const response = await DELETE(request);
+      expect(response.status).toBe(204);
+      expect(deleteMiniMaxSettings).toHaveBeenCalledWith(mockUserId);
+    });
+
+    it('should handle delete errors gracefully', async () => {
+      vi.mocked(deleteOpenRouterSettings).mockRejectedValue(new Error('Delete failed'));
+
+      const request = new Request('https://example.com/api/ai/settings', {
+        method: 'DELETE',
+        body: JSON.stringify({ provider: 'openrouter' }),
+      });
+
+      const response = await DELETE(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(body.error).toContain('Failed to delete');
+      expect(loggers.ai.error).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Add 208 tests across 14 test files covering:
- AI settings routes (GET/POST/PATCH/DELETE)
- Ollama models discovery route
- LM Studio models discovery route
- Chat messages routes (list, edit, delete)
- Global conversations routes (list, create, get, update, delete)
- Global conversation messages routes (edit, delete)
- Global conversation usage statistics route
- Page agents create route
- Page agents config route
- Page agents conversations routes (list, create, update, delete)

All tests follow the established patterns:
- Comprehensive mocking of database, auth, and permissions
- Testing authentication, authorization, validation, happy paths, and error handling
- Proper async params handling for Next.js 15