### PR TITLE
feat(security): audit page read sub-routes

### DIFF
--- a/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
+++ b/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
@@ -90,15 +90,8 @@ const AUDIT_EXEMPT_ROUTES = new Map<string, string>([
   ['drives/[driveId]/search/regex', 'Regex search within drive — follow-up'],
   ['drives/[driveId]/trash', 'Trash list for drive — follow-up'],
 
-  // --- Page sub-routes (read-only data fetches, covered by parent page audit) ---
+  // --- Page sub-routes (remaining without direct audit coverage) ---
   // TODO: Add audit coverage in follow-up PR
-  ['pages/[pageId]/agent-config', 'Page agent config — follow-up'],
-  ['pages/[pageId]/ai-usage', 'AI usage stats — follow-up'],
-  ['pages/[pageId]/breadcrumbs', 'Breadcrumb navigation — follow-up'],
-  ['pages/[pageId]/children', 'Child page list — follow-up'],
-  ['pages/[pageId]/history', 'Page history view — follow-up'],
-  ['pages/[pageId]/permissions/check', 'Permission check — follow-up'],
-  ['pages/[pageId]/processing-status', 'Processing status poll — follow-up'],
   ['pages/[pageId]/reprocess', 'Reprocess trigger — follow-up'],
   ['pages/[pageId]/tasks/[taskId]', 'Individual task CRUD — follow-up'],
   ['pages/[pageId]/tasks/reorder', 'Task reorder — follow-up'],

--- a/apps/web/src/app/api/pages/[pageId]/agent-config/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/agent-config/route.ts
@@ -6,6 +6,7 @@ import { pageSpaceTools } from '@/lib/ai/core';
 import { loggers } from '@pagespace/lib/server';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import { applyPageMutation, PageRevisionMismatchError } from '@/services/api/page-mutation-service';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
@@ -65,6 +66,8 @@ export async function GET(
       loggers.api.error('Error fetching drive prompt:', error as Error);
       // Continue without drive prompt on error
     }
+
+    logAuditEvent(request, userId, 'read', 'agent_config', pageId, { action: 'get_agent_config' });
 
     return NextResponse.json({
       pageId,
@@ -252,6 +255,8 @@ export async function PATCH(
         updatedFields: Object.keys(updateData),
       });
     }
+
+    logAuditEvent(request, userId, 'write', 'agent_config', pageId, { action: 'update_agent_config', updatedFields: Object.keys(updateData) });
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/pages/[pageId]/ai-usage/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/ai-usage/route.ts
@@ -3,6 +3,7 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db, aiUsageLogs, pages, eq, desc } from '@pagespace/db';
 import { getUserAccessLevel, loggers } from '@pagespace/lib/server';
 import { getContextWindow } from '@pagespace/lib/ai-monitoring';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 
 const AUTH_OPTIONS = { allow: ['session'] as const };
 
@@ -95,6 +96,8 @@ export async function GET(
     const contextUsagePercent = currentContextSize > 0 && contextWindowSize > 0
       ? Math.round((currentContextSize / contextWindowSize) * 100)
       : 0;
+
+    logAuditEvent(request, userId, 'read', 'ai_usage', pageId, { action: 'view_ai_usage', logCount: logs.length });
 
     return NextResponse.json({
       logs,

--- a/apps/web/src/app/api/pages/[pageId]/breadcrumbs/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/breadcrumbs/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { canUserViewPage } from '@pagespace/lib/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { pages, db, drives, sql } from '@pagespace/db';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 
 interface BreadcrumbPage {
   id: string;
@@ -106,5 +107,8 @@ export async function GET(req: Request, { params }: { params: Promise<{ pageId: 
   }
 
   const breadcrumbs = await getBreadcrumbs(pageId);
+
+  logAuditEvent(req, auth.userId, 'read', 'page_breadcrumb', pageId, { action: 'get_breadcrumbs', depth: breadcrumbs.length });
+
   return NextResponse.json(breadcrumbs);
 }

--- a/apps/web/src/app/api/pages/[pageId]/children/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/children/route.ts
@@ -3,6 +3,7 @@ import { pages, taskItems, db, and, eq, asc, isNotNull } from '@pagespace/db';
 import { canUserViewPage, loggers } from '@pagespace/lib/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { jsonResponse } from '@pagespace/lib/api-utils';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false } as const;
 
@@ -40,6 +41,8 @@ export async function GET(req: Request, { params }: { params: Promise<{ pageId: 
       ...child,
       isTaskLinked: taskLinkedSet.has(child.id),
     }));
+
+    logAuditEvent(req, auth.userId, 'read', 'page_children', pageId, { action: 'list_children', count: childrenWithTaskInfo.length });
 
     return jsonResponse(childrenWithTaskInfo);
   } catch (error) {

--- a/apps/web/src/app/api/pages/[pageId]/history/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/history/route.ts
@@ -6,6 +6,7 @@ import { getPageVersionHistory, getUserRetentionDays } from '@/services/api';
 import { isActivityEligibleForRollback } from '@pagespace/lib/permissions';
 import { loggers } from '@pagespace/lib/server';
 import { maskIdentifier } from '@/lib/logging/mask';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 
@@ -112,6 +113,8 @@ export async function GET(
     total,
     retentionDays,
   });
+
+  logAuditEvent(request, userId, 'read', 'page_history', pageId, { action: 'view_history', count: versionsWithRollback.length });
 
   return NextResponse.json({
     versions: versionsWithRollback,

--- a/apps/web/src/app/api/pages/[pageId]/permissions/check/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/permissions/check/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getUserAccessLevel, loggers } from '@pagespace/lib/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false } as const;
 
@@ -18,7 +19,9 @@ export async function GET(
 
   try {
     const permissions = await getUserAccessLevel(auth.userId, pageId);
-    
+
+    logAuditEvent(req, auth.userId, 'read', 'page_permission', pageId, { action: 'check_permissions' });
+
     if (!permissions) {
       return NextResponse.json({
         canView: false,

--- a/apps/web/src/app/api/pages/[pageId]/processing-status/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/processing-status/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { db, pages, eq } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { createPageServiceToken, canUserViewPage } from '@pagespace/lib';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 
 const PROCESSOR_URL = process.env.PROCESSOR_URL || 'http://processor:3003';
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
@@ -44,6 +45,8 @@ export async function GET(
         { status: 404 }
       );
     }
+
+    logAuditEvent(request, userId, 'read', 'page_processing', pageId, { action: 'check_processing_status', status: page.processingStatus });
 
     // Return final status if processing is done
     if (page.processingStatus !== 'pending' && page.processingStatus !== 'processing') {


### PR DESCRIPTION
## Summary
- Add SecurityAuditService coverage to 7 page read sub-routes
- Covers: agent-config (GET+PATCH), ai-usage, breadcrumbs, children, history, permissions/check, processing-status
- All audit calls are fire-and-forget with GDPR-safe details (no PII in hash chain)

## Test plan
- [ ] `pnpm --filter web vitest run src/app/api/__tests__/security-audit-coverage.test.ts` passes
- [ ] Verify no PII in any logAuditEvent details objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)