### PR TITLE
feat(security): wire SecurityAuditService into AI/chat routes

### DIFF
--- a/apps/web/src/app/api/ai/abort/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/abort/__tests__/route.test.ts
@@ -41,6 +41,11 @@ vi.mock('@pagespace/lib/auth', async () => {
   };
 });
 
+// Mock audit helper (boundary)
+vi.mock('@/lib/audit/route-audit', () => ({
+  logAuditEvent: vi.fn(),
+}));
+
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { abortStream } from '@/lib/ai/core/stream-abort-registry';
 import { loggers } from '@pagespace/lib/server';

--- a/apps/web/src/app/api/ai/abort/route.ts
+++ b/apps/web/src/app/api/ai/abort/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { abortStream } from '@/lib/ai/core/stream-abort-registry';
-import { loggers, securityAudit } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/server';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 import { checkRateLimit } from '@pagespace/lib/auth';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
@@ -61,10 +62,10 @@ export async function POST(request: Request) {
       reason: result.reason,
     });
 
-    securityAudit.logDataAccess(userId, 'write', 'ai_chat_stream', streamId, {
+    logAuditEvent(request, userId, 'write', 'ai_chat_stream', streamId, {
       action: 'abort',
       aborted: result.aborted,
-    }).catch(() => {});
+    });
 
     return NextResponse.json(result);
   } catch (error) {

--- a/apps/web/src/app/api/ai/abort/route.ts
+++ b/apps/web/src/app/api/ai/abort/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { abortStream } from '@/lib/ai/core/stream-abort-registry';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { checkRateLimit } from '@pagespace/lib/auth';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
@@ -60,6 +60,11 @@ export async function POST(request: Request) {
       aborted: result.aborted,
       reason: result.reason,
     });
+
+    securityAudit.logDataAccess(userId, 'write', 'ai_chat_stream', streamId, {
+      action: 'abort',
+      aborted: result.aborted,
+    }).catch(() => {});
 
     return NextResponse.json(result);
   } catch (error) {

--- a/apps/web/src/app/api/ai/chat/__tests__/mcp-scope.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/mcp-scope.test.ts
@@ -177,6 +177,11 @@ vi.mock('@/lib/ai/core/model-capabilities', () => ({
   hasVisionCapability: vi.fn().mockReturnValue(true),
 }));
 
+// Mock audit helper (boundary)
+vi.mock('@/lib/audit/route-audit', () => ({
+  logAuditEvent: vi.fn(),
+}));
+
 import { authenticateRequestWithOptions, checkMCPPageScope } from '@/lib/auth';
 
 // ============================================================================

--- a/apps/web/src/app/api/ai/chat/messages/[messageId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/chat/messages/[messageId]/__tests__/route.test.ts
@@ -71,6 +71,11 @@ vi.mock('@pagespace/db', () => ({
   eq: vi.fn(),
 }));
 
+// Mock audit helper (boundary)
+vi.mock('@/lib/audit/route-audit', () => ({
+  logAuditEvent: vi.fn(),
+}));
+
 import { chatMessageRepository } from '@/lib/repositories/chat-message-repository';
 import { getActorInfo, logMessageActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { db } from '@pagespace/db';

--- a/apps/web/src/app/api/ai/chat/messages/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/chat/messages/[messageId]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
-import { canUserEditPage, conversationCache } from '@pagespace/lib/server';
-import { loggers, securityAudit } from '@pagespace/lib/server';
+import { canUserEditPage, conversationCache, loggers } from '@pagespace/lib/server';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 import { maskIdentifier } from '@/lib/logging/mask';
 import {
   chatMessageRepository,
@@ -121,10 +121,10 @@ export async function PATCH(
       pageId: maskIdentifier(message.pageId)
     });
 
-    securityAudit.logDataAccess(userId, 'write', 'ai_chat_message', messageId, {
+    logAuditEvent(request, userId, 'write', 'ai_chat_message', messageId, {
       action: 'edit_message',
       pageId: message.pageId,
-    }).catch(() => {});
+    });
 
     return NextResponse.json({
       success: true,
@@ -216,10 +216,10 @@ export async function DELETE(
       pageId: maskIdentifier(message.pageId)
     });
 
-    securityAudit.logDataAccess(userId, 'delete', 'ai_chat_message', messageId, {
+    logAuditEvent(request, userId, 'delete', 'ai_chat_message', messageId, {
       action: 'delete_message',
       pageId: message.pageId,
-    }).catch(() => {});
+    });
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/ai/chat/messages/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/chat/messages/[messageId]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
 import { canUserEditPage, conversationCache } from '@pagespace/lib/server';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { maskIdentifier } from '@/lib/logging/mask';
 import {
   chatMessageRepository,
@@ -121,6 +121,11 @@ export async function PATCH(
       pageId: maskIdentifier(message.pageId)
     });
 
+    securityAudit.logDataAccess(userId, 'write', 'ai_chat_message', messageId, {
+      action: 'edit_message',
+      pageId: message.pageId,
+    }).catch(() => {});
+
     return NextResponse.json({
       success: true,
       message: 'Message updated successfully'
@@ -210,6 +215,11 @@ export async function DELETE(
       messageId: maskIdentifier(messageId),
       pageId: maskIdentifier(message.pageId)
     });
+
+    securityAudit.logDataAccess(userId, 'delete', 'ai_chat_message', messageId, {
+      action: 'delete_message',
+      pageId: message.pageId,
+    }).catch(() => {});
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/ai/chat/messages/[messageId]/undo/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/chat/messages/[messageId]/undo/__tests__/route.test.ts
@@ -62,6 +62,11 @@ vi.mock('@/lib/logging/mask', () => ({
   maskIdentifier: vi.fn((id) => `***${id.slice(-4)}`),
 }));
 
+// Mock audit helper (boundary)
+vi.mock('@/lib/audit/route-audit', () => ({
+  logAuditEvent: vi.fn(),
+}));
+
 import { previewAiUndo, executeAiUndo, type AiUndoPreview } from '@/services/api';
 import { authenticateRequestWithOptions, checkMCPPageScope } from '@/lib/auth';
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';

--- a/apps/web/src/app/api/ai/chat/messages/[messageId]/undo/route.ts
+++ b/apps/web/src/app/api/ai/chat/messages/[messageId]/undo/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope, type AuthResult } from '@/lib/auth';
-import { canUserEditPage } from '@pagespace/lib/server';
-import { loggers } from '@pagespace/lib/server';
+import { canUserEditPage, loggers, securityAudit } from '@pagespace/lib/server';
 import { maskIdentifier } from '@/lib/logging/mask';
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 import { previewAiUndo, executeAiUndo, type AiUndoPreview } from '@/services/api';
@@ -111,6 +110,12 @@ export async function GET(
       messagesAffected: preview.messagesAffected,
       activitiesAffected: preview.activitiesAffected.length,
     });
+
+    securityAudit.logDataAccess(userId, 'read', 'ai_chat_undo', messageId, {
+      action: 'undo_preview',
+      source: preview.source,
+      messagesAffected: preview.messagesAffected,
+    }).catch(() => {});
 
     return NextResponse.json(preview);
   } catch (error) {
@@ -251,6 +256,13 @@ export async function POST(
         channelCount: broadcastedChannels.size,
       });
     }
+
+    securityAudit.logDataAccess(userId, 'write', 'ai_chat_undo', messageId, {
+      action: 'undo_execute',
+      mode,
+      messagesDeleted: result.messagesDeleted,
+      activitiesRolledBack: result.activitiesRolledBack,
+    }).catch(() => {});
 
     return NextResponse.json({
       ...result,

--- a/apps/web/src/app/api/ai/chat/messages/[messageId]/undo/route.ts
+++ b/apps/web/src/app/api/ai/chat/messages/[messageId]/undo/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope, type AuthResult } from '@/lib/auth';
-import { canUserEditPage, loggers, securityAudit } from '@pagespace/lib/server';
+import { canUserEditPage, loggers } from '@pagespace/lib/server';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 import { maskIdentifier } from '@/lib/logging/mask';
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 import { previewAiUndo, executeAiUndo, type AiUndoPreview } from '@/services/api';
@@ -111,11 +112,11 @@ export async function GET(
       activitiesAffected: preview.activitiesAffected.length,
     });
 
-    securityAudit.logDataAccess(userId, 'read', 'ai_chat_undo', messageId, {
+    logAuditEvent(request, userId, 'read', 'ai_chat_undo', messageId, {
       action: 'undo_preview',
       source: preview.source,
       messagesAffected: preview.messagesAffected,
-    }).catch(() => {});
+    });
 
     return NextResponse.json(preview);
   } catch (error) {
@@ -257,12 +258,12 @@ export async function POST(
       });
     }
 
-    securityAudit.logDataAccess(userId, 'write', 'ai_chat_undo', messageId, {
+    logAuditEvent(request, userId, 'write', 'ai_chat_undo', messageId, {
       action: 'undo_execute',
       mode,
       messagesDeleted: result.messagesDeleted,
       activitiesRolledBack: result.activitiesRolledBack,
-    }).catch(() => {});
+    });
 
     return NextResponse.json({
       ...result,

--- a/apps/web/src/app/api/ai/chat/messages/__tests__/mcp-scope.test.ts
+++ b/apps/web/src/app/api/ai/chat/messages/__tests__/mcp-scope.test.ts
@@ -45,6 +45,11 @@ vi.mock('@/lib/ai/core', () => ({
   })),
 }));
 
+// Mock audit helper (boundary)
+vi.mock('@/lib/audit/route-audit', () => ({
+  logAuditEvent: vi.fn(),
+}));
+
 import { authenticateRequestWithOptions, checkMCPPageScope } from '@/lib/auth';
 import { canUserViewPage } from '@pagespace/lib/server';
 import { chatMessageRepository } from '@/lib/repositories/chat-message-repository';

--- a/apps/web/src/app/api/ai/chat/messages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/chat/messages/__tests__/route.test.ts
@@ -45,6 +45,11 @@ vi.mock('@/lib/ai/core', () => ({
   })),
 }));
 
+// Mock audit helper (boundary)
+vi.mock('@/lib/audit/route-audit', () => ({
+  logAuditEvent: vi.fn(),
+}));
+
 import { chatMessageRepository } from '@/lib/repositories/chat-message-repository';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { canUserViewPage, loggers } from '@pagespace/lib/server';

--- a/apps/web/src/app/api/ai/chat/messages/route.ts
+++ b/apps/web/src/app/api/ai/chat/messages/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
 import { convertDbMessageToUIMessage } from '@/lib/ai/core';
-import { loggers, securityAudit, canUserViewPage } from '@pagespace/lib/server';
+import { loggers, canUserViewPage } from '@pagespace/lib/server';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 import { chatMessageRepository } from '@/lib/repositories/chat-message-repository';
 
 // Auth options: GET is read-only operation
@@ -45,10 +46,10 @@ export async function GET(request: Request) {
     // Convert to UIMessage format with tool calls and results
     const messages = dbMessages.map(convertDbMessageToUIMessage);
 
-    securityAudit.logDataAccess(auth.userId, 'read', 'ai_chat_message', pageId, {
+    logAuditEvent(request, auth.userId, 'read', 'ai_chat_message', pageId, {
       action: 'list_messages',
       conversationId: conversationId || undefined,
-    }).catch(() => {});
+    });
 
     return NextResponse.json(messages);
 

--- a/apps/web/src/app/api/ai/chat/messages/route.ts
+++ b/apps/web/src/app/api/ai/chat/messages/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
 import { convertDbMessageToUIMessage } from '@/lib/ai/core';
-import { loggers } from '@pagespace/lib/server';
-import { canUserViewPage } from '@pagespace/lib/server';
+import { loggers, securityAudit, canUserViewPage } from '@pagespace/lib/server';
 import { chatMessageRepository } from '@/lib/repositories/chat-message-repository';
 
 // Auth options: GET is read-only operation
@@ -45,6 +44,11 @@ export async function GET(request: Request) {
 
     // Convert to UIMessage format with tool calls and results
     const messages = dbMessages.map(convertDbMessageToUIMessage);
+
+    securityAudit.logDataAccess(auth.userId, 'read', 'ai_chat_message', pageId, {
+      action: 'list_messages',
+      conversationId: conversationId || undefined,
+    }).catch(() => {});
 
     return NextResponse.json(messages);
 

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -60,7 +60,8 @@ import {
 } from '@/lib/ai/core';
 import { db, users, chatMessages, pages, drives, eq, and } from '@pagespace/db';
 import { createId } from '@paralleldrive/cuid2';
-import { loggers, securityAudit, conversationCache, type CachedMessage } from '@pagespace/lib/server';
+import { loggers, conversationCache, type CachedMessage } from '@pagespace/lib/server';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 import { maskIdentifier } from '@/lib/logging/mask';
 import { trackFeature } from '@pagespace/lib/activity-tracker';
 import { AIMonitoring } from '@pagespace/lib/ai-monitoring';
@@ -359,10 +360,10 @@ export async function POST(request: Request) {
         
         loggers.ai.debug('AI Chat API: User message saved to database');
 
-        securityAudit.logDataAccess(userId, 'write', 'ai_chat', chatId, {
+        logAuditEvent(request, userId, 'write', 'ai_chat', chatId, {
           action: 'chat_message',
           conversationId,
-        }).catch(() => {});
+        });
       } catch (error) {
         loggers.ai.error('AI Chat API: Failed to save user message', error as Error);
         return NextResponse.json({
@@ -1270,9 +1271,9 @@ export async function GET(request: Request) {
     // Check GLM settings
     const glmSettings = await getUserGLMSettings(userId);
 
-    securityAudit.logDataAccess(userId, 'read', 'ai_chat_settings', pageId || userId, {
+    logAuditEvent(request, userId, 'read', 'ai_chat_settings', pageId || userId, {
       action: 'get_provider_settings',
-    }).catch(() => {});
+    });
 
     return NextResponse.json({
       currentProvider,
@@ -1515,11 +1516,11 @@ export async function PATCH(request: Request) {
       model: sanitizedModel
     });
 
-    securityAudit.logDataAccess(auth.userId, 'write', 'ai_chat_settings', sanitizedPageId, {
+    logAuditEvent(request, auth.userId, 'write', 'ai_chat_settings', sanitizedPageId, {
       action: 'update_page_settings',
       provider: sanitizedProvider,
       model: sanitizedModel,
-    }).catch(() => {});
+    });
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -60,7 +60,7 @@ import {
 } from '@/lib/ai/core';
 import { db, users, chatMessages, pages, drives, eq, and } from '@pagespace/db';
 import { createId } from '@paralleldrive/cuid2';
-import { loggers, conversationCache, type CachedMessage } from '@pagespace/lib/server';
+import { loggers, securityAudit, conversationCache, type CachedMessage } from '@pagespace/lib/server';
 import { maskIdentifier } from '@/lib/logging/mask';
 import { trackFeature } from '@pagespace/lib/activity-tracker';
 import { AIMonitoring } from '@pagespace/lib/ai-monitoring';
@@ -358,6 +358,11 @@ export async function POST(request: Request) {
         });
         
         loggers.ai.debug('AI Chat API: User message saved to database');
+
+        securityAudit.logDataAccess(userId, 'write', 'ai_chat', chatId, {
+          action: 'chat_message',
+          conversationId,
+        }).catch(() => {});
       } catch (error) {
         loggers.ai.error('AI Chat API: Failed to save user message', error as Error);
         return NextResponse.json({
@@ -1265,6 +1270,10 @@ export async function GET(request: Request) {
     // Check GLM settings
     const glmSettings = await getUserGLMSettings(userId);
 
+    securityAudit.logDataAccess(userId, 'read', 'ai_chat_settings', pageId || userId, {
+      action: 'get_provider_settings',
+    }).catch(() => {});
+
     return NextResponse.json({
       currentProvider,
       currentModel,
@@ -1505,6 +1514,12 @@ export async function PATCH(request: Request) {
       provider: sanitizedProvider,
       model: sanitizedModel
     });
+
+    securityAudit.logDataAccess(auth.userId, 'write', 'ai_chat_settings', sanitizedPageId, {
+      action: 'update_page_settings',
+      provider: sanitizedProvider,
+      model: sanitizedModel,
+    }).catch(() => {});
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/ai/global/[id]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/__tests__/route.test.ts
@@ -36,6 +36,11 @@ vi.mock('@pagespace/lib/server', () => ({
   },
 }));
 
+// Mock audit helper (boundary)
+vi.mock('@/lib/audit/route-audit', () => ({
+  logAuditEvent: vi.fn(),
+}));
+
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/server';

--- a/apps/web/src/app/api/ai/global/[id]/messages/[messageId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/[messageId]/__tests__/route.test.ts
@@ -53,6 +53,11 @@ vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
   logMessageActivity: vi.fn(),
 }));
 
+// Mock audit helper (boundary)
+vi.mock('@/lib/audit/route-audit', () => ({
+  logAuditEvent: vi.fn(),
+}));
+
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 import { getActorInfo, logMessageActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';

--- a/apps/web/src/app/api/ai/global/[id]/messages/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/[messageId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { maskIdentifier } from '@/lib/logging/mask';
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 import { processMessageContentUpdate } from '@/lib/repositories/chat-message-repository';
@@ -83,6 +83,11 @@ export async function PATCH(
       conversationId: maskIdentifier(conversationId)
     });
 
+    securityAudit.logDataAccess(userId, 'write', 'global_chat_message', messageId, {
+      action: 'edit_message',
+      conversationId,
+    }).catch(() => {});
+
     return NextResponse.json({
       success: true,
       message: 'Message updated successfully'
@@ -157,6 +162,11 @@ export async function DELETE(
       messageId: maskIdentifier(messageId),
       conversationId: maskIdentifier(conversationId)
     });
+
+    securityAudit.logDataAccess(userId, 'delete', 'global_chat_message', messageId, {
+      action: 'delete_message',
+      conversationId,
+    }).catch(() => {});
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/ai/global/[id]/messages/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/[messageId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers, securityAudit } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/server';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 import { maskIdentifier } from '@/lib/logging/mask';
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 import { processMessageContentUpdate } from '@/lib/repositories/chat-message-repository';
@@ -83,10 +84,10 @@ export async function PATCH(
       conversationId: maskIdentifier(conversationId)
     });
 
-    securityAudit.logDataAccess(userId, 'write', 'global_chat_message', messageId, {
+    logAuditEvent(request, userId, 'write', 'global_chat_message', messageId, {
       action: 'edit_message',
       conversationId,
-    }).catch(() => {});
+    });
 
     return NextResponse.json({
       success: true,
@@ -163,10 +164,10 @@ export async function DELETE(
       conversationId: maskIdentifier(conversationId)
     });
 
-    securityAudit.logDataAccess(userId, 'delete', 'global_chat_message', messageId, {
+    logAuditEvent(request, userId, 'delete', 'global_chat_message', messageId, {
       action: 'delete_message',
       conversationId,
-    }).catch(() => {});
+    });
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -39,7 +39,8 @@ import {
 import { db, conversations, messages, drives, eq, and, desc, gt, lt } from '@pagespace/db';
 import { createId } from '@paralleldrive/cuid2';
 import { getMCPBridge } from '@/lib/mcp';
-import { loggers, securityAudit } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/server';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 import { maskIdentifier } from '@/lib/logging/mask';
 import type { MCPTool } from '@/types/mcp';
 import { AIMonitoring } from '@pagespace/lib/ai-monitoring';
@@ -167,9 +168,9 @@ export async function GET(
       ? orderedMessages[orderedMessages.length - 1].id // Last message (newest) for loading newer messages
       : null;
 
-    securityAudit.logDataAccess(userId, 'read', 'global_chat_message', id, {
+    logAuditEvent(request, userId, 'read', 'global_chat_message', id, {
       action: 'list_messages',
-    }).catch(() => {});
+    });
 
     return NextResponse.json({
       messages: uiMessages,
@@ -330,9 +331,9 @@ export async function POST(
           uiMessage: userMessage, // Pass UIMessage to preserve part ordering
         });
 
-        securityAudit.logDataAccess(userId, 'write', 'global_chat_message', conversationId, {
+        logAuditEvent(request, userId, 'write', 'global_chat_message', conversationId, {
           action: 'chat_message',
-        }).catch(() => {});
+        });
 
         // Update conversation lastMessageAt and auto-generate title if needed
         const updateData: {

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -39,7 +39,7 @@ import {
 import { db, conversations, messages, drives, eq, and, desc, gt, lt } from '@pagespace/db';
 import { createId } from '@paralleldrive/cuid2';
 import { getMCPBridge } from '@/lib/mcp';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { maskIdentifier } from '@/lib/logging/mask';
 import type { MCPTool } from '@/types/mcp';
 import { AIMonitoring } from '@pagespace/lib/ai-monitoring';
@@ -166,6 +166,10 @@ export async function GET(
     const prevCursor = orderedMessages.length > 0
       ? orderedMessages[orderedMessages.length - 1].id // Last message (newest) for loading newer messages
       : null;
+
+    securityAudit.logDataAccess(userId, 'read', 'global_chat_message', id, {
+      action: 'list_messages',
+    }).catch(() => {});
 
     return NextResponse.json({
       messages: uiMessages,
@@ -325,6 +329,10 @@ export async function POST(
           toolResults: undefined,
           uiMessage: userMessage, // Pass UIMessage to preserve part ordering
         });
+
+        securityAudit.logDataAccess(userId, 'write', 'global_chat_message', conversationId, {
+          action: 'chat_message',
+        }).catch(() => {});
 
         // Update conversation lastMessageAt and auto-generate title if needed
         const updateData: {

--- a/apps/web/src/app/api/ai/global/[id]/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
@@ -27,6 +27,10 @@ export async function GET(
         error: 'Conversation not found'
       }, { status: 404 });
     }
+
+    securityAudit.logDataAccess(userId, 'read', 'global_chat', id, {
+      action: 'get_conversation',
+    }).catch(() => {});
 
     return NextResponse.json(conversation);
   } catch (error) {
@@ -65,6 +69,10 @@ export async function PATCH(
       }, { status: 404 });
     }
 
+    securityAudit.logDataAccess(userId, 'write', 'global_chat', id, {
+      action: 'update_conversation',
+    }).catch(() => {});
+
     return NextResponse.json(updatedConversation);
   } catch (error) {
     loggers.api.error('Error updating conversation:', error as Error);
@@ -98,6 +106,10 @@ export async function DELETE(
         error: 'Conversation not found'
       }, { status: 404 });
     }
+
+    securityAudit.logDataAccess(userId, 'delete', 'global_chat', id, {
+      action: 'delete_conversation',
+    }).catch(() => {});
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/apps/web/src/app/api/ai/global/[id]/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers, securityAudit } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/server';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
@@ -28,9 +29,9 @@ export async function GET(
       }, { status: 404 });
     }
 
-    securityAudit.logDataAccess(userId, 'read', 'global_chat', id, {
+    logAuditEvent(request, userId, 'read', 'global_chat', id, {
       action: 'get_conversation',
-    }).catch(() => {});
+    });
 
     return NextResponse.json(conversation);
   } catch (error) {
@@ -69,9 +70,9 @@ export async function PATCH(
       }, { status: 404 });
     }
 
-    securityAudit.logDataAccess(userId, 'write', 'global_chat', id, {
+    logAuditEvent(request, userId, 'write', 'global_chat', id, {
       action: 'update_conversation',
-    }).catch(() => {});
+    });
 
     return NextResponse.json(updatedConversation);
   } catch (error) {
@@ -107,9 +108,9 @@ export async function DELETE(
       }, { status: 404 });
     }
 
-    securityAudit.logDataAccess(userId, 'delete', 'global_chat', id, {
+    logAuditEvent(request, userId, 'delete', 'global_chat', id, {
       action: 'delete_conversation',
-    }).catch(() => {});
+    });
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/apps/web/src/app/api/ai/global/[id]/usage/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/usage/__tests__/route.test.ts
@@ -42,6 +42,11 @@ vi.mock('@pagespace/lib/ai-monitoring', () => ({
   getContextWindow: vi.fn(() => 200000),
 }));
 
+// Mock audit helper (boundary)
+vi.mock('@/lib/audit/route-audit', () => ({
+  logAuditEvent: vi.fn(),
+}));
+
 import {
   globalConversationRepository,
   calculateUsageSummary as mockedCalculateUsageSummary,

--- a/apps/web/src/app/api/ai/global/[id]/usage/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/usage/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers, securityAudit } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/server';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 import { getContextWindow } from '@pagespace/lib/ai-monitoring';
 import {
   globalConversationRepository,
@@ -37,9 +38,9 @@ export async function GET(
     // Calculate summary statistics (pure function)
     const summary = calculateUsageSummary(logs, getContextWindow);
 
-    securityAudit.logDataAccess(userId, 'read', 'global_chat_usage', id, {
+    logAuditEvent(request, userId, 'read', 'global_chat_usage', id, {
       action: 'view_usage',
-    }).catch(() => {});
+    });
 
     return NextResponse.json({
       logs,

--- a/apps/web/src/app/api/ai/global/[id]/usage/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/usage/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { getContextWindow } from '@pagespace/lib/ai-monitoring';
 import {
   globalConversationRepository,
@@ -36,6 +36,10 @@ export async function GET(
 
     // Calculate summary statistics (pure function)
     const summary = calculateUsageSummary(logs, getContextWindow);
+
+    securityAudit.logDataAccess(userId, 'read', 'global_chat_usage', id, {
+      action: 'view_usage',
+    }).catch(() => {});
 
     return NextResponse.json({
       logs,

--- a/apps/web/src/app/api/ai/global/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/global/__tests__/route.test.ts
@@ -35,6 +35,11 @@ vi.mock('@pagespace/lib/server', () => ({
   },
 }));
 
+// Mock audit helper (boundary)
+vi.mock('@/lib/audit/route-audit', () => ({
+  logAuditEvent: vi.fn(),
+}));
+
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/server';

--- a/apps/web/src/app/api/ai/global/active/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/global/active/__tests__/route.test.ts
@@ -34,6 +34,11 @@ vi.mock('@pagespace/lib/server', () => ({
   },
 }));
 
+// Mock audit helper (boundary)
+vi.mock('@/lib/audit/route-audit', () => ({
+  logAuditEvent: vi.fn(),
+}));
+
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/server';

--- a/apps/web/src/app/api/ai/global/active/route.ts
+++ b/apps/web/src/app/api/ai/global/active/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers, securityAudit } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/server';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
@@ -17,9 +18,9 @@ export async function GET(request: Request) {
 
     const conversation = await globalConversationRepository.getActiveGlobalConversation(userId);
 
-    securityAudit.logDataAccess(userId, 'read', 'global_chat', conversation?.id || 'none', {
+    logAuditEvent(request, userId, 'read', 'global_chat', conversation?.id || 'none', {
       action: 'get_active_conversation',
-    }).catch(() => {});
+    });
 
     return NextResponse.json(conversation);
   } catch (error) {

--- a/apps/web/src/app/api/ai/global/active/route.ts
+++ b/apps/web/src/app/api/ai/global/active/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
@@ -16,6 +16,11 @@ export async function GET(request: Request) {
     const userId = auth.userId;
 
     const conversation = await globalConversationRepository.getActiveGlobalConversation(userId);
+
+    securityAudit.logDataAccess(userId, 'read', 'global_chat', conversation?.id || 'none', {
+      action: 'get_active_conversation',
+    }).catch(() => {});
+
     return NextResponse.json(conversation);
   } catch (error) {
     loggers.api.error('Error fetching global conversation:', error as Error);

--- a/apps/web/src/app/api/ai/global/route.ts
+++ b/apps/web/src/app/api/ai/global/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers, securityAudit } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/server';
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 
 // Allow streaming responses up to 5 minutes
 export const maxDuration = 300;
@@ -41,6 +42,10 @@ export async function GET(request: Request) {
       ? directionParam
       : 'before';
 
+    logAuditEvent(request, userId, 'read', 'global_chat', 'list', {
+      action: 'list_conversations',
+    });
+
     if (usePagination) {
       // New paginated response format
       const result = await globalConversationRepository.listConversationsPaginated(userId, {
@@ -48,19 +53,12 @@ export async function GET(request: Request) {
         cursor,
         direction,
       });
-      securityAudit.logDataAccess(userId, 'read', 'global_chat', 'list', {
-        action: 'list_conversations',
-      }).catch(() => {});
 
       return NextResponse.json(result);
     } else {
       // Legacy response format (array of all conversations)
       // Still supported for backward compatibility
       const userConversations = await globalConversationRepository.listConversations(userId);
-
-      securityAudit.logDataAccess(userId, 'read', 'global_chat', 'list', {
-        action: 'list_conversations',
-      }).catch(() => {});
 
       return NextResponse.json(userConversations);
     }
@@ -90,9 +88,9 @@ export async function POST(request: Request) {
       contextId,
     });
 
-    securityAudit.logDataAccess(userId, 'write', 'global_chat', newConversation.id, {
+    logAuditEvent(request, userId, 'write', 'global_chat', newConversation.id, {
       action: 'create_conversation',
-    }).catch(() => {});
+    });
 
     return NextResponse.json(newConversation);
   } catch (error) {

--- a/apps/web/src/app/api/ai/global/route.ts
+++ b/apps/web/src/app/api/ai/global/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
 
@@ -48,11 +48,20 @@ export async function GET(request: Request) {
         cursor,
         direction,
       });
+      securityAudit.logDataAccess(userId, 'read', 'global_chat', 'list', {
+        action: 'list_conversations',
+      }).catch(() => {});
+
       return NextResponse.json(result);
     } else {
       // Legacy response format (array of all conversations)
       // Still supported for backward compatibility
       const userConversations = await globalConversationRepository.listConversations(userId);
+
+      securityAudit.logDataAccess(userId, 'read', 'global_chat', 'list', {
+        action: 'list_conversations',
+      }).catch(() => {});
+
       return NextResponse.json(userConversations);
     }
   } catch (error) {
@@ -80,6 +89,10 @@ export async function POST(request: Request) {
       type,
       contextId,
     });
+
+    securityAudit.logDataAccess(userId, 'write', 'global_chat', newConversation.id, {
+      action: 'create_conversation',
+    }).catch(() => {});
 
     return NextResponse.json(newConversation);
   } catch (error) {

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/config/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/config/__tests__/route.test.ts
@@ -84,6 +84,11 @@ vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
   getActorInfo: vi.fn().mockResolvedValue({ actorEmail: 'test@example.com', actorDisplayName: 'Test User' }),
 }));
 
+// Mock audit helper (boundary)
+vi.mock('@/lib/audit/route-audit', () => ({
+  logAuditEvent: vi.fn(),
+}));
+
 import { pageAgentRepository } from '@/lib/repositories/page-agent-repository';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope } from '@/lib/auth';
 import { canUserEditPage, agentAwarenessCache } from '@pagespace/lib/server';

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/config/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/config/route.ts
@@ -5,7 +5,8 @@ const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 import { canUserEditPage, agentAwarenessCache } from '@pagespace/lib/server';
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { pageSpaceTools } from '@/lib/ai/core';
-import { loggers, securityAudit } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/server';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 import { pageAgentRepository, type AgentConfigUpdate } from '@/lib/repositories/page-agent-repository';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import { applyPageMutation, PageRevisionMismatchError } from '@/services/api/page-mutation-service';
@@ -166,10 +167,10 @@ export async function PUT(
       userId
     });
 
-    securityAudit.logDataAccess(userId, 'write', 'page_agent', agentId, {
+    logAuditEvent(request, userId, 'write', 'page_agent', agentId, {
       action: 'update_config',
       updatedFields,
-    }).catch(() => {});
+    });
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/config/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/config/route.ts
@@ -5,7 +5,7 @@ const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 import { canUserEditPage, agentAwarenessCache } from '@pagespace/lib/server';
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { pageSpaceTools } from '@/lib/ai/core';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { pageAgentRepository, type AgentConfigUpdate } from '@/lib/repositories/page-agent-repository';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import { applyPageMutation, PageRevisionMismatchError } from '@/services/api/page-mutation-service';
@@ -165,6 +165,11 @@ export async function PUT(
       updatedFields,
       userId
     });
+
+    securityAudit.logDataAccess(userId, 'write', 'page_agent', agentId, {
+      action: 'update_config',
+      updatedFields,
+    }).catch(() => {});
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/__tests__/route.test.ts
@@ -43,6 +43,11 @@ vi.mock('@pagespace/lib/server', () => ({
   },
 }));
 
+// Mock audit helper (boundary)
+vi.mock('@/lib/audit/route-audit', () => ({
+  logAuditEvent: vi.fn(),
+}));
+
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
 import { canUserEditPage, loggers } from '@pagespace/lib/server';

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/[messageId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
-import { canUserEditPage, loggers, securityAudit } from '@pagespace/lib/server';
+import { canUserEditPage, loggers } from '@pagespace/lib/server';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 import { maskIdentifier } from '@/lib/logging/mask';
 import {
   chatMessageRepository,
@@ -99,11 +100,11 @@ export async function PATCH(
       conversationId: maskIdentifier(conversationId),
     });
 
-    securityAudit.logDataAccess(userId, 'write', 'page_agent_message', messageId, {
+    logAuditEvent(request, userId, 'write', 'page_agent_message', messageId, {
       action: 'edit_message',
       agentId,
       conversationId,
-    }).catch(() => {});
+    });
 
     return NextResponse.json({
       success: true,
@@ -194,11 +195,11 @@ export async function DELETE(
       conversationId: maskIdentifier(conversationId),
     });
 
-    securityAudit.logDataAccess(userId, 'delete', 'page_agent_message', messageId, {
+    logAuditEvent(request, userId, 'delete', 'page_agent_message', messageId, {
       action: 'delete_message',
       agentId,
       conversationId,
-    }).catch(() => {});
+    });
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/[messageId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
-import { canUserEditPage, loggers } from '@pagespace/lib/server';
+import { canUserEditPage, loggers, securityAudit } from '@pagespace/lib/server';
 import { maskIdentifier } from '@/lib/logging/mask';
 import {
   chatMessageRepository,
@@ -99,6 +99,12 @@ export async function PATCH(
       conversationId: maskIdentifier(conversationId),
     });
 
+    securityAudit.logDataAccess(userId, 'write', 'page_agent_message', messageId, {
+      action: 'edit_message',
+      agentId,
+      conversationId,
+    }).catch(() => {});
+
     return NextResponse.json({
       success: true,
       message: 'Message updated successfully',
@@ -187,6 +193,12 @@ export async function DELETE(
       agentId: maskIdentifier(agentId),
       conversationId: maskIdentifier(conversationId),
     });
+
+    securityAudit.logDataAccess(userId, 'delete', 'page_agent_message', messageId, {
+      action: 'delete_message',
+      agentId,
+      conversationId,
+    }).catch(() => {});
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/route.ts
@@ -1,9 +1,8 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
 import { db, chatMessages, pages, eq, and, desc, sql } from '@pagespace/db';
-import { canUserViewPage } from '@pagespace/lib/server';
+import { canUserViewPage, loggers, securityAudit } from '@pagespace/lib/server';
 import { convertDbMessageToUIMessage } from '@/lib/ai/core';
-import { loggers } from '@pagespace/lib/server';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
 
 // Auth options: GET is read-only operation
@@ -161,6 +160,11 @@ export async function GET(
     const prevCursor = orderedMessages.length > 0
       ? orderedMessages[orderedMessages.length - 1].id // Last message (newest) for loading newer messages
       : null;
+
+    securityAudit.logDataAccess(auth.userId, 'read', 'page_agent_message', conversationId, {
+      action: 'list_messages',
+      agentId,
+    }).catch(() => {});
 
     return NextResponse.json({
       messages,

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
 import { db, chatMessages, pages, eq, and, desc, sql } from '@pagespace/db';
-import { canUserViewPage, loggers, securityAudit } from '@pagespace/lib/server';
+import { canUserViewPage, loggers } from '@pagespace/lib/server';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 import { convertDbMessageToUIMessage } from '@/lib/ai/core';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
 
@@ -161,10 +162,10 @@ export async function GET(
       ? orderedMessages[orderedMessages.length - 1].id // Last message (newest) for loading newer messages
       : null;
 
-    securityAudit.logDataAccess(auth.userId, 'read', 'page_agent_message', conversationId, {
+    logAuditEvent(request, auth.userId, 'read', 'page_agent_message', conversationId, {
       action: 'list_messages',
       agentId,
-    }).catch(() => {});
+    });
 
     return NextResponse.json({
       messages,

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
-import { canUserEditPage, conversationCache, loggers, securityAudit } from '@pagespace/lib/server';
+import { canUserEditPage, conversationCache, loggers } from '@pagespace/lib/server';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
 
 // Auth options: PATCH and DELETE are write operations requiring CSRF protection
@@ -81,10 +82,10 @@ export async function PATCH(
       title
     );
 
-    securityAudit.logDataAccess(auth.userId, 'write', 'page_agent_conversation', conversationId, {
+    logAuditEvent(request, auth.userId, 'write', 'page_agent_conversation', conversationId, {
       action: 'update_conversation',
       agentId,
-    }).catch(() => {});
+    });
 
     return NextResponse.json({
       success: true,
@@ -172,10 +173,10 @@ export async function DELETE(
       messageCount: metadata?.messageCount || 0,
     });
 
-    securityAudit.logDataAccess(auth.userId, 'delete', 'page_agent_conversation', conversationId, {
+    logAuditEvent(request, auth.userId, 'delete', 'page_agent_conversation', conversationId, {
       action: 'delete_conversation',
       agentId,
-    }).catch(() => {});
+    });
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
-import { canUserEditPage, conversationCache } from '@pagespace/lib/server';
-import { loggers } from '@pagespace/lib/server';
+import { canUserEditPage, conversationCache, loggers, securityAudit } from '@pagespace/lib/server';
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
 
 // Auth options: PATCH and DELETE are write operations requiring CSRF protection
@@ -81,6 +80,11 @@ export async function PATCH(
       agentId,
       title
     );
+
+    securityAudit.logDataAccess(auth.userId, 'write', 'page_agent_conversation', conversationId, {
+      action: 'update_conversation',
+      agentId,
+    }).catch(() => {});
 
     return NextResponse.json({
       success: true,
@@ -167,6 +171,11 @@ export async function DELETE(
       userId: auth.userId,
       messageCount: metadata?.messageCount || 0,
     });
+
+    securityAudit.logDataAccess(auth.userId, 'delete', 'page_agent_conversation', conversationId, {
+      action: 'delete_conversation',
+      agentId,
+    }).catch(() => {});
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/__tests__/route.test.ts
@@ -58,6 +58,11 @@ vi.mock('@paralleldrive/cuid2', () => ({
   createId: vi.fn(() => 'generated_conv_id'),
 }));
 
+// Mock audit helper (boundary)
+vi.mock('@/lib/audit/route-audit', () => ({
+  logAuditEvent: vi.fn(),
+}));
+
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
 import { canUserViewPage, loggers } from '@pagespace/lib/server';

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/route.ts
@@ -1,8 +1,7 @@
 import { NextResponse } from 'next/server';
 import { createId } from '@paralleldrive/cuid2';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
-import { canUserViewPage } from '@pagespace/lib/server';
-import { loggers } from '@pagespace/lib/server';
+import { canUserViewPage, loggers, securityAudit } from '@pagespace/lib/server';
 import {
   conversationRepository,
   extractPreviewText,
@@ -96,6 +95,10 @@ export async function GET(
     // Get total count for pagination
     const totalCount = await conversationRepository.countConversations(agentId);
 
+    securityAudit.logDataAccess(auth.userId, 'read', 'page_agent_conversation', agentId, {
+      action: 'list_conversations',
+    }).catch(() => {});
+
     return NextResponse.json({
       conversations,
       pagination: {
@@ -161,6 +164,11 @@ export async function POST(
 
     // Generate new conversation ID using createId
     const conversationId = createId();
+
+    securityAudit.logDataAccess(auth.userId, 'write', 'page_agent_conversation', conversationId, {
+      action: 'create_conversation',
+      agentId,
+    }).catch(() => {});
 
     return NextResponse.json({
       conversationId,

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { createId } from '@paralleldrive/cuid2';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
-import { canUserViewPage, loggers, securityAudit } from '@pagespace/lib/server';
+import { canUserViewPage, loggers } from '@pagespace/lib/server';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 import {
   conversationRepository,
   extractPreviewText,
@@ -95,9 +96,9 @@ export async function GET(
     // Get total count for pagination
     const totalCount = await conversationRepository.countConversations(agentId);
 
-    securityAudit.logDataAccess(auth.userId, 'read', 'page_agent_conversation', agentId, {
+    logAuditEvent(request, auth.userId, 'read', 'page_agent_conversation', agentId, {
       action: 'list_conversations',
-    }).catch(() => {});
+    });
 
     return NextResponse.json({
       conversations,
@@ -165,16 +166,18 @@ export async function POST(
     // Generate new conversation ID using createId
     const conversationId = createId();
 
-    securityAudit.logDataAccess(auth.userId, 'write', 'page_agent_conversation', conversationId, {
-      action: 'create_conversation',
-      agentId,
-    }).catch(() => {});
-
-    return NextResponse.json({
+    const response = {
       conversationId,
       title: customTitle || 'New conversation',
       createdAt: new Date(),
+    };
+
+    logAuditEvent(request, auth.userId, 'write', 'page_agent_conversation', conversationId, {
+      action: 'create_conversation',
+      agentId,
     });
+
+    return NextResponse.json(response);
 
   } catch (error) {
     loggers.ai.error('Error creating conversation:', error as Error);

--- a/apps/web/src/app/api/ai/page-agents/consult/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/route.ts
@@ -16,7 +16,7 @@ import {
   type ToolExecutionContext,
 } from '@/lib/ai/core';
 import { db, pages, drives, eq, chatMessages } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 
 /**
  * Format tool execution results into human-readable text
@@ -456,6 +456,10 @@ export async function POST(request: Request) {
       responseLength: responseText.length,
       userId
     });
+
+    securityAudit.logDataAccess(userId, 'write', 'page_agent', agentId, {
+      action: 'consult_agent',
+    }).catch(() => {});
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/ai/page-agents/consult/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/route.ts
@@ -16,7 +16,8 @@ import {
   type ToolExecutionContext,
 } from '@/lib/ai/core';
 import { db, pages, drives, eq, chatMessages } from '@pagespace/db';
-import { loggers, securityAudit } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/server';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 
 /**
  * Format tool execution results into human-readable text
@@ -457,9 +458,9 @@ export async function POST(request: Request) {
       userId
     });
 
-    securityAudit.logDataAccess(userId, 'write', 'page_agent', agentId, {
+    logAuditEvent(request, userId, 'write', 'page_agent', agentId, {
       action: 'consult_agent',
-    }).catch(() => {});
+    });
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/ai/page-agents/create/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/create/__tests__/route.test.ts
@@ -63,6 +63,11 @@ vi.mock('@/lib/ai/core', () => ({
   },
 }));
 
+// Mock audit helper (boundary)
+vi.mock('@/lib/audit/route-audit', () => ({
+  logAuditEvent: vi.fn(),
+}));
+
 import { pageAgentRepository } from '@/lib/repositories/page-agent-repository';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope } from '@/lib/auth';
 import { canUserEditPage, agentAwarenessCache } from '@pagespace/lib/server';

--- a/apps/web/src/app/api/ai/page-agents/create/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/create/route.ts
@@ -137,7 +137,6 @@ export async function POST(request: Request) {
     logAuditEvent(request, userId, 'write', 'page_agent', newAgent.id, {
       action: 'create_agent',
       driveId,
-      title,
     });
 
     return NextResponse.json({

--- a/apps/web/src/app/api/ai/page-agents/create/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/create/route.ts
@@ -5,7 +5,7 @@ const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 import { canUserEditPage, agentAwarenessCache } from '@pagespace/lib/server';
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { pageSpaceTools } from '@/lib/ai/core';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { pageAgentRepository, type AgentData } from '@/lib/repositories/page-agent-repository';
 
 /**
@@ -132,6 +132,12 @@ export async function POST(request: Request) {
       parentId,
       userId
     });
+
+    securityAudit.logDataAccess(userId, 'write', 'page_agent', newAgent.id, {
+      action: 'create_agent',
+      driveId,
+      title,
+    }).catch(() => {});
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/ai/page-agents/create/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/create/route.ts
@@ -5,7 +5,8 @@ const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 import { canUserEditPage, agentAwarenessCache } from '@pagespace/lib/server';
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { pageSpaceTools } from '@/lib/ai/core';
-import { loggers, securityAudit } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/server';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 import { pageAgentRepository, type AgentData } from '@/lib/repositories/page-agent-repository';
 
 /**
@@ -133,11 +134,11 @@ export async function POST(request: Request) {
       userId
     });
 
-    securityAudit.logDataAccess(userId, 'write', 'page_agent', newAgent.id, {
+    logAuditEvent(request, userId, 'write', 'page_agent', newAgent.id, {
       action: 'create_agent',
       driveId,
       title,
-    }).catch(() => {});
+    });
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/ai/page-agents/multi-drive/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/multi-drive/route.ts
@@ -3,7 +3,8 @@ import { authenticateRequestWithOptions, isAuthError, getAllowedDriveIds } from 
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const };
 import { db, pages, drives, eq, and } from '@pagespace/db';
-import { getUserDriveAccess, canUserViewPage, loggers, securityAudit } from '@pagespace/lib/server';
+import { getUserDriveAccess, canUserViewPage, loggers } from '@pagespace/lib/server';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 
 interface AgentSummary {
   id: string;
@@ -178,11 +179,11 @@ export async function GET(request: Request) {
       ]
     };
 
-    securityAudit.logDataAccess(userId, 'read', 'page_agent', 'list', {
+    logAuditEvent(request, userId, 'read', 'page_agent', 'list', {
       action: 'list_agents_multi_drive',
       driveCount: scopedDrives.length,
       agentCount: totalAgentCount,
-    }).catch(() => {});
+    });
 
     if (groupByDrive) {
       return NextResponse.json({ ...baseResult, agentsByDrive });

--- a/apps/web/src/app/api/ai/page-agents/multi-drive/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/multi-drive/route.ts
@@ -3,8 +3,7 @@ import { authenticateRequestWithOptions, isAuthError, getAllowedDriveIds } from 
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const };
 import { db, pages, drives, eq, and } from '@pagespace/db';
-import { getUserDriveAccess, canUserViewPage } from '@pagespace/lib/server';
-import { loggers } from '@pagespace/lib/server';
+import { getUserDriveAccess, canUserViewPage, loggers, securityAudit } from '@pagespace/lib/server';
 
 interface AgentSummary {
   id: string;
@@ -178,6 +177,12 @@ export async function GET(request: Request) {
         `Accessible drives: ${scopedDrives.map(d => d.name).join(', ')}`
       ]
     };
+
+    securityAudit.logDataAccess(userId, 'read', 'page_agent', 'list', {
+      action: 'list_agents_multi_drive',
+      driveCount: scopedDrives.length,
+      agentCount: totalAgentCount,
+    }).catch(() => {});
 
     if (groupByDrive) {
       return NextResponse.json({ ...baseResult, agentsByDrive });

--- a/apps/web/src/app/api/ai/settings/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/settings/__tests__/route.test.ts
@@ -76,6 +76,11 @@ vi.mock('@/lib/subscription/rate-limit-middleware', () => ({
   requiresProSubscription: vi.fn(),
 }));
 
+// Mock audit helper (boundary)
+vi.mock('@/lib/audit/route-audit', () => ({
+  logAuditEvent: vi.fn(),
+}));
+
 import { aiSettingsRepository } from '@/lib/repositories/ai-settings-repository';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/server';

--- a/apps/web/src/app/api/ai/settings/route.ts
+++ b/apps/web/src/app/api/ai/settings/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import {
   getUserOpenRouterSettings,
   createOpenRouterSettings,
@@ -121,6 +121,10 @@ export async function GET(request: Request) {
 
     // Check Azure OpenAI settings
     const azureOpenAISettings = await getUserAzureOpenAISettings(userId);
+
+    securityAudit.logDataAccess(userId, 'read', 'ai_settings', userId, {
+      action: 'get_settings',
+    }).catch(() => {});
 
     return NextResponse.json({
       currentProvider: user?.currentAiProvider || 'pagespace',
@@ -276,6 +280,11 @@ export async function POST(request: Request) {
         await createAzureOpenAISettings(userId, sanitizedApiKey, sanitizedBaseUrl);
       }
 
+      securityAudit.logDataAccess(userId, 'write', 'ai_settings', provider, {
+        action: 'save_api_key',
+        provider,
+      }).catch(() => {});
+
       return NextResponse.json(
         {
           success: true,
@@ -361,8 +370,14 @@ export async function PATCH(request: Request) {
     try {
       await aiSettingsRepository.updateProviderSettings(userId, { provider, model });
 
+      securityAudit.logDataAccess(userId, 'write', 'ai_settings', provider, {
+        action: 'update_model_selection',
+        provider,
+        model,
+      }).catch(() => {});
+
       return NextResponse.json(
-        { 
+        {
           success: true,
           provider,
           model,
@@ -429,6 +444,11 @@ export async function DELETE(request: Request) {
       } else if (provider === 'azure_openai') {
         await deleteAzureOpenAISettings(userId);
       }
+
+      securityAudit.logDataAccess(userId, 'delete', 'ai_settings', provider, {
+        action: 'delete_api_key',
+        provider,
+      }).catch(() => {});
 
       // Return success with 204 No Content
       return new Response(null, { status: 204 });

--- a/apps/web/src/app/api/ai/settings/route.ts
+++ b/apps/web/src/app/api/ai/settings/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers, securityAudit } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/server';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 import {
   getUserOpenRouterSettings,
   createOpenRouterSettings,
@@ -122,9 +123,9 @@ export async function GET(request: Request) {
     // Check Azure OpenAI settings
     const azureOpenAISettings = await getUserAzureOpenAISettings(userId);
 
-    securityAudit.logDataAccess(userId, 'read', 'ai_settings', userId, {
+    logAuditEvent(request, userId, 'read', 'ai_settings', userId, {
       action: 'get_settings',
-    }).catch(() => {});
+    });
 
     return NextResponse.json({
       currentProvider: user?.currentAiProvider || 'pagespace',
@@ -280,10 +281,10 @@ export async function POST(request: Request) {
         await createAzureOpenAISettings(userId, sanitizedApiKey, sanitizedBaseUrl);
       }
 
-      securityAudit.logDataAccess(userId, 'write', 'ai_settings', provider, {
+      logAuditEvent(request, userId, 'write', 'ai_settings', provider, {
         action: 'save_api_key',
         provider,
-      }).catch(() => {});
+      });
 
       return NextResponse.json(
         {
@@ -370,11 +371,11 @@ export async function PATCH(request: Request) {
     try {
       await aiSettingsRepository.updateProviderSettings(userId, { provider, model });
 
-      securityAudit.logDataAccess(userId, 'write', 'ai_settings', provider, {
+      logAuditEvent(request, userId, 'write', 'ai_settings', provider, {
         action: 'update_model_selection',
         provider,
         model,
-      }).catch(() => {});
+      });
 
       return NextResponse.json(
         {
@@ -445,10 +446,10 @@ export async function DELETE(request: Request) {
         await deleteAzureOpenAISettings(userId);
       }
 
-      securityAudit.logDataAccess(userId, 'delete', 'ai_settings', provider, {
+      logAuditEvent(request, userId, 'delete', 'ai_settings', provider, {
         action: 'delete_api_key',
         provider,
-      }).catch(() => {});
+      });
 
       // Return success with 204 No Content
       return new Response(null, { status: 204 });

--- a/apps/web/src/lib/audit/__tests__/route-audit.test.ts
+++ b/apps/web/src/lib/audit/__tests__/route-audit.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@pagespace/lib/server', () => ({
+  securityAudit: {
+    logDataAccess: vi.fn(),
+  },
+  loggers: {
+    api: {
+      warn: vi.fn(),
+    },
+  },
+}));
+
+import { securityAudit, loggers } from '@pagespace/lib/server';
+import { logAuditEvent, extractAuditMeta } from '../route-audit';
+
+function fakeRequest(headers: Record<string, string> = {}): Request {
+  return {
+    headers: {
+      get: (name: string) => headers[name.toLowerCase()] ?? null,
+    },
+  } as unknown as Request;
+}
+
+describe('extractAuditMeta', () => {
+  it('extracts ipAddress from x-forwarded-for (first entry)', () => {
+    const req = fakeRequest({ 'x-forwarded-for': '1.2.3.4, 10.0.0.1' });
+    const meta = extractAuditMeta(req);
+    expect(meta.ipAddress).toBe('1.2.3.4');
+  });
+
+  it('falls back to x-real-ip when x-forwarded-for is absent', () => {
+    const req = fakeRequest({ 'x-real-ip': '5.6.7.8' });
+    const meta = extractAuditMeta(req);
+    expect(meta.ipAddress).toBe('5.6.7.8');
+  });
+
+  it('returns unknown when no IP headers present', () => {
+    const req = fakeRequest();
+    const meta = extractAuditMeta(req);
+    expect(meta.ipAddress).toBe('unknown');
+  });
+
+  it('extracts userAgent from user-agent header', () => {
+    const req = fakeRequest({ 'user-agent': 'Mozilla/5.0' });
+    const meta = extractAuditMeta(req);
+    expect(meta.userAgent).toBe('Mozilla/5.0');
+  });
+
+  it('returns unknown when no user-agent header', () => {
+    const req = fakeRequest();
+    const meta = extractAuditMeta(req);
+    expect(meta.userAgent).toBe('unknown');
+  });
+});
+
+describe('logAuditEvent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(securityAudit.logDataAccess).mockResolvedValue(undefined);
+  });
+
+  it('calls securityAudit.logDataAccess with the provided args', () => {
+    const req = fakeRequest({ 'x-forwarded-for': '1.2.3.4', 'user-agent': 'TestAgent' });
+    logAuditEvent(req, 'user-1', 'read', 'ai_chat', 'res-1', { action: 'test' });
+
+    expect(securityAudit.logDataAccess).toHaveBeenCalledWith(
+      'user-1',
+      'read',
+      'ai_chat',
+      'res-1',
+      {
+        action: 'test',
+        ipAddress: '1.2.3.4',
+        userAgent: 'TestAgent',
+      }
+    );
+  });
+
+  it('logs a warning when securityAudit rejects', async () => {
+    const error = new Error('DB connection lost');
+    vi.mocked(securityAudit.logDataAccess).mockRejectedValueOnce(error);
+
+    const req = fakeRequest();
+    logAuditEvent(req, 'user-1', 'write', 'ai_chat', 'res-1', { action: 'test' });
+
+    // Let the microtask queue flush so the .catch handler runs
+    await vi.waitFor(() => {
+      expect(loggers.api.warn).toHaveBeenCalledWith(
+        'Security audit log failed',
+        expect.objectContaining({
+          error: 'DB connection lost',
+          resourceType: 'ai_chat',
+        })
+      );
+    });
+  });
+
+  it('does not throw when securityAudit rejects', async () => {
+    vi.mocked(securityAudit.logDataAccess).mockRejectedValueOnce(new Error('fail'));
+
+    const req = fakeRequest();
+    // Should not throw
+    expect(() => {
+      logAuditEvent(req, 'user-1', 'read', 'ai_chat', 'res-1', { action: 'test' });
+    }).not.toThrow();
+
+    // Flush microtasks
+    await new Promise(resolve => setTimeout(resolve, 0));
+  });
+});

--- a/apps/web/src/lib/audit/__tests__/route-audit.test.ts
+++ b/apps/web/src/lib/audit/__tests__/route-audit.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('@pagespace/lib/server', () => ({
   securityAudit: {
-    logDataAccess: vi.fn(),
+    logEvent: vi.fn(),
   },
   loggers: {
     api: {
@@ -57,34 +57,53 @@ describe('extractAuditMeta', () => {
 describe('logAuditEvent', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(securityAudit.logDataAccess).mockResolvedValue(undefined);
+    vi.mocked(securityAudit.logEvent).mockResolvedValue(undefined);
   });
 
-  it('calls securityAudit.logDataAccess with the provided args', () => {
+  it('calls securityAudit.logEvent with top-level PII fields (not in details)', () => {
     const req = fakeRequest({ 'x-forwarded-for': '1.2.3.4', 'user-agent': 'TestAgent' });
     logAuditEvent(req, 'user-1', 'read', 'ai_chat', 'res-1', { action: 'test' });
 
-    expect(securityAudit.logDataAccess).toHaveBeenCalledWith(
-      'user-1',
-      'read',
-      'ai_chat',
-      'res-1',
-      {
-        action: 'test',
-        ipAddress: '1.2.3.4',
-        userAgent: 'TestAgent',
-      }
-    );
+    expect(securityAudit.logEvent).toHaveBeenCalledWith({
+      eventType: 'data.read',
+      userId: 'user-1',
+      resourceType: 'ai_chat',
+      resourceId: 'res-1',
+      ipAddress: '1.2.3.4',
+      userAgent: 'TestAgent',
+      details: { action: 'test' },
+    });
+  });
+
+  it('keeps ipAddress and userAgent out of the details object', () => {
+    const req = fakeRequest({ 'x-forwarded-for': '1.2.3.4', 'user-agent': 'TestAgent' });
+    logAuditEvent(req, 'user-1', 'write', 'ai_chat', 'res-1', { action: 'test' });
+
+    const callArg = vi.mocked(securityAudit.logEvent).mock.calls[0][0];
+    expect(callArg.details).not.toHaveProperty('ipAddress');
+    expect(callArg.details).not.toHaveProperty('userAgent');
+  });
+
+  it('maps operation to correct event type', () => {
+    const req = fakeRequest();
+    const ops = ['read', 'write', 'delete', 'export', 'share'] as const;
+    const expected = ['data.read', 'data.write', 'data.delete', 'data.export', 'data.share'];
+
+    ops.forEach((op, i) => {
+      vi.clearAllMocks();
+      vi.mocked(securityAudit.logEvent).mockResolvedValue(undefined);
+      logAuditEvent(req, 'u', op, 'r', 'id');
+      expect(vi.mocked(securityAudit.logEvent).mock.calls[0][0].eventType).toBe(expected[i]);
+    });
   });
 
   it('logs a warning when securityAudit rejects', async () => {
     const error = new Error('DB connection lost');
-    vi.mocked(securityAudit.logDataAccess).mockRejectedValueOnce(error);
+    vi.mocked(securityAudit.logEvent).mockRejectedValueOnce(error);
 
     const req = fakeRequest();
     logAuditEvent(req, 'user-1', 'write', 'ai_chat', 'res-1', { action: 'test' });
 
-    // Let the microtask queue flush so the .catch handler runs
     await vi.waitFor(() => {
       expect(loggers.api.warn).toHaveBeenCalledWith(
         'Security audit log failed',
@@ -97,15 +116,13 @@ describe('logAuditEvent', () => {
   });
 
   it('does not throw when securityAudit rejects', async () => {
-    vi.mocked(securityAudit.logDataAccess).mockRejectedValueOnce(new Error('fail'));
+    vi.mocked(securityAudit.logEvent).mockRejectedValueOnce(new Error('fail'));
 
     const req = fakeRequest();
-    // Should not throw
     expect(() => {
       logAuditEvent(req, 'user-1', 'read', 'ai_chat', 'res-1', { action: 'test' });
     }).not.toThrow();
 
-    // Flush microtasks
     await new Promise(resolve => setTimeout(resolve, 0));
   });
 });

--- a/apps/web/src/lib/audit/route-audit.ts
+++ b/apps/web/src/lib/audit/route-audit.ts
@@ -1,4 +1,13 @@
 import { securityAudit, loggers } from '@pagespace/lib/server';
+import type { SecurityEventType } from '@pagespace/db';
+
+const DATA_EVENT_MAP: Record<string, SecurityEventType> = {
+  read: 'data.read',
+  write: 'data.write',
+  delete: 'data.delete',
+  export: 'data.export',
+  share: 'data.share',
+};
 
 interface AuditMeta {
   ipAddress: string;
@@ -14,6 +23,14 @@ export function extractAuditMeta(request: Request): AuditMeta {
   return { ipAddress, userAgent };
 }
 
+/**
+ * Log a data-access audit event with request metadata.
+ *
+ * Uses logEvent() directly so ipAddress and userAgent are stored as
+ * top-level AuditEvent fields — which are excluded from the hash chain
+ * per GDPR compliance (#541). Putting them inside `details` would
+ * include them in the hash, breaking the right-to-erasure invariant.
+ */
 export function logAuditEvent(
   request: Request,
   userId: string,
@@ -24,10 +41,14 @@ export function logAuditEvent(
 ): void {
   const { ipAddress, userAgent } = extractAuditMeta(request);
   securityAudit
-    .logDataAccess(userId, operation, resourceType, resourceId, {
-      ...details,
+    .logEvent({
+      eventType: DATA_EVENT_MAP[operation],
+      userId,
+      resourceType,
+      resourceId,
       ipAddress,
       userAgent,
+      details,
     })
     .catch((err: Error) => {
       loggers.api.warn('Security audit log failed', {

--- a/apps/web/src/lib/audit/route-audit.ts
+++ b/apps/web/src/lib/audit/route-audit.ts
@@ -1,0 +1,38 @@
+import { securityAudit, loggers } from '@pagespace/lib/server';
+
+interface AuditMeta {
+  ipAddress: string;
+  userAgent: string;
+}
+
+export function extractAuditMeta(request: Request): AuditMeta {
+  const ipAddress =
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    request.headers.get('x-real-ip') ||
+    'unknown';
+  const userAgent = request.headers.get('user-agent') || 'unknown';
+  return { ipAddress, userAgent };
+}
+
+export function logAuditEvent(
+  request: Request,
+  userId: string,
+  operation: 'read' | 'write' | 'delete' | 'export' | 'share',
+  resourceType: string,
+  resourceId: string,
+  details?: Record<string, unknown>
+): void {
+  const { ipAddress, userAgent } = extractAuditMeta(request);
+  securityAudit
+    .logDataAccess(userId, operation, resourceType, resourceId, {
+      ...details,
+      ipAddress,
+      userAgent,
+    })
+    .catch((err: Error) => {
+      loggers.api.warn('Security audit log failed', {
+        error: err.message,
+        resourceType,
+      });
+    });
+}

--- a/tasks/ai-chat-auditor-fixes.md
+++ b/tasks/ai-chat-auditor-fixes.md
@@ -1,0 +1,22 @@
+# AI Chat Auditor Fixes
+
+**Status**: IN PROGRESS
+**Branch**: pu/ai-chat-auditor
+**Context**: Review findings from SecurityAuditService wiring into AI/chat routes
+
+## Requirements
+
+### Fix 1: Audit failure visibility
+- Given a securityAudit.logDataAccess call that rejects, should log a warning via loggers.api.warn instead of silently swallowing
+- Given the warning, should include the error message and the resource type for debugging
+
+### Fix 2: Request metadata in audit events
+- Given a Request object, should extract ipAddress from x-forwarded-for or x-real-ip headers
+- Given a Request object, should extract userAgent from user-agent header
+- Given extracted metadata, should pass ipAddress and userAgent to securityAudit.logDataAccess details
+
+### Fix 3: Duplicate audit in global/route.ts GET
+- Given the paginated and legacy branches in GET /api/ai/global, should emit a single audit call, not two identical ones
+
+### Fix 4: Premature audit in conversations POST
+- Given POST /api/ai/page-agents/[agentId]/conversations, should audit after the response data is assembled, not before

--- a/tasks/ai-chat-auditor-fixes.md
+++ b/tasks/ai-chat-auditor-fixes.md
@@ -1,22 +1,27 @@
 # AI Chat Auditor Fixes
 
-**Status**: IN PROGRESS
+**Status**: COMPLETED
 **Branch**: pu/ai-chat-auditor
 **Context**: Review findings from SecurityAuditService wiring into AI/chat routes
 
 ## Requirements
 
-### Fix 1: Audit failure visibility
-- Given a securityAudit.logDataAccess call that rejects, should log a warning via loggers.api.warn instead of silently swallowing
+### Fix 1: Audit failure visibility ✅
+- Given a securityAudit call that rejects, should log a warning via loggers.api.warn instead of silently swallowing
 - Given the warning, should include the error message and the resource type for debugging
 
-### Fix 2: Request metadata in audit events
+### Fix 2: Request metadata in audit events ✅
 - Given a Request object, should extract ipAddress from x-forwarded-for or x-real-ip headers
 - Given a Request object, should extract userAgent from user-agent header
-- Given extracted metadata, should pass ipAddress and userAgent to securityAudit.logDataAccess details
+- Given extracted metadata, should pass ipAddress and userAgent as top-level AuditEvent fields (NOT inside details)
 
-### Fix 3: Duplicate audit in global/route.ts GET
+### Fix 3: Duplicate audit in global/route.ts GET ✅
 - Given the paginated and legacy branches in GET /api/ai/global, should emit a single audit call, not two identical ones
 
-### Fix 4: Premature audit in conversations POST
+### Fix 4: Premature audit in conversations POST ✅
 - Given POST /api/ai/page-agents/[agentId]/conversations, should audit after the response data is assembled, not before
+
+### Fix 5: GDPR hash chain compliance ✅
+- Given ipAddress and userAgent are PII fields excluded from hash computation per #541, should NOT place them inside the details object (which IS hashed)
+- Given the logAuditEvent helper, should call logEvent() directly with top-level ipAddress/userAgent fields instead of logDataAccess() which only accepts a details bag
+- Given the hash chain invariant, should have a test that explicitly verifies PII stays out of the details object


### PR DESCRIPTION
## Summary
- Wire `SecurityAuditService.logEvent()` into all 20 AI/chat API routes via a centralized `logAuditEvent` helper
- Extract request metadata (IP address, user-agent) from request headers and pass as top-level `AuditEvent` fields (excluded from hash chain per GDPR #541)
- Replace silent `.catch(() => {})` with warning logs so audit failures are observable
- Deduplicate audit call in `global/route.ts` GET and fix premature audit ordering in conversations POST

## What changed
- **New**: `apps/web/src/lib/audit/route-audit.ts` — `logAuditEvent()` and `extractAuditMeta()` utilities
- **New**: `apps/web/src/lib/audit/__tests__/route-audit.test.ts` — 10 tests covering metadata extraction, event type mapping, GDPR hash chain safety, and error handling
- **Modified**: 20 route files under `apps/web/src/app/api/ai/` — all now use `logAuditEvent(request, ...)` instead of raw `securityAudit.logDataAccess(...).catch(() => {})`
- **Task plan**: `tasks/ai-chat-auditor-fixes.md` — 5 requirements, all completed

## GDPR compliance
`ipAddress` and `userAgent` are PII fields that must stay out of the audit hash chain (per #541) so right-to-erasure doesn't break chain verification. The helper calls `logEvent()` directly with top-level PII fields (which `computeSecurityEventHash` explicitly excludes), rather than `logDataAccess()` which would put them in the `details` bag (which IS hashed). A dedicated test asserts this invariant.

## Test plan
- [ ] `pnpm --filter web exec vitest run src/lib/audit/__tests__/route-audit.test.ts` — 10 tests pass
- [ ] `pnpm lint --filter web` — clean (only pre-existing CalendarView warnings)
- [ ] Verify audit events appear in `security_audit_log` table with `ipAddress` and `userAgent` populated
- [ ] Verify hash chain remains verifiable after PII anonymization

🤖 Generated with [Claude Code](https://claude.com/claude-code)