### PR TITLE
Remove pull-to-refresh and custom scroll area from canvas

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
@@ -13,8 +13,6 @@ import { useAuth } from '@/hooks/useAuth';
 import { useSocket } from '@/hooks/useSocket';
 import { PageEventPayload } from '@/lib/websocket';
 import { openExternalUrl } from '@/lib/navigation/app-navigation';
-import { PullToRefresh } from '@/components/ui/pull-to-refresh';
-import { CustomScrollArea } from '@/components/ui/custom-scroll-area';
 
 interface CanvasPageViewProps {
   page: TreePage;
@@ -141,23 +139,6 @@ const CanvasPageView = ({ page }: CanvasPageViewProps) => {
     }
   }, [router, user]);
 
-  // Pull-to-refresh handler
-  const handleRefresh = useCallback(async () => {
-    try {
-      const response = await fetchWithAuth(`/api/pages/${page.id}`);
-      if (response.ok) {
-        const updatedPage = await response.json();
-        const newContent = typeof updatedPage.content === 'string' ? updatedPage.content : '';
-        updateContentFromServer(newContent);
-      }
-    } catch (error) {
-      console.error('Failed to refresh canvas:', error);
-    }
-  }, [page.id, updateContentFromServer]);
-
-  // Disable pull-to-refresh when in code mode
-  const isPullToRefreshDisabled = activeTab === 'code';
-
   return (
     <div ref={containerRef} className="h-full flex flex-col relative">
       <div className="flex border-b">
@@ -174,31 +155,22 @@ const CanvasPageView = ({ page }: CanvasPageViewProps) => {
           View
         </button>
       </div>
-      <PullToRefresh
-        direction="top"
-        onRefresh={handleRefresh}
-        disabled={isPullToRefreshDisabled}
-        className="flex-1"
-      >
-        <CustomScrollArea className="h-full">
-          <div className={`flex justify-center items-start p-4 ${activeTab === 'code' ? 'h-full' : ''}`}>
-            {activeTab === 'code' && (
-              <MonacoEditor
-                value={content}
-                onChange={(newValue) => setContent(newValue || '')}
-                language="html"
-              />
-            )}
-            {activeTab === 'view' && (
-              <div className="w-full h-full bg-background text-foreground">
-                <ErrorBoundary>
-                  <ShadowCanvas html={content} onNavigate={handleNavigation} />
-                </ErrorBoundary>
-              </div>
-            )}
-          </div>
-        </CustomScrollArea>
-      </PullToRefresh>
+      {activeTab === 'code' && (
+        <div className="flex-1 min-h-0">
+          <MonacoEditor
+            value={content}
+            onChange={(newValue) => setContent(newValue || '')}
+            language="html"
+          />
+        </div>
+      )}
+      {activeTab === 'view' && (
+        <div className="flex-1 w-full bg-background text-foreground">
+          <ErrorBoundary>
+            <ShadowCanvas html={content} onNavigate={handleNavigation} />
+          </ErrorBoundary>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
Simplified the CanvasPageView component by removing the pull-to-refresh functionality and custom scroll area wrapper. The layout now uses a cleaner conditional rendering approach for code and view tabs.

## Key Changes
- Removed `PullToRefresh` and `CustomScrollArea` component imports
- Deleted the `handleRefresh` callback that fetched updated page content from the server
- Removed `isPullToRefreshDisabled` state logic
- Replaced wrapped layout with direct conditional rendering of tab content
- Simplified DOM structure by removing unnecessary wrapper components
- Added `min-h-0` to code editor container to ensure proper flex layout behavior

## Implementation Details
- The code and view tabs now render directly without intermediate scroll/refresh wrappers
- Both tab contents use `flex-1` to fill available space
- The view tab maintains `w-full` for full-width rendering
- Removed server-side refresh capability; content updates now rely on existing state management

https://claude.ai/code/session_0112v61RDQYzuhTgQWJMmRCk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed pull-to-refresh functionality from the canvas page view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->