### PR TITLE
fix(avatar): fix upload and add image cropper with circle/square selection

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -89,6 +89,7 @@
     "react-day-picker": "^9.11.3",
     "react-dom": "^19.1.2",
     "react-hook-form": "^7.62.0",
+    "react-image-crop": "^11.0.10",
     "react-pdf": "^10.1.0",
     "recharts": "^3.1.2",
     "shiki": "^3.20.0",

--- a/apps/web/src/components/dialogs/ImageCropperDialog.tsx
+++ b/apps/web/src/components/dialogs/ImageCropperDialog.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useState, useRef, useCallback } from "react";
+import ReactCrop, {
+  centerCrop,
+  makeAspectCrop,
+  type Crop,
+  type PixelCrop,
+} from "react-image-crop";
+import "react-image-crop/dist/ReactCrop.css";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Loader2, Circle, Square } from "lucide-react";
+
+interface ImageCropperDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  imageSrc: string;
+  onCropComplete: (croppedBlob: Blob) => void;
+}
+
+type CropShape = "circle" | "square";
+
+function centerAspectCrop(
+  mediaWidth: number,
+  mediaHeight: number,
+  aspect: number
+): Crop {
+  return centerCrop(
+    makeAspectCrop(
+      {
+        unit: "%",
+        width: 90,
+      },
+      aspect,
+      mediaWidth,
+      mediaHeight
+    ),
+    mediaWidth,
+    mediaHeight
+  );
+}
+
+async function getCroppedImage(
+  image: HTMLImageElement,
+  crop: PixelCrop,
+  shape: CropShape
+): Promise<Blob> {
+  const canvas = document.createElement("canvas");
+  const ctx = canvas.getContext("2d");
+
+  if (!ctx) {
+    throw new Error("No 2d context");
+  }
+
+  const scaleX = image.naturalWidth / image.width;
+  const scaleY = image.naturalHeight / image.height;
+
+  const pixelRatio = window.devicePixelRatio || 1;
+
+  canvas.width = Math.floor(crop.width * scaleX * pixelRatio);
+  canvas.height = Math.floor(crop.height * scaleY * pixelRatio);
+
+  ctx.scale(pixelRatio, pixelRatio);
+  ctx.imageSmoothingQuality = "high";
+
+  const cropX = crop.x * scaleX;
+  const cropY = crop.y * scaleY;
+  const cropWidth = crop.width * scaleX;
+  const cropHeight = crop.height * scaleY;
+
+  // Apply circular mask if shape is circle
+  if (shape === "circle") {
+    ctx.beginPath();
+    ctx.arc(
+      (crop.width * scaleX) / 2,
+      (crop.height * scaleY) / 2,
+      Math.min(crop.width * scaleX, crop.height * scaleY) / 2,
+      0,
+      2 * Math.PI
+    );
+    ctx.clip();
+  }
+
+  ctx.drawImage(
+    image,
+    cropX,
+    cropY,
+    cropWidth,
+    cropHeight,
+    0,
+    0,
+    crop.width * scaleX,
+    crop.height * scaleY
+  );
+
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (blob) {
+          resolve(blob);
+        } else {
+          reject(new Error("Failed to create blob"));
+        }
+      },
+      "image/png",
+      1
+    );
+  });
+}
+
+export function ImageCropperDialog({
+  open,
+  onOpenChange,
+  imageSrc,
+  onCropComplete,
+}: ImageCropperDialogProps) {
+  const [crop, setCrop] = useState<Crop>();
+  const [completedCrop, setCompletedCrop] = useState<PixelCrop>();
+  const [shape, setShape] = useState<CropShape>("circle");
+  const [isProcessing, setIsProcessing] = useState(false);
+  const imgRef = useRef<HTMLImageElement>(null);
+
+  const onImageLoad = useCallback(
+    (e: React.SyntheticEvent<HTMLImageElement>) => {
+      const { width, height } = e.currentTarget;
+      setCrop(centerAspectCrop(width, height, 1));
+    },
+    []
+  );
+
+  const handleCropComplete = async () => {
+    if (!imgRef.current || !completedCrop) return;
+
+    setIsProcessing(true);
+    try {
+      const croppedBlob = await getCroppedImage(
+        imgRef.current,
+        completedCrop,
+        shape
+      );
+      onCropComplete(croppedBlob);
+      onOpenChange(false);
+    } catch (error) {
+      console.error("Error cropping image:", error);
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Crop Avatar</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="flex justify-center">
+            <RadioGroup
+              value={shape}
+              onValueChange={(value) => setShape(value as CropShape)}
+              className="flex gap-4"
+            >
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="circle" id="circle" />
+                <Label htmlFor="circle" className="flex items-center gap-1 cursor-pointer">
+                  <Circle className="h-4 w-4" />
+                  Circle
+                </Label>
+              </div>
+              <div className="flex items-center space-x-2">
+                <RadioGroupItem value="square" id="square" />
+                <Label htmlFor="square" className="flex items-center gap-1 cursor-pointer">
+                  <Square className="h-4 w-4" />
+                  Square
+                </Label>
+              </div>
+            </RadioGroup>
+          </div>
+
+          <div className="flex justify-center max-h-[400px] overflow-auto">
+            <ReactCrop
+              crop={crop}
+              onChange={(_, percentCrop) => setCrop(percentCrop)}
+              onComplete={(c) => setCompletedCrop(c)}
+              aspect={1}
+              circularCrop={shape === "circle"}
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                ref={imgRef}
+                alt="Crop preview"
+                src={imageSrc}
+                onLoad={onImageLoad}
+                className="max-w-full"
+              />
+            </ReactCrop>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isProcessing}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleCropComplete}
+            disabled={!completedCrop || isProcessing}
+          >
+            {isProcessing ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Processing...
+              </>
+            ) : (
+              "Apply"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/ui/avatar.tsx
+++ b/apps/web/src/components/ui/avatar.tsx
@@ -28,7 +28,7 @@ function AvatarImage({
   return (
     <AvatarPrimitive.Image
       data-slot="avatar-image"
-      className={cn("aspect-square size-full", className)}
+      className={cn("aspect-square size-full object-cover", className)}
       {...props}
     />
   )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -536,6 +536,9 @@ importers:
       react-hook-form:
         specifier: ^7.62.0
         version: 7.63.0(react@19.2.1)
+      react-image-crop:
+        specifier: ^11.0.10
+        version: 11.0.10(react@19.2.1)
       react-pdf:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.1.13)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -8532,6 +8535,11 @@ packages:
     peerDependencies:
       react: ^19.1.2
 
+  react-image-crop@11.0.10:
+    resolution: {integrity: sha512-+5FfDXUgYLLqBh1Y/uQhIycpHCbXkI50a+nbfkB1C0xXXUTwkisHDo2QCB1SQJyHCqIuia4FeyReqXuMDKWQTQ==}
+    peerDependencies:
+      react: ^19.1.2
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -9860,6 +9868,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -18583,6 +18592,10 @@ snapshots:
       - utf-8-validate
 
   react-hook-form@7.63.0(react@19.2.1):
+    dependencies:
+      react: 19.2.1
+
+  react-image-crop@11.0.10(react@19.2.1):
     dependencies:
       react: 19.2.1
 


### PR DESCRIPTION
- Fix Content-Type error by using fetchWithAuth directly for FormData uploads
  instead of post() helper which sets application/json
- Add object-cover to AvatarImage to prevent stretching of non-square images
- Add ImageCropperDialog with react-image-crop for cropping avatars before upload
- Support both circular and square crop shapes with toggle selection

https://claude.ai/code/session_01CDBVCSm6GHT4eNLGWazg7r