### PR TITLE
Add integration tests for conversation cache invalidation

### DIFF
--- a/apps/web/src/app/api/ai/chat/messages/[messageId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/chat/messages/[messageId]/__tests__/route.test.ts
@@ -27,11 +27,16 @@ vi.mock('@/lib/auth', () => ({
   checkMCPPageScope: vi.fn(),
 }));
 
+// Hoisted mocks for cache invalidation testing
+const { mockInvalidateConversation } = vi.hoisted(() => ({
+  mockInvalidateConversation: vi.fn().mockResolvedValue(undefined),
+}));
+
 // Mock permissions (boundary)
 vi.mock('@pagespace/lib/server', () => ({
   canUserEditPage: vi.fn(),
   conversationCache: {
-    invalidateConversation: vi.fn().mockResolvedValue(undefined),
+    invalidateConversation: mockInvalidateConversation,
   },
   loggers: {
     api: {
@@ -388,6 +393,93 @@ describe('PATCH /api/ai/chat/messages/[messageId]', () => {
     });
   });
 
+  describe('cache invalidation', () => {
+    it('should invalidate conversation cache after successful edit', async () => {
+      const message = mockChatMessage();
+      vi.mocked(chatMessageRepository.getMessageById).mockResolvedValue(message);
+
+      const request = createPatchRequest(mockMessageId, { content: 'Updated content' });
+      const context = createContext(mockMessageId);
+
+      await PATCH(request, context);
+
+      expect(mockInvalidateConversation).toHaveBeenCalledWith(
+        message.pageId,
+        message.conversationId
+      );
+    });
+
+    it('should invalidate cache with correct pageId and conversationId', async () => {
+      const specificMessage = mockChatMessage({
+        pageId: 'specific_page_123',
+      });
+      // Override conversationId via full mock
+      const fullMessage = { ...specificMessage, conversationId: 'specific_conv_456' };
+      vi.mocked(chatMessageRepository.getMessageById).mockResolvedValue(fullMessage);
+
+      const request = createPatchRequest(mockMessageId, { content: 'Updated' });
+      const context = createContext(mockMessageId);
+
+      await PATCH(request, context);
+
+      expect(mockInvalidateConversation).toHaveBeenCalledWith(
+        'specific_page_123',
+        'specific_conv_456'
+      );
+    });
+
+    it('should NOT invalidate cache when authentication fails', async () => {
+      vi.mocked(isAuthError).mockReturnValue(true);
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthError(401));
+
+      const request = createPatchRequest(mockMessageId, { content: 'Updated' });
+      const context = createContext(mockMessageId);
+
+      await PATCH(request, context);
+
+      expect(mockInvalidateConversation).not.toHaveBeenCalled();
+    });
+
+    it('should NOT invalidate cache when message not found', async () => {
+      vi.mocked(chatMessageRepository.getMessageById).mockResolvedValue(null);
+
+      const request = createPatchRequest(mockMessageId, { content: 'Updated' });
+      const context = createContext(mockMessageId);
+
+      await PATCH(request, context);
+
+      expect(mockInvalidateConversation).not.toHaveBeenCalled();
+    });
+
+    it('should NOT invalidate cache when permission denied', async () => {
+      vi.mocked(canUserEditPage).mockResolvedValue(false);
+
+      const request = createPatchRequest(mockMessageId, { content: 'Updated' });
+      const context = createContext(mockMessageId);
+
+      await PATCH(request, context);
+
+      expect(mockInvalidateConversation).not.toHaveBeenCalled();
+    });
+
+    it('should invalidate cache before activity logging', async () => {
+      const callOrder: string[] = [];
+      mockInvalidateConversation.mockImplementation(async () => {
+        callOrder.push('invalidate');
+      });
+      vi.mocked(logMessageActivity).mockImplementation(() => {
+        callOrder.push('logActivity');
+      });
+
+      const request = createPatchRequest(mockMessageId, { content: 'Updated' });
+      const context = createContext(mockMessageId);
+
+      await PATCH(request, context);
+
+      expect(callOrder).toEqual(['invalidate', 'logActivity']);
+    });
+  });
+
   describe('error handling', () => {
     it('should return 500 when repository throws', async () => {
       vi.mocked(chatMessageRepository.updateMessageContent).mockRejectedValue(
@@ -624,6 +716,92 @@ describe('DELETE /api/ai/chat/messages/[messageId]', () => {
         'Message deleted successfully',
         expect.any(Object)
       );
+    });
+  });
+
+  describe('cache invalidation', () => {
+    it('should invalidate conversation cache after successful deletion', async () => {
+      const message = mockChatMessage();
+      vi.mocked(chatMessageRepository.getMessageById).mockResolvedValue(message);
+
+      const request = createDeleteRequest(mockMessageId);
+      const context = createContext(mockMessageId);
+
+      await DELETE(request, context);
+
+      expect(mockInvalidateConversation).toHaveBeenCalledWith(
+        message.pageId,
+        message.conversationId
+      );
+    });
+
+    it('should invalidate cache with correct pageId and conversationId', async () => {
+      const specificMessage = mockChatMessage({
+        pageId: 'delete_page_123',
+      });
+      const fullMessage = { ...specificMessage, conversationId: 'delete_conv_456' };
+      vi.mocked(chatMessageRepository.getMessageById).mockResolvedValue(fullMessage);
+
+      const request = createDeleteRequest(mockMessageId);
+      const context = createContext(mockMessageId);
+
+      await DELETE(request, context);
+
+      expect(mockInvalidateConversation).toHaveBeenCalledWith(
+        'delete_page_123',
+        'delete_conv_456'
+      );
+    });
+
+    it('should NOT invalidate cache when authentication fails', async () => {
+      vi.mocked(isAuthError).mockReturnValue(true);
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthError(401));
+
+      const request = createDeleteRequest(mockMessageId);
+      const context = createContext(mockMessageId);
+
+      await DELETE(request, context);
+
+      expect(mockInvalidateConversation).not.toHaveBeenCalled();
+    });
+
+    it('should NOT invalidate cache when message not found', async () => {
+      vi.mocked(chatMessageRepository.getMessageById).mockResolvedValue(null);
+
+      const request = createDeleteRequest(mockMessageId);
+      const context = createContext(mockMessageId);
+
+      await DELETE(request, context);
+
+      expect(mockInvalidateConversation).not.toHaveBeenCalled();
+    });
+
+    it('should NOT invalidate cache when permission denied', async () => {
+      vi.mocked(canUserEditPage).mockResolvedValue(false);
+
+      const request = createDeleteRequest(mockMessageId);
+      const context = createContext(mockMessageId);
+
+      await DELETE(request, context);
+
+      expect(mockInvalidateConversation).not.toHaveBeenCalled();
+    });
+
+    it('should invalidate cache before activity logging', async () => {
+      const callOrder: string[] = [];
+      mockInvalidateConversation.mockImplementation(async () => {
+        callOrder.push('invalidate');
+      });
+      vi.mocked(logMessageActivity).mockImplementation(() => {
+        callOrder.push('logActivity');
+      });
+
+      const request = createDeleteRequest(mockMessageId);
+      const context = createContext(mockMessageId);
+
+      await DELETE(request, context);
+
+      expect(callOrder).toEqual(['invalidate', 'logActivity']);
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds 12 integration tests for cache invalidation on message edit/delete
- Tests verify `conversationCache.invalidateConversation()` is called correctly
- Covers success paths, auth failures, 404s, 403s, and operation ordering

## Test plan
- [x] All 49 route tests pass locally
- [x] Tests use `vi.hoisted()` for proper mock hoisting

🤖 Generated with [Claude Code](https://claude.com/claude-code)