### PR TITLE
refactor(tests): align test files with unit testing rubric

### DIFF
--- a/apps/web/src/lib/ai/tools/__tests__/drive-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/drive-tools.test.ts
@@ -1,31 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Mock database and dependencies
+// Mock database - only mock what's actually used in tests
 vi.mock('@pagespace/db', () => ({
   db: {
-    select: vi.fn().mockReturnThis(),
-    from: vi.fn().mockReturnThis(),
-    where: vi.fn(),
-    insert: vi.fn().mockReturnThis(),
-    values: vi.fn().mockReturnThis(),
-    returning: vi.fn(),
-    update: vi.fn().mockReturnThis(),
-    set: vi.fn().mockReturnThis(),
     query: {
       drives: { findFirst: vi.fn() },
-      driveMembers: { findFirst: vi.fn() },
     },
   },
   drives: { id: 'id', ownerId: 'ownerId' },
-  driveMembers: { driveId: 'driveId' },
   eq: vi.fn(),
   and: vi.fn(),
-  or: vi.fn(),
-  isNull: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/server', () => ({
-  getUserDriveAccess: vi.fn(),
   loggers: {
     ai: {
       child: vi.fn(() => ({
@@ -53,6 +40,17 @@ import type { ToolExecutionContext } from '../../core';
 
 const mockDb = vi.mocked(db);
 
+/**
+ * @scaffold - happy path coverage deferred
+ *
+ * These tests cover authentication and validation error paths.
+ * Happy path tests (list_drives returning data, create_drive success, etc.)
+ * are deferred because they require either:
+ * - A repository seam to avoid query-builder chain mocking, OR
+ * - Integration tests against a real database
+ *
+ * TODO: Add DriveRepository seam and test happy paths against it.
+ */
 describe('drive-tools', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -72,7 +70,6 @@ describe('drive-tools', () => {
         driveTools.list_drives.execute({}, context)
       ).rejects.toThrow('User authentication required');
     });
-
   });
 
   describe('create_drive', () => {

--- a/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
@@ -178,10 +178,11 @@ describe('page-write-tools', () => {
         context
       );
 
+      // Observable outcomes prove the operation succeeded
       expect(result.success).toBe(true);
       expect(result.linesReplaced).toBe(1);
+      // Verify permission check was called with correct arguments
       expect(mockCanUserEditPage).toHaveBeenCalledWith('user-123', 'page-1');
-      expect(mockDb.update).toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/lib/ai/tools/__tests__/search-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/search-tools.test.ts
@@ -1,29 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Mock database and dependencies
-vi.mock('@pagespace/db', () => ({
-  db: {
-    select: vi.fn().mockReturnThis(),
-    selectDistinct: vi.fn().mockReturnThis(),
-    from: vi.fn().mockReturnThis(),
-    where: vi.fn(),
-    limit: vi.fn(),
-    query: {
-      pages: { findFirst: vi.fn() },
-      drives: { findFirst: vi.fn() },
-    },
-  },
-  pages: { id: 'id', driveId: 'driveId', content: 'content', title: 'title' },
-  drives: { id: 'id', isTrashed: 'isTrashed' },
-  eq: vi.fn(),
-  and: vi.fn(),
-  sql: vi.fn(),
-  inArray: vi.fn(),
-}));
-
+// Mock only the boundary we actually test
 vi.mock('@pagespace/lib/server', () => ({
   getUserDriveAccess: vi.fn(),
-  getUserAccessiblePagesInDriveWithDetails: vi.fn(),
 }));
 
 import { searchTools } from '../search-tools';
@@ -32,6 +11,23 @@ import type { ToolExecutionContext } from '../../core';
 
 const mockGetUserDriveAccess = vi.mocked(getUserDriveAccess);
 
+/**
+ * @scaffold - happy path coverage deferred
+ *
+ * These tests cover authentication and authorization error paths.
+ * Happy path tests (actual search results, filtering, pagination) are deferred
+ * because they require either:
+ * - A SearchRepository seam to avoid complex DB iteration mocking, OR
+ * - Integration tests against a real database with seeded content
+ *
+ * The search logic involves iterating over pages and matching patterns,
+ * which is impractical to mock without coupling to implementation details.
+ *
+ * TODO: Add SearchService seam with methods like:
+ * - searchByRegex(driveId, pattern, options): SearchResult[]
+ * - searchByGlob(driveId, pattern, options): SearchResult[]
+ * Then test happy paths against that seam.
+ */
 describe('search-tools', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -70,7 +66,6 @@ describe('search-tools', () => {
         )
       ).rejects.toThrow("You don't have access to this drive");
     });
-
   });
 
   describe('glob_search', () => {
@@ -104,7 +99,6 @@ describe('search-tools', () => {
         )
       ).rejects.toThrow("You don't have access to this drive");
     });
-
   });
 
   describe('multi_drive_search', () => {

--- a/apps/web/src/lib/mcp/__tests__/mcp-bridge.test.ts
+++ b/apps/web/src/lib/mcp/__tests__/mcp-bridge.test.ts
@@ -92,8 +92,7 @@ describe('MCPBridge', () => {
       // Start the request but don't await it yet
       const promise = bridge.executeTool('user-123', 'my-server', 'my-tool', { foo: 'bar' });
 
-      // Verify send was called
-      expect(mockWs.send).toHaveBeenCalledTimes(1);
+      // Verify send was called with correct payload
       const sentData = JSON.parse((mockWs.send as ReturnType<typeof vi.fn>).mock.calls[0][0]);
       expect(sentData.type).toBe('tool_execute');
       expect(sentData.serverName).toBe('my-server');


### PR DESCRIPTION
- ai-tools.test.ts: Add @scaffold label, replace brittle key counting with spread-equality assertion, add collision detection test
- page-write-tools.test.ts: Remove weak "only called" assertion, rely on observable outcomes (result.success, result.linesReplaced)
- mcp-bridge.test.ts: Remove call count assertion, keep payload assertions
- drive-tools.test.ts: Remove unused chain mocks, add @scaffold note with TODO for DriveRepository seam
- search-tools.test.ts: Remove unused chain mocks, add @scaffold note with TODO for SearchService seam

These changes follow the unit testing rubric principles:
- Test observable outcomes, not internal mechanics
- Mock only at boundary seams
- Label scaffold/aggregation tests appropriately
- Document deferred happy path coverage with seam proposals