### PR TITLE
fix: prevent channel input from scrolling past viewport

### DIFF
--- a/apps/web/src/app/dashboard/inbox/channel/[pageId]/page.tsx
+++ b/apps/web/src/app/dashboard/inbox/channel/[pageId]/page.tsx
@@ -427,125 +427,127 @@ export default function InboxChannelPage() {
       </div>
 
       {/* Messages */}
-      <PullToRefresh direction="top" onRefresh={handleRefresh}>
-        <ScrollArea className="h-full flex-grow" ref={scrollAreaRef}>
-          <div className="p-4 space-y-4 max-w-4xl mx-auto">
-            {hasMore && (
-              <div className="flex justify-center py-2">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={handleLoadOlder}
-                  disabled={loadingOlder}
-                >
-                  {loadingOlder ? 'Loading...' : 'Load older messages'}
-                </Button>
-              </div>
-            )}
-            {messages.map((m) => {
-              const isAi = !!m.aiMeta;
-              const displayName = isAi ? m.aiMeta!.senderName : m.user?.name;
-              const aiLabel = isAi
-                ? m.aiMeta!.senderType === 'global_assistant'
-                  ? 'global assistant'
-                  : 'agent'
-                : null;
-              const avatarFallback = isAi
-                ? m.aiMeta!.senderType === 'agent'
-                  ? 'A'
-                  : m.aiMeta!.senderName?.[0]
-                : m.user?.name?.[0];
-
-              return (
-              <div key={m.id} className="group flex items-start gap-4">
-                <Avatar className="shrink-0">
-                  {!isAi && <AvatarImage src={m.user?.image || ''} />}
-                  <AvatarFallback>{avatarFallback}</AvatarFallback>
-                </Avatar>
-                <div className="flex flex-col min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
-                    <span className="font-semibold text-sm">{displayName}</span>
-                    {aiLabel && (
-                      <span className="text-xs px-1.5 py-0.5 rounded-full bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-300 font-medium">
-                        {aiLabel}
-                      </span>
-                    )}
-                    <span className="text-xs text-muted-foreground">
-                      {new Date(m.createdAt).toLocaleTimeString()}
-                    </span>
-                  </div>
-                  {m.content && (
-                    <div className="prose prose-sm dark:prose-invert max-w-none">
-                      <StreamingMarkdown
-                        content={m.content}
-                        isStreaming={false}
-                      />
-                    </div>
-                  )}
-                  {/* File attachment */}
-                  {hasAttachment(m) && (
-                    <div className="mt-2">
-                      {isImageAttachment(m) ? (
-                        <a
-                          href={`/api/files/${getFileId(m)}/view?filename=${encodeURIComponent(getAttachmentName(m))}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="block max-w-sm"
-                        >
-                          {/* eslint-disable-next-line @next/next/no-img-element -- auth-gated API route; processor already optimizes on upload */}
-                          <img
-                            src={`/api/files/${getFileId(m)}/view`}
-                            alt={getAttachmentName(m)}
-                            className="rounded-lg max-h-64 object-contain border border-border/50"
-                          />
-                        </a>
-                      ) : (
-                        <a
-                          href={`/api/files/${getFileId(m)}/download?filename=${encodeURIComponent(getAttachmentName(m))}`}
-                          className="flex items-center gap-3 p-3 bg-muted/50 hover:bg-muted rounded-lg border border-border/50 max-w-sm transition-colors"
-                        >
-                          <div className="w-10 h-10 rounded bg-muted flex items-center justify-center shrink-0">
-                            {getAttachmentMimeType(m).includes('pdf') ? (
-                              <FileText className="h-5 w-5 text-red-500" />
-                            ) : getAttachmentMimeType(m).includes('document') || getAttachmentMimeType(m).includes('word') ? (
-                              <FileText className="h-5 w-5 text-blue-500" />
-                            ) : (
-                              <FileIcon className="h-5 w-5 text-muted-foreground" />
-                            )}
-                          </div>
-                          <div className="flex-1 min-w-0">
-                            <p className="text-sm font-medium truncate">{getAttachmentName(m)}</p>
-                            {getAttachmentSize(m) != null && (
-                              <p className="text-xs text-muted-foreground">
-                                {formatFileSize(getAttachmentSize(m)!)}
-                              </p>
-                            )}
-                          </div>
-                          <Download className="h-4 w-4 text-muted-foreground shrink-0" />
-                        </a>
-                      )}
-                    </div>
-                  )}
-                  {/* Reactions */}
-                  {user && !m.id.startsWith('temp-') && (
-                    <MessageReactions
-                      reactions={m.reactions || []}
-                      currentUserId={user.id}
-                      onAddReaction={(emoji) => handleAddReaction(m.id, emoji)}
-                      onRemoveReaction={(emoji) => handleRemoveReaction(m.id, emoji)}
-                      canReact={permissions?.canView || false}
-                    />
-                  )}
+      <div className="flex-grow overflow-hidden">
+        <PullToRefresh direction="top" onRefresh={handleRefresh}>
+          <ScrollArea className="h-full" ref={scrollAreaRef}>
+            <div className="p-4 space-y-4 max-w-4xl mx-auto">
+              {hasMore && (
+                <div className="flex justify-center py-2">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={handleLoadOlder}
+                    disabled={loadingOlder}
+                  >
+                    {loadingOlder ? 'Loading...' : 'Load older messages'}
+                  </Button>
                 </div>
-              </div>
-              );
-            })}
-          </div>
-        </ScrollArea>
-      </PullToRefresh>
+              )}
+              {messages.map((m) => {
+                const isAi = !!m.aiMeta;
+                const displayName = isAi ? m.aiMeta!.senderName : m.user?.name;
+                const aiLabel = isAi
+                  ? m.aiMeta!.senderType === 'global_assistant'
+                    ? 'global assistant'
+                    : 'agent'
+                  : null;
+                const avatarFallback = isAi
+                  ? m.aiMeta!.senderType === 'agent'
+                    ? 'A'
+                    : m.aiMeta!.senderName?.[0]
+                  : m.user?.name?.[0];
+
+                return (
+                <div key={m.id} className="group flex items-start gap-4">
+                  <Avatar className="shrink-0">
+                    {!isAi && <AvatarImage src={m.user?.image || ''} />}
+                    <AvatarFallback>{avatarFallback}</AvatarFallback>
+                  </Avatar>
+                  <div className="flex flex-col min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="font-semibold text-sm">{displayName}</span>
+                      {aiLabel && (
+                        <span className="text-xs px-1.5 py-0.5 rounded-full bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-300 font-medium">
+                          {aiLabel}
+                        </span>
+                      )}
+                      <span className="text-xs text-muted-foreground">
+                        {new Date(m.createdAt).toLocaleTimeString()}
+                      </span>
+                    </div>
+                    {m.content && (
+                      <div className="prose prose-sm dark:prose-invert max-w-none">
+                        <StreamingMarkdown
+                          content={m.content}
+                          isStreaming={false}
+                        />
+                      </div>
+                    )}
+                    {/* File attachment */}
+                    {hasAttachment(m) && (
+                      <div className="mt-2">
+                        {isImageAttachment(m) ? (
+                          <a
+                            href={`/api/files/${getFileId(m)}/view?filename=${encodeURIComponent(getAttachmentName(m))}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="block max-w-sm"
+                          >
+                            {/* eslint-disable-next-line @next/next/no-img-element -- auth-gated API route; processor already optimizes on upload */}
+                            <img
+                              src={`/api/files/${getFileId(m)}/view`}
+                              alt={getAttachmentName(m)}
+                              className="rounded-lg max-h-64 object-contain border border-border/50"
+                            />
+                          </a>
+                        ) : (
+                          <a
+                            href={`/api/files/${getFileId(m)}/download?filename=${encodeURIComponent(getAttachmentName(m))}`}
+                            className="flex items-center gap-3 p-3 bg-muted/50 hover:bg-muted rounded-lg border border-border/50 max-w-sm transition-colors"
+                          >
+                            <div className="w-10 h-10 rounded bg-muted flex items-center justify-center shrink-0">
+                              {getAttachmentMimeType(m).includes('pdf') ? (
+                                <FileText className="h-5 w-5 text-red-500" />
+                              ) : getAttachmentMimeType(m).includes('document') || getAttachmentMimeType(m).includes('word') ? (
+                                <FileText className="h-5 w-5 text-blue-500" />
+                              ) : (
+                                <FileIcon className="h-5 w-5 text-muted-foreground" />
+                              )}
+                            </div>
+                            <div className="flex-1 min-w-0">
+                              <p className="text-sm font-medium truncate">{getAttachmentName(m)}</p>
+                              {getAttachmentSize(m) != null && (
+                                <p className="text-xs text-muted-foreground">
+                                  {formatFileSize(getAttachmentSize(m)!)}
+                                </p>
+                              )}
+                            </div>
+                            <Download className="h-4 w-4 text-muted-foreground shrink-0" />
+                          </a>
+                        )}
+                      </div>
+                    )}
+                    {/* Reactions */}
+                    {user && !m.id.startsWith('temp-') && (
+                      <MessageReactions
+                        reactions={m.reactions || []}
+                        currentUserId={user.id}
+                        onAddReaction={(emoji) => handleAddReaction(m.id, emoji)}
+                        onRemoveReaction={(emoji) => handleRemoveReaction(m.id, emoji)}
+                        canReact={permissions?.canView || false}
+                      />
+                    )}
+                  </div>
+                </div>
+                );
+              })}
+            </div>
+          </ScrollArea>
+        </PullToRefresh>
+      </div>
 
       {/* Input */}
-      <div className="flex-shrink-0 p-4">
+      <div className="flex-shrink-0 border-t border-border p-4">
         <div className="max-w-4xl mx-auto">
           {canEdit ? (
             <ChannelInput

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -360,119 +360,121 @@ function ChannelView({ page }: ChannelViewProps) {
 
   return (
     <div className="flex flex-col h-full">
-        <PullToRefresh direction="top" onRefresh={handleRefresh}>
-          <ScrollArea className="h-full flex-grow" ref={scrollAreaRef}>
-              <div className="p-4 space-y-4 max-w-4xl mx-auto">
-                  {hasMore && (
-                    <div className="flex justify-center py-2">
-                      <button
-                        onClick={handleLoadOlder}
-                        disabled={loadingOlder}
-                        className="text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
-                      >
-                        {loadingOlder ? 'Loading...' : 'Load older messages'}
-                      </button>
-                    </div>
-                  )}
-                  {messages.map((m) => {
-                      const isAi = !!m.aiMeta;
-                      const displayName = isAi ? m.aiMeta!.senderName : m.user?.name;
-                      const aiLabel = isAi
-                        ? m.aiMeta!.senderType === 'global_assistant'
-                          ? 'global assistant'
-                          : 'agent'
-                        : null;
-                      const avatarFallback = isAi
-                        ? m.aiMeta!.senderType === 'agent' ? 'A' : m.aiMeta!.senderName?.[0]
-                        : m.user?.name?.[0];
-                      return (
-                      <div key={m.id} className="group flex items-start gap-4">
-                          <Avatar className="shrink-0">
-                              {!isAi && <AvatarImage src={m.user?.image || ''} />}
-                              <AvatarFallback>{avatarFallback}</AvatarFallback>
-                          </Avatar>
-                          <div className="flex flex-col min-w-0 flex-1">
-                              <div className="flex items-center gap-2">
-                                  <span className="font-semibold text-sm">{displayName}</span>
-                                  {aiLabel && (
-                                    <span className="text-xs px-1.5 py-0.5 rounded-full bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-300 font-medium">
-                                      {aiLabel}
-                                    </span>
-                                  )}
-                                  <span className="text-xs text-muted-foreground">
-                                      {new Date(m.createdAt).toLocaleTimeString()}
-                                  </span>
-                              </div>
-                              {m.content && (
-                                <div className="prose prose-sm dark:prose-invert max-w-none">
-                                  <StreamingMarkdown
-                                    content={m.content}
-                                    isStreaming={false}
-                                  />
-                                </div>
-                              )}
-                              {/* File attachment */}
-                              {hasAttachment(m) && (
-                                <div className="mt-2">
-                                  {isImageAttachment(m) ? (
-                                    <a
-                                      href={`/api/files/${getFileId(m)}/view?filename=${encodeURIComponent(getAttachmentName(m))}`}
-                                      target="_blank"
-                                      rel="noopener noreferrer"
-                                      className="block max-w-sm"
-                                    >
-                                      {/* eslint-disable-next-line @next/next/no-img-element -- auth-gated API route; processor already optimizes on upload */}
-                                      <img
-                                        src={`/api/files/${getFileId(m)}/view`}
-                                        alt={getAttachmentName(m)}
-                                        className="rounded-lg max-h-64 object-contain border border-border/50"
-                                      />
-                                    </a>
-                                  ) : (
-                                    <a
-                                      href={`/api/files/${getFileId(m)}/download?filename=${encodeURIComponent(getAttachmentName(m))}`}
-                                      className="flex items-center gap-3 p-3 bg-muted/50 hover:bg-muted rounded-lg border border-border/50 max-w-sm transition-colors"
-                                    >
-                                      <div className="w-10 h-10 rounded bg-muted flex items-center justify-center shrink-0">
-                                        {getAttachmentMimeType(m).includes('pdf') ? (
-                                          <FileText className="h-5 w-5 text-red-500" />
-                                        ) : getAttachmentMimeType(m).includes('document') || getAttachmentMimeType(m).includes('word') ? (
-                                          <FileText className="h-5 w-5 text-blue-500" />
-                                        ) : (
-                                          <FileIcon className="h-5 w-5 text-muted-foreground" />
-                                        )}
-                                      </div>
-                                      <div className="flex-1 min-w-0">
-                                        <p className="text-sm font-medium truncate">{getAttachmentName(m)}</p>
-                                        {getAttachmentSize(m) != null && (
-                                          <p className="text-xs text-muted-foreground">
-                                            {formatFileSize(getAttachmentSize(m)!)}
-                                          </p>
-                                        )}
-                                      </div>
-                                      <Download className="h-4 w-4 text-muted-foreground shrink-0" />
-                                    </a>
-                                  )}
-                                </div>
-                              )}
-                              {/* Reactions */}
-                              {user && !m.id.startsWith('temp-') && (
-                                <MessageReactions
-                                  reactions={m.reactions || []}
-                                  currentUserId={user.id}
-                                  onAddReaction={(emoji) => handleAddReaction(m.id, emoji)}
-                                  onRemoveReaction={(emoji) => handleRemoveReaction(m.id, emoji)}
-                                  canReact={permissions?.canView || false}
-                                />
-                              )}
-                          </div>
+        <div className="flex-grow overflow-hidden">
+          <PullToRefresh direction="top" onRefresh={handleRefresh}>
+            <ScrollArea className="h-full" ref={scrollAreaRef}>
+                <div className="p-4 space-y-4 max-w-4xl mx-auto">
+                    {hasMore && (
+                      <div className="flex justify-center py-2">
+                        <button
+                          onClick={handleLoadOlder}
+                          disabled={loadingOlder}
+                          className="text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
+                        >
+                          {loadingOlder ? 'Loading...' : 'Load older messages'}
+                        </button>
                       </div>
-                      );
-                  })}
-              </div>
-          </ScrollArea>
-        </PullToRefresh>
-        <div className="p-4">
+                    )}
+                    {messages.map((m) => {
+                        const isAi = !!m.aiMeta;
+                        const displayName = isAi ? m.aiMeta!.senderName : m.user?.name;
+                        const aiLabel = isAi
+                          ? m.aiMeta!.senderType === 'global_assistant'
+                            ? 'global assistant'
+                            : 'agent'
+                          : null;
+                        const avatarFallback = isAi
+                          ? m.aiMeta!.senderType === 'agent' ? 'A' : m.aiMeta!.senderName?.[0]
+                          : m.user?.name?.[0];
+                        return (
+                        <div key={m.id} className="group flex items-start gap-4">
+                            <Avatar className="shrink-0">
+                                {!isAi && <AvatarImage src={m.user?.image || ''} />}
+                                <AvatarFallback>{avatarFallback}</AvatarFallback>
+                            </Avatar>
+                            <div className="flex flex-col min-w-0 flex-1">
+                                <div className="flex items-center gap-2">
+                                    <span className="font-semibold text-sm">{displayName}</span>
+                                    {aiLabel && (
+                                      <span className="text-xs px-1.5 py-0.5 rounded-full bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-300 font-medium">
+                                        {aiLabel}
+                                      </span>
+                                    )}
+                                    <span className="text-xs text-muted-foreground">
+                                        {new Date(m.createdAt).toLocaleTimeString()}
+                                    </span>
+                                </div>
+                                {m.content && (
+                                  <div className="prose prose-sm dark:prose-invert max-w-none">
+                                    <StreamingMarkdown
+                                      content={m.content}
+                                      isStreaming={false}
+                                    />
+                                  </div>
+                                )}
+                                {/* File attachment */}
+                                {hasAttachment(m) && (
+                                  <div className="mt-2">
+                                    {isImageAttachment(m) ? (
+                                      <a
+                                        href={`/api/files/${getFileId(m)}/view?filename=${encodeURIComponent(getAttachmentName(m))}`}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="block max-w-sm"
+                                      >
+                                        {/* eslint-disable-next-line @next/next/no-img-element -- auth-gated API route; processor already optimizes on upload */}
+                                        <img
+                                          src={`/api/files/${getFileId(m)}/view`}
+                                          alt={getAttachmentName(m)}
+                                          className="rounded-lg max-h-64 object-contain border border-border/50"
+                                        />
+                                      </a>
+                                    ) : (
+                                      <a
+                                        href={`/api/files/${getFileId(m)}/download?filename=${encodeURIComponent(getAttachmentName(m))}`}
+                                        className="flex items-center gap-3 p-3 bg-muted/50 hover:bg-muted rounded-lg border border-border/50 max-w-sm transition-colors"
+                                      >
+                                        <div className="w-10 h-10 rounded bg-muted flex items-center justify-center shrink-0">
+                                          {getAttachmentMimeType(m).includes('pdf') ? (
+                                            <FileText className="h-5 w-5 text-red-500" />
+                                          ) : getAttachmentMimeType(m).includes('document') || getAttachmentMimeType(m).includes('word') ? (
+                                            <FileText className="h-5 w-5 text-blue-500" />
+                                          ) : (
+                                            <FileIcon className="h-5 w-5 text-muted-foreground" />
+                                          )}
+                                        </div>
+                                        <div className="flex-1 min-w-0">
+                                          <p className="text-sm font-medium truncate">{getAttachmentName(m)}</p>
+                                          {getAttachmentSize(m) != null && (
+                                            <p className="text-xs text-muted-foreground">
+                                              {formatFileSize(getAttachmentSize(m)!)}
+                                            </p>
+                                          )}
+                                        </div>
+                                        <Download className="h-4 w-4 text-muted-foreground shrink-0" />
+                                      </a>
+                                    )}
+                                  </div>
+                                )}
+                                {/* Reactions */}
+                                {user && !m.id.startsWith('temp-') && (
+                                  <MessageReactions
+                                    reactions={m.reactions || []}
+                                    currentUserId={user.id}
+                                    onAddReaction={(emoji) => handleAddReaction(m.id, emoji)}
+                                    onRemoveReaction={(emoji) => handleRemoveReaction(m.id, emoji)}
+                                    canReact={permissions?.canView || false}
+                                  />
+                                )}
+                            </div>
+                        </div>
+                        );
+                    })}
+                </div>
+            </ScrollArea>
+          </PullToRefresh>
+        </div>
+        <div className="flex-shrink-0 border-t border-border p-4">
           <div className="max-w-4xl mx-auto">
             {canEdit ? (
               <ChannelInput


### PR DESCRIPTION
Wrap the PullToRefresh/ScrollArea in an overflow-hidden container
(matching the working DM page pattern) so the messages area is
constrained to available space. Add flex-shrink-0 and border-t to
the input section to keep it pinned at the bottom.

https://claude.ai/code/session_01DZ7YzV4vQ72AogsHJz2jgH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized inbox channel message layout and scroll container structure.

* **Style**
  * Adjusted timestamp positioning in message headers.
  * Added border styling to the message container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->