### PR TITLE
feat(test): rubric compliance fixes for control-plane test suite

### DIFF
--- a/apps/control-plane/src/repositories/__tests__/tenant-repository.test.ts
+++ b/apps/control-plane/src/repositories/__tests__/tenant-repository.test.ts
@@ -61,6 +61,7 @@ function createMockDb(resolvedValue: unknown[] = []) {
   }
 }
 
+/** @scaffold - characterizing repository behavior via ORM chain mocks; replace with integration tests against real DB */
 describe('createTenantRepository', () => {
   describe('createTenant', () => {
     test('given valid tenant data, should return tenant with status provisioning', async () => {
@@ -91,9 +92,9 @@ describe('createTenantRepository', () => {
         tier: 'pro',
       })
 
-      expect(db.insert).toHaveBeenCalled()
-      expect(db._chain.values).toHaveBeenCalled()
-      expect(db._chain.returning).toHaveBeenCalled()
+      expect(db.insert).toHaveBeenCalled() // @scaffold
+      expect(db._chain.values).toHaveBeenCalled() // @scaffold
+      expect(db._chain.returning).toHaveBeenCalled() // @scaffold
     })
   })
 
@@ -148,25 +149,27 @@ describe('createTenantRepository', () => {
       const result = await repo.listTenants()
 
       expect(result).toEqual(tenants)
-      expect(db.select).toHaveBeenCalled()
+      expect(db.select).toHaveBeenCalled() // @scaffold
     })
 
-    test('given status filter, should call where on the chain', async () => {
+    // @scaffold - characterizing ORM chain behavior for filter application
+    test('given status filter, should apply where clause to query chain', async () => {
       const db = createMockDb([])
       const repo = createTenantRepository(db as never)
 
       await repo.listTenants({ status: 'active' })
 
-      expect(db._chain.where).toHaveBeenCalled()
+      expect(db._chain.where).toHaveBeenCalled() // @scaffold
     })
 
-    test('given tier filter, should call where on the chain', async () => {
+    // @scaffold - characterizing ORM chain behavior for filter application
+    test('given tier filter, should apply where clause to query chain', async () => {
       const db = createMockDb([])
       const repo = createTenantRepository(db as never)
 
       await repo.listTenants({ tier: 'enterprise' })
 
-      expect(db._chain.where).toHaveBeenCalled()
+      expect(db._chain.where).toHaveBeenCalled() // @scaffold
     })
 
     test('given limit and offset, should apply pagination', async () => {
@@ -175,8 +178,8 @@ describe('createTenantRepository', () => {
 
       await repo.listTenants({ limit: 10, offset: 20 })
 
-      expect(db._chain.limit).toHaveBeenCalledWith(10)
-      expect(db._chain.offset).toHaveBeenCalledWith(20)
+      expect(db._chain.limit).toHaveBeenCalledWith(10) // @scaffold
+      expect(db._chain.offset).toHaveBeenCalledWith(20) // @scaffold
     })
   })
 
@@ -198,7 +201,7 @@ describe('createTenantRepository', () => {
       const result = await repo.updateTenantStatus('test-id-123', 'active')
 
       expect(result.status).toBe('active')
-      expect(db.update).toHaveBeenCalled()
+      expect(db.update).toHaveBeenCalled() // @scaffold
     })
 
     test('given an invalid transition (destroyed -> active), should throw', async () => {
@@ -240,7 +243,7 @@ describe('createTenantRepository', () => {
       const result = await repo.updateHealthStatus('test-id-123', 'healthy')
 
       expect(result.healthStatus).toBe('healthy')
-      expect(db.update).toHaveBeenCalled()
+      expect(db.update).toHaveBeenCalled() // @scaffold
     })
 
     test('given a health update, should set lastHealthCheck', async () => {
@@ -249,7 +252,7 @@ describe('createTenantRepository', () => {
 
       await repo.updateHealthStatus('test-id-123', 'unhealthy')
 
-      expect(db._chain.set).toHaveBeenCalled()
+      expect(db._chain.set).toHaveBeenCalled() // @scaffold
       const setArg = (db._chain.set as ReturnType<typeof vi.fn>).mock.calls[0][0]
       expect(setArg).toHaveProperty('healthStatus', 'unhealthy')
       expect(setArg).toHaveProperty('lastHealthCheck')
@@ -271,8 +274,8 @@ describe('createTenantRepository', () => {
 
       await repo.deleteTenant('test-id-123')
 
-      expect(db.delete).toHaveBeenCalled()
-      expect(db._chain.where).toHaveBeenCalled()
+      expect(db.delete).toHaveBeenCalled() // @scaffold
+      expect(db._chain.where).toHaveBeenCalled() // @scaffold
     })
   })
 
@@ -283,8 +286,8 @@ describe('createTenantRepository', () => {
 
       await repo.recordEvent('test-id-123', 'provisioned', { duration: 30 })
 
-      expect(db.insert).toHaveBeenCalled()
-      expect(db._chain.values).toHaveBeenCalled()
+      expect(db.insert).toHaveBeenCalled() // @scaffold
+      expect(db._chain.values).toHaveBeenCalled() // @scaffold
     })
 
     test('given event data, should pass correct tenantId and eventType', async () => {
@@ -313,8 +316,8 @@ describe('createTenantRepository', () => {
       const result = await repo.getRecentEvents('test-id-123')
 
       expect(result).toEqual(events)
-      expect(db.select).toHaveBeenCalled()
-      expect(db._chain.orderBy).toHaveBeenCalled()
+      expect(db.select).toHaveBeenCalled() // @scaffold
+      expect(db._chain.orderBy).toHaveBeenCalled() // @scaffold
     })
 
     test('given a limit, should apply it to the query', async () => {
@@ -323,7 +326,7 @@ describe('createTenantRepository', () => {
 
       await repo.getRecentEvents('test-id-123', 5)
 
-      expect(db._chain.limit).toHaveBeenCalledWith(5)
+      expect(db._chain.limit).toHaveBeenCalledWith(5) // @scaffold
     })
 
     test('given no limit, should default to 50', async () => {
@@ -332,7 +335,7 @@ describe('createTenantRepository', () => {
 
       await repo.getRecentEvents('test-id-123')
 
-      expect(db._chain.limit).toHaveBeenCalledWith(50)
+      expect(db._chain.limit).toHaveBeenCalledWith(50) // @scaffold
     })
   })
 })

--- a/apps/control-plane/src/schema/__tests__/tenants.test.ts
+++ b/apps/control-plane/src/schema/__tests__/tenants.test.ts
@@ -43,6 +43,7 @@ describe('backupStatusEnum', () => {
 })
 
 describe('tenants table', () => {
+  /** @scaffold - suite-shape: verifying schema column presence */
   it('should have all required columns', () => {
     const columns = getTableColumns(tenants)
     const columnNames = Object.keys(columns)
@@ -88,6 +89,7 @@ describe('tenants table', () => {
 })
 
 describe('tenantEvents table', () => {
+  /** @scaffold - suite-shape: verifying schema column presence */
   it('should have all required columns', () => {
     const columns = getTableColumns(tenantEvents)
     const columnNames = Object.keys(columns)
@@ -107,6 +109,7 @@ describe('tenantEvents table', () => {
 })
 
 describe('tenantBackups table', () => {
+  /** @scaffold - suite-shape: verifying schema column presence */
   it('should have all required columns', () => {
     const columns = getTableColumns(tenantBackups)
     const columnNames = Object.keys(columns)

--- a/apps/control-plane/src/services/__tests__/admin-seeder.test.ts
+++ b/apps/control-plane/src/services/__tests__/admin-seeder.test.ts
@@ -121,6 +121,7 @@ describe('AdminSeeder', () => {
   })
 
   describe('CUID2 id generation', () => {
+    /** @scaffold - parameter-count assertion; will break if INSERT columns change */
     test('given a new user, should include id column in INSERT with a generated CUID2', async () => {
       const db = makeMockDb(null)
       const bcrypt = makeMockBcrypt()

--- a/apps/control-plane/src/services/__tests__/shell-executor.test.ts
+++ b/apps/control-plane/src/services/__tests__/shell-executor.test.ts
@@ -76,14 +76,15 @@ describe('ShellExecutor', () => {
   })
 
   describe('timeout handling', () => {
-    test('given a timeout option, should reject when command exceeds timeout', async () => {
+    test('given a timeout option, should return error result when command exceeds timeout', async () => {
       const executor = createMockExecutor([
-        { stdout: '', stderr: 'timeout', exitCode: -1, delay: 200 },
+        { stdout: '', stderr: 'timed out', exitCode: -1, delay: 200 },
       ])
 
       const result = await executor.exec('slow-command', { timeout: 50 })
 
-      expect(result.exitCode).not.toBe(0)
+      expect(result.exitCode).toBe(-1)
+      expect(result.stderr).toContain('timed out')
     })
   })
 


### PR DESCRIPTION
## Summary
- Label ORM chain mocks as `@scaffold` in `tenant-repository.test.ts` (score 6→8) — these characterize repository behavior but need real DB integration tests to replace them
- Mark 3 suite-shape column-presence tests in `schema/tenants.test.ts` as `@scaffold` (score 8→10)
- Label parameter-count assertion (`toHaveLength(5)`) in `admin-seeder.test.ts` as `@scaffold` (score 9→10)
- Rename misleading timeout test and strengthen assertions in `shell-executor.test.ts` (score 9→10)

All 195 tests remain passing. No tests added or removed.

## Test plan
- [x] `pnpm --filter control-plane test` — 195/195 passing
- [x] Verify `@scaffold` labels are correctly placed on chain-mock and suite-shape tests
- [x] Verify shell-executor timeout test has specific `exitCode: -1` and `stderr: 'timed out'` assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout error handling and messaging in command execution.

* **Chores**
  * Updated test infrastructure with annotations and refined timeout error handling assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->