### PR TITLE
Reorder sidebar components: move DriveSwitcher above Dashboard

### DIFF
--- a/apps/web/src/components/layout/left-sidebar/index.tsx
+++ b/apps/web/src/components/layout/left-sidebar/index.tsx
@@ -77,24 +77,21 @@ export default function Sidebar({ className }: SidebarProps) {
       )}
     >
       <div className="flex h-full flex-col px-3 py-3">
-        {/* Dashboard link - always visible */}
+        {/* Drive Switcher - always visible, at top */}
         {/* On macOS Electron in sheet mode, add left padding to clear stoplight buttons */}
+        <div className={cn("mb-3", isElectronMac && isSheetBreakpoint && "pl-[60px]")}>
+          <DriveSwitcher />
+        </div>
+
+        {/* Dashboard link - always visible */}
         <Link
           href="/dashboard"
           onClick={() => isSheetBreakpoint && setLeftSheetOpen(false)}
-          className={cn(
-            "flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground mb-3",
-            isElectronMac && isSheetBreakpoint && "pl-[60px]"
-          )}
+          className="flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground mb-3"
         >
           <Home className="h-4 w-4" />
           Dashboard
         </Link>
-
-        {/* Drive Switcher - below Dashboard */}
-        <div className="mb-3">
-          <DriveSwitcher />
-        </div>
 
         {/* Main content area */}
         <div className="flex-1 flex flex-col min-h-0 overflow-hidden">


### PR DESCRIPTION
## Summary
Reordered the left sidebar layout to position the DriveSwitcher component above the Dashboard link, improving the visual hierarchy and navigation flow.

## Key Changes
- Moved `DriveSwitcher` component from below the Dashboard link to the top of the sidebar
- Moved the macOS Electron sheet mode padding logic (`pl-[60px]`) from the Dashboard link to the DriveSwitcher wrapper div
- Simplified the Dashboard link className by removing the conditional padding, as it's no longer needed
- Updated comments to reflect the new component order

## Implementation Details
- The DriveSwitcher is now the first interactive element users encounter in the sidebar, making drive selection more prominent
- The macOS Electron stoplight button clearance padding is now applied to the DriveSwitcher container instead of the Dashboard link, maintaining the same visual result
- No functional changes to component behavior; this is purely a reordering and styling reorganization

https://claude.ai/code/session_01A74K55caDf9Kx2VDn6FPBx