### PR TITLE
fix(desktop): use secure storage for WSClient JWT auth

### DIFF
--- a/apps/desktop/src/main/auth-storage.ts
+++ b/apps/desktop/src/main/auth-storage.ts
@@ -1,0 +1,149 @@
+import { app, safeStorage } from 'electron';
+import { promises as fs } from 'node:fs';
+import * as path from 'path';
+import { decodeJwt } from 'jose';
+import { logger } from './logger';
+
+export interface StoredAuthSession {
+  accessToken: string;
+  refreshToken: string;
+  csrfToken?: string | null;
+  deviceToken?: string | null;
+}
+
+let authSessionPath: string | null = null;
+
+function ensureAuthSessionPath(): string {
+  if (!authSessionPath) {
+    if (!app.isReady()) {
+      throw new Error('Application not ready to resolve userData path');
+    }
+    authSessionPath = path.join(app.getPath('userData'), 'auth-session.bin');
+  }
+  return authSessionPath;
+}
+
+export async function saveAuthSession(sessionData: StoredAuthSession): Promise<void> {
+  try {
+    const payload = JSON.stringify(sessionData);
+    const encryptionAvailable = safeStorage.isEncryptionAvailable();
+    const encrypted = encryptionAvailable
+      ? safeStorage.encryptString(payload)
+      : Buffer.from(payload, 'utf8');
+
+    await fs.writeFile(ensureAuthSessionPath(), encrypted);
+    logger.info('[Auth] Session stored securely', {
+      encrypted: encryptionAvailable,
+      payloadSize: payload.length,
+    });
+  } catch (error) {
+    logger.error('[Auth] Failed to persist session', {
+      error,
+      encryptionAvailable: safeStorage.isEncryptionAvailable(),
+    });
+    throw error;
+  }
+}
+
+export async function loadAuthSession(): Promise<StoredAuthSession | null> {
+  try {
+    const filePath = ensureAuthSessionPath();
+    const raw = await fs.readFile(filePath);
+
+    let session: StoredAuthSession;
+
+    // FIX: Always try decryption first, regardless of isEncryptionAvailable()
+    // On macOS, isEncryptionAvailable() can return different values at different times
+    // (Keychain lock state, app launched before login, code signing issues, etc.)
+    // If we saved encrypted but isEncryptionAvailable() returns false on load,
+    // we'd skip decryption and corrupt the data.
+    try {
+      // Try decryption first - this handles:
+      // 1. Encrypted data when safeStorage is available (normal case)
+      // 2. Encrypted data when safeStorage reports unavailable (the bug case)
+      const decoded = safeStorage.decryptString(raw);
+      session = JSON.parse(decoded) as StoredAuthSession;
+      logger.debug('[Auth] Session decrypted successfully');
+    } catch (decryptError) {
+      // Decryption failed - could be:
+      // 1. Plain text data (saved when encryption was unavailable)
+      // 2. Keychain locked/unavailable but data is valid encrypted
+      // 3. Corrupted data
+      const encryptionAvailable = safeStorage.isEncryptionAvailable();
+      logger.debug('[Auth] Decryption failed, attempting plain text parse', {
+        error: decryptError instanceof Error ? decryptError.message : String(decryptError),
+        encryptionAvailable,
+      });
+
+      try {
+        const decoded = raw.toString('utf8');
+        session = JSON.parse(decoded) as StoredAuthSession;
+        logger.debug('[Auth] Plain text session loaded successfully');
+      } catch (parseError) {
+        // Data is neither valid decrypted nor valid plain text JSON
+        // IMPORTANT: Only delete if we're confident it's truly corrupted.
+        // If encryption is unavailable (Keychain locked), the file might contain
+        // valid encrypted data that will decrypt once Keychain becomes available.
+        if (encryptionAvailable) {
+          // Encryption IS available but both decrypt and plain text failed = truly corrupted
+          logger.error('[Auth] Session file is corrupted - deleting for clean re-login', {
+            rawLength: raw.length,
+            firstBytes: raw.subarray(0, 20).toString('hex'),
+          });
+          try {
+            await fs.unlink(filePath);
+            logger.info('[Auth] Corrupted session file deleted');
+          } catch (unlinkError) {
+            logger.warn('[Auth] Failed to delete corrupted session file', {
+              error: unlinkError instanceof Error ? unlinkError.message : String(unlinkError),
+            });
+          }
+        } else {
+          // Encryption unavailable - file might be valid encrypted data waiting for Keychain
+          // Don't delete; return null and let user retry when Keychain is available
+          logger.warn('[Auth] Cannot load session - Keychain may be locked. Keeping file for retry.', {
+            rawLength: raw.length,
+          });
+        }
+        return null;
+      }
+    }
+
+    // Validate token expiry before returning
+    if (session.accessToken) {
+      try {
+        const payload = decodeJwt(session.accessToken);
+        const now = Math.floor(Date.now() / 1000);
+
+        // Check if access token is expired (with 30 second buffer)
+        if (payload.exp && payload.exp < now + 30) {
+          logger.info('[Auth] Access token expired or expiring soon, session will auto-refresh');
+          // Don't return null - let the app load and auto-refresh will handle it
+          // This prevents unnecessary logouts when tokens just need refreshing
+        }
+      } catch (error) {
+        logger.warn('[Auth] Failed to decode access token', { error });
+        // Token might be malformed, but let the app try to use it
+        // The server will reject it if invalid, triggering refresh
+      }
+    }
+
+    return session;
+  } catch (error: any) {
+    if (error?.code === 'ENOENT') {
+      return null;
+    }
+    logger.error('[Auth] Failed to load session', { error });
+    return null;
+  }
+}
+
+export async function clearAuthSession(): Promise<void> {
+  try {
+    await fs.unlink(ensureAuthSessionPath());
+  } catch (error: any) {
+    if (error?.code !== 'ENOENT') {
+      logger.error('[Auth] Failed to clear stored session', { error });
+    }
+  }
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,17 +1,16 @@
-import { app, BrowserWindow, Menu, shell, ipcMain, Tray, nativeImage, dialog, session, safeStorage, powerMonitor } from 'electron';
+import { app, BrowserWindow, Menu, shell, ipcMain, Tray, nativeImage, dialog, session, powerMonitor } from 'electron';
 import electronUpdaterPkg from 'electron-updater';
 const { autoUpdater } = electronUpdaterPkg;
 import * as path from 'path';
-import { promises as fs } from 'node:fs';
 import Store from 'electron-store';
 import { getMCPManager } from './mcp-manager';
 import { initializeWSClient, shutdownWSClient, getWSClient } from './ws-client';
 import type { MCPConfig } from '../shared/mcp-types';
 import { logger } from './logger';
+import { loadAuthSession, saveAuthSession, clearAuthSession, type StoredAuthSession } from './auth-storage';
 import nodeMachineId from 'node-machine-id';
 const { machineIdSync } = nodeMachineId;
 import * as os from 'node:os';
-import { decodeJwt } from 'jose';
 
 // Configuration store for user preferences
 interface StoreSchema {
@@ -33,150 +32,7 @@ let isQuitting = false; // Track if app is quitting (used to distinguish close f
 let isSuspended = false; // Track system suspend state for auth refresh coordination
 let suspendTime: number | null = null; // Track when system was suspended
 
-interface StoredAuthSession {
-  accessToken: string;
-  refreshToken: string;
-  csrfToken?: string | null;
-  deviceToken?: string | null;
-}
-
-let authSessionPath: string | null = null;
 let cachedMachineId: string | null = null;
-
-function ensureAuthSessionPath(): string {
-  if (!authSessionPath) {
-    if (!app.isReady()) {
-      throw new Error('Application not ready to resolve userData path');
-    }
-    authSessionPath = path.join(app.getPath('userData'), 'auth-session.bin');
-  }
-  return authSessionPath;
-}
-
-async function saveAuthSession(sessionData: StoredAuthSession): Promise<void> {
-  try {
-    const payload = JSON.stringify(sessionData);
-    const encryptionAvailable = safeStorage.isEncryptionAvailable();
-    const encrypted = encryptionAvailable
-      ? safeStorage.encryptString(payload)
-      : Buffer.from(payload, 'utf8');
-
-    await fs.writeFile(ensureAuthSessionPath(), encrypted);
-    logger.info('[Auth] Session stored securely', {
-      encrypted: encryptionAvailable,
-      payloadSize: payload.length,
-    });
-  } catch (error) {
-    logger.error('[Auth] Failed to persist session', {
-      error,
-      encryptionAvailable: safeStorage.isEncryptionAvailable(),
-    });
-    throw error;
-  }
-}
-
-async function loadAuthSession(): Promise<StoredAuthSession | null> {
-  try {
-    const filePath = ensureAuthSessionPath();
-    const raw = await fs.readFile(filePath);
-
-    let session: StoredAuthSession;
-
-    // FIX: Always try decryption first, regardless of isEncryptionAvailable()
-    // On macOS, isEncryptionAvailable() can return different values at different times
-    // (Keychain lock state, app launched before login, code signing issues, etc.)
-    // If we saved encrypted but isEncryptionAvailable() returns false on load,
-    // we'd skip decryption and corrupt the data.
-    try {
-      // Try decryption first - this handles:
-      // 1. Encrypted data when safeStorage is available (normal case)
-      // 2. Encrypted data when safeStorage reports unavailable (the bug case)
-      const decoded = safeStorage.decryptString(raw);
-      session = JSON.parse(decoded) as StoredAuthSession;
-      logger.debug('[Auth] Session decrypted successfully');
-    } catch (decryptError) {
-      // Decryption failed - could be:
-      // 1. Plain text data (saved when encryption was unavailable)
-      // 2. Keychain locked/unavailable but data is valid encrypted
-      // 3. Corrupted data
-      const encryptionAvailable = safeStorage.isEncryptionAvailable();
-      logger.debug('[Auth] Decryption failed, attempting plain text parse', {
-        error: decryptError instanceof Error ? decryptError.message : String(decryptError),
-        encryptionAvailable,
-      });
-
-      try {
-        const decoded = raw.toString('utf8');
-        session = JSON.parse(decoded) as StoredAuthSession;
-        logger.debug('[Auth] Plain text session loaded successfully');
-      } catch (parseError) {
-        // Data is neither valid decrypted nor valid plain text JSON
-        // IMPORTANT: Only delete if we're confident it's truly corrupted.
-        // If encryption is unavailable (Keychain locked), the file might contain
-        // valid encrypted data that will decrypt once Keychain becomes available.
-        if (encryptionAvailable) {
-          // Encryption IS available but both decrypt and plain text failed = truly corrupted
-          logger.error('[Auth] Session file is corrupted - deleting for clean re-login', {
-            rawLength: raw.length,
-            firstBytes: raw.subarray(0, 20).toString('hex'),
-          });
-          try {
-            await fs.unlink(filePath);
-            logger.info('[Auth] Corrupted session file deleted');
-          } catch (unlinkError) {
-            logger.warn('[Auth] Failed to delete corrupted session file', {
-              error: unlinkError instanceof Error ? unlinkError.message : String(unlinkError),
-            });
-          }
-        } else {
-          // Encryption unavailable - file might be valid encrypted data waiting for Keychain
-          // Don't delete; return null and let user retry when Keychain is available
-          logger.warn('[Auth] Cannot load session - Keychain may be locked. Keeping file for retry.', {
-            rawLength: raw.length,
-          });
-        }
-        return null;
-      }
-    }
-
-    // Validate token expiry before returning
-    if (session.accessToken) {
-      try {
-        const payload = decodeJwt(session.accessToken);
-        const now = Math.floor(Date.now() / 1000);
-
-        // Check if access token is expired (with 30 second buffer)
-        if (payload.exp && payload.exp < now + 30) {
-          logger.info('[Auth] Access token expired or expiring soon, session will auto-refresh');
-          // Don't return null - let the app load and auto-refresh will handle it
-          // This prevents unnecessary logouts when tokens just need refreshing
-        }
-      } catch (error) {
-        logger.warn('[Auth] Failed to decode access token', { error });
-        // Token might be malformed, but let the app try to use it
-        // The server will reject it if invalid, triggering refresh
-      }
-    }
-
-    return session;
-  } catch (error: any) {
-    if (error?.code === 'ENOENT') {
-      return null;
-    }
-    logger.error('[Auth] Failed to load session', { error });
-    return null;
-  }
-}
-
-async function clearAuthSession(): Promise<void> {
-  try {
-    await fs.unlink(ensureAuthSessionPath());
-  } catch (error: any) {
-    if (error?.code !== 'ENOENT') {
-      logger.error('[Auth] Failed to clear stored session', { error });
-    }
-  }
-}
 
 function getMachineIdentifier(): string {
   if (cachedMachineId) {
@@ -891,7 +747,6 @@ function setupPowerMonitor(): void {
 
 // App lifecycle
 app.whenReady().then(async () => {
-  authSessionPath = path.join(app.getPath('userData'), 'auth-session.bin');
   // Initialize MCP manager
   try {
     const mcpManager = getMCPManager();
@@ -912,17 +767,13 @@ app.whenReady().then(async () => {
   setupPowerMonitor();
 
   // Initialize WebSocket client for MCP bridge
-  if (mainWindow) {
-    initializeWSClient(mainWindow);
-  }
+  initializeWSClient();
 
   app.on('activate', () => {
     // On macOS, re-create window when dock icon is clicked
     if (BrowserWindow.getAllWindows().length === 0) {
       createWindow();
-      if (mainWindow) {
-        initializeWSClient(mainWindow);
-      }
+      initializeWSClient();
     }
   });
 });


### PR DESCRIPTION
## Summary
- Fix MCP tools failing with "Desktop app not connected" error
- Extract auth storage functions to shared `auth-storage.ts` module  
- WSClient now uses `loadAuthSession()` from secure storage (same as Socket.IO)

## Problem
WSClient was reading JWT from browser cookies, which may not exist due to:
- Domain mismatch
- httpOnly flags
- Timing issues on startup

This was **technical debt** - WSClient was created before secure storage existed (Oct 2025) and was never updated when the Auth Flow Overhaul added `loadAuthSession()` (Nov 2025).

## Solution
Use the same token source as Socket.IO - Electron secure storage via `loadAuthSession()`.

## Test plan
- [ ] Build desktop app: `pnpm build:desktop`
- [ ] Run desktop app and login
- [ ] Check main process logs for "Connected to server" 
- [ ] Trigger AI tool (list_drives) in browser
- [ ] Verify MCP tool executes without "Desktop app not connected" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Authentication sessions are now encrypted and stored securely with automatic token expiration detection and comprehensive error handling.

* **Refactor**
  * Restructured authentication session management for improved reliability and maintainability across the desktop application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->