### PR TITLE
[web] Fix Monaco worker URL resolution in blob contexts

### DIFF
--- a/apps/web/src/lib/editor/monaco/__tests__/loader-config.test.ts
+++ b/apps/web/src/lib/editor/monaco/__tests__/loader-config.test.ts
@@ -46,15 +46,27 @@ describe('loader-config', () => {
     const origin = 'https://app.pagespace.local';
 
     it('builds default Monaco vs path for empty asset prefix', () => {
-      expect(resolveMonacoVsPath('', origin)).toBe('/_next/static/monaco/vs');
+      expect(resolveMonacoVsPath('', origin)).toBe('https://app.pagespace.local/_next/static/monaco/vs');
     });
 
     it('builds Monaco vs path using normalized relative asset prefix', () => {
-      expect(resolveMonacoVsPath('/app-assets/', origin)).toBe('/app-assets/_next/static/monaco/vs');
+      expect(resolveMonacoVsPath('/app-assets/', origin)).toBe('https://app.pagespace.local/app-assets/_next/static/monaco/vs');
     });
 
     it('falls back to default Monaco vs path for cross-origin asset prefix', () => {
-      expect(resolveMonacoVsPath('https://cdn.example.com/assets', origin)).toBe('/_next/static/monaco/vs');
+      expect(resolveMonacoVsPath('https://cdn.example.com/assets', origin)).toBe('https://app.pagespace.local/_next/static/monaco/vs');
+    });
+
+    it('returns absolute URL output that stays valid in blob worker contexts', () => {
+      const monacoVsPath = resolveMonacoVsPath('', origin);
+      const workerModuleUrl = new URL(
+        `${monacoVsPath}/language/html/htmlWorker.js`,
+        'blob:https://app.pagespace.local/some-worker-id'
+      );
+
+      expect(workerModuleUrl.toString()).toBe(
+        'https://app.pagespace.local/_next/static/monaco/vs/language/html/htmlWorker.js'
+      );
     });
   });
 
@@ -79,7 +91,7 @@ describe('loader-config', () => {
         };
       };
 
-      expect(getMonacoVsPath(monacoWindow)).toBe('/tenant-assets/_next/static/monaco/vs');
+      expect(getMonacoVsPath(monacoWindow)).toBe('https://app.pagespace.local/tenant-assets/_next/static/monaco/vs');
     });
   });
 });

--- a/apps/web/src/lib/editor/monaco/loader-config.ts
+++ b/apps/web/src/lib/editor/monaco/loader-config.ts
@@ -42,7 +42,12 @@ export const buildMonacoVsPath = (assetPrefix: string): string =>
 
 export const resolveMonacoVsPath = (rawAssetPrefix: string, origin: string): string => {
   const assetPrefix = resolveAssetPrefix(rawAssetPrefix, origin);
-  return buildMonacoVsPath(assetPrefix);
+  const monacoVsPath = buildMonacoVsPath(assetPrefix);
+
+  // Monaco can run worker bootstrapping from blob: URLs (e.g., with COI helpers).
+  // In that context, absolute-path URLs like "/_next/..." cannot be resolved, so
+  // we provide an absolute same-origin URL.
+  return new URL(monacoVsPath, origin).toString();
 };
 
 export const getMonacoVsPath = (targetWindow: MonacoWindow): string =>


### PR DESCRIPTION
## Summary
- fix Monaco loader `vs` path resolution to emit absolute same-origin URLs
- prevent worker bootstrap failures when Monaco runs from `blob:` worker contexts (`workerMain.js?vscode-coi=3`)
- add regression coverage for blob-worker URL resolution in loader-config tests

## Root Cause
PR #527 moved Monaco to self-hosted assets and configured `paths.vs` with a path-only value like `/_next/static/monaco/vs`. In blob worker execution contexts, that path cannot be parsed/resolved for `fetch`, causing `Failed to parse URL` for `htmlWorker.js`.

## Validation
- `pnpm --filter web exec vitest run src/lib/editor/monaco/__tests__/loader-config.test.ts`
- result: `13 passed`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Monaco editor now uses absolute, origin-based URLs for asset paths instead of relative paths, improving compatibility across different contexts.

* **Tests**
  * Updated tests to verify proper absolute URL resolution for Monaco editor paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->