### PR TITLE
fix(processor): make auth required by default, prevent accidental disable

### DIFF
--- a/apps/processor/src/middleware/__tests__/auth.test.ts
+++ b/apps/processor/src/middleware/__tests__/auth.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+/**
+ * Auth Middleware Tests
+ *
+ * Validates that authentication cannot be accidentally disabled in production.
+ * The AUTH_REQUIRED flag should:
+ * - Always be true when PROCESSOR_AUTH_REQUIRED is not set
+ * - Always be true when PROCESSOR_AUTH_REQUIRED=true
+ * - Throw an error if PROCESSOR_AUTH_REQUIRED=false in production
+ * - Only allow PROCESSOR_AUTH_REQUIRED=false in development mode
+ */
+
+// Mock all external dependencies that auth.ts imports
+vi.mock('@pagespace/lib/auth', () => ({
+  sessionService: {
+    validateSession: vi.fn(),
+  },
+}));
+
+vi.mock('@pagespace/lib/permissions', () => ({
+  EnforcedAuthContext: {
+    fromSession: vi.fn(),
+  },
+}));
+
+describe('AUTH_REQUIRED security behavior', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.resetModules();
+  });
+
+  describe('given PROCESSOR_AUTH_REQUIRED is not set', () => {
+    it('should require auth (AUTH_REQUIRED = true)', async () => {
+      delete process.env.PROCESSOR_AUTH_REQUIRED;
+      delete process.env.NODE_ENV;
+
+      const { AUTH_REQUIRED } = await import('../auth');
+      expect(AUTH_REQUIRED).toBe(true);
+    });
+  });
+
+  describe('given PROCESSOR_AUTH_REQUIRED=true', () => {
+    it('should require auth (AUTH_REQUIRED = true)', async () => {
+      process.env.PROCESSOR_AUTH_REQUIRED = 'true';
+      delete process.env.NODE_ENV;
+
+      const { AUTH_REQUIRED } = await import('../auth');
+      expect(AUTH_REQUIRED).toBe(true);
+    });
+  });
+
+  describe('given PROCESSOR_AUTH_REQUIRED=false in production', () => {
+    it('should throw an error refusing to disable auth', async () => {
+      process.env.PROCESSOR_AUTH_REQUIRED = 'false';
+      process.env.NODE_ENV = 'production';
+
+      await expect(import('../auth')).rejects.toThrow(
+        'PROCESSOR_AUTH_REQUIRED=false is only allowed in development mode'
+      );
+    });
+  });
+
+  describe('given PROCESSOR_AUTH_REQUIRED=false with NODE_ENV unset', () => {
+    it('should throw an error (fail-safe: unset NODE_ENV is not development)', async () => {
+      process.env.PROCESSOR_AUTH_REQUIRED = 'false';
+      delete process.env.NODE_ENV;
+
+      await expect(import('../auth')).rejects.toThrow(
+        'PROCESSOR_AUTH_REQUIRED=false is only allowed in development mode'
+      );
+    });
+  });
+
+  describe('given PROCESSOR_AUTH_REQUIRED=false in development', () => {
+    it('should allow auth to be disabled (AUTH_REQUIRED = false)', async () => {
+      process.env.PROCESSOR_AUTH_REQUIRED = 'false';
+      process.env.NODE_ENV = 'development';
+
+      const { AUTH_REQUIRED } = await import('../auth');
+      expect(AUTH_REQUIRED).toBe(false);
+    });
+  });
+
+  describe('given PROCESSOR_AUTH_REQUIRED=false in test mode', () => {
+    it('should throw an error (test mode is not development)', async () => {
+      process.env.PROCESSOR_AUTH_REQUIRED = 'false';
+      process.env.NODE_ENV = 'test';
+
+      await expect(import('../auth')).rejects.toThrow(
+        'PROCESSOR_AUTH_REQUIRED=false is only allowed in development mode'
+      );
+    });
+  });
+
+  describe('given random PROCESSOR_AUTH_REQUIRED value', () => {
+    it('should require auth for any value other than false', async () => {
+      process.env.PROCESSOR_AUTH_REQUIRED = 'yes';
+      delete process.env.NODE_ENV;
+
+      const { AUTH_REQUIRED } = await import('../auth');
+      expect(AUTH_REQUIRED).toBe(true);
+    });
+  });
+
+  describe('given empty string PROCESSOR_AUTH_REQUIRED', () => {
+    it('should require auth (empty string is not false)', async () => {
+      process.env.PROCESSOR_AUTH_REQUIRED = '';
+      delete process.env.NODE_ENV;
+
+      const { AUTH_REQUIRED } = await import('../auth');
+      expect(AUTH_REQUIRED).toBe(true);
+    });
+  });
+});

--- a/apps/processor/src/middleware/auth.ts
+++ b/apps/processor/src/middleware/auth.ts
@@ -2,7 +2,23 @@ import type { NextFunction, Request, Response } from 'express';
 import { sessionService, type SessionClaims } from '@pagespace/lib/auth';
 import { EnforcedAuthContext } from '@pagespace/lib/permissions';
 
-export const AUTH_REQUIRED = process.env.PROCESSOR_AUTH_REQUIRED !== 'false';
+/**
+ * Authentication is ALWAYS required in production.
+ * In development only, it can be explicitly disabled with PROCESSOR_AUTH_REQUIRED=false.
+ */
+export const AUTH_REQUIRED = (() => {
+  const wantsDisabled = process.env.PROCESSOR_AUTH_REQUIRED === 'false';
+  const isDevelopment = process.env.NODE_ENV === 'development';
+
+  if (wantsDisabled && !isDevelopment) {
+    throw new Error(
+      'PROCESSOR_AUTH_REQUIRED=false is only allowed in development mode. ' +
+      'Authentication cannot be disabled in production.'
+    );
+  }
+
+  return !wantsDisabled;
+})();
 
 function collectCandidateUrls(req: Request): string[] {
   const rawValues: Array<string | undefined | null> = [


### PR DESCRIPTION
## Summary

- Prevents `PROCESSOR_AUTH_REQUIRED=false` from disabling authentication in production
- Authentication can now only be disabled in development mode (`NODE_ENV=development`)
- Throws error at startup if auth disable is attempted outside development, failing fast
- Added 8 comprehensive tests covering all env var scenarios

## Security Fix

**Before:** `PROCESSOR_AUTH_REQUIRED=false` could disable auth in any environment, risking accidental production misconfiguration.

**After:**
| Scenario | Behavior |
|----------|----------|
| Missing env var | Auth REQUIRED (secure default) |
| `PROCESSOR_AUTH_REQUIRED=true` | Auth REQUIRED |
| `PROCESSOR_AUTH_REQUIRED=false` + production | THROWS ERROR |
| `PROCESSOR_AUTH_REQUIRED=false` + development | Auth disabled (dev convenience) |
| `PROCESSOR_AUTH_REQUIRED=false` + no NODE_ENV | THROWS ERROR (fail-safe) |

## Test plan

- [x] All 8 new auth middleware tests pass
- [x] Existing processor tests still pass
- [ ] Manual verification: start processor with `PROCESSOR_AUTH_REQUIRED=false` without `NODE_ENV=development` and confirm startup failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for authentication configuration behavior across different environment modes.

* **Documentation**
  * Updated security documentation to reflect authentication configuration changes.

* **Bug Fixes**
  * Enhanced authentication validation to prevent disabling auth in production environments; now only permitted in development mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->