### PR TITLE
fix(reorder): allow fractional and negative positions for task reorde…

### DIFF
--- a/apps/web/src/app/api/pages/reorder/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/reorder/__tests__/route.test.ts
@@ -161,16 +161,40 @@ describe('PATCH /api/pages/reorder', () => {
       expect(pageReorderService.reorderPage).not.toHaveBeenCalled();
     });
 
-    it('returns 400 for negative position values', async () => {
+    it('accepts negative position values (for fractional positioning)', async () => {
       const response = await PATCH(createRequest({
         pageId: mockPageId,
         newParentId: null,
         newPosition: -1,
       }));
-      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(pageReorderService.reorderPage).toHaveBeenCalledWith(
+        expect.objectContaining({ newPosition: -1 })
+      );
+    });
+
+    it('accepts fractional position values (for between-item positioning)', async () => {
+      const response = await PATCH(createRequest({
+        pageId: mockPageId,
+        newParentId: null,
+        newPosition: 2.5,
+      }));
+
+      expect(response.status).toBe(200);
+      expect(pageReorderService.reorderPage).toHaveBeenCalledWith(
+        expect.objectContaining({ newPosition: 2.5 })
+      );
+    });
+
+    it('returns 400 for non-finite position values', async () => {
+      const response = await PATCH(createRequest({
+        pageId: mockPageId,
+        newParentId: null,
+        newPosition: Infinity,
+      }));
 
       expect(response.status).toBe(400);
-      expect(body.error).toMatch(/position|non-negative/i);
       expect(pageReorderService.reorderPage).not.toHaveBeenCalled();
     });
 

--- a/apps/web/src/app/api/pages/reorder/route.ts
+++ b/apps/web/src/app/api/pages/reorder/route.ts
@@ -10,7 +10,7 @@ const AUTH_OPTIONS = { allow: ['jwt', 'mcp'] as const, requireCSRF: true };
 const reorderSchema = z.object({
   pageId: z.string(),
   newParentId: z.string().nullable(),
-  newPosition: z.number().int().gte(0, 'Position must be a non-negative integer'),
+  newPosition: z.number().finite(),
 });
 
 export async function PATCH(request: Request) {


### PR DESCRIPTION
…ring

The Zod validation schema required newPosition to be a non-negative integer, but the frontend uses fractional positioning (averaging neighbor positions) when reordering tasks between items. This caused validation failures when reordering task lists with more than 2 tasks.

- Remove .int() and .gte(0) constraints from reorderSchema
- Add .finite() to prevent Infinity/NaN values
- Update tests to verify fractional (2.5) and negative (-1) positions work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page reordering validation to accept negative and fractional position values, while maintaining rejection of invalid non-finite values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->