### PR TITLE
[web] Portal mention suggestion popup to document.body to fix centered floating input

### DIFF
--- a/apps/web/src/components/mentions/SuggestionPopup.tsx
+++ b/apps/web/src/components/mentions/SuggestionPopup.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { MentionSuggestion } from '@/types/mentions';
 import { Position } from '@/services/positioningService';
 
@@ -141,7 +142,7 @@ export default function SuggestionPopup({
     ? `fixed z-50 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 ${getRoundingClasses()} shadow-xl min-w-56 max-w-sm backdrop-blur-sm bg-white/95 dark:bg-gray-800/95`
     : `fixed z-50 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 ${getRoundingClasses()} shadow-lg min-w-48 max-w-sm`;
 
-  return (
+  const popup = (
     <div
       className={`
         ${variantClasses}
@@ -157,4 +158,10 @@ export default function SuggestionPopup({
       {renderContent()}
     </div>
   );
+
+  if (typeof document === 'undefined') {
+    return popup;
+  }
+
+  return createPortal(popup, document.body);
 }


### PR DESCRIPTION
### Motivation
- Mentions typed in the floating input's centered (new conversation) state were not visible because the suggestion popup could be clipped/hidden by transformed or overflow-constrained ancestors of the input.

### Description
- Render `SuggestionPopup` into `document.body` using `createPortal(...)` to avoid clipping while keeping the existing fixed-position coordinates in `apps/web/src/components/mentions/SuggestionPopup.tsx`.
- Preserve SSR safety by returning the popup JSX directly when `typeof document === 'undefined'` to avoid client-only runtime errors.
- Add `createPortal` import from `react-dom` and wrap the existing popup markup with a portal while leaving the popup styling/positioning logic unchanged.

### Testing
- Ran `pnpm --filter web exec eslint src/components/mentions/SuggestionPopup.tsx` which succeeded.
- Ran `pnpm --filter web typecheck` which failed due to pre-existing workspace module resolution/type declaration issues (unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69842035f9c48320b58e3bd3ad573f2f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering behavior of the suggestion popup component to better handle positioning and visual layering in complex page layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->