### PR TITLE
fix(ui): reduce toast notifications and fix iOS safe area positioning

### DIFF
--- a/apps/web/src/app/auth/signin/page.tsx
+++ b/apps/web/src/app/auth/signin/page.tsx
@@ -67,9 +67,6 @@ function SignInForm() {
       const result = await actions.login(email, password);
 
       if (result.success) {
-        // Show success message
-        toast.success("Welcome back! You've been signed in successfully.");
-        
         // Use replace to avoid back navigation issues
         router.replace(result.redirectTo ?? '/dashboard');
       } else {
@@ -106,8 +103,6 @@ function SignInForm() {
 
           // Clear authFailedPermanently flag to allow auth validation
           useAuthStore.getState().setAuthFailedPermanently(false);
-
-          toast.success("Welcome! You've been signed in successfully.");
 
           // Directly set auth state - no API call needed
           // This is synchronous and prevents race conditions where the dashboard
@@ -194,8 +189,6 @@ function SignInForm() {
 
           // Clear authFailedPermanently flag to allow auth validation
           useAuthStore.getState().setAuthFailedPermanently(false);
-
-          toast.success("Welcome! You've been signed in successfully.");
 
           // Directly set auth state - no API call needed
           if (result.user) {

--- a/apps/web/src/app/auth/signup/page.tsx
+++ b/apps/web/src/app/auth/signup/page.tsx
@@ -103,7 +103,6 @@ export default function SignUp() {
       // Handle successful signup (303 redirect)
       if (signupResponse.status === 303 || signupResponse.type === 'opaqueredirect') {
         // Success! Server sent redirect
-        toast.success(`Welcome to PageSpace, ${name}! Let's get started.`);
         setLoadingMessage("Taking you to your dashboard...");
 
         // Navigate to dashboard (or follow the Location header)
@@ -170,7 +169,6 @@ export default function SignUp() {
         if (result.success) {
           const { useAuthStore } = await import('@/stores/useAuthStore');
           useAuthStore.getState().setAuthFailedPermanently(false);
-          toast.success("Welcome! You've been signed in successfully.");
 
           if (result.user) {
             useAuthStore.getState().setUser(result.user);
@@ -248,7 +246,6 @@ export default function SignUp() {
         if (result.success) {
           const { useAuthStore } = await import('@/stores/useAuthStore');
           useAuthStore.getState().setAuthFailedPermanently(false);
-          toast.success("Welcome! You've been signed in successfully.");
 
           if (result.user) {
             useAuthStore.getState().setUser(result.user);

--- a/apps/web/src/app/settings/account/page.tsx
+++ b/apps/web/src/app/settings/account/page.tsx
@@ -111,7 +111,6 @@ export default function AccountPage() {
       if (mutate) {
         await mutate(); // Refresh user data
       }
-      toast.success("Profile updated successfully");
     } catch (error) {
       console.error("Profile update error:", error);
       toast.error(error instanceof Error ? error.message : "Failed to update profile");
@@ -156,7 +155,6 @@ export default function AccountPage() {
     try {
       await post('/api/account/avatar', formData);
 
-      toast.success('Avatar uploaded successfully');
       setAvatarFile(null);
 
       // Refresh user data to get new avatar URL
@@ -177,7 +175,6 @@ export default function AccountPage() {
     try {
       await del('/api/account/avatar');
 
-      toast.success('Avatar deleted successfully');
       setAvatarPreview(null);
       setAvatarFile(null);
 
@@ -277,8 +274,6 @@ export default function AccountPage() {
     setIsDeletingAccount(true);
     try {
       await del("/api/account", { emailConfirmation });
-
-      toast.success("Account deleted successfully. Redirecting...");
 
       // Clear authentication and redirect to home
       setTimeout(() => {

--- a/apps/web/src/components/auth/GoogleOneTap.tsx
+++ b/apps/web/src/components/auth/GoogleOneTap.tsx
@@ -77,8 +77,6 @@ export function GoogleOneTap({
         const data = await res.json();
 
         if (res.ok && data.success) {
-          toast.success("Welcome! You've been signed in with Google.");
-
           if (onSuccess) {
             onSuccess(data.user);
           }

--- a/apps/web/src/components/layout/left-sidebar/CreatePageDialog.tsx
+++ b/apps/web/src/components/layout/left-sidebar/CreatePageDialog.tsx
@@ -72,7 +72,6 @@ export default function CreatePageDialog({ parentId, isOpen, setIsOpen, onPageCr
         }
 
         const result = await response.json();
-        toast.success('File uploaded successfully');
         onPageCreated(result.page);
         setIsOpen(false);
         setTitle('');
@@ -100,7 +99,6 @@ export default function CreatePageDialog({ parentId, isOpen, setIsOpen, onPageCr
         content
       });
 
-      toast.success('Page created successfully');
       onPageCreated(newPage);
       setIsOpen(false);
       setTitle('');

--- a/apps/web/src/components/layout/middle-content/content-header/EditableTitle.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/EditableTitle.tsx
@@ -56,7 +56,6 @@ export function EditableTitle({ pageId: propPageId }: { pageId?: string | null }
       const updatedPage = await patch<{ id: string; title: string }>(`/api/pages/${page.id}`, { title });
       updateNode(updatedPage.id, { title: updatedPage.title });
       mutate(`/api/pages/${page.id}/breadcrumbs`);
-      toast.success('Title updated successfully');
     } catch (error) {
       console.error(error);
       toast.error('Failed to update title');

--- a/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
@@ -39,7 +39,6 @@ const CanvasPageView = ({ page }: CanvasPageViewProps) => {
       }
       await patch(`/api/pages/${pageId}`, { content: newValue }, { headers });
       console.log('Save successful');
-      toast.success('Page saved successfully!');
     } catch (error) {
       console.error('Failed to save page content:', error);
       toast.error('Failed to save page content.');
@@ -74,7 +73,6 @@ const CanvasPageView = ({ page }: CanvasPageViewProps) => {
             const newContent = typeof updatedPage.content === 'string' ? updatedPage.content : '';
             // Use updateContentFromServer to avoid triggering auto-save loop
             updateContentFromServer(newContent);
-            toast.success('Canvas updated');
           }
         } catch (error) {
           console.error('Failed to fetch updated canvas content:', error);

--- a/apps/web/src/components/ui/sonner.tsx
+++ b/apps/web/src/components/ui/sonner.tsx
@@ -1,10 +1,29 @@
 "use client"
 
 import { useTheme } from "next-themes"
+import { useEffect, useState } from "react"
 import { Toaster as Sonner, ToasterProps } from "sonner"
 
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme()
+  const [offset, setOffset] = useState("80px")
+
+  useEffect(() => {
+    // Check for iOS Capacitor app and adjust offset for safe area
+    const isCapacitorIOS = document.documentElement.classList.contains('capacitor-ios')
+    if (isCapacitorIOS) {
+      // Get the safe area inset from CSS custom property
+      const safeAreaTop = getComputedStyle(document.documentElement)
+        .getPropertyValue('--safe-area-top')
+        .trim()
+
+      if (safeAreaTop && safeAreaTop !== '0px') {
+        // Parse the safe area value and add to base offset
+        const safeAreaValue = parseInt(safeAreaTop, 10) || 0
+        setOffset(`${80 + safeAreaValue}px`)
+      }
+    }
+  }, [])
 
   return (
     <Sonner
@@ -17,7 +36,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
           "--normal-border": "var(--border)",
         } as React.CSSProperties
       }
-      offset="80px"
+      offset={offset}
       {...props}
     />
   )

--- a/apps/web/src/lib/ai/shared/hooks/useConversations.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useConversations.ts
@@ -119,7 +119,6 @@ export function useConversations({
           const messagesData = await response.json();
           const messages = messagesData.messages || [];
           onConversationLoad?.(conversationId, messages);
-          toast.success('Conversation loaded');
         } else {
           throw new Error('Failed to load conversation');
         }
@@ -154,7 +153,6 @@ export function useConversations({
         }
 
         onConversationCreate?.(newConversationId);
-        toast.success('New conversation started');
         return newConversationId;
       }
       return null;
@@ -185,8 +183,6 @@ export function useConversations({
           if (conversationId === currentConversationId) {
             onConversationDelete?.(conversationId);
           }
-
-          toast.success('Conversation deleted');
         }
       } catch (error) {
         console.error('Failed to delete conversation:', error);


### PR DESCRIPTION
- Remove redundant success toasts where UI provides clear feedback:
  - Sign in/sign up success (user is redirected to dashboard)
  - Profile/avatar updates (form state changes are visible)
  - Page creation (user is navigated to new page)
  - Title updates (title visually changes immediately)
  - Canvas saves (auto-save should be silent)
  - Conversation load/create/delete (UI shows state changes)
  - Account deletion (user is redirected)
- Keep error toasts (always important)
- Keep toasts for non-obvious actions (password change, email verification)
- Fix toast positioning on iOS Capacitor apps by accounting for safe area
  inset at the top of the screen

https://claude.ai/code/session_01FaEF36XZVTzRAFuewqS3Ei

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed success notifications from sign-in, sign-up, account updates, page creation, and conversation operations to streamline user feedback across the app.

* **Style**
  * Improved toast notification positioning on iOS devices to respect system safe-area boundaries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->