### PR TITLE
Fix mention spacing by storing display text in textarea instead of markdown IDs

### DIFF
--- a/apps/web/src/components/ai/chat/input/ChatTextarea.tsx
+++ b/apps/web/src/components/ai/chat/input/ChatTextarea.tsx
@@ -11,11 +11,12 @@ import {
 import { cn } from '@/lib/utils';
 import { MentionHighlightOverlay } from '@/components/ui/mention-highlight-overlay';
 import { useMentionOverlay } from '@/hooks/useMentionOverlay';
+import { useMentionTracker } from '@/hooks/useMentionTracker';
 
 export interface ChatTextareaProps {
-  /** Current input value */
+  /** Current input value (markdown format with @[label](id:type) mentions) */
   value: string;
-  /** Input change handler */
+  /** Input change handler (receives markdown format) */
   onChange: (value: string) => void;
   /** Send message handler (triggered on Enter without Shift) */
   onSend: () => void;
@@ -66,20 +67,32 @@ const ChatTextareaInner = forwardRef<ChatTextareaRef, ChatTextareaProps>(
     ref
   ) => {
     const textareaRef = useRef<HTMLTextAreaElement>(null);
-    const { overlayRef, hasMentions, handleScroll } = useMentionOverlay(textareaRef, value);
     const context = useSuggestionContext();
     // Track IME composition state to prevent accidental sends during predictive text
     const [isComposing, setIsComposing] = useState(false);
 
+    // Convert between markdown (parent) and display text (textarea)
+    const {
+      displayText,
+      mentions,
+      hasMentions,
+      handleDisplayTextChange,
+      registerMention,
+    } = useMentionTracker(value, onChange);
+
+    const { overlayRef, handleScroll } = useMentionOverlay(textareaRef, hasMentions);
+
     const suggestion = useSuggestion({
       inputRef: textareaRef as React.RefObject<HTMLTextAreaElement>,
-      onValueChange: onChange,
+      onValueChange: handleDisplayTextChange,
       trigger: '@',
       driveId,
       crossDrive,
-      mentionFormat: 'markdown-typed',
+      mentionFormat: 'label',
       variant: 'chat',
       popupPlacement,
+      mentionRanges: mentions,
+      onMentionInserted: registerMention,
     });
 
     useImperativeHandle(ref, () => ({
@@ -131,7 +144,7 @@ const ChatTextareaInner = forwardRef<ChatTextareaRef, ChatTextareaProps>(
       <div className="relative flex-1 min-w-0 overflow-hidden">
         <Textarea
           ref={textareaRef}
-          value={value}
+          value={displayText}
           onChange={(e) => suggestion.handleValueChange(e.target.value)}
           onKeyDown={handleKeyDown}
           onPaste={handlePaste}
@@ -162,7 +175,8 @@ const ChatTextareaInner = forwardRef<ChatTextareaRef, ChatTextareaProps>(
         {hasMentions && (
           <MentionHighlightOverlay
             ref={overlayRef}
-            value={value}
+            value={displayText}
+            mentions={mentions}
             className={cn(
               'px-3 py-2 text-base md:text-sm',
               'text-foreground',

--- a/apps/web/src/components/ui/mention-highlight-overlay/__tests__/MentionHighlightOverlay.test.tsx
+++ b/apps/web/src/components/ui/mention-highlight-overlay/__tests__/MentionHighlightOverlay.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import type { TrackedMention } from '@/hooks/useMentionTracker';
 
 const { mockNavigateToPage } = vi.hoisted(() => ({
   mockNavigateToPage: vi.fn(),
@@ -19,19 +20,22 @@ describe('MentionHighlightOverlay', () => {
 
   describe('text rendering', () => {
     it('given plain text with no mentions, should render text in spans', () => {
-      render(<MentionHighlightOverlay value="hello world" />);
+      render(<MentionHighlightOverlay value="hello world" mentions={[]} />);
 
       expect(screen.getByText('hello world')).toBeInTheDocument();
     });
 
     it('given empty string, should render zero-width space', () => {
-      const { container } = render(<MentionHighlightOverlay value="" />);
+      const { container } = render(<MentionHighlightOverlay value="" mentions={[]} />);
 
       expect(container.textContent).toBe('\u200B');
     });
 
     it('given a single page mention, should render formatted @label', () => {
-      render(<MentionHighlightOverlay value="@[My Page](abc123:page)" />);
+      const mentions: TrackedMention[] = [
+        { start: 0, end: 8, label: 'My Page', id: 'abc123', type: 'page' },
+      ];
+      render(<MentionHighlightOverlay value="@My Page" mentions={mentions} />);
 
       const mention = screen.getByText('@My Page');
       expect(mention).toBeInTheDocument();
@@ -39,7 +43,10 @@ describe('MentionHighlightOverlay', () => {
     });
 
     it('given a single user mention, should render formatted @label', () => {
-      render(<MentionHighlightOverlay value="@[Alice](user1:user)" />);
+      const mentions: TrackedMention[] = [
+        { start: 0, end: 6, label: 'Alice', id: 'user1', type: 'user' },
+      ];
+      render(<MentionHighlightOverlay value="@Alice" mentions={mentions} />);
 
       const mention = screen.getByText('@Alice');
       expect(mention).toBeInTheDocument();
@@ -47,8 +54,12 @@ describe('MentionHighlightOverlay', () => {
     });
 
     it('given mixed content with multiple mention types, should render all segments correctly', () => {
+      const mentions: TrackedMention[] = [
+        { start: 6, end: 10, label: 'Doc', id: 'id1', type: 'page' },
+        { start: 15, end: 19, label: 'Bob', id: 'id2', type: 'user' },
+      ];
       const { container } = render(
-        <MentionHighlightOverlay value="Hello @[Doc](id1:page) and @[Bob](id2:user) bye" />
+        <MentionHighlightOverlay value="Hello @Doc and @Bob bye" mentions={mentions} />
       );
 
       const overlay = container.firstElementChild!;
@@ -63,8 +74,12 @@ describe('MentionHighlightOverlay', () => {
     });
 
     it('given multiple page mentions, should render each with correct label', () => {
+      const mentions: TrackedMention[] = [
+        { start: 0, end: 6, label: 'First', id: 'id1', type: 'page' },
+        { start: 12, end: 19, label: 'Second', id: 'id2', type: 'page' },
+      ];
       render(
-        <MentionHighlightOverlay value="@[First](id1:page) then @[Second](id2:page)" />
+        <MentionHighlightOverlay value="@First then @Second" mentions={mentions} />
       );
 
       expect(screen.getByText('@First')).toBeInTheDocument();
@@ -74,14 +89,20 @@ describe('MentionHighlightOverlay', () => {
 
   describe('page mention interaction', () => {
     it('given a page mention, should have role="link" and pointer-events-auto', () => {
-      render(<MentionHighlightOverlay value="@[My Page](abc123:page)" />);
+      const mentions: TrackedMention[] = [
+        { start: 0, end: 8, label: 'My Page', id: 'abc123', type: 'page' },
+      ];
+      render(<MentionHighlightOverlay value="@My Page" mentions={mentions} />);
 
       const mention = screen.getByRole('link', { hidden: true });
       expect(mention).toHaveClass('pointer-events-auto');
     });
 
     it('given a page mention mousedown, should call navigateToPage with correct id', () => {
-      render(<MentionHighlightOverlay value="@[My Page](abc123:page)" />);
+      const mentions: TrackedMention[] = [
+        { start: 0, end: 8, label: 'My Page', id: 'abc123', type: 'page' },
+      ];
+      render(<MentionHighlightOverlay value="@My Page" mentions={mentions} />);
 
       const mention = screen.getByRole('link', { hidden: true });
       // fireEvent.mouseDown is needed since the handler is onMouseDown, not onClick
@@ -96,8 +117,12 @@ describe('MentionHighlightOverlay', () => {
     });
 
     it('given multiple page mentions, should navigate to correct id for each', () => {
+      const mentions: TrackedMention[] = [
+        { start: 0, end: 6, label: 'First', id: 'id1', type: 'page' },
+        { start: 11, end: 18, label: 'Second', id: 'id2', type: 'page' },
+      ];
       render(
-        <MentionHighlightOverlay value="@[First](id1:page) and @[Second](id2:page)" />
+        <MentionHighlightOverlay value="@First and @Second" mentions={mentions} />
       );
 
       const links = screen.getAllByRole('link', { hidden: true });
@@ -117,13 +142,19 @@ describe('MentionHighlightOverlay', () => {
 
   describe('user mention interaction', () => {
     it('given a user mention, should NOT have role="link"', () => {
-      render(<MentionHighlightOverlay value="@[Alice](user1:user)" />);
+      const mentions: TrackedMention[] = [
+        { start: 0, end: 6, label: 'Alice', id: 'user1', type: 'user' },
+      ];
+      render(<MentionHighlightOverlay value="@Alice" mentions={mentions} />);
 
       expect(screen.queryByRole('link', { hidden: true })).not.toBeInTheDocument();
     });
 
     it('given a user mention, should NOT have pointer-events-auto class', () => {
-      render(<MentionHighlightOverlay value="@[Alice](user1:user)" />);
+      const mentions: TrackedMention[] = [
+        { start: 0, end: 6, label: 'Alice', id: 'user1', type: 'user' },
+      ];
+      render(<MentionHighlightOverlay value="@Alice" mentions={mentions} />);
 
       const mention = screen.getByText('@Alice');
       expect(mention).not.toHaveClass('pointer-events-auto');
@@ -132,14 +163,14 @@ describe('MentionHighlightOverlay', () => {
 
   describe('container attributes', () => {
     it('given rendered overlay, should have aria-hidden="true"', () => {
-      const { container } = render(<MentionHighlightOverlay value="test" />);
+      const { container } = render(<MentionHighlightOverlay value="test" mentions={[]} />);
 
       const overlay = container.firstElementChild;
       expect(overlay).toHaveAttribute('aria-hidden', 'true');
     });
 
     it('given rendered overlay, should have correct base classes', () => {
-      const { container } = render(<MentionHighlightOverlay value="test" />);
+      const { container } = render(<MentionHighlightOverlay value="test" mentions={[]} />);
 
       const overlay = container.firstElementChild;
       expect(overlay).toHaveClass(
@@ -153,7 +184,7 @@ describe('MentionHighlightOverlay', () => {
 
     it('given custom className, should merge with base classes', () => {
       const { container } = render(
-        <MentionHighlightOverlay value="test" className="px-3 py-2 custom-class" />
+        <MentionHighlightOverlay value="test" mentions={[]} className="px-3 py-2 custom-class" />
       );
 
       const overlay = container.firstElementChild;
@@ -162,7 +193,7 @@ describe('MentionHighlightOverlay', () => {
 
     it('given a ref, should forward to the container div', () => {
       const ref = React.createRef<HTMLDivElement>();
-      render(<MentionHighlightOverlay ref={ref} value="test" />);
+      render(<MentionHighlightOverlay ref={ref} value="test" mentions={[]} />);
 
       expect(ref.current).toBeInstanceOf(HTMLDivElement);
       expect(ref.current).toHaveAttribute('aria-hidden', 'true');

--- a/apps/web/src/hooks/__tests__/useMentionOverlay.test.ts
+++ b/apps/web/src/hooks/__tests__/useMentionOverlay.test.ts
@@ -8,45 +8,25 @@ describe('useMentionOverlay', () => {
   });
 
   describe('hasMentions', () => {
-    it('given plain text, should return false', () => {
+    it('given false, should return false', () => {
       const ref = createTextareaRef();
-      const { result } = renderHook(() => useMentionOverlay(ref, 'hello world'));
+      const { result } = renderHook(() => useMentionOverlay(ref, false));
 
       expect(result.current.hasMentions).toBe(false);
     });
 
-    it('given text with page mention, should return true', () => {
+    it('given true, should return true', () => {
       const ref = createTextareaRef();
-      const { result } = renderHook(() =>
-        useMentionOverlay(ref, 'Hi @[Doc](id:page)')
-      );
+      const { result } = renderHook(() => useMentionOverlay(ref, true));
 
       expect(result.current.hasMentions).toBe(true);
-    });
-
-    it('given text with user mention, should return true', () => {
-      const ref = createTextareaRef();
-      const { result } = renderHook(() =>
-        useMentionOverlay(ref, 'Hi @[Alice](user1:user)')
-      );
-
-      expect(result.current.hasMentions).toBe(true);
-    });
-
-    it('given incomplete mention syntax, should return false', () => {
-      const ref = createTextareaRef();
-      const { result } = renderHook(() =>
-        useMentionOverlay(ref, '@[incomplete](missing)')
-      );
-
-      expect(result.current.hasMentions).toBe(false);
     });
   });
 
   describe('overlayRef', () => {
     it('given initial render, should return a ref with current null', () => {
       const ref = createTextareaRef();
-      const { result } = renderHook(() => useMentionOverlay(ref, 'test'));
+      const { result } = renderHook(() => useMentionOverlay(ref, false));
 
       expect(result.current.overlayRef).toHaveProperty('current', null);
     });
@@ -56,7 +36,7 @@ describe('useMentionOverlay', () => {
     it('given textarea with scrollTop, should sync to overlay scrollTop', () => {
       const textareaRef = createTextareaRef(100);
       const { result } = renderHook(() =>
-        useMentionOverlay(textareaRef, 'test')
+        useMentionOverlay(textareaRef, false)
       );
 
       // Simulate an overlay element being attached to the ref
@@ -73,7 +53,7 @@ describe('useMentionOverlay', () => {
     it('given no overlay element, should not throw', () => {
       const textareaRef = createTextareaRef(50);
       const { result } = renderHook(() =>
-        useMentionOverlay(textareaRef, 'test')
+        useMentionOverlay(textareaRef, false)
       );
 
       // overlayRef.current is null by default - should not throw

--- a/apps/web/src/hooks/__tests__/useMentionTracker.test.ts
+++ b/apps/web/src/hooks/__tests__/useMentionTracker.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import {
+  markdownToDisplay,
+  displayToMarkdown,
+  TrackedMention,
+} from '../useMentionTracker';
+
+describe('markdownToDisplay', () => {
+  it('given plain text with no mentions, should return text unchanged', () => {
+    const result = markdownToDisplay('hello world');
+
+    expect(result.displayText).toBe('hello world');
+    expect(result.mentions).toEqual([]);
+  });
+
+  it('given empty string, should return empty string', () => {
+    const result = markdownToDisplay('');
+
+    expect(result.displayText).toBe('');
+    expect(result.mentions).toEqual([]);
+  });
+
+  it('given a single page mention, should extract display text and position', () => {
+    const result = markdownToDisplay('@[My Page](abc123:page)');
+
+    expect(result.displayText).toBe('@My Page');
+    expect(result.mentions).toEqual([
+      { start: 0, end: 8, label: 'My Page', id: 'abc123', type: 'page' },
+    ]);
+  });
+
+  it('given a single user mention, should extract display text and position', () => {
+    const result = markdownToDisplay('@[Alice](user1:user)');
+
+    expect(result.displayText).toBe('@Alice');
+    expect(result.mentions).toEqual([
+      { start: 0, end: 6, label: 'Alice', id: 'user1', type: 'user' },
+    ]);
+  });
+
+  it('given mention surrounded by text, should calculate correct positions', () => {
+    const result = markdownToDisplay('Hello @[Alice](user1:user) world');
+
+    expect(result.displayText).toBe('Hello @Alice world');
+    expect(result.mentions).toEqual([
+      { start: 6, end: 12, label: 'Alice', id: 'user1', type: 'user' },
+    ]);
+  });
+
+  it('given multiple mentions, should track all positions correctly', () => {
+    const result = markdownToDisplay(
+      'Hey @[Alice](a:user) and @[Doc](d:page) bye'
+    );
+
+    expect(result.displayText).toBe('Hey @Alice and @Doc bye');
+    expect(result.mentions).toHaveLength(2);
+    expect(result.mentions[0]).toEqual({
+      start: 4,
+      end: 10,
+      label: 'Alice',
+      id: 'a',
+      type: 'user',
+    });
+    expect(result.mentions[1]).toEqual({
+      start: 15,
+      end: 19,
+      label: 'Doc',
+      id: 'd',
+      type: 'page',
+    });
+  });
+
+  it('given adjacent mentions, should calculate positions correctly', () => {
+    const result = markdownToDisplay('@[Alice](a:user)@[Bob](b:user)');
+
+    expect(result.displayText).toBe('@Alice@Bob');
+    expect(result.mentions).toEqual([
+      { start: 0, end: 6, label: 'Alice', id: 'a', type: 'user' },
+      { start: 6, end: 10, label: 'Bob', id: 'b', type: 'user' },
+    ]);
+  });
+});
+
+describe('displayToMarkdown', () => {
+  it('given plain text with no mentions, should return text unchanged', () => {
+    const result = displayToMarkdown('hello world', []);
+
+    expect(result).toBe('hello world');
+  });
+
+  it('given display text with a single mention, should reconstruct markdown', () => {
+    const mentions: TrackedMention[] = [
+      { start: 0, end: 8, label: 'My Page', id: 'abc123', type: 'page' },
+    ];
+    const result = displayToMarkdown('@My Page', mentions);
+
+    expect(result).toBe('@[My Page](abc123:page)');
+  });
+
+  it('given display text with mention in context, should reconstruct markdown', () => {
+    const mentions: TrackedMention[] = [
+      { start: 6, end: 12, label: 'Alice', id: 'user1', type: 'user' },
+    ];
+    const result = displayToMarkdown('Hello @Alice world', mentions);
+
+    expect(result).toBe('Hello @[Alice](user1:user) world');
+  });
+
+  it('given display text with multiple mentions, should reconstruct all', () => {
+    const mentions: TrackedMention[] = [
+      { start: 4, end: 10, label: 'Alice', id: 'a', type: 'user' },
+      { start: 15, end: 19, label: 'Doc', id: 'd', type: 'page' },
+    ];
+    const result = displayToMarkdown('Hey @Alice and @Doc bye', mentions);
+
+    expect(result).toBe('Hey @[Alice](a:user) and @[Doc](d:page) bye');
+  });
+
+  it('given roundtrip, should preserve markdown', () => {
+    const original = 'Hello @[Alice](user1:user) and @[My Doc](doc1:page) bye';
+    const { displayText, mentions } = markdownToDisplay(original);
+    const roundtripped = displayToMarkdown(displayText, mentions);
+
+    expect(roundtripped).toBe(original);
+  });
+
+  it('given multiple roundtrips, should remain stable', () => {
+    const original = 'Check @[Report](r1:page) cc @[Bob](b1:user)';
+
+    const first = markdownToDisplay(original);
+    const markdown1 = displayToMarkdown(first.displayText, first.mentions);
+
+    const second = markdownToDisplay(markdown1);
+    const markdown2 = displayToMarkdown(second.displayText, second.mentions);
+
+    expect(markdown1).toBe(original);
+    expect(markdown2).toBe(original);
+  });
+});

--- a/apps/web/src/hooks/useMentionOverlay.ts
+++ b/apps/web/src/hooks/useMentionOverlay.ts
@@ -1,13 +1,10 @@
 import { useRef, useCallback } from 'react';
 
-const MENTION_PATTERN = /@\[[^\]]+\]\([^:]+:[^)]+\)/;
-
 export function useMentionOverlay(
   textareaRef: React.RefObject<HTMLTextAreaElement | null>,
-  value: string
+  hasMentions: boolean
 ) {
   const overlayRef = useRef<HTMLDivElement>(null);
-  const hasMentions = MENTION_PATTERN.test(value);
 
   const handleScroll = useCallback(() => {
     if (textareaRef.current && overlayRef.current) {

--- a/apps/web/src/hooks/useMentionTracker.ts
+++ b/apps/web/src/hooks/useMentionTracker.ts
@@ -1,0 +1,235 @@
+import { useRef, useCallback, useMemo } from 'react';
+import { MentionType } from '@/types/mentions';
+
+export interface TrackedMention {
+  start: number;
+  end: number;
+  label: string;
+  id: string;
+  type: MentionType;
+}
+
+const MENTION_REGEX = /@\[([^\]]+)\]\(([^:]+):([^)]+)\)/g;
+
+/**
+ * Parse markdown-typed mention format into display text and tracked positions.
+ *
+ * Input:  "Hello @[Alice](user123:user) world"
+ * Output: { displayText: "Hello @Alice world", mentions: [{start:6, end:12, ...}] }
+ */
+export function markdownToDisplay(markdown: string): {
+  displayText: string;
+  mentions: TrackedMention[];
+} {
+  const mentions: TrackedMention[] = [];
+  let displayText = '';
+  let lastIndex = 0;
+
+  MENTION_REGEX.lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = MENTION_REGEX.exec(markdown)) !== null) {
+    const [fullMatch, label, id, type] = match;
+
+    displayText += markdown.slice(lastIndex, match.index);
+
+    const mentionStart = displayText.length;
+    const displayMention = `@${label}`;
+    displayText += displayMention;
+
+    mentions.push({
+      start: mentionStart,
+      end: mentionStart + displayMention.length,
+      label,
+      id,
+      type: type as MentionType,
+    });
+
+    lastIndex = match.index + fullMatch.length;
+  }
+
+  displayText += markdown.slice(lastIndex);
+
+  return { displayText, mentions };
+}
+
+/**
+ * Convert display text + tracked mentions back to markdown-typed format.
+ *
+ * Input:  "Hello @Alice world", [{start:6, end:12, label:"Alice", id:"user123", type:"user"}]
+ * Output: "Hello @[Alice](user123:user) world"
+ */
+export function displayToMarkdown(
+  displayText: string,
+  mentions: TrackedMention[]
+): string {
+  if (mentions.length === 0) return displayText;
+
+  const sorted = [...mentions].sort((a, b) => a.start - b.start);
+
+  let markdown = '';
+  let lastIndex = 0;
+
+  for (const mention of sorted) {
+    markdown += displayText.slice(lastIndex, mention.start);
+    markdown += `@[${mention.label}](${mention.id}:${mention.type})`;
+    lastIndex = mention.end;
+  }
+
+  markdown += displayText.slice(lastIndex);
+
+  return markdown;
+}
+
+/**
+ * Find the edit region between old and new text.
+ * Returns the range in old text that was replaced and the corresponding range in new text.
+ */
+function findEditRegion(
+  oldText: string,
+  newText: string
+): { start: number; oldEnd: number; newEnd: number } {
+  let start = 0;
+  while (
+    start < oldText.length &&
+    start < newText.length &&
+    oldText[start] === newText[start]
+  ) {
+    start++;
+  }
+
+  let oldEnd = oldText.length;
+  let newEnd = newText.length;
+  while (
+    oldEnd > start &&
+    newEnd > start &&
+    oldText[oldEnd - 1] === newText[newEnd - 1]
+  ) {
+    oldEnd--;
+    newEnd--;
+  }
+
+  return { start, oldEnd, newEnd };
+}
+
+/**
+ * Update mention positions after a text edit.
+ * Removes mentions that overlap the edited region and shifts those after it.
+ */
+function updateMentionPositions(
+  mentions: TrackedMention[],
+  oldText: string,
+  newText: string
+): TrackedMention[] {
+  if (mentions.length === 0) return [];
+
+  const { start, oldEnd, newEnd } = findEditRegion(oldText, newText);
+  const delta = (newEnd - start) - (oldEnd - start);
+
+  return mentions
+    .filter((m) => {
+      // Remove mentions that overlap with the edited region in old text
+      return !(m.start < oldEnd && m.end > start);
+    })
+    .map((m) => {
+      if (m.start >= oldEnd) {
+        // Shift mentions after the edit
+        return { ...m, start: m.start + delta, end: m.end + delta };
+      }
+      return m;
+    });
+}
+
+export interface UseMentionTrackerResult {
+  /** Display text shown in the textarea (no IDs) */
+  displayText: string;
+  /** Tracked mention positions in the display text */
+  mentions: TrackedMention[];
+  /** Whether any mentions exist */
+  hasMentions: boolean;
+  /** Handle textarea text changes — updates positions and reports markdown to parent */
+  handleDisplayTextChange: (newDisplayText: string) => void;
+  /** Register a newly inserted mention (call before handleDisplayTextChange) */
+  registerMention: (mention: TrackedMention) => void;
+}
+
+/**
+ * Manages the bidirectional conversion between markdown mention format
+ * (used by parent/API) and display text (shown in the textarea).
+ *
+ * The parent passes markdown like "Hello @[Alice](user123:user) world"
+ * and this hook converts it to display text "Hello @Alice world" for the textarea,
+ * while tracking mention positions to reconstruct the markdown on changes.
+ */
+export function useMentionTracker(
+  markdownValue: string,
+  onMarkdownChange: (markdown: string) => void
+): UseMentionTrackerResult {
+  const displayTextRef = useRef('');
+  const mentionsRef = useRef<TrackedMention[]>([]);
+  const lastReportedMarkdownRef = useRef('');
+  const pendingMentionsRef = useRef<TrackedMention[]>([]);
+
+  // Parse markdown -> display text when value changes externally
+  const { displayText, mentions } = useMemo(() => {
+    // Skip re-parse if this value came from our own onChange
+    if (markdownValue === lastReportedMarkdownRef.current) {
+      return {
+        displayText: displayTextRef.current,
+        mentions: mentionsRef.current,
+      };
+    }
+
+    const parsed = markdownToDisplay(markdownValue);
+    displayTextRef.current = parsed.displayText;
+    mentionsRef.current = parsed.mentions;
+    return parsed;
+  }, [markdownValue]);
+
+  const registerMention = useCallback((mention: TrackedMention) => {
+    pendingMentionsRef.current.push(mention);
+  }, []);
+
+  const handleDisplayTextChange = useCallback(
+    (newDisplayText: string) => {
+      const oldDisplayText = displayTextRef.current;
+
+      // Update existing mention positions based on the text diff
+      const updatedMentions = updateMentionPositions(
+        mentionsRef.current,
+        oldDisplayText,
+        newDisplayText
+      );
+
+      // Merge in pending mentions from suggestion selection
+      const allMentions = [...updatedMentions, ...pendingMentionsRef.current];
+      pendingMentionsRef.current = [];
+
+      // Sort by position
+      allMentions.sort((a, b) => a.start - b.start);
+
+      // Validate mention text still matches (safety check)
+      const validMentions = allMentions.filter((m) => {
+        const textAtPosition = newDisplayText.slice(m.start, m.end);
+        return textAtPosition === `@${m.label}`;
+      });
+
+      displayTextRef.current = newDisplayText;
+      mentionsRef.current = validMentions;
+
+      // Convert to markdown and notify parent
+      const markdown = displayToMarkdown(newDisplayText, validMentions);
+      lastReportedMarkdownRef.current = markdown;
+      onMarkdownChange(markdown);
+    },
+    [onMarkdownChange]
+  );
+
+  return {
+    displayText,
+    mentions,
+    hasMentions: mentions.length > 0,
+    handleDisplayTextChange,
+    registerMention,
+  };
+}


### PR DESCRIPTION
The mention overlay pattern stored @[label](id:type) in the textarea and
rendered just @label in the overlay, causing a large gap of empty space
after each mention where the invisible ID characters occupied width.

Introduces useMentionTracker hook that converts between markdown format
(used by parent/API) and display text (shown in textarea). Mention
positions are tracked and updated on edits, so the overlay and textarea
text match character-for-character with no spacing artifacts.

https://claude.ai/code/session_019m6bu4AStmCU4TPrtqczCd