### PR TITLE
[web] add channel-aware read/send tool call rendering

### DIFF
--- a/apps/web/src/components/ai/shared/chat/tool-calls/CompactToolCallRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/CompactToolCallRenderer.tsx
@@ -16,7 +16,8 @@ import {
   AlertCircle,
   Loader2,
   Clock,
-  Bot
+  Bot,
+  MessageSquare
 } from 'lucide-react';
 
 import { PageTreeRenderer, type TreeItem } from './PageTreeRenderer';
@@ -66,6 +67,53 @@ const safeJsonParse = (value: unknown): Record<string, unknown> | null => {
   return null;
 };
 
+const buildChannelTranscript = (channelMessages: unknown): string | null => {
+  if (!Array.isArray(channelMessages) || channelMessages.length === 0) {
+    return null;
+  }
+
+  const lines = channelMessages.flatMap((entry, index) => {
+    if (typeof entry !== 'object' || entry === null) {
+      return [];
+    }
+
+    const message = entry as Record<string, unknown>;
+    const lineNumber = typeof message.lineNumber === 'number' ? message.lineNumber : index + 1;
+    const createdAt = typeof message.createdAt === 'string' ? message.createdAt : '';
+    const senderName = typeof message.senderName === 'string' ? message.senderName : 'Unknown';
+    const senderType = typeof message.senderType === 'string' ? message.senderType : 'user';
+    const content = typeof message.content === 'string' ? message.content : '';
+
+    const senderPrefix = senderType === 'agent'
+      ? '[agent]'
+      : senderType === 'global_assistant'
+        ? '[assistant]'
+        : '[user]';
+
+    const timestamp = createdAt ? ` (${createdAt})` : '';
+    return [`${lineNumber}→${senderPrefix} ${senderName}${timestamp}: ${content}`];
+  });
+
+  return lines.length > 0 ? lines.join('\n') : null;
+};
+
+const getSendChannelMessagePreview = (
+  parsedInput: Record<string, unknown> | null,
+  parsedOutput: Record<string, unknown>
+): string | null => {
+  const outputPreview = parsedOutput.messagePreview;
+  if (typeof outputPreview === 'string' && outputPreview.trim().length > 0) {
+    return outputPreview.trim();
+  }
+
+  const inputContent = parsedInput?.content;
+  if (typeof inputContent === 'string' && inputContent.trim().length > 0) {
+    return inputContent.trim();
+  }
+
+  return null;
+};
+
 // Tool name mapping (moved outside component to avoid recreation)
 const TOOL_NAME_MAP: Record<string, string> = {
   'ask_agent': 'Ask Agent',
@@ -75,6 +123,7 @@ const TOOL_NAME_MAP: Record<string, string> = {
   'replace_lines': 'Replace',
   'create_page': 'Create',
   'rename_page': 'Rename',
+  'send_channel_message': 'Send Message',
   'trash': 'Trash',
   'restore': 'Restore',
   'move_page': 'Move',
@@ -108,6 +157,8 @@ const CompactToolCallRendererInternal: React.FC<{ part: ToolPart; toolName: stri
         return <FolderOpen className={iconClass} />;
       case 'read_page':
         return <Eye className={iconClass} />;
+      case 'send_channel_message':
+        return <MessageSquare className={iconClass} />;
       case 'replace_lines':
         return <Edit className={iconClass} />;
       case 'create_page':
@@ -227,6 +278,13 @@ const CompactToolCallRendererInternal: React.FC<{ part: ToolPart; toolName: stri
         return title.length > 20 ? title.substring(0, 17) + '...' : title;
       }
 
+      if (toolName === 'send_channel_message') {
+        const preview = getSendChannelMessagePreview(parsedInput, result);
+        if (preview) {
+          return preview.length > 30 ? preview.substring(0, 27) + '...' : preview;
+        }
+      }
+
       if (result.message) {
         const msg = result.message as string;
         return msg.length > 30 ? msg.substring(0, 27) + '...' : msg;
@@ -245,7 +303,7 @@ const CompactToolCallRendererInternal: React.FC<{ part: ToolPart; toolName: stri
     }
 
     return 'Pending';
-  }, [error, state, parsedOutput, toolName]);
+  }, [error, state, parsedInput, parsedOutput, toolName]);
 
   // Memoize rich content for expanded view
   const richContent = useMemo((): React.ReactNode | null => {
@@ -314,16 +372,26 @@ const CompactToolCallRendererInternal: React.FC<{ part: ToolPart; toolName: stri
       );
     }
 
-    if (toolName === 'read_page' && (result.rawContent != null || result.content != null)) {
-      return (
-        <RichContentRenderer
-          title={(result.title as string) || 'Document'}
-          content={(result.rawContent ?? result.content) as string}
-          pageId={result.pageId as string | undefined}
-          pageType={result.type as string | undefined}
-          maxHeight={200}
-        />
-      );
+    if (toolName === 'read_page') {
+      const directContentValue = result.rawContent ?? result.content;
+      const directContent = typeof directContentValue === 'string' && directContentValue.length > 0
+        ? directContentValue
+        : undefined;
+      const channelTranscript = buildChannelTranscript(result.channelMessages);
+      const hasChannelMessagesArray = Array.isArray(result.channelMessages);
+      const content = directContent ?? channelTranscript ?? (hasChannelMessagesArray ? 'Channel has no messages yet.' : undefined);
+
+      if (content !== undefined) {
+        return (
+          <RichContentRenderer
+            title={(result.title as string) || 'Document'}
+            content={content}
+            pageId={result.pageId as string | undefined}
+            pageType={result.type as string | undefined}
+            maxHeight={200}
+          />
+        );
+      }
     }
 
     if (toolName === 'list_conversations' && result.conversations != null) {
@@ -478,6 +546,38 @@ const CompactToolCallRendererInternal: React.FC<{ part: ToolPart; toolName: stri
           message={(result.summary as string | undefined) || `${(result.updatedCount as number | undefined) || 0} cells updated`}
           errorMessage={result.error as string | undefined}
         />
+      );
+    }
+
+    // === CHANNEL TOOLS ===
+    if (toolName === 'send_channel_message') {
+      const messagePreview = getSendChannelMessagePreview(parsedInput, result);
+      const channelTitle = result.channelTitle;
+      const previewTitle = typeof channelTitle === 'string' && channelTitle.length > 0
+        ? `Message Preview · #${channelTitle}`
+        : 'Message Preview';
+
+      return (
+        <div>
+          <ActionResultRenderer
+            actionType="update"
+            success={result.success !== false}
+            title={channelTitle as string | undefined}
+            pageId={result.channelId as string | undefined}
+            pageType="CHANNEL"
+            message={(result.summary || result.message) as string | undefined}
+            errorMessage={result.error as string | undefined}
+          />
+          {messagePreview && (
+            <RichContentRenderer
+              title={previewTitle}
+              content={messagePreview}
+              pageId={result.channelId as string | undefined}
+              pageType="CHANNEL"
+              maxHeight={160}
+            />
+          )}
+        </div>
       );
     }
 

--- a/apps/web/src/components/ai/shared/chat/tool-calls/ToolCallRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/ToolCallRenderer.tsx
@@ -46,6 +46,53 @@ const safeJsonParse = (value: unknown): Record<string, unknown> | null => {
   return null;
 };
 
+const buildChannelTranscript = (channelMessages: unknown): string | null => {
+  if (!Array.isArray(channelMessages) || channelMessages.length === 0) {
+    return null;
+  }
+
+  const lines = channelMessages.flatMap((entry, index) => {
+    if (typeof entry !== 'object' || entry === null) {
+      return [];
+    }
+
+    const message = entry as Record<string, unknown>;
+    const lineNumber = typeof message.lineNumber === 'number' ? message.lineNumber : index + 1;
+    const createdAt = typeof message.createdAt === 'string' ? message.createdAt : '';
+    const senderName = typeof message.senderName === 'string' ? message.senderName : 'Unknown';
+    const senderType = typeof message.senderType === 'string' ? message.senderType : 'user';
+    const content = typeof message.content === 'string' ? message.content : '';
+
+    const senderPrefix = senderType === 'agent'
+      ? '[agent]'
+      : senderType === 'global_assistant'
+        ? '[assistant]'
+        : '[user]';
+
+    const timestamp = createdAt ? ` (${createdAt})` : '';
+    return [`${lineNumber}→${senderPrefix} ${senderName}${timestamp}: ${content}`];
+  });
+
+  return lines.length > 0 ? lines.join('\n') : null;
+};
+
+const getSendChannelMessagePreview = (
+  parsedInput: Record<string, unknown> | null,
+  parsedOutput: Record<string, unknown>
+): string | null => {
+  const outputPreview = parsedOutput.messagePreview;
+  if (typeof outputPreview === 'string' && outputPreview.trim().length > 0) {
+    return outputPreview.trim();
+  }
+
+  const inputContent = parsedInput?.content;
+  if (typeof inputContent === 'string' && inputContent.trim().length > 0) {
+    return inputContent.trim();
+  }
+
+  return null;
+};
+
 // Helper to parse list_pages paths format into tree structure
 // Path format: "📁 [FOLDER](Task) ID: xxx Path: /drive/folder"
 const parsePathsToTree = (paths: string[], _driveId?: string): TreeItem[] => {
@@ -138,6 +185,7 @@ const TOOL_NAME_MAP: Record<string, string> = {
   'list_trash': 'Trash',
   'list_conversations': 'Conversations',
   'read_conversation': 'Conversation',
+  'send_channel_message': 'Send Message',
   // Page write tools
   'replace_lines': 'Edit Document',
   'create_page': 'Create Page',
@@ -317,15 +365,25 @@ const ToolCallRendererInternal: React.FC<{ part: ToolPart; toolName: string }> =
       );
     }
 
-    if (toolName === 'read_page' && (parsedOutput.rawContent || parsedOutput.content)) {
-      return (
-        <RichContentRenderer
-          title={(parsedOutput.title as string | undefined) || 'Document'}
-          content={(parsedOutput.rawContent || parsedOutput.content) as string}
-          pageId={parsedOutput.pageId as string | undefined}
-          pageType={parsedOutput.type as string | undefined}
-        />
-      );
+    if (toolName === 'read_page') {
+      const directContentValue = parsedOutput.rawContent ?? parsedOutput.content;
+      const directContent = typeof directContentValue === 'string' && directContentValue.length > 0
+        ? directContentValue
+        : undefined;
+      const channelTranscript = buildChannelTranscript(parsedOutput.channelMessages);
+      const hasChannelMessagesArray = Array.isArray(parsedOutput.channelMessages);
+      const content = directContent ?? channelTranscript ?? (hasChannelMessagesArray ? 'Channel has no messages yet.' : undefined);
+
+      if (content !== undefined) {
+        return (
+          <RichContentRenderer
+            title={(parsedOutput.title as string | undefined) || 'Document'}
+            content={content}
+            pageId={parsedOutput.pageId as string | undefined}
+            pageType={parsedOutput.type as string | undefined}
+          />
+        );
+      }
     }
 
     if (toolName === 'list_conversations' && parsedOutput.conversations) {
@@ -476,6 +534,38 @@ const ToolCallRendererInternal: React.FC<{ part: ToolPart; toolName: string }> =
           message={(parsedOutput.summary as string | undefined) || `${(parsedOutput.updatedCount as number | undefined) || 0} cells updated`}
           errorMessage={parsedOutput.error as string | undefined}
         />
+      );
+    }
+
+    // === CHANNEL TOOLS ===
+    if (toolName === 'send_channel_message') {
+      const messagePreview = getSendChannelMessagePreview(parsedInput, parsedOutput);
+      const channelTitle = parsedOutput.channelTitle;
+      const previewTitle = typeof channelTitle === 'string' && channelTitle.length > 0
+        ? `Message Preview · #${channelTitle}`
+        : 'Message Preview';
+
+      return (
+        <div>
+          <ActionResultRenderer
+            actionType="update"
+            success={parsedOutput.success !== false}
+            title={channelTitle as string | undefined}
+            pageId={parsedOutput.channelId as string | undefined}
+            pageType="CHANNEL"
+            message={(parsedOutput.summary || parsedOutput.message) as string | undefined}
+            errorMessage={parsedOutput.error as string | undefined}
+          />
+          {messagePreview && (
+            <RichContentRenderer
+              title={previewTitle}
+              content={messagePreview}
+              pageId={parsedOutput.channelId as string | undefined}
+              pageType="CHANNEL"
+              maxHeight={220}
+            />
+          )}
+        </div>
       );
     }
 

--- a/apps/web/src/lib/ai/tools/__tests__/channel-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/channel-tools.test.ts
@@ -223,6 +223,7 @@ describe('channel-tools', () => {
       expect(result.success).toBe(true);
       expect(result.senderName).toBe('Alice');
       expect(result.senderType).toBe('global_assistant');
+      expect(result.messagePreview).toBe('Hello from assistant');
     });
 
     it('sends message as page agent with agent title', async () => {

--- a/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
@@ -15,11 +15,17 @@ vi.mock('@pagespace/db', () => ({
       drives: { findFirst: vi.fn() },
       taskItems: { findFirst: vi.fn() },
       chatMessages: { findFirst: vi.fn() },
+      channelMessages: { findMany: vi.fn() },
     },
   },
   pages: { id: 'id', driveId: 'driveId', type: 'type', isTrashed: 'isTrashed' },
   drives: { id: 'id' },
   taskItems: { pageId: 'pageId' },
+  channelMessages: {
+    pageId: 'pageId',
+    isActive: 'isActive',
+    createdAt: 'createdAt',
+  },
   chatMessages: {
     id: 'id',
     pageId: 'pageId',
@@ -168,6 +174,65 @@ describe('page-read-tools', () => {
           context
         )
       ).rejects.toThrow('Page with ID "non-existent" not found');
+    });
+
+    it('returns channel messages when reading a CHANNEL page', async () => {
+      mockDb.query.pages.findFirst = vi.fn().mockResolvedValue(createMockPage('', 'CHANNEL'));
+      mockDb.query.taskItems = { findFirst: vi.fn().mockResolvedValue(null) } as unknown as typeof mockDb.query.taskItems;
+      mockDb.query.channelMessages = {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: 'msg-1',
+            content: 'First channel message',
+            createdAt: new Date('2025-01-15T10:00:00.000Z'),
+            userId: 'user-1',
+            aiMeta: null,
+            user: { id: 'user-1', name: 'Alice' },
+          },
+          {
+            id: 'msg-2',
+            content: 'AI follow-up',
+            createdAt: new Date('2025-01-15T10:05:00.000Z'),
+            userId: 'user-2',
+            aiMeta: { senderType: 'global_assistant', senderName: 'Assistant' },
+            user: { id: 'user-2', name: 'Bob' },
+          },
+        ]),
+      } as unknown as typeof mockDb.query.channelMessages;
+      mockGetUserAccessLevel.mockResolvedValue(createMockAccessLevel('editor'));
+
+      const result = await pageReadTools.read_page.execute!(
+        { title: 'General', pageId: 'page-1' },
+        createAuthContext()
+      );
+
+      assert({
+        given: 'a CHANNEL page with two messages',
+        should: 'return success',
+        actual: (result as { success: boolean }).success,
+        expected: true,
+      });
+
+      assert({
+        given: 'a CHANNEL page',
+        should: 'return messageCount for messages read',
+        actual: (result as { messageCount: number }).messageCount,
+        expected: 2,
+      });
+
+      assert({
+        given: 'channel output',
+        should: 'include formatted assistant attribution in transcript',
+        actual: (result as { content: string }).content.includes('[assistant] Assistant'),
+        expected: true,
+      });
+
+      assert({
+        given: 'channel output',
+        should: 'include structured channelMessages array',
+        actual: Array.isArray((result as { channelMessages: unknown[] }).channelMessages),
+        expected: true,
+      });
     });
 
     describe('line range support', () => {

--- a/apps/web/src/lib/ai/tools/channel-tools.ts
+++ b/apps/web/src/lib/ai/tools/channel-tools.ts
@@ -237,6 +237,7 @@ export const channelTools = {
           channelTitle: channel.title,
           senderName: senderIdentity.senderName,
           senderType: senderIdentity.senderType,
+          messagePreview: content.trim(),
           message: `Successfully sent message to channel "${channel.title}"`,
           summary: `Posted to #${channel.title} as ${senderIdentity.senderName} (${senderIdentity.senderType === 'global_assistant' ? 'global assistant' : 'agent'})`,
         };

--- a/apps/web/src/lib/ai/tools/page-read-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-read-tools.ts
@@ -1,6 +1,6 @@
 import { tool } from 'ai';
 import { z } from 'zod';
-import { db, pages, taskItems, taskLists, chatMessages, eq, and, asc, isNotNull, count, max, min, inArray } from '@pagespace/db';
+import { db, pages, taskItems, taskLists, chatMessages, channelMessages, eq, and, asc, isNotNull, count, max, min, inArray } from '@pagespace/db';
 import { buildTree, getUserAccessLevel, getUserDriveAccess, getUserAccessiblePagesInDriveWithDetails, getPageTypeEmoji, isFolderPage, PageType } from '@pagespace/lib/server';
 import { type ToolExecutionContext, getSuggestedVisionModels } from '../core';
 import { addLineBreaksForAI } from '@/lib/editor/line-breaks';
@@ -91,7 +91,7 @@ export const pageReadTools = {
    * Read existing documents to understand context and content
    */
   read_page: tool({
-    description: 'Read the content of any page (document, AI chat, channel, etc.) using its ID. Returns content with line numbers. Use lineStart/lineEnd to read specific line ranges.',
+    description: 'Read the content of any page (document, AI chat, channel, etc.) using its ID. Returns content with line numbers. For CHANNEL pages, returns a message transcript. Use lineStart/lineEnd to read specific line ranges.',
     inputSchema: z.object({
       title: z.string().describe('The document title for display context'),
       pageId: z.string().describe('The unique ID of the page to read'),
@@ -298,6 +298,192 @@ export const pageReadTools = {
           return {
             success: false,
             error: `Invalid line range: lineStart (${lineStart}) cannot be greater than lineEnd (${lineEnd})`,
+          };
+        }
+
+        // Handle CHANNEL pages - return message transcript (lineStart/lineEnd map to message numbers)
+        if (page.type === 'CHANNEL') {
+          const messages = await db.query.channelMessages.findMany({
+            where: and(
+              eq(channelMessages.pageId, page.id),
+              eq(channelMessages.isActive, true)
+            ),
+            with: {
+              user: {
+                columns: {
+                  id: true,
+                  name: true,
+                },
+              },
+            },
+            orderBy: [asc(channelMessages.createdAt)],
+          });
+
+          const totalMessages = messages.length;
+          const isRangeRequest = lineStart !== undefined || lineEnd !== undefined;
+
+          const extractMessageText = (content: string): string => {
+            try {
+              const parsed = JSON.parse(content) as {
+                originalContent?: unknown;
+                parts?: Array<{ type?: string; text?: string }>;
+                textParts?: string[];
+              };
+
+              if (typeof parsed.originalContent === 'string') {
+                return parsed.originalContent;
+              }
+
+              if (Array.isArray(parsed.parts)) {
+                const textParts = parsed.parts
+                  .filter(part => part?.type === 'text' && typeof part.text === 'string')
+                  .map(part => part.text as string);
+                if (textParts.length > 0) {
+                  return textParts.join('\n');
+                }
+              }
+
+              if (Array.isArray(parsed.textParts)) {
+                return parsed.textParts.join('\n');
+              }
+            } catch {
+              // Fall through and return raw content
+            }
+
+            return content;
+          };
+
+          const getSenderInfo = (message: typeof messages[number]) => {
+            const senderName = message.aiMeta?.senderName || message.user?.name || 'Unknown';
+
+            if (message.aiMeta?.senderType === 'agent') {
+              return { senderType: 'agent' as const, senderName, prefix: '[agent]' };
+            }
+
+            if (message.aiMeta?.senderType === 'global_assistant') {
+              return { senderType: 'global_assistant' as const, senderName, prefix: '[assistant]' };
+            }
+
+            return { senderType: 'user' as const, senderName, prefix: '[user]' };
+          };
+
+          if (totalMessages === 0) {
+            return {
+              success: true,
+              pageId: page.id,
+              title: page.title,
+              type: page.type,
+              contentMode: page.contentMode || 'html',
+              isTaskLinked,
+              content: '',
+              rawContent: '',
+              lineCount: 0,
+              totalLines: 0,
+              messageCount: 0,
+              totalMessages: 0,
+              channelMessages: [],
+              summary: `Channel "${page.title}" has no messages yet`,
+              stats: {
+                documentType: page.type,
+                lineCount: 0,
+                messageCount: 0,
+                totalMessages: 0,
+                wordCount: 0,
+                characterCount: 0,
+              },
+              nextSteps: [
+                'Use send_channel_message to post the first update',
+                'Use list_pages to find related documents for context',
+              ],
+            };
+          }
+
+          const effectiveStart = lineStart ?? 1;
+          const effectiveEnd = lineEnd !== undefined ? Math.min(lineEnd, totalMessages) : totalMessages;
+
+          if (effectiveStart > totalMessages) {
+            return {
+              success: true,
+              pageId: page.id,
+              title: page.title,
+              type: page.type,
+              isTaskLinked,
+              content: '',
+              rawContent: '',
+              lineCount: 0,
+              totalLines: totalMessages,
+              messageCount: 0,
+              totalMessages,
+              channelMessages: [],
+              rangeStart: effectiveStart,
+              rangeEnd: effectiveEnd,
+              rangeMessage: `Requested range (${effectiveStart}-${lineEnd ?? totalMessages}) is beyond channel length (${totalMessages} messages)`,
+              summary: `Channel "${page.title}" has ${totalMessages} message${totalMessages === 1 ? '' : 's'}, but requested range starts at message ${effectiveStart}`,
+            };
+          }
+
+          const selectedMessages = messages.slice(effectiveStart - 1, effectiveEnd);
+
+          const transcriptLines = selectedMessages.map((message, index) => {
+            const lineNumber = effectiveStart + index;
+            const sender = getSenderInfo(message);
+            const timestamp = message.createdAt.toISOString();
+            const messageText = extractMessageText(message.content);
+            return `${lineNumber}→${sender.prefix} ${sender.senderName} (${timestamp}): ${messageText}`;
+          });
+
+          const rawTranscriptLines = selectedMessages.map(message => {
+            const sender = getSenderInfo(message);
+            const timestamp = message.createdAt.toISOString();
+            const messageText = extractMessageText(message.content);
+            return `${sender.prefix} ${sender.senderName} (${timestamp}): ${messageText}`;
+          });
+
+          const rawContent = rawTranscriptLines.join('\n');
+          const content = transcriptLines.join('\n');
+
+          return {
+            success: true,
+            pageId: page.id,
+            title: page.title,
+            type: page.type,
+            contentMode: page.contentMode || 'html',
+            isTaskLinked,
+            content,
+            rawContent,
+            lineCount: selectedMessages.length,
+            totalLines: totalMessages,
+            messageCount: selectedMessages.length,
+            totalMessages,
+            channelMessages: selectedMessages.map((message, index) => {
+              const sender = getSenderInfo(message);
+              const messageText = extractMessageText(message.content);
+              return {
+                id: message.id,
+                lineNumber: effectiveStart + index,
+                createdAt: message.createdAt.toISOString(),
+                senderId: message.userId,
+                senderName: sender.senderName,
+                senderType: sender.senderType,
+                content: messageText,
+              };
+            }),
+            ...(isRangeRequest && { rangeStart: effectiveStart, rangeEnd: effectiveEnd }),
+            summary: isRangeRequest
+              ? `Read messages ${effectiveStart}-${effectiveEnd} of channel "${page.title}" (${selectedMessages.length} of ${totalMessages} messages)`
+              : `Read channel "${page.title}" (${totalMessages} messages)`,
+            stats: {
+              documentType: page.type,
+              lineCount: selectedMessages.length,
+              messageCount: selectedMessages.length,
+              totalMessages,
+              wordCount: rawContent.split(/\s+/).filter(Boolean).length,
+              characterCount: rawContent.length,
+            },
+            nextSteps: [
+              'Use send_channel_message to post a response in this channel',
+              'Use these messages as context before drafting updates',
+            ],
           };
         }
 


### PR DESCRIPTION
## Summary
- add CHANNEL support in read_page so it returns structured channelMessages plus transcript content with lineStart/lineEnd ranges
- include messagePreview in send_channel_message tool results
- update rich tool call renderers to render read_page channel transcripts (including empty-channel fallback)
- update rich tool call renderers to render send_channel_message with a preview panel
- add/update tool tests for channel transcript output and message preview

## Testing
- attempted: pnpm --filter web test -- apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts apps/web/src/lib/ai/tools/__tests__/channel-tools.test.ts
- result: could not run in this workspace because dependencies are not installed (node_modules missing; vitest command not found)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Send Message" tool for sending messages to channels
  * Implemented channel message transcript display with sender attribution, timestamps, and message numbering
  * Added message previews for channel messaging operations

* **Tests**
  * Added test coverage for channel messaging and channel page reading functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->