### PR TITLE
chore(ci): refresh stale GitHub Actions bumps

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -92,7 +92,7 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Upload macOS artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: macos-packages
           path: |
@@ -139,7 +139,7 @@ jobs:
           CSC_KEY_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PWD }}
 
       - name: Upload Windows artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: windows-packages
           path: |
@@ -182,7 +182,7 @@ jobs:
         run: pnpm --filter desktop package:linux
 
       - name: Upload Linux artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: linux-packages
           path: |
@@ -200,7 +200,7 @@ jobs:
       contents: write
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -116,7 +116,7 @@ jobs:
             grafana/k6 run /scripts/tests/load/auth-baseline.k6.js
 
       - name: Upload load test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: load-test-results-${{ github.run_id }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -218,7 +218,7 @@ jobs:
           fetch-depth: 0
 
       - name: TruffleHog Secret Scan
-        uses: trufflesecurity/trufflehog@v3.93.4
+        uses: trufflesecurity/trufflehog@v3.93.6
         with:
           path: ./
           base: ${{ github.event.before }}


### PR DESCRIPTION
## Summary
- bump actions/upload-artifact to v7 in the desktop and load-test workflows
- bump actions/download-artifact to v8 in the desktop release workflow
- bump trufflesecurity/trufflehog to v3.93.6 in the security workflow

## Why
The stale Dependabot PRs #744, #745, and #746 are no longer clean to merge as-is. This replacement PR applies only the intended workflow dependency updates on top of current master without bringing along unrelated branch drift.

## Validation
- parsed the modified workflow YAML with Ruby YAML.load_file
- ran git diff --check on the updated workflow files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions versions across CI/CD workflows to maintain compatibility and reliability of automated build, testing, and security scanning processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->