### PR TITLE
fix(ui): add proper text wrapping to direct message bubbles on mobile

### DIFF
--- a/apps/web/src/app/dashboard/messages/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/messages/[conversationId]/page.tsx
@@ -207,12 +207,12 @@ export default function ConversationPage() {
                     )}
                   </div>
 
-                  <div className={`p-3 rounded-lg ${
+                  <div className={`p-3 rounded-lg max-w-full ${
                     isOwnMessage
                       ? 'bg-primary/5 dark:bg-primary/10 ml-8'
                       : 'bg-gray-50 dark:bg-gray-800/50 mr-8'
                   }`}>
-                    <div className="text-gray-900 dark:text-gray-100">
+                    <div className="text-gray-900 dark:text-gray-100 break-words [overflow-wrap:anywhere] min-w-0">
                       {renderMessageParts(convertToMessageParts(message.content))}
                     </div>
                   </div>

--- a/apps/web/src/components/messages/MessagePartRenderer.tsx
+++ b/apps/web/src/components/messages/MessagePartRenderer.tsx
@@ -77,10 +77,10 @@ const MessagePartRenderer: React.FC<MessagePartRendererProps> = ({ part, index }
 
       // If no mentions found, just return the plain text
       if (textElements.length === 0) {
-        return <span key={index}>{text}</span>;
+        return <span key={index} className="break-words [overflow-wrap:anywhere]">{text}</span>;
       }
 
-      return <span key={index}>{textElements}</span>;
+      return <span key={index} className="break-words [overflow-wrap:anywhere]">{textElements}</span>;
 
     case 'rich-text':
       const textContent = typeof part.content === 'string'
@@ -129,7 +129,7 @@ const MessagePartRenderer: React.FC<MessagePartRendererProps> = ({ part, index }
         elements.push(<span key={`${index}-text-${lastIndex}`}>{remainingText}</span>);
       }
 
-      return <div key={index} className="whitespace-pre-wrap">{elements}</div>;
+      return <div key={index} className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{elements}</div>;
 
     case 'tool-invocation':
       return (
@@ -140,7 +140,7 @@ const MessagePartRenderer: React.FC<MessagePartRendererProps> = ({ part, index }
           <div className="font-semibold">
             {part.toolInvocation?.toolName}
           </div>
-          <pre className="text-xs whitespace-pre-wrap">
+          <pre className="text-xs whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
             {JSON.stringify(part.toolInvocation?.args, null, 2)}
           </pre>
         </div>


### PR DESCRIPTION
Add break-words and overflow-wrap:anywhere CSS to message bubbles and
text spans to prevent long words/URLs from overflowing on mobile widths.

https://claude.ai/code/session_01TLC9SQABJx52DC8XxApJmD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved message bubble container sizing and layout constraints.
  * Enhanced text wrapping and word-break handling across message displays to prevent overflow and ensure long content renders properly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->