### PR TITLE
fix(mobile): prevent horizontal dragging in drive selection dropdown

### DIFF
--- a/apps/web/src/components/layout/navbar/DriveSwitcher.tsx
+++ b/apps/web/src/components/layout/navbar/DriveSwitcher.tsx
@@ -153,7 +153,7 @@ export default function DriveSwitcher() {
 
           <DropdownMenuSeparator />
 
-          <CustomScrollArea className="max-h-[320px]">
+          <CustomScrollArea className="max-h-[320px] overflow-x-hidden">
             {/* Favorites Section */}
             {favoriteDrives.length > 0 && (
               <>


### PR DESCRIPTION
Add overflow-x-hidden to CustomScrollArea in DriveSwitcher to restrict
scrolling to vertical-only on mobile/capacitor devices.

https://claude.ai/code/session_01HakkF38RkRrcCdfUdnzPbz