### PR TITLE
fix(api): enable MCP token support for task and agent-config routes

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/agent-config/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/agent-config/route.ts
@@ -7,8 +7,8 @@ import { loggers } from '@pagespace/lib/server';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import { applyPageMutation, PageRevisionMismatchError } from '@/services/api/page-mutation-service';
 
-const AUTH_OPTIONS_READ = { allow: ['jwt'] as const, requireCSRF: false };
-const AUTH_OPTIONS_WRITE = { allow: ['jwt'] as const, requireCSRF: true };
+const AUTH_OPTIONS_READ = { allow: ['jwt', 'mcp'] as const, requireCSRF: false };
+const AUTH_OPTIONS_WRITE = { allow: ['jwt', 'mcp'] as const, requireCSRF: true };
 
 /**
  * GET - Get Page AI agent configuration
@@ -263,3 +263,8 @@ export async function PATCH(
     );
   }
 }
+
+/**
+ * PUT - Update Page AI agent configuration (alias for PATCH)
+ */
+export { PATCH as PUT };

--- a/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/route.ts
@@ -6,7 +6,7 @@ import { broadcastTaskEvent, broadcastPageEvent, createPageEventPayload } from '
 import { getActorInfo, logPageActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { applyPageMutation, PageRevisionMismatchError } from '@/services/api/page-mutation-service';
 
-const AUTH_OPTIONS = { allow: ['jwt'] as const, requireCSRF: true };
+const AUTH_OPTIONS = { allow: ['jwt', 'mcp'] as const, requireCSRF: true };
 
 /**
  * PATCH /api/pages/[pageId]/tasks/[taskId]


### PR DESCRIPTION
- Add 'mcp' to AUTH_OPTIONS allow list in tasks/[taskId] route
  (fixes 401 "MCP tokens are not permitted for this endpoint")
- Add 'mcp' to AUTH_OPTIONS in agent-config route
- Export PATCH as PUT in agent-config route
  (fixes 405 Method Not Allowed when clients use PUT)