### PR TITLE
fix(auth): disable Google One Tap on mobile browsers

### DIFF
--- a/apps/web/src/components/auth/GoogleOneTap.tsx
+++ b/apps/web/src/components/auth/GoogleOneTap.tsx
@@ -147,6 +147,20 @@ export function GoogleOneTap({
       return;
     }
 
+    // Don't run on mobile browsers - Google One Tap (FedCM) has limited support
+    // on mobile and causes repeated prompts/re-renders leading to login loops
+    if (typeof window !== 'undefined' && typeof navigator !== 'undefined') {
+      const userAgent = navigator.userAgent.toLowerCase();
+      const isMobileBrowser =
+        /android|webos|iphone|ipad|ipod|blackberry|iemobile|opera mini|mobile|tablet/i.test(
+          userAgent
+        );
+      if (isMobileBrowser) {
+        console.debug('Google One Tap: Skipping on mobile browser');
+        return;
+      }
+    }
+
     const clientId = process.env.NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID;
     if (!clientId) {
       console.warn('Google One Tap: Missing NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID');


### PR DESCRIPTION
Google One Tap with FedCM has limited support on mobile browsers and
causes repeated prompts/re-renders, leading to a login loop where
users get spammed at the login page. This adds user agent detection
to skip One Tap initialization on mobile devices, allowing users to
use the regular Google OAuth button instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled Google One Tap authentication prompts on mobile browsers to eliminate unnecessary notifications and re-renders, providing a smoother mobile user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->