### PR TITLE
[web] Fix page format controls and Monaco color crash

### DIFF
--- a/apps/web/src/app/settings/display/page.tsx
+++ b/apps/web/src/app/settings/display/page.tsx
@@ -10,7 +10,7 @@ import { Label } from '@/components/ui/label';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { toast } from 'sonner';
-import { Eye, Loader2, ArrowLeft, Info } from 'lucide-react';
+import { Eye, Loader2, ArrowLeft, Info, FileText } from 'lucide-react';
 
 interface DisplaySetting {
   id: 'SHOW_TOKEN_COUNTS' | 'SHOW_CODE_TOGGLE' | 'DEFAULT_MARKDOWN_MODE';
@@ -19,7 +19,15 @@ interface DisplaySetting {
   preferenceKey: 'showTokenCounts' | 'showCodeToggle' | 'defaultMarkdownMode';
 }
 
-const DISPLAY_SETTINGS: DisplaySetting[] = [
+interface DisplaySettingsSection {
+  key: string;
+  title: string;
+  description: string;
+  icon: typeof Eye;
+  settings: DisplaySetting[];
+}
+
+const INTERFACE_SETTINGS: DisplaySetting[] = [
   {
     id: 'SHOW_TOKEN_COUNTS',
     label: 'Show AI token counts',
@@ -28,15 +36,35 @@ const DISPLAY_SETTINGS: DisplaySetting[] = [
   },
   {
     id: 'SHOW_CODE_TOGGLE',
-    label: 'Show code editor toggle',
-    description: 'Display Rich/Code toggle buttons for document and canvas pages',
+    label: 'Show Rich/Code view toggle',
+    description: 'Display stable Rich and Code buttons for document pages',
     preferenceKey: 'showCodeToggle',
   },
+];
+
+const PAGE_SETTINGS: DisplaySetting[] = [
   {
     id: 'DEFAULT_MARKDOWN_MODE',
-    label: 'Default to Markdown for new documents',
-    description: 'New document pages will store content as markdown instead of HTML',
+    label: 'Default new document pages to Markdown',
+    description: 'Sets the global default save format for newly created document pages',
     preferenceKey: 'defaultMarkdownMode',
+  },
+];
+
+const SETTINGS_SECTIONS: DisplaySettingsSection[] = [
+  {
+    key: 'global-page-settings',
+    title: 'Global Page Settings',
+    description: 'Set default behavior for how new document pages are created.',
+    icon: FileText,
+    settings: PAGE_SETTINGS,
+  },
+  {
+    key: 'display-settings',
+    title: 'Display Settings',
+    description: 'Control optional interface elements.',
+    icon: Eye,
+    settings: INTERFACE_SETTINGS,
   },
 ];
 
@@ -82,58 +110,58 @@ export default function DisplaySettingsPage() {
         </Button>
         <h1 className="text-3xl font-bold flex items-center gap-2">
           <Eye className="h-8 w-8" />
-          Display Settings
+          Display & Page Settings
         </h1>
         <p className="text-muted-foreground mt-2">
-          Customize which UI elements are shown throughout the application.
+          Configure global page defaults and optional UI elements.
         </p>
       </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Eye className="h-5 w-5" />
-            Interface Options
-          </CardTitle>
-          <CardDescription>
-            Toggle visibility of optional interface elements.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          {DISPLAY_SETTINGS.map((setting) => {
-            const isEnabled = preferences[setting.preferenceKey];
+      {SETTINGS_SECTIONS.map((section) => (
+        <Card key={section.key}>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <section.icon className="h-5 w-5" />
+              {section.title}
+            </CardTitle>
+            <CardDescription>{section.description}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {section.settings.map((setting) => {
+              const isEnabled = preferences[setting.preferenceKey];
 
-            return (
-              <div
-                key={setting.id}
-                className="flex items-center justify-between p-3 rounded-lg border bg-card hover:bg-accent/50 transition-colors"
-              >
-                <div className="space-y-0.5">
-                  <Label
-                    htmlFor={setting.id}
-                    className="text-sm font-medium cursor-pointer"
-                  >
-                    {setting.label}
-                  </Label>
-                  <p className="text-xs text-muted-foreground">
-                    {setting.description}
-                  </p>
+              return (
+                <div
+                  key={setting.id}
+                  className="flex items-center justify-between p-3 rounded-lg border bg-card hover:bg-accent/50 transition-colors"
+                >
+                  <div className="space-y-0.5">
+                    <Label
+                      htmlFor={setting.id}
+                      className="text-sm font-medium cursor-pointer"
+                    >
+                      {setting.label}
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      {setting.description}
+                    </p>
+                  </div>
+                  <Switch
+                    id={setting.id}
+                    checked={isEnabled}
+                    onCheckedChange={(checked) => handleToggle(setting, checked)}
+                  />
                 </div>
-                <Switch
-                  id={setting.id}
-                  checked={isEnabled}
-                  onCheckedChange={(checked) => handleToggle(setting, checked)}
-                />
-              </div>
-            );
-          })}
-        </CardContent>
-      </Card>
+              );
+            })}
+          </CardContent>
+        </Card>
+      ))}
 
       <Alert>
         <Info className="h-4 w-4" />
         <AlertDescription>
-          These settings are saved to your account and will apply across all your devices.
+          These settings are saved to your account and apply across all your devices.
         </AlertDescription>
       </Alert>
     </div>

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -94,8 +94,8 @@ export default function SettingsPage() {
           available: true,
         },
         {
-          title: "Display",
-          description: "Customize what UI elements are shown",
+          title: "Display & Pages",
+          description: "Manage interface visibility and global page defaults",
           icon: Eye,
           href: "/settings/display",
           available: true,

--- a/apps/web/src/components/layout/middle-content/content-header/EditorToggles.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/EditorToggles.tsx
@@ -1,126 +1,20 @@
 "use client";
 
-import { useState, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { useDocumentStore } from '@/stores/useDocumentStore';
-import { useDocumentManagerStore } from '@/stores/useDocumentManagerStore';
-import { useParams } from 'next/navigation';
-import useSWR from 'swr';
-import { PageType, isDocumentPage, isCanvasPage } from '@pagespace/lib/client-safe';
-import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useMobile } from '@/hooks/useMobile';
 import { useDisplayPreferences } from '@/hooks/useDisplayPreferences';
-import { useDocumentSaving } from '@/hooks/useDocument';
-import { toast } from 'sonner';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
-import { ArrowRightLeft } from 'lucide-react';
-
-const fetcher = async (url: string) => {
-  const response = await fetchWithAuth(url);
-  if (!response.ok) {
-    throw new Error(`Failed to fetch: ${response.status}`);
-  }
-  return response.json();
-};
 
 export function EditorToggles() {
   const activeView = useDocumentStore((state) => state.activeView);
   const setActiveView = useDocumentStore((state) => state.setActiveView);
-  const params = useParams();
-  const pageId = params.pageId as string;
   const isMobile = useMobile();
   const { preferences } = useDisplayPreferences();
-  const [isConverting, setIsConverting] = useState(false);
-  const { saveDocument } = useDocumentSaving(pageId);
-
-  // Fetch page data to determine type
-  const { data: pageData, mutate } = useSWR(
-    pageId ? `/api/pages/${pageId}` : null,
-    fetcher,
-    {
-      revalidateOnFocus: false,
-      refreshInterval: 300000,
-    }
-  );
-
-  const contentMode = pageData?.contentMode || 'html';
-  const isMarkdown = contentMode === 'markdown';
-
-  const handleConvert = useCallback(async () => {
-    const targetMode = isMarkdown ? 'html' : 'markdown';
-    const confirmMessage = isMarkdown
-      ? 'Convert this page from Markdown to Rich Text (HTML)?'
-      : 'Convert this page from Rich Text (HTML) to Markdown?';
-
-    if (!confirm(confirmMessage)) return;
-
-    setIsConverting(true);
-    try {
-      // Force-save pending edits before converting to ensure conversion uses latest content
-      const doc = useDocumentManagerStore.getState().documents.get(pageId);
-      if (doc?.isDirty) {
-        // Clear any pending debounced save
-        if (doc.saveTimeout) {
-          clearTimeout(doc.saveTimeout);
-        }
-        const saveResult = await saveDocument(doc.content);
-        if (!saveResult) {
-          toast.error('Please save your changes before converting');
-          setIsConverting(false);
-          return;
-        }
-      }
-
-      const response = await fetchWithAuth(`/api/pages/${pageId}/convert-content-mode`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ targetMode }),
-      });
-
-      if (!response.ok) {
-        const data = await response.json().catch(() => ({}));
-        throw new Error(data.error || 'Conversion failed');
-      }
-
-      const result = await response.json();
-
-      // Update local document store with converted content
-      const store = useDocumentManagerStore.getState();
-      store.updateDocument(pageId, {
-        content: result.content,
-        contentMode: result.contentMode,
-        revision: result.revision,
-        isDirty: false,
-        lastSaved: Date.now(),
-        lastUpdateTime: Date.now(),
-      });
-
-      // Revalidate SWR cache
-      await mutate();
-
-      toast.success(`Converted to ${targetMode === 'markdown' ? 'Markdown' : 'Rich Text'}`);
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Conversion failed');
-    } finally {
-      setIsConverting(false);
-    }
-  }, [pageId, isMarkdown, mutate, saveDocument]);
-
-  // Only show editor toggles if preference is enabled, for document/canvas pages, and not on mobile
-  const pageType = pageData?.type as PageType;
-  const isValidPageType = pageType && (isDocumentPage(pageType) || isCanvasPage(pageType));
-  const shouldShowToggles = preferences.showCodeToggle && isValidPageType;
+  const shouldShowToggles = preferences.showCodeToggle;
 
   if (!shouldShowToggles || isMobile) {
     return null;
   }
-
-  const codeLabel = isMarkdown ? 'Markdown' : 'HTML';
 
   return (
     <div className="flex items-center gap-2">
@@ -136,26 +30,8 @@ export function EditorToggles() {
         size="sm"
         onClick={() => setActiveView('code')}
       >
-        {codeLabel}
+        Code
       </Button>
-      {isDocumentPage(pageType) && (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="sm" disabled={isConverting} aria-label="Convert content mode">
-              <ArrowRightLeft className="h-3.5 w-3.5" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem onClick={handleConvert} disabled={isConverting}>
-              {isConverting
-                ? 'Converting...'
-                : isMarkdown
-                  ? 'Convert to Rich Text (HTML)'
-                  : 'Convert to Markdown'}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      )}
     </div>
   );
 }

--- a/apps/web/src/components/layout/middle-content/content-header/PageSetupButton.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/PageSetupButton.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useCallback, useState } from 'react';
+import useSWR from 'swr';
+import { Settings2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { useDocumentSaving } from '@/hooks/useDocument';
+import { useDocumentManagerStore } from '@/stores/useDocumentManagerStore';
+
+interface PageSetupButtonProps {
+  pageId: string;
+}
+
+interface PageDetails {
+  contentMode?: 'html' | 'markdown';
+}
+
+const fetcher = async (url: string): Promise<PageDetails> => {
+  const response = await fetchWithAuth(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch page details: ${response.status}`);
+  }
+  return response.json();
+};
+
+export function PageSetupButton({ pageId }: PageSetupButtonProps) {
+  const [isConverting, setIsConverting] = useState(false);
+  const { saveDocument } = useDocumentSaving(pageId);
+
+  const { data: pageData, mutate } = useSWR(
+    pageId ? `/api/pages/${pageId}` : null,
+    fetcher,
+    {
+      revalidateOnFocus: false,
+      refreshInterval: 300000,
+    }
+  );
+
+  const contentMode = pageData?.contentMode === 'markdown' ? 'markdown' : 'html';
+  const isDisabled = isConverting || !pageData;
+
+  const handleModeChange = useCallback(async (nextMode: string) => {
+    if (nextMode !== 'html' && nextMode !== 'markdown') {
+      return;
+    }
+
+    if (nextMode === contentMode || isConverting) {
+      return;
+    }
+
+    const confirmMessage = nextMode === 'markdown'
+      ? 'Convert this page from Rich Text to Markdown?'
+      : 'Convert this page from Markdown to Rich Text?';
+
+    if (!window.confirm(confirmMessage)) {
+      return;
+    }
+
+    setIsConverting(true);
+
+    try {
+      const doc = useDocumentManagerStore.getState().documents.get(pageId);
+      if (doc?.isDirty) {
+        if (doc.saveTimeout) {
+          clearTimeout(doc.saveTimeout);
+        }
+
+        const saveResult = await saveDocument(doc.content);
+        if (!saveResult) {
+          toast.error('Please save your changes before converting');
+          return;
+        }
+      }
+
+      const response = await fetchWithAuth(`/api/pages/${pageId}/convert-content-mode`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ targetMode: nextMode }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.error || 'Conversion failed');
+      }
+
+      const result = await response.json();
+
+      const store = useDocumentManagerStore.getState();
+      store.updateDocument(pageId, {
+        content: result.content,
+        contentMode: result.contentMode,
+        revision: result.revision,
+        isDirty: false,
+        lastSaved: Date.now(),
+        lastUpdateTime: Date.now(),
+      });
+
+      await mutate();
+      toast.success(`Converted to ${nextMode === 'markdown' ? 'Markdown' : 'Rich Text'}`);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Conversion failed');
+    } finally {
+      setIsConverting(false);
+    }
+  }, [contentMode, isConverting, mutate, pageId, saveDocument]);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          disabled={isDisabled}
+          aria-label="Page setup"
+        >
+          <Settings2 className="h-4 w-4 sm:mr-2" />
+          <span className="hidden sm:inline">Page Setup</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuLabel>Page Format</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuRadioGroup value={contentMode} onValueChange={handleModeChange}>
+          <DropdownMenuRadioItem value="html" disabled={isDisabled}>
+            Rich Text
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="markdown" disabled={isDisabled}>
+            Markdown
+          </DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/web/src/components/layout/middle-content/content-header/index.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/index.tsx
@@ -4,6 +4,7 @@ import React, { memo, useCallback, useMemo, useState } from 'react';
 import { EditableTitle } from './EditableTitle';
 import { Breadcrumbs } from './Breadcrumbs';
 import { EditorToggles } from './EditorToggles';
+import { PageSetupButton } from './PageSetupButton';
 import { SaveStatusIndicator } from './SaveStatusIndicator';
 import { ShareDialog } from './page-settings/ShareDialog';
 import { usePageTree } from '@/hooks/usePageTree';
@@ -113,8 +114,9 @@ export function ViewHeader({ children, pageId: propPageId }: ContentHeaderProps 
           <EditableTitle pageId={pageId} />
           <DocumentSaveStatus pageId={page?.id ?? null} enabled={showSaveStatus} />
         </div>
-        <div className="flex items-center gap-1 sm:gap-2 flex-shrink-0">
+        <div className="flex flex-wrap items-center justify-end gap-1 sm:gap-2">
           {pageIsDocument && <EditorToggles />}
+          {pageIsDocument && page && <PageSetupButton pageId={page.id} />}
           {(pageIsDocument || pageIsSheet) && page && (
             <ExportDropdown pageId={page.id} pageTitle={page.title} pageType={page.type} />
           )}

--- a/apps/web/src/hooks/useMonacoTheme.ts
+++ b/apps/web/src/hooks/useMonacoTheme.ts
@@ -2,36 +2,159 @@ import { useTheme } from 'next-themes';
 import { useEffect, useState } from 'react';
 import type { Monaco } from '@monaco-editor/react';
 
-let _ctx: CanvasRenderingContext2D | null = null;
-function getCanvasContext(): CanvasRenderingContext2D {
-  if (!_ctx) {
-    _ctx = document.createElement('canvas').getContext('2d');
-  }
-  if (!_ctx) throw new Error('Canvas 2D context unavailable');
-  return _ctx;
-}
-
-function resolveColor(cssValue: string): string {
-  const ctx = getCanvasContext();
-  ctx.fillStyle = cssValue;
-  return ctx.fillStyle;
-}
-
-function withAlpha(color: string, alpha: number): string {
-  const resolved = resolveColor(color);
-  if (resolved.startsWith('#')) {
-    const hex = Math.round(alpha * 255).toString(16).padStart(2, '0');
-    return resolved + hex;
-  }
-  const match = resolved.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
-  if (match) {
-    return `rgba(${match[1]}, ${match[2]}, ${match[3]}, ${alpha})`;
-  }
-  return resolved;
-}
-
 function getCssVar(name: string): string {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function byteToHex(value: number): string {
+  return clamp(Math.round(value), 0, 255).toString(16).padStart(2, '0');
+}
+
+function normalizeHexColor(value: string): string | null {
+  const normalized = value.trim().toLowerCase();
+
+  if (/^#[0-9a-f]{6}$/.test(normalized) || /^#[0-9a-f]{8}$/.test(normalized)) {
+    return normalized;
+  }
+
+  if (/^#[0-9a-f]{3}$/.test(normalized)) {
+    const r = normalized[1];
+    const g = normalized[2];
+    const b = normalized[3];
+    return `#${r}${r}${g}${g}${b}${b}`;
+  }
+
+  if (/^#[0-9a-f]{4}$/.test(normalized)) {
+    const r = normalized[1];
+    const g = normalized[2];
+    const b = normalized[3];
+    const a = normalized[4];
+    return `#${r}${r}${g}${g}${b}${b}${a}${a}`;
+  }
+
+  return null;
+}
+
+function parseRgbChannel(value: string): number | null {
+  const channel = value.trim();
+  if (channel.endsWith('%')) {
+    const percent = Number.parseFloat(channel.slice(0, -1));
+    if (!Number.isFinite(percent)) return null;
+    return clamp((percent / 100) * 255, 0, 255);
+  }
+
+  const numeric = Number.parseFloat(channel);
+  if (!Number.isFinite(numeric)) return null;
+  return clamp(numeric, 0, 255);
+}
+
+function parseAlphaChannel(value: string): number | null {
+  const alpha = value.trim();
+  if (alpha.endsWith('%')) {
+    const percent = Number.parseFloat(alpha.slice(0, -1));
+    if (!Number.isFinite(percent)) return null;
+    return clamp(percent / 100, 0, 1);
+  }
+
+  const numeric = Number.parseFloat(alpha);
+  if (!Number.isFinite(numeric)) return null;
+  return clamp(numeric, 0, 1);
+}
+
+function parseRgbLikeColorToHex(value: string): string | null {
+  const input = value.trim();
+  const match = input.match(/^rgba?\((.*)\)$/i);
+  if (!match) return null;
+
+  const content = match[1].trim();
+  let rgbParts: string[] = [];
+  let alphaPart: string | undefined;
+
+  if (content.includes(',')) {
+    const parts = content.split(',').map((part) => part.trim());
+    if (parts.length < 3) return null;
+    rgbParts = parts.slice(0, 3);
+    alphaPart = parts[3];
+  } else {
+    const slashParts = content.split('/');
+    const rgbTokens = slashParts[0]?.trim().split(/\s+/) ?? [];
+    if (rgbTokens.length < 3) return null;
+    rgbParts = rgbTokens.slice(0, 3);
+    alphaPart = slashParts[1]?.trim();
+  }
+
+  const r = parseRgbChannel(rgbParts[0] ?? '');
+  const g = parseRgbChannel(rgbParts[1] ?? '');
+  const b = parseRgbChannel(rgbParts[2] ?? '');
+  if (r === null || g === null || b === null) return null;
+
+  const a = alphaPart ? parseAlphaChannel(alphaPart) : 1;
+  if (a === null) return null;
+
+  const alphaHex = a < 1 ? byteToHex(a * 255) : '';
+  return `#${byteToHex(r)}${byteToHex(g)}${byteToHex(b)}${alphaHex}`;
+}
+
+function getComputedColorValue(cssValue: string): string | null {
+  const probe = document.createElement('span');
+  probe.style.color = '';
+  probe.style.color = cssValue;
+
+  if (!probe.style.color) {
+    return null;
+  }
+
+  probe.style.display = 'none';
+  const parent = document.body ?? document.documentElement;
+  parent.appendChild(probe);
+  const computed = getComputedStyle(probe).color.trim();
+  probe.remove();
+
+  return computed || null;
+}
+
+function resolveColor(cssValue: string, fallback: string): string {
+  const fallbackHex = normalizeHexColor(fallback) ?? '#000000';
+
+  if (!cssValue) {
+    return fallbackHex;
+  }
+
+  const directHex = normalizeHexColor(cssValue);
+  if (directHex) {
+    return directHex;
+  }
+
+  const directRgbHex = parseRgbLikeColorToHex(cssValue);
+  if (directRgbHex) {
+    return directRgbHex;
+  }
+
+  const computed = getComputedColorValue(cssValue);
+  if (computed) {
+    const computedHex = normalizeHexColor(computed) ?? parseRgbLikeColorToHex(computed);
+    if (computedHex) {
+      return computedHex;
+    }
+  }
+
+  return fallbackHex;
+}
+
+function withAlpha(color: string, alpha: number, fallback: string): string {
+  const resolved = resolveColor(color, fallback);
+  const normalized = normalizeHexColor(resolved) ?? normalizeHexColor(fallback) ?? '#000000';
+
+  const r = Number.parseInt(normalized.slice(1, 3), 16);
+  const g = Number.parseInt(normalized.slice(3, 5), 16);
+  const b = Number.parseInt(normalized.slice(5, 7), 16);
+  const a = byteToHex(clamp(alpha, 0, 1) * 255);
+
+  return `#${byteToHex(r)}${byteToHex(g)}${byteToHex(b)}${a}`;
 }
 
 export function useMonacoTheme(monaco: Monaco | null): string {
@@ -45,33 +168,64 @@ export function useMonacoTheme(monaco: Monaco | null): string {
 
     const isDark = resolvedTheme === 'dark';
     const name = isDark ? 'pagespace-dark' : 'pagespace-light';
+    const fallbackTheme = isDark ? 'vs-dark' : 'vs';
 
-    const bg = resolveColor(getCssVar('--background'));
-    const fg = resolveColor(getCssVar('--foreground'));
-    const border = resolveColor(getCssVar('--border'));
-    const muted = resolveColor(getCssVar('--muted'));
+    const fallbackPalette = isDark
+      ? {
+          background: '#262626',
+          foreground: '#f0f0f0',
+          border: '#404040',
+          muted: '#2e2e2e',
+          mutedForeground: '#8f8f8f',
+          primary: '#5b8cff',
+          card: '#1f1f1f',
+          input: '#303030',
+        }
+      : {
+          background: '#ffffff',
+          foreground: '#1f1f1f',
+          border: '#d9d9d9',
+          muted: '#f3f3f3',
+          mutedForeground: '#7a7a7a',
+          primary: '#3f6dff',
+          card: '#ffffff',
+          input: '#f8f8f8',
+        };
 
-    monaco.editor.defineTheme(name, {
-      base: isDark ? 'vs-dark' : 'vs',
-      inherit: true,
-      rules: [],
-      colors: {
-        'editor.background': bg,
-        'editor.foreground': fg,
-        'editor.lineHighlightBackground': muted,
-        'editorLineNumber.foreground': resolveColor(getCssVar('--muted-foreground')),
-        'editorGutter.background': bg,
-        'editor.selectionBackground': isDark
-          ? withAlpha(getCssVar('--primary'), 0.25)
-          : withAlpha(getCssVar('--primary'), 0.20),
-        'editorWidget.background': resolveColor(getCssVar('--card')),
-        'editorWidget.border': border,
-        'input.background': resolveColor(getCssVar('--input')),
-        'input.border': border,
-      },
-    });
+    const bg = resolveColor(getCssVar('--background'), fallbackPalette.background);
+    const fg = resolveColor(getCssVar('--foreground'), fallbackPalette.foreground);
+    const border = resolveColor(getCssVar('--border'), fallbackPalette.border);
+    const muted = resolveColor(getCssVar('--muted'), fallbackPalette.muted);
+    const mutedForeground = resolveColor(getCssVar('--muted-foreground'), fallbackPalette.mutedForeground);
+    const card = resolveColor(getCssVar('--card'), fallbackPalette.card);
+    const input = resolveColor(getCssVar('--input'), fallbackPalette.input);
+    const primary = resolveColor(getCssVar('--primary'), fallbackPalette.primary);
 
-    setThemeName(name);
+    try {
+      monaco.editor.defineTheme(name, {
+        base: fallbackTheme,
+        inherit: true,
+        rules: [],
+        colors: {
+          'editor.background': bg,
+          'editor.foreground': fg,
+          'editor.lineHighlightBackground': muted,
+          'editorLineNumber.foreground': mutedForeground,
+          'editorGutter.background': bg,
+          'editor.selectionBackground': isDark
+            ? withAlpha(primary, 0.25, fallbackPalette.primary)
+            : withAlpha(primary, 0.20, fallbackPalette.primary),
+          'editorWidget.background': card,
+          'editorWidget.border': border,
+          'input.background': input,
+          'input.border': border,
+        },
+      });
+      setThemeName(name);
+    } catch (error) {
+      console.error('Failed to define Monaco theme, falling back to default theme:', error);
+      setThemeName(fallbackTheme);
+    }
   }, [monaco, resolvedTheme]);
 
   return themeName;


### PR DESCRIPTION
## Summary
This PR separates editor view controls from page content-format controls and fixes a Monaco crash caused by OKLCH theme tokens.

## What Changed
- Keep editor toggle labels stable as Rich and Code (no HTML/Markdown label swap).
- Move per-page format conversion into a dedicated Page Setup dropdown for document pages.
- Improve header action layout to wrap on narrower widths to avoid control collisions.
- Rework Settings copy/organization to surface global page defaults more clearly.
- Harden Monaco theme generation by normalizing CSS colors to Monaco-safe hex values and adding fallback behavior if theme definition fails.

## User-Visible Behavior
- Switching page format (Rich Text vs Markdown persistence) no longer implies a view-mode toggle.
- Rich/Code controls remain separate from format conversion controls.
- The Monaco Illegal value for token color: oklch(...) crash is prevented.

## Testing
- Could not run pnpm --filter web typecheck or pnpm --filter web lint in this worktree because dependencies are not installed (node_modules missing).
