### PR TITLE
Add pageId to processor service file upload request

### DIFF
--- a/apps/web/src/app/api/channels/[pageId]/upload/route.ts
+++ b/apps/web/src/app/api/channels/[pageId]/upload/route.ts
@@ -142,6 +142,7 @@ export async function POST(
     // Forward file to processor service
     const processorFormData = new FormData();
     processorFormData.append('file', file);
+    processorFormData.append('pageId', pageId);
     processorFormData.append('userId', userId);
     processorFormData.append('driveId', driveId);
 


### PR DESCRIPTION
## Summary
Added `pageId` parameter to the FormData sent to the processor service during file uploads, enabling the processor to have context about which page the file is being uploaded to.

## Changes
- Appended `pageId` to the processor FormData payload in the channel upload route
- This allows the processor service to associate uploaded files with their corresponding page context

## Implementation Details
The `pageId` is already available in the route handler (from the dynamic route parameter `[pageId]`) and is now forwarded alongside existing parameters (`userId` and `driveId`) to the processor service for more complete request context.

https://claude.ai/code/session_01XjS67dCivLt3JuZ1dj6UKg