### PR TITLE
fix(ui): truncate long page titles in sidebar welcome message

### DIFF
--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -605,10 +605,10 @@ const SidebarChatTab: React.FC = () => {
           <div className="p-3 min-w-0 overflow-x-hidden">
             <div className="space-y-1.5 min-w-0 max-w-full break-words">
             {displayMessages.length === 0 ? (
-              <div className="flex items-center justify-center h-20 text-muted-foreground text-xs text-center">
-                <div>
-                  <p className="font-medium">{assistantName}</p>
-                  <p className="text-xs">
+              <div className="flex items-center justify-center h-20 text-muted-foreground text-xs text-center overflow-hidden">
+                <div className="max-w-full px-2">
+                  <p className="font-medium truncate">{assistantName}</p>
+                  <p className="text-xs truncate">
                     {locationContext
                       ? `Context-aware help for ${locationContext.currentPage?.title || locationContext.currentDrive?.name}`
                       : 'Ask me anything about your workspace'}


### PR DESCRIPTION
Add text truncation to the welcome message area in the right sidebar chat tab to prevent long page/drive names from causing vertical growth and taking up valuable chat UI space.

Changes:
- Add overflow-hidden to the welcome message container
- Add max-w-full to inner div for proper width constraint
- Add truncate class to assistant name and context text paragraphs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed text overflow handling in the AI assistant sidebar's empty state. The assistant name and help text now properly truncate to prevent layout issues and maintain a clean interface appearance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->