### PR TITLE
feat: log login rate-limit denials as security audit events

### DIFF
--- a/apps/web/src/app/api/auth/__tests__/login.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/login.test.ts
@@ -94,6 +94,18 @@ vi.mock('@pagespace/lib/activity-tracker', () => ({
   trackAuthEvent: vi.fn(),
 }));
 
+vi.mock('@pagespace/lib/audit', () => ({
+  securityAudit: {
+    logEvent: vi.fn().mockResolvedValue(undefined),
+  },
+  maskEmail: vi.fn((email: string) => {
+    const [local, domain] = email.split('@');
+    if (!local || !domain) return '***@***';
+    const visibleChars = Math.min(2, local.length);
+    return `${local.slice(0, visibleChars)}***@${domain}`;
+  }),
+}));
+
 vi.mock('cookie', () => ({
   serialize: vi.fn().mockReturnValue('mock-cookie'),
   parse: vi.fn(() => ({ login_csrf: 'valid-csrf-token' })),
@@ -132,6 +144,7 @@ import {
   resetDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
 } from '@pagespace/lib/security';
+import { securityAudit } from '@pagespace/lib/audit';
 
 // Test fixtures
 const mockUser: User = {
@@ -447,6 +460,67 @@ describe('POST /api/auth/login', () => {
 
       // Database should not be queried when rate limited
       expect(authRepository.findUserByEmail).not.toHaveBeenCalled();
+    });
+
+    it('emits security audit event when IP rate limit triggers', async () => {
+      vi.mocked(getClientIP).mockReturnValue('192.168.1.1');
+      vi.mocked(checkDistributedRateLimit)
+        .mockResolvedValueOnce({ allowed: false, retryAfter: 900, attemptsRemaining: 0 })
+        .mockResolvedValue({ allowed: true, attemptsRemaining: 4 });
+
+      const request = createLoginRequest(validLoginPayload);
+      await POST(request);
+
+      expect(securityAudit.logEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: 'security.rate.limited',
+          ipAddress: '192.168.1.1',
+          details: expect.objectContaining({
+            limiter: 'ip',
+            endpoint: '/api/auth/login',
+          }),
+          riskScore: 0.4,
+        })
+      );
+    });
+
+    it('emits security audit event when email rate limit triggers', async () => {
+      vi.mocked(getClientIP).mockReturnValue('10.0.0.1');
+      vi.mocked(checkDistributedRateLimit)
+        .mockResolvedValueOnce({ allowed: true, attemptsRemaining: 4 })
+        .mockResolvedValueOnce({ allowed: false, retryAfter: 900, attemptsRemaining: 0 });
+
+      const request = createLoginRequest(validLoginPayload);
+      await POST(request);
+
+      expect(securityAudit.logEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: 'security.rate.limited',
+          ipAddress: '10.0.0.1',
+          details: expect.objectContaining({
+            limiter: 'email',
+            endpoint: '/api/auth/login',
+          }),
+          riskScore: 0.4,
+        })
+      );
+    });
+
+    it('masks email in security audit event details', async () => {
+      vi.mocked(checkDistributedRateLimit)
+        .mockResolvedValueOnce({ allowed: true, attemptsRemaining: 4 })
+        .mockResolvedValueOnce({ allowed: false, retryAfter: 900, attemptsRemaining: 0 });
+
+      const request = createLoginRequest(validLoginPayload);
+      await POST(request);
+
+      expect(securityAudit.logEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          details: expect.objectContaining({
+            email: 'te***@example.com',
+          }),
+        })
+      );
     });
   });
 

--- a/apps/web/src/app/api/auth/__tests__/mobile-login.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/mobile-login.test.ts
@@ -55,6 +55,18 @@ vi.mock('@pagespace/lib/activity-tracker', () => ({
   trackAuthEvent: vi.fn(),
 }));
 
+vi.mock('@pagespace/lib/audit', () => ({
+  securityAudit: {
+    logEvent: vi.fn().mockResolvedValue(undefined),
+  },
+  maskEmail: vi.fn((email: string) => {
+    const [local, domain] = email.split('@');
+    if (!local || !domain) return '***@***';
+    const visibleChars = Math.min(2, local.length);
+    return `${local.slice(0, visibleChars)}***@${domain}`;
+  }),
+}));
+
 // Mock distributed rate limiting (P1-T5)
 vi.mock('@pagespace/lib/security', () => ({
   checkDistributedRateLimit: vi.fn().mockResolvedValue({
@@ -81,6 +93,7 @@ import {
   resetDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
 } from '@pagespace/lib/security';
+import { securityAudit } from '@pagespace/lib/audit';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
 
 describe('/api/auth/mobile/login', () => {
@@ -498,6 +511,86 @@ describe('/api/auth/mobile/login', () => {
       // Assert
       expect(response.status).toBe(429);
       expect(body.error).toContain('Too many login attempts for this email');
+    });
+
+    it('emits security audit event when IP rate limit triggers', async () => {
+      vi.mocked(checkDistributedRateLimit)
+        .mockResolvedValueOnce({ allowed: false, retryAfter: 900, attemptsRemaining: 0 })
+        .mockResolvedValue({ allowed: true, attemptsRemaining: 4 });
+
+      const request = new Request('http://localhost/api/auth/mobile/login', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-forwarded-for': '192.168.1.1',
+        },
+        body: JSON.stringify(validLoginPayload),
+      });
+
+      await POST(request);
+
+      expect(securityAudit.logEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: 'security.rate.limited',
+          ipAddress: '192.168.1.1',
+          details: expect.objectContaining({
+            limiter: 'ip',
+            endpoint: '/api/auth/mobile/login',
+          }),
+          riskScore: 0.4,
+        })
+      );
+    });
+
+    it('emits security audit event when email rate limit triggers', async () => {
+      vi.mocked(checkDistributedRateLimit)
+        .mockResolvedValueOnce({ allowed: true, attemptsRemaining: 4 })
+        .mockResolvedValueOnce({ allowed: false, retryAfter: 900, attemptsRemaining: 0 });
+
+      const request = new Request('http://localhost/api/auth/mobile/login', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-forwarded-for': '10.0.0.1',
+        },
+        body: JSON.stringify(validLoginPayload),
+      });
+
+      await POST(request);
+
+      expect(securityAudit.logEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: 'security.rate.limited',
+          ipAddress: '10.0.0.1',
+          details: expect.objectContaining({
+            limiter: 'email',
+            endpoint: '/api/auth/mobile/login',
+          }),
+          riskScore: 0.4,
+        })
+      );
+    });
+
+    it('masks email in security audit event details', async () => {
+      vi.mocked(checkDistributedRateLimit)
+        .mockResolvedValueOnce({ allowed: true, attemptsRemaining: 4 })
+        .mockResolvedValueOnce({ allowed: false, retryAfter: 900, attemptsRemaining: 0 });
+
+      const request = new Request('http://localhost/api/auth/mobile/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validLoginPayload),
+      });
+
+      await POST(request);
+
+      expect(securityAudit.logEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          details: expect.objectContaining({
+            email: 'te***@example.com',
+          }),
+        })
+      );
     });
   });
 

--- a/apps/web/src/app/api/auth/login/route.ts
+++ b/apps/web/src/app/api/auth/login/route.ts
@@ -16,6 +16,7 @@ import {
 import { parse } from 'cookie';
 import { loggers, logAuthEvent, logSecurityEvent } from '@pagespace/lib/server';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
+import { securityAudit, maskEmail } from '@pagespace/lib/audit';
 import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-started-drive';
 import { validateLoginCSRFToken, getClientIP } from '@/lib/auth';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';
@@ -92,6 +93,12 @@ export async function POST(req: Request) {
     ]);
 
     if (!distributedIpLimit.allowed) {
+      securityAudit.logEvent({
+        eventType: 'security.rate.limited',
+        ipAddress: clientIP,
+        details: { limiter: 'ip', endpoint: '/api/auth/login', email: maskEmail(email) },
+        riskScore: 0.4,
+      }).catch(() => {});
       return Response.json(
         {
           error: 'Too many login attempts from this IP address. Please try again later.',
@@ -109,6 +116,12 @@ export async function POST(req: Request) {
     }
 
     if (!distributedEmailLimit.allowed) {
+      securityAudit.logEvent({
+        eventType: 'security.rate.limited',
+        ipAddress: clientIP,
+        details: { limiter: 'email', endpoint: '/api/auth/login', email: maskEmail(email) },
+        riskScore: 0.4,
+      }).catch(() => {});
       return Response.json(
         {
           error: 'Too many login attempts for this email. Please try again later.',

--- a/apps/web/src/app/api/auth/mobile/login/route.ts
+++ b/apps/web/src/app/api/auth/mobile/login/route.ts
@@ -14,6 +14,7 @@ import { generateCSRFToken } from '@pagespace/lib/server';
 import { sessionService } from '@pagespace/lib/auth';
 import { loggers, logAuthEvent } from '@pagespace/lib/server';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
+import { securityAudit, maskEmail } from '@pagespace/lib/audit';
 import { getClientIP } from '@/lib/auth';
 import { createSessionCookie } from '@/lib/auth/cookie-config';
 
@@ -49,6 +50,12 @@ export async function POST(req: Request) {
     ]);
 
     if (!distributedIpLimit.allowed) {
+      securityAudit.logEvent({
+        eventType: 'security.rate.limited',
+        ipAddress: clientIP,
+        details: { limiter: 'ip', endpoint: '/api/auth/mobile/login', email: maskEmail(email) },
+        riskScore: 0.4,
+      }).catch(() => {});
       return Response.json(
         {
           error: 'Too many login attempts from this IP address. Please try again later.',
@@ -66,6 +73,12 @@ export async function POST(req: Request) {
     }
 
     if (!distributedEmailLimit.allowed) {
+      securityAudit.logEvent({
+        eventType: 'security.rate.limited',
+        ipAddress: clientIP,
+        details: { limiter: 'email', endpoint: '/api/auth/mobile/login', email: maskEmail(email) },
+        riskScore: 0.4,
+      }).catch(() => {});
       return Response.json(
         {
           error: 'Too many login attempts for this email. Please try again later.',

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -223,6 +223,11 @@
       "import": "./dist/auth/secure-compare.js",
       "require": "./dist/auth/secure-compare.js"
     },
+    "./audit": {
+      "types": "./dist/audit/index.d.ts",
+      "import": "./dist/audit/index.js",
+      "require": "./dist/audit/index.js"
+    },
     "./security": {
       "types": "./dist/security/index.d.ts",
       "import": "./dist/security/index.js",
@@ -388,6 +393,9 @@
       ],
       "secure-compare": [
         "./dist/auth/secure-compare.d.ts"
+      ],
+      "audit": [
+        "./dist/audit/index.d.ts"
       ],
       "security": [
         "./dist/security/index.d.ts"

--- a/packages/lib/src/audit/__tests__/mask-email.test.ts
+++ b/packages/lib/src/audit/__tests__/mask-email.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { maskEmail } from '../index';
+
+describe('maskEmail', () => {
+  it('masks standard email addresses', () => {
+    expect(maskEmail('john@example.com')).toBe('jo***@example.com');
+  });
+
+  it('masks short local parts', () => {
+    expect(maskEmail('j@example.com')).toBe('j***@example.com');
+  });
+
+  it('masks two-char local parts', () => {
+    expect(maskEmail('ab@example.com')).toBe('ab***@example.com');
+  });
+
+  it('limits visible characters to 2', () => {
+    expect(maskEmail('longusername@example.com')).toBe('lo***@example.com');
+  });
+
+  it('returns fallback for invalid email without @', () => {
+    expect(maskEmail('invalid')).toBe('***@***');
+  });
+
+  it('returns fallback for empty string', () => {
+    expect(maskEmail('')).toBe('***@***');
+  });
+
+  it('preserves the domain', () => {
+    expect(maskEmail('test@my-company.co.uk')).toBe('te***@my-company.co.uk');
+  });
+});

--- a/packages/lib/src/audit/index.ts
+++ b/packages/lib/src/audit/index.ts
@@ -11,3 +11,11 @@ export {
   type AuditEvent,
   type QueryEventsOptions,
 } from './security-audit';
+
+/** Mask email to prevent PII in audit logs (e.g., john@example.com -> jo***@example.com) */
+export function maskEmail(email: string): string {
+  const [local, domain] = email.split('@');
+  if (!local || !domain) return '***@***';
+  const visibleChars = Math.min(2, local.length);
+  return `${local.slice(0, visibleChars)}***@${domain}`;
+}


### PR DESCRIPTION
## Summary

Closes #536

- Emit immutable `security.rate.limited` audit events when rate limiters deny login attempts on both web (`/api/auth/login`) and mobile (`/api/auth/mobile/login`) endpoints
- Events include masked email addresses, client IP, and which limiter (IP vs email) triggered
- Added shared `maskEmail()` utility to `@pagespace/lib/audit`

## Changes

- **packages/lib/src/audit/index.ts** — Added shared `maskEmail()` utility (masks to `jo***@example.com` format)
- **packages/lib/package.json** — Added `@pagespace/lib/audit` export path
- **apps/web/src/app/api/auth/login/route.ts** — Emit audit events on IP/email rate limit denial
- **apps/web/src/app/api/auth/mobile/login/route.ts** — Emit audit events on IP/email rate limit denial
- **apps/web/src/app/api/auth/__tests__/login.test.ts** — 3 new tests (IP audit, email audit, email masking)
- **apps/web/src/app/api/auth/__tests__/mobile-login.test.ts** — 3 new tests (IP audit, email audit, email masking)
- **packages/lib/src/audit/__tests__/mask-email.test.ts** — 7 unit tests for `maskEmail()`

## Design decisions

- Audit calls are fire-and-forget (`.catch(() => {})`) so audit failure never blocks the 429 response
- Reuses existing `security.rate.limited` event type and 0.4 risk score from `SecurityAuditService`
- Event details distinguish which limiter triggered (`ip` vs `email`) and which endpoint

## Test plan

- [x] All 61 login tests pass (36 web + 25 mobile)
- [x] No new typecheck errors
- [ ] Verify audit events appear in `security_audit_log` table after rate-limit trigger in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)