### PR TITLE
fix(streaming): persist AI responses when user backgrounds app on iOS/Capacitor

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -19,6 +19,7 @@ import { useAssistantSettingsStore } from '@/stores/useAssistantSettingsStore';
 import { buildPagePath } from '@/lib/tree/tree-utils';
 import { useDriveStore } from '@/hooks/useDrive';
 import { useAuth } from '@/hooks/useAuth';
+import { useAppStateRecovery } from '@/hooks/useAppStateRecovery';
 import { toast } from 'sonner';
 import { PageAgentSettingsTab, PageAgentHistoryTab, type PageAgentSettingsTabRef } from '@/components/ai/page-agents';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
@@ -341,6 +342,18 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
       console.error('Failed to refresh messages:', error);
     }
   }, [currentConversationId, page.id, setMessages]);
+
+  // ============================================
+  // APP STATE RECOVERY
+  // ============================================
+
+  // Auto-refresh messages when returning from background (iOS/Capacitor)
+  // This handles the case where streaming continued server-side while user was away
+  useAppStateRecovery({
+    onForeground: handlePullUpRefresh,
+    minBackgroundTime: 2000, // Refresh if backgrounded for more than 2 seconds
+    enabled: !!currentConversationId && activeTab === 'chat',
+  });
 
   // ============================================
   // RENDER

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -53,6 +53,7 @@ import { useEditingStore } from '@/stores/useEditingStore';
 import { useAssistantSettingsStore } from '@/stores/useAssistantSettingsStore';
 import { useGlobalChat } from '@/contexts/GlobalChatContext';
 import { usePageAgentDashboardStore } from '@/stores/page-agents';
+import { useAppStateRecovery } from '@/hooks/useAppStateRecovery';
 
 // Shared hooks and components
 import {
@@ -361,6 +362,18 @@ const GlobalAssistantView: React.FC = () => {
     setGlobalMessages,
     setGlobalLocalMessages,
   ]);
+
+  // ============================================
+  // APP STATE RECOVERY
+  // ============================================
+
+  // Auto-refresh messages when returning from background (iOS/Capacitor)
+  // This handles the case where streaming continued server-side while user was away
+  useAppStateRecovery({
+    onForeground: handlePullUpRefresh,
+    minBackgroundTime: 2000, // Refresh if backgrounded for more than 2 seconds
+    enabled: !!currentConversationId,
+  });
 
   // ============================================
   // GLOBAL MODE SYNC EFFECTS

--- a/apps/web/src/hooks/useAppStateRecovery.ts
+++ b/apps/web/src/hooks/useAppStateRecovery.ts
@@ -1,0 +1,131 @@
+/**
+ * useAppStateRecovery Hook
+ *
+ * Provides automatic data recovery when the app returns from background.
+ * This is especially important for iOS/Capacitor where HTTP streams are
+ * terminated when the app is backgrounded.
+ *
+ * The server continues streaming and saves to DB, so when the user returns,
+ * this hook triggers a refresh to fetch the completed data.
+ */
+
+import { useEffect, useRef, useCallback } from 'react';
+import { isCapacitorApp, getPlatform } from '@/lib/capacitor-bridge';
+
+interface UseAppStateRecoveryOptions {
+  /** Callback when app returns from background */
+  onForeground?: () => void | Promise<void>;
+  /** Minimum time in background before triggering recovery (ms) */
+  minBackgroundTime?: number;
+  /** Whether the hook is enabled */
+  enabled?: boolean;
+}
+
+interface UseAppStateRecoveryReturn {
+  /** Whether the app is currently in background */
+  isBackground: boolean;
+  /** Time when app went to background (null if in foreground) */
+  backgroundTime: number | null;
+  /** Manually trigger recovery */
+  triggerRecovery: () => void;
+}
+
+export function useAppStateRecovery({
+  onForeground,
+  minBackgroundTime = 1000, // Default: 1 second
+  enabled = true,
+}: UseAppStateRecoveryOptions = {}): UseAppStateRecoveryReturn {
+  const backgroundTimeRef = useRef<number | null>(null);
+  const isBackgroundRef = useRef(false);
+  const onForegroundRef = useRef(onForeground);
+
+  // Keep callback ref updated
+  useEffect(() => {
+    onForegroundRef.current = onForeground;
+  }, [onForeground]);
+
+  const triggerRecovery = useCallback(() => {
+    if (onForegroundRef.current) {
+      onForegroundRef.current();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    // Handle iOS/Capacitor app state changes
+    if (isCapacitorApp()) {
+      let cleanup: (() => void) | undefined;
+
+      const setupCapacitorListener = async () => {
+        try {
+          const { App } = await import('@capacitor/app');
+
+          const listener = await App.addListener('appStateChange', ({ isActive }) => {
+            if (!isActive) {
+              // App going to background
+              backgroundTimeRef.current = Date.now();
+              isBackgroundRef.current = true;
+            } else {
+              // App returning to foreground
+              const bgTime = backgroundTimeRef.current;
+              const duration = bgTime ? Date.now() - bgTime : 0;
+
+              backgroundTimeRef.current = null;
+              isBackgroundRef.current = false;
+
+              // Trigger recovery if backgrounded long enough
+              if (duration >= minBackgroundTime && onForegroundRef.current) {
+                console.log(`[AppState] Returning from background (${Math.round(duration / 1000)}s), triggering recovery`);
+                onForegroundRef.current();
+              }
+            }
+          });
+
+          cleanup = () => {
+            listener.remove();
+          };
+        } catch (error) {
+          console.error('[AppState] Failed to setup Capacitor listener:', error);
+        }
+      };
+
+      setupCapacitorListener();
+
+      return () => {
+        cleanup?.();
+      };
+    }
+
+    // Handle web visibility changes (fallback for non-Capacitor)
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        backgroundTimeRef.current = Date.now();
+        isBackgroundRef.current = true;
+      } else if (document.visibilityState === 'visible') {
+        const bgTime = backgroundTimeRef.current;
+        const duration = bgTime ? Date.now() - bgTime : 0;
+
+        backgroundTimeRef.current = null;
+        isBackgroundRef.current = false;
+
+        if (duration >= minBackgroundTime && onForegroundRef.current) {
+          console.log(`[Visibility] Returning to visible (${Math.round(duration / 1000)}s), triggering recovery`);
+          onForegroundRef.current();
+        }
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [enabled, minBackgroundTime]);
+
+  return {
+    isBackground: isBackgroundRef.current,
+    backgroundTime: backgroundTimeRef.current,
+    triggerRecovery,
+  };
+}


### PR DESCRIPTION
Previously, when users left the app on iOS/Capacitor, the HTTP stream connection
would be terminated, causing the AI stream to abort and any unsaved response to
be lost.

Changes:
- Server-side: Remove abortSignal from streamText() so AI streams complete
  regardless of client connection state. The response is saved to DB in
  onFinish callback, ensuring no data loss.
- Client-side: Add useAppStateRecovery hook that auto-refreshes messages
  when app returns from background, fetching any completed responses from DB.
- Apply fix to both page chat (/api/ai/chat) and global assistant routes.

The server continues streaming and saves to DB even if the client disconnects.
When the user returns, they see the completed message.

https://claude.ai/code/session_01WEmViczLVrKGch6tCvJ2zq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic conversation refresh when returning to the app after backgrounding, ensuring you see the latest messages.
  * Improved AI chat resilience: responses continue processing and are saved server-side even if your connection is interrupted.

* **Performance**
  * Optimized chat streaming responsiveness with improved throttle settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->