### PR TITLE
fix(desktop): only apply traffic light padding on macOS

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -926,7 +926,6 @@ async function handleAuthExchange(url: string): Promise<boolean> {
 
     const code = urlObj.searchParams.get('code');
     const provider = urlObj.searchParams.get('provider') || 'unknown';
-    const isNewUser = urlObj.searchParams.get('isNewUser') === 'true';
 
     if (!code) {
       logger.error('[Auth Exchange] Missing code in deep link');


### PR DESCRIPTION
The 80px left padding for traffic light buttons was being applied
on all platforms including Windows, where these buttons don't exist.
Now the padding is conditional on `process.platform === 'darwin'`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macOS window control button spacing so traffic-light controls no longer overlap the header.
* **Chores**
  * Stopped reading a "new user" flag from deep-link parameters (the app no longer derives that value from incoming links).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->