### PR TITLE
fix(sidebar): fix drag-drop race condition losing projection state

### DIFF
--- a/apps/web/src/components/ui/sortable-tree/SortableTree.tsx
+++ b/apps/web/src/components/ui/sortable-tree/SortableTree.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useCallback, useRef, useEffect, ReactNode } from "react";
+import { useState, useMemo, useCallback, useRef, ReactNode } from "react";
 import {
   DndContext,
   DragEndEvent,
@@ -110,13 +110,12 @@ export function SortableTree<T extends TreeItem>({
   }, [sortableItems, activeId, overId, offsetLeft, indentationWidth]);
 
   // Store the last valid projection in a ref to avoid race conditions
-  // where projected becomes null right before handleDragEnd is called
+  // where projected becomes null right before handleDragEnd is called.
+  // Updated synchronously during render to avoid useEffect lag.
   const projectedRef = useRef<Projection | null>(null);
-  useEffect(() => {
-    if (projected) {
-      projectedRef.current = projected;
-    }
-  }, [projected]);
+  if (projected) {
+    projectedRef.current = projected;
+  }
 
   const handleDragStart = useCallback(({ active }: DragStartEvent) => {
     setActiveId(active.id);


### PR DESCRIPTION
Use a ref to store the last valid projection to avoid race conditions where the projected value becomes null right before handleDragEnd is called (e.g., if onDragOver fires with over=null just before release).

This ensures the move operation uses the correct projection data even if React state changes cause a re-render between the last onDragOver and onDragEnd events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-and-drop reliability in the sortable tree component by fixing a race condition that could occur during drag operations, ensuring more consistent item positioning behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->