### PR TITLE
feat: hide 'Open in new tab' options on mobile Capacitor apps

### DIFF
--- a/apps/web/src/components/layout/left-sidebar/DashboardFooter.tsx
+++ b/apps/web/src/components/layout/left-sidebar/DashboardFooter.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/context-menu";
 import { useLayoutStore } from "@/stores/useLayoutStore";
 import { useBreakpoint } from "@/hooks/useBreakpoint";
+import { useCapacitor } from "@/hooks/useCapacitor";
 import { useTabsStore } from "@/stores/useTabsStore";
 import { shouldOpenInNewTab } from "@/lib/tabs/tab-navigation-utils";
 import { cn } from "@/lib/utils";
@@ -63,6 +64,7 @@ export default function DashboardFooter() {
   const isSheetBreakpoint = useBreakpoint("(max-width: 1023px)");
   const setLeftSheetOpen = useLayoutStore((state) => state.setLeftSheetOpen);
   const createTab = useTabsStore((state) => state.createTab);
+  const { isNative } = useCapacitor();
 
   const handleLinkClick = (e: MouseEvent<HTMLAnchorElement>, href: string) => {
     if (shouldOpenInNewTab(e)) {
@@ -102,36 +104,47 @@ export default function DashboardFooter() {
       </CollapsibleTrigger>
       <CollapsibleContent className="px-1 pb-2">
         <div className="space-y-0.5">
-          {actions.map((action) => (
-            <ContextMenu key={action.label}>
-              <ContextMenuTrigger asChild>
-                <Link
-                  href={action.href}
-                  onClick={(e) => handleLinkClick(e, action.href)}
-                  onAuxClick={(e) => {
-                    if (e.button === 1) {
-                      e.preventDefault();
-                      handleOpenInNewTab(action.href);
-                    }
-                  }}
-                  className={cn(
-                    "flex items-center gap-2.5 py-1.5 px-2 rounded-md text-sm transition-colors",
-                    "hover:bg-accent hover:text-accent-foreground",
-                    "text-muted-foreground"
-                  )}
-                >
-                  <action.icon className="h-4 w-4" />
-                  {action.label}
-                </Link>
-              </ContextMenuTrigger>
-              <ContextMenuContent>
-                <ContextMenuItem onSelect={() => handleOpenInNewTab(action.href)}>
-                  <ExternalLink className="mr-2 h-4 w-4" />
-                  Open in new tab
-                </ContextMenuItem>
-              </ContextMenuContent>
-            </ContextMenu>
-          ))}
+          {actions.map((action) => {
+            const linkElement = (
+              <Link
+                href={action.href}
+                onClick={(e) => handleLinkClick(e, action.href)}
+                onAuxClick={isNative ? undefined : (e) => {
+                  if (e.button === 1) {
+                    e.preventDefault();
+                    handleOpenInNewTab(action.href);
+                  }
+                }}
+                className={cn(
+                  "flex items-center gap-2.5 py-1.5 px-2 rounded-md text-sm transition-colors",
+                  "hover:bg-accent hover:text-accent-foreground",
+                  "text-muted-foreground"
+                )}
+              >
+                <action.icon className="h-4 w-4" />
+                {action.label}
+              </Link>
+            );
+
+            // On native apps, don't show the context menu with "Open in new tab"
+            if (isNative) {
+              return <div key={action.label}>{linkElement}</div>;
+            }
+
+            return (
+              <ContextMenu key={action.label}>
+                <ContextMenuTrigger asChild>
+                  {linkElement}
+                </ContextMenuTrigger>
+                <ContextMenuContent>
+                  <ContextMenuItem onSelect={() => handleOpenInNewTab(action.href)}>
+                    <ExternalLink className="mr-2 h-4 w-4" />
+                    Open in new tab
+                  </ContextMenuItem>
+                </ContextMenuContent>
+              </ContextMenu>
+            );
+          })}
         </div>
       </CollapsibleContent>
     </Collapsible>

--- a/apps/web/src/components/layout/left-sidebar/DriveFooter.tsx
+++ b/apps/web/src/components/layout/left-sidebar/DriveFooter.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/components/ui/context-menu";
 import { useLayoutStore } from "@/stores/useLayoutStore";
 import { useBreakpoint } from "@/hooks/useBreakpoint";
+import { useCapacitor } from "@/hooks/useCapacitor";
 import { useTabsStore } from "@/stores/useTabsStore";
 import { shouldOpenInNewTab } from "@/lib/tabs/tab-navigation-utils";
 import { cn } from "@/lib/utils";
@@ -41,6 +42,7 @@ export default function DriveFooter({ canManage }: DriveFooterProps) {
   const isSheetBreakpoint = useBreakpoint("(max-width: 1023px)");
   const setLeftSheetOpen = useLayoutStore((state) => state.setLeftSheetOpen);
   const createTab = useTabsStore((state) => state.createTab);
+  const { isNative } = useCapacitor();
 
   const { driveId: driveIdParams } = params;
   const driveId = Array.isArray(driveIdParams) ? driveIdParams[0] : driveIdParams;
@@ -118,36 +120,47 @@ export default function DriveFooter({ canManage }: DriveFooterProps) {
       </CollapsibleTrigger>
       <CollapsibleContent className="px-1 pb-2">
         <div className="space-y-0.5">
-          {actions.map((action) => (
-            <ContextMenu key={action.label}>
-              <ContextMenuTrigger asChild>
-                <Link
-                  href={action.href}
-                  onClick={(e) => handleLinkClick(e, action.href)}
-                  onAuxClick={(e) => {
-                    if (e.button === 1) {
-                      e.preventDefault();
-                      handleOpenInNewTab(action.href);
-                    }
-                  }}
-                  className={cn(
-                    "flex items-center gap-2.5 py-1.5 px-2 rounded-md text-sm transition-colors",
-                    "hover:bg-accent hover:text-accent-foreground",
-                    "text-muted-foreground"
-                  )}
-                >
-                  <action.icon className="h-4 w-4" />
-                  {action.label}
-                </Link>
-              </ContextMenuTrigger>
-              <ContextMenuContent>
-                <ContextMenuItem onSelect={() => handleOpenInNewTab(action.href)}>
-                  <ExternalLink className="mr-2 h-4 w-4" />
-                  Open in new tab
-                </ContextMenuItem>
-              </ContextMenuContent>
-            </ContextMenu>
-          ))}
+          {actions.map((action) => {
+            const linkElement = (
+              <Link
+                href={action.href}
+                onClick={(e) => handleLinkClick(e, action.href)}
+                onAuxClick={isNative ? undefined : (e) => {
+                  if (e.button === 1) {
+                    e.preventDefault();
+                    handleOpenInNewTab(action.href);
+                  }
+                }}
+                className={cn(
+                  "flex items-center gap-2.5 py-1.5 px-2 rounded-md text-sm transition-colors",
+                  "hover:bg-accent hover:text-accent-foreground",
+                  "text-muted-foreground"
+                )}
+              >
+                <action.icon className="h-4 w-4" />
+                {action.label}
+              </Link>
+            );
+
+            // On native apps, don't show the context menu with "Open in new tab"
+            if (isNative) {
+              return <div key={action.label}>{linkElement}</div>;
+            }
+
+            return (
+              <ContextMenu key={action.label}>
+                <ContextMenuTrigger asChild>
+                  {linkElement}
+                </ContextMenuTrigger>
+                <ContextMenuContent>
+                  <ContextMenuItem onSelect={() => handleOpenInNewTab(action.href)}>
+                    <ExternalLink className="mr-2 h-4 w-4" />
+                    Open in new tab
+                  </ContextMenuItem>
+                </ContextMenuContent>
+              </ContextMenu>
+            );
+          })}
         </div>
       </CollapsibleContent>
     </Collapsible>

--- a/apps/web/src/components/layout/left-sidebar/FavoritesSection.tsx
+++ b/apps/web/src/components/layout/left-sidebar/FavoritesSection.tsx
@@ -17,6 +17,7 @@ import { PageTypeIcon } from "@/components/common/PageTypeIcon";
 import { useFavorites } from "@/hooks/useFavorites";
 import { useLayoutStore } from "@/stores/useLayoutStore";
 import { useBreakpoint } from "@/hooks/useBreakpoint";
+import { useCapacitor } from "@/hooks/useCapacitor";
 import { cn } from "@/lib/utils";
 import type { PageType } from "@pagespace/lib/client-safe";
 import { toast } from "sonner";
@@ -27,6 +28,7 @@ export default function FavoritesSection() {
   const isSheetBreakpoint = useBreakpoint("(max-width: 1023px)");
   const setLeftSheetOpen = useLayoutStore((state) => state.setLeftSheetOpen);
   const createTab = useTabsStore((state) => state.createTab);
+  const { isNative } = useCapacitor();
 
   useEffect(() => {
     if (!isSynced) {
@@ -90,6 +92,7 @@ export default function FavoritesSection() {
               onNavigate={(e) => handleNavigate(href, e)}
               onOpenInNewTab={() => handleOpenInNewTab(href)}
               onRemove={() => handleRemoveFavorite(favorite.id)}
+              isNative={isNative}
             />
           );
         })}
@@ -117,9 +120,10 @@ interface FavoriteItemProps {
   onNavigate: (e: MouseEvent<HTMLButtonElement>) => void;
   onOpenInNewTab: () => void;
   onRemove: () => void;
+  isNative: boolean;
 }
 
-function FavoriteItem({ favorite, onNavigate, onOpenInNewTab, onRemove }: FavoriteItemProps) {
+function FavoriteItem({ favorite, onNavigate, onOpenInNewTab, onRemove, isNative }: FavoriteItemProps) {
   const [isHovered, setIsHovered] = useState(false);
 
   const title =
@@ -138,7 +142,7 @@ function FavoriteItem({ favorite, onNavigate, onOpenInNewTab, onRemove }: Favori
     >
       <button
         onClick={onNavigate}
-        onAuxClick={(e) => {
+        onAuxClick={isNative ? undefined : (e) => {
           if (e.button === 1) {
             e.preventDefault();
             onOpenInNewTab();
@@ -183,10 +187,12 @@ function FavoriteItem({ favorite, onNavigate, onOpenInNewTab, onRemove }: Favori
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-48">
-          <DropdownMenuItem onSelect={onOpenInNewTab}>
-            <ExternalLink className="mr-2 h-4 w-4" />
-            Open in new tab
-          </DropdownMenuItem>
+          {!isNative && (
+            <DropdownMenuItem onSelect={onOpenInNewTab}>
+              <ExternalLink className="mr-2 h-4 w-4" />
+              Open in new tab
+            </DropdownMenuItem>
+          )}
           <DropdownMenuItem
             onSelect={onRemove}
             className="text-muted-foreground"

--- a/apps/web/src/components/layout/left-sidebar/page-tree/PageTreeItem.tsx
+++ b/apps/web/src/components/layout/left-sidebar/page-tree/PageTreeItem.tsx
@@ -16,6 +16,7 @@ import {
   Undo2,
 } from "lucide-react";
 import { useTouchDevice } from "@/hooks/useTouchDevice";
+import { useCapacitor } from "@/hooks/useCapacitor";
 import { TreePage } from "@/hooks/usePageTree";
 import { PageTypeIcon } from "@/components/common/PageTypeIcon";
 import {
@@ -98,6 +99,7 @@ export function PageTreeItem({
   const { addFavorite, removeFavorite, isFavorite } = useFavorites();
   const createTab = useTabsStore((state) => state.createTab);
   const isTouchDevice = useTouchDevice();
+  const { isNative } = useCapacitor();
   const hasChildren = item.children && item.children.length > 0;
 
   const linkHref = `/dashboard/${params.driveId}/${item.id}`;
@@ -283,7 +285,7 @@ export function PageTreeItem({
               <Link
                 href={linkHref}
                 onClick={handleLinkClick}
-                onMouseDown={handleMouseDown}
+                onMouseDown={isNative ? undefined : handleMouseDown}
                 onPointerDown={(e) => e.stopPropagation()}
                 onTouchEnd={(e) => e.stopPropagation()}
                 className="flex-1 min-w-0 ml-1.5 truncate text-sm font-medium text-gray-900 dark:text-gray-100 hover:underline cursor-pointer touch-manipulation"
@@ -336,10 +338,12 @@ export function PageTreeItem({
               </>
             ) : (
               <>
-                <ContextMenuItem onSelect={handleOpenInNewTab}>
-                  <ExternalLink className="mr-2 h-4 w-4" />
-                  <span>Open in new tab</span>
-                </ContextMenuItem>
+                {!isNative && (
+                  <ContextMenuItem onSelect={handleOpenInNewTab}>
+                    <ExternalLink className="mr-2 h-4 w-4" />
+                    <span>Open in new tab</span>
+                  </ContextMenuItem>
+                )}
                 <ContextMenuItem onSelect={() => onOpenCreateDialog(item.id)}>
                   <FolderPlus className="mr-2 h-4 w-4" />
                   <span>Add child page</span>


### PR DESCRIPTION
Tabs are not supported in mobile Capacitor apps, so the "Open in new tab"
context menu items and middle-click handlers should be hidden on native
platforms. This change conditionally renders these elements based on the
`isNative` flag from the useCapacitor hook.

Modified components:
- PageTreeItem: Hide context menu item and middle-click handler
- FavoritesSection: Hide dropdown menu item and middle-click handler
- RecentsSection: Skip context menu entirely on native (only had new tab option)
- DriveFooter: Skip context menu entirely on native (only had new tab option)
- DashboardFooter: Skip context menu entirely on native (only had new tab option)

https://claude.ai/code/session_01ACNDLDMe2NHEEebK2NmeoP