### PR TITLE
fix(chat): center refresh button and raise position above input

### DIFF
--- a/apps/web/src/components/ai/shared/chat/ChatMessagesArea.tsx
+++ b/apps/web/src/components/ai/shared/chat/ChatMessagesArea.tsx
@@ -231,15 +231,19 @@ const ChatMessagesAreaInner = forwardRef<ChatMessagesAreaRef, ChatMessagesAreaPr
         {showPullUpSpinner && (
           <div
             className={cn(
-              'absolute left-1/2 -translate-x-1/2 z-50 pointer-events-none',
+              'absolute inset-x-0 flex justify-center z-50 pointer-events-none',
               'transition-opacity duration-150'
             )}
             style={{
-              bottom: 100,
+              bottom: 140,
               opacity: spinnerOpacity,
-              transform: `translateX(-50%) translateY(${Math.min(0, -(pullDistance - 20))}px) scale(${spinnerScale})`,
             }}
           >
+            <div
+              style={{
+                transform: `translateY(${Math.min(0, -(pullDistance - 20))}px) scale(${spinnerScale})`,
+              }}
+            >
             <div
               className={cn(
                 'flex items-center justify-center w-10 h-10 rounded-full',
@@ -257,6 +261,7 @@ const ChatMessagesAreaInner = forwardRef<ChatMessagesAreaRef, ChatMessagesAreaPr
                   transform: !isPullUpRefreshing ? `rotate(${spinnerRotation}deg)` : undefined,
                 }}
               />
+            </div>
             </div>
           </div>
         )}


### PR DESCRIPTION
- Use flex centering (inset-x-0 flex justify-center) instead of transform-based
  centering to avoid conflicts with inline transform styles
- Raise bottom position from 100px to 140px to be higher above the input area
- Separate dynamic transforms (translateY, scale) into wrapper div

https://claude.ai/code/session_01KkHaBaQtnFPH76FCMNicCi