### PR TITLE
[web] Self-host Monaco assets and harden CSP

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,6 +1,5 @@
 import type { NextConfig } from "next";
 import path from "path";
-import MonacoWebpackPlugin from "monaco-editor-webpack-plugin";
 import CopyPlugin from "copy-webpack-plugin";
 
 const nextConfig: NextConfig = {
@@ -18,19 +17,20 @@ const nextConfig: NextConfig = {
         process: false,
         os: false,
       };
+      const outputPath = config.output.path ?? path.join(__dirname, ".next");
+
       config.plugins.push(
-        new MonacoWebpackPlugin({
-          languages: ["javascript", "typescript", "html", "css", "json"],
-          // Monaco worker entry names already include ".worker"
-          // (e.g. "editor.worker"), so appending ".worker.js" here produces
-          // doubled names like "editor.worker.worker.js".
-          filename: "static/[name].js",
-        }),
         new CopyPlugin({
-          patterns: [{
-            from: require.resolve("pdfjs-dist/build/pdf.worker.min.mjs"),
-            to: path.join(__dirname, "public", "pdf.worker.min.mjs"),
-          }],
+          patterns: [
+            {
+              from: path.dirname(require.resolve("monaco-editor/min/vs/loader.js")),
+              to: path.join(outputPath, "static", "monaco", "vs"),
+            },
+            {
+              from: require.resolve("pdfjs-dist/build/pdf.worker.min.mjs"),
+              to: path.join(__dirname, "public", "pdf.worker.min.mjs"),
+            },
+          ],
         })
       );
     }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -135,7 +135,6 @@
     "eslint": "^9",
     "eslint-config-next": "15.3.9",
     "eslint-plugin-react-hooks": "^5.2.0",
-    "monaco-editor-webpack-plugin": "^7.1.0",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.5",
     "typescript": "^5"

--- a/apps/web/src/components/editors/MonacoEditor.tsx
+++ b/apps/web/src/components/editors/MonacoEditor.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useCallback } from 'react';
 import Editor, { useMonaco, type Monaco } from '@monaco-editor/react';
 import type { editor } from 'monaco-editor';
 import { useMonacoTheme } from '@/hooks/useMonacoTheme';
+import { configureMonacoLoader } from '@/lib/editor/monaco/loader-config';
 import { registerSudolangLanguage } from '@/lib/editor/monaco/sudolang-language';
 
 interface MonacoEditorProps {
@@ -15,69 +16,7 @@ interface MonacoEditorProps {
   className?: string;
 }
 
-type MonacoWindow = Window & {
-  __NEXT_DATA__?: {
-    assetPrefix?: string;
-  };
-};
-
-let isMonacoEnvironmentConfigured = false;
-
-const WORKER_FILE_BY_LABEL: Record<string, string> = {
-  json: 'json.worker.js',
-  css: 'css.worker.js',
-  html: 'html.worker.js',
-  typescript: 'ts.worker.js',
-  javascript: 'ts.worker.js',
-};
-
-const trimTrailingSlash = (value: string): string =>
-  value.endsWith('/') ? value.slice(0, -1) : value;
-
-const getMonacoWorkerFileName = (label: string): string => {
-  return WORKER_FILE_BY_LABEL[label] ?? 'editor.worker.js';
-};
-
-const getAssetPrefix = (): string => {
-  if (typeof window === 'undefined') return '';
-
-  const nextData = (window as MonacoWindow).__NEXT_DATA__;
-  const rawAssetPrefix = (nextData?.assetPrefix ?? '').trim();
-
-  if (!rawAssetPrefix || rawAssetPrefix === '/') return '';
-
-  if (rawAssetPrefix.startsWith('/')) {
-    return trimTrailingSlash(rawAssetPrefix);
-  }
-
-  try {
-    const assetPrefixUrl = new URL(rawAssetPrefix, window.location.origin);
-
-    // Keep Monaco workers same-origin so they always satisfy worker-src 'self'.
-    if (assetPrefixUrl.origin !== window.location.origin) {
-      return '';
-    }
-
-    return trimTrailingSlash(assetPrefixUrl.pathname || '');
-  } catch {
-    return '';
-  }
-};
-
-const configureMonacoEnvironment = (): void => {
-  if (typeof window === 'undefined' || isMonacoEnvironmentConfigured) return;
-
-  const assetPrefix = getAssetPrefix();
-  const workerBasePath = `${assetPrefix}/_next/static`;
-
-  window.MonacoEnvironment = {
-    getWorkerUrl: (_moduleId: string, label: string) =>
-      `${workerBasePath}/${getMonacoWorkerFileName(label)}`,
-  };
-  isMonacoEnvironmentConfigured = true;
-};
-
-configureMonacoEnvironment();
+configureMonacoLoader();
 
 const MonacoEditor = ({ value, onChange, readOnly, language = 'markdown', options: optionOverrides, className }: MonacoEditorProps) => {
   const monaco = useMonaco();

--- a/apps/web/src/lib/editor/monaco/__tests__/loader-config.test.ts
+++ b/apps/web/src/lib/editor/monaco/__tests__/loader-config.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildMonacoVsPath,
+  getMonacoVsPath,
+  resolveAssetPrefix,
+  resolveMonacoVsPath,
+  trimTrailingSlash,
+} from '../loader-config';
+
+describe('loader-config', () => {
+  describe('trimTrailingSlash', () => {
+    it('removes a trailing slash when present', () => {
+      expect(trimTrailingSlash('/assets/')).toBe('/assets');
+    });
+
+    it('returns original value when no trailing slash exists', () => {
+      expect(trimTrailingSlash('/assets')).toBe('/assets');
+    });
+  });
+
+  describe('resolveAssetPrefix', () => {
+    const origin = 'https://app.pagespace.local';
+
+    it('returns empty string for empty asset prefix', () => {
+      expect(resolveAssetPrefix('', origin)).toBe('');
+    });
+
+    it('returns empty string for root-only asset prefix', () => {
+      expect(resolveAssetPrefix('/', origin)).toBe('');
+    });
+
+    it('normalizes relative asset prefix and trims trailing slash', () => {
+      expect(resolveAssetPrefix('/app-assets/', origin)).toBe('/app-assets');
+    });
+
+    it('accepts same-origin absolute asset prefix and returns pathname only', () => {
+      expect(resolveAssetPrefix('https://app.pagespace.local/cdn/', origin)).toBe('/cdn');
+    });
+
+    it('falls back to empty prefix for cross-origin absolute asset prefix', () => {
+      expect(resolveAssetPrefix('https://cdn.example.com/assets', origin)).toBe('');
+    });
+  });
+
+  describe('resolveMonacoVsPath', () => {
+    const origin = 'https://app.pagespace.local';
+
+    it('builds default Monaco vs path for empty asset prefix', () => {
+      expect(resolveMonacoVsPath('', origin)).toBe('/_next/static/monaco/vs');
+    });
+
+    it('builds Monaco vs path using normalized relative asset prefix', () => {
+      expect(resolveMonacoVsPath('/app-assets/', origin)).toBe('/app-assets/_next/static/monaco/vs');
+    });
+
+    it('falls back to default Monaco vs path for cross-origin asset prefix', () => {
+      expect(resolveMonacoVsPath('https://cdn.example.com/assets', origin)).toBe('/_next/static/monaco/vs');
+    });
+  });
+
+  describe('buildMonacoVsPath', () => {
+    it('concatenates asset prefix and Monaco vs relative path', () => {
+      expect(buildMonacoVsPath('/tenant')).toBe('/tenant/_next/static/monaco/vs');
+    });
+  });
+
+  describe('getMonacoVsPath', () => {
+    it('reads asset prefix from __NEXT_DATA__ and resolves Monaco vs path', () => {
+      const monacoWindow = {
+        __NEXT_DATA__: {
+          assetPrefix: '/tenant-assets/',
+        },
+        location: {
+          origin: 'https://app.pagespace.local',
+        },
+      } as unknown as Window & {
+        __NEXT_DATA__?: {
+          assetPrefix?: string;
+        };
+      };
+
+      expect(getMonacoVsPath(monacoWindow)).toBe('/tenant-assets/_next/static/monaco/vs');
+    });
+  });
+});

--- a/apps/web/src/lib/editor/monaco/loader-config.ts
+++ b/apps/web/src/lib/editor/monaco/loader-config.ts
@@ -1,0 +1,66 @@
+import { loader } from '@monaco-editor/react';
+
+type MonacoWindow = Window & {
+  __NEXT_DATA__?: {
+    assetPrefix?: string;
+  };
+};
+
+const MONACO_VS_RELATIVE_PATH = '/_next/static/monaco/vs';
+
+let isMonacoLoaderConfigured = false;
+
+export const trimTrailingSlash = (value: string): string =>
+  value.endsWith('/') ? value.slice(0, -1) : value;
+
+export const resolveAssetPrefix = (rawAssetPrefix: string, origin: string): string => {
+  const normalizedAssetPrefix = rawAssetPrefix.trim();
+
+  if (!normalizedAssetPrefix || normalizedAssetPrefix === '/') {
+    return '';
+  }
+
+  if (normalizedAssetPrefix.startsWith('/')) {
+    return trimTrailingSlash(normalizedAssetPrefix);
+  }
+
+  try {
+    const assetPrefixUrl = new URL(normalizedAssetPrefix, origin);
+
+    if (assetPrefixUrl.origin !== origin) {
+      return '';
+    }
+
+    return trimTrailingSlash(assetPrefixUrl.pathname || '');
+  } catch {
+    return '';
+  }
+};
+
+export const buildMonacoVsPath = (assetPrefix: string): string =>
+  `${assetPrefix}${MONACO_VS_RELATIVE_PATH}`;
+
+export const resolveMonacoVsPath = (rawAssetPrefix: string, origin: string): string => {
+  const assetPrefix = resolveAssetPrefix(rawAssetPrefix, origin);
+  return buildMonacoVsPath(assetPrefix);
+};
+
+export const getMonacoVsPath = (targetWindow: MonacoWindow): string =>
+  resolveMonacoVsPath(
+    targetWindow.__NEXT_DATA__?.assetPrefix ?? '',
+    targetWindow.location.origin
+  );
+
+export const configureMonacoLoader = (): void => {
+  if (typeof window === 'undefined' || isMonacoLoaderConfigured) {
+    return;
+  }
+
+  loader.config({
+    paths: {
+      vs: getMonacoVsPath(window as MonacoWindow),
+    },
+  });
+
+  isMonacoLoaderConfigured = true;
+};

--- a/apps/web/src/middleware/__tests__/security-headers.test.ts
+++ b/apps/web/src/middleware/__tests__/security-headers.test.ts
@@ -151,6 +151,12 @@ describe('Security Headers', () => {
       expect(csp).toContain('https://accounts.google.com');
     });
 
+    it('does not allow jsDelivr CDN sources', () => {
+      const csp = buildCSPPolicy('test-nonce');
+
+      expect(csp).not.toContain('https://cdn.jsdelivr.net');
+    });
+
     it('allows Google accounts and Stripe iframes via frame-src', () => {
       const csp = buildCSPPolicy('test-nonce');
 

--- a/apps/web/src/middleware/security-headers.ts
+++ b/apps/web/src/middleware/security-headers.ts
@@ -51,12 +51,11 @@ export const buildCSPPolicy = (nonce: string): string => {
       "'strict-dynamic'",
       "'unsafe-inline'", // Fallback for older browsers (ignored when strict-dynamic present)
       'https://accounts.google.com', // Google One Tap authentication
-      'https://cdn.jsdelivr.net', // Monaco editor CDN
     ],
-    'style-src': ["'self'", "'unsafe-inline'", 'https://cdn.jsdelivr.net', 'https://accounts.google.com'],
+    'style-src': ["'self'", "'unsafe-inline'", 'https://accounts.google.com'],
     'img-src': ["'self'", 'data:', 'blob:', 'https:'],
     'connect-src': ["'self'", 'ws:', 'wss:', 'https:'],
-    'font-src': ["'self'", 'data:', 'https://cdn.jsdelivr.net'],
+    'font-src': ["'self'", 'data:'],
     // Monaco and other browser tooling may initialize workers from blob URLs.
     'worker-src': ["'self'", 'blob:'],
     'frame-src': ['https://accounts.google.com', 'https://js.stripe.com'], // Google One Tap + Stripe Elements iframes

--- a/docs/1.0-overview/changelog.md
+++ b/docs/1.0-overview/changelog.md
@@ -1,3 +1,17 @@
+## 2026-02-10
+
+### Monaco Worker Stability + CSP Hardening
+
+Fixed Monaco worker bootstrapping by self-hosting Monaco `vs` runtime assets and removing CDN allowances that were only needed for Monaco loading.
+
+#### Changed ✅
+
+- Monaco loader now resolves to self-hosted assets at `/_next/static/monaco/vs`
+- Webpack build now copies `monaco-editor/min/vs` into `.next/static/monaco/vs`
+- Removed legacy `window.MonacoEnvironment.getWorkerUrl` override that pointed to non-existent worker files
+- Removed `monaco-editor-webpack-plugin` dependency from `apps/web`
+- CSP no longer allows `https://cdn.jsdelivr.net` in `script-src`, `style-src`, or `font-src`
+
 ## 2026-02-05
 
 ### Documentation Update - AI Memory Benchmarking Roadmap

--- a/docs/2.0-architecture/2.5-integrations/monaco-editor.md
+++ b/docs/2.0-architecture/2.5-integrations/monaco-editor.md
@@ -31,25 +31,18 @@ The Monaco Editor does not manage its own persistent state. It receives the page
 
 ### Web Worker Configuration
 
-A critical piece of the implementation is the `useEffect` hook that configures the paths for Monaco's web workers. Because Next.js bundles dependencies in a specific way, we must explicitly tell Monaco where to find its worker files for different languages (HTML, CSS, JS/TS). This ensures that features like syntax analysis and validation work correctly.
+A critical piece of the implementation is Monaco loader configuration that points the AMD runtime to self-hosted Monaco assets under `/_next/static/monaco/vs`. This ensures worker scripts resolve correctly in production without depending on external CDNs.
 
 ```typescript
-// apps/web/src/components/editors/MonacoEditor.tsx
-useEffect(() => {
-  if (typeof window !== 'undefined') {
-    window.MonacoEnvironment = {
-      getWorkerUrl: (_moduleId: string, label: string) => {
-        if (label === 'json') return '/_next/static/json.worker.js';
-        if (label === 'css') return '/_next/static/css.worker.js';
-        if (label === 'html') return '/_next/static/html.worker.js';
-        if (label === 'typescript' || label === 'javascript')
-          return '/_next/static/ts.worker.js';
-        return '/_next/static/editor.worker.js';
-      },
-    };
-  }
-}, []);
+// apps/web/src/lib/editor/monaco/loader-config.ts
+loader.config({
+  paths: {
+    vs: `${assetPrefix}/_next/static/monaco/vs`,
+  },
+});
 ```
+
+The `vs` assets are copied at build time in `apps/web/next.config.ts` from `monaco-editor/min/vs` to `.next/static/monaco/vs`.
 
 ### Editor Configuration
 
@@ -84,4 +77,4 @@ options={{
 }}
 ```
 
-**Last Updated:** 2025-08-21
+**Last Updated:** 2026-02-10

--- a/docs/security/compliance-sovereignty-analysis.md
+++ b/docs/security/compliance-sovereignty-analysis.md
@@ -332,8 +332,6 @@ index, etc.).
 ### 2.7. CDN Dependencies Load External Scripts
 
 **Current state**: The application loads external scripts from:
-- `cdn.jsdelivr.net` (Monaco editor)
-- `unpkg.com` (PDF.js worker)
 - `accounts.google.com` (One Tap)
 - `js.stripe.com` (payment UI)
 
@@ -341,10 +339,16 @@ index, etc.).
 external loads will fail. Some compliance regimes require Subresource Integrity
 (SRI) hashes for all external scripts.
 
-**What's needed**: Self-host Monaco and PDF.js. Add SRI hashes for any remaining
-external scripts.
+**What's needed**: Keep Monaco and PDF.js self-hosted (completed). For remaining
+third-party scripts, note that Stripe.js and Google One Tap do not support SRI
+(their scripts are dynamically generated and versioned). The primary
+compensating control is strict CSP allowlisting, which is already in place:
+`script-src` allows only `accounts.google.com`, and `frame-src` allows
+`accounts.google.com` and `js.stripe.com`. SRI remains applicable only for
+self-hosted assets where we control versioning.
 
-**Effort**: Medium. Bundle Monaco and PDF.js locally.
+**Effort**: Low. CSP allowlisting already configured; no further hardening
+required for Stripe/Google integrations beyond current controls.
 
 ---
 
@@ -438,8 +442,7 @@ Every path where data leaves the PageSpace deployment boundary.
 | 4 | Payment info | Stripe | Subscription purchase | Payment details (handled by Stripe.js) | No alternative configured |
 | 5 | OAuth credentials | Google | Google sign-in | Email, profile info | Optional (email auth available) |
 | 6 | Calendar tokens | Google Calendar API | Calendar sync | Calendar events, attendees | Optional feature |
-| 7 | HTTP requests | cdn.jsdelivr.net, unpkg.com | Page load (Monaco, PDF.js) | IP address, User-Agent only | Can self-host |
-| 8 | HTTP requests | accounts.google.com | Google One Tap render | IP address, cookies | Optional |
+| 7 | HTTP requests | accounts.google.com | Google One Tap render | IP address, cookies | Optional |
 
 ---
 
@@ -466,11 +469,10 @@ Every path where data leaves the PageSpace deployment boundary.
 
 ### P2 — Required for SOC 2 / enterprise sales
 
-8. **Self-host Monaco and PDF.js** — Eliminates external CDN dependency.
-9. **Add audit log integrity verification cron** — Hash chain exists but is never
+8. **Add audit log integrity verification cron** — Hash chain exists but is never
    verified.
-10. **Standardize bcrypt cost factor** — Minor inconsistency (cost 10 vs 12).
-11. **Add AI provider DPA references** — Link to each provider's data processing
+9. **Standardize bcrypt cost factor** — Minor inconsistency (cost 10 vs 12).
+10. **Add AI provider DPA references** — Link to each provider's data processing
     terms.
 
 ### P3 — Required for HIPAA / FedRAMP / air-gapped
@@ -503,7 +505,7 @@ to be stripped or replaced for a compliance-clean on-premise deployment:
 | Google One Tap | Remove | Trivial | UI-only removal |
 | Google Calendar | Remove | Low | Optional integration |
 | Cloud AI providers | Remove from config; Ollama/LM Studio only | Low | Provider factory already supports this |
-| CDN scripts (Monaco, PDF.js) | Bundle locally | Medium | Self-host static assets |
+| CDN scripts (Monaco, PDF.js) | Completed: self-hosted | N/A | No external CDN dependency for Monaco/PDF.js |
 
 ### 7.2. What Stays as-Is for Local White-Label
 
@@ -548,4 +550,4 @@ When entering compliance or white-label conversations, use this framing:
 - Cloud AI provider compliance with data residency laws
 - HIPAA compliance with cloud AI or Resend email
 - FedRAMP authorization (requires authorized infrastructure stack)
-- Air-gapped deployment (external CDN scripts block this today)
+- Air-gapped deployment without removing all remaining external integrations

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -719,9 +719,6 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^5.2.0
         version: 5.2.0(eslint@9.36.0(jiti@2.6.0))
-      monaco-editor-webpack-plugin:
-        specifier: ^7.1.0
-        version: 7.1.0(monaco-editor@0.52.2)(webpack@5.101.3(esbuild@0.19.12))
       tailwindcss:
         specifier: ^4
         version: 4.1.13
@@ -8045,12 +8042,6 @@ packages:
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
-
-  monaco-editor-webpack-plugin@7.1.0:
-    resolution: {integrity: sha512-ZjnGINHN963JQkFqjjcBtn1XBtUATDZBMgNQhDQwd78w2ukRhFXAPNgWuacaQiDZsUr4h1rWv5Mv6eriKuOSzA==}
-    peerDependencies:
-      monaco-editor: '>= 0.31.0'
-      webpack: ^4.5.0 || 5.x
 
   monaco-editor@0.52.2:
     resolution: {integrity: sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==}
@@ -18232,12 +18223,6 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.1
-
-  monaco-editor-webpack-plugin@7.1.0(monaco-editor@0.52.2)(webpack@5.101.3(esbuild@0.19.12)):
-    dependencies:
-      loader-utils: 2.0.4
-      monaco-editor: 0.52.2
-      webpack: 5.101.3(esbuild@0.19.12)
 
   monaco-editor@0.52.2: {}
 


### PR DESCRIPTION
## Summary

- Self-host Monaco editor runtime assets at `/_next/static/monaco/vs` to eliminate external CDN dependency
- Remove `cdn.jsdelivr.net` from CSP `script-src`, `style-src`, and `font-src` directives
- Extract Monaco loader configuration to dedicated, testable module with unit tests
- Remove `monaco-editor-webpack-plugin` dependency (replaced by CopyPlugin)

## Security Impact

This change hardens the Content Security Policy by removing external CDN allowances that were only needed for Monaco loading. Self-hosting Monaco assets:

- Eliminates supply chain attack surface from third-party CDN
- Enables air-gapped/offline deployments
- Improves compliance posture (SOC 2, enterprise requirements)

## Test plan

- [ ] Verify Monaco editor loads correctly in browser
- [ ] Check DevTools Network tab shows assets from `/_next/static/monaco/vs`
- [ ] Confirm no CSP violations in console
- [ ] Run unit tests: `pnpm --filter web vitest run src/lib/editor/monaco/__tests__/`
- [ ] Run security header tests: `pnpm --filter web vitest run src/middleware/__tests__/security-headers.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Tightened Content Security Policy to remove external CDN allowances for Monaco assets.

* **Refactor**
  * Centralized and simplified Monaco loader initialization; editor component unchanged for users.

* **Chores**
  * Build now ensures Monaco assets and the PDF worker are copied into the app bundle; removed legacy build plugin.

* **Tests**
  * Added unit tests for loader path logic and a CSP test asserting absence of the CDN.

* **Documentation**
  * Updated changelog, architecture, and compliance docs to reflect these changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->