### PR TITLE
docker: speed up builds with pnpm cache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,15 +1,31 @@
 # Dependencies
 node_modules/
+node_modules
+**/node_modules/
+**/node_modules
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
+.pnpm-store/
+**/.pnpm-store
+**/.pnpm-store/
 
 # Build outputs
 .next/
+**/.next/
 out/
 build/
 dist/
+**/out/
+**/build/
+**/dist/
+.turbo/
+**/.turbo/
+
+# Internal package builds are needed by some Docker builds (e.g. Next.js subpath exports)
+!packages/**/dist/
+!packages/**/dist/**
 
 # Environment files
 .env.local
@@ -94,6 +110,10 @@ pids/
 
 # Documentation (not needed in container)
 docs/
+
+# Non-server apps (not needed for these images)
+apps/desktop/
+apps/ios/
 
 # Docker files themselves
 Dockerfile*

--- a/apps/processor/Dockerfile
+++ b/apps/processor/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.6
 FROM node:22.17.0-alpine AS base
 
 # Install system dependencies for Sharp and Tesseract
@@ -17,24 +18,27 @@ RUN apk add --no-cache \
 # Set working directory
 WORKDIR /app
 
-# Install pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
+# Enable corepack and pin pnpm (with basic retry for transient network issues)
+RUN corepack enable && (corepack prepare pnpm@10.13.1 --activate || corepack prepare pnpm@10.13.1 --activate || corepack prepare pnpm@10.13.1 --activate)
 
-# Copy workspace configuration files
-COPY pnpm-workspace.yaml package.json pnpm-lock.yaml tsconfig.json ./
-COPY packages ./packages
+# Copy only manifests for dependency install caching
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY packages/db/package.json ./packages/db/
+COPY packages/lib/package.json ./packages/lib/
 COPY apps/processor/package.json ./apps/processor/
 
 # Install all dependencies
 # Install dependencies (allow lockfile update since processor deps changed)
-RUN pnpm install --no-frozen-lockfile --prod=false
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store pnpm config set store-dir /pnpm/store && pnpm install --no-frozen-lockfile --prod=false
+
+# Now copy source code AFTER dependencies are installed
+COPY tsconfig.json ./
+COPY packages ./packages
+COPY apps/processor ./apps/processor
 
 # Build shared workspaces before compiling the processor
 RUN pnpm --filter @pagespace/db build \
   && pnpm --filter @pagespace/lib build
-
-# Copy processor source code
-COPY apps/processor ./apps/processor
 
 # Build the processor service
 WORKDIR /app/apps/processor
@@ -55,9 +59,6 @@ RUN apk add --no-cache \
     freetype
 
 WORKDIR /app
-
-# Install pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
 
 # Copy built application
 COPY --from=base /app/node_modules ./node_modules

--- a/apps/realtime/Dockerfile
+++ b/apps/realtime/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.6
 # This Dockerfile runs the realtime service.
 # It uses the same pattern as the working migrate container.
 FROM node:22.17.0-alpine
@@ -13,7 +14,7 @@ RUN apk add --no-cache git && \
 
 # Enable corepack and prepare specific pnpm version
 RUN corepack enable && \
-    corepack prepare pnpm@10.13.1 --activate
+    (corepack prepare pnpm@10.13.1 --activate || corepack prepare pnpm@10.13.1 --activate || corepack prepare pnpm@10.13.1 --activate)
 
 # Copy package files first for better Docker layer caching
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
@@ -23,7 +24,7 @@ COPY apps/web/package.json ./apps/web/
 COPY apps/realtime/package.json ./apps/realtime/
 
 # Install ALL dependencies for the entire monorepo
-RUN pnpm install --frozen-lockfile --prod=false
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store pnpm config set store-dir /pnpm/store && pnpm install --frozen-lockfile --prod=false
 
 # Copy only the source code needed (avoid copying node_modules)
 COPY packages ./packages

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,9 +1,10 @@
-# Install dependencies only when needed  
+# syntax=docker/dockerfile:1.6
+# Install dependencies only when needed
 FROM node:22.17.0-alpine AS deps
 WORKDIR /app
 
-# Enable corepack for pnpm
-RUN corepack enable
+# Enable corepack and pin pnpm (with basic retry for transient network issues)
+RUN corepack enable && (corepack prepare pnpm@10.13.1 --activate || corepack prepare pnpm@10.13.1 --activate || corepack prepare pnpm@10.13.1 --activate)
 
 # Copy only package files for dependency installation
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
@@ -13,7 +14,7 @@ COPY apps/web/package.json ./apps/web/
 COPY apps/realtime/package.json ./apps/realtime/
 
 # Install ALL dependencies for the entire monorepo
-RUN pnpm install --frozen-lockfile
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store pnpm config set store-dir /pnpm/store && pnpm install --frozen-lockfile
 
 # Now copy source code AFTER dependencies are installed
 COPY packages ./packages
@@ -23,7 +24,7 @@ COPY tsconfig.json ./
 # Rebuild the source code only when needed
 FROM node:22.17.0-alpine AS builder
 WORKDIR /app
-RUN corepack enable && corepack prepare pnpm@10.13.1 --activate
+RUN corepack enable && (corepack prepare pnpm@10.13.1 --activate || corepack prepare pnpm@10.13.1 --activate || corepack prepare pnpm@10.13.1 --activate)
 
 # Copy the installed dependencies and the entire source code
 COPY --from=deps /app .

--- a/apps/web/Dockerfile.migrate
+++ b/apps/web/Dockerfile.migrate
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.6
 # This Dockerfile is for running database migrations.
 # It includes all dev dependencies needed for the migration script.
 FROM node:22.17.0-alpine
@@ -13,7 +14,7 @@ RUN apk add --no-cache git && \
 
 # Enable corepack and prepare specific pnpm version
 RUN corepack enable && \
-    corepack prepare pnpm@10.13.1 --activate
+    (corepack prepare pnpm@10.13.1 --activate || corepack prepare pnpm@10.13.1 --activate || corepack prepare pnpm@10.13.1 --activate)
 
 # Copy package files first for better Docker layer caching
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
@@ -23,7 +24,7 @@ COPY apps/web/package.json ./apps/web/
 COPY apps/realtime/package.json ./apps/realtime/
 
 # Install ALL dependencies for the entire monorepo
-RUN pnpm install --frozen-lockfile
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store pnpm config set store-dir /pnpm/store && pnpm install --frozen-lockfile
 
 # Copy only the source code needed (avoid copying node_modules)
 COPY packages ./packages

--- a/docs/docker-build-notes.md
+++ b/docs/docker-build-notes.md
@@ -1,0 +1,36 @@
+# Docker Build Caching Notes (pnpm + Turbo Monorepo)
+
+## Quick inventory (before changes)
+
+- `apps/web/Dockerfile`: multi-stage (`deps` → `builder` → `runner`); `deps` ran `pnpm install` without a persistent pnpm store cache mount.
+- `apps/web/Dockerfile.migrate`: single-stage; ran `pnpm install` without a persistent pnpm store cache mount.
+- `apps/realtime/Dockerfile`: single-stage; ran `pnpm install` without a persistent pnpm store cache mount.
+- `apps/processor/Dockerfile`: multi-stage; copied `packages/` source **before** `pnpm install` (frequent cache invalidation) and used `pnpm@latest` via Corepack.
+
+`docker-compose.yml` builds these images from the repo root context (`context: .`).
+
+## What changed
+
+- Added BuildKit syntax to Dockerfiles using cache mounts: `# syntax=docker/dockerfile:1.6`.
+- Pinned pnpm consistently via Corepack (`pnpm@10.13.1`) and removed any `pnpm@latest` usage.
+- Every `pnpm install` now uses a persistent BuildKit cache mount for the pnpm store and sets `store-dir` to `/pnpm/store`:
+  - `--mount=type=cache,id=pnpm-store,target=/pnpm/store`
+- Reordered the processor Dockerfile so only manifest files are copied before dependency install; full source is copied **after** the install layer.
+- Updated root `.dockerignore` to reduce context churn (`**/node_modules`, `**/.next`, `**/dist`, `.pnpm-store`, `.turbo`, etc.).
+
+## Why caching now persists
+
+- The pnpm content-addressable store is cached outside the image build using BuildKit cache mounts, so re-running installs reuses already-downloaded packages.
+- Dependency installation layers are now based only on monorepo manifest files (lockfile + relevant `package.json` files), so normal source edits do not invalidate the install layer.
+
+## What invalidates the dependency install layer
+
+For each image, the `pnpm install` layer invalidates only when these copied inputs change:
+
+- Root: `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`
+- Workspace manifests copied in that Dockerfile (e.g. `apps/web/package.json`, `packages/db/package.json`, etc.)
+
+## Remaining unavoidable cache invalidators (expected)
+
+- Base image changes (e.g. `node:22.17.0-alpine` updates) or `apk add` lines changing will invalidate those layers.
+- Any change to the files explicitly `COPY`'d before build steps (source code, configs) will re-run build layers (but should not re-run dependency install unless manifests changed).


### PR DESCRIPTION
## Summary\n- Add BuildKit cache mounts for pnpm store in all Dockerfiles that run \Scope: all 7 workspace projects
Lockfile is up to date, resolution step is skipped
Already up to date

apps/web prepare$ next-ws patch
apps/web prepare: [next-ws] Patching Next.js v15.3.6 with '>=15.0.0 <=15.5.6'
apps/web prepare: [?25l[1G[next-ws] ⠋ Add WebSocket server setup script to NextNodeServer constructor[1G[2K[next-ws] ✔ Add WebSocket server setup script to NextNodeServer constructor
apps/web prepare: [?25h[?25l[1G[2K[next-ws] ✔ Prevent Next.js from immediately closing WebSocket connections
apps/web prepare: [?25h[?25l[1G[2K[next-ws] ✔ Add UPGRADE as allowed export from route modules
apps/web prepare: [?25h[?25l[1G[2K[next-ws] ✔ Add WebSocket contextual headers resolution to request headers
apps/web prepare: [?25h[?25l[1G[2K[next-ws] ✔ Add WebSocket contextual cookies resolution to request cookies
apps/web prepare: [?25h[next-ws] Saving patch trace file...
apps/web prepare: [next-ws] All done!
apps/web prepare: Done
Done in 1.7s using pnpm v10.13.1 (`id=pnpm-store`, `target=/pnpm/store`) and set `store-dir` to `/pnpm/store`.\n- Pin pnpm consistently via Corepack (`pnpm@10.13.1`) and remove `pnpm@latest`.\n- Reorder install steps so deps layers only depend on monorepo manifests (lockfile/workspace/package.json files), not source.\n- Fix `apps/processor/Dockerfile` to avoid copying `packages/` (or other source) before dependency install.\n- Update root `.dockerignore` to reduce context churn (ignore non-server apps, node_modules, .next, dist, .turbo, etc.) while keeping required `packages/**/dist` for Next.js builds.\n\n## Why rebuilds are faster\n- pnpm downloads are reused via BuildKit cache mount at `/pnpm/store` across rebuilds.\n- Dependency install layers are only invalidated by manifest changes, so normal source edits do not re-run installs.\n\n## Dependency layer invalidators\n- `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`\n- Workspace manifests copied in deps stages: `apps/web/package.json`, `apps/realtime/package.json`, `apps/processor/package.json`, `packages/db/package.json`, `packages/lib/package.json`\n\n## Notes\n- Build/run commands and docker-compose compatibility are unchanged.