### PR TITLE
Support file downloads from files table with drive-level access control

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -342,7 +342,7 @@ export default function ChannelView({ page }: ChannelViewProps) {
                                 <div className="mt-2">
                                   {m.attachmentMeta.mimeType.startsWith('image/') ? (
                                     <a
-                                      href={`/api/files/${m.fileId}/view`}
+                                      href={`/api/files/${m.fileId}/view?filename=${encodeURIComponent(m.attachmentMeta.originalName)}`}
                                       target="_blank"
                                       rel="noopener noreferrer"
                                       className="block max-w-sm"
@@ -355,7 +355,7 @@ export default function ChannelView({ page }: ChannelViewProps) {
                                     </a>
                                   ) : (
                                     <a
-                                      href={`/api/files/${m.fileId}/download`}
+                                      href={`/api/files/${m.fileId}/download?filename=${encodeURIComponent(m.attachmentMeta.originalName)}`}
                                       className="flex items-center gap-3 p-3 bg-muted/50 hover:bg-muted rounded-lg border border-border/50 max-w-sm transition-colors"
                                     >
                                       <div className="w-10 h-10 rounded bg-muted flex items-center justify-center shrink-0">


### PR DESCRIPTION
## Summary
Extended the file download and view endpoints to support files stored in the `files` table (channel attachments) in addition to the existing `pages` table support. Added drive-level access control for files table entries using drive membership verification.

## Key Changes
- **Dual file source support**: Both endpoints now check for files in the `pages` table first (FILE-type pages), then fall back to the `files` table (channel attachments)
- **Drive-level access control**: Files from the `files` table require the user to be a member of the associated drive
- **Service token generation**: Uses `createDriveServiceToken` for files table entries instead of `createPageServiceToken`
- **Code refactoring**: Extracted common file fetching logic into reusable helper functions (`fetchAndDownloadFile` and `fetchAndServeFile`)
- **Improved error handling**: More detailed error logging with file/page IDs and content hashes for better debugging

## Implementation Details
- Files table entries use `storagePath` or `id` as the content hash (fallback to `id` if `storagePath` is not set)
- Drive membership is verified using `driveMembers` table with both `driveId` and `userId` conditions
- Helper functions handle processor communication, response validation, and header configuration
- Maintains existing security headers and MIME type handling for dangerous file types
- Both endpoints maintain backward compatibility with existing FILE-type page downloads

https://claude.ai/code/session_0168Mk63SNuLe88fpVhsueaZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and logging for file download and view operations with better timeout protection and validation.

* **Refactor**
  * Consolidated file access logic for both FILE-type pages and drive-based files, reducing code duplication and strengthening access control with membership verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->