### PR TITLE
fix(ui): fix Activity and History buttons not opening sheet on mobile

### DIFF
--- a/apps/web/src/components/layout/Layout.tsx
+++ b/apps/web/src/components/layout/Layout.tsx
@@ -20,7 +20,7 @@ import { useIOSKeyboardInit } from "@/hooks/useIOSKeyboardInit";
 import { dismissKeyboard } from "@/hooks/useMobileKeyboard";
 import { useRouter, usePathname } from "next/navigation";
 import { isCapacitorApp } from "@/lib/capacitor-bridge";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect } from "react";
 import {
   Sheet,
   SheetContent,
@@ -48,10 +48,14 @@ function Layout({ children }: LayoutProps) {
   const setLeftSidebarOpen = useLayoutStore(state => state.setLeftSidebarOpen);
   const setRightSidebarOpen = useLayoutStore(state => state.setRightSidebarOpen);
 
+  // Mobile sheet state from store (allows other components to control sheets)
+  const leftSheetOpen = useLayoutStore(state => state.leftSheetOpen);
+  const rightSheetOpen = useLayoutStore(state => state.rightSheetOpen);
+  const setLeftSheetOpen = useLayoutStore(state => state.setLeftSheetOpen);
+  const setRightSheetOpen = useLayoutStore(state => state.setRightSheetOpen);
+
   const hasHydrated = useHasHydrated();
   const shouldOverlaySidebars = useBreakpoint("(max-width: 1279px)");
-  const [leftSheetOpen, setLeftSheetOpen] = useState(false);
-  const [rightSheetOpen, setRightSheetOpen] = useState(false);
 
   useResponsivePanels();
 
@@ -72,7 +76,7 @@ function Layout({ children }: LayoutProps) {
       setLeftSheetOpen(false);
       setRightSheetOpen(false);
     }
-  }, [isSheetBreakpoint]);
+  }, [isSheetBreakpoint, setLeftSheetOpen, setRightSheetOpen]);
 
   // Auto-close sheets on navigation (Capacitor only)
   // This fixes the issue where tapping a sidebar item navigates but leaves the sheet open
@@ -81,7 +85,7 @@ function Layout({ children }: LayoutProps) {
       setLeftSheetOpen(false);
       setRightSheetOpen(false);
     }
-  }, [pathname, isSheetBreakpoint]);
+  }, [pathname, isSheetBreakpoint, setLeftSheetOpen, setRightSheetOpen]);
 
   // Handle authentication redirect with Next.js router for faster navigation
   useEffect(() => {
@@ -94,13 +98,11 @@ function Layout({ children }: LayoutProps) {
   const handleLeftPanelToggle = useCallback(() => {
     dismissKeyboard();
     if (isSheetBreakpoint) {
-      setLeftSheetOpen((open) => {
-        const nextOpen = !open;
-        if (nextOpen && rightSheetOpen) {
-          setRightSheetOpen(false);
-        }
-        return nextOpen;
-      });
+      const nextOpen = !leftSheetOpen;
+      if (nextOpen && rightSheetOpen) {
+        setRightSheetOpen(false);
+      }
+      setLeftSheetOpen(nextOpen);
       return;
     }
 
@@ -119,10 +121,13 @@ function Layout({ children }: LayoutProps) {
     toggleLeftSidebar();
   }, [
     isSheetBreakpoint,
+    leftSheetOpen,
     rightSheetOpen,
     shouldOverlaySidebars,
     leftSidebarOpen,
     rightSidebarOpen,
+    setLeftSheetOpen,
+    setRightSheetOpen,
     setLeftSidebarOpen,
     setRightSidebarOpen,
     toggleLeftSidebar,
@@ -131,13 +136,11 @@ function Layout({ children }: LayoutProps) {
   const handleRightPanelToggle = useCallback(() => {
     dismissKeyboard();
     if (isSheetBreakpoint) {
-      setRightSheetOpen((open) => {
-        const nextOpen = !open;
-        if (nextOpen && leftSheetOpen) {
-          setLeftSheetOpen(false);
-        }
-        return nextOpen;
-      });
+      const nextOpen = !rightSheetOpen;
+      if (nextOpen && leftSheetOpen) {
+        setLeftSheetOpen(false);
+      }
+      setRightSheetOpen(nextOpen);
       return;
     }
 
@@ -157,9 +160,12 @@ function Layout({ children }: LayoutProps) {
   }, [
     isSheetBreakpoint,
     leftSheetOpen,
+    rightSheetOpen,
     shouldOverlaySidebars,
     leftSidebarOpen,
     rightSidebarOpen,
+    setLeftSheetOpen,
+    setRightSheetOpen,
     setLeftSidebarOpen,
     setRightSidebarOpen,
     toggleRightSidebar,

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -72,7 +72,7 @@ import { ChatInput, type ChatInputRef } from '@/components/ai/chat/input';
 
 const GlobalAssistantView: React.FC = () => {
   const pathname = usePathname();
-  const { rightSidebarOpen, toggleRightSidebar } = useLayoutStore();
+  const { setRightSidebarOpen, setRightSheetOpen } = useLayoutStore();
 
   // ============================================
   // GLOBAL CHAT CONTEXT - for Global Assistant mode
@@ -445,12 +445,16 @@ const GlobalAssistantView: React.FC = () => {
   };
 
   const handleOpenActivity = () => {
-    if (!rightSidebarOpen) toggleRightSidebar();
+    // Open both sidebar (desktop) and sheet (mobile) to ensure visibility on all breakpoints
+    setRightSidebarOpen(true);
+    setRightSheetOpen(true);
     setActiveTab('activity');
   };
 
   const handleOpenHistory = () => {
-    if (!rightSidebarOpen) toggleRightSidebar();
+    // Open both sidebar (desktop) and sheet (mobile) to ensure visibility on all breakpoints
+    setRightSidebarOpen(true);
+    setRightSheetOpen(true);
     setActiveTab('history');
   };
 

--- a/apps/web/src/stores/useLayoutStore.ts
+++ b/apps/web/src/stores/useLayoutStore.ts
@@ -9,6 +9,10 @@ interface LayoutState {
   rightSidebarOpen: boolean;
   taskListViewMode: TaskListViewMode;
 
+  // Mobile sheet state (NOT persisted - sheets start closed on page load)
+  leftSheetOpen: boolean;
+  rightSheetOpen: boolean;
+
   // Hydration state
   rehydrated: boolean;
 
@@ -18,6 +22,8 @@ interface LayoutState {
   toggleRightSidebar: () => void;
   setLeftSidebarOpen: (open: boolean) => void;
   setRightSidebarOpen: (open: boolean) => void;
+  setLeftSheetOpen: (open: boolean) => void;
+  setRightSheetOpen: (open: boolean) => void;
   setTaskListViewMode: (mode: TaskListViewMode) => void;
 }
 
@@ -29,6 +35,10 @@ export const useLayoutStore = create<LayoutState>()(
       rightSidebarOpen: false,
       taskListViewMode: 'table',
       rehydrated: false,
+
+      // Mobile sheet state (NOT persisted)
+      leftSheetOpen: false,
+      rightSheetOpen: false,
 
       setRehydrated: () => {
         set({ rehydrated: true });
@@ -52,6 +62,14 @@ export const useLayoutStore = create<LayoutState>()(
 
       setRightSidebarOpen: (open: boolean) => {
         set({ rightSidebarOpen: open });
+      },
+
+      setLeftSheetOpen: (open: boolean) => {
+        set({ leftSheetOpen: open });
+      },
+
+      setRightSheetOpen: (open: boolean) => {
+        set({ rightSheetOpen: open });
       },
     }),
     {


### PR DESCRIPTION
The Activity and History buttons in GlobalAssistantView were only toggling
the rightSidebarOpen state, which controls the desktop sidebar. On mobile,
the sidebar is rendered as a Sheet component with separate state.

Changes:
- Add leftSheetOpen and rightSheetOpen state to useLayoutStore (not persisted)
- Update Layout.tsx to use sheet state from store instead of local useState
- Update handleOpenActivity and handleOpenHistory to set both sidebar and
  sheet open states, ensuring visibility on all breakpoints

https://claude.ai/code/session_01TD1VRYC1c8UtJFMXXcvGYD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Mobile sheet state for left/right panels moved from local component state to a centralized shared state for consistent behavior.
  * Added non-persisted mobile sheet state and explicit setters to control open/close behavior.
  * Toggle handlers now ensure opening one sheet closes the opposite one.

* **Bug Fixes**
  * Right-hand panel now reliably opens on both desktop and mobile views.

* **Chore**
  * Public component interfaces remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->