### PR TITLE
fix: preserve sessionId/requestId in middleware-flushed api_metrics

### DIFF
--- a/apps/web/src/middleware/monitoring.ts
+++ b/apps/web/src/middleware/monitoring.ts
@@ -19,6 +19,8 @@ interface RequestMetrics {
   duration: number;
   timestamp: Date;
   userId?: string;
+  sessionId?: string;
+  requestId?: string;
   ip?: string;
   userAgent?: string;
   requestSize?: number;
@@ -93,6 +95,8 @@ class MetricsCollector {
           duration: metric.duration,
           timestamp: metric.timestamp,
           userId: metric.userId,
+          sessionId: metric.sessionId,
+          requestId: metric.requestId,
           ip: metric.ip,
           userAgent: metric.userAgent,
           requestSize: metric.requestSize,
@@ -332,6 +336,8 @@ export async function monitoringMiddleware(
       duration,
       timestamp: startedAt,
       userId,
+      sessionId: context.sessionId,
+      requestId,
       ip: context.ip,
       userAgent: context.userAgent,
       requestSize,
@@ -395,6 +401,8 @@ export async function monitoringMiddleware(
       duration,
       timestamp: startedAt,
       userId,
+      sessionId: context.sessionId,
+      requestId,
       ip: context.ip,
       userAgent: context.userAgent,
       error: errorMessage


### PR DESCRIPTION
Closes #538

## Summary
- Added `sessionId` and `requestId` fields to the `RequestMetrics` interface in the monitoring middleware
- Populated them in both the success and error `track()` calls
- Included them in the database flush insert mapping

This ensures that when metrics are batch-flushed to the `api_metrics` table, the `session_id` and `request_id` columns (which already existed in the DB schema) are now populated.

## Changes
- `apps/web/src/middleware/monitoring.ts`
  - Added `sessionId?: string` and `requestId?: string` to `RequestMetrics` interface
  - Added `sessionId: context.sessionId` and `requestId` to the success-path `metricsCollector.track()` call
  - Added `sessionId: context.sessionId` and `requestId` to the error-path `metricsCollector.track()` call
  - Added `sessionId: metric.sessionId` and `requestId: metric.requestId` to the flush `db.insert()` mapping

## Notes
- The `apiMetrics` DB schema already had `sessionId` and `requestId` columns — they were just never populated by the middleware flush
- The `MonitoringIngestPayload` (separate ingest endpoint) was already passing these fields correctly — only the buffered DB flush was missing them
- `requestId` comes from `getOrCreateRequestId(request)` which was already being called for the ingest path and response headers
- `sessionId` comes from `context.sessionId` via `extractRequestContext()` — the same source already used in the ingest payload

## Test plan
- [x] `monitoring.ts` has zero type errors
- [x] All 2 existing monitoring tests pass
- [ ] Verify `api_metrics` rows contain `session_id` and `request_id` after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)