### PR TITLE
Fix activity button positioning in header

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -524,20 +524,20 @@ const GlobalAssistantView: React.FC = () => {
           <Button
             variant="ghost"
             size="icon"
-            onClick={handleOpenActivity}
-            className="h-8 w-8"
-            title="Open Activity"
-          >
-            <Activity className="h-4 w-4" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
             onClick={handleOpenHistory}
             className="h-8 w-8"
             title="View History"
           >
             <History className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleOpenActivity}
+            className="h-8 w-8"
+            title="Open Activity"
+          >
+            <Activity className="h-4 w-4" />
           </Button>
           <Button
             variant="outline"


### PR DESCRIPTION
The History and Activity buttons in the content header were in opposite order compared to their corresponding tabs in the right sidebar. This aligns the button order (History, Activity) with the tab order for visual consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Interface Updates**
  * Reordered the History and Activity view buttons in the dashboard assistant for improved navigation flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->