### PR TITLE
Disable polling in AI usage hooks, rely on Socket.IO events

### DIFF
--- a/apps/web/src/components/ai/shared/AiUsageMonitor.tsx
+++ b/apps/web/src/components/ai/shared/AiUsageMonitor.tsx
@@ -32,14 +32,12 @@ export function AiUsageMonitor({ conversationId, pageId, className, compact = fa
 
   // Use conversation-based tracking for Global Assistant
   const { usage: conversationUsage, isLoading: conversationLoading, isError: conversationError, mutate: mutateConversation } = useAiUsage(
-    conversationId,
-    15000
+    conversationId
   );
 
   // Use page-based tracking for Page AI (fallback)
   const { usage: pageUsage, isLoading: pageLoading, isError: pageError, mutate: mutatePage } = usePageAiUsage(
-    !conversationId ? pageId : null, // Only query if no conversationId
-    15000
+    !conversationId ? pageId : null // Only query if no conversationId
   );
 
   // Socket.IO listener for real-time usage updates

--- a/apps/web/src/hooks/useAiUsage.ts
+++ b/apps/web/src/hooks/useAiUsage.ts
@@ -75,12 +75,16 @@ const fetcher = async (url: string) => {
 };
 
 /**
- * Hook for fetching AI usage data for a specific conversation
+ * Hook for fetching AI usage data for a specific conversation.
+ *
+ * Usage data only changes when a message completes, so polling is disabled
+ * by default. Updates are driven by Socket.IO `usage:updated` events which
+ * trigger SWR `mutate()` in AiUsageMonitor.
  *
  * @param conversationId - The conversation ID to fetch usage for
- * @param refreshInterval - Optional refresh interval in milliseconds (default: 15000ms)
+ * @param refreshInterval - Optional refresh interval in milliseconds (default: 0 = disabled)
  */
-export function useAiUsage(conversationId: string | null | undefined, refreshInterval = 15000) {
+export function useAiUsage(conversationId: string | null | undefined, refreshInterval = 0) {
   const swrKey = conversationId
     ? `/api/ai/global/${encodeURIComponent(conversationId)}/usage`
     : null;
@@ -135,9 +139,11 @@ export function useAiUsage(conversationId: string | null | undefined, refreshInt
 }
 
 /**
- * Hook for fetching AI usage data for a specific page (across all conversations)
+ * Hook for fetching AI usage data for a specific page (across all conversations).
+ *
+ * Updates are driven by Socket.IO events; polling is disabled by default.
  */
-export function usePageAiUsage(pageId: string | null | undefined, refreshInterval = 15000) {
+export function usePageAiUsage(pageId: string | null | undefined, refreshInterval = 0) {
   const swrKey = pageId
     ? `/api/pages/${encodeURIComponent(pageId)}/ai-usage`
     : null;


### PR DESCRIPTION
## Summary
This change disables automatic polling in the AI usage hooks and relies on Socket.IO events for real-time updates instead. This reduces unnecessary API calls and improves efficiency by only fetching data when it actually changes.

## Key Changes
- Changed default `refreshInterval` from `15000ms` to `0` (disabled) in `useAiUsage()` hook
- Changed default `refreshInterval` from `15000ms` to `0` (disabled) in `usePageAiUsage()` hook
- Updated JSDoc comments to clarify that polling is disabled by default and updates are driven by Socket.IO `usage:updated` events
- Removed explicit `refreshInterval` parameter passing in `AiUsageMonitor` component since it now uses the new default

## Implementation Details
- AI usage data only changes when a message completes, making continuous polling inefficient
- The `AiUsageMonitor` component already listens for Socket.IO `usage:updated` events and triggers SWR `mutate()` calls to refresh data when needed
- This approach provides real-time updates without the overhead of periodic polling
- The `refreshInterval` parameter remains available for cases where polling is explicitly needed

https://claude.ai/code/session_01D2AhTkUgV6EjazvXy1cGzU