### PR TITLE
Fix mention system: display/ID separation + multi-word queries

### DIFF
--- a/apps/web/src/components/messages/ChatInput.tsx
+++ b/apps/web/src/components/messages/ChatInput.tsx
@@ -8,6 +8,7 @@ import { SuggestionProvider, useSuggestionContext } from '@/components/providers
 import { cn } from '@/lib/utils';
 import { MentionHighlightOverlay } from '@/components/ui/mention-highlight-overlay';
 import { useMentionOverlay } from '@/hooks/useMentionOverlay';
+import { useMentionTracker } from '@/hooks/useMentionTracker';
 
 interface ChatInputProps {
   value: string;
@@ -32,20 +33,27 @@ const ChatInputWithProvider = forwardRef<ChatInputRef, ChatInputProps>(({
   crossDrive = false
 }, ref) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const { overlayRef, hasMentions, handleScroll } = useMentionOverlay(textareaRef, value);
   const context = useSuggestionContext();
   // Track IME composition state to prevent accidental sends during predictive text
   const [isComposing, setIsComposing] = useState(false);
 
+  // Bidirectional mention tracker: textarea shows display text, parent gets markdown
+  const { displayText, mentions, hasMentions, handleDisplayTextChange, registerMention } =
+    useMentionTracker(value, onChange);
+
+  const { overlayRef, handleScroll } = useMentionOverlay(textareaRef, hasMentions);
+
   const suggestion = useSuggestion({
     inputRef: textareaRef as React.RefObject<HTMLTextAreaElement>,
-    onValueChange: onChange,
+    onValueChange: handleDisplayTextChange,
     trigger: '@',
     driveId,
     crossDrive,
-    mentionFormat: 'markdown-typed',
+    mentionFormat: 'label',
     variant: 'chat',
     popupPlacement: 'top',
+    mentionRanges: mentions,
+    onMentionInserted: registerMention,
   });
 
   useImperativeHandle(ref, () => ({
@@ -76,7 +84,7 @@ const ChatInputWithProvider = forwardRef<ChatInputRef, ChatInputProps>(({
     <div className="w-full relative">
       <Textarea
         ref={textareaRef}
-        value={value}
+        value={displayText}
         onChange={(e) => suggestion.handleValueChange(e.target.value)}
         onKeyDown={handleKeyDown}
         onScroll={handleScroll}
@@ -92,7 +100,8 @@ const ChatInputWithProvider = forwardRef<ChatInputRef, ChatInputProps>(({
       {hasMentions && (
         <MentionHighlightOverlay
           ref={overlayRef}
-          value={value}
+          value={displayText}
+          mentions={mentions}
           className="px-3 py-2 text-base md:text-sm text-foreground min-h-[40px] max-h-[120px]"
         />
       )}

--- a/apps/web/src/components/ui/mention-highlight-overlay/__tests__/MentionHighlightOverlay.test.tsx
+++ b/apps/web/src/components/ui/mention-highlight-overlay/__tests__/MentionHighlightOverlay.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { TrackedMention } from '@/lib/mentions/mentionDisplayUtils';
 
 const { mockNavigateToPage } = vi.hoisted(() => ({
   mockNavigateToPage: vi.fn(),
@@ -19,19 +20,22 @@ describe('MentionHighlightOverlay', () => {
 
   describe('text rendering', () => {
     it('given plain text with no mentions, should render text in spans', () => {
-      render(<MentionHighlightOverlay value="hello world" />);
+      render(<MentionHighlightOverlay value="hello world" mentions={[]} />);
 
       expect(screen.getByText('hello world')).toBeInTheDocument();
     });
 
     it('given empty string, should render zero-width space', () => {
-      const { container } = render(<MentionHighlightOverlay value="" />);
+      const { container } = render(<MentionHighlightOverlay value="" mentions={[]} />);
 
       expect(container.textContent).toBe('\u200B');
     });
 
     it('given a single page mention, should render formatted @label', () => {
-      render(<MentionHighlightOverlay value="@[My Page](abc123:page)" />);
+      const mentions: TrackedMention[] = [
+        { start: 0, end: 8, label: 'My Page', id: 'abc123', type: 'page' },
+      ];
+      render(<MentionHighlightOverlay value="@My Page" mentions={mentions} />);
 
       const mention = screen.getByText('@My Page');
       expect(mention).toBeInTheDocument();
@@ -39,7 +43,10 @@ describe('MentionHighlightOverlay', () => {
     });
 
     it('given a single user mention, should render formatted @label', () => {
-      render(<MentionHighlightOverlay value="@[Alice](user1:user)" />);
+      const mentions: TrackedMention[] = [
+        { start: 0, end: 6, label: 'Alice', id: 'user1', type: 'user' },
+      ];
+      render(<MentionHighlightOverlay value="@Alice" mentions={mentions} />);
 
       const mention = screen.getByText('@Alice');
       expect(mention).toBeInTheDocument();
@@ -47,8 +54,12 @@ describe('MentionHighlightOverlay', () => {
     });
 
     it('given mixed content with multiple mention types, should render all segments correctly', () => {
+      const mentions: TrackedMention[] = [
+        { start: 6, end: 10, label: 'Doc', id: 'id1', type: 'page' },
+        { start: 15, end: 19, label: 'Bob', id: 'id2', type: 'user' },
+      ];
       const { container } = render(
-        <MentionHighlightOverlay value="Hello @[Doc](id1:page) and @[Bob](id2:user) bye" />
+        <MentionHighlightOverlay value="Hello @Doc and @Bob bye" mentions={mentions} />
       );
 
       const overlay = container.firstElementChild!;
@@ -63,8 +74,12 @@ describe('MentionHighlightOverlay', () => {
     });
 
     it('given multiple page mentions, should render each with correct label', () => {
+      const mentions: TrackedMention[] = [
+        { start: 0, end: 6, label: 'First', id: 'id1', type: 'page' },
+        { start: 12, end: 19, label: 'Second', id: 'id2', type: 'page' },
+      ];
       render(
-        <MentionHighlightOverlay value="@[First](id1:page) then @[Second](id2:page)" />
+        <MentionHighlightOverlay value="@First then @Second" mentions={mentions} />
       );
 
       expect(screen.getByText('@First')).toBeInTheDocument();
@@ -74,17 +89,22 @@ describe('MentionHighlightOverlay', () => {
 
   describe('page mention interaction', () => {
     it('given a page mention, should have role="link" and pointer-events-auto', () => {
-      render(<MentionHighlightOverlay value="@[My Page](abc123:page)" />);
+      const mentions: TrackedMention[] = [
+        { start: 0, end: 8, label: 'My Page', id: 'abc123', type: 'page' },
+      ];
+      render(<MentionHighlightOverlay value="@My Page" mentions={mentions} />);
 
       const mention = screen.getByRole('link', { hidden: true });
       expect(mention).toHaveClass('pointer-events-auto');
     });
 
     it('given a page mention mousedown, should call navigateToPage with correct id', () => {
-      render(<MentionHighlightOverlay value="@[My Page](abc123:page)" />);
+      const mentions: TrackedMention[] = [
+        { start: 0, end: 8, label: 'My Page', id: 'abc123', type: 'page' },
+      ];
+      render(<MentionHighlightOverlay value="@My Page" mentions={mentions} />);
 
       const mention = screen.getByRole('link', { hidden: true });
-      // fireEvent.mouseDown is needed since the handler is onMouseDown, not onClick
       const event = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
       Object.defineProperty(event, 'preventDefault', { value: vi.fn() });
       Object.defineProperty(event, 'stopPropagation', { value: vi.fn() });
@@ -96,8 +116,12 @@ describe('MentionHighlightOverlay', () => {
     });
 
     it('given multiple page mentions, should navigate to correct id for each', () => {
+      const mentions: TrackedMention[] = [
+        { start: 0, end: 6, label: 'First', id: 'id1', type: 'page' },
+        { start: 11, end: 18, label: 'Second', id: 'id2', type: 'page' },
+      ];
       render(
-        <MentionHighlightOverlay value="@[First](id1:page) and @[Second](id2:page)" />
+        <MentionHighlightOverlay value="@First and @Second" mentions={mentions} />
       );
 
       const links = screen.getAllByRole('link', { hidden: true });
@@ -117,13 +141,19 @@ describe('MentionHighlightOverlay', () => {
 
   describe('user mention interaction', () => {
     it('given a user mention, should NOT have role="link"', () => {
-      render(<MentionHighlightOverlay value="@[Alice](user1:user)" />);
+      const mentions: TrackedMention[] = [
+        { start: 0, end: 6, label: 'Alice', id: 'user1', type: 'user' },
+      ];
+      render(<MentionHighlightOverlay value="@Alice" mentions={mentions} />);
 
       expect(screen.queryByRole('link', { hidden: true })).not.toBeInTheDocument();
     });
 
     it('given a user mention, should NOT have pointer-events-auto class', () => {
-      render(<MentionHighlightOverlay value="@[Alice](user1:user)" />);
+      const mentions: TrackedMention[] = [
+        { start: 0, end: 6, label: 'Alice', id: 'user1', type: 'user' },
+      ];
+      render(<MentionHighlightOverlay value="@Alice" mentions={mentions} />);
 
       const mention = screen.getByText('@Alice');
       expect(mention).not.toHaveClass('pointer-events-auto');
@@ -132,14 +162,14 @@ describe('MentionHighlightOverlay', () => {
 
   describe('container attributes', () => {
     it('given rendered overlay, should have aria-hidden="true"', () => {
-      const { container } = render(<MentionHighlightOverlay value="test" />);
+      const { container } = render(<MentionHighlightOverlay value="test" mentions={[]} />);
 
       const overlay = container.firstElementChild;
       expect(overlay).toHaveAttribute('aria-hidden', 'true');
     });
 
     it('given rendered overlay, should have correct base classes', () => {
-      const { container } = render(<MentionHighlightOverlay value="test" />);
+      const { container } = render(<MentionHighlightOverlay value="test" mentions={[]} />);
 
       const overlay = container.firstElementChild;
       expect(overlay).toHaveClass(
@@ -153,7 +183,7 @@ describe('MentionHighlightOverlay', () => {
 
     it('given custom className, should merge with base classes', () => {
       const { container } = render(
-        <MentionHighlightOverlay value="test" className="px-3 py-2 custom-class" />
+        <MentionHighlightOverlay value="test" mentions={[]} className="px-3 py-2 custom-class" />
       );
 
       const overlay = container.firstElementChild;
@@ -162,7 +192,7 @@ describe('MentionHighlightOverlay', () => {
 
     it('given a ref, should forward to the container div', () => {
       const ref = React.createRef<HTMLDivElement>();
-      render(<MentionHighlightOverlay ref={ref} value="test" />);
+      render(<MentionHighlightOverlay ref={ref} value="test" mentions={[]} />);
 
       expect(ref.current).toBeInstanceOf(HTMLDivElement);
       expect(ref.current).toHaveAttribute('aria-hidden', 'true');

--- a/apps/web/src/hooks/__tests__/useMentionOverlay.test.ts
+++ b/apps/web/src/hooks/__tests__/useMentionOverlay.test.ts
@@ -8,45 +8,25 @@ describe('useMentionOverlay', () => {
   });
 
   describe('hasMentions', () => {
-    it('given plain text, should return false', () => {
+    it('given hasMentions=false, should return false', () => {
       const ref = createTextareaRef();
-      const { result } = renderHook(() => useMentionOverlay(ref, 'hello world'));
+      const { result } = renderHook(() => useMentionOverlay(ref, false));
 
       expect(result.current.hasMentions).toBe(false);
     });
 
-    it('given text with page mention, should return true', () => {
+    it('given hasMentions=true, should return true', () => {
       const ref = createTextareaRef();
-      const { result } = renderHook(() =>
-        useMentionOverlay(ref, 'Hi @[Doc](id:page)')
-      );
+      const { result } = renderHook(() => useMentionOverlay(ref, true));
 
       expect(result.current.hasMentions).toBe(true);
-    });
-
-    it('given text with user mention, should return true', () => {
-      const ref = createTextareaRef();
-      const { result } = renderHook(() =>
-        useMentionOverlay(ref, 'Hi @[Alice](user1:user)')
-      );
-
-      expect(result.current.hasMentions).toBe(true);
-    });
-
-    it('given incomplete mention syntax, should return false', () => {
-      const ref = createTextareaRef();
-      const { result } = renderHook(() =>
-        useMentionOverlay(ref, '@[incomplete](missing)')
-      );
-
-      expect(result.current.hasMentions).toBe(false);
     });
   });
 
   describe('overlayRef', () => {
     it('given initial render, should return a ref with current null', () => {
       const ref = createTextareaRef();
-      const { result } = renderHook(() => useMentionOverlay(ref, 'test'));
+      const { result } = renderHook(() => useMentionOverlay(ref, false));
 
       expect(result.current.overlayRef).toHaveProperty('current', null);
     });
@@ -56,7 +36,7 @@ describe('useMentionOverlay', () => {
     it('given textarea with scrollTop, should sync to overlay scrollTop', () => {
       const textareaRef = createTextareaRef(100);
       const { result } = renderHook(() =>
-        useMentionOverlay(textareaRef, 'test')
+        useMentionOverlay(textareaRef, false)
       );
 
       // Simulate an overlay element being attached to the ref
@@ -73,7 +53,7 @@ describe('useMentionOverlay', () => {
     it('given no overlay element, should not throw', () => {
       const textareaRef = createTextareaRef(50);
       const { result } = renderHook(() =>
-        useMentionOverlay(textareaRef, 'test')
+        useMentionOverlay(textareaRef, false)
       );
 
       // overlayRef.current is null by default - should not throw

--- a/apps/web/src/hooks/__tests__/useMentionTracker.test.ts
+++ b/apps/web/src/hooks/__tests__/useMentionTracker.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useMentionTracker } from '../useMentionTracker';
+
+describe('useMentionTracker', () => {
+  describe('initial parsing', () => {
+    it('given plain text, should return display text unchanged with no mentions', () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() =>
+        useMentionTracker('hello world', onChange)
+      );
+
+      expect(result.current.displayText).toBe('hello world');
+      expect(result.current.mentions).toEqual([]);
+      expect(result.current.hasMentions).toBe(false);
+    });
+
+    it('given markdown with mentions, should parse into display text', () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() =>
+        useMentionTracker('@[Alice](u1:user) hi @[Doc](p1:page)', onChange)
+      );
+
+      expect(result.current.displayText).toBe('@Alice hi @Doc');
+      expect(result.current.mentions).toHaveLength(2);
+      expect(result.current.hasMentions).toBe(true);
+    });
+
+    it('given empty string, should return empty state', () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() => useMentionTracker('', onChange));
+
+      expect(result.current.displayText).toBe('');
+      expect(result.current.mentions).toEqual([]);
+      expect(result.current.hasMentions).toBe(false);
+    });
+  });
+
+  describe('handleDisplayTextChange', () => {
+    it('given text typed after mentions, should preserve mentions and report markdown', () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() =>
+        useMentionTracker('@[Alice](u1:user)', onChange)
+      );
+
+      act(() => {
+        result.current.handleDisplayTextChange('@Alice hi');
+      });
+
+      expect(onChange).toHaveBeenCalledWith('@[Alice](u1:user) hi');
+      expect(result.current.displayText).toBe('@Alice hi');
+      expect(result.current.mentions).toHaveLength(1);
+    });
+
+    it('given mention text edited by user, should remove that mention', () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() =>
+        useMentionTracker('@[Alice](u1:user)', onChange)
+      );
+
+      act(() => {
+        // User deletes last char of "@Alice" → "@Alic"
+        result.current.handleDisplayTextChange('@Alic');
+      });
+
+      expect(result.current.mentions).toHaveLength(0);
+      expect(onChange).toHaveBeenCalledWith('@Alic');
+    });
+
+    it('given plain text change with no mentions, should pass through unchanged', () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() =>
+        useMentionTracker('hello', onChange)
+      );
+
+      act(() => {
+        result.current.handleDisplayTextChange('hello world');
+      });
+
+      expect(onChange).toHaveBeenCalledWith('hello world');
+    });
+  });
+
+  describe('registerMention', () => {
+    it('given a registered mention before display change, should include it in mentions', () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() =>
+        useMentionTracker('', onChange)
+      );
+
+      act(() => {
+        // Simulate suggestion insertion: register mention, then update display text
+        result.current.registerMention({
+          start: 0,
+          end: 6,
+          label: 'Alice',
+          id: 'u1',
+          type: 'user',
+        });
+        result.current.handleDisplayTextChange('@Alice ');
+      });
+
+      expect(result.current.mentions).toHaveLength(1);
+      expect(result.current.mentions[0].label).toBe('Alice');
+      expect(onChange).toHaveBeenCalledWith('@[Alice](u1:user) ');
+    });
+
+    it('given a mention registered alongside existing mentions, should track both', () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() =>
+        useMentionTracker('@[Alice](u1:user) ', onChange)
+      );
+
+      act(() => {
+        result.current.registerMention({
+          start: 7,
+          end: 11,
+          label: 'Doc',
+          id: 'p1',
+          type: 'page',
+        });
+        result.current.handleDisplayTextChange('@Alice @Doc ');
+      });
+
+      expect(result.current.mentions).toHaveLength(2);
+      expect(onChange).toHaveBeenCalledWith(
+        '@[Alice](u1:user) @[Doc](p1:page) '
+      );
+    });
+  });
+
+  describe('external value changes', () => {
+    it('given parent value changes after send (cleared), should reset state', () => {
+      const onChange = vi.fn();
+      const { result, rerender } = renderHook(
+        ({ value, onChange: cb }) => useMentionTracker(value, cb),
+        { initialProps: { value: '@[Alice](u1:user)', onChange } }
+      );
+
+      expect(result.current.displayText).toBe('@Alice');
+
+      // Parent clears value (e.g. after message send)
+      rerender({ value: '', onChange });
+
+      expect(result.current.displayText).toBe('');
+      expect(result.current.mentions).toEqual([]);
+      expect(result.current.hasMentions).toBe(false);
+    });
+
+    it('given own onChange was the source, should NOT re-parse', () => {
+      const onChange = vi.fn();
+      const { result, rerender } = renderHook(
+        ({ value, onChange: cb }) => useMentionTracker(value, cb),
+        { initialProps: { value: '', onChange } }
+      );
+
+      // Simulate user typing and the parent updating value to match
+      act(() => {
+        result.current.handleDisplayTextChange('hello');
+      });
+
+      // Parent re-renders with the same markdown we reported
+      rerender({ value: 'hello', onChange });
+
+      // Should still be 'hello', not re-parsed (which would give same result anyway for plain text)
+      expect(result.current.displayText).toBe('hello');
+    });
+  });
+});

--- a/apps/web/src/hooks/useMentionOverlay.ts
+++ b/apps/web/src/hooks/useMentionOverlay.ts
@@ -1,13 +1,10 @@
 import { useRef, useCallback } from 'react';
 
-const MENTION_PATTERN = /@\[[^\]]+\]\([^:]+:[^)]+\)/;
-
 export function useMentionOverlay(
   textareaRef: React.RefObject<HTMLTextAreaElement | null>,
-  value: string
+  hasMentions: boolean
 ) {
   const overlayRef = useRef<HTMLDivElement>(null);
-  const hasMentions = MENTION_PATTERN.test(value);
 
   const handleScroll = useCallback(() => {
     if (textareaRef.current && overlayRef.current) {

--- a/apps/web/src/hooks/useMentionTracker.ts
+++ b/apps/web/src/hooks/useMentionTracker.ts
@@ -1,0 +1,127 @@
+import { useCallback, useRef, useState } from 'react';
+import {
+  TrackedMention,
+  markdownToDisplay,
+  displayToMarkdown,
+  updateMentionPositions,
+} from '@/lib/mentions/mentionDisplayUtils';
+
+export interface UseMentionTrackerResult {
+  /** Display-only text (no IDs) for the textarea */
+  displayText: string;
+  /** Tracked mention positions in display text */
+  mentions: TrackedMention[];
+  /** Whether any mentions exist */
+  hasMentions: boolean;
+  /** Called when the textarea display text changes (user typing) */
+  handleDisplayTextChange: (newDisplayText: string) => void;
+  /** Register a newly inserted mention (called before handleDisplayTextChange) */
+  registerMention: (mention: TrackedMention) => void;
+}
+
+/**
+ * Manages bidirectional conversion between:
+ * - Display text: "@Alice hi @Doc" (shown in textarea)
+ * - Markdown text: "@[Alice](u1:user) hi @[Doc](p1:page)" (stored in parent state)
+ *
+ * Parses markdown → display when parent changes externally.
+ * Reconstructs display → markdown when user types.
+ */
+export function useMentionTracker(
+  value: string,
+  onChange: (markdown: string) => void
+): UseMentionTrackerResult {
+  const [displayText, setDisplayText] = useState<string>(() => {
+    const { displayText: dt } = markdownToDisplay(value);
+    return dt;
+  });
+  const [mentions, setMentions] = useState<TrackedMention[]>(() => {
+    const { mentions: m } = markdownToDisplay(value);
+    return m;
+  });
+
+  // Refs for stable access in callbacks (avoid stale closures)
+  const mentionsRef = useRef<TrackedMention[]>(mentions);
+  mentionsRef.current = mentions;
+
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
+  // Track the last markdown we reported to parent, to skip re-parse on our own changes
+  const lastReportedMarkdownRef = useRef<string>(value);
+  // Track the previous value prop to detect external changes
+  const prevValueRef = useRef<string>(value);
+  // Track the last display text to diff against
+  const lastDisplayTextRef = useRef<string>(displayText);
+  // Queue for mentions about to be inserted
+  const pendingMentionsRef = useRef<TrackedMention[]>([]);
+
+  // Detect external value changes (parent changed value, not us)
+  if (value !== prevValueRef.current) {
+    prevValueRef.current = value;
+
+    // Only re-parse if this change didn't come from our own onChange
+    if (value !== lastReportedMarkdownRef.current) {
+      const { displayText: newDisplay, mentions: newMentions } =
+        markdownToDisplay(value);
+      setDisplayText(newDisplay);
+      setMentions(newMentions);
+      mentionsRef.current = newMentions;
+      lastDisplayTextRef.current = newDisplay;
+      lastReportedMarkdownRef.current = value;
+    }
+  }
+
+  const registerMention = useCallback((mention: TrackedMention) => {
+    pendingMentionsRef.current.push(mention);
+  }, []);
+
+  const handleDisplayTextChange = useCallback(
+    (newDisplayText: string) => {
+      const oldDisplayText = lastDisplayTextRef.current;
+      const currentMentions = mentionsRef.current;
+
+      // Start with existing mentions, updated for the text edit
+      let updatedMentions = updateMentionPositions(
+        currentMentions,
+        oldDisplayText,
+        newDisplayText
+      );
+
+      // Merge any pending mentions (from suggestion insertion)
+      if (pendingMentionsRef.current.length > 0) {
+        updatedMentions = [...updatedMentions, ...pendingMentionsRef.current];
+        updatedMentions.sort((a, b) => a.start - b.start);
+        pendingMentionsRef.current = [];
+      }
+
+      // Validate: ensure each mention's text in displayText matches "@label"
+      const validMentions = updatedMentions.filter((m) => {
+        const slice = newDisplayText.slice(m.start, m.end);
+        return slice === `@${m.label}`;
+      });
+
+      // Reconstruct markdown
+      const markdown = displayToMarkdown(newDisplayText, validMentions);
+
+      // Update state and refs synchronously
+      setDisplayText(newDisplayText);
+      setMentions(validMentions);
+      mentionsRef.current = validMentions;
+      lastDisplayTextRef.current = newDisplayText;
+      lastReportedMarkdownRef.current = markdown;
+
+      // Report to parent
+      onChangeRef.current(markdown);
+    },
+    [] // stable — reads from refs
+  );
+
+  return {
+    displayText,
+    mentions,
+    hasMentions: mentions.length > 0,
+    handleDisplayTextChange,
+    registerMention,
+  };
+}

--- a/apps/web/src/lib/mentions/__tests__/mentionDisplayUtils.test.ts
+++ b/apps/web/src/lib/mentions/__tests__/mentionDisplayUtils.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect } from 'vitest';
+import {
+  markdownToDisplay,
+  displayToMarkdown,
+  findEditRegion,
+  updateMentionPositions,
+  TrackedMention,
+} from '../mentionDisplayUtils';
+
+describe('markdownToDisplay', () => {
+  it('given plain text with no mentions, should return text unchanged with empty mentions', () => {
+    const result = markdownToDisplay('hello world');
+    expect(result).toEqual({ displayText: 'hello world', mentions: [] });
+  });
+
+  it('given empty string, should return empty display text', () => {
+    const result = markdownToDisplay('');
+    expect(result).toEqual({ displayText: '', mentions: [] });
+  });
+
+  it('given a single page mention, should extract label and track position', () => {
+    const result = markdownToDisplay('@[My Doc](p1:page)');
+    expect(result.displayText).toBe('@My Doc');
+    expect(result.mentions).toEqual([
+      { start: 0, end: 7, label: 'My Doc', id: 'p1', type: 'page' },
+    ]);
+  });
+
+  it('given a single user mention, should extract label and track position', () => {
+    const result = markdownToDisplay('@[Alice](u1:user)');
+    expect(result.displayText).toBe('@Alice');
+    expect(result.mentions).toEqual([
+      { start: 0, end: 6, label: 'Alice', id: 'u1', type: 'user' },
+    ]);
+  });
+
+  it('given mixed text with mentions, should track all positions correctly', () => {
+    const result = markdownToDisplay(
+      '@[Alice](u1:user) hi @[Doc](p1:page)'
+    );
+    expect(result.displayText).toBe('@Alice hi @Doc');
+    expect(result.mentions).toHaveLength(2);
+    expect(result.mentions[0]).toEqual({
+      start: 0,
+      end: 6,
+      label: 'Alice',
+      id: 'u1',
+      type: 'user',
+    });
+    expect(result.mentions[1]).toEqual({
+      start: 10,
+      end: 14,
+      label: 'Doc',
+      id: 'p1',
+      type: 'page',
+    });
+  });
+
+  it('given text before and after mention, should preserve surrounding text', () => {
+    const result = markdownToDisplay('Hello @[Alice](u1:user) bye');
+    expect(result.displayText).toBe('Hello @Alice bye');
+    expect(result.mentions).toEqual([
+      { start: 6, end: 12, label: 'Alice', id: 'u1', type: 'user' },
+    ]);
+  });
+
+  it('given adjacent mentions with no space, should track both positions', () => {
+    const result = markdownToDisplay('@[A](a:user)@[B](b:page)');
+    expect(result.displayText).toBe('@A@B');
+    expect(result.mentions).toEqual([
+      { start: 0, end: 2, label: 'A', id: 'a', type: 'user' },
+      { start: 2, end: 4, label: 'B', id: 'b', type: 'page' },
+    ]);
+  });
+});
+
+describe('displayToMarkdown', () => {
+  it('given text with no mentions, should return text unchanged', () => {
+    expect(displayToMarkdown('hello world', [])).toBe('hello world');
+  });
+
+  it('given display text with tracked mentions, should reconstruct markdown', () => {
+    const mentions: TrackedMention[] = [
+      { start: 0, end: 6, label: 'Alice', id: 'u1', type: 'user' },
+    ];
+    expect(displayToMarkdown('@Alice', mentions)).toBe(
+      '@[Alice](u1:user)'
+    );
+  });
+
+  it('given multiple mentions, should reconstruct all in correct positions', () => {
+    const mentions: TrackedMention[] = [
+      { start: 0, end: 6, label: 'Alice', id: 'u1', type: 'user' },
+      { start: 10, end: 14, label: 'Doc', id: 'p1', type: 'page' },
+    ];
+    expect(displayToMarkdown('@Alice hi @Doc', mentions)).toBe(
+      '@[Alice](u1:user) hi @[Doc](p1:page)'
+    );
+  });
+
+  it('given round-trip conversion, should be lossless', () => {
+    const original = 'Hello @[Alice](u1:user), see @[My Doc](p1:page) please';
+    const { displayText, mentions } = markdownToDisplay(original);
+    const reconstructed = displayToMarkdown(displayText, mentions);
+    expect(reconstructed).toBe(original);
+  });
+});
+
+describe('findEditRegion', () => {
+  it('given identical strings, should return start=end', () => {
+    const result = findEditRegion('abc', 'abc');
+    expect(result).toEqual({ start: 3, oldEnd: 3, newEnd: 3 });
+  });
+
+  it('given insertion at end, should detect appended text', () => {
+    const result = findEditRegion('abc', 'abcd');
+    expect(result).toEqual({ start: 3, oldEnd: 3, newEnd: 4 });
+  });
+
+  it('given deletion at end, should detect removed text', () => {
+    const result = findEditRegion('abcd', 'abc');
+    expect(result).toEqual({ start: 3, oldEnd: 4, newEnd: 3 });
+  });
+
+  it('given insertion in middle, should detect inserted region', () => {
+    const result = findEditRegion('ac', 'abc');
+    expect(result).toEqual({ start: 1, oldEnd: 1, newEnd: 2 });
+  });
+
+  it('given replacement in middle, should detect replaced region', () => {
+    const result = findEditRegion('abc', 'axc');
+    expect(result).toEqual({ start: 1, oldEnd: 2, newEnd: 2 });
+  });
+
+  it('given complete replacement, should return full range', () => {
+    const result = findEditRegion('abc', 'xyz');
+    expect(result).toEqual({ start: 0, oldEnd: 3, newEnd: 3 });
+  });
+});
+
+describe('updateMentionPositions', () => {
+  const baseMentions: TrackedMention[] = [
+    { start: 0, end: 6, label: 'Alice', id: 'u1', type: 'user' },
+    { start: 10, end: 14, label: 'Doc', id: 'p1', type: 'page' },
+  ];
+
+  it('given no change, should return mentions unchanged', () => {
+    const result = updateMentionPositions(baseMentions, '@Alice hi @Doc', '@Alice hi @Doc');
+    expect(result).toEqual(baseMentions);
+  });
+
+  it('given text appended after all mentions, should keep all mentions', () => {
+    const result = updateMentionPositions(
+      baseMentions,
+      '@Alice hi @Doc',
+      '@Alice hi @Doc more text'
+    );
+    expect(result).toEqual(baseMentions);
+  });
+
+  it('given text inserted between mentions, should shift later mentions', () => {
+    // Insert " extra" between mentions: "@Alice hi extra @Doc"
+    const result = updateMentionPositions(
+      baseMentions,
+      '@Alice hi @Doc',
+      '@Alice hi extra @Doc'
+    );
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual(baseMentions[0]); // First mention unchanged
+    expect(result[1]).toEqual({
+      start: 16,
+      end: 20,
+      label: 'Doc',
+      id: 'p1',
+      type: 'page',
+    });
+  });
+
+  it('given text deleted between mentions, should shift later mentions back', () => {
+    // Delete " hi " → "@Alice@Doc"
+    const result = updateMentionPositions(
+      baseMentions,
+      '@Alice hi @Doc',
+      '@Alice @Doc'
+    );
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual(baseMentions[0]);
+    expect(result[1]).toEqual({
+      start: 7,
+      end: 11,
+      label: 'Doc',
+      id: 'p1',
+      type: 'page',
+    });
+  });
+
+  it('given edit overlapping a mention, should remove that mention', () => {
+    // Modify "@Alice" → "@Ali" — overlaps first mention
+    const result = updateMentionPositions(
+      baseMentions,
+      '@Alice hi @Doc',
+      '@Ali hi @Doc'
+    );
+    // First mention is removed (overlapped by edit), second is shifted
+    expect(result).toHaveLength(1);
+    expect(result[0].label).toBe('Doc');
+    expect(result[0].start).toBe(8);
+    expect(result[0].end).toBe(12);
+  });
+
+  it('given edit within a mention, should remove that mention', () => {
+    // Type inside "@Alice" → "@Alxice"
+    const result = updateMentionPositions(
+      baseMentions,
+      '@Alice hi @Doc',
+      '@Alxice hi @Doc'
+    );
+    // First mention removed, second shifted
+    expect(result).toHaveLength(1);
+    expect(result[0].label).toBe('Doc');
+  });
+
+  it('given empty mentions array, should return empty', () => {
+    const result = updateMentionPositions([], 'abc', 'abcd');
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/mentions/mentionDisplayUtils.ts
+++ b/apps/web/src/lib/mentions/mentionDisplayUtils.ts
@@ -1,0 +1,155 @@
+import { MentionType } from '@/types/mentions';
+
+export interface TrackedMention {
+  /** Position of '@' in display text */
+  start: number;
+  /** Position after last character of label in display text */
+  end: number;
+  label: string;
+  id: string;
+  type: MentionType;
+}
+
+/** Regex matching @[Label](id:type) in markdown */
+const MENTION_MARKDOWN_RE = /@\[([^\]]+)\]\(([^:]+):([^)]+)\)/g;
+
+/**
+ * Parse markdown mention text into display text + tracked positions.
+ *
+ * "@[Alice](u1:user) hi @[Doc](p1:page)"
+ * → { displayText: "@Alice hi @Doc", mentions: [{start:0,end:6,...}, {start:11,end:15,...}] }
+ */
+export function markdownToDisplay(markdown: string): {
+  displayText: string;
+  mentions: TrackedMention[];
+} {
+  const mentions: TrackedMention[] = [];
+  let displayText = '';
+  let lastIndex = 0;
+
+  MENTION_MARKDOWN_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = MENTION_MARKDOWN_RE.exec(markdown)) !== null) {
+    const [fullMatch, label, id, type] = match;
+
+    // Append text before this mention
+    displayText += markdown.slice(lastIndex, match.index);
+
+    const displayLabel = `@${label}`;
+    const start = displayText.length;
+    const end = start + displayLabel.length;
+
+    mentions.push({ start, end, label, id, type: type as MentionType });
+    displayText += displayLabel;
+
+    lastIndex = match.index + fullMatch.length;
+  }
+
+  // Append remaining text
+  displayText += markdown.slice(lastIndex);
+
+  return { displayText, mentions };
+}
+
+/**
+ * Reconstruct markdown from display text + tracked mentions.
+ *
+ * displayToMarkdown("@Alice hi @Doc", mentions) → "@[Alice](u1:user) hi @[Doc](p1:page)"
+ */
+export function displayToMarkdown(
+  displayText: string,
+  mentions: TrackedMention[]
+): string {
+  if (mentions.length === 0) return displayText;
+
+  // Sort mentions by position to process left-to-right
+  const sorted = [...mentions].sort((a, b) => a.start - b.start);
+  let result = '';
+  let lastIndex = 0;
+
+  for (const mention of sorted) {
+    // Append text before this mention
+    result += displayText.slice(lastIndex, mention.start);
+    // Append markdown format
+    result += `@[${mention.label}](${mention.id}:${mention.type})`;
+    lastIndex = mention.end;
+  }
+
+  // Append remaining text
+  result += displayText.slice(lastIndex);
+
+  return result;
+}
+
+/**
+ * Find the changed region between two strings.
+ * Returns the first differing index and the end indices in old/new.
+ */
+export function findEditRegion(
+  oldText: string,
+  newText: string
+): { start: number; oldEnd: number; newEnd: number } {
+  // Find first differing character from the start
+  let start = 0;
+  const minLen = Math.min(oldText.length, newText.length);
+  while (start < minLen && oldText[start] === newText[start]) {
+    start++;
+  }
+
+  // Find first differing character from the end
+  let oldEnd = oldText.length;
+  let newEnd = newText.length;
+  while (
+    oldEnd > start &&
+    newEnd > start &&
+    oldText[oldEnd - 1] === newText[newEnd - 1]
+  ) {
+    oldEnd--;
+    newEnd--;
+  }
+
+  return { start, oldEnd, newEnd };
+}
+
+/**
+ * Update mention positions after a text edit, removing mentions
+ * that overlap the edit region and shifting those that follow.
+ */
+export function updateMentionPositions(
+  mentions: TrackedMention[],
+  oldText: string,
+  newText: string
+): TrackedMention[] {
+  const { start: editStart, oldEnd: editOldEnd, newEnd: editNewEnd } =
+    findEditRegion(oldText, newText);
+
+  // No change
+  if (editStart === editOldEnd && editStart === editNewEnd) return mentions;
+
+  const shift = editNewEnd - editOldEnd;
+  const result: TrackedMention[] = [];
+
+  for (const mention of mentions) {
+    // Mention is entirely before the edit — keep as-is
+    if (mention.end <= editStart) {
+      result.push(mention);
+      continue;
+    }
+
+    // Mention is entirely after the edit — shift
+    if (mention.start >= editOldEnd) {
+      result.push({
+        ...mention,
+        start: mention.start + shift,
+        end: mention.end + shift,
+      });
+      continue;
+    }
+
+    // Mention overlaps the edit region — remove it (it's been modified by the user)
+    // This covers: partial overlap from left, partial overlap from right, and edit within mention
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

- **Separates display text from markdown storage** in the chat mention system — textarea shows `@Label` while parent state holds `@[Label](id:type)`, eliminating the spacing gap caused by invisible ID characters
- **Fixes multi-word mention queries** (`@My Doc`) by removing the regex that treated space as a mention terminator, replacing it with position-based detection
- **Adds Escape dismissal tracking** so pressing Escape closes the popup permanently for that `@` trigger without reopening on subsequent typing

## Changes

### New files
| File | Purpose |
|------|---------|
| `lib/mentions/mentionDisplayUtils.ts` | Pure functions: `markdownToDisplay`, `displayToMarkdown`, `findEditRegion`, `updateMentionPositions` |
| `hooks/useMentionTracker.ts` | Bidirectional state hook managing display ↔ markdown conversion with ref-based position tracking |
| + tests for both | 34 new tests |

### Modified files
| File | Change |
|------|--------|
| `hooks/useSuggestion.ts` | Added `mentionRanges`/`onMentionInserted` props; replaced `/^[^\s\[\]]+\s/` regex with position-based detection; added `dismissedTriggerRef` for Escape |
| `hooks/useMentionOverlay.ts` | Simplified to accept `hasMentions: boolean` instead of computing via regex |
| `MentionHighlightOverlay.tsx` | Accepts `mentions: TrackedMention[]` prop, renders from tracked positions instead of regex |
| `ChatTextarea.tsx` / `ChatInput.tsx` | Wire `useMentionTracker` between parent and textarea; `mentionFormat` changed from `'markdown-typed'` to `'label'` |

### Not modified
`mention-processor.ts`, API routes, server-side code — parent state always holds markdown format, so AI/API consumers are unaffected.

## Test plan

- [x] Unit tests: 54 tests pass across 4 test files (mentionDisplayUtils, useMentionTracker, useMentionOverlay, MentionHighlightOverlay)
- [x] Full test suite: 197/198 test files pass (1 pre-existing DB connectivity failure)
- [x] TypeScript: full build succeeds with no errors
- [ ] Manual: type `@` → popup opens, type multi-word query → popup stays open
- [ ] Manual: select mention → `@Label` appears formatted, parent state has markdown
- [ ] Manual: send message → AI receives and processes the mention correctly
- [ ] Manual: type `@` → press Escape → continue typing → no popup reopens
- [ ] Manual: click at end of existing mention → popup does NOT reopen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streamlined mention formatting in chat—labels now display cleanly instead of markdown syntax.
  * Improved mention tracking system for consistent display and recognition across chat inputs.

* **Bug Fixes**
  * Enhanced handling of mentions during IME composition and text editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->