### PR TITLE
Fix middle section headers stuck loading

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,10 +142,15 @@ useEffect(() => {
   return () => useEditingStore.getState().endStreaming(id);
 }, [status, id]);
 
-// For SWR protection:
-const isAnyActive = useEditingStore(state => state.isAnyActive());
+// For SWR protection (CRITICAL: must allow initial fetch):
+import { useRef } from 'react';
+import { isEditingActive } from '@/stores/useEditingStore';
+
+const hasLoadedRef = useRef(false);
 useSWR(key, fetcher, {
-  isPaused: () => isAnyActive,
+  // Only pause AFTER initial load - never block the first fetch
+  isPaused: () => hasLoadedRef.current && isEditingActive(),
+  onSuccess: () => { hasLoadedRef.current = true; },
   refreshInterval: 300000, // 5 minutes
   revalidateOnFocus: false,
 });


### PR DESCRIPTION
The isPaused option in SWR blocks ALL fetching including the initial fetch. This caused section headers to be stuck in perpetual loading skeleton state when any editing session was active during mount.

Changes:
- Add hasLoadedRef to useBreadcrumbs, usePageTree, useConversations
- Only pause revalidation AFTER initial data has loaded successfully
- Update documentation with correct isPaused pattern in CLAUDE.md
- Update ui-refresh-protection.md with detailed pattern explanation

The fix ensures initial data always loads, while still preventing unnecessary revalidation during active editing/streaming sessions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data loading behavior to allow initial data fetches while preventing unintended refreshes during active editing sessions.

* **Documentation**
  * Updated guidance on polling protection patterns to reflect improved data loading behavior that supports initial loads while protecting against UI refresh issues during editing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->