### PR TITLE
Fix REGEX_QUERY_TIMEOUT_MS type and remove redundant String conversion

### DIFF
--- a/packages/lib/src/services/drive-search-service.ts
+++ b/packages/lib/src/services/drive-search-service.ts
@@ -95,7 +95,7 @@ const MAX_REGEX_PATTERN_LENGTH = 500;
 const MAX_REGEX_RESULTS = 100;
 const MAX_REGEX_LINE_PREVIEWS = 5;
 const MAX_REGEX_LINE_CONTENT_LENGTH = 200;
-const REGEX_QUERY_TIMEOUT_MS = 3000;
+const REGEX_QUERY_TIMEOUT_MS = '3000';
 const POSTGRES_STATEMENT_TIMEOUT_CODE = '57014';
 const REGEX_META_CHARS = /[\\^$.*+?()[\]{}|]/;
 
@@ -397,7 +397,7 @@ export async function regexSearchPages(
   try {
     matchingPages = await db.transaction(async (tx) => {
       await tx.execute(
-        sql`SELECT set_config('statement_timeout', ${String(REGEX_QUERY_TIMEOUT_MS)}, true)`
+        sql`SELECT set_config('statement_timeout', ${REGEX_QUERY_TIMEOUT_MS}, true)`
       );
       return tx
         .select({


### PR DESCRIPTION
## Summary
This PR fixes a type inconsistency in the drive search service where `REGEX_QUERY_TIMEOUT_MS` was being defined as a number but used as a string, requiring an unnecessary `String()` conversion.

## Changes
- Changed `REGEX_QUERY_TIMEOUT_MS` constant from `3000` (number) to `'3000'` (string) to match its intended usage
- Removed the redundant `String()` conversion when passing the timeout value to the SQL query, since the constant is now already a string

## Details
The `set_config()` PostgreSQL function expects a string value for the `statement_timeout` parameter. Previously, the constant was defined as a number and then converted to a string at the call site. This change makes the constant definition match its actual usage, eliminating the need for the conversion and improving code clarity.

https://claude.ai/code/session_01NXSTMp8uyhPwhEP7qgPL6H