### PR TITLE
fix(security): eliminate shell injection in infrastructure tests (CWE-78 #120-#123)

### DIFF
--- a/docs/security/CODEQL_ALERT_LOG.md
+++ b/docs/security/CODEQL_ALERT_LOG.md
@@ -213,3 +213,31 @@ The callback handler has layered security controls:
 
 - `apps/web/src/app/api/auth/google/callback/__tests__/route.test.ts` — comprehensive callback contract tests
 - `apps/web/src/app/api/auth/google/__tests__/open-redirect-protection.test.ts` — defense-in-depth returnUrl validation
+
+## Batch 8: Shell Command Injection in Infrastructure Tests (4 alerts fixed)
+
+**Branch**: `pu/sec-shell-inject`
+**Date**: 2026-04-08
+**Total Alerts**: 4 (all `js/shell-command-injection-from-environment` MEDIUM)
+**Disposition**: All 4 fixed — switched `execSync()` with string interpolation to `execFileSync()` with array args
+
+### Analysis
+
+CodeQL's `js/shell-command-injection-from-environment` rule flags shell commands built via string interpolation of paths resolved from `__dirname`. While these are test files with hardcoded arguments (no real exploitability), `execSync()` with template literals passes the command through a shell interpreter where metacharacters in paths could theoretically be exploited. Switching to `execFileSync()` with array arguments bypasses the shell entirely, eliminating the injection surface.
+
+**Rating: S2 (Should Fix)** — Not exploitable in practice (test files, hardcoded args, `__dirname`-derived paths), but `execFileSync` with array args is the correct API and the fix is trivial.
+
+### Alert Disposition
+
+| Alert | Rule | Severity | File | CWE | Fix Summary | Status |
+|-------|------|----------|------|-----|-------------|--------|
+| #120 | js/shell-command-injection-from-environment | medium | image-runtime.test.ts:25 | CWE-78 | Refactored `run()`/`composeCmd()` → `composeRun()`/`composeArgs()` using `execFileSync('docker', [...args])` | FIXED |
+| #121 | js/shell-command-injection-from-environment | medium | image-runtime.test.ts:57 | CWE-78 | `cleanup()` now uses `execFileSync('docker', composeArgs(...))` instead of `execSync(composeCmd(...))` | FIXED |
+| #122 | js/shell-command-injection-from-environment | medium | generate-tenant-env.test.ts:9 | CWE-78 | `execSync(\`bash ${SCRIPT} ${args}\`)` → `execFileSync('bash', [SCRIPT, ...args.split(' ').filter(Boolean)])` | FIXED |
+| #123 | js/shell-command-injection-from-environment | medium | tenant-stack.test.ts:10 | CWE-78 | `execSync(\`bash ${SCRIPT} ${args}\`)` → `execFileSync('bash', [SCRIPT, ...args.split(' ').filter(Boolean)])` | FIXED |
+
+### Files Modified (3 files)
+
+- `infrastructure/__tests__/tenant-stack.test.ts` — `execSync` → `execFileSync` with array args
+- `infrastructure/__tests__/generate-tenant-env.test.ts` — `execSync` → `execFileSync` with array args
+- `infrastructure/scripts/__tests__/image-runtime.test.ts` — Refactored `run()`/`composeCmd()` to `composeRun()`/`composeArgs()` using `execFileSync`

--- a/infrastructure/__tests__/generate-tenant-env.test.ts
+++ b/infrastructure/__tests__/generate-tenant-env.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { resolve } from 'path';
 
 const SCRIPT = resolve(__dirname, '../scripts/generate-tenant-env.sh');
 
 function runScript(args: string): { code: number; stdout: string; stderr: string } {
   try {
-    const stdout = execSync(`bash ${SCRIPT} ${args}`, {
+    const stdout = execFileSync('bash', [SCRIPT, ...args.split(' ').filter(Boolean)], {
       encoding: 'utf-8',
       timeout: 10_000,
     });

--- a/infrastructure/__tests__/tenant-stack.test.ts
+++ b/infrastructure/__tests__/tenant-stack.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { readFileSync, accessSync, constants } from 'fs';
 import { resolve } from 'path';
 
@@ -7,7 +7,7 @@ const SCRIPT = resolve(__dirname, '../scripts/tenant-stack.sh');
 
 function runScript(args: string): { code: number; stdout: string; stderr: string } {
   try {
-    const stdout = execSync(`bash ${SCRIPT} ${args}`, {
+    const stdout = execFileSync('bash', [SCRIPT, ...args.split(' ').filter(Boolean)], {
       encoding: 'utf-8',
       timeout: 5_000,
       env: { ...process.env, DRY_RUN: '1' },

--- a/infrastructure/scripts/__tests__/image-runtime.test.ts
+++ b/infrastructure/scripts/__tests__/image-runtime.test.ts
@@ -13,7 +13,7 @@
  *   cd infrastructure && npx vitest run scripts/__tests__/image-runtime.test.ts --timeout 120000
  */
 import { describe, it, expect, afterAll } from 'vitest';
-import { execSync, ExecSyncOptions } from 'child_process';
+import { execSync, execFileSync, ExecSyncOptions } from 'child_process';
 import { resolve } from 'path';
 import { readFileSync } from 'fs';
 
@@ -21,21 +21,19 @@ const COMPOSE_FILE = resolve(__dirname, '../../docker-compose.test.yml');
 const PROJECT_NAME = `ps-image-test-${Date.now()}`;
 const EXEC_OPTS: ExecSyncOptions = { stdio: 'pipe', timeout: 120_000 };
 
-function run(cmd: string): string {
-  return execSync(cmd, EXEC_OPTS).toString().trim();
+function composeArgs(subcommand: string): string[] {
+  return ['compose', '-p', PROJECT_NAME, '-f', COMPOSE_FILE, ...subcommand.split(' ')];
 }
 
-function composeCmd(subcommand: string): string {
-  return `docker compose -p ${PROJECT_NAME} -f ${COMPOSE_FILE} ${subcommand}`;
+function composeRun(subcommand: string): string {
+  return execFileSync('docker', composeArgs(subcommand), EXEC_OPTS).toString().trim();
 }
 
 function waitForHealthy(service: string, maxWaitSec = 60): void {
   const deadline = Date.now() + maxWaitSec * 1000;
   while (Date.now() < deadline) {
     try {
-      const health = run(
-        composeCmd(`ps --format json ${service}`),
-      );
+      const health = composeRun(`ps --format json ${service}`);
       // docker compose ps --format json may return one JSON object per line
       const lines = health.split('\n').filter(Boolean);
       for (const line of lines) {
@@ -54,7 +52,7 @@ function waitForHealthy(service: string, maxWaitSec = 60): void {
 
 function cleanup(): void {
   try {
-    execSync(composeCmd('down -v --remove-orphans'), { stdio: 'ignore', timeout: 30_000 });
+    execFileSync('docker', composeArgs('down -v --remove-orphans'), { stdio: 'ignore', timeout: 30_000 });
   } catch {
     // best-effort cleanup
   }
@@ -88,22 +86,25 @@ describe.skipIf(!canRun)('Image runtime env verification', () => {
 
   it('should start processor with runtime env vars and pass health check', () => {
     cleanup();
-    run(composeCmd('up -d processor-test'));
+    composeRun('up -d processor-test');
     waitForHealthy('processor-test', 60);
 
-    const response = run(`docker compose -p ${PROJECT_NAME} -f ${COMPOSE_FILE} exec processor-test node -e "require('http').get('http://localhost:3003/health', (r) => { let d=''; r.on('data', c => d+=c); r.on('end', () => { console.log(r.statusCode); process.exit(r.statusCode === 200 ? 0 : 1); }); })"`);
+    const response = execFileSync('docker', [
+      ...composeArgs('exec processor-test node -e'),
+      "require('http').get('http://localhost:3003/health', (r) => { let d=''; r.on('data', c => d+=c); r.on('end', () => { console.log(r.statusCode); process.exit(r.statusCode === 200 ? 0 : 1); }); })",
+    ], EXEC_OPTS).toString().trim();
     expect(response).toContain('200');
   }, 90_000);
 
   it('should start web with runtime env vars without crashing', () => {
-    run(composeCmd('up -d web-test'));
+    composeRun('up -d web-test');
 
     // Web needs postgres - check that container stays running for 10s
     const deadline = Date.now() + 15_000;
     let lastState = '';
     while (Date.now() < deadline) {
       try {
-        const output = run(composeCmd('ps --format json web-test'));
+        const output = composeRun('ps --format json web-test');
         const lines = output.split('\n').filter(Boolean);
         for (const line of lines) {
           const parsed = JSON.parse(line);
@@ -122,13 +123,13 @@ describe.skipIf(!canRun)('Image runtime env verification', () => {
   }, 30_000);
 
   it('should start realtime with runtime env vars without crashing', () => {
-    run(composeCmd('up -d realtime-test'));
+    composeRun('up -d realtime-test');
 
     const deadline = Date.now() + 15_000;
     let lastState = '';
     while (Date.now() < deadline) {
       try {
-        const output = run(composeCmd('ps --format json realtime-test'));
+        const output = composeRun('ps --format json realtime-test');
         const lines = output.split('\n').filter(Boolean);
         for (const line of lines) {
           const parsed = JSON.parse(line);


### PR DESCRIPTION
## Summary
- Switch `execSync()` with template-literal interpolation to `execFileSync()` with array args in 3 infrastructure test files
- Resolves 4 CodeQL `js/shell-command-injection-from-environment` alerts (#120, #121, #122, #123)
- Rated **S2 (Should Fix)** — not exploitable (test files, hardcoded args, `__dirname` paths) but `execFileSync` is the correct API

## Changes
| File | Change |
|------|--------|
| `infrastructure/__tests__/tenant-stack.test.ts` | `execSync(`bash ${SCRIPT} ${args}`)` → `execFileSync('bash', [SCRIPT, ...args])` |
| `infrastructure/__tests__/generate-tenant-env.test.ts` | Same pattern |
| `infrastructure/scripts/__tests__/image-runtime.test.ts` | Refactored `run()`/`composeCmd()` → `composeRun()`/`composeArgs()` using `execFileSync('docker', [...])` |
| `docs/security/CODEQL_ALERT_LOG.md` | Added Batch 8 triage log |

## Test plan
- [x] `vitest run infrastructure/__tests__/tenant-stack.test.ts` — 10/10 passing
- [x] `vitest run infrastructure/__tests__/generate-tenant-env.test.ts` — 20/20 passing
- [ ] `image-runtime.test.ts` — requires Docker; changes are syntactically identical in pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)