### PR TITLE
Fix scrollbar spacing in AI chat components

### DIFF
--- a/apps/web/src/components/ai/shared/chat/ChatMessagesArea.tsx
+++ b/apps/web/src/components/ai/shared/chat/ChatMessagesArea.tsx
@@ -107,10 +107,10 @@ export const ChatMessagesArea = forwardRef<ChatMessagesAreaRef, ChatMessagesArea
     );
 
     return (
-      <div className="flex-1 min-h-0 overflow-hidden px-4">
+      <div className="flex-1 min-h-0 overflow-hidden">
         <ScrollArea className="h-full" ref={scrollAreaRef}>
-          <div className="max-w-4xl mx-auto w-full">
-            <div className="space-y-2 pr-1 sm:pr-4 pt-3 pb-34">
+          <div className="max-w-4xl mx-auto w-full px-4">
+            <div className="space-y-2 pt-3 pb-34">
               {isLoading ? (
                 <LoadingSkeleton />
               ) : messages.length === 0 ? (


### PR DESCRIPTION
Move horizontal padding from the ScrollArea wrapper to the content
container inside, so the scrollbar is flush with the right edge
instead of being inset with spacing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined horizontal spacing in the chat interface to improve content alignment and visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->