### PR TITLE
feat(desktop): reduce default window size to 1100x700

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -22,7 +22,7 @@ interface StoreSchema {
 
 const store = new Store<StoreSchema>({
   defaults: {
-    windowBounds: { width: 1400, height: 900 },
+    windowBounds: { width: 1100, height: 700 },
     minimizeToTray: true,
   },
 }) as any; // Type assertion to work around electron-store v10 type definitions
@@ -211,7 +211,7 @@ function injectDesktopStyles(): void {
 
 function createWindow(): void {
   // Get saved window bounds
-  const windowBounds = store.get('windowBounds') || { width: 1400, height: 900 };
+  const windowBounds = store.get('windowBounds') || { width: 1100, height: 700 };
 
   // Create the browser window
   mainWindow = new BrowserWindow({


### PR DESCRIPTION
Changed default Electron window dimensions from 1400x900 to 1100x700 for a more compact initial appearance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default application window dimensions to 1100×700 pixels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->