### PR TITLE
Fix dashboard context detection for full-page routes

### DIFF
--- a/apps/web/src/hooks/__tests__/useDashboardContext.test.ts
+++ b/apps/web/src/hooks/__tests__/useDashboardContext.test.ts
@@ -108,6 +108,67 @@ describe('useDashboardContext', () => {
   });
 
   // ============================================
+  // Full-page routes (isDashboardContext = false)
+  // ============================================
+  describe('full-page routes (false)', () => {
+    it('should return false for /dashboard/calendar', () => {
+      vi.mocked(useParams).mockReturnValue({});
+      vi.mocked(usePathname).mockReturnValue('/dashboard/calendar');
+
+      const { result } = renderHook(() => useDashboardContext());
+      expect(result.current.isDashboardContext).toBe(false);
+    });
+
+    it('should return false for /dashboard/tasks', () => {
+      vi.mocked(useParams).mockReturnValue({});
+      vi.mocked(usePathname).mockReturnValue('/dashboard/tasks');
+
+      const { result } = renderHook(() => useDashboardContext());
+      expect(result.current.isDashboardContext).toBe(false);
+    });
+
+    it('should return false for /dashboard/inbox', () => {
+      vi.mocked(useParams).mockReturnValue({});
+      vi.mocked(usePathname).mockReturnValue('/dashboard/inbox');
+
+      const { result } = renderHook(() => useDashboardContext());
+      expect(result.current.isDashboardContext).toBe(false);
+    });
+
+    it('should return false for drive-level calendar /dashboard/[driveId]/calendar', () => {
+      vi.mocked(useParams).mockReturnValue({ driveId: 'drive-123' });
+      vi.mocked(usePathname).mockReturnValue('/dashboard/drive-123/calendar');
+
+      const { result } = renderHook(() => useDashboardContext());
+      expect(result.current.isDashboardContext).toBe(false);
+    });
+
+    it('should return false for drive-level tasks /dashboard/[driveId]/tasks', () => {
+      vi.mocked(useParams).mockReturnValue({ driveId: 'drive-123' });
+      vi.mocked(usePathname).mockReturnValue('/dashboard/drive-123/tasks');
+
+      const { result } = renderHook(() => useDashboardContext());
+      expect(result.current.isDashboardContext).toBe(false);
+    });
+
+    it('should return false for drive-level inbox /dashboard/[driveId]/inbox', () => {
+      vi.mocked(useParams).mockReturnValue({ driveId: 'drive-123' });
+      vi.mocked(usePathname).mockReturnValue('/dashboard/drive-123/inbox');
+
+      const { result } = renderHook(() => useDashboardContext());
+      expect(result.current.isDashboardContext).toBe(false);
+    });
+
+    it('should return false for nested inbox route /dashboard/inbox/dm/[conversationId]', () => {
+      vi.mocked(useParams).mockReturnValue({ conversationId: 'conv-789' });
+      vi.mocked(usePathname).mockReturnValue('/dashboard/inbox/dm/conv-789');
+
+      const { result } = renderHook(() => useDashboardContext());
+      expect(result.current.isDashboardContext).toBe(false);
+    });
+  });
+
+  // ============================================
   // Edge Cases
   // ============================================
   describe('edge cases', () => {

--- a/apps/web/src/hooks/useDashboardContext.ts
+++ b/apps/web/src/hooks/useDashboardContext.ts
@@ -2,6 +2,10 @@
 
 import { useParams, usePathname } from 'next/navigation';
 
+// Full-page routes that render their own content in the center panel
+// (no GlobalAssistantView). The sidebar should show the chat tab for these.
+const FULL_PAGE_ROUTE_PATTERN = /\/(calendar|tasks|inbox)(\/|$)/;
+
 /**
  * Hook to detect if we're on a "dashboard context" where GlobalAssistantView
  * is displayed in the middle panel.
@@ -13,15 +17,22 @@ import { useParams, usePathname } from 'next/navigation';
  * NOT dashboard context:
  * - /dashboard/[driveId]/[pageId] (viewing a specific page)
  * - /dashboard/[driveId]/settings (settings pages)
+ * - /dashboard/calendar, /dashboard/tasks, /dashboard/inbox (full-page routes)
+ * - /dashboard/[driveId]/calendar, etc. (drive-level full-page routes)
  */
 export function useDashboardContext() {
   const params = useParams();
   const pathname = usePathname();
 
-  // Dashboard context = no pageId in params and not on special settings routes
+  // Full-page routes render their own content (no GlobalAssistantView),
+  // so the sidebar should show the chat tab independently
+  const isFullPageRoute = FULL_PAGE_ROUTE_PATTERN.test(pathname || '');
+
+  // Dashboard context = no pageId in params, not on special routes, not on full-page routes
   const isDashboardContext = !params.pageId &&
     !pathname.endsWith('/settings') &&
-    !pathname.endsWith('/settings/mcp');
+    !pathname.endsWith('/settings/mcp') &&
+    !isFullPageRoute;
 
   return { isDashboardContext };
 }


### PR DESCRIPTION
## Summary
Updated the `useDashboardContext` hook to correctly identify full-page routes (calendar, tasks, inbox) as non-dashboard contexts. These routes render their own content in the center panel without the GlobalAssistantView, so the sidebar should independently display the chat tab.

## Changes
- Added `FULL_PAGE_ROUTE_PATTERN` regex to identify calendar, tasks, and inbox routes at both global and drive levels
- Updated `isDashboardContext` logic to return `false` for full-page routes
- Added comprehensive test coverage for all full-page route variations:
  - Global routes: `/dashboard/calendar`, `/dashboard/tasks`, `/dashboard/inbox`
  - Drive-level routes: `/dashboard/[driveId]/calendar`, etc.
  - Nested routes: `/dashboard/inbox/dm/[conversationId]`

## Implementation Details
The regex pattern `/\/(calendar|tasks|inbox)(\/|$)/` matches these routes at any nesting level, ensuring the sidebar chat tab is displayed independently when users navigate to these full-page views. This prevents the GlobalAssistantView from being rendered in the center panel where these routes need to display their own content.

https://claude.ai/code/session_014W6Wzoq7q2oW5HvWf9ubiP