### PR TITLE
test: cron auth fail-closed and anti-replay coverage (#562)

### DIFF
--- a/apps/web/src/lib/auth/__tests__/cron-auth.test.ts
+++ b/apps/web/src/lib/auth/__tests__/cron-auth.test.ts
@@ -238,8 +238,57 @@ describe('cron-auth', () => {
       expect(data.error).toContain('signature');
     });
 
-    it('given missing headers, should return 403', async () => {
+    it('given missing timestamp header, should return 403', async () => {
       const request = createSignedRequest({ omitHeaders: ['x-cron-timestamp'] });
+      const response = validateSignedCronRequest(request);
+
+      expect(response).not.toBeNull();
+      expect(response!.status).toBe(403);
+      const data = await response!.json();
+      expect(data.error).toContain('missing');
+    });
+
+    it('given completely unsigned request (no cron headers), should return 403', async () => {
+      const request = new Request('http://web:3000/api/cron/test', {
+        method: 'POST',
+        headers: { host: 'web:3000' },
+      });
+      const response = validateSignedCronRequest(request);
+
+      expect(response).not.toBeNull();
+      expect(response!.status).toBe(403);
+      const data = await response!.json();
+      expect(data.error).toContain('missing cron authentication headers');
+    });
+
+    it('given request with only Authorization header (no cron signature), should return 403', async () => {
+      const request = new Request('http://web:3000/api/cron/test', {
+        method: 'POST',
+        headers: {
+          host: 'web:3000',
+          authorization: 'Bearer some-token',
+        },
+      });
+      const response = validateSignedCronRequest(request);
+
+      expect(response).not.toBeNull();
+      expect(response!.status).toBe(403);
+      const data = await response!.json();
+      expect(data.error).toContain('missing cron authentication headers');
+    });
+
+    it('given missing nonce header, should return 403', async () => {
+      const request = createSignedRequest({ omitHeaders: ['x-cron-nonce'] });
+      const response = validateSignedCronRequest(request);
+
+      expect(response).not.toBeNull();
+      expect(response!.status).toBe(403);
+      const data = await response!.json();
+      expect(data.error).toContain('missing');
+    });
+
+    it('given missing signature header, should return 403', async () => {
+      const request = createSignedRequest({ omitHeaders: ['x-cron-signature'] });
       const response = validateSignedCronRequest(request);
 
       expect(response).not.toBeNull();


### PR DESCRIPTION
## Summary
Audited all cron routes and cron authentication for issue #562. Found that the codebase was already well-implemented:

- **Fail-closed in production**: `validateSignedCronRequest` in `cron-auth.ts` already denies requests when `CRON_SECRET` is missing in production (returns 403)
- **All 8 cron routes already use `validateSignedCronRequest`**: calendar-sync, cleanup-orphaned-files, cleanup-tokens, purge-ai-usage-logs, purge-deleted-messages, retention-cleanup, verify-audit-chain, and workflows
- **Internal routes** (contact, monitoring/ingest) use separate auth mechanisms appropriate to their purpose (INTERNAL_API_SECRET, MONITORING_INGEST_KEY) and are not cron endpoints

Added 4 new test cases to strengthen coverage for the specific scenarios called out in #562:
- Completely unsigned request (no cron headers at all) is denied
- Request with only Authorization header (no cron signature) is denied
- Missing nonce header is denied
- Missing signature header is denied

## Changes
- `apps/web/src/lib/auth/__tests__/cron-auth.test.ts` — Added 4 new test cases (27 → 31 tests)

## Notes
- No code changes were needed to `cron-auth.ts` itself — the fail-closed behavior and signed validation were already correctly implemented
- All 8 cron routes were already migrated to `validateSignedCronRequest` — no legacy auth patterns found
- The 2 internal API routes (`/api/internal/contact`, `/api/internal/monitoring/ingest`) use different auth mechanisms (shared secrets) appropriate for non-cron internal APIs
- Typecheck passes clean; all 31 tests pass

## Test plan
- [x] `pnpm vitest run src/lib/auth/__tests__/cron-auth.test.ts` — 31/31 pass
- [x] `pnpm --filter web typecheck` — clean

Closes #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)