### PR TITLE
feat(security): wire SecurityAuditService into drive + permission routes

### DIFF
--- a/apps/web/src/app/api/drives/[driveId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/__tests__/route.test.ts
@@ -19,6 +19,7 @@ vi.mock('@pagespace/lib/server', () => ({
   getDriveWithAccess: vi.fn(),
   updateDrive: vi.fn(),
   trashDrive: vi.fn(),
+  securityAudit: { logEvent: vi.fn().mockResolvedValue(undefined), logDataAccess: vi.fn().mockResolvedValue(undefined) },
   loggers: {
     api: {
       info: vi.fn(),

--- a/apps/web/src/app/api/drives/[driveId]/backups/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/backups/__tests__/route.test.ts
@@ -9,6 +9,7 @@ import type { SessionAuthResult, AuthError } from '@/lib/auth';
 // ============================================================================
 
 vi.mock('@pagespace/lib/server', () => ({
+  securityAudit: { logEvent: vi.fn().mockResolvedValue(undefined), logDataAccess: vi.fn().mockResolvedValue(undefined) },
   loggers: {
     api: {
       info: vi.fn(),

--- a/apps/web/src/app/api/drives/[driveId]/backups/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/backups/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod/v4';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { createDriveBackup, listDriveBackups } from '@/services/api/drive-backup-service';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
@@ -67,6 +67,8 @@ export async function POST(request: Request, { params }: { params: Promise<{ dri
     if (!result.success) {
       return NextResponse.json({ error: result.error }, { status: 403 });
     }
+
+    securityAudit.logDataAccess(auth.userId, 'write', 'drive', driveId, { operation: 'create_backup' }).catch(() => {});
 
     return NextResponse.json({
       backupId: result.backupId,

--- a/apps/web/src/app/api/drives/[driveId]/backups/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/backups/route.ts
@@ -68,7 +68,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ dri
       return NextResponse.json({ error: result.error }, { status: 403 });
     }
 
-    securityAudit.logDataAccess(auth.userId, 'write', 'drive', driveId, { operation: 'create_backup' }).catch(() => {});
+    securityAudit.logDataAccess(auth.userId, 'write', 'drive', driveId, { operation: 'create_backup' })?.catch(() => {});
 
     return NextResponse.json({
       backupId: result.backupId,

--- a/apps/web/src/app/api/drives/[driveId]/integrations/[connectionId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/integrations/[connectionId]/__tests__/route.test.ts
@@ -7,6 +7,7 @@ import type { SessionAuthResult, AuthError } from '@/lib/auth';
 // ============================================================================
 
 vi.mock('@pagespace/lib/server', () => ({
+  securityAudit: { logEvent: vi.fn().mockResolvedValue(undefined), logDataAccess: vi.fn().mockResolvedValue(undefined) },
   loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },

--- a/apps/web/src/app/api/drives/[driveId]/integrations/[connectionId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/integrations/[connectionId]/route.ts
@@ -88,7 +88,7 @@ export async function DELETE(
       deletedBy: auth.userId,
     });
 
-    securityAudit.logDataAccess(auth.userId, 'delete', 'drive', driveId, { connectionId, connectionName: connection.name, operation: 'delete_integration' }).catch(() => {});
+    securityAudit.logDataAccess(auth.userId, 'delete', 'drive', driveId, { connectionId, connectionName: connection.name, operation: 'delete_integration' })?.catch(() => {});
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/apps/web/src/app/api/drives/[driveId]/integrations/[connectionId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/integrations/[connectionId]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { getDriveAccess } from '@pagespace/lib/services/drive-service';
 import { getConnectionById, getConnectionWithProvider, deleteConnection } from '@pagespace/lib/integrations';
 
@@ -87,6 +87,8 @@ export async function DELETE(
       connectionName: connection.name,
       deletedBy: auth.userId,
     });
+
+    securityAudit.logDataAccess(auth.userId, 'delete', 'drive', driveId, { connectionId, connectionName: connection.name, operation: 'delete_integration' }).catch(() => {});
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/apps/web/src/app/api/drives/[driveId]/integrations/audit/export/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/integrations/audit/export/__tests__/route.test.ts
@@ -7,6 +7,7 @@ import type { SessionAuthResult, AuthError } from '@/lib/auth';
 // ============================================================================
 
 vi.mock('@pagespace/lib/server', () => ({
+  securityAudit: { logEvent: vi.fn().mockResolvedValue(undefined), logDataAccess: vi.fn().mockResolvedValue(undefined) },
   loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },

--- a/apps/web/src/app/api/drives/[driveId]/integrations/audit/export/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/integrations/audit/export/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db, desc, integrationAuditLog } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { getDriveAccess } from '@pagespace/lib/services/drive-service';
 import { format } from 'date-fns';
 import { buildAuditLogWhereClause, parseAuditFilterParams } from '../audit-filters';
@@ -87,6 +87,8 @@ export async function GET(
     });
 
     const csv = `${CSV_HEADER}\n${csvRows.join('\n')}`;
+
+    securityAudit.logDataAccess(auth.userId, 'export', 'drive', driveId, { format: 'csv' }).catch(() => {});
 
     return new Response(csv, {
       headers: {

--- a/apps/web/src/app/api/drives/[driveId]/integrations/audit/export/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/integrations/audit/export/route.ts
@@ -88,7 +88,7 @@ export async function GET(
 
     const csv = `${CSV_HEADER}\n${csvRows.join('\n')}`;
 
-    securityAudit.logDataAccess(auth.userId, 'export', 'drive', driveId, { format: 'csv' }).catch(() => {});
+    securityAudit.logDataAccess(auth.userId, 'export', 'drive', driveId, { format: 'csv' })?.catch(() => {});
 
     return new Response(csv, {
       headers: {

--- a/apps/web/src/app/api/drives/[driveId]/members/[userId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/[userId]/__tests__/route.test.ts
@@ -23,6 +23,7 @@ vi.mock('@pagespace/lib/server', () => ({
   updateMemberPermissions: vi.fn(),
   invalidateUserPermissions: vi.fn().mockResolvedValue(undefined),
   invalidateDrivePermissions: vi.fn().mockResolvedValue(undefined),
+  securityAudit: { logEvent: vi.fn().mockResolvedValue(undefined), logDataAccess: vi.fn().mockResolvedValue(undefined) },
   loggers: {
     api: {
       info: vi.fn(),

--- a/apps/web/src/app/api/drives/[driveId]/members/[userId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/[userId]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import {
   loggers,
+  securityAudit,
   checkDriveAccess,
   getDriveMemberDetails,
   getMemberPermissions,
@@ -162,6 +163,8 @@ export async function PATCH(
       permissions
     );
 
+    securityAudit.logEvent({ eventType: 'authz.role.assigned', userId: currentUserId, resourceType: 'drive', resourceId: driveId, details: { targetUserId: userId, newRole: role } }).catch(() => {});
+
     // Invalidate permission caches so changes take effect immediately
     await Promise.all([
       invalidateUserPermissions(userId),
@@ -313,6 +316,8 @@ export async function DELETE(
       invitedAt: memberData.invitedAt,
       acceptedAt: memberData.acceptedAt,
     }, actorInfo);
+
+    securityAudit.logEvent({ eventType: 'authz.permission.revoked', userId: currentUserId, resourceType: 'drive', resourceId: driveId, details: { targetUserId } }).catch(() => {});
 
     // Broadcast member removal event
     await broadcastDriveMemberEvent(

--- a/apps/web/src/app/api/drives/[driveId]/members/[userId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/[userId]/route.ts
@@ -154,7 +154,7 @@ export async function PATCH(
         previousRole: oldRole as string,
       }, actorInfo);
 
-      securityAudit.logEvent({ eventType: 'authz.role.assigned', userId: currentUserId, resourceType: 'drive', resourceId: driveId, details: { targetUserId: userId, previousRole: oldRole, newRole: role } }).catch(() => {});
+      securityAudit.logEvent({ eventType: 'authz.role.assigned', userId: currentUserId, resourceType: 'drive', resourceId: driveId, details: { targetUserId: userId, previousRole: oldRole, newRole: role } })?.catch(() => {});
     }
 
     // Update permissions
@@ -166,7 +166,7 @@ export async function PATCH(
     );
 
     if (permissions.length > 0) {
-      securityAudit.logEvent({ eventType: 'authz.permission.granted', userId: currentUserId, resourceType: 'drive', resourceId: driveId, details: { targetUserId: userId, permissionsUpdated: permissions.length } }).catch(() => {});
+      securityAudit.logEvent({ eventType: 'authz.permission.granted', userId: currentUserId, resourceType: 'drive', resourceId: driveId, details: { targetUserId: userId, permissionsUpdated: permissions.length } })?.catch(() => {});
     }
 
     // Invalidate permission caches so changes take effect immediately
@@ -321,7 +321,7 @@ export async function DELETE(
       acceptedAt: memberData.acceptedAt,
     }, actorInfo);
 
-    securityAudit.logEvent({ eventType: 'authz.permission.revoked', userId: currentUserId, resourceType: 'drive', resourceId: driveId, details: { targetUserId } }).catch(() => {});
+    securityAudit.logEvent({ eventType: 'authz.permission.revoked', userId: currentUserId, resourceType: 'drive', resourceId: driveId, details: { targetUserId } })?.catch(() => {});
 
     // Broadcast member removal event
     await broadcastDriveMemberEvent(

--- a/apps/web/src/app/api/drives/[driveId]/members/[userId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/[userId]/route.ts
@@ -153,6 +153,8 @@ export async function PATCH(
         role: role as string,
         previousRole: oldRole as string,
       }, actorInfo);
+
+      securityAudit.logEvent({ eventType: 'authz.role.assigned', userId: currentUserId, resourceType: 'drive', resourceId: driveId, details: { targetUserId: userId, previousRole: oldRole, newRole: role } }).catch(() => {});
     }
 
     // Update permissions
@@ -163,7 +165,9 @@ export async function PATCH(
       permissions
     );
 
-    securityAudit.logEvent({ eventType: 'authz.role.assigned', userId: currentUserId, resourceType: 'drive', resourceId: driveId, details: { targetUserId: userId, newRole: role } }).catch(() => {});
+    if (permissions.length > 0) {
+      securityAudit.logEvent({ eventType: 'authz.permission.granted', userId: currentUserId, resourceType: 'drive', resourceId: driveId, details: { targetUserId: userId, permissionsUpdated: permissions.length } }).catch(() => {});
+    }
 
     // Invalidate permission caches so changes take effect immediately
     await Promise.all([

--- a/apps/web/src/app/api/drives/[driveId]/members/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/__tests__/route.test.ts
@@ -17,6 +17,7 @@ vi.mock('@pagespace/lib/server', () => ({
   listDriveMembers: vi.fn(),
   isMemberOfDrive: vi.fn(),
   addDriveMember: vi.fn(),
+  securityAudit: { logEvent: vi.fn().mockResolvedValue(undefined), logDataAccess: vi.fn().mockResolvedValue(undefined) },
   loggers: {
     api: {
       info: vi.fn(),

--- a/apps/web/src/app/api/drives/[driveId]/members/invite/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/invite/__tests__/route.test.ts
@@ -39,6 +39,7 @@ vi.mock('@pagespace/lib/server', () => ({
   loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
+  securityAudit: { logEvent: vi.fn().mockResolvedValue(undefined), logDataAccess: vi.fn().mockResolvedValue(undefined) },
   invalidateUserPermissions: vi.fn().mockResolvedValue(undefined),
   invalidateDrivePermissions: vi.fn().mockResolvedValue(undefined),
 }));

--- a/apps/web/src/app/api/drives/[driveId]/members/invite/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/invite/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { createDriveNotification, isEmailVerified } from '@pagespace/lib';
-import { loggers, invalidateUserPermissions, invalidateDrivePermissions } from '@pagespace/lib/server';
+import { loggers, securityAudit, invalidateUserPermissions, invalidateDrivePermissions } from '@pagespace/lib/server';
 import { broadcastDriveMemberEvent, createDriveMemberEventPayload } from '@/lib/websocket';
 import { getActorInfo, logMemberActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { trackDriveOperation } from '@pagespace/lib/activity-tracker';
@@ -172,6 +172,8 @@ export async function POST(
       targetUserEmail: invitedUserEmail,
       role,
     }, actorInfo);
+
+    securityAudit.logEvent({ eventType: 'authz.permission.granted', userId, resourceType: 'drive', resourceId: driveId, details: { operation: 'invite' } }).catch(() => {});
 
     return NextResponse.json({
       memberId,

--- a/apps/web/src/app/api/drives/[driveId]/members/invite/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/invite/route.ts
@@ -173,7 +173,7 @@ export async function POST(
       role,
     }, actorInfo);
 
-    securityAudit.logEvent({ eventType: 'authz.permission.granted', userId, resourceType: 'drive', resourceId: driveId, details: { operation: 'invite' } }).catch(() => {});
+    securityAudit.logEvent({ eventType: 'authz.permission.granted', userId, resourceType: 'drive', resourceId: driveId, details: { targetUserId: invitedUserId, role, operation: 'invite' } }).catch(() => {});
 
     return NextResponse.json({
       memberId,

--- a/apps/web/src/app/api/drives/[driveId]/members/invite/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/invite/route.ts
@@ -173,7 +173,7 @@ export async function POST(
       role,
     }, actorInfo);
 
-    securityAudit.logEvent({ eventType: 'authz.permission.granted', userId, resourceType: 'drive', resourceId: driveId, details: { targetUserId: invitedUserId, role, operation: 'invite' } }).catch(() => {});
+    securityAudit.logEvent({ eventType: 'authz.permission.granted', userId, resourceType: 'drive', resourceId: driveId, details: { targetUserId: invitedUserId, role, operation: 'invite' } })?.catch(() => {});
 
     return NextResponse.json({
       memberId,

--- a/apps/web/src/app/api/drives/[driveId]/members/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import {
   loggers,
+  securityAudit,
   checkDriveAccess,
   listDriveMembers,
   isMemberOfDrive,
@@ -96,6 +97,8 @@ export async function POST(
       targetUserId: invitedUserId,
       role: role as string,
     }, actorInfo);
+
+    securityAudit.logEvent({ eventType: 'authz.permission.granted', userId, resourceType: 'drive', resourceId: driveId, details: { targetUserId: invitedUserId, role } }).catch(() => {});
 
     return NextResponse.json({ member: newMember });
   } catch (error) {

--- a/apps/web/src/app/api/drives/[driveId]/members/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/route.ts
@@ -98,7 +98,7 @@ export async function POST(
       role: role as string,
     }, actorInfo);
 
-    securityAudit.logEvent({ eventType: 'authz.permission.granted', userId, resourceType: 'drive', resourceId: driveId, details: { targetUserId: invitedUserId, role } }).catch(() => {});
+    securityAudit.logEvent({ eventType: 'authz.permission.granted', userId, resourceType: 'drive', resourceId: driveId, details: { targetUserId: invitedUserId, role } })?.catch(() => {});
 
     return NextResponse.json({ member: newMember });
   } catch (error) {

--- a/apps/web/src/app/api/drives/[driveId]/restore/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/restore/__tests__/route.test.ts
@@ -23,6 +23,7 @@ vi.mock('@pagespace/db', () => ({
 }));
 
 vi.mock('@pagespace/lib/server', () => ({
+  securityAudit: { logEvent: vi.fn().mockResolvedValue(undefined), logDataAccess: vi.fn().mockResolvedValue(undefined) },
   loggers: {
     api: {
       info: vi.fn(),

--- a/apps/web/src/app/api/drives/[driveId]/restore/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/restore/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { drives, db, eq, and } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket';
 import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
 import { authenticateRequestWithOptions, isAuthError, isMCPAuthResult, checkMCPDriveScope } from '@/lib/auth';
@@ -65,6 +65,8 @@ export async function POST(
       previousValues: { isTrashed: true },
       newValues: { isTrashed: false },
     });
+
+    securityAudit.logDataAccess(auth.userId, 'write', 'drive', driveId, { operation: 'restore' }).catch(() => {});
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/apps/web/src/app/api/drives/[driveId]/restore/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/restore/route.ts
@@ -66,7 +66,7 @@ export async function POST(
       newValues: { isTrashed: false },
     });
 
-    securityAudit.logDataAccess(auth.userId, 'write', 'drive', driveId, { operation: 'restore' }).catch(() => {});
+    securityAudit.logDataAccess(auth.userId, 'write', 'drive', driveId, { operation: 'restore' })?.catch(() => {});
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/apps/web/src/app/api/drives/[driveId]/roles/[roleId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/roles/[roleId]/__tests__/route.test.ts
@@ -11,6 +11,10 @@ import type { DriveRoleAccessInfo, DriveRole, RolePermissions } from '@pagespace
 // ============================================================================
 
 vi.mock('@pagespace/lib/server', () => ({
+  securityAudit: {
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+  },
   checkDriveAccessForRoles: vi.fn(),
   getRoleById: vi.fn(),
   updateDriveRole: vi.fn(),

--- a/apps/web/src/app/api/drives/[driveId]/roles/[roleId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/roles/[roleId]/route.ts
@@ -129,7 +129,7 @@ export async function PATCH(
       previousPermissions: summarizePermissions(existingRole.permissions),
     }, actorInfo);
 
-    securityAudit.logEvent({ eventType: 'authz.role.assigned', userId, resourceType: 'drive', resourceId: driveId, details: { roleId, operation: 'update' } }).catch(() => {});
+    securityAudit.logEvent({ eventType: 'authz.role.assigned', userId, resourceType: 'drive', resourceId: driveId, details: { roleId, operation: 'update' } })?.catch(() => {});
 
     return NextResponse.json({ role: updatedRole });
   } catch (error) {
@@ -182,7 +182,7 @@ export async function DELETE(
       previousPermissions: summarizePermissions(existingRole.permissions),
     }, actorInfo);
 
-    securityAudit.logEvent({ eventType: 'authz.role.removed', userId, resourceType: 'drive', resourceId: driveId, details: { roleId } }).catch(() => {});
+    securityAudit.logEvent({ eventType: 'authz.role.removed', userId, resourceType: 'drive', resourceId: driveId, details: { roleId } })?.catch(() => {});
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/apps/web/src/app/api/drives/[driveId]/roles/[roleId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/roles/[roleId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import {
+  securityAudit,
   checkDriveAccessForRoles,
   getRoleById,
   updateDriveRole,
@@ -128,6 +129,8 @@ export async function PATCH(
       previousPermissions: summarizePermissions(existingRole.permissions),
     }, actorInfo);
 
+    securityAudit.logEvent({ eventType: 'authz.role.assigned', userId, resourceType: 'drive', resourceId: driveId, details: { roleId, operation: 'update' } }).catch(() => {});
+
     return NextResponse.json({ role: updatedRole });
   } catch (error) {
     console.error('Error updating role:', error);
@@ -178,6 +181,8 @@ export async function DELETE(
       driveId,
       previousPermissions: summarizePermissions(existingRole.permissions),
     }, actorInfo);
+
+    securityAudit.logEvent({ eventType: 'authz.role.removed', userId, resourceType: 'drive', resourceId: driveId, details: { roleId } }).catch(() => {});
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/apps/web/src/app/api/drives/[driveId]/roles/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/roles/__tests__/route.test.ts
@@ -11,6 +11,7 @@ import type { DriveRoleAccessInfo, DriveRole, RolePermissions } from '@pagespace
 // ============================================================================
 
 vi.mock('@pagespace/lib/server', () => ({
+  securityAudit: { logEvent: vi.fn().mockResolvedValue(undefined), logDataAccess: vi.fn().mockResolvedValue(undefined) },
   checkDriveAccessForRoles: vi.fn(),
   listDriveRoles: vi.fn(),
   createDriveRole: vi.fn(),

--- a/apps/web/src/app/api/drives/[driveId]/roles/reorder/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/roles/reorder/__tests__/route.test.ts
@@ -11,6 +11,7 @@ import type { DriveRoleAccessInfo } from '@pagespace/lib/server';
 // ============================================================================
 
 vi.mock('@pagespace/lib/server', () => ({
+  securityAudit: { logEvent: vi.fn().mockResolvedValue(undefined), logDataAccess: vi.fn().mockResolvedValue(undefined) },
   checkDriveAccessForRoles: vi.fn(),
   reorderDriveRoles: vi.fn(),
 }));

--- a/apps/web/src/app/api/drives/[driveId]/roles/reorder/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/roles/reorder/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import {
+  securityAudit,
   checkDriveAccessForRoles,
   reorderDriveRoles,
 } from '@pagespace/lib/server';
@@ -57,6 +58,8 @@ export async function PATCH(
       previousOrder,
       newOrder: roleIds,
     }, actorInfo);
+
+    securityAudit.logEvent({ eventType: 'authz.role.assigned', userId, resourceType: 'drive', resourceId: driveId, details: { operation: 'reorder', previousOrder, newOrder: roleIds } }).catch(() => {});
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/apps/web/src/app/api/drives/[driveId]/roles/reorder/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/roles/reorder/route.ts
@@ -59,7 +59,7 @@ export async function PATCH(
       newOrder: roleIds,
     }, actorInfo);
 
-    securityAudit.logEvent({ eventType: 'authz.role.assigned', userId, resourceType: 'drive', resourceId: driveId, details: { operation: 'reorder', previousOrder, newOrder: roleIds } }).catch(() => {});
+    securityAudit.logEvent({ eventType: 'authz.role.assigned', userId, resourceType: 'drive', resourceId: driveId, details: { operation: 'reorder', previousOrder, newOrder: roleIds } })?.catch(() => {});
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/apps/web/src/app/api/drives/[driveId]/roles/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/roles/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import {
+  securityAudit,
   checkDriveAccessForRoles,
   listDriveRoles,
   createDriveRole,
@@ -107,6 +108,8 @@ export async function POST(
       driveId,
       permissions: permissionsSummary,
     }, actorInfo);
+
+    securityAudit.logEvent({ eventType: 'authz.role.assigned', userId, resourceType: 'drive', resourceId: driveId, details: { roleName: newRole.name, operation: 'create' } }).catch(() => {});
 
     return NextResponse.json({ role: newRole }, { status: 201 });
   } catch (error) {

--- a/apps/web/src/app/api/drives/[driveId]/roles/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/roles/route.ts
@@ -109,7 +109,7 @@ export async function POST(
       permissions: permissionsSummary,
     }, actorInfo);
 
-    securityAudit.logEvent({ eventType: 'authz.role.assigned', userId, resourceType: 'drive', resourceId: driveId, details: { roleName: newRole.name, operation: 'create' } }).catch(() => {});
+    securityAudit.logEvent({ eventType: 'authz.role.assigned', userId, resourceType: 'drive', resourceId: driveId, details: { roleName: newRole.name, operation: 'create' } })?.catch(() => {});
 
     return NextResponse.json({ role: newRole }, { status: 201 });
   } catch (error) {

--- a/apps/web/src/app/api/drives/[driveId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/route.ts
@@ -157,7 +157,7 @@ export async function PATCH(
       newValues: Object.keys(newValues).length > 0 ? newValues : undefined,
     });
 
-    securityAudit.logDataAccess(userId, 'write', 'drive', driveId, { operation: 'update' }).catch(() => {});
+    securityAudit.logDataAccess(userId, 'write', 'drive', driveId, { operation: 'update' })?.catch(() => {});
 
     return NextResponse.json(updatedDrive);
   } catch (error) {
@@ -241,7 +241,7 @@ export async function DELETE(
       newValues: { isTrashed: true },
     });
 
-    securityAudit.logDataAccess(userId, 'delete', 'drive', driveId, { operation: 'trash' }).catch(() => {});
+    securityAudit.logDataAccess(userId, 'delete', 'drive', driveId, { operation: 'trash' })?.catch(() => {});
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/apps/web/src/app/api/drives/[driveId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/route.ts
@@ -7,7 +7,7 @@ import {
   updateDrive,
   trashDrive,
 } from '@pagespace/lib/server';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
 import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope, isMCPAuthResult } from '@/lib/auth';
@@ -157,6 +157,8 @@ export async function PATCH(
       newValues: Object.keys(newValues).length > 0 ? newValues : undefined,
     });
 
+    securityAudit.logDataAccess(userId, 'write', 'drive', driveId, { operation: 'update' }).catch(() => {});
+
     return NextResponse.json(updatedDrive);
   } catch (error) {
     if (error instanceof z.ZodError) {
@@ -238,6 +240,8 @@ export async function DELETE(
       previousValues: { isTrashed: drive.isTrashed },
       newValues: { isTrashed: true },
     });
+
+    securityAudit.logDataAccess(userId, 'delete', 'drive', driveId, { operation: 'trash' }).catch(() => {});
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/apps/web/src/app/api/drives/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/__tests__/route.test.ts
@@ -16,6 +16,7 @@ import type { DriveWithAccess } from '@pagespace/lib/server';
 vi.mock('@pagespace/lib/server', () => ({
   listAccessibleDrives: vi.fn(),
   createDrive: vi.fn(),
+  securityAudit: { logEvent: vi.fn().mockResolvedValue(undefined), logDataAccess: vi.fn().mockResolvedValue(undefined) },
   loggers: {
     api: {
       info: vi.fn(),

--- a/apps/web/src/app/api/drives/route.ts
+++ b/apps/web/src/app/api/drives/route.ts
@@ -100,7 +100,7 @@ export async function POST(request: Request) {
       name: newDrive.name,
     }, actorInfo);
 
-    securityAudit.logDataAccess(userId, 'write', 'drive', newDrive.id, { name, operation: 'create' }).catch(() => {});
+    securityAudit.logDataAccess(userId, 'write', 'drive', newDrive.id, { name, operation: 'create' })?.catch(() => {});
 
     return jsonResponse(newDrive, { status: 201 });
   } catch (error) {

--- a/apps/web/src/app/api/drives/route.ts
+++ b/apps/web/src/app/api/drives/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { listAccessibleDrives, createDrive } from '@pagespace/lib/server';
 import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { trackDriveOperation } from '@pagespace/lib/activity-tracker';
 import { authenticateRequestWithOptions, isAuthError, filterDrivesByMCPScope, checkMCPCreateScope } from '@/lib/auth';
 import { jsonResponse } from '@pagespace/lib/api-utils';
@@ -99,6 +99,8 @@ export async function POST(request: Request) {
       id: newDrive.id,
       name: newDrive.name,
     }, actorInfo);
+
+    securityAudit.logDataAccess(userId, 'write', 'drive', newDrive.id, { name, operation: 'create' }).catch(() => {});
 
     return jsonResponse(newDrive, { status: 201 });
   } catch (error) {

--- a/apps/web/src/app/api/pages/[pageId]/permissions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/permissions/__tests__/route.test.ts
@@ -39,6 +39,7 @@ vi.mock('@pagespace/lib', () => ({
 
 // Mock zero-trust functions
 vi.mock('@pagespace/lib/server', () => ({
+  securityAudit: { logEvent: vi.fn().mockResolvedValue(undefined), logDataAccess: vi.fn().mockResolvedValue(undefined) },
   loggers: {
     api: {
       info: vi.fn(),

--- a/apps/web/src/app/api/pages/[pageId]/permissions/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/permissions/route.ts
@@ -120,7 +120,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
       ctx.userId
     );
 
-    securityAudit.logEvent({ eventType: 'authz.permission.granted', userId: ctx.userId, resourceType: 'page', resourceId: pageId, details: { targetUserId, canView, canEdit } }).catch(() => {});
+    securityAudit.logEvent({ eventType: 'authz.permission.granted', userId: ctx.userId, resourceType: 'page', resourceId: pageId, details: { targetUserId, canView, canEdit } })?.catch(() => {});
 
     // Fetch permission details for response
     const page = await db.query.pages.findFirst({
@@ -189,7 +189,7 @@ export async function DELETE(req: Request, { params }: { params: Promise<{ pageI
         ctx.userId
       );
 
-      securityAudit.logEvent({ eventType: 'authz.permission.revoked', userId: ctx.userId, resourceType: 'page', resourceId: pageId, details: { targetUserId } }).catch(() => {});
+      securityAudit.logEvent({ eventType: 'authz.permission.revoked', userId: ctx.userId, resourceType: 'page', resourceId: pageId, details: { targetUserId } })?.catch(() => {});
 
       // CRITICAL: Kick user from real-time rooms immediately (zero-trust revocation)
       await Promise.all([

--- a/apps/web/src/app/api/pages/[pageId]/permissions/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/permissions/route.ts
@@ -9,6 +9,7 @@ import { z } from 'zod/v4';
 import { createPermissionNotification } from '@pagespace/lib';
 import {
   loggers,
+  securityAudit,
   grantPagePermission,
   revokePagePermission,
 } from '@pagespace/lib/server';
@@ -119,6 +120,8 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
       ctx.userId
     );
 
+    securityAudit.logEvent({ eventType: 'authz.permission.granted', userId: ctx.userId, resourceType: 'page', resourceId: pageId, details: { targetUserId, canView, canEdit } }).catch(() => {});
+
     // Fetch permission details for response
     const page = await db.query.pages.findFirst({
       where: eq(pages.id, pageId),
@@ -185,6 +188,8 @@ export async function DELETE(req: Request, { params }: { params: Promise<{ pageI
         {},
         ctx.userId
       );
+
+      securityAudit.logEvent({ eventType: 'authz.permission.revoked', userId: ctx.userId, resourceType: 'page', resourceId: pageId, details: { targetUserId } }).catch(() => {});
 
       // CRITICAL: Kick user from real-time rooms immediately (zero-trust revocation)
       await Promise.all([


### PR DESCRIPTION
## Summary
- Wires `SecurityAuditService` hash-chained audit logging into all drive management and permission/role mutation routes (17 audit points across 13 files)
- Drive CRUD uses `logDataAccess` (create, update, trash, restore, backup, CSV export, integration deletion)
- Permission and role changes use `logEvent` with `authz.*` event types (grant, revoke, role assign/remove, role reorder)
- Role-change audit gated on actual role change (`role && role !== oldRole`); permission-only updates emit `authz.permission.granted` separately
- All calls are fire-and-forget (`?.catch(() => {})`) — never block the request path
- All 13 affected test files updated with `securityAudit` mocks (351 tests passing)

## Test plan
- [x] `pnpm typecheck` passes cleanly (0 errors)
- [x] Rebased on latest master — no merge conflicts
- [x] All 351 route tests pass locally across 13 affected test files
- [x] ESLint passes cleanly
- [ ] CI Unit Tests green
- [ ] CI Lint & TypeScript Check green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive security audit logging across the application. The system now records security events for drive operations (creation, updates, deletions, restores, backups), member and role management, permission changes, and data access activities. Audit logging operates asynchronously to ensure optimal performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->