### PR TITLE
feat(security): functional audit pipeline + standalone query

### DIFF
--- a/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
+++ b/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
@@ -21,7 +21,7 @@ const API_DIR = join(__dirname, '..');
  * adapter, logSecurityEvent adapter, and withAdminAuth wrapper.
  */
 const AUDIT_CALL_PATTERN =
-  /securityAudit\.|logAuditEvent\(|logAuthEvent\(|logSecurityEvent\(|withAdminAuth[<(]/;
+  /securityAudit\.|logAuditEvent\(|logAuthEvent\(|logSecurityEvent\(|withAdminAuth[<(]|audit\(|auditRequest\(/;
 
 /**
  * Routes explicitly exempt from audit coverage.

--- a/packages/lib/src/audit/__tests__/audit-log.test.ts
+++ b/packages/lib/src/audit/__tests__/audit-log.test.ts
@@ -277,6 +277,67 @@ describe('auditRequest()', () => {
     );
   });
 
+  it('given empty x-forwarded-for header, should fall back to x-real-ip', () => {
+    const req = new Request('http://localhost/api/test', {
+      headers: {
+        'x-forwarded-for': '',
+        'x-real-ip': '192.168.1.1',
+        'user-agent': 'TestAgent/1.0',
+      },
+    });
+
+    auditRequest(req, {
+      eventType: 'data.read',
+      userId: 'user-1',
+    });
+
+    expect(mockSecurityAudit.logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ipAddress: '192.168.1.1',
+      })
+    );
+  });
+
+  it('given whitespace-only x-forwarded-for, should fall back to x-real-ip', () => {
+    const req = new Request('http://localhost/api/test', {
+      headers: {
+        'x-forwarded-for': '  ',
+        'x-real-ip': '172.16.0.1',
+        'user-agent': 'TestAgent/1.0',
+      },
+    });
+
+    auditRequest(req, {
+      eventType: 'data.read',
+      userId: 'user-1',
+    });
+
+    expect(mockSecurityAudit.logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ipAddress: '172.16.0.1',
+      })
+    );
+  });
+
+  it('given empty user-agent header, should use "unknown"', () => {
+    const req = new Request('http://localhost/api/test', {
+      headers: {
+        'user-agent': '',
+      },
+    });
+
+    auditRequest(req, {
+      eventType: 'data.read',
+      userId: 'user-1',
+    });
+
+    expect(mockSecurityAudit.logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userAgent: 'unknown',
+      })
+    );
+  });
+
   it('given a Request and event, should delegate to audit() for dual-write', () => {
     const req = new Request('http://localhost/api/test', {
       headers: { 'user-agent': 'TestAgent/1.0' },

--- a/packages/lib/src/audit/__tests__/audit-log.test.ts
+++ b/packages/lib/src/audit/__tests__/audit-log.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Hoisted mocks — shared state accessible from vi.mock factories
+const { mockLoggers, mockSecurityAudit } = vi.hoisted(() => ({
+  mockLoggers: {
+    security: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  },
+  mockSecurityAudit: {
+    logEvent: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock('../../logging/logger-config', () => ({
+  loggers: mockLoggers,
+}));
+
+vi.mock('../security-audit', () => ({
+  securityAudit: mockSecurityAudit,
+}));
+
+vi.mock('@pagespace/db', () => ({
+  securityAuditLog: {},
+}));
+
+import { audit, auditRequest } from '../audit-log';
+
+describe('audit()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSecurityAudit.logEvent.mockResolvedValue(undefined);
+  });
+
+  it('given an AuditEvent, should write to structured logger', () => {
+    audit({
+      eventType: 'auth.login.success',
+      userId: 'user-1',
+    });
+
+    expect(mockLoggers.security.info).toHaveBeenCalledWith(
+      expect.stringContaining('auth.login.success'),
+      expect.objectContaining({ eventType: 'auth.login.success', userId: 'user-1' })
+    );
+  });
+
+  it('given an AuditEvent, should write to tamper-evident audit DB', () => {
+    audit({
+      eventType: 'auth.login.success',
+      userId: 'user-1',
+    });
+
+    expect(mockSecurityAudit.logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'auth.login.success',
+        userId: 'user-1',
+      })
+    );
+  });
+
+  it('given riskScore >= 0.5, should log at warn level', () => {
+    audit({
+      eventType: 'authz.access.denied',
+      userId: 'user-1',
+      riskScore: 0.5,
+    });
+
+    expect(mockLoggers.security.warn).toHaveBeenCalled();
+    expect(mockLoggers.security.info).not.toHaveBeenCalled();
+  });
+
+  it('given riskScore < 0.5, should log at info level', () => {
+    audit({
+      eventType: 'auth.login.success',
+      userId: 'user-1',
+      riskScore: 0.3,
+    });
+
+    expect(mockLoggers.security.info).toHaveBeenCalled();
+    expect(mockLoggers.security.warn).not.toHaveBeenCalled();
+  });
+
+  it('given no riskScore, should log at info level', () => {
+    audit({
+      eventType: 'data.read',
+      userId: 'user-1',
+    });
+
+    expect(mockLoggers.security.info).toHaveBeenCalled();
+    expect(mockLoggers.security.warn).not.toHaveBeenCalled();
+  });
+
+  it('given the DB throws, should catch and log warning without throwing', async () => {
+    mockSecurityAudit.logEvent.mockRejectedValueOnce(new Error('DB down'));
+
+    // Should not throw
+    audit({
+      eventType: 'auth.login.success',
+      userId: 'user-1',
+    });
+
+    await vi.waitFor(() => {
+      expect(mockLoggers.security.warn).toHaveBeenCalledWith(
+        expect.stringContaining('audit write failed'),
+        expect.objectContaining({ error: expect.any(Error) })
+      );
+    });
+  });
+
+  it('given an event with all fields, should pass them through to the DB', () => {
+    audit({
+      eventType: 'data.write',
+      userId: 'user-1',
+      sessionId: 'sess-1',
+      serviceId: 'web',
+      resourceType: 'page',
+      resourceId: 'page-1',
+      ipAddress: '1.2.3.4',
+      userAgent: 'Mozilla/5.0',
+      details: { action: 'update' },
+      riskScore: 0.1,
+      anomalyFlags: ['new_device'],
+    });
+
+    expect(mockSecurityAudit.logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'data.write',
+        userId: 'user-1',
+        sessionId: 'sess-1',
+        serviceId: 'web',
+        resourceType: 'page',
+        resourceId: 'page-1',
+        ipAddress: '1.2.3.4',
+        userAgent: 'Mozilla/5.0',
+        details: { action: 'update' },
+        riskScore: 0.1,
+        anomalyFlags: ['new_device'],
+      })
+    );
+  });
+});
+
+describe('auditRequest()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSecurityAudit.logEvent.mockResolvedValue(undefined);
+  });
+
+  it('given a Request, should extract ipAddress from x-forwarded-for header', () => {
+    const req = new Request('http://localhost/api/test', {
+      headers: {
+        'x-forwarded-for': '10.0.0.1, 10.0.0.2',
+        'user-agent': 'TestAgent/1.0',
+      },
+    });
+
+    auditRequest(req, {
+      eventType: 'data.read',
+      userId: 'user-1',
+      resourceType: 'page',
+      resourceId: 'page-1',
+    });
+
+    expect(mockSecurityAudit.logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ipAddress: '10.0.0.1',
+      })
+    );
+  });
+
+  it('given no x-forwarded-for, should fall back to x-real-ip', () => {
+    const req = new Request('http://localhost/api/test', {
+      headers: {
+        'x-real-ip': '192.168.1.1',
+        'user-agent': 'TestAgent/1.0',
+      },
+    });
+
+    auditRequest(req, {
+      eventType: 'data.read',
+      userId: 'user-1',
+    });
+
+    expect(mockSecurityAudit.logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ipAddress: '192.168.1.1',
+      })
+    );
+  });
+
+  it('given no IP headers, should use "unknown"', () => {
+    const req = new Request('http://localhost/api/test', {
+      headers: { 'user-agent': 'TestAgent/1.0' },
+    });
+
+    auditRequest(req, {
+      eventType: 'data.read',
+      userId: 'user-1',
+    });
+
+    expect(mockSecurityAudit.logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ipAddress: 'unknown',
+      })
+    );
+  });
+
+  it('given a Request, should extract userAgent from headers', () => {
+    const req = new Request('http://localhost/api/test', {
+      headers: { 'user-agent': 'Mozilla/5.0 Chrome' },
+    });
+
+    auditRequest(req, {
+      eventType: 'data.read',
+      userId: 'user-1',
+    });
+
+    expect(mockSecurityAudit.logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userAgent: 'Mozilla/5.0 Chrome',
+      })
+    );
+  });
+
+  it('given no user-agent header, should use "unknown"', () => {
+    const req = new Request('http://localhost/api/test');
+
+    auditRequest(req, {
+      eventType: 'data.read',
+      userId: 'user-1',
+    });
+
+    expect(mockSecurityAudit.logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userAgent: 'unknown',
+      })
+    );
+  });
+
+  it('given event already has ipAddress, should not override with header value', () => {
+    const req = new Request('http://localhost/api/test', {
+      headers: {
+        'x-forwarded-for': '10.0.0.1',
+        'user-agent': 'TestAgent/1.0',
+      },
+    });
+
+    auditRequest(req, {
+      eventType: 'data.read',
+      userId: 'user-1',
+      ipAddress: '99.99.99.99',
+    });
+
+    expect(mockSecurityAudit.logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ipAddress: '99.99.99.99',
+      })
+    );
+  });
+
+  it('given event already has userAgent, should not override with header value', () => {
+    const req = new Request('http://localhost/api/test', {
+      headers: {
+        'x-forwarded-for': '10.0.0.1',
+        'user-agent': 'FromHeader/1.0',
+      },
+    });
+
+    auditRequest(req, {
+      eventType: 'data.read',
+      userId: 'user-1',
+      userAgent: 'ExplicitAgent/2.0',
+    });
+
+    expect(mockSecurityAudit.logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userAgent: 'ExplicitAgent/2.0',
+      })
+    );
+  });
+
+  it('given a Request and event, should delegate to audit() for dual-write', () => {
+    const req = new Request('http://localhost/api/test', {
+      headers: { 'user-agent': 'TestAgent/1.0' },
+    });
+
+    auditRequest(req, {
+      eventType: 'security.rate.limited',
+      riskScore: 0.5,
+    });
+
+    // Should log at warn level (riskScore >= 0.5) AND write to DB
+    expect(mockLoggers.security.warn).toHaveBeenCalled();
+    expect(mockSecurityAudit.logEvent).toHaveBeenCalled();
+  });
+});

--- a/packages/lib/src/audit/__tests__/audit-query.test.ts
+++ b/packages/lib/src/audit/__tests__/audit-query.test.ts
@@ -107,4 +107,26 @@ describe('queryAuditEvents()', () => {
 
     expect(eq).toHaveBeenCalledWith(mockSecurityAuditLog.ipAddress, '10.0.0.1');
   });
+
+  it('given limit: 0, should apply limit(0) to query', async () => {
+    mockDb._chain.orderBy.mockReturnValue({ limit: mockDb._chain.limit });
+    mockDb._chain.limit.mockResolvedValue([]);
+
+    const result = await queryAuditEvents({ limit: 0 });
+
+    expect(mockDb._chain.limit).toHaveBeenCalledWith(0);
+    expect(result).toEqual([]);
+  });
+
+  it('given negative limit, should throw an error', async () => {
+    await expect(queryAuditEvents({ limit: -1 })).rejects.toThrow(
+      'limit must be a non-negative integer'
+    );
+  });
+
+  it('given non-integer limit, should throw an error', async () => {
+    await expect(queryAuditEvents({ limit: 1.5 })).rejects.toThrow(
+      'limit must be a non-negative integer'
+    );
+  });
 });

--- a/packages/lib/src/audit/__tests__/audit-query.test.ts
+++ b/packages/lib/src/audit/__tests__/audit-query.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockDb, mockSecurityAuditLog } = vi.hoisted(() => {
+  const mockLimit = vi.fn();
+  const mockOrderBy = vi.fn().mockReturnValue({ limit: mockLimit });
+  const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
+  const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+  const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
+
+  return {
+    mockDb: {
+      select: mockSelect,
+      _chain: { select: mockSelect, from: mockFrom, where: mockWhere, orderBy: mockOrderBy, limit: mockLimit },
+    },
+    mockSecurityAuditLog: {
+      userId: 'userId',
+      eventType: 'eventType',
+      resourceType: 'resourceType',
+      resourceId: 'resourceId',
+      ipAddress: 'ipAddress',
+      timestamp: 'timestamp',
+    },
+  };
+});
+
+vi.mock('@pagespace/db', () => ({
+  db: mockDb,
+  securityAuditLog: mockSecurityAuditLog,
+  desc: vi.fn((col: string) => `desc(${col})`),
+  and: vi.fn((...args: unknown[]) => ({ and: args })),
+  gte: vi.fn((col: string, val: unknown) => ({ gte: [col, val] })),
+  lte: vi.fn((col: string, val: unknown) => ({ lte: [col, val] })),
+  eq: vi.fn((col: string, val: unknown) => ({ eq: [col, val] })),
+}));
+
+import { queryAuditEvents } from '../audit-query';
+import { eq, gte, lte } from '@pagespace/db';
+
+describe('queryAuditEvents()', () => {
+  const mockEvents = [
+    { id: 'evt-1', eventType: 'auth.login.success', userId: 'user-1' },
+    { id: 'evt-2', eventType: 'auth.logout', userId: 'user-1' },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset the chain: orderBy resolves to mockEvents by default (no limit)
+    mockDb._chain.orderBy.mockResolvedValue(mockEvents);
+    mockDb._chain.limit.mockResolvedValue(mockEvents);
+    mockDb._chain.where.mockReturnValue({ orderBy: mockDb._chain.orderBy });
+    mockDb._chain.from.mockReturnValue({ where: mockDb._chain.where });
+    mockDb._chain.select.mockReturnValue({ from: mockDb._chain.from });
+  });
+
+  it('given no filters, should return all events ordered by timestamp desc', async () => {
+    const result = await queryAuditEvents({});
+
+    expect(mockDb.select).toHaveBeenCalled();
+    expect(result).toEqual(mockEvents);
+  });
+
+  it('given userId filter, should apply eq condition on userId', async () => {
+    await queryAuditEvents({ userId: 'user-1' });
+
+    expect(eq).toHaveBeenCalledWith(mockSecurityAuditLog.userId, 'user-1');
+  });
+
+  it('given eventType filter, should apply eq condition on eventType', async () => {
+    await queryAuditEvents({ eventType: 'auth.login.failure' });
+
+    expect(eq).toHaveBeenCalledWith(mockSecurityAuditLog.eventType, 'auth.login.failure');
+  });
+
+  it('given fromTimestamp filter, should apply gte condition', async () => {
+    const from = new Date('2026-01-01');
+    await queryAuditEvents({ fromTimestamp: from });
+
+    expect(gte).toHaveBeenCalledWith(mockSecurityAuditLog.timestamp, from);
+  });
+
+  it('given toTimestamp filter, should apply lte condition', async () => {
+    const to = new Date('2026-01-31');
+    await queryAuditEvents({ toTimestamp: to });
+
+    expect(lte).toHaveBeenCalledWith(mockSecurityAuditLog.timestamp, to);
+  });
+
+  it('given limit, should apply limit to query', async () => {
+    mockDb._chain.orderBy.mockReturnValue({ limit: mockDb._chain.limit });
+    mockDb._chain.limit.mockResolvedValue([mockEvents[0]]);
+
+    const result = await queryAuditEvents({ limit: 1 });
+
+    expect(mockDb._chain.limit).toHaveBeenCalledWith(1);
+    expect(result).toEqual([mockEvents[0]]);
+  });
+
+  it('given resourceType and resourceId filters, should apply both conditions', async () => {
+    await queryAuditEvents({ resourceType: 'page', resourceId: 'page-1' });
+
+    expect(eq).toHaveBeenCalledWith(mockSecurityAuditLog.resourceType, 'page');
+    expect(eq).toHaveBeenCalledWith(mockSecurityAuditLog.resourceId, 'page-1');
+  });
+
+  it('given ipAddress filter, should apply eq condition on ipAddress', async () => {
+    await queryAuditEvents({ ipAddress: '10.0.0.1' });
+
+    expect(eq).toHaveBeenCalledWith(mockSecurityAuditLog.ipAddress, '10.0.0.1');
+  });
+});

--- a/packages/lib/src/audit/audit-log.ts
+++ b/packages/lib/src/audit/audit-log.ts
@@ -1,0 +1,46 @@
+/**
+ * Functional Audit Pipeline
+ *
+ * Composed functions that always dual-write to both the structured logger
+ * and the tamper-evident audit DB. Replaces the scattered pattern of
+ * choosing between logAuthEvent, logSecurityEvent, securityAudit, and logAuditEvent.
+ */
+
+import { securityAudit, type AuditEvent } from './security-audit';
+import { loggers } from '../logging/logger-config';
+
+/**
+ * Dual-write an audit event to the structured logger and audit DB.
+ * Fire-and-forget: DB errors are caught and logged as warnings.
+ */
+export function audit(event: AuditEvent): void {
+  const level = (event.riskScore ?? 0) >= 0.5 ? 'warn' : 'info';
+  loggers.security[level](`[Audit] ${event.eventType}`, { ...event });
+
+  securityAudit.logEvent(event).catch((error: unknown) => {
+    loggers.security.warn('[Audit] audit write failed', {
+      error: error instanceof Error ? error : new Error(String(error)),
+      eventType: event.eventType,
+    });
+  });
+}
+
+/**
+ * Dual-write an audit event with automatic request metadata extraction.
+ * Extracts ipAddress and userAgent from the Request headers unless
+ * already provided on the event.
+ */
+export function auditRequest(request: Request, event: AuditEvent): void {
+  const ipAddress =
+    event.ipAddress ??
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+    request.headers.get('x-real-ip') ??
+    'unknown';
+
+  const userAgent =
+    event.userAgent ??
+    request.headers.get('user-agent') ??
+    'unknown';
+
+  audit({ ...event, ipAddress, userAgent });
+}

--- a/packages/lib/src/audit/audit-log.ts
+++ b/packages/lib/src/audit/audit-log.ts
@@ -31,15 +31,19 @@ export function audit(event: AuditEvent): void {
  * already provided on the event.
  */
 export function auditRequest(request: Request, event: AuditEvent): void {
+  const forwardedFor = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim();
+  const realIp = request.headers.get('x-real-ip')?.trim();
+  const headerUserAgent = request.headers.get('user-agent')?.trim();
+
   const ipAddress =
     event.ipAddress ??
-    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
-    request.headers.get('x-real-ip') ??
+    (forwardedFor || undefined) ??
+    (realIp || undefined) ??
     'unknown';
 
   const userAgent =
     event.userAgent ??
-    request.headers.get('user-agent') ??
+    (headerUserAgent || undefined) ??
     'unknown';
 
   audit({ ...event, ipAddress, userAgent });

--- a/packages/lib/src/audit/audit-query.ts
+++ b/packages/lib/src/audit/audit-query.ts
@@ -52,7 +52,10 @@ export async function queryAuditEvents(
     .where(conditions.length > 0 ? and(...conditions) : undefined)
     .orderBy(desc(securityAuditLog.timestamp));
 
-  if (options.limit) {
+  if (options.limit !== undefined) {
+    if (!Number.isInteger(options.limit) || options.limit < 0) {
+      throw new Error('limit must be a non-negative integer');
+    }
     return baseQuery.limit(options.limit);
   }
 

--- a/packages/lib/src/audit/audit-query.ts
+++ b/packages/lib/src/audit/audit-query.ts
@@ -1,0 +1,60 @@
+/**
+ * Standalone audit query function.
+ *
+ * Extracts the query logic from SecurityAuditService into a plain function
+ * so callers don't need a class instance or initialization ceremony.
+ */
+
+import { db, securityAuditLog, desc, and, gte, lte, eq } from '@pagespace/db';
+import type { SelectSecurityAuditLog } from '@pagespace/db';
+import type { QueryEventsOptions } from './security-audit';
+
+/**
+ * Query audit events with filtering options.
+ * Standalone equivalent of SecurityAuditService.queryEvents().
+ */
+export async function queryAuditEvents(
+  options: QueryEventsOptions
+): Promise<SelectSecurityAuditLog[]> {
+  const conditions = [];
+
+  if (options.userId) {
+    conditions.push(eq(securityAuditLog.userId, options.userId));
+  }
+
+  if (options.eventType) {
+    conditions.push(eq(securityAuditLog.eventType, options.eventType));
+  }
+
+  if (options.resourceType) {
+    conditions.push(eq(securityAuditLog.resourceType, options.resourceType));
+  }
+
+  if (options.resourceId) {
+    conditions.push(eq(securityAuditLog.resourceId, options.resourceId));
+  }
+
+  if (options.ipAddress) {
+    conditions.push(eq(securityAuditLog.ipAddress, options.ipAddress));
+  }
+
+  if (options.fromTimestamp) {
+    conditions.push(gte(securityAuditLog.timestamp, options.fromTimestamp));
+  }
+
+  if (options.toTimestamp) {
+    conditions.push(lte(securityAuditLog.timestamp, options.toTimestamp));
+  }
+
+  const baseQuery = db
+    .select()
+    .from(securityAuditLog)
+    .where(conditions.length > 0 ? and(...conditions) : undefined)
+    .orderBy(desc(securityAuditLog.timestamp));
+
+  if (options.limit) {
+    return baseQuery.limit(options.limit);
+  }
+
+  return baseQuery;
+}

--- a/packages/lib/src/audit/index.ts
+++ b/packages/lib/src/audit/index.ts
@@ -19,6 +19,10 @@ export {
 
 export { auditSafe } from './audit-safe';
 
+export { audit, auditRequest } from './audit-log';
+
+export { queryAuditEvents } from './audit-query';
+
 export {
   verifyAndAlert,
   setChainAlertHandler,

--- a/packages/lib/src/audit/security-audit.ts
+++ b/packages/lib/src/audit/security-audit.ts
@@ -16,8 +16,9 @@
  */
 
 import { createHash } from 'crypto';
-import { db, securityAuditLog, desc, and, gte, lte, eq, sql } from '@pagespace/db';
+import { db, securityAuditLog, desc, sql } from '@pagespace/db';
 import type { SecurityEventType, SelectSecurityAuditLog } from '@pagespace/db';
+import { queryAuditEvents } from './audit-query';
 
 /**
  * Audit event input structure
@@ -400,53 +401,10 @@ export class SecurityAuditService {
 
   /**
    * Query audit events with filtering options.
-   *
-   * @param options - Query filtering options
-   * @returns Array of matching audit events
+   * Delegates to the standalone queryAuditEvents() function.
    */
   async queryEvents(options: QueryEventsOptions): Promise<SelectSecurityAuditLog[]> {
-    const conditions = [];
-
-    if (options.userId) {
-      conditions.push(eq(securityAuditLog.userId, options.userId));
-    }
-
-    if (options.eventType) {
-      conditions.push(eq(securityAuditLog.eventType, options.eventType));
-    }
-
-    if (options.resourceType) {
-      conditions.push(eq(securityAuditLog.resourceType, options.resourceType));
-    }
-
-    if (options.resourceId) {
-      conditions.push(eq(securityAuditLog.resourceId, options.resourceId));
-    }
-
-    if (options.ipAddress) {
-      conditions.push(eq(securityAuditLog.ipAddress, options.ipAddress));
-    }
-
-    if (options.fromTimestamp) {
-      conditions.push(gte(securityAuditLog.timestamp, options.fromTimestamp));
-    }
-
-    if (options.toTimestamp) {
-      conditions.push(lte(securityAuditLog.timestamp, options.toTimestamp));
-    }
-
-    const baseQuery = db
-      .select()
-      .from(securityAuditLog)
-      .where(conditions.length > 0 ? and(...conditions) : undefined)
-      .orderBy(desc(securityAuditLog.timestamp));
-
-    // Apply limit if specified
-    if (options.limit) {
-      return baseQuery.limit(options.limit);
-    }
-
-    return baseQuery;
+    return queryAuditEvents(options);
   }
 
   /**

--- a/packages/lib/src/server.ts
+++ b/packages/lib/src/server.ts
@@ -44,7 +44,7 @@ export * from './auth/oauth-types';
 export * from './logging';
 
 // Security audit adapter (server-only)
-export { auditAuthEvent, auditSecurityEvent, auditSafe, maskEmail, securityAudit } from './audit';
+export { auditAuthEvent, auditSecurityEvent, auditSafe, maskEmail, securityAudit, audit, auditRequest, queryAuditEvents } from './audit';
 
 // Monitoring (activity logging, AI monitoring)
 export * from './monitoring';


### PR DESCRIPTION
## Summary
- Add `audit()` and `auditRequest()` — dual-write functions that log to both the structured logger and tamper-evident audit DB, with automatic IP/user-agent extraction from request headers
- Add standalone `queryAuditEvents()` function and deduplicate `SecurityAuditService.queryEvents()` to delegate to it
- Update security-audit-coverage gate regex to recognize the new `audit()` / `auditRequest()` API
- Add 28 tests covering all paths (risk-level branching, header fallback chains, override-wins, DB failure resilience, query filters, empty header normalization, limit validation)

## Review feedback addressed
- **Empty header normalization** (Codex + CodeRabbit): Header values are now pre-extracted, trimmed, and normalized via `(value || undefined)` so the `??` fallback chain correctly falls through for empty/whitespace strings
- **Limit validation** (CodeRabbit): `limit: 0` is now correctly applied; negative/non-integer limits throw a clear error

## Test plan
- [x] 107/107 audit module tests pass
- [x] Full monorepo build succeeds (13/13 tasks)
- [x] `auditRequest()` correctly extracts IP from `x-forwarded-for` (first entry), falls back to `x-real-ip`, then `"unknown"`
- [x] Empty/whitespace headers correctly fall through to next fallback
- [x] Pre-set `ipAddress`/`userAgent` on the event are not overridden by headers
- [x] `audit()` logs at warn level when `riskScore >= 0.5`, info otherwise
- [x] DB write failures are caught and logged without throwing
- [x] Coverage gate recognizes `audit(` and `auditRequest(` patterns
- [x] `queryAuditEvents({ limit: 0 })` correctly applies limit
- [x] Negative/non-integer limits throw clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audit logging and request-aware audit functions with automatic persistence.
  * Added audit-event query API to retrieve and filter historical security audit records.
* **Tests**
  * New test suites covering audit logging, request enrichment, query behavior, and resilience on write failures.
  * Updated security-audit coverage check to recognize additional audit call patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->