### PR TITLE
fix(ui): position mention suggestions based on input placement

### DIFF
--- a/apps/web/src/components/ai/chat/input/ChatInput.tsx
+++ b/apps/web/src/components/ai/chat/input/ChatInput.tsx
@@ -48,6 +48,8 @@ export interface ChatInputProps {
   onMcpServerToggle?: (serverName: string, enabled: boolean) => void;
   /** Whether MCP section should be shown (desktop only) */
   showMcp?: boolean;
+  /** Popup placement for mention suggestions: 'top' (default) for docked input, 'bottom' for centered input */
+  popupPlacement?: 'top' | 'bottom';
   /** Override provider from props (for page-level settings) */
   selectedProvider?: string | null;
   /** Override model from props (for page-level settings) */
@@ -96,6 +98,7 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
       isMcpServerEnabled,
       onMcpServerToggle,
       showMcp = false,
+      popupPlacement = 'top',
       selectedProvider: propProvider,
       selectedModel: propModel,
       onProviderModelChange,
@@ -176,6 +179,7 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
             crossDrive={crossDrive}
             disabled={disabled}
             variant={variant}
+            popupPlacement={popupPlacement}
           />
 
           <InputActions

--- a/apps/web/src/components/ai/chat/input/ChatTextarea.tsx
+++ b/apps/web/src/components/ai/chat/input/ChatTextarea.tsx
@@ -27,6 +27,8 @@ export interface ChatTextareaProps {
   disabled?: boolean;
   /** Style variant: 'main' for InputCard context, 'sidebar' for sidebar contrast */
   variant?: 'main' | 'sidebar';
+  /** Popup placement: 'top' for suggestions above (docked input), 'bottom' for suggestions below (centered input) */
+  popupPlacement?: 'top' | 'bottom';
   /** Additional class names */
   className?: string;
 }
@@ -53,6 +55,7 @@ const ChatTextareaInner = forwardRef<ChatTextareaRef, ChatTextareaProps>(
       crossDrive = false,
       disabled = false,
       variant = 'main',
+      popupPlacement = 'top',
       className,
     },
     ref
@@ -70,7 +73,7 @@ const ChatTextareaInner = forwardRef<ChatTextareaRef, ChatTextareaProps>(
       crossDrive,
       mentionFormat: 'markdown-typed',
       variant: 'chat',
-      popupPlacement: 'top',
+      popupPlacement,
     });
 
     useImperativeHandle(ref, () => ({
@@ -133,7 +136,7 @@ const ChatTextareaInner = forwardRef<ChatTextareaRef, ChatTextareaProps>(
           onSelect={suggestion.actions.selectSuggestion}
           onSelectionChange={suggestion.actions.selectItem}
           variant="overlay"
-          popupPlacement="top"
+          popupPlacement={popupPlacement}
         />
       </div>
     );

--- a/apps/web/src/components/ai/chat/layouts/ChatLayout.tsx
+++ b/apps/web/src/components/ai/chat/layouts/ChatLayout.tsx
@@ -80,6 +80,8 @@ export interface ChatLayoutProps {
     isMcpServerEnabled?: (serverName: string) => boolean;
     onMcpServerToggle?: (serverName: string, enabled: boolean) => void;
     showMcp?: boolean;
+    /** Input position: 'centered' for new conversations, 'docked' when there are messages */
+    inputPosition?: InputPosition;
   }) => React.ReactNode;
 
   /** MCP running servers count */
@@ -219,6 +221,7 @@ export const ChatLayout = React.forwardRef<ChatLayoutRef, ChatLayoutProps>(
           isMcpServerEnabled,
           onMcpServerToggle,
           showMcp,
+          inputPosition,
         })
       : defaultInputContent;
 

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -468,6 +468,7 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
                 isMcpServerEnabled={props.isMcpServerEnabled}
                 onMcpServerToggle={props.onMcpServerToggle}
                 showMcp={props.showMcp}
+                popupPlacement={props.inputPosition === 'centered' ? 'bottom' : 'top'}
                 selectedProvider={selectedProvider}
                 selectedModel={selectedModel}
                 onProviderModelChange={(provider, model) => {

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -629,6 +629,7 @@ const GlobalAssistantView: React.FC = () => {
             isMcpServerEnabled={props.isMcpServerEnabled}
             onMcpServerToggle={props.onMcpServerToggle}
             showMcp={props.showMcp}
+            popupPlacement={props.inputPosition === 'centered' ? 'bottom' : 'top'}
           />
         )}
       />

--- a/apps/web/src/components/mentions/SuggestionPopup.tsx
+++ b/apps/web/src/components/mentions/SuggestionPopup.tsx
@@ -86,30 +86,6 @@ export default function SuggestionPopup({
         `}
       >
         {items.map((suggestion, index) => {
-          const isFirst = index === 0;
-          const isLast = index === items.length - 1;
-
-          let roundingClasses = '';
-          if (variant === 'inline') {
-            if (popupPlacement === 'top') {
-              // When reversed, swap the rounding
-              if (isFirst) roundingClasses += 'rounded-b-lg ';
-              if (isLast) roundingClasses += 'rounded-t-lg';
-            } else {
-              if (isFirst) roundingClasses += 'rounded-t-lg ';
-              if (isLast) roundingClasses += 'rounded-b-lg';
-            }
-          } else {
-            if (popupPlacement === 'top') {
-              // When reversed, swap the rounding
-              if (isFirst) roundingClasses += 'rounded-b-md ';
-              if (isLast) roundingClasses += 'rounded-t-md';
-            } else {
-              if (isFirst) roundingClasses += 'rounded-t-md ';
-              if (isLast) roundingClasses += 'rounded-b-md';
-            }
-          }
-
           return (
             <li
               key={`${suggestion.id}-${index}`}
@@ -121,37 +97,49 @@ export default function SuggestionPopup({
                 hover:bg-gray-100 hover:dark:bg-gray-700
                 ${selectedIndex === index ? 'bg-gray-100 dark:bg-gray-700' : ''}
                 ${selectedIndex === index ? 'border-l-2 border-blue-500' : ''}
-                ${roundingClasses}
               `}
               onClick={() => onSelect(suggestion)}
               onMouseEnter={() => onSelectionChange(index)}
             >
               <div className="flex items-center gap-2">
-              <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                {suggestion.label}
-              </span>
-              {suggestion.type && (
-                <span className="text-xs text-gray-500 ml-auto">
-                  {suggestion.type}
+                <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                  {suggestion.label}
                 </span>
-              )}
-            </div>
-            {suggestion.description && (
-              <div className="text-xs text-gray-500 mt-1 truncate">
-                {suggestion.description}
+                {suggestion.type && (
+                  <span className="text-xs text-gray-500 ml-auto">
+                    {suggestion.type}
+                  </span>
+                )}
               </div>
-            )}
-          </li>
+              {suggestion.description && (
+                <div className="text-xs text-gray-500 mt-1 truncate">
+                  {suggestion.description}
+                </div>
+              )}
+            </li>
           );
         })}
       </ul>
     );
   };
 
+  // Get corner rounding based on placement
+  // When popup is above input (top), round top corners more; when below (bottom), round bottom corners more
+  const getRoundingClasses = () => {
+    if (variant === 'inline') {
+      return popupPlacement === 'top'
+        ? 'rounded-t-lg rounded-b-sm'
+        : 'rounded-b-lg rounded-t-sm';
+    }
+    return popupPlacement === 'top'
+      ? 'rounded-t-lg rounded-b-sm'
+      : 'rounded-b-lg rounded-t-sm';
+  };
+
   // Get variant-specific classes
-  const variantClasses = variant === 'inline' 
-    ? 'fixed z-50 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-xl min-w-56 max-w-sm backdrop-blur-sm bg-white/95 dark:bg-gray-800/95'
-    : 'fixed z-50 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md shadow-lg min-w-48 max-w-sm';
+  const variantClasses = variant === 'inline'
+    ? `fixed z-50 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 ${getRoundingClasses()} shadow-xl min-w-56 max-w-sm backdrop-blur-sm bg-white/95 dark:bg-gray-800/95`
+    : `fixed z-50 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 ${getRoundingClasses()} shadow-lg min-w-48 max-w-sm`;
 
   return (
     <div

--- a/apps/web/src/hooks/useSuggestion.ts
+++ b/apps/web/src/hooks/useSuggestion.ts
@@ -185,6 +185,7 @@ export function useSuggestion({
               position = positioningService.calculateTextareaPosition({
                 element,
                 textBeforeCursor,
+                placement: popupPlacement,
               });
             } else {
               position = positioningService.calculateInlinePosition({
@@ -195,6 +196,7 @@ export function useSuggestion({
             position = positioningService.calculateTextareaPosition({
               element,
               textBeforeCursor,
+              placement: popupPlacement,
             });
           }
 
@@ -222,6 +224,7 @@ export function useSuggestion({
     suggestion.actions,
     getSelectionStart,
     variant,
+    popupPlacement,
     effectiveTriggerPattern
   ]);
 

--- a/apps/web/src/services/positioningService.ts
+++ b/apps/web/src/services/positioningService.ts
@@ -9,6 +9,8 @@ export interface TextareaPositionParams {
   element: HTMLTextAreaElement | HTMLInputElement;
   textBeforeCursor: string;
   preferredWidth?: number;
+  /** Where to position the popup relative to the input: 'top' (above) or 'bottom' (below) */
+  placement?: 'top' | 'bottom';
 }
 
 export interface RichlinePositionParams {
@@ -64,12 +66,20 @@ export const positioningService = {
   calculateTextareaPosition: (
     params: TextareaPositionParams
   ): Position => {
-    const { element } = params;
+    const { element, placement = 'top' } = params;
     const rect = element.getBoundingClientRect();
     const viewportHeight = getViewportHeight();
 
-    // Anchor to the bottom of the viewport, with a gap above the textarea
-    // Account for keyboard height on iOS
+    if (placement === 'bottom') {
+      // Position below the input (dropdown style for centered input)
+      return {
+        top: rect.bottom + 8,
+        left: rect.left,
+        width: rect.width,
+      };
+    }
+
+    // Position above the input (default, for docked input at bottom of screen)
     return {
       bottom: viewportHeight - rect.top + 8,
       left: rect.left,


### PR DESCRIPTION
When the floating input is centered (new conversation mode), suggestions now
appear as a dropdown below the input. When the input is docked to the bottom,
suggestions pop up above the input as before.

- Add inputPosition to ChatLayout's renderInput callback
- Add popupPlacement prop to ChatInput and ChatTextarea
- Update positioningService to support both 'top' and 'bottom' placement
- Update SuggestionPopup corner styling based on placement direction

https://claude.ai/code/session_01W685trsfMzw7a4cozprYXd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added adaptive positioning for AI suggestion popups, which now intelligently appear above or below the chat input
  * Popup placement automatically adjusts based on the input layout configuration for optimal visibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->