### PR TITLE
Fix right sidebar text and tool call rendering

### DIFF
--- a/apps/web/src/components/ai/shared/chat/CompactMessageRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/CompactMessageRenderer.tsx
@@ -55,7 +55,7 @@ const CompactTextBlock: React.FC<CompactTextBlockProps> = React.memo(({
 
   return (
     <div
-      className={`group relative text-xs mb-1 min-w-0 max-w-full overflow-hidden ${role === 'user'
+      className={`group relative text-xs mb-1 min-w-0 max-w-full ${role === 'user'
           ? 'p-2 rounded-md bg-primary/10 dark:bg-accent/20 ml-2'
           : ''
         }`}
@@ -79,7 +79,7 @@ const CompactTextBlock: React.FC<CompactTextBlockProps> = React.memo(({
         </div>
       ) : (
         <>
-          <div className={`text-gray-900 dark:text-gray-100 prose prose-xs dark:prose-invert min-w-0 max-w-full overflow-hidden ${styles.compactProseContent}`}>
+          <div className={`text-gray-900 dark:text-gray-100 prose prose-xs dark:prose-invert min-w-0 max-w-full break-words ${styles.compactProseContent}`}>
             <StreamingMarkdown content={content} id={`${messageId}-text`} isStreaming={isStreaming} />
           </div>
           {/* Always show footer with buttons; timestamp only when createdAt exists */}
@@ -338,7 +338,7 @@ export const CompactMessageRenderer: React.FC<CompactMessageRendererProps> = Rea
 
   return (
     <>
-      <div key={message.id} className="mb-1 min-w-0 max-w-full overflow-hidden" style={{ contentVisibility: 'auto', containIntrinsicSize: 'auto 80px' }}>
+      <div key={message.id} className="mb-1 min-w-0 max-w-full" style={{ contentVisibility: 'auto', containIntrinsicSize: 'auto 80px' }}>
         {groupedParts.map((group, index) => {
           if (isTextGroupPart(group)) {
             const isLastTextBlock = index === groupedParts.length - 1;

--- a/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
@@ -75,7 +75,7 @@ const TextBlock: React.FC<TextBlockProps> = React.memo(({
         />
       ) : (
         <>
-          <div className="text-gray-900 dark:text-gray-100 prose prose-sm dark:prose-invert max-w-full overflow-hidden prose-pre:bg-gray-100 dark:prose-pre:bg-gray-800">
+          <div className="text-gray-900 dark:text-gray-100 prose prose-sm dark:prose-invert max-w-full prose-pre:bg-gray-100 dark:prose-pre:bg-gray-800">
             <div className="break-words overflow-wrap-anywhere">
               <StreamingMarkdown content={content} id={`${messageId}-text`} isStreaming={isStreaming} />
             </div>

--- a/apps/web/src/components/ai/shared/chat/tool-calls/CompactToolCallRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/CompactToolCallRenderer.tsx
@@ -247,9 +247,9 @@ export const CompactToolCallRenderer: React.FC<CompactToolCallRendererProps> = (
     if (!isExpanded) return null;
 
     return (
-      <div className="mt-1 p-1.5 bg-gray-50 dark:bg-gray-800/50 rounded text-[10px] space-y-1 max-w-full overflow-hidden">
+      <div className="mt-1 p-1.5 bg-gray-50 dark:bg-gray-800/50 rounded text-[10px] space-y-1 max-w-full break-words">
         {input ? (
-          <div className="space-y-0.5 max-w-full overflow-hidden">
+          <div className="space-y-0.5 max-w-full break-words">
             <div className="font-medium text-gray-600 dark:text-gray-400">Input:</div>
             <pre className="text-gray-500 dark:text-gray-500 overflow-x-auto whitespace-pre-wrap break-all max-w-full">
               {JSON.stringify(typeof input === 'string' ? JSON.parse(input) : input, null, 2)}
@@ -258,7 +258,7 @@ export const CompactToolCallRenderer: React.FC<CompactToolCallRendererProps> = (
         ) : null}
 
         {output ? (
-          <div className="space-y-0.5 max-w-full overflow-hidden">
+          <div className="space-y-0.5 max-w-full break-words">
             <div className="font-medium text-gray-600 dark:text-gray-400">Result:</div>
             {(() => {
               try {
@@ -311,7 +311,7 @@ export const CompactToolCallRenderer: React.FC<CompactToolCallRendererProps> = (
         ) : null}
 
         {error ? (
-          <div className="p-1 bg-red-50 dark:bg-red-900/20 rounded max-w-full overflow-hidden">
+          <div className="p-1 bg-red-50 dark:bg-red-900/20 rounded max-w-full break-words">
             <div className="text-red-600 dark:text-red-400 break-words">{error}</div>
           </div>
         ) : null}
@@ -320,10 +320,10 @@ export const CompactToolCallRenderer: React.FC<CompactToolCallRendererProps> = (
   };
 
   return (
-    <div className="py-0.5 text-[11px] max-w-full overflow-hidden">
+    <div className="py-0.5 text-[11px] max-w-full">
       <button
         onClick={() => setIsExpanded(!isExpanded)}
-        className="w-full flex items-center space-x-1.5 text-left hover:bg-muted/30 rounded py-0.5 px-1 transition-colors max-w-full overflow-hidden"
+        className="w-full flex items-center space-x-1.5 text-left hover:bg-muted/30 rounded py-0.5 px-1 transition-colors max-w-full"
       >
         {isExpanded ? <ChevronDown className="h-3 w-3 flex-shrink-0" /> : <ChevronRight className="h-3 w-3 flex-shrink-0" />}
         <div className="flex-shrink-0">{getToolIcon(toolName)}</div>


### PR DESCRIPTION
Replace overflow-hidden with break-words on text containers to allow proper word wrapping instead of clipping content. The CSS module already had proper word-breaking rules but the parent overflow-hidden was preventing them from working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text wrapping behavior in AI chat messages to ensure long content displays properly instead of being clipped or hidden.
  * Enhanced content rendering in compact message views and tool call renderers for better readability and visibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->