### PR TITLE
feat(security): audit drive sub-routes

### DIFF
--- a/apps/web/src/app/api/drives/[driveId]/access/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/access/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope } from '@/lib/auth';
 import { updateDriveLastAccessed } from '@pagespace/lib/services/drive-service';
 import { loggers } from '@pagespace/lib/server';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 
@@ -19,6 +20,7 @@ export async function POST(
     if (scopeError) return scopeError;
 
     await updateDriveLastAccessed(auth.userId, driveId);
+    logAuditEvent(request, auth.userId, 'write', 'drive', driveId, { action: 'update_last_accessed' });
     return NextResponse.json({ success: true });
   } catch (error) {
     loggers.api.error('Failed to update drive access time', { error: error instanceof Error ? error.message : String(error) });

--- a/apps/web/src/app/api/drives/[driveId]/agents/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/agents/route.ts
@@ -3,6 +3,7 @@ import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope } from 
 import { db, pages, drives, eq, and } from '@pagespace/db';
 import { getUserDriveAccess, canUserViewPage } from '@pagespace/lib/server';
 import { loggers } from '@pagespace/lib/server';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 
 interface DriveAgentSummary {
   id: string;
@@ -134,6 +135,8 @@ export async function GET(
       accessibleAgents: accessibleAgents.length,
       userId
     });
+
+    logAuditEvent(request, userId, 'read', 'drive_agent', driveId, { action: 'list_agents', count: accessibleAgents.length });
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/drives/[driveId]/assignees/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/assignees/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 import { db, pages, driveMembers, userProfiles, users, drives, eq, and } from '@pagespace/db';
 import { getUserDriveAccess, canUserViewPage } from '@pagespace/lib/server';
 
@@ -158,6 +159,8 @@ export async function GET(
 
     // Count user assignees (members + owner if added separately)
     const userAssigneeCount = assignees.filter((a) => a.type === 'user').length;
+
+    logAuditEvent(request, userId, 'read', 'drive_member', driveId, { action: 'list_assignees', count: assignees.length });
 
     return NextResponse.json({
       assignees,

--- a/apps/web/src/app/api/drives/[driveId]/history/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/history/route.ts
@@ -5,6 +5,7 @@ import { isDriveOwnerOrAdmin } from '@pagespace/lib';
 import { getDriveVersionHistory, getUserRetentionDays } from '@/services/api';
 import { isActivityEligibleForRollback } from '@pagespace/lib/permissions';
 import { loggers } from '@pagespace/lib/server';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 import { maskIdentifier } from '@/lib/logging/mask';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
@@ -109,6 +110,8 @@ export async function GET(
     total,
     retentionDays,
   });
+
+  logAuditEvent(request, userId, 'read', 'drive_history', driveId, { action: 'view_history', count: versionsWithRollback.length });
 
   return NextResponse.json({
     versions: versionsWithRollback,

--- a/apps/web/src/app/api/drives/[driveId]/integrations/audit/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/integrations/audit/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db, count, desc, integrationAuditLog } from '@pagespace/db';
 import { loggers } from '@pagespace/lib/server';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 import { getDriveAccess } from '@pagespace/lib/services/drive-service';
 import { buildAuditLogWhereClause, parseAuditListParams } from './audit-filters';
 
@@ -47,6 +48,8 @@ export async function GET(
     ]);
 
     const total = Number(countResult[0]?.count ?? 0);
+
+    logAuditEvent(request, auth.userId, 'read', 'integration_audit_log', driveId, { action: 'view_integration_audit', count: logs.length });
 
     return NextResponse.json({
       logs: logs.map((log) => ({

--- a/apps/web/src/app/api/drives/[driveId]/integrations/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/integrations/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db } from '@pagespace/db';
 import { loggers } from '@pagespace/lib/server';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 import { getDriveAccess } from '@pagespace/lib/services/drive-service';
 import {
   listDriveConnections,
@@ -64,6 +65,8 @@ export async function GET(
         description: c.provider.description,
       } : null,
     }));
+
+    logAuditEvent(request, auth.userId, 'read', 'drive_integration', driveId, { action: 'list_connections', count: safeConnections.length });
 
     return NextResponse.json({ connections: safeConnections });
   } catch (error) {
@@ -153,6 +156,8 @@ export async function POST(
         state,
       });
 
+      logAuditEvent(request, auth.userId, 'write', 'drive_integration', driveId, { action: 'create_connection', providerId });
+
       return NextResponse.json({ url });
     }
 
@@ -173,6 +178,8 @@ export async function POST(
       connectedBy: auth.userId,
       connectedAt: new Date(),
     });
+
+    logAuditEvent(request, auth.userId, 'write', 'drive_integration', driveId, { action: 'create_connection', providerId });
 
     return NextResponse.json({
       connection: {

--- a/apps/web/src/app/api/drives/[driveId]/pages/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/pages/route.ts
@@ -4,6 +4,7 @@ import { pages, drives, pagePermissions, driveMembers, taskItems, taskLists, db,
 import { loggers } from '@pagespace/lib/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope } from '@/lib/auth';
 import { jsonResponse } from '@pagespace/lib/api-utils';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 
@@ -190,6 +191,7 @@ export async function GET(
     });
 
     const pageTree = buildTree(pagesWithFlags);
+    logAuditEvent(request, userId, 'read', 'drive_page_tree', driveId, { action: 'list_pages', count: pageResults.length });
     return jsonResponse(pageTree);
   } catch (error) {
     loggers.api.error('Error fetching pages:', error as Error);

--- a/apps/web/src/app/api/drives/[driveId]/permissions-tree/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/permissions-tree/route.ts
@@ -3,6 +3,7 @@ import { db, eq, and } from '@pagespace/db';
 import { drives, pages, pagePermissions, driveMembers } from '@pagespace/db';
 import { verifyAuth } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/server';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 
 interface PageNode {
   id: string;
@@ -122,6 +123,8 @@ export async function GET(
       slug: drive[0].slug,
       ownerId: drive[0].ownerId,
     };
+
+    logAuditEvent(request, user.id, 'read', 'drive_permissions', driveId, { action: 'view_permissions_tree', pageCount: allPages.length });
 
     return NextResponse.json({
       drive: driveInfo,

--- a/apps/web/src/app/api/drives/[driveId]/search/glob/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/search/glob/route.ts
@@ -6,6 +6,7 @@ import {
   globSearchPages,
   loggers,
 } from '@pagespace/lib/server';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const };
 
@@ -90,6 +91,8 @@ export async function GET(
       resultCount: searchResults.results.length,
       userId,
     });
+
+    logAuditEvent(request, userId, 'read', 'drive_search', driveId, { action: 'glob_search', resultCount: searchResults.results.length });
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/drives/[driveId]/search/regex/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/search/regex/route.ts
@@ -6,6 +6,7 @@ import {
   regexSearchPages,
   loggers,
 } from '@pagespace/lib/server';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const };
 
@@ -80,6 +81,8 @@ export async function GET(
       resultCount: searchResults.results.length,
       userId,
     });
+
+    logAuditEvent(request, userId, 'read', 'drive_search', driveId, { action: 'regex_search', resultCount: searchResults.results.length });
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/drives/[driveId]/trash/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/trash/route.ts
@@ -3,6 +3,7 @@ import { drives, pages, driveMembers, db, and, eq, asc } from '@pagespace/db';
 import { buildTree } from '@pagespace/lib/server';
 import { loggers } from '@pagespace/lib/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope } from '@/lib/auth';
+import { logAuditEvent } from '@/lib/audit/route-audit';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const };
 
@@ -70,6 +71,8 @@ export async function GET(request: Request, context: { params: Promise<DrivePara
     });
 
     const tree = buildTree(trashedPages);
+
+    logAuditEvent(request, auth.userId, 'read', 'drive_trash', driveId, { action: 'list_trashed_pages', count: trashedPages.length });
 
     return NextResponse.json(tree);
   } catch (error) {


### PR DESCRIPTION
## Summary
- Add SecurityAuditService coverage to 11 drive sub-routes
- Covers: access, agents, assignees, history, integrations, integrations/audit, pages, permissions-tree, search/glob, search/regex, trash
- All audit calls are fire-and-forget with GDPR-safe details (no PII in hash chain)

## Test plan
- [ ] `pnpm --filter web vitest run src/app/api/__tests__/security-audit-coverage.test.ts` passes
- [ ] Verify no PII in any logAuditEvent details objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)