### PR TITLE
fix(ai): enable web search tools for AI chat pages

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -15,6 +15,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Loader2, Settings, MessageSquare, History, Plus, Save } from 'lucide-react';
 import { UIMessage, DefaultChatTransport } from 'ai';
 import { useEditingStore } from '@/stores/useEditingStore';
+import { useAssistantSettingsStore } from '@/stores/useAssistantSettingsStore';
 import { buildPagePath } from '@/lib/tree/tree-utils';
 import { useDriveStore } from '@/hooks/useDrive';
 import { useAuth } from '@/hooks/useAuth';
@@ -94,6 +95,9 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
     allServersEnabled,
     setAllServersEnabled,
   } = useMCPTools({ conversationId: currentConversationId });
+
+  // Get web search setting from global assistant settings store
+  const webSearchEnabled = useAssistantSettingsStore((state) => state.webSearchEnabled);
 
   const {
     conversations,
@@ -272,6 +276,8 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
           conversationId: currentConversationId,
           selectedProvider,
           selectedModel,
+          isReadOnly,
+          webSearchEnabled,
           mcpTools: mcpToolSchemas.length > 0 ? mcpToolSchemas : undefined,
           pageContext: {
             pageId: page.id,
@@ -302,6 +308,7 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
     selectedProvider,
     selectedModel,
     mcpToolSchemas,
+    webSearchEnabled,
   ]);
 
   const handleUndoSuccess = useCallback(async () => {


### PR DESCRIPTION
AiChatView was not passing webSearchEnabled to the API, causing web search tools to always be filtered out for AI chat pages. This fix adds the webSearchEnabled parameter from the assistant settings store to the request body, matching the behavior of GlobalAssistantView.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added web search setting for AI chat interactions, allowing users to toggle web search on or off during conversations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->