### PR TITLE
fix(realtime): fix shared drive permissions not updating in sidebar

### DIFF
--- a/apps/web/src/app/api/drives/[driveId]/members/[userId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/[userId]/__tests__/route.test.ts
@@ -21,6 +21,8 @@ vi.mock('@pagespace/lib/server', () => ({
   getMemberPermissions: vi.fn(),
   updateMemberRole: vi.fn(),
   updateMemberPermissions: vi.fn(),
+  invalidateUserPermissions: vi.fn().mockResolvedValue(undefined),
+  invalidateDrivePermissions: vi.fn().mockResolvedValue(undefined),
   loggers: {
     api: {
       info: vi.fn(),

--- a/apps/web/src/app/api/drives/[driveId]/members/[userId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/[userId]/route.ts
@@ -7,6 +7,8 @@ import {
   getMemberPermissions,
   updateMemberRole,
   updateMemberPermissions,
+  invalidateUserPermissions,
+  invalidateDrivePermissions,
 } from '@pagespace/lib/server';
 import { createDriveNotification } from '@pagespace/lib';
 import { broadcastDriveMemberEvent, createDriveMemberEventPayload } from '@/lib/websocket';
@@ -151,6 +153,12 @@ export async function PATCH(
       currentUserId,
       permissions
     );
+
+    // Invalidate permission caches so changes take effect immediately
+    await Promise.all([
+      invalidateUserPermissions(userId),
+      invalidateDrivePermissions(driveId),
+    ]);
 
     return NextResponse.json({
       success: true,
@@ -299,6 +307,12 @@ export async function DELETE(
         driveName: access.drive.name,
       })
     );
+
+    // Invalidate permission caches so removed user loses access immediately
+    await Promise.all([
+      invalidateUserPermissions(targetUserId),
+      invalidateDrivePermissions(driveId),
+    ]);
 
     // Note: No in-app notification sent for removal - the broadcast event
     // will trigger a page refresh/redirect for the removed user, and the


### PR DESCRIPTION
- Fix useGlobalDriveSocket to use user.id instead of socket.id for channel subscription
  (socket.id is the Socket.IO connection ID, not the user ID, so member events were
  never being received)
- Add permission cache invalidation when members are added/updated/removed
- Store joined user ID in ref for proper cleanup on unmount

These changes ensure that when someone shares a drive with a user:
1. The realtime event is properly received (correct channel subscription)
2. Permission caches are invalidated immediately (no stale permissions)
3. The sidebar refreshes to show the newly shared drive

https://claude.ai/code/session_017uoRQb8sw7PuoxVgK2hhhQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Permission changes for drive members now take effect immediately via cache invalidation after updates or removals.

* **Improvements**
  * Invitations and role updates propagate in real time more reliably.
  * Live-update connection now joins and leaves user-specific channels based on the signed-in user for cleaner session handling.

* **Tests**
  * Added mocks to cover the new permission invalidation paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->