### PR TITLE
Replace fetch with fetchWithAuth for authenticated API calls

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInput.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInput.tsx
@@ -7,6 +7,7 @@ import { cn } from '@/lib/utils';
 import { InputCard } from '@/components/ui/floating-input';
 import { ChatTextarea, type ChatTextareaRef } from '@/components/ai/chat/input/ChatTextarea';
 import { ChannelInputFooter } from './ChannelInputFooter';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 
 // File attachment info returned from upload
 export interface FileAttachment {
@@ -113,10 +114,9 @@ export const ChannelInput = forwardRef<ChannelInputRef, ChannelInputProps>(
         const formData = new FormData();
         formData.append('file', file);
 
-        const response = await fetch(`/api/channels/${channelId}/upload`, {
+        const response = await fetchWithAuth(`/api/channels/${channelId}/upload`, {
           method: 'POST',
           body: formData,
-          credentials: 'include',
         });
 
         if (!response.ok) {

--- a/apps/web/src/components/version-history/VersionHistoryPanel.tsx
+++ b/apps/web/src/components/version-history/VersionHistoryPanel.tsx
@@ -24,7 +24,7 @@ import { Label } from '@/components/ui/label';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { VersionHistoryItem } from './VersionHistoryItem';
 import { useToast } from '@/hooks/useToast';
-import { post } from '@/lib/auth/auth-fetch';
+import { fetchWithAuth, post } from '@/lib/auth/auth-fetch';
 import type { ActivityActionResult } from '@/types/activity-actions';
 import type { ActivityLog } from '@/components/activity/types';
 
@@ -106,7 +106,7 @@ export function VersionHistoryPanel({
         ? `/api/pages/${pageId}/history?${params}`
         : `/api/drives/${driveId}/history?${params}`;
 
-      const response = await fetch(endpoint);
+      const response = await fetchWithAuth(endpoint);
       if (!response.ok) {
         logger.debug('[History:Fetch] Fetch failed with status', {
           status: response.status,


### PR DESCRIPTION
## Summary
Standardize API calls to use the `fetchWithAuth` utility function instead of raw `fetch` calls, ensuring consistent authentication handling across the application.

## Changes
- **ChannelInput.tsx**: Replace `fetch` with `fetchWithAuth` for file upload endpoint and remove redundant `credentials: 'include'` option
- **VersionHistoryPanel.tsx**: Replace `fetch` with `fetchWithAuth` for history endpoint and update import statement to include `fetchWithAuth`

## Implementation Details
- The `fetchWithAuth` utility function centralizes authentication logic, eliminating the need for manual `credentials: 'include'` configuration
- This change improves maintainability by ensuring all authenticated requests follow the same pattern
- No functional changes to the API calls themselves, only the mechanism for handling authentication

https://claude.ai/code/session_019XLxD31GHKcz93HH49FHR9