### PR TITLE
fix(ai): hide price estimates for PageSpace provider models

### DIFF
--- a/apps/web/src/components/ai/shared/AiUsageMonitor.tsx
+++ b/apps/web/src/components/ai/shared/AiUsageMonitor.tsx
@@ -7,7 +7,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { Activity, DollarSign, Database, AlertCircle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useSocketStore } from '@/stores/useSocketStore';
-import { getUserFacingModelName } from '@/lib/ai/core/ai-providers-config';
+import { getUserFacingModelName, isPageSpaceProvider } from '@/lib/ai/core/ai-providers-config';
 
 interface AiUsageMonitorProps {
   conversationId?: string | null | undefined;
@@ -141,8 +141,8 @@ export function AiUsageMonitor({ conversationId, pageId, className, compact = fa
             </TooltipContent>
           </Tooltip>
 
-          {/* Session Cost */}
-          {usage.billing.cost > 0 && (
+          {/* Session Cost - hidden for PageSpace provider (included in subscription) */}
+          {usage.billing.cost > 0 && !isPageSpaceProvider(usage.provider) && (
             <Tooltip>
               <TooltipTrigger asChild>
                 <div className="flex items-center gap-1">
@@ -230,8 +230,8 @@ export function AiUsageMonitor({ conversationId, pageId, className, compact = fa
             </Tooltip>
           </div>
 
-          {/* Cost (if applicable) */}
-          {usage.billing.cost > 0 && (
+          {/* Cost (if applicable) - hidden for PageSpace provider (included in subscription) */}
+          {usage.billing.cost > 0 && !isPageSpaceProvider(usage.provider) && (
             <Tooltip>
               <TooltipTrigger asChild>
                 <div className="flex items-center justify-between pt-1 text-xs">

--- a/apps/web/src/lib/ai/core/ai-providers-config.ts
+++ b/apps/web/src/lib/ai/core/ai-providers-config.ts
@@ -30,6 +30,15 @@ export function isPageSpaceModelAlias(model: string): boolean {
   return model.toLowerCase() in PAGESPACE_MODEL_ALIASES;
 }
 
+/**
+ * Check if a provider is the PageSpace provider
+ * Used to hide pricing info for PageSpace models (included in subscription)
+ * while still showing prices for GLM Coder Plan (pay-per-use)
+ */
+export function isPageSpaceProvider(provider: string | null | undefined): boolean {
+  return provider === 'pagespace';
+}
+
 export const AI_PROVIDERS = {
   pagespace: {
     name: 'PageSpace',


### PR DESCRIPTION
PageSpace AI models (Standard/Pro) are included in subscription, so displaying cost estimates is misleading. This change hides the price display in chats sidebar and AI chat pages when using the PageSpace provider, while still showing prices for GLM Coder Plan users who pay per use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hid Session Cost and Total Cost displays when using PageSpace as the AI provider, while maintaining cost visibility for other providers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->