### PR TITLE
fix(security): migrate export rate limit to distributed Redis

### DIFF
--- a/apps/web/src/app/api/account/export/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/export/__tests__/route.test.ts
@@ -16,6 +16,18 @@ vi.mock('@pagespace/lib/compliance/export/gdpr-export', () => ({
   collectAllUserData: vi.fn(),
 }));
 
+vi.mock('@pagespace/lib/security', () => ({
+  checkDistributedRateLimit: vi.fn(),
+  DISTRIBUTED_RATE_LIMITS: {
+    EXPORT_DATA: {
+      maxAttempts: 1,
+      windowMs: 24 * 60 * 60 * 1000,
+      blockDurationMs: 24 * 60 * 60 * 1000,
+      progressiveDelay: false,
+    },
+  },
+}));
+
 // Mock archiver - return an event emitter-like object
 const mockArchive = {
   on: vi.fn(),
@@ -29,6 +41,8 @@ vi.mock('archiver', () => ({
 
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { collectAllUserData } from '@pagespace/lib/compliance/export/gdpr-export';
+import { checkDistributedRateLimit } from '@pagespace/lib/security';
+import { GET } from '../route';
 
 // Test helpers
 const mockSessionAuth = (userId: string): SessionAuthResult => ({
@@ -59,16 +73,11 @@ const mockUserData = {
 };
 
 describe('GET /api/account/export', () => {
-  /**
-   * We use dynamic import with vi.resetModules() so each test gets a fresh
-   * module with a clean lastExportMap (the in-memory rate limit state).
-   */
-  let GET: (request: Request) => Promise<Response>;
-
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockSessionAuth('user-1'));
     vi.mocked(isAuthError).mockReturnValue(false);
+    vi.mocked(checkDistributedRateLimit).mockResolvedValue({ allowed: true, attemptsRemaining: 0 });
 
     // Reset the archive mock handlers
     mockArchive.on.mockReset();
@@ -89,11 +98,6 @@ describe('GET /api/account/export', () => {
       }
       return mockArchive;
     });
-
-    // Re-import to get fresh module state (clean rate limit map)
-    vi.resetModules();
-    const mod = await import('../route');
-    GET = mod.GET;
   });
 
   describe('authentication', () => {
@@ -183,22 +187,33 @@ describe('GET /api/account/export', () => {
   });
 
   describe('rate limiting', () => {
-    it('returns 429 on second export within 24 hours', async () => {
+    it('returns 429 when rate limit is exceeded', async () => {
+      vi.mocked(checkDistributedRateLimit).mockResolvedValue({
+        allowed: false,
+        retryAfter: 86400,
+        attemptsRemaining: 0,
+      });
+
+      const response = await GET(createRequest());
+      const body = await response.json();
+
+      expect(response.status).toBe(429);
+      expect(body.error).toBe('Export rate limit exceeded. You can request one export per 24 hours.');
+      expect(response.headers.get('Retry-After')).toBe('86400');
+    });
+
+    it('calls checkDistributedRateLimit with correct key and config', async () => {
       vi.mocked(collectAllUserData).mockResolvedValue(mockUserData as never);
 
-      // First export should succeed
-      const response1 = await GET(createRequest());
-      expect(response1.status).toBe(200);
+      await GET(createRequest());
 
-      // Second export should be rate limited
-      const response2 = await GET(createRequest());
-      const body = await response2.json();
-
-      expect(response2.status).toBe(429);
-      expect(body.error).toBe('Export rate limit exceeded. You can request one export per 24 hours.');
-      const retryAfter = Number(response2.headers.get('Retry-After'));
-      expect(retryAfter).toBeGreaterThan(0);
-      expect(retryAfter).toBeLessThanOrEqual(86400);
+      expect(checkDistributedRateLimit).toHaveBeenCalledWith(
+        'export:user:user-1',
+        expect.objectContaining({
+          maxAttempts: 1,
+          windowMs: 24 * 60 * 60 * 1000,
+        })
+      );
     });
   });
 

--- a/apps/web/src/app/api/account/export/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/export/__tests__/route.test.ts
@@ -18,6 +18,7 @@ vi.mock('@pagespace/lib/compliance/export/gdpr-export', () => ({
 
 vi.mock('@pagespace/lib/security', () => ({
   checkDistributedRateLimit: vi.fn(),
+  resetDistributedRateLimit: vi.fn(),
   DISTRIBUTED_RATE_LIMITS: {
     EXPORT_DATA: {
       maxAttempts: 1,
@@ -41,7 +42,7 @@ vi.mock('archiver', () => ({
 
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { collectAllUserData } from '@pagespace/lib/compliance/export/gdpr-export';
-import { checkDistributedRateLimit } from '@pagespace/lib/security';
+import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security';
 import { GET } from '../route';
 
 // Test helpers
@@ -133,6 +134,14 @@ describe('GET /api/account/export', () => {
       expect(response.status).toBe(404);
       expect(body.error).toBe('User not found');
     });
+
+    it('resets rate limit on 404 so user can retry', async () => {
+      vi.mocked(collectAllUserData).mockResolvedValue(null);
+
+      await GET(createRequest());
+
+      expect(resetDistributedRateLimit).toHaveBeenCalledWith('export:user:user-1');
+    });
   });
 
   describe('successful export', () => {
@@ -184,6 +193,14 @@ describe('GET /api/account/export', () => {
 
       expect(mockArchive.finalize).toHaveBeenCalledTimes(1);
     });
+
+    it('does not reset rate limit on successful export', async () => {
+      vi.mocked(collectAllUserData).mockResolvedValue(mockUserData as never);
+
+      await GET(createRequest());
+
+      expect(resetDistributedRateLimit).not.toHaveBeenCalled();
+    });
   });
 
   describe('rate limiting', () => {
@@ -228,6 +245,16 @@ describe('GET /api/account/export', () => {
       expect(response.status).toBe(500);
       expect(body.error).toBe('Failed to generate data export');
       consoleSpy.mockRestore();
+    });
+
+    it('resets rate limit on 500 so user can retry', async () => {
+      vi.mocked(collectAllUserData).mockRejectedValueOnce(new Error('DB error'));
+
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      await GET(createRequest());
+      consoleSpy.mockRestore();
+
+      expect(resetDistributedRateLimit).toHaveBeenCalledWith('export:user:user-1');
     });
 
     it('propagates archive error to ReadableStream controller', async () => {

--- a/apps/web/src/app/api/account/export/route.ts
+++ b/apps/web/src/app/api/account/export/route.ts
@@ -1,7 +1,7 @@
 import { collectAllUserData } from '@pagespace/lib/compliance/export/gdpr-export';
 import { db } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security';
+import { checkDistributedRateLimit, resetDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security';
 import archiver from 'archiver';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
@@ -23,8 +23,9 @@ export async function GET(request: Request) {
   const userId = auth.userId;
 
   // Rate limiting (distributed via Redis)
+  const rateLimitKey = `export:user:${userId}`;
   const rateLimitResult = await checkDistributedRateLimit(
-    `export:user:${userId}`,
+    rateLimitKey,
     DISTRIBUTED_RATE_LIMITS.EXPORT_DATA
   );
 
@@ -45,6 +46,7 @@ export async function GET(request: Request) {
     );
 
     if (!data) {
+      await resetDistributedRateLimit(rateLimitKey);
       return Response.json({ error: 'User not found' }, { status: 404 });
     }
 
@@ -88,6 +90,7 @@ export async function GET(request: Request) {
       },
     });
   } catch (error) {
+    await resetDistributedRateLimit(rateLimitKey);
     console.error('[GDPR Export] Error generating export:', error);
     return Response.json(
       { error: 'Failed to generate data export' },

--- a/apps/web/src/app/api/account/export/route.ts
+++ b/apps/web/src/app/api/account/export/route.ts
@@ -1,13 +1,10 @@
 import { collectAllUserData } from '@pagespace/lib/compliance/export/gdpr-export';
 import { db } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security';
 import archiver from 'archiver';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
-
-// Rate limit: track last export time per user (in-memory, resets on deploy)
-const lastExportMap = new Map<string, number>();
-const EXPORT_COOLDOWN_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 /**
  * GET /api/account/export
@@ -25,15 +22,18 @@ export async function GET(request: Request) {
   }
   const userId = auth.userId;
 
-  // Rate limiting
-  const lastExport = lastExportMap.get(userId);
-  if (lastExport && Date.now() - lastExport < EXPORT_COOLDOWN_MS) {
-    const retryAfterSeconds = Math.ceil((EXPORT_COOLDOWN_MS - (Date.now() - lastExport)) / 1000);
+  // Rate limiting (distributed via Redis)
+  const rateLimitResult = await checkDistributedRateLimit(
+    `export:user:${userId}`,
+    DISTRIBUTED_RATE_LIMITS.EXPORT_DATA
+  );
+
+  if (!rateLimitResult.allowed) {
     return Response.json(
       { error: 'Export rate limit exceeded. You can request one export per 24 hours.' },
       {
         status: 429,
-        headers: { 'Retry-After': String(retryAfterSeconds) },
+        headers: { 'Retry-After': String(rateLimitResult.retryAfter || 86400) },
       }
     );
   }
@@ -47,9 +47,6 @@ export async function GET(request: Request) {
     if (!data) {
       return Response.json({ error: 'User not found' }, { status: 404 });
     }
-
-    // Record this export for rate limiting
-    lastExportMap.set(userId, Date.now());
 
     // Build ZIP archive
     const archive = archiver('zip', { zlib: { level: 6 } });

--- a/packages/lib/src/security/distributed-rate-limit.ts
+++ b/packages/lib/src/security/distributed-rate-limit.ts
@@ -54,14 +54,14 @@ let cleanupIntervalId: ReturnType<typeof setInterval> | null = null;
 
 /**
  * Start the cleanup interval for in-memory rate limiting.
- * Uses 2-hour cutoff to match longest rate limit window (1 hour) with buffer.
+ * Uses 25-hour cutoff to match longest rate limit window (EXPORT_DATA 24h) with buffer.
  */
 function startCleanupInterval(): void {
   if (cleanupIntervalId) return;
 
   cleanupIntervalId = setInterval(() => {
     const now = Date.now();
-    const cutoff = now - 2 * 60 * 60 * 1000; // 2 hours (matches longest window + buffer)
+    const cutoff = now - 25 * 60 * 60 * 1000; // 25 hours (matches longest window — EXPORT_DATA 24h — plus buffer)
 
     for (const [key, attempt] of inMemoryAttempts.entries()) {
       if (attempt.lastAttempt < cutoff) {

--- a/packages/lib/src/security/distributed-rate-limit.ts
+++ b/packages/lib/src/security/distributed-rate-limit.ts
@@ -412,6 +412,12 @@ export const DISTRIBUTED_RATE_LIMITS = {
     blockDurationMs: 60 * 60 * 1000,
     progressiveDelay: false,
   },
+  EXPORT_DATA: {
+    maxAttempts: 1,
+    windowMs: 24 * 60 * 60 * 1000, // 24 hours
+    blockDurationMs: 24 * 60 * 60 * 1000,
+    progressiveDelay: false,
+  },
   MAGIC_LINK: {
     maxAttempts: 3,
     windowMs: 15 * 60 * 1000, // 15 minutes


### PR DESCRIPTION
## Summary
- Replaced in-memory `Map()` rate limit in the GDPR export endpoint with the existing Redis-backed `checkDistributedRateLimit` system
- Added `EXPORT_DATA` config to `DISTRIBUTED_RATE_LIMITS` (1 request per 24 hours)
- Rate limit now persists across deploys/restarts and is shared across all instances
- Rate limit is refunded on failure paths (404/500) so transient errors don't lock users out for 24 hours
- Updated in-memory fallback cleanup cutoff from 2h to 25h to match the new longest window

## Why
The in-memory Map reset on every deploy and wasn't shared across instances, so users could bypass the 1-per-24h limit by hitting a different instance or waiting for a restart.

## Test plan
- [x] Updated tests mock `checkDistributedRateLimit` instead of relying on in-memory state
- [x] Verified 429 response with `Retry-After` header when rate limited
- [x] Verified correct rate limit key (`export:user:{userId}`) and config passed
- [x] Verified rate limit is reset on 404 (user not found) path
- [x] Verified rate limit is reset on 500 (exception) path
- [x] Verified rate limit is NOT reset on successful export
- [x] All 14 export route tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)