### PR TITLE
Prevent sidebar collapse when navigating to drive items

### DIFF
--- a/apps/web/src/components/layout/left-sidebar/FavoritesSection.tsx
+++ b/apps/web/src/components/layout/left-sidebar/FavoritesSection.tsx
@@ -43,7 +43,7 @@ export default function FavoritesSection() {
     }
   }, [isSynced, fetchFavorites]);
 
-  const handleNavigate = useCallback((href: string, e?: MouseEvent) => {
+  const handleNavigate = useCallback((href: string, itemType: "page" | "drive", e?: MouseEvent) => {
     if (e && shouldOpenInNewTab(e)) {
       e.preventDefault();
       createTab({ path: href });
@@ -51,7 +51,7 @@ export default function FavoritesSection() {
     }
 
     router.push(href);
-    if (isSheetBreakpoint) {
+    if (isSheetBreakpoint && itemType !== "drive") {
       setLeftSheetOpen(false);
     }
   }, [router, isSheetBreakpoint, setLeftSheetOpen, createTab]);
@@ -113,7 +113,7 @@ export default function FavoritesSection() {
                 <FavoriteItem
                   key={favorite.id}
                   favorite={favorite}
-                  onNavigate={(e) => handleNavigate(href, e)}
+                  onNavigate={(e) => handleNavigate(href, favorite.itemType, e)}
                   onOpenInNewTab={() => handleOpenInNewTab(href)}
                   onRemove={() => handleRemoveFavorite(favorite.id)}
                   isNative={isNative}


### PR DESCRIPTION
## Summary
Updated the navigation handler in the FavoritesSection to prevent the left sidebar from collapsing when users navigate to drive items, while maintaining the collapse behavior for page items.

## Key Changes
- Modified `handleNavigate` callback to accept an `itemType` parameter ("page" | "drive") to distinguish between different favorite item types
- Updated the sidebar collapse logic to only close the sheet when navigating to pages (`itemType !== "drive"`)
- Passed the `favorite.itemType` to the navigation handler when clicking favorite items

## Implementation Details
The change ensures that drive items remain accessible in the sidebar after navigation, improving the user experience for drive-related workflows where users may need to quickly switch between multiple drive items. Page items continue to collapse the sidebar as before, maintaining the existing behavior for that use case.

https://claude.ai/code/session_018MZqovd9rHoa2KafhdTH4g

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation behavior when selecting items from favorites, with enhanced handling for different item types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->