### PR TITLE
Improve calendar time gutter sticky positioning and alignment

### DIFF
--- a/apps/web/src/components/calendar/DayView.tsx
+++ b/apps/web/src/components/calendar/DayView.tsx
@@ -133,16 +133,18 @@ export function DayView({ currentDate, events, tasks, handlers }: DayViewProps) 
       <div ref={containerRef} className="flex-1 overflow-auto">
         <div className="flex min-h-full">
           {/* Time gutter */}
-          <div className="w-20 shrink-0 border-r">
+          <div className="w-20 shrink-0 border-r sticky left-0 bg-background z-10">
             {HOURS.map((hour) => (
               <div
                 key={hour}
                 className="relative border-b"
                 style={{ height: HOUR_HEIGHT }}
               >
-                <span className="absolute -top-2.5 right-3 text-xs text-muted-foreground">
-                  {format(setHours(new Date(), hour), 'h a')}
-                </span>
+                {hour > 0 && (
+                  <span className="absolute top-0 right-3 -translate-y-1/2 text-xs text-muted-foreground leading-none">
+                    {format(setHours(new Date(), hour), 'h a')}
+                  </span>
+                )}
               </div>
             ))}
           </div>

--- a/apps/web/src/components/calendar/WeekView.tsx
+++ b/apps/web/src/components/calendar/WeekView.tsx
@@ -157,16 +157,18 @@ export function WeekView({ currentDate, events, tasks, handlers }: WeekViewProps
       <div ref={containerRef} className="flex-1 overflow-auto">
         <div className="flex min-h-full">
           {/* Time gutter */}
-          <div className="w-16 shrink-0 border-r">
+          <div className="w-16 shrink-0 border-r sticky left-0 bg-background z-10">
             {HOURS.map((hour) => (
               <div
                 key={hour}
                 className="relative border-b"
                 style={{ height: HOUR_HEIGHT }}
               >
-                <span className="absolute -top-2.5 right-2 text-xs text-muted-foreground">
-                  {format(setHours(new Date(), hour), 'h a')}
-                </span>
+                {hour > 0 && (
+                  <span className="absolute top-0 right-2 -translate-y-1/2 text-xs text-muted-foreground leading-none">
+                    {format(setHours(new Date(), hour), 'h a')}
+                  </span>
+                )}
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
Enhanced the time gutter in both DayView and WeekView calendar components to be sticky during horizontal scrolling and improved the visual alignment of hour labels.

## Key Changes
- Made the time gutter (`sticky left-0 bg-background z-10`) so it remains visible when scrolling horizontally through calendar events
- Improved hour label positioning by:
  - Changing from `-top-2.5` to `top-0 -translate-y-1/2` for more precise vertical centering
  - Adding `leading-none` to prevent line-height from affecting alignment
  - Hiding the "0" hour label (midnight) with `hour > 0` conditional to reduce visual clutter
- Applied consistent changes across both DayView and WeekView components

## Implementation Details
The time gutter now uses CSS `sticky` positioning with proper z-index layering to ensure it stays visible during horizontal scrolling while maintaining the calendar's visual hierarchy. The hour label centering uses CSS transforms for more reliable alignment across different browsers and font sizes.

https://claude.ai/code/session_012VnPGU2n6WUM4Z856xxgDU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Calendar day and week views now feature sticky time gutters that remain visible while scrolling through events.
  * Improved hour label positioning and alignment to enhance readability and clarity of time markers in calendar grids.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->