### PR TITLE
feat(ai): hide underlying model details from users

### DIFF
--- a/apps/web/src/components/activity/ActivityItem.tsx
+++ b/apps/web/src/components/activity/ActivityItem.tsx
@@ -18,6 +18,7 @@ import { useToast } from '@/hooks/useToast';
 import { post } from '@/lib/auth/auth-fetch';
 import { operationConfig, resourceTypeIcons, defaultOperationConfig } from './constants';
 import { getInitials } from './utils';
+import { getUserFacingModelName } from '@/lib/ai/core/ai-providers-config';
 import type { ActivityLog } from './types';
 import type { ActivityActionPreview, ActivityActionResult } from '@/types/activity-actions';
 
@@ -108,8 +109,7 @@ export function ActivityItem({ activity, context, onRollback, onRollbackToPointS
           {activity.isAiGenerated && (
             <Badge variant="outline" className="text-xs gap-1">
               <Bot className="h-3 w-3" />
-              AI
-              {activity.aiModel && <span className="text-muted-foreground">({activity.aiModel})</span>}
+              {getUserFacingModelName(activity.aiProvider, activity.aiModel)}
             </Badge>
           )}
         </div>

--- a/apps/web/src/components/ai/page-agents/PageAgentConversationRenderer.tsx
+++ b/apps/web/src/components/ai/page-agents/PageAgentConversationRenderer.tsx
@@ -4,6 +4,7 @@ import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/component
 import { Badge } from '@/components/ui/badge';
 import { StreamingMarkdown } from '@/components/ai/shared';
 import { cn } from '@/lib/utils';
+import { getUserFacingModelName } from '@/lib/ai/core/ai-providers-config';
 
 type TaskStatus = 'pending' | 'in_progress' | 'completed' | 'error';
 
@@ -177,22 +178,14 @@ export const PageAgentConversationRenderer: React.FC<PageAgentConversationRender
         {/* Success state */}
         {taskStatus === 'completed' && output && (
           <div className="space-y-3">
-            {/* Provider/Model badges (only non-default) */}
-            {(output.metadata?.provider && output.metadata.provider !== 'default') ||
-             (output.metadata?.model && output.metadata.model !== 'default') ? (
+            {/* AI Model badge (only non-default) */}
+            {output.metadata?.model && output.metadata.model !== 'default' && (
               <div className="flex items-center gap-2 flex-wrap">
-                {output.metadata?.provider && output.metadata.provider !== 'default' && (
-                  <Badge variant="secondary" className="capitalize text-xs">
-                    {output.metadata.provider}
-                  </Badge>
-                )}
-                {output.metadata?.model && output.metadata.model !== 'default' && (
-                  <Badge variant="outline" className="text-xs">
-                    {output.metadata.model}
-                  </Badge>
-                )}
+                <Badge variant="secondary" className="text-xs">
+                  {getUserFacingModelName(output.metadata.provider, output.metadata.model)}
+                </Badge>
               </div>
-            ) : null}
+            )}
 
             {/* Context if provided */}
             {context && (

--- a/apps/web/src/components/ai/shared/AiUsageMonitor.tsx
+++ b/apps/web/src/components/ai/shared/AiUsageMonitor.tsx
@@ -7,6 +7,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { Activity, DollarSign, Database, AlertCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useSocketStore } from '@/stores/useSocketStore';
+import { getUserFacingModelName } from '@/lib/ai/core/ai-providers-config';
 
 interface AiUsageMonitorProps {
   conversationId?: string | null | undefined;
@@ -152,7 +153,7 @@ export function AiUsageMonitor({ conversationId, pageId, className, compact = fa
               <TooltipContent>
                 <p>Session cost: {formatCost(usage.billing.cost)}</p>
                 <p className="text-xs text-muted-foreground">Total tokens billed: {formatNumber(usage.billing.totalTokens)}</p>
-                <p className="text-xs text-muted-foreground">Model: {usage.model}</p>
+                <p className="text-xs text-muted-foreground">Model: {getUserFacingModelName(usage.provider, usage.model)}</p>
               </TooltipContent>
             </Tooltip>
           )}
@@ -167,7 +168,7 @@ export function AiUsageMonitor({ conversationId, pageId, className, compact = fa
         {/* Header */}
         <div className="flex items-center justify-between text-xs text-muted-foreground">
           <span className="font-medium">AI Usage</span>
-          <span className="font-mono">{usage.model}</span>
+          <span className="font-mono">{getUserFacingModelName(usage.provider, usage.model)}</span>
         </div>
 
         {/* Context Window (Real Usage) - Show tokens/window instead of percentage */}
@@ -240,7 +241,7 @@ export function AiUsageMonitor({ conversationId, pageId, className, compact = fa
               </TooltipTrigger>
               <TooltipContent>
                 <p>Total cost for this conversation</p>
-                <p className="text-xs text-muted-foreground">Provider: {usage.provider}</p>
+                <p className="text-xs text-muted-foreground">Powered by: {getUserFacingModelName(usage.provider, usage.model)}</p>
               </TooltipContent>
             </Tooltip>
           )}

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarActivityTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarActivityTab.tsx
@@ -31,6 +31,7 @@ import {
 } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { fetchWithAuth, post } from '@/lib/auth/auth-fetch';
+import { getUserFacingModelName } from '@/lib/ai/core/ai-providers-config';
 import { RollbackConfirmDialog } from '@/components/version-history/RollbackConfirmDialog';
 import { RollbackToPointDialog, type RollbackToPointContext } from '@/components/activity/RollbackToPointDialog';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
@@ -482,12 +483,12 @@ export default function SidebarActivityTab() {
                               addSuffix: true,
                             })}
                           </span>
-                          {activity.isAiGenerated && activity.aiModel && (
+                          {activity.isAiGenerated && (
                             <Badge
                               variant="secondary"
                               className="text-[10px] h-4 px-1.5 py-0"
                             >
-                              {activity.aiModel}
+                              {getUserFacingModelName(activity.aiProvider, activity.aiModel)}
                             </Badge>
                           )}
                         </div>

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarSettingsTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarSettingsTab.tsx
@@ -8,7 +8,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { CheckCircle, XCircle, Key, ExternalLink, Zap, Bot, Wrench, FolderTree } from 'lucide-react';
 import { Switch } from '@/components/ui/switch';
 import { toast } from 'sonner';
-import { AI_PROVIDERS, getBackendProvider } from '@/lib/ai/core/ai-providers-config';
+import { AI_PROVIDERS, getBackendProvider, getUserFacingModelName } from '@/lib/ai/core/ai-providers-config';
 import { patch, fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useAssistantSettingsStore } from '@/stores/useAssistantSettingsStore';
 import type { AgentInfo } from '@/types/agent';
@@ -395,15 +395,9 @@ const SidebarSettingsTab: React.FC<SidebarSettingsTabProps> = ({
               </CardHeader>
               <CardContent className="space-y-3">
                 <div className="flex items-center justify-between text-xs">
-                  <span className="text-muted-foreground">Provider</span>
+                  <span className="text-muted-foreground">AI Model</span>
                   <Badge variant="secondary">
-                    {selectedAgent.aiProvider || 'Default'}
-                  </Badge>
-                </div>
-                <div className="flex items-center justify-between text-xs">
-                  <span className="text-muted-foreground">Model</span>
-                  <Badge variant="secondary">
-                    {selectedAgent.aiModel || 'Default'}
+                    {getUserFacingModelName(selectedAgent.aiProvider, selectedAgent.aiModel)}
                   </Badge>
                 </div>
                 {selectedAgent.enabledTools && selectedAgent.enabledTools.length > 0 && (

--- a/apps/web/src/components/version-history/VersionHistoryItem.tsx
+++ b/apps/web/src/components/version-history/VersionHistoryItem.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { operationConfig, resourceTypeIcons, defaultOperationConfig } from '@/components/activity/constants';
 import { getInitials } from '@/components/activity/utils';
+import { getUserFacingModelName } from '@/lib/ai/core/ai-providers-config';
 import { RollbackConfirmDialog } from './RollbackConfirmDialog';
 import { RollbackToPointDialog, type RollbackToPointContext } from '@/components/activity/RollbackToPointDialog';
 import { useToast } from '@/hooks/useToast';
@@ -134,8 +135,7 @@ export function VersionHistoryItem({
             {activity.isAiGenerated && (
               <Badge variant="outline" className="text-xs gap-1">
                 <Bot className="h-3 w-3" />
-                AI
-                {activity.aiModel && <span className="text-muted-foreground">({activity.aiModel})</span>}
+                {getUserFacingModelName(activity.aiProvider, activity.aiModel)}
               </Badge>
             )}
           </div>

--- a/apps/web/src/lib/ai/core/ai-providers-config.ts
+++ b/apps/web/src/lib/ai/core/ai-providers-config.ts
@@ -357,3 +357,37 @@ export function getModelDisplayName(provider: string, model: string): string {
 
 export type AIProvider = keyof typeof AI_PROVIDERS;
 export type AIModel<T extends AIProvider> = keyof typeof AI_PROVIDERS[T]['models'];
+
+/**
+ * Get user-facing display name for AI usage.
+ * Hides underlying model details from users for privacy/branding.
+ *
+ * For PageSpace provider: Shows "PageSpace Standard" or "PageSpace Pro"
+ * For all other providers: Shows "PageSpace AI" to abstract away the underlying model
+ *
+ * @param provider - The AI provider (e.g., 'pagespace', 'openrouter', 'google')
+ * @param model - The model identifier (e.g., 'glm-4.5-air', 'glm-4.7')
+ * @returns User-friendly display name
+ */
+export function getUserFacingModelName(provider: string | null | undefined, model: string | null | undefined): string {
+  // Default fallback
+  if (!model) {
+    return 'PageSpace AI';
+  }
+
+  // For PageSpace provider, show tier-based naming
+  if (provider === 'pagespace') {
+    if (model === 'glm-4.7') {
+      return 'PageSpace Pro';
+    }
+    if (model === 'glm-4.5-air') {
+      return 'PageSpace Standard';
+    }
+    // Any other PageSpace model defaults to Standard
+    return 'PageSpace Standard';
+  }
+
+  // For all other providers, abstract away the model details
+  // Users shouldn't see the underlying model names (GLM, Claude, GPT, etc.)
+  return 'PageSpace AI';
+}


### PR DESCRIPTION
Add getUserFacingModelName utility function to abstract model details:
- PageSpace provider shows "PageSpace Standard" or "PageSpace Pro"
- All other providers show "PageSpace AI" to hide underlying models

Updates all user-facing components to use the new function:
- ActivityItem: Show branded AI name instead of raw model
- VersionHistoryItem: Same branded display
- SidebarActivityTab: Same branded display
- AiUsageMonitor: Hide model/provider details in tooltips and headers
- SidebarSettingsTab: Simplify agent config display
- PageAgentConversationRenderer: Single branded badge

Users no longer see raw model names like "GLM 4.7", "Claude", etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced AI model name display throughout the application with clearer, more user-friendly labels.
  * Improved consistency in AI model identification across activity history, settings, usage monitoring, and version history for a better user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->