### PR TITLE
feat(terminal): add TerminalView UI with Gridland Canvas renderer

### DIFF
--- a/apps/web/src/components/layout/middle-content/CenterPanel.tsx
+++ b/apps/web/src/components/layout/middle-content/CenterPanel.tsx
@@ -15,6 +15,7 @@ import FileViewer from './page-views/file/FileViewer';
 import SheetView from './page-views/sheet/SheetView';
 import TaskListView from './page-views/task-list/TaskListView';
 import CodePageView from './page-views/code/CodePageView';
+import TerminalView from './page-views/terminal/TerminalView';
 import { CustomScrollArea } from '@/components/ui/custom-scroll-area';
 import { PullToRefresh } from '@/components/ui/pull-to-refresh';
 import { getPageTypeComponent } from '@pagespace/lib/client-safe';
@@ -149,6 +150,7 @@ const PageContent = memo(({ pageId }: { pageId: string | null }) => {
     SheetView,
     TaskListView,
     CodePageView,
+    TerminalView,
   };
 
   const componentName = getPageTypeComponent(page.type);
@@ -169,6 +171,9 @@ const PageContent = memo(({ pageId }: { pageId: string | null }) => {
   } else if (componentName === 'CodePageView') {
     // CodePageView accepts only pageId (new pattern)
     pageComponent = <CodePageView key={`code-${page.id}`} pageId={page.id} />;
+  } else if (componentName === 'TerminalView') {
+    // TerminalView accepts only pageId (new pattern)
+    pageComponent = <TerminalView key={`terminal-${page.id}`} pageId={page.id} />;
   } else if (componentName === 'CanvasPageView') {
     // CanvasPageView should remount per page to isolate edit/undo state
     pageComponent = <CanvasPageView key={`canvas-${page.id}`} page={page} />;

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/GridlandTerminal.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/GridlandTerminal.tsx
@@ -88,8 +88,21 @@ const themes = {
 
 function TerminalContent({ session, onCommand, onClear, isDark, isReadOnly }: GridlandTerminalProps) {
   const [input, setInput] = useState('');
-  const [, setHistoryIndex] = useState(-1);
+  const [historyIndex, setHistoryIndex] = useState(-1);
   const theme = isDark ? themes.dark : themes.light;
+
+  // Derive input from historyIndex — keeps updaters pure (no side effects)
+  useEffect(() => {
+    if (historyIndex < 0) {
+      setInput('');
+      return;
+    }
+    const commands = session.history.map(h => h.command);
+    const idx = commands.length - 1 - historyIndex;
+    if (idx >= 0 && idx < commands.length) {
+      setInput(commands[idx]);
+    }
+  }, [historyIndex, session.history]);
 
   const handleSubmit = useCallback(() => {
     const trimmed = input.trim();
@@ -122,28 +135,14 @@ function TerminalContent({ session, onCommand, onClear, isDark, isReadOnly }: Gr
 
     if (key.name === 'up') {
       setHistoryIndex(prev => {
-        const commands = session.history.map(h => h.command);
         const next = prev + 1;
-        if (next < commands.length) {
-          setInput(commands[commands.length - 1 - next]);
-          return next;
-        }
-        return prev;
+        return next < session.history.length ? next : prev;
       });
       return;
     }
 
     if (key.name === 'down') {
-      setHistoryIndex(prev => {
-        if (prev <= 0) {
-          setInput('');
-          return -1;
-        }
-        const commands = session.history.map(h => h.command);
-        const next = prev - 1;
-        setInput(commands[commands.length - 1 - next]);
-        return next;
-      });
+      setHistoryIndex(prev => (prev <= 0 ? -1 : prev - 1));
       return;
     }
 

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/GridlandTerminal.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/GridlandTerminal.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import React, { useState, useCallback, useRef, useEffect, type ReactNode } from 'react';
+import { TUI } from '@gridland/web';
+import { useKeyboard, type KeyEvent } from '@gridland/utils';
+
+// ── Typed Gridland primitives ────────────────────────────────────────────
+// Gridland's reconciler defines intrinsic elements (box, text, scrollbox)
+// at runtime. These wrappers provide TypeScript types without conflicting
+// with the global JSX.IntrinsicElements (HTML text, input, code).
+
+interface BoxProps {
+  children?: ReactNode;
+  flexDirection?: 'row' | 'column';
+  flexGrow?: number;
+  width?: number | string;
+  height?: number | string;
+  padding?: number;
+  gap?: number;
+  border?: boolean;
+  borderStyle?: 'single' | 'rounded' | 'double' | 'bold';
+  borderColor?: string;
+  backgroundColor?: string;
+}
+
+interface TextProps {
+  children?: ReactNode;
+  fg?: string;
+  bold?: boolean;
+  dim?: boolean;
+}
+
+interface ScrollboxProps {
+  children?: ReactNode;
+  flexDirection?: 'row' | 'column';
+  flexGrow?: number;
+}
+
+function Box(props: BoxProps) {
+  return React.createElement('box', props);
+}
+
+function Text(props: TextProps) {
+  return React.createElement('text', props);
+}
+
+function Scrollbox(props: ScrollboxProps) {
+  return React.createElement('scrollbox', props);
+}
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+interface HistoryEntry {
+  command: string;
+  output: string;
+  timestamp: number;
+}
+
+interface TerminalSession {
+  history: HistoryEntry[];
+}
+
+interface GridlandTerminalProps {
+  session: TerminalSession;
+  onCommand: (command: string) => void;
+  onClear: () => void;
+  isDark: boolean;
+  isReadOnly: boolean;
+}
+
+// ── Theme ────────────────────────────────────────────────────────────────
+
+const PROMPT = '$ ';
+
+const themes = {
+  dark: {
+    bg: '#1a1b26',
+    fg: '#c0caf5',
+    prompt: '#7aa2f7',
+    output: '#9ece6a',
+    dim: '#565f89',
+    border: '#3b4261',
+    inputBg: '#1f2335',
+  },
+  light: {
+    bg: '#f5f5f5',
+    fg: '#343b58',
+    prompt: '#2e7de9',
+    output: '#587539',
+    dim: '#8990b3',
+    border: '#c4c8da',
+    inputBg: '#e9e9ec',
+  },
+};
+
+// ── Terminal content (runs inside TUI reconciler) ────────────────────────
+
+function TerminalContent({ session, onCommand, onClear, isDark, isReadOnly }: GridlandTerminalProps) {
+  const [input, setInput] = useState('');
+  const [, setHistoryIndex] = useState(-1);
+  const theme = isDark ? themes.dark : themes.light;
+
+  const handleSubmit = useCallback(() => {
+    const trimmed = input.trim();
+    if (!trimmed) return;
+
+    if (trimmed === 'clear') {
+      onClear();
+      setInput('');
+      setHistoryIndex(-1);
+      return;
+    }
+
+    onCommand(trimmed);
+    setInput('');
+    setHistoryIndex(-1);
+  }, [input, onCommand, onClear]);
+
+  useKeyboard((key: KeyEvent) => {
+    if (isReadOnly) return;
+
+    if (key.name === 'return') {
+      handleSubmit();
+      return;
+    }
+
+    if (key.name === 'backspace') {
+      setInput(prev => prev.slice(0, -1));
+      return;
+    }
+
+    if (key.name === 'up') {
+      setHistoryIndex(prev => {
+        const commands = session.history.map(h => h.command);
+        const next = prev + 1;
+        if (next < commands.length) {
+          setInput(commands[commands.length - 1 - next]);
+          return next;
+        }
+        return prev;
+      });
+      return;
+    }
+
+    if (key.name === 'down') {
+      setHistoryIndex(prev => {
+        if (prev <= 0) {
+          setInput('');
+          return -1;
+        }
+        const commands = session.history.map(h => h.command);
+        const next = prev - 1;
+        setInput(commands[commands.length - 1 - next]);
+        return next;
+      });
+      return;
+    }
+
+    if (key.name === 'l' && key.ctrl) {
+      onClear();
+      return;
+    }
+
+    if (key.name === 'u' && key.ctrl) {
+      setInput('');
+      return;
+    }
+
+    if (key.sequence && key.sequence.length === 1 && !key.ctrl && !key.meta) {
+      setInput(prev => prev + key.sequence);
+    }
+  });
+
+  return (
+    <Box flexDirection="column" flexGrow={1}>
+      {/* Header bar */}
+      <Box height={1} flexDirection="row" backgroundColor={theme.border}>
+        <Text fg={theme.fg} bold> Terminal </Text>
+        <Box flexGrow={1} />
+        <Text fg={theme.dim}> {session.history.length} commands </Text>
+      </Box>
+
+      {/* Scrollable output */}
+      <Scrollbox flexGrow={1} flexDirection="column">
+        {session.history.length === 0 && (
+          <Box flexDirection="column" padding={1}>
+            <Text fg={theme.dim}>PageSpace Terminal</Text>
+            <Text fg={theme.dim}>Type a command and press Enter. Type &quot;clear&quot; to reset.</Text>
+            <Text fg={theme.dim}>Shell connection not yet configured.</Text>
+          </Box>
+        )}
+
+        {session.history.map((entry, i) => (
+          <Box key={i} flexDirection="column">
+            <Box flexDirection="row">
+              <Text fg={theme.prompt} bold>{PROMPT}</Text>
+              <Text fg={theme.fg}>{entry.command}</Text>
+            </Box>
+            {entry.output && (
+              <Box>
+                <Text fg={theme.output}>{entry.output}</Text>
+              </Box>
+            )}
+          </Box>
+        ))}
+      </Scrollbox>
+
+      {/* Input line */}
+      <Box height={1} flexDirection="row" backgroundColor={theme.inputBg}>
+        <Text fg={theme.prompt} bold>{PROMPT}</Text>
+        <Text fg={theme.fg}>{input}</Text>
+        <Text fg={theme.prompt}>{'\u2588'}</Text>
+      </Box>
+    </Box>
+  );
+}
+
+// ── Outer wrapper (manages DOM container + TUI mount) ────────────────────
+
+export default function GridlandTerminal(props: GridlandTerminalProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
+  const theme = props.isDark ? themes.dark : themes.light;
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const observer = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        setDimensions({
+          width: entry.contentRect.width,
+          height: entry.contentRect.height,
+        });
+      }
+    });
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div ref={containerRef} className="w-full h-full">
+      {dimensions.width > 0 && dimensions.height > 0 && (
+        <TUI
+          style={{ width: dimensions.width, height: dimensions.height }}
+          backgroundColor={theme.bg}
+          fontSize={14}
+          autoFocus
+        >
+          <TerminalContent {...props} />
+        </TUI>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/GridlandTerminal.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/GridlandTerminal.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useCallback, useRef, useEffect, type ReactNode } from 'react';
 import { TUI } from '@gridland/web';
 import { useKeyboard, type KeyEvent } from '@gridland/utils';
+import type { TerminalSession } from './types';
 
 // ── Typed Gridland primitives ────────────────────────────────────────────
 // Gridland's reconciler defines intrinsic elements (box, text, scrollbox)
@@ -49,16 +50,6 @@ function Scrollbox(props: ScrollboxProps) {
 }
 
 // ── Types ────────────────────────────────────────────────────────────────
-
-interface HistoryEntry {
-  command: string;
-  output: string;
-  timestamp: number;
-}
-
-interface TerminalSession {
-  history: HistoryEntry[];
-}
 
 interface GridlandTerminalProps {
   session: TerminalSession;

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/TerminalView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/TerminalView.tsx
@@ -39,7 +39,6 @@ const TerminalView = ({ pageId }: TerminalViewProps) => {
   const [isReadOnly, setIsReadOnly] = useState(false);
   const [session, setSession] = useState<TerminalSession>({ history: [] });
   const isDirtyRef = useRef(false);
-  const hasInitializedRef = useRef(false);
   const socket = useSocket();
   const { user } = useAuth();
   const { resolvedTheme } = useTheme();
@@ -61,19 +60,15 @@ const TerminalView = ({ pageId }: TerminalViewProps) => {
 
   // Initialize document when component mounts or pageId changes
   useEffect(() => {
-    hasInitializedRef.current = true;
     initializeAndActivate();
-    return () => {
-      hasInitializedRef.current = false;
-    };
   }, [pageId, initializeAndActivate]);
 
-  // Sync document content to local session state
+  // Sync document content to local session state (skip when locally dirty)
   useEffect(() => {
-    if (documentState?.content) {
+    if (documentState?.content && !documentState.isDirty) {
       setSession(parseSession(documentState.content));
     }
-  }, [documentState?.content]);
+  }, [documentState?.content, documentState?.isDirty]);
 
   // Register editing state when document is dirty
   useEffect(() => {
@@ -93,19 +88,19 @@ const TerminalView = ({ pageId }: TerminalViewProps) => {
 
   // Check user permissions
   useEffect(() => {
-    const checkPermissions = async () => {
-      if (!user?.id) return;
-      try {
-        const response = await fetchWithAuth(`/api/pages/${pageId}/permissions/check`);
+    if (!user?.id) return;
+    const controller = new AbortController();
+    fetchWithAuth(`/api/pages/${pageId}/permissions/check`, { signal: controller.signal })
+      .then(async (response) => {
         if (response.ok) {
           const permissions = await response.json();
           setIsReadOnly(!permissions.canEdit);
         }
-      } catch (error) {
-        console.error('Failed to check permissions:', error);
-      }
-    };
-    checkPermissions();
+      })
+      .catch((err) => {
+        if (err.name !== 'AbortError') console.error('Failed to check permissions:', err);
+      });
+    return () => controller.abort();
   }, [user?.id, pageId]);
 
   // Keep a ref to latest documentState to avoid stale closures in socket handler

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/TerminalView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/TerminalView.tsx
@@ -146,12 +146,12 @@ const TerminalView = ({ pageId }: TerminalViewProps) => {
 
   // Handle command submission — gated on document initialization
   const handleCommand = useCallback((command: string) => {
-    if (isReadOnly || !documentState) {
-      if (!isReadOnly && !documentState) {
-        toast.error('Terminal is still loading');
-      } else {
-        toast.error('You do not have permission to edit this page');
-      }
+    if (!documentState) {
+      toast.error('Terminal is still loading');
+      return;
+    }
+    if (isReadOnly) {
+      toast.error('You do not have permission to edit this page');
       return;
     }
 
@@ -161,14 +161,12 @@ const TerminalView = ({ pageId }: TerminalViewProps) => {
       timestamp: Date.now(),
     };
 
-    setSession(prev => {
-      const updated = { history: [...prev.history, entry] };
-      const serialized = serializeSession(updated);
-      updateContent(serialized);
-      saveWithDebounce(serialized);
-      return updated;
-    });
-  }, [isReadOnly, documentState, updateContent, saveWithDebounce]);
+    const updated: TerminalSession = { history: [...session.history, entry] };
+    setSession(updated);
+    const serialized = serializeSession(updated);
+    updateContent(serialized);
+    saveWithDebounce(serialized);
+  }, [isReadOnly, documentState, session.history, updateContent, saveWithDebounce]);
 
   // Handle clearing the terminal
   const handleClear = useCallback(() => {

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/TerminalView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/TerminalView.tsx
@@ -100,7 +100,7 @@ const TerminalView = ({ pageId }: TerminalViewProps) => {
     const checkPermissions = async () => {
       if (!user?.id) return;
       try {
-        const response = await fetchWithAuth(`/api/pages/${pageId}/permissions/check?userId=${user.id}`);
+        const response = await fetchWithAuth(`/api/pages/${pageId}/permissions/check`);
         if (response.ok) {
           const permissions = await response.json();
           setIsReadOnly(!permissions.canEdit);
@@ -157,7 +157,7 @@ const TerminalView = ({ pageId }: TerminalViewProps) => {
 
     const entry = {
       command,
-      output: 'Shell not connected. PTY backend required.',
+      output: 'Shell connection not yet configured.',
       timestamp: Date.now(),
     };
 
@@ -264,4 +264,4 @@ const TerminalView = ({ pageId }: TerminalViewProps) => {
   );
 };
 
-export default React.memo(TerminalView, (prevProps, nextProps) => prevProps.pageId === nextProps.pageId);
+export default React.memo(TerminalView);

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/TerminalView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/TerminalView.tsx
@@ -59,18 +59,14 @@ const TerminalView = ({ pageId }: TerminalViewProps) => {
     forceSaveRef.current = forceSave;
   }, [forceSave]);
 
-  // Initialize document when component mounts
+  // Initialize document when component mounts or pageId changes
   useEffect(() => {
-    if (!hasInitializedRef.current) {
-      hasInitializedRef.current = true;
-      initializeAndActivate();
-    }
+    hasInitializedRef.current = true;
+    initializeAndActivate();
+    return () => {
+      hasInitializedRef.current = false;
+    };
   }, [pageId, initializeAndActivate]);
-
-  // Reset initialization flag when pageId changes
-  useEffect(() => {
-    hasInitializedRef.current = false;
-  }, [pageId]);
 
   // Sync document content to local session state
   useEffect(() => {
@@ -198,7 +194,7 @@ const TerminalView = ({ pageId }: TerminalViewProps) => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key === 's') {
         e.preventDefault();
-        forceSaveRef.current();
+        forceSaveRef.current().catch(console.error);
       }
     };
     document.addEventListener('keydown', handleKeyDown);

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/TerminalView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/TerminalView.tsx
@@ -11,19 +11,10 @@ import { useAuth } from '@/hooks/useAuth';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useEditingStore } from '@/stores/useEditingStore';
 import { useTheme } from 'next-themes';
+import type { TerminalSession } from './types';
 
 interface TerminalViewProps {
   pageId: string;
-}
-
-interface HistoryEntry {
-  command: string;
-  output: string;
-  timestamp: number;
-}
-
-interface TerminalSession {
-  history: HistoryEntry[];
 }
 
 function parseSession(content: string): TerminalSession {
@@ -48,6 +39,7 @@ const TerminalView = ({ pageId }: TerminalViewProps) => {
   const [isReadOnly, setIsReadOnly] = useState(false);
   const [session, setSession] = useState<TerminalSession>({ history: [] });
   const isDirtyRef = useRef(false);
+  const hasInitializedRef = useRef(false);
   const socket = useSocket();
   const { user } = useAuth();
   const { resolvedTheme } = useTheme();
@@ -67,10 +59,18 @@ const TerminalView = ({ pageId }: TerminalViewProps) => {
     forceSaveRef.current = forceSave;
   }, [forceSave]);
 
-  // Initialize document when component mounts or pageId changes
+  // Initialize document when component mounts
   useEffect(() => {
-    initializeAndActivate();
+    if (!hasInitializedRef.current) {
+      hasInitializedRef.current = true;
+      initializeAndActivate();
+    }
   }, [pageId, initializeAndActivate]);
+
+  // Reset initialization flag when pageId changes
+  useEffect(() => {
+    hasInitializedRef.current = false;
+  }, [pageId]);
 
   // Sync document content to local session state
   useEffect(() => {
@@ -144,14 +144,18 @@ const TerminalView = ({ pageId }: TerminalViewProps) => {
     };
   }, [socket, pageId, updateContentFromServer]);
 
-  // Handle command submission
+  // Handle command submission — gated on document initialization
   const handleCommand = useCallback((command: string) => {
-    if (isReadOnly) {
-      toast.error('You do not have permission to edit this page');
+    if (isReadOnly || !documentState) {
+      if (!isReadOnly && !documentState) {
+        toast.error('Terminal is still loading');
+      } else {
+        toast.error('You do not have permission to edit this page');
+      }
       return;
     }
 
-    const entry: HistoryEntry = {
+    const entry = {
       command,
       output: 'Shell not connected. PTY backend required.',
       timestamp: Date.now(),
@@ -164,17 +168,17 @@ const TerminalView = ({ pageId }: TerminalViewProps) => {
       saveWithDebounce(serialized);
       return updated;
     });
-  }, [isReadOnly, updateContent, saveWithDebounce]);
+  }, [isReadOnly, documentState, updateContent, saveWithDebounce]);
 
   // Handle clearing the terminal
   const handleClear = useCallback(() => {
-    if (isReadOnly) return;
+    if (isReadOnly || !documentState) return;
     const updated: TerminalSession = { history: [] };
     setSession(updated);
     const serialized = serializeSession(updated);
     updateContent(serialized);
     saveWithDebounce(serialized);
-  }, [isReadOnly, updateContent, saveWithDebounce]);
+  }, [isReadOnly, documentState, updateContent, saveWithDebounce]);
 
   // Track isDirty in ref
   useEffect(() => {
@@ -239,7 +243,7 @@ const TerminalView = ({ pageId }: TerminalViewProps) => {
           onCommand={handleCommand}
           onClear={handleClear}
           isDark={isDark}
-          isReadOnly={isReadOnly}
+          isReadOnly={isReadOnly || isLoading || !documentState}
         />
       </div>
 

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/TerminalView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/TerminalView.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import React, { useEffect, useState, useCallback, useRef } from 'react';
+import dynamic from 'next/dynamic';
+import { useDocument } from '@/hooks/useDocument';
+import { motion, AnimatePresence } from 'motion/react';
+import { useSocket } from '@/hooks/useSocket';
+import { PageEventPayload } from '@/lib/websocket';
+import { toast } from 'sonner';
+import { useAuth } from '@/hooks/useAuth';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { useEditingStore } from '@/stores/useEditingStore';
+import { useTheme } from 'next-themes';
+
+interface TerminalViewProps {
+  pageId: string;
+}
+
+interface HistoryEntry {
+  command: string;
+  output: string;
+  timestamp: number;
+}
+
+interface TerminalSession {
+  history: HistoryEntry[];
+}
+
+function parseSession(content: string): TerminalSession {
+  try {
+    const parsed = JSON.parse(content);
+    return { history: Array.isArray(parsed.history) ? parsed.history : [] };
+  } catch {
+    return { history: [] };
+  }
+}
+
+function serializeSession(session: TerminalSession): string {
+  return JSON.stringify(session);
+}
+
+const GridlandTerminal = dynamic(
+  () => import('./GridlandTerminal'),
+  { ssr: false }
+);
+
+const TerminalView = ({ pageId }: TerminalViewProps) => {
+  const [isReadOnly, setIsReadOnly] = useState(false);
+  const [session, setSession] = useState<TerminalSession>({ history: [] });
+  const isDirtyRef = useRef(false);
+  const socket = useSocket();
+  const { user } = useAuth();
+  const { resolvedTheme } = useTheme();
+
+  const {
+    document: documentState,
+    isLoading,
+    initializeAndActivate,
+    updateContent,
+    updateContentFromServer,
+    saveWithDebounce,
+    forceSave,
+  } = useDocument(pageId);
+
+  const forceSaveRef = useRef(forceSave);
+  useEffect(() => {
+    forceSaveRef.current = forceSave;
+  }, [forceSave]);
+
+  // Initialize document when component mounts or pageId changes
+  useEffect(() => {
+    initializeAndActivate();
+  }, [pageId, initializeAndActivate]);
+
+  // Sync document content to local session state
+  useEffect(() => {
+    if (documentState?.content) {
+      setSession(parseSession(documentState.content));
+    }
+  }, [documentState?.content]);
+
+  // Register editing state when document is dirty
+  useEffect(() => {
+    const componentId = `terminal-${pageId}`;
+    if (documentState?.isDirty && !isReadOnly) {
+      useEditingStore.getState().startEditing(componentId, 'document', {
+        pageId,
+        componentName: 'TerminalView',
+      });
+    } else {
+      useEditingStore.getState().endEditing(componentId);
+    }
+    return () => {
+      useEditingStore.getState().endEditing(componentId);
+    };
+  }, [documentState?.isDirty, pageId, isReadOnly]);
+
+  // Check user permissions
+  useEffect(() => {
+    const checkPermissions = async () => {
+      if (!user?.id) return;
+      try {
+        const response = await fetchWithAuth(`/api/pages/${pageId}/permissions/check?userId=${user.id}`);
+        if (response.ok) {
+          const permissions = await response.json();
+          setIsReadOnly(!permissions.canEdit);
+        }
+      } catch (error) {
+        console.error('Failed to check permissions:', error);
+      }
+    };
+    checkPermissions();
+  }, [user?.id, pageId]);
+
+  // Keep a ref to latest documentState to avoid stale closures in socket handler
+  const documentStateRef = useRef(documentState);
+  useEffect(() => {
+    documentStateRef.current = documentState;
+  }, [documentState]);
+
+  // Listen for content updates from other sources
+  useEffect(() => {
+    if (!socket) return;
+    const handleContentUpdate = async (eventData: PageEventPayload) => {
+      if (eventData.socketId && eventData.socketId === socket.id) return;
+      if (eventData.pageId === pageId) {
+        try {
+          const response = await fetchWithAuth(`/api/pages/${pageId}`);
+          if (response.ok) {
+            const updatedPage = await response.json();
+            const currentDoc = documentStateRef.current;
+            if (updatedPage.content !== currentDoc?.content && !currentDoc?.isDirty) {
+              updateContentFromServer(updatedPage.content, updatedPage.revision);
+            }
+          }
+        } catch (error) {
+          console.error('Failed to fetch updated content:', error);
+        }
+      }
+    };
+    socket.on('page:content-updated', handleContentUpdate);
+    return () => {
+      socket.off('page:content-updated', handleContentUpdate);
+    };
+  }, [socket, pageId, updateContentFromServer]);
+
+  // Handle command submission
+  const handleCommand = useCallback((command: string) => {
+    if (isReadOnly) {
+      toast.error('You do not have permission to edit this page');
+      return;
+    }
+
+    const entry: HistoryEntry = {
+      command,
+      output: 'Shell not connected. PTY backend required.',
+      timestamp: Date.now(),
+    };
+
+    setSession(prev => {
+      const updated = { history: [...prev.history, entry] };
+      const serialized = serializeSession(updated);
+      updateContent(serialized);
+      saveWithDebounce(serialized);
+      return updated;
+    });
+  }, [isReadOnly, updateContent, saveWithDebounce]);
+
+  // Handle clearing the terminal
+  const handleClear = useCallback(() => {
+    if (isReadOnly) return;
+    const updated: TerminalSession = { history: [] };
+    setSession(updated);
+    const serialized = serializeSession(updated);
+    updateContent(serialized);
+    saveWithDebounce(serialized);
+  }, [isReadOnly, updateContent, saveWithDebounce]);
+
+  // Track isDirty in ref
+  useEffect(() => {
+    isDirtyRef.current = documentState?.isDirty || false;
+  }, [documentState?.isDirty]);
+
+  // Cleanup on unmount - auto-save
+  useEffect(() => {
+    return () => {
+      if (isDirtyRef.current) {
+        forceSaveRef.current().catch(console.error);
+      }
+    };
+  }, []);
+
+  // Ctrl+S to save
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+        e.preventDefault();
+        forceSaveRef.current();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
+  // Auto-save on window blur
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const handleBlur = () => {
+      if (isDirtyRef.current) {
+        forceSaveRef.current().catch(console.error);
+      }
+    };
+    window.addEventListener('blur', handleBlur);
+    return () => window.removeEventListener('blur', handleBlur);
+  }, []);
+
+  const isDark = resolvedTheme === 'dark';
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -10 }}
+      transition={{ duration: 0.2 }}
+      className="h-full flex flex-col relative"
+    >
+      {isReadOnly && (
+        <div className="bg-yellow-50 dark:bg-yellow-900/20 border-b border-yellow-200 dark:border-yellow-800 px-4 py-2">
+          <p className="text-sm text-yellow-800 dark:text-yellow-200 text-center">
+            You don&apos;t have permission to edit this page
+          </p>
+        </div>
+      )}
+
+      <div className="flex-1 min-h-0">
+        <GridlandTerminal
+          session={session}
+          onCommand={handleCommand}
+          onClear={handleClear}
+          isDark={isDark}
+          isReadOnly={isReadOnly}
+        />
+      </div>
+
+      <AnimatePresence>
+        {isLoading && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="absolute inset-0 bg-background/80 backdrop-blur-sm flex items-center justify-center"
+          >
+            <div className="flex items-center gap-2">
+              <div className="w-4 h-4 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+              <span className="text-sm text-muted-foreground">Loading terminal...</span>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </motion.div>
+  );
+};
+
+export default React.memo(TerminalView, (prevProps, nextProps) => prevProps.pageId === nextProps.pageId);

--- a/apps/web/src/components/layout/middle-content/page-views/terminal/types.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/terminal/types.ts
@@ -1,0 +1,9 @@
+export interface HistoryEntry {
+  command: string;
+  output: string;
+  timestamp: number;
+}
+
+export interface TerminalSession {
+  history: HistoryEntry[];
+}


### PR DESCRIPTION
## Summary
- `GridlandTerminal.tsx` — Gridland TUI component with keyboard input (Enter, Up/Down history, Ctrl+L/U), light/dark theme, typed wrapper components (Box, Text, Scrollbox)
- `TerminalView.tsx` — Page view wrapper with useDocument persistence, permission checks, real-time socket sync, auto-save, editing store integration
- `CenterPanel.tsx` — Wire TerminalView into component map and routing (pageId-only pattern)
- `types.ts` — Shared `HistoryEntry`/`TerminalSession` type definitions

**Depends on**: #823

### Review feedback addressed
- **[P2] Block commands until document init** — `handleCommand`/`handleClear` gated on `documentState`, `isReadOnly` propagated through loading state to block keyboard input, `hasInitializedRef` guard added (matching CodePageView pattern)

## Test plan
- [ ] Create a Terminal page via Create Page dialog
- [ ] Type commands and press Enter — history persists
- [ ] Up/Down arrows navigate command history
- [ ] Type `clear` to reset
- [ ] Toggle light/dark theme — terminal canvas adapts
- [ ] Navigate away and back — session restores
- [ ] Verify commands cannot be submitted during initial load (loading overlay blocks input)
- [ ] `pnpm typecheck` and `pnpm --filter web lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Terminal View component with an interactive terminal UI supporting command history navigation, keyboard shortcuts (Up/Down for history, Ctrl+L/Ctrl+U to clear), and Enter to submit commands.
  * Terminal content automatically synchronizes with the server in real-time and auto-saves on user actions and window events.
  * Read-only mode available when insufficient permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->