### PR TITLE
fix(middleware): add /api/cron/ to public routes for server-to-server auth

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -73,6 +73,7 @@ export async function middleware(req: NextRequest) {
       pathname.startsWith('/api/auth/google') ||
       pathname.startsWith('/api/mcp/') ||
       pathname.startsWith('/api/drives') ||
+      pathname === '/api/cron' ||
       pathname.startsWith('/api/cron/')
     ) {
       const { response } = createSecureResponse(isProduction, req, isAPIRoute);


### PR DESCRIPTION
Cron endpoints were unreachable because middleware required session cookies.
External cron schedulers make server-to-server requests without cookies,
so they were blocked with 401 before reaching the cron handler's own
CRON_SECRET validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated routing logic so scheduled/cron endpoints are treated as public-route bypasses for automated background processes; these endpoints continue to enforce their own authorization. No public-facing API signatures or exported declarations were changed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->