### PR TITLE
fix(permissions): allow ADMIN and OWNER roles to manage drives

### DIFF
--- a/apps/web/src/hooks/usePermissions.ts
+++ b/apps/web/src/hooks/usePermissions.ts
@@ -138,5 +138,8 @@ export function getPermissionErrorMessage(action: string, resource: string = 'pa
  */
 export function canManageDrive(drive: { isOwned?: boolean; role?: string } | null | undefined): boolean {
   if (!drive) return false;
-  return drive.isOwned === true || drive.role === 'ADMIN';
+  if (drive.isOwned === true) return true;
+  // Check for ADMIN or OWNER role (case-insensitive for robustness)
+  const role = drive.role?.toUpperCase();
+  return role === 'ADMIN' || role === 'OWNER';
 }


### PR DESCRIPTION
The canManageDrive function was only checking for 'ADMIN' role, causing the new page button to show as locked for shared drive admins. This fix adds support for 'OWNER' role and makes the check case-insensitive for robustness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drive management permissions to properly recognize users with owner and admin roles, with case-insensitive role matching.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->