### PR TITLE
fix(mcp): add toolsReady flag to prevent empty tools on first render

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -753,6 +753,14 @@ app.whenReady().then(async () => {
     await mcpManager.initialize();
     logger.info('MCP Manager initialized successfully', {});
 
+    // Register callback for immediate broadcast when tools become ready
+    // This ensures renderer gets notified as soon as tools are available,
+    // without waiting for the 3-second polling interval
+    mcpManager.setOnToolsReady((serverName) => {
+      logger.debug('Tools ready callback triggered', { serverName });
+      broadcastMCPStatusChange();
+    });
+
     // Start broadcasting status changes
     startMCPStatusBroadcasting();
   } catch (error) {

--- a/apps/desktop/src/shared/mcp-types.ts
+++ b/apps/desktop/src/shared/mcp-types.ts
@@ -45,6 +45,12 @@ export interface MCPServerStatusInfo {
   lastCrashAt?: Date;
   enabled: boolean;
   autoStart: boolean;
+  /**
+   * Whether tools have been fetched and cached for this server.
+   * A server can be 'running' but not have tools ready yet (during initialization).
+   * Only consider tools "available" when BOTH status === 'running' AND toolsReady === true.
+   */
+  toolsReady?: boolean;
 }
 
 /**

--- a/apps/web/src/lib/ai/shared/hooks/useMCPTools.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useMCPTools.ts
@@ -62,11 +62,13 @@ export function useMCPTools({ conversationId }: UseMCPToolsOptions): UseMCPTools
   // All MCP tool schemas from running servers (unfiltered)
   const [allMcpToolSchemas, setAllMcpToolSchemas] = useState<MCPToolSchema[]>([]);
 
-  // Get names of running servers
+  // Get names of running servers with tools ready
+  // Only consider tools "available" when BOTH status === 'running' AND toolsReady === true
+  // This prevents the race condition where server shows running but tools aren't cached yet
   const runningServerNames = useMemo(() => {
     if (!mcp.isDesktop) return [];
     return Object.entries(mcp.serverStatuses)
-      .filter(([, status]) => status.status === 'running')
+      .filter(([, status]) => status.status === 'running' && status.toolsReady === true)
       .map(([name]) => name);
   }, [mcp.isDesktop, mcp.serverStatuses]);
 

--- a/apps/web/src/types/mcp.ts
+++ b/apps/web/src/types/mcp.ts
@@ -25,6 +25,12 @@ export interface MCPServerStatusInfo {
   lastCrashAt?: Date;
   enabled: boolean;
   autoStart: boolean;
+  /**
+   * Whether tools have been fetched and cached for this server.
+   * A server can be 'running' but not have tools ready yet (during initialization).
+   * Only consider tools "available" when BOTH status === 'running' AND toolsReady === true.
+   */
+  toolsReady?: boolean;
 }
 
 /**


### PR DESCRIPTION
Root cause: Server status became 'running' before tools were cached.
The fire-and-forget tool initialization in startServer() meant the
renderer could fetch tools before getMCPTools() completed.

Solution:
- Add toolsReady boolean to MCPServerStatusInfo interface
- Track toolsReady state in MCPManager (false on start, true after
  tools fetched, reset on stop)
- Add onToolsReady callback for immediate broadcast when tools ready
- Update useMCPTools to filter on status=running AND toolsReady=true

This ensures MCP tools are only shown as available when they are
actually cached and ready to use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP server tool availability detection to prevent using tools before they're fully loaded
  * Tools are now made available immediately when ready instead of waiting for polling intervals

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->