### PR TITLE
Fix unequal visual spacing between nav buttons in top bar

### DIFF
--- a/apps/web/src/components/layout/main-header/index.tsx
+++ b/apps/web/src/components/layout/main-header/index.tsx
@@ -26,27 +26,29 @@ export default function TopBar({ onToggleLeftPanel, onToggleRightPanel }: TopBar
     <header className="sticky top-0 z-50 pt-[env(safe-area-inset-top)] liquid-glass-thin border-b border-[var(--separator)] text-card-foreground shadow-[var(--shadow-ambient)] dark:shadow-none">
       <div className="flex flex-wrap items-center gap-2 px-3 py-2.5 sm:px-4">
         <div className="flex min-w-0 flex-1 items-center gap-2">
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={onToggleLeftPanel}
-            className="lg:hidden"
-            aria-label="Toggle navigation"
-          >
-            <PanelLeft className="h-5 w-5" />
-          </Button>
+          <div className="flex items-center">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onToggleLeftPanel}
+              className="lg:hidden"
+              aria-label="Toggle navigation"
+            >
+              <PanelLeft className="h-5 w-5" />
+            </Button>
 
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={onToggleLeftPanel}
-            className="hidden lg:flex"
-            aria-label="Collapse navigation"
-          >
-            <PanelLeft className="h-5 w-5" />
-          </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onToggleLeftPanel}
+              className="hidden lg:flex"
+              aria-label="Collapse navigation"
+            >
+              <PanelLeft className="h-5 w-5" />
+            </Button>
 
-          <NavButtons />
+            <NavButtons />
+          </div>
 
           <Link
             href="/dashboard"


### PR DESCRIPTION
Group the sidebar toggle and back/forward buttons into a single
flex container without internal gap. This equalizes the visual
spacing on both sides of the back/forward buttons by removing
the extra button padding that was accumulating between the
sidebar button and NavButtons as separate gap-2 siblings.

https://claude.ai/code/session_01NkTPjFRnkcUSFQDNSq11Fi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the internal structure of the main header layout to improve code organization and maintainability. The visual appearance and functionality remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->