### PR TITLE
codex/fix cold start swr page tree

### DIFF
--- a/apps/web/src/stores/__tests__/useAuthStore.test.ts
+++ b/apps/web/src/stores/__tests__/useAuthStore.test.ts
@@ -813,6 +813,18 @@ describe('authStoreHelpers', () => {
       expect(authStoreHelpers.needsAuthCheck()).toBe(false);
     });
 
+    it('given initialized unauthenticated state with failed attempt, should return true', () => {
+      useAuthStore.setState({
+        lastAuthCheck: null,
+        _serverSessionInitialized: true,
+        isAuthenticated: false,
+        lastFailedAuthCheck: Date.now(),
+        authFailedPermanently: false,
+      });
+
+      expect(authStoreHelpers.needsAuthCheck()).toBe(true);
+    });
+
     it('given recent auth check, should return false', () => {
       useAuthStore.setState({ lastAuthCheck: Date.now() - 1000 }); // 1 second ago
 
@@ -939,6 +951,19 @@ describe('authStoreHelpers', () => {
       });
 
       expect(authStoreHelpers.shouldLoadSession()).toBe(false);
+    });
+
+    it('given server initialized unauthenticated with failed attempt, should return true', () => {
+      useAuthStore.setState({
+        hasHydrated: true,
+        _serverSessionInitialized: true,
+        isAuthenticated: false,
+        lastAuthCheck: null,
+        lastFailedAuthCheck: Date.now(),
+        authFailedPermanently: false,
+      });
+
+      expect(authStoreHelpers.shouldLoadSession()).toBe(true);
     });
   });
 

--- a/apps/web/src/stores/useAuthStore.ts
+++ b/apps/web/src/stores/useAuthStore.ts
@@ -598,6 +598,10 @@ export const authStoreHelpers = {
       // After this boot has already performed an auth load and determined no active session,
       // avoid re-checking on every component mount.
       if (state._serverSessionInitialized && !state.isAuthenticated) {
+        // If the last attempt failed transiently, allow another retry on subsequent mounts.
+        if (state.lastFailedAuthCheck && !state.authFailedPermanently) {
+          return true;
+        }
         return false;
       }
       return true;


### PR DESCRIPTION
- **[web] Fix cold-start page tree SWR deadlock**
- **[web] Prevent auth loading race across useAuth mounts**
- **[web] Handle useAuth initial loadSession rejection**
- **[web] fix cold-start auth revalidation and stable tree updater**
- **[web] fix auth promise publication race**
- **[web] fix auth promise race test assertion**
- **[web] stabilize overlapping auth promise test**
- **[web] stop repeated auth checks on mount**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented redundant authentication checks on startup by recognizing when a server session has already been initialized, reducing unnecessary network calls and improving startup responsiveness.
  * Adjusted retry behavior so transient auth failures can be retried while avoiding repeated checks after a confirmed unauthenticated server state.

* **Tests**
  * Expanded test coverage for session initialization and various authentication states to ensure correct startup and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->