### PR TITLE
Fix iPad keyboard toolbar overlay handling

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -179,6 +179,9 @@
   * {
     @apply border-border outline-ring/50;
   }
+  html {
+    background-color: var(--background);
+  }
   body {
     @apply bg-background text-foreground;
   }

--- a/apps/web/src/components/ui/floating-input/InputPositioner.tsx
+++ b/apps/web/src/components/ui/floating-input/InputPositioner.tsx
@@ -91,6 +91,14 @@ export function InputPositioner({
       >
         {children}
       </div>
+      {/* Background fill behind safe area - extends UI behind iPad keyboard toolbar */}
+      {!isCentered && (
+        <div
+          className="absolute bottom-0 left-0 right-0 bg-background"
+          style={{ height: 'var(--safe-bottom-offset, 0px)' }}
+          aria-hidden="true"
+        />
+      )}
     </motion.div>
   );
 }

--- a/apps/web/src/hooks/useIOSKeyboardInit.ts
+++ b/apps/web/src/hooks/useIOSKeyboardInit.ts
@@ -27,12 +27,21 @@ export function useIOSKeyboardInit(): void {
         showListener = await Keyboard.addListener(
           "keyboardWillShow",
           (info) => {
-            document.body.style.setProperty(
-              "--keyboard-height",
-              `${info.keyboardHeight}px`
-            );
-            document.body.classList.add("keyboard-open");
-            document.documentElement.classList.add("keyboard-open");
+            // iPad external keyboard toolbar is typically ~55px tall.
+            // Don't shrink the app for it - let the toolbar overlay naturally
+            // so the UI extends behind it. Full on-screen keyboards are 300+px.
+            const isExternalKeyboardToolbar = info.keyboardHeight < 100;
+
+            if (isExternalKeyboardToolbar) {
+              document.body.style.setProperty("--keyboard-height", "0px");
+            } else {
+              document.body.style.setProperty(
+                "--keyboard-height",
+                `${info.keyboardHeight}px`
+              );
+              document.body.classList.add("keyboard-open");
+              document.documentElement.classList.add("keyboard-open");
+            }
             window.scrollTo(0, 0);
           }
         );


### PR DESCRIPTION
## Summary
Improved handling of iPad's external keyboard toolbar to prevent unnecessary UI shrinking while maintaining proper keyboard support for full on-screen keyboards.

## Key Changes
- **useIOSKeyboardInit.ts**: Added detection for iPad's external keyboard toolbar (< 100px height) to distinguish it from full on-screen keyboards. The toolbar now overlays naturally without triggering keyboard-open state or shrinking the UI.
- **InputPositioner.tsx**: Added a background fill element behind the safe area that extends behind the iPad keyboard toolbar, ensuring visual continuity when the UI extends behind the toolbar.
- **globals.css**: Set explicit background color on the `html` element to ensure consistent background rendering across the entire viewport.

## Implementation Details
- The external keyboard toolbar detection uses a 100px height threshold, as iPad toolbars are typically ~55px while full keyboards are 300+px
- The background fill div uses CSS custom property `--safe-bottom-offset` for flexible height configuration
- The fill element is only rendered when content is not centered, maintaining layout consistency
- All changes maintain backward compatibility with existing keyboard handling for standard on-screen keyboards

https://claude.ai/code/session_01UBHund2513D3bvW2pjqLXo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visual rendering of input areas when using keyboard on iOS devices
  * Enhanced handling of external iPad keyboard toolbars to prevent unwanted UI adjustments
  * Updated global background color styling for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->