### PR TITLE
Fix TabBar visibility on iPad by distinguishing tablet devices

### DIFF
--- a/apps/web/src/components/layout/tabs/TabBar.tsx
+++ b/apps/web/src/components/layout/tabs/TabBar.tsx
@@ -20,6 +20,7 @@ import {
 import { Plus } from 'lucide-react';
 import { useTabsStore, selectHasMultipleTabs } from '@/stores/useTabsStore';
 import { useBreakpoint } from '@/hooks/useBreakpoint';
+import { useIsTablet } from '@/hooks/useDeviceTier';
 import { TabItem } from './TabItem';
 import { cn } from '@/lib/utils';
 import { getEffectiveBinding, matchesKeyEvent } from '@/stores/useHotkeyStore';
@@ -32,7 +33,8 @@ export const TabBar = memo(function TabBar({ className }: TabBarProps) {
   const router = useRouter();
   const params = useParams();
   const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const isMobile = useBreakpoint('(max-width: 1023px)');
+  const isSmallViewport = useBreakpoint('(max-width: 1023px)');
+  const isTablet = useIsTablet();
 
   const tabs = useTabsStore((state) => state.tabs);
   const activeTabId = useTabsStore((state) => state.activeTabId);
@@ -181,8 +183,8 @@ export const TabBar = memo(function TabBar({ className }: TabBarProps) {
     }
   }, [activeTabId]);
 
-  // Auto-hide on mobile or when 0 or 1 tabs
-  if (isMobile || !hasMultipleTabs) {
+  // Auto-hide on mobile phones or when 0 or 1 tabs (iPad keeps the tab bar)
+  if ((isSmallViewport && !isTablet) || !hasMultipleTabs) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
Updated the TabBar auto-hide logic to properly handle iPad and other tablet devices. Previously, the TabBar would hide on all devices with viewports ≤1023px, but now it correctly distinguishes between mobile phones and tablets, keeping the TabBar visible on tablets while hiding it on phones.

## Changes
- Imported `useIsTablet` hook from `@/hooks/useDeviceTier` to detect tablet devices
- Renamed `isMobile` variable to `isSmallViewport` for clarity, as it now represents viewport size rather than device type
- Updated the auto-hide condition from `isMobile || !hasMultipleTabs` to `(isSmallViewport && !isTablet) || !hasMultipleTabs`
- Updated the comment to clarify that the TabBar hides on mobile phones specifically, while iPads retain the tab bar

## Implementation Details
The fix uses a two-part check: the TabBar now only hides when both conditions are met:
1. The viewport is small (≤1023px), AND
2. The device is NOT a tablet

This allows tablets like iPad to maintain the TabBar for better usability, while phones still hide it to save screen space.

https://claude.ai/code/session_01GA9GG1NndAhutYhzpmEFR3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TabBar visibility on tablet devices to ensure the navigation bar remains accessible even on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->