### PR TITLE
feat(security): wire SecurityAuditService into comms routes

### DIFF
--- a/apps/web/src/app/api/channels/[pageId]/messages/[messageId]/reactions/route.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/[messageId]/reactions/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { channelMessages, channelMessageReactions, db, eq, and } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { canUserViewPage } from '@pagespace/lib/server';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { createSignedBroadcastHeaders } from '@pagespace/lib/broadcast-auth';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
@@ -54,6 +54,10 @@ export async function POST(req: Request, { params }: RouteParams) {
       userId,
       emoji,
     }).returning();
+
+    securityAudit.logDataAccess(userId, 'write', 'reaction', messageId).catch((error) => {
+      loggers.security.warn('[Channels] audit log failed', { error: error instanceof Error ? error.message : String(error), userId });
+    });
 
     // Fetch with user info for broadcast
     const reactionWithUser = await db.query.channelMessageReactions.findFirst({
@@ -149,6 +153,10 @@ export async function DELETE(req: Request, { params }: RouteParams) {
   if (result.length === 0) {
     return NextResponse.json({ error: 'Reaction not found' }, { status: 404 });
   }
+
+  securityAudit.logDataAccess(userId, 'delete', 'reaction', messageId).catch((error) => {
+    loggers.security.warn('[Channels] audit log failed', { error: error instanceof Error ? error.message : String(error), userId });
+  });
 
   // Broadcast reaction removal to channel
   if (process.env.INTERNAL_REALTIME_URL) {

--- a/apps/web/src/app/api/channels/[pageId]/messages/route.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { channelMessages, channelReadStatus, db, eq, and, desc, or, isNull, gt, lt, inArray, files, pages, driveMembers, pagePermissions } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
 import { canUserViewPage, canUserEditPage } from '@pagespace/lib/server';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { createSignedBroadcastHeaders } from '@pagespace/lib/broadcast-auth';
 import { broadcastInboxEvent } from '@/lib/websocket/socket-utils';
 
@@ -106,6 +106,10 @@ export async function GET(req: Request, { params }: { params: Promise<{ pageId: 
     ? `${page[0].createdAt.toISOString()}|${page[0].id}`
     : null;
 
+  securityAudit.logDataAccess(userId, 'read', 'channel_message', pageId).catch((error) => {
+    loggers.security.warn('[Channels] audit log failed', { error: error instanceof Error ? error.message : String(error), userId });
+  });
+
   return NextResponse.json({ messages: page, nextCursor, hasMore });
 }
 
@@ -157,6 +161,10 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
     fileId: fileId || null,
     attachmentMeta: attachmentMeta || null,
   }).returning();
+
+  securityAudit.logDataAccess(userId, 'write', 'channel_message', createdMessage.id).catch((error) => {
+    loggers.security.warn('[Channels] audit log failed', { error: error instanceof Error ? error.message : String(error), userId });
+  });
 
   // Update sender's read status - sending a message means they've read the channel
   await db

--- a/apps/web/src/app/api/channels/[pageId]/upload/route.ts
+++ b/apps/web/src/app/api/channels/[pageId]/upload/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db, pages, files, filePages, eq } from '@pagespace/db';
-import { canUserEditPage } from '@pagespace/lib/server';
+import { canUserEditPage, loggers, securityAudit } from '@pagespace/lib/server';
 import {
   checkStorageQuota,
   updateStorageUsage,
@@ -203,6 +203,10 @@ export async function POST(
     await updateStorageUsage(userId, file.size, {
       driveId,
       eventType: 'upload'
+    });
+
+    securityAudit.logDataAccess(userId, 'write', 'channel_upload', contentHash).catch((error) => {
+      loggers.security.warn('[Channels] audit log failed', { error: error instanceof Error ? error.message : String(error), userId });
     });
 
     // Log activity

--- a/apps/web/src/app/api/inbox/route.ts
+++ b/apps/web/src/app/api/inbox/route.ts
@@ -16,7 +16,7 @@ export async function GET(request: Request) {
     if (isAuthError(auth)) return auth.error;
     const userId = auth.userId;
 
-    securityAudit.logDataAccess(userId, 'read', 'inbox', userId).catch((error) => {
+    securityAudit.logDataAccess(userId, 'read', 'inbox', 'self').catch((error) => {
       loggers.security.warn('[Inbox] audit log failed', { error: error instanceof Error ? error.message : String(error), userId });
     });
 

--- a/apps/web/src/app/api/inbox/route.ts
+++ b/apps/web/src/app/api/inbox/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db, sql } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers, getBatchPagePermissions } from '@pagespace/lib/server';
+import { loggers, getBatchPagePermissions, securityAudit } from '@pagespace/lib/server';
 import type { InboxItem, InboxResponse } from '@pagespace/lib';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
 import { toISOTimestamp } from '@/lib/utils/timestamp';
@@ -15,6 +15,10 @@ export async function GET(request: Request) {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
     if (isAuthError(auth)) return auth.error;
     const userId = auth.userId;
+
+    securityAudit.logDataAccess(userId, 'read', 'inbox', userId).catch((error) => {
+      loggers.security.warn('[Inbox] audit log failed', { error: error instanceof Error ? error.message : String(error), userId });
+    });
 
     const { searchParams } = new URL(request.url);
     const limit = parseBoundedIntParam(searchParams.get('limit'), {

--- a/apps/web/src/app/api/inbox/route.ts
+++ b/apps/web/src/app/api/inbox/route.ts
@@ -16,10 +16,6 @@ export async function GET(request: Request) {
     if (isAuthError(auth)) return auth.error;
     const userId = auth.userId;
 
-    securityAudit.logDataAccess(userId, 'read', 'inbox', 'self').catch((error) => {
-      loggers.security.warn('[Inbox] audit log failed', { error: error instanceof Error ? error.message : String(error), userId });
-    });
-
     const { searchParams } = new URL(request.url);
     const limit = parseBoundedIntParam(searchParams.get('limit'), {
       defaultValue: 20,
@@ -130,6 +126,10 @@ export async function GET(request: Request) {
       const nextCursor = lastItem
         ? lastItem.lastMessageAt || `id:${lastItem.id}`
         : null;
+
+      securityAudit.logDataAccess(userId, 'read', 'inbox', 'self').catch((error) => {
+        loggers.security.warn('[Inbox] audit log failed', { error: error instanceof Error ? error.message : String(error), userId });
+      });
 
       return NextResponse.json({
         items: paginatedItems,
@@ -304,6 +304,10 @@ export async function GET(request: Request) {
     const nextCursor = lastItem
       ? lastItem.lastMessageAt || `id:${lastItem.id}`
       : null;
+
+    securityAudit.logDataAccess(userId, 'read', 'inbox', 'self').catch((error) => {
+      loggers.security.warn('[Inbox] audit log failed', { error: error instanceof Error ? error.message : String(error), userId });
+    });
 
     return NextResponse.json({
       items: paginatedItems,

--- a/apps/web/src/app/api/messages/[conversationId]/route.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db, directMessages, dmConversations, eq, and, or, desc, lt } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { createOrUpdateMessageNotification, isEmailVerified } from '@pagespace/lib';
 import { createSignedBroadcastHeaders } from '@pagespace/lib/broadcast-auth';
 import { broadcastInboxEvent } from '@/lib/websocket/socket-utils';
@@ -105,6 +105,10 @@ export async function GET(
     // Reverse messages to show oldest first
     messages.reverse();
 
+    securityAudit.logDataAccess(userId, 'read', 'message', conversationId).catch((error) => {
+      loggers.security.warn('[Messages] audit log failed', { error: error instanceof Error ? error.message : String(error), userId });
+    });
+
     return NextResponse.json({ messages });
   } catch (error) {
     loggers.api.error('Error fetching messages:', error as Error);
@@ -179,6 +183,10 @@ export async function POST(
         content,
       })
       .returning();
+
+    securityAudit.logDataAccess(userId, 'write', 'message', newMessage.id).catch((error) => {
+      loggers.security.warn('[Messages] audit log failed', { error: error instanceof Error ? error.message : String(error), userId });
+    });
 
     // Update conversation's last message info
     const messagePreview = content.length > 100
@@ -305,6 +313,10 @@ export async function PATCH(
       .update(dmConversations)
       .set(updateField)
       .where(eq(dmConversations.id, conversationId));
+
+    securityAudit.logDataAccess(userId, 'write', 'message', conversationId, { operation: 'mark_read' }).catch((error) => {
+      loggers.security.warn('[Messages] audit log failed', { error: error instanceof Error ? error.message : String(error), userId });
+    });
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/apps/web/src/app/api/messages/conversations/[conversationId]/route.ts
+++ b/apps/web/src/app/api/messages/conversations/[conversationId]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db, sql } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import type { ConversationDetailRow } from '@/types/messaging';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
@@ -75,6 +75,10 @@ export async function GET(
         avatarUrl: row.user_avatar_url,
       },
     };
+
+    securityAudit.logDataAccess(userId, 'read', 'conversation', conversationId).catch((error) => {
+      loggers.security.warn('[Messages] audit log failed', { error: error instanceof Error ? error.message : String(error), userId });
+    });
 
     return NextResponse.json({ conversation });
   } catch (error) {

--- a/apps/web/src/app/api/messages/conversations/route.ts
+++ b/apps/web/src/app/api/messages/conversations/route.ts
@@ -221,6 +221,10 @@ export async function POST(request: Request) {
       .limit(1);
 
     if (existingConversation) {
+      securityAudit.logDataAccess(userId, 'read', 'conversation', existingConversation.id).catch((error) => {
+        loggers.security.warn('[Messages] audit log failed', { error: error instanceof Error ? error.message : String(error), userId });
+      });
+
       return NextResponse.json({ conversation: existingConversation });
     }
 

--- a/apps/web/src/app/api/messages/conversations/route.ts
+++ b/apps/web/src/app/api/messages/conversations/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db, dmConversations, connections, eq, and, or, sql } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { isEmailVerified } from '@pagespace/lib';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
 import { toISOTimestamp } from '@/lib/utils/timestamp';
@@ -120,6 +120,10 @@ export async function GET(request: Request) {
       ? conversations[conversations.length - 1].lastMessageAt
       : null;
 
+    securityAudit.logDataAccess(userId, 'read', 'conversation', userId).catch((error) => {
+      loggers.security.warn('[Messages] audit log failed', { error: error instanceof Error ? error.message : String(error), userId });
+    });
+
     return NextResponse.json({
       conversations,
       pagination: {
@@ -228,6 +232,10 @@ export async function POST(request: Request) {
         participant2Id,
       })
       .returning();
+
+    securityAudit.logDataAccess(userId, 'write', 'conversation', newConversation.id).catch((error) => {
+      loggers.security.warn('[Messages] audit log failed', { error: error instanceof Error ? error.message : String(error), userId });
+    });
 
     return NextResponse.json({ conversation: newConversation });
   } catch (error) {

--- a/apps/web/src/app/api/messages/conversations/route.ts
+++ b/apps/web/src/app/api/messages/conversations/route.ts
@@ -120,7 +120,7 @@ export async function GET(request: Request) {
       ? conversations[conversations.length - 1].lastMessageAt
       : null;
 
-    securityAudit.logDataAccess(userId, 'read', 'conversation', userId).catch((error) => {
+    securityAudit.logDataAccess(userId, 'read', 'conversation', 'self').catch((error) => {
       loggers.security.warn('[Messages] audit log failed', { error: error instanceof Error ? error.message : String(error), userId });
     });
 

--- a/apps/web/src/app/api/messages/threads/route.ts
+++ b/apps/web/src/app/api/messages/threads/route.ts
@@ -19,7 +19,7 @@ export async function GET(request: Request) {
       fetchChannelsWithLastMessage(userId),
     ]);
 
-    securityAudit.logDataAccess(userId, 'read', 'message_threads', userId).catch((error) => {
+    securityAudit.logDataAccess(userId, 'read', 'message_threads', 'self').catch((error) => {
       loggers.security.warn('[Messages] audit log failed', { error: error instanceof Error ? error.message : String(error), userId });
     });
 

--- a/apps/web/src/app/api/messages/threads/route.ts
+++ b/apps/web/src/app/api/messages/threads/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db, sql } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import type { ConversationRow, ChannelThreadRow } from '@/types/messaging';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
@@ -18,6 +18,10 @@ export async function GET(request: Request) {
       fetchDMConversations(userId),
       fetchChannelsWithLastMessage(userId),
     ]);
+
+    securityAudit.logDataAccess(userId, 'read', 'message_threads', userId).catch((error) => {
+      loggers.security.warn('[Messages] audit log failed', { error: error instanceof Error ? error.message : String(error), userId });
+    });
 
     return NextResponse.json({
       dms: dmResults,

--- a/apps/web/src/app/api/notifications/[id]/route.ts
+++ b/apps/web/src/app/api/notifications/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { deleteNotification } from '@pagespace/lib';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 
@@ -17,6 +17,11 @@ export async function DELETE(
 
   try {
     await deleteNotification(id, userId);
+
+    securityAudit.logDataAccess(userId, 'delete', 'notification', id).catch((error) => {
+      loggers.security.warn('[Notifications] audit log failed', { error: error instanceof Error ? error.message : String(error), userId });
+    });
+
     return NextResponse.json({ success: true });
   } catch (error) {
     loggers.api.error('Error deleting notification:', error as Error);

--- a/apps/web/src/app/api/notifications/push-tokens/route.ts
+++ b/apps/web/src/app/api/notifications/push-tokens/route.ts
@@ -99,6 +99,10 @@ export async function DELETE(req: Request) {
 
     await unregisterPushToken(userId, token);
 
+    securityAudit.logTokenRevoked(userId, 'push_token', 'user_request').catch((error) => {
+      loggers.security.warn('[Notifications] audit log failed', { error: error instanceof Error ? error.message : String(error), userId });
+    });
+
     return NextResponse.json({ success: true });
   } catch (error) {
     loggers.api.error('Error unregistering push token:', error as Error);

--- a/apps/web/src/app/api/notifications/push-tokens/route.ts
+++ b/apps/web/src/app/api/notifications/push-tokens/route.ts
@@ -4,7 +4,7 @@ import {
   unregisterPushToken,
   getUserPushTokens,
 } from '@pagespace/lib/notifications';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
@@ -61,6 +61,10 @@ export async function POST(req: Request) {
       deviceName,
       webPushSubscription
     );
+
+    securityAudit.logTokenCreated(userId, 'push_token').catch((error) => {
+      loggers.security.warn('[Notifications] audit log failed', { error: error instanceof Error ? error.message : String(error), userId });
+    });
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/notifications/route.ts
+++ b/apps/web/src/app/api/notifications/route.ts
@@ -30,7 +30,7 @@ export async function GET(req: Request) {
     const notifications = await getUserNotifications(userId, limit);
     const unreadCount = await getUnreadNotificationCount(userId);
 
-    securityAudit.logDataAccess(userId, 'read', 'notification', userId).catch((error) => {
+    securityAudit.logDataAccess(userId, 'read', 'notification', 'self').catch((error) => {
       loggers.security.warn('[Notifications] audit log failed', { error: error instanceof Error ? error.message : String(error), userId });
     });
 

--- a/apps/web/src/app/api/notifications/route.ts
+++ b/apps/web/src/app/api/notifications/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getUserNotifications, getUnreadNotificationCount } from '@pagespace/lib';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
 
@@ -29,6 +29,10 @@ export async function GET(req: Request) {
 
     const notifications = await getUserNotifications(userId, limit);
     const unreadCount = await getUnreadNotificationCount(userId);
+
+    securityAudit.logDataAccess(userId, 'read', 'notification', userId).catch((error) => {
+      loggers.security.warn('[Notifications] audit log failed', { error: error instanceof Error ? error.message : String(error), userId });
+    });
 
     return NextResponse.json({
       notifications,

--- a/apps/web/src/app/api/notifications/unsubscribe/[token]/route.ts
+++ b/apps/web/src/app/api/notifications/unsubscribe/[token]/route.ts
@@ -105,7 +105,7 @@ export async function GET(
     // Redirect to a confirmation page
     const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
 
-    securityAudit.logDataAccess(userId, 'write', 'notification_prefs', userId).catch((error) => {
+    securityAudit.logDataAccess(userId, 'write', 'notification_prefs', 'self').catch((error) => {
       loggers.security.warn('[Notifications] audit log failed', { error: error instanceof Error ? error.message : String(error), userId });
     });
 

--- a/apps/web/src/app/api/notifications/unsubscribe/[token]/route.ts
+++ b/apps/web/src/app/api/notifications/unsubscribe/[token]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db, emailNotificationPreferences, emailUnsubscribeTokens, eq, and, gt, isNull } from '@pagespace/db';
 import { hashToken } from '@pagespace/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 
 type NotificationType =
   | 'PERMISSION_GRANTED'
@@ -104,6 +104,10 @@ export async function GET(
 
     // Redirect to a confirmation page
     const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+
+    securityAudit.logDataAccess(userId, 'write', 'notification_prefs', userId).catch((error) => {
+      loggers.security.warn('[Notifications] audit log failed', { error: error instanceof Error ? error.message : String(error), userId });
+    });
 
     // Validate notification type before using in redirect URL
     if (!VALID_NOTIFICATION_TYPES.has(notificationType)) {

--- a/packages/lib/src/audit/__tests__/security-audit.test.ts
+++ b/packages/lib/src/audit/__tests__/security-audit.test.ts
@@ -632,4 +632,58 @@ describe('GDPR-Safe Hash Chain (#541)', () => {
 
     expect(hash1).not.toBe(hash2);
   });
+
+  it('resourceId containing userId cannot be anonymized without breaking chain', () => {
+    const timestamp = new Date('2026-01-25T10:00:00Z');
+    const userId = 'user-abc-123';
+
+    // Simulates the bug: passing userId as resourceId
+    const eventWithUserIdInResource: AuditEvent = {
+      eventType: 'data.read',
+      userId,
+      resourceType: 'inbox',
+      resourceId: userId,
+    };
+
+    const hashBefore = computeSecurityEventHash(eventWithUserIdInResource, 'genesis', timestamp);
+
+    // After GDPR anonymization: userId column nulled, but resourceId remains
+    const anonymizedEvent: AuditEvent = {
+      ...eventWithUserIdInResource,
+      userId: undefined,
+      // resourceId still contains the userId — can't be nulled without breaking hash
+    };
+
+    const hashAfter = computeSecurityEventHash(anonymizedEvent, 'genesis', timestamp);
+
+    // Hash is stable (userId excluded) but resourceId still leaks the user ID
+    expect(hashBefore).toBe(hashAfter);
+    // The PII is permanently embedded — this is why callers must use 'self' instead
+    expect(anonymizedEvent.resourceId).toBe(userId);
+  });
+
+  it('using "self" as resourceId avoids PII in hash-protected fields', () => {
+    const timestamp = new Date('2026-01-25T10:00:00Z');
+
+    const event: AuditEvent = {
+      eventType: 'data.read',
+      userId: 'user-abc-123',
+      resourceType: 'inbox',
+      resourceId: 'self',
+    };
+
+    const hashBefore = computeSecurityEventHash(event, 'genesis', timestamp);
+
+    // After GDPR anonymization: only PII fields nulled
+    const anonymizedEvent: AuditEvent = {
+      ...event,
+      userId: undefined,
+    };
+
+    const hashAfter = computeSecurityEventHash(anonymizedEvent, 'genesis', timestamp);
+
+    // Hash stable AND no PII remains anywhere in the record
+    expect(hashBefore).toBe(hashAfter);
+    expect(anonymizedEvent.resourceId).toBe('self');
+  });
 });


### PR DESCRIPTION
## Summary
- Wire `securityAudit.logDataAccess` and `logTokenCreated` into 12 communication route files (channels, messages, notifications, inbox)
- 18 total audit calls covering read, write, and delete operations across all comms routes
- Uses fire-and-forget `.catch()` pattern consistent with existing audit wiring in auth/export routes
- GDPR-safe: uses `'self'` as `resourceId` for list/self endpoints to avoid leaking `userId` into hash-protected fields
- Added `logTokenRevoked` audit for push-token DELETE (token revocation)

## Routes Covered
| Domain | Routes | Audit Calls |
|--------|--------|-------------|
| Channels | messages, reactions, upload | 5 |
| Messages | DMs, conversations, threads | 7 |
| Notifications | list, delete, push-tokens (create+revoke), unsubscribe | 5 |
| Inbox | unified inbox | 1 |

## GDPR Compliance
- `resourceId` is included in the tamper-evident hash chain and **cannot be anonymized** under right-to-erasure
- All list/self endpoints use `'self'` instead of `userId` as `resourceId`
- 2 new tests document this invariant in `security-audit.test.ts`

## Test plan
- [x] `pnpm typecheck` passes
- [x] All 74 audit tests pass (5 test files)
- [x] No functional changes — all audit calls are fire-and-forget, non-blocking
- [x] Imports resolve to `@pagespace/lib/server`
- [x] Review feedback addressed (inbox audit timing, push-token DELETE gap, GDPR resourceId fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)