### PR TITLE
fix(security): replace silent .catch(() => {}) with observable error logging

### DIFF
--- a/apps/web/src/app/api/admin/audit-logs/__tests__/search-security.test.ts
+++ b/apps/web/src/app/api/admin/audit-logs/__tests__/search-security.test.ts
@@ -52,6 +52,7 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
       debug: vi.fn(),
     },
+    security: { warn: vi.fn() },
   },
 }));
 

--- a/apps/web/src/app/api/admin/users/[userId]/export/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/export/__tests__/route.test.ts
@@ -19,6 +19,7 @@ vi.mock('@pagespace/lib/server', () => ({
   loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
     auth: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
+    security: { warn: vi.fn() },
   },
   logSecurityEvent: vi.fn(),
   securityAudit: {

--- a/apps/web/src/app/api/admin/users/[userId]/gift-subscription/__tests__/route.security.test.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/gift-subscription/__tests__/route.security.test.ts
@@ -86,6 +86,9 @@ vi.mock('@pagespace/lib/server', async () => {
         debug: vi.fn(),
         error: vi.fn(),
       },
+      security: {
+        warn: vi.fn(),
+      },
     },
     logSecurityEvent: vi.fn(),
   };

--- a/apps/web/src/app/api/auth/__tests__/logout.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/logout.test.ts
@@ -283,7 +283,7 @@ describe('/api/auth/logout', () => {
       expect(response.status).toBe(200);
       expect(mockSecurityWarn).toHaveBeenCalledWith(
         '[Logout] audit logLogout failed',
-        expect.objectContaining({ error: expect.any(Error), userId: 'test-user-id' })
+        expect.objectContaining({ error: expect.any(String), userId: 'test-user-id' })
       );
     });
 
@@ -304,7 +304,7 @@ describe('/api/auth/logout', () => {
       expect(response.status).toBe(200);
       expect(mockSecurityWarn).toHaveBeenCalledWith(
         '[Logout] audit logTokenRevoked failed',
-        expect.objectContaining({ error: expect.any(Error), userId: 'test-user-id' })
+        expect.objectContaining({ error: expect.any(String), userId: 'test-user-id' })
       );
     });
   });

--- a/apps/web/src/app/api/auth/__tests__/logout.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/logout.test.ts
@@ -51,6 +51,9 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
       debug: vi.fn(),
     },
+    security: {
+      warn: vi.fn(),
+    },
   },
   logAuthEvent: vi.fn(),
   securityAudit: {
@@ -66,7 +69,7 @@ vi.mock('@pagespace/lib/activity-tracker', () => ({
 import { sessionService } from '@pagespace/lib/auth';
 import { getSessionFromCookies, appendClearCookies } from '@/lib/auth/cookie-config';
 import { getClientIP } from '@/lib/auth';
-import { logAuthEvent } from '@pagespace/lib/server';
+import { loggers, logAuthEvent, securityAudit } from '@pagespace/lib/server';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
 
 describe('/api/auth/logout', () => {
@@ -255,6 +258,54 @@ describe('/api/auth/logout', () => {
       // Should not log when no user ID
       expect(logAuthEvent).not.toHaveBeenCalled();
       expect(trackAuthEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('audit persistence failure logging', () => {
+    const mockSecurityWarn = vi.mocked(loggers.security.warn);
+    const mockLogLogout = vi.mocked(securityAudit.logLogout);
+    const mockLogTokenRevoked = vi.mocked(securityAudit.logTokenRevoked);
+
+    it('logs warning when logLogout rejects and still returns 200', async () => {
+      mockLogLogout.mockRejectedValueOnce(new Error('Audit DB down'));
+
+      const request = new Request('http://localhost/api/auth/logout', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: 'session=ps_sess_mock_session_token',
+        },
+      });
+
+      const response = await POST(request);
+      await new Promise(process.nextTick);
+
+      expect(response.status).toBe(200);
+      expect(mockSecurityWarn).toHaveBeenCalledWith(
+        '[Logout] audit logLogout failed',
+        expect.objectContaining({ error: expect.any(Error), userId: 'test-user-id' })
+      );
+    });
+
+    it('logs warning when logTokenRevoked rejects and still returns 200', async () => {
+      mockLogTokenRevoked.mockRejectedValueOnce(new Error('Write failed'));
+
+      const request = new Request('http://localhost/api/auth/logout', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Cookie: 'session=ps_sess_mock_session_token',
+        },
+      });
+
+      const response = await POST(request);
+      await new Promise(process.nextTick);
+
+      expect(response.status).toBe(200);
+      expect(mockSecurityWarn).toHaveBeenCalledWith(
+        '[Logout] audit logTokenRevoked failed',
+        expect.objectContaining({ error: expect.any(Error), userId: 'test-user-id' })
+      );
     });
   });
 });

--- a/apps/web/src/app/api/auth/logout/route.ts
+++ b/apps/web/src/app/api/auth/logout/route.ts
@@ -38,8 +38,12 @@ export async function POST(req: Request) {
       ip: clientIP,
       userAgent: req.headers.get('user-agent')
     });
-    securityAudit.logLogout(userId, sessionClaims?.sessionId ?? 'unknown', clientIP).catch(() => {});
-    securityAudit.logTokenRevoked(userId, 'session', 'user_logout').catch(() => {});
+    securityAudit.logLogout(userId, sessionClaims?.sessionId ?? 'unknown', clientIP).catch((error) => {
+      loggers.security.warn('[Logout] audit logLogout failed', { error, userId });
+    });
+    securityAudit.logTokenRevoked(userId, 'session', 'user_logout').catch((error) => {
+      loggers.security.warn('[Logout] audit logTokenRevoked failed', { error, userId });
+    });
   }
 
   const headers = new Headers();

--- a/apps/web/src/app/api/auth/logout/route.ts
+++ b/apps/web/src/app/api/auth/logout/route.ts
@@ -39,10 +39,10 @@ export async function POST(req: Request) {
       userAgent: req.headers.get('user-agent')
     });
     securityAudit.logLogout(userId, sessionClaims?.sessionId ?? 'unknown', clientIP).catch((error) => {
-      loggers.security.warn('[Logout] audit logLogout failed', { error, userId });
+      loggers.security.warn('[Logout] audit logLogout failed', { error: error instanceof Error ? error.message : String(error), userId });
     });
     securityAudit.logTokenRevoked(userId, 'session', 'user_logout').catch((error) => {
-      loggers.security.warn('[Logout] audit logTokenRevoked failed', { error, userId });
+      loggers.security.warn('[Logout] audit logTokenRevoked failed', { error: error instanceof Error ? error.message : String(error), userId });
     });
   }
 

--- a/apps/web/src/lib/auth/__tests__/admin-audit-coverage.test.ts
+++ b/apps/web/src/lib/auth/__tests__/admin-audit-coverage.test.ts
@@ -20,6 +20,9 @@ vi.mock('../csrf-validation', () => ({
 // Mock security event logging
 vi.mock('@pagespace/lib/server', () => ({
   logSecurityEvent: vi.fn(),
+  loggers: {
+    security: { warn: vi.fn() },
+  },
   securityAudit: {
     logDataAccess: vi.fn().mockResolvedValue(undefined),
     logEvent: vi.fn().mockResolvedValue(undefined),
@@ -30,12 +33,14 @@ vi.mock('@pagespace/lib/server', () => ({
 import { withAdminAuth } from '../auth';
 import { authenticateSessionRequest } from '../index';
 import { validateAdminAccess } from '../admin-role';
-import { securityAudit } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 
 const mockAuthenticateRequest = vi.mocked(authenticateSessionRequest);
 const mockValidateAdminAccess = vi.mocked(validateAdminAccess);
 const mockLogDataAccess = vi.mocked(securityAudit.logDataAccess);
 const mockLogEvent = vi.mocked(securityAudit.logEvent);
+const mockLogAccessDenied = vi.mocked(securityAudit.logAccessDenied);
+const mockSecurityWarn = vi.mocked(loggers.security.warn);
 
 function mockAdminAuth() {
   mockAuthenticateRequest.mockResolvedValue({
@@ -334,6 +339,53 @@ describe('Admin audit coverage (withAdminAuth)', () => {
           }),
           riskScore: 0.5,
         })
+      );
+    });
+  });
+
+  describe('audit persistence failure logging', () => {
+    it('logs warning when logDataAccess rejects', async () => {
+      mockAdminAuth();
+      mockLogDataAccess.mockRejectedValueOnce(new Error('DB write timeout'));
+      const wrappedHandler = withAdminAuth(handler);
+      const request = new Request('http://localhost/api/admin/users');
+
+      await wrappedHandler(request);
+      await new Promise(process.nextTick);
+
+      expect(mockSecurityWarn).toHaveBeenCalledWith(
+        '[AdminAuth] audit logDataAccess failed',
+        expect.objectContaining({ error: expect.any(Error), userId: 'admin-123' })
+      );
+    });
+
+    it('logs warning when logEvent rejects', async () => {
+      mockAuthDenied();
+      mockLogEvent.mockRejectedValueOnce(new Error('Audit service down'));
+      const wrappedHandler = withAdminAuth(handler);
+      const request = new Request('http://localhost/api/admin/users');
+
+      await wrappedHandler(request);
+      await new Promise(process.nextTick);
+
+      expect(mockSecurityWarn).toHaveBeenCalledWith(
+        '[AdminAuth] audit logEvent failed',
+        expect.objectContaining({ error: expect.any(Error), endpoint: '/api/admin/users' })
+      );
+    });
+
+    it('logs warning when logAccessDenied rejects', async () => {
+      mockAdminRoleDenied();
+      mockLogAccessDenied.mockRejectedValueOnce(new Error('Connection refused'));
+      const wrappedHandler = withAdminAuth(handler);
+      const request = new Request('http://localhost/api/admin/users');
+
+      await wrappedHandler(request);
+      await new Promise(process.nextTick);
+
+      expect(mockSecurityWarn).toHaveBeenCalledWith(
+        '[AdminAuth] audit logAccessDenied failed',
+        expect.objectContaining({ error: expect.any(Error), userId: 'user-456' })
       );
     });
   });

--- a/apps/web/src/lib/auth/__tests__/admin-audit-coverage.test.ts
+++ b/apps/web/src/lib/auth/__tests__/admin-audit-coverage.test.ts
@@ -355,7 +355,7 @@ describe('Admin audit coverage (withAdminAuth)', () => {
 
       expect(mockSecurityWarn).toHaveBeenCalledWith(
         '[AdminAuth] audit logDataAccess failed',
-        expect.objectContaining({ error: expect.any(Error), userId: 'admin-123' })
+        expect.objectContaining({ error: 'DB write timeout', userId: 'admin-123' })
       );
     });
 
@@ -370,7 +370,7 @@ describe('Admin audit coverage (withAdminAuth)', () => {
 
       expect(mockSecurityWarn).toHaveBeenCalledWith(
         '[AdminAuth] audit logEvent failed',
-        expect.objectContaining({ error: expect.any(Error), endpoint: '/api/admin/users' })
+        expect.objectContaining({ error: 'Audit service down', endpoint: '/api/admin/users' })
       );
     });
 
@@ -385,7 +385,7 @@ describe('Admin audit coverage (withAdminAuth)', () => {
 
       expect(mockSecurityWarn).toHaveBeenCalledWith(
         '[AdminAuth] audit logAccessDenied failed',
-        expect.objectContaining({ error: expect.any(Error), userId: 'user-456' })
+        expect.objectContaining({ error: 'Connection refused', userId: 'user-456' })
       );
     });
   });

--- a/apps/web/src/lib/auth/__tests__/auth.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.test.ts
@@ -22,6 +22,9 @@ vi.mock('../csrf-validation', () => ({
 // Mock security event logging
 vi.mock('@pagespace/lib/server', () => ({
   logSecurityEvent: vi.fn(),
+  loggers: {
+    security: { warn: vi.fn() },
+  },
   securityAudit: {
     logAccessDenied: vi.fn().mockResolvedValue(undefined),
   },

--- a/apps/web/src/lib/auth/auth.ts
+++ b/apps/web/src/lib/auth/auth.ts
@@ -131,7 +131,7 @@ export async function verifyAdminAuth(request: Request): Promise<VerifiedUser | 
         action: 'deny_access',
       });
       securityAudit.logAccessDenied(user.id, 'admin_route', method, 'csrf_validation_failed').catch((error) => {
-        loggers.security.warn('[AdminAuth] audit logAccessDenied failed', { error, userId: user.id, reason: 'csrf_validation_failed' });
+        loggers.security.warn('[AdminAuth] audit logAccessDenied failed', { error: error instanceof Error ? error.message : String(error), userId: user.id, reason: 'csrf_validation_failed' });
       });
       // Return the CSRF error response directly to preserve error codes
       return csrfError;
@@ -160,7 +160,7 @@ export async function verifyAdminAuth(request: Request): Promise<VerifiedUser | 
       'admin_access',
       validationResult.reason ?? 'admin_role_version_validation_failed'
     ).catch((error) => {
-      loggers.security.warn('[AdminAuth] audit logAccessDenied failed', { error, userId: user.id });
+      loggers.security.warn('[AdminAuth] audit logAccessDenied failed', { error: error instanceof Error ? error.message : String(error), userId: user.id });
     });
     return NextResponse.json(
       { error: 'Forbidden: Admin access required' },
@@ -192,7 +192,7 @@ function emitAdminAuditAccess(user: VerifiedUser, request: Request, endpoint: st
     endpoint,
     { method: request.method, ipAddress }
   ).catch((error) => {
-    loggers.security.warn('[AdminAuth] audit logDataAccess failed', { error, userId: user.id, endpoint });
+    loggers.security.warn('[AdminAuth] audit logDataAccess failed', { error: error instanceof Error ? error.message : String(error), userId: user.id, endpoint });
   });
 }
 
@@ -206,6 +206,6 @@ function emitAdminAuditDenied(request: Request, endpoint: string, ipAddress?: st
     details: { method: request.method, reason: 'admin_auth_denied' },
     riskScore: 0.5,
   }).catch((error) => {
-    loggers.security.warn('[AdminAuth] audit logEvent failed', { error, userId, endpoint });
+    loggers.security.warn('[AdminAuth] audit logEvent failed', { error: error instanceof Error ? error.message : String(error), userId, endpoint });
   });
 }

--- a/apps/web/src/lib/auth/auth.ts
+++ b/apps/web/src/lib/auth/auth.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { authenticateSessionRequest, isAuthError } from './index';
 import { validateAdminAccess, type AdminValidationResult } from './admin-role';
 import { validateCSRF } from './csrf-validation';
-import { logSecurityEvent, securityAudit } from '@pagespace/lib/server';
+import { loggers, logSecurityEvent, securityAudit } from '@pagespace/lib/server';
 
 export interface VerifiedUser {
   id: string;
@@ -130,7 +130,9 @@ export async function verifyAdminAuth(request: Request): Promise<VerifiedUser | 
         authType: 'session',
         action: 'deny_access',
       });
-      securityAudit.logAccessDenied(user.id, 'admin_route', method, 'csrf_validation_failed').catch(() => {});
+      securityAudit.logAccessDenied(user.id, 'admin_route', method, 'csrf_validation_failed').catch((error) => {
+        loggers.security.warn('[AdminAuth] audit logAccessDenied failed', { error, userId: user.id, reason: 'csrf_validation_failed' });
+      });
       // Return the CSRF error response directly to preserve error codes
       return csrfError;
     }
@@ -157,7 +159,9 @@ export async function verifyAdminAuth(request: Request): Promise<VerifiedUser | 
       'admin_route',
       'admin_access',
       validationResult.reason ?? 'admin_role_version_validation_failed'
-    ).catch(() => {});
+    ).catch((error) => {
+      loggers.security.warn('[AdminAuth] audit logAccessDenied failed', { error, userId: user.id });
+    });
     return NextResponse.json(
       { error: 'Forbidden: Admin access required' },
       { status: 403 }
@@ -187,7 +191,9 @@ function emitAdminAuditAccess(user: VerifiedUser, request: Request, endpoint: st
     'admin-endpoint',
     endpoint,
     { method: request.method, ipAddress }
-  ).catch(() => {});
+  ).catch((error) => {
+    loggers.security.warn('[AdminAuth] audit logDataAccess failed', { error, userId: user.id, endpoint });
+  });
 }
 
 function emitAdminAuditDenied(request: Request, endpoint: string, ipAddress?: string, userId?: string): void {
@@ -199,5 +205,7 @@ function emitAdminAuditDenied(request: Request, endpoint: string, ipAddress?: st
     ipAddress,
     details: { method: request.method, reason: 'admin_auth_denied' },
     riskScore: 0.5,
-  }).catch(() => {});
+  }).catch((error) => {
+    loggers.security.warn('[AdminAuth] audit logEvent failed', { error, userId, endpoint });
+  });
 }


### PR DESCRIPTION
## Summary
- Replace 6 silent `securityAudit.*().catch(() => {})` calls with `loggers.security.warn()` error logging across `auth.ts` and `logout/route.ts`
- Audit failures still never block requests (fire-and-forget preserved), but persistence failures are now observable in monitoring/compliance dashboards
- Matches the existing pattern in `security-audit-adapter.ts`

## Changes
- **apps/web/src/lib/auth/auth.ts** — 4 `.catch(() => {})` replaced with warn logging (logAccessDenied x2, logDataAccess, logEvent)
- **apps/web/src/app/api/auth/logout/route.ts** — 2 `.catch(() => {})` replaced with warn logging (logLogout, logTokenRevoked)
- **apps/web/src/lib/auth/__tests__/admin-audit-coverage.test.ts** — 3 new tests for audit persistence failure logging
- **apps/web/src/app/api/auth/__tests__/logout.test.ts** — 2 new tests for audit persistence failure logging
- **4 test files** — added `loggers.security.warn` to `@pagespace/lib/server` mocks that exercise admin auth paths (fixes 19 unhandled rejections in CI)

## Test plan
- [x] 18/18 admin-audit-coverage tests pass (15 existing + 3 new)
- [x] 10/10 logout tests pass (8 existing + 2 new)
- [x] 8/8 auth.test.ts pass
- [x] Zero remaining `securityAudit.*.catch(() => {})` in codebase (grep verified)
- [x] All existing auth tests unaffected
- [x] Rebased on latest master (includes #865-#870)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Audit logging failures now emit security warning logs (with context) instead of being silently ignored; normal responses and control flow remain unchanged.

* **Tests**
  * Added tests covering audit persistence failures to verify warning logging behavior and ensure audit failures don’t break endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->