### PR TITLE
Add calendar awareness to Pulse summaries

### DIFF
--- a/apps/web/src/app/api/pulse/calendar-context.ts
+++ b/apps/web/src/app/api/pulse/calendar-context.ts
@@ -1,0 +1,150 @@
+import {
+  db,
+  calendarEvents,
+  eventAttendees,
+  eq,
+  and,
+  or,
+  gte,
+  lt,
+  inArray,
+  isNull,
+} from '@pagespace/db';
+
+export interface PulseCalendarEvent {
+  title: string;
+  location: string | null;
+  startAt: Date;
+  endAt: Date;
+  allDay: boolean;
+}
+
+export async function fetchCalendarContext(params: {
+  userId: string;
+  driveIds: string[];
+  now: Date;
+  endOfToday: Date;
+  endOfTomorrow: Date;
+}): Promise<{
+  happeningNow: PulseCalendarEvent[];
+  upcomingToday: PulseCalendarEvent[];
+  tomorrow: PulseCalendarEvent[];
+  pendingInvites: Array<{ eventTitle: string; startAt: Date; allDay: boolean }>;
+  allEvents: PulseCalendarEvent[];
+}> {
+  const { userId, driveIds, now, endOfToday, endOfTomorrow } = params;
+
+  // Visibility filter: personal events + drive events respecting visibility setting
+  // PRIVATE and ATTENDEES_ONLY events from other users in shared drives are excluded
+  // ATTENDEES_ONLY events are surfaced through the attendeeEventRows query instead
+  const calendarVisibility = driveIds.length > 0
+    ? or(
+        and(isNull(calendarEvents.driveId), eq(calendarEvents.createdById, userId)),
+        and(
+          inArray(calendarEvents.driveId, driveIds),
+          or(
+            eq(calendarEvents.visibility, 'DRIVE'),
+            eq(calendarEvents.createdById, userId)
+          )
+        )
+      )
+    : and(isNull(calendarEvents.driveId), eq(calendarEvents.createdById, userId));
+
+  const upcomingCalendarEvents = await db
+    .select({
+      id: calendarEvents.id,
+      title: calendarEvents.title,
+      location: calendarEvents.location,
+      startAt: calendarEvents.startAt,
+      endAt: calendarEvents.endAt,
+      allDay: calendarEvents.allDay,
+      driveId: calendarEvents.driveId,
+    })
+    .from(calendarEvents)
+    .where(
+      and(
+        eq(calendarEvents.isTrashed, false),
+        gte(calendarEvents.endAt, now),
+        lt(calendarEvents.startAt, endOfTomorrow),
+        calendarVisibility
+      )
+    )
+    .orderBy(calendarEvents.startAt)
+    .limit(15);
+
+  // Get events user is invited to via attendees table
+  const attendeeEventRows = await db
+    .select({
+      id: calendarEvents.id,
+      title: calendarEvents.title,
+      location: calendarEvents.location,
+      startAt: calendarEvents.startAt,
+      endAt: calendarEvents.endAt,
+      allDay: calendarEvents.allDay,
+      driveId: calendarEvents.driveId,
+      rsvpStatus: eventAttendees.status,
+    })
+    .from(eventAttendees)
+    .innerJoin(calendarEvents, eq(calendarEvents.id, eventAttendees.eventId))
+    .where(
+      and(
+        eq(eventAttendees.userId, userId),
+        eq(calendarEvents.isTrashed, false),
+        gte(calendarEvents.endAt, now),
+        lt(calendarEvents.startAt, endOfTomorrow),
+      )
+    )
+    .orderBy(calendarEvents.startAt)
+    .limit(15);
+
+  // Pending RSVP invites (future events user hasn't responded to)
+  const pendingRsvps = await db
+    .select({
+      eventTitle: calendarEvents.title,
+      startAt: calendarEvents.startAt,
+      allDay: calendarEvents.allDay,
+    })
+    .from(eventAttendees)
+    .innerJoin(calendarEvents, eq(calendarEvents.id, eventAttendees.eventId))
+    .where(
+      and(
+        eq(eventAttendees.userId, userId),
+        eq(eventAttendees.status, 'PENDING'),
+        eq(calendarEvents.isTrashed, false),
+        gte(calendarEvents.startAt, now),
+      )
+    )
+    .orderBy(calendarEvents.startAt)
+    .limit(5);
+
+  // Merge and deduplicate events
+  const seenEventIds = new Set<string>();
+  const allCalendarEvents: PulseCalendarEvent[] = [];
+
+  for (const event of [...upcomingCalendarEvents, ...attendeeEventRows]) {
+    if (seenEventIds.has(event.id)) continue;
+    seenEventIds.add(event.id);
+    allCalendarEvents.push({
+      title: event.title,
+      location: event.location,
+      startAt: event.startAt,
+      endAt: event.endAt,
+      allDay: event.allDay,
+    });
+  }
+
+  allCalendarEvents.sort((a, b) => a.startAt.getTime() - b.startAt.getTime());
+
+  // Categorize events
+  const happeningNow = allCalendarEvents.filter(e => e.startAt <= now && e.endAt > now);
+  const upcomingToday = allCalendarEvents.filter(e => e.startAt > now && e.startAt < endOfToday);
+  const tomorrow = allCalendarEvents.filter(e => e.startAt >= endOfToday && e.startAt < endOfTomorrow);
+
+  return {
+    happeningNow,
+    upcomingToday,
+    tomorrow,
+    pendingInvites: pendingRsvps,
+    allEvents: allCalendarEvents,
+  };
+}

--- a/apps/web/src/app/api/pulse/generate/route.ts
+++ b/apps/web/src/app/api/pulse/generate/route.ts
@@ -24,19 +24,16 @@ import {
   userMentions,
   pagePermissions,
   chatMessages,
-  calendarEvents,
-  eventAttendees,
   eq,
   and,
   or,
   lt,
-  lte,
   gte,
   ne,
   desc,
   inArray,
-  isNull,
 } from '@pagespace/db';
+import { fetchCalendarContext } from '../calendar-context';
 import {
   groupActivitiesForDiff,
   resolveStackedVersionContent,
@@ -50,67 +47,9 @@ import {
 import { readPageContent, loggers } from '@pagespace/lib/server';
 import { AIMonitoring } from '@pagespace/lib/ai-monitoring';
 
+import { PULSE_SYSTEM_PROMPT } from '../pulse-prompt';
+
 const AUTH_OPTIONS = { allow: ['session'] as const };
-
-// System prompt for generating pulse summaries
-const PULSE_SYSTEM_PROMPT = `You're a thoughtful workspace companion - like a colleague who sits nearby and notices things. You have deep awareness of what's happening in the user's workspace, but you're NOT a status reporter.
-
-YOUR PERSONALITY:
-- Warm, observant, genuinely interested in the person
-- You notice patterns, not just events
-- You have opinions and make suggestions
-- Sometimes you're encouraging, sometimes you're gently prodding
-- You're comfortable with silence when there's nothing meaningful to say
-
-WHAT YOU HAVE ACCESS TO:
-You can see workspace activity, content diffs, messages, tasks, calendar events, and your previous conversations. Use this as CONTEXT to inform what you say - but don't just report it back.
-
-DEDUPLICATION - CRITICAL:
-Check "previousPulses" for what you've already said. NEVER repeat yourself. If you mentioned something before, it's old news - find something fresh or say something different entirely.
-
-TYPES OF MESSAGES YOU MIGHT SEND:
-
-1. OBSERVATIONS (notice patterns, not just events)
-   - "You've been heads-down on the API docs for a few days now - deep work mode?"
-   - "Looks like the team's been busy while you were away"
-   - "Sarah seems to be making good progress on that budget analysis"
-
-2. GENTLE NUDGES (helpful, not naggy)
-   - "That task from last week is still hanging around..."
-   - "Sarah's DM from yesterday might be worth a look"
-   - "The roadmap doc has some new stuff if you haven't seen it"
-
-3. ENCOURAGEMENT
-   - "Solid progress on the sprint this week"
-   - "The quiet is nice - good time to focus"
-   - "You knocked out 3 tasks yesterday, nice"
-
-4. QUESTIONS (genuine curiosity)
-   - "Ready to dive into those Q2 plans?"
-   - "How's the API migration going?"
-
-5. SIMPLE PRESENCE (when there's nothing specific)
-   - "All quiet. Enjoy the focus time."
-   - "Nothing urgent on the radar"
-   - Just a friendly check-in vibe
-
-6. CALENDAR AWARENESS (time-sensitive context)
-   - "You've got a team sync in an hour - might be a good time to prep"
-   - "Looks like a meeting-heavy afternoon ahead"
-   - "Sarah invited you to a design review tomorrow - haven't RSVPed yet"
-
-WHAT NOT TO DO:
-- Don't list what changed like a changelog
-- Don't say "X updated Y" repeatedly
-- Don't start every message with a greeting
-- Don't manufacture importance when things are calm
-- Don't repeat ANYTHING from previous pulses
-- Don't sound like a notification system
-
-READING CONTEXT:
-When you see content diffs, understand WHAT was written, not just that something changed. But you don't need to report every change - pick what's actually interesting or relevant.
-
-Keep it to 1-3 sentences. Sound like a person, not a bot.`;
 
 export async function POST(req: Request) {
   const auth = await authenticateRequestWithOptions(req, AUTH_OPTIONS);
@@ -543,109 +482,13 @@ export async function POST(req: Request) {
     // ========================================
     const endOfTomorrow = new Date(endOfToday.getTime() + 24 * 60 * 60 * 1000);
 
-    // Get events the user can see: personal events + drive events
-    const calendarVisibility = driveIds.length > 0
-      ? or(
-          and(isNull(calendarEvents.driveId), eq(calendarEvents.createdById, userId)),
-          inArray(calendarEvents.driveId, driveIds)
-        )
-      : and(isNull(calendarEvents.driveId), eq(calendarEvents.createdById, userId));
-
-    const upcomingCalendarEvents = await db
-      .select({
-        id: calendarEvents.id,
-        title: calendarEvents.title,
-        location: calendarEvents.location,
-        startAt: calendarEvents.startAt,
-        endAt: calendarEvents.endAt,
-        allDay: calendarEvents.allDay,
-        driveId: calendarEvents.driveId,
-      })
-      .from(calendarEvents)
-      .where(
-        and(
-          eq(calendarEvents.isTrashed, false),
-          gte(calendarEvents.endAt, now),
-          lt(calendarEvents.startAt, endOfTomorrow),
-          calendarVisibility
-        )
-      )
-      .orderBy(calendarEvents.startAt)
-      .limit(15);
-
-    // Get events user is invited to via attendees table
-    const attendeeEventRows = await db
-      .select({
-        id: calendarEvents.id,
-        title: calendarEvents.title,
-        location: calendarEvents.location,
-        startAt: calendarEvents.startAt,
-        endAt: calendarEvents.endAt,
-        allDay: calendarEvents.allDay,
-        driveId: calendarEvents.driveId,
-        rsvpStatus: eventAttendees.status,
-      })
-      .from(eventAttendees)
-      .innerJoin(calendarEvents, eq(calendarEvents.id, eventAttendees.eventId))
-      .where(
-        and(
-          eq(eventAttendees.userId, userId),
-          eq(calendarEvents.isTrashed, false),
-          gte(calendarEvents.endAt, now),
-          lt(calendarEvents.startAt, endOfTomorrow),
-        )
-      )
-      .orderBy(calendarEvents.startAt)
-      .limit(15);
-
-    // Pending RSVP invites (future events user hasn't responded to)
-    const pendingRsvps = await db
-      .select({
-        eventTitle: calendarEvents.title,
-        startAt: calendarEvents.startAt,
-        allDay: calendarEvents.allDay,
-      })
-      .from(eventAttendees)
-      .innerJoin(calendarEvents, eq(calendarEvents.id, eventAttendees.eventId))
-      .where(
-        and(
-          eq(eventAttendees.userId, userId),
-          eq(eventAttendees.status, 'PENDING'),
-          eq(calendarEvents.isTrashed, false),
-          gte(calendarEvents.startAt, now),
-        )
-      )
-      .orderBy(calendarEvents.startAt)
-      .limit(5);
-
-    // Merge and deduplicate events
-    const seenEventIds = new Set<string>();
-    const allCalendarEvents: Array<{
-      title: string;
-      location: string | null;
-      startAt: Date;
-      endAt: Date;
-      allDay: boolean;
-    }> = [];
-
-    for (const event of [...upcomingCalendarEvents, ...attendeeEventRows]) {
-      if (seenEventIds.has(event.id)) continue;
-      seenEventIds.add(event.id);
-      allCalendarEvents.push({
-        title: event.title,
-        location: event.location,
-        startAt: event.startAt,
-        endAt: event.endAt,
-        allDay: event.allDay,
-      });
-    }
-
-    allCalendarEvents.sort((a, b) => a.startAt.getTime() - b.startAt.getTime());
-
-    // Categorize events
-    const happeningNow = allCalendarEvents.filter(e => e.startAt <= now && e.endAt > now);
-    const upcomingToday = allCalendarEvents.filter(e => e.startAt > now && e.startAt < endOfToday);
-    const tomorrowEvents = allCalendarEvents.filter(e => e.startAt >= endOfToday && e.startAt < endOfTomorrow);
+    const calendarContext = await fetchCalendarContext({
+      userId, driveIds, now, endOfToday, endOfTomorrow,
+    });
+    const { happeningNow, upcomingToday } = calendarContext;
+    const tomorrowEvents = calendarContext.tomorrow;
+    const pendingRsvps = calendarContext.pendingInvites;
+    const allCalendarEvents = calendarContext.allEvents;
 
     // ========================================
     // BUILD THE RICH CONTEXT WITH DIFFS

--- a/apps/web/src/app/api/pulse/pulse-prompt.ts
+++ b/apps/web/src/app/api/pulse/pulse-prompt.ts
@@ -1,0 +1,58 @@
+export const PULSE_SYSTEM_PROMPT = `You're a thoughtful workspace companion - like a colleague who sits nearby and notices things. You have deep awareness of what's happening in the user's workspace, but you're NOT a status reporter.
+
+YOUR PERSONALITY:
+- Warm, observant, genuinely interested in the person
+- You notice patterns, not just events
+- You have opinions and make suggestions
+- Sometimes you're encouraging, sometimes you're gently prodding
+- You're comfortable with silence when there's nothing meaningful to say
+
+WHAT YOU HAVE ACCESS TO:
+You can see workspace activity, content diffs, messages, tasks, calendar events, and your previous conversations. Use this as CONTEXT to inform what you say - but don't just report it back.
+
+DEDUPLICATION - CRITICAL:
+Check "previousPulses" for what you've already said. NEVER repeat yourself. If you mentioned something before, it's old news - find something fresh or say something different entirely.
+
+TYPES OF MESSAGES YOU MIGHT SEND:
+
+1. OBSERVATIONS (notice patterns, not just events)
+   - "You've been heads-down on the API docs for a few days now - deep work mode?"
+   - "Looks like the team's been busy while you were away"
+   - "Sarah seems to be making good progress on that budget analysis"
+
+2. GENTLE NUDGES (helpful, not naggy)
+   - "That task from last week is still hanging around..."
+   - "Sarah's DM from yesterday might be worth a look"
+   - "The roadmap doc has some new stuff if you haven't seen it"
+
+3. ENCOURAGEMENT
+   - "Solid progress on the sprint this week"
+   - "The quiet is nice - good time to focus"
+   - "You knocked out 3 tasks yesterday, nice"
+
+4. QUESTIONS (genuine curiosity)
+   - "Ready to dive into those Q2 plans?"
+   - "How's the API migration going?"
+
+5. SIMPLE PRESENCE (when there's nothing specific)
+   - "All quiet. Enjoy the focus time."
+   - "Nothing urgent on the radar"
+   - Just a friendly check-in vibe
+
+6. CALENDAR AWARENESS (time-sensitive context)
+   - "You've got a team sync in an hour - might be a good time to prep"
+   - "Looks like a meeting-heavy afternoon ahead"
+   - "Sarah invited you to a design review tomorrow - haven't RSVPed yet"
+
+WHAT NOT TO DO:
+- Don't list what changed like a changelog
+- Don't say "X updated Y" repeatedly
+- Don't start every message with a greeting
+- Don't manufacture importance when things are calm
+- Don't repeat ANYTHING from previous pulses
+- Don't sound like a notification system
+
+READING CONTEXT:
+When you see content diffs, understand WHAT was written, not just that something changed. But you don't need to report every change - pick what's actually interesting or relevant.
+
+Keep it to 1-3 sentences. Sound like a person, not a bot.`;

--- a/apps/web/src/app/api/pulse/route.ts
+++ b/apps/web/src/app/api/pulse/route.ts
@@ -169,11 +169,17 @@ export async function GET(req: Request) {
       unreadCount = unreadResult?.count ?? 0;
     }
 
-    // Calendar events today
+    // Calendar events today - respect visibility settings
     const calendarVisibility = driveIds.length > 0
       ? or(
           and(isNull(calendarEvents.driveId), eq(calendarEvents.createdById, userId)),
-          inArray(calendarEvents.driveId, driveIds)
+          and(
+            inArray(calendarEvents.driveId, driveIds),
+            or(
+              eq(calendarEvents.visibility, 'DRIVE'),
+              eq(calendarEvents.createdById, userId)
+            )
+          )
         )
       : and(isNull(calendarEvents.driveId), eq(calendarEvents.createdById, userId));
 

--- a/packages/db/src/schema/dashboard.ts
+++ b/packages/db/src/schema/dashboard.ts
@@ -79,6 +79,13 @@ export const pulseSummaries = pgTable('pulse_summaries', {
       recentOperations: string[]; // Brief descriptions
     };
     chatHighlights?: string[]; // Relevant chat snippets
+    calendar?: {
+      happeningNow: number;
+      upcomingToday: number;
+      tomorrow: number;
+      pendingInvites: number;
+      events: { title: string; startAt: string }[];
+    };
   }>(),
 
   // AI generation metadata


### PR DESCRIPTION
Pulse now includes calendar event data when generating AI summaries,
enabling time-sensitive observations like upcoming meetings, events
in progress, and pending RSVP invitations.

Changes:
- Query calendarEvents and eventAttendees in both on-demand and cron
  generation routes to fetch events happening now, upcoming today,
  and tomorrow
- Include pending RSVP invitations as context for gentle nudges
- Add calendar section to AI context data with categorized events
- Update system prompt with calendar awareness message type examples
- Add calendar stats (upcomingToday, pendingInvites) to GET /api/pulse
  response for real-time stat display
- Update PulseResponse type to include calendar stats

https://claude.ai/code/session_01X2zYjFPfB2Ha2k6HRYb2FT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pulse now provides calendar-aware insights by incorporating upcoming calendar events.
  * Events happening now, later today, and tomorrow are integrated into pulse content to improve relevance.
  * Pulse summaries now surface calendar statistics (upcoming today, pending RSVPs) and include a small sample of events.
  * Calendar visibility respects personal and shared drive permissions when showing events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->