### PR TITLE
Support multiple output formats in tool renderers

### DIFF
--- a/apps/web/src/lib/ai/tools/activity-tools.ts
+++ b/apps/web/src/lib/ai/tools/activity-tools.ts
@@ -102,6 +102,7 @@ async function getLastVisitTime(userId: string): Promise<Date | undefined> {
 
 // Compact activity format optimized for AI context efficiency
 interface CompactActivity {
+  id: string;              // CUID2 activity ID from database
   ts: string;              // ISO timestamp
   op: string;              // operation
   res: string;             // resourceType
@@ -512,6 +513,7 @@ When summarizing multiple changes, group them thematically and describe the over
           // Build compact activity
           const actorIdx = actorMap.get(activity.actorEmail)!.idx;
           const compact: CompactActivity = {
+            id: activity.id,
             ts: activity.timestamp.toISOString(),
             op: activity.operation,
             res: activity.resourceType,


### PR DESCRIPTION
## Summary
Enhanced tool call renderers to support multiple output formats from AI tools, improving compatibility with different response structures while maintaining backward compatibility.

## Key Changes

- **list_pages tool**: Added support for converting `paths` array format to tree structure via new `parsePathsToTree()` helper function that parses path strings and builds a hierarchical tree
- **list_drives tool**: Added data transformation to map tool output field `title` to renderer's expected `name` field, with fallback logic
- **get_activity tool**: Added support for grouped `drives` format in addition to flat `activities` array, with automatic flattening and operation-to-action mapping

## Implementation Details

- **Path parsing**: Regex-based parser extracts folder/page type, ID, and path from formatted strings like `"📁 [FOLDER](Task) ID: xxx Path: /drive/folder"`
- **Tree building**: Recursive depth-first algorithm constructs hierarchical tree from flat parsed pages
- **Activity mapping**: Converts grouped drive activities to flat ActivityItem array with proper timestamp sorting and actor resolution
- **Backward compatibility**: All changes preserve existing format support - renderers check for new formats only if old formats aren't present
- **Type safety**: Maintains proper TypeScript typing throughout transformations with explicit type annotations

These changes allow the renderers to work with both current and future tool output formats without breaking existing functionality.

https://claude.ai/code/session_01AKG5EjddKT1CVdkLYfnvX9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced support for displaying pages in alternative formats.
  * Improved activity data presentation with better organization and enriched metadata display.

* **Bug Fixes**
  * Fixed compatibility issues with various drive and page listing formats to ensure consistent rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->