### PR TITLE
feat(calendar): Google Calendar-style drive filtering

### DIFF
--- a/apps/web/src/components/calendar/AgendaView.tsx
+++ b/apps/web/src/components/calendar/AgendaView.tsx
@@ -19,9 +19,10 @@ import {
   CalendarEvent,
   CalendarHandlers,
   TaskWithDueDate,
+  EventColorConfig,
   getEventsForDay,
   getTasksForDay,
-  getEventColors,
+  resolveEventColor,
   TASK_OVERLAY_STYLE,
   ATTENDEE_STATUS_CONFIG,
 } from './calendar-types';
@@ -32,9 +33,11 @@ interface AgendaViewProps {
   tasks: TaskWithDueDate[];
   handlers: CalendarHandlers;
   showGoogleCalendarHint?: boolean;
+  driveColorMap?: Map<string | null, EventColorConfig> | null;
+  context?: 'user' | 'drive';
 }
 
-export function AgendaView({ currentDate, events, tasks, handlers, showGoogleCalendarHint = true }: AgendaViewProps) {
+export function AgendaView({ currentDate, events, tasks, handlers, showGoogleCalendarHint = true, driveColorMap, context = 'drive' }: AgendaViewProps) {
   // Get all days in the current month
   const monthDays = useMemo(() => {
     const monthStart = startOfMonth(currentDate);
@@ -135,6 +138,7 @@ export function AgendaView({ currentDate, events, tasks, handlers, showGoogleCal
                   <EventCard
                     key={event.id}
                     event={event}
+                    colors={resolveEventColor(event, context, driveColorMap ?? null)}
                     onClick={() => handlers.onEventClick(event)}
                   />
                 ))}
@@ -159,12 +163,13 @@ export function AgendaView({ currentDate, events, tasks, handlers, showGoogleCal
 // Event card component
 function EventCard({
   event,
+  colors,
   onClick,
 }: {
   event: CalendarEvent;
+  colors: EventColorConfig;
   onClick: () => void;
 }) {
-  const colors = getEventColors(event.color);
   const isAllDay = event.allDay;
   const startTime = format(new Date(event.startAt), 'h:mm a');
   const endTime = format(new Date(event.endAt), 'h:mm a');

--- a/apps/web/src/components/calendar/CalendarSidebar.tsx
+++ b/apps/web/src/components/calendar/CalendarSidebar.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import type { EventColorConfig } from './calendar-types';
+
+interface CalendarEntry {
+  key: string;
+  name: string;
+  color: EventColorConfig;
+  visible: boolean;
+}
+
+interface CalendarSidebarProps {
+  calendars: CalendarEntry[];
+  onToggle: (key: string) => void;
+  onShowAll: () => void;
+  onHideAll: () => void;
+  className?: string;
+}
+
+export function CalendarSidebar({
+  calendars,
+  onToggle,
+  onShowAll,
+  onHideAll,
+  className,
+}: CalendarSidebarProps) {
+  const allVisible = calendars.every((c) => c.visible);
+  const noneVisible = calendars.every((c) => !c.visible);
+
+  return (
+    <div className={cn('flex flex-col gap-1', className)}>
+      <div className="flex items-center justify-between px-1 mb-1">
+        <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+          My Calendars
+        </span>
+        <button
+          className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+          onClick={allVisible ? () => onHideAll() : () => onShowAll()}
+        >
+          {allVisible ? 'Hide all' : 'Show all'}
+        </button>
+      </div>
+
+      {calendars.map((cal) => (
+        <label
+          key={cal.key}
+          className={cn(
+            'flex items-center gap-2 px-1.5 py-1 rounded cursor-pointer transition-colors',
+            'hover:bg-muted/50',
+            !cal.visible && 'opacity-50'
+          )}
+        >
+          <button
+            role="checkbox"
+            aria-checked={cal.visible}
+            onClick={() => onToggle(cal.key)}
+            className={cn(
+              'size-3.5 shrink-0 rounded-sm border transition-colors',
+              cal.visible
+                ? cn(cal.color.dot, 'border-transparent')
+                : 'border-muted-foreground/40 bg-transparent'
+            )}
+          >
+            {cal.visible && (
+              <svg viewBox="0 0 14 14" className="size-3.5 text-white">
+                <path
+                  d="M11.5 3.5L5.5 9.5L2.5 6.5"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  fill="none"
+                />
+              </svg>
+            )}
+          </button>
+          <span className="text-sm truncate">{cal.name}</span>
+        </label>
+      ))}
+
+      {noneVisible && (
+        <p className="text-xs text-muted-foreground px-1.5 py-2">
+          All calendars hidden
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/calendar/CalendarSidebar.tsx
+++ b/apps/web/src/components/calendar/CalendarSidebar.tsx
@@ -43,18 +43,22 @@ export function CalendarSidebar({
       </div>
 
       {calendars.map((cal) => (
-        <label
+        <div
           key={cal.key}
+          role="button"
+          tabIndex={0}
+          onClick={() => onToggle(cal.key)}
+          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggle(cal.key); } }}
           className={cn(
             'flex items-center gap-2 px-1.5 py-1 rounded cursor-pointer transition-colors',
             'hover:bg-muted/50',
             !cal.visible && 'opacity-50'
           )}
         >
-          <button
+          <span
             role="checkbox"
             aria-checked={cal.visible}
-            onClick={() => onToggle(cal.key)}
+            aria-label={`Toggle ${cal.name}`}
             className={cn(
               'size-3.5 shrink-0 rounded-sm border transition-colors',
               cal.visible
@@ -74,9 +78,9 @@ export function CalendarSidebar({
                 />
               </svg>
             )}
-          </button>
+          </span>
           <span className="text-sm truncate">{cal.name}</span>
-        </label>
+        </div>
       ))}
 
       {noneVisible && (

--- a/apps/web/src/components/calendar/CalendarSidebar.tsx
+++ b/apps/web/src/components/calendar/CalendarSidebar.tsx
@@ -25,8 +25,9 @@ export function CalendarSidebar({
   onHideAll,
   className,
 }: CalendarSidebarProps) {
-  const allVisible = calendars.every((c) => c.visible);
-  const noneVisible = calendars.every((c) => !c.visible);
+  const hasCalendars = calendars.length > 0;
+  const allVisible = hasCalendars && calendars.every((c) => c.visible);
+  const noneVisible = hasCalendars && calendars.every((c) => !c.visible);
 
   return (
     <div className={cn('flex flex-col gap-1', className)}>

--- a/apps/web/src/components/calendar/CalendarView.tsx
+++ b/apps/web/src/components/calendar/CalendarView.tsx
@@ -94,10 +94,10 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
     useCalendarFilterStore();
   const [sidebarOpen, setSidebarOpen] = useState(true);
 
-  // Fetch drives on mount for sidebar
+  // Force-refresh drives on mount so the sidebar reflects current memberships
   const isUserContext = context === 'user';
   useEffect(() => {
-    if (isUserContext) fetchDrives();
+    if (isUserContext) fetchDrives(false, true);
   }, [isUserContext, fetchDrives]);
 
   // Build drive color map

--- a/apps/web/src/components/calendar/CalendarView.tsx
+++ b/apps/web/src/components/calendar/CalendarView.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo, useEffect } from 'react';
 import { format, addMonths, subMonths, addWeeks, subWeeks, addDays, subDays } from 'date-fns';
-import { ChevronLeft, ChevronRight, Plus, Calendar as CalendarIcon, List, LayoutGrid, Clock } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Plus, Calendar as CalendarIcon, List, LayoutGrid, Clock, PanelLeft } from 'lucide-react';
 import useSWR from 'swr';
 import { Button } from '@/components/ui/button';
 import { Toggle } from '@/components/ui/toggle';
@@ -16,6 +16,8 @@ import {
 import { cn } from '@/lib/utils';
 import { useDeviceTier } from '@/hooks/useDeviceTier';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { useDriveStore } from '@/hooks/useDrive';
+import { useCalendarFilterStore } from '@/stores/useCalendarFilterStore';
 import { useCalendarData } from './useCalendarData';
 import { MonthView } from './MonthView';
 import { WeekView } from './WeekView';
@@ -23,10 +25,13 @@ import { DayView } from './DayView';
 import { AgendaView } from './AgendaView';
 import { MobileCalendarView } from './MobileCalendarView';
 import { EventModal } from './EventModal';
+import { CalendarSidebar } from './CalendarSidebar';
 import {
   CalendarViewMode,
   CalendarEvent,
   CalendarHandlers,
+  EventColorConfig,
+  getDriveCalendarColor,
 } from './calendar-types';
 
 interface CalendarViewProps {
@@ -81,6 +86,69 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
     includePersonal: context === 'user',
     includeTasks: showTasks,
   });
+
+  // Drive filtering (root calendar only)
+  const drives = useDriveStore((s) => s.drives);
+  const fetchDrives = useDriveStore((s) => s.fetchDrives);
+  const { hiddenCalendars, toggleCalendar, showAll, hideAll, isVisible } =
+    useCalendarFilterStore();
+  const [sidebarOpen, setSidebarOpen] = useState(true);
+
+  // Fetch drives on mount for sidebar
+  const isUserContext = context === 'user';
+  useEffect(() => {
+    if (isUserContext) fetchDrives();
+  }, [isUserContext, fetchDrives]);
+
+  // Build drive color map
+  const driveColorMap = useMemo(() => {
+    if (!isUserContext) return null;
+    const map = new Map<string | null, EventColorConfig>();
+    const driveIds = drives.map((d) => d.id);
+    map.set(null, getDriveCalendarColor(null, driveIds));
+    for (const drive of drives) {
+      map.set(drive.id, getDriveCalendarColor(drive.id, driveIds));
+    }
+    return map;
+  }, [isUserContext, drives]);
+
+  // Build sidebar calendar entries
+  const calendarEntries = useMemo(() => {
+    if (!isUserContext || !driveColorMap) return [];
+    const entries = [
+      {
+        key: 'personal',
+        name: 'Personal',
+        color: driveColorMap.get(null)!,
+        visible: isVisible('personal'),
+      },
+    ];
+    for (const drive of drives) {
+      entries.push({
+        key: drive.id,
+        name: drive.name,
+        color: driveColorMap.get(drive.id)!,
+        visible: isVisible(drive.id),
+      });
+    }
+    return entries;
+  }, [isUserContext, driveColorMap, drives, isVisible, hiddenCalendars]);
+
+  // Filter events and tasks by visibility
+  const filteredEvents = useMemo(() => {
+    if (!isUserContext) return events;
+    return events.filter((e) => isVisible(e.driveId ?? 'personal'));
+  }, [isUserContext, events, isVisible, hiddenCalendars]);
+
+  const filteredTasks = useMemo(() => {
+    if (!isUserContext) return tasks;
+    return tasks.filter((t) => isVisible(t.driveId));
+  }, [isUserContext, tasks, isVisible, hiddenCalendars]);
+
+  const allCalendarKeys = useMemo(
+    () => calendarEntries.map((c) => c.key),
+    [calendarEntries]
+  );
 
   const { data: googleCalendarStatus } = useSWR<GoogleCalendarStatusResponse>(
     '/api/integrations/google-calendar/status',
@@ -205,14 +273,20 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
     return (
       <div className={cn('flex flex-col h-full', className)}>
         <MobileCalendarView
-          events={events}
-          tasks={tasks}
+          events={filteredEvents}
+          tasks={filteredTasks}
           handlers={handlers}
           showTasks={showTasks}
           onShowTasksChange={setShowTasks}
           showGoogleCalendarHint={showGoogleCalendarHint}
           isLoading={isLoading}
           currentDate={currentDate}
+          driveColorMap={driveColorMap}
+          context={context}
+          calendarEntries={isUserContext ? calendarEntries : undefined}
+          onToggleCalendar={toggleCalendar}
+          onShowAllCalendars={showAll}
+          onHideAllCalendars={() => hideAll(allCalendarKeys)}
         />
         {/* Event modal - shared between mobile and desktop */}
         <EventModal
@@ -234,6 +308,18 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 px-4 py-3 border-b bg-background">
         <div className="flex items-center gap-3">
+          {/* Sidebar toggle (root calendar only) */}
+          {isUserContext && (
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => setSidebarOpen((o) => !o)}
+              aria-label={sidebarOpen ? 'Hide calendars sidebar' : 'Show calendars sidebar'}
+              className="hidden sm:flex"
+            >
+              <PanelLeft className="h-4 w-4" />
+            </Button>
+          )}
           {/* Navigation */}
           <div className="flex items-center gap-1">
             <Button variant="outline" size="icon" onClick={handlePrevious} aria-label="Previous">
@@ -362,49 +448,72 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
         </div>
       </div>
 
-      {/* Calendar content */}
-      <div className="flex-1 overflow-hidden">
-        {isLoading ? (
-          <div className="flex items-center justify-center h-full">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
-          </div>
-        ) : (
-          <>
-            {viewMode === 'month' && (
-              <MonthView
-                currentDate={currentDate}
-                events={events}
-                tasks={showTasks ? tasks : []}
-                handlers={handlers}
-              />
-            )}
-            {viewMode === 'week' && (
-              <WeekView
-                currentDate={currentDate}
-                events={events}
-                tasks={showTasks ? tasks : []}
-                handlers={handlers}
-              />
-            )}
-            {viewMode === 'day' && (
-              <DayView
-                currentDate={currentDate}
-                events={events}
-                tasks={showTasks ? tasks : []}
-                handlers={handlers}
-              />
-            )}
-            {viewMode === 'agenda' && (
-              <AgendaView
-                currentDate={currentDate}
-                events={events}
-                tasks={showTasks ? tasks : []}
-                handlers={handlers}
-                showGoogleCalendarHint={showGoogleCalendarHint}
-              />
-            )}
-          </>
+      {/* Calendar body: sidebar + content */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Sidebar (root calendar, desktop only) */}
+        {isUserContext && sidebarOpen && (
+          <aside className="w-52 shrink-0 border-r overflow-y-auto p-3 hidden sm:block">
+            <CalendarSidebar
+              calendars={calendarEntries}
+              onToggle={toggleCalendar}
+              onShowAll={showAll}
+              onHideAll={() => hideAll(allCalendarKeys)}
+            />
+          </aside>
         )}
+
+        {/* Calendar content */}
+        <div className="flex-1 overflow-hidden">
+          {isLoading ? (
+            <div className="flex items-center justify-center h-full">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+            </div>
+          ) : (
+            <>
+              {viewMode === 'month' && (
+                <MonthView
+                  currentDate={currentDate}
+                  events={filteredEvents}
+                  tasks={showTasks ? filteredTasks : []}
+                  handlers={handlers}
+                  driveColorMap={driveColorMap}
+                  context={context}
+                />
+              )}
+              {viewMode === 'week' && (
+                <WeekView
+                  currentDate={currentDate}
+                  events={filteredEvents}
+                  tasks={showTasks ? filteredTasks : []}
+                  handlers={handlers}
+                  driveColorMap={driveColorMap}
+                  context={context}
+                />
+              )}
+              {viewMode === 'day' && (
+                <DayView
+                  currentDate={currentDate}
+                  events={filteredEvents}
+                  tasks={showTasks ? filteredTasks : []}
+                  handlers={handlers}
+                  driveColorMap={driveColorMap}
+                  context={context}
+                />
+              )}
+              {viewMode === 'agenda' && (
+                <AgendaView
+                  currentDate={currentDate}
+                  events={filteredEvents}
+                  tasks={showTasks ? filteredTasks : []}
+                  handlers={handlers}
+                  showGoogleCalendarHint={showGoogleCalendarHint}
+                  driveColorMap={driveColorMap}
+                  context={context}
+                />
+              )}
+            </>
+          )}
+        </div>
       </div>
 
       {/* Event modal */}

--- a/apps/web/src/components/calendar/DayView.tsx
+++ b/apps/web/src/components/calendar/DayView.tsx
@@ -14,10 +14,11 @@ import {
   CalendarEvent,
   CalendarHandlers,
   TaskWithDueDate,
+  EventColorConfig,
   getEventsForDay,
   getTasksForDay,
   isToday,
-  getEventColors,
+  resolveEventColor,
   TASK_OVERLAY_STYLE,
 } from './calendar-types';
 
@@ -26,12 +27,14 @@ interface DayViewProps {
   events: CalendarEvent[];
   tasks: TaskWithDueDate[];
   handlers: CalendarHandlers;
+  driveColorMap?: Map<string | null, EventColorConfig> | null;
+  context?: 'user' | 'drive';
 }
 
 const HOURS = Array.from({ length: 24 }, (_, i) => i);
 const HOUR_HEIGHT = 64; // Taller for day view
 
-export function DayView({ currentDate, events, tasks, handlers }: DayViewProps) {
+export function DayView({ currentDate, events, tasks, handlers, driveColorMap, context = 'drive' }: DayViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
   // Get events and tasks for the current day
@@ -115,6 +118,7 @@ export function DayView({ currentDate, events, tasks, handlers }: DayViewProps) 
               <AllDayEventCard
                 key={event.id}
                 event={event}
+                colors={resolveEventColor(event, context, driveColorMap ?? null)}
                 onClick={() => handlers.onEventClick(event)}
               />
             ))}
@@ -172,6 +176,7 @@ export function DayView({ currentDate, events, tasks, handlers }: DayViewProps) 
                 <TimedEventCard
                   key={event.id}
                   event={event}
+                  colors={resolveEventColor(event, context, driveColorMap ?? null)}
                   style={{ top, height }}
                   onClick={() => handlers.onEventClick(event)}
                 />
@@ -206,14 +211,15 @@ function CurrentTimeIndicator() {
 // Timed event card (expanded)
 function TimedEventCard({
   event,
+  colors,
   style,
   onClick,
 }: {
   event: CalendarEvent;
+  colors: EventColorConfig;
   style: { top: number; height: number };
   onClick: () => void;
 }) {
-  const colors = getEventColors(event.color);
   const showDetails = style.height > 60;
 
   return (
@@ -269,12 +275,13 @@ function TimedEventCard({
 // All-day event card
 function AllDayEventCard({
   event,
+  colors,
   onClick,
 }: {
   event: CalendarEvent;
+  colors: EventColorConfig;
   onClick: () => void;
 }) {
-  const colors = getEventColors(event.color);
 
   return (
     <button

--- a/apps/web/src/components/calendar/MobileCalendarView.tsx
+++ b/apps/web/src/components/calendar/MobileCalendarView.tsx
@@ -14,10 +14,17 @@ import {
   isYesterday,
 } from 'date-fns';
 import { cn } from '@/lib/utils';
-import { ChevronDown, ListTodo, CalendarDays, Calendar } from 'lucide-react';
+import { ChevronDown, ListTodo, CalendarDays, Calendar, SlidersHorizontal } from 'lucide-react';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Toggle } from '@/components/ui/toggle';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from '@/components/ui/sheet';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -27,16 +34,25 @@ import {
 import { MobileWeekStrip } from './MobileWeekStrip';
 import { MobileDayAgenda } from './MobileDayAgenda';
 import { MobileMonthPicker } from './MobileMonthPicker';
+import { CalendarSidebar } from './CalendarSidebar';
 import {
   CalendarEvent,
   CalendarHandlers,
   TaskWithDueDate,
+  EventColorConfig,
   getEventsForDay,
   getTasksForDay,
-  getEventColors,
+  resolveEventColor,
   TASK_OVERLAY_STYLE,
   isToday,
 } from './calendar-types';
+
+interface CalendarEntryForMobile {
+  key: string;
+  name: string;
+  color: EventColorConfig;
+  visible: boolean;
+}
 
 interface MobileCalendarViewProps {
   events: CalendarEvent[];
@@ -47,6 +63,12 @@ interface MobileCalendarViewProps {
   showGoogleCalendarHint?: boolean;
   isLoading?: boolean;
   currentDate?: Date;
+  driveColorMap?: Map<string | null, EventColorConfig> | null;
+  context?: 'user' | 'drive';
+  calendarEntries?: CalendarEntryForMobile[];
+  onToggleCalendar?: (key: string) => void;
+  onShowAllCalendars?: () => void;
+  onHideAllCalendars?: () => void;
 }
 
 type MobileViewMode = 'day' | 'month';
@@ -60,6 +82,12 @@ export function MobileCalendarView({
   showGoogleCalendarHint = true,
   isLoading,
   currentDate: parentDate,
+  driveColorMap,
+  context = 'drive',
+  calendarEntries,
+  onToggleCalendar,
+  onShowAllCalendars,
+  onHideAllCalendars,
 }: MobileCalendarViewProps) {
   const [selectedDate, setSelectedDate] = useState(() => parentDate ?? new Date());
   const [currentWeekStart, setCurrentWeekStart] = useState(() =>
@@ -205,6 +233,29 @@ export function MobileCalendarView({
 
         {/* Right controls */}
         <div className="flex items-center gap-1">
+          {/* Calendar filter (root calendar only) */}
+          {calendarEntries && onToggleCalendar && onShowAllCalendars && onHideAllCalendars && (
+            <Sheet>
+              <SheetTrigger asChild>
+                <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Filter calendars">
+                  <SlidersHorizontal className="h-4 w-4" />
+                </Button>
+              </SheetTrigger>
+              <SheetContent side="bottom" className="h-auto max-h-[60vh]">
+                <SheetHeader>
+                  <SheetTitle>Calendars</SheetTitle>
+                </SheetHeader>
+                <div className="py-4">
+                  <CalendarSidebar
+                    calendars={calendarEntries}
+                    onToggle={onToggleCalendar}
+                    onShowAll={onShowAllCalendars}
+                    onHideAll={onHideAllCalendars}
+                  />
+                </div>
+              </SheetContent>
+            </Sheet>
+          )}
           {/* View mode toggle */}
           <div className="flex items-center bg-muted rounded-md p-0.5">
             <button
@@ -256,6 +307,8 @@ export function MobileCalendarView({
         tasks={showTasks ? tasks : []}
         onDateSelect={handleDateSelect}
         onWeekChange={handleWeekChange}
+        driveColorMap={driveColorMap}
+        context={context}
       />
 
       {/* Main content area with swipe support */}
@@ -273,6 +326,8 @@ export function MobileCalendarView({
             tasks={tasks}
             handlers={handlers}
             showTasks={showTasks}
+            driveColorMap={driveColorMap}
+            context={context}
           />
         ) : (
           // Month agenda view - shows all events for the month
@@ -284,6 +339,8 @@ export function MobileCalendarView({
             showTasks={showTasks}
             showGoogleCalendarHint={showGoogleCalendarHint}
             onDateSelect={handleDateSelect}
+            driveColorMap={driveColorMap}
+            context={context}
           />
         )}
       </div>
@@ -308,6 +365,8 @@ function MobileMonthAgenda({
   showTasks,
   showGoogleCalendarHint,
   onDateSelect,
+  driveColorMap,
+  context = 'drive',
 }: {
   selectedDate: Date;
   events: CalendarEvent[];
@@ -316,6 +375,8 @@ function MobileMonthAgenda({
   showTasks: boolean;
   showGoogleCalendarHint: boolean;
   onDateSelect: (date: Date) => void;
+  driveColorMap?: Map<string | null, EventColorConfig> | null;
+  context?: 'user' | 'drive';
 }) {
   // Get all days in the current month with events/tasks
   const dayGroups = useMemo(() => {
@@ -400,7 +461,7 @@ function MobileMonthAgenda({
               {/* Events for this day */}
               <div className="space-y-2 pl-13">
                 {group.events.map((event: CalendarEvent) => {
-                  const colors = getEventColors(event.color);
+                  const colors = resolveEventColor(event, context, driveColorMap ?? null);
                   return (
                     <button
                       key={event.id}

--- a/apps/web/src/components/calendar/MobileDayAgenda.tsx
+++ b/apps/web/src/components/calendar/MobileDayAgenda.tsx
@@ -11,9 +11,10 @@ import {
   CalendarEvent,
   CalendarHandlers,
   TaskWithDueDate,
+  EventColorConfig,
   getEventsForDay,
   getTasksForDay,
-  getEventColors,
+  resolveEventColor,
   TASK_OVERLAY_STYLE,
   ATTENDEE_STATUS_CONFIG,
 } from './calendar-types';
@@ -24,6 +25,8 @@ interface MobileDayAgendaProps {
   tasks: TaskWithDueDate[];
   handlers: CalendarHandlers;
   showTasks: boolean;
+  driveColorMap?: Map<string | null, EventColorConfig> | null;
+  context?: 'user' | 'drive';
 }
 
 export function MobileDayAgenda({
@@ -32,6 +35,8 @@ export function MobileDayAgenda({
   tasks,
   handlers,
   showTasks,
+  driveColorMap,
+  context = 'drive',
 }: MobileDayAgendaProps) {
   // Get events and tasks for the selected day
   const dayEvents = useMemo(() => getEventsForDay(events, selectedDate), [events, selectedDate]);
@@ -110,6 +115,7 @@ export function MobileDayAgenda({
                     <MobileEventCard
                       key={event.id}
                       event={event}
+                      colors={resolveEventColor(event, context, driveColorMap ?? null)}
                       onClick={() => handlers.onEventClick(event)}
                     />
                   ))}
@@ -130,6 +136,7 @@ export function MobileDayAgenda({
                     <MobileEventCard
                       key={event.id}
                       event={event}
+                      colors={resolveEventColor(event, context, driveColorMap ?? null)}
                       onClick={() => handlers.onEventClick(event)}
                     />
                   ))}
@@ -180,12 +187,13 @@ function EmptyState({ onCreateEvent }: { onCreateEvent: () => void }) {
 // Mobile-optimized event card
 function MobileEventCard({
   event,
+  colors,
   onClick,
 }: {
   event: CalendarEvent;
+  colors: EventColorConfig;
   onClick: () => void;
 }) {
-  const colors = getEventColors(event.color);
   const startTime = format(new Date(event.startAt), 'h:mm a');
   const endTime = format(new Date(event.endAt), 'h:mm a');
 

--- a/apps/web/src/components/calendar/MobileWeekStrip.tsx
+++ b/apps/web/src/components/calendar/MobileWeekStrip.tsx
@@ -16,10 +16,11 @@ import { Button } from '@/components/ui/button';
 import {
   CalendarEvent,
   TaskWithDueDate,
+  EventColorConfig,
   getEventsForDay,
   getTasksForDay,
   isToday,
-  getEventColors,
+  resolveEventColor,
 } from './calendar-types';
 
 interface MobileWeekStripProps {
@@ -29,6 +30,8 @@ interface MobileWeekStripProps {
   tasks: TaskWithDueDate[];
   onDateSelect: (date: Date) => void;
   onWeekChange: (date: Date) => void;
+  driveColorMap?: Map<string | null, EventColorConfig> | null;
+  context?: 'user' | 'drive';
 }
 
 const WEEKDAY_LABELS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
@@ -40,6 +43,8 @@ export function MobileWeekStrip({
   tasks,
   onDateSelect,
   onWeekChange,
+  driveColorMap,
+  context = 'drive',
 }: MobileWeekStripProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -110,7 +115,7 @@ export function MobileWeekStrip({
 
           // Get the primary event color for the indicator
           const primaryEventColor = dayEvents.length > 0
-            ? getEventColors(dayEvents[0].color).dot
+            ? resolveEventColor(dayEvents[0], context, driveColorMap ?? null).dot
             : null;
 
           return (

--- a/apps/web/src/components/calendar/MonthView.tsx
+++ b/apps/web/src/components/calendar/MonthView.tsx
@@ -15,10 +15,11 @@ import {
   CalendarEvent,
   CalendarHandlers,
   TaskWithDueDate,
+  EventColorConfig,
   getEventsForDay,
   getTasksForDay,
   isToday,
-  getEventColors,
+  resolveEventColor,
   TASK_OVERLAY_STYLE,
 } from './calendar-types';
 
@@ -27,12 +28,14 @@ interface MonthViewProps {
   events: CalendarEvent[];
   tasks: TaskWithDueDate[];
   handlers: CalendarHandlers;
+  driveColorMap?: Map<string | null, EventColorConfig> | null;
+  context?: 'user' | 'drive';
 }
 
 const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 const MAX_VISIBLE_EVENTS = 3;
 
-export function MonthView({ currentDate, events, tasks, handlers }: MonthViewProps) {
+export function MonthView({ currentDate, events, tasks, handlers, driveColorMap, context = 'drive' }: MonthViewProps) {
   // Calculate the days to display
   const calendarDays = useMemo(() => {
     const monthStart = startOfMonth(currentDate);
@@ -129,6 +132,7 @@ export function MonthView({ currentDate, events, tasks, handlers }: MonthViewPro
                       <EventPill
                         key={event.id}
                         event={event}
+                        colors={resolveEventColor(event, context, driveColorMap ?? null)}
                         onClick={(e) => {
                           e.stopPropagation();
                           handlers.onEventClick(event);
@@ -177,12 +181,13 @@ export function MonthView({ currentDate, events, tasks, handlers }: MonthViewPro
 // Event pill component
 function EventPill({
   event,
+  colors,
   onClick,
 }: {
   event: CalendarEvent;
+  colors: EventColorConfig;
   onClick: (e: React.MouseEvent) => void;
 }) {
-  const colors = getEventColors(event.color);
   const isAllDay = event.allDay;
   const startTime = isAllDay ? '' : format(new Date(event.startAt), 'h:mm a');
 

--- a/apps/web/src/components/calendar/WeekView.tsx
+++ b/apps/web/src/components/calendar/WeekView.tsx
@@ -16,9 +16,10 @@ import {
   CalendarEvent,
   CalendarHandlers,
   TaskWithDueDate,
+  EventColorConfig,
   getTasksForDay,
   isToday,
-  getEventColors,
+  resolveEventColor,
   TASK_OVERLAY_STYLE,
 } from './calendar-types';
 
@@ -27,12 +28,14 @@ interface WeekViewProps {
   events: CalendarEvent[];
   tasks: TaskWithDueDate[];
   handlers: CalendarHandlers;
+  driveColorMap?: Map<string | null, EventColorConfig> | null;
+  context?: 'user' | 'drive';
 }
 
 const HOURS = Array.from({ length: 24 }, (_, i) => i);
 const HOUR_HEIGHT = 48; // pixels per hour
 
-export function WeekView({ currentDate, events, tasks, handlers }: WeekViewProps) {
+export function WeekView({ currentDate, events, tasks, handlers, driveColorMap, context = 'drive' }: WeekViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
   // Calculate the days of the current week
@@ -136,6 +139,7 @@ export function WeekView({ currentDate, events, tasks, handlers }: WeekViewProps
                     <AllDayEventPill
                       key={event.id}
                       event={event}
+                      colors={resolveEventColor(event, context, driveColorMap ?? null)}
                       onClick={() => handlers.onEventClick(event)}
                     />
                   ))}
@@ -202,7 +206,7 @@ export function WeekView({ currentDate, events, tasks, handlers }: WeekViewProps
                 {/* Timed events */}
                 {dayTimedEvents.map((event) => {
                   const { top, height } = getEventStyle(event, day);
-                  const colors = getEventColors(event.color);
+                  const colors = resolveEventColor(event, context, driveColorMap ?? null);
 
                   return (
                     <button
@@ -259,12 +263,13 @@ function CurrentTimeIndicator() {
 // All-day event pill
 function AllDayEventPill({
   event,
+  colors,
   onClick,
 }: {
   event: CalendarEvent;
+  colors: EventColorConfig;
   onClick: () => void;
 }) {
-  const colors = getEventColors(event.color);
 
   return (
     <button

--- a/apps/web/src/components/calendar/__tests__/CalendarSidebar.test.tsx
+++ b/apps/web/src/components/calendar/__tests__/CalendarSidebar.test.tsx
@@ -1,0 +1,144 @@
+import { describe, test, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { assert } from './riteway';
+import { CalendarSidebar } from '../CalendarSidebar';
+import { DRIVE_CALENDAR_COLORS, PERSONAL_CALENDAR_COLOR } from '../calendar-types';
+
+const makeCalendars = (overrides: Record<string, boolean> = {}) => [
+  {
+    key: 'personal',
+    name: 'Personal',
+    color: PERSONAL_CALENDAR_COLOR,
+    visible: overrides['personal'] ?? true,
+  },
+  {
+    key: 'drive-aaa',
+    name: 'Work Drive',
+    color: DRIVE_CALENDAR_COLORS[0],
+    visible: overrides['drive-aaa'] ?? true,
+  },
+  {
+    key: 'drive-bbb',
+    name: 'Side Project',
+    color: DRIVE_CALENDAR_COLORS[1],
+    visible: overrides['drive-bbb'] ?? true,
+  },
+];
+
+describe('CalendarSidebar', () => {
+  test('renders calendar entries', () => {
+    const calendars = makeCalendars();
+    render(
+      <CalendarSidebar
+        calendars={calendars}
+        onToggle={() => {}}
+        onShowAll={() => {}}
+        onHideAll={() => {}}
+      />
+    );
+
+    assert({
+      given: 'a list of calendars',
+      should: 'render the My Calendars heading',
+      actual: screen.getByText('My Calendars') !== null,
+      expected: true,
+    });
+
+    assert({
+      given: 'a personal calendar entry',
+      should: 'render the Personal label',
+      actual: screen.getByText('Personal') !== null,
+      expected: true,
+    });
+
+    assert({
+      given: 'drive calendar entries',
+      should: 'render each drive name',
+      actual: screen.getByText('Work Drive') !== null && screen.getByText('Side Project') !== null,
+      expected: true,
+    });
+  });
+
+  test('checkbox toggle callback', () => {
+    const onToggle = vi.fn();
+    render(
+      <CalendarSidebar
+        calendars={makeCalendars()}
+        onToggle={onToggle}
+        onShowAll={() => {}}
+        onHideAll={() => {}}
+      />
+    );
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[1]); // click "Work Drive" checkbox
+
+    assert({
+      given: 'a click on a calendar checkbox',
+      should: 'call onToggle with the calendar key',
+      actual: onToggle.mock.calls[0][0],
+      expected: 'drive-aaa',
+    });
+  });
+
+  test('hide all button when all visible', () => {
+    const onHideAll = vi.fn();
+    render(
+      <CalendarSidebar
+        calendars={makeCalendars()}
+        onToggle={() => {}}
+        onShowAll={() => {}}
+        onHideAll={onHideAll}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Hide all'));
+
+    assert({
+      given: 'all calendars visible and clicking Hide all',
+      should: 'call onHideAll',
+      actual: onHideAll.mock.calls.length,
+      expected: 1,
+    });
+  });
+
+  test('show all button when some hidden', () => {
+    const onShowAll = vi.fn();
+    render(
+      <CalendarSidebar
+        calendars={makeCalendars({ 'drive-aaa': false })}
+        onToggle={() => {}}
+        onShowAll={onShowAll}
+        onHideAll={() => {}}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Show all'));
+
+    assert({
+      given: 'some calendars hidden and clicking Show all',
+      should: 'call onShowAll',
+      actual: onShowAll.mock.calls.length,
+      expected: 1,
+    });
+  });
+
+  test('hidden calendar has unchecked checkbox', () => {
+    render(
+      <CalendarSidebar
+        calendars={makeCalendars({ 'drive-aaa': false })}
+        onToggle={() => {}}
+        onShowAll={() => {}}
+        onHideAll={() => {}}
+      />
+    );
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    assert({
+      given: 'a hidden calendar',
+      should: 'have aria-checked=false on its checkbox',
+      actual: checkboxes[1].getAttribute('aria-checked'),
+      expected: 'false',
+    });
+  });
+});

--- a/apps/web/src/components/calendar/__tests__/calendar-types.test.ts
+++ b/apps/web/src/components/calendar/__tests__/calendar-types.test.ts
@@ -1,0 +1,178 @@
+import { describe, test } from 'vitest';
+import { assert } from './riteway';
+import {
+  DRIVE_CALENDAR_COLORS,
+  PERSONAL_CALENDAR_COLOR,
+  getDriveCalendarColor,
+  resolveEventColor,
+  getEventColors,
+} from '../calendar-types';
+import type { CalendarEvent, EventColorConfig } from '../calendar-types';
+
+describe('DRIVE_CALENDAR_COLORS', () => {
+  test('palette structure', () => {
+    assert({
+      given: 'the drive calendar palette',
+      should: 'have at least 8 distinct colors',
+      actual: DRIVE_CALENDAR_COLORS.length >= 8,
+      expected: true,
+    });
+
+    const first = DRIVE_CALENDAR_COLORS[0];
+    assert({
+      given: 'a palette entry',
+      should: 'have bg, border, text, and dot properties',
+      actual: 'bg' in first && 'border' in first && 'text' in first && 'dot' in first,
+      expected: true,
+    });
+  });
+});
+
+describe('PERSONAL_CALENDAR_COLOR', () => {
+  test('structure', () => {
+    assert({
+      given: 'the personal calendar color',
+      should: 'have bg, border, text, and dot properties',
+      actual:
+        'bg' in PERSONAL_CALENDAR_COLOR &&
+        'border' in PERSONAL_CALENDAR_COLOR &&
+        'text' in PERSONAL_CALENDAR_COLOR &&
+        'dot' in PERSONAL_CALENDAR_COLOR,
+      expected: true,
+    });
+  });
+});
+
+describe('getDriveCalendarColor', () => {
+  const driveIds = ['drive-aaa', 'drive-bbb', 'drive-ccc'];
+
+  test('personal events', () => {
+    const color = getDriveCalendarColor(null, driveIds);
+    assert({
+      given: 'a personal event (driveId=null)',
+      should: 'return the personal calendar color',
+      actual: color,
+      expected: PERSONAL_CALENDAR_COLOR,
+    });
+  });
+
+  test('deterministic assignment', () => {
+    const color1 = getDriveCalendarColor('drive-aaa', driveIds);
+    const color2 = getDriveCalendarColor('drive-aaa', driveIds);
+    assert({
+      given: 'the same driveId called twice',
+      should: 'return the same color both times',
+      actual: color1,
+      expected: color2,
+    });
+  });
+
+  test('different drives get different colors', () => {
+    const colorA = getDriveCalendarColor('drive-aaa', driveIds);
+    const colorB = getDriveCalendarColor('drive-bbb', driveIds);
+    assert({
+      given: 'two different driveIds',
+      should: 'return different colors',
+      actual: colorA.dot !== colorB.dot,
+      expected: true,
+    });
+  });
+
+  test('stable across drive order', () => {
+    const shuffled = ['drive-ccc', 'drive-aaa', 'drive-bbb'];
+    const colorOriginal = getDriveCalendarColor('drive-bbb', driveIds);
+    const colorShuffled = getDriveCalendarColor('drive-bbb', shuffled);
+    assert({
+      given: 'the same driveId with different array orderings',
+      should: 'return the same color (sorts internally)',
+      actual: colorOriginal,
+      expected: colorShuffled,
+    });
+  });
+
+  test('unknown driveId fallback', () => {
+    const color = getDriveCalendarColor('drive-unknown', driveIds);
+    assert({
+      given: 'a driveId not in the driveIds array',
+      should: 'return the first palette color as fallback',
+      actual: color,
+      expected: DRIVE_CALENDAR_COLORS[0],
+    });
+  });
+});
+
+describe('resolveEventColor', () => {
+  const driveColorMap = new Map<string | null, EventColorConfig>([
+    [null, PERSONAL_CALENDAR_COLOR],
+    ['drive-aaa', DRIVE_CALENDAR_COLORS[0]],
+    ['drive-bbb', DRIVE_CALENDAR_COLORS[1]],
+  ]);
+
+  const makeEvent = (overrides: Partial<CalendarEvent> = {}): CalendarEvent => ({
+    id: 'evt-1',
+    driveId: 'drive-aaa',
+    createdById: 'user-1',
+    pageId: null,
+    title: 'Test Event',
+    description: null,
+    location: null,
+    startAt: '2026-04-10T09:00:00Z',
+    endAt: '2026-04-10T10:00:00Z',
+    allDay: false,
+    timezone: 'UTC',
+    recurrenceRule: null,
+    visibility: 'DRIVE',
+    color: 'meeting',
+    syncedFromGoogle: false,
+    googleSyncReadOnly: null,
+    createdAt: '2026-04-10T08:00:00Z',
+    updatedAt: '2026-04-10T08:00:00Z',
+    createdBy: { id: 'user-1', name: 'Test', image: null },
+    attendees: [],
+    ...overrides,
+  });
+
+  test('user context with drive color map', () => {
+    const event = makeEvent({ driveId: 'drive-aaa', color: 'meeting' });
+    const color = resolveEventColor(event, 'user', driveColorMap);
+    assert({
+      given: 'a drive event in user context with a driveColorMap',
+      should: 'return the drive color, not the event color',
+      actual: color,
+      expected: DRIVE_CALENDAR_COLORS[0],
+    });
+  });
+
+  test('user context personal event', () => {
+    const event = makeEvent({ driveId: null, color: 'default' });
+    const color = resolveEventColor(event, 'user', driveColorMap);
+    assert({
+      given: 'a personal event in user context',
+      should: 'return the personal calendar color',
+      actual: color,
+      expected: PERSONAL_CALENDAR_COLOR,
+    });
+  });
+
+  test('drive context ignores drive color map', () => {
+    const event = makeEvent({ driveId: 'drive-aaa', color: 'meeting' });
+    const color = resolveEventColor(event, 'drive', driveColorMap);
+    assert({
+      given: 'an event in drive context',
+      should: 'return the per-event color, not the drive color',
+      actual: color,
+      expected: getEventColors('meeting'),
+    });
+  });
+
+  test('null driveColorMap falls back to event color', () => {
+    const event = makeEvent({ color: 'deadline' });
+    const color = resolveEventColor(event, 'user', null);
+    assert({
+      given: 'a null driveColorMap',
+      should: 'fall back to the per-event color',
+      actual: color,
+      expected: getEventColors('deadline'),
+    });
+  });
+});

--- a/apps/web/src/components/calendar/__tests__/riteway.ts
+++ b/apps/web/src/components/calendar/__tests__/riteway.ts
@@ -1,0 +1,13 @@
+import { expect } from 'vitest';
+
+interface AssertParams {
+  given: string;
+  should: string;
+  actual: unknown;
+  expected: unknown;
+}
+
+export const assert = ({ given, should, actual, expected }: AssertParams): void => {
+  const message = `Given ${given}, should ${should}`;
+  expect(actual, message).toEqual(expected);
+};

--- a/apps/web/src/components/calendar/calendar-types.ts
+++ b/apps/web/src/components/calendar/calendar-types.ts
@@ -81,6 +81,60 @@ export interface TaskWithDueDate {
   driveId: string;
 }
 
+// Color config shape shared by event colors and drive calendar colors
+export type EventColorConfig = {
+  bg: string;
+  border: string;
+  text: string;
+  dot: string;
+};
+
+// Drive calendar color palette — visually distinct colors for sub-calendars
+export const DRIVE_CALENDAR_COLORS: EventColorConfig[] = [
+  { bg: 'bg-blue-500/10', border: 'border-l-blue-500', text: 'text-blue-600', dot: 'bg-blue-500' },
+  { bg: 'bg-emerald-500/10', border: 'border-l-emerald-500', text: 'text-emerald-600', dot: 'bg-emerald-500' },
+  { bg: 'bg-violet-500/10', border: 'border-l-violet-500', text: 'text-violet-600', dot: 'bg-violet-500' },
+  { bg: 'bg-amber-500/10', border: 'border-l-amber-500', text: 'text-amber-600', dot: 'bg-amber-500' },
+  { bg: 'bg-rose-500/10', border: 'border-l-rose-500', text: 'text-rose-600', dot: 'bg-rose-500' },
+  { bg: 'bg-cyan-500/10', border: 'border-l-cyan-500', text: 'text-cyan-600', dot: 'bg-cyan-500' },
+  { bg: 'bg-orange-500/10', border: 'border-l-orange-500', text: 'text-orange-600', dot: 'bg-orange-500' },
+  { bg: 'bg-pink-500/10', border: 'border-l-pink-500', text: 'text-pink-600', dot: 'bg-pink-500' },
+  { bg: 'bg-teal-500/10', border: 'border-l-teal-500', text: 'text-teal-600', dot: 'bg-teal-500' },
+  { bg: 'bg-indigo-500/10', border: 'border-l-indigo-500', text: 'text-indigo-600', dot: 'bg-indigo-500' },
+];
+
+// Dedicated color for personal (non-drive) events
+export const PERSONAL_CALENDAR_COLOR: EventColorConfig = {
+  bg: 'bg-slate-500/10',
+  border: 'border-l-slate-500',
+  text: 'text-slate-600',
+  dot: 'bg-slate-500',
+};
+
+// Deterministic drive-to-color assignment
+export function getDriveCalendarColor(
+  driveId: string | null,
+  driveIds: string[]
+): EventColorConfig {
+  if (driveId === null) return PERSONAL_CALENDAR_COLOR;
+  const sorted = [...driveIds].sort();
+  const index = sorted.indexOf(driveId);
+  if (index < 0) return DRIVE_CALENDAR_COLORS[0];
+  return DRIVE_CALENDAR_COLORS[index % DRIVE_CALENDAR_COLORS.length];
+}
+
+// Resolve an event's display color based on context
+export function resolveEventColor(
+  event: CalendarEvent,
+  context: 'user' | 'drive',
+  driveColorMap: Map<string | null, EventColorConfig> | null
+): EventColorConfig {
+  if (context === 'drive' || !driveColorMap) {
+    return getEventColors(event.color);
+  }
+  return driveColorMap.get(event.driveId) ?? getEventColors(event.color);
+}
+
 // Event color configurations
 export const EVENT_COLORS = {
   default: {

--- a/apps/web/src/stores/__tests__/riteway.ts
+++ b/apps/web/src/stores/__tests__/riteway.ts
@@ -1,0 +1,13 @@
+import { expect } from 'vitest';
+
+interface AssertParams {
+  given: string;
+  should: string;
+  actual: unknown;
+  expected: unknown;
+}
+
+export const assert = ({ given, should, actual, expected }: AssertParams): void => {
+  const message = `Given ${given}, should ${should}`;
+  expect(actual, message).toEqual(expected);
+};

--- a/apps/web/src/stores/__tests__/useCalendarFilterStore.test.ts
+++ b/apps/web/src/stores/__tests__/useCalendarFilterStore.test.ts
@@ -1,0 +1,104 @@
+import { describe, test, beforeEach } from 'vitest';
+import { assert } from './riteway';
+import { useCalendarFilterStore } from '../useCalendarFilterStore';
+
+// Reset store between tests to avoid shared mutable state
+beforeEach(() => {
+  useCalendarFilterStore.setState({
+    hiddenCalendars: [],
+  });
+});
+
+describe('useCalendarFilterStore', () => {
+  test('default visibility', () => {
+    const { hiddenCalendars } = useCalendarFilterStore.getState();
+    assert({
+      given: 'a fresh store with no saved state',
+      should: 'have no hidden calendars (all visible)',
+      actual: hiddenCalendars,
+      expected: [],
+    });
+  });
+
+  test('isVisible for unhidden calendar', () => {
+    const { isVisible } = useCalendarFilterStore.getState();
+    assert({
+      given: 'a calendar key not in the hidden list',
+      should: 'return true (visible)',
+      actual: isVisible('drive-aaa'),
+      expected: true,
+    });
+  });
+
+  test('toggleCalendar hides a visible calendar', () => {
+    useCalendarFilterStore.getState().toggleCalendar('drive-aaa');
+    const { hiddenCalendars, isVisible } = useCalendarFilterStore.getState();
+    assert({
+      given: 'toggling a visible calendar',
+      should: 'add it to the hidden list',
+      actual: hiddenCalendars,
+      expected: ['drive-aaa'],
+    });
+    assert({
+      given: 'a hidden calendar',
+      should: 'return false from isVisible',
+      actual: isVisible('drive-aaa'),
+      expected: false,
+    });
+  });
+
+  test('toggleCalendar shows a hidden calendar', () => {
+    useCalendarFilterStore.setState({ hiddenCalendars: ['drive-aaa'] });
+    useCalendarFilterStore.getState().toggleCalendar('drive-aaa');
+    const { hiddenCalendars, isVisible } = useCalendarFilterStore.getState();
+    assert({
+      given: 'toggling a hidden calendar',
+      should: 'remove it from the hidden list',
+      actual: hiddenCalendars,
+      expected: [],
+    });
+    assert({
+      given: 'a calendar that was toggled back to visible',
+      should: 'return true from isVisible',
+      actual: isVisible('drive-aaa'),
+      expected: true,
+    });
+  });
+
+  test('personal calendar key', () => {
+    useCalendarFilterStore.getState().toggleCalendar('personal');
+    const { isVisible } = useCalendarFilterStore.getState();
+    assert({
+      given: 'the personal calendar toggled off',
+      should: 'return false for the personal key',
+      actual: isVisible('personal'),
+      expected: false,
+    });
+  });
+
+  test('hideAll', () => {
+    const keys = ['personal', 'drive-aaa', 'drive-bbb'];
+    useCalendarFilterStore.getState().hideAll(keys);
+    const { isVisible } = useCalendarFilterStore.getState();
+    assert({
+      given: 'hideAll called with all calendar keys',
+      should: 'hide all calendars',
+      actual: keys.every((k) => !isVisible(k)),
+      expected: true,
+    });
+  });
+
+  test('showAll', () => {
+    useCalendarFilterStore.setState({
+      hiddenCalendars: ['personal', 'drive-aaa', 'drive-bbb'],
+    });
+    useCalendarFilterStore.getState().showAll();
+    const { hiddenCalendars } = useCalendarFilterStore.getState();
+    assert({
+      given: 'showAll called after hiding some calendars',
+      should: 'clear the hidden list',
+      actual: hiddenCalendars,
+      expected: [],
+    });
+  });
+});

--- a/apps/web/src/stores/useCalendarFilterStore.ts
+++ b/apps/web/src/stores/useCalendarFilterStore.ts
@@ -1,0 +1,39 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface CalendarFilterState {
+  hiddenCalendars: string[];
+  toggleCalendar: (key: string) => void;
+  showAll: () => void;
+  hideAll: (keys: string[]) => void;
+  isVisible: (key: string) => boolean;
+}
+
+export const useCalendarFilterStore = create<CalendarFilterState>()(
+  persist(
+    (set, get) => ({
+      hiddenCalendars: [],
+
+      toggleCalendar: (key: string) => {
+        const { hiddenCalendars } = get();
+        if (hiddenCalendars.includes(key)) {
+          set({ hiddenCalendars: hiddenCalendars.filter((k) => k !== key) });
+        } else {
+          set({ hiddenCalendars: [...hiddenCalendars, key] });
+        }
+      },
+
+      showAll: () => set({ hiddenCalendars: [] }),
+
+      hideAll: (keys: string[]) => set({ hiddenCalendars: [...keys] }),
+
+      isVisible: (key: string) => !get().hiddenCalendars.includes(key),
+    }),
+    {
+      name: 'calendar-filter-storage',
+      partialize: (state) => ({
+        hiddenCalendars: state.hiddenCalendars,
+      }),
+    }
+  )
+);

--- a/plan.md
+++ b/plan.md
@@ -22,6 +22,19 @@ A generic integration sandbox allowing:
 
 ---
 
+### Drive Calendar Filtering
+
+**Status**: 📋 PLANNED
+**Epic**: [tasks/drive-calendar-filtering.md](tasks/drive-calendar-filtering.md)
+**Goal**: Google Calendar-style drive filtering for the root calendar
+
+**Next Steps**:
+1. Drive Color Palette
+2. Calendar Filter Store
+3. Calendar Sidebar Component
+
+---
+
 ## Completed Epics
 
 _None yet_

--- a/plan.md
+++ b/plan.md
@@ -24,20 +24,23 @@ A generic integration sandbox allowing:
 
 ### Drive Calendar Filtering
 
-**Status**: 📋 PLANNED
+**Status**: ✅ COMPLETED
 **Epic**: [tasks/drive-calendar-filtering.md](tasks/drive-calendar-filtering.md)
 **Goal**: Google Calendar-style drive filtering for the root calendar
 
-**Next Steps**:
-1. Drive Color Palette
-2. Calendar Filter Store
-3. Calendar Sidebar Component
+All tasks delivered:
+1. ✅ Drive Color Palette
+2. ✅ Calendar Filter Store
+3. ✅ Calendar Sidebar Component
+4. ✅ CalendarView Integration
+5. ✅ View Color Resolution (7 view files)
+6. ✅ Mobile Filter Sheet
 
 ---
 
 ## Completed Epics
 
-_None yet_
+- **Drive Calendar Filtering** — Google Calendar-style drive filtering for the root calendar
 
 ---
 

--- a/tasks/drive-calendar-filtering.md
+++ b/tasks/drive-calendar-filtering.md
@@ -1,0 +1,76 @@
+# Drive Calendar Filtering Epic
+
+**Status**: ✅ COMPLETED (2026-04-10)
+**Goal**: Google Calendar-style drive filtering for the root calendar
+
+## Overview
+
+Users viewing the root calendar (`/dashboard/calendar`) see events from all drives mixed together with no way to distinguish sources or filter by drive. This makes calendars with multiple active drives overwhelming and hard to scan. Adding a sidebar with toggleable, color-coded drive "sub-calendars" — matching the mental model of Google Calendar — lets users quickly see which drive an event belongs to and focus on the drives they care about right now.
+
+---
+
+## Drive Color Palette
+
+Add a deterministic color palette and color resolution utilities to the existing calendar-types module.
+
+**Requirements**:
+- Given a set of accessible drives, should assign each drive a stable, visually distinct color from a fixed palette
+- Given a personal event (driveId=null), should always assign a dedicated personal calendar color
+- Given a calendar event in the root calendar (context='user'), should resolve to the drive's color instead of the per-event color
+- Given a calendar event in a single-drive calendar (context='drive'), should continue using the per-event color as before
+
+---
+
+## Calendar Filter Store
+
+Create a Zustand persist store that tracks which drive calendars are visible.
+
+**Requirements**:
+- Given a fresh session with no saved state, should default all calendars to visible
+- Given a user toggling a drive off, should persist that choice to localStorage across page reloads
+- Given a user clicking "show all" or "hide all", should toggle all calendars at once
+
+---
+
+## Calendar Sidebar Component
+
+Build a sidebar listing each drive as a toggleable sub-calendar with its assigned color.
+
+**Requirements**:
+- Given the root calendar view, should display a "My Calendars" sidebar with "Personal" and one row per accessible drive
+- Given each row, should show a colored checkbox and the calendar name
+- Given a click on a checkbox, should toggle that calendar's visibility via the filter store
+
+---
+
+## CalendarView Integration
+
+Wire the filter store, drive store, and color map into CalendarView to filter events and display the sidebar.
+
+**Requirements**:
+- Given context='user', should render the sidebar alongside the calendar content in a flex layout
+- Given hidden calendars in the filter store, should exclude matching events and tasks before passing to views
+- Given context='drive', should not render the sidebar or apply any filtering
+- Given a sidebar toggle button in the header, should collapse/expand the sidebar on desktop
+
+---
+
+## View Color Resolution
+
+Replace all getEventColors calls across view components with the new drive-aware color resolver.
+
+**Requirements**:
+- Given a view rendering events in context='user' with a driveColorMap, should color events by their drive source
+- Given a view rendering events in context='drive' or without a driveColorMap, should fall back to per-event color
+- Given all 7 view files (MonthView, WeekView, DayView, AgendaView, MobileCalendarView, MobileDayAgenda, MobileWeekStrip), should use the same resolveEventColor function
+
+---
+
+## Mobile Filter Sheet
+
+Add a filter trigger to the mobile calendar that opens a bottom sheet with the same drive toggles.
+
+**Requirements**:
+- Given the mobile calendar view, should display a filter icon button in the header
+- Given a tap on the filter button, should open a Sheet containing the CalendarSidebar component
+- Given filter changes in the sheet, should immediately reflect in the mobile calendar view


### PR DESCRIPTION
## Summary
- Adds a sidebar to the root calendar (`/dashboard/calendar`) that lists each drive as a toggleable, color-coded sub-calendar — matching the Google Calendar mental model
- Events are colored by their source drive in the combined view; toggling a drive on/off instantly hides/shows its events across all view modes
- Desktop: collapsible sidebar with panel toggle button. Mobile: bottom sheet via filter icon

## What changed
- **`calendar-types.ts`** — 10-color `DRIVE_CALENDAR_COLORS` palette, `PERSONAL_CALENDAR_COLOR`, deterministic `getDriveCalendarColor()`, context-aware `resolveEventColor()`
- **`useCalendarFilterStore.ts`** (new) — Zustand persist store tracking hidden calendars in localStorage
- **`CalendarSidebar.tsx`** (new) — Presentational component with colored checkboxes, show/hide all, keyboard accessible
- **`CalendarView.tsx`** — Wires stores, computes filtered events/tasks + color map, renders sidebar in flex layout
- **7 view files** — All `getEventColors()` calls replaced with `resolveEventColor()` for drive-aware coloring
- **`MobileCalendarView.tsx`** — Adds Sheet-based filter UI with CalendarSidebar

## Design decisions
- **No API/DB changes** — events already carry `drive` data, drives already cached client-side
- **Deterministic colors** — stable palette assignment by sorted drive ID, no migration needed
- **Drive color overrides per-event color** in root calendar (Google Calendar model); single-drive views unchanged
- **All new props optional** with backward-compatible defaults — zero breaking changes
- **Force-refresh drives** on root calendar mount to avoid stale-cache inconsistencies

## Review-driven improvements
- Force-refresh drives on mount (Codex review: stale cache could hide new drives)
- Guard empty-state visibility flags (CodeRabbit: `Array.every()` returns true on empty arrays)
- Improve CalendarSidebar accessibility: `aria-label` on checkboxes, keyboard support, proper semantic HTML

## Test plan
- [x] 23 unit tests passing (`pnpm --filter web test`)
- [ ] Navigate to `/dashboard/calendar` — sidebar appears with "Personal" + all drives
- [ ] Events colored by drive source across month/week/day/agenda views
- [ ] Toggle a drive off → its events disappear; toggle back → they reappear
- [ ] Refresh page → filter state persists (localStorage)
- [ ] Click sidebar toggle button → sidebar collapses/expands
- [ ] Navigate to `/dashboard/{driveId}/calendar` → no sidebar, original per-event colors
- [ ] Mobile: filter icon opens bottom sheet with same toggles

🤖 Generated with [Claude Code](https://claude.com/claude-code)