### PR TITLE
Add support for 2026 AI models (GPT-5.3, Claude 4.6)

### DIFF
--- a/apps/web/src/lib/ai/core/ai-providers-config.ts
+++ b/apps/web/src/lib/ai/core/ai-providers-config.ts
@@ -41,12 +41,18 @@ export const AI_PROVIDERS = {
   openrouter: {
     name: 'OpenRouter (Paid)',
     models: {
+      // Anthropic Models (2026)
+      'anthropic/claude-opus-4.6': 'Claude Opus 4.6',
+
       // Anthropic Models (2025)
       'anthropic/claude-opus-4.5': 'Claude Opus 4.5',
       'anthropic/claude-sonnet-4.5': 'Claude Sonnet 4.5',
       'anthropic/claude-haiku-4.5': 'Claude Haiku 4.5',
       'anthropic/claude-3.5-sonnet': 'Claude 3.5 Sonnet',
       'anthropic/claude-3-haiku': 'Claude 3 Haiku',
+
+      // OpenAI Models (2026)
+      'openai/gpt-5.3-codex': 'GPT-5.3 Codex',
 
       // OpenAI Models (2025)
       'openai/gpt-5.2': 'GPT-5.2',
@@ -192,6 +198,9 @@ export const AI_PROVIDERS = {
   openai: {
     name: 'OpenAI',
     models: {
+      // GPT-5.3 Models (2026)
+      'gpt-5.3-codex': 'GPT-5.3 Codex',
+
       // GPT-5.2 Models (2025)
       'gpt-5.2': 'GPT-5.2',
       'gpt-5.2-codex': 'GPT-5.2 Codex',
@@ -236,6 +245,9 @@ export const AI_PROVIDERS = {
   anthropic: {
     name: 'Anthropic',
     models: {
+      // Claude 4.6 Models (2026)
+      'claude-opus-4-6-20260204': 'Claude Opus 4.6',
+
       // Claude 4.5 Models (2025)
       'claude-opus-4-5-20251124': 'Claude Opus 4.5',
       'claude-sonnet-4-5-20250929': 'Claude Sonnet 4.5',

--- a/apps/web/src/lib/ai/core/model-capabilities.ts
+++ b/apps/web/src/lib/ai/core/model-capabilities.ts
@@ -12,6 +12,10 @@ const capabilityLogger = loggers.ai.child({ module: 'model-capabilities' });
  * Includes models that can process images, PDFs with images, etc.
  */
 const VISION_CAPABLE_MODELS: Record<string, boolean> = {
+  // OpenAI GPT-5.3 Models (all have vision)
+  'gpt-5.3-codex': true,
+  'openai/gpt-5.3-codex': true,
+
   // OpenAI GPT-5.2 Models (all have vision)
   'gpt-5.2': true,
   'gpt-5.2-codex': true,
@@ -53,6 +57,8 @@ const VISION_CAPABLE_MODELS: Record<string, boolean> = {
   'openai/gpt-4': true,
   
   // Anthropic Claude 3+ (all have vision)
+  'claude-opus-4-6-20260204': true,
+  'anthropic/claude-opus-4.6': true,
   'claude-opus-4-1-20250805': true,
   'claude-sonnet-4-1-20250805': true,
   'claude-3-7-sonnet-20250219': true,


### PR DESCRIPTION
## Summary
This PR adds support for the latest 2026 AI models across multiple providers: GPT-5.3 Codex from OpenAI and Claude Opus 4.6 from Anthropic. These models are now available through both direct provider APIs and the OpenRouter aggregation service.

## Changes Made
- **AI Providers Configuration**: Added new 2026 model entries to the provider configurations:
  - OpenAI: `gpt-5.3-codex` (GPT-5.3 Codex)
  - Anthropic: `claude-opus-4-6-20260204` (Claude Opus 4.6)
  - OpenRouter: Both models with their respective provider prefixes

- **Model Capabilities**: Updated vision capability mappings to include the new models:
  - `gpt-5.3-codex` and `openai/gpt-5.3-codex` marked as vision-capable
  - `claude-opus-4-6-20260204` and `anthropic/claude-opus-4.6` marked as vision-capable

## Implementation Details
- New models are organized under "2026" comment sections, maintaining consistency with existing year-based grouping
- All new models are configured with vision capabilities enabled, consistent with their predecessors
- Changes maintain backward compatibility with existing 2025 models

https://claude.ai/code/session_01HjZYfzSMk93QtiabTaaerB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new AI models: Claude Opus 4.6 (Anthropic) and GPT-5.3 Codex (OpenAI)
  * Expanded model availability across OpenRouter, OpenAI, and Anthropic integrations
  * Enabled vision capabilities for newly supported models

<!-- end of auto-generated comment: release notes by coderabbit.ai -->