### PR TITLE
Fix favorites state sync in DriveSwitcher and removeFavorite

### DIFF
--- a/apps/web/src/components/layout/navbar/DriveSwitcher.tsx
+++ b/apps/web/src/components/layout/navbar/DriveSwitcher.tsx
@@ -35,8 +35,8 @@ export default function DriveSwitcher() {
   const currentDriveId = useDriveStore((state) => state.currentDriveId);
   const setCurrentDrive = useDriveStore((state) => state.setCurrentDrive);
 
-  // Favorites store
-  const { isFavorite, addFavorite, removeFavorite, fetchFavorites, isSynced } = useFavorites();
+  // Favorites store - subscribe to driveIds directly so useMemo recomputes when favorites change
+  const { isFavorite, addFavorite, removeFavorite, fetchFavorites, isSynced, driveIds } = useFavorites();
 
   const { driveId } = params;
   const urlDriveId = Array.isArray(driveId) ? driveId[0] : driveId;
@@ -94,7 +94,7 @@ export default function DriveSwitcher() {
       recentDrives: recent,
       allDrives: sortedAll,
     };
-  }, [drives, searchQuery, isFavorite]);
+  }, [drives, searchQuery, isFavorite, driveIds]);
 
   const handleSelectDrive = (drive: Drive) => {
     setCurrentDrive(drive.id);


### PR DESCRIPTION
## Summary
This PR fixes state synchronization issues in the favorites system by ensuring the DriveSwitcher component properly recomputes when favorites change, and by improving the `removeFavorite` function to maintain consistency across all state structures.

## Key Changes

- **DriveSwitcher.tsx**: Added `driveIds` to the `useFavorites` hook destructuring and included it in the `useMemo` dependency array. This ensures the memoized drives list recomputes whenever favorites change, preventing stale UI state.

- **useFavorites.ts - removeFavorite**: Refactored the optimistic update logic to:
  - Remove from the `favorites` array, `pageIds` Set, and `driveIds` Set in a single atomic operation
  - Removed the `fetchFavorites()` call after API success (relying on optimistic updates instead)
  - Improved error rollback to restore all three state structures consistently
  - Simplified the logic by consolidating multiple `set()` calls into single operations

- **useFavorites.test.ts**: Updated test to verify optimistic removal from both the favorites array and the `pageIds` Set before the API call completes, ensuring the UI updates immediately.

## Implementation Details

The changes follow an optimistic update pattern where:
1. State is immediately updated on the client
2. API call is made in the background
3. On error, state is rolled back to the previous state

This provides better UX with instant feedback while maintaining data consistency across the `favorites` array and lookup Sets (`pageIds`, `driveIds`).

https://claude.ai/code/session_01MKMLsd9w8YL6d5cnYWTP7u