### PR TITLE
Refactor sidebar sections with improved visual hierarchy

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -115,6 +115,10 @@
 
   /* Separators (hairline) */
   --separator: oklch(0.90 0.005 230 / 0.08);
+
+  /* Sidebar section dividers - visible but soft */
+  --sidebar-divider: oklch(0.87 0.006 230);
+  --sidebar-section-bg: oklch(0 0 0 / 0.02);
 }
 
 .dark {
@@ -165,6 +169,10 @@
 
   /* Separators (Dark Mode) */
   --separator: oklch(0.94 0 0 / 0.08);
+
+  /* Sidebar section dividers - visible but soft */
+  --sidebar-divider: oklch(0.26 0 0);
+  --sidebar-section-bg: oklch(1 0 0 / 0.035);
 }
 
 @layer base {

--- a/apps/web/src/components/layout/left-sidebar/DashboardFooter.tsx
+++ b/apps/web/src/components/layout/left-sidebar/DashboardFooter.tsx
@@ -80,14 +80,14 @@ export default function DashboardFooter() {
     <Collapsible
       open={!dashboardFooterCollapsed}
       onOpenChange={(open) => setDashboardFooterCollapsed(!open)}
-      className="border-t border-[var(--separator)]"
+      className="border-t border-[var(--sidebar-divider)]"
     >
       <CollapsibleTrigger asChild>
         <Button
           variant="ghost"
-          className="w-full justify-between px-2 py-2 h-auto font-normal text-muted-foreground hover:text-foreground"
+          className="w-full justify-between px-2 py-2.5 h-auto font-normal text-muted-foreground hover:text-foreground bg-[var(--sidebar-section-bg)]"
         >
-          <span className="text-xs font-medium">User Actions</span>
+          <span className="text-[11px] font-semibold tracking-wide">User Actions</span>
           <ChevronDown
             className={cn(
               "h-3.5 w-3.5 transition-transform duration-200",

--- a/apps/web/src/components/layout/left-sidebar/DashboardSidebar.tsx
+++ b/apps/web/src/components/layout/left-sidebar/DashboardSidebar.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import { CustomScrollArea } from "@/components/ui/custom-scroll-area";
+import Pulse from "./Pulse";
 import FavoritesSection from "./FavoritesSection";
 import RecentsSection from "./RecentsSection";
 
 export default function DashboardSidebar() {
   return (
     <CustomScrollArea className="flex-1">
-      <div>
+      <div className="flex flex-col">
+        <Pulse />
         <FavoritesSection />
         <RecentsSection />
       </div>

--- a/apps/web/src/components/layout/left-sidebar/FavoritesSection.tsx
+++ b/apps/web/src/components/layout/left-sidebar/FavoritesSection.tsx
@@ -78,14 +78,14 @@ export default function FavoritesSection() {
     <Collapsible
       open={!favoritesCollapsed}
       onOpenChange={(open) => setFavoritesCollapsed(!open)}
-      className="border-t border-[var(--separator)]"
+      className="border-t border-[var(--sidebar-divider)]"
     >
       <CollapsibleTrigger asChild>
         <Button
           variant="ghost"
-          className="w-full justify-between px-2 py-2 h-auto font-normal text-muted-foreground hover:text-foreground"
+          className="w-full justify-between px-2 py-2.5 h-auto font-normal text-muted-foreground hover:text-foreground bg-[var(--sidebar-section-bg)]"
         >
-          <span className="text-xs font-medium flex items-center gap-1.5">
+          <span className="text-[11px] font-semibold tracking-wide flex items-center gap-1.5">
             <Star className="h-3.5 w-3.5" />
             Favorites
           </span>
@@ -234,8 +234,8 @@ function FavoriteItem({ favorite, onNavigate, onOpenInNewTab, onRemove, isNative
 
 function FavoritesSkeleton() {
   return (
-    <div className="border-t border-[var(--separator)]">
-      <div className="flex items-center justify-between px-2 py-2">
+    <div className="border-t border-[var(--sidebar-divider)]">
+      <div className="flex items-center justify-between px-2 py-2.5 bg-[var(--sidebar-section-bg)]">
         <Skeleton className="h-4 w-20" />
         <Skeleton className="h-3.5 w-3.5" />
       </div>

--- a/apps/web/src/components/layout/left-sidebar/PrimaryNavigation.tsx
+++ b/apps/web/src/components/layout/left-sidebar/PrimaryNavigation.tsx
@@ -51,7 +51,7 @@ export default function PrimaryNavigation({ driveId }: PrimaryNavigationProps) {
     };
 
     return (
-        <nav className="flex flex-col gap-0.5 mb-3">
+        <nav className="flex flex-col gap-0.5 mb-2">
             {navigation.map((item) => {
                 const isActive = item.exact
                     ? pathname === item.href

--- a/apps/web/src/components/layout/left-sidebar/Pulse.tsx
+++ b/apps/web/src/components/layout/left-sidebar/Pulse.tsx
@@ -89,15 +89,15 @@ export default function Pulse() {
     <Collapsible
       open={!pulseCollapsed}
       onOpenChange={(open) => setPulseCollapsed(!open)}
-      className="border-t border-[var(--separator)]"
+      className="border-t border-[var(--sidebar-divider)]"
     >
       <div className="flex items-center">
         <CollapsibleTrigger asChild>
           <Button
             variant="ghost"
-            className="flex-1 justify-between px-2 py-2 h-auto font-normal text-muted-foreground hover:text-foreground"
+            className="flex-1 justify-between px-2 py-2.5 h-auto font-normal text-muted-foreground hover:text-foreground bg-[var(--sidebar-section-bg)]"
           >
-            <span className="text-xs font-medium">Pulse</span>
+            <span className="text-[11px] font-semibold tracking-wide">Pulse</span>
             <ChevronDown
               className={cn(
                 "h-3.5 w-3.5 transition-transform duration-200",
@@ -145,8 +145,8 @@ export default function Pulse() {
 
 function PulseSkeleton() {
   return (
-    <div className="border-t border-[var(--separator)]">
-      <div className="flex items-center justify-between px-2 py-2">
+    <div className="border-t border-[var(--sidebar-divider)]">
+      <div className="flex items-center justify-between px-2 py-2.5 bg-[var(--sidebar-section-bg)]">
         <Skeleton className="h-4 w-12" />
         <Skeleton className="h-3.5 w-3.5" />
       </div>

--- a/apps/web/src/components/layout/left-sidebar/RecentsSection.tsx
+++ b/apps/web/src/components/layout/left-sidebar/RecentsSection.tsx
@@ -100,14 +100,14 @@ export default function RecentsSection() {
     <Collapsible
       open={!recentsCollapsed}
       onOpenChange={(open) => setRecentsCollapsed(!open)}
-      className="border-t border-[var(--separator)]"
+      className="border-t border-[var(--sidebar-divider)]"
     >
       <CollapsibleTrigger asChild>
         <Button
           variant="ghost"
-          className="w-full justify-between px-2 py-2 h-auto font-normal text-muted-foreground hover:text-foreground"
+          className="w-full justify-between px-2 py-2.5 h-auto font-normal text-muted-foreground hover:text-foreground bg-[var(--sidebar-section-bg)]"
         >
-          <span className="text-xs font-medium flex items-center gap-1.5">
+          <span className="text-[11px] font-semibold tracking-wide flex items-center gap-1.5">
             <Clock className="h-3.5 w-3.5" />
             Recents
           </span>
@@ -196,8 +196,8 @@ function RecentItem({ page, onNavigate, onOpenInNewTab, isNative }: RecentItemPr
 
 function RecentsSkeleton() {
   return (
-    <div className="border-t border-[var(--separator)]">
-      <div className="flex items-center justify-between px-2 py-2">
+    <div className="border-t border-[var(--sidebar-divider)]">
+      <div className="flex items-center justify-between px-2 py-2.5 bg-[var(--sidebar-section-bg)]">
         <Skeleton className="h-4 w-16" />
         <Skeleton className="h-3.5 w-3.5" />
       </div>

--- a/apps/web/src/components/layout/left-sidebar/index.tsx
+++ b/apps/web/src/components/layout/left-sidebar/index.tsx
@@ -18,13 +18,11 @@ import { useAuth } from "@/hooks/useAuth";
 import { useBreakpoint } from "@/hooks/useBreakpoint";
 import { getPermissionErrorMessage, canManageDrive } from "@/hooks/usePermissions";
 import { useDriveStore } from "@/hooks/useDrive";
-import { useLayoutStore } from "@/stores/useLayoutStore";
 
 import CreatePageDialog from "./CreatePageDialog";
 import DashboardFooter from "./DashboardFooter";
 import DashboardSidebar from "./DashboardSidebar";
 import DriveFooter from "./DriveFooter";
-import Pulse from "./Pulse";
 import PageTree from "./page-tree/PageTree";
 import PrimaryNavigation from "./PrimaryNavigation";
 import DriveSwitcher from "@/components/layout/navbar/DriveSwitcher";
@@ -46,8 +44,6 @@ export default function Sidebar({ className }: SidebarProps) {
   // Use selective Zustand subscriptions to prevent unnecessary re-renders
   const drives = useDriveStore((state) => state.drives);
   const fetchDrives = useDriveStore((state) => state.fetchDrives);
-  const dashboardFooterCollapsed = useLayoutStore((state) => state.dashboardFooterCollapsed);
-
   const driveId = Array.isArray(driveIdParams) ? driveIdParams[0] : driveIdParams;
   const { mutate } = useSWRConfig();
 
@@ -145,9 +141,6 @@ export default function Sidebar({ className }: SidebarProps) {
 
         {/* Drive footer - only shown when in a drive */}
         {driveId && <DriveFooter canManage={canManage} />}
-
-        {/* Pulse - shown when NOT in a drive and User Actions is collapsed */}
-        {!driveId && dashboardFooterCollapsed && <Pulse />}
 
         {/* Dashboard footer - only shown when NOT in a drive */}
         {!driveId && <DashboardFooter />}


### PR DESCRIPTION
## Summary
This PR improves the visual design and organization of the left sidebar by introducing dedicated CSS variables for section dividers and backgrounds, refactoring the Pulse component placement, and enhancing the typography of section headers.

## Key Changes

- **New CSS Variables**: Added `--sidebar-divider` and `--sidebar-section-bg` variables to `globals.css` for both light and dark modes, replacing the generic `--separator` variable for sidebar-specific styling
  - Light mode: Subtle divider with soft background tint
  - Dark mode: Adjusted opacity and color values for better contrast

- **Sidebar Section Headers**: Updated all section headers (Favorites, Recents, User Actions, Pulse) with:
  - Increased font size from `text-xs` to `text-[11px]`
  - Enhanced font weight from `font-medium` to `font-semibold`
  - Added letter spacing with `tracking-wide`
  - Applied background color using new `--sidebar-section-bg` variable
  - Increased vertical padding from `py-2` to `py-2.5`

- **Pulse Component Relocation**: Moved Pulse from conditional rendering in the main sidebar to always render within `DashboardSidebar`, simplifying the component hierarchy and removing layout store dependency

- **Border Updates**: Replaced all sidebar section borders from `border-[var(--separator)]` to `border-[var(--sidebar-divider)]` for consistent, more visible dividers

- **Minor Spacing Adjustment**: Reduced `PrimaryNavigation` bottom margin from `mb-3` to `mb-2` for tighter spacing

## Implementation Details

The refactoring maintains all existing functionality while improving visual consistency. The new CSS variables provide better semantic meaning and make future theme adjustments easier. The Pulse component is now always present in the dashboard sidebar rather than conditionally rendered based on the footer collapse state, resulting in cleaner component logic.

https://claude.ai/code/session_012SzeHwLsJednVaV2V7uTS8