### PR TITLE
fix(security): use mkdtemp() for secure temp dirs in tenant migration tests

### DIFF
--- a/scripts/__tests__/tenant-export.test.ts
+++ b/scripts/__tests__/tenant-export.test.ts
@@ -6,7 +6,7 @@
  * Run: docker compose -f docker-compose.test.yml up -d && cd scripts && npx vitest run
  */
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
-import { mkdir, writeFile, readFile, rm } from 'fs/promises';
+import { mkdir, mkdtemp, writeFile, readFile, rm } from 'fs/promises';
 import { existsSync } from 'fs';
 import path from 'path';
 import os from 'os';
@@ -41,7 +41,7 @@ beforeEach(async () => {
   await seedFixtures(db);
 
   // Create temp dirs for output and file storage
-  tmpDir = path.join(os.tmpdir(), `pagespace-export-test-${Date.now()}`);
+  tmpDir = await mkdtemp(path.join(os.tmpdir(), 'pagespace-export-test-'));
   fileStoragePath = path.join(tmpDir, 'source-files');
   await mkdir(fileStoragePath, { recursive: true });
 

--- a/scripts/__tests__/tenant-import.test.ts
+++ b/scripts/__tests__/tenant-import.test.ts
@@ -6,7 +6,7 @@
  * Run: docker compose -f docker-compose.test.yml up -d && cd scripts && npx vitest run
  */
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
-import { mkdir, writeFile, readFile, rm } from 'fs/promises';
+import { mkdir, mkdtemp, writeFile, readFile, rm } from 'fs/promises';
 import { existsSync } from 'fs';
 import path from 'path';
 import os from 'os';
@@ -44,7 +44,7 @@ beforeEach(async () => {
   await seedFixtures(db);
 
   // Create temp dirs
-  tmpDir = path.join(os.tmpdir(), `pagespace-import-test-${Date.now()}`);
+  tmpDir = await mkdtemp(path.join(os.tmpdir(), 'pagespace-import-test-'));
   fileStoragePath = path.join(tmpDir, 'source-files');
   bundleDir = path.join(tmpDir, 'bundle');
   await mkdir(fileStoragePath, { recursive: true });

--- a/scripts/__tests__/tenant-validate.test.ts
+++ b/scripts/__tests__/tenant-validate.test.ts
@@ -6,7 +6,7 @@
  * Run: docker compose -f docker-compose.test.yml up -d && cd scripts && npx vitest run
  */
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
-import { mkdir, writeFile, rm } from 'fs/promises';
+import { mkdir, mkdtemp, writeFile, rm } from 'fs/promises';
 import { existsSync } from 'fs';
 import path from 'path';
 import os from 'os';
@@ -42,7 +42,7 @@ beforeEach(async () => {
   await truncateAll(db);
   await seedFixtures(db);
 
-  tmpDir = path.join(os.tmpdir(), `pagespace-validate-test-${Date.now()}`);
+  tmpDir = await mkdtemp(path.join(os.tmpdir(), 'pagespace-validate-test-'));
   fileStoragePath = path.join(tmpDir, 'files');
   await mkdir(fileStoragePath, { recursive: true });
 


### PR DESCRIPTION
## Summary
- Replace predictable `os.tmpdir() + Date.now()` temp directory creation with atomic `mkdtemp()` in 3 tenant migration test files
- Resolves CodeQL alerts #125-131 (CWE-377: insecure temporary file creation)
- Dismisses #136-137 as false positives (user-specified `outputDir`, not predictable temp naming)

## Changes
- `scripts/__tests__/tenant-export.test.ts` — `mkdtemp()` for export test temp dir
- `scripts/__tests__/tenant-import.test.ts` — `mkdtemp()` for import test temp dir
- `scripts/__tests__/tenant-validate.test.ts` — `mkdtemp()` for validate test temp dir

## Test plan
- [ ] Verify tenant migration tests still pass (`cd scripts && npx vitest run`)
- [ ] Confirm no remaining `os.tmpdir() + Date.now()` patterns in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved temporary directory creation in test setup across multiple test files by using system-level directory generation instead of timestamp-based paths, enhancing test reliability and isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->