### PR TITLE
feat(security): wire SecurityAuditService into all auth routes

### DIFF
--- a/apps/web/src/app/api/auth/__tests__/device-refresh.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/device-refresh.test.ts
@@ -30,8 +30,20 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
       debug: vi.fn(),
     },
+    security: {
+      warn: vi.fn(),
+    },
   },
   logAuthEvent: vi.fn(),
+  securityAudit: {
+    logAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    logAuthFailure: vi.fn().mockResolvedValue(undefined),
+    logTokenCreated: vi.fn().mockResolvedValue(undefined),
+    logTokenRevoked: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logLogout: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 vi.mock('@pagespace/lib/activity-tracker', () => ({

--- a/apps/web/src/app/api/auth/__tests__/google-callback-redirect.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/google-callback-redirect.test.ts
@@ -79,12 +79,24 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
       debug: vi.fn(),
     },
+    security: {
+      warn: vi.fn(),
+    },
   },
   logAuthEvent: vi.fn(),
   validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
     deviceToken: 'mock-device-token',
     deviceTokenRecordId: 'device-record-id',
   }),
+  securityAudit: {
+    logAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    logAuthFailure: vi.fn().mockResolvedValue(undefined),
+    logTokenCreated: vi.fn().mockResolvedValue(undefined),
+    logTokenRevoked: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logLogout: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 vi.mock('@pagespace/lib/security', () => ({

--- a/apps/web/src/app/api/auth/__tests__/mcp-tokens.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/mcp-tokens.test.ts
@@ -17,6 +17,7 @@ vi.mock('@/lib/repositories/session-repository', () => ({
 vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
   isAuthError: vi.fn(),
+  getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
 }));
 
 vi.mock('@pagespace/lib/server', () => ({

--- a/apps/web/src/app/api/auth/__tests__/mcp-tokens.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/mcp-tokens.test.ts
@@ -25,6 +25,18 @@ vi.mock('@pagespace/lib/server', () => ({
       error: vi.fn(),
       info: vi.fn(),
     },
+    security: {
+      warn: vi.fn(),
+    },
+  },
+  securityAudit: {
+    logAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    logAuthFailure: vi.fn().mockResolvedValue(undefined),
+    logTokenCreated: vi.fn().mockResolvedValue(undefined),
+    logTokenRevoked: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logLogout: vi.fn().mockResolvedValue(undefined),
   },
 }));
 

--- a/apps/web/src/app/api/auth/__tests__/mobile-oauth-google-exchange.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/mobile-oauth-google-exchange.test.ts
@@ -32,8 +32,20 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
       debug: vi.fn(),
     },
+    security: {
+      warn: vi.fn(),
+    },
   },
   logAuthEvent: vi.fn(),
+  securityAudit: {
+    logAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    logAuthFailure: vi.fn().mockResolvedValue(undefined),
+    logTokenCreated: vi.fn().mockResolvedValue(undefined),
+    logTokenRevoked: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logLogout: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 vi.mock('@pagespace/lib/auth', () => ({

--- a/apps/web/src/app/api/auth/__tests__/mobile-refresh.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/mobile-refresh.test.ts
@@ -40,6 +40,18 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
       debug: vi.fn(),
     },
+    security: {
+      warn: vi.fn(),
+    },
+  },
+  securityAudit: {
+    logAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    logAuthFailure: vi.fn().mockResolvedValue(undefined),
+    logTokenCreated: vi.fn().mockResolvedValue(undefined),
+    logTokenRevoked: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logLogout: vi.fn().mockResolvedValue(undefined),
   },
 }));
 

--- a/apps/web/src/app/api/auth/__tests__/verify-email.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/verify-email.test.ts
@@ -16,6 +16,18 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
       debug: vi.fn(),
     },
+    security: {
+      warn: vi.fn(),
+    },
+  },
+  securityAudit: {
+    logAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    logAuthFailure: vi.fn().mockResolvedValue(undefined),
+    logTokenCreated: vi.fn().mockResolvedValue(undefined),
+    logTokenRevoked: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logLogout: vi.fn().mockResolvedValue(undefined),
   },
 }));
 

--- a/apps/web/src/app/api/auth/apple/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/apple/callback/__tests__/route.test.ts
@@ -71,11 +71,23 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
       debug: vi.fn(),
     },
+    security: {
+      warn: vi.fn(),
+    },
   },
   logAuthEvent: vi.fn(),
   validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
     deviceToken: 'mock-device-token',
   }),
+  securityAudit: {
+    logAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    logAuthFailure: vi.fn().mockResolvedValue(undefined),
+    logTokenCreated: vi.fn().mockResolvedValue(undefined),
+    logTokenRevoked: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logLogout: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 vi.mock('@pagespace/lib/activity-tracker', () => ({

--- a/apps/web/src/app/api/auth/apple/callback/route.ts
+++ b/apps/web/src/app/api/auth/apple/callback/route.ts
@@ -6,7 +6,7 @@ import {
   DISTRIBUTED_RATE_LIMITS,
 } from '@pagespace/lib/security';
 import { createId } from '@paralleldrive/cuid2';
-import { loggers, logAuthEvent, validateOrCreateDeviceToken } from '@pagespace/lib/server';
+import { loggers, logAuthEvent, securityAudit, validateOrCreateDeviceToken } from '@pagespace/lib/server';
 import { revokeSessionsForLogin, createWebDeviceToken } from '@/lib/auth';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
 import { NextResponse } from 'next/server';
@@ -55,6 +55,9 @@ export async function POST(req: Request) {
         errorHint: errorHint ? String(errorHint).slice(0, 100) : 'none',
       });
       const errorType = errorHint === 'user_cancelled_authorize' ? 'access_denied' : 'oauth_error';
+      securityAudit.logAuthFailure('unknown', getClientIP(req), 'apple_oauth_rejected').catch((error) => {
+        loggers.security.warn('[AppleCallback] audit logAuthFailure failed', { error: error instanceof Error ? error.message : String(error) });
+      });
 
       if (verifiedState?.platform === 'desktop') {
         return NextResponse.redirect(`pagespace://auth-error?error=${errorType}`);
@@ -209,6 +212,9 @@ export async function POST(req: Request) {
       provider: 'apple',
       userAgent: req.headers.get('user-agent')
     });
+    securityAudit.logAuthSuccess(user.id, sessionClaims.sessionId, clientIP, req.headers.get('user-agent') || 'unknown').catch((error) => {
+      loggers.security.warn('[AppleCallback] audit logAuthSuccess failed', { error: error instanceof Error ? error.message : String(error), userId: user.id });
+    });
 
     // DESKTOP PLATFORM: Redirect with tokens encoded via exchange code
     if (platform === 'desktop') {
@@ -325,6 +331,9 @@ export async function POST(req: Request) {
 
   } catch (error) {
     loggers.auth.error('Apple OAuth callback error', error as Error);
+    securityAudit.logAuthFailure('unknown', getClientIP(req), 'apple_oauth_error').catch((auditError) => {
+      loggers.security.warn('[AppleCallback] audit logAuthFailure failed', { error: auditError instanceof Error ? auditError.message : String(auditError) });
+    });
     const errorRedirectBase = process.env.NEXTAUTH_URL || process.env.WEB_APP_URL || req.url;
     return NextResponse.redirect(new URL('/auth/signin?error=oauth_error', errorRedirectBase));
   }

--- a/apps/web/src/app/api/auth/apple/native/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/apple/native/__tests__/route.test.ts
@@ -68,11 +68,23 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
       debug: vi.fn(),
     },
+    security: {
+      warn: vi.fn(),
+    },
   },
   logAuthEvent: vi.fn(),
   validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
     deviceToken: 'mock-device-token',
   }),
+  securityAudit: {
+    logAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    logAuthFailure: vi.fn().mockResolvedValue(undefined),
+    logTokenCreated: vi.fn().mockResolvedValue(undefined),
+    logTokenRevoked: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logLogout: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 vi.mock('@pagespace/lib/activity-tracker', () => ({

--- a/apps/web/src/app/api/auth/apple/native/route.ts
+++ b/apps/web/src/app/api/auth/apple/native/route.ts
@@ -1,6 +1,6 @@
 import { sessionService, generateCSRFToken, SESSION_DURATION_MS, verifyAppleIdToken } from '@pagespace/lib/auth';
 import { createId } from '@paralleldrive/cuid2';
-import { loggers, logAuthEvent, validateOrCreateDeviceToken } from '@pagespace/lib/server';
+import { loggers, logAuthEvent, securityAudit, validateOrCreateDeviceToken } from '@pagespace/lib/server';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
 import { z } from 'zod/v4';
 import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-started-drive';
@@ -80,6 +80,9 @@ export async function POST(req: Request) {
       loggers.auth.warn('Invalid Apple ID token', {
         platform,
         error: verificationResult.error
+      });
+      securityAudit.logAuthFailure('unknown', clientIP, 'apple_native_invalid_token').catch((error) => {
+        loggers.security.warn('[AppleNative] audit logAuthFailure failed', { error: error instanceof Error ? error.message : String(error) });
       });
       return Response.json({ error: verificationResult.error || 'Invalid token' }, { status: 401 });
     }
@@ -200,6 +203,9 @@ export async function POST(req: Request) {
       platform,
       isNewUser,
     });
+    securityAudit.logAuthSuccess(user.id, sessionClaims.sessionId, clientIP, req.headers.get('user-agent') || 'unknown').catch((error) => {
+      loggers.security.warn('[AppleNative] audit logAuthSuccess failed', { error: error instanceof Error ? error.message : String(error), userId: user.id });
+    });
 
     // Set session cookie so middleware recognizes the authenticated session
     const headers = new Headers();
@@ -225,6 +231,9 @@ export async function POST(req: Request) {
     });
   } catch (error) {
     loggers.auth.error('Native Apple auth error', error as Error, { clientIP });
+    securityAudit.logAuthFailure('unknown', clientIP, 'apple_native_error').catch((auditError) => {
+      loggers.security.warn('[AppleNative] audit logAuthFailure failed', { error: auditError instanceof Error ? auditError.message : String(auditError) });
+    });
 
     // Check if it's an Apple token verification error
     if (error instanceof Error && error.message.includes('expired')) {

--- a/apps/web/src/app/api/auth/desktop/exchange/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/desktop/exchange/__tests__/route.test.ts
@@ -32,6 +32,18 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
       debug: vi.fn(),
     },
+    security: {
+      warn: vi.fn(),
+    },
+  },
+  securityAudit: {
+    logAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    logAuthFailure: vi.fn().mockResolvedValue(undefined),
+    logTokenCreated: vi.fn().mockResolvedValue(undefined),
+    logTokenRevoked: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logLogout: vi.fn().mockResolvedValue(undefined),
   },
 }));
 

--- a/apps/web/src/app/api/auth/desktop/exchange/route.ts
+++ b/apps/web/src/app/api/auth/desktop/exchange/route.ts
@@ -18,8 +18,9 @@
  */
 
 import { consumeExchangeCode } from '@pagespace/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { createSessionCookie } from '@/lib/auth/cookie-config';
+import { getClientIP } from '@/lib/auth';
 import { z } from 'zod/v4';
 
 const exchangeRequestSchema = z.object({
@@ -56,6 +57,9 @@ export async function POST(req: Request) {
     loggers.auth.info('Desktop OAuth exchange successful', {
       userId: data.userId,
       provider: data.provider,
+    });
+    securityAudit.logTokenCreated(data.userId, 'desktop', getClientIP(req)).catch((error) => {
+      loggers.security.warn('[DesktopExchange] audit logTokenCreated failed', { error: error instanceof Error ? error.message : String(error), userId: data.userId });
     });
 
     // Return tokens in response body (secure - not logged by proxies)

--- a/apps/web/src/app/api/auth/device/refresh/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/device/refresh/__tests__/route.test.ts
@@ -108,7 +108,7 @@ import { POST } from '../route';
 import { authRepository } from '@/lib/repositories/auth-repository';
 import { sessionRepository } from '@/lib/repositories/session-repository';
 import { atomicDeviceTokenRotation } from '@pagespace/db/transactions/auth-transactions';
-import { validateDeviceToken, updateDeviceTokenActivity, generateCSRFToken, loggers } from '@pagespace/lib/server';
+import { validateDeviceToken, updateDeviceTokenActivity, generateCSRFToken, loggers, securityAudit } from '@pagespace/lib/server';
 import { sessionService } from '@pagespace/lib/auth';
 import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
@@ -172,6 +172,15 @@ describe('POST /api/auth/device/refresh', () => {
       type: 'user',
       scopes: ['*'],
     } as never);
+
+    // Re-setup securityAudit mocks after resetAllMocks
+    vi.mocked(securityAudit.logAuthSuccess).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logAuthFailure).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logTokenCreated).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logTokenRevoked).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logDataAccess).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logEvent).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logLogout).mockResolvedValue(undefined);
   });
 
   describe('input validation', () => {

--- a/apps/web/src/app/api/auth/device/refresh/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/device/refresh/__tests__/route.test.ts
@@ -52,8 +52,20 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
       debug: vi.fn(),
     },
+    security: {
+      warn: vi.fn(),
+    },
   },
   logAuthEvent: vi.fn(),
+  securityAudit: {
+    logAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    logAuthFailure: vi.fn().mockResolvedValue(undefined),
+    logTokenCreated: vi.fn().mockResolvedValue(undefined),
+    logTokenRevoked: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logLogout: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 vi.mock('@pagespace/lib/security', () => ({

--- a/apps/web/src/app/api/auth/device/refresh/route.ts
+++ b/apps/web/src/app/api/auth/device/refresh/route.ts
@@ -14,7 +14,7 @@ import {
   DISTRIBUTED_RATE_LIMITS,
 } from '@pagespace/lib/security';
 import { hashToken, getTokenPrefix, sessionService } from '@pagespace/lib/auth';
-import { loggers, logAuthEvent } from '@pagespace/lib/server';
+import { loggers, logAuthEvent, securityAudit } from '@pagespace/lib/server';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
 import { getClientIP, appendSessionCookie } from '@/lib/auth';
 
@@ -161,6 +161,9 @@ export async function POST(req: Request) {
     await updateDeviceTokenActivity(activeDeviceTokenId, normalizedIP);
 
     logAuthEvent('login', user.id, user.email, normalizedIP ?? 'unknown', 'Device token refresh');
+    securityAudit.logTokenCreated(user.id, 'device_refresh', normalizedIP ?? 'unknown').catch((error) => {
+      loggers.security.warn('[DeviceRefresh] audit logTokenCreated failed', { error: error instanceof Error ? error.message : String(error), userId: user.id });
+    });
     trackAuthEvent(user.id, 'refresh', {
       platform: deviceRecord.platform,
       ip: normalizedIP ?? 'unknown',

--- a/apps/web/src/app/api/auth/device/register/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/device/register/__tests__/route.test.ts
@@ -10,6 +10,18 @@ vi.mock('@/lib/auth', () => ({
 vi.mock('@pagespace/lib/server', () => ({
   loggers: {
     auth: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    security: {
+      warn: vi.fn(),
+    },
+  },
+  securityAudit: {
+    logAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    logAuthFailure: vi.fn().mockResolvedValue(undefined),
+    logTokenCreated: vi.fn().mockResolvedValue(undefined),
+    logTokenRevoked: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logLogout: vi.fn().mockResolvedValue(undefined),
   },
 }));
 

--- a/apps/web/src/app/api/auth/device/register/route.ts
+++ b/apps/web/src/app/api/auth/device/register/route.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod/v4';
 import { authenticateRequestWithOptions, isAuthError, getClientIP, createWebDeviceToken } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import {
   checkDistributedRateLimit,
   resetDistributedRateLimit,
@@ -69,6 +69,9 @@ export async function POST(req: Request) {
     loggers.auth.info('Device token registered via lazy registration', {
       userId: auth.userId,
       deviceId,
+    });
+    securityAudit.logTokenCreated(auth.userId, 'device', clientIP).catch((error) => {
+      loggers.security.warn('[DeviceRegister] audit logTokenCreated failed', { error: error instanceof Error ? error.message : String(error), userId: auth.userId });
     });
 
     return Response.json({ deviceToken });

--- a/apps/web/src/app/api/auth/google/__tests__/google-callback-redirect.test.ts
+++ b/apps/web/src/app/api/auth/google/__tests__/google-callback-redirect.test.ts
@@ -74,12 +74,24 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
       debug: vi.fn(),
     },
+    security: {
+      warn: vi.fn(),
+    },
   },
   logAuthEvent: vi.fn(),
   validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
     deviceToken: 'mock-device-token',
     deviceTokenRecordId: 'device-record-id',
   }),
+  securityAudit: {
+    logAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    logAuthFailure: vi.fn().mockResolvedValue(undefined),
+    logTokenCreated: vi.fn().mockResolvedValue(undefined),
+    logTokenRevoked: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logLogout: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 vi.mock('@pagespace/lib/security', () => ({

--- a/apps/web/src/app/api/auth/google/__tests__/one-tap.test.ts
+++ b/apps/web/src/app/api/auth/google/__tests__/one-tap.test.ts
@@ -72,8 +72,20 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
       debug: vi.fn(),
     },
+    security: {
+      warn: vi.fn(),
+    },
   },
   logAuthEvent: vi.fn(),
+  securityAudit: {
+    logAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    logAuthFailure: vi.fn().mockResolvedValue(undefined),
+    logTokenCreated: vi.fn().mockResolvedValue(undefined),
+    logTokenRevoked: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logLogout: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 vi.mock('@pagespace/lib/security', () => ({

--- a/apps/web/src/app/api/auth/google/__tests__/open-redirect-protection.test.ts
+++ b/apps/web/src/app/api/auth/google/__tests__/open-redirect-protection.test.ts
@@ -18,12 +18,24 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
       debug: vi.fn(),
     },
+    security: {
+      warn: vi.fn(),
+    },
   },
   logAuthEvent: vi.fn(),
   validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
     deviceToken: 'mock-device-token',
     deviceTokenRecordId: 'device-record-id',
   }),
+  securityAudit: {
+    logAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    logAuthFailure: vi.fn().mockResolvedValue(undefined),
+    logTokenCreated: vi.fn().mockResolvedValue(undefined),
+    logTokenRevoked: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logLogout: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 vi.mock('@pagespace/lib/security', () => ({

--- a/apps/web/src/app/api/auth/google/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/callback/__tests__/route.test.ts
@@ -91,8 +91,20 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
       debug: vi.fn(),
     },
+    security: {
+      warn: vi.fn(),
+    },
   },
   logAuthEvent: vi.fn(),
+  securityAudit: {
+    logAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    logAuthFailure: vi.fn().mockResolvedValue(undefined),
+    logTokenCreated: vi.fn().mockResolvedValue(undefined),
+    logTokenRevoked: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logLogout: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 vi.mock('@pagespace/lib/security', () => ({

--- a/apps/web/src/app/api/auth/google/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/callback/__tests__/route.test.ts
@@ -151,7 +151,7 @@ vi.mock('@/lib/auth/google-avatar', () => ({
 import { GET } from '../route';
 import { authRepository } from '@/lib/repositories/auth-repository';
 import { sessionService, generateCSRFToken, createExchangeCode } from '@pagespace/lib/auth';
-import { validateOrCreateDeviceToken, logAuthEvent, loggers } from '@pagespace/lib/server';
+import { validateOrCreateDeviceToken, logAuthEvent, loggers, securityAudit } from '@pagespace/lib/server';
 import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
 import { createId } from '@paralleldrive/cuid2';
@@ -292,6 +292,15 @@ describe('GET /api/auth/google/callback', () => {
     vi.mocked(authRepository.findUserById).mockResolvedValue(null);
     vi.mocked(authRepository.createUser).mockResolvedValue(mockNewUser as never);
     vi.mocked(authRepository.updateUser).mockResolvedValue(undefined);
+
+    // Re-setup securityAudit mocks after resetAllMocks
+    vi.mocked(securityAudit.logAuthSuccess).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logAuthFailure).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logTokenCreated).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logTokenRevoked).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logDataAccess).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logEvent).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logLogout).mockResolvedValue(undefined);
   });
 
   afterEach(() => {

--- a/apps/web/src/app/api/auth/google/callback/route.ts
+++ b/apps/web/src/app/api/auth/google/callback/route.ts
@@ -5,7 +5,7 @@ import {
   DISTRIBUTED_RATE_LIMITS,
 } from '@pagespace/lib/security';
 import { createId } from '@paralleldrive/cuid2';
-import { loggers, logAuthEvent, validateOrCreateDeviceToken } from '@pagespace/lib/server';
+import { loggers, logAuthEvent, securityAudit, validateOrCreateDeviceToken } from '@pagespace/lib/server';
 import { revokeSessionsForLogin, createWebDeviceToken } from '@/lib/auth';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
 import { OAuth2Client } from 'google-auth-library';
@@ -51,6 +51,9 @@ export async function GET(req: Request) {
         errorHint: errorHint ? String(errorHint).slice(0, 100) : 'none',
       });
       const errorType = errorHint === 'access_denied' ? 'access_denied' : 'oauth_error';
+      securityAudit.logAuthFailure('unknown', getClientIP(req), 'google_oauth_rejected').catch((error) => {
+        loggers.security.warn('[GoogleCallback] audit logAuthFailure failed', { error: error instanceof Error ? error.message : String(error) });
+      });
 
       if (verifiedState?.platform === 'desktop') {
         return NextResponse.redirect(`pagespace://auth-error?error=${errorType}`);
@@ -224,6 +227,9 @@ export async function GET(req: Request) {
       provider: 'google',
       userAgent: req.headers.get('user-agent')
     });
+    securityAudit.logAuthSuccess(user.id, sessionClaims.sessionId, clientIP, req.headers.get('user-agent') || 'unknown').catch((error) => {
+      loggers.security.warn('[GoogleCallback] audit logAuthSuccess failed', { error: error instanceof Error ? error.message : String(error), userId: user.id });
+    });
 
     // DESKTOP PLATFORM: Redirect with tokens encoded in URL
     // OAuth callbacks happen via browser redirect from Google, so we can't return JSON
@@ -383,6 +389,9 @@ export async function GET(req: Request) {
 
   } catch (error) {
     loggers.auth.error('Google OAuth callback error', error as Error);
+    securityAudit.logAuthFailure('unknown', getClientIP(req), 'google_oauth_error').catch((auditError) => {
+      loggers.security.warn('[GoogleCallback] audit logAuthFailure failed', { error: auditError instanceof Error ? auditError.message : String(auditError) });
+    });
     const errorRedirectBase = process.env.NEXTAUTH_URL || process.env.WEB_APP_URL || new URL(req.url).origin;
     return NextResponse.redirect(new URL('/auth/signin?error=oauth_error', errorRedirectBase));
   }

--- a/apps/web/src/app/api/auth/google/native/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/native/__tests__/route.test.ts
@@ -130,7 +130,7 @@ vi.mock('@/lib/auth/google-avatar', () => ({
 
 import { authRepository } from '@/lib/repositories/auth-repository';
 import { sessionService, generateCSRFToken } from '@pagespace/lib/auth';
-import { validateOrCreateDeviceToken, logAuthEvent } from '@pagespace/lib/server';
+import { validateOrCreateDeviceToken, logAuthEvent, securityAudit } from '@pagespace/lib/server';
 import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security';
 import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-started-drive';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
@@ -242,6 +242,15 @@ describe('POST /api/auth/google/native', () => {
     vi.mocked(authRepository.findUserById).mockResolvedValue(null);
     vi.mocked(authRepository.createUser).mockResolvedValue(mockNewUser as never);
     vi.mocked(authRepository.updateUser).mockResolvedValue(undefined);
+
+    // Re-setup securityAudit mocks after resetAllMocks
+    vi.mocked(securityAudit.logAuthSuccess).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logAuthFailure).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logTokenCreated).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logTokenRevoked).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logDataAccess).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logEvent).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logLogout).mockResolvedValue(undefined);
   });
 
   afterEach(() => {

--- a/apps/web/src/app/api/auth/google/native/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/native/__tests__/route.test.ts
@@ -75,8 +75,20 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
       debug: vi.fn(),
     },
+    security: {
+      warn: vi.fn(),
+    },
   },
   logAuthEvent: vi.fn(),
+  securityAudit: {
+    logAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    logAuthFailure: vi.fn().mockResolvedValue(undefined),
+    logTokenCreated: vi.fn().mockResolvedValue(undefined),
+    logTokenRevoked: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logLogout: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 vi.mock('@pagespace/lib/security', () => ({

--- a/apps/web/src/app/api/auth/google/native/route.ts
+++ b/apps/web/src/app/api/auth/google/native/route.ts
@@ -1,7 +1,7 @@
 import { OAuth2Client } from 'google-auth-library';
 import { sessionService, generateCSRFToken, SESSION_DURATION_MS } from '@pagespace/lib/auth';
 import { createId } from '@paralleldrive/cuid2';
-import { loggers, logAuthEvent, validateOrCreateDeviceToken } from '@pagespace/lib/server';
+import { loggers, logAuthEvent, securityAudit, validateOrCreateDeviceToken } from '@pagespace/lib/server';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
 import { z } from 'zod/v4';
 import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-started-drive';
@@ -86,6 +86,9 @@ export async function POST(req: Request) {
     const payload = ticket.getPayload();
     if (!payload?.email) {
       loggers.auth.warn('Invalid Google ID token - missing email', { platform });
+      securityAudit.logAuthFailure('unknown', clientIP, 'google_native_invalid_token').catch((error) => {
+        loggers.security.warn('[GoogleNative] audit logAuthFailure failed', { error: error instanceof Error ? error.message : String(error) });
+      });
       return Response.json({ error: 'Invalid token' }, { status: 401 });
     }
 
@@ -224,6 +227,9 @@ export async function POST(req: Request) {
       platform,
       isNewUser,
     });
+    securityAudit.logAuthSuccess(user.id, sessionClaims.sessionId, clientIP, req.headers.get('user-agent') || 'unknown').catch((error) => {
+      loggers.security.warn('[GoogleNative] audit logAuthSuccess failed', { error: error instanceof Error ? error.message : String(error), userId: user.id });
+    });
 
     // Set session cookie so middleware recognizes the authenticated session
     const headers = new Headers();
@@ -250,6 +256,9 @@ export async function POST(req: Request) {
     });
   } catch (error) {
     loggers.auth.error('Native Google auth error', error as Error, { clientIP });
+    securityAudit.logAuthFailure('unknown', clientIP, 'google_native_error').catch((auditError) => {
+      loggers.security.warn('[GoogleNative] audit logAuthFailure failed', { error: auditError instanceof Error ? auditError.message : String(auditError) });
+    });
 
     // Check if it's a Google token verification error
     if (error instanceof Error && error.message.includes('Token used too late')) {

--- a/apps/web/src/app/api/auth/google/one-tap/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/one-tap/__tests__/route.test.ts
@@ -73,8 +73,20 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
       debug: vi.fn(),
     },
+    security: {
+      warn: vi.fn(),
+    },
   },
   logAuthEvent: vi.fn(),
+  securityAudit: {
+    logAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    logAuthFailure: vi.fn().mockResolvedValue(undefined),
+    logTokenCreated: vi.fn().mockResolvedValue(undefined),
+    logTokenRevoked: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logLogout: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 vi.mock('@pagespace/lib/security', () => ({

--- a/apps/web/src/app/api/auth/google/one-tap/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/one-tap/__tests__/route.test.ts
@@ -131,7 +131,7 @@ vi.mock('@/lib/auth/google-avatar', () => ({
 import { POST } from '../route';
 import { authRepository } from '@/lib/repositories/auth-repository';
 import { sessionService, generateCSRFToken } from '@pagespace/lib/auth';
-import { logAuthEvent, loggers } from '@pagespace/lib/server';
+import { logAuthEvent, loggers, securityAudit } from '@pagespace/lib/server';
 import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
 import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-started-drive';
@@ -230,6 +230,15 @@ describe('POST /api/auth/google/one-tap', () => {
     vi.mocked(authRepository.findUserById).mockResolvedValue(null);
     vi.mocked(authRepository.createUser).mockResolvedValue(mockNewUser as never);
     vi.mocked(authRepository.updateUser).mockResolvedValue(undefined);
+
+    // Re-setup securityAudit mocks after resetAllMocks
+    vi.mocked(securityAudit.logAuthSuccess).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logAuthFailure).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logTokenCreated).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logTokenRevoked).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logDataAccess).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logEvent).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logLogout).mockResolvedValue(undefined);
   });
 
   afterEach(() => {

--- a/apps/web/src/app/api/auth/google/one-tap/route.ts
+++ b/apps/web/src/app/api/auth/google/one-tap/route.ts
@@ -7,7 +7,7 @@ import {
   DISTRIBUTED_RATE_LIMITS,
 } from '@pagespace/lib/security';
 import { createId } from '@paralleldrive/cuid2';
-import { loggers, logAuthEvent } from '@pagespace/lib/server';
+import { loggers, logAuthEvent, securityAudit } from '@pagespace/lib/server';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
 import { OAuth2Client } from 'google-auth-library';
 import { NextResponse } from 'next/server';
@@ -85,6 +85,9 @@ export async function POST(req: Request) {
     } catch (verifyError) {
       loggers.auth.warn('Google ID token verification failed', {
         error: verifyError instanceof Error ? verifyError.message : String(verifyError),
+      });
+      securityAudit.logAuthFailure('unknown', clientIP, 'google_one_tap_verify_failed').catch((error) => {
+        loggers.security.warn('[GoogleOneTap] audit logAuthFailure failed', { error: error instanceof Error ? error.message : String(error) });
       });
       return NextResponse.json(
         { error: 'Invalid Google credential. Please try again.' },
@@ -237,6 +240,9 @@ export async function POST(req: Request) {
     }
 
     const csrfToken = generateCSRFToken(sessionClaims.sessionId);
+    securityAudit.logAuthSuccess(user.id, sessionClaims.sessionId, clientIP, req.headers.get('user-agent') || 'unknown').catch((error) => {
+      loggers.security.warn('[GoogleOneTap] audit logAuthSuccess failed', { error: error instanceof Error ? error.message : String(error), userId: user.id });
+    });
 
     let deviceTokenValue: string | undefined;
     if (deviceId) {
@@ -277,6 +283,9 @@ export async function POST(req: Request) {
     );
   } catch (error) {
     loggers.auth.error('Google One Tap error', error as Error);
+    securityAudit.logAuthFailure('unknown', getClientIP(req), 'google_one_tap_error').catch((auditError) => {
+      loggers.security.warn('[GoogleOneTap] audit logAuthFailure failed', { error: auditError instanceof Error ? auditError.message : String(auditError) });
+    });
     return NextResponse.json(
       { error: 'An unexpected error occurred. Please try again.' },
       { status: 500 }

--- a/apps/web/src/app/api/auth/magic-link/send/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/send/route.ts
@@ -8,7 +8,7 @@ import {
 import { createMagicLinkToken } from '@pagespace/lib/auth/magic-link-service';
 import { sendEmail } from '@pagespace/lib/services/email-service';
 import { MagicLinkEmail } from '@pagespace/lib/email-templates/MagicLinkEmail';
-import { loggers, logSecurityEvent } from '@pagespace/lib/server';
+import { loggers, logSecurityEvent, securityAudit } from '@pagespace/lib/server';
 import { validateLoginCSRFToken, getClientIP } from '@/lib/auth';
 
 const sendMagicLinkSchema = z.object({
@@ -193,6 +193,9 @@ export async function POST(req: Request) {
         email: maskEmail(normalizedEmail),
         isNewUser: result.data.isNewUser,
         ip: clientIP,
+      });
+      securityAudit.logDataAccess(normalizedEmail, 'write', 'magic_link', normalizedEmail).catch((error) => {
+        loggers.security.warn('[MagicLinkSend] audit logDataAccess failed', { error: error instanceof Error ? error.message : String(error) });
       });
     } catch (error) {
       // Log but don't expose email sending errors

--- a/apps/web/src/app/api/auth/magic-link/send/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/send/route.ts
@@ -194,8 +194,13 @@ export async function POST(req: Request) {
         isNewUser: result.data.isNewUser,
         ip: clientIP,
       });
-      securityAudit.logDataAccess('anonymous', 'write', 'magic_link', 'magic_link_request').catch((error) => {
-        loggers.security.warn('[MagicLinkSend] audit logDataAccess failed', { error: error instanceof Error ? error.message : String(error) });
+      securityAudit.logEvent({
+        eventType: 'data.write',
+        resourceType: 'magic_link',
+        resourceId: 'magic_link_request',
+        ipAddress: clientIP,
+      }).catch((error) => {
+        loggers.security.warn('[MagicLinkSend] audit logEvent failed', { error: error instanceof Error ? error.message : String(error) });
       });
     } catch (error) {
       // Log but don't expose email sending errors

--- a/apps/web/src/app/api/auth/magic-link/send/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/send/route.ts
@@ -194,7 +194,7 @@ export async function POST(req: Request) {
         isNewUser: result.data.isNewUser,
         ip: clientIP,
       });
-      securityAudit.logDataAccess(normalizedEmail, 'write', 'magic_link', normalizedEmail).catch((error) => {
+      securityAudit.logDataAccess('anonymous', 'write', 'magic_link', 'magic_link_request').catch((error) => {
         loggers.security.warn('[MagicLinkSend] audit logDataAccess failed', { error: error instanceof Error ? error.message : String(error) });
       });
     } catch (error) {

--- a/apps/web/src/app/api/auth/magic-link/verify/__tests__/desktop-verify.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/__tests__/desktop-verify.test.ts
@@ -57,8 +57,22 @@ vi.mock('@pagespace/lib/verification-utils', () => ({
 }));
 
 vi.mock('@pagespace/lib/server', () => ({
-  loggers: { auth: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } },
+  loggers: {
+    auth: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    security: {
+      warn: vi.fn(),
+    },
+  },
   logAuthEvent: vi.fn(),
+  securityAudit: {
+    logAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    logAuthFailure: vi.fn().mockResolvedValue(undefined),
+    logTokenCreated: vi.fn().mockResolvedValue(undefined),
+    logTokenRevoked: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logLogout: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 vi.mock('@pagespace/lib/activity-tracker', () => ({

--- a/apps/web/src/app/api/auth/magic-link/verify/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/__tests__/route.test.ts
@@ -56,8 +56,20 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
       debug: vi.fn(),
     },
+    security: {
+      warn: vi.fn(),
+    },
   },
   logAuthEvent: vi.fn(),
+  securityAudit: {
+    logAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    logAuthFailure: vi.fn().mockResolvedValue(undefined),
+    logTokenCreated: vi.fn().mockResolvedValue(undefined),
+    logTokenRevoked: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logLogout: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 vi.mock('@pagespace/lib/activity-tracker', () => ({

--- a/apps/web/src/app/api/auth/magic-link/verify/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/route.ts
@@ -9,7 +9,7 @@ import {
 } from '@pagespace/lib/auth';
 import { verifyMagicLinkToken, type DesktopMagicLinkMetadata } from '@pagespace/lib/auth/magic-link-service';
 import { markEmailVerified } from '@pagespace/lib/verification-utils';
-import { loggers, logAuthEvent } from '@pagespace/lib/server';
+import { loggers, logAuthEvent, securityAudit } from '@pagespace/lib/server';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
 import { getClientIP } from '@/lib/auth';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';
@@ -48,6 +48,9 @@ export async function GET(req: Request) {
       loggers.auth.warn('Magic link verification failed', {
         error: result.error.code,
         ip: clientIP,
+      });
+      securityAudit.logAuthFailure('unknown', clientIP, `magic_link_${result.error.code.toLowerCase()}`).catch((error) => {
+        loggers.security.warn('[MagicLinkVerify] audit logAuthFailure failed', { error: error instanceof Error ? error.message : String(error) });
       });
 
       return redirectWithError(errorCode);
@@ -165,6 +168,9 @@ export async function GET(req: Request) {
           });
 
           loggers.auth.info('Magic link login successful (desktop)', { userId, ip: clientIP });
+          securityAudit.logAuthSuccess(userId, sessionClaims.sessionId, clientIP, req.headers.get('user-agent') || 'unknown').catch((error) => {
+            loggers.security.warn('[MagicLinkVerify] audit logAuthSuccess failed', { error: error instanceof Error ? error.message : String(error), userId });
+          });
 
           const headers = new Headers();
           appendSessionCookie(headers, sessionToken);
@@ -227,6 +233,9 @@ export async function GET(req: Request) {
       userId,
       isNewUser,
       ip: clientIP,
+    });
+    securityAudit.logAuthSuccess(userId, sessionClaims.sessionId, clientIP, req.headers.get('user-agent') || 'unknown').catch((error) => {
+      loggers.security.warn('[MagicLinkVerify] audit logAuthSuccess failed', { error: error instanceof Error ? error.message : String(error), userId });
     });
 
     return NextResponse.redirect(redirectUrl.toString(), {

--- a/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/__tests__/route.test.ts
@@ -36,6 +36,18 @@ vi.mock('@pagespace/lib/server', () => ({
       info: vi.fn(),
       warn: vi.fn(),
     },
+    security: {
+      warn: vi.fn(),
+    },
+  },
+  securityAudit: {
+    logAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    logAuthFailure: vi.fn().mockResolvedValue(undefined),
+    logTokenCreated: vi.fn().mockResolvedValue(undefined),
+    logTokenRevoked: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logLogout: vi.fn().mockResolvedValue(undefined),
   },
 }));
 

--- a/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/__tests__/route.test.ts
@@ -27,6 +27,7 @@ vi.mock('@/lib/repositories/session-repository', () => ({
 vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
   isAuthError: vi.fn(),
+  getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
 }));
 
 vi.mock('@pagespace/lib/server', () => ({
@@ -59,7 +60,7 @@ vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
 import { DELETE } from '../route';
 import { sessionRepository } from '@/lib/repositories/session-repository';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 
 const createContext = (tokenId = 'token-123') => ({
@@ -90,6 +91,15 @@ describe('DELETE /api/auth/mcp-tokens/[tokenId]', () => {
     });
 
     vi.mocked(sessionRepository.revokeMcpToken).mockResolvedValue(undefined);
+
+    // Re-setup securityAudit mocks after resetAllMocks
+    vi.mocked(securityAudit.logAuthSuccess).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logAuthFailure).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logTokenCreated).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logTokenRevoked).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logDataAccess).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logEvent).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logLogout).mockResolvedValue(undefined);
   });
 
   it('returns auth error when not authenticated', async () => {

--- a/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/route.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { sessionRepository } from '@/lib/repositories/session-repository';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { getActorInfo, logTokenActivity } from '@pagespace/lib/monitoring/activity-logger';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
@@ -35,6 +35,9 @@ export async function DELETE(
       tokenType: 'mcp',
       tokenName: existingToken.name,
     }, actorInfo);
+    securityAudit.logTokenRevoked(userId, 'mcp', 'user_revoked').catch((error) => {
+      loggers.security.warn('[McpTokenRevoke] audit logTokenRevoked failed', { error: error instanceof Error ? error.message : String(error), userId });
+    });
 
     return NextResponse.json({ message: 'Token revoked successfully' });
   } catch (error) {

--- a/apps/web/src/app/api/auth/mcp-tokens/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/__tests__/route.test.ts
@@ -44,6 +44,18 @@ vi.mock('@pagespace/lib/server', () => ({
       info: vi.fn(),
       warn: vi.fn(),
     },
+    security: {
+      warn: vi.fn(),
+    },
+  },
+  securityAudit: {
+    logAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    logAuthFailure: vi.fn().mockResolvedValue(undefined),
+    logTokenCreated: vi.fn().mockResolvedValue(undefined),
+    logTokenRevoked: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logLogout: vi.fn().mockResolvedValue(undefined),
   },
 }));
 

--- a/apps/web/src/app/api/auth/mcp-tokens/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/__tests__/route.test.ts
@@ -35,6 +35,7 @@ vi.mock('@/lib/repositories/session-repository', () => ({
 vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
   isAuthError: vi.fn(),
+  getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
 }));
 
 vi.mock('@pagespace/lib/server', () => ({
@@ -79,7 +80,7 @@ vi.mock('@pagespace/lib/services/drive-service', () => ({
 import { POST, GET } from '../route';
 import { sessionRepository } from '@/lib/repositories/session-repository';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { getDriveAccess } from '@pagespace/lib/services/drive-service';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import { generateToken } from '@pagespace/lib/auth';
@@ -124,6 +125,15 @@ describe('/api/auth/mcp-tokens (additional coverage)', () => {
       isMember: true,
       role: 'OWNER',
     } as never);
+
+    // Re-setup securityAudit mocks after resetAllMocks
+    vi.mocked(securityAudit.logAuthSuccess).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logAuthFailure).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logTokenCreated).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logTokenRevoked).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logDataAccess).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logEvent).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logLogout).mockResolvedValue(undefined);
   });
 
   describe('POST /api/auth/mcp-tokens', () => {

--- a/apps/web/src/app/api/auth/mcp-tokens/route.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { authenticateRequestWithOptions, isAuthError, getClientIP } from '@/lib/auth';
 import { sessionRepository } from '@/lib/repositories/session-repository';
 import { z } from 'zod/v4';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { getActorInfo, logTokenActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { generateToken } from '@pagespace/lib/auth';
 import { getDriveAccess } from '@pagespace/lib/services/drive-service';
@@ -76,6 +76,8 @@ export async function POST(req: NextRequest) {
       driveScopes = await sessionRepository.findDrivesByIds(driveIds);
     }
 
+    const clientIP = getClientIP(req);
+
     // Log activity for audit trail (token creation is a security event)
     const actorInfo = await getActorInfo(userId);
     logTokenActivity(userId, 'token_create', {
@@ -83,6 +85,9 @@ export async function POST(req: NextRequest) {
       tokenType: 'mcp',
       tokenName: newToken.name,
     }, actorInfo);
+    securityAudit.logTokenCreated(userId, 'mcp', clientIP).catch((error) => {
+      loggers.security.warn('[McpTokenCreate] audit logTokenCreated failed', { error: error instanceof Error ? error.message : String(error), userId });
+    });
 
     // Return the raw token ONCE to the user - this is the only time they'll see it
     // Response format matches GET for consistency
@@ -111,6 +116,9 @@ export async function GET(req: NextRequest) {
 
   try {
     const tokensWithDrives = await sessionRepository.findUserMcpTokensWithDrives(userId);
+    securityAudit.logDataAccess(userId, 'read', 'mcp_token', userId).catch((error) => {
+      loggers.security.warn('[McpTokenList] audit logDataAccess failed', { error: error instanceof Error ? error.message : String(error), userId });
+    });
     return NextResponse.json(tokensWithDrives);
   } catch (error) {
     loggers.auth.error('Error fetching MCP tokens:', error as Error);

--- a/apps/web/src/app/api/auth/me/route.ts
+++ b/apps/web/src/app/api/auth/me/route.ts
@@ -1,4 +1,5 @@
 import { requireAuth, isAuthError } from '@/lib/auth/auth-helpers';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { authRepository } from '@/lib/repositories/auth-repository';
 import { isExternalHttpUrl } from '@/lib/auth/google-avatar';
 
@@ -17,6 +18,10 @@ export async function GET(req: Request) {
   if (process.env.NODE_ENV === 'development' && process.env.DEBUG_AUTH === 'true') {
     console.log(`[AUTH] User profile loaded: ${user.email} (provider: ${user.provider}, id: ${user.id})`);
   }
+
+  securityAudit.logDataAccess(auth.userId, 'read', 'user_profile', auth.userId).catch((error) => {
+    loggers.security.warn('[AuthMe] audit logDataAccess failed', { error: error instanceof Error ? error.message : String(error), userId: auth.userId });
+  });
 
   const safeImage = isExternalHttpUrl(user.image) ? null : user.image;
 

--- a/apps/web/src/app/api/auth/mobile/oauth/google/exchange/route.ts
+++ b/apps/web/src/app/api/auth/mobile/oauth/google/exchange/route.ts
@@ -58,7 +58,7 @@ import {
   DISTRIBUTED_RATE_LIMITS,
 } from '@pagespace/lib/security';
 import { sessionService } from '@pagespace/lib/auth';
-import { loggers, logAuthEvent } from '@pagespace/lib/server';
+import { loggers, logAuthEvent, securityAudit } from '@pagespace/lib/server';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
 import { verifyOAuthIdToken, createOrLinkOAuthUser, OAuthProvider } from '@pagespace/lib/server';
 import type { MobileOAuthResponse } from '@pagespace/lib/server';
@@ -166,6 +166,9 @@ export async function POST(req: Request) {
     if (!verificationResult.success || !verificationResult.userInfo) {
       loggers.auth.warn('Google ID token verification failed', {
         error: verificationResult.error,
+      });
+      securityAudit.logAuthFailure('unknown', clientIP, 'mobile_google_verify_failed').catch((error) => {
+        loggers.security.warn('[MobileGoogleExchange] audit logAuthFailure failed', { error: error instanceof Error ? error.message : String(error) });
       });
 
       // Track failed OAuth attempt
@@ -302,6 +305,9 @@ export async function POST(req: Request) {
 
     // Generate CSRF token using session ID
     const csrfToken = generateCSRFToken(sessionClaims.sessionId);
+    securityAudit.logAuthSuccess(user.id, sessionClaims.sessionId, clientIP, req.headers.get('user-agent') || 'unknown').catch((error) => {
+      loggers.security.warn('[MobileGoogleExchange] audit logAuthSuccess failed', { error: error instanceof Error ? error.message : String(error), userId: user.id });
+    });
 
     // Return tokens in JSON response for mobile client
     // Note: No refreshToken - mobile uses device tokens for refresh
@@ -334,6 +340,9 @@ export async function POST(req: Request) {
     return Response.json(response, { status: 200, headers });
   } catch (error) {
     loggers.auth.error('Mobile Google OAuth error', error as Error);
+    securityAudit.logAuthFailure('unknown', getClientIP(req), 'mobile_google_exchange_error').catch((auditError) => {
+      loggers.security.warn('[MobileGoogleExchange] audit logAuthFailure failed', { error: auditError instanceof Error ? auditError.message : String(auditError) });
+    });
 
     // Track failed OAuth attempt
     trackAuthEvent(undefined, 'failed_oauth', {

--- a/apps/web/src/app/api/auth/mobile/refresh/route.ts
+++ b/apps/web/src/app/api/auth/mobile/refresh/route.ts
@@ -13,7 +13,7 @@ import {
 } from '@pagespace/lib/security';
 import { hashToken, getTokenPrefix, sessionService } from '@pagespace/lib/auth';
 import { z } from 'zod/v4';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { getClientIP, appendSessionCookie } from '@/lib/auth';
 
 const refreshSchema = z.object({
@@ -147,6 +147,9 @@ export async function POST(req: Request) {
     }
 
     const csrfToken = generateCSRFToken(sessionClaims.sessionId);
+    securityAudit.logTokenCreated(user.id, 'mobile_refresh', normalizedIP ?? 'unknown').catch((error) => {
+      loggers.security.warn('[MobileRefresh] audit logTokenCreated failed', { error: error instanceof Error ? error.message : String(error), userId: user.id });
+    });
 
     // Reset rate limit on successful refresh
     try {

--- a/apps/web/src/app/api/auth/passkey/[passkeyId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/[passkeyId]/__tests__/route.test.ts
@@ -22,8 +22,20 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
       debug: vi.fn(),
     },
+    security: {
+      warn: vi.fn(),
+    },
   },
   logSecurityEvent: vi.fn(),
+  securityAudit: {
+    logAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    logAuthFailure: vi.fn().mockResolvedValue(undefined),
+    logTokenCreated: vi.fn().mockResolvedValue(undefined),
+    logTokenRevoked: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logLogout: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 vi.mock('@pagespace/lib/activity-tracker', () => ({

--- a/apps/web/src/app/api/auth/passkey/[passkeyId]/route.ts
+++ b/apps/web/src/app/api/auth/passkey/[passkeyId]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod/v4';
 import { deletePasskey, updatePasskeyName, validateCSRFToken } from '@pagespace/lib/auth';
-import { loggers, logSecurityEvent } from '@pagespace/lib/server';
+import { loggers, logSecurityEvent, securityAudit } from '@pagespace/lib/server';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
 import {
   authenticateSessionRequest,
@@ -90,6 +90,9 @@ export async function DELETE(
       userId,
       passkeyId,
       ip: clientIP,
+    });
+    securityAudit.logTokenRevoked(userId, 'passkey', 'user_deleted').catch((error) => {
+      loggers.security.warn('[PasskeyDelete] audit logTokenRevoked failed', { error: error instanceof Error ? error.message : String(error), userId });
     });
 
     return NextResponse.json({ success: true });

--- a/apps/web/src/app/api/auth/passkey/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/__tests__/route.test.ts
@@ -20,6 +20,18 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
       debug: vi.fn(),
     },
+    security: {
+      warn: vi.fn(),
+    },
+  },
+  securityAudit: {
+    logAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    logAuthFailure: vi.fn().mockResolvedValue(undefined),
+    logTokenCreated: vi.fn().mockResolvedValue(undefined),
+    logTokenRevoked: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logLogout: vi.fn().mockResolvedValue(undefined),
   },
 }));
 

--- a/apps/web/src/app/api/auth/passkey/authenticate/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/authenticate/__tests__/route.test.ts
@@ -44,8 +44,20 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
       debug: vi.fn(),
     },
+    security: {
+      warn: vi.fn(),
+    },
   },
   logSecurityEvent: vi.fn(),
+  securityAudit: {
+    logAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    logAuthFailure: vi.fn().mockResolvedValue(undefined),
+    logTokenCreated: vi.fn().mockResolvedValue(undefined),
+    logTokenRevoked: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logLogout: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 vi.mock('@pagespace/lib/activity-tracker', () => ({

--- a/apps/web/src/app/api/auth/passkey/authenticate/route.ts
+++ b/apps/web/src/app/api/auth/passkey/authenticate/route.ts
@@ -6,7 +6,7 @@ import {
   generateCSRFToken,
   SESSION_DURATION_MS,
 } from '@pagespace/lib/auth';
-import { loggers, logSecurityEvent } from '@pagespace/lib/server';
+import { loggers, logSecurityEvent, securityAudit } from '@pagespace/lib/server';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
 import {
   checkDistributedRateLimit,
@@ -102,6 +102,9 @@ export async function POST(req: Request) {
         error: result.error.code,
         ip: clientIP,
       });
+      securityAudit.logAuthFailure('unknown', clientIP, `passkey_auth_${result.error.code.toLowerCase()}`).catch((error) => {
+        loggers.security.warn('[PasskeyAuth] audit logAuthFailure failed', { error: error instanceof Error ? error.message : String(error) });
+      });
 
       return NextResponse.json(
         { error: errorInfo.message, code: result.error.code },
@@ -152,6 +155,9 @@ export async function POST(req: Request) {
     loggers.auth.info('Passkey login successful', {
       userId,
       ip: clientIP,
+    });
+    securityAudit.logAuthSuccess(userId, sessionClaims.sessionId, clientIP, req.headers.get('user-agent') || 'unknown').catch((error) => {
+      loggers.security.warn('[PasskeyAuth] audit logAuthSuccess failed', { error: error instanceof Error ? error.message : String(error), userId });
     });
 
     let deviceTokenValue: string | undefined;

--- a/apps/web/src/app/api/auth/passkey/register/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/register/__tests__/route.test.ts
@@ -21,8 +21,20 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
       debug: vi.fn(),
     },
+    security: {
+      warn: vi.fn(),
+    },
   },
   logSecurityEvent: vi.fn(),
+  securityAudit: {
+    logAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    logAuthFailure: vi.fn().mockResolvedValue(undefined),
+    logTokenCreated: vi.fn().mockResolvedValue(undefined),
+    logTokenRevoked: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logLogout: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 vi.mock('@pagespace/lib/activity-tracker', () => ({

--- a/apps/web/src/app/api/auth/passkey/register/route.ts
+++ b/apps/web/src/app/api/auth/passkey/register/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod/v4';
 import { verifyRegistration, validateCSRFToken } from '@pagespace/lib/auth';
-import { loggers, logSecurityEvent } from '@pagespace/lib/server';
+import { loggers, logSecurityEvent, securityAudit } from '@pagespace/lib/server';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
 import {
   checkDistributedRateLimit,
@@ -131,6 +131,9 @@ export async function POST(req: Request) {
       userId,
       passkeyId: result.data.passkeyId,
       ip: clientIP,
+    });
+    securityAudit.logTokenCreated(userId, 'passkey', clientIP).catch((error) => {
+      loggers.security.warn('[PasskeyRegister] audit logTokenCreated failed', { error: error instanceof Error ? error.message : String(error), userId });
     });
 
     return NextResponse.json({

--- a/apps/web/src/app/api/auth/passkey/route.ts
+++ b/apps/web/src/app/api/auth/passkey/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { listUserPasskeys } from '@pagespace/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import {
   authenticateSessionRequest,
   isAuthError,
@@ -40,6 +40,10 @@ export async function GET(req: Request) {
         { status: 500 }
       );
     }
+
+    securityAudit.logDataAccess(userId, 'read', 'passkey', userId).catch((error) => {
+      loggers.security.warn('[PasskeyList] audit logDataAccess failed', { error: error instanceof Error ? error.message : String(error), userId });
+    });
 
     return NextResponse.json({
       passkeys: result.data.passkeys,

--- a/apps/web/src/app/api/auth/resend-verification/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/resend-verification/__tests__/route.test.ts
@@ -49,6 +49,18 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
       debug: vi.fn(),
     },
+    security: {
+      warn: vi.fn(),
+    },
+  },
+  securityAudit: {
+    logAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    logAuthFailure: vi.fn().mockResolvedValue(undefined),
+    logTokenCreated: vi.fn().mockResolvedValue(undefined),
+    logTokenRevoked: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logLogout: vi.fn().mockResolvedValue(undefined),
   },
 }));
 

--- a/apps/web/src/app/api/auth/resend-verification/route.ts
+++ b/apps/web/src/app/api/auth/resend-verification/route.ts
@@ -3,7 +3,7 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { createVerificationToken } from '@pagespace/lib';
 import { sendEmail } from '@pagespace/lib/services/email-service';
 import { VerificationEmail } from '@pagespace/lib/email-templates/VerificationEmail';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security';
 import React from 'react';
 import { authRepository } from '@/lib/repositories/auth-repository';
@@ -72,6 +72,9 @@ export async function POST(request: Request) {
       });
 
       loggers.auth.info('Verification email resent', { userId: user.id, email: user.email });
+      securityAudit.logDataAccess(auth.userId, 'write', 'email_verification', auth.userId).catch((error) => {
+        loggers.security.warn('[ResendVerification] audit logDataAccess failed', { error: error instanceof Error ? error.message : String(error), userId: auth.userId });
+      });
 
       return NextResponse.json({
         message: 'Verification email sent successfully. Please check your inbox.'

--- a/apps/web/src/app/api/auth/signup-passkey/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/signup-passkey/__tests__/route.test.ts
@@ -40,9 +40,21 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
       debug: vi.fn(),
     },
+    security: {
+      warn: vi.fn(),
+    },
   },
   logAuthEvent: vi.fn(),
   logSecurityEvent: vi.fn(),
+  securityAudit: {
+    logAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    logAuthFailure: vi.fn().mockResolvedValue(undefined),
+    logTokenCreated: vi.fn().mockResolvedValue(undefined),
+    logTokenRevoked: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logLogout: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 vi.mock('@pagespace/lib/activity-tracker', () => ({

--- a/apps/web/src/app/api/auth/signup-passkey/route.ts
+++ b/apps/web/src/app/api/auth/signup-passkey/route.ts
@@ -7,7 +7,7 @@ import {
   generateCSRFToken,
   SESSION_DURATION_MS,
 } from '@pagespace/lib/auth';
-import { loggers, logAuthEvent, logSecurityEvent } from '@pagespace/lib/server';
+import { loggers, logAuthEvent, logSecurityEvent, securityAudit } from '@pagespace/lib/server';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
 import {
   checkDistributedRateLimit,
@@ -135,6 +135,9 @@ export async function POST(req: Request) {
         ip: clientIP,
         email: email.substring(0, 3) + '***',
       });
+      securityAudit.logAuthFailure(email || 'unknown', clientIP, `passkey_signup_${result.error.code.toLowerCase()}`).catch((error) => {
+        loggers.security.warn('[SignupPasskey] audit logAuthFailure failed', { error: error instanceof Error ? error.message : String(error) });
+      });
 
       return NextResponse.json(
         { error: errorInfo.message, code: result.error.code },
@@ -233,6 +236,12 @@ export async function POST(req: Request) {
     loggers.auth.info('Passkey signup session created', {
       userId,
       ip: clientIP,
+    });
+    securityAudit.logAuthSuccess(userId, sessionClaims.sessionId, clientIP, req.headers.get('user-agent') || 'unknown').catch((error) => {
+      loggers.security.warn('[SignupPasskey] audit logAuthSuccess failed', { error: error instanceof Error ? error.message : String(error), userId });
+    });
+    securityAudit.logTokenCreated(userId, 'passkey', clientIP).catch((error) => {
+      loggers.security.warn('[SignupPasskey] audit logTokenCreated failed', { error: error instanceof Error ? error.message : String(error), userId });
     });
 
     // Build response headers with session cookie

--- a/apps/web/src/app/api/auth/signup-passkey/route.ts
+++ b/apps/web/src/app/api/auth/signup-passkey/route.ts
@@ -135,7 +135,7 @@ export async function POST(req: Request) {
         ip: clientIP,
         email: email.substring(0, 3) + '***',
       });
-      securityAudit.logAuthFailure(email || 'unknown', clientIP, `passkey_signup_${result.error.code.toLowerCase()}`).catch((error) => {
+      securityAudit.logAuthFailure('unknown', clientIP, `passkey_signup_${result.error.code.toLowerCase()}`).catch((error) => {
         loggers.security.warn('[SignupPasskey] audit logAuthFailure failed', { error: error instanceof Error ? error.message : String(error) });
       });
 

--- a/apps/web/src/app/api/auth/socket-token/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/socket-token/__tests__/route.test.ts
@@ -28,6 +28,29 @@ vi.mock('@/lib/repositories/session-repository', () => ({
   },
 }));
 
+vi.mock('@pagespace/lib/server', () => ({
+  loggers: {
+    auth: {
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    },
+    security: {
+      warn: vi.fn(),
+    },
+  },
+  securityAudit: {
+    logAuthSuccess: vi.fn().mockResolvedValue(undefined),
+    logAuthFailure: vi.fn().mockResolvedValue(undefined),
+    logTokenCreated: vi.fn().mockResolvedValue(undefined),
+    logTokenRevoked: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logLogout: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
 import { requireAuth, isAuthError } from '@/lib/auth/auth-helpers';
 import { sessionRepository } from '@/lib/repositories/session-repository';
 import { GET } from '../route';

--- a/apps/web/src/app/api/auth/socket-token/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/socket-token/__tests__/route.test.ts
@@ -22,6 +22,10 @@ vi.mock('@/lib/auth/auth-helpers', () => ({
   isAuthError: vi.fn(),
 }));
 
+vi.mock('@/lib/auth', () => ({
+  getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
+}));
+
 vi.mock('@/lib/repositories/session-repository', () => ({
   sessionRepository: {
     createSocketToken: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/src/app/api/auth/socket-token/route.ts
+++ b/apps/web/src/app/api/auth/socket-token/route.ts
@@ -1,4 +1,6 @@
 import { requireAuth, isAuthError } from '@/lib/auth/auth-helpers';
+import { getClientIP } from '@/lib/auth';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { sessionRepository } from '@/lib/repositories/session-repository';
 import { randomBytes, createHash } from 'crypto';
 
@@ -30,6 +32,10 @@ export async function GET(request: Request) {
     tokenHash,
     userId: auth.userId,
     expiresAt,
+  });
+
+  securityAudit.logTokenCreated(auth.userId, 'socket', getClientIP(request)).catch((error) => {
+    loggers.security.warn('[SocketToken] audit logTokenCreated failed', { error: error instanceof Error ? error.message : String(error), userId: auth.userId });
   });
 
   // Return with no-cache headers to prevent token reuse across sessions

--- a/apps/web/src/app/api/auth/verify-email/route.ts
+++ b/apps/web/src/app/api/auth/verify-email/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyToken, markEmailVerified } from '@pagespace/lib/verification-utils';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
 
 export async function GET(request: NextRequest) {
@@ -27,6 +27,9 @@ export async function GET(request: NextRequest) {
     // Log verification
     loggers.auth.info('Email verified', { userId });
     trackAuthEvent(userId, 'email_verified', {});
+    securityAudit.logDataAccess(userId, 'write', 'email_verification', userId).catch((error) => {
+      loggers.security.warn('[VerifyEmail] audit logDataAccess failed', { error: error instanceof Error ? error.message : String(error), userId });
+    });
 
     // Redirect to dashboard - triggers auth refresh via ?auth=success
     const baseUrl = process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';

--- a/apps/web/src/app/api/auth/ws-token/route.ts
+++ b/apps/web/src/app/api/auth/ws-token/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { verifyAuth, getClientIP } from '@/lib/auth';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { sessionService } from '@pagespace/lib';
 import { checkDistributedRateLimit } from '@pagespace/lib/security';
 
@@ -41,13 +42,17 @@ export async function POST(request: Request) {
     );
   }
 
+  const clientIP = getClientIP(request);
   const token = await sessionService.createSession({
     userId: user.id,
     type: 'service',
     scopes: ['mcp:*'],
     expiresInMs: WS_TOKEN_EXPIRY_MS,
     createdByService: 'desktop',
-    createdByIp: getClientIP(request),
+    createdByIp: clientIP,
+  });
+  securityAudit.logTokenCreated(user.id, 'websocket', clientIP).catch((error) => {
+    loggers.security.warn('[WsToken] audit logTokenCreated failed', { error: error instanceof Error ? error.message : String(error), userId: user.id });
   });
 
   return NextResponse.json({ token });


### PR DESCRIPTION
## Summary

- Wire tamper-evident SecurityAuditService (hash chain audit logging) into all 24 previously uncovered auth routes under `apps/web/src/app/api/auth/`
- Every OAuth callback, passkey operation, token management endpoint, magic link flow, and user verification route now has appropriate security audit coverage
- All calls use fire-and-forget `.catch()` pattern — audit failures never block auth responses
- GDPR-safe: no PII in hash-chain-included fields (`details`, `resourceId`); PII only in excluded fields (`userId`, `ipAddress`, `userAgent`) that can be anonymized

### Audit methods wired per route category

| Category | Routes | Methods |
|----------|--------|---------|
| OAuth callbacks | google/callback, apple/callback, google/native, apple/native, google/one-tap, mobile/oauth/google/exchange | `logAuthSuccess`, `logAuthFailure` |
| Magic links | magic-link/send, magic-link/verify | `logDataAccess`, `logAuthSuccess`, `logAuthFailure` |
| Passkey ops | passkey (list), passkey/[id] (delete), passkey/authenticate, passkey/register, signup-passkey | `logAuthSuccess`, `logAuthFailure`, `logTokenCreated`, `logTokenRevoked`, `logDataAccess` |
| Token mgmt | mcp-tokens (POST/GET), mcp-tokens/[id] (DELETE), device/register, device/refresh, desktop/exchange, mobile/refresh, socket-token, ws-token | `logTokenCreated`, `logTokenRevoked`, `logDataAccess` |
| User verification | me, resend-verification, verify-email | `logDataAccess` |

### Skipped routes (no security events)

- `csrf`, `login-csrf` — stateless CSRF token generation
- `passkey/authenticate/options`, `passkey/register/options`, `signup-passkey/options` — WebAuthn options requests, no mutation
- `google/signin`, `apple/signin` — OAuth flow initiation (URL generation only, no auth event)

### 44 total audit calls across 25 route files (24 new + 1 existing logout)

## Test plan

- [x] `tsc --noEmit` passes clean on `apps/web` and `packages/lib`
- [x] Grep confirms 25 route files have `securityAudit` calls
- [x] Grep confirms skipped routes (csrf, signin, options) have zero audit calls
- [x] GDPR review: no PII in hash-chain-included fields
- [ ] CI checks pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)