### PR TITLE
Refine workspace selector padding and alignment

### DIFF
--- a/apps/web/src/components/layout/left-sidebar/workspace-selector.tsx
+++ b/apps/web/src/components/layout/left-sidebar/workspace-selector.tsx
@@ -80,9 +80,9 @@ export default function DriveSwitcher() {
   return (
     <>
       <DropdownMenu>
-        <div className="flex items-center gap-2 p-2">
+        <div className="flex items-center gap-2 px-2 py-1.5">
           <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="icon" className="shrink-0 text-muted-foreground">
+            <Button variant="ghost" size="icon" className="shrink-0 text-muted-foreground -ml-2.5">
               <ChevronsUpDown className="h-4 w-4" />
             </Button>
           </DropdownMenuTrigger>


### PR DESCRIPTION
## Summary
Adjusted the padding and alignment of the workspace selector dropdown trigger to improve visual consistency and spacing in the left sidebar.

## Changes
- Modified the container padding from `p-2` to `px-2 py-1.5` for more precise vertical spacing control
- Added negative left margin (`-ml-2.5`) to the dropdown trigger button to better align the chevron icon with the overall layout

## Details
These changes fine-tune the visual presentation of the workspace selector component, ensuring better alignment of the dropdown trigger button and more balanced padding around the element. The adjustment from uniform padding to differentiated horizontal and vertical padding provides tighter vertical spacing while maintaining horizontal consistency.

https://claude.ai/code/session_01PFuSjp5yvP2pq9649g4shD