### PR TITLE
fix(activity): prevent horizontal overflow on mobile

### DIFF
--- a/apps/web/src/components/activity/ActivityDashboard.tsx
+++ b/apps/web/src/components/activity/ActivityDashboard.tsx
@@ -233,8 +233,8 @@ export function ActivityDashboard({ context, driveId: initialDriveId, driveName 
   // Loading skeleton
   if (loading && activities.length === 0) {
     return (
-      <div className="h-full overflow-y-auto">
-        <div className="container mx-auto px-4 py-10 sm:px-6 lg:px-10 max-w-5xl">
+      <div className="h-full overflow-y-auto overflow-x-hidden">
+        <div className="container mx-auto px-4 py-6 sm:py-10 sm:px-6 lg:px-10 max-w-5xl">
           <div className="space-y-6">
             <Skeleton className="h-8 w-48" />
             <Skeleton className="h-10 w-full" />
@@ -256,13 +256,13 @@ export function ActivityDashboard({ context, driveId: initialDriveId, driveName 
       : 'Your recent activity across all drives';
 
   return (
-    <div className="h-full">
+    <div className="h-full overflow-x-hidden">
       <PullToRefresh
         direction="top"
         onRefresh={handleRefresh}
       >
         <CustomScrollArea className="h-full">
-          <div className="container mx-auto px-4 py-10 sm:px-6 lg:px-10 max-w-5xl">
+          <div className="container mx-auto px-4 py-6 sm:py-10 sm:px-6 lg:px-10 max-w-5xl">
             {/* Header */}
             <div className="mb-6">
               <Button

--- a/apps/web/src/components/activity/ActivityFilterBar.tsx
+++ b/apps/web/src/components/activity/ActivityFilterBar.tsx
@@ -31,14 +31,14 @@ export function ActivityFilterBar({
   onDriveChange,
 }: ActivityFilterBarProps) {
   return (
-    <div className="flex flex-wrap items-center gap-3">
+    <div className="flex flex-wrap items-center gap-2 sm:gap-3">
       {/* Drive Selector - only in user context (dashboard) */}
       {context === 'user' && drives.length > 0 && onDriveChange && (
         <Select
           value={driveId || 'all'}
           onValueChange={(value) => onDriveChange(value === 'all' ? '' : value)}
         >
-          <SelectTrigger className="w-[180px]">
+          <SelectTrigger className="w-[calc(50%-4px)] sm:w-[180px]">
             <SelectValue placeholder="All drives" />
           </SelectTrigger>
           <SelectContent>
@@ -78,7 +78,7 @@ export function ActivityFilterBar({
           onFiltersChange({ operation: value === 'all' ? undefined : value })
         }
       >
-        <SelectTrigger className="w-[150px]">
+        <SelectTrigger className="w-[calc(50%-4px)] sm:w-[150px]">
           <SelectValue placeholder="Operation" />
         </SelectTrigger>
         <SelectContent>
@@ -98,7 +98,7 @@ export function ActivityFilterBar({
           onFiltersChange({ resourceType: value === 'all' ? undefined : value })
         }
       >
-        <SelectTrigger className="w-[130px]">
+        <SelectTrigger className="w-[calc(50%-4px)] sm:w-[130px]">
           <SelectValue placeholder="Resource" />
         </SelectTrigger>
         <SelectContent>
@@ -110,8 +110,8 @@ export function ActivityFilterBar({
         </SelectContent>
       </Select>
 
-      {/* Spacer */}
-      <div className="flex-1" />
+      {/* Spacer - hidden on mobile */}
+      <div className="hidden sm:block sm:flex-1" />
 
       {/* Export Button */}
       <ExportButton context={context} driveId={driveId} filters={filters} />

--- a/apps/web/src/components/activity/ActivityGroupItem.tsx
+++ b/apps/web/src/components/activity/ActivityGroupItem.tsx
@@ -83,7 +83,7 @@ export function ActivityGroupItem({
     <>
       <Collapsible open={isOpen} onOpenChange={setIsOpen}>
         {/* Group Header */}
-        <div className="flex items-center gap-4 py-4 border-b group">
+        <div className="flex items-center gap-2 sm:gap-4 py-4 border-b group">
           {/* Expand/Collapse button */}
           <CollapsibleTrigger asChild>
             <Button variant="ghost" size="icon" className="h-6 w-6 shrink-0">
@@ -97,7 +97,7 @@ export function ActivityGroupItem({
           </CollapsibleTrigger>
 
           {/* Avatar */}
-          <Avatar className="h-10 w-10 shrink-0">
+          <Avatar className="h-8 w-8 sm:h-10 sm:w-10 shrink-0">
             <AvatarImage src={summary.actorImage || undefined} alt={summary.actorName} />
             <AvatarFallback>
               {getInitials(summary.actorName, summary.actorName)}
@@ -105,10 +105,10 @@ export function ActivityGroupItem({
           </Avatar>
 
           {/* Content */}
-          <div className="flex-1 min-w-0 space-y-1">
-            <div className="flex flex-wrap items-center gap-2">
-              <span className="font-medium text-sm">{summary.actorName}</span>
-              <Badge variant={badgeVariant} className="text-xs">
+          <div className="flex-1 min-w-0 space-y-1 overflow-hidden">
+            <div className="flex flex-wrap items-center gap-1 sm:gap-2">
+              <span className="font-medium text-sm truncate max-w-[100px] sm:max-w-none">{summary.actorName}</span>
+              <Badge variant={badgeVariant} className="text-xs shrink-0">
                 <GroupIcon className="h-3 w-3 mr-1" />
                 {summary.label}
               </Badge>
@@ -120,9 +120,9 @@ export function ActivityGroupItem({
           </div>
 
           {/* Timestamp and Actions */}
-          <div className="flex items-start gap-2">
+          <div className="flex items-start gap-1 sm:gap-2 shrink-0">
             <div className="text-xs text-muted-foreground shrink-0 text-right">
-              <div>{format(new Date(summary.timestamp), 'h:mm a')}</div>
+              <div className="hidden sm:block">{format(new Date(summary.timestamp), 'h:mm a')}</div>
               <div className="text-muted-foreground/60">
                 {formatDistanceToNow(new Date(summary.timestamp), { addSuffix: true })}
               </div>
@@ -153,7 +153,7 @@ export function ActivityGroupItem({
 
         {/* Expanded Content - Individual Activities */}
         <CollapsibleContent>
-          <div className="pl-10 border-l-2 border-muted ml-5">
+          <div className="pl-4 sm:pl-10 border-l-2 border-muted ml-3 sm:ml-5">
             {activities.map((activity) => (
               <ActivityItem
                 key={activity.id}

--- a/apps/web/src/components/activity/ActivityItem.tsx
+++ b/apps/web/src/components/activity/ActivityItem.tsx
@@ -91,25 +91,25 @@ export function ActivityItem({ activity, context, onRollback, onRollbackToPointS
 
   return (
     <>
-    <div className="flex items-start gap-4 py-4 border-b last:border-b-0 group">
+    <div className="flex items-start gap-2 sm:gap-4 py-4 border-b last:border-b-0 group">
       {/* Avatar */}
-      <Avatar className="h-10 w-10 shrink-0">
+      <Avatar className="h-8 w-8 sm:h-10 sm:w-10 shrink-0">
         <AvatarImage src={actorImage || undefined} alt={actorName} />
         <AvatarFallback>{getInitials(activity.actorDisplayName, activity.actorEmail)}</AvatarFallback>
       </Avatar>
 
       {/* Content */}
-      <div className="flex-1 min-w-0 space-y-1">
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="font-medium text-sm">{actorName}</span>
-          <Badge variant={opConfig.variant} className="text-xs">
+      <div className="flex-1 min-w-0 space-y-1 overflow-hidden">
+        <div className="flex flex-wrap items-center gap-1 sm:gap-2">
+          <span className="font-medium text-sm truncate max-w-[120px] sm:max-w-none">{actorName}</span>
+          <Badge variant={opConfig.variant} className="text-xs shrink-0">
             <OpIcon className="h-3 w-3 mr-1" />
             {opConfig.label}
           </Badge>
           {activity.isAiGenerated && (
-            <Badge variant="outline" className="text-xs gap-1">
-              <Bot className="h-3 w-3" />
-              {getUserFacingModelName(activity.aiProvider, activity.aiModel)}
+            <Badge variant="outline" className="text-xs gap-1 max-w-[100px] sm:max-w-[150px]">
+              <Bot className="h-3 w-3 shrink-0" />
+              <span className="truncate">{getUserFacingModelName(activity.aiProvider, activity.aiModel)}</span>
             </Badge>
           )}
         </div>
@@ -130,9 +130,9 @@ export function ActivityItem({ activity, context, onRollback, onRollbackToPointS
       </div>
 
       {/* Timestamp and Actions */}
-      <div className="flex items-start gap-2">
+      <div className="flex items-start gap-1 sm:gap-2 shrink-0">
         <div className="text-xs text-muted-foreground shrink-0 text-right">
-          <div>{format(new Date(activity.timestamp), 'h:mm a')}</div>
+          <div className="hidden sm:block">{format(new Date(activity.timestamp), 'h:mm a')}</div>
           <div className="text-muted-foreground/60">
             {formatDistanceToNow(new Date(activity.timestamp), { addSuffix: true })}
           </div>

--- a/apps/web/src/components/activity/ActorFilter.tsx
+++ b/apps/web/src/components/activity/ActorFilter.tsx
@@ -83,7 +83,7 @@ export function ActorFilter({ driveId, context, value, onChange }: ActorFilterPr
           role="combobox"
           aria-expanded={open}
           className={cn(
-            'w-[180px] justify-between',
+            'w-[calc(50%-4px)] sm:w-[180px] justify-between',
             !value && 'text-muted-foreground'
           )}
           disabled={loading || actors.length === 0}
@@ -119,7 +119,7 @@ export function ActorFilter({ driveId, context, value, onChange }: ActorFilterPr
           )}
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[200px] p-0" align="start">
+      <PopoverContent className="w-[min(200px,calc(100vw-32px))] p-0" align="start">
         <Command>
           <CommandInput placeholder="Search users..." />
           <CommandList>

--- a/apps/web/src/components/activity/DateRangeFilter.tsx
+++ b/apps/web/src/components/activity/DateRangeFilter.tsx
@@ -92,7 +92,7 @@ export function DateRangeFilter({ startDate, endDate, onDateChange }: DateRangeF
         <Button
           variant="outline"
           className={cn(
-            'w-[200px] justify-start text-left font-normal',
+            'w-[calc(50%-4px)] sm:w-[200px] justify-start text-left font-normal',
             !hasDateRange && 'text-muted-foreground'
           )}
         >


### PR DESCRIPTION
- Use responsive widths on filter controls (50% on mobile, fixed on desktop)
- Reduce gaps between elements on mobile (gap-2 vs gap-4)
- Truncate actor names and AI model badges to prevent overflow
- Use smaller avatars on mobile (8x8 vs 10x10)
- Hide exact timestamps on mobile, show relative time only
- Reduce nested content padding in activity groups on mobile
- Add overflow-x-hidden to root container

https://claude.ai/code/session_01HTp6TqAqgp2y5EZvKvGi95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layout and spacing across activity components for better mobile experience.
  * Enhanced handling of long content to prevent overflow on smaller screens.
  * Adjusted component sizing and spacing for improved visual consistency across breakpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->