### PR TITLE
feat(security): audit wave 2 — miscellaneous routes

### DIFF
--- a/apps/web/src/app/api/account/drives-status/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/drives-status/__tests__/route.test.ts
@@ -35,6 +35,10 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
+  securityAudit: {
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+  },
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -43,7 +47,7 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 import { db } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 
 // Helper to create mock SessionAuthResult
@@ -285,6 +289,21 @@ describe('GET /api/account/drives-status', () => {
     // 0 members should be treated as solo (auto-delete)
     expect(body.soloDrives).toHaveLength(1);
     expect(body.multiMemberDrives).toEqual([]);
+  });
+
+  it('logs audit event on successful GET', async () => {
+    vi.mocked(db.query.drives.findMany).mockResolvedValue([
+      mockDrive({ id: 'drive_solo', name: 'My Drive' }),
+    ]);
+    setupSelectMocks(1);
+
+    const request = new Request('https://example.com/api/account/drives-status');
+    await GET(request);
+
+    expect(securityAudit.logDataAccess).toHaveBeenCalledWith(
+      mockUserId, 'read', 'account_drives_status', mockUserId,
+      expect.objectContaining({ operation: 'drives_status_check' })
+    );
   });
 
   it('should correctly count multiple admins in multi-member drive', async () => {

--- a/apps/web/src/app/api/account/drives-status/route.ts
+++ b/apps/web/src/app/api/account/drives-status/route.ts
@@ -1,5 +1,5 @@
 import { db, eq, and, sql, drives, driveMembers, users } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
@@ -90,6 +90,8 @@ export async function GET(req: Request) {
         });
       }
     }
+
+    securityAudit.logDataAccess(userId, 'read', 'account_drives_status', userId, { operation: 'drives_status_check' }).catch(e => loggers.auth.warn('Audit log failed', e));
 
     return Response.json({
       soloDrives,

--- a/apps/web/src/app/api/account/verification-status/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/verification-status/__tests__/route.test.ts
@@ -5,6 +5,21 @@ vi.mock('@/lib/auth', () => ({
   verifyAuth: vi.fn(),
 }));
 
+vi.mock('@pagespace/lib/server', () => ({
+  loggers: {
+    auth: {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    },
+  },
+  securityAudit: {
+    logEvent: vi.fn().mockResolvedValue(undefined),
+    logDataAccess: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
 vi.mock('@pagespace/db', () => ({
   db: {
     select: vi.fn(),
@@ -16,6 +31,7 @@ vi.mock('@pagespace/db', () => ({
 import { GET } from '../route';
 import { verifyAuth } from '@/lib/auth';
 import { db } from '@pagespace/db';
+import { securityAudit } from '@pagespace/lib/server';
 
 // Test helpers
 const createRequest = () =>
@@ -84,6 +100,24 @@ describe('GET /api/account/verification-status', () => {
 
       expect(response.status).toBe(200);
       expect(body.emailVerified).toBe(verifiedDate.toISOString());
+    });
+
+    it('logs audit event on successful GET', async () => {
+      vi.mocked(verifyAuth).mockResolvedValue({
+        id: 'user-1',
+        role: 'user',
+        tokenVersion: 0,
+        adminRoleVersion: 0,
+        authTransport: 'cookie',
+      });
+      mockSelectChain([{ emailVerified: new Date() }]);
+
+      await GET(createRequest());
+
+      expect(securityAudit.logDataAccess).toHaveBeenCalledWith(
+        'user-1', 'read', 'account_verification_status', 'user-1',
+        expect.objectContaining({ operation: 'verification_status_check' })
+      );
     });
 
     it('returns null emailVerified for unverified user', async () => {

--- a/apps/web/src/app/api/account/verification-status/route.ts
+++ b/apps/web/src/app/api/account/verification-status/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { verifyAuth } from '@/lib/auth';
 import { db, users, eq } from '@pagespace/db';
+import { loggers, securityAudit } from '@pagespace/lib/server';
 
 export async function GET(request: Request) {
   try {
@@ -19,6 +20,8 @@ export async function GET(request: Request) {
     if (!user) {
       return NextResponse.json({ error: 'User not found' }, { status: 404 });
     }
+
+    securityAudit.logDataAccess(authUser.id, 'read', 'account_verification_status', authUser.id, { operation: 'verification_status_check' }).catch(e => loggers.auth.warn('Audit log failed', e));
 
     return NextResponse.json({ emailVerified: user.emailVerified });
   } catch (error) {


### PR DESCRIPTION
## Summary
- Add `securityAudit.logDataAccess` to **2 remaining uncovered authenticated routes**:
  - `account/drives-status` (GET) — logs read of drive ownership/membership data
  - `account/verification-status` (GET) — logs read of email verification status
- TDD: wrote failing tests first, then added minimal audit calls to make them pass
- All other uncovered routes are correctly on the skip list (health, webhooks, public assets, read receipts, internal/monitoring, dev-only)

## Routes skipped (documented)
`/health`, `/track`, `/pulse/*`, `/internal/*`, `/monitoring/*`, `/compiled-css`, `/debug/*`, `/avatar/[userId]/[filename]`, `/desktop-bridge/status`, `/provisioning-status/*`, `/notifications/[id]/read`, `/notifications/read-all`, `/channels/[pageId]/read`, `/contact`, `/stripe/webhook`, `/integrations/google-calendar/webhook`, `/memory/cron` (HMAC-signed cron, no user session)

## Test plan
- [x] RED: Wrote failing audit test for each route — verified test fails (route doesn't call securityAudit yet)
- [x] GREEN: Added minimal `securityAudit.logDataAccess` call — verified test passes
- [x] All 153 account route tests pass
- [x] 3172/3184 API tests pass (12 pre-existing failures in unrelated admin/ollama tests)
- [x] `pnpm typecheck` passes (all 12 tasks successful)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented comprehensive security audit logging across account status endpoints to track and record all data access events and user operations with detailed metadata.

* **Tests**
  * Added test coverage to verify audit logging is triggered correctly on account endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->