### PR TITLE
feat(terminal): install @gridland/web and configure webpack shims

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -34,15 +34,14 @@ const nextConfig: NextConfig = {
         })
       );
     }
-    // Gridland stubs: @gridland/web uses CJS require for bun:ffi at build time.
-    // Alias to its shipped browser shims so webpack can resolve them.
+    // @gridland/web requires bun:ffi at build time — alias to its shipped browser shims.
     const gridlandShims = path.join(__dirname, "node_modules/@gridland/web/src/shims");
-    config.resolve = config.resolve || {};
+    const bunFfiShim = path.join(gridlandShims, "bun-ffi.ts");
     config.resolve.alias = {
       ...config.resolve.alias,
-      "bun:ffi": path.join(gridlandShims, "bun-ffi.ts"),
+      "bun:ffi": bunFfiShim,
       "bun-ffi-structs": path.join(gridlandShims, "bun-ffi-structs.ts"),
-      bun: path.join(gridlandShims, "bun-ffi.ts"),
+      bun: bunFfiShim,
     };
 
     return config;

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -34,6 +34,17 @@ const nextConfig: NextConfig = {
         })
       );
     }
+    // Gridland stubs: @gridland/web uses CJS require for bun:ffi at build time.
+    // Alias to its shipped browser shims so webpack can resolve them.
+    const gridlandShims = path.join(__dirname, "node_modules/@gridland/web/src/shims");
+    config.resolve = config.resolve || {};
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "bun:ffi": path.join(gridlandShims, "bun-ffi.ts"),
+      "bun-ffi-structs": path.join(gridlandShims, "bun-ffi-structs.ts"),
+      bun: path.join(gridlandShims, "bun-ffi.ts"),
+    };
+
     return config;
   },
 };

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -33,16 +33,17 @@ const nextConfig: NextConfig = {
           ],
         })
       );
+
+      // @gridland/web requires bun:ffi at build time — alias to its shipped browser shims.
+      const gridlandShims = path.join(__dirname, "node_modules/@gridland/web/src/shims");
+      const bunFfiShim = path.join(gridlandShims, "bun-ffi.ts");
+      config.resolve.alias = {
+        ...config.resolve.alias,
+        "bun:ffi": bunFfiShim,
+        "bun-ffi-structs": path.join(gridlandShims, "bun-ffi-structs.ts"),
+        bun: bunFfiShim,
+      };
     }
-    // @gridland/web requires bun:ffi at build time — alias to its shipped browser shims.
-    const gridlandShims = path.join(__dirname, "node_modules/@gridland/web/src/shims");
-    const bunFfiShim = path.join(gridlandShims, "bun-ffi.ts");
-    config.resolve.alias = {
-      ...config.resolve.alias,
-      "bun:ffi": bunFfiShim,
-      "bun-ffi-structs": path.join(gridlandShims, "bun-ffi-structs.ts"),
-      bun: bunFfiShim,
-    };
 
     return config;
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,6 +26,8 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@gridland/utils": "^0.2.53",
+    "@gridland/web": "^0.2.53",
     "@monaco-editor/react": "^4.7.0",
     "@openrouter/ai-sdk-provider": "^1.1.2",
     "@pagespace/db": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,7 +338,7 @@ importers:
         version: 4.0.423(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@remotion/tailwind':
         specifier: ^4.0.421
-        version: 4.0.423(@remotion/bundler@4.0.423(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2))(typescript@5.9.2)(webpack@5.105.0)
+        version: 4.0.423(@remotion/bundler@4.0.423(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2))(typescript@5.9.2)(webpack@5.105.0(esbuild@0.19.12))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -594,6 +594,12 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.1)
+      '@gridland/utils':
+        specifier: ^0.2.53
+        version: 0.2.53(react@19.2.1)
+      '@gridland/web':
+        specifier: ^0.2.53
+        version: 0.2.53(react@19.2.1)
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.52.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -915,7 +921,7 @@ importers:
         version: 8.18.1
       copy-webpack-plugin:
         specifier: ^12.0.2
-        version: 12.0.2(webpack@5.105.0)
+        version: 12.0.2(webpack@5.105.0(esbuild@0.19.12))
       eslint:
         specifier: ^9
         version: 9.36.0(jiti@2.6.0)
@@ -2763,6 +2769,16 @@ packages:
 
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
+
+  '@gridland/utils@0.2.53':
+    resolution: {integrity: sha512-O8Nv2OZreiBJHFCh9L40uiKe8oNvT2DWkbxWxwhtS64covyss10qz9GuJ90K0OSw8Uf6aMOvavcc3ITKcJzgLg==}
+    peerDependencies:
+      react: ^19.1.2
+
+  '@gridland/web@0.2.53':
+    resolution: {integrity: sha512-P8ceTS/QL8ATSJG2aWNQ1dydhujiEy3+lPECelcrlp6vCA5bbPRBu0Mt22PKOaYE4ZyuLmzg7M+dnIxwAlP1Yw==}
+    peerDependencies:
+      react: ^19.1.2
 
   '@hexagon/base64@1.1.28':
     resolution: {integrity: sha512-lhqDEAvWixy3bZ+UOYbPwUbBkwBq5C1LAJ/xPC8Oi+lL54oyakv/npbA0aU2hgCsx/1NUd4IBvV03+aUBWxerw==}
@@ -9042,6 +9058,11 @@ packages:
     engines: {node: '>= 20'}
     hasBin: true
 
+  marked@17.0.5:
+    resolution: {integrity: sha512-6hLvc0/JEbRjRgzI6wnT2P1XuM1/RrrDEX0kPt0N7jGm1133g6X7DlxFasUIx+72aKAr904GTxhSLDrd5DIlZg==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   marked@7.0.4:
     resolution: {integrity: sha512-t8eP0dXRJMtMvBojtkcsA7n48BkauktUKzfkPSCq85ZMTJ0v76Rke4DYz01omYpPTUh4p/f7HePgRo3ebG8+QQ==}
     engines: {node: '>= 16'}
@@ -10540,6 +10561,12 @@ packages:
 
   react-promise-suspense@0.3.4:
     resolution: {integrity: sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==}
+
+  react-reconciler@0.33.0:
+    resolution: {integrity: sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^19.1.2
 
   react-redux@9.2.0:
     resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
@@ -12282,6 +12309,9 @@ packages:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
 
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
+
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
@@ -13772,6 +13802,20 @@ snapshots:
   '@fontsource/space-grotesk@5.2.10': {}
 
   '@gar/promisify@1.1.3': {}
+
+  '@gridland/utils@0.2.53(react@19.2.1)':
+    dependencies:
+      react: 19.2.1
+
+  '@gridland/web@0.2.53(react@19.2.1)':
+    dependencies:
+      '@gridland/utils': 0.2.53(react@19.2.1)
+      diff: 8.0.3
+      events: 3.3.0
+      marked: 17.0.5
+      react: 19.2.1
+      react-reconciler: 0.33.0(react@19.2.1)
+      yoga-layout: 3.2.1
 
   '@hexagon/base64@1.1.28': {}
 
@@ -15511,7 +15555,7 @@ snapshots:
       remotion: 4.0.423(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       source-map: 0.7.3
       style-loader: 4.0.0(webpack@5.105.0(esbuild@0.25.0))
-      webpack: 5.105.0(esbuild@0.25.0)
+      webpack: 5.105.0(esbuild@0.19.12)
     transitivePeerDependencies:
       - '@swc/core'
       - bufferutil
@@ -15660,13 +15704,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@remotion/tailwind@4.0.423(@remotion/bundler@4.0.423(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2))(typescript@5.9.2)(webpack@5.105.0)':
+  '@remotion/tailwind@4.0.423(@remotion/bundler@4.0.423(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2))(typescript@5.9.2)(webpack@5.105.0(esbuild@0.19.12))':
     dependencies:
       '@remotion/bundler': 4.0.423(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       autoprefixer: 10.4.20(postcss@8.4.47)
       css-loader: 5.2.7(webpack@5.105.0(esbuild@0.25.0))
       postcss: 8.4.47
-      postcss-loader: 7.3.4(postcss@8.4.47)(typescript@5.9.2)(webpack@5.105.0)
+      postcss-loader: 7.3.4(postcss@8.4.47)(typescript@5.9.2)(webpack@5.105.0(esbuild@0.19.12))
       postcss-preset-env: 8.5.1(postcss@8.4.47)
       style-loader: 4.0.0(webpack@5.105.0(esbuild@0.25.0))
       tailwindcss: 3.4.13(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2))
@@ -17823,7 +17867,7 @@ snapshots:
 
   cookiejar@2.1.4: {}
 
-  copy-webpack-plugin@12.0.2(webpack@5.105.0):
+  copy-webpack-plugin@12.0.2(webpack@5.105.0(esbuild@0.19.12)):
     dependencies:
       fast-glob: 3.3.3
       glob-parent: 6.0.2
@@ -17831,7 +17875,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.2
       serialize-javascript: 6.0.2
-      webpack: 5.105.0(esbuild@0.25.0)
+      webpack: 5.105.0(esbuild@0.19.12)
 
   core-util-is@1.0.2:
     optional: true
@@ -17930,7 +17974,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       schema-utils: 3.3.0
       semver: 7.7.2
-      webpack: 5.105.0(esbuild@0.25.0)
+      webpack: 5.105.0(esbuild@0.19.12)
 
   css-prefers-color-scheme@8.0.2(postcss@8.4.47):
     dependencies:
@@ -20880,6 +20924,8 @@ snapshots:
 
   marked@17.0.1: {}
 
+  marked@17.0.5: {}
+
   marked@7.0.4: {}
 
   matcher@3.0.0:
@@ -22260,13 +22306,13 @@ snapshots:
       postcss: 8.5.6
       ts-node: 10.9.2(@types/node@20.19.17)(typescript@5.9.2)
 
-  postcss-loader@7.3.4(postcss@8.4.47)(typescript@5.9.2)(webpack@5.105.0):
+  postcss-loader@7.3.4(postcss@8.4.47)(typescript@5.9.2)(webpack@5.105.0(esbuild@0.19.12)):
     dependencies:
       cosmiconfig: 8.3.6(typescript@5.9.2)
       jiti: 1.21.7
       postcss: 8.4.47
       semver: 7.7.2
-      webpack: 5.105.0(esbuild@0.25.0)
+      webpack: 5.105.0(esbuild@0.19.12)
     transitivePeerDependencies:
       - typescript
 
@@ -22821,6 +22867,11 @@ snapshots:
   react-promise-suspense@0.3.4:
     dependencies:
       fast-deep-equal: 2.0.1
+
+  react-reconciler@0.33.0(react@19.2.1):
+    dependencies:
+      react: 19.2.1
+      scheduler: 0.27.0
 
   react-redux@9.2.0(@types/react@19.1.13)(react@19.2.1)(redux@5.0.1):
     dependencies:
@@ -23892,7 +23943,7 @@ snapshots:
 
   style-loader@4.0.0(webpack@5.105.0(esbuild@0.25.0)):
     dependencies:
-      webpack: 5.105.0(esbuild@0.25.0)
+      webpack: 5.105.0(esbuild@0.19.12)
 
   style-to-js@1.1.17:
     dependencies:
@@ -24042,16 +24093,16 @@ snapshots:
       mkdirp: 0.5.6
       rimraf: 2.6.3
 
-  terser-webpack-plugin@5.3.16(esbuild@0.25.0)(webpack@5.105.0(esbuild@0.25.0)):
+  terser-webpack-plugin@5.3.16(esbuild@0.19.12)(webpack@5.105.0(esbuild@0.19.12)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.44.0
-      webpack: 5.105.0(esbuild@0.25.0)
+      webpack: 5.105.0(esbuild@0.19.12)
     optionalDependencies:
-      esbuild: 0.25.0
+      esbuild: 0.19.12
 
   terser@5.44.0:
     dependencies:
@@ -24759,7 +24810,7 @@ snapshots:
 
   webpack-sources@3.3.3: {}
 
-  webpack@5.105.0(esbuild@0.25.0):
+  webpack@5.105.0(esbuild@0.19.12):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -24783,7 +24834,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(esbuild@0.25.0)(webpack@5.105.0(esbuild@0.25.0))
+      terser-webpack-plugin: 5.3.16(esbuild@0.19.12)(webpack@5.105.0(esbuild@0.19.12))
       watchpack: 2.5.1
       webpack-sources: 3.3.3
     transitivePeerDependencies:
@@ -24982,6 +25033,8 @@ snapshots:
   yoctocolors-cjs@2.1.3: {}
 
   yoctocolors@2.1.2: {}
+
+  yoga-layout@3.2.1: {}
 
   zip-stream@6.0.1:
     dependencies:


### PR DESCRIPTION
## Summary
- Install `@gridland/web` and `@gridland/utils` (^0.2.53) for Canvas-based TUI rendering
- Add `bun:ffi`, `bun-ffi-structs`, and `bun` webpack aliases in `next.config.ts` pointing to Gridland's browser shims
- Does NOT use `withGridland` plugin (it adds `@gridland/web` to `transpilePackages` which breaks `"use client"` directives)

**Depends on**: #822

## Changes
| File | Change |
|------|--------|
| `apps/web/package.json` | Add `@gridland/web` + `@gridland/utils` deps |
| `apps/web/next.config.ts` | 3 webpack resolve aliases for FFI browser shims |
| `pnpm-lock.yaml` | Lockfile update |

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] No `"use client"` SWC errors during build
- [ ] `pnpm --filter web build` — has pre-existing failure on master (`Can't resolve '@pagespace/lib/client-safe'`), not caused by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new utility and web framework module dependencies.
  * Updated build configuration for improved module resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->