### PR TITLE
fix(security): add webhook alerting on audit chain failure (#544)

### DIFF
--- a/apps/web/src/app/api/cron/verify-audit-chain/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/verify-audit-chain/__tests__/route.test.ts
@@ -14,6 +14,7 @@ vi.mock('next/server', () => ({
         headers: { 'content-type': 'application/json' },
       }),
   },
+  after: (fn: () => void | Promise<void>) => fn(),
 }));
 
 vi.mock('@pagespace/lib', () => ({
@@ -109,6 +110,9 @@ describe('GET /api/cron/verify-audit-chain — webhook alerting', () => {
       entriesVerified: 50,
       invalidEntries: 1,
       breakPosition: 50,
+      breakReason: 'Hash mismatch at position 50',
+      verificationStartedAt: '2026-04-08T12:00:00.000Z',
+      verificationCompletedAt: '2026-04-08T12:00:01.000Z',
       durationMs: 1000,
     });
   });
@@ -184,9 +188,6 @@ describe('GET /api/cron/verify-audit-chain — webhook alerting', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     await GET(makeRequest());
-
-    // Allow the microtask (.catch handler) to run
-    await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(warnSpy).toHaveBeenCalledWith(
       '[Cron] Webhook alert delivery failed:',

--- a/apps/web/src/app/api/cron/verify-audit-chain/route.ts
+++ b/apps/web/src/app/api/cron/verify-audit-chain/route.ts
@@ -1,5 +1,5 @@
 import { verifySecurityAuditChain } from '@pagespace/lib';
-import { NextResponse } from 'next/server';
+import { after, NextResponse } from 'next/server';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
 
 /**
@@ -29,24 +29,34 @@ export async function GET(request: Request) {
 
       const webhookUrl = process.env.AUDIT_ALERT_WEBHOOK_URL;
       if (webhookUrl && webhookUrl.startsWith('https://')) {
-        fetch(webhookUrl, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            event: 'audit_chain_integrity_failure',
-            timestamp: new Date().toISOString(),
-            environment: process.env.NODE_ENV,
-            details: {
-              isValid: result.isValid,
-              totalEntries: result.totalEntries,
-              entriesVerified: result.entriesVerified,
-              invalidEntries: result.invalidEntries,
-              breakPosition: result.breakPoint?.position ?? null,
-              durationMs: result.durationMs,
-            },
-          }),
-        }).catch((err) => {
-          console.warn('[Cron] Webhook alert delivery failed:', err.message);
+        after(async () => {
+          try {
+            await fetch(webhookUrl, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                event: 'audit_chain_integrity_failure',
+                timestamp: new Date().toISOString(),
+                environment: process.env.NODE_ENV,
+                details: {
+                  isValid: result.isValid,
+                  totalEntries: result.totalEntries,
+                  entriesVerified: result.entriesVerified,
+                  invalidEntries: result.invalidEntries,
+                  breakPosition: result.breakPoint?.position ?? null,
+                  breakReason: result.breakPoint?.description ?? null,
+                  verificationStartedAt: result.verificationStartedAt.toISOString(),
+                  verificationCompletedAt: result.verificationCompletedAt.toISOString(),
+                  durationMs: result.durationMs,
+                },
+              }),
+            });
+          } catch (err) {
+            console.warn(
+              '[Cron] Webhook alert delivery failed:',
+              err instanceof Error ? err.message : String(err)
+            );
+          }
         });
       }
     } else {
@@ -77,6 +87,7 @@ export async function GET(request: Request) {
   }
 }
 
+/** POST handler — delegates to GET for cron systems that POST. */
 export async function POST(request: Request) {
   return GET(request);
 }


### PR DESCRIPTION
## Summary

- Adds webhook alerting when the security audit hash chain verification cron job detects integrity failures
- Uses Next.js `after()` for reliable delivery on serverless/edge deployments (not unawaited fetch)
- When `AUDIT_ALERT_WEBHOOK_URL` env var is set (HTTPS only), POSTs structured JSON to that URL
- Payload includes sanitized metrics + failure reason + verification timestamps — no raw hashes or entry IDs
- Existing `console.error` behavior preserved as fallback — this is purely additive
- 7 tests covering: webhook fires, enriched payload, no-leak validation, no-op without env var, fire-and-forget resilience, success-path guard, HTTPS enforcement, and operational warn logging

Closes #544

## Files changed

| File | What changed |
|------|-------------|
| `apps/web/src/app/api/cron/verify-audit-chain/route.ts` | Webhook alerting via `after()`, sanitized payload with `breakReason` + timestamps, HTTPS-only guard |
| `apps/web/src/app/api/cron/verify-audit-chain/__tests__/route.test.ts` | 7 tests for all webhook alerting behavior and security hardening |

## Review guide — use `/aidd:review`

> **Reviewer agent**: Run `/aidd:review` against this PR. The checklist below maps each review criterion to the specific thing to verify in this diff.

### 1. Code structure & organization
- The webhook logic uses `after()` from `next/server` inside the `if (!result.isValid)` block. Verify it doesn't change the control flow — the `else` branch and `return NextResponse.json(...)` must be untouched.

### 2. Coding standards (javascript.mdc)
- Single new import: `after` from `next/server`. Confirm no unused imports.
- `webhookUrl` is `const`, read once from `process.env`. Confirm no mutation.
- `after()` wraps an async IIFE with try/catch — matches the existing pattern in `apps/web/src/app/api/integrations/google-calendar/webhook/route.ts`.

### 3. Test coverage & quality (tdd.mdc)
- 7 tests use Given/Should naming. Verify each name matches its assertions.
- `after()` mocked to invoke synchronously — tests remain deterministic.
- `process.env` snapshot/restore in `beforeEach`/`afterEach` — confirm no env leakage.
- No-leak test explicitly asserts absence of hashes, entry IDs in payload.

### 4. Security (OWASP top 10)
- **SSRF (A10:2021)**: HTTPS-only guard (`webhookUrl.startsWith('https://')`) + server env var, not user input.
- **Information exposure (A01:2021)**: Payload sends `breakReason` (description text) and `breakPosition` (integer), but NOT raw hashes (`storedHash`, `computedHash`, `previousHashUsed`) or entry IDs.
- **Injection**: URL passed directly to `fetch()`, no string interpolation.

### 5. Architecture & design
- `after()` ensures webhook delivery completes reliably on serverless deployments.
- Webhook only fires on `!result.isValid`, never on success or on the outer `catch` (verification errors).

### 6. Functional requirements (#544)
- [x] Given `AUDIT_ALERT_WEBHOOK_URL` set + chain fails → POST structured JSON via `after()`
- [x] Given `AUDIT_ALERT_WEBHOOK_URL` NOT set → only `console.error`
- [x] Payload: `{ event, timestamp, environment, details: { isValid, totalEntries, entriesVerified, invalidEntries, breakPosition, breakReason, verificationStartedAt, verificationCompletedAt, durationMs } }`
- [x] Fire-and-forget: webhook failure does not affect cron response
- [x] `console.error` preserved (additive)
- [x] HTTPS-only enforcement on webhook URL
- [x] Sanitized payload — no raw hashes or entry IDs

## Test plan

- [x] `pnpm --filter web exec npx vitest run src/app/api/cron/verify-audit-chain/` — 7/7 passing
- [x] All cron route tests pass (12/12 including workflows)
- [ ] Manual: set `AUDIT_ALERT_WEBHOOK_URL=https://webhook.site/<id>` and trigger cron with a broken chain — confirm payload arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)