### PR TITLE
fix: show AI chat action buttons after streaming completes

### DIFF
--- a/apps/web/src/components/ai/shared/chat/CompactMessageRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/CompactMessageRenderer.tsx
@@ -82,23 +82,26 @@ const CompactTextBlock: React.FC<CompactTextBlockProps> = React.memo(({
           <div className={`text-gray-900 dark:text-gray-100 prose prose-xs dark:prose-invert max-w-full overflow-hidden ${styles.compactProseContent}`}>
             <StreamingMarkdown content={content} id={`${messageId}-text`} isStreaming={isStreaming} />
           </div>
-          {createdAt && (
-            <div className="flex items-center justify-between mt-1">
-              <div className="text-[10px] text-gray-500">
-                {new Date(createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-                {editedAt && <span className="ml-1">(edited)</span>}
-              </div>
-              {onEdit && onDelete && !isEditing && (
-                <MessageActionButtons
-                  onEdit={onEdit}
-                  onDelete={onDelete}
-                  onRetry={onRetry}
-                  onUndoFromHere={onUndoFromHere}
-                  compact
-                />
+          {/* Always show footer with buttons; timestamp only when createdAt exists */}
+          <div className="flex items-center justify-between mt-1">
+            <div className="text-[10px] text-gray-500">
+              {createdAt && (
+                <>
+                  {new Date(createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                  {editedAt && <span className="ml-1">(edited)</span>}
+                </>
               )}
             </div>
-          )}
+            {onEdit && onDelete && !isEditing && (
+              <MessageActionButtons
+                onEdit={onEdit}
+                onDelete={onDelete}
+                onRetry={onRetry}
+                onUndoFromHere={onUndoFromHere}
+                compact
+              />
+            )}
+          </div>
         </>
       )}
     </div>

--- a/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
@@ -80,22 +80,25 @@ const TextBlock: React.FC<TextBlockProps> = React.memo(({
               <StreamingMarkdown content={content} id={`${messageId}-text`} isStreaming={isStreaming} />
             </div>
           </div>
-          {createdAt && (
-            <div className="flex items-center justify-between mt-2">
-              <div className="text-xs text-gray-500">
-                {new Date(createdAt).toLocaleTimeString()}
-                {editedAt && <span className="ml-2">(edited)</span>}
-              </div>
-              {onEdit && onDelete && !isEditing && (
-                <MessageActionButtons
-                  onEdit={onEdit}
-                  onDelete={onDelete}
-                  onRetry={onRetry}
-                  onUndoFromHere={onUndoFromHere}
-                />
+          {/* Always show footer with buttons; timestamp only when createdAt exists */}
+          <div className="flex items-center justify-between mt-2">
+            <div className="text-xs text-gray-500">
+              {createdAt && (
+                <>
+                  {new Date(createdAt).toLocaleTimeString()}
+                  {editedAt && <span className="ml-2">(edited)</span>}
+                </>
               )}
             </div>
-          )}
+            {onEdit && onDelete && !isEditing && (
+              <MessageActionButtons
+                onEdit={onEdit}
+                onDelete={onDelete}
+                onRetry={onRetry}
+                onUndoFromHere={onUndoFromHere}
+              />
+            )}
+          </div>
         </>
       )}
     </div>


### PR DESCRIPTION
The message action buttons (edit, delete, retry, undo) were not visible after AI streaming finished because they were wrapped inside a `{createdAt && ...}` conditional. During streaming, the AI SDK's useChat hook creates messages without a createdAt timestamp (only populated when saved to DB), causing the entire footer with buttons to not render.

Fixed by separating the button rendering from the timestamp condition:
- Buttons now always render when handlers are provided
- Timestamp only shows when createdAt exists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced message footer rendering in chat components. Footer sections now render with improved conditional logic. Timestamps and edit indicators display when available, while Edit/Delete action buttons appear based on editing state and handler availability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->