### PR TITLE
feat(security): audit mcp-ws route via unified audit() pipeline

### DIFF
--- a/apps/web/src/app/api/mcp-ws/__tests__/route.security.test.ts
+++ b/apps/web/src/app/api/mcp-ws/__tests__/route.security.test.ts
@@ -75,7 +75,7 @@ vi.mock('@pagespace/lib/server', () => ({
     security: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
     api: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
   },
-  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 import {
@@ -88,7 +88,7 @@ import {
   validateMessageSize,
 } from '@/lib/websocket';
 import { sessionService } from '@pagespace/lib';
-import { audit } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/server';
 
 // Mock session expiry (1 hour from now)
 const mockSessionExpiry = new Date(Date.now() + 60 * 60 * 1000);
@@ -188,12 +188,11 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
       await UPGRADE(mockClient, mockServer, mockRequest);
 
       expect(mockClient.close).toHaveBeenCalledWith(1008, 'Insufficient permissions');
-      expect(audit).toHaveBeenCalledWith(
+      expect(auditRequest).toHaveBeenCalledWith(
+        mockRequest,
         expect.objectContaining({
           eventType: 'authz.access.denied',
           userId: 'user_123',
-          ipAddress: '192.168.1.1',
-          userAgent: 'Mozilla/5.0 Test',
           resourceType: 'mcp_websocket',
           riskScore: 0.5,
           details: expect.objectContaining({
@@ -228,7 +227,7 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
       }
     });
 
-    it('should not leak sensitive data in logs', async () => {
+    it('should not leak sensitive data into audit events or console', async () => {
       const consoleSpy = vi.spyOn(console, 'log');
       const errorSpy = vi.spyOn(console, 'error');
 
@@ -246,13 +245,22 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
       const { UPGRADE } = await import('../route');
       await UPGRADE(mockClient, mockServer, mockRequest);
 
-      const allLogs = [
+      const sensitivePattern = /password|secret|api[_-]?key|bearer|svc_mock_opaque_token|token(?!Version)/i;
+
+      // Assert audit payloads do not carry raw token/secret values (these now
+      // flow through auditRequest(), which is mocked — spying on console alone
+      // would miss any regression that pipes raw credentials into audit details).
+      const auditSerialized = vi
+        .mocked(auditRequest)
+        .mock.calls.map((call) => JSON.stringify(call[1]))
+        .join(' ');
+      expect(auditSerialized).not.toMatch(sensitivePattern);
+
+      const allConsoleLogs = [
         ...consoleSpy.mock.calls.flat(),
         ...errorSpy.mock.calls.flat(),
       ].join(' ');
-
-      // Should not contain tokens, API keys, passwords
-      expect(allLogs).not.toMatch(/password|secret|key|token(?!Version)/i);
+      expect(allConsoleLogs).not.toMatch(sensitivePattern);
 
       consoleSpy.mockRestore();
       errorSpy.mockRestore();
@@ -305,11 +313,12 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
       const pingMessage = JSON.stringify({ type: 'ping' });
       messageHandler!.call(mockClient, Buffer.from(pingMessage));
 
-      expect(audit).toHaveBeenCalledWith(
+      expect(auditRequest).toHaveBeenCalledWith(
+        mockRequest,
         expect.objectContaining({
           eventType: 'security.anomaly.detected',
           userId: 'user_123',
-          ipAddress: '192.168.1.1',
+          resourceType: 'mcp_websocket',
           riskScore: 0.7,
           details: expect.objectContaining({
             originalEvent: 'ws_fingerprint_mismatch',
@@ -329,10 +338,11 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
       const { UPGRADE } = await import('../route');
       await UPGRADE(mockClient, mockServer, mockRequest);
 
-      expect(audit).toHaveBeenCalledWith(
+      expect(auditRequest).toHaveBeenCalledWith(
+        mockRequest,
         expect.objectContaining({
           eventType: 'auth.login.failure',
-          ipAddress: '192.168.1.1',
+          resourceType: 'mcp_websocket',
           riskScore: 0.3,
           details: expect.objectContaining({
             originalEvent: 'ws_authentication_failed',
@@ -350,10 +360,11 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
       const { UPGRADE } = await import('../route');
       await UPGRADE(mockClient, mockServer, mockRequest);
 
-      expect(audit).toHaveBeenCalledWith(
+      expect(auditRequest).toHaveBeenCalledWith(
+        mockRequest,
         expect.objectContaining({
           eventType: 'auth.login.failure',
-          ipAddress: '192.168.1.1',
+          resourceType: 'mcp_websocket',
           riskScore: 0.3,
           details: expect.objectContaining({
             originalEvent: 'ws_session_validation_error',
@@ -382,13 +393,12 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
       const { UPGRADE } = await import('../route');
       await UPGRADE(mockClient, mockServer, mockRequest);
 
-      expect(audit).toHaveBeenCalledWith(
+      expect(auditRequest).toHaveBeenCalledWith(
+        mockRequest,
         expect.objectContaining({
           eventType: 'auth.session.created',
           userId: 'user_123',
           sessionId: 'session_123',
-          ipAddress: '192.168.1.1',
-          userAgent: 'Mozilla/5.0 Test',
           resourceType: 'mcp_websocket',
           riskScore: 0,
           details: expect.objectContaining({
@@ -396,9 +406,17 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
           }),
         })
       );
+
+      // Fingerprint must NOT be persisted in audit details (privacy: client-linkable
+      // pseudonym that would resist GDPR erasure in the tamper-evident hash chain).
+      const sessionAuditCall = vi.mocked(auditRequest).mock.calls.find(
+        ([, event]) => event.eventType === 'auth.session.created'
+      );
+      expect(sessionAuditCall).toBeDefined();
+      expect((sessionAuditCall![1].details ?? {}) as Record<string, unknown>).not.toHaveProperty('fingerprint');
     });
 
-    it('should NOT audit normal disconnections (code 1000/1001)', async () => {
+    it.each([1000, 1001])('should NOT audit normal disconnection (code %i)', async (closeCode) => {
       vi.mocked(sessionService.validateSession).mockResolvedValue({
         sessionId: 'session_123',
         userId: 'user_123',
@@ -413,7 +431,7 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
       const { UPGRADE } = await import('../route');
       await UPGRADE(mockClient, mockServer, mockRequest);
 
-      vi.mocked(audit).mockClear();
+      vi.mocked(auditRequest).mockClear();
 
       const closeHandler = vi.mocked(mockClient.on).mock.calls.find(
         (call) => call[0] === 'close'
@@ -421,10 +439,12 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
 
       expect(typeof closeHandler).toBe('function');
 
-      closeHandler!.call(mockClient, 1000, Buffer.from('Normal closure'));
+      closeHandler!.call(mockClient, closeCode, Buffer.from('Normal closure'));
 
-      const closeAuditCalls = vi.mocked(audit).mock.calls.filter((call) =>
-        (call[0] as { details?: { originalEvent?: string } })?.details?.originalEvent === 'ws_connection_closed'
+      const closeAuditCalls = vi.mocked(auditRequest).mock.calls.filter(
+        ([, event]) =>
+          (event as { details?: { originalEvent?: string } })?.details?.originalEvent ===
+          'ws_connection_closed'
       );
       expect(closeAuditCalls).toHaveLength(0);
     });
@@ -452,11 +472,12 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
 
       closeHandler!.call(mockClient, 1006, Buffer.from('Abnormal closure'));
 
-      expect(audit).toHaveBeenCalledWith(
+      expect(auditRequest).toHaveBeenCalledWith(
+        mockRequest,
         expect.objectContaining({
           eventType: 'security.anomaly.detected',
           userId: 'user_123',
-          ipAddress: '192.168.1.1',
+          resourceType: 'mcp_websocket',
           riskScore: 0.3,
           details: expect.objectContaining({
             originalEvent: 'ws_connection_closed',
@@ -537,11 +558,12 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
       const largeMessage = JSON.stringify({ type: 'ping' });
       messageHandler!.call(mockClient, Buffer.from(largeMessage));
 
-      expect(audit).toHaveBeenCalledWith(
+      expect(auditRequest).toHaveBeenCalledWith(
+        mockRequest,
         expect.objectContaining({
           eventType: 'security.anomaly.detected',
           userId: 'user_123',
-          ipAddress: '192.168.1.1',
+          resourceType: 'mcp_websocket',
           riskScore: 0.3,
           details: expect.objectContaining({
             originalEvent: 'ws_message_too_large',
@@ -581,11 +603,12 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
 
       messageHandler!.call(mockClient, Buffer.from('{ invalid json'));
 
-      expect(audit).toHaveBeenCalledWith(
+      expect(auditRequest).toHaveBeenCalledWith(
+        mockRequest,
         expect.objectContaining({
           eventType: 'security.anomaly.detected',
           userId: 'user_123',
-          ipAddress: '192.168.1.1',
+          resourceType: 'mcp_websocket',
           riskScore: 0.3,
           details: expect.objectContaining({
             originalEvent: 'ws_message_json_parse_error',
@@ -621,11 +644,12 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
 
       errorHandler!.call(mockClient, new Error('Test error'));
 
-      expect(audit).toHaveBeenCalledWith(
+      expect(auditRequest).toHaveBeenCalledWith(
+        mockRequest,
         expect.objectContaining({
           eventType: 'security.anomaly.detected',
           userId: 'user_123',
-          ipAddress: '192.168.1.1',
+          resourceType: 'mcp_websocket',
           riskScore: 0.3,
           details: expect.objectContaining({
             originalEvent: 'ws_error',

--- a/apps/web/src/app/api/mcp-ws/__tests__/route.security.test.ts
+++ b/apps/web/src/app/api/mcp-ws/__tests__/route.security.test.ts
@@ -51,7 +51,6 @@ vi.mock('@/lib/websocket/ws-security', () => ({
   getConnectionFingerprint: vi.fn(() => 'mock_fingerprint_hash_1234567890abcdef'),
   verifyFingerprint: vi.fn(() => true),
   validateMessageSize: vi.fn(() => ({ valid: true })),
-  logSecurityEvent: vi.fn(),
   isSecureConnection: vi.fn(() => true),
 }));
 
@@ -76,10 +75,7 @@ vi.mock('@pagespace/lib/server', () => ({
     security: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
     api: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
   },
-  securityAudit: {
-    logDataAccess: vi.fn().mockResolvedValue(undefined),
-    logEvent: vi.fn().mockResolvedValue(undefined),
-  },
+  audit: vi.fn(),
 }));
 
 import {
@@ -89,11 +85,10 @@ import {
 } from '@/lib/websocket';
 import {
   getConnectionFingerprint,
-  logSecurityEvent,
   validateMessageSize,
 } from '@/lib/websocket';
 import { sessionService } from '@pagespace/lib';
-import { securityAudit } from '@pagespace/lib/server';
+import { audit } from '@pagespace/lib/server';
 
 // Mock session expiry (1 hour from now)
 const mockSessionExpiry = new Date(Date.now() + 60 * 60 * 1000);
@@ -105,9 +100,6 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // Re-apply mock resolved values after restoreAllMocks in afterEach
-    vi.mocked(securityAudit.logEvent).mockResolvedValue(undefined);
-    vi.mocked(securityAudit.logDataAccess).mockResolvedValue(undefined);
 
     // Create mock WebSocket client
     mockClient = {
@@ -196,14 +188,18 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
       await UPGRADE(mockClient, mockServer, mockRequest);
 
       expect(mockClient.close).toHaveBeenCalledWith(1008, 'Insufficient permissions');
-      expect(logSecurityEvent).toHaveBeenCalledWith(
-        'ws_insufficient_permissions',
-        {
+      expect(audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: 'authz.access.denied',
           userId: 'user_123',
-          ip: '192.168.1.1',
-          severity: 'warn',
-          scopes: ['read:pages'],
-        }
+          ipAddress: '192.168.1.1',
+          riskScore: 0.5,
+          details: expect.objectContaining({
+            originalEvent: 'ws_insufficient_permissions',
+            component: 'mcp_websocket',
+            scopes: ['read:pages'],
+          }),
+        })
       );
     });
   });
@@ -308,13 +304,18 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
       const pingMessage = JSON.stringify({ type: 'ping' });
       messageHandler!.call(mockClient, Buffer.from(pingMessage));
 
-      expect(logSecurityEvent).toHaveBeenCalledWith(
-        'ws_fingerprint_mismatch',
-        {
+      expect(audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: 'security.anomaly.detected',
           userId: 'user_123',
-          severity: 'critical',
-          reason: 'Connection fingerprint changed - possible session hijacking',
-        }
+          ipAddress: '192.168.1.1',
+          riskScore: 0.7,
+          details: expect.objectContaining({
+            originalEvent: 'ws_fingerprint_mismatch',
+            component: 'mcp_websocket',
+            reason: 'Connection fingerprint changed - possible session hijacking',
+          }),
+        })
       );
 
       expect(mockClient.close).toHaveBeenCalledWith(1008, 'Security violation');
@@ -322,37 +323,45 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
   });
 
   describe('A07 - Identification and Authentication Failures', () => {
-    it('should log authentication failures', async () => {
+    it('should audit authentication failures', async () => {
       vi.mocked(sessionService.validateSession).mockResolvedValue(null);
 
       const { UPGRADE } = await import('../route');
       await UPGRADE(mockClient, mockServer, mockRequest);
 
-      expect(logSecurityEvent).toHaveBeenCalledWith(
-        'ws_authentication_failed',
-        {
-          ip: '192.168.1.1',
-          severity: 'warn',
-          reason: 'Invalid or expired session token',
-        }
+      expect(audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: 'auth.login.failure',
+          ipAddress: '192.168.1.1',
+          riskScore: 0.3,
+          details: expect.objectContaining({
+            originalEvent: 'ws_authentication_failed',
+            component: 'mcp_websocket',
+            reason: 'Invalid or expired session token',
+          }),
+        })
       );
 
       expect(mockClient.close).toHaveBeenCalledWith(1008, 'Invalid or expired token');
     });
 
-    it('should handle session validation errors gracefully', async () => {
+    it('should audit session validation errors', async () => {
       vi.mocked(sessionService.validateSession).mockRejectedValue(new Error('Database error'));
 
       const { UPGRADE } = await import('../route');
       await UPGRADE(mockClient, mockServer, mockRequest);
 
-      expect(logSecurityEvent).toHaveBeenCalledWith(
-        'ws_session_validation_error',
-        {
-          ip: '192.168.1.1',
-          severity: 'error',
-          error: 'Database error',
-        }
+      expect(audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: 'auth.login.failure',
+          ipAddress: '192.168.1.1',
+          riskScore: 0.3,
+          details: expect.objectContaining({
+            originalEvent: 'ws_session_validation_error',
+            component: 'mcp_websocket',
+            error: 'Database error',
+          }),
+        })
       );
 
       expect(mockClient.close).toHaveBeenCalledWith(1008, 'Authentication error');
@@ -360,7 +369,7 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
   });
 
   describe('A09 - Security Logging and Monitoring Failures', () => {
-    it('should log WebSocket connection as session event, not data access', async () => {
+    it('should audit successful connections via audit pipeline', async () => {
       vi.mocked(sessionService.validateSession).mockResolvedValue({
         sessionId: 'session_123',
         userId: 'user_123',
@@ -375,20 +384,22 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
       const { UPGRADE } = await import('../route');
       await UPGRADE(mockClient, mockServer, mockRequest);
 
-      // WebSocket connection is a session event, not a data read
-      expect(securityAudit.logEvent).toHaveBeenCalledWith(
+      expect(audit).toHaveBeenCalledWith(
         expect.objectContaining({
           eventType: 'auth.session.created',
           userId: 'user_123',
           sessionId: 'session_123',
-          resourceType: 'mcp_websocket',
+          ipAddress: '192.168.1.1',
+          riskScore: 0,
+          details: expect.objectContaining({
+            originalEvent: 'ws_connection_established',
+            component: 'mcp_websocket',
+          }),
         })
       );
-      // Should NOT use logDataAccess for connection events
-      expect(securityAudit.logDataAccess).not.toHaveBeenCalled();
     });
 
-    it('should log successful connections with user ID', async () => {
+    it('should NOT audit normal disconnections (code 1000/1001)', async () => {
       vi.mocked(sessionService.validateSession).mockResolvedValue({
         sessionId: 'session_123',
         userId: 'user_123',
@@ -403,19 +414,23 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
       const { UPGRADE } = await import('../route');
       await UPGRADE(mockClient, mockServer, mockRequest);
 
-      expect(logSecurityEvent).toHaveBeenCalledWith(
-        'ws_connection_established',
-        {
-          userId: 'user_123',
-          sessionId: 'session_123',
-          ip: '192.168.1.1',
-          severity: 'info',
-          fingerprint: 'mock_fingerprint...',
-        }
+      vi.mocked(audit).mockClear();
+
+      const closeHandler = vi.mocked(mockClient.on).mock.calls.find(
+        (call) => call[0] === 'close'
+      )?.[1];
+
+      expect(typeof closeHandler).toBe('function');
+
+      closeHandler!.call(mockClient, 1000, Buffer.from('Normal closure'));
+
+      const closeAuditCalls = vi.mocked(audit).mock.calls.filter((call) =>
+        (call[0] as { details?: { originalEvent?: string } })?.details?.originalEvent === 'ws_connection_closed'
       );
+      expect(closeAuditCalls).toHaveLength(0);
     });
 
-    it('should log disconnections with reason', async () => {
+    it('should audit abnormal disconnections (non-normal close codes)', async () => {
       vi.mocked(sessionService.validateSession).mockResolvedValue({
         sessionId: 'session_123',
         userId: 'user_123',
@@ -436,22 +451,65 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
 
       expect(typeof closeHandler).toBe('function');
 
+      closeHandler!.call(mockClient, 1006, Buffer.from('Abnormal closure'));
+
+      expect(audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: 'security.anomaly.detected',
+          userId: 'user_123',
+          ipAddress: '192.168.1.1',
+          riskScore: 0.3,
+          details: expect.objectContaining({
+            originalEvent: 'ws_connection_closed',
+            component: 'mcp_websocket',
+            code: 1006,
+            reason: 'Abnormal closure',
+          }),
+        })
+      );
+    });
+
+    it('should only cancel user fetch requests once on close', async () => {
+      vi.mocked(sessionService.validateSession).mockResolvedValue({
+        sessionId: 'session_123',
+        userId: 'user_123',
+        userRole: 'user',
+        tokenVersion: 1,
+        adminRoleVersion: 0,
+        type: 'service',
+        scopes: ['mcp:*'],
+        expiresAt: mockSessionExpiry,
+      });
+
+      const { getConnection } = await import('@/lib/websocket');
+      vi.mocked(getConnection).mockReturnValue(mockClient);
+
+      const { getFetchBridge, isFetchBridgeInitialized } = await import('@/lib/fetch-bridge');
+      vi.mocked(isFetchBridgeInitialized).mockReturnValue(true);
+      const cancelSpy = vi.fn();
+      vi.mocked(getFetchBridge).mockReturnValue({
+        handleResponseStart: vi.fn(),
+        handleResponseChunk: vi.fn(),
+        handleResponseEnd: vi.fn(),
+        handleResponseError: vi.fn(),
+        cancelUserRequests: cancelSpy,
+      } as unknown as ReturnType<typeof getFetchBridge>);
+
+      const { UPGRADE } = await import('../route');
+      await UPGRADE(mockClient, mockServer, mockRequest);
+
+      const closeHandler = vi.mocked(mockClient.on).mock.calls.find(
+        (call) => call[0] === 'close'
+      )?.[1];
+
       closeHandler!.call(mockClient, 1000, Buffer.from('Normal closure'));
 
-      expect(logSecurityEvent).toHaveBeenCalledWith(
-        'ws_connection_closed',
-        {
-          userId: 'user_123',
-          code: 1000,
-          reason: 'Normal closure',
-          severity: 'info',
-        }
-      );
+      expect(cancelSpy).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('Additional Security Controls', () => {
-    it('should validate message size to prevent DoS', async () => {
+    it('should audit oversized messages', async () => {
       vi.mocked(sessionService.validateSession).mockResolvedValue({
         sessionId: 'session_123',
         userId: 'user_123',
@@ -481,14 +539,19 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
       const largeMessage = JSON.stringify({ type: 'ping' });
       messageHandler!.call(mockClient, Buffer.from(largeMessage));
 
-      expect(logSecurityEvent).toHaveBeenCalledWith(
-        'ws_message_too_large',
-        {
+      expect(audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: 'security.anomaly.detected',
           userId: 'user_123',
-          size: 10 * 1024 * 1024,
-          maxSize: 1024 * 1024,
-          severity: 'warn',
-        }
+          ipAddress: '192.168.1.1',
+          riskScore: 0.3,
+          details: expect.objectContaining({
+            originalEvent: 'ws_message_too_large',
+            component: 'mcp_websocket',
+            size: 10 * 1024 * 1024,
+            maxSize: 1024 * 1024,
+          }),
+        })
       );
 
       expect(mockClient.send).toHaveBeenCalledWith(
@@ -496,7 +559,7 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
       );
     });
 
-    it('should handle malformed JSON gracefully', async () => {
+    it('should audit malformed JSON messages', async () => {
       vi.mocked(sessionService.validateSession).mockResolvedValue({
         sessionId: 'session_123',
         userId: 'user_123',
@@ -521,19 +584,25 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
 
       messageHandler!.call(mockClient, Buffer.from('{ invalid json'));
 
-      const securityArgs = vi.mocked(logSecurityEvent).mock.calls.find(
-        (call) => call[0] === 'ws_message_json_parse_error'
+      expect(audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: 'security.anomaly.detected',
+          userId: 'user_123',
+          ipAddress: '192.168.1.1',
+          riskScore: 0.3,
+          details: expect.objectContaining({
+            originalEvent: 'ws_message_json_parse_error',
+            component: 'mcp_websocket',
+          }),
+        })
       );
-      expect(securityArgs).not.toBeUndefined();
-      expect(securityArgs![1].userId).toBe('user_123');
-      expect(securityArgs![1].severity).toBe('warn');
 
       expect(mockClient.send).toHaveBeenCalledWith(
         JSON.stringify({ type: 'error', error: 'invalid_json', reason: 'Message is not valid JSON' })
       );
     });
 
-    it('should handle WebSocket errors without crashing', async () => {
+    it('should audit WebSocket errors', async () => {
       vi.mocked(sessionService.validateSession).mockResolvedValue({
         sessionId: 'session_123',
         userId: 'user_123',
@@ -556,13 +625,18 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
 
       errorHandler!.call(mockClient, new Error('Test error'));
 
-      expect(logSecurityEvent).toHaveBeenCalledWith(
-        'ws_error',
-        {
+      expect(audit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: 'security.anomaly.detected',
           userId: 'user_123',
-          error: 'Test error',
-          severity: 'error',
-        }
+          ipAddress: '192.168.1.1',
+          riskScore: 0.3,
+          details: expect.objectContaining({
+            originalEvent: 'ws_error',
+            component: 'mcp_websocket',
+            error: 'Test error',
+          }),
+        })
       );
     });
   });

--- a/apps/web/src/app/api/mcp-ws/__tests__/route.security.test.ts
+++ b/apps/web/src/app/api/mcp-ws/__tests__/route.security.test.ts
@@ -193,10 +193,11 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
           eventType: 'authz.access.denied',
           userId: 'user_123',
           ipAddress: '192.168.1.1',
+          userAgent: 'Mozilla/5.0 Test',
+          resourceType: 'mcp_websocket',
           riskScore: 0.5,
           details: expect.objectContaining({
             originalEvent: 'ws_insufficient_permissions',
-            component: 'mcp_websocket',
             scopes: ['read:pages'],
           }),
         })
@@ -312,7 +313,6 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
           riskScore: 0.7,
           details: expect.objectContaining({
             originalEvent: 'ws_fingerprint_mismatch',
-            component: 'mcp_websocket',
             reason: 'Connection fingerprint changed - possible session hijacking',
           }),
         })
@@ -336,7 +336,6 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
           riskScore: 0.3,
           details: expect.objectContaining({
             originalEvent: 'ws_authentication_failed',
-            component: 'mcp_websocket',
             reason: 'Invalid or expired session token',
           }),
         })
@@ -358,7 +357,6 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
           riskScore: 0.3,
           details: expect.objectContaining({
             originalEvent: 'ws_session_validation_error',
-            component: 'mcp_websocket',
             error: 'Database error',
           }),
         })
@@ -390,10 +388,11 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
           userId: 'user_123',
           sessionId: 'session_123',
           ipAddress: '192.168.1.1',
+          userAgent: 'Mozilla/5.0 Test',
+          resourceType: 'mcp_websocket',
           riskScore: 0,
           details: expect.objectContaining({
             originalEvent: 'ws_connection_established',
-            component: 'mcp_websocket',
           }),
         })
       );
@@ -461,7 +460,6 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
           riskScore: 0.3,
           details: expect.objectContaining({
             originalEvent: 'ws_connection_closed',
-            component: 'mcp_websocket',
             code: 1006,
             reason: 'Abnormal closure',
           }),
@@ -547,7 +545,6 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
           riskScore: 0.3,
           details: expect.objectContaining({
             originalEvent: 'ws_message_too_large',
-            component: 'mcp_websocket',
             size: 10 * 1024 * 1024,
             maxSize: 1024 * 1024,
           }),
@@ -592,7 +589,6 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
           riskScore: 0.3,
           details: expect.objectContaining({
             originalEvent: 'ws_message_json_parse_error',
-            component: 'mcp_websocket',
           }),
         })
       );
@@ -633,7 +629,6 @@ describe('WebSocket MCP Bridge - Security Tests', () => {
           riskScore: 0.3,
           details: expect.objectContaining({
             originalEvent: 'ws_error',
-            component: 'mcp_websocket',
             error: 'Test error',
           }),
         })

--- a/apps/web/src/app/api/mcp-ws/route.ts
+++ b/apps/web/src/app/api/mcp-ws/route.ts
@@ -25,7 +25,7 @@ import {
   isFetchResponseErrorMessage,
 } from '@/lib/websocket';
 import { sessionService, type SessionClaims } from '@pagespace/lib';
-import { audit } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/server';
 
 // Initialize cleanup interval on module load
 // This prevents memory leaks from stale connections
@@ -66,18 +66,11 @@ export async function UPGRADE(
   request: NextRequest
 ) {
   const requestUrl = request.url;
-  const clientIp =
-    request.headers.get('x-forwarded-for')?.split(',')[0].trim() ||
-    request.headers.get('x-real-ip')?.trim() ||
-    'unknown';
-  const clientUserAgent = request.headers.get('user-agent')?.trim() || 'unknown';
 
   // SECURITY CHECK 1: Verify secure connection in production
   if (!isSecureConnection(requestUrl, request)) {
-    audit({
+    auditRequest(request, {
       eventType: 'security.anomaly.detected',
-      ipAddress: clientIp,
-      userAgent: clientUserAgent,
       resourceType: 'mcp_websocket',
       riskScore: 0.7,
       details: { originalEvent: 'ws_insecure_connection_rejected', url: requestUrl },
@@ -89,10 +82,8 @@ export async function UPGRADE(
   // SECURITY CHECK 2: Extract and validate opaque token from Authorization header
   const authHeader = request.headers.get('authorization');
   if (!authHeader?.startsWith('Bearer ')) {
-    audit({
+    auditRequest(request, {
       eventType: 'auth.login.failure',
-      ipAddress: clientIp,
-      userAgent: clientUserAgent,
       resourceType: 'mcp_websocket',
       riskScore: 0.3,
       details: { originalEvent: 'ws_authentication_failed', reason: 'Missing Authorization header' },
@@ -108,10 +99,8 @@ export async function UPGRADE(
   try {
     claims = await sessionService.validateSession(token);
   } catch (error) {
-    audit({
+    auditRequest(request, {
       eventType: 'auth.login.failure',
-      ipAddress: clientIp,
-      userAgent: clientUserAgent,
       resourceType: 'mcp_websocket',
       riskScore: 0.3,
       details: { originalEvent: 'ws_session_validation_error', error: error instanceof Error ? error.message : String(error) },
@@ -121,10 +110,8 @@ export async function UPGRADE(
   }
 
   if (!claims) {
-    audit({
+    auditRequest(request, {
       eventType: 'auth.login.failure',
-      ipAddress: clientIp,
-      userAgent: clientUserAgent,
       resourceType: 'mcp_websocket',
       riskScore: 0.3,
       details: { originalEvent: 'ws_authentication_failed', reason: 'Invalid or expired session token' },
@@ -137,11 +124,9 @@ export async function UPGRADE(
 
   // SECURITY CHECK 3: Verify scope allows MCP operations
   if (!claims.scopes.includes('mcp:*') && !claims.scopes.includes('*')) {
-    audit({
+    auditRequest(request, {
       eventType: 'authz.access.denied',
       userId,
-      ipAddress: clientIp,
-      userAgent: clientUserAgent,
       resourceType: 'mcp_websocket',
       riskScore: 0.5,
       details: { originalEvent: 'ws_insufficient_permissions', scopes: claims.scopes },
@@ -161,15 +146,16 @@ export async function UPGRADE(
   // Mark as verified immediately - session service already validated the token
   markChallengeVerified(client);
 
-  audit({
+  // Fingerprint is intentionally NOT embedded in audit details — it is a
+  // stable, client-linkable pseudonym (hash of IP+UA) that would persist in
+  // the tamper-evident audit chain and resist GDPR erasure requests.
+  auditRequest(request, {
     eventType: 'auth.session.created',
     userId,
     sessionId: claims.sessionId,
-    ipAddress: clientIp,
-    userAgent: clientUserAgent,
     resourceType: 'mcp_websocket',
     riskScore: 0,
-    details: { originalEvent: 'ws_connection_established', fingerprint: fingerprint.substring(0, 16) + '...' },
+    details: { originalEvent: 'ws_connection_established' },
   });
 
   // Send welcome message (no challenge needed - session service did the auth)
@@ -187,11 +173,9 @@ export async function UPGRADE(
       // SECURITY CHECK 5: Validate message size
       const sizeValidation = validateMessageSize(data);
       if (!sizeValidation.valid) {
-        audit({
+        auditRequest(request, {
           eventType: 'security.anomaly.detected',
           userId,
-          ipAddress: clientIp,
-          userAgent: clientUserAgent,
           resourceType: 'mcp_websocket',
           riskScore: 0.3,
           details: { originalEvent: 'ws_message_too_large', size: sizeValidation.size, maxSize: sizeValidation.maxSize },
@@ -211,11 +195,9 @@ export async function UPGRADE(
       try {
         parsedData = JSON.parse(data.toString());
       } catch (error) {
-        audit({
+        auditRequest(request, {
           eventType: 'security.anomaly.detected',
           userId,
-          ipAddress: clientIp,
-          userAgent: clientUserAgent,
           resourceType: 'mcp_websocket',
           riskScore: 0.3,
           details: { originalEvent: 'ws_message_json_parse_error', error: error instanceof Error ? error.message : String(error) },
@@ -234,11 +216,9 @@ export async function UPGRADE(
       const validationResult = validateIncomingMessageWithError(parsedData);
 
       if (!validationResult.success) {
-        audit({
+        auditRequest(request, {
           eventType: 'security.anomaly.detected',
           userId,
-          ipAddress: clientIp,
-          userAgent: clientUserAgent,
           resourceType: 'mcp_websocket',
           riskScore: 0.3,
           details: { originalEvent: 'ws_message_validation_failed', error: validationResult.error, issues: validationResult.issues },
@@ -261,11 +241,9 @@ export async function UPGRADE(
         // SECURITY CHECK 6: Verify connection fingerprint on ping to detect session hijacking
         const currentFingerprint = getConnectionFingerprint(request);
         if (!verifyConnectionFingerprint(client, currentFingerprint)) {
-          audit({
+          auditRequest(request, {
             eventType: 'security.anomaly.detected',
             userId,
-            ipAddress: clientIp,
-            userAgent: clientUserAgent,
             resourceType: 'mcp_websocket',
             riskScore: 0.7,
             details: { originalEvent: 'ws_fingerprint_mismatch', reason: 'Connection fingerprint changed - possible session hijacking' },
@@ -291,11 +269,9 @@ export async function UPGRADE(
         const health = checkConnectionHealth(client);
 
         if (!health.isHealthy) {
-          audit({
+          auditRequest(request, {
             eventType: 'security.anomaly.detected',
             userId,
-            ipAddress: clientIp,
-            userAgent: clientUserAgent,
             resourceType: 'mcp_websocket',
             riskScore: 0.5,
             details: { originalEvent: 'ws_unhealthy_connection_tool_attempt', reason: health.reason, readyState: health.readyState },
@@ -336,11 +312,9 @@ export async function UPGRADE(
         if (isFetchResponseErrorMessage(message)) {
           // Fetch errors are typically network/provider issues, not security events.
           // Log at low risk so they don't inflate anomaly signals.
-          audit({
+          auditRequest(request, {
             eventType: 'security.anomaly.detected',
             userId,
-            ipAddress: clientIp,
-            userAgent: clientUserAgent,
             resourceType: 'mcp_websocket',
             riskScore: 0.1,
             details: { originalEvent: 'ws_fetch_response_error', requestId: message.id, error: message.error },
@@ -352,11 +326,9 @@ export async function UPGRADE(
 
       // Note: Unknown message types are now caught by Zod validation above
     } catch (error) {
-      audit({
+      auditRequest(request, {
         eventType: 'security.anomaly.detected',
         userId,
-        ipAddress: clientIp,
-        userAgent: clientUserAgent,
         resourceType: 'mcp_websocket',
         riskScore: 0.3,
         details: { originalEvent: 'ws_message_parse_error', error: error instanceof Error ? error.message : String(error) },
@@ -377,11 +349,9 @@ export async function UPGRADE(
     // them would pollute forensics with noise.
     const isNormalClose = code === 1000 || code === 1001;
     if (!isNormalClose) {
-      audit({
+      auditRequest(request, {
         eventType: 'security.anomaly.detected',
         userId,
-        ipAddress: clientIp,
-        userAgent: clientUserAgent,
         resourceType: 'mcp_websocket',
         riskScore: 0.3,
         details: { originalEvent: 'ws_connection_closed', code, reason: reason.toString() },
@@ -399,11 +369,9 @@ export async function UPGRADE(
 
   // Handle errors
   client.on('error', (error) => {
-    audit({
+    auditRequest(request, {
       eventType: 'security.anomaly.detected',
       userId,
-      ipAddress: clientIp,
-      userAgent: clientUserAgent,
       resourceType: 'mcp_websocket',
       riskScore: 0.3,
       details: { originalEvent: 'ws_error', error: error instanceof Error ? error.message : String(error) },

--- a/apps/web/src/app/api/mcp-ws/route.ts
+++ b/apps/web/src/app/api/mcp-ws/route.ts
@@ -13,7 +13,6 @@ import {
   verifyConnectionFingerprint,
   getConnectionFingerprint,
   validateMessageSize,
-  logSecurityEvent,
   isSecureConnection,
   validateIncomingMessageWithError,
   type IncomingMessage,
@@ -26,7 +25,7 @@ import {
   isFetchResponseErrorMessage,
 } from '@/lib/websocket';
 import { sessionService, type SessionClaims } from '@pagespace/lib';
-import { loggers, securityAudit } from '@pagespace/lib/server';
+import { audit } from '@pagespace/lib/server';
 
 // Initialize cleanup interval on module load
 // This prevents memory leaks from stale connections
@@ -72,10 +71,11 @@ export async function UPGRADE(
 
   // SECURITY CHECK 1: Verify secure connection in production
   if (!isSecureConnection(requestUrl, request)) {
-    logSecurityEvent('ws_insecure_connection_rejected', {
-      ip: clientIp,
-      url: requestUrl,
-      severity: 'error',
+    audit({
+      eventType: 'security.anomaly.detected',
+      ipAddress: clientIp,
+      riskScore: 0.7,
+      details: { originalEvent: 'ws_insecure_connection_rejected', component: 'mcp_websocket', url: requestUrl },
     });
     client.close(1008, 'Secure connection required');
     return;
@@ -84,10 +84,11 @@ export async function UPGRADE(
   // SECURITY CHECK 2: Extract and validate opaque token from Authorization header
   const authHeader = request.headers.get('authorization');
   if (!authHeader?.startsWith('Bearer ')) {
-    logSecurityEvent('ws_authentication_failed', {
-      ip: clientIp,
-      severity: 'warn',
-      reason: 'Missing Authorization header',
+    audit({
+      eventType: 'auth.login.failure',
+      ipAddress: clientIp,
+      riskScore: 0.3,
+      details: { originalEvent: 'ws_authentication_failed', component: 'mcp_websocket', reason: 'Missing Authorization header' },
     });
     client.close(1008, 'Authorization required');
     return;
@@ -100,20 +101,22 @@ export async function UPGRADE(
   try {
     claims = await sessionService.validateSession(token);
   } catch (error) {
-    logSecurityEvent('ws_session_validation_error', {
-      ip: clientIp,
-      severity: 'error',
-      error: error instanceof Error ? error.message : String(error),
+    audit({
+      eventType: 'auth.login.failure',
+      ipAddress: clientIp,
+      riskScore: 0.3,
+      details: { originalEvent: 'ws_session_validation_error', component: 'mcp_websocket', error: error instanceof Error ? error.message : String(error) },
     });
     client.close(1008, 'Authentication error');
     return;
   }
 
   if (!claims) {
-    logSecurityEvent('ws_authentication_failed', {
-      ip: clientIp,
-      severity: 'warn',
-      reason: 'Invalid or expired session token',
+    audit({
+      eventType: 'auth.login.failure',
+      ipAddress: clientIp,
+      riskScore: 0.3,
+      details: { originalEvent: 'ws_authentication_failed', component: 'mcp_websocket', reason: 'Invalid or expired session token' },
     });
     client.close(1008, 'Invalid or expired token');
     return;
@@ -123,11 +126,12 @@ export async function UPGRADE(
 
   // SECURITY CHECK 3: Verify scope allows MCP operations
   if (!claims.scopes.includes('mcp:*') && !claims.scopes.includes('*')) {
-    logSecurityEvent('ws_insufficient_permissions', {
+    audit({
+      eventType: 'authz.access.denied',
       userId,
-      ip: clientIp,
-      severity: 'warn',
-      scopes: claims.scopes,
+      ipAddress: clientIp,
+      riskScore: 0.5,
+      details: { originalEvent: 'ws_insufficient_permissions', component: 'mcp_websocket', scopes: claims.scopes },
     });
     client.close(1008, 'Insufficient permissions');
     return;
@@ -144,24 +148,14 @@ export async function UPGRADE(
   // Mark as verified immediately - session service already validated the token
   markChallengeVerified(client);
 
-  logSecurityEvent('ws_connection_established', {
-    userId,
-    sessionId: claims.sessionId,
-    ip: clientIp,
-    severity: 'info',
-    fingerprint: fingerprint.substring(0, 16) + '...',
-  });
-
-  securityAudit.logEvent({
+  audit({
     eventType: 'auth.session.created',
     userId,
     sessionId: claims.sessionId,
+    ipAddress: clientIp,
     resourceType: 'mcp_websocket',
-  }).catch((error) => {
-    loggers.security.warn('[MCP-WS] audit log failed', {
-      error: error instanceof Error ? error.message : String(error),
-      userId,
-    });
+    riskScore: 0,
+    details: { originalEvent: 'ws_connection_established', component: 'mcp_websocket', fingerprint: fingerprint.substring(0, 16) + '...' },
   });
 
   // Send welcome message (no challenge needed - session service did the auth)
@@ -179,11 +173,12 @@ export async function UPGRADE(
       // SECURITY CHECK 5: Validate message size
       const sizeValidation = validateMessageSize(data);
       if (!sizeValidation.valid) {
-        logSecurityEvent('ws_message_too_large', {
+        audit({
+          eventType: 'security.anomaly.detected',
           userId,
-          size: sizeValidation.size,
-          maxSize: sizeValidation.maxSize,
-          severity: 'warn',
+          ipAddress: clientIp,
+          riskScore: 0.3,
+          details: { originalEvent: 'ws_message_too_large', component: 'mcp_websocket', size: sizeValidation.size, maxSize: sizeValidation.maxSize },
         });
         client.send(
           JSON.stringify({
@@ -200,10 +195,12 @@ export async function UPGRADE(
       try {
         parsedData = JSON.parse(data.toString());
       } catch (error) {
-        logSecurityEvent('ws_message_json_parse_error', {
+        audit({
+          eventType: 'security.anomaly.detected',
           userId,
-          error: error instanceof Error ? error.message : String(error),
-          severity: 'warn',
+          ipAddress: clientIp,
+          riskScore: 0.3,
+          details: { originalEvent: 'ws_message_json_parse_error', component: 'mcp_websocket', error: error instanceof Error ? error.message : String(error) },
         });
         client.send(
           JSON.stringify({
@@ -219,11 +216,12 @@ export async function UPGRADE(
       const validationResult = validateIncomingMessageWithError(parsedData);
 
       if (!validationResult.success) {
-        logSecurityEvent('ws_message_validation_failed', {
+        audit({
+          eventType: 'security.anomaly.detected',
           userId,
-          error: validationResult.error,
-          issues: validationResult.issues,
-          severity: 'warn',
+          ipAddress: clientIp,
+          riskScore: 0.3,
+          details: { originalEvent: 'ws_message_validation_failed', component: 'mcp_websocket', error: validationResult.error, issues: validationResult.issues },
         });
         client.send(
           JSON.stringify({
@@ -243,10 +241,12 @@ export async function UPGRADE(
         // SECURITY CHECK 6: Verify connection fingerprint on ping to detect session hijacking
         const currentFingerprint = getConnectionFingerprint(request);
         if (!verifyConnectionFingerprint(client, currentFingerprint)) {
-          logSecurityEvent('ws_fingerprint_mismatch', {
+          audit({
+            eventType: 'security.anomaly.detected',
             userId,
-            severity: 'critical',
-            reason: 'Connection fingerprint changed - possible session hijacking',
+            ipAddress: clientIp,
+            riskScore: 0.7,
+            details: { originalEvent: 'ws_fingerprint_mismatch', component: 'mcp_websocket', reason: 'Connection fingerprint changed - possible session hijacking' },
           });
           client.send(
             JSON.stringify({
@@ -269,11 +269,12 @@ export async function UPGRADE(
         const health = checkConnectionHealth(client);
 
         if (!health.isHealthy) {
-          logSecurityEvent('ws_unhealthy_connection_tool_attempt', {
+          audit({
+            eventType: 'security.anomaly.detected',
             userId,
-            reason: health.reason,
-            readyState: health.readyState,
-            severity: 'warn',
+            ipAddress: clientIp,
+            riskScore: 0.5,
+            details: { originalEvent: 'ws_unhealthy_connection_tool_attempt', component: 'mcp_websocket', reason: health.reason, readyState: health.readyState },
           });
           client.send(
             JSON.stringify({
@@ -286,29 +287,17 @@ export async function UPGRADE(
         }
       }
 
-      // Handle tool execution responses
+      // Handle tool execution responses (protocol-level ack, not audited)
       if (isToolResultMessage(message)) {
-        logSecurityEvent('ws_tool_execution_result', {
-          userId,
-          requestId: message.id,
-          success: message.success,
-          severity: 'info',
-        });
-
         const mcpBridge = getMCPBridge();
         mcpBridge.handleToolResponse(message);
         return;
       }
 
       // Handle fetch bridge responses (desktop proxying HTTP for local AI providers)
+      // These are protocol-level transport events, not audit events
       if (isFetchBridgeInitialized()) {
         if (isFetchResponseStartMessage(message)) {
-          logSecurityEvent('ws_fetch_response_start', {
-            userId,
-            requestId: message.id,
-            status: message.status,
-            severity: 'info',
-          });
           getFetchBridge().handleResponseStart(message);
           return;
         }
@@ -321,11 +310,14 @@ export async function UPGRADE(
           return;
         }
         if (isFetchResponseErrorMessage(message)) {
-          logSecurityEvent('ws_fetch_response_error', {
+          // Fetch errors are typically network/provider issues, not security events.
+          // Log at low risk so they don't inflate anomaly signals.
+          audit({
+            eventType: 'security.anomaly.detected',
             userId,
-            requestId: message.id,
-            error: message.error,
-            severity: 'warn',
+            ipAddress: clientIp,
+            riskScore: 0.1,
+            details: { originalEvent: 'ws_fetch_response_error', component: 'mcp_websocket', requestId: message.id, error: message.error },
           });
           getFetchBridge().handleResponseError(message);
           return;
@@ -334,10 +326,12 @@ export async function UPGRADE(
 
       // Note: Unknown message types are now caught by Zod validation above
     } catch (error) {
-      logSecurityEvent('ws_message_parse_error', {
+      audit({
+        eventType: 'security.anomaly.detected',
         userId,
-        error: error instanceof Error ? error.message : String(error),
-        severity: 'error',
+        ipAddress: clientIp,
+        riskScore: 0.3,
+        details: { originalEvent: 'ws_message_parse_error', component: 'mcp_websocket', error: error instanceof Error ? error.message : String(error) },
       });
       client.send(
         JSON.stringify({
@@ -350,34 +344,37 @@ export async function UPGRADE(
 
   // Handle client disconnect
   client.on('close', (code, reason) => {
-    // Check before unregister — if another socket replaced this one, don't cancel its fetches
-    const isActiveConnection = getConnection(userId) === client;
-
-    logSecurityEvent('ws_connection_closed', {
-      userId,
-      code,
-      reason: reason.toString(),
-      severity: 'info',
-    });
+    // Only audit abnormal closes. Normal closes (1000 = clean, 1001 = going away)
+    // are routine transport-level lifecycle events, not security events — auditing
+    // them would pollute forensics with noise.
+    const isNormalClose = code === 1000 || code === 1001;
+    if (!isNormalClose) {
+      audit({
+        eventType: 'security.anomaly.detected',
+        userId,
+        ipAddress: clientIp,
+        riskScore: 0.3,
+        details: { originalEvent: 'ws_connection_closed', component: 'mcp_websocket', code, reason: reason.toString() },
+      });
+    }
 
     // Clean up resources — only cancel fetch-bridge requests if this socket
     // is still the active connection (prevents stale socket from canceling
-    // in-flight requests after a reconnect)
+    // in-flight requests after a reconnect).
     if (isFetchBridgeInitialized() && getConnection(userId) === client) {
       getFetchBridge().cancelUserRequests(userId);
     }
     unregisterConnection(userId, client);
-    if (isActiveConnection) {
-      getFetchBridge().cancelUserRequests(userId);
-    }
   });
 
   // Handle errors
   client.on('error', (error) => {
-    logSecurityEvent('ws_error', {
+    audit({
+      eventType: 'security.anomaly.detected',
       userId,
-      error: error instanceof Error ? error.message : String(error),
-      severity: 'error',
+      ipAddress: clientIp,
+      riskScore: 0.3,
+      details: { originalEvent: 'ws_error', component: 'mcp_websocket', error: error instanceof Error ? error.message : String(error) },
     });
   });
 }

--- a/apps/web/src/app/api/mcp-ws/route.ts
+++ b/apps/web/src/app/api/mcp-ws/route.ts
@@ -67,15 +67,20 @@ export async function UPGRADE(
 ) {
   const requestUrl = request.url;
   const clientIp =
-    request.headers.get('x-forwarded-for')?.split(',')[0].trim() || 'unknown';
+    request.headers.get('x-forwarded-for')?.split(',')[0].trim() ||
+    request.headers.get('x-real-ip')?.trim() ||
+    'unknown';
+  const clientUserAgent = request.headers.get('user-agent')?.trim() || 'unknown';
 
   // SECURITY CHECK 1: Verify secure connection in production
   if (!isSecureConnection(requestUrl, request)) {
     audit({
       eventType: 'security.anomaly.detected',
       ipAddress: clientIp,
+      userAgent: clientUserAgent,
+      resourceType: 'mcp_websocket',
       riskScore: 0.7,
-      details: { originalEvent: 'ws_insecure_connection_rejected', component: 'mcp_websocket', url: requestUrl },
+      details: { originalEvent: 'ws_insecure_connection_rejected', url: requestUrl },
     });
     client.close(1008, 'Secure connection required');
     return;
@@ -87,8 +92,10 @@ export async function UPGRADE(
     audit({
       eventType: 'auth.login.failure',
       ipAddress: clientIp,
+      userAgent: clientUserAgent,
+      resourceType: 'mcp_websocket',
       riskScore: 0.3,
-      details: { originalEvent: 'ws_authentication_failed', component: 'mcp_websocket', reason: 'Missing Authorization header' },
+      details: { originalEvent: 'ws_authentication_failed', reason: 'Missing Authorization header' },
     });
     client.close(1008, 'Authorization required');
     return;
@@ -104,8 +111,10 @@ export async function UPGRADE(
     audit({
       eventType: 'auth.login.failure',
       ipAddress: clientIp,
+      userAgent: clientUserAgent,
+      resourceType: 'mcp_websocket',
       riskScore: 0.3,
-      details: { originalEvent: 'ws_session_validation_error', component: 'mcp_websocket', error: error instanceof Error ? error.message : String(error) },
+      details: { originalEvent: 'ws_session_validation_error', error: error instanceof Error ? error.message : String(error) },
     });
     client.close(1008, 'Authentication error');
     return;
@@ -115,8 +124,10 @@ export async function UPGRADE(
     audit({
       eventType: 'auth.login.failure',
       ipAddress: clientIp,
+      userAgent: clientUserAgent,
+      resourceType: 'mcp_websocket',
       riskScore: 0.3,
-      details: { originalEvent: 'ws_authentication_failed', component: 'mcp_websocket', reason: 'Invalid or expired session token' },
+      details: { originalEvent: 'ws_authentication_failed', reason: 'Invalid or expired session token' },
     });
     client.close(1008, 'Invalid or expired token');
     return;
@@ -130,8 +141,10 @@ export async function UPGRADE(
       eventType: 'authz.access.denied',
       userId,
       ipAddress: clientIp,
+      userAgent: clientUserAgent,
+      resourceType: 'mcp_websocket',
       riskScore: 0.5,
-      details: { originalEvent: 'ws_insufficient_permissions', component: 'mcp_websocket', scopes: claims.scopes },
+      details: { originalEvent: 'ws_insufficient_permissions', scopes: claims.scopes },
     });
     client.close(1008, 'Insufficient permissions');
     return;
@@ -153,9 +166,10 @@ export async function UPGRADE(
     userId,
     sessionId: claims.sessionId,
     ipAddress: clientIp,
+    userAgent: clientUserAgent,
     resourceType: 'mcp_websocket',
     riskScore: 0,
-    details: { originalEvent: 'ws_connection_established', component: 'mcp_websocket', fingerprint: fingerprint.substring(0, 16) + '...' },
+    details: { originalEvent: 'ws_connection_established', fingerprint: fingerprint.substring(0, 16) + '...' },
   });
 
   // Send welcome message (no challenge needed - session service did the auth)
@@ -177,8 +191,10 @@ export async function UPGRADE(
           eventType: 'security.anomaly.detected',
           userId,
           ipAddress: clientIp,
+          userAgent: clientUserAgent,
+          resourceType: 'mcp_websocket',
           riskScore: 0.3,
-          details: { originalEvent: 'ws_message_too_large', component: 'mcp_websocket', size: sizeValidation.size, maxSize: sizeValidation.maxSize },
+          details: { originalEvent: 'ws_message_too_large', size: sizeValidation.size, maxSize: sizeValidation.maxSize },
         });
         client.send(
           JSON.stringify({
@@ -199,8 +215,10 @@ export async function UPGRADE(
           eventType: 'security.anomaly.detected',
           userId,
           ipAddress: clientIp,
+          userAgent: clientUserAgent,
+          resourceType: 'mcp_websocket',
           riskScore: 0.3,
-          details: { originalEvent: 'ws_message_json_parse_error', component: 'mcp_websocket', error: error instanceof Error ? error.message : String(error) },
+          details: { originalEvent: 'ws_message_json_parse_error', error: error instanceof Error ? error.message : String(error) },
         });
         client.send(
           JSON.stringify({
@@ -220,8 +238,10 @@ export async function UPGRADE(
           eventType: 'security.anomaly.detected',
           userId,
           ipAddress: clientIp,
+          userAgent: clientUserAgent,
+          resourceType: 'mcp_websocket',
           riskScore: 0.3,
-          details: { originalEvent: 'ws_message_validation_failed', component: 'mcp_websocket', error: validationResult.error, issues: validationResult.issues },
+          details: { originalEvent: 'ws_message_validation_failed', error: validationResult.error, issues: validationResult.issues },
         });
         client.send(
           JSON.stringify({
@@ -245,8 +265,10 @@ export async function UPGRADE(
             eventType: 'security.anomaly.detected',
             userId,
             ipAddress: clientIp,
+            userAgent: clientUserAgent,
+            resourceType: 'mcp_websocket',
             riskScore: 0.7,
-            details: { originalEvent: 'ws_fingerprint_mismatch', component: 'mcp_websocket', reason: 'Connection fingerprint changed - possible session hijacking' },
+            details: { originalEvent: 'ws_fingerprint_mismatch', reason: 'Connection fingerprint changed - possible session hijacking' },
           });
           client.send(
             JSON.stringify({
@@ -273,8 +295,10 @@ export async function UPGRADE(
             eventType: 'security.anomaly.detected',
             userId,
             ipAddress: clientIp,
+            userAgent: clientUserAgent,
+            resourceType: 'mcp_websocket',
             riskScore: 0.5,
-            details: { originalEvent: 'ws_unhealthy_connection_tool_attempt', component: 'mcp_websocket', reason: health.reason, readyState: health.readyState },
+            details: { originalEvent: 'ws_unhealthy_connection_tool_attempt', reason: health.reason, readyState: health.readyState },
           });
           client.send(
             JSON.stringify({
@@ -316,8 +340,10 @@ export async function UPGRADE(
             eventType: 'security.anomaly.detected',
             userId,
             ipAddress: clientIp,
+            userAgent: clientUserAgent,
+            resourceType: 'mcp_websocket',
             riskScore: 0.1,
-            details: { originalEvent: 'ws_fetch_response_error', component: 'mcp_websocket', requestId: message.id, error: message.error },
+            details: { originalEvent: 'ws_fetch_response_error', requestId: message.id, error: message.error },
           });
           getFetchBridge().handleResponseError(message);
           return;
@@ -330,8 +356,10 @@ export async function UPGRADE(
         eventType: 'security.anomaly.detected',
         userId,
         ipAddress: clientIp,
+        userAgent: clientUserAgent,
+        resourceType: 'mcp_websocket',
         riskScore: 0.3,
-        details: { originalEvent: 'ws_message_parse_error', component: 'mcp_websocket', error: error instanceof Error ? error.message : String(error) },
+        details: { originalEvent: 'ws_message_parse_error', error: error instanceof Error ? error.message : String(error) },
       });
       client.send(
         JSON.stringify({
@@ -353,8 +381,10 @@ export async function UPGRADE(
         eventType: 'security.anomaly.detected',
         userId,
         ipAddress: clientIp,
+        userAgent: clientUserAgent,
+        resourceType: 'mcp_websocket',
         riskScore: 0.3,
-        details: { originalEvent: 'ws_connection_closed', component: 'mcp_websocket', code, reason: reason.toString() },
+        details: { originalEvent: 'ws_connection_closed', code, reason: reason.toString() },
       });
     }
 
@@ -373,8 +403,10 @@ export async function UPGRADE(
       eventType: 'security.anomaly.detected',
       userId,
       ipAddress: clientIp,
+      userAgent: clientUserAgent,
+      resourceType: 'mcp_websocket',
       riskScore: 0.3,
-      details: { originalEvent: 'ws_error', component: 'mcp_websocket', error: error instanceof Error ? error.message : String(error) },
+      details: { originalEvent: 'ws_error', error: error instanceof Error ? error.message : String(error) },
     });
   });
 }

--- a/apps/web/src/lib/websocket/ws-security.ts
+++ b/apps/web/src/lib/websocket/ws-security.ts
@@ -1,6 +1,5 @@
 import type { NextRequest } from 'next/server';
 import { createHash } from 'crypto';
-import { logger } from '@pagespace/lib';
 
 /**
  * WebSocket Security Utilities
@@ -8,9 +7,10 @@ import { logger } from '@pagespace/lib';
  * Implements defense-in-depth security controls for WebSocket connections:
  * - Connection fingerprinting (IP + User-Agent hashing)
  * - Message size validation
- * - Security event logging
  *
- * Note: Authentication is now handled by session service (opaque tokens)
+ * Note: Authentication is now handled by session service (opaque tokens).
+ * Security event logging is handled by the centralized `audit()` pipeline
+ * from `@pagespace/lib/server`.
  */
 
 // ============================================================================
@@ -97,65 +97,6 @@ export function validateMessageSize(message: Buffer | ArrayBuffer | Buffer[] | s
   }
 
   return { valid: true };
-}
-
-// ============================================================================
-// SECURITY LOGGING
-// ============================================================================
-
-/**
- * Log security event (structured logging for SIEM integration)
- *
- * @param event - Security event type
- * @param details - Event details
- */
-export function logSecurityEvent(
-  event: string,
-  details: {
-    userId?: string;
-    ip?: string;
-    severity: 'info' | 'warn' | 'error' | 'critical';
-    [key: string]: unknown;
-  }
-): void {
-  // Extract severity for log level routing
-  const { severity, ...restDetails } = details;
-
-  // Create context for structured logging
-  const context = {
-    userId: details.userId,
-    ip: details.ip,
-    component: 'ws-security',
-    eventType: event,
-  };
-
-  // Build metadata excluding severity and context fields
-  const metadata: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(restDetails)) {
-    if (key !== 'userId' && key !== 'ip') {
-      metadata[key] = value;
-    }
-  }
-
-  // Create child logger with context
-  const securityLogger = logger.child(context);
-
-  // Route to appropriate log level using structured logger
-  switch (severity) {
-    case 'critical':
-      securityLogger.fatal(`WebSocket Security Event: ${event}`, metadata);
-      break;
-    case 'error':
-      securityLogger.error(`WebSocket Security Event: ${event}`, metadata);
-      break;
-    case 'warn':
-      securityLogger.warn(`WebSocket Security Event: ${event}`, metadata);
-      break;
-    case 'info':
-    default:
-      securityLogger.info(`WebSocket Security Event: ${event}`, metadata);
-      break;
-  }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Migrates the WebSocket MCP bridge (`/api/mcp-ws`) from legacy dual-write logging (`logSecurityEvent` + `securityAudit`) to the single `auditRequest()` function from `@pagespace/lib/server`, and tightens several semantic and privacy issues surfaced during review.

## Key Changes

- **Unified audit pipeline** — every security event in the route now flows through `auditRequest(request, event)`, which auto-extracts `ipAddress` (with `x-forwarded-for` → `x-real-ip` fallback) and `userAgent` from the request headers. Replaces hand-rolled header parsing.
- **`resourceType: 'mcp_websocket'`** stamped on every audit event so forensic queries can filter by resource type.
- **Privacy fix — fingerprint removed from audit details** — the connection fingerprint (SHA-256 of IP+UA) is a stable client-linkable pseudonym. The audit hash chain deliberately keeps `ipAddress`/`userAgent` out of `details` so they can be GDPR-anonymized; embedding the fingerprint there reintroduced linkable data into the immutable part of the chain. Truncated 16-char prefix wasn't useful for verification anyway.
- **Normal-close noise eliminated** — code 1000/1001 disconnects no longer audit (routine lifecycle, not security signals). Abnormal closes are audited as `security.anomaly.detected`.
- **Protocol noise dropped** — `ws_tool_execution_result` and `ws_fetch_response_start` no longer audit (high-volume protocol acks, not security events).
- **Risk score recalibration:**
  - DB error during session validation: 0.5 → 0.3 (infrastructure failure, not security risk)
  - Generic WebSocket error: 0.5 → 0.3 (network noise)
  - Fetch response error: 0.3 → 0.1 (commonly network/provider issues)
- **Pre-existing bug fix** — close handler was calling `cancelUserRequests()` twice on active connections, with the second call missing its `isFetchBridgeInitialized()` guard.
- **Dead code removal** — unused `logSecurityEvent` function in `apps/web/src/lib/websocket/ws-security.ts`.

## Test plan

- [x] `pnpm --filter web typecheck` — clean
- [x] `pnpm --filter web lint` — only pre-existing CalendarView warnings
- [x] `pnpm test:unit` — 20/20 mcp-ws security tests pass (added 4 new cases, removed 1 obsolete)
- [x] New test: normal close (1000 **and** 1001) does NOT audit (parameterized via `it.each`)
- [x] New test: abnormal close (1006) audits as `security.anomaly.detected`
- [x] New test: `cancelUserRequests` fires exactly once on close
- [x] New test: `auth.session.created` details does NOT contain a `fingerprint` key (locks in the privacy fix)
- [x] Strengthened test: "should not leak sensitive data" now asserts against `auditRequest` mock payloads in addition to `console.*`, so a regression piping a raw bearer token into `audit({ details })` would be caught.
- [ ] Manual smoke test: connect desktop app, verify WS upgrade succeeds and MCP tool execution works

## Review history

- Initial implementation in 0c212e8c
- Forensic enrichment (userAgent + resourceType + x-real-ip) in 3731b4f1
- CodeRabbit feedback addressed in c37bae74:
  - Switched `audit()` → `auditRequest()` per CodeRabbit suggestion
  - Removed fingerprint from audit details (privacy)
  - Strengthened secret-leak regression test
  - Parameterized 1000/1001 close-code test

🤖 Generated with [Claude Code](https://claude.com/claude-code)