### PR TITLE
fix(security): replace ReDoS-vulnerable email regex (#102, #103, #124)

### DIFF
--- a/apps/control-plane/src/validation/__tests__/tenant-validation.test.ts
+++ b/apps/control-plane/src/validation/__tests__/tenant-validation.test.ts
@@ -170,6 +170,18 @@ describe('validateEmail', () => {
     const result = validateEmail('user@example')
     expect(result.valid).toBe(false)
   })
+
+  test('given a ReDoS attack string, should complete in under 100ms', () => {
+    // Trailing space forces regex failure, triggering polynomial backtracking
+    // on vulnerable patterns where [^\s@] overlaps with literal '.'
+    // At 10k repeats the vulnerable regex takes ~900ms; fixed regex takes <1ms
+    const malicious = '!@' + '!.'.repeat(10000) + ' '
+    const start = performance.now()
+    const result = validateEmail(malicious)
+    const elapsed = performance.now() - start
+    expect(result.valid).toBe(false)
+    expect(elapsed).toBeLessThan(100)
+  })
 })
 
 describe('validateTier', () => {

--- a/apps/control-plane/src/validation/tenant-validation.ts
+++ b/apps/control-plane/src/validation/tenant-validation.ts
@@ -37,7 +37,7 @@ export const validateEmail = (email: string): ValidationResult => {
     return { valid: false, error: 'Email is required' }
   }
 
-  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+  const emailPattern = /^[^\s@]+@[^\s@.]+(\.[^\s@.]+)+$/
   if (!emailPattern.test(email)) {
     return { valid: false, error: 'Invalid email format' }
   }

--- a/apps/marketing/src/app/api/contact/route.ts
+++ b/apps/marketing/src/app/api/contact/route.ts
@@ -64,7 +64,7 @@ export async function POST(request: Request) {
     if (!name || typeof name !== "string" || name.trim().length === 0 || name.length > 100) {
       return Response.json({ error: "Valid name is required (max 100 characters)" }, { status: 400 });
     }
-    if (!email || typeof email !== "string" || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    if (!email || typeof email !== "string" || !/^[^\s@]+@[^\s@.]+(\.[^\s@.]+)+$/.test(email)) {
       return Response.json({ error: "Valid email is required" }, { status: 400 });
     }
     if (!subject || typeof subject !== "string" || subject.trim().length === 0 || subject.length > 200) {

--- a/apps/web/src/app/api/internal/contact/route.ts
+++ b/apps/web/src/app/api/internal/contact/route.ts
@@ -34,7 +34,7 @@ export async function POST(request: Request) {
   if (!name || typeof name !== 'string' || name.trim().length === 0 || name.length > 100) {
     return NextResponse.json({ error: 'Valid name is required (max 100 characters)' }, { status: 400 });
   }
-  if (!email || typeof email !== 'string' || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+  if (!email || typeof email !== 'string' || !/^[^\s@]+@[^\s@.]+(\.[^\s@.]+)+$/.test(email)) {
     return NextResponse.json({ error: 'Valid email is required' }, { status: 400 });
   }
   if (!subject || typeof subject !== 'string' || subject.trim().length === 0 || subject.length > 200) {


### PR DESCRIPTION
## Summary
- **Severity: S2 (High)** — 3 user-facing endpoints with polynomial ReDoS in email validation regex
- Replaced `/^[^\s@]+@[^\s@]+\.[^\s@]+$/` with `/^[^\s@]+@[^\s@.]+(\.[^\s@.]+)+$/` in 3 files
- The domain portion `[^\s@]+\.[^\s@]+` had overlapping character classes (`[^\s@]` matches `.`), causing polynomial backtracking on adversarial input
- Fixed by excluding `.` from domain character classes — eliminates ambiguity, 0.3ms at 20k chars vs 3114ms before

## CodeQL Alerts Resolved
- #103 — `apps/web/src/app/api/internal/contact/route.ts`
- #102 — `apps/marketing/src/app/api/contact/route.ts`
- #124 — `apps/control-plane/src/validation/tenant-validation.ts`

## Test plan
- [x] Added ReDoS regression test (10k-repeat adversarial input must complete <100ms)
- [x] All 316 existing control-plane tests pass
- [x] Typecheck passes for marketing and control-plane
- [x] Web typecheck has pre-existing unrelated errors only

🤖 Generated with [Claude Code](https://claude.com/claude-code)