### PR TITLE
fix: tighten CSP connect-src for air-gapped deployments

### DIFF
--- a/apps/web/src/middleware/__tests__/security-headers.test.ts
+++ b/apps/web/src/middleware/__tests__/security-headers.test.ts
@@ -157,6 +157,25 @@ describe('Security Headers', () => {
       expect(csp).not.toContain('https://cdn.jsdelivr.net');
     });
 
+    it('does not use https: wildcard in connect-src', () => {
+      const csp = buildCSPPolicy('test-nonce');
+
+      // connect-src should list specific domains, not a blanket https: wildcard
+      const connectSrc = csp.split(';').find((d: string) => d.trim().startsWith('connect-src'));
+      expect(connectSrc).toBeDefined();
+      // Ensure 'https:' as a standalone scheme-source is absent
+      expect(connectSrc).not.toMatch(/\bhttps:\s/);
+      expect(connectSrc).not.toMatch(/\bhttps:$/);
+    });
+
+    it('allows Stripe and Google connect-src in cloud mode', () => {
+      const csp = buildCSPPolicy('test-nonce');
+
+      const connectSrc = csp.split(';').find((d: string) => d.trim().startsWith('connect-src'));
+      expect(connectSrc).toContain('https://accounts.google.com');
+      expect(connectSrc).toContain('https://*.stripe.com');
+    });
+
     it('allows Google accounts and Stripe iframes via frame-src', () => {
       const csp = buildCSPPolicy('test-nonce');
 

--- a/apps/web/src/middleware/security-headers.ts
+++ b/apps/web/src/middleware/security-headers.ts
@@ -61,12 +61,19 @@ export const buildCSPPolicy = (nonce: string): string => {
     frameSrc.push('https://accounts.google.com', 'https://js.stripe.com');
   }
 
+  const connectSrc = ["'self'", 'ws:', 'wss:'];
+
+  // Cloud mode: allow Stripe client SDK and Google One Tap connections
+  if (!IS_ONPREM) {
+    connectSrc.push('https://accounts.google.com', 'https://*.stripe.com');
+  }
+
   const directives: CSPDirectives = {
     'default-src': ["'self'"],
     'script-src': scriptSrc,
     'style-src': styleSrc,
     'img-src': ["'self'", 'data:', 'blob:', 'https:'],
-    'connect-src': ["'self'", 'ws:', 'wss:', 'https:'],
+    'connect-src': connectSrc,
     'font-src': ["'self'", 'data:'],
     // Monaco and other browser tooling may initialize workers from blob URLs.
     'worker-src': ["'self'", 'blob:'],


### PR DESCRIPTION
Closes #466

## Summary
- Replaced blanket `https:` wildcard in CSP `connect-src` with specific domains required for client-side connections
- PDF.js worker was already bundled locally (no CDN reference to remove)
- No unused CDN references found elsewhere in CSP

## Changes
- **apps/web/src/middleware/security-headers.ts**: Replaced `'https:'` in `connect-src` with specific domains:
  - Cloud mode: `'self'`, `ws:`, `wss:`, `https://accounts.google.com`, `https://*.stripe.com`
  - On-prem mode: `'self'`, `ws:`, `wss:` only (no external domains)
- **apps/web/src/middleware/__tests__/security-headers.test.ts**: Added two new tests:
  - Verifies `https:` wildcard is absent from `connect-src`
  - Verifies Stripe and Google domains are present in `connect-src` for cloud mode

## Notes
- **PDF.js worker (Task 1)**: Already completed in prior work. `PDFViewer.tsx:23` references `/pdf.worker.min.mjs` (local path), and `next.config.ts:30-32` copies the worker from `pdfjs-dist` to `public/` at build time.
- **CSP connect-src (Task 2)**: The `https:` wildcard allowed any HTTPS connection from the browser. All AI provider API calls (OpenAI, Anthropic, Google, OpenRouter, xAI, Brave Search, GLM, MiniMax) happen server-side in API route handlers, so they don't need client CSP allowlisting. Only Google One Tap (`accounts.google.com`) and Stripe client SDK (`*.stripe.com`) need client-side connect-src.
- **CDN cleanup (Task 3)**: No unused CDN references found. `cdn.jsdelivr.net` was already removed in prior work (confirmed by existing test).

## Test plan
- [ ] Verify PDF viewer still loads PDFs correctly (worker served locally)
- [ ] Verify Google One Tap sign-in works (connect-src allows accounts.google.com)
- [ ] Verify Stripe checkout/billing flows work (connect-src allows *.stripe.com)
- [ ] Verify on-prem mode has no external connect-src domains
- [ ] Check browser console for CSP violations on key flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)