### PR TITLE
Support file relation for message attachments

### DIFF
--- a/apps/web/src/lib/attachment-utils.ts
+++ b/apps/web/src/lib/attachment-utils.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared utilities for channel message attachment rendering.
+ * Used by both the inbox channel page and the ChannelView component.
+ */
+
+export interface AttachmentMeta {
+  originalName: string;
+  size: number;
+  mimeType: string;
+  contentHash: string;
+}
+
+export interface FileRelation {
+  id: string;
+  mimeType: string | null;
+  sizeBytes: number;
+}
+
+interface MessageWithAttachment {
+  fileId?: string | null;
+  attachmentMeta?: AttachmentMeta | null;
+  file?: FileRelation | null;
+}
+
+export function isImageAttachment(m: MessageWithAttachment): boolean {
+  if (m.attachmentMeta?.mimeType?.startsWith('image/')) return true;
+  if (m.file?.mimeType?.startsWith('image/')) return true;
+  return false;
+}
+
+export function getFileId(m: MessageWithAttachment): string | null {
+  return m.fileId || m.file?.id || null;
+}
+
+export function getAttachmentName(m: MessageWithAttachment): string {
+  return m.attachmentMeta?.originalName || 'Attachment';
+}
+
+export function getAttachmentMimeType(m: MessageWithAttachment): string {
+  return m.attachmentMeta?.mimeType || m.file?.mimeType || '';
+}
+
+export function getAttachmentSize(m: MessageWithAttachment): number | null {
+  return m.attachmentMeta?.size ?? m.file?.sizeBytes ?? null;
+}
+
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function hasAttachment(m: MessageWithAttachment): boolean {
+  return !!(m.attachmentMeta || m.file) && getFileId(m) !== null;
+}


### PR DESCRIPTION
## Summary
- Fixed channel image attachments not rendering inline when `attachmentMeta` is null but the `file` relation exists on the message
- Extracted shared attachment utilities into a dedicated module (`apps/web/src/lib/attachment-utils.ts`)

## Key Changes
- **New shared module** `apps/web/src/lib/attachment-utils.ts` containing:
  - `AttachmentMeta` and `FileRelation` type exports
  - `isImageAttachment()` — checks if attachment is an image via either data source
  - `getFileId()` — returns file ID, preferring `fileId` over `file.id`
  - `getAttachmentName()` — gets display name with fallback
  - `getAttachmentMimeType()` — resolves mime type from either data source
  - `getAttachmentSize()` — gets file size from either data source
  - `formatFileSize()` — formats bytes into human-readable string (B/KB/MB)
  - `hasAttachment()` — checks if a message has a renderable attachment
- Updated both inbox channel page and ChannelView component to import from the shared module
- Made file size display conditional to handle cases where size data may not be available

## How to Validate
1. Open a channel with image attachments — images should render inline
2. Open a channel with non-image file attachments — file cards should display with correct icon and size
3. Messages with `file` relation but no `attachmentMeta` should still render correctly
4. Messages with neither should not show any attachment UI

https://claude.ai/code/session_01XMJCysGFCVp6bhpAtw5EwF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved file attachment display: clearer names, sizes and correct image previews with reliable view/download links.

* **Refactor**
  * Centralized attachment handling across message views for consistent rendering of images and document icons.

* **Bug Fix**
  * Better error handling for initial data fetch to surface failures more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->