### PR TITLE
Improve extractPreviewText to handle structured content formats

### DIFF
--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/__tests__/route.test.ts
@@ -21,12 +21,16 @@ vi.mock('@/lib/repositories/conversation-repository', () => ({
     if (!content) return 'New conversation';
     try {
       const parsed = JSON.parse(content);
+      if (typeof parsed === 'object' && !Array.isArray(parsed)) {
+        if (parsed.originalContent && typeof parsed.originalContent === 'string') return parsed.originalContent.substring(0, 100);
+        if (Array.isArray(parsed.textParts) && parsed.textParts.length > 0) return parsed.textParts[0].substring(0, 100);
+        if (parsed.parts?.[0]?.text) return parsed.parts[0].text.substring(0, 100);
+      }
       if (Array.isArray(parsed) && parsed[0]?.text) return parsed[0].text.substring(0, 100);
-      if (parsed.parts?.[0]?.text) return parsed.parts[0].text.substring(0, 100);
     } catch {
       return content.substring(0, 100);
     }
-    return 'New conversation';
+    return content.substring(0, 100);
   }),
   generateTitle: vi.fn((preview: string) => preview.length > 50 ? preview.substring(0, 50) + '...' : preview),
 }));
@@ -418,6 +422,33 @@ describe('extractPreviewText (pure function)', () => {
     const { extractPreviewText } = actualModule;
 
     expect(extractPreviewText('plain text message')).toBe('plain text message');
+  });
+
+  it('should extract text from structured content with originalContent', async () => {
+    const actualModule = await vi.importActual<
+      typeof import('@/lib/repositories/conversation-repository')
+    >('@/lib/repositories/conversation-repository');
+    const { extractPreviewText } = actualModule;
+
+    const content = JSON.stringify({
+      textParts: ['Hello structured'],
+      partsOrder: [{ index: 0, type: 'text' }],
+      originalContent: 'Hello structured',
+    });
+    expect(extractPreviewText(content)).toBe('Hello structured');
+  });
+
+  it('should extract text from structured content with textParts when originalContent is missing', async () => {
+    const actualModule = await vi.importActual<
+      typeof import('@/lib/repositories/conversation-repository')
+    >('@/lib/repositories/conversation-repository');
+    const { extractPreviewText } = actualModule;
+
+    const content = JSON.stringify({
+      textParts: ['Hello from textParts'],
+      partsOrder: [{ index: 0, type: 'text' }],
+    });
+    expect(extractPreviewText(content)).toBe('Hello from textParts');
   });
 });
 

--- a/apps/web/src/lib/repositories/conversation-repository.ts
+++ b/apps/web/src/lib/repositories/conversation-repository.ts
@@ -47,10 +47,21 @@ export function extractPreviewText(content: string | null): string {
 
   try {
     const parsed = JSON.parse(content);
+    // Structured content format (textParts/originalContent from saveMessageToDatabase)
+    if (typeof parsed === 'object' && !Array.isArray(parsed)) {
+      if (parsed.originalContent && typeof parsed.originalContent === 'string') {
+        return parsed.originalContent.substring(0, 100);
+      }
+      if (Array.isArray(parsed.textParts) && parsed.textParts.length > 0 && typeof parsed.textParts[0] === 'string') {
+        return parsed.textParts[0].substring(0, 100);
+      }
+      if (parsed.parts?.[0]?.text) {
+        return parsed.parts[0].text.substring(0, 100);
+      }
+    }
+    // Legacy array format
     if (Array.isArray(parsed) && parsed.length > 0 && parsed[0].text) {
       return parsed[0].text.substring(0, 100);
-    } else if (typeof parsed === 'object' && parsed.parts?.[0]?.text) {
-      return parsed.parts[0].text.substring(0, 100);
     }
     // JSON parsed but didn't match expected formats - use raw content
     return content.substring(0, 100);


### PR DESCRIPTION
## Summary
Enhanced the `extractPreviewText` function to properly handle structured content formats with `originalContent` and `textParts` fields, improving preview text extraction for conversations with complex message structures.

## Key Changes
- **Reordered extraction logic** to prioritize structured content formats (object with `originalContent`/`textParts`) before legacy array formats
- **Added support for `originalContent` field** as the primary extraction source for structured messages
- **Added fallback to `textParts` array** when `originalContent` is not available
- **Maintained backward compatibility** with existing `parts[].text` and legacy array formats
- **Updated fallback behavior** to return truncated raw content instead of "New conversation" when JSON parsing succeeds but no recognized format is found
- **Added comprehensive test coverage** for the new structured content extraction paths

## Implementation Details
The extraction now follows this priority order:
1. Structured object format with `originalContent` field
2. Structured object format with `textParts` array
3. Structured object format with `parts[].text` 
4. Legacy array format with `[].text`
5. Raw content (truncated to 100 chars)

This change ensures that messages saved with the structured format from `saveMessageToDatabase` are properly previewed in conversation lists.

https://claude.ai/code/session_01UmwS4Zc6LgRhic2qMYwEmX