### PR TITLE
Fix right sidebar persistence on iPad landscape mode

### DIFF
--- a/apps/web/src/components/layout/Layout.tsx
+++ b/apps/web/src/components/layout/Layout.tsx
@@ -60,11 +60,11 @@ function Layout({ children }: LayoutProps) {
   const shouldOverlaySidebarsDefault = useBreakpoint("(max-width: 1279px)");
   const { isTablet } = useDeviceTier();
 
-  // On tablet (iPad), the left sidebar becomes persistent at 1024px+ (landscape)
-  // instead of 1280px+, giving iPad a persistent navigation sidebar while keeping
-  // all other views mobile-optimized (handled by useMobile() returning true for tablets).
+  // On tablet (iPad), both sidebars become persistent at 1024px+ (landscape)
+  // instead of 1280px+, giving iPad persistent navigation and assistant sidebars
+  // while keeping all other views mobile-optimized (handled by useMobile() returning true for tablets).
   const shouldOverlayLeftSidebar = isTablet ? isSheetBreakpoint : shouldOverlaySidebarsDefault;
-  const shouldOverlayRightSidebar = shouldOverlaySidebarsDefault;
+  const shouldOverlayRightSidebar = isTablet ? isSheetBreakpoint : shouldOverlaySidebarsDefault;
 
   useResponsivePanels();
 
@@ -151,13 +151,12 @@ function Layout({ children }: LayoutProps) {
       return;
     }
 
-    // Right sidebar is in overlay mode: toggle with exclusive logic
+    // Right sidebar is in overlay mode (desktop 1024-1279px): exclusive toggle
     if (shouldOverlayRightSidebar) {
       if (rightSidebarOpen) {
         setRightSidebarOpen(false);
       } else {
         // Only close left sidebar if left is also in overlay mode
-        // (On iPad, left sidebar is persistent so we don't close it)
         if (shouldOverlayLeftSidebar && leftSidebarOpen) {
           setLeftSidebarOpen(false);
         }
@@ -166,7 +165,7 @@ function Layout({ children }: LayoutProps) {
       return;
     }
 
-    // Right sidebar is in persistent mode (>=1280px on all platforms)
+    // Right sidebar is in persistent mode (>=1280px, or iPad >=1024px)
     toggleRightSidebar();
   }, [
     isSheetBreakpoint,
@@ -284,8 +283,13 @@ function Layout({ children }: LayoutProps) {
             )}
           </main>
 
-          {!shouldOverlayRightSidebar && rightSidebarOpen && (
-            <div className="relative hidden flex-shrink-0 xl:flex xl:w-[18rem] 2xl:w-80 pt-4 overflow-hidden">
+          {!shouldOverlayRightSidebar && !isSheetBreakpoint && rightSidebarOpen && (
+            <div className={cn(
+              "relative flex-shrink-0 pt-4 overflow-hidden",
+              isTablet
+                ? "flex w-[18rem]"
+                : "hidden xl:flex xl:w-[18rem] 2xl:w-80"
+            )}>
               <RightPanel className="h-full w-full" />
             </div>
           )}


### PR DESCRIPTION
## Summary
This PR fixes the right sidebar (assistant panel) behavior on iPad landscape mode to be persistent at 1024px+, matching the left sidebar behavior. Previously, the right sidebar would only become persistent at 1280px+ on all platforms, creating an inconsistent experience on iPad.

## Key Changes
- Updated `shouldOverlayRightSidebar` logic to use the tablet-specific breakpoint (`isSheetBreakpoint`) when on iPad, making it persistent at 1024px+ in landscape mode
- Updated comments to reflect that both sidebars are now persistent on iPad at 1024px+
- Simplified the right sidebar toggle logic by removing the now-redundant comment about iPad left sidebar persistence
- Fixed the right sidebar render condition to properly handle the tablet persistent state by adding `!isSheetBreakpoint` check and applying responsive classes based on device tier

## Implementation Details
- The right sidebar now respects the same tablet breakpoint logic as the left sidebar
- On iPad landscape (1024px+): both sidebars are persistent
- On desktop (1024-1279px): both sidebars are in overlay mode
- On desktop (1280px+): both sidebars are persistent
- The render logic now conditionally applies Tailwind classes (`hidden xl:flex` vs `flex`) based on whether the device is a tablet, ensuring proper display in persistent mode

https://claude.ai/code/session_016yT6CmMAp7za8dpRJ6JKp2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsive sidebar behavior on tablets to ensure both sidebars remain accessible in landscape orientation (1024px+).
  * Enhanced sidebar persistence and overlay logic for consistent display behavior across tablet and desktop layouts.
  * Optimized responsive breakpoint handling for better visual consistency across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->