### PR TITLE
fix: restrict global drive websocket broadcasts to authorized recipients

### DIFF
--- a/apps/realtime/src/__tests__/rooms.test.ts
+++ b/apps/realtime/src/__tests__/rooms.test.ts
@@ -71,9 +71,11 @@ const createRoomHandlers = (socket: ReturnType<typeof createMockSocket>) => {
         const notificationRoom = `notifications:${user.id}`;
         const taskRoom = `user:${user.id}:tasks`;
         const calendarRoom = `user:${user.id}:calendar`;
+        const userDrivesRoom = `user:${user.id}:drives`;
         socket.join(notificationRoom);
         socket.join(taskRoom);
         socket.join(calendarRoom);
+        socket.join(userDrivesRoom);
       }
     },
 
@@ -140,20 +142,20 @@ const createRoomHandlers = (socket: ReturnType<typeof createMockSocket>) => {
       socket.leave(driveCalendarRoom);
     },
 
-    // join_global_drives handler
-    joinGlobalDrives: () => {
+    // Auto-join user-specific drives room (on connect)
+    joinUserDrivesRoom: () => {
       if (!user?.id) return;
 
-      const globalDrivesRoom = 'global:drives';
-      socket.join(globalDrivesRoom);
+      const userDrivesRoom = `user:${user.id}:drives`;
+      socket.join(userDrivesRoom);
     },
 
-    // leave_global_drives handler
-    leaveGlobalDrives: () => {
+    // Leave user-specific drives room
+    leaveUserDrivesRoom: () => {
       if (!user?.id) return;
 
-      const globalDrivesRoom = 'global:drives';
-      socket.leave(globalDrivesRoom);
+      const userDrivesRoom = `user:${user.id}:drives`;
+      socket.leave(userDrivesRoom);
     },
   };
 };
@@ -164,7 +166,7 @@ describe('Room Management', () => {
   });
 
   describe('auto-join on connect', () => {
-    it('given authenticated user connects, should join notifications, tasks, and calendar rooms', () => {
+    it('given authenticated user connects, should join notifications, tasks, calendar, and drives rooms', () => {
       const userId = 'test-user-123';
       const socket = createMockSocket(userId);
       const handlers = createRoomHandlers(socket);
@@ -174,6 +176,7 @@ describe('Room Management', () => {
       expect(socket.hasJoinedRoom(`notifications:${userId}`)).toBe(true);
       expect(socket.hasJoinedRoom(`user:${userId}:tasks`)).toBe(true);
       expect(socket.hasJoinedRoom(`user:${userId}:calendar`)).toBe(true);
+      expect(socket.hasJoinedRoom(`user:${userId}:drives`)).toBe(true);
     });
 
     it('given unauthenticated socket, should not join any rooms', () => {
@@ -373,41 +376,106 @@ describe('Room Management', () => {
     });
   });
 
-  describe('join_global_drives', () => {
-    it('given authenticated user, should join global:drives room', () => {
+  describe('user-scoped drives room', () => {
+    it('given authenticated user on connect, should auto-join user:{userId}:drives room', () => {
       const userId = 'test-user-123';
       const socket = createMockSocket(userId);
       const handlers = createRoomHandlers(socket);
 
-      handlers.joinGlobalDrives();
+      handlers.onConnect();
 
-      expect(socket.hasJoinedRoom('global:drives')).toBe(true);
+      expect(socket.hasJoinedRoom(`user:${userId}:drives`)).toBe(true);
     });
 
-    it('given unauthenticated socket, should not join room', () => {
+    it('given authenticated user, should join user:{userId}:drives room', () => {
+      const userId = 'test-user-123';
+      const socket = createMockSocket(userId);
+      const handlers = createRoomHandlers(socket);
+
+      handlers.joinUserDrivesRoom();
+
+      expect(socket.hasJoinedRoom(`user:${userId}:drives`)).toBe(true);
+    });
+
+    it('given unauthenticated socket, should not join user drives room', () => {
       const socket = createMockSocket(undefined);
       const handlers = createRoomHandlers(socket);
 
-      handlers.joinGlobalDrives();
+      handlers.joinUserDrivesRoom();
 
       expect(socket.join).not.toHaveBeenCalled();
     });
-  });
 
-  describe('leave_global_drives', () => {
-    it('given user in global:drives room, should leave the room', () => {
+    it('given user in user drives room, should leave the room', () => {
       const userId = 'test-user-123';
       const socket = createMockSocket(userId);
       const handlers = createRoomHandlers(socket);
 
-      // First join
-      handlers.joinGlobalDrives();
-      expect(socket.hasJoinedRoom('global:drives')).toBe(true);
+      handlers.joinUserDrivesRoom();
+      expect(socket.hasJoinedRoom(`user:${userId}:drives`)).toBe(true);
 
-      // Then leave
-      handlers.leaveGlobalDrives();
+      handlers.leaveUserDrivesRoom();
 
-      expect(socket.leave).toHaveBeenCalledWith('global:drives');
+      expect(socket.leave).toHaveBeenCalledWith(`user:${userId}:drives`);
+      expect(socket.hasJoinedRoom(`user:${userId}:drives`)).toBe(false);
+    });
+  });
+
+  describe('drive event isolation (security)', () => {
+    it('given two users, user A should NOT be in user B drives room', () => {
+      const userA = 'user-a-111';
+      const userB = 'user-b-222';
+      const socketA = createMockSocket(userA);
+      const socketB = createMockSocket(userB);
+      const handlersA = createRoomHandlers(socketA);
+      const handlersB = createRoomHandlers(socketB);
+
+      handlersA.onConnect();
+      handlersB.onConnect();
+
+      // Each user is in their own drives room
+      expect(socketA.hasJoinedRoom(`user:${userA}:drives`)).toBe(true);
+      expect(socketB.hasJoinedRoom(`user:${userB}:drives`)).toBe(true);
+
+      // Neither user is in the other's drives room
+      expect(socketA.hasJoinedRoom(`user:${userB}:drives`)).toBe(false);
+      expect(socketB.hasJoinedRoom(`user:${userA}:drives`)).toBe(false);
+    });
+
+    it('given drive member, should receive events via drive-specific room', async () => {
+      const userId = 'test-user-123';
+      const driveId = 'test-drive-456';
+      const socket = createMockSocket(userId);
+      const handlers = createRoomHandlers(socket);
+
+      vi.mocked(getUserDriveAccess).mockResolvedValue(true);
+
+      await handlers.joinDrive(driveId);
+
+      expect(socket.hasJoinedRoom(`drive:${driveId}`)).toBe(true);
+    });
+
+    it('given non-member, should NOT join drive-specific room', async () => {
+      const userId = 'non-member-999';
+      const driveId = 'test-drive-456';
+      const socket = createMockSocket(userId);
+      const handlers = createRoomHandlers(socket);
+
+      vi.mocked(getUserDriveAccess).mockResolvedValue(false);
+
+      await handlers.joinDrive(driveId);
+
+      expect(socket.hasJoinedRoom(`drive:${driveId}`)).toBe(false);
+      expect(socket.hasJoinedRoom(`drive:${driveId}:calendar`)).toBe(false);
+    });
+
+    it('given no global:drives room exists, no user should be in it', () => {
+      const socket = createMockSocket('any-user');
+      const handlers = createRoomHandlers(socket);
+
+      handlers.onConnect();
+
+      // Verify no global:drives room was joined
       expect(socket.hasJoinedRoom('global:drives')).toBe(false);
     });
   });

--- a/docs/2.0-architecture/2.5-integrations/socket-io.md
+++ b/docs/2.0-architecture/2.5-integrations/socket-io.md
@@ -60,8 +60,7 @@ io.use(async (socket: AuthSocket, next) => {
 -   **`join_channel`:** Client emits with a `pageId`. Server verifies user has access via `getUserAccessLevel()` before joining the room
 -   **`join_drive`:** Client emits with a `driveId`. Server verifies access via `getUserDriveAccess()` before joining `drive:${driveId}` room
 -   **`leave_drive`:** Client leaves a specific drive room
--   **`join_global_drives`:** Client joins the global drives room for system-wide drive updates
--   **`leave_global_drives`:** Client leaves the global drives room
+-   **User drives room:** Each user is auto-joined to `user:${userId}:drives` on connection for scoped drive event delivery
 -   **`disconnect`:** Standard event for logging when a user disconnects
 
 ### 4. Broadcast Endpoint (`/api/broadcast`)
@@ -122,8 +121,7 @@ socket.on('new_message', handleNewMessage);
 | `join_channel`          | Client → Server     | Requests to join a specific page's room. Server validates permissions before allowing the join.         |
 | `join_drive`            | Client → Server     | Requests to join a drive room. Server validates drive access before allowing the join.                 |
 | `leave_drive`           | Client → Server     | Leaves a specific drive room.                                                                           |
-| `join_global_drives`    | Client → Server     | Joins the global drives room for system-wide updates.                                                  |
-| `leave_global_drives`   | Client → Server     | Leaves the global drives room.                                                                          |
+| *(auto-joined)*         | Server → Client     | User auto-joins `user:${userId}:drives` on connect for scoped drive events.                            |
 | `new_message`           | Server → Client     | Broadcasts a new message to all clients in a specific channel room.                                     |
 | `notification:new`      | Server → Client     | Broadcasts a new notification to a user's personal notification room.                                  |
 


### PR DESCRIPTION
## Summary
Closes #560

Verified and hardened websocket drive event isolation. The server (`apps/realtime/src/index.ts`) and client (`socket-utils.ts`, `useGlobalDriveSocket.ts`) were already correctly using user-scoped `user:{userId}:drives` rooms instead of a global room. The `broadcastDriveEvent` function already requires explicit `recipientUserIds`. The main work was removing stale `global:drives` references from tests and docs, aligning test handlers with the actual server behavior, and adding new security isolation tests.

## Changes
- **apps/realtime/src/__tests__/rooms.test.ts**: Replaced stale `global:drives` test handlers (`joinGlobalDrives`/`leaveGlobalDrives`) with user-scoped `joinUserDrivesRoom`/`leaveUserDrivesRoom`. Updated `onConnect` handler to include `user:{userId}:drives` auto-join (matching actual server). Added new `drive event isolation (security)` test section with 4 tests:
  - Two users cannot see each other's drives rooms
  - Drive member can join drive-specific room
  - Non-member is denied drive-specific room
  - No `global:drives` room exists
- **docs/2.0-architecture/2.5-integrations/socket-io.md**: Replaced `join_global_drives`/`leave_global_drives` references with documentation of auto-joined `user:{userId}:drives` pattern

## Notes
- The actual server code in `apps/realtime/src/index.ts` was already secure — it auto-joins `user:{userId}:drives` per-user and the `join_drive` handler checks `getUserDriveAccess()` before allowing room joins. No changes were needed to the production server or client code.
- `broadcastDriveEvent()` in `socket-utils.ts` already requires an explicit `recipientUserIds` array, ensuring only authorized users receive drive metadata.
- The `useGlobalDriveSocket.ts` hook already subscribes to `user:{userId}:drives` (not a global room).

## Test plan
- [x] All 22 room management tests pass
- [x] All 22 socket-utils tests pass
- [ ] Verify real-time drive events still work in staging (create/update/delete drives)

🤖 Generated with [Claude Code](https://claude.com/claude-code)