### PR TITLE
Increase fetch proxy timeouts for local model support

### DIFF
--- a/apps/desktop/src/shared/fetch-proxy-types.ts
+++ b/apps/desktop/src/shared/fetch-proxy-types.ts
@@ -59,7 +59,7 @@ export type FetchProxyResponse =
 /** Maximum chunk size in bytes for streaming response body */
 export const FETCH_PROXY_CHUNK_SIZE = 65536; // 64KB
 
-/** Overall timeout for fetch proxy requests in milliseconds (5 min safety backstop — server-side 30s activity timeout is the real guard) */
+/** Overall timeout for fetch proxy requests in milliseconds (5 min safety backstop — matches server-side overall timeout) */
 export const FETCH_PROXY_TIMEOUT_MS = 300000; // 5min
 
 /** Maximum number of concurrent fetch proxy requests */

--- a/apps/web/src/lib/fetch-bridge/__tests__/fetch-bridge.test.ts
+++ b/apps/web/src/lib/fetch-bridge/__tests__/fetch-bridge.test.ts
@@ -214,7 +214,7 @@ describe('FetchBridge', () => {
       );
     });
 
-    it('times out after 120s overall even with active chunks', async () => {
+    it('times out after 5min overall even with active chunks', async () => {
       const mockWs = createMockWebSocket(1);
       mockGetConnection.mockReturnValue(mockWs as WebSocket);
       mockCheckConnectionHealth.mockReturnValue(healthyConnection());
@@ -233,9 +233,9 @@ describe('FetchBridge', () => {
         headers: {},
       });
 
-      // Keep sending chunks every 20s to prevent activity timeout
-      for (let elapsed = 0; elapsed < 110_000; elapsed += 20_000) {
-        vi.advanceTimersByTime(20_000);
+      // Keep sending chunks every 60s to prevent activity timeout
+      for (let elapsed = 0; elapsed < 280_000; elapsed += 60_000) {
+        vi.advanceTimersByTime(60_000);
         bridge.handleResponseChunk({
           type: 'fetch_response_chunk',
           id: requestId,
@@ -243,15 +243,15 @@ describe('FetchBridge', () => {
         });
       }
 
-      // This final advance pushes past 120s overall
-      vi.advanceTimersByTime(20_000);
+      // This final advance pushes past 300s overall
+      vi.advanceTimersByTime(60_000);
       await promise;
 
       // The overall timeout should have fired
       expect(bridge.getPendingRequestCount()).toBe(0);
     });
 
-    it('times out after 30s of inactivity', async () => {
+    it('times out after 120s of inactivity', async () => {
       const mockWs = createMockWebSocket(1);
       mockGetConnection.mockReturnValue(mockWs as WebSocket);
       mockCheckConnectionHealth.mockReturnValue(healthyConnection());
@@ -259,7 +259,7 @@ describe('FetchBridge', () => {
       const promise = bridge.proxyFetch('user-1', 'http://localhost:11434/api/chat');
       await flushMicrotasks();
 
-      vi.advanceTimersByTime(30_000);
+      vi.advanceTimersByTime(120_000);
 
       await expect(promise).rejects.toThrow('Fetch activity timeout');
     });
@@ -299,14 +299,14 @@ describe('FetchBridge', () => {
 
       const response = await promise;
 
-      // Advance 20s, send chunk (resets timeout), advance 20s more — should still be alive
-      vi.advanceTimersByTime(20_000);
+      // Advance 100s, send chunk (resets timeout), advance 100s more — should still be alive
+      vi.advanceTimersByTime(100_000);
       bridge.handleResponseChunk({
         type: 'fetch_response_chunk',
         id: requestId,
         chunk: btoa('chunk1'),
       });
-      vi.advanceTimersByTime(20_000);
+      vi.advanceTimersByTime(100_000);
       bridge.handleResponseChunk({
         type: 'fetch_response_chunk',
         id: requestId,

--- a/apps/web/src/lib/fetch-bridge/fetch-bridge.ts
+++ b/apps/web/src/lib/fetch-bridge/fetch-bridge.ts
@@ -23,8 +23,8 @@ interface PendingFetchRequest {
   userId: string;
 }
 
-const ACTIVITY_TIMEOUT_MS = 30_000; // 30s between chunks
-const OVERALL_TIMEOUT_MS = 120_000; // 120s total
+const ACTIVITY_TIMEOUT_MS = 120_000; // 120s between chunks (local models like LM Studio/Ollama need time to load)
+const OVERALL_TIMEOUT_MS = 300_000; // 5min total
 
 export class FetchBridge {
   private pendingRequests: Map<string, PendingFetchRequest> = new Map();
@@ -90,7 +90,7 @@ export class FetchBridge {
       const stream = new ReadableStream<Uint8Array>({
         start: (controller) => {
           const activityTimeout = setTimeout(() => {
-            this.cleanupRequest(requestId, new Error('Fetch activity timeout: no data received for 30s'));
+            this.cleanupRequest(requestId, new Error('Fetch activity timeout: no data received for 120s'));
           }, ACTIVITY_TIMEOUT_MS);
 
           const overallTimeout = setTimeout(() => {
@@ -195,7 +195,7 @@ export class FetchBridge {
     // Reset activity timeout
     clearTimeout(pending.activityTimeout);
     pending.activityTimeout = setTimeout(() => {
-      this.cleanupRequest(msg.id, new Error('Fetch activity timeout: no data received for 30s'));
+      this.cleanupRequest(msg.id, new Error('Fetch activity timeout: no data received for 120s'));
     }, ACTIVITY_TIMEOUT_MS);
 
     // Decode base64 chunk and enqueue (inside try to catch malformed base64)

--- a/apps/web/src/lib/fetch-bridge/fetch-bridge.ts
+++ b/apps/web/src/lib/fetch-bridge/fetch-bridge.ts
@@ -90,11 +90,11 @@ export class FetchBridge {
       const stream = new ReadableStream<Uint8Array>({
         start: (controller) => {
           const activityTimeout = setTimeout(() => {
-            this.cleanupRequest(requestId, new Error('Fetch activity timeout: no data received for 120s'));
+            this.cleanupRequest(requestId, new Error(`Fetch activity timeout: no data received for ${ACTIVITY_TIMEOUT_MS / 1000}s`));
           }, ACTIVITY_TIMEOUT_MS);
 
           const overallTimeout = setTimeout(() => {
-            this.cleanupRequest(requestId, new Error('Fetch overall timeout after 120s'));
+            this.cleanupRequest(requestId, new Error(`Fetch overall timeout after ${OVERALL_TIMEOUT_MS / 1000}s`));
           }, OVERALL_TIMEOUT_MS);
 
           this.pendingRequests.set(requestId, {
@@ -195,7 +195,7 @@ export class FetchBridge {
     // Reset activity timeout
     clearTimeout(pending.activityTimeout);
     pending.activityTimeout = setTimeout(() => {
-      this.cleanupRequest(msg.id, new Error('Fetch activity timeout: no data received for 120s'));
+      this.cleanupRequest(msg.id, new Error(`Fetch activity timeout: no data received for ${ACTIVITY_TIMEOUT_MS / 1000}s`));
     }, ACTIVITY_TIMEOUT_MS);
 
     // Decode base64 chunk and enqueue (inside try to catch malformed base64)


### PR DESCRIPTION
## Summary
Increased timeout values for the fetch proxy to better support local models (like LM Studio and Ollama) that require more time to load and process requests.

## Key Changes
- **Activity timeout**: Increased from 30s to 120s between chunks
  - Local models need more time to load and generate responses
  - Prevents premature timeouts during model inference
  
- **Overall timeout**: Increased from 120s to 300s (5 minutes)
  - Provides sufficient time for complete request/response cycles with slower local models
  - Aligns with the client-side timeout already set to 5 minutes
  
- **Error messages**: Updated to reflect new 120s activity timeout value

- **Test updates**: Adjusted all timeout-related tests to match new values
  - Updated test descriptions and timing assertions
  - Maintained test logic while using new timeout constants

## Implementation Details
- Constants updated in `fetch-bridge.ts` with explanatory comments about local model support
- Client-side type definitions updated to clarify that the 5min overall timeout matches server-side behavior
- All timeout references (error messages, test assertions) kept in sync with new values

https://claude.ai/code/session_01BoHjBGtLzZeGMAUiFJWLWb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased client-side fetch timeouts: activity timeout from 30s to 120s and overall timeout to 5 minutes; updated user-facing timeout messages accordingly.
  * Minor comment adjusted to clarify timeout correspondence.

* **Tests**
  * Updated unit tests to reflect the new activity and overall timeout timings and chunk-sending cadence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->