### PR TITLE
fix(ai): prevent chat conversation loss when AI creates a page

### DIFF
--- a/apps/web/src/hooks/__tests__/usePageTree.test.ts
+++ b/apps/web/src/hooks/__tests__/usePageTree.test.ts
@@ -283,7 +283,7 @@ describe('usePageTree', () => {
   });
 
   describe('invalidateTree', () => {
-    it('given no active editing, should delete cache and mutate', () => {
+    it('given no active editing, should mutate without deleting cache', () => {
       mockSWRState.data = [createMockTreePage()];
       mockIsAnyEditing.mockReturnValue(false);
 
@@ -293,7 +293,7 @@ describe('usePageTree', () => {
         result.current.invalidateTree();
       });
 
-      expect(mockCacheDelete).toHaveBeenCalledWith('/api/drives/drive-123/pages');
+      expect(mockCacheDelete).not.toHaveBeenCalled();
       expect(mockMutate).toHaveBeenCalled();
     });
 

--- a/apps/web/src/hooks/usePageTree.ts
+++ b/apps/web/src/hooks/usePageTree.ts
@@ -125,18 +125,18 @@ export function usePageTree(driveId?: string, trashView?: boolean) {
 
   const invalidateTree = useCallback(() => {
     if (swrKey) {
-      // Don't revalidate tree if user is actively editing to prevent component remounting
-      // Allow revalidation during AI streaming to show real-time updates
+      // Guard: skip revalidation during document/form editing to prevent editor remounting.
+      // AI streaming is intentionally NOT blocked — without cache.delete, revalidation
+      // fetches fresh data in the background (stale-while-revalidate) without causing unmounts.
       const isEditing = useEditingStore.getState().isAnyEditing();
       if (isEditing) {
         console.log('⏸️ Skipping tree revalidation - document editing in progress');
         return;
       }
 
-      cache.delete(swrKey);
-      mutate(); // Re-fetch
+      mutate();
     }
-  }, [swrKey, cache, mutate]);
+  }, [swrKey, mutate]);
 
   const updateNode = useCallback((nodeId: string, updates: Partial<TreePage>) => {
     // Avoid optimistic mutation before the first tree snapshot exists.


### PR DESCRIPTION
## Summary
- **Bug**: When AI in a chat page uses the `create_page` tool, the conversation is lost — screen flashes and user sees the empty "start conversation" view
- **Root cause**: `invalidateTree()` called `cache.delete(swrKey)` before `mutate()`, momentarily setting SWR data to `undefined`. This caused `CenterPanel` to render a `<Skeleton>` (because `isLoading` became `true`), unmounting `AiChatView`. On remount, the init effect created a fresh conversation and wiped all messages.
- **Fix**: Remove `cache.delete` from `invalidateTree()` so `mutate()` re-fetches in the background while keeping stale data visible (standard stale-while-revalidate pattern). `cache.delete` is preserved in `retry()` (user-initiated) and self-healing stuck detection where it's appropriate.

## Test plan
- [x] `usePageTree` unit tests pass (15/15)
- [ ] Manual: Open AI Chat page → ask AI to create a page → conversation should remain intact, new page appears in sidebar without flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page tree data synchronization to use direct revalidation instead of cache deletion, ensuring more reliable updates when the editing state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->