### PR TITLE
Fix mention links in input area breaking Capacitor and desktop navigation

### DIFF
--- a/apps/web/src/components/ui/mention-highlight-overlay/MentionHighlightOverlay.tsx
+++ b/apps/web/src/components/ui/mention-highlight-overlay/MentionHighlightOverlay.tsx
@@ -14,7 +14,7 @@ interface MentionHighlightOverlayProps {
 }
 
 /**
- * MentionHighlightOverlay renders text with @mentions as formatted bold links.
+ * MentionHighlightOverlay renders text with @mentions as colored, underlined spans.
  *
  * It is designed to sit on top of a textarea with transparent text,
  * mirroring the exact same layout so that the formatted mentions
@@ -56,7 +56,7 @@ export const MentionHighlightOverlay = forwardRef<
       elements.push(
         <span
           key={`mention-${mention.start}`}
-          className="font-semibold text-primary"
+          className="text-primary underline decoration-primary/50"
         >
           {mentionText}
         </span>


### PR DESCRIPTION
Mentions in the chat input overlay were clickable with pointer-events-auto
and onMouseDown navigation, which caused Capacitor to open Safari and
desktop to navigate unexpectedly. Mentions only need to be clickable links
after the message is sent, not while composing in the input area.

https://claude.ai/code/session_01GYLvK25trZPtojWbjhq6v5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Mention highlights have been updated to render uniformly as styled text without interactive navigation. Previously, different mention types displayed inconsistently—some as navigable links and others as static text. This change standardizes mention display across the application for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->