### PR TITLE
Enhance CSRF protection for debug endpoints and document analytics exemption

### DIFF
--- a/apps/web/src/app/api/debug/chat-messages/route.ts
+++ b/apps/web/src/app/api/debug/chat-messages/route.ts
@@ -3,7 +3,8 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db, chatMessages, eq, and, desc } from '@pagespace/db';
 import { loggers } from '@pagespace/lib/server';
 
-const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
+const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
+const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
 
 /**
  * Debug endpoint to test chat message persistence
@@ -15,7 +16,7 @@ export async function GET(request: Request) {
   try {
     loggers.api.debug('🔍 Debug: GET /api/debug/chat-messages', {});
 
-    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
     if (isAuthError(auth)) return auth.error;
 
     const { searchParams } = new URL(request.url);
@@ -115,7 +116,7 @@ export async function POST(request: Request) {
   try {
     loggers.api.debug('🧪 Debug: POST /api/debug/chat-messages - Manual save test', {});
 
-    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
     if (isAuthError(auth)) return auth.error;
 
     const { pageId, testMessages }: { pageId: string; testMessages?: TestMessage[] } = await request.json();

--- a/apps/web/src/app/api/track/route.ts
+++ b/apps/web/src/app/api/track/route.ts
@@ -7,6 +7,11 @@ import { NextResponse } from 'next/server';
 import { trackActivity, trackFeature, trackError } from '@pagespace/lib/activity-tracker';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 
+// CSRF protection intentionally disabled for analytics tracking:
+// 1. Beacon API (navigator.sendBeacon) cannot set custom headers including CSRF tokens
+// 2. This endpoint only writes to analytics logs, not user data
+// 3. Auth is optional - allows tracking even for unauthenticated users
+// 4. All events are fire-and-forget with no user-visible effects
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
 
 export async function POST(request: Request) {


### PR DESCRIPTION
## Summary
This PR improves security by implementing proper CSRF protection for debug endpoints while maintaining necessary exemptions for analytics tracking. The changes differentiate between read and write operations, applying stricter security requirements to write operations.

## Key Changes
- **Debug endpoints**: Split `AUTH_OPTIONS` into `AUTH_OPTIONS_READ` and `AUTH_OPTIONS_WRITE` to enforce CSRF protection only on POST requests that modify data
  - GET requests (read-only) continue to allow session auth without CSRF tokens
  - POST requests (write operations) now require CSRF token validation
- **Analytics endpoint**: Added comprehensive documentation explaining why CSRF protection is intentionally disabled for the `/api/track` endpoint, covering:
  - Technical limitation: Beacon API cannot set custom headers
  - Functional scope: Endpoint only writes to analytics logs, not user data
  - User impact: Optional auth with fire-and-forget semantics

## Implementation Details
The debug endpoint now properly distinguishes between safe (GET) and unsafe (POST) HTTP methods, applying CSRF validation only where state changes occur. This follows security best practices while maintaining the functionality of read-only debug operations.

https://claude.ai/code/session_016FaKo2Y837fqmcKKpjDrND