### PR TITLE
fix(security): exclude PII from activity log hash chain

### DIFF
--- a/packages/lib/src/monitoring/__tests__/activity-logger.test.ts
+++ b/packages/lib/src/monitoring/__tests__/activity-logger.test.ts
@@ -180,11 +180,17 @@ describe('activity-logger', () => {
       expect(serializeLogDataForHash(baseHashData)).toBe(serializeLogDataForHash(baseHashData));
     });
 
-    it('should include required fields', () => {
+    it('should include required non-PII fields', () => {
       const parsed = JSON.parse(serializeLogDataForHash(baseHashData));
       expect(parsed.id).toBe('log-1');
-      expect(parsed.userId).toBe('user-1');
-      expect(parsed.actorEmail).toBe('test@example.com');
+      expect(parsed.operation).toBe('create');
+      expect(parsed.resourceType).toBe('page');
+    });
+
+    it('should exclude PII fields (userId, actorEmail) for GDPR compliance', () => {
+      const parsed = JSON.parse(serializeLogDataForHash(baseHashData));
+      expect(parsed).not.toHaveProperty('userId');
+      expect(parsed).not.toHaveProperty('actorEmail');
     });
 
     it('should use null for absent optional fields', () => {
@@ -307,9 +313,126 @@ describe('activity-logger', () => {
       expect(verifyLogHash(baseHashData, 'wrong', 'prev')).toBe(false);
     });
 
-    it('should return false when data is modified', () => {
+    it('should return false when non-PII data is modified', () => {
       const h = computeLogHash(baseHashData, 'prev');
-      expect(verifyLogHash({ ...baseHashData, userId: 'hacker' }, h, 'prev')).toBe(false);
+      expect(verifyLogHash({ ...baseHashData, operation: 'delete' }, h, 'prev')).toBe(false);
+    });
+
+    it('should return true when only PII fields are changed (GDPR exclusion)', () => {
+      const h = computeLogHash(baseHashData, 'prev');
+      expect(verifyLogHash({ ...baseHashData, userId: 'hacker', actorEmail: 'anon@deleted.com' }, h, 'prev')).toBe(true);
+    });
+  });
+
+  // ── GDPR-Safe Hash Chain (#541) ──────────────────────────────────────────
+  describe('GDPR-Safe Hash Chain (#541)', () => {
+    it('hash is stable after userId/actorEmail anonymization', () => {
+      const data = {
+        id: 'log-gdpr',
+        timestamp: new Date('2026-01-25T10:00:00Z'),
+        userId: 'user-real-123',
+        actorEmail: 'real-user@example.com',
+        operation: 'create',
+        resourceType: 'page',
+        resourceId: 'page-1',
+        driveId: 'drive-1',
+      };
+
+      const hashBefore = computeLogHash(data, 'prev-hash');
+
+      const anonymized = {
+        ...data,
+        userId: undefined,
+        actorEmail: 'deleted-user@anonymized.local',
+      };
+
+      const hashAfter = computeLogHash(anonymized, 'prev-hash');
+
+      expect(hashBefore).toBe(hashAfter);
+    });
+
+    it('hash changes when non-PII fields change', () => {
+      const data1 = {
+        id: 'log-1',
+        timestamp: new Date('2026-01-25T10:00:00Z'),
+        userId: 'user-1',
+        actorEmail: 'test@example.com',
+        operation: 'create',
+        resourceType: 'page',
+        resourceId: 'page-1',
+        driveId: 'drive-1',
+      };
+
+      const data2 = { ...data1, resourceId: 'page-2' };
+
+      const hash1 = computeLogHash(data1, 'prev');
+      const hash2 = computeLogHash(data2, 'prev');
+
+      expect(hash1).not.toBe(hash2);
+    });
+
+    it('PII fields are excluded: changing them does not change hash', () => {
+      const base = {
+        id: 'log-pii',
+        timestamp: new Date('2026-01-25T10:00:00Z'),
+        operation: 'update',
+        resourceType: 'page',
+        resourceId: 'page-1',
+        driveId: 'drive-1',
+      };
+
+      const withPII = {
+        ...base,
+        userId: 'user-xyz',
+        actorEmail: 'alice@example.com',
+      };
+
+      const withoutPII = { ...base };
+
+      const hash1 = computeLogHash(withPII, 'prev-hash');
+      const hash2 = computeLogHash(withoutPII, 'prev-hash');
+
+      expect(hash1).toBe(hash2);
+    });
+
+    it('chain remains valid after PII anonymization', () => {
+      const seed = 'a'.repeat(64);
+      const entry1 = {
+        id: 'log-chain-1',
+        timestamp: new Date('2026-01-25T10:00:00Z'),
+        userId: 'user-1',
+        actorEmail: 'alice@example.com',
+        operation: 'create',
+        resourceType: 'page',
+        resourceId: 'page-1',
+        driveId: 'drive-1',
+      };
+
+      const hash1 = computeLogHash(entry1, seed);
+
+      const entry2 = {
+        id: 'log-chain-2',
+        timestamp: new Date('2026-01-25T10:01:00Z'),
+        userId: 'user-1',
+        actorEmail: 'alice@example.com',
+        operation: 'update',
+        resourceType: 'page',
+        resourceId: 'page-1',
+        driveId: 'drive-1',
+      };
+
+      const hash2 = computeLogHash(entry2, hash1);
+
+      // Anonymize PII
+      const anonEntry1 = { ...entry1, userId: undefined, actorEmail: 'deleted@anon.local' };
+      const anonEntry2 = { ...entry2, userId: undefined, actorEmail: 'deleted@anon.local' };
+
+      // Recompute chain with anonymized data
+      const reHash1 = computeLogHash(anonEntry1, seed);
+      const reHash2 = computeLogHash(anonEntry2, reHash1);
+
+      expect(reHash1).toBe(hash1);
+      expect(reHash2).toBe(hash2);
     });
   });
 

--- a/packages/lib/src/monitoring/__tests__/activity-logger.test.ts
+++ b/packages/lib/src/monitoring/__tests__/activity-logger.test.ts
@@ -85,8 +85,6 @@ const flush = () => new Promise(resolve => setTimeout(resolve, 10));
 const baseHashData = {
   id: 'log-1',
   timestamp: new Date('2024-01-01T00:00:00.000Z'),
-  userId: 'user-1',
-  actorEmail: 'test@example.com',
   operation: 'create',
   resourceType: 'page',
   resourceId: 'page-1',
@@ -187,7 +185,7 @@ describe('activity-logger', () => {
       expect(parsed.resourceType).toBe('page');
     });
 
-    it('should exclude PII fields (userId, actorEmail) for GDPR compliance', () => {
+    it('should not contain PII fields (userId, actorEmail)', () => {
       const parsed = JSON.parse(serializeLogDataForHash(baseHashData));
       expect(parsed).not.toHaveProperty('userId');
       expect(parsed).not.toHaveProperty('actorEmail');
@@ -318,90 +316,76 @@ describe('activity-logger', () => {
       expect(verifyLogHash({ ...baseHashData, operation: 'delete' }, h, 'prev')).toBe(false);
     });
 
-    it('should return true when only PII fields are changed (GDPR exclusion)', () => {
+    it('should verify identical data produces matching hash', () => {
       const h = computeLogHash(baseHashData, 'prev');
-      expect(verifyLogHash({ ...baseHashData, userId: 'hacker', actorEmail: 'anon@deleted.com' }, h, 'prev')).toBe(true);
+      expect(verifyLogHash({ ...baseHashData }, h, 'prev')).toBe(true);
     });
   });
 
   // ── GDPR-Safe Hash Chain (#541) ──────────────────────────────────────────
   describe('GDPR-Safe Hash Chain (#541)', () => {
-    it('hash is stable after userId/actorEmail anonymization', () => {
-      const data = {
-        id: 'log-gdpr',
+    it('hash only depends on non-PII fields', () => {
+      const hash1 = computeLogHash({
+        id: 'log-1',
         timestamp: new Date('2026-01-25T10:00:00Z'),
-        userId: 'user-real-123',
-        actorEmail: 'real-user@example.com',
         operation: 'create',
         resourceType: 'page',
         resourceId: 'page-1',
         driveId: 'drive-1',
-      };
+      }, 'prev-hash');
 
-      const hashBefore = computeLogHash(data, 'prev-hash');
+      // Same non-PII fields, same hash — regardless of what PII existed on the row
+      const hash2 = computeLogHash({
+        id: 'log-1',
+        timestamp: new Date('2026-01-25T10:00:00Z'),
+        operation: 'create',
+        resourceType: 'page',
+        resourceId: 'page-1',
+        driveId: 'drive-1',
+      }, 'prev-hash');
 
-      const anonymized = {
-        ...data,
-        userId: undefined,
-        actorEmail: 'deleted-user@anonymized.local',
-      };
-
-      const hashAfter = computeLogHash(anonymized, 'prev-hash');
-
-      expect(hashBefore).toBe(hashAfter);
+      expect(hash1).toBe(hash2);
     });
 
     it('hash changes when non-PII fields change', () => {
-      const data1 = {
+      const base = {
         id: 'log-1',
         timestamp: new Date('2026-01-25T10:00:00Z'),
-        userId: 'user-1',
-        actorEmail: 'test@example.com',
         operation: 'create',
         resourceType: 'page',
         resourceId: 'page-1',
         driveId: 'drive-1',
       };
 
-      const data2 = { ...data1, resourceId: 'page-2' };
-
-      const hash1 = computeLogHash(data1, 'prev');
-      const hash2 = computeLogHash(data2, 'prev');
+      const hash1 = computeLogHash(base, 'prev');
+      const hash2 = computeLogHash({ ...base, resourceId: 'page-2' }, 'prev');
 
       expect(hash1).not.toBe(hash2);
     });
 
-    it('PII fields are excluded: changing them does not change hash', () => {
-      const base = {
-        id: 'log-pii',
+    it('serialized hash data contains zero PII fields', () => {
+      const serialized = serializeLogDataForHash({
+        id: 'log-1',
         timestamp: new Date('2026-01-25T10:00:00Z'),
         operation: 'update',
         resourceType: 'page',
         resourceId: 'page-1',
         driveId: 'drive-1',
-      };
+      });
 
-      const withPII = {
-        ...base,
-        userId: 'user-xyz',
-        actorEmail: 'alice@example.com',
-      };
-
-      const withoutPII = { ...base };
-
-      const hash1 = computeLogHash(withPII, 'prev-hash');
-      const hash2 = computeLogHash(withoutPII, 'prev-hash');
-
-      expect(hash1).toBe(hash2);
+      const parsed = JSON.parse(serialized);
+      expect(Object.keys(parsed).sort()).toEqual([
+        'contentSnapshot', 'driveId', 'id', 'metadata', 'newValues',
+        'operation', 'pageId', 'previousValues', 'resourceId',
+        'resourceType', 'timestamp',
+      ]);
     });
 
-    it('chain remains valid after PII anonymization', () => {
+    it('chain remains valid when entries are recomputed', () => {
       const seed = 'a'.repeat(64);
       const entry1 = {
         id: 'log-chain-1',
         timestamp: new Date('2026-01-25T10:00:00Z'),
-        userId: 'user-1',
-        actorEmail: 'alice@example.com',
         operation: 'create',
         resourceType: 'page',
         resourceId: 'page-1',
@@ -413,8 +397,6 @@ describe('activity-logger', () => {
       const entry2 = {
         id: 'log-chain-2',
         timestamp: new Date('2026-01-25T10:01:00Z'),
-        userId: 'user-1',
-        actorEmail: 'alice@example.com',
         operation: 'update',
         resourceType: 'page',
         resourceId: 'page-1',
@@ -423,13 +405,9 @@ describe('activity-logger', () => {
 
       const hash2 = computeLogHash(entry2, hash1);
 
-      // Anonymize PII
-      const anonEntry1 = { ...entry1, userId: undefined, actorEmail: 'deleted@anon.local' };
-      const anonEntry2 = { ...entry2, userId: undefined, actorEmail: 'deleted@anon.local' };
-
-      // Recompute chain with anonymized data
-      const reHash1 = computeLogHash(anonEntry1, seed);
-      const reHash2 = computeLogHash(anonEntry2, reHash1);
+      // Recompute chain from same data — hashes must be identical
+      const reHash1 = computeLogHash(entry1, seed);
+      const reHash2 = computeLogHash(entry2, reHash1);
 
       expect(reHash1).toBe(hash1);
       expect(reHash2).toBe(hash2);

--- a/packages/lib/src/monitoring/__tests__/hash-chain-verifier-full.test.ts
+++ b/packages/lib/src/monitoring/__tests__/hash-chain-verifier-full.test.ts
@@ -198,7 +198,7 @@ describe('hash-chain-verifier (full coverage)', () => {
 
     it('should detect tampering via content modification', async () => {
       const chain = buildValidChain(3);
-      chain[1]!.userId = 'modified-user'; // hash stays same but content differs
+      chain[1]!.operation = 'modified-operation'; // hash stays same but content differs
       setupDbMocks(chain);
 
       const result = await verifyHashChain();

--- a/packages/lib/src/monitoring/__tests__/hash-chain-verifier-full.test.ts
+++ b/packages/lib/src/monitoring/__tests__/hash-chain-verifier-full.test.ts
@@ -80,17 +80,16 @@ function buildValidChain(count: number): MockEntry[] {
   for (let i = 0; i < count; i++) {
     const timestamp = new Date(1_700_000_000_000 + i * 1000);
     const id = `entry-${i}`;
-    const entryData = {
+    const hashData = {
       id,
       timestamp,
-      userId: 'u1',
-      actorEmail: 'test@example.com',
       operation: 'create',
       resourceType: 'page',
       resourceId: `page-${i}`,
       driveId: 'drive-1',
     };
-    const logHash = computeLogHash(entryData, prevHash);
+    const logHash = computeLogHash(hashData, prevHash);
+    const entryData = { ...hashData, userId: 'u1', actorEmail: 'test@example.com' };
 
     entries.push({
       ...entryData,
@@ -535,20 +534,20 @@ describe('hash-chain-verifier (full coverage)', () => {
     });
 
     it('should use empty string when neither chainSeed nor previousLogHash is present', async () => {
-      const entryData = {
+      const hashData = {
         id: 'orphan',
         timestamp: new Date('2024-01-01T00:00:00.000Z'),
-        userId: 'u1',
-        actorEmail: 'test@example.com',
         operation: 'create',
         resourceType: 'page',
         resourceId: 'page-orphan',
         driveId: 'drive-1',
       };
-      const logHash = computeLogHash(entryData, '');
+      const logHash = computeLogHash(hashData, '');
 
       mockFindFirst.mockResolvedValueOnce({
-        ...entryData,
+        ...hashData,
+        userId: 'u1',
+        actorEmail: 'test@example.com',
         pageId: null,
         contentSnapshot: null,
         previousValues: null,
@@ -592,11 +591,9 @@ describe('hash-chain-verifier (full coverage)', () => {
     });
 
     it('should correctly handle entry with optional fields', async () => {
-      const baseData = {
+      const hashData = {
         id: 'full-entry',
         timestamp: new Date('2024-06-01T12:00:00.000Z'),
-        userId: 'u1',
-        actorEmail: 'test@example.com',
         operation: 'update',
         resourceType: 'page',
         resourceId: 'page-1',
@@ -608,10 +605,12 @@ describe('hash-chain-verifier (full coverage)', () => {
         metadata: { key: 'value' },
       };
       const seed = generateChainSeed();
-      const logHash = computeLogHash(baseData, seed);
+      const logHash = computeLogHash(hashData, seed);
 
       mockFindFirst.mockResolvedValueOnce({
-        ...baseData,
+        ...hashData,
+        userId: 'u1',
+        actorEmail: 'test@example.com',
         previousLogHash: null,
         logHash,
         chainSeed: seed,

--- a/packages/lib/src/monitoring/__tests__/hash-chain-verifier.test.ts
+++ b/packages/lib/src/monitoring/__tests__/hash-chain-verifier.test.ts
@@ -158,18 +158,17 @@ function createValidHashChain(count: number): typeof mockLogEntries {
     const timestamp = new Date(Date.now() + i * 1000);
     const id = `log-${i + 1}`;
 
-    const entryData = {
+    const hashData = {
       id,
       timestamp,
-      userId: 'user-123',
-      actorEmail: 'test@example.com',
       operation: 'create',
       resourceType: 'page',
       resourceId: `page-${i + 1}`,
       driveId: 'drive-1',
     };
 
-    const logHash = computeLogHash(entryData, previousHash);
+    const logHash = computeLogHash(hashData, previousHash);
+    const entryData = { ...hashData, userId: 'user-123', actorEmail: 'test@example.com' };
 
     entries.push({
       ...entryData,

--- a/packages/lib/src/monitoring/__tests__/hash-chain-verifier.test.ts
+++ b/packages/lib/src/monitoring/__tests__/hash-chain-verifier.test.ts
@@ -268,8 +268,8 @@ describe('hash-chain-verifier', () => {
     it('should detect tampering when content is modified', async () => {
       // Arrange - create valid chain then modify content
       mockLogEntries = createValidHashChain(3);
-      // Modify the userId of the 2nd entry (which changes its hash)
-      mockLogEntries[1]!.userId = 'modified-user';
+      // Modify a non-PII field of the 2nd entry (which changes its hash)
+      mockLogEntries[1]!.operation = 'modified-operation';
 
       // Mock count query
       vi.mocked(db.select).mockReturnValue({

--- a/packages/lib/src/monitoring/activity-logger.ts
+++ b/packages/lib/src/monitoring/activity-logger.ts
@@ -69,12 +69,15 @@ export interface HashChainData {
 /**
  * Data used to compute the hash of a log entry.
  * Includes immutable fields that define the entry's content.
+ *
+ * PII fields (userId, actorEmail) are accepted but excluded from hash
+ * computation for GDPR compliance — see serializeLogDataForHash().
  */
 interface HashableLogData {
   id: string;
   timestamp: Date;
-  userId: string;
-  actorEmail: string;
+  userId?: string;
+  actorEmail?: string;
   operation: string;
   resourceType: string;
   resourceId: string;
@@ -114,16 +117,23 @@ export function computeHash(data: string, previousHash: string): string {
  * Creates a deterministic JSON string from the hashable fields.
  * Uses sorted keys to ensure consistent hash computation.
  *
+ * PII fields excluded from hash computation for GDPR compliance (#541).
+ * These fields may be anonymized/deleted under right-to-erasure requests,
+ * so they must not be part of the hash chain to keep it verifiable.
+ *
+ * Excluded: userId, actorEmail
+ * Included: id, timestamp, operation, resourceType, resourceId, driveId,
+ *           pageId, contentSnapshot, previousValues, newValues, metadata
+ *
  * @param data - Log entry data to serialize
  * @returns Deterministic JSON string
  */
 export function serializeLogDataForHash(data: HashableLogData): string {
   // Create object with sorted keys for deterministic serialization
+  // Note: userId and actorEmail are intentionally excluded (PII — GDPR right-to-erasure)
   const hashableObject = {
     id: data.id,
     timestamp: data.timestamp.toISOString(),
-    userId: data.userId,
-    actorEmail: data.actorEmail,
     operation: data.operation,
     resourceType: data.resourceType,
     resourceId: data.resourceId,

--- a/packages/lib/src/monitoring/activity-logger.ts
+++ b/packages/lib/src/monitoring/activity-logger.ts
@@ -67,17 +67,13 @@ export interface HashChainData {
 }
 
 /**
- * Data used to compute the hash of a log entry.
- * Includes immutable fields that define the entry's content.
- *
- * PII fields (userId, actorEmail) are accepted but excluded from hash
- * computation for GDPR compliance — see serializeLogDataForHash().
+ * Fields included in the tamper-evident hash chain.
+ * PII (userId, actorEmail) is deliberately excluded so the chain
+ * stays verifiable after GDPR right-to-erasure anonymization (#541).
  */
 interface HashableLogData {
   id: string;
   timestamp: Date;
-  userId?: string;
-  actorEmail?: string;
   operation: string;
   resourceType: string;
   resourceId: string;
@@ -114,23 +110,9 @@ export function computeHash(data: string, previousHash: string): string {
 
 /**
  * Serialize log entry data for hashing.
- * Creates a deterministic JSON string from the hashable fields.
- * Uses sorted keys to ensure consistent hash computation.
- *
- * PII fields excluded from hash computation for GDPR compliance (#541).
- * These fields may be anonymized/deleted under right-to-erasure requests,
- * so they must not be part of the hash chain to keep it verifiable.
- *
- * Excluded: userId, actorEmail
- * Included: id, timestamp, operation, resourceType, resourceId, driveId,
- *           pageId, contentSnapshot, previousValues, newValues, metadata
- *
- * @param data - Log entry data to serialize
- * @returns Deterministic JSON string
+ * Creates a deterministic JSON string with sorted keys.
  */
 export function serializeLogDataForHash(data: HashableLogData): string {
-  // Create object with sorted keys for deterministic serialization
-  // Note: userId and actorEmail are intentionally excluded (PII — GDPR right-to-erasure)
   const hashableObject = {
     id: data.id,
     timestamp: data.timestamp.toISOString(),
@@ -527,8 +509,6 @@ export async function logActivity(input: ActivityLogInput): Promise<void> {
       {
         id: values.id,
         timestamp: values.timestamp,
-        userId: values.userId,
-        actorEmail: values.actorEmail,
         operation: values.operation,
         resourceType: values.resourceType,
         resourceId: values.resourceId,
@@ -621,8 +601,6 @@ export async function logActivityWithTx(
     {
       id: values.id,
       timestamp: values.timestamp,
-      userId: values.userId,
-      actorEmail: values.actorEmail,
       operation: values.operation,
       resourceType: values.resourceType,
       resourceId: values.resourceId,

--- a/packages/lib/src/monitoring/hash-chain-verifier.ts
+++ b/packages/lib/src/monitoring/hash-chain-verifier.ts
@@ -256,13 +256,11 @@ export async function verifyHashChain(
         // Determine what previous hash to use
         const hashInput = previousHash ?? '';
 
-        // Compute expected hash
+        // Compute expected hash (PII fields excluded per GDPR #541)
         const computedHash = computeLogHash(
           {
             id: storedEntry.id,
             timestamp: storedEntry.timestamp,
-            userId: storedEntry.userId,
-            actorEmail: storedEntry.actorEmail,
             operation: storedEntry.operation,
             resourceType: storedEntry.resourceType,
             resourceId: storedEntry.resourceId,
@@ -544,13 +542,11 @@ export async function verifyEntry(
       previousHashUsed = storedEntry.previousLogHash;
     }
 
-    // Compute expected hash
+    // Compute expected hash (PII fields excluded per GDPR #541)
     const computedHash = computeLogHash(
       {
         id: storedEntry.id,
         timestamp: storedEntry.timestamp,
-        userId: storedEntry.userId,
-        actorEmail: storedEntry.actorEmail,
         operation: storedEntry.operation,
         resourceType: storedEntry.resourceType,
         resourceId: storedEntry.resourceId,

--- a/scripts/rehash-activity-logs.ts
+++ b/scripts/rehash-activity-logs.ts
@@ -1,0 +1,87 @@
+#!/usr/bin/env tsx
+/**
+ * Migration Script: Reset Activity Log Hash Chain (PII Exclusion)
+ *
+ * Clears the legacy hash chain that included PII fields (userId, actorEmail)
+ * in the hash computation. After this script runs, the next logActivity() call
+ * will seed a fresh chain using the new PII-free algorithm.
+ *
+ * Background: The old hash algorithm included userId and actorEmail. When a
+ * user is deleted (userId → null, actorEmail → anonymized), those stored
+ * hashes become unverifiable. Rather than rehash every row, we reset the
+ * chain so all future entries are hashed correctly from the start.
+ *
+ * What this does:
+ *   1. Nulls logHash, previousLogHash, and chainSeed on all existing rows
+ *   2. The next logActivity() call detects no prior hash → generates a new
+ *      chainSeed and starts a fresh tamper-evident chain
+ *
+ * Run with: pnpm tsx scripts/rehash-activity-logs.ts
+ * Dry run:  pnpm tsx scripts/rehash-activity-logs.ts --dry-run
+ */
+
+import 'dotenv/config';
+import { db, activityLogs } from '@pagespace/db';
+import { isNotNull, count, sql } from 'drizzle-orm';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+async function resetHashChain(): Promise<void> {
+  console.log(`\n${'='.repeat(60)}`);
+  console.log('  Activity Log Hash Chain Reset (PII Exclusion)');
+  console.log(`  Mode: ${DRY_RUN ? 'DRY RUN (no writes)' : 'LIVE'}`);
+  console.log(`${'='.repeat(60)}\n`);
+
+  // Count entries with hashes
+  const [countResult] = await db
+    .select({ total: count() })
+    .from(activityLogs)
+    .where(isNotNull(activityLogs.logHash));
+
+  const totalEntries = countResult?.total ?? 0;
+  console.log(`Found ${totalEntries} entries with existing logHash.`);
+
+  if (totalEntries === 0) {
+    console.log('Nothing to reset — chain is already clean.');
+    return;
+  }
+
+  if (DRY_RUN) {
+    console.log(`\nDry run: would null logHash, previousLogHash, chainSeed on ${totalEntries} rows.`);
+    console.log('Run without --dry-run to apply.');
+    return;
+  }
+
+  // Single UPDATE — null all hash chain fields
+  const result = await db.execute(
+    sql`UPDATE activity_logs SET "logHash" = NULL, "previousLogHash" = NULL, "chainSeed" = NULL WHERE "logHash" IS NOT NULL`
+  );
+
+  console.log(`Reset ${totalEntries} rows.`);
+
+  // Verify
+  const [verifyResult] = await db
+    .select({ remaining: count() })
+    .from(activityLogs)
+    .where(isNotNull(activityLogs.logHash));
+
+  const remaining = verifyResult?.remaining ?? 0;
+  if (remaining === 0) {
+    console.log('Verification passed — zero rows with logHash remaining.');
+  } else {
+    console.error(`Verification FAILED — ${remaining} rows still have logHash.`);
+    process.exit(1);
+  }
+
+  console.log('\nThe next logActivity() call will seed a fresh PII-free chain.');
+}
+
+resetHashChain()
+  .then(() => {
+    console.log('\nDone.');
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error('\nFailed:', error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- Excludes `userId` and `actorEmail` from hash computation in `serializeLogDataForHash()` so the activity log hash chain remains verifiable after GDPR right-to-erasure anonymization
- **Type-boundary enforcement**: `HashableLogData` no longer accepts PII fields — the compiler prevents userId/actorEmail from entering the hash chain
- **Migration included**: `scripts/rehash-activity-logs.ts` resets the legacy hash chain so the next `logActivity()` call seeds a fresh PII-free chain
- Matches the pattern already applied to the security audit hash chain in PR #541

## Changes
- `packages/lib/src/monitoring/activity-logger.ts` — PII fields removed from `HashableLogData` interface and `serializeLogDataForHash()`, call sites updated
- `packages/lib/src/monitoring/hash-chain-verifier.ts` — PII removed from `computeLogHash` calls
- `packages/lib/src/monitoring/__tests__/*.test.ts` — Updated + new GDPR tests
- `scripts/rehash-activity-logs.ts` — **NEW** — Resets legacy hash chain (supports `--dry-run`)

## Deploy steps
1. Deploy code
2. Run `pnpm tsx scripts/rehash-activity-logs.ts --dry-run` to preview
3. Run `pnpm tsx scripts/rehash-activity-logs.ts` to reset legacy hashes
4. The next `logActivity()` call will seed a fresh PII-free chain

## Test plan
- [x] `pnpm test` — all 3992 tests pass (151 files)
- [x] `pnpm typecheck` — clean (compiler enforces PII exclusion)
- [ ] Run `--dry-run` in staging to verify script connects and counts correctly
- [ ] Run live in staging, then verify new entries produce valid chain via `verifyHashChain()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)