### PR TITLE
feat(epic-11): close the loop — Stripe→provisioning bridge, email, status page

### DIFF
--- a/apps/control-plane/src/services/__tests__/provisioning-engine.test.ts
+++ b/apps/control-plane/src/services/__tests__/provisioning-engine.test.ts
@@ -54,6 +54,10 @@ function makeMockHealthPoller() {
   return vi.fn().mockResolvedValue({ healthy: true })
 }
 
+function makeMockEmailSender() {
+  return vi.fn().mockResolvedValue(undefined)
+}
+
 function makeDeps(overrides: Partial<ProvisioningDeps> = {}): ProvisioningDeps {
   return {
     repo: makeMockRepo(),
@@ -61,6 +65,7 @@ function makeDeps(overrides: Partial<ProvisioningDeps> = {}): ProvisioningDeps {
     fs: makeMockFs(),
     seeder: makeMockSeeder(),
     pollHealth: makeMockHealthPoller(),
+    sendProvisioningEmail: makeMockEmailSender(),
     basePath: '/data/tenants',
     scriptsPath: '/opt/infrastructure/scripts',
     composePath: '/opt/infrastructure/docker-compose.tenant.yml',
@@ -347,6 +352,67 @@ describe('ProvisioningEngine', () => {
     })
   })
 
+  describe('provisioning email', () => {
+    test('given a new admin user, should send provisioning email with credentials', async () => {
+      const deps = makeDeps()
+      const engine = createProvisioningEngine(deps)
+
+      await engine.provision({ slug: 'acme', ownerEmail: 'owner@acme.com', tier: 'business' })
+
+      expect(deps.sendProvisioningEmail).toHaveBeenCalledWith({
+        loginUrl: 'https://acme.pagespace.ai',
+        adminEmail: 'owner@acme.com',
+        temporaryPassword: 'TempPass!',
+      })
+    })
+
+    test('given an existing admin user, should send email without temporaryPassword', async () => {
+      const deps = makeDeps()
+      ;(deps.seeder.seed as ReturnType<typeof vi.fn>).mockResolvedValue({
+        email: 'owner@acme.com',
+        temporaryPassword: 'SomePass!',
+        alreadyExisted: true,
+      })
+      const engine = createProvisioningEngine(deps)
+
+      await engine.provision({ slug: 'acme', ownerEmail: 'owner@acme.com', tier: 'business' })
+
+      expect(deps.sendProvisioningEmail).toHaveBeenCalledWith({
+        loginUrl: 'https://acme.pagespace.ai',
+        adminEmail: 'owner@acme.com',
+      })
+    })
+
+    test('given email send failure, should not fail provisioning', async () => {
+      const deps = makeDeps()
+      ;(deps.sendProvisioningEmail as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('SMTP connection refused')
+      )
+      const engine = createProvisioningEngine(deps)
+
+      const result = await engine.provision({ slug: 'acme', ownerEmail: 'owner@acme.com', tier: 'business' })
+
+      expect(result.tenantId).toBe('tenant-123')
+      expect(deps.repo.updateTenantStatus).toHaveBeenCalledWith('tenant-123', 'active')
+    })
+
+    test('given email send failure, should still record provisioned event', async () => {
+      const deps = makeDeps()
+      ;(deps.sendProvisioningEmail as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('SMTP connection refused')
+      )
+      const engine = createProvisioningEngine(deps)
+
+      await engine.provision({ slug: 'acme', ownerEmail: 'owner@acme.com', tier: 'business' })
+
+      expect(deps.repo.recordEvent).toHaveBeenCalledWith(
+        'tenant-123',
+        'provisioned',
+        expect.any(Object)
+      )
+    })
+  })
+
   describe('step ordering', () => {
     test('given a valid request, should execute steps in the correct order', async () => {
       const callOrder: string[] = []
@@ -396,7 +462,11 @@ describe('ProvisioningEngine', () => {
         return { healthy: true }
       })
 
-      const deps = makeDeps({ repo, executor, fs, seeder, pollHealth })
+      const sendProvisioningEmail = vi.fn().mockImplementation(async () => {
+        callOrder.push('send-email')
+      })
+
+      const deps = makeDeps({ repo, executor, fs, seeder, pollHealth, sendProvisioningEmail })
       const engine = createProvisioningEngine(deps)
 
       await engine.provision({ slug: 'acme', ownerEmail: 'owner@acme.com', tier: 'business' })
@@ -410,6 +480,7 @@ describe('ProvisioningEngine', () => {
         'compose-up',
         'poll-health',
         'seed-admin',
+        'send-email',
         'update-status',
         'record-event',
       ])

--- a/apps/control-plane/src/services/__tests__/provisioning-engine.test.ts
+++ b/apps/control-plane/src/services/__tests__/provisioning-engine.test.ts
@@ -375,6 +375,17 @@ describe('ProvisioningEngine', () => {
       })
     })
 
+    test('given a custom tenantBaseDomain, should use it in the login URL', async () => {
+      const deps = makeDeps()
+      const engine = createProvisioningEngine({ ...deps, tenantBaseDomain: 'example.com' })
+
+      await engine.provision({ slug: 'acme', ownerEmail: 'owner@acme.com', tier: 'business' })
+
+      expect(deps.sendProvisioningEmail).toHaveBeenCalledWith(
+        expect.objectContaining({ loginUrl: 'https://acme.example.com' })
+      )
+    })
+
     test('given an existing admin user, should send email without temporaryPassword', async () => {
       const deps = makeDeps()
       ;(deps.seeder.seed as ReturnType<typeof vi.fn>).mockResolvedValue({

--- a/apps/control-plane/src/services/__tests__/provisioning-engine.test.ts
+++ b/apps/control-plane/src/services/__tests__/provisioning-engine.test.ts
@@ -353,6 +353,15 @@ describe('ProvisioningEngine', () => {
   })
 
   describe('provisioning email', () => {
+    test('given no sendProvisioningEmail dep, should provision successfully without sending email', async () => {
+      const { sendProvisioningEmail: _, ...depsWithoutEmail } = makeDeps()
+      const engine = createProvisioningEngine(depsWithoutEmail)
+
+      const result = await engine.provision({ slug: 'acme', ownerEmail: 'owner@acme.com', tier: 'business' })
+
+      expect(result.tenantId).toBe('tenant-123')
+    })
+
     test('given a new admin user, should send provisioning email with credentials', async () => {
       const deps = makeDeps()
       const engine = createProvisioningEngine(deps)

--- a/apps/control-plane/src/services/provisioning-engine.ts
+++ b/apps/control-plane/src/services/provisioning-engine.ts
@@ -29,6 +29,7 @@ export type ProvisioningDeps = {
   seeder: AdminSeeder
   pollHealth: (slug: string) => Promise<{ healthy: boolean }>
   sendProvisioningEmail?: (data: ProvisioningEmailData) => Promise<void>
+  tenantBaseDomain?: string
   basePath: string
   scriptsPath: string
   composePath: string
@@ -50,6 +51,7 @@ export function createProvisioningEngine(deps: ProvisioningDeps) {
   const {
     repo, executor, fs, seeder, pollHealth,
     sendProvisioningEmail = async () => { console.warn('sendProvisioningEmail not configured — skipping provisioning email') },
+    tenantBaseDomain = 'pagespace.ai',
     basePath, scriptsPath, composePath,
   } = deps
 
@@ -123,7 +125,7 @@ export function createProvisioningEngine(deps: ProvisioningDeps) {
         // Step 9: Send provisioning email (fire-and-forget — must not fail provisioning)
         try {
           await sendProvisioningEmail({
-            loginUrl: `https://${request.slug}.pagespace.ai`,
+            loginUrl: `https://${request.slug}.${tenantBaseDomain}`,
             adminEmail: request.ownerEmail,
             ...(!seedResult.alreadyExisted && seedResult.temporaryPassword
               ? { temporaryPassword: seedResult.temporaryPassword }

--- a/apps/control-plane/src/services/provisioning-engine.ts
+++ b/apps/control-plane/src/services/provisioning-engine.ts
@@ -28,7 +28,7 @@ export type ProvisioningDeps = {
   fs: FsLike
   seeder: AdminSeeder
   pollHealth: (slug: string) => Promise<{ healthy: boolean }>
-  sendProvisioningEmail: (data: ProvisioningEmailData) => Promise<void>
+  sendProvisioningEmail?: (data: ProvisioningEmailData) => Promise<void>
   basePath: string
   scriptsPath: string
   composePath: string
@@ -47,7 +47,11 @@ function getEnvVar(envContent: string, name: string): string | undefined {
 }
 
 export function createProvisioningEngine(deps: ProvisioningDeps) {
-  const { repo, executor, fs, seeder, pollHealth, sendProvisioningEmail, basePath, scriptsPath, composePath } = deps
+  const {
+    repo, executor, fs, seeder, pollHealth,
+    sendProvisioningEmail = async () => { console.warn('sendProvisioningEmail not configured — skipping provisioning email') },
+    basePath, scriptsPath, composePath,
+  } = deps
 
   return {
     async provision(request: ProvisionRequest) {
@@ -118,14 +122,13 @@ export function createProvisioningEngine(deps: ProvisioningDeps) {
 
         // Step 9: Send provisioning email (fire-and-forget — must not fail provisioning)
         try {
-          const emailData: ProvisioningEmailData = {
+          await sendProvisioningEmail({
             loginUrl: `https://${request.slug}.pagespace.ai`,
             adminEmail: request.ownerEmail,
-          }
-          if (!seedResult.alreadyExisted && seedResult.temporaryPassword) {
-            emailData.temporaryPassword = seedResult.temporaryPassword
-          }
-          await sendProvisioningEmail(emailData)
+            ...(!seedResult.alreadyExisted && seedResult.temporaryPassword
+              ? { temporaryPassword: seedResult.temporaryPassword }
+              : {}),
+          })
         } catch {
           // Email failure must NOT fail provisioning
         }

--- a/apps/control-plane/src/services/provisioning-engine.ts
+++ b/apps/control-plane/src/services/provisioning-engine.ts
@@ -16,12 +16,19 @@ type AdminSeeder = {
   }>
 }
 
+type ProvisioningEmailData = {
+  loginUrl: string
+  adminEmail: string
+  temporaryPassword?: string
+}
+
 export type ProvisioningDeps = {
   repo: TenantRepo
   executor: ShellExecutor
   fs: FsLike
   seeder: AdminSeeder
   pollHealth: (slug: string) => Promise<{ healthy: boolean }>
+  sendProvisioningEmail: (data: ProvisioningEmailData) => Promise<void>
   basePath: string
   scriptsPath: string
   composePath: string
@@ -40,7 +47,7 @@ function getEnvVar(envContent: string, name: string): string | undefined {
 }
 
 export function createProvisioningEngine(deps: ProvisioningDeps) {
-  const { repo, executor, fs, seeder, pollHealth, basePath, scriptsPath, composePath } = deps
+  const { repo, executor, fs, seeder, pollHealth, sendProvisioningEmail, basePath, scriptsPath, composePath } = deps
 
   return {
     async provision(request: ProvisionRequest) {
@@ -109,10 +116,24 @@ export function createProvisioningEngine(deps: ProvisioningDeps) {
           databaseUrl,
         })
 
-        // Step 9: Update status to active
+        // Step 9: Send provisioning email (fire-and-forget — must not fail provisioning)
+        try {
+          const emailData: ProvisioningEmailData = {
+            loginUrl: `https://${request.slug}.pagespace.ai`,
+            adminEmail: request.ownerEmail,
+          }
+          if (!seedResult.alreadyExisted && seedResult.temporaryPassword) {
+            emailData.temporaryPassword = seedResult.temporaryPassword
+          }
+          await sendProvisioningEmail(emailData)
+        } catch {
+          // Email failure must NOT fail provisioning
+        }
+
+        // Step 10: Update status to active
         await repo.updateTenantStatus(tenant.id, 'active')
 
-        // Step 10: Record provisioned event
+        // Step 11: Record provisioned event
         await repo.recordEvent(tenant.id, 'provisioned', {
           ownerEmail: request.ownerEmail,
           tier: request.tier,

--- a/apps/web/src/app/api/provisioning-status/[slug]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/provisioning-status/[slug]/__tests__/route.test.ts
@@ -139,4 +139,38 @@ describe('GET /api/provisioning-status/[slug]', () => {
     expect(body.tier).toBeUndefined();
     expect(body.recentEvents).toBeUndefined();
   });
+
+  describe('slug validation', () => {
+    it('should return 400 for slug with path traversal characters', async () => {
+      const { request, context } = makeRequest('../../etc/passwd');
+      const response = await GET(request, context);
+
+      expect(response.status).toBe(400);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 for slug that is too short', async () => {
+      const { request, context } = makeRequest('ab');
+      const response = await GET(request, context);
+
+      expect(response.status).toBe(400);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 for slug with uppercase letters', async () => {
+      const { request, context } = makeRequest('AcMe');
+      const response = await GET(request, context);
+
+      expect(response.status).toBe(400);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 for slug with spaces', async () => {
+      const { request, context } = makeRequest('my tenant');
+      const response = await GET(request, context);
+
+      expect(response.status).toBe(400);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/web/src/app/api/provisioning-status/[slug]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/provisioning-status/[slug]/__tests__/route.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GET } from '../route';
+
+const originalFetch = global.fetch;
+
+describe('GET /api/provisioning-status/[slug]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CONTROL_PLANE_URL = 'http://control-plane:4000';
+    process.env.CONTROL_PLANE_API_KEY = 'test-api-key';
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    delete process.env.CONTROL_PLANE_URL;
+    delete process.env.CONTROL_PLANE_API_KEY;
+  });
+
+  function makeRequest(slug: string) {
+    const request = new Request(`https://example.com/api/provisioning-status/${slug}`);
+    const context = { params: Promise.resolve({ slug }) };
+    return { request, context };
+  }
+
+  it('should proxy to control-plane and return tenant status', async () => {
+    const tenantData = { slug: 'acme', status: 'provisioning', name: 'acme' };
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => tenantData,
+    });
+
+    const { request, context } = makeRequest('acme');
+    const response = await GET(request, context);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.slug).toBe('acme');
+    expect(body.status).toBe('provisioning');
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://control-plane:4000/api/tenants/acme',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'X-API-Key': 'test-api-key',
+        }),
+      }),
+    );
+  });
+
+  it('should return active status when tenant is ready', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ slug: 'acme', status: 'active', name: 'acme' }),
+    });
+
+    const { request, context } = makeRequest('acme');
+    const response = await GET(request, context);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.status).toBe('active');
+  });
+
+  it('should return failed status when provisioning fails', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ slug: 'acme', status: 'failed', name: 'acme' }),
+    });
+
+    const { request, context } = makeRequest('acme');
+    const response = await GET(request, context);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.status).toBe('failed');
+  });
+
+  it('should return 404 when tenant not found on control-plane', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ error: 'Tenant "unknown" not found' }),
+    });
+
+    const { request, context } = makeRequest('unknown');
+    const response = await GET(request, context);
+
+    expect(response.status).toBe(404);
+  });
+
+  it('should return 503 when CONTROL_PLANE_URL is not configured', async () => {
+    delete process.env.CONTROL_PLANE_URL;
+
+    const { request, context } = makeRequest('acme');
+    const response = await GET(request, context);
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body.error).toBe('Provisioning service unavailable');
+  });
+
+  it('should return 502 when control-plane is unreachable', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('Connection refused')
+    );
+
+    const { request, context } = makeRequest('acme');
+    const response = await GET(request, context);
+    const body = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(body.error).toBe('Failed to reach provisioning service');
+  });
+
+  it('should only return slug and status fields to the client', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        slug: 'acme',
+        status: 'active',
+        name: 'acme',
+        ownerEmail: 'secret@acme.com',
+        tier: 'business',
+        recentEvents: [],
+      }),
+    });
+
+    const { request, context } = makeRequest('acme');
+    const response = await GET(request, context);
+    const body = await response.json();
+
+    expect(body.slug).toBe('acme');
+    expect(body.status).toBe('active');
+    expect(body.ownerEmail).toBeUndefined();
+    expect(body.tier).toBeUndefined();
+    expect(body.recentEvents).toBeUndefined();
+  });
+});

--- a/apps/web/src/app/api/provisioning-status/[slug]/route.ts
+++ b/apps/web/src/app/api/provisioning-status/[slug]/route.ts
@@ -1,0 +1,45 @@
+import { loggers } from '@pagespace/lib/server';
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await context.params;
+
+  const controlPlaneUrl = process.env.CONTROL_PLANE_URL;
+  if (!controlPlaneUrl) {
+    return Response.json(
+      { error: 'Provisioning service unavailable' },
+      { status: 503 }
+    );
+  }
+
+  try {
+    const response = await fetch(`${controlPlaneUrl}/api/tenants/${slug}`, {
+      headers: {
+        'X-API-Key': process.env.CONTROL_PLANE_API_KEY || '',
+      },
+    });
+
+    if (!response.ok) {
+      return Response.json(
+        { error: `Tenant not found` },
+        { status: response.status }
+      );
+    }
+
+    const data = await response.json() as { slug: string; status: string };
+
+    // Only expose slug and status to the client — no internal details
+    return Response.json({
+      slug: data.slug,
+      status: data.status,
+    });
+  } catch (error) {
+    loggers.api.error('Failed to reach control-plane', error instanceof Error ? error : undefined, { slug });
+    return Response.json(
+      { error: 'Failed to reach provisioning service' },
+      { status: 502 }
+    );
+  }
+}

--- a/apps/web/src/app/api/provisioning-status/[slug]/route.ts
+++ b/apps/web/src/app/api/provisioning-status/[slug]/route.ts
@@ -1,10 +1,17 @@
 import { loggers } from '@pagespace/lib/server';
 
+// Mirrors control-plane's tenant-validation.ts SLUG_PATTERN
+const SLUG_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+
 export async function GET(
   _request: Request,
   context: { params: Promise<{ slug: string }> }
 ) {
   const { slug } = await context.params;
+
+  if (!slug || slug.length < 3 || slug.length > 63 || !SLUG_PATTERN.test(slug)) {
+    return Response.json({ error: 'Invalid slug' }, { status: 400 });
+  }
 
   const controlPlaneUrl = process.env.CONTROL_PLANE_URL;
   if (!controlPlaneUrl) {

--- a/apps/web/src/app/api/stripe/webhook/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/webhook/__tests__/route.test.ts
@@ -778,6 +778,34 @@ describe('POST /api/stripe/webhook', () => {
         }),
       );
     });
+
+    it('should still return 200 when control-plane returns non-2xx', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+        ok: false,
+        status: 409,
+        json: async () => ({ error: 'Tenant slug "acme" already exists' }),
+      });
+
+      const session = mockCheckoutSession({
+        mode: 'subscription',
+        customer: 'cus_new123',
+        customerEmail: 'admin@acme.com',
+        metadata: { slug: 'acme', tier: 'business' },
+      });
+      const event = mockStripeEvent('checkout.session.completed', session);
+      mockStripeWebhooksConstructEvent.mockReturnValue(event);
+
+      const request = new Request('https://example.com/api/stripe/webhook', {
+        method: 'POST',
+        body: JSON.stringify(event),
+        headers: { 'stripe-signature': 'valid_signature' },
+      }) as unknown as import('next/server').NextRequest;
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      expect(global.fetch).toHaveBeenCalled();
+    });
   });
 
   describe('Event Processing', () => {

--- a/apps/web/src/app/api/stripe/webhook/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/webhook/__tests__/route.test.ts
@@ -191,6 +191,7 @@ const mockCheckoutSession = (overrides: Partial<{
   mode: string;
   customer: string;
   customerEmail: string;
+  metadata: Record<string, string>;
 }> = {}): Stripe.Checkout.Session => ({
   id: overrides.id ?? 'cs_123',
   mode: (overrides.mode ?? 'subscription') as Stripe.Checkout.Session.Mode,
@@ -203,6 +204,7 @@ const mockCheckoutSession = (overrides: Partial<{
     tax_exempt: 'none',
     tax_ids: null,
   },
+  metadata: overrides.metadata ?? {},
   object: 'checkout.session',
 } as Stripe.Checkout.Session);
 
@@ -616,6 +618,165 @@ describe('POST /api/stripe/webhook', () => {
 
       expect(response.status).toBe(200);
       expect(body.received).toBe(true);
+    });
+  });
+
+  describe('Control-Plane Provisioning Bridge', () => {
+    const originalFetch = global.fetch;
+
+    beforeEach(() => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 202,
+        json: async () => ({ slug: 'acme', status: 'provisioning' }),
+      });
+      process.env.CONTROL_PLANE_URL = 'http://control-plane:4000';
+      process.env.CONTROL_PLANE_API_KEY = 'test-api-key';
+    });
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+      delete process.env.CONTROL_PLANE_URL;
+      delete process.env.CONTROL_PLANE_API_KEY;
+    });
+
+    it('should call control-plane to provision tenant when metadata.slug is present', async () => {
+      const session = mockCheckoutSession({
+        mode: 'subscription',
+        customer: 'cus_new123',
+        customerEmail: 'admin@acme.com',
+        metadata: { slug: 'acme', tier: 'business' },
+      });
+      const event = mockStripeEvent('checkout.session.completed', session);
+      mockStripeWebhooksConstructEvent.mockReturnValue(event);
+
+      const request = new Request('https://example.com/api/stripe/webhook', {
+        method: 'POST',
+        body: JSON.stringify(event),
+        headers: { 'stripe-signature': 'valid_signature' },
+      }) as unknown as import('next/server').NextRequest;
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://control-plane:4000/api/tenants',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+            'X-API-Key': 'test-api-key',
+          }),
+          body: JSON.stringify({
+            slug: 'acme',
+            name: 'acme',
+            ownerEmail: 'admin@acme.com',
+            tier: 'business',
+          }),
+        }),
+      );
+    });
+
+    it('should not call control-plane when metadata.slug is absent', async () => {
+      const session = mockCheckoutSession({
+        mode: 'subscription',
+        customer: 'cus_new123',
+        customerEmail: 'test@example.com',
+      });
+      const event = mockStripeEvent('checkout.session.completed', session);
+      mockStripeWebhooksConstructEvent.mockReturnValue(event);
+
+      const request = new Request('https://example.com/api/stripe/webhook', {
+        method: 'POST',
+        body: JSON.stringify(event),
+        headers: { 'stripe-signature': 'valid_signature' },
+      }) as unknown as import('next/server').NextRequest;
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should skip provisioning when CONTROL_PLANE_URL is not set', async () => {
+      delete process.env.CONTROL_PLANE_URL;
+
+      const session = mockCheckoutSession({
+        mode: 'subscription',
+        customer: 'cus_new123',
+        customerEmail: 'admin@acme.com',
+        metadata: { slug: 'acme', tier: 'business' },
+      });
+      const event = mockStripeEvent('checkout.session.completed', session);
+      mockStripeWebhooksConstructEvent.mockReturnValue(event);
+
+      const request = new Request('https://example.com/api/stripe/webhook', {
+        method: 'POST',
+        body: JSON.stringify(event),
+        headers: { 'stripe-signature': 'valid_signature' },
+      }) as unknown as import('next/server').NextRequest;
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should not throw when control-plane call fails', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('Connection refused')
+      );
+
+      const session = mockCheckoutSession({
+        mode: 'subscription',
+        customer: 'cus_new123',
+        customerEmail: 'admin@acme.com',
+        metadata: { slug: 'acme', tier: 'business' },
+      });
+      const event = mockStripeEvent('checkout.session.completed', session);
+      mockStripeWebhooksConstructEvent.mockReturnValue(event);
+
+      const request = new Request('https://example.com/api/stripe/webhook', {
+        method: 'POST',
+        body: JSON.stringify(event),
+        headers: { 'stripe-signature': 'valid_signature' },
+      }) as unknown as import('next/server').NextRequest;
+
+      const response = await POST(request);
+
+      // Must still return 200 — fire-and-forget
+      expect(response.status).toBe(200);
+    });
+
+    it('should default tier to pro when metadata.tier is absent', async () => {
+      const session = mockCheckoutSession({
+        mode: 'subscription',
+        customer: 'cus_new123',
+        customerEmail: 'admin@acme.com',
+        metadata: { slug: 'acme' },
+      });
+      const event = mockStripeEvent('checkout.session.completed', session);
+      mockStripeWebhooksConstructEvent.mockReturnValue(event);
+
+      const request = new Request('https://example.com/api/stripe/webhook', {
+        method: 'POST',
+        body: JSON.stringify(event),
+        headers: { 'stripe-signature': 'valid_signature' },
+      }) as unknown as import('next/server').NextRequest;
+
+      await POST(request);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'http://control-plane:4000/api/tenants',
+        expect.objectContaining({
+          body: JSON.stringify({
+            slug: 'acme',
+            name: 'acme',
+            ownerEmail: 'admin@acme.com',
+            tier: 'pro',
+          }),
+        }),
+      );
     });
   });
 

--- a/apps/web/src/app/api/stripe/webhook/route.ts
+++ b/apps/web/src/app/api/stripe/webhook/route.ts
@@ -305,11 +305,19 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
               tier,
             }),
           });
-          loggers.api.info('Control-plane provisioning triggered', {
-            slug,
-            tier,
-            status: response.status,
-          });
+          if (!response.ok) {
+            loggers.api.warn('Control-plane provisioning returned non-2xx', {
+              slug,
+              tier,
+              status: response.status,
+            });
+          } else {
+            loggers.api.info('Control-plane provisioning triggered', {
+              slug,
+              tier,
+              status: response.status,
+            });
+          }
         } catch (error) {
           loggers.api.error('Failed to trigger control-plane provisioning', error instanceof Error ? error : undefined, { slug });
         }

--- a/apps/web/src/app/api/stripe/webhook/route.ts
+++ b/apps/web/src/app/api/stripe/webhook/route.ts
@@ -281,6 +281,40 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
 
       loggers.api.info('Linked Stripe customer to user', { customerId, email: customerEmail });
     }
+
+    // Bridge to control-plane: trigger tenant provisioning if metadata.slug is present
+    const slug = session.metadata?.slug;
+    if (slug) {
+      const controlPlaneUrl = process.env.CONTROL_PLANE_URL;
+      if (!controlPlaneUrl) {
+        loggers.api.warn('CONTROL_PLANE_URL not set, skipping tenant provisioning', { slug });
+      } else {
+        try {
+          const tier = session.metadata?.tier || 'pro';
+          const ownerEmail = session.customer_details?.email || '';
+          const response = await fetch(`${controlPlaneUrl}/api/tenants`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-API-Key': process.env.CONTROL_PLANE_API_KEY || '',
+            },
+            body: JSON.stringify({
+              slug,
+              name: slug,
+              ownerEmail,
+              tier,
+            }),
+          });
+          loggers.api.info('Control-plane provisioning triggered', {
+            slug,
+            tier,
+            status: response.status,
+          });
+        } catch (error) {
+          loggers.api.error('Failed to trigger control-plane provisioning', error instanceof Error ? error : undefined, { slug });
+        }
+      }
+    }
   }
 }
 

--- a/apps/web/src/app/provisioning/[slug]/page.tsx
+++ b/apps/web/src/app/provisioning/[slug]/page.tsx
@@ -3,6 +3,8 @@
 import { use, useState } from 'react';
 import useSWR from 'swr';
 
+const TENANT_BASE_DOMAIN = process.env.NEXT_PUBLIC_TENANT_BASE_DOMAIN || 'pagespace.ai';
+
 const fetcher = async (url: string) => {
   const res = await fetch(url);
   if (!res.ok) throw new Error(`Status check failed (${res.status})`);
@@ -66,7 +68,7 @@ export default function ProvisioningStatusPage({
               Check your email for login credentials.
             </p>
             <a
-              href={`https://${slug}.pagespace.ai`}
+              href={`https://${slug}.${TENANT_BASE_DOMAIN}`}
               className="inline-block rounded-md bg-blue-600 px-6 py-3 text-sm font-semibold text-white shadow-sm hover:bg-blue-500"
             >
               Go to your environment

--- a/apps/web/src/app/provisioning/[slug]/page.tsx
+++ b/apps/web/src/app/provisioning/[slug]/page.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { use } from 'react';
+import useSWR from 'swr';
+
+const fetcher = (url: string) => fetch(url).then(res => res.json());
+
+type ProvisioningStatus = {
+  slug: string;
+  status: 'provisioning' | 'active' | 'failed';
+};
+
+export default function ProvisioningStatusPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = use(params);
+
+  const { data } = useSWR<ProvisioningStatus>(
+    `/api/provisioning-status/${slug}`,
+    fetcher,
+    {
+      refreshInterval: data?.status === 'provisioning' ? 3000 : 0,
+      revalidateOnFocus: false,
+    }
+  );
+
+  const status = data?.status ?? 'provisioning';
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="max-w-md w-full p-8 bg-white rounded-lg shadow-md text-center">
+        {status === 'provisioning' && (
+          <>
+            <div className="mx-auto mb-6 h-12 w-12 animate-spin rounded-full border-4 border-blue-200 border-t-blue-600" />
+            <h1 className="text-xl font-semibold text-gray-900 mb-2">
+              Setting up your environment
+            </h1>
+            <p className="text-gray-600">
+              Your environment is being set up. This usually takes a few minutes.
+            </p>
+          </>
+        )}
+
+        {status === 'active' && (
+          <>
+            <div className="mx-auto mb-6 flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
+              <svg className="h-6 w-6 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+              </svg>
+            </div>
+            <h1 className="text-xl font-semibold text-gray-900 mb-2">
+              Your environment is ready!
+            </h1>
+            <p className="text-gray-600 mb-6">
+              Check your email for login credentials.
+            </p>
+            <a
+              href={`https://${slug}.pagespace.ai`}
+              className="inline-block rounded-md bg-blue-600 px-6 py-3 text-sm font-semibold text-white shadow-sm hover:bg-blue-500"
+            >
+              Go to your environment
+            </a>
+          </>
+        )}
+
+        {status === 'failed' && (
+          <>
+            <div className="mx-auto mb-6 flex h-12 w-12 items-center justify-center rounded-full bg-red-100">
+              <svg className="h-6 w-6 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </div>
+            <h1 className="text-xl font-semibold text-gray-900 mb-2">
+              Something went wrong
+            </h1>
+            <p className="text-gray-600">
+              Our team has been notified. Please contact support if this persists.
+            </p>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/provisioning/[slug]/page.tsx
+++ b/apps/web/src/app/provisioning/[slug]/page.tsx
@@ -1,9 +1,13 @@
 'use client';
 
-import { use } from 'react';
+import { use, useState } from 'react';
 import useSWR from 'swr';
 
-const fetcher = (url: string) => fetch(url).then(res => res.json());
+const fetcher = async (url: string) => {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Status check failed (${res.status})`);
+  return res.json();
+};
 
 type ProvisioningStatus = {
   slug: string;
@@ -16,17 +20,22 @@ export default function ProvisioningStatusPage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = use(params);
+  const [lastStatus, setLastStatus] = useState<string>('provisioning');
 
-  const { data } = useSWR<ProvisioningStatus>(
+  const { data, error } = useSWR<ProvisioningStatus>(
     `/api/provisioning-status/${slug}`,
     fetcher,
     {
-      refreshInterval: data?.status === 'provisioning' ? 3000 : 0,
+      refreshInterval: 3000,
+      isPaused: () => lastStatus === 'active' || lastStatus === 'failed',
       revalidateOnFocus: false,
+      onSuccess: (d) => setLastStatus(d.status),
     }
   );
 
-  const status = data?.status ?? 'provisioning';
+  const status: 'provisioning' | 'active' | 'failed' | 'error' = error
+    ? 'error'
+    : (data?.status ?? 'provisioning');
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50">
@@ -77,6 +86,22 @@ export default function ProvisioningStatusPage({
             </h1>
             <p className="text-gray-600">
               Our team has been notified. Please contact support if this persists.
+            </p>
+          </>
+        )}
+
+        {status === 'error' && (
+          <>
+            <div className="mx-auto mb-6 flex h-12 w-12 items-center justify-center rounded-full bg-red-100">
+              <svg className="h-6 w-6 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </div>
+            <h1 className="text-xl font-semibold text-gray-900 mb-2">
+              Unable to check provisioning status
+            </h1>
+            <p className="text-gray-600">
+              Please try refreshing the page. Contact support if this persists.
             </p>
           </>
         )}

--- a/packages/lib/src/__tests__/export-utils.test.ts
+++ b/packages/lib/src/__tests__/export-utils.test.ts
@@ -35,7 +35,7 @@ describe('export-utils', () => {
   describe('generateDOCX', () => {
     it('converts HTML to DOCX when result is an ArrayBuffer', async () => {
       const mockBuffer = new ArrayBuffer(8);
-      (HTMLtoDOCX as ReturnType<typeof vi.fn>).mockResolvedValue(mockBuffer);
+      vi.mocked(HTMLtoDOCX).mockResolvedValue(mockBuffer as unknown as Buffer);
 
       const result = await generateDOCX('<p>Hello</p>', 'Test Doc');
 
@@ -50,7 +50,7 @@ describe('export-utils', () => {
 
     it('converts HTML to DOCX when result is a Blob', async () => {
       const mockBlob = new Blob(['docx content'], { type: 'application/octet-stream' });
-      (HTMLtoDOCX as ReturnType<typeof vi.fn>).mockResolvedValue(mockBlob);
+      vi.mocked(HTMLtoDOCX).mockResolvedValue(mockBlob as unknown as Buffer);
 
       const result = await generateDOCX('<p>Hello</p>', 'Test Doc');
 
@@ -59,7 +59,7 @@ describe('export-utils', () => {
 
     it('returns result directly if already a Buffer-like type', async () => {
       const bufferData = Buffer.from('some data');
-      (HTMLtoDOCX as ReturnType<typeof vi.fn>).mockResolvedValue(bufferData);
+      vi.mocked(HTMLtoDOCX).mockResolvedValue(bufferData);
 
       const result = await generateDOCX('<h1>Title</h1>', 'My Title');
 
@@ -68,7 +68,7 @@ describe('export-utils', () => {
 
     it('throws an error when html-to-docx fails', async () => {
       const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-      (HTMLtoDOCX as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('conversion failed'));
+      vi.mocked(HTMLtoDOCX).mockRejectedValue(new Error('conversion failed'));
 
       await expect(generateDOCX('<p>bad</p>', 'Fail')).rejects.toThrow('Failed to generate DOCX');
       expect(consoleSpy).toHaveBeenCalledWith('Error generating DOCX:', expect.objectContaining({ message: 'conversion failed' }));

--- a/packages/lib/src/email-templates/TenantProvisioningCompleteEmail.tsx
+++ b/packages/lib/src/email-templates/TenantProvisioningCompleteEmail.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Link,
+  Section,
+  Text,
+} from '@react-email/components';
+import { emailStyles } from './shared-styles';
+
+interface TenantProvisioningCompleteEmailProps {
+  adminEmail: string;
+  loginUrl: string;
+  temporaryPassword?: string;
+}
+
+export function TenantProvisioningCompleteEmail({
+  adminEmail,
+  loginUrl,
+  temporaryPassword,
+}: TenantProvisioningCompleteEmailProps) {
+  return (
+    <Html>
+      <Head />
+      <Body style={emailStyles.main}>
+        <Container style={emailStyles.container}>
+          <Section style={emailStyles.header}>
+            <Heading style={emailStyles.headerTitle}>PageSpace</Heading>
+          </Section>
+          <Section style={emailStyles.content}>
+            <Text style={emailStyles.contentHeading}>Your environment is ready!</Text>
+            <Text style={emailStyles.paragraph}>
+              Your PageSpace environment has been provisioned and is ready to use.
+            </Text>
+            <Text style={emailStyles.paragraph}>
+              <strong>Login email:</strong> {adminEmail}
+            </Text>
+            {temporaryPassword && (
+              <Text style={emailStyles.paragraph}>
+                <strong>Temporary password:</strong> {temporaryPassword}
+                <br />
+                Please change your password after your first login.
+              </Text>
+            )}
+            <Section style={emailStyles.buttonContainer}>
+              <Button style={emailStyles.button} href={loginUrl}>
+                Sign In to Your Environment
+              </Button>
+            </Section>
+            <Text style={emailStyles.hint}>
+              Or copy and paste this link into your browser:
+              <br />
+              <Link href={loginUrl} style={emailStyles.link}>
+                {loginUrl}
+              </Link>
+            </Text>
+          </Section>
+          <Section style={emailStyles.footer}>
+            <Text style={emailStyles.footerText}>
+              This is a one-time provisioning email from PageSpace.
+            </Text>
+          </Section>
+        </Container>
+      </Body>
+    </Html>
+  );
+}

--- a/tasks/tenant-epic-3-traefik-proxy.md
+++ b/tasks/tenant-epic-3-traefik-proxy.md
@@ -7,6 +7,8 @@
 
 Each tenant gets a subdomain (`{slug}.pagespace.ai`) routing to their isolated Docker stack. Traefik v3 auto-discovers tenant containers via Docker labels, terminates TLS with a wildcard Let's Encrypt cert, and routes HTTP + WebSocket traffic to the right services. This replaces per-tenant nginx config with zero-touch auto-discovery.
 
+**Caddy coexistence**: The current production deploy at pagespace.ai (`/Users/jono/production/PageSpace-Deploy/`) uses Caddy for the main domain and all existing services. Traefik is additive — it handles only tenant subdomains (`*.pagespace.ai`). Both can run in parallel: Caddy on ports 80/443 for `pagespace.ai` and `www.pagespace.ai`, Traefik on internal ports for tenant routing, fronted by Caddy as a reverse proxy. A full Caddy-to-Traefik cutover is out of scope for this epic and should be tracked separately if needed.
+
 ---
 
 ## Traefik Static Config

--- a/tasks/tenant-epic-6-control-plane.md
+++ b/tasks/tenant-epic-6-control-plane.md
@@ -1,6 +1,6 @@
 # Control Plane - Tenant Registry & API (Parent Epic)
 
-**Status**: IN PROGRESS
+**Status**: COMPLETE
 **Goal**: The orchestration brain that provisions, monitors, and manages isolated tenant stacks
 
 ## Overview
@@ -11,8 +11,8 @@ This epic was too large for a single PR. It has been broken into 4 sub-epics tha
 |---|---|---|---|
 | 6a - Scaffold & Schema | [tenant-epic-6a-control-plane-scaffold.md](tenant-epic-6a-control-plane-scaffold.md) | None | COMPLETE |
 | 6b - Repository & Validation | [tenant-epic-6b-tenant-repository.md](tenant-epic-6b-tenant-repository.md) | 6a | COMPLETE |
-| 6c - Provisioning Engine | [tenant-epic-6c-provisioning-engine.md](tenant-epic-6c-provisioning-engine.md) | 6a, 6b, Epic 5 | PLANNED |
-| 6d - REST API | [tenant-epic-6d-rest-api.md](tenant-epic-6d-rest-api.md) | 6a, 6b, 6c | PLANNED |
+| 6c - Provisioning Engine | [tenant-epic-6c-provisioning-engine.md](tenant-epic-6c-provisioning-engine.md) | 6a, 6b, Epic 5 | COMPLETE |
+| 6d - REST API | [tenant-epic-6d-rest-api.md](tenant-epic-6d-rest-api.md) | 6a, 6b, 6c | COMPLETE |
 
 **Approach**: Work progressively — complete 6a, evaluate, then 6b, evaluate, etc. Each sub-epic is a separate PR with its own evaluation gate. Re-scope downstream sub-epics based on what you learn implementing upstream ones.
 

--- a/tasks/tenant-epic-7-stripe-billing.md
+++ b/tasks/tenant-epic-7-stripe-billing.md
@@ -11,6 +11,20 @@ Isolated infrastructure customers pay via Stripe at the control plane level, not
 
 ---
 
+## Standards & Rules
+
+Read and follow these before writing any code. They apply to every task in this epic.
+
+- **TDD Process** (`.claude/rules/tdd.mdc`): Write the test FIRST. Run it. Watch it fail. Then implement ONLY the code needed to make it pass. Repeat for each requirement. Do not write implementation before tests.
+- **Test Rubric** (`.pu/templates/rubric-review.md`): Score each test file against the rubric before committing. Tests must be contract-first, mock only at boundaries, and assert observable outcomes.
+- **Deferred Work Policy** (`.claude/rules/deferred-work-policy.mdc`): Complete all requirements. Update this plan if you deviate. No silent substitutions.
+- **Commit Convention** (`.claude/rules/commit.mdc`): Use conventional commits (`feat:`, `fix:`, `test:`, `chore:`).
+- **Pre-Merge Audit** (`.claude/rules/pre-merge-audit.mdc`): Before opening a PR, audit every requirement in this plan against your diff.
+
+**Missing repo method**: The webhook handler references `getTenantByStripeSubscription(subscriptionId)` to look up a tenant. This method does not exist in the Epic 6b repository interface. Before implementing the webhook, add this method to `apps/control-plane/src/repositories/tenant-repository.ts` and its tests.
+
+---
+
 ## Stripe Product & Price Setup
 
 Define the Stripe product configuration for isolated infrastructure tiers.

--- a/tasks/tenant-epic-8-data-migration.md
+++ b/tasks/tenant-epic-8-data-migration.md
@@ -11,6 +11,20 @@ When a team upgrades to isolated infrastructure, their existing data (drives, pa
 
 ---
 
+## Standards & Rules
+
+Read and follow these before writing any code. They apply to every task in this epic.
+
+- **TDD Process** (`.claude/rules/tdd.mdc`): Write the test FIRST. Run it. Watch it fail. Then implement ONLY the code needed to make it pass. Repeat for each requirement. Do not write implementation before tests.
+- **Test Rubric** (`.pu/templates/rubric-review.md`): Score each test file against the rubric before committing. Tests must be contract-first, mock only at boundaries, and assert observable outcomes.
+- **Deferred Work Policy** (`.claude/rules/deferred-work-policy.mdc`): Complete all requirements. Update this plan if you deviate. No silent substitutions.
+- **Commit Convention** (`.claude/rules/commit.mdc`): Use conventional commits (`feat:`, `fix:`, `test:`, `chore:`).
+- **Pre-Merge Audit** (`.claude/rules/pre-merge-audit.mdc`): Before opening a PR, audit every requirement in this plan against your diff.
+
+**Note on test approach**: The export script's TDD approach mentions using a test database seeded with known data. Per the rubric, this is correct — migration correctness (joins, FK handling, row counts) must be validated against a real DB, not mocked. Use a separate test database (`pagespace_test`) and seed it in test setup. These are integration tests, not unit tests, and should be labeled clearly.
+
+---
+
 ## Export Script
 
 Create a script that exports a team's complete data from the shared instance.

--- a/tasks/tenant-epic-9-operational-tooling.md
+++ b/tasks/tenant-epic-9-operational-tooling.md
@@ -11,6 +11,18 @@ Running 10-20 isolated tenant stacks requires operational automation. This epic 
 
 ---
 
+## Standards & Rules
+
+Read and follow these before writing any code. They apply to every task in this epic.
+
+- **TDD Process** (`.claude/rules/tdd.mdc`): Write the test FIRST. Run it. Watch it fail. Then implement ONLY the code needed to make it pass. Repeat for each requirement. Do not write implementation before tests.
+- **Test Rubric** (`.pu/templates/rubric-review.md`): Score each test file against the rubric before committing. Tests must be contract-first, mock only at boundaries, and assert observable outcomes.
+- **Deferred Work Policy** (`.claude/rules/deferred-work-policy.mdc`): Complete all requirements. Update this plan if you deviate. No silent substitutions.
+- **Commit Convention** (`.claude/rules/commit.mdc`): Use conventional commits (`feat:`, `fix:`, `test:`, `chore:`).
+- **Pre-Merge Audit** (`.claude/rules/pre-merge-audit.mdc`): Before opening a PR, audit every requirement in this plan against your diff.
+
+---
+
 ## Per-Tenant Backup Service
 
 Automated pg_dump + file storage backup per tenant, scheduled via control plane.


### PR DESCRIPTION
## Summary

Epic 11 wires three gaps that disconnect the isolated infrastructure pipeline, completing the end-to-end customer journey from Stripe checkout to a running tenant environment.

### Gap 1: Stripe → Control-Plane Bridge
- After Stripe checkout links a customer, if `session.metadata.slug` is present, POST to the control-plane to start tenant provisioning
- Fire-and-forget: logs result, never throws, skips if `CONTROL_PLANE_URL` not set
- Logs warning for non-2xx control-plane responses (not silently swallowed)

### Gap 2: Provisioning Notification Email
- `sendProvisioningEmail` added as optional dependency to provisioning engine (defaults to console.warn when not configured)
- After admin seeder, sends credentials email with login URL and temporary password (only for new accounts)
- Email failure cannot fail provisioning (try/catch)
- `TenantProvisioningCompleteEmail.tsx` React email template added to packages/lib

### Gap 3: Provisioning Status Page
- `GET /api/provisioning-status/[slug]` proxies to control-plane with server-side API key (never exposed to browser)
- Slug validation (defense-in-depth regex matching control-plane's `SLUG_PATTERN`)
- Only exposes `slug` and `status` fields — strips internal data (ownerEmail, tier, events)
- `/provisioning/[slug]` page with SWR polling at 3s, stops on terminal states via `isPaused`
- Four UI states: provisioning (spinner), active (checkmark + link), failed (error), error (fetch failure)
- Fetcher throws on non-OK responses so SWR error state works correctly

## Files Changed

| File | Change |
|------|--------|
| `apps/web/src/app/api/stripe/webhook/route.ts` | Added control-plane provisioning call in `handleCheckoutCompleted()` |
| `apps/control-plane/src/services/provisioning-engine.ts` | Added optional `sendProvisioningEmail` dep, immutable email data |
| `apps/web/src/app/api/provisioning-status/[slug]/route.ts` | **New** — proxy route with slug validation |
| `apps/web/src/app/provisioning/[slug]/page.tsx` | **New** — polling status page |
| `packages/lib/src/email-templates/TenantProvisioningCompleteEmail.tsx` | **New** — email template |

## Test plan

- [ ] `pnpm --filter control-plane typecheck` passes (was failing before fix)
- [ ] `pnpm --filter control-plane vitest run` — 200 tests pass (11 suites)
- [ ] `pnpm --filter web vitest run src/app/api/stripe/webhook/__tests__/route.test.ts` — 29 tests pass
- [ ] `pnpm --filter web vitest run src/app/api/provisioning-status` — 11 tests pass
- [ ] No merge conflicts with master
- [ ] No TODO/FIXME markers in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time provisioning status page with polling and clear states (provisioning, active, failed)
  * Provisioning completion email template and optional email delivery step
  * Stripe webhook bridge to automatically request tenant provisioning after checkout

* **Bug Fixes**
  * Provisioning proceeds and tenant status updates even if email delivery fails

* **Tests**
  * New and expanded test suites covering provisioning emails, status API, webhook behavior, and utilities

* **Documentation**
  * Updated epics with standards, testing rules, and rollout notes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->