### PR TITLE
Fix folder creation input validation error

### DIFF
--- a/packages/lib/src/content/page-types.config.ts
+++ b/packages/lib/src/content/page-types.config.ts
@@ -183,13 +183,13 @@ export function canPageTypeAcceptUploads(type: PageType): boolean {
   return PAGE_TYPE_CONFIGS[type]?.capabilities.canAcceptUploads || false;
 }
 
-export function getDefaultContent(type: PageType): any {
+export function getDefaultContent(type: PageType): string {
   const config = PAGE_TYPE_CONFIGS[type];
   if (!config) return '';
-  
+
   const content = config.defaultContent();
-  // For CHANNEL and AI_CHAT, return stringified JSON for consistency
-  if (type === PageType.CHANNEL || type === PageType.AI_CHAT) {
+  // Stringify JSON content for types that return objects
+  if (type === PageType.FOLDER || type === PageType.CHANNEL || type === PageType.AI_CHAT) {
     return JSON.stringify(content);
   }
   return content;


### PR DESCRIPTION
The getDefaultContent function was returning an object { children: [] } for FOLDER pages, but the API expects a string for the content field. This caused Zod validation to fail with "expected string, received object".

Added FOLDER to the list of page types that get their default content stringified, alongside CHANNEL and AI_CHAT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced content processing consistency by standardizing how folder content is handled alongside existing channel and AI chat content types, ensuring uniform formatting and data representation across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->