### PR TITLE
refactor(ai): migrate AI UI to shadcn and improve message rendering

### DIFF
--- a/apps/web/src/components/ai/shared/chat/ChatMessagesArea.tsx
+++ b/apps/web/src/components/ai/shared/chat/ChatMessagesArea.tsx
@@ -17,8 +17,6 @@ interface ChatMessagesAreaProps {
   isLoading: boolean;
   /** Whether the AI is currently streaming a response */
   isStreaming: boolean;
-  /** Name to show in streaming indicator */
-  assistantName?: string;
   /** Empty state message */
   emptyMessage?: string;
   /** Edit message handler */
@@ -49,7 +47,6 @@ export const ChatMessagesArea = forwardRef<ChatMessagesAreaRef, ChatMessagesArea
       messages,
       isLoading,
       isStreaming,
-      assistantName = 'Assistant',
       emptyMessage = 'Start a conversation with the AI assistant',
       onEdit,
       onDelete,
@@ -134,7 +131,7 @@ export const ChatMessagesArea = forwardRef<ChatMessagesAreaRef, ChatMessagesArea
               )}
 
               {isStreaming && !isLoading && (
-                <StreamingIndicator assistantName={assistantName} />
+                <StreamingIndicator />
               )}
 
               {/* Invisible element to mark the bottom for scrolling */}

--- a/apps/web/src/components/ai/shared/chat/CompactMessageRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/CompactMessageRenderer.tsx
@@ -95,28 +95,39 @@ const CompactTextBlock: React.FC<CompactTextBlockProps> = React.memo(({
 
   return (
     <div
-      className={`group relative p-2 rounded-md text-xs ${role === 'user'
-          ? 'bg-primary/10 dark:bg-accent/20 ml-2'
-          : 'bg-gray-50 dark:bg-gray-800/50'
+      className={`group relative text-xs mb-1 ${role === 'user'
+          ? 'p-2 rounded-md bg-primary/10 dark:bg-accent/20 ml-2'
+          : ''
         }`}
     >
-      <div className="flex items-center justify-between mb-0.5">
-        <div className={`text-xs font-medium ${role === 'user' ? 'text-primary dark:text-primary' : 'text-gray-700 dark:text-gray-300'
-          }`}>
-          {role === 'user' ? 'You' : 'AI'}
-          {editedAt && !isEditing && (
-            <span className="ml-1 text-[10px] text-muted-foreground">(edited)</span>
+      {role === 'user' && (
+        <div className="flex items-center justify-between mb-0.5">
+          <div className="text-xs font-medium text-primary dark:text-primary">
+            You
+            {editedAt && !isEditing && (
+              <span className="ml-1 text-[10px] text-muted-foreground">(edited)</span>
+            )}
+          </div>
+          {onEdit && onDelete && !isEditing && (
+            <MessageActionButtons
+              onEdit={onEdit}
+              onDelete={onDelete}
+              onRetry={onRetry}
+              compact
+            />
           )}
         </div>
-        {onEdit && onDelete && !isEditing && (
+      )}
+      {role !== 'user' && onEdit && onDelete && !isEditing && (
+        <div className="flex justify-end mb-0.5">
           <MessageActionButtons
             onEdit={onEdit}
             onDelete={onDelete}
             onRetry={onRetry}
             compact
           />
-        )}
-      </div>
+        </div>
+      )}
 
       {isEditing && onSaveEdit && onCancelEdit ? (
         <div className="text-xs">

--- a/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
@@ -94,27 +94,37 @@ const TextBlock: React.FC<TextBlockProps> = React.memo(({
 
   return (
     <div
-      className={`group relative p-3 rounded-lg mb-2 ${role === 'user'
-        ? 'bg-primary/10 dark:bg-accent/20 ml-2 sm:ml-8'
-        : 'bg-gray-50 dark:bg-gray-800/50 mr-2 sm:mr-8'
+      className={`group relative mb-2 ${role === 'user'
+        ? 'p-3 rounded-lg bg-primary/10 dark:bg-accent/20 ml-2 sm:ml-8'
+        : 'mr-2 sm:mr-8'
         }`}
     >
-      <div className="flex items-center justify-between mb-1">
-        <div className={`text-sm font-medium ${role === 'user' ? 'text-primary dark:text-primary' : 'text-gray-700 dark:text-gray-300'
-          }`}>
-          {role === 'user' ? 'You' : 'Assistant'}
-          {editedAt && !isEditing && (
-            <span className="ml-2 text-xs text-muted-foreground">(edited)</span>
+      {role === 'user' && (
+        <div className="flex items-center justify-between mb-1">
+          <div className="text-sm font-medium text-primary dark:text-primary">
+            You
+            {editedAt && !isEditing && (
+              <span className="ml-2 text-xs text-muted-foreground">(edited)</span>
+            )}
+          </div>
+          {onEdit && onDelete && !isEditing && (
+            <MessageActionButtons
+              onEdit={onEdit}
+              onDelete={onDelete}
+              onRetry={onRetry}
+            />
           )}
         </div>
-        {onEdit && onDelete && !isEditing && (
+      )}
+      {role !== 'user' && onEdit && onDelete && !isEditing && (
+        <div className="flex justify-end mb-1">
           <MessageActionButtons
             onEdit={onEdit}
             onDelete={onDelete}
             onRetry={onRetry}
           />
-        )}
-      </div>
+        </div>
+      )}
 
       {isEditing && onSaveEdit && onCancelEdit ? (
         <MessageEditor

--- a/apps/web/src/components/ai/shared/chat/StreamingIndicator.tsx
+++ b/apps/web/src/components/ai/shared/chat/StreamingIndicator.tsx
@@ -7,8 +7,6 @@ import React from 'react';
 import { Loader2 } from 'lucide-react';
 
 interface StreamingIndicatorProps {
-  /** Name of the assistant (e.g., "Assistant", "Global Assistant", agent name) */
-  assistantName?: string;
   /** Custom message to show instead of "Thinking..." */
   message?: string;
   /** Optional className for styling */
@@ -19,18 +17,14 @@ interface StreamingIndicatorProps {
  * Streaming indicator shown while AI is generating a response
  */
 export const StreamingIndicator: React.FC<StreamingIndicatorProps> = ({
-  assistantName = 'Assistant',
   message = 'Thinking...',
   className,
 }) => {
   return (
     <div
-      className={`mb-4 p-3 rounded-lg bg-gray-50 dark:bg-gray-800/50 mr-8 ${className || ''}`}
+      className={`mb-4 mr-8 ${className || ''}`}
       style={{ contain: 'layout style paint' }}
     >
-      <div className="text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">
-        {assistantName}
-      </div>
       <div className="flex items-center space-x-2 text-gray-500">
         <Loader2 className="h-4 w-4 animate-spin" style={{ willChange: 'transform' }} />
         <span>{message}</span>

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -397,7 +397,6 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
             messages={messages}
             isLoading={isLoading}
             isStreaming={isStreaming}
-            assistantName="Assistant"
             emptyMessage="Start a conversation with the AI assistant"
             onEdit={!isReadOnly ? handleEdit : undefined}
             onDelete={!isReadOnly ? handleDelete : undefined}

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -529,7 +529,6 @@ const GlobalAssistantView: React.FC = () => {
         messages={messages}
         isLoading={isLoading}
         isStreaming={isStreaming}
-        assistantName={selectedAgent ? selectedAgent.title : 'Global Assistant'}
         emptyMessage={
           selectedAgent
             ? `Start a conversation with ${selectedAgent.title}`

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -600,10 +600,7 @@ const SidebarChatTab: React.FC = () => {
             )}
 
             {displayIsStreaming && (
-              <div className="p-2 rounded-lg bg-gray-50 dark:bg-gray-800/50">
-                <div className="text-xs font-medium mb-1 text-gray-700 dark:text-gray-300">
-                  {assistantName}
-                </div>
+              <div className="mb-1">
                 <div className="flex items-center space-x-2 text-gray-500 text-xs">
                   <Loader2 className="h-3 w-3 animate-spin" />
                   <span>Thinking...</span>


### PR DESCRIPTION
## Summary
- Migrated AI components to use shadcn/ui primitives
- Restructured AI components into functional groups (ui, chat, tools)
- Improved tool call rendering with inline/borderless design
- Added task dropdowns to AI chat headers with expandable editing
- Removed bubble styling from assistant messages for cleaner inline look
- Various bug fixes for task management, code blocks, and accessibility

## Changes
- **Component restructure**: Consolidated message rendering into `shared/chat/`
- **Tool calls**: Made tool calls inline/borderless, added task dropdowns
- **Message styling**: Removed assistant message bubbles, kept user bubbles
- **Task management**: Added per-field loading, optimistic updates, status toggles
- **Code blocks**: Improved language inference, error handling, accessibility

## Test plan
- [x] Verify AI chat displays correctly in sidebar, page AI, and global assistant
- [x] Verify user messages still have bubble styling
- [x] Verify assistant messages are inline without bubbles
- [x] Verify tool calls render correctly
- [x] Verify task dropdowns work with editing and navigation
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized chat message header structure with separate layouts for user and assistant messages
  * Repositioned edit and delete action buttons to dedicated right-aligned areas for improved clarity

* **Style**
  * Removed assistant name labels from chat messages and streaming indicators across the interface
  * Simplified visual styling including message backgrounds, container padding, and indicator spacing

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->