### PR TITLE
feat: add primary navigation with Tasks and Calendar to sidebar

### DIFF
--- a/apps/web/src/components/layout/left-sidebar/DashboardFooter.tsx
+++ b/apps/web/src/components/layout/left-sidebar/DashboardFooter.tsx
@@ -4,7 +4,6 @@ import { type MouseEvent } from "react";
 import Link from "next/link";
 import {
   Activity,
-  CheckSquare,
   ChevronDown,
   ExternalLink,
   Settings,
@@ -31,11 +30,6 @@ import { shouldOpenInNewTab } from "@/lib/tabs/tab-navigation-utils";
 import { cn } from "@/lib/utils";
 
 const actions = [
-  {
-    icon: CheckSquare,
-    label: "Tasks",
-    href: "/dashboard/tasks",
-  },
   {
     icon: Activity,
     label: "Activity",

--- a/apps/web/src/components/layout/left-sidebar/DashboardSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/DashboardSidebar.tsx
@@ -9,11 +9,11 @@ export default function DashboardSidebar() {
   return (
     <CustomScrollArea className="flex-1">
       <div className="space-y-6 py-2">
-        {/* Pulse - Activity summary */}
-        <Pulse />
-
         {/* Favorites - Pinned drives and pages */}
         <FavoritesSection />
+
+        {/* Pulse - Activity summary */}
+        <Pulse />
 
         {/* Recents - Recently viewed pages */}
         <RecentsSection />

--- a/apps/web/src/components/layout/left-sidebar/DriveFooter.tsx
+++ b/apps/web/src/components/layout/left-sidebar/DriveFooter.tsx
@@ -5,7 +5,6 @@ import Link from "next/link";
 import { useParams } from "next/navigation";
 import {
   Activity,
-  CheckSquare,
   ChevronDown,
   ExternalLink,
   Settings,
@@ -70,12 +69,6 @@ export default function DriveFooter({ canManage }: DriveFooterProps) {
       icon: Activity,
       label: "Activity",
       href: `/dashboard/${driveId}/activity`,
-      show: true,
-    },
-    {
-      icon: CheckSquare,
-      label: "Tasks",
-      href: `/dashboard/${driveId}/tasks`,
       show: true,
     },
     {

--- a/apps/web/src/components/layout/left-sidebar/PrimaryNavigation.tsx
+++ b/apps/web/src/components/layout/left-sidebar/PrimaryNavigation.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Calendar, CheckSquare, Home, Inbox } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { useLayoutStore } from "@/stores/useLayoutStore";
+import { useBreakpoint } from "@/hooks/useBreakpoint";
+
+interface PrimaryNavigationProps {
+    driveId?: string;
+}
+
+export default function PrimaryNavigation({ driveId }: PrimaryNavigationProps) {
+    const pathname = usePathname();
+    const isSheetBreakpoint = useBreakpoint("(max-width: 1023px)");
+    const setLeftSheetOpen = useLayoutStore((state) => state.setLeftSheetOpen);
+
+    const navigation = [
+        {
+            name: "Dashboard",
+            href: "/dashboard",
+            icon: Home,
+            exact: true,
+        },
+        {
+            name: "Inbox",
+            href: driveId ? `/dashboard/${driveId}/inbox` : "/dashboard/inbox",
+            icon: Inbox,
+            exact: false,
+        },
+        {
+            name: "Tasks",
+            href: driveId ? `/dashboard/${driveId}/tasks` : "/dashboard/tasks",
+            icon: CheckSquare,
+            exact: false,
+        },
+        {
+            name: "Calendar",
+            href: driveId ? `/dashboard/${driveId}/calendar` : "/dashboard/calendar",
+            icon: Calendar,
+            exact: false,
+        },
+    ];
+
+    const handleLinkClick = () => {
+        if (isSheetBreakpoint) {
+            setLeftSheetOpen(false);
+        }
+    };
+
+    return (
+        <nav className="flex flex-col gap-0.5 mb-3">
+            {navigation.map((item) => {
+                const isActive = item.exact
+                    ? pathname === item.href
+                    : pathname?.startsWith(item.href);
+
+                return (
+                    <Link
+                        key={item.name}
+                        href={item.href}
+                        onClick={handleLinkClick}
+                        className={cn(
+                            "flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm font-medium transition-colors",
+                            isActive
+                                ? "bg-accent text-accent-foreground"
+                                : "text-sidebar-foreground hover:bg-accent hover:text-accent-foreground"
+                        )}
+                    >
+                        <item.icon className="h-4 w-4" />
+                        {item.name}
+                    </Link>
+                );
+            })}
+        </nav>
+    );
+}

--- a/apps/web/src/components/layout/left-sidebar/index.tsx
+++ b/apps/web/src/components/layout/left-sidebar/index.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useSWRConfig } from "swr";
-import { Home, Inbox, Lock, Plus, Search } from "lucide-react";
+import { Lock, Plus, Search } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -19,13 +18,13 @@ import { useAuth } from "@/hooks/useAuth";
 import { useBreakpoint } from "@/hooks/useBreakpoint";
 import { getPermissionErrorMessage, canManageDrive } from "@/hooks/usePermissions";
 import { useDriveStore } from "@/hooks/useDrive";
-import { useLayoutStore } from "@/stores/useLayoutStore";
 
 import CreatePageDialog from "./CreatePageDialog";
 import DashboardFooter from "./DashboardFooter";
 import DashboardSidebar from "./DashboardSidebar";
 import DriveFooter from "./DriveFooter";
 import PageTree from "./page-tree/PageTree";
+import PrimaryNavigation from "./PrimaryNavigation";
 import DriveSwitcher from "@/components/layout/navbar/DriveSwitcher";
 
 export interface SidebarProps {
@@ -41,7 +40,6 @@ export default function Sidebar({ className }: SidebarProps) {
   const { driveId: driveIdParams } = params;
   const { user } = useAuth();
   const isSheetBreakpoint = useBreakpoint("(max-width: 1023px)");
-  const setLeftSheetOpen = useLayoutStore((state) => state.setLeftSheetOpen);
 
   // Use selective Zustand subscriptions to prevent unnecessary re-renders
   const drives = useDriveStore((state) => state.drives);
@@ -84,25 +82,8 @@ export default function Sidebar({ className }: SidebarProps) {
           <DriveSwitcher />
         </div>
 
-        {/* Dashboard link - always visible */}
-        <Link
-          href="/dashboard"
-          onClick={() => isSheetBreakpoint && setLeftSheetOpen(false)}
-          className="flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
-        >
-          <Home className="h-4 w-4" />
-          Dashboard
-        </Link>
-
-        {/* Inbox link - always visible */}
-        <Link
-          href={driveId ? `/dashboard/${driveId}/inbox` : "/dashboard/inbox"}
-          onClick={() => isSheetBreakpoint && setLeftSheetOpen(false)}
-          className="flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground mb-3"
-        >
-          <Inbox className="h-4 w-4" />
-          Inbox
-        </Link>
+        {/* Primary Navigation (Dashboard, Inbox, Tasks, Calendar) */}
+        <PrimaryNavigation driveId={driveId as string} />
 
         {/* Main content area */}
         <div className="flex-1 flex flex-col min-h-0 overflow-hidden">


### PR DESCRIPTION
## Summary

Redesigns the sidebar navigation to prominently display Dashboard, Inbox, Tasks, and Calendar as top-level navigation items in both dashboard and drive contexts.

**Changes:**
- Add new `PrimaryNavigation` component with four main navigation items
- Context-aware routing: links adapt based on whether user is in a drive or dashboard
- Active state highlighting based on current pathname
- Reorder `DashboardSidebar`: Favorites now appears above Pulse
- Remove Tasks from footer menus (promoted to primary nav)

## Before/After

**Before:** Tasks buried in collapsible footer, Calendar had no navigation entry point

**After:**
```
DriveSwitcher
─────────────
Dashboard     → /dashboard
Inbox         → /dashboard/inbox (or /dashboard/[driveId]/inbox)
Tasks         → /dashboard/tasks (or /dashboard/[driveId]/tasks)
Calendar      → /dashboard/calendar (or /dashboard/[driveId]/calendar)
─────────────
[Dashboard context: Favorites → Pulse]
[Drive context: Search + PageTree]
```

## Test plan

- [ ] Navigate to `/dashboard` - verify primary nav shows all 4 items
- [ ] Click each nav item - verify correct routing
- [ ] Navigate to a drive - verify primary nav adapts URLs to drive context
- [ ] Verify active state highlights current route
- [ ] Verify Tasks no longer appears in footer menus
- [ ] Verify Favorites appears above Pulse in dashboard context
- [ ] Test on mobile (sheet view) - verify sheet closes on nav click