### PR TITLE
fix: require HMAC auth for all webhook paths (#563)

### DIFF
--- a/apps/web/src/app/api/integrations/google-calendar/webhook/__tests__/route.test.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/webhook/__tests__/route.test.ts
@@ -101,10 +101,13 @@ describe('Google Calendar Webhook Route', () => {
   });
 
   describe('sync confirmation (resourceState=sync)', () => {
-    it('given sync state, should return 200 without auth check', async () => {
+    it('given sync state with valid token, should return 200', async () => {
+      const userId = 'user-sync-123';
+      const token = generateWebhookToken(userId);
+
       const request = createWebhookRequest({
         resourceState: 'sync',
-        channelToken: null, // No token provided
+        channelToken: token,
       });
 
       const response = await POST(request);
@@ -112,6 +115,47 @@ describe('Google Calendar Webhook Route', () => {
       expect(response.status).toBe(200);
       const data = await response.json();
       expect(data.ok).toBe(true);
+    });
+
+    it('given sync state without token, should return 401', async () => {
+      const request = createWebhookRequest({
+        resourceState: 'sync',
+        channelToken: null,
+      });
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data.error).toBe('Missing authentication token');
+    });
+
+    it('given sync state with invalid token, should return 401', async () => {
+      const request = createWebhookRequest({
+        resourceState: 'sync',
+        channelToken: 'invalid.token',
+      });
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(401);
+      const data = await response.json();
+      expect(data.error).toBe('Invalid authentication token');
+    });
+
+    it('given sync state with valid token, should NOT trigger calendar sync', async () => {
+      const { syncGoogleCalendar } = await import('@/lib/integrations/google-calendar/sync-service');
+      const userId = 'user-sync-456';
+      const token = generateWebhookToken(userId);
+
+      const request = createWebhookRequest({
+        resourceState: 'sync',
+        channelToken: token,
+      });
+
+      await POST(request);
+
+      expect(syncGoogleCalendar).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/integrations/google-calendar/webhook/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/webhook/route.ts
@@ -17,8 +17,9 @@ import { validateWebhookAuth } from '@/lib/integrations/google-calendar/webhook-
  * - X-Goog-Channel-Token: Secret token we provided during watch registration
  *
  * Zero-trust authentication:
- * - All sync-triggering requests MUST include a valid HMAC token
+ * - ALL requests MUST include a valid HMAC token (including sync confirmations)
  * - No fallback to channel/resource ID lookup
+ * - No unauthenticated code paths
  */
 export async function POST(request: Request) {
   try {
@@ -32,24 +33,25 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Missing headers' }, { status: 400 });
     }
 
-    // Initial sync notification - just acknowledge (no auth required for sync confirmation)
-    if (resourceState === 'sync') {
-      loggers.api.info('Google Calendar webhook: sync confirmation received', { channelId, hasToken: !!channelToken });
-      return NextResponse.json({ ok: true });
-    }
-
-    // Zero-trust authentication: require valid HMAC token
+    // Zero-trust authentication: ALL requests MUST have a valid HMAC token
     const authResult = validateWebhookAuth(channelToken);
     if (authResult instanceof NextResponse) {
       loggers.api.warn('Google Calendar webhook: auth failed', {
         channelId,
         resourceId,
+        resourceState,
         hasToken: !!channelToken,
       });
       return authResult;
     }
 
     const { userId } = authResult;
+
+    // Initial sync notification - acknowledge after auth verification
+    if (resourceState === 'sync') {
+      loggers.api.info('Google Calendar webhook: sync confirmation received', { channelId, userId });
+      return NextResponse.json({ ok: true });
+    }
 
     loggers.api.info('Google Calendar webhook: triggering sync', {
       userId,


### PR DESCRIPTION
## Summary
Hardened the Google Calendar webhook handler to require strict HMAC authentication on ALL code paths, closing the unauthenticated fallback via `resourceState=sync`.

Previously, the `sync` confirmation path (sent by Google when a watch channel is first established) bypassed authentication entirely — any request with `resourceState: sync` and valid channel/resource IDs would get a 200 OK without token verification. Now authentication runs **before** the resource state check, so every request must carry a valid HMAC token.

Closes #563

## Changes
- `apps/web/src/app/api/integrations/google-calendar/webhook/route.ts`
  - Moved `validateWebhookAuth()` call **above** the `resourceState === 'sync'` check so auth runs first for all requests
  - Added `resourceState` to auth failure log for better diagnostics
  - Updated doc comment to reflect zero unauthenticated paths

- `apps/web/src/app/api/integrations/google-calendar/webhook/__tests__/route.test.ts`
  - Replaced the single "sync without auth" test with 4 new tests:
    - Sync with valid token returns 200
    - Sync without token returns 401
    - Sync with invalid token returns 401
    - Sync with valid token does NOT trigger calendar sync (correct behavior for sync confirmations)
  - Total test count: 17 route tests + 11 auth tests + 17 token tests = 45 passing

## Notes
- The `webhook-auth.ts` and `webhook-token.ts` modules were already well-implemented with zero-trust, timing-safe HMAC verification, and fail-closed production behavior. No changes needed there.
- Google echoes back the `X-Goog-Channel-Token` on sync notifications (since we provide it during `watch()` registration), so requiring auth on sync is both correct and compatible.

## Test plan
- [x] All 45 webhook tests pass (route, auth, token)
- [ ] Verify sync confirmations from Google still succeed (token is echoed back from watch registration)
- [ ] Verify calendar change notifications continue to trigger sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)