### PR TITLE
docs: update stale compliance doc and prototype panes

### DIFF
--- a/docs/security/compliance-sovereignty-analysis.md
+++ b/docs/security/compliance-sovereignty-analysis.md
@@ -139,18 +139,24 @@ qualifying "local models only" is dangerous.
 ### 1.2. AI Usage Logging → Right to Erasure / GDPR Article 17
 
 **What happens**: Every AI interaction logs the first 1000 characters of the
-user's prompt and the AI's response to the `ai_usage_logs` table. This data is
-stored indefinitely with no automatic retention policy or deletion mechanism.
+user's prompt and the AI's response to the `ai_usage_logs` table.
 
-**Why it's incompatible**:
-- No TTL or automatic purge on `ai_usage_logs`
-- No API endpoint to delete a user's AI usage history
+**Status — partially resolved**:
+- ~~Account deletion does NOT purge these logs~~ → **Fixed**: `deleteAiUsageLogsForUser()` purges on account deletion
+- ~~No API endpoint to delete a user's AI usage history~~ → **Fixed**: account deletion handles this via FK cascade
+- ~~Conversation messages retained indefinitely~~ → **Fixed**: 30-day purge cron for soft-deleted messages + FK cascade on account deletion
+
+**Remaining gaps**:
+- No TTL or automatic purge on `ai_usage_logs` for non-deleted accounts (logs accumulate indefinitely while account is active)
 - No mechanism to selectively redact prompt/completion content
-- Account deletion does NOT purge these logs
-- Conversation `messages` table retains full message content indefinitely
 
-**Affected compliance regimes**: GDPR Article 17 (right to erasure), CCPA
-(right to delete), any "right to be forgotten" regulation.
+**Severity**: Downgraded from hard incompatibility to modification-required.
+Account deletion now satisfies Art. 17 for erasure requests. The remaining gap
+is retention minimization for active accounts.
+
+**Affected compliance regimes**: GDPR Article 17 (right to erasure — now
+partially satisfied), CCPA (right to delete — satisfied on account deletion),
+data minimization (active account retention still unbounded).
 
 **Key files**:
 - `packages/db/src/schema/monitoring.ts` (lines 144-203: `ai_usage_logs` schema)
@@ -222,34 +228,42 @@ residency, any regime requiring all PII processing to be on-premise.
 These features work today but would need changes to pass audits in regulated
 environments.
 
-### 2.1. No Data Retention Policy Engine
+### 2.1. No Data Retention Policy Engine (Partial)
 
-**Current state**: No automatic data expiration exists for:
-- AI usage logs (indefinite)
-- Conversation messages (indefinite, soft-delete only via `isActive` flag)
-- Activity/audit logs (indefinite)
-- Client analytics events (indefinite)
-- Security audit logs (indefinite)
+**Current state**: Retention exists for some data categories but not all:
+- ~~AI usage logs (indefinite)~~ → **Partial**: purged on account deletion; no TTL for active accounts
+- ~~Conversation messages (indefinite)~~ → **Fixed**: 30-day purge cron for soft-deleted messages + FK cascade on account deletion
+- Sessions and tokens → **Fixed**: TTL-based cleanup on cron schedule
+- Page versions → **Fixed**: 30-day auto-retention with pinnable exemptions
+- AI logs → **Fixed**: anonymize at 30 days, purge at 90 days (configurable via `AI_LOG_RETENTION_DAYS`)
+- Activity/audit logs (indefinite — no retention policy)
+- Client analytics events (indefinite — no retention policy)
+- Security audit logs (indefinite — no retention policy)
 
-**What's needed**: Configurable retention windows with automatic purge jobs.
-Most compliance frameworks require documented retention schedules.
+**What's needed**: Configurable retention windows for the remaining categories
+(activity logs, analytics, security audit logs) and admin configuration UI.
 
-**Effort**: Medium. Requires cron jobs and admin configuration UI.
+**Effort**: Medium. Core retention engine and cron infrastructure exists; needs
+extension to remaining data categories and admin-facing configuration.
 
 ---
 
-### 2.2. Incomplete Data Subject Access / Export
+### 2.2. ~~Incomplete Data Subject Access / Export~~ → RESOLVED
 
-**Current state**: No mechanism exists for a user to:
-- Export all their personal data (GDPR Article 15 / CCPA right to know)
-- See which third parties received their data
-- Download their conversation history, uploaded files, or activity logs
+**Current state**: Data subject access and export is implemented:
+- **User DSAR export**: `GET /api/account/export` — ZIP archive with JSON files
+  covering profile, drives, pages, messages, files metadata, activity logs,
+  AI usage logs, and tasks. Rate-limited to 1 export per 24 hours.
+- **Admin DSAR endpoint**: `GET /api/admin/users/[userId]/export` — admin-only
+  endpoint for processing data subject access requests. Logs which admin
+  accessed which user's data for audit trail.
 
-**What's needed**: Data export endpoint that packages all user data in a
-portable format (JSON/ZIP).
+**Remaining gap**: No "which third parties received data" view — users cannot
+see a summary of which AI providers, integrations, or external services
+processed their data.
 
-**Effort**: Medium-high. Requires aggregating data across multiple tables and
-file storage.
+**Effort**: Low for the remaining gap (query integration credentials +
+AI usage logs by provider).
 
 ---
 
@@ -365,14 +379,21 @@ accessed, retention limits for cached calendar data, and token revocation UI.
 
 ---
 
-### 2.9. Security Audit Log Integrity Verification
+### 2.9. Security Audit Log Integrity Verification (Partially Resolved)
 
-**Current state**: Tamper-evident hash chain exists in `security_audit_log` but
-no automated verification process runs to detect tampering.
+**Current state**: Security audit chain integrity is now verified automatically:
+- **Fixed (#541)**: Hash chain GDPR-safe — PII fields excluded from hash
+  computation so anonymization doesn't break the chain
+- **Fixed**: Daily verification cron (`/api/cron/verify-audit-chain`) recomputes
+  hashes and verifies chain links. HMAC-signed cron requests. Pluggable
+  `ChainAlertHandler` for Slack/email/PagerDuty alerting.
 
-**What's needed**: Periodic chain integrity verification job with alerting.
+**Remaining gap**: Activity log hash chain still broken by anonymization — PII
+fields are included in `serializeLogDataForHash()`. Fix in progress on branch
+`pu/hash-chain-pii`.
 
-**Effort**: Low. The infrastructure exists; needs a cron job.
+**Effort**: Low. Security audit chain is done; activity log chain fix follows
+the same pattern.
 
 ---
 
@@ -459,11 +480,12 @@ Every path where data leaves the PageSpace deployment boundary.
 
 ### P1 — Required for GDPR/CCPA readiness
 
-4. **Build data subject export endpoint** — Users cannot export their data today.
+4. ~~**Build data subject export endpoint**~~ — **DONE**. `GET /api/account/export`
+   (user) and `GET /api/admin/users/[userId]/export` (admin DSAR). ZIP with JSON.
 5. **Add consent management for AI providers** — No disclosure or consent record
    when selecting external AI providers.
-6. **Implement conversation message hard-delete** — Only soft-delete (`isActive`)
-   exists today.
+6. ~~**Implement conversation message hard-delete**~~ — **DONE**. 30-day purge cron
+   hard-deletes soft-deleted messages. FK cascade on account deletion.
 7. **Document data retention schedules** — No formal retention policy exists for
    any data category.
 
@@ -540,10 +562,10 @@ When entering compliance or white-label conversations, use this framing:
 - "Payment processing" — only relevant for SaaS mode, not on-prem
 
 **Do not promise without engineering work**:
-- GDPR right-to-erasure compliance (file deletion gap)
-- Data subject export / portability
-- Configurable data retention policies
-- Formal audit log integrity verification
+- GDPR right-to-erasure compliance (file deletion gap remains — DB erasure is done)
+- ~~Data subject export / portability~~ → **Resolved**: DSAR export endpoints exist
+- Configurable data retention policies (partial — AI logs and messages have retention; activity/analytics/audit logs do not)
+- ~~Formal audit log integrity verification~~ → **Resolved**: daily verification cron with alerting (activity log chain fix in progress)
 - Database encryption at rest (TDE needed for regulated industries)
 
 **Never promise** (without fundamental changes):

--- a/docs/security/compliance-sovereignty-analysis.md
+++ b/docs/security/compliance-sovereignty-analysis.md
@@ -142,9 +142,9 @@ qualifying "local models only" is dangerous.
 user's prompt and the AI's response to the `ai_usage_logs` table.
 
 **Status — partially resolved**:
-- ~~Account deletion does NOT purge these logs~~ → **Fixed**: `deleteAiUsageLogsForUser()` purges on account deletion
-- ~~No API endpoint to delete a user's AI usage history~~ → **Fixed**: account deletion handles this via FK cascade
-- ~~Conversation messages retained indefinitely~~ → **Fixed**: 30-day purge cron for soft-deleted messages + FK cascade on account deletion
+- ~~Account deletion does NOT purge these logs~~ → **Fixed**: `deleteAiUsageLogsForUser()` explicitly purges on account deletion (no FK cascade — manual deletion is the only path)
+- ~~No API endpoint to delete a user's AI usage history~~ → **Fixed**: account deletion handles this via explicit purge call
+- ~~Conversation messages retained indefinitely~~ → **Fixed**: 30-day purge cron hard-deletes soft-deleted messages; account deletion cascade removes user-owned messages. **Note**: shared-page assistant messages saved with `userId: null` survive account deletion and may contain user-derived content.
 
 **Remaining gaps**:
 - No TTL or automatic purge on `ai_usage_logs` for non-deleted accounts (logs accumulate indefinitely while account is active)
@@ -379,21 +379,18 @@ accessed, retention limits for cached calendar data, and token revocation UI.
 
 ---
 
-### 2.9. Security Audit Log Integrity Verification (Partially Resolved)
+### 2.9. ~~Security Audit Log Integrity Verification~~ → RESOLVED
 
-**Current state**: Security audit chain integrity is now verified automatically:
-- **Fixed (#541)**: Hash chain GDPR-safe — PII fields excluded from hash
+**Current state**: Both hash chains are now integrity-verified and GDPR-safe:
+- **Fixed (#541)**: Security audit hash chain — PII fields excluded from hash
   computation so anonymization doesn't break the chain
+- **Fixed (#866)**: Activity log hash chain — PII fields excluded from hash
+  computation (matching security audit pattern)
+- **Fixed (#867)**: Activity log writes now serialized with
+  `pg_advisory_xact_lock`, preventing chain forking on concurrent writes
 - **Fixed**: Daily verification cron (`/api/cron/verify-audit-chain`) recomputes
   hashes and verifies chain links. HMAC-signed cron requests. Pluggable
   `ChainAlertHandler` for Slack/email/PagerDuty alerting.
-
-**Remaining gap**: Activity log hash chain still broken by anonymization — PII
-fields are included in `serializeLogDataForHash()`. Fix in progress on branch
-`pu/hash-chain-pii`.
-
-**Effort**: Low. Security audit chain is done; activity log chain fix follows
-the same pattern.
 
 ---
 
@@ -491,9 +488,11 @@ Every path where data leaves the PageSpace deployment boundary.
 
 ### P2 — Required for SOC 2 / enterprise sales
 
-8. **Add audit log integrity verification cron** — Hash chain exists but is never
-   verified.
-9. **Standardize bcrypt cost factor** — Minor inconsistency (cost 10 vs 12).
+8. ~~**Add audit log integrity verification cron**~~ — **RESOLVED**. Daily
+   verification cron exists with alerting. Both security audit and activity log
+   chains are now GDPR-safe and serialized (#541, #866, #867).
+9. ~~**Standardize bcrypt cost factor**~~ — **N/A**. Password-based authentication
+   removed entirely (#861).
 10. **Add AI provider DPA references** — Link to each provider's data processing
     terms.
 
@@ -565,7 +564,7 @@ When entering compliance or white-label conversations, use this framing:
 - GDPR right-to-erasure compliance (file deletion gap remains — DB erasure is done)
 - ~~Data subject export / portability~~ → **Resolved**: DSAR export endpoints exist
 - Configurable data retention policies (partial — AI logs and messages have retention; activity/analytics/audit logs do not)
-- ~~Formal audit log integrity verification~~ → **Resolved**: daily verification cron with alerting (activity log chain fix in progress)
+- ~~Formal audit log integrity verification~~ → **Resolved**: daily verification cron with alerting; both chains GDPR-safe and serialized (#541, #866, #867)
 - Database encryption at rest (TDE needed for regulated industries)
 
 **Never promise** (without fundamental changes):

--- a/docs/security/compliance-sovereignty-analysis.md
+++ b/docs/security/compliance-sovereignty-analysis.md
@@ -522,7 +522,7 @@ to be stripped or replaced for a compliance-clean on-premise deployment:
 |---------------|----------------------|--------|-------|
 | Stripe billing | Remove entirely, or license-key model | Low-medium | No billing needed for single-tenant on-prem |
 | Resend email | Self-hosted SMTP (Postfix, etc.) | Medium | Only needed if email verification is required |
-| Google OAuth | Remove; use local email+password auth only | Low | Original auth system already exists |
+| Google OAuth | Remove; use magic links + passkeys | Low | Password auth removed (#861); on-prem uses magic links |
 | Google One Tap | Remove | Trivial | UI-only removal |
 | Google Calendar | Remove | Low | Optional integration |
 | Cloud AI providers | Remove from config; Ollama/LM Studio only | Low | Provider factory already supports this |

--- a/prototypes/pagespace-endgame/src/components/panes/CompliancePane.tsx
+++ b/prototypes/pagespace-endgame/src/components/panes/CompliancePane.tsx
@@ -341,7 +341,10 @@ export function CompliancePane() {
             stored <code>logHash</code>. Security audit chain is{" "}
             <strong style={{ color: "var(--green)" }}>fixed (#541)</strong>
             {" "}&mdash; PII fields excluded from hash computation so the
-            chain remains valid after GDPR anonymization.
+            chain remains valid after GDPR anonymization.{" "}
+            <strong style={{ color: "var(--amber)" }}>
+              Activity log fix in progress (pu/hash-chain-pii).
+            </strong>
           </p>
         </Card>
       </div>
@@ -351,7 +354,10 @@ export function CompliancePane() {
           <p style={{ marginTop: 6, fontSize: 12 }}>
             The 1-export-per-24-hours DSAR rate limit uses an in-process{" "}
             <code>Map()</code>. Resets on deploy/restart. Not shared across
-            instances. Works for single instance but won&apos;t scale.
+            instances. Works for single instance but won&apos;t scale.{" "}
+            <strong style={{ color: "var(--amber)" }}>
+              Fix in progress (pu/export-rate-limit).
+            </strong>
           </p>
         </Card>
       </div>
@@ -462,7 +468,7 @@ export function CompliancePane() {
         <Feature
           nameColor="var(--cyan)"
           name="Hash-chain-safe anonymization"
-          description="Anonymization that preserves chain link integrity. Hash computed over anonymization-stable fields only, or chain links maintained through the anonymization process."
+          description="Anonymization that preserves chain link integrity. Hash computed over anonymization-stable fields only, or chain links maintained through the anonymization process. In progress (pu/hash-chain-pii)."
           style={{ padding: "16px 14px", fontSize: 14 }}
         />
       </FeatureRow>
@@ -482,7 +488,7 @@ export function CompliancePane() {
         <Feature
           nameColor="var(--cyan)"
           name="Distributed export rate limit"
-          description="Redis-backed export rate limiting (matching existing auth rate limiter pattern). Shared across instances. Survives deploys."
+          description="Redis-backed export rate limiting (matching existing auth rate limiter pattern). Shared across instances. Survives deploys. In progress (pu/export-rate-limit)."
           style={{ padding: "16px 14px", fontSize: 14 }}
         />
       </FeatureRow>

--- a/prototypes/pagespace-endgame/src/components/panes/CompliancePane.tsx
+++ b/prototypes/pagespace-endgame/src/components/panes/CompliancePane.tsx
@@ -241,19 +241,21 @@ export function CompliancePane() {
       </h2>
       <p style={{ marginBottom: 20, maxWidth: 720 }}>
         The security infrastructure is solid but has coverage gaps.
-        The SIEM adapter is built but not wired. The security audit
-        service covers ~1.6% of routes. The activity log hash chain has
-        a known fork vulnerability. Agent-level security is missing entirely.
+        The SIEM adapter is built but not wired. Audit service coverage
+        expanded to pages, drives, permissions, settings, account, files,
+        and export routes (#868-870) but not yet 100%. Agent-level security
+        is missing entirely.
       </p>
 
       <div className="g2" style={{ marginBottom: 8 }}>
-        <Card accent="red">
-          <h4>SecurityAuditService: ~5 of 252 routes (~2%)</h4>
+        <Card accent="amber">
+          <h4>SecurityAuditService: expanded but not 100%</h4>
           <p style={{ marginTop: 6, fontSize: 12 }}>
-            Hash chain audit service exists with advisory lock serialization
-            and 35 event types. But only wired to login, logout, and mobile
-            login routes. Core operations (pages, drives, files, permissions,
-            settings, admin actions) are not security-audited.
+            Hash chain audit service with advisory lock serialization and
+            35 event types. Now wired to auth, pages, drives, permissions,
+            settings, account, files, and export routes (#868-870).
+            Remaining: admin actions, trash, invitations, and other
+            secondary routes.
           </p>
         </Card>
         <Card accent="red">
@@ -268,15 +270,14 @@ export function CompliancePane() {
         </Card>
       </div>
       <div className="g2" style={{ marginBottom: 8 }}>
-        <Card accent="red">
-          <h4>Activity log hash chain can fork</h4>
+        <Card accent="green">
+          <h4>Activity log hash chain &mdash; Fixed</h4>
           <p style={{ marginTop: 6, fontSize: 12 }}>
-            Activity log writes not serialized with row locking. Concurrent
-            writes can create chain forks. Security audit chain uses
-            advisory locks and is safe. Activity logs have hash chain fields
-            (<code>previousLogHash</code>, <code>logHash</code>,{" "}
-            <code>chainSeed</code>) but no locking to prevent concurrent
-            forking.
+            Activity log writes now serialized with{" "}
+            <code>pg_advisory_xact_lock</code> (#867), matching the
+            security audit chain pattern. Chain forking on concurrent
+            writes is prevented. PII excluded from hash computation
+            (#866) so GDPR anonymization preserves chain integrity.
           </p>
         </Card>
         <Card accent="red">
@@ -332,32 +333,21 @@ export function CompliancePane() {
         </Card>
       </div>
       <div className="g2" style={{ marginBottom: 8 }}>
-        <Card accent="amber">
-          <h4>Activity log hash chain broken by anonymization</h4>
+        <Card accent="green">
+          <h4>Activity log hash chain &mdash; Fixed</h4>
           <p style={{ marginTop: 6, fontSize: 12 }}>
-            Account deletion anonymizes <code>actorEmail</code> in activity
-            logs, but this field is included in{" "}
-            <code>serializeLogDataForHash()</code> &mdash; invalidating the
-            stored <code>logHash</code>. Security audit chain is{" "}
-            <strong style={{ color: "var(--green)" }}>fixed (#541)</strong>
-            {" "}&mdash; PII fields excluded from hash computation so the
-            chain remains valid after GDPR anonymization.{" "}
-            <strong style={{ color: "var(--amber)" }}>
-              Activity log fix in progress (pu/hash-chain-pii).
-            </strong>
+            Both security audit (#541) and activity log (#866) chains now
+            exclude PII from hash computation &mdash; GDPR anonymization
+            preserves chain integrity. Activity log writes serialized with{" "}
+            <code>pg_advisory_xact_lock</code> (#867).
           </p>
         </Card>
-      </div>
-      <div className="g2" style={{ marginBottom: 8 }}>
-        <Card accent="amber">
-          <h4>Export rate limit is in-memory</h4>
+        <Card accent="green">
+          <h4>Export rate limit &mdash; Fixed</h4>
           <p style={{ marginTop: 6, fontSize: 12 }}>
-            The 1-export-per-24-hours DSAR rate limit uses an in-process{" "}
-            <code>Map()</code>. Resets on deploy/restart. Not shared across
-            instances. Works for single instance but won&apos;t scale.{" "}
-            <strong style={{ color: "var(--amber)" }}>
-              Fix in progress (pu/export-rate-limit).
-            </strong>
+            DSAR export rate limit migrated to distributed Redis (#865).
+            Shared across instances, survives deploys/restarts. Matches
+            existing auth rate limiter pattern.
           </p>
         </Card>
       </div>
@@ -384,7 +374,7 @@ export function CompliancePane() {
         <Feature
           nameColor="var(--cyan)"
           name="100% audit coverage"
-          description="Wire SecurityAuditService to all security-relevant routes. Every page CRUD, permission change, file upload, admin action produces an immutable audit event. 35 event types already defined &mdash; just need wiring."
+          description="SecurityAuditService now covers auth, pages, drives, permissions, settings, account, files, and export (#868-870). Remaining: admin actions, trash, invitations, and secondary routes."
           style={{ padding: "16px 14px", fontSize: 14 }}
         />
         <Feature
@@ -395,8 +385,8 @@ export function CompliancePane() {
         />
         <Feature
           nameColor="var(--cyan)"
-          name="Fix chain integrity"
-          description="Add pg_advisory_xact_lock serialization to activity log hash chain writes (matching security audit pattern). Add GeoIP integration to replace IP prefix heuristic in anomaly detection."
+          name="Fix chain integrity — Done"
+          description="Activity log hash chain writes serialized with pg_advisory_xact_lock (#867). PII excluded from hash computation (#866). Both chains GDPR-safe. Remaining: GeoIP integration to replace IP prefix heuristic in anomaly detection."
           style={{ padding: "16px 14px", fontSize: 14 }}
         />
       </FeatureRow>
@@ -467,8 +457,8 @@ export function CompliancePane() {
         />
         <Feature
           nameColor="var(--cyan)"
-          name="Hash-chain-safe anonymization"
-          description="Anonymization that preserves chain link integrity. Hash computed over anonymization-stable fields only, or chain links maintained through the anonymization process. In progress (pu/hash-chain-pii)."
+          name="Hash-chain-safe anonymization — Done"
+          description="Implemented: PII fields excluded from hash computation in both security audit (#541) and activity log (#866) chains. Writes serialized with advisory locks (#867). Anonymization preserves chain integrity."
           style={{ padding: "16px 14px", fontSize: 14 }}
         />
       </FeatureRow>
@@ -487,8 +477,8 @@ export function CompliancePane() {
         />
         <Feature
           nameColor="var(--cyan)"
-          name="Distributed export rate limit"
-          description="Redis-backed export rate limiting (matching existing auth rate limiter pattern). Shared across instances. Survives deploys. In progress (pu/export-rate-limit)."
+          name="Distributed export rate limit — Done"
+          description="Implemented (#865): Redis-backed export rate limiting matching existing auth rate limiter pattern. Shared across instances, survives deploys."
           style={{ padding: "16px 14px", fontSize: 14 }}
         />
       </FeatureRow>

--- a/prototypes/pagespace-endgame/src/components/panes/CompliancePane.tsx
+++ b/prototypes/pagespace-endgame/src/components/panes/CompliancePane.tsx
@@ -45,6 +45,17 @@ export function CompliancePane() {
         </Card>
       </div>
 
+      <Card accent="green" style={{ marginBottom: 16 }}>
+        <h4>Activity log hash chain integrity</h4>
+        <p style={{ marginTop: 6, fontSize: 12 }}>
+          Activity log writes serialized with{" "}
+          <code>pg_advisory_xact_lock</code> (#867), matching the security
+          audit chain pattern. PII fields excluded from hash computation
+          (#866) so GDPR anonymization preserves chain integrity. Both
+          chains are now tamper-evident and GDPR-safe.
+        </p>
+      </Card>
+
       <h3 style={{ marginBottom: 12 }}>Activity logs</h3>
       <div className="g2" style={{ marginBottom: 16 }}>
         <Card accent="green">
@@ -129,8 +140,9 @@ export function CompliancePane() {
           <p style={{ marginTop: 6, fontSize: 12 }}>
             User DSAR export (<code>GET /api/account/export</code>): ZIP
             archive with JSON files for profile, drives, pages, messages,
-            files metadata, activity logs, AI usage logs, tasks. Rate-limited
-            to 1 per 24 hours. Admin DSAR endpoint
+            files metadata, activity logs, AI usage logs, tasks. Distributed
+            Redis-backed rate limit (1 per 24 hours, survives deploys).
+            Admin DSAR endpoint
             (<code>GET /api/admin/users/[userId]/export</code>) with
             security audit logging of which admin accessed which user&apos;s data.
           </p>
@@ -269,28 +281,16 @@ export function CompliancePane() {
           </p>
         </Card>
       </div>
-      <div className="g2" style={{ marginBottom: 8 }}>
-        <Card accent="green">
-          <h4>Activity log hash chain &mdash; Fixed</h4>
-          <p style={{ marginTop: 6, fontSize: 12 }}>
-            Activity log writes now serialized with{" "}
-            <code>pg_advisory_xact_lock</code> (#867), matching the
-            security audit chain pattern. Chain forking on concurrent
-            writes is prevented. PII excluded from hash computation
-            (#866) so GDPR anonymization preserves chain integrity.
-          </p>
-        </Card>
-        <Card accent="red">
-          <h4>No agent-specific audit trails</h4>
-          <p style={{ marginTop: 6, fontSize: 12 }}>
-            Security audit is user-centric. When an agent makes a change,
-            it&apos;s attributed to the user who triggered it, not the agent.
-            Activity logs track <code>isAiGenerated</code> and AI model,
-            but can&apos;t answer: &ldquo;what did agent X do across all
-            conversations?&rdquo;
-          </p>
-        </Card>
-      </div>
+      <Card accent="red" style={{ marginBottom: 8 }}>
+        <h4>No agent-specific audit trails</h4>
+        <p style={{ marginTop: 6, fontSize: 12 }}>
+          Security audit is user-centric. When an agent makes a change,
+          it&apos;s attributed to the user who triggered it, not the agent.
+          Activity logs track <code>isAiGenerated</code> and AI model,
+          but can&apos;t answer: &ldquo;what did agent X do across all
+          conversations?&rdquo;
+        </p>
+      </Card>
       <div className="g2" style={{ marginBottom: 8 }}>
         <Card accent="amber">
           <h4>Capability gates: tools + pages, no budgets</h4>
@@ -332,25 +332,6 @@ export function CompliancePane() {
           </p>
         </Card>
       </div>
-      <div className="g2" style={{ marginBottom: 8 }}>
-        <Card accent="green">
-          <h4>Activity log hash chain &mdash; Fixed</h4>
-          <p style={{ marginTop: 6, fontSize: 12 }}>
-            Both security audit (#541) and activity log (#866) chains now
-            exclude PII from hash computation &mdash; GDPR anonymization
-            preserves chain integrity. Activity log writes serialized with{" "}
-            <code>pg_advisory_xact_lock</code> (#867).
-          </p>
-        </Card>
-        <Card accent="green">
-          <h4>Export rate limit &mdash; Fixed</h4>
-          <p style={{ marginTop: 6, fontSize: 12 }}>
-            DSAR export rate limit migrated to distributed Redis (#865).
-            Shared across instances, survives deploys/restarts. Matches
-            existing auth rate limiter pattern.
-          </p>
-        </Card>
-      </div>
 
       <hr />
 
@@ -385,8 +366,8 @@ export function CompliancePane() {
         />
         <Feature
           nameColor="var(--cyan)"
-          name="Fix chain integrity — Done"
-          description="Activity log hash chain writes serialized with pg_advisory_xact_lock (#867). PII excluded from hash computation (#866). Both chains GDPR-safe. Remaining: GeoIP integration to replace IP prefix heuristic in anomaly detection."
+          name="GeoIP anomaly detection"
+          description="Replace IP prefix heuristic in anomaly detection with real GeoIP integration. Geographic distance-based impossible travel detection instead of /16 and /48 prefix comparison."
           style={{ padding: "16px 14px", fontSize: 14 }}
         />
       </FeatureRow>
@@ -442,7 +423,7 @@ export function CompliancePane() {
       </FeatureRow>
 
       <h3 style={{ marginBottom: 12 }}>Full GDPR compliance</h3>
-      <FeatureRow columns={3}>
+      <FeatureRow columns={4}>
         <Feature
           nameColor="var(--cyan)"
           name="Cookie consent system"
@@ -457,28 +438,14 @@ export function CompliancePane() {
         />
         <Feature
           nameColor="var(--cyan)"
-          name="Hash-chain-safe anonymization — Done"
-          description="Implemented: PII fields excluded from hash computation in both security audit (#541) and activity log (#866) chains. Writes serialized with advisory locks (#867). Anonymization preserves chain integrity."
-          style={{ padding: "16px 14px", fontSize: 14 }}
-        />
-      </FeatureRow>
-      <FeatureRow columns={3}>
-        <Feature
-          nameColor="var(--cyan)"
           name="Wire PII scrubber"
-          description="Integrate existing scrubPII() into AI logging pipeline as defense-in-depth. Schedule orphan file cleanup on cron. Both implementations exist &mdash; just need wiring."
+          description="Integrate existing scrubPII() into AI logging pipeline as defense-in-depth. The utility exists and catches email, phone, SSN, credit card &mdash; just needs wiring into the logging path."
           style={{ padding: "16px 14px", fontSize: 14 }}
         />
         <Feature
           nameColor="var(--cyan)"
           name="Formal retention schedules"
           description="Documented retention period per data class with legal basis. Configurable per org. Make AI log purge thresholds (30/90 days) configurable via env vars. Automated enforcement via existing retention engine."
-          style={{ padding: "16px 14px", fontSize: 14 }}
-        />
-        <Feature
-          nameColor="var(--cyan)"
-          name="Distributed export rate limit — Done"
-          description="Implemented (#865): Redis-backed export rate limiting matching existing auth rate limiter pattern. Shared across instances, survives deploys."
           style={{ padding: "16px 14px", fontSize: 14 }}
         />
       </FeatureRow>

--- a/prototypes/pagespace-endgame/src/components/panes/GdprPane.tsx
+++ b/prototypes/pagespace-endgame/src/components/panes/GdprPane.tsx
@@ -138,8 +138,7 @@ export function GdprPane() {
       <p style={{ marginBottom: 20, maxWidth: 720 }}>
         Data subject rights (access, erasure, portability) are solid. AI
         provider consent is handled via TOS &mdash; PageSpace is an AI product.
-        The remaining gaps are cookie consent, data residency, and edge cases
-        around message deletion and hash chain integrity.
+        The remaining gaps are cookie consent and data residency.
       </p>
 
       <FeatureRow columns={2}>
@@ -157,30 +156,23 @@ export function GdprPane() {
         />
       </FeatureRow>
 
-      <Card accent="amber" style={{ marginBottom: 12 }}>
-        <h4>Activity log hash chain broken by anonymization</h4>
+      <Card accent="green" style={{ marginBottom: 12 }}>
+        <h4>Activity log hash chain &mdash; Fixed</h4>
         <p style={{ marginTop: 6, fontSize: 12 }}>
-          Account deletion anonymizes activity log entries, but this
-          changes the data that was hashed &mdash; invalidating the
-          hash chain. The tamper-evident property is compromised for
-          entries involving deleted users. Security audit chain is{" "}
-          <strong style={{ color: "var(--green)" }}>fixed (#541)</strong>
-          {" "}&mdash; PII fields excluded from hash computation.{" "}
-          <strong style={{ color: "var(--amber)" }}>
-            Activity log fix in progress (pu/hash-chain-pii).
-          </strong>
+          Both security audit and activity log hash chains are now GDPR-safe.
+          PII fields excluded from hash computation (#541, #866) so
+          anonymization preserves chain integrity. Activity log writes
+          serialized with <code>pg_advisory_xact_lock</code> (#867),
+          preventing chain forking on concurrent writes.
         </p>
       </Card>
 
-      <Card accent="amber" style={{ marginBottom: 12 }}>
-        <h4>Export rate limit is in-memory</h4>
+      <Card accent="green" style={{ marginBottom: 12 }}>
+        <h4>Export rate limit &mdash; Fixed</h4>
         <p style={{ marginTop: 6, fontSize: 12 }}>
-          The 1-export-per-24-hours rate limit uses an in-process <code>Map()</code>.
-          Resets on deploy/restart. Not shared across instances. Works for single
-          instance but won&apos;t scale.{" "}
-          <strong style={{ color: "var(--amber)" }}>
-            Fix in progress (pu/export-rate-limit).
-          </strong>
+          DSAR export rate limit migrated to distributed Redis (#865).
+          Shared across instances, survives deploys/restarts. Matches
+          existing auth rate limiter pattern.
         </p>
       </Card>
 
@@ -223,15 +215,13 @@ export function GdprPane() {
             GDPR Art. 17 right to erasure satisfied for message content.
           </p>
         </Card>
-        <Card accent="blue">
-          <h4>Hash-chain-safe anonymization</h4>
+        <Card accent="green">
+          <h4>Hash-chain-safe anonymization &mdash; Done</h4>
           <p style={{ marginTop: 6, fontSize: 12 }}>
-            Anonymization that preserves chain link integrity. Hash computed
-            over anonymization-stable fields only, or chain links explicitly
-            maintained through the anonymization process.{" "}
-            <strong style={{ color: "var(--amber)" }}>
-              In progress (pu/hash-chain-pii).
-            </strong>
+            Implemented: PII fields excluded from hash computation in both
+            security audit (#541) and activity log (#866) chains. Activity
+            log writes serialized with advisory locks (#867). Anonymization
+            preserves chain integrity.
           </p>
         </Card>
       </div>

--- a/prototypes/pagespace-endgame/src/components/panes/GdprPane.tsx
+++ b/prototypes/pagespace-endgame/src/components/panes/GdprPane.tsx
@@ -71,9 +71,9 @@ export function GdprPane() {
         <p style={{ marginTop: 6, fontSize: 12 }}>
           Messages use a two-stage deletion path: soft-delete via{" "}
           <code>isActive</code> flag, then a 30-day purge cron hard-deletes
-          the rows. On account deletion, FK cascade removes all messages
-          immediately. Satisfies GDPR Art. 17 right to erasure for message
-          content.
+          the rows. On account deletion, FK cascade removes user-owned
+          messages immediately. Note: shared-page assistant messages stored
+          with <code>userId: null</code> may survive account deletion.
         </p>
       </Card>
 
@@ -211,8 +211,9 @@ export function GdprPane() {
           <h4>Hard-delete for messages &mdash; Done</h4>
           <p style={{ marginTop: 6, fontSize: 12 }}>
             Implemented: 30-day purge cron hard-deletes soft-deleted messages.
-            FK cascade on account deletion removes all messages immediately.
-            GDPR Art. 17 right to erasure satisfied for message content.
+            FK cascade on account deletion removes user-owned messages
+            immediately. Remaining gap: shared-page assistant messages with{" "}
+            <code>userId: null</code> may persist.
           </p>
         </Card>
         <Card accent="green">

--- a/prototypes/pagespace-endgame/src/components/panes/GdprPane.tsx
+++ b/prototypes/pagespace-endgame/src/components/panes/GdprPane.tsx
@@ -26,8 +26,9 @@ export function GdprPane() {
             <code>GET /api/account/export</code> &mdash; returns a ZIP archive
             with JSON files covering all user data: profile, drives, pages,
             messages (AI chat, channels, DMs), files metadata, activity logs,
-            AI usage logs, and tasks. Rate-limited to 1 export per 24 hours.
-            Machine-readable JSON format for portability.
+            AI usage logs, and tasks. Distributed Redis-backed rate limit
+            (1 per 24 hours, survives deploys). Machine-readable JSON format
+            for portability.
           </p>
         </Card>
         <Card accent="green">
@@ -66,16 +67,27 @@ export function GdprPane() {
         </Card>
       </div>
 
-      <Card accent="green" style={{ marginBottom: 16 }}>
-        <h4>Message deletion: two-stage hard-delete</h4>
-        <p style={{ marginTop: 6, fontSize: 12 }}>
-          Messages use a two-stage deletion path: soft-delete via{" "}
-          <code>isActive</code> flag, then a 30-day purge cron hard-deletes
-          the rows. On account deletion, FK cascade removes user-owned
-          messages immediately. Note: shared-page assistant messages stored
-          with <code>userId: null</code> may survive account deletion.
-        </p>
-      </Card>
+      <div className="g2" style={{ marginBottom: 16 }}>
+        <Card accent="green">
+          <h4>Message hard-delete</h4>
+          <p style={{ marginTop: 6, fontSize: 12 }}>
+            Two-stage deletion: soft-delete via <code>isActive</code> flag,
+            then 30-day purge cron hard-deletes the rows. On account deletion,
+            FK cascade removes user-owned messages immediately. Note:
+            shared-page assistant messages with <code>userId: null</code> may
+            survive account deletion.
+          </p>
+        </Card>
+        <Card accent="green">
+          <h4>Hash chain GDPR safety</h4>
+          <p style={{ marginTop: 6, fontSize: 12 }}>
+            Both security audit and activity log hash chains exclude PII
+            from hash computation (#541, #866). Anonymization on account
+            deletion preserves chain integrity. Activity log writes
+            serialized with <code>pg_advisory_xact_lock</code> (#867).
+          </p>
+        </Card>
+      </div>
 
       <h3 style={{ marginBottom: 12 }}>Data Retention &amp; Minimization</h3>
       <FeatureRow columns={4}>
@@ -156,26 +168,6 @@ export function GdprPane() {
         />
       </FeatureRow>
 
-      <Card accent="green" style={{ marginBottom: 12 }}>
-        <h4>Activity log hash chain &mdash; Fixed</h4>
-        <p style={{ marginTop: 6, fontSize: 12 }}>
-          Both security audit and activity log hash chains are now GDPR-safe.
-          PII fields excluded from hash computation (#541, #866) so
-          anonymization preserves chain integrity. Activity log writes
-          serialized with <code>pg_advisory_xact_lock</code> (#867),
-          preventing chain forking on concurrent writes.
-        </p>
-      </Card>
-
-      <Card accent="green" style={{ marginBottom: 12 }}>
-        <h4>Export rate limit &mdash; Fixed</h4>
-        <p style={{ marginTop: 6, fontSize: 12 }}>
-          DSAR export rate limit migrated to distributed Redis (#865).
-          Shared across instances, survives deploys/restarts. Matches
-          existing auth rate limiter pattern.
-        </p>
-      </Card>
-
       <hr />
 
       {/* ── End Game ── */}
@@ -205,27 +197,6 @@ export function GdprPane() {
           style={{ padding: "16px 14px", fontSize: 14 }}
         />
       </FeatureRow>
-
-      <div className="g2">
-        <Card accent="green">
-          <h4>Hard-delete for messages &mdash; Done</h4>
-          <p style={{ marginTop: 6, fontSize: 12 }}>
-            Implemented: 30-day purge cron hard-deletes soft-deleted messages.
-            FK cascade on account deletion removes user-owned messages
-            immediately. Remaining gap: shared-page assistant messages with{" "}
-            <code>userId: null</code> may persist.
-          </p>
-        </Card>
-        <Card accent="green">
-          <h4>Hash-chain-safe anonymization &mdash; Done</h4>
-          <p style={{ marginTop: 6, fontSize: 12 }}>
-            Implemented: PII fields excluded from hash computation in both
-            security audit (#541) and activity log (#866) chains. Activity
-            log writes serialized with advisory locks (#867). Anonymization
-            preserves chain integrity.
-          </p>
-        </Card>
-      </div>
 
       <Card style={{ borderColor: "var(--border2)", marginTop: 12 }}>
         <h4 style={{ color: "var(--dim)" }}>

--- a/prototypes/pagespace-endgame/src/components/panes/GdprPane.tsx
+++ b/prototypes/pagespace-endgame/src/components/panes/GdprPane.tsx
@@ -66,6 +66,17 @@ export function GdprPane() {
         </Card>
       </div>
 
+      <Card accent="green" style={{ marginBottom: 16 }}>
+        <h4>Message deletion: two-stage hard-delete</h4>
+        <p style={{ marginTop: 6, fontSize: 12 }}>
+          Messages use a two-stage deletion path: soft-delete via{" "}
+          <code>isActive</code> flag, then a 30-day purge cron hard-deletes
+          the rows. On account deletion, FK cascade removes all messages
+          immediately. Satisfies GDPR Art. 17 right to erasure for message
+          content.
+        </p>
+      </Card>
+
       <h3 style={{ marginBottom: 12 }}>Data Retention &amp; Minimization</h3>
       <FeatureRow columns={4}>
         <Feature
@@ -146,35 +157,30 @@ export function GdprPane() {
         />
       </FeatureRow>
 
-      <div className="g2" style={{ marginBottom: 12 }}>
-        <Card accent="amber">
-          <h4>Message deletion is soft-delete only</h4>
-          <p style={{ marginTop: 6, fontSize: 12 }}>
-            Conversation messages use an <code>isActive</code> flag for
-            deletion. GDPR Art. 17 may require true hard-delete. Current
-            soft-delete means message content persists in the database
-            even after &ldquo;deletion.&rdquo;
-          </p>
-        </Card>
-        <Card accent="amber">
-          <h4>Activity log hash chain broken by anonymization</h4>
-          <p style={{ marginTop: 6, fontSize: 12 }}>
-            Account deletion anonymizes activity log entries, but this
-            changes the data that was hashed &mdash; invalidating the
-            hash chain. The tamper-evident property is compromised for
-            entries involving deleted users. Security audit chain is{" "}
-            <strong style={{ color: "var(--green)" }}>fixed (#541)</strong>
-            {" "}&mdash; PII fields excluded from hash computation.
-          </p>
-        </Card>
-      </div>
+      <Card accent="amber" style={{ marginBottom: 12 }}>
+        <h4>Activity log hash chain broken by anonymization</h4>
+        <p style={{ marginTop: 6, fontSize: 12 }}>
+          Account deletion anonymizes activity log entries, but this
+          changes the data that was hashed &mdash; invalidating the
+          hash chain. The tamper-evident property is compromised for
+          entries involving deleted users. Security audit chain is{" "}
+          <strong style={{ color: "var(--green)" }}>fixed (#541)</strong>
+          {" "}&mdash; PII fields excluded from hash computation.{" "}
+          <strong style={{ color: "var(--amber)" }}>
+            Activity log fix in progress (pu/hash-chain-pii).
+          </strong>
+        </p>
+      </Card>
 
       <Card accent="amber" style={{ marginBottom: 12 }}>
         <h4>Export rate limit is in-memory</h4>
         <p style={{ marginTop: 6, fontSize: 12 }}>
           The 1-export-per-24-hours rate limit uses an in-process <code>Map()</code>.
           Resets on deploy/restart. Not shared across instances. Works for single
-          instance but won&apos;t scale.
+          instance but won&apos;t scale.{" "}
+          <strong style={{ color: "var(--amber)" }}>
+            Fix in progress (pu/export-rate-limit).
+          </strong>
         </p>
       </Card>
 
@@ -209,12 +215,12 @@ export function GdprPane() {
       </FeatureRow>
 
       <div className="g2">
-        <Card accent="blue">
-          <h4>Hard-delete for messages</h4>
+        <Card accent="green">
+          <h4>Hard-delete for messages &mdash; Done</h4>
           <p style={{ marginTop: 6, fontSize: 12 }}>
-            True deletion path for conversation messages with audit tombstones
-            (record that deletion occurred without preserving content). Supports
-            GDPR Art. 17 right to erasure for all data types.
+            Implemented: 30-day purge cron hard-deletes soft-deleted messages.
+            FK cascade on account deletion removes all messages immediately.
+            GDPR Art. 17 right to erasure satisfied for message content.
           </p>
         </Card>
         <Card accent="blue">
@@ -222,7 +228,10 @@ export function GdprPane() {
           <p style={{ marginTop: 6, fontSize: 12 }}>
             Anonymization that preserves chain link integrity. Hash computed
             over anonymization-stable fields only, or chain links explicitly
-            maintained through the anonymization process.
+            maintained through the anonymization process.{" "}
+            <strong style={{ color: "var(--amber)" }}>
+              In progress (pu/hash-chain-pii).
+            </strong>
           </p>
         </Card>
       </div>


### PR DESCRIPTION
## Summary
- **compliance-sovereignty-analysis.md**: Updated 6 sections where gaps were listed as unfixed but are now implemented — DSAR export (resolved), message hard-delete (resolved), AI log purge on account deletion (resolved), audit chain verification (resolved), retention engine (partial). Downgraded section 1.2 severity. Marked P1 items #4 and #6 as DONE.
- **GdprPane.tsx**: Moved message deletion from Gaps to Current (green, two-stage description). Added "fix in progress" notes for hash-chain-pii and export-rate-limit branches. Converted End Game hard-delete card to Done.
- **CompliancePane.tsx**: Added "fix in progress" notes for activity log hash chain and export rate limit gaps/end-game items.

## Test plan
- [ ] Verify prototype renders correctly (`cd prototypes/pagespace-endgame && pnpm dev`)
- [ ] Spot-check compliance doc markdown renders properly on GitHub
- [ ] Confirm no claims contradict current codebase state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated compliance docs with retention/erasure behaviors, DSAR export details, and resolved audit-integrity items.

* **New Features**
  * DSAR export (ZIP/JSON) available with distributed rate limiting; UI compliance panels reflect resolved items.

* **Bug Fixes**
  * Conversation messages now hard-purge after 30 days and are removed on account deletion; audit log integrity verification fixed.

* **Known Gap**
  * AI usage logs lack automatic TTL while accounts remain active (requires further work).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->