### PR TITLE
Add MCP token scope validation to bulk page operations

### DIFF
--- a/apps/web/src/app/api/pages/bulk-copy/route.ts
+++ b/apps/web/src/app/api/pages/bulk-copy/route.ts
@@ -3,7 +3,7 @@ import { z } from 'zod/v4';
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { loggers, pageTreeCache } from '@pagespace/lib/server';
 import { pages, drives, driveMembers, db, and, eq, inArray, desc, isNull } from '@pagespace/db';
-import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope, getAllowedDriveIds } from '@/lib/auth';
 import { canUserViewPage } from '@pagespace/lib/server';
 import { createId } from '@paralleldrive/cuid2';
 
@@ -43,6 +43,12 @@ export async function POST(request: Request) {
 
     if (!targetDrive) {
       return NextResponse.json({ error: 'Target drive not found' }, { status: 404 });
+    }
+
+    // Check MCP token scope for target drive
+    const targetScopeError = checkMCPDriveScope(auth, targetDriveId);
+    if (targetScopeError) {
+      return targetScopeError;
     }
 
     // Check user has edit access to target drive
@@ -87,6 +93,20 @@ export async function POST(request: Request) {
 
     if (sourcePages.length !== pageIds.length) {
       return NextResponse.json({ error: 'Some pages not found' }, { status: 404 });
+    }
+
+    // Check MCP token scope for all source pages
+    const allowedDriveIds = getAllowedDriveIds(auth);
+    if (allowedDriveIds.length > 0) {
+      const allowedSet = new Set(allowedDriveIds);
+      for (const page of sourcePages) {
+        if (!allowedSet.has(page.driveId)) {
+          return NextResponse.json(
+            { error: 'This token does not have access to one or more source pages' },
+            { status: 403 }
+          );
+        }
+      }
     }
 
     // Verify view permissions for all pages


### PR DESCRIPTION
## Summary
Add MCP (Model Context Protocol) token scope validation to bulk page operations (copy, move, delete) to ensure tokens can only access pages and drives they're authorized for.

## Changes
- **bulk-copy**: Added scope checks for target drive and all source pages
- **bulk-move**: Added scope checks for target drive and all source pages  
- **bulk-delete**: Added scope check for all pages being deleted
- Imported `checkMCPDriveScope` and `getAllowedDriveIds` auth utilities across all three endpoints

## Implementation Details
- For operations with a target drive (copy/move), validate the MCP token has access to the target drive using `checkMCPDriveScope()`
- For all operations, validate the MCP token has access to all source pages by checking each page's `driveId` against the token's allowed drives via `getAllowedDriveIds()`
- Scope validation occurs before permission checks to fail fast on unauthorized token access
- Returns 403 Forbidden with descriptive error messages when token scope is insufficient
- Only performs scope validation when MCP token has drive restrictions (allowedDriveIds.length > 0)

https://claude.ai/code/session_01LCRzfRgSsLUqbfAQCHXEUB