### PR TITLE
Split DriveSwitcher into navigable name and dropdown toggle

### DIFF
--- a/apps/web/src/components/layout/navbar/DriveSwitcher.tsx
+++ b/apps/web/src/components/layout/navbar/DriveSwitcher.tsx
@@ -131,21 +131,40 @@ export default function DriveSwitcher() {
     return <Skeleton className="h-9 w-40" />;
   }
 
+  const handleNavigateToDriveRoot = () => {
+    if (currentDriveId) {
+      router.push(`/dashboard/${currentDriveId}`);
+    } else {
+      setIsOpen(true);
+    }
+  };
+
   return (
     <>
-      <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="ghost"
-            className="flex items-center gap-2 px-2 h-9 max-w-[200px]"
-          >
-            <Folder className="h-4 w-4 shrink-0" />
-            <span className="truncate font-medium">
-              {currentDrive ? currentDrive.name : "Select Drive"}
-            </span>
-            <ChevronsUpDown className="h-4 w-4 shrink-0 text-muted-foreground" />
-          </Button>
-        </DropdownMenuTrigger>
+      <div className="flex items-center h-9 rounded-md">
+        {/* Clicking folder + name navigates to drive root */}
+        <button
+          onClick={handleNavigateToDriveRoot}
+          className="flex items-center gap-2 pl-2 pr-1 h-9 max-w-[170px] hover:bg-accent rounded-l-md transition-colors"
+          title={currentDrive ? `Go to ${currentDrive.name} root` : "Select a drive"}
+        >
+          <Folder className="h-4 w-4 shrink-0" />
+          <span className="truncate font-medium">
+            {currentDrive ? currentDrive.name : "Select Drive"}
+          </span>
+        </button>
+
+        {/* Chevron opens the drive switcher dropdown */}
+        <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              className="px-1 h-9 w-7 shrink-0 rounded-l-none rounded-r-md"
+              title="Switch drive"
+            >
+              <ChevronsUpDown className="h-4 w-4 text-muted-foreground" />
+            </Button>
+          </DropdownMenuTrigger>
         <DropdownMenuContent className="w-64" align="start">
           {/* Search */}
           <div className="p-2">
@@ -246,7 +265,8 @@ export default function DriveSwitcher() {
             Create Drive
           </DropdownMenuItem>
         </DropdownMenuContent>
-      </DropdownMenu>
+        </DropdownMenu>
+      </div>
 
       <CreateDriveDialog isOpen={isCreateDriveOpen} setIsOpen={setCreateDriveOpen} />
     </>


### PR DESCRIPTION
## Summary
Refactored the DriveSwitcher component to separate the drive name display from the dropdown trigger, enabling direct navigation to the drive root when clicking the folder icon and name.

## Key Changes
- Split the single button into two interactive elements:
  - Left section (folder icon + drive name): Navigates to the drive root when clicked
  - Right section (chevron icon): Opens the drive switcher dropdown menu
- Added `handleNavigateToDriveRoot()` function that navigates to `/dashboard/{driveId}` or opens the dropdown if no drive is selected
- Updated styling to reflect the two-part layout with rounded corners on appropriate sides
- Added descriptive `title` attributes for better UX clarity
- Wrapped both elements in a flex container for proper alignment and spacing

## Implementation Details
- The left button uses `hover:bg-accent` for visual feedback on interaction
- The right button (dropdown trigger) has `rounded-l-none rounded-r-md` to create a cohesive two-part appearance
- Maintains all existing dropdown functionality while adding the new navigation feature
- The dropdown menu content remains unchanged

https://claude.ai/code/session_011ztG1vdgTQzZ3s76q2XGCK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved drive switcher interaction: the drive name button now directly navigates to that drive, while the dropdown menu (accessed via chevron) allows switching between drives. Enhanced accessibility with improved tooltips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->