### PR TITLE
fix(mobile): improve text wrapping in chat to avoid orphaned characters

### DIFF
--- a/apps/web/src/components/ai/shared/chat/CompactMessageRenderer.module.css
+++ b/apps/web/src/components/ai/shared/chat/CompactMessageRenderer.module.css
@@ -5,17 +5,26 @@
  * ROOT CAUSE: AI streaming can generate long unbreakable strings (URLs, code, base64)
  *             that expand beyond the 320px sidebar width, causing layout overflow.
  *
- * STRATEGY: Apply max-width and word-breaking to all ReactMarkdown output elements
+ * STRATEGY: Apply max-width and smart word-breaking to all ReactMarkdown output elements
  *           because dynamically rendered HTML doesn't inherit Tailwind utilities.
+ *
+ * WORD-BREAKING APPROACH:
+ * - Use overflow-wrap: break-word (not anywhere/break-all) for prose text
+ * - Add hyphens: auto for proper hyphenation when words must break
+ * - Add text-wrap: pretty to avoid orphaned words/characters on line endings
+ * - Reserve break-all only for code, URLs, and truly unbreakable strings
  */
 
 .compactProseContent {
   /* Base constraint - all content must respect container width */
   width: 100%;
   max-width: 100%;
-  min-width: 0;             /* Allow shrinking in flex contexts */
-  overflow-wrap: anywhere;  /* Break words at any point when necessary */
-  word-break: break-word;   /* Fallback for browsers without overflow-wrap support */
+  min-width: 0;               /* Allow shrinking in flex contexts */
+  overflow-wrap: break-word;  /* Only break words when necessary to prevent overflow */
+  word-break: normal;         /* Use normal word-breaking rules for prose */
+  hyphens: auto;              /* Enable automatic hyphenation when words break */
+  -webkit-hyphens: auto;      /* Safari support */
+  text-wrap: pretty;          /* Avoid orphaned words/characters at line endings */
 }
 
 /* Markdown content elements need width constraints - enumerated to avoid breaking icons/UI components */
@@ -66,12 +75,13 @@
 
 /**
  * Links - Long URLs are the #1 cause of width breaking in markdown
+ * Links need break-all since URLs don't have natural word boundaries
  * display: inline-block allows width constraints to work on inline elements
  */
 .compactProseContent a {
   max-width: 100%;
-  overflow-wrap: anywhere;
-  word-break: break-word;
+  overflow-wrap: anywhere;  /* URLs have no word boundaries, break anywhere */
+  word-break: break-all;    /* Aggressive breaking for URLs */
   display: inline-block;    /* Required for max-width to apply */
 }
 
@@ -88,20 +98,26 @@
 .compactProseContent table td,
 .compactProseContent table th {
   max-width: min(200px, 50vw);  /* Responsive: smaller on narrow screens */
-  overflow-wrap: anywhere;
-  word-break: break-word;
+  overflow-wrap: break-word;    /* Only break when necessary */
+  word-break: normal;           /* Normal word boundaries */
+  hyphens: auto;                /* Hyphenate when breaking */
+  -webkit-hyphens: auto;        /* Safari support */
 }
 
 /**
  * Text containers - Paragraphs, list items, blockquotes
  * These inherit base rules but need explicit max-width for ReactMarkdown elements
+ * Use smarter word-breaking with hyphenation to avoid orphaned characters
  */
 .compactProseContent p,
 .compactProseContent li,
 .compactProseContent blockquote {
   max-width: 100%;
-  overflow-wrap: anywhere;
-  word-break: break-word;
+  overflow-wrap: break-word;  /* Only break when necessary */
+  word-break: normal;         /* Normal word boundaries */
+  hyphens: auto;              /* Hyphenate when breaking words */
+  -webkit-hyphens: auto;      /* Safari support */
+  text-wrap: pretty;          /* Avoid orphans at line endings */
 }
 
 /**

--- a/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
@@ -76,7 +76,7 @@ const TextBlock: React.FC<TextBlockProps> = React.memo(({
       ) : (
         <>
           <div className="text-gray-900 dark:text-gray-100 prose prose-sm dark:prose-invert max-w-full prose-pre:bg-gray-100 dark:prose-pre:bg-gray-800">
-            <div className="break-words overflow-wrap-anywhere">
+            <div className="[overflow-wrap:break-word] [hyphens:auto] [text-wrap:pretty]">
               <StreamingMarkdown content={content} id={`${messageId}-text`} isStreaming={isStreaming} />
             </div>
           </div>

--- a/apps/web/src/components/ai/shared/chat/StreamingMarkdown.tsx
+++ b/apps/web/src/components/ai/shared/chat/StreamingMarkdown.tsx
@@ -68,10 +68,10 @@ function CustomPre({ children, ...props }: HTMLAttributes<HTMLPreElement> & { ch
   );
 }
 
-// Custom paragraph component with word breaking
+// Custom paragraph component with smart word breaking and hyphenation
 function CustomParagraph({ children, ...props }: HTMLAttributes<HTMLParagraphElement> & { children?: ReactNode }) {
   return (
-    <p className="min-w-0 max-w-full [overflow-wrap:anywhere]" {...props}>
+    <p className="min-w-0 max-w-full [overflow-wrap:break-word] [hyphens:auto] [text-wrap:pretty]" {...props}>
       {children}
     </p>
   );
@@ -86,19 +86,19 @@ function CustomTable({ children, ...props }: TableHTMLAttributes<HTMLTableElemen
   );
 }
 
-// Custom list item component with word breaking
+// Custom list item component with smart word breaking and hyphenation
 function CustomListItem({ children, ...props }: HTMLAttributes<HTMLLIElement> & { children?: ReactNode }) {
   return (
-    <li className="min-w-0 max-w-full break-all [overflow-wrap:anywhere]" {...props}>
+    <li className="min-w-0 max-w-full [overflow-wrap:break-word] [hyphens:auto] [text-wrap:pretty]" {...props}>
       {children}
     </li>
   );
 }
 
-// Custom span component for inline text - uses overflow-wrap only to preserve word boundaries
+// Custom span component for inline text - uses smart word breaking to preserve word boundaries
 function CustomSpan({ children, ...props }: HTMLAttributes<HTMLSpanElement> & { children?: ReactNode }) {
   return (
-    <span className="min-w-0 max-w-full [overflow-wrap:anywhere]" {...props}>
+    <span className="min-w-0 max-w-full [overflow-wrap:break-word] [hyphens:auto]" {...props}>
       {children}
     </span>
   );


### PR DESCRIPTION
Replace aggressive word-breaking (break-all, overflow-wrap: anywhere) with
smarter alternatives for prose text:
- Use overflow-wrap: break-word to only break words when necessary
- Add hyphens: auto for proper hyphenation when words must break
- Add text-wrap: pretty to help browsers avoid orphaned words/characters

This prevents the issue where a full sentence appears on one line but a
single letter ends up alone on the next line. Code blocks and URLs still
use aggressive breaking since they have no natural word boundaries.

https://claude.ai/code/session_01EuuKyzdKagS7TVtXkcRAzP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved text wrapping and word-breaking behavior in chat messages for cleaner, more readable display
  * Enhanced handling of long URLs and content with smarter breaking strategies to prevent excessive word breaks
  * Enabled smart hyphenation and text-wrap optimization to minimize layout overflow and prevent orphaned text

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->