### PR TITLE
fix(ai): remove duplicate PageSpace model aliases from selector

### DIFF
--- a/apps/web/src/lib/ai/core/ai-providers-config.ts
+++ b/apps/web/src/lib/ai/core/ai-providers-config.ts
@@ -36,9 +36,6 @@ export const AI_PROVIDERS = {
     models: {
       'glm-4.5-air': 'Standard',
       'glm-4.7': 'Pro (Pro/Business)',
-      // Aliases are also valid model selections
-      standard: 'Standard',
-      pro: 'Pro (Pro/Business)',
     },
   },
   openrouter: {
@@ -373,6 +370,10 @@ export function getDefaultModel(provider: string): string {
 export function isValidModel(provider: string, model: string): boolean {
   const providerConfig = AI_PROVIDERS[provider as keyof typeof AI_PROVIDERS];
   if (!providerConfig) return false;
+  // For PageSpace, also accept aliases (standard, pro)
+  if (provider === 'pagespace' && isPageSpaceModelAlias(model)) {
+    return true;
+  }
   return model in providerConfig.models;
 }
 


### PR DESCRIPTION
Model selectors were showing "Standard" and "Pro" twice because the AI_PROVIDERS.pagespace.models object contained both actual model IDs (glm-4.5-air, glm-4.7) and their aliases (standard, pro).

The aliases are intended for internal storage/API use only and get resolved via resolvePageSpaceModel() before API calls. Removed the aliases from the models object to prevent duplicate UI entries.

Updated isValidModel() to still accept aliases for PageSpace so agents with aiModel: 'standard' are validated correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized PageSpace AI provider model alias handling to ensure aliases remain valid while streamlining configuration data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->