### PR TITLE
Increase z-index of floating input positioner for proper layering

### DIFF
--- a/apps/web/src/components/ui/floating-input/InputPositioner.tsx
+++ b/apps/web/src/components/ui/floating-input/InputPositioner.tsx
@@ -63,7 +63,7 @@ export function InputPositioner({
   return (
     <motion.div
       className={cn(
-        'absolute z-10 left-0 right-0',
+        'absolute z-30 left-0 right-0',
         // Horizontal padding varies by state
         isCentered ? 'px-6' : 'px-4',
         className


### PR DESCRIPTION
## Summary
Updated the z-index of the InputPositioner component from `z-10` to `z-30` to ensure proper stacking context and prevent overlapping issues with other UI elements.

## Changes
- Increased z-index value in InputPositioner className from `z-10` to `z-30`

## Details
This change ensures the floating input component appears above other elements that may use intermediate z-index values (e.g., `z-20`), preventing visual layering issues where the input could be hidden behind other UI components. The higher z-index value maintains the floating input's intended prominence in the component hierarchy.

https://claude.ai/code/session_01FkNsBunH3ojDjLbQd8uwzK