### PR TITLE
fix(cron): schedule missing GDPR retention and orphan cleanup jobs

### DIFF
--- a/apps/web/src/app/api/cron/cleanup-orphaned-files/route.ts
+++ b/apps/web/src/app/api/cron/cleanup-orphaned-files/route.ts
@@ -83,11 +83,19 @@ export async function GET(request: Request) {
       }
     }
 
-    // Delete DB records (even if physical delete failed - the file is orphaned regardless)
-    const dbDeleted = await deleteFileRecords(
-      db as Parameters<typeof deleteFileRecords>[0],
-      orphans.map(o => o.id),
-    );
+    // Only delete DB records for orphans whose physical files were successfully
+    // deleted (or had no storagePath). Failed physical deletes are skipped so
+    // they retry on the next scheduled run.
+    const safeToDelete = orphans
+      .filter(o => !failedPhysicalDeletes.includes(o.id))
+      .map(o => o.id);
+
+    const dbDeleted = safeToDelete.length > 0
+      ? await deleteFileRecords(
+          db as Parameters<typeof deleteFileRecords>[0],
+          safeToDelete,
+        )
+      : 0;
 
     console.log(
       `[Cron] Orphaned file cleanup: ${orphans.length} orphans found, ` +

--- a/docker/cron/crontab
+++ b/docker/cron/crontab
@@ -19,6 +19,10 @@
 # Syncs Google Calendar connections that are due based on their sync frequency
 */5 * * * * cron-curl GET http://web:3000/api/cron/calendar-sync >> /var/log/cron/calendar-sync.log 2>&1
 
+# Retention cleanup - Daily at 1am UTC
+# Deletes expired rows from sessions, tokens, page versions, drive backups, permissions, monitoring data
+0 1 * * * cron-curl GET http://web:3000/api/cron/retention-cleanup >> /var/log/cron/retention-cleanup.log 2>&1
+
 # Security audit chain verification - Daily at 2am UTC
 # Verifies hash chain integrity of security audit log
 0 2 * * * cron-curl GET http://web:3000/api/cron/verify-audit-chain >> /var/log/cron/audit-chain.log 2>&1
@@ -34,3 +38,7 @@
 # Workflow execution - Every 5 minutes
 # Checks for due scheduled workflows and executes them
 */5 * * * * cron-curl POST http://web:3000/api/cron/workflows >> /var/log/cron/workflows.log 2>&1
+
+# Orphaned file cleanup - Weekly on Sundays at 5am UTC
+# Detects and deletes file records with zero references + physical files
+0 5 * * 0 cron-curl GET http://web:3000/api/cron/cleanup-orphaned-files >> /var/log/cron/orphan-cleanup.log 2>&1

--- a/packages/lib/src/compliance/retention/monitoring-retention.test.ts
+++ b/packages/lib/src/compliance/retention/monitoring-retention.test.ts
@@ -29,7 +29,6 @@ vi.mock('@pagespace/db', () => ({
   },
   apiMetrics: { id: 'apiMetrics.id', timestamp: 'apiMetrics.timestamp' },
   systemLogs: { id: 'systemLogs.id', timestamp: 'systemLogs.timestamp' },
-  securityAuditLog: { id: 'securityAuditLog.id', timestamp: 'securityAuditLog.timestamp' },
 }));
 
 import {
@@ -37,10 +36,9 @@ import {
   getRetentionCutoff,
   cleanupApiMetrics,
   cleanupSystemLogs,
-  cleanupSecurityAuditLog,
   runMonitoringRetentionCleanup,
 } from './monitoring-retention';
-import { apiMetrics, systemLogs, securityAuditLog } from '@pagespace/db';
+import { apiMetrics, systemLogs } from '@pagespace/db';
 
 const originalEnv = process.env;
 
@@ -48,7 +46,6 @@ beforeEach(() => {
   process.env = { ...originalEnv };
   delete process.env.RETENTION_API_METRICS_DAYS;
   delete process.env.RETENTION_SYSTEM_LOGS_DAYS;
-  delete process.env.RETENTION_SECURITY_AUDIT_DAYS;
   vi.clearAllMocks();
   mockReturning.mockResolvedValue([]);
 });
@@ -64,35 +61,30 @@ describe('getRetentionConfig', () => {
     expect(config).toEqual({
       apiMetricsDays: 90,
       systemLogsDays: 30,
-      securityAuditDays: 365,
     });
   });
 
   it('given_validEnvVars_usesCustomValues', () => {
     process.env.RETENTION_API_METRICS_DAYS = '60';
     process.env.RETENTION_SYSTEM_LOGS_DAYS = '14';
-    process.env.RETENTION_SECURITY_AUDIT_DAYS = '730';
 
     const config = getRetentionConfig();
 
     expect(config).toEqual({
       apiMetricsDays: 60,
       systemLogsDays: 14,
-      securityAuditDays: 730,
     });
   });
 
   it('given_invalidEnvVars_fallsBackToDefaults', () => {
     process.env.RETENTION_API_METRICS_DAYS = 'not-a-number';
     process.env.RETENTION_SYSTEM_LOGS_DAYS = '-5';
-    process.env.RETENTION_SECURITY_AUDIT_DAYS = '0';
 
     const config = getRetentionConfig();
 
     expect(config).toEqual({
       apiMetricsDays: 90,
       systemLogsDays: 30,
-      securityAuditDays: 365,
     });
   });
 
@@ -166,39 +158,21 @@ describe('cleanupSystemLogs', () => {
   });
 });
 
-describe('cleanupSecurityAuditLog', () => {
-  it('given_noExpiredRows_returnsZeroDeleted', async () => {
-    const result = await cleanupSecurityAuditLog({ retentionDays: 365 });
-
-    expect(result).toEqual({ table: 'security_audit_log', deleted: 0 });
-    expect(mockDeleteTable).toHaveBeenCalledWith(securityAuditLog);
-  });
-
-  it('given_expiredRows_returnsDeletedCount', async () => {
-    mockReturning.mockResolvedValueOnce([{ id: '1' }]);
-
-    const result = await cleanupSecurityAuditLog({ retentionDays: 365 });
-
-    expect(result).toEqual({ table: 'security_audit_log', deleted: 1 });
-  });
-});
-
 describe('runMonitoringRetentionCleanup', () => {
-  it('given_defaultConfig_cleansUpAllThreeTables', async () => {
+  it('given_defaultConfig_cleansUpMetricsAndLogs', async () => {
     const results = await runMonitoringRetentionCleanup();
     const tables = results.map(r => r.table).sort();
 
-    expect(tables).toEqual(['api_metrics', 'security_audit_log', 'system_logs']);
+    expect(tables).toEqual(['api_metrics', 'system_logs']);
   });
 
-  it('given_customEnvConfig_stillCleansAllThreeTables', async () => {
+  it('given_customEnvConfig_stillCleansBothTables', async () => {
     process.env.RETENTION_API_METRICS_DAYS = '45';
     process.env.RETENTION_SYSTEM_LOGS_DAYS = '7';
-    process.env.RETENTION_SECURITY_AUDIT_DAYS = '180';
 
     const results = await runMonitoringRetentionCleanup();
 
-    expect(results).toHaveLength(3);
+    expect(results).toHaveLength(2);
     for (const result of results) {
       expect(typeof result.table).toBe('string');
       expect(typeof result.deleted).toBe('number');

--- a/packages/lib/src/compliance/retention/monitoring-retention.ts
+++ b/packages/lib/src/compliance/retention/monitoring-retention.ts
@@ -1,15 +1,13 @@
 import { lt } from 'drizzle-orm';
-import { db, apiMetrics, systemLogs, securityAuditLog } from '@pagespace/db';
+import { db, apiMetrics, systemLogs } from '@pagespace/db';
 import type { CleanupResult } from './retention-engine';
 
 const DEFAULT_API_METRICS_DAYS = 90;
 const DEFAULT_SYSTEM_LOGS_DAYS = 30;
-const DEFAULT_SECURITY_AUDIT_DAYS = 365;
 
 export interface RetentionConfig {
   apiMetricsDays: number;
   systemLogsDays: number;
-  securityAuditDays: number;
 }
 
 function parsePositiveInt(value: string | undefined, fallback: number): number {
@@ -23,7 +21,6 @@ export function getRetentionConfig(): RetentionConfig {
   return {
     apiMetricsDays: parsePositiveInt(process.env.RETENTION_API_METRICS_DAYS, DEFAULT_API_METRICS_DAYS),
     systemLogsDays: parsePositiveInt(process.env.RETENTION_SYSTEM_LOGS_DAYS, DEFAULT_SYSTEM_LOGS_DAYS),
-    securityAuditDays: parsePositiveInt(process.env.RETENTION_SECURITY_AUDIT_DAYS, DEFAULT_SECURITY_AUDIT_DAYS),
   };
 }
 
@@ -49,21 +46,14 @@ export async function cleanupSystemLogs(opts: { retentionDays: number }): Promis
   return { table: 'system_logs', deleted: result.length };
 }
 
-export async function cleanupSecurityAuditLog(opts: { retentionDays: number }): Promise<CleanupResult> {
-  const cutoff = getRetentionCutoff(opts.retentionDays);
-  const result = await db
-    .delete(securityAuditLog)
-    .where(lt(securityAuditLog.timestamp, cutoff))
-    .returning({ id: securityAuditLog.id });
-  return { table: 'security_audit_log', deleted: result.length };
-}
+// security_audit_log is intentionally excluded — tamper-evident hash chain
+// requires infinite retention to preserve chain integrity for verification.
 
 export async function runMonitoringRetentionCleanup(): Promise<CleanupResult[]> {
   const config = getRetentionConfig();
   const results = await Promise.all([
     cleanupApiMetrics({ retentionDays: config.apiMetricsDays }),
     cleanupSystemLogs({ retentionDays: config.systemLogsDays }),
-    cleanupSecurityAuditLog({ retentionDays: config.securityAuditDays }),
   ]);
   return results;
 }

--- a/packages/lib/src/compliance/retention/retention-engine.test.ts
+++ b/packages/lib/src/compliance/retention/retention-engine.test.ts
@@ -31,7 +31,6 @@ vi.mock('./monitoring-retention', () => ({
   runMonitoringRetentionCleanup: vi.fn().mockResolvedValue([
     { table: 'api_metrics', deleted: 0 },
     { table: 'system_logs', deleted: 0 },
-    { table: 'security_audit_log', deleted: 0 },
   ]),
 }));
 
@@ -227,12 +226,12 @@ describe('cleanupExpiredAiUsageLogs', () => {
 });
 
 describe('runRetentionCleanup', () => {
-  it('given_allCleanupsSucceed_returnsResultsForAll12Tables', async () => {
+  it('given_allCleanupsSucceed_returnsResultsForAll11Tables', async () => {
     const { db } = createMockDb([]);
 
     const results = await runRetentionCleanup(db);
 
-    expect(results).toHaveLength(12);
+    expect(results).toHaveLength(11);
   });
 
   it('given_allCleanupsSucceed_includesBothExpiryAndMonitoringTables', async () => {
@@ -249,7 +248,6 @@ describe('runRetentionCleanup', () => {
       'page_permissions',
       'page_versions',
       'pulse_summaries',
-      'security_audit_log',
       'sessions',
       'socket_tokens',
       'system_logs',

--- a/prototypes/pagespace-endgame/src/components/panes/CompliancePane.tsx
+++ b/prototypes/pagespace-endgame/src/components/panes/CompliancePane.tsx
@@ -161,19 +161,22 @@ export function CompliancePane() {
           </p>
         </Card>
         <Card accent="amber">
-          <h4>PII scrubber &amp; orphan cleanup</h4>
+          <h4>PII scrubber</h4>
           <p style={{ marginTop: 6, fontSize: 12 }}>
             PII scrubbing utility exists (email, phone, SSN, credit card with
             Luhn validation) but is{" "}
             <strong style={{ color: "var(--amber)" }}>
               not yet integrated into the AI logging pipeline
             </strong>
-            . File orphan detection endpoint built (finds zero-reference files,
-            deletes via processor service) but{" "}
-            <strong style={{ color: "var(--amber)" }}>
-              not yet on the cron schedule
-            </strong>
             .
+          </p>
+        </Card>
+        <Card accent="green">
+          <h4>Orphaned file cleanup</h4>
+          <p style={{ marginTop: 6, fontSize: 12 }}>
+            Cron job detects orphaned files (zero references across filePages,
+            channelMessages, and pages), deletes physical files via processor
+            service, then removes DB records. Runs weekly on Sundays at 5am UTC.
           </p>
         </Card>
       </div>

--- a/prototypes/pagespace-endgame/src/components/panes/CompliancePane.tsx
+++ b/prototypes/pagespace-endgame/src/components/panes/CompliancePane.tsx
@@ -175,8 +175,9 @@ export function CompliancePane() {
           <h4>Orphaned file cleanup</h4>
           <p style={{ marginTop: 6, fontSize: 12 }}>
             Cron job detects orphaned files (zero references across filePages,
-            channelMessages, and pages), deletes physical files via processor
-            service, then removes DB records. Runs weekly on Sundays at 5am UTC.
+            channelMessages, and pages), attempts physical deletion via the
+            processor service, then removes DB records only for files whose
+            physical deletion succeeded. Runs weekly on Sundays at 5am UTC.
           </p>
         </Card>
       </div>

--- a/prototypes/pagespace-endgame/src/components/panes/DatabasePane.tsx
+++ b/prototypes/pagespace-endgame/src/components/panes/DatabasePane.tsx
@@ -172,17 +172,19 @@ export function DatabasePane() {
         {/* RIGHT SIDEBAR: current details */}
         <div>
           <div style={{ fontSize: 9, fontWeight: 600, letterSpacing: 1.5, color: "var(--amber)", textTransform: "uppercase" as CSSProperties["textTransform"], marginBottom: 10 }}>
-            8 Cron Jobs
+            10 Cron Jobs
           </div>
           <div style={{ background: "var(--s1)", border: "1px solid var(--border)", borderRadius: 10, padding: "10px 12px", marginBottom: 14 }}>
             <CronJob schedule="*/5 min" name="Calendar sync" endpoint="/api/cron/calendar-sync" />
             <CronJob schedule="*/5 min" name="Workflows" endpoint="/api/cron/workflows" />
             <CronJob schedule="hourly" name="Token cleanup" endpoint="/api/cron/cleanup-tokens" />
             <CronJob schedule="*/6h" name="Pulse" endpoint="/api/pulse/cron" />
+            <CronJob schedule="1am" name="Retention cleanup" endpoint="/api/cron/retention-cleanup" />
             <CronJob schedule="2am" name="Audit verify" endpoint="/api/cron/verify-audit-chain" />
             <CronJob schedule="3am" name="AI log purge" endpoint="/api/cron/purge-ai-usage-logs" />
             <CronJob schedule="4am" name="Msg purge" endpoint="/api/cron/purge-deleted-messages" />
             <CronJob schedule="6am" name="Memory" endpoint="/api/memory/cron" />
+            <CronJob schedule="Sun 5am" name="Orphan cleanup" endpoint="/api/cron/cleanup-orphaned-files" />
           </div>
 
           <div style={{ fontSize: 9, fontWeight: 600, letterSpacing: 1.5, color: "var(--cyan)", textTransform: "uppercase" as CSSProperties["textTransform"], marginBottom: 10 }}>

--- a/prototypes/pagespace-endgame/src/components/panes/GdprPane.tsx
+++ b/prototypes/pagespace-endgame/src/components/panes/GdprPane.tsx
@@ -89,7 +89,7 @@ export function GdprPane() {
         <Feature
           nameColor="var(--green)"
           name="File orphan cleanup"
-          description="Cron job detects orphaned files (zero references), deletes physical files via processor service, then removes DB records. Content-addressed store cleanup."
+          description="Cron job detects orphaned files (zero references), attempts physical deletion via processor service, then removes DB records only for successfully deleted files. Content-addressed store cleanup."
           style={{ padding: "16px 14px", fontSize: 14 }}
         />
       </FeatureRow>


### PR DESCRIPTION
## Summary

- Two cron endpoints (`/api/cron/retention-cleanup` and `/api/cron/cleanup-orphaned-files`) were fully implemented and authenticated but **never scheduled** in the Docker crontab — expired personal data and orphaned files accumulated indefinitely
- Adds **retention-cleanup** at 1 AM UTC daily: cleans expired sessions, tokens, page versions, drive backups, permissions, and monitoring data
- Adds **orphaned file cleanup** at 5 AM UTC Sundays: detects file records with zero references and deletes physical files via processor service
- **Removes `security_audit_log` from retention cleanup** — the tamper-evident SHA-256 hash chain requires infinite retention since the chain verifier treats any gap as tampering (no gap-aware mode)
- **Fixes non-atomic orphan delete path**: DB records are now only removed for orphans whose physical files were successfully deleted; failed ones retry on the next weekly run
- Updates endgame prototype: DatabasePane shows 10 cron jobs, CompliancePane promotes orphan cleanup from amber to green

## Changes

| File | Change |
|------|--------|
| `docker/cron/crontab` | 2 new cron entries |
| `packages/lib/src/compliance/retention/monitoring-retention.ts` | Remove `cleanupSecurityAuditLog()` for infinite hash chain retention |
| `packages/lib/src/compliance/retention/monitoring-retention.test.ts` | Remove security audit log test cases |
| `packages/lib/src/compliance/retention/retention-engine.test.ts` | Update expected table counts (12→11) |
| `apps/web/src/app/api/cron/cleanup-orphaned-files/route.ts` | Gate DB deletion on successful physical delete |
| `prototypes/pagespace-endgame/src/components/panes/DatabasePane.tsx` | Add 2 cron jobs, update count 8→10 |
| `prototypes/pagespace-endgame/src/components/panes/CompliancePane.tsx` | Split PII/orphan card, orphan now green |

## Test plan

- [x] Retention and monitoring-retention tests pass (31/31)
- [x] TypeScript check passes for packages/lib
- [ ] Verify crontab syntax is valid
- [ ] Deploy to staging and confirm both endpoints respond to cron-curl with 200
- [ ] Check `/var/log/cron/retention-cleanup.log` and `/var/log/cron/orphan-cleanup.log` populate after schedule fires
- [ ] Confirm existing cron jobs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated daily retention cleanup (1:00am UTC) and weekly orphaned-file cleanup (Sunday 5:00am UTC) cron tasks; UI updated to show both jobs and a new "Orphaned file cleanup" card.

* **Bug Fixes / Behavior Changes**
  * Orphaned-file cleanup now only removes database records when physical deletions succeed.
  * Security audit log removed from automated retention cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->