### PR TITLE
Fix cross-page undo leakage in editor views

### DIFF
--- a/apps/web/src/components/layout/middle-content/CenterPanel.tsx
+++ b/apps/web/src/components/layout/middle-content/CenterPanel.tsx
@@ -165,10 +165,16 @@ const PageContent = memo(({ pageId }: { pageId: string | null }) => {
     );
   } else if (componentName === 'DocumentView') {
     // DocumentView accepts only pageId (new pattern)
-    pageComponent = <DocumentView pageId={page.id} />;
+    pageComponent = <DocumentView key={`document-${page.id}`} pageId={page.id} />;
   } else if (componentName === 'CodePageView') {
     // CodePageView accepts only pageId (new pattern)
-    pageComponent = <CodePageView pageId={page.id} />;
+    pageComponent = <CodePageView key={`code-${page.id}`} pageId={page.id} />;
+  } else if (componentName === 'CanvasPageView') {
+    // CanvasPageView should remount per page to isolate edit/undo state
+    pageComponent = <CanvasPageView key={`canvas-${page.id}`} page={page} />;
+  } else if (componentName === 'SheetView') {
+    // SheetView should remount per page to isolate undo/redo history
+    pageComponent = <SheetView key={`sheet-${page.id}`} page={page} />;
   } else {
     // Other components still accept full page object
     // Type assertion: we've excluded DocumentView above, so ViewComponent here


### PR DESCRIPTION
## Summary
- isolate page view instances by keying editor-backed views per page ID in `CenterPanel`
- remount `DocumentView`, `CodePageView`, `CanvasPageView`, and `SheetView` when page changes
- prevent `Cmd/Ctrl+Z` history from leaking across navigated pages

## Why
Undo history was being reused across page navigation in some editors, allowing undo actions to apply previous page state to the current page.

## Testing
- not run locally (`node_modules` missing in this workspace, so `pnpm --filter web typecheck` cannot execute)
- manual verification recommended:
  1. edit page A, then navigate to page B of same type
  2. press `Cmd/Ctrl+Z`
  3. confirm undo does not apply changes from page A to page B


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page navigation and rendering to ensure proper state isolation when switching between different page types, resulting in cleaner and more stable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->