### PR TITLE
fix(ui): increase scroll-to-bottom button spacing above input on mobile

### DIFF
--- a/apps/web/src/components/ai/shared/chat/ChatMessagesArea.tsx
+++ b/apps/web/src/components/ai/shared/chat/ChatMessagesArea.tsx
@@ -263,7 +263,7 @@ const ChatMessagesAreaInner = forwardRef<ChatMessagesAreaRef, ChatMessagesAreaPr
 
         {/* Scroll-to-bottom button - only visible when user scrolls up */}
         {/* Positioned higher (bottom-36) to appear above floating input in middle content area */}
-        <ConversationScrollButton className="z-20 bottom-36" />
+        <ConversationScrollButton className="z-20 bottom-44 sm:bottom-36" />
 
         <UndoAiChangesDialog
           open={!!undoDialogMessageId}

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -765,7 +765,7 @@ const SidebarChatTab: React.FC = () => {
             displayIsStreaming={displayIsStreaming}
           />
           {/* Scroll-to-bottom button - visible when user scrolls up */}
-          <ConversationScrollButton className="z-10" />
+          <ConversationScrollButton className="z-10 bottom-8" />
         </Conversation>
       </div>
 


### PR DESCRIPTION
Adds more bottom spacing for the scroll-to-bottom button in AI chats to prevent
overlap with floating input on mobile/Capacitor. Uses responsive classes to
apply larger spacing (bottom-44) on mobile while keeping existing spacing on
larger screens.

https://claude.ai/code/session_01H6ueGV1cACxgLSvTHggPG1