### PR TITLE
fix(ui): improve tab bar styling with darker recessed trough effect

### DIFF
--- a/apps/web/src/components/layout/tabs/TabBar.tsx
+++ b/apps/web/src/components/layout/tabs/TabBar.tsx
@@ -144,7 +144,9 @@ export const TabBar = memo(function TabBar({ className }: TabBarProps) {
         exit={{ height: 0, opacity: 0 }}
         transition={{ duration: 0.15, ease: 'easeOut' }}
         className={cn(
-          "flex-shrink-0 bg-primary overflow-hidden",
+          "flex-shrink-0 overflow-hidden",
+          "bg-[oklch(0.35_0.08_235)] dark:bg-[oklch(0.20_0.06_235)]",
+          "shadow-[inset_0_2px_4px_rgba(0,0,0,0.3),inset_0_1px_2px_rgba(0,0,0,0.2)]",
           className
         )}
       >

--- a/apps/web/src/components/layout/tabs/TabItem.tsx
+++ b/apps/web/src/components/layout/tabs/TabItem.tsx
@@ -83,8 +83,8 @@ export const TabItem = memo(function TabItem({
             "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white",
             "max-w-[180px] min-w-[100px]",
             isActive
-              ? "bg-white/20 text-white"
-              : "text-white/80 hover:bg-white/10 hover:text-white",
+              ? "bg-white/15 text-white"
+              : "text-white/70 hover:bg-white/10 hover:text-white",
             tab.isPinned && "min-w-0 max-w-[60px] px-2"
           )}
         >
@@ -135,9 +135,9 @@ export const TabItem = memo(function TabItem({
             </button>
           )}
 
-          {/* Active tab indicator */}
+          {/* Active tab indicator - uses primary color to contrast with both dark trough and white content */}
           {isActive && (
-            <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-white" />
+            <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary dark:bg-primary" />
           )}
         </div>
       </ContextMenuTrigger>


### PR DESCRIPTION
- Use darker, less saturated blue for tab bar background
- Add inset shadow to create "cut into" depth effect
- Change active tab indicator from white to primary color for better
  contrast against both the dark trough and white content below

https://claude.ai/code/session_01A3fq9iyVpds9UXxz1n95Ai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated tab bar background colors with light and dark theme variants
  * Refined tab item active and inactive state colors for better visibility
  * Changed tab indicator color to primary color for improved contrast

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->