### PR TITLE
fix(mobile): add safe area padding to TaskListView footer and SheetView action sheet

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/sheet/SheetView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/sheet/SheetView.tsx
@@ -1869,7 +1869,7 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
           />
           {/* Action Sheet */}
           <div
-            className="fixed inset-x-0 bottom-0 z-50 rounded-t-2xl bg-background p-4 pb-8 shadow-lg sm:hidden"
+            className="fixed inset-x-0 bottom-0 z-50 rounded-t-2xl bg-background p-4 pb-[calc(2rem+env(safe-area-inset-bottom))] shadow-lg sm:hidden"
             role="dialog"
             aria-modal="true"
             aria-label="Cell actions"

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -1019,7 +1019,7 @@ export default function TaskListView({ page }: TaskListViewProps) {
       </div>
 
       {/* Footer stats */}
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 px-4 py-2 border-t bg-muted/50 text-sm text-muted-foreground">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 px-4 py-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] border-t bg-muted/50 text-sm text-muted-foreground">
         <div className="flex flex-wrap gap-x-4 gap-y-1">
           <span><strong>{stats.total}</strong> tasks</span>
           <span><strong>{stats.inProgress}</strong> in progress</span>


### PR DESCRIPTION
Add bottom safe area inset padding for Capacitor app to prevent content being cut off by rounded corners on iOS devices.

https://claude.ai/code/session_01RFSeYtgbE4AWr6Z2ZERHev