### PR TITLE
feat(security): wire SecurityAuditService into settings and account routes

### DIFF
--- a/apps/web/src/app/api/account/__tests__/delete-route.test.ts
+++ b/apps/web/src/app/api/account/__tests__/delete-route.test.ts
@@ -22,6 +22,10 @@ vi.mock('@pagespace/lib/server', () => ({
   activityLogRepository: {
     anonymizeForUser: vi.fn(),
   },
+  securityAudit: {
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 vi.mock('@/lib/auth', () => ({

--- a/apps/web/src/app/api/account/__tests__/get-patch-route.test.ts
+++ b/apps/web/src/app/api/account/__tests__/get-patch-route.test.ts
@@ -35,6 +35,10 @@ vi.mock('@pagespace/lib/server', () => ({
   activityLogRepository: {
     anonymizeForUser: vi.fn(),
   },
+  securityAudit: {
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 vi.mock('@/lib/auth', () => ({

--- a/apps/web/src/app/api/account/devices/[deviceId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/devices/[deviceId]/__tests__/route.test.ts
@@ -29,6 +29,10 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
     },
   },
+  securityAudit: {
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 vi.mock('@pagespace/lib/secure-compare', () => ({

--- a/apps/web/src/app/api/account/devices/[deviceId]/route.ts
+++ b/apps/web/src/app/api/account/devices/[deviceId]/route.ts
@@ -60,7 +60,7 @@ export async function DELETE(
       deviceInfo: `${device.platform ?? 'Unknown'} - ${device.deviceName ?? 'Unknown'}`,
     }, actorInfo);
 
-    securityAudit.logEvent({ eventType: 'auth.device.revoked', userId, resourceType: 'device', resourceId: deviceId }).catch(() => {});
+    securityAudit.logEvent({ eventType: 'auth.device.revoked', userId, resourceType: 'device', resourceId: deviceId }).catch(e => loggers.auth.warn('Audit log failed', e));
 
     return Response.json({
       message: 'Device revoked successfully',

--- a/apps/web/src/app/api/account/devices/[deviceId]/route.ts
+++ b/apps/web/src/app/api/account/devices/[deviceId]/route.ts
@@ -1,5 +1,5 @@
 import { db, eq, deviceTokens } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { secureCompare } from '@pagespace/lib/secure-compare';
 import { hashToken } from '@pagespace/lib/auth';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
@@ -59,6 +59,8 @@ export async function DELETE(
       tokenName: device.deviceName ?? undefined,
       deviceInfo: `${device.platform ?? 'Unknown'} - ${device.deviceName ?? 'Unknown'}`,
     }, actorInfo);
+
+    securityAudit.logEvent({ eventType: 'auth.device.revoked', userId, resourceType: 'device', resourceId: deviceId }).catch(() => {});
 
     return Response.json({
       message: 'Device revoked successfully',

--- a/apps/web/src/app/api/account/devices/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/devices/__tests__/route.test.ts
@@ -38,6 +38,10 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
     },
   },
+  securityAudit: {
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 vi.mock('@pagespace/lib/auth', () => ({

--- a/apps/web/src/app/api/account/devices/route.ts
+++ b/apps/web/src/app/api/account/devices/route.ts
@@ -192,7 +192,7 @@ export async function DELETE(req: Request) {
 
     loggers.auth.info(`User ${userId} revoked all other devices`);
 
-    securityAudit.logEvent({ eventType: 'auth.device.revoked', userId, details: { operation: 'revoke_all_other_devices' } }).catch(() => {});
+    securityAudit.logEvent({ eventType: 'auth.device.revoked', userId, resourceType: 'device', details: { operation: 'revoke_all_other_devices' } }).catch(e => loggers.auth.warn('Audit log failed', e));
 
     return Response.json({
       message: 'All other devices have been logged out',

--- a/apps/web/src/app/api/account/devices/route.ts
+++ b/apps/web/src/app/api/account/devices/route.ts
@@ -1,5 +1,5 @@
 import { users, db, eq, deviceTokens, sql, and, isNull, gt } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { hashToken } from '@pagespace/lib/auth';
 import { secureCompare } from '@pagespace/lib/secure-compare';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
@@ -191,6 +191,8 @@ export async function DELETE(req: Request) {
     }
 
     loggers.auth.info(`User ${userId} revoked all other devices`);
+
+    securityAudit.logEvent({ eventType: 'auth.device.revoked', userId, details: { operation: 'revoke_all_other_devices' } }).catch(() => {});
 
     return Response.json({
       message: 'All other devices have been logged out',

--- a/apps/web/src/app/api/account/export/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/export/__tests__/route.test.ts
@@ -12,6 +12,20 @@ vi.mock('@pagespace/db', () => ({
   db: {},
 }));
 
+vi.mock('@pagespace/lib/server', () => ({
+  loggers: {
+    auth: {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+    },
+  },
+  securityAudit: {
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
 vi.mock('@pagespace/lib/compliance/export/gdpr-export', () => ({
   collectAllUserData: vi.fn(),
 }));

--- a/apps/web/src/app/api/account/export/route.ts
+++ b/apps/web/src/app/api/account/export/route.ts
@@ -2,7 +2,7 @@ import { collectAllUserData } from '@pagespace/lib/compliance/export/gdpr-export
 import { db } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { checkDistributedRateLimit, resetDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security';
-import { securityAudit } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import archiver from 'archiver';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
@@ -40,8 +40,6 @@ export async function GET(request: Request) {
     );
   }
 
-  securityAudit.logDataAccess(userId, 'export', 'account', userId, { operation: 'gdpr_export' }).catch(() => {});
-
   try {
     const data = await collectAllUserData(
       db as Parameters<typeof collectAllUserData>[0],
@@ -52,6 +50,8 @@ export async function GET(request: Request) {
       await resetDistributedRateLimit(rateLimitKey);
       return Response.json({ error: 'User not found' }, { status: 404 });
     }
+
+    securityAudit.logDataAccess(userId, 'export', 'account', userId, { operation: 'gdpr_export' }).catch(e => loggers.auth.warn('Audit log failed', e));
 
     // Build ZIP archive
     const archive = archiver('zip', { zlib: { level: 6 } });

--- a/apps/web/src/app/api/account/export/route.ts
+++ b/apps/web/src/app/api/account/export/route.ts
@@ -2,6 +2,7 @@ import { collectAllUserData } from '@pagespace/lib/compliance/export/gdpr-export
 import { db } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { checkDistributedRateLimit, resetDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security';
+import { securityAudit } from '@pagespace/lib/server';
 import archiver from 'archiver';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
@@ -38,6 +39,8 @@ export async function GET(request: Request) {
       }
     );
   }
+
+  securityAudit.logDataAccess(userId, 'export', 'account', userId, { operation: 'gdpr_export' }).catch(() => {});
 
   try {
     const data = await collectAllUserData(

--- a/apps/web/src/app/api/account/handle-drive/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/handle-drive/__tests__/route.test.ts
@@ -32,6 +32,10 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
+  securityAudit: {
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 vi.mock('@/lib/auth', () => ({

--- a/apps/web/src/app/api/account/handle-drive/route.ts
+++ b/apps/web/src/app/api/account/handle-drive/route.ts
@@ -1,5 +1,5 @@
 import { db, eq, and, drives, driveMembers } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { getActorInfo, logDriveActivity } from '@pagespace/lib/monitoring/activity-logger';
 
@@ -83,6 +83,8 @@ export async function POST(req: Request) {
 
       loggers.auth.info(`Drive ownership transferred: ${driveId} from ${userId} to ${newOwnerId}`);
 
+      securityAudit.logDataAccess(userId, 'write', 'drive', driveId, { operation: 'ownership_transfer', newOwnerId }).catch(() => {});
+
       return Response.json({
         success: true,
         message: 'Drive ownership transferred successfully',
@@ -95,6 +97,8 @@ export async function POST(req: Request) {
       await db.delete(drives).where(eq(drives.id, driveId));
 
       loggers.auth.info(`Drive deleted during account deletion preparation: ${driveId} by ${userId}`);
+
+      securityAudit.logDataAccess(userId, 'delete', 'drive', driveId, { operation: 'drive_delete' }).catch(() => {});
 
       return Response.json({
         success: true,

--- a/apps/web/src/app/api/account/handle-drive/route.ts
+++ b/apps/web/src/app/api/account/handle-drive/route.ts
@@ -83,7 +83,7 @@ export async function POST(req: Request) {
 
       loggers.auth.info(`Drive ownership transferred: ${driveId} from ${userId} to ${newOwnerId}`);
 
-      securityAudit.logDataAccess(userId, 'write', 'drive', driveId, { operation: 'ownership_transfer', newOwnerId }).catch(() => {});
+      securityAudit.logDataAccess(userId, 'write', 'drive', driveId, { operation: 'ownership_transfer', newOwnerId }).catch(e => loggers.auth.warn('Audit log failed', e));
 
       return Response.json({
         success: true,
@@ -98,7 +98,7 @@ export async function POST(req: Request) {
 
       loggers.auth.info(`Drive deleted during account deletion preparation: ${driveId} by ${userId}`);
 
-      securityAudit.logDataAccess(userId, 'delete', 'drive', driveId, { operation: 'drive_delete' }).catch(() => {});
+      securityAudit.logDataAccess(userId, 'delete', 'drive', driveId, { operation: 'drive_delete' }).catch(e => loggers.auth.warn('Audit log failed', e));
 
       return Response.json({
         success: true,

--- a/apps/web/src/app/api/account/route.ts
+++ b/apps/web/src/app/api/account/route.ts
@@ -258,8 +258,13 @@ export async function DELETE(req: Request) {
       loggers.auth.error('Could not delete monitoring data during account deletion:', error as Error);
     }
 
-    // Log security audit BEFORE user deletion so the userId FK is still valid
-    await securityAudit.logEvent({ eventType: 'admin.user.deleted', userId, resourceType: 'account', resourceId: userId }).catch(e => loggers.auth.warn('Audit log failed', e));
+    // Log security audit BEFORE user deletion so the userId FK is still valid.
+    // Timeout prevents stalling account deletion if the advisory lock hangs.
+    const AUDIT_TIMEOUT_MS = 5000;
+    await Promise.race([
+      securityAudit.logEvent({ eventType: 'admin.user.deleted', userId, resourceType: 'account', resourceId: userId }),
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('Audit timeout')), AUDIT_TIMEOUT_MS)),
+    ]).catch(e => loggers.auth.warn('Audit log failed before account deletion', e));
 
     // Delete the user via repository seam (FK set null will preserve activity logs with userId = null)
     await accountRepository.deleteUser(userId);

--- a/apps/web/src/app/api/account/route.ts
+++ b/apps/web/src/app/api/account/route.ts
@@ -100,7 +100,7 @@ export async function PATCH(req: Request) {
       updatedFields,
     }, actorInfo);
 
-    securityAudit.logDataAccess(userId, 'write', 'account', userId, { operation: 'profile_update', updatedFields }).catch(() => {});
+    securityAudit.logDataAccess(userId, 'write', 'account', userId, { operation: 'profile_update', updatedFields }).catch(e => loggers.auth.warn('Audit log failed', e));
 
     return Response.json({
       id: updatedUser.id,
@@ -263,7 +263,7 @@ export async function DELETE(req: Request) {
 
     loggers.auth.info(`User account deleted: ${userId}`);
 
-    securityAudit.logEvent({ eventType: 'admin.user.deleted', userId, resourceType: 'account', resourceId: userId }).catch(() => {});
+    securityAudit.logEvent({ eventType: 'admin.user.deleted', userId, resourceType: 'account', resourceId: userId }).catch(e => loggers.auth.warn('Audit log failed', e));
 
     return Response.json({ message: 'Account deleted successfully' }, { status: 200 });
   } catch (error) {

--- a/apps/web/src/app/api/account/route.ts
+++ b/apps/web/src/app/api/account/route.ts
@@ -258,12 +258,13 @@ export async function DELETE(req: Request) {
       loggers.auth.error('Could not delete monitoring data during account deletion:', error as Error);
     }
 
+    // Log security audit BEFORE user deletion so the userId FK is still valid
+    await securityAudit.logEvent({ eventType: 'admin.user.deleted', userId, resourceType: 'account', resourceId: userId }).catch(e => loggers.auth.warn('Audit log failed', e));
+
     // Delete the user via repository seam (FK set null will preserve activity logs with userId = null)
     await accountRepository.deleteUser(userId);
 
     loggers.auth.info(`User account deleted: ${userId}`);
-
-    securityAudit.logEvent({ eventType: 'admin.user.deleted', userId, resourceType: 'account', resourceId: userId }).catch(e => loggers.auth.warn('Audit log failed', e));
 
     return Response.json({ message: 'Account deleted successfully' }, { status: 200 });
   } catch (error) {

--- a/apps/web/src/app/api/account/route.ts
+++ b/apps/web/src/app/api/account/route.ts
@@ -1,5 +1,5 @@
 import { users, db, eq } from '@pagespace/db';
-import { loggers, accountRepository, activityLogRepository } from '@pagespace/lib/server';
+import { loggers, accountRepository, activityLogRepository, securityAudit } from '@pagespace/lib/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { createUserServiceToken, deleteAiUsageLogsForUser, deleteMonitoringDataForUser, isValidEmail, type ServiceScope } from '@pagespace/lib';
 import { createAnonymizedActorEmail } from '@pagespace/lib/compliance/anonymize';
@@ -99,6 +99,8 @@ export async function PATCH(req: Request) {
       targetUserEmail: updatedUser.email,
       updatedFields,
     }, actorInfo);
+
+    securityAudit.logDataAccess(userId, 'write', 'account', userId, { operation: 'profile_update', updatedFields }).catch(() => {});
 
     return Response.json({
       id: updatedUser.id,
@@ -260,6 +262,8 @@ export async function DELETE(req: Request) {
     await accountRepository.deleteUser(userId);
 
     loggers.auth.info(`User account deleted: ${userId}`);
+
+    securityAudit.logEvent({ eventType: 'admin.user.deleted', userId, resourceType: 'account', resourceId: userId }).catch(() => {});
 
     return Response.json({ message: 'Account deleted successfully' }, { status: 200 });
   } catch (error) {

--- a/apps/web/src/app/api/settings/display-preferences/route.ts
+++ b/apps/web/src/app/api/settings/display-preferences/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db, displayPreferences, eq, and } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
@@ -91,6 +91,7 @@ export async function PATCH(request: Request) {
         ))
         .returning();
 
+      securityAudit.logEvent({ eventType: 'admin.settings.changed', userId, resourceType: 'display_preference' }).catch(() => {});
       return NextResponse.json({ preference: updated });
     } else {
       const [created] = await db
@@ -102,6 +103,7 @@ export async function PATCH(request: Request) {
         })
         .returning();
 
+      securityAudit.logEvent({ eventType: 'admin.settings.changed', userId, resourceType: 'display_preference' }).catch(() => {});
       return NextResponse.json({ preference: created });
     }
   } catch (error) {

--- a/apps/web/src/app/api/settings/display-preferences/route.ts
+++ b/apps/web/src/app/api/settings/display-preferences/route.ts
@@ -91,7 +91,7 @@ export async function PATCH(request: Request) {
         ))
         .returning();
 
-      securityAudit.logEvent({ eventType: 'admin.settings.changed', userId, resourceType: 'display_preference' }).catch(() => {});
+      securityAudit.logEvent({ eventType: 'admin.settings.changed', userId, resourceType: 'display_preference' }).catch(e => loggers.api.warn('Audit log failed', e));
       return NextResponse.json({ preference: updated });
     } else {
       const [created] = await db
@@ -103,7 +103,7 @@ export async function PATCH(request: Request) {
         })
         .returning();
 
-      securityAudit.logEvent({ eventType: 'admin.settings.changed', userId, resourceType: 'display_preference' }).catch(() => {});
+      securityAudit.logEvent({ eventType: 'admin.settings.changed', userId, resourceType: 'display_preference' }).catch(e => loggers.api.warn('Audit log failed', e));
       return NextResponse.json({ preference: created });
     }
   } catch (error) {

--- a/apps/web/src/app/api/settings/hotkey-preferences/__tests__/route.test.ts
+++ b/apps/web/src/app/api/settings/hotkey-preferences/__tests__/route.test.ts
@@ -38,6 +38,10 @@ vi.mock('@pagespace/lib/server', () => ({
   loggers: {
     api: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
   },
+  securityAudit: {
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 vi.mock('@/lib/hotkeys/registry', () => ({

--- a/apps/web/src/app/api/settings/hotkey-preferences/route.ts
+++ b/apps/web/src/app/api/settings/hotkey-preferences/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db, userHotkeyPreferences, eq, and } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { getHotkeyDefinition } from '@/lib/hotkeys/registry';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
@@ -79,6 +79,7 @@ export async function PATCH(request: Request) {
         ))
         .returning();
 
+      securityAudit.logEvent({ eventType: 'admin.settings.changed', userId, resourceType: 'hotkey_preference' }).catch(() => {});
       return NextResponse.json({ preference: updated });
     } else {
       const [created] = await db
@@ -90,6 +91,7 @@ export async function PATCH(request: Request) {
         })
         .returning();
 
+      securityAudit.logEvent({ eventType: 'admin.settings.changed', userId, resourceType: 'hotkey_preference' }).catch(() => {});
       return NextResponse.json({ preference: created });
     }
   } catch (error) {

--- a/apps/web/src/app/api/settings/hotkey-preferences/route.ts
+++ b/apps/web/src/app/api/settings/hotkey-preferences/route.ts
@@ -79,7 +79,7 @@ export async function PATCH(request: Request) {
         ))
         .returning();
 
-      securityAudit.logEvent({ eventType: 'admin.settings.changed', userId, resourceType: 'hotkey_preference' }).catch(() => {});
+      securityAudit.logEvent({ eventType: 'admin.settings.changed', userId, resourceType: 'hotkey_preference' }).catch(e => loggers.api.warn('Audit log failed', e));
       return NextResponse.json({ preference: updated });
     } else {
       const [created] = await db
@@ -91,7 +91,7 @@ export async function PATCH(request: Request) {
         })
         .returning();
 
-      securityAudit.logEvent({ eventType: 'admin.settings.changed', userId, resourceType: 'hotkey_preference' }).catch(() => {});
+      securityAudit.logEvent({ eventType: 'admin.settings.changed', userId, resourceType: 'hotkey_preference' }).catch(e => loggers.api.warn('Audit log failed', e));
       return NextResponse.json({ preference: created });
     }
   } catch (error) {

--- a/apps/web/src/app/api/settings/notification-preferences/route.ts
+++ b/apps/web/src/app/api/settings/notification-preferences/route.ts
@@ -102,7 +102,7 @@ export async function PATCH(request: Request) {
         ))
         .returning();
 
-      securityAudit.logEvent({ eventType: 'admin.settings.changed', userId, resourceType: 'notification_preference' }).catch(() => {});
+      securityAudit.logEvent({ eventType: 'admin.settings.changed', userId, resourceType: 'notification_preference' }).catch(e => loggers.api.warn('Audit log failed', e));
       return NextResponse.json({ preference: updated });
     } else {
       // Create new preference
@@ -115,7 +115,7 @@ export async function PATCH(request: Request) {
         })
         .returning();
 
-      securityAudit.logEvent({ eventType: 'admin.settings.changed', userId, resourceType: 'notification_preference' }).catch(() => {});
+      securityAudit.logEvent({ eventType: 'admin.settings.changed', userId, resourceType: 'notification_preference' }).catch(e => loggers.api.warn('Audit log failed', e));
       return NextResponse.json({ preference: created });
     }
   } catch (error) {

--- a/apps/web/src/app/api/settings/notification-preferences/route.ts
+++ b/apps/web/src/app/api/settings/notification-preferences/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db, emailNotificationPreferences, eq, and } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
@@ -102,6 +102,7 @@ export async function PATCH(request: Request) {
         ))
         .returning();
 
+      securityAudit.logEvent({ eventType: 'admin.settings.changed', userId, resourceType: 'notification_preference' }).catch(() => {});
       return NextResponse.json({ preference: updated });
     } else {
       // Create new preference
@@ -114,6 +115,7 @@ export async function PATCH(request: Request) {
         })
         .returning();
 
+      securityAudit.logEvent({ eventType: 'admin.settings.changed', userId, resourceType: 'notification_preference' }).catch(() => {});
       return NextResponse.json({ preference: created });
     }
   } catch (error) {

--- a/apps/web/src/app/api/settings/personalization/route.ts
+++ b/apps/web/src/app/api/settings/personalization/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db, userPersonalization, eq } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
@@ -139,6 +139,8 @@ export async function PATCH(request: Request) {
         set: updateData,
       })
       .returning();
+
+    securityAudit.logEvent({ eventType: 'admin.settings.changed', userId, resourceType: 'personalization' }).catch(() => {});
 
     return NextResponse.json({
       personalization: {

--- a/apps/web/src/app/api/settings/personalization/route.ts
+++ b/apps/web/src/app/api/settings/personalization/route.ts
@@ -140,7 +140,7 @@ export async function PATCH(request: Request) {
       })
       .returning();
 
-    securityAudit.logEvent({ eventType: 'admin.settings.changed', userId, resourceType: 'personalization' }).catch(() => {});
+    securityAudit.logEvent({ eventType: 'admin.settings.changed', userId, resourceType: 'personalization' }).catch(e => loggers.api.warn('Audit log failed', e));
 
     return NextResponse.json({
       personalization: {


### PR DESCRIPTION
## Summary
- Wires `SecurityAuditService` hash-chained audit logging into 9 account and settings API routes (11 audit call sites total)
- Covers account profile updates, account deletion, GDPR data export, device revocation, display/notification/hotkey/personalization settings, and drive ownership transfer/deletion
- Account deletion audit event is `await`ed with a 5s timeout before user deletion to preserve userId FK integrity without risking indefinite stalls
- All other audit calls use fire-and-forget pattern with `.catch(e => loggers.*.warn(...))` for observability

## Routes covered

| Route | Event |
|-------|-------|
| `account/route.ts` PATCH | `logDataAccess` — profile_update |
| `account/route.ts` DELETE | `logEvent` — admin.user.deleted (awaited with timeout, before user deletion) |
| `account/export/route.ts` GET | `logDataAccess` — gdpr_export (after successful data collection) |
| `account/devices/route.ts` DELETE | `logEvent` — auth.device.revoked (all other devices) |
| `account/devices/[deviceId]/route.ts` DELETE | `logEvent` — auth.device.revoked (single device) |
| `settings/display-preferences/route.ts` PATCH | `logEvent` — admin.settings.changed |
| `settings/notification-preferences/route.ts` PATCH | `logEvent` — admin.settings.changed |
| `settings/hotkey-preferences/route.ts` PATCH | `logEvent` — admin.settings.changed |
| `settings/personalization/route.ts` PATCH | `logEvent` — admin.settings.changed |
| `account/handle-drive/route.ts` POST (transfer) | `logDataAccess` — ownership_transfer |
| `account/handle-drive/route.ts` POST (delete) | `logDataAccess` — drive_delete |

## Key design decisions
- **Account deletion ordering**: Audit event logged before `deleteUser()` so the userId FK is still valid at insert time
- **Timeout protection**: Account deletion audit wrapped in `Promise.race` with 5s timeout to prevent stalling on advisory lock contention
- **GDPR export**: Audit logged after successful data collection (log what happened, not what was attempted)
- **Observability**: Silent `.catch(() => {})` replaced with `.catch(e => loggers.*.warn(...))` so audit failures are visible in logs
- **Consistency**: All device revocation events include `resourceType: 'device'`

## Validation
- [x] `pnpm typecheck` passes
- [x] All 7 affected test files updated with `securityAudit` mock (114 tests pass)
- [x] Rebased on latest master — no merge conflicts
- [x] Both Codex P1 and CodeRabbit review comments addressed with code fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)