### PR TITLE
Add drive deletion with confirmation dialog and safety checks

### DIFF
--- a/apps/web/src/app/dashboard/[driveId]/settings/page.tsx
+++ b/apps/web/src/app/dashboard/[driveId]/settings/page.tsx
@@ -8,6 +8,7 @@ import { ChevronLeft, Shield } from 'lucide-react';
 import { useDriveStore } from '@/hooks/useDrive';
 import { RolesManager } from '@/components/settings/RolesManager';
 import { DriveAISettings } from '@/components/settings/DriveAISettings';
+import { DriveDeleteSection } from '@/components/settings/DriveDeleteSection';
 
 export default function DriveSettingsPage() {
   const params = useParams();
@@ -86,6 +87,11 @@ export default function DriveSettingsPage() {
         <div className="space-y-6">
           <RolesManager driveId={driveId} />
           <DriveAISettings driveId={driveId} />
+
+          {/* Danger Zone - Only show to owners */}
+          {drive.isOwned && (
+            <DriveDeleteSection driveId={driveId} driveName={drive.name} />
+          )}
         </div>
       </div>
     </div>

--- a/apps/web/src/components/dialogs/DeleteDriveDialog.tsx
+++ b/apps/web/src/components/dialogs/DeleteDriveDialog.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -8,12 +9,18 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { AlertTriangle } from "lucide-react";
 
 interface DeleteDriveDialogProps {
   isOpen: boolean;
   onClose: () => void;
   onConfirm: () => void;
   driveName: string;
+  isDeleting?: boolean;
+  memberCount?: number;
 }
 
 export function DeleteDriveDialog({
@@ -21,21 +28,75 @@ export function DeleteDriveDialog({
   onClose,
   onConfirm,
   driveName,
+  isDeleting = false,
+  memberCount = 1,
 }: DeleteDriveDialogProps) {
+  const [nameConfirmation, setNameConfirmation] = useState("");
+
+  const isNameMatch = nameConfirmation.trim().toLowerCase() === driveName.toLowerCase();
+
+  const handleConfirm = () => {
+    if (isNameMatch) {
+      onConfirm();
+    }
+  };
+
+  const handleClose = () => {
+    if (!isDeleting) {
+      setNameConfirmation("");
+      onClose();
+    }
+  };
+
   return (
-    <AlertDialog open={isOpen} onOpenChange={onClose}>
+    <AlertDialog open={isOpen} onOpenChange={handleClose}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Delete Drive &quot;{driveName}&quot;?</AlertDialogTitle>
+          <AlertDialogTitle>Delete Drive?</AlertDialogTitle>
           <AlertDialogDescription>
-            This action will move the drive and all its contents to the trash. 
-            You can restore it later from the trash if needed.
+            This will move the drive to trash. You can restore it within 30 days.
           </AlertDialogDescription>
         </AlertDialogHeader>
+
+        <div className="space-y-4">
+          <Alert variant="destructive">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertDescription>
+              <p className="font-semibold mb-2">Warning:</p>
+              <ul className="list-disc list-inside text-sm space-y-1 ml-2">
+                {memberCount > 1 && (
+                  <li>{memberCount - 1} other member{memberCount > 2 ? 's' : ''} will lose access to this drive</li>
+                )}
+                <li>All pages and content in this drive will be moved to trash</li>
+                <li>The drive can be restored from trash within 30 days</li>
+              </ul>
+            </AlertDescription>
+          </Alert>
+
+          <div className="space-y-2">
+            <Label htmlFor="drive-name-confirmation">
+              Type the drive name <strong>{driveName}</strong> to confirm:
+            </Label>
+            <Input
+              id="drive-name-confirmation"
+              type="text"
+              value={nameConfirmation}
+              onChange={(e) => setNameConfirmation(e.target.value)}
+              placeholder="Enter drive name"
+              disabled={isDeleting}
+              autoComplete="off"
+            />
+          </div>
+        </div>
+
         <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction onClick={onConfirm} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
-            Move to Trash
+          <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleConfirm}
+            disabled={!isNameMatch || isDeleting}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            {isDeleting ? "Deleting Drive..." : "Delete Drive"}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/apps/web/src/components/settings/DriveDeleteSection.tsx
+++ b/apps/web/src/components/settings/DriveDeleteSection.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Trash2 } from 'lucide-react';
+import { useToast } from '@/hooks/useToast';
+import { del, fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { DeleteDriveDialog } from '@/components/dialogs/DeleteDriveDialog';
+import { useDriveStore } from '@/hooks/useDrive';
+
+interface DriveDeleteSectionProps {
+  driveId: string;
+  driveName: string;
+}
+
+export function DriveDeleteSection({ driveId, driveName }: DriveDeleteSectionProps) {
+  const [showDialog, setShowDialog] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [memberCount, setMemberCount] = useState(1);
+  const { toast } = useToast();
+  const router = useRouter();
+  const removeDrive = useDriveStore((state) => state.removeDrive);
+
+  useEffect(() => {
+    const fetchMemberCount = async () => {
+      try {
+        const response = await fetchWithAuth(`/api/drives/${driveId}/members`);
+        if (response.ok) {
+          const data = await response.json();
+          setMemberCount(data.members?.length ?? 1);
+        }
+      } catch {
+        // Silently fail - member count is optional
+      }
+    };
+    fetchMemberCount();
+  }, [driveId]);
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    try {
+      await del(`/api/drives/${driveId}`);
+
+      toast({
+        title: 'Drive deleted',
+        description: 'The drive has been moved to trash.',
+      });
+
+      // Remove from local store
+      removeDrive(driveId);
+
+      // Navigate to dashboard
+      router.push('/dashboard');
+    } catch (error) {
+      console.error('Error deleting drive:', error);
+      toast({
+        title: 'Error',
+        description: 'Failed to delete drive. Please try again.',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsDeleting(false);
+      setShowDialog(false);
+    }
+  };
+
+  return (
+    <>
+      <Card className="border-destructive/50">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-destructive">
+            <Trash2 className="w-5 h-5" />
+            Delete Drive
+          </CardTitle>
+          <CardDescription>
+            Permanently delete this drive and all its contents. This action moves the drive to trash
+            where it can be restored within 30 days.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            <div className="text-sm text-muted-foreground">
+              <p className="mb-2">Deleting this drive will:</p>
+              <ul className="list-disc list-inside space-y-1 ml-2">
+                <li>Move all pages and content to trash</li>
+                <li>Revoke access for all members</li>
+                <li>Stop all AI agents and automations</li>
+              </ul>
+            </div>
+            <Button
+              variant="destructive"
+              onClick={() => setShowDialog(true)}
+            >
+              <Trash2 className="w-4 h-4 mr-2" />
+              Delete Drive
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <DeleteDriveDialog
+        isOpen={showDialog}
+        onClose={() => setShowDialog(false)}
+        onConfirm={handleDelete}
+        driveName={driveName}
+        isDeleting={isDeleting}
+        memberCount={memberCount}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
Implements a comprehensive drive deletion feature with enhanced safety measures, including a confirmation dialog that requires users to type the drive name and displays warnings about affected members and content.

## Key Changes
- **New DriveDeleteSection component**: Dedicated UI section in drive settings for managing drive deletion, only visible to drive owners
- **Enhanced DeleteDriveDialog**: Upgraded confirmation dialog with:
  - Name confirmation requirement (user must type drive name to proceed)
  - Warning alerts showing impact on members and content
  - Loading state during deletion
  - Disabled interactions while deletion is in progress
- **Member count integration**: Fetches and displays the number of members who will lose access
- **Settings page integration**: Added danger zone section to drive settings page with ownership check
- **State management**: Integrates with existing drive store to remove deleted drives from local state
- **Navigation**: Redirects to dashboard after successful deletion

## Implementation Details
- Uses `fetchWithAuth` and `del` utilities for API communication
- Implements optimistic UI updates with loading states
- Includes error handling with user-friendly toast notifications
- Case-insensitive name matching for confirmation
- Prevents dialog closure during deletion operation
- Fetches member count on component mount with graceful fallback

https://claude.ai/code/session_01M74gsKuSh2XeXKXSodMxrR