### PR TITLE
Add ESLint disable comments and lazy loading to image elements

### DIFF
--- a/apps/web/src/app/dashboard/inbox/channel/[pageId]/page.tsx
+++ b/apps/web/src/app/dashboard/inbox/channel/[pageId]/page.tsx
@@ -418,10 +418,12 @@ export default function InboxChannelPage() {
                           rel="noopener noreferrer"
                           className="block max-w-sm"
                         >
+                          {/* eslint-disable-next-line @next/next/no-img-element -- auth-gated API route; processor already optimizes on upload */}
                           <img
                             src={`/api/files/${m.fileId}/view`}
                             alt={m.attachmentMeta.originalName}
                             className="rounded-lg max-h-64 object-contain border border-border/50"
+                            loading="lazy"
                           />
                         </a>
                       ) : (

--- a/apps/web/src/components/ai/shared/chat/tool-calls/WebSearchRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/WebSearchRenderer.tsx
@@ -44,6 +44,7 @@ const FaviconImage: React.FC<{ src: string }> = memo(function FaviconImage({ src
   }
 
   return (
+    // eslint-disable-next-line @next/next/no-img-element -- external favicons from arbitrary domains; 16px images don't benefit from optimization
     <img
       src={src}
       alt=""

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInput.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInput.tsx
@@ -253,6 +253,7 @@ export const ChannelInput = forwardRef<ChannelInputRef, ChannelInputProps>(
                 ) : attachment ? (
                   <>
                     {attachment.mimeType.startsWith('image/') ? (
+                      // eslint-disable-next-line @next/next/no-img-element -- 32px thumbnail preview; auth-gated API route
                       <img
                         src={`/api/files/${attachment.id}/view`}
                         alt={attachment.originalName}

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -352,10 +352,12 @@ export default function ChannelView({ page }: ChannelViewProps) {
                                       rel="noopener noreferrer"
                                       className="block max-w-sm"
                                     >
+                                      {/* eslint-disable-next-line @next/next/no-img-element -- auth-gated API route; processor already optimizes on upload */}
                                       <img
                                         src={`/api/files/${m.fileId}/view`}
                                         alt={m.attachmentMeta.originalName}
                                         className="rounded-lg max-h-64 object-contain border border-border/50"
+                                        loading="lazy"
                                       />
                                     </a>
                                   ) : (


### PR DESCRIPTION
## Summary
This PR adds ESLint disable comments to `<img>` elements that don't use Next.js `Image` component and implements lazy loading for optimized performance.

## Key Changes
- Added `@next/next/no-img-element` ESLint disable comments with justifications to 4 image elements across multiple components:
  - **InboxChannelPage**: Auth-gated API route with pre-optimized uploads
  - **WebSearchRenderer**: External favicons from arbitrary domains (16px images don't benefit from optimization)
  - **ChannelInput**: Small 32px thumbnail preview from auth-gated API route
  - **ChannelView**: Auth-gated API route with pre-optimized uploads
- Added `loading="lazy"` attribute to two larger image elements in InboxChannelPage and ChannelView for improved performance

## Implementation Details
- Each disable comment includes a specific justification explaining why the Next.js Image component is not used
- Lazy loading is applied to full-size image previews (max-h-64) to defer loading until needed
- Small thumbnail previews (32px) and external favicons are excluded from lazy loading as they have minimal performance impact

https://claude.ai/code/session_01M1SwHEcmK6CwkEsYB5C75S