### PR TITLE
feat(ai): add PageSpace model aliases (standard/pro) for AI agents

### DIFF
--- a/apps/web/src/app/api/ai/page-agents/create/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/create/route.ts
@@ -85,7 +85,7 @@ export async function POST(request: Request) {
     // Get next position
     const nextPosition = await pageAgentRepository.getNextPosition(drive.id, parentId || null);
 
-    // Prepare agent data
+    // Prepare agent data with default PageSpace provider and standard model
     const agentData: AgentData = {
       title,
       type: 'AI_CHAT',
@@ -95,17 +95,15 @@ export async function POST(request: Request) {
       parentId: parentId || null,
       isTrashed: false,
       systemPrompt,
+      // Default to PageSpace provider with "standard" model
+      // Agents can use 'standard' or 'pro' as friendly aliases
+      aiProvider: aiProvider || 'pagespace',
+      aiModel: aiModel || 'standard',
     };
 
     // Add optional configuration (save even if empty array)
     if (enabledTools !== undefined) {
       agentData.enabledTools = enabledTools;
-    }
-    if (aiProvider) {
-      agentData.aiProvider = aiProvider;
-    }
-    if (aiModel) {
-      agentData.aiModel = aiModel;
     }
 
     // Create the agent
@@ -143,8 +141,8 @@ export async function POST(request: Request) {
         systemPrompt: systemPrompt.substring(0, 100) + (systemPrompt.length > 100 ? '...' : ''),
         enabledToolsCount: enabledTools?.length || 0,
         enabledTools: enabledTools || [],
-        aiProvider: aiProvider || 'default',
-        aiModel: aiModel || 'default',
+        aiProvider: agentData.aiProvider,
+        aiModel: agentData.aiModel,
         hasWelcomeMessage: !!welcomeMessage
       },
       stats: {

--- a/apps/web/src/lib/ai/core/provider-factory.ts
+++ b/apps/web/src/lib/ai/core/provider-factory.ts
@@ -35,6 +35,7 @@ import {
   getUserMiniMaxSettings,
   createMiniMaxSettings,
 } from './ai-utils';
+import { resolvePageSpaceModel } from './ai-providers-config';
 
 export interface ProviderRequest {
   selectedProvider?: string;
@@ -86,7 +87,12 @@ export async function createAIProvider(
   // Get user's current AI provider settings
   const [user] = await db.select().from(users).where(eq(users.id, userId));
   const currentProvider = selectedProvider || user?.currentAiProvider || 'pagespace';
-  const currentModel = selectedModel || user?.currentAiModel || 'glm-4.5-air';
+  let currentModel = selectedModel || user?.currentAiModel || 'glm-4.5-air';
+
+  // Resolve model aliases for PageSpace provider (e.g., 'standard' -> 'glm-4.5-air')
+  if (currentProvider === 'pagespace') {
+    currentModel = resolvePageSpaceModel(currentModel);
+  }
 
   try {
     let model;


### PR DESCRIPTION
- Add PAGESPACE_MODEL_ALIASES mapping 'standard' -> 'glm-4.5-air' and 'pro' -> 'glm-4.7'
- Add resolvePageSpaceModel() to convert aliases to actual model IDs
- New AI agents now default to provider='pagespace' and model='standard'
- Provider factory resolves aliases before passing to backend
- Agents can now use 'standard' or 'pro' without knowing underlying model names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agents now created with default AI provider and model settings automatically applied
  * AI model selection now supports user-friendly aliases (standard, pro) for easier configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->