### PR TITLE
Refactor hotkey preferences to use centralized auth fetch

### DIFF
--- a/apps/web/src/hooks/useHotkeyPreferences.ts
+++ b/apps/web/src/hooks/useHotkeyPreferences.ts
@@ -1,6 +1,7 @@
 import useSWR from 'swr';
 import { useEffect } from 'react';
 import { useHotkeyStore } from '@/stores/useHotkeyStore';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 
 interface HotkeyPreference {
   hotkeyId: string;
@@ -12,7 +13,7 @@ interface HotkeyPreferencesResponse {
 }
 
 const fetcher = async (url: string): Promise<HotkeyPreferencesResponse> => {
-  const res = await fetch(url, { credentials: 'include' });
+  const res = await fetchWithAuth(url);
   if (!res.ok) throw new Error('Failed to fetch hotkey preferences');
   return res.json();
 };
@@ -45,15 +46,10 @@ export function useHotkeyPreferences() {
 }
 
 export async function updateHotkeyPreference(hotkeyId: string, binding: string): Promise<void> {
-  const csrfMeta = document.querySelector('meta[name="csrf-token"]');
-  const csrfToken = csrfMeta?.getAttribute('content') ?? '';
-
-  const res = await fetch('/api/settings/hotkey-preferences', {
+  const res = await fetchWithAuth('/api/settings/hotkey-preferences', {
     method: 'PATCH',
-    credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
-      'X-CSRF-Token': csrfToken,
     },
     body: JSON.stringify({ hotkeyId, binding }),
   });


### PR DESCRIPTION
## Summary
Refactored the hotkey preferences hooks to use a centralized `fetchWithAuth` utility instead of manually handling authentication credentials and CSRF tokens.

## Key Changes
- Replaced manual `fetch` calls with `fetchWithAuth` utility in both the `useHotkeyPreferences` hook and `updateHotkeyPreference` function
- Removed manual CSRF token extraction from DOM meta tags in `updateHotkeyPreference`
- Removed explicit `credentials: 'include'` from fetch options (now handled by `fetchWithAuth`)
- Removed manual `X-CSRF-Token` header assignment (now handled by `fetchWithAuth`)

## Benefits
- **Centralized auth logic**: Authentication and CSRF handling is now managed in one place, reducing duplication
- **Improved maintainability**: Changes to auth strategy only need to be made in the `fetchWithAuth` utility
- **Cleaner code**: Removes boilerplate auth-related code from individual hooks
- **Consistency**: Ensures all API calls use the same authentication approach

https://claude.ai/code/session_01RNSc2TiN2pjubnTrbbCHvS