### PR TITLE
[web] Gate page tree fetch on auth readiness

### DIFF
--- a/apps/web/src/hooks/__tests__/usePageTree.test.ts
+++ b/apps/web/src/hooks/__tests__/usePageTree.test.ts
@@ -13,6 +13,7 @@ const {
   mockCacheDelete,
   mockSWRState,
   mockIsAnyEditing,
+  mockAuthState,
 } = vi.hoisted(() => ({
   mockFetchWithAuth: vi.fn(),
   mockMutate: vi.fn(),
@@ -22,6 +23,11 @@ const {
     error: undefined as unknown,
   },
   mockIsAnyEditing: vi.fn(() => false),
+  mockAuthState: {
+    hasHydrated: true,
+    isLoading: false,
+    isAuthenticated: true,
+  },
 }));
 
 // Mock dependencies with hoisted mocks
@@ -36,6 +42,10 @@ vi.mock('@/stores/useEditingStore', () => ({
     }),
   },
   isEditingActive: () => mockIsAnyEditing(),
+}));
+
+vi.mock('@/stores/useAuthStore', () => ({
+  useAuthStore: (selector: (state: typeof mockAuthState) => unknown) => selector(mockAuthState),
 }));
 
 vi.mock('@/lib/tree/tree-utils', () => ({
@@ -92,6 +102,9 @@ describe('usePageTree', () => {
     mockSWRState.data = undefined;
     mockSWRState.error = undefined;
     mockIsAnyEditing.mockReturnValue(false);
+    mockAuthState.hasHydrated = true;
+    mockAuthState.isLoading = false;
+    mockAuthState.isAuthenticated = true;
   });
 
   afterEach(() => {


### PR DESCRIPTION
### Motivation
- The page tree hook could start network fetches before the auth store was hydrated on desktop/capacitor cold starts, causing the UI to hang in an infinite skeleton state until a manual refresh.
- Prior fixes reduced some failure modes, but `usePageTree` still initiated SWR fetches too early when session/auth state wasn't ready.

### Description
- Gate `usePageTree` fetch key on auth readiness by reading `hasHydrated`, `isLoading`, and `isAuthenticated` from `useAuthStore` and only setting the SWR key when auth is ready (`shouldFetch`).
- Adjust `isLoading` returned by `usePageTree` to account for auth hydration/loading state so the UI doesn't misinterpret pre-auth state as a permanent fetch failure.
- Update unit tests for `usePageTree` to mock the auth store (`useAuthStore`) and set expected hydrated/auth states in `apps/web/src/hooks/__tests__/usePageTree.test.ts`.

### Testing
- Updated the unit test file `apps/web/src/hooks/__tests__/usePageTree.test.ts` to mock `useAuthStore` state for the new gating logic; tests were modified but not executed as part of this change.
- No automated test runs were performed for this patch (no CI/test commands executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69870b316d208320946ac60350638c54)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened test setup for authentication state handling and data operations.

* **Bug Fixes**
  * Loading indicators now accurately reflect authentication and synchronization status.
  * Data fetching properly awaits authentication completion before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->