### PR TITLE
feat(ui): add copy button to code blocks in AI chat messages

### DIFF
--- a/apps/web/src/components/ai/shared/chat/StreamingMarkdown.tsx
+++ b/apps/web/src/components/ai/shared/chat/StreamingMarkdown.tsx
@@ -107,7 +107,7 @@ function CodeCopyButton({ code, className }: { code: string; className?: string 
       className={cn(
         'absolute top-2 right-2 p-1.5 rounded-md',
         'bg-background/80 hover:bg-muted border border-border/50',
-        'opacity-0 group-hover:opacity-100 transition-opacity',
+        'opacity-0 group-hover:opacity-100 [@media(hover:none)]:opacity-100 transition-opacity',
         'focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring',
         className
       )}


### PR DESCRIPTION
Add copy-to-clipboard functionality for code blocks rendered in AI chat
markdown. The button appears on hover with visual feedback (checkmark
icon for 2 seconds after copying).

https://claude.ai/code/session_01VUFNvkQjaYLBE76WY5Dsdg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added copy-to-clipboard for code blocks in AI chat responses. A small, unobtrusive button appears on code blocks, shows a copy icon that switches to a check on success, auto-resets after a short delay, and preserves existing streaming behavior so chat rendering remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->