### PR TITLE
fix: address code review findings for Docker security PR

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -16,7 +16,7 @@ on:
         default: '30s'
 
 env:
-  NODE_VERSION: '20'
+  NODE_VERSION: '22.17.0'
 
 jobs:
   load-test:
@@ -25,7 +25,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16
+        image: postgres:17.5-alpine
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: pagespace_test
@@ -48,7 +48,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  NODE_VERSION: '22'
+  NODE_VERSION: '22.17.0'
 
 jobs:
   unit-tests:
@@ -17,7 +17,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:17-alpine
+        image: postgres:17.5-alpine
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: pagespace_test

--- a/apps/realtime/Dockerfile
+++ b/apps/realtime/Dockerfile
@@ -11,6 +11,7 @@ RUN corepack enable && \
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY packages/db/package.json ./packages/db/
 COPY packages/lib/package.json ./packages/lib/
+# apps/web/package.json is required by pnpm-workspace.yaml to resolve the dependency graph
 COPY apps/web/package.json ./apps/web/
 COPY apps/realtime/package.json ./apps/realtime/
 
@@ -25,31 +26,35 @@ RUN pnpm --filter @pagespace/db build && \
     pnpm --filter @pagespace/lib build && \
     pnpm --filter realtime build
 
+# Deploy only the realtime service and its production dependencies
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store pnpm --filter realtime deploy /app/deploy --prod
+
 # Stage 2: Production runner
 FROM node:22.17.0-alpine AS runner
 WORKDIR /app
 
-RUN corepack enable && \
-    (corepack prepare pnpm@10.13.1 --activate || corepack prepare pnpm@10.13.1 --activate || corepack prepare pnpm@10.13.1 --activate)
+# Copy the self-contained deployment (only realtime + production deps)
+COPY --from=builder /app/deploy/node_modules ./node_modules
+COPY --from=builder /app/deploy/package.json ./
 
-# Copy manifests and lockfile for production install
-COPY --from=builder /app/package.json /app/pnpm-lock.yaml /app/pnpm-workspace.yaml ./
+# Copy only compiled output from packages (not source/tests)
+COPY --from=builder /app/packages/db/dist ./packages/db/dist
 COPY --from=builder /app/packages/db/package.json ./packages/db/
+COPY --from=builder /app/packages/db/drizzle ./packages/db/drizzle
+COPY --from=builder /app/packages/lib/dist ./packages/lib/dist
 COPY --from=builder /app/packages/lib/package.json ./packages/lib/
-COPY --from=builder /app/apps/web/package.json ./apps/web/
+
+# Copy only compiled realtime output
+COPY --from=builder /app/apps/realtime/dist ./apps/realtime/dist
 COPY --from=builder /app/apps/realtime/package.json ./apps/realtime/
-
-# Install production-only dependencies
-RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store pnpm config set store-dir /pnpm/store && pnpm install --frozen-lockfile --prod
-
-# Copy built artifacts from builder
-COPY --from=builder /app/packages ./packages
-COPY --from=builder /app/apps/realtime ./apps/realtime
 
 ENV NODE_ENV=production
 
 USER node
 
 EXPOSE 3001
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
+  CMD node -e "try { process.kill(1, 0); } catch(e) { process.exit(1); }"
 
 CMD ["node", "apps/realtime/dist/index.js"]

--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -19,7 +19,9 @@ import { handleKickRequest } from './kick-handler';
 import { presenceTracker, type PresenceViewer } from './presence-tracker';
 import { withPerEventAuth, type AuthSocket } from './per-event-auth';
 
-dotenv.config({ path: '../../.env' });
+if (process.env.NODE_ENV !== 'production') {
+  dotenv.config({ path: '../../.env' });
+}
 
 /**
  * Validate a short-lived socket token (ps_sock_* format).

--- a/apps/web/Dockerfile.seed
+++ b/apps/web/Dockerfile.seed
@@ -26,5 +26,7 @@ COPY packages ./packages
 COPY apps ./apps
 COPY tsconfig.json ./
 
-# Run seed
+# Env vars are injected at runtime (not baked into the image).
+# When running standalone: docker run --env-file .env <image>
+# When running via compose: use env_file: .env in the service definition
 CMD ["pnpm", "--filter", "@pagespace/db", "db:seed"]


### PR DESCRIPTION
## Summary
- **Realtime Dockerfile hardened**: replaced unfiltered `pnpm install --prod` with `pnpm --filter realtime deploy` for self-contained production dependencies (eliminates web stack from runtime image). Selective copy of only `dist/` and `package.json` from packages. Added `HEALTHCHECK` for consistency with processor/worker.
- **Realtime dotenv guarded**: `dotenv.config()` now only runs when `NODE_ENV !== 'production'`, preventing broken relative path in compiled container.
- **CI versions pinned**: `test.yml` and `load-test.yml` now use exact `Node 22.17.0` and `postgres:17.5-alpine` matching docker-compose.yml. Also bumped `load-test.yml` checkout action to v6.
- **Seed Dockerfile documented**: added comments explaining runtime env injection pattern (`docker run --env-file .env`).

## Addresses
**From initial code review:**
1. [Medium] Seed Dockerfile env docs
2. [Low] Migrate script env-file verified (no issue — uses `process.env` directly)
3. [Low] Selective package copy in realtime runner
4. [Low] Realtime HEALTHCHECK added

**From Codex review:**
1. [Medium] Filtered production install via `pnpm deploy`
2. [Low] Pinned CI versions to exact matches
3. [Low] Load-test workflow aligned (Node 22.17.0, Postgres 17.5-alpine)
4. [Low] Dotenv guarded behind NODE_ENV check

## Test plan
- [ ] `docker compose build realtime` succeeds with new multi-stage + deploy pattern
- [ ] Realtime image contains only production deps (no web/processor packages)
- [ ] `docker exec <realtime> whoami` → `node`
- [ ] CI passes with pinned Node 22.17.0 and Postgres 17.5-alpine
- [ ] Realtime service starts correctly in production (env vars from compose, not dotenv)

🤖 Generated with [Claude Code](https://claude.com/claude-code)