### PR TITLE
fix: ignore internal conflicts when undoing AI tool chains

### DIFF
--- a/apps/web/src/services/api/rollback-service.ts
+++ b/apps/web/src/services/api/rollback-service.ts
@@ -1452,9 +1452,9 @@ export async function executeRollback(
   activityId: string,
   userId: string,
   context: RollbackContext,
-  options?: { tx?: typeof db; force?: boolean }
+  options?: { tx?: typeof db; force?: boolean; undoGroupActivityIds?: string[] }
 ): Promise<RollbackResult> {
-  const { tx, force } = options ?? {};
+  const { tx, force, undoGroupActivityIds } = options ?? {};
   loggers.api.debug('[Rollback:Execute] Starting execution', {
     activityId,
     userId,
@@ -1463,7 +1463,7 @@ export async function executeRollback(
     force,
   });
 
-  const preview = await previewRollback(activityId, userId, context, { force });
+  const preview = await previewRollback(activityId, userId, context, { force, undoGroupActivityIds });
 
   if (!preview.canExecute) {
     loggers.api.debug('[Rollback:Execute] Aborting - preview check failed', {


### PR DESCRIPTION
## Summary

- When undoing multiple activities from the same AI conversation, conflict detection was incorrectly flagging changes made by other activities in the same undo batch as external conflicts
- Now passes undo group context to the preview function and ignores conflicts from activities being undone together

## Problem

When AI makes a tool chain like `create agent → update agent config → do other stuff`, and the user tries to undo the whole chain, the undo would fail with:

```
Cannot undo agent_config_update on [Page Name]: Agent settings have been modified since this update
```

This happened because when previewing the rollback for the first `agent_config_update`, it saw that the DB had been modified (by the second `agent_config_update` in the same tool chain) and flagged it as a conflict - even though that second activity would also be rolled back.

## Solution

- Added `undoGroupActivityIds?: string[]` option to `previewRollback()`
- When a conflict is detected and undo group context is provided, query for external modifications (changes NOT from activities in the undo group)
- If all modifications came from the undo group, ignore the conflict as it will be rolled back anyway
- Applied to all resource types: pages, drives, agents, messages, members, permissions

## Test plan

- [x] TypeScript checks pass
- [x] All ai-undo-service tests pass (16 tests)
- [x] All rollback-service tests pass (29 tests)
- [ ] Manual test: undo an AI tool chain with multiple agent_config_update activities

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved undo/rollback behavior: conflict detection now ignores internal conflicts within the same undo batch and focuses on external modifications, making multi-activity undos (including AI-generated undos) more reliable and less prone to false conflict reports.
  * Undo previews and execution now preserve undo-group context across the preview/execute flow for consistent outcomes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->