### PR TITLE
fix(security): harden integration OAuth callback (CWE-807 #98-101)

### DIFF
--- a/apps/web/src/app/api/user/integrations/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/user/integrations/callback/__tests__/route.test.ts
@@ -131,7 +131,7 @@ describe('GET /api/user/integrations/callback', () => {
   const savedEnv: Record<string, string | undefined> = {};
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
 
     // Save original env
     for (const key of envKeys) {
@@ -144,9 +144,16 @@ describe('GET /api/user/integrations/callback', () => {
     process.env.INTEGRATION_GITHUB_CLIENT_ID = 'gh-client-id';
     process.env.INTEGRATION_GITHUB_CLIENT_SECRET = 'gh-client-secret';
 
-    // Default mock behaviors
+    // Default mock behaviors (must re-establish after resetAllMocks)
     mockGetProviderById.mockResolvedValue(mockProvider);
     mockVerifySignedState.mockReturnValue(mockStateData);
+    mockExchangeOAuthCode.mockResolvedValue({ accessToken: 'mock-access-token', refreshToken: 'mock-refresh-token', expiresIn: 3600 });
+    mockEncryptCredentials.mockResolvedValue('encrypted-credentials-blob');
+    mockCreateConnection.mockResolvedValue({ id: 'conn-1' });
+    mockFindUserConnection.mockResolvedValue(null);
+    mockFindDriveConnection.mockResolvedValue(null);
+    mockUpdateConnectionCredentials.mockResolvedValue(undefined);
+    mockUpdateConnectionStatus.mockResolvedValue(undefined);
     mockGetDriveAccess.mockResolvedValue({ isOwner: true, isAdmin: true });
   });
 
@@ -266,7 +273,7 @@ describe('GET /api/user/integrations/callback', () => {
 
   describe('Alert #101: State verification', () => {
     it('redirects with invalid_state when verifySignedState returns null', async () => {
-      mockVerifySignedState.mockReturnValue(null);
+      mockVerifySignedState.mockReturnValueOnce(null);
       const request = createCallbackRequest({ code: 'auth-code', state: 'invalid-state' });
       const response = await GET(request);
 
@@ -276,7 +283,7 @@ describe('GET /api/user/integrations/callback', () => {
     });
 
     it('logs warning when state verification fails', async () => {
-      mockVerifySignedState.mockReturnValue(null);
+      mockVerifySignedState.mockReturnValueOnce(null);
       const request = createCallbackRequest({ code: 'auth-code', state: 'invalid-state' });
       await GET(request);
 
@@ -318,7 +325,7 @@ describe('GET /api/user/integrations/callback', () => {
     });
 
     it('redirects with provider_not_found when provider does not exist', async () => {
-      mockGetProviderById.mockResolvedValue(null);
+      mockGetProviderById.mockResolvedValueOnce(null);
       const request = createCallbackRequest({ code: 'auth-code', state: 'valid-state' });
       const response = await GET(request);
 
@@ -328,7 +335,7 @@ describe('GET /api/user/integrations/callback', () => {
     });
 
     it('redirects with not_oauth when provider is not OAuth2', async () => {
-      mockGetProviderById.mockResolvedValue({
+      mockGetProviderById.mockResolvedValueOnce({
         ...mockProvider,
         config: { authMethod: { type: 'api_key' } },
       });
@@ -344,8 +351,8 @@ describe('GET /api/user/integrations/callback', () => {
   // ── Happy path: user-scoped connection ───────────────────────────
 
   describe('User-scoped connection', () => {
-    it('creates new connection when none exists', async () => {
-      mockFindUserConnection.mockResolvedValue(null);
+    it('creates new connection with default visibility when none exists', async () => {
+      mockFindUserConnection.mockResolvedValueOnce(null);
       const request = createCallbackRequest({ code: 'auth-code', state: 'valid-state' });
       await GET(request);
 
@@ -356,20 +363,56 @@ describe('GET /api/user/integrations/callback', () => {
           userId: 'user-123',
           name: 'My GitHub',
           status: 'active',
+          visibility: 'owned_drives',
         })
       );
     });
 
-    it('updates existing connection credentials', async () => {
+    it('creates connection with explicit visibility from state', async () => {
+      mockVerifySignedState.mockReturnValueOnce({
+        ...mockStateData,
+        visibility: 'private',
+      });
+      mockFindUserConnection.mockResolvedValueOnce(null);
+      const request = createCallbackRequest({ code: 'auth-code', state: 'valid-state' });
+      await GET(request);
+
+      expect(mockCreateConnection).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          visibility: 'private',
+        })
+      );
+    });
+
+    it('falls back to default visibility for invalid value', async () => {
+      mockVerifySignedState.mockReturnValueOnce({
+        ...mockStateData,
+        visibility: 'bogus_value',
+      });
+      mockFindUserConnection.mockResolvedValueOnce(null);
+      const request = createCallbackRequest({ code: 'auth-code', state: 'valid-state' });
+      await GET(request);
+
+      expect(mockCreateConnection).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          visibility: 'owned_drives',
+        })
+      );
+    });
+
+    it('updates existing connection credentials and visibility', async () => {
       const existing = { id: 'existing-conn-1' };
-      mockFindUserConnection.mockResolvedValue(existing);
+      mockFindUserConnection.mockResolvedValueOnce(existing);
       const request = createCallbackRequest({ code: 'auth-code', state: 'valid-state' });
       await GET(request);
 
       expect(mockUpdateConnectionCredentials).toHaveBeenCalledWith(
         expect.anything(),
         'existing-conn-1',
-        'encrypted-credentials-blob'
+        'encrypted-credentials-blob',
+        'owned_drives'
       );
       expect(mockUpdateConnectionStatus).toHaveBeenCalledWith(
         expect.anything(),
@@ -410,7 +453,7 @@ describe('GET /api/user/integrations/callback', () => {
     });
 
     it('rejects when user lacks admin access to drive', async () => {
-      mockGetDriveAccess.mockResolvedValue({ isOwner: false, isAdmin: false });
+      mockGetDriveAccess.mockResolvedValueOnce({ isOwner: false, isAdmin: false });
       const request = createCallbackRequest({ code: 'auth-code', state: 'valid-state' });
       const response = await GET(request);
 
@@ -420,7 +463,7 @@ describe('GET /api/user/integrations/callback', () => {
     });
 
     it('creates drive-scoped connection for admin users', async () => {
-      mockGetDriveAccess.mockResolvedValue({ isOwner: false, isAdmin: true });
+      mockGetDriveAccess.mockResolvedValueOnce({ isOwner: false, isAdmin: true });
       const request = createCallbackRequest({ code: 'auth-code', state: 'valid-state' });
       await GET(request);
 
@@ -440,7 +483,7 @@ describe('GET /api/user/integrations/callback', () => {
 
   describe('Return URL validation', () => {
     it('uses safe relative returnUrl from state', async () => {
-      mockVerifySignedState.mockReturnValue({
+      mockVerifySignedState.mockReturnValueOnce({
         ...mockStateData,
         returnUrl: '/settings/integrations/github',
       });
@@ -452,7 +495,7 @@ describe('GET /api/user/integrations/callback', () => {
     });
 
     it('falls back to default for unsafe returnUrl', async () => {
-      mockVerifySignedState.mockReturnValue({
+      mockVerifySignedState.mockReturnValueOnce({
         ...mockStateData,
         returnUrl: 'https://evil.com/steal',
       });
@@ -464,7 +507,7 @@ describe('GET /api/user/integrations/callback', () => {
     });
 
     it('rejects protocol-relative returnUrl', async () => {
-      mockVerifySignedState.mockReturnValue({
+      mockVerifySignedState.mockReturnValueOnce({
         ...mockStateData,
         returnUrl: '//evil.com/steal',
       });
@@ -480,7 +523,7 @@ describe('GET /api/user/integrations/callback', () => {
 
   describe('Token exchange errors', () => {
     it('redirects with missing_tokens when no access token returned', async () => {
-      mockExchangeOAuthCode.mockResolvedValue({ accessToken: null });
+      mockExchangeOAuthCode.mockResolvedValueOnce({ accessToken: null });
       const request = createCallbackRequest({ code: 'auth-code', state: 'valid-state' });
       const response = await GET(request);
 
@@ -494,7 +537,7 @@ describe('GET /api/user/integrations/callback', () => {
 
   describe('Unexpected errors', () => {
     it('redirects with unexpected error on thrown exception', async () => {
-      mockGetProviderById.mockRejectedValue(new Error('DB connection failed'));
+      mockGetProviderById.mockRejectedValueOnce(new Error('DB connection failed'));
       const request = createCallbackRequest({ code: 'auth-code', state: 'valid-state' });
       const response = await GET(request);
 
@@ -505,7 +548,7 @@ describe('GET /api/user/integrations/callback', () => {
 
     it('logs the error on unexpected exception', async () => {
       const dbError = new Error('DB connection failed');
-      mockGetProviderById.mockRejectedValue(dbError);
+      mockGetProviderById.mockRejectedValueOnce(dbError);
       const request = createCallbackRequest({ code: 'auth-code', state: 'valid-state' });
       await GET(request);
 

--- a/apps/web/src/app/api/user/integrations/callback/route.ts
+++ b/apps/web/src/app/api/user/integrations/callback/route.ts
@@ -158,7 +158,7 @@ export async function GET(request: Request) {
       // User-scoped connection
       const existing = await findUserConnection(db, userId, providerId);
       if (existing) {
-        await updateConnectionCredentials(db, existing.id, encrypted);
+        await updateConnectionCredentials(db, existing.id, encrypted, visibility);
         await updateConnectionStatus(db, existing.id, 'active');
       } else {
         await createConnection(db, {

--- a/docs/security/CODEQL_ALERT_LOG.md
+++ b/docs/security/CODEQL_ALERT_LOG.md
@@ -133,7 +133,7 @@ Following Eric Elliott's zero-trust philosophy: **Never trust user input. Assume
 
 ### Files Modified (26 files)
 
-**Processor App (6 files):**
+**Processor App (5 files):**
 - `apps/processor/src/cache/content-store.ts` — Path traversal prevention, prototype pollution guards, preset validation
 - `apps/processor/src/api/upload.ts` — Path containment checks for temp files
 - `apps/processor/src/api/avatar.ts` — Rate limiting middleware
@@ -156,12 +156,12 @@ Following Eric Elliott's zero-trust philosophy: **Never trust user input. Assume
 - `apps/web/src/stores/page-agents/usePageAgentDashboardStore.ts` — Agent ID validation
 - `apps/web/public/sw.js` — Message origin verification
 
-**Desktop App (2 files):**
+**Desktop App (3 files):**
 - `apps/desktop/src/offline.html` — URL redirect validation
 - `apps/desktop/src/main/auth-storage.ts` — Session data validation
 - `apps/desktop/src/main/ws-client.ts` — WebSocket URL validation
 
-**Shared Packages (3 files):**
+**Shared Packages (4 files):**
 - `packages/lib/src/services/drive-search-service.ts` — Regex injection prevention + type fix
 - `packages/lib/src/services/notification-email-service.ts` — Log injection prevention
 - `packages/lib/src/file-processing/file-processor.ts` — Hardcoded API URLs

--- a/packages/lib/src/integrations/repositories/connection-repository.ts
+++ b/packages/lib/src/integrations/repositories/connection-repository.ts
@@ -206,7 +206,8 @@ export const updateConnectionLastUsed = async (
 export const updateConnectionCredentials = async (
   database: typeof defaultDb,
   connectionId: string,
-  credentials: Record<string, string>
+  credentials: Record<string, string>,
+  visibility?: 'private' | 'owned_drives' | 'all_drives'
 ): Promise<IntegrationConnection | null> => {
   const [updated] = await database
     .update(integrationConnections)
@@ -214,6 +215,7 @@ export const updateConnectionCredentials = async (
       credentials,
       status: 'active',
       statusMessage: null,
+      ...(visibility && { visibility }),
     })
     .where(eq(integrationConnections.id, connectionId))
     .returning();


### PR DESCRIPTION
## Summary
- **Alerts #98-100 (S3)**: Added Zod schema validation for `code`/`state` params and `String(error).slice(0, 100)` log sanitization to break CodeQL taint chains in the integration OAuth callback
- **Alert #101 (S4)**: Dismissed as false positive — `verifySignedState()` provides HMAC-SHA256 + timingSafeEqual verification, which IS the security check (same class as reverted alert #80)
- Added 30 contract tests covering error handling, input validation, state verification, connection creation, and return URL safety

## Severity Ratings

| Alert | Line | Issue | Rating |
|-------|------|-------|--------|
| #98 | 37 | `error` param logged raw | S3 — log sanitization |
| #99 | 43 | `code` presence-only check | S3 — Zod validation |
| #100 | 43 | `state` presence-only check | S3 — Zod validation |
| #101 | 57 | Branch on `verifySignedState()` result | S4 — false positive |

## Test plan
- [x] 30 contract tests pass (error handling, input validation, state verification, happy path)
- [ ] Verify CodeQL re-scan clears alerts #98-100
- [ ] Verify alert #101 can be dismissed in CodeQL dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation of OAuth integration callback parameters.
  * Improved OAuth error message handling with better sanitization.

* **Tests**
  * Added comprehensive test coverage for OAuth integration callback flows, covering various scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->