### PR TITLE
Remove Markdown hint from channel input footer

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInputFooter.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInputFooter.tsx
@@ -219,11 +219,6 @@ export function ChannelInputFooter({
             <TooltipContent side="top">Attach file</TooltipContent>
           </Tooltip>
         )}
-
-        {/* Markdown hint */}
-        <span className="text-xs text-muted-foreground/60 hidden sm:inline">
-          Markdown supported
-        </span>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Removed the "Markdown supported" hint text from the channel input footer component.

## Changes
- Removed the markdown hint span element that displayed "Markdown supported" text in the channel input footer
- This text was only visible on small screens and above (hidden on mobile via `hidden sm:inline`)

## Rationale
The markdown hint appears to be redundant or no longer needed in the UI. This simplifies the footer layout and reduces visual clutter in the input area.

https://claude.ai/code/session_01FMzdzbsRtLZVMYjxSJd1R6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the "Markdown supported" hint from the channel input footer on larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->