### PR TITLE
feat(security): scrub PII from auth log metadata

### DIFF
--- a/apps/web/src/app/api/admin/users/[userId]/gift-subscription/__tests__/route.pii.test.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/gift-subscription/__tests__/route.pii.test.ts
@@ -25,51 +25,45 @@ const subscriptionRow = {
   status: 'active',
 };
 
-let selectCount = 0;
+const userSelectThenable = {
+  from: () => ({
+    where: () => Promise.resolve([targetUser]),
+  }),
+};
 
-vi.mock('@pagespace/db', () => {
-  const noActiveSelect = {
-    from: () => ({
-      where: () => ({
-        orderBy: () => ({
-          limit: () => Promise.resolve([]),
-        }),
+const noActiveSubsSelect = {
+  from: () => ({
+    where: () => ({
+      orderBy: () => ({
+        limit: () => Promise.resolve([]),
       }),
     }),
-  };
-  const activeSelect = {
-    from: () => ({
-      where: () => ({
-        orderBy: () => ({
-          limit: () => Promise.resolve([subscriptionRow]),
-        }),
-      }),
-    }),
-  };
-  const userSelect = {
-    from: () => ({
-      where: () => Promise.resolve([targetUser]),
-    }),
-  };
+  }),
+};
 
-  return {
-    db: {
-      select: vi.fn(() => {
-        selectCount++;
-        // POST: 1st call user lookup, 2nd call subscriptions check (should return [])
-        // DELETE: 1st user, 2nd active subscription (should return [active])
-        if (selectCount % 2 === 1) return userSelect;
-        return process.env.__GIFT_TEST_MODE__ === 'delete' ? activeSelect : noActiveSelect;
+const activeSubsSelect = {
+  from: () => ({
+    where: () => ({
+      orderBy: () => ({
+        limit: () => Promise.resolve([subscriptionRow]),
       }),
-    },
-    users: {},
-    subscriptions: { userId: 'userId', status: 'status', updatedAt: 'updatedAt' },
-    eq: vi.fn(),
-    and: vi.fn(),
-    inArray: vi.fn(),
-    desc: vi.fn(),
-  };
-});
+    }),
+  }),
+};
+
+const { dbSelectMock } = vi.hoisted(() => ({ dbSelectMock: vi.fn() }));
+
+vi.mock('@pagespace/db', () => ({
+  db: {
+    select: dbSelectMock,
+  },
+  users: {},
+  subscriptions: { userId: 'userId', status: 'status', updatedAt: 'updatedAt' },
+  eq: vi.fn(),
+  and: vi.fn(),
+  inArray: vi.fn(),
+  desc: vi.fn(),
+}));
 
 vi.mock('@/lib/stripe', () => ({
   stripe: {
@@ -98,20 +92,21 @@ vi.mock('@/lib/stripe-config', () => ({
   },
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
-    api: {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
+vi.mock('@pagespace/lib/server', async () => {
+  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
+    '@pagespace/lib/audit/mask-email'
+  );
+  return {
+    loggers: {
+      api: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
     },
-  },
-  maskEmail: (email: string) => {
-    const [local, domain] = email.split('@');
-    if (!local || !domain) return '***@***';
-    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
-  },
-}));
+    maskEmail,
+  };
+});
 
 import { POST, DELETE } from '../route';
 import { loggers } from '@pagespace/lib/server';
@@ -119,11 +114,14 @@ import { loggers } from '@pagespace/lib/server';
 describe('Gift subscription PII scrub', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    selectCount = 0;
-    delete process.env.__GIFT_TEST_MODE__;
+    dbSelectMock.mockReset();
   });
 
   it('POST: masks targetUserEmail and omits targetUserName in "Admin gifted subscription" log', async () => {
+    dbSelectMock
+      .mockReturnValueOnce(userSelectThenable)
+      .mockReturnValueOnce(noActiveSubsSelect);
+
     const req = new NextRequest('http://localhost/api/admin/users/user-target/gift-subscription', {
       method: 'POST',
       body: JSON.stringify({ tier: 'pro', reason: 'thanks' }),
@@ -141,7 +139,10 @@ describe('Gift subscription PII scrub', () => {
   });
 
   it('DELETE: masks targetUserEmail and omits targetUserName in "Admin revoked subscription" log', async () => {
-    process.env.__GIFT_TEST_MODE__ = 'delete';
+    dbSelectMock
+      .mockReturnValueOnce(userSelectThenable)
+      .mockReturnValueOnce(activeSubsSelect);
+
     const req = new NextRequest('http://localhost/api/admin/users/user-target/gift-subscription', {
       method: 'DELETE',
     });

--- a/apps/web/src/app/api/admin/users/[userId]/gift-subscription/__tests__/route.pii.test.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/gift-subscription/__tests__/route.pii.test.ts
@@ -25,6 +25,8 @@ const subscriptionRow = {
   status: 'active',
 };
 
+let selectCount = 0;
+
 vi.mock('@pagespace/db', () => {
   const noActiveSelect = {
     from: () => ({
@@ -50,7 +52,6 @@ vi.mock('@pagespace/db', () => {
     }),
   };
 
-  let selectCount = 0;
   return {
     db: {
       select: vi.fn(() => {
@@ -118,6 +119,7 @@ import { loggers } from '@pagespace/lib/server';
 describe('Gift subscription PII scrub', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    selectCount = 0;
     delete process.env.__GIFT_TEST_MODE__;
   });
 

--- a/apps/web/src/app/api/admin/users/[userId]/gift-subscription/__tests__/route.pii.test.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/gift-subscription/__tests__/route.pii.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Unit tests for PII scrubbing in gift-subscription admin routes.
+ * Asserts that targetUser.email is masked and targetUserName is omitted from log metadata.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/auth', () => ({
+  withAdminAuth: <T>(handler: (admin: { id: string }, req: Request, ctx: T) => Promise<Response>) =>
+    (req: Request, ctx: T) => handler({ id: 'admin-1' }, req, ctx),
+}));
+
+const targetUser = {
+  id: 'user-target',
+  name: 'Jane Doe',
+  email: 'jane@example.com',
+  subscriptionTier: 'free',
+};
+
+const subscriptionRow = {
+  id: 'sub-row-1',
+  userId: 'user-target',
+  stripeSubscriptionId: 'sub_stripe_1',
+  status: 'active',
+};
+
+vi.mock('@pagespace/db', () => {
+  const noActiveSelect = {
+    from: () => ({
+      where: () => ({
+        orderBy: () => ({
+          limit: () => Promise.resolve([]),
+        }),
+      }),
+    }),
+  };
+  const activeSelect = {
+    from: () => ({
+      where: () => ({
+        orderBy: () => ({
+          limit: () => Promise.resolve([subscriptionRow]),
+        }),
+      }),
+    }),
+  };
+  const userSelect = {
+    from: () => ({
+      where: () => Promise.resolve([targetUser]),
+    }),
+  };
+
+  let selectCount = 0;
+  return {
+    db: {
+      select: vi.fn(() => {
+        selectCount++;
+        // POST: 1st call user lookup, 2nd call subscriptions check (should return [])
+        // DELETE: 1st user, 2nd active subscription (should return [active])
+        if (selectCount % 2 === 1) return userSelect;
+        return process.env.__GIFT_TEST_MODE__ === 'delete' ? activeSelect : noActiveSelect;
+      }),
+    },
+    users: {},
+    subscriptions: { userId: 'userId', status: 'status', updatedAt: 'updatedAt' },
+    eq: vi.fn(),
+    and: vi.fn(),
+    inArray: vi.fn(),
+    desc: vi.fn(),
+  };
+});
+
+vi.mock('@/lib/stripe', () => ({
+  stripe: {
+    coupons: {
+      create: vi.fn().mockResolvedValue({ id: 'coupon_1' }),
+    },
+    subscriptions: {
+      create: vi.fn().mockResolvedValue({ id: 'sub_new', status: 'active' }),
+      cancel: vi.fn().mockResolvedValue({ id: 'sub_stripe_1', status: 'canceled' }),
+    },
+  },
+  Stripe: { errors: { StripeError: class extends Error {} } },
+}));
+
+vi.mock('@/lib/stripe-customer', () => ({
+  getOrCreateStripeCustomer: vi.fn().mockResolvedValue('cus_1'),
+}));
+
+vi.mock('@/lib/stripe-errors', () => ({
+  getUserFriendlyStripeError: (e: Error) => e.message,
+}));
+
+vi.mock('@/lib/stripe-config', () => ({
+  stripeConfig: {
+    priceIds: { pro: 'price_pro', founder: 'price_founder', business: 'price_business' },
+  },
+}));
+
+vi.mock('@pagespace/lib/server', () => ({
+  loggers: {
+    api: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  },
+  maskEmail: (email: string) => {
+    const [local, domain] = email.split('@');
+    if (!local || !domain) return '***@***';
+    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
+  },
+}));
+
+import { POST, DELETE } from '../route';
+import { loggers } from '@pagespace/lib/server';
+
+describe('Gift subscription PII scrub', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.__GIFT_TEST_MODE__;
+  });
+
+  it('POST: masks targetUserEmail and omits targetUserName in "Admin gifted subscription" log', async () => {
+    const req = new NextRequest('http://localhost/api/admin/users/user-target/gift-subscription', {
+      method: 'POST',
+      body: JSON.stringify({ tier: 'pro', reason: 'thanks' }),
+    });
+    const ctx = { params: Promise.resolve({ userId: 'user-target' }) };
+    await POST(req, ctx);
+
+    const call = vi.mocked(loggers.api.info).mock.calls.find(
+      c => c[0] === 'Admin gifted subscription'
+    );
+    expect(call).toBeDefined();
+    const meta = call?.[1] as Record<string, unknown>;
+    expect(meta.targetUserEmail).toBe('ja***@example.com');
+    expect(meta).not.toHaveProperty('targetUserName');
+  });
+
+  it('DELETE: masks targetUserEmail and omits targetUserName in "Admin revoked subscription" log', async () => {
+    process.env.__GIFT_TEST_MODE__ = 'delete';
+    const req = new NextRequest('http://localhost/api/admin/users/user-target/gift-subscription', {
+      method: 'DELETE',
+    });
+    const ctx = { params: Promise.resolve({ userId: 'user-target' }) };
+    await DELETE(req, ctx);
+
+    const call = vi.mocked(loggers.api.info).mock.calls.find(
+      c => c[0] === 'Admin revoked subscription'
+    );
+    expect(call).toBeDefined();
+    const meta = call?.[1] as Record<string, unknown>;
+    expect(meta.targetUserEmail).toBe('ja***@example.com');
+    expect(meta).not.toHaveProperty('targetUserName');
+  });
+});

--- a/apps/web/src/app/api/admin/users/[userId]/gift-subscription/route.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/gift-subscription/route.ts
@@ -5,7 +5,7 @@ import { stripe, Stripe } from '@/lib/stripe';
 import { getOrCreateStripeCustomer } from '@/lib/stripe-customer';
 import { getUserFriendlyStripeError } from '@/lib/stripe-errors';
 import { stripeConfig } from '@/lib/stripe-config';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, maskEmail } from '@pagespace/lib/server';
 
 type GiftTier = 'pro' | 'founder' | 'business';
 
@@ -116,8 +116,7 @@ export const POST = withAdminAuth<RouteContext>(async (adminUser, request, conte
     loggers.api.info('Admin gifted subscription', {
       adminId: adminUserId,
       targetUserId,
-      targetUserName: targetUser.name,
-      targetUserEmail: targetUser.email,
+      targetUserEmail: maskEmail(targetUser.email),
       tier: giftTier,
       subscriptionId: subscription.id,
       couponId: giftCoupon.id,
@@ -199,8 +198,7 @@ export const DELETE = withAdminAuth<RouteContext>(async (adminUser, request, con
     loggers.api.info('Admin revoked subscription', {
       adminId: adminUserId,
       targetUserId,
-      targetUserName: targetUser.name,
-      targetUserEmail: targetUser.email,
+      targetUserEmail: maskEmail(targetUser.email),
       subscriptionId: activeSubscription.stripeSubscriptionId,
       previousTier: targetUser.subscriptionTier,
     });

--- a/apps/web/src/app/api/auth/__tests__/google-callback-redirect.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/google-callback-redirect.test.ts
@@ -88,6 +88,11 @@ vi.mock('@pagespace/lib/server', () => ({
     deviceToken: 'mock-device-token',
     deviceTokenRecordId: 'device-record-id',
   }),
+  maskEmail: (email: string) => {
+    const [local, domain] = email.split('@');
+    if (!local || !domain) return '***@***';
+    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
+  },
 }));
 
 vi.mock('@pagespace/lib/security', () => ({

--- a/apps/web/src/app/api/auth/__tests__/google-callback-redirect.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/google-callback-redirect.test.ts
@@ -76,23 +76,23 @@ vi.mock('@pagespace/lib/server', async () => {
     '@pagespace/lib/audit/mask-email'
   );
   return {
-  loggers: {
-    auth: {
-      error: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      debug: vi.fn(),
+    loggers: {
+      auth: {
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      },
+      security: {
+        warn: vi.fn(),
+      },
     },
-    security: {
-      warn: vi.fn(),
-    },
-  },
-  auditRequest: vi.fn(),
-  validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
-    deviceToken: 'mock-device-token',
-    deviceTokenRecordId: 'device-record-id',
-  }),
-  maskEmail,
+    auditRequest: vi.fn(),
+    validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
+      deviceToken: 'mock-device-token',
+      deviceTokenRecordId: 'device-record-id',
+    }),
+    maskEmail,
   };
 });
 

--- a/apps/web/src/app/api/auth/__tests__/google-callback-redirect.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/google-callback-redirect.test.ts
@@ -71,7 +71,11 @@ vi.mock('@/lib/auth/cookie-config', () => ({
   createDeviceTokenHandoffCookie: vi.fn().mockReturnValue('ps_device_token=mock; Path=/; Max-Age=60'),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
+vi.mock('@pagespace/lib/server', async () => {
+  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
+    '@pagespace/lib/audit/mask-email'
+  );
+  return {
   loggers: {
     auth: {
       error: vi.fn(),
@@ -88,12 +92,9 @@ vi.mock('@pagespace/lib/server', () => ({
     deviceToken: 'mock-device-token',
     deviceTokenRecordId: 'device-record-id',
   }),
-  maskEmail: (email: string) => {
-    const [local, domain] = email.split('@');
-    if (!local || !domain) return '***@***';
-    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
-  },
-}));
+  maskEmail,
+  };
+});
 
 vi.mock('@pagespace/lib/security', () => ({
   checkDistributedRateLimit: vi.fn(),

--- a/apps/web/src/app/api/auth/__tests__/mobile-oauth-google-exchange.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/mobile-oauth-google-exchange.test.ts
@@ -14,7 +14,11 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { POST } from '../mobile/oauth/google/exchange/route';
 
 // Mock dependencies
-vi.mock('@pagespace/lib/server', () => ({
+vi.mock('@pagespace/lib/server', async () => {
+  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
+    '@pagespace/lib/audit/mask-email'
+  );
+  return {
   generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
   validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
     deviceToken: 'mock-device-token',
@@ -37,12 +41,9 @@ vi.mock('@pagespace/lib/server', () => ({
     },
   },
   auditRequest: vi.fn(),
-  maskEmail: (email: string) => {
-    const [local, domain] = email.split('@');
-    if (!local || !domain) return '***@***';
-    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
-  },
-}));
+  maskEmail,
+  };
+});
 
 vi.mock('@pagespace/lib/auth', () => ({
   sessionService: {

--- a/apps/web/src/app/api/auth/__tests__/mobile-oauth-google-exchange.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/mobile-oauth-google-exchange.test.ts
@@ -19,29 +19,29 @@ vi.mock('@pagespace/lib/server', async () => {
     '@pagespace/lib/audit/mask-email'
   );
   return {
-  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
-  validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
-    deviceToken: 'mock-device-token',
-  }),
-  verifyOAuthIdToken: vi.fn(),
-  createOrLinkOAuthUser: vi.fn(),
-  OAuthProvider: {
-    GOOGLE: 'google',
-    APPLE: 'apple',
-  },
-  loggers: {
-    auth: {
-      error: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      debug: vi.fn(),
+    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+    validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
+      deviceToken: 'mock-device-token',
+    }),
+    verifyOAuthIdToken: vi.fn(),
+    createOrLinkOAuthUser: vi.fn(),
+    OAuthProvider: {
+      GOOGLE: 'google',
+      APPLE: 'apple',
     },
-    security: {
-      warn: vi.fn(),
+    loggers: {
+      auth: {
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      },
+      security: {
+        warn: vi.fn(),
+      },
     },
-  },
-  auditRequest: vi.fn(),
-  maskEmail,
+    auditRequest: vi.fn(),
+    maskEmail,
   };
 });
 

--- a/apps/web/src/app/api/auth/__tests__/mobile-oauth-google-exchange.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/mobile-oauth-google-exchange.test.ts
@@ -37,6 +37,11 @@ vi.mock('@pagespace/lib/server', () => ({
     },
   },
   auditRequest: vi.fn(),
+  maskEmail: (email: string) => {
+    const [local, domain] = email.split('@');
+    if (!local || !domain) return '***@***';
+    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
+  },
 }));
 
 vi.mock('@pagespace/lib/auth', () => ({
@@ -96,6 +101,7 @@ import {
   createOrLinkOAuthUser,
   validateOrCreateDeviceToken,
   auditRequest,
+  loggers,
 } from '@pagespace/lib/server';
 import {
   checkDistributedRateLimit,
@@ -810,6 +816,56 @@ describe('/api/auth/mobile/oauth/google/exchange', () => {
       const body = await response.json();
 
       expect(body.refreshToken).toBeUndefined();
+    });
+  });
+
+  describe('PII scrub in log metadata', () => {
+    const findInfoCall = (msg: string) =>
+      vi.mocked(loggers.auth.info).mock.calls.find(call => call[0] === msg);
+
+    it('masks email in "Google ID token verified" log', async () => {
+      const request = new Request('http://localhost/api/auth/mobile/oauth/google/exchange', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validExchangePayload),
+      });
+
+      await POST(request);
+
+      const call = findInfoCall('Google ID token verified');
+      expect(call).toBeDefined();
+      const meta = call?.[1] as { email?: string };
+      expect(meta.email).toBe('oa***@example.com');
+    });
+
+    it('masks email in "Creating or linking OAuth user" log', async () => {
+      const request = new Request('http://localhost/api/auth/mobile/oauth/google/exchange', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validExchangePayload),
+      });
+
+      await POST(request);
+
+      const call = findInfoCall('Creating or linking OAuth user');
+      expect(call).toBeDefined();
+      const meta = call?.[1] as { email?: string };
+      expect(meta.email).toBe('oa***@example.com');
+    });
+
+    it('masks email in "OAuth user created/linked" log', async () => {
+      const request = new Request('http://localhost/api/auth/mobile/oauth/google/exchange', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(validExchangePayload),
+      });
+
+      await POST(request);
+
+      const call = findInfoCall('OAuth user created/linked');
+      expect(call).toBeDefined();
+      const meta = call?.[1] as { email?: string };
+      expect(meta.email).toBe('oa***@example.com');
     });
   });
 });

--- a/apps/web/src/app/api/auth/apple/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/apple/callback/__tests__/route.test.ts
@@ -63,7 +63,11 @@ vi.mock('@paralleldrive/cuid2', () => ({
   createId: vi.fn().mockReturnValue('mock-cuid'),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
+vi.mock('@pagespace/lib/server', async () => {
+  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
+    '@pagespace/lib/audit/mask-email'
+  );
+  return {
   loggers: {
     auth: {
       error: vi.fn(),
@@ -79,12 +83,9 @@ vi.mock('@pagespace/lib/server', () => ({
   validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
     deviceToken: 'mock-device-token',
   }),
-  maskEmail: (email: string) => {
-    const [local, domain] = email.split('@');
-    if (!local || !domain) return '***@***';
-    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
-  },
-}));
+  maskEmail,
+  };
+});
 
 vi.mock('@pagespace/lib/activity-tracker', () => ({
   trackAuthEvent: vi.fn(),

--- a/apps/web/src/app/api/auth/apple/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/apple/callback/__tests__/route.test.ts
@@ -68,22 +68,22 @@ vi.mock('@pagespace/lib/server', async () => {
     '@pagespace/lib/audit/mask-email'
   );
   return {
-  loggers: {
-    auth: {
-      error: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      debug: vi.fn(),
+    loggers: {
+      auth: {
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      },
+      security: {
+        warn: vi.fn(),
+      },
     },
-    security: {
-      warn: vi.fn(),
-    },
-  },
-  auditRequest: vi.fn(),
-  validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
-    deviceToken: 'mock-device-token',
-  }),
-  maskEmail,
+    auditRequest: vi.fn(),
+    validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
+      deviceToken: 'mock-device-token',
+    }),
+    maskEmail,
   };
 });
 

--- a/apps/web/src/app/api/auth/apple/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/apple/callback/__tests__/route.test.ts
@@ -79,6 +79,11 @@ vi.mock('@pagespace/lib/server', () => ({
   validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
     deviceToken: 'mock-device-token',
   }),
+  maskEmail: (email: string) => {
+    const [local, domain] = email.split('@');
+    if (!local || !domain) return '***@***';
+    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
+  },
 }));
 
 vi.mock('@pagespace/lib/activity-tracker', () => ({
@@ -1009,6 +1014,94 @@ describe('POST /api/auth/apple/callback', () => {
         'Apple OAuth callback error',
         new Error('Network failure')
       );
+    });
+  });
+
+  describe('PII scrub in log metadata', () => {
+    const findInfoCall = (msg: string) =>
+      vi.mocked(loggers.auth.info).mock.calls.find(call => call[0] === msg);
+
+    it('masks email in "Creating new user via Apple OAuth" log', async () => {
+      const state = createSignedState({ returnUrl: '/dashboard', platform: 'web' });
+      const request = createCallbackRequest({ id_token: 'valid-token', state });
+      await POST(request);
+
+      const call = findInfoCall('Creating new user via Apple OAuth');
+      expect(call).toBeDefined();
+      const meta = call?.[1] as { email?: string };
+      expect(meta.email).toBe('te***@example.com');
+    });
+
+    it('does not include name in "New user created via Apple OAuth" log', async () => {
+      const state = createSignedState({ returnUrl: '/dashboard', platform: 'web' });
+      const request = createCallbackRequest({ id_token: 'valid-token', state });
+      await POST(request);
+
+      const call = findInfoCall('New user created via Apple OAuth');
+      expect(call).toBeDefined();
+      const meta = call?.[1] as Record<string, unknown>;
+      expect(meta).not.toHaveProperty('name');
+      expect(meta).toHaveProperty('userId');
+    });
+
+    it('masks email in "Updating existing user via Apple OAuth" log', async () => {
+      const existingUser = {
+        id: 'existing-id',
+        name: null,
+        email: 'test@example.com',
+        image: null,
+        emailVerified: new Date(),
+        tokenVersion: 0,
+        appleId: null,
+      };
+      vi.mocked(authRepository.findUserByAppleIdOrEmail).mockResolvedValueOnce(existingUser as never);
+      vi.mocked(authRepository.findUserById).mockResolvedValueOnce({ ...existingUser, name: 'test', appleId: 'apple-sub-123' } as never);
+
+      const state = createSignedState({ returnUrl: '/dashboard', platform: 'web' });
+      const request = createCallbackRequest({ id_token: 'valid-token', state });
+      await POST(request);
+
+      const call = findInfoCall('Updating existing user via Apple OAuth');
+      expect(call).toBeDefined();
+      const meta = call?.[1] as { email?: string };
+      expect(meta.email).toBe('te***@example.com');
+    });
+
+    it('does not include name in "User updated via Apple OAuth" log', async () => {
+      const existingUser = {
+        id: 'existing-id',
+        name: null,
+        email: 'test@example.com',
+        image: null,
+        emailVerified: new Date(),
+        tokenVersion: 0,
+        appleId: null,
+      };
+      vi.mocked(authRepository.findUserByAppleIdOrEmail).mockResolvedValueOnce(existingUser as never);
+      vi.mocked(authRepository.findUserById).mockResolvedValueOnce({ ...existingUser, name: 'test', appleId: 'apple-sub-123' } as never);
+
+      const state = createSignedState({ returnUrl: '/dashboard', platform: 'web' });
+      const request = createCallbackRequest({ id_token: 'valid-token', state });
+      await POST(request);
+
+      const call = findInfoCall('User updated via Apple OAuth');
+      expect(call).toBeDefined();
+      const meta = call?.[1] as Record<string, unknown>;
+      expect(meta).not.toHaveProperty('name');
+      expect(meta).toHaveProperty('userId');
+    });
+
+    it('masks email in desktop missing-deviceId error log', async () => {
+      const state = createSignedState({ returnUrl: '/dashboard', platform: 'desktop' });
+      const request = createCallbackRequest({ id_token: 'valid-token', state });
+      await POST(request);
+
+      const errCall = vi.mocked(loggers.auth.error).mock.calls.find(
+        call => call[0] === 'Desktop OAuth callback missing deviceId'
+      );
+      expect(errCall).toBeDefined();
+      const meta = errCall?.[1] as { email?: string };
+      expect(meta.email).toBe('te***@example.com');
     });
   });
 });

--- a/apps/web/src/app/api/auth/apple/callback/route.ts
+++ b/apps/web/src/app/api/auth/apple/callback/route.ts
@@ -6,7 +6,7 @@ import {
   DISTRIBUTED_RATE_LIMITS,
 } from '@pagespace/lib/security';
 import { createId } from '@paralleldrive/cuid2';
-import { loggers, auditRequest, validateOrCreateDeviceToken } from '@pagespace/lib/server';
+import { loggers, auditRequest, validateOrCreateDeviceToken, maskEmail } from '@pagespace/lib/server';
 import { revokeSessionsForLogin, createWebDeviceToken } from '@/lib/auth';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
 import { NextResponse } from 'next/server';
@@ -133,7 +133,7 @@ export async function POST(req: Request) {
     if (user) {
       // Update existing user if needed
       if (!user.appleId || !user.name) {
-        loggers.auth.info('Updating existing user via Apple OAuth', { email });
+        loggers.auth.info('Updating existing user via Apple OAuth', { email: maskEmail(email) });
         await authRepository.updateUser(user.id, {
           appleId: appleId || user.appleId,
           provider: 'apple',
@@ -142,11 +142,11 @@ export async function POST(req: Request) {
         });
 
         user = await authRepository.findUserById(user.id) || user;
-        loggers.auth.info('User updated via Apple OAuth', { userId: user.id, name: user.name });
+        loggers.auth.info('User updated via Apple OAuth', { userId: user.id });
       }
     } else {
       // Create new user
-      loggers.auth.info('Creating new user via Apple OAuth', { email });
+      loggers.auth.info('Creating new user via Apple OAuth', { email: maskEmail(email) });
       user = await authRepository.createUser({
         id: createId(),
         name: userName,
@@ -160,7 +160,7 @@ export async function POST(req: Request) {
         storageUsedBytes: 0,
         subscriptionTier: 'free',
       });
-      loggers.auth.info('New user created via Apple OAuth', { userId: user.id, name: user.name });
+      loggers.auth.info('New user created via Apple OAuth', { userId: user.id });
     }
 
     // Provision getting started drive for new users
@@ -225,7 +225,7 @@ export async function POST(req: Request) {
       if (!deviceId) {
         loggers.auth.error('Desktop OAuth callback missing deviceId', {
           userId: user.id,
-          email: user.email,
+          email: maskEmail(user.email),
         });
           return NextResponse.redirect(new URL('/auth/signin?error=oauth_error', baseUrl));
       }

--- a/apps/web/src/app/api/auth/apple/native/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/apple/native/__tests__/route.test.ts
@@ -65,22 +65,22 @@ vi.mock('@pagespace/lib/server', async () => {
     '@pagespace/lib/audit/mask-email'
   );
   return {
-  loggers: {
-    auth: {
-      error: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      debug: vi.fn(),
+    loggers: {
+      auth: {
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      },
+      security: {
+        warn: vi.fn(),
+      },
     },
-    security: {
-      warn: vi.fn(),
-    },
-  },
-  auditRequest: vi.fn(),
-  validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
-    deviceToken: 'mock-device-token',
-  }),
-  maskEmail,
+    auditRequest: vi.fn(),
+    validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
+      deviceToken: 'mock-device-token',
+    }),
+    maskEmail,
   };
 });
 

--- a/apps/web/src/app/api/auth/apple/native/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/apple/native/__tests__/route.test.ts
@@ -60,7 +60,11 @@ vi.mock('@paralleldrive/cuid2', () => ({
   createId: vi.fn().mockReturnValue('mock-cuid'),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
+vi.mock('@pagespace/lib/server', async () => {
+  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
+    '@pagespace/lib/audit/mask-email'
+  );
+  return {
   loggers: {
     auth: {
       error: vi.fn(),
@@ -76,12 +80,9 @@ vi.mock('@pagespace/lib/server', () => ({
   validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
     deviceToken: 'mock-device-token',
   }),
-  maskEmail: (email: string) => {
-    const [local, domain] = email.split('@');
-    if (!local || !domain) return '***@***';
-    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
-  },
-}));
+  maskEmail,
+  };
+});
 
 vi.mock('@pagespace/lib/activity-tracker', () => ({
   trackAuthEvent: vi.fn(),

--- a/apps/web/src/app/api/auth/apple/native/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/apple/native/__tests__/route.test.ts
@@ -76,6 +76,11 @@ vi.mock('@pagespace/lib/server', () => ({
   validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
     deviceToken: 'mock-device-token',
   }),
+  maskEmail: (email: string) => {
+    const [local, domain] = email.split('@');
+    if (!local || !domain) return '***@***';
+    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
+  },
 }));
 
 vi.mock('@pagespace/lib/activity-tracker', () => ({
@@ -655,6 +660,54 @@ describe('POST /api/auth/apple/native', () => {
 
       expect(response.status).toBe(401);
       expect(body.error).toBe('Token expired. Please try again.');
+    });
+  });
+
+  describe('PII scrub in log metadata', () => {
+    const findInfoCall = (msg: string) =>
+      vi.mocked(loggers.auth.info).mock.calls.find(call => call[0] === msg);
+
+    it('masks email in "Creating new user via native Apple OAuth" log', async () => {
+      vi.mocked(authRepository.findUserByAppleIdOrEmail).mockResolvedValue(null);
+      vi.mocked(authRepository.createUser).mockResolvedValue({
+        id: 'new-user-id',
+        name: 'Test',
+        email: 'test@example.com',
+        appleId: 'apple-sub-123',
+        tokenVersion: 0,
+        provider: 'apple',
+        image: null,
+        emailVerified: new Date(),
+      } as never);
+
+      await POST(createNativeRequest(validPayload));
+
+      const call = findInfoCall('Creating new user via native Apple OAuth');
+      expect(call).toBeDefined();
+      const meta = call?.[1] as { email?: string };
+      expect(meta.email).toBe('te***@example.com');
+    });
+
+    it('masks email in "Updating existing user via native Apple OAuth" log', async () => {
+      const existingUser = {
+        id: 'existing-id',
+        name: null,
+        email: 'test@example.com',
+        appleId: null,
+        tokenVersion: 0,
+        provider: 'email',
+        image: null,
+        emailVerified: new Date(),
+      };
+      vi.mocked(authRepository.findUserByAppleIdOrEmail).mockResolvedValueOnce(existingUser as never);
+      vi.mocked(authRepository.findUserById).mockResolvedValueOnce({ ...existingUser, name: 'Joe', appleId: 'apple-sub-123' } as never);
+
+      await POST(createNativeRequest({ ...validPayload, givenName: 'Joe' }));
+
+      const call = findInfoCall('Updating existing user via native Apple OAuth');
+      expect(call).toBeDefined();
+      const meta = call?.[1] as { email?: string };
+      expect(meta.email).toBe('te***@example.com');
     });
   });
 });

--- a/apps/web/src/app/api/auth/apple/native/route.ts
+++ b/apps/web/src/app/api/auth/apple/native/route.ts
@@ -1,6 +1,6 @@
 import { sessionService, generateCSRFToken, SESSION_DURATION_MS, verifyAppleIdToken } from '@pagespace/lib/auth';
 import { createId } from '@paralleldrive/cuid2';
-import { loggers, auditRequest, validateOrCreateDeviceToken } from '@pagespace/lib/server';
+import { loggers, auditRequest, validateOrCreateDeviceToken, maskEmail } from '@pagespace/lib/server';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
 import { z } from 'zod/v4';
 import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-started-drive';
@@ -103,7 +103,7 @@ export async function POST(req: Request) {
       // Update existing user if needed
       const needsUpdate = !user.appleId || (!user.name && name);
       if (needsUpdate) {
-        loggers.auth.info('Updating existing user via native Apple OAuth', { email, platform });
+        loggers.auth.info('Updating existing user via native Apple OAuth', { email: maskEmail(email), platform });
         await authRepository.updateUser(user.id, {
           appleId: user.appleId || appleId,
           provider: user.provider === 'email' ? 'apple' : user.provider,
@@ -115,7 +115,7 @@ export async function POST(req: Request) {
       }
     } else {
       isNewUser = true;
-      loggers.auth.info('Creating new user via native Apple OAuth', { email, platform });
+      loggers.auth.info('Creating new user via native Apple OAuth', { email: maskEmail(email), platform });
       user = await authRepository.createUser({
         id: createId(),
         name: name || email.split('@')[0],

--- a/apps/web/src/app/api/auth/google/__tests__/google-callback-redirect.test.ts
+++ b/apps/web/src/app/api/auth/google/__tests__/google-callback-redirect.test.ts
@@ -71,23 +71,23 @@ vi.mock('@pagespace/lib/server', async () => {
     '@pagespace/lib/audit/mask-email'
   );
   return {
-  loggers: {
-    auth: {
-      error: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      debug: vi.fn(),
+    loggers: {
+      auth: {
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      },
+      security: {
+        warn: vi.fn(),
+      },
     },
-    security: {
-      warn: vi.fn(),
-    },
-  },
-  auditRequest: vi.fn(),
-  validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
-    deviceToken: 'mock-device-token',
-    deviceTokenRecordId: 'device-record-id',
-  }),
-  maskEmail,
+    auditRequest: vi.fn(),
+    validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
+      deviceToken: 'mock-device-token',
+      deviceTokenRecordId: 'device-record-id',
+    }),
+    maskEmail,
   };
 });
 

--- a/apps/web/src/app/api/auth/google/__tests__/google-callback-redirect.test.ts
+++ b/apps/web/src/app/api/auth/google/__tests__/google-callback-redirect.test.ts
@@ -66,7 +66,11 @@ vi.mock('@/lib/auth/cookie-config', () => ({
   createDeviceTokenHandoffCookie: vi.fn().mockReturnValue('ps_device_token=mock; Path=/; Max-Age=60'),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
+vi.mock('@pagespace/lib/server', async () => {
+  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
+    '@pagespace/lib/audit/mask-email'
+  );
+  return {
   loggers: {
     auth: {
       error: vi.fn(),
@@ -83,12 +87,9 @@ vi.mock('@pagespace/lib/server', () => ({
     deviceToken: 'mock-device-token',
     deviceTokenRecordId: 'device-record-id',
   }),
-  maskEmail: (email: string) => {
-    const [local, domain] = email.split('@');
-    if (!local || !domain) return '***@***';
-    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
-  },
-}));
+  maskEmail,
+  };
+});
 
 vi.mock('@pagespace/lib/security', () => ({
   checkDistributedRateLimit: vi.fn(),

--- a/apps/web/src/app/api/auth/google/__tests__/google-callback-redirect.test.ts
+++ b/apps/web/src/app/api/auth/google/__tests__/google-callback-redirect.test.ts
@@ -83,6 +83,11 @@ vi.mock('@pagespace/lib/server', () => ({
     deviceToken: 'mock-device-token',
     deviceTokenRecordId: 'device-record-id',
   }),
+  maskEmail: (email: string) => {
+    const [local, domain] = email.split('@');
+    if (!local || !domain) return '***@***';
+    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
+  },
 }));
 
 vi.mock('@pagespace/lib/security', () => ({

--- a/apps/web/src/app/api/auth/google/__tests__/one-tap.test.ts
+++ b/apps/web/src/app/api/auth/google/__tests__/one-tap.test.ts
@@ -69,19 +69,19 @@ vi.mock('@pagespace/lib/server', async () => {
     '@pagespace/lib/audit/mask-email'
   );
   return {
-  loggers: {
-    auth: {
-      error: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      debug: vi.fn(),
+    loggers: {
+      auth: {
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      },
+      security: {
+        warn: vi.fn(),
+      },
     },
-    security: {
-      warn: vi.fn(),
-    },
-  },
-  auditRequest: vi.fn(),
-  maskEmail,
+    auditRequest: vi.fn(),
+    maskEmail,
   };
 });
 

--- a/apps/web/src/app/api/auth/google/__tests__/one-tap.test.ts
+++ b/apps/web/src/app/api/auth/google/__tests__/one-tap.test.ts
@@ -77,6 +77,11 @@ vi.mock('@pagespace/lib/server', () => ({
     },
   },
   auditRequest: vi.fn(),
+  maskEmail: (email: string) => {
+    const [local, domain] = email.split('@');
+    if (!local || !domain) return '***@***';
+    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
+  },
 }));
 
 vi.mock('@pagespace/lib/security', () => ({

--- a/apps/web/src/app/api/auth/google/__tests__/one-tap.test.ts
+++ b/apps/web/src/app/api/auth/google/__tests__/one-tap.test.ts
@@ -64,7 +64,11 @@ vi.mock('@/lib/auth/cookie-config', () => ({
   getSessionFromCookies: vi.fn().mockReturnValue('ps_sess_mock_session_token'),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
+vi.mock('@pagespace/lib/server', async () => {
+  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
+    '@pagespace/lib/audit/mask-email'
+  );
+  return {
   loggers: {
     auth: {
       error: vi.fn(),
@@ -77,12 +81,9 @@ vi.mock('@pagespace/lib/server', () => ({
     },
   },
   auditRequest: vi.fn(),
-  maskEmail: (email: string) => {
-    const [local, domain] = email.split('@');
-    if (!local || !domain) return '***@***';
-    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
-  },
-}));
+  maskEmail,
+  };
+});
 
 vi.mock('@pagespace/lib/security', () => ({
   checkDistributedRateLimit: vi.fn(),

--- a/apps/web/src/app/api/auth/google/__tests__/open-redirect-protection.test.ts
+++ b/apps/web/src/app/api/auth/google/__tests__/open-redirect-protection.test.ts
@@ -15,23 +15,23 @@ vi.mock('@pagespace/lib/server', async () => {
     '@pagespace/lib/audit/mask-email'
   );
   return {
-  loggers: {
-    auth: {
-      error: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      debug: vi.fn(),
+    loggers: {
+      auth: {
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      },
+      security: {
+        warn: vi.fn(),
+      },
     },
-    security: {
-      warn: vi.fn(),
-    },
-  },
-  auditRequest: vi.fn(),
-  validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
-    deviceToken: 'mock-device-token',
-    deviceTokenRecordId: 'device-record-id',
-  }),
-  maskEmail,
+    auditRequest: vi.fn(),
+    validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
+      deviceToken: 'mock-device-token',
+      deviceTokenRecordId: 'device-record-id',
+    }),
+    maskEmail,
   };
 });
 

--- a/apps/web/src/app/api/auth/google/__tests__/open-redirect-protection.test.ts
+++ b/apps/web/src/app/api/auth/google/__tests__/open-redirect-protection.test.ts
@@ -10,7 +10,11 @@ import { POST } from '../signin/route';
 import { GET } from '../callback/route';
 
 // Mock dependencies for signin
-vi.mock('@pagespace/lib/server', () => ({
+vi.mock('@pagespace/lib/server', async () => {
+  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
+    '@pagespace/lib/audit/mask-email'
+  );
+  return {
   loggers: {
     auth: {
       error: vi.fn(),
@@ -27,12 +31,9 @@ vi.mock('@pagespace/lib/server', () => ({
     deviceToken: 'mock-device-token',
     deviceTokenRecordId: 'device-record-id',
   }),
-  maskEmail: (email: string) => {
-    const [local, domain] = email.split('@');
-    if (!local || !domain) return '***@***';
-    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
-  },
-}));
+  maskEmail,
+  };
+});
 
 vi.mock('@pagespace/lib/security', () => ({
   checkDistributedRateLimit: vi.fn().mockResolvedValue({ allowed: true, attemptsRemaining: 5 }),

--- a/apps/web/src/app/api/auth/google/__tests__/open-redirect-protection.test.ts
+++ b/apps/web/src/app/api/auth/google/__tests__/open-redirect-protection.test.ts
@@ -27,6 +27,11 @@ vi.mock('@pagespace/lib/server', () => ({
     deviceToken: 'mock-device-token',
     deviceTokenRecordId: 'device-record-id',
   }),
+  maskEmail: (email: string) => {
+    const [local, domain] = email.split('@');
+    if (!local || !domain) return '***@***';
+    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
+  },
 }));
 
 vi.mock('@pagespace/lib/security', () => ({

--- a/apps/web/src/app/api/auth/google/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/callback/__tests__/route.test.ts
@@ -96,6 +96,11 @@ vi.mock('@pagespace/lib/server', () => ({
     },
   },
   auditRequest: vi.fn(),
+  maskEmail: (email: string) => {
+    const [local, domain] = email.split('@');
+    if (!local || !domain) return '***@***';
+    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
+  },
 }));
 
 vi.mock('@pagespace/lib/security', () => ({
@@ -1145,6 +1150,78 @@ describe('GET /api/auth/google/callback', () => {
       expect(locationUrl.searchParams.get('error')).toBe('oauth_error');
       expect(locationUrl.searchParams.has('code')).toBe(false);
       expect(locationUrl.searchParams.has('state')).toBe(false);
+    });
+  });
+
+  describe('PII scrub in log metadata', () => {
+    const findInfoCall = (msg: string) =>
+      vi.mocked(loggers.auth.info).mock.calls.find(call => call[0] === msg);
+
+    it('masks email in "Creating new user" log', async () => {
+      const request = createCallbackRequest({ code: 'valid-code' });
+      await GET(request);
+
+      const call = findInfoCall('Creating new user via Google OAuth');
+      expect(call).toBeDefined();
+      const meta = call?.[1] as { email?: string };
+      expect(meta.email).toBe('te***@example.com');
+    });
+
+    it('does not include name in "New user created" log', async () => {
+      const request = createCallbackRequest({ code: 'valid-code' });
+      await GET(request);
+
+      const call = findInfoCall('New user created via Google OAuth');
+      expect(call).toBeDefined();
+      const meta = call?.[1] as Record<string, unknown>;
+      expect(meta).not.toHaveProperty('name');
+      expect(meta).toHaveProperty('userId');
+    });
+
+    it('masks email in "Updating existing user" log', async () => {
+      const userWithoutGoogleId = { ...mockExistingUser, googleId: null };
+      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValueOnce(userWithoutGoogleId as never);
+      vi.mocked(authRepository.findUserById).mockResolvedValueOnce(mockExistingUser as never);
+
+      const request = createCallbackRequest({ code: 'valid-code' });
+      await GET(request);
+
+      const call = findInfoCall('Updating existing user via Google OAuth');
+      expect(call).toBeDefined();
+      const meta = call?.[1] as { email?: string };
+      expect(meta.email).toBe('te***@example.com');
+    });
+
+    it('does not include name in "User updated" log', async () => {
+      const userWithoutGoogleId = { ...mockExistingUser, googleId: null };
+      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValueOnce(userWithoutGoogleId as never);
+      vi.mocked(authRepository.findUserById).mockResolvedValueOnce(mockExistingUser as never);
+
+      const request = createCallbackRequest({ code: 'valid-code' });
+      await GET(request);
+
+      const call = findInfoCall('User updated via Google OAuth');
+      expect(call).toBeDefined();
+      const meta = call?.[1] as Record<string, unknown>;
+      expect(meta).not.toHaveProperty('name');
+      expect(meta).toHaveProperty('userId');
+    });
+
+    it('masks email in desktop missing-deviceId error log', async () => {
+      const state = createSignedState({
+        returnUrl: '/dashboard',
+        platform: 'desktop',
+      });
+
+      const request = createCallbackRequest({ code: 'valid-code', state });
+      await GET(request);
+
+      const errCall = vi.mocked(loggers.auth.error).mock.calls.find(
+        call => call[0] === 'Desktop OAuth callback missing deviceId'
+      );
+      expect(errCall).toBeDefined();
+      const meta = errCall?.[1] as { email?: string };
+      expect(meta.email).toBe('te***@example.com');
     });
   });
 

--- a/apps/web/src/app/api/auth/google/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/callback/__tests__/route.test.ts
@@ -84,23 +84,23 @@ vi.mock('@pagespace/lib/server', async () => {
     '@pagespace/lib/audit/mask-email'
   );
   return {
-  validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
-    deviceToken: 'mock-device-token',
-    deviceTokenRecordId: 'device-record-id',
-  }),
-  loggers: {
-    auth: {
-      error: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      debug: vi.fn(),
+    validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
+      deviceToken: 'mock-device-token',
+      deviceTokenRecordId: 'device-record-id',
+    }),
+    loggers: {
+      auth: {
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      },
+      security: {
+        warn: vi.fn(),
+      },
     },
-    security: {
-      warn: vi.fn(),
-    },
-  },
-  auditRequest: vi.fn(),
-  maskEmail,
+    auditRequest: vi.fn(),
+    maskEmail,
   };
 });
 

--- a/apps/web/src/app/api/auth/google/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/callback/__tests__/route.test.ts
@@ -79,7 +79,11 @@ vi.mock('@pagespace/lib/auth', () => ({
   SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
+vi.mock('@pagespace/lib/server', async () => {
+  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
+    '@pagespace/lib/audit/mask-email'
+  );
+  return {
   validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
     deviceToken: 'mock-device-token',
     deviceTokenRecordId: 'device-record-id',
@@ -96,12 +100,9 @@ vi.mock('@pagespace/lib/server', () => ({
     },
   },
   auditRequest: vi.fn(),
-  maskEmail: (email: string) => {
-    const [local, domain] = email.split('@');
-    if (!local || !domain) return '***@***';
-    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
-  },
-}));
+  maskEmail,
+  };
+});
 
 vi.mock('@pagespace/lib/security', () => ({
   checkDistributedRateLimit: vi.fn(),

--- a/apps/web/src/app/api/auth/google/callback/route.ts
+++ b/apps/web/src/app/api/auth/google/callback/route.ts
@@ -5,7 +5,7 @@ import {
   DISTRIBUTED_RATE_LIMITS,
 } from '@pagespace/lib/security';
 import { createId } from '@paralleldrive/cuid2';
-import { loggers, auditRequest, validateOrCreateDeviceToken } from '@pagespace/lib/server';
+import { loggers, auditRequest, validateOrCreateDeviceToken, maskEmail } from '@pagespace/lib/server';
 import { revokeSessionsForLogin, createWebDeviceToken } from '@/lib/auth';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
 import { OAuth2Client } from 'google-auth-library';
@@ -137,7 +137,7 @@ export async function GET(req: Request) {
         user.image !== resolvedImage ||
         (email_verified && !user.emailVerified)
       ) {
-        loggers.auth.info('Updating existing user via Google OAuth', { email });
+        loggers.auth.info('Updating existing user via Google OAuth', { email: maskEmail(email) });
         await authRepository.updateUser(user.id, {
           googleId: googleId || user.googleId,
           provider: user.provider === 'email' ? 'google' : user.provider,
@@ -147,10 +147,10 @@ export async function GET(req: Request) {
         });
 
         user = await authRepository.findUserById(user.id) || user;
-        loggers.auth.info('User updated via Google OAuth', { userId: user.id, name: user.name });
+        loggers.auth.info('User updated via Google OAuth', { userId: user.id });
       }
     } else {
-      loggers.auth.info('Creating new user via Google OAuth', { email });
+      loggers.auth.info('Creating new user via Google OAuth', { email: maskEmail(email) });
       user = await authRepository.createUser({
         id: createId(),
         name: userName,
@@ -176,7 +176,7 @@ export async function GET(req: Request) {
         user = { ...user, image: resolvedImage };
       }
 
-      loggers.auth.info('New user created via Google OAuth', { userId: user.id, name: user.name });
+      loggers.auth.info('New user created via Google OAuth', { userId: user.id });
     }
 
     let isNewlyProvisioned = false;
@@ -242,7 +242,7 @@ export async function GET(req: Request) {
       if (!deviceId) {
         loggers.auth.error('Desktop OAuth callback missing deviceId', {
           userId: user.id,
-          email: user.email,
+          email: maskEmail(user.email),
         });
           return NextResponse.redirect(new URL('/auth/signin?error=oauth_error', baseUrl));
       }

--- a/apps/web/src/app/api/auth/google/native/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/native/__tests__/route.test.ts
@@ -68,23 +68,23 @@ vi.mock('@pagespace/lib/server', async () => {
     '@pagespace/lib/audit/mask-email'
   );
   return {
-  validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
-    deviceToken: 'mock-device-token',
-    deviceTokenRecordId: 'device-record-id',
-  }),
-  loggers: {
-    auth: {
-      error: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      debug: vi.fn(),
+    validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
+      deviceToken: 'mock-device-token',
+      deviceTokenRecordId: 'device-record-id',
+    }),
+    loggers: {
+      auth: {
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      },
+      security: {
+        warn: vi.fn(),
+      },
     },
-    security: {
-      warn: vi.fn(),
-    },
-  },
-  auditRequest: vi.fn(),
-  maskEmail,
+    auditRequest: vi.fn(),
+    maskEmail,
   };
 });
 

--- a/apps/web/src/app/api/auth/google/native/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/native/__tests__/route.test.ts
@@ -63,7 +63,11 @@ vi.mock('@pagespace/lib/auth', () => ({
   SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
+vi.mock('@pagespace/lib/server', async () => {
+  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
+    '@pagespace/lib/audit/mask-email'
+  );
+  return {
   validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
     deviceToken: 'mock-device-token',
     deviceTokenRecordId: 'device-record-id',
@@ -80,12 +84,9 @@ vi.mock('@pagespace/lib/server', () => ({
     },
   },
   auditRequest: vi.fn(),
-  maskEmail: (email: string) => {
-    const [local, domain] = email.split('@');
-    if (!local || !domain) return '***@***';
-    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
-  },
-}));
+  maskEmail,
+  };
+});
 
 vi.mock('@pagespace/lib/security', () => ({
   checkDistributedRateLimit: vi.fn(),

--- a/apps/web/src/app/api/auth/google/native/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/native/__tests__/route.test.ts
@@ -80,6 +80,11 @@ vi.mock('@pagespace/lib/server', () => ({
     },
   },
   auditRequest: vi.fn(),
+  maskEmail: (email: string) => {
+    const [local, domain] = email.split('@');
+    if (!local || !domain) return '***@***';
+    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
+  },
 }));
 
 vi.mock('@pagespace/lib/security', () => ({
@@ -121,7 +126,7 @@ vi.mock('@/lib/auth/google-avatar', () => ({
 
 import { authRepository } from '@/lib/repositories/auth-repository';
 import { sessionService, generateCSRFToken } from '@pagespace/lib/auth';
-import { validateOrCreateDeviceToken, auditRequest } from '@pagespace/lib/server';
+import { validateOrCreateDeviceToken, auditRequest, loggers } from '@pagespace/lib/server';
 import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security';
 import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-started-drive';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
@@ -713,5 +718,37 @@ describe('POST /api/auth/google/native', () => {
       expect((updateArgs[1] as Record<string, unknown>).image).toBe('/processed-avatar.jpg');
     });
 
+  });
+
+  describe('PII scrub in log metadata', () => {
+    const findInfoCall = (msg: string) =>
+      vi.mocked(loggers.auth.info).mock.calls.find(call => call[0] === msg);
+
+    it('masks email in "Creating new user via native Google OAuth" log', async () => {
+      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValue(null);
+      vi.mocked(authRepository.createUser).mockResolvedValue(mockNewUser as never);
+
+      const request = createNativeRequest(validNativePayload);
+      await POST(request);
+
+      const call = findInfoCall('Creating new user via native Google OAuth');
+      expect(call).toBeDefined();
+      const meta = call?.[1] as { email?: string };
+      expect(meta.email).toBe('te***@example.com');
+    });
+
+    it('masks email in "Updating existing user via native Google OAuth" log', async () => {
+      const userWithoutGoogleId = { ...mockExistingUser, googleId: null };
+      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValueOnce(userWithoutGoogleId as never);
+      vi.mocked(authRepository.findUserById).mockResolvedValueOnce(mockExistingUser as never);
+
+      const request = createNativeRequest(validNativePayload);
+      await POST(request);
+
+      const call = findInfoCall('Updating existing user via native Google OAuth');
+      expect(call).toBeDefined();
+      const meta = call?.[1] as { email?: string };
+      expect(meta.email).toBe('te***@example.com');
+    });
   });
 });

--- a/apps/web/src/app/api/auth/google/native/route.ts
+++ b/apps/web/src/app/api/auth/google/native/route.ts
@@ -1,7 +1,7 @@
 import { OAuth2Client } from 'google-auth-library';
 import { sessionService, generateCSRFToken, SESSION_DURATION_MS } from '@pagespace/lib/auth';
 import { createId } from '@paralleldrive/cuid2';
-import { loggers, auditRequest, validateOrCreateDeviceToken } from '@pagespace/lib/server';
+import { loggers, auditRequest, validateOrCreateDeviceToken, maskEmail } from '@pagespace/lib/server';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
 import { z } from 'zod/v4';
 import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-started-drive';
@@ -114,7 +114,7 @@ export async function POST(req: Request) {
         user.image !== resolvedImage ||
         (email_verified && !user.emailVerified)
       ) {
-        loggers.auth.info('Updating existing user via native Google OAuth', { email, platform });
+        loggers.auth.info('Updating existing user via native Google OAuth', { email: maskEmail(email), platform });
         await authRepository.updateUser(user.id, {
           googleId: googleId || user.googleId,
           provider: user.provider === 'email' ? 'google' : user.provider,
@@ -127,7 +127,7 @@ export async function POST(req: Request) {
       }
     } else {
       isNewUser = true;
-      loggers.auth.info('Creating new user via native Google OAuth', { email, platform });
+      loggers.auth.info('Creating new user via native Google OAuth', { email: maskEmail(email), platform });
       user = await authRepository.createUser({
         id: createId(),
         name: name || email.split('@')[0],

--- a/apps/web/src/app/api/auth/google/one-tap/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/one-tap/__tests__/route.test.ts
@@ -65,7 +65,11 @@ vi.mock('@pagespace/lib/auth', () => ({
   SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
+vi.mock('@pagespace/lib/server', async () => {
+  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
+    '@pagespace/lib/audit/mask-email'
+  );
+  return {
   loggers: {
     auth: {
       error: vi.fn(),
@@ -78,12 +82,9 @@ vi.mock('@pagespace/lib/server', () => ({
     },
   },
   auditRequest: vi.fn(),
-  maskEmail: (email: string) => {
-    const [local, domain] = email.split('@');
-    if (!local || !domain) return '***@***';
-    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
-  },
-}));
+  maskEmail,
+  };
+});
 
 vi.mock('@pagespace/lib/security', () => ({
   checkDistributedRateLimit: vi.fn(),

--- a/apps/web/src/app/api/auth/google/one-tap/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/one-tap/__tests__/route.test.ts
@@ -70,19 +70,19 @@ vi.mock('@pagespace/lib/server', async () => {
     '@pagespace/lib/audit/mask-email'
   );
   return {
-  loggers: {
-    auth: {
-      error: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      debug: vi.fn(),
+    loggers: {
+      auth: {
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      },
+      security: {
+        warn: vi.fn(),
+      },
     },
-    security: {
-      warn: vi.fn(),
-    },
-  },
-  auditRequest: vi.fn(),
-  maskEmail,
+    auditRequest: vi.fn(),
+    maskEmail,
   };
 });
 

--- a/apps/web/src/app/api/auth/google/one-tap/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/one-tap/__tests__/route.test.ts
@@ -78,6 +78,11 @@ vi.mock('@pagespace/lib/server', () => ({
     },
   },
   auditRequest: vi.fn(),
+  maskEmail: (email: string) => {
+    const [local, domain] = email.split('@');
+    if (!local || !domain) return '***@***';
+    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
+  },
 }));
 
 vi.mock('@pagespace/lib/security', () => ({
@@ -677,6 +682,67 @@ describe('POST /api/auth/google/one-tap', () => {
         'Google One Tap error',
         new Error('Database error')
       );
+    });
+  });
+
+  describe('PII scrub in log metadata', () => {
+    const findInfoCall = (msg: string) =>
+      vi.mocked(loggers.auth.info).mock.calls.find(call => call[0] === msg);
+
+    it('masks email in "Creating new user via Google One Tap" log', async () => {
+      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValue(null);
+      vi.mocked(authRepository.createUser).mockResolvedValue(mockNewUser as never);
+
+      const request = createOneTapRequest(validOneTapPayload);
+      await POST(request);
+
+      const call = findInfoCall('Creating new user via Google One Tap');
+      expect(call).toBeDefined();
+      const meta = call?.[1] as { email?: string };
+      expect(meta.email).toBe('te***@example.com');
+    });
+
+    it('does not include name in "New user created via Google One Tap" log', async () => {
+      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValue(null);
+      vi.mocked(authRepository.createUser).mockResolvedValue(mockNewUser as never);
+
+      const request = createOneTapRequest(validOneTapPayload);
+      await POST(request);
+
+      const call = findInfoCall('New user created via Google One Tap');
+      expect(call).toBeDefined();
+      const meta = call?.[1] as Record<string, unknown>;
+      expect(meta).not.toHaveProperty('name');
+      expect(meta).toHaveProperty('userId');
+    });
+
+    it('masks email in "Updating existing user via Google One Tap" log', async () => {
+      const userWithoutGoogleId = { ...mockExistingUser, googleId: null };
+      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValueOnce(userWithoutGoogleId as never);
+      vi.mocked(authRepository.findUserById).mockResolvedValueOnce(mockExistingUser as never);
+
+      const request = createOneTapRequest(validOneTapPayload);
+      await POST(request);
+
+      const call = findInfoCall('Updating existing user via Google One Tap');
+      expect(call).toBeDefined();
+      const meta = call?.[1] as { email?: string };
+      expect(meta.email).toBe('te***@example.com');
+    });
+
+    it('does not include name in "User updated via Google One Tap" log', async () => {
+      const userWithoutGoogleId = { ...mockExistingUser, googleId: null };
+      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValueOnce(userWithoutGoogleId as never);
+      vi.mocked(authRepository.findUserById).mockResolvedValueOnce(mockExistingUser as never);
+
+      const request = createOneTapRequest(validOneTapPayload);
+      await POST(request);
+
+      const call = findInfoCall('User updated via Google One Tap');
+      expect(call).toBeDefined();
+      const meta = call?.[1] as Record<string, unknown>;
+      expect(meta).not.toHaveProperty('name');
+      expect(meta).toHaveProperty('userId');
     });
   });
 });

--- a/apps/web/src/app/api/auth/google/one-tap/route.ts
+++ b/apps/web/src/app/api/auth/google/one-tap/route.ts
@@ -7,7 +7,7 @@ import {
   DISTRIBUTED_RATE_LIMITS,
 } from '@pagespace/lib/security';
 import { createId } from '@paralleldrive/cuid2';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers, auditRequest, maskEmail } from '@pagespace/lib/server';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
 import { OAuth2Client } from 'google-auth-library';
 import { NextResponse } from 'next/server';
@@ -137,7 +137,7 @@ export async function POST(req: Request) {
         user.image !== resolvedImage ||
         (email_verified && !user.emailVerified)
       ) {
-        loggers.auth.info('Updating existing user via Google One Tap', { email });
+        loggers.auth.info('Updating existing user via Google One Tap', { email: maskEmail(email) });
         await authRepository.updateUser(user.id, {
           googleId: googleId || user.googleId,
           provider: user.provider === 'email' ? 'google' : user.provider,
@@ -150,13 +150,12 @@ export async function POST(req: Request) {
         user = await authRepository.findUserById(user.id) || user;
         loggers.auth.info('User updated via Google One Tap', {
           userId: user.id,
-          name: user.name,
         });
       }
     } else {
       // Create new user
       isNewUser = true;
-      loggers.auth.info('Creating new user via Google One Tap', { email });
+      loggers.auth.info('Creating new user via Google One Tap', { email: maskEmail(email) });
       user = await authRepository.createUser({
         id: createId(),
         name: userName,
@@ -184,7 +183,6 @@ export async function POST(req: Request) {
 
       loggers.auth.info('New user created via Google One Tap', {
         userId: user.id,
-        name: user.name,
       });
     }
 

--- a/apps/web/src/app/api/auth/mobile/oauth/google/exchange/route.ts
+++ b/apps/web/src/app/api/auth/mobile/oauth/google/exchange/route.ts
@@ -58,7 +58,7 @@ import {
   DISTRIBUTED_RATE_LIMITS,
 } from '@pagespace/lib/security';
 import { sessionService } from '@pagespace/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers, auditRequest, maskEmail } from '@pagespace/lib/server';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
 import { verifyOAuthIdToken, createOrLinkOAuthUser, OAuthProvider } from '@pagespace/lib/server';
 import type { MobileOAuthResponse } from '@pagespace/lib/server';
@@ -189,7 +189,7 @@ export async function POST(req: Request) {
 
     const { userInfo } = verificationResult;
     loggers.auth.info('Google ID token verified', {
-      email: userInfo.email,
+      email: maskEmail(userInfo.email),
       provider: userInfo.provider,
     });
 
@@ -217,7 +217,7 @@ export async function POST(req: Request) {
 
     // Create or link user account
     loggers.auth.info('Creating or linking OAuth user', {
-      email: userInfo.email,
+      email: maskEmail(userInfo.email),
       provider: userInfo.provider,
     });
 
@@ -240,7 +240,7 @@ export async function POST(req: Request) {
 
     loggers.auth.info('OAuth user created/linked', {
       userId: user.id,
-      email: user.email,
+      email: maskEmail(user.email),
       provider: user.provider,
     });
 

--- a/apps/web/src/app/api/auth/resend-verification/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/resend-verification/__tests__/route.test.ts
@@ -41,7 +41,11 @@ vi.mock('@pagespace/lib/email-templates/VerificationEmail', () => ({
   VerificationEmail: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
+vi.mock('@pagespace/lib/server', async () => {
+  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
+    '@pagespace/lib/audit/mask-email'
+  );
+  return {
   loggers: {
     auth: {
       error: vi.fn(),
@@ -55,12 +59,9 @@ vi.mock('@pagespace/lib/server', () => ({
   },
   audit: vi.fn(),
   auditRequest: vi.fn(),
-  maskEmail: (email: string) => {
-    const [local, domain] = email.split('@');
-    if (!local || !domain) return '***@***';
-    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
-  },
-}));
+  maskEmail,
+  };
+});
 
 vi.mock('@pagespace/lib/security', () => ({
   checkDistributedRateLimit: vi.fn().mockResolvedValue({

--- a/apps/web/src/app/api/auth/resend-verification/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/resend-verification/__tests__/route.test.ts
@@ -55,6 +55,11 @@ vi.mock('@pagespace/lib/server', () => ({
   },
   audit: vi.fn(),
   auditRequest: vi.fn(),
+  maskEmail: (email: string) => {
+    const [local, domain] = email.split('@');
+    if (!local || !domain) return '***@***';
+    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
+  },
 }));
 
 vi.mock('@pagespace/lib/security', () => ({
@@ -182,7 +187,7 @@ describe('POST /api/auth/resend-verification', () => {
       expect(response.headers.get('Retry-After')).toBe('3600');
       expect(loggers.auth.warn).toHaveBeenCalledWith(
         'Email resend rate limit exceeded',
-        { email: 'test@example.com' }
+        { email: 'te***@example.com' }
       );
     });
 
@@ -247,7 +252,7 @@ describe('POST /api/auth/resend-verification', () => {
 
       expect(loggers.auth.info).toHaveBeenCalledWith(
         'Verification email resent',
-        { userId: 'test-user-id', email: 'test@example.com' }
+        { userId: 'test-user-id', email: 'te***@example.com' }
       );
     });
 

--- a/apps/web/src/app/api/auth/resend-verification/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/resend-verification/__tests__/route.test.ts
@@ -46,20 +46,20 @@ vi.mock('@pagespace/lib/server', async () => {
     '@pagespace/lib/audit/mask-email'
   );
   return {
-  loggers: {
-    auth: {
-      error: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      debug: vi.fn(),
+    loggers: {
+      auth: {
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      },
+      security: {
+        warn: vi.fn(),
+      },
     },
-    security: {
-      warn: vi.fn(),
-    },
-  },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
-  maskEmail,
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
+    maskEmail,
   };
 });
 

--- a/apps/web/src/app/api/auth/resend-verification/route.ts
+++ b/apps/web/src/app/api/auth/resend-verification/route.ts
@@ -3,7 +3,7 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { createVerificationToken } from '@pagespace/lib';
 import { sendEmail } from '@pagespace/lib/services/email-service';
 import { VerificationEmail } from '@pagespace/lib/email-templates/VerificationEmail';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers, auditRequest, maskEmail } from '@pagespace/lib/server';
 import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security';
 import React from 'react';
 import { authRepository } from '@/lib/repositories/auth-repository';
@@ -31,7 +31,7 @@ export async function POST(request: Request) {
     );
 
     if (!rateLimitResult.allowed) {
-      loggers.auth.warn('Email resend rate limit exceeded', { email: user.email });
+      loggers.auth.warn('Email resend rate limit exceeded', { email: maskEmail(user.email) });
       return NextResponse.json(
         { error: 'Too many verification emails requested. Please try again later.' },
         {
@@ -71,7 +71,7 @@ export async function POST(request: Request) {
         }),
       });
 
-      loggers.auth.info('Verification email resent', { userId: user.id, email: user.email });
+      loggers.auth.info('Verification email resent', { userId: user.id, email: maskEmail(user.email) });
       auditRequest(request, { eventType: 'data.write', userId: auth.userId, resourceType: 'email_verification', resourceId: auth.userId });
 
       return NextResponse.json({

--- a/apps/web/src/app/api/auth/signup-passkey/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/signup-passkey/__tests__/route.test.ts
@@ -37,19 +37,19 @@ vi.mock('@pagespace/lib/server', async () => {
     '@pagespace/lib/audit/mask-email'
   );
   return {
-  loggers: {
-    auth: {
-      error: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      debug: vi.fn(),
+    loggers: {
+      auth: {
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      },
+      security: {
+        warn: vi.fn(),
+      },
     },
-    security: {
-      warn: vi.fn(),
-    },
-  },
-  auditRequest: vi.fn(),
-  maskEmail,
+    auditRequest: vi.fn(),
+    maskEmail,
   };
 });
 

--- a/apps/web/src/app/api/auth/signup-passkey/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/signup-passkey/__tests__/route.test.ts
@@ -45,6 +45,11 @@ vi.mock('@pagespace/lib/server', () => ({
     },
   },
   auditRequest: vi.fn(),
+  maskEmail: (email: string) => {
+    const [local, domain] = email.split('@');
+    if (!local || !domain) return '***@***';
+    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
+  },
 }));
 
 vi.mock('@pagespace/lib/activity-tracker', () => ({
@@ -485,8 +490,23 @@ describe('POST /api/auth/signup-passkey', () => {
 
       expect(loggers.auth.warn).toHaveBeenCalledWith('Passkey signup failed', expect.objectContaining({
         error: 'VERIFICATION_FAILED',
-        email: 'use***',
+        email: 'us***@example.com',
       }));
+    });
+  });
+
+  describe('PII scrub in log metadata', () => {
+    const findInfoCall = (msg: string) =>
+      vi.mocked(loggers.auth.info).mock.calls.find(call => call[0] === msg);
+
+    it('masks email and omits name in "Passkey signup successful" log', async () => {
+      await POST(createRequest());
+
+      const call = findInfoCall('Passkey signup successful');
+      expect(call).toBeDefined();
+      const meta = call?.[1] as Record<string, unknown>;
+      expect(meta.email).toBe('us***@example.com');
+      expect(meta).not.toHaveProperty('name');
     });
   });
 
@@ -517,7 +537,7 @@ describe('POST /api/auth/signup-passkey', () => {
       expect(loggers.auth.error).toHaveBeenCalledWith(
         'Passkey signup verification error',
         new Error('Unexpected'),
-        { email: 'user@example.com', clientIP: '127.0.0.1' },
+        { email: 'us***@example.com', clientIP: '127.0.0.1' },
       );
     });
   });

--- a/apps/web/src/app/api/auth/signup-passkey/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/signup-passkey/__tests__/route.test.ts
@@ -32,7 +32,11 @@ vi.mock('@pagespace/lib/auth', () => ({
   SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
+vi.mock('@pagespace/lib/server', async () => {
+  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
+    '@pagespace/lib/audit/mask-email'
+  );
+  return {
   loggers: {
     auth: {
       error: vi.fn(),
@@ -45,12 +49,9 @@ vi.mock('@pagespace/lib/server', () => ({
     },
   },
   auditRequest: vi.fn(),
-  maskEmail: (email: string) => {
-    const [local, domain] = email.split('@');
-    if (!local || !domain) return '***@***';
-    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
-  },
-}));
+  maskEmail,
+  };
+});
 
 vi.mock('@pagespace/lib/activity-tracker', () => ({
   trackAuthEvent: vi.fn(),

--- a/apps/web/src/app/api/auth/signup-passkey/options/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/signup-passkey/options/__tests__/route.test.ts
@@ -22,6 +22,11 @@ vi.mock('@pagespace/lib/server', () => ({
     },
   },
   auditRequest: vi.fn(),
+  maskEmail: (email: string) => {
+    const [local, domain] = email.split('@');
+    if (!local || !domain) return '***@***';
+    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
+  },
 }));
 
 vi.mock('@pagespace/lib/security', () => ({
@@ -110,7 +115,7 @@ describe('POST /api/auth/signup-passkey/options', () => {
       await POST(createRequest());
 
       expect(loggers.auth.info).toHaveBeenCalledWith('Passkey signup options generated', expect.objectContaining({
-        email: 'use***',
+        email: 'us***@example.com',
       }));
     });
   });
@@ -248,7 +253,7 @@ describe('POST /api/auth/signup-passkey/options', () => {
       expect(body.error).toBe('An account with this email already exists');
       expect(body.code).toBe('EMAIL_EXISTS');
       expect(loggers.auth.info).toHaveBeenCalledWith('Passkey signup - email already exists', expect.objectContaining({
-        email: 'use***',
+        email: 'us***@example.com',
       }));
     });
 

--- a/apps/web/src/app/api/auth/signup-passkey/options/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/signup-passkey/options/__tests__/route.test.ts
@@ -12,7 +12,11 @@ vi.mock('@pagespace/lib/auth', () => ({
   generateRegistrationOptionsForSignup: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
+vi.mock('@pagespace/lib/server', async () => {
+  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
+    '@pagespace/lib/audit/mask-email'
+  );
+  return {
   loggers: {
     auth: {
       error: vi.fn(),
@@ -22,12 +26,9 @@ vi.mock('@pagespace/lib/server', () => ({
     },
   },
   auditRequest: vi.fn(),
-  maskEmail: (email: string) => {
-    const [local, domain] = email.split('@');
-    if (!local || !domain) return '***@***';
-    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
-  },
-}));
+  maskEmail,
+  };
+});
 
 vi.mock('@pagespace/lib/security', () => ({
   checkDistributedRateLimit: vi.fn(),

--- a/apps/web/src/app/api/auth/signup-passkey/options/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/signup-passkey/options/__tests__/route.test.ts
@@ -17,16 +17,16 @@ vi.mock('@pagespace/lib/server', async () => {
     '@pagespace/lib/audit/mask-email'
   );
   return {
-  loggers: {
-    auth: {
-      error: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      debug: vi.fn(),
+    loggers: {
+      auth: {
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      },
     },
-  },
-  auditRequest: vi.fn(),
-  maskEmail,
+    auditRequest: vi.fn(),
+    maskEmail,
   };
 });
 

--- a/apps/web/src/app/api/auth/signup-passkey/options/route.ts
+++ b/apps/web/src/app/api/auth/signup-passkey/options/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod/v4';
 import { generateRegistrationOptionsForSignup } from '@pagespace/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers, auditRequest, maskEmail } from '@pagespace/lib/server';
 import {
   checkDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
@@ -97,7 +97,7 @@ export async function POST(req: Request) {
       if (result.error.code === 'EMAIL_EXISTS') {
         loggers.auth.info('Passkey signup - email already exists', {
           ip: clientIP,
-          email: normalizedEmail.substring(0, 3) + '***',
+          email: maskEmail(normalizedEmail),
         });
         return NextResponse.json(
           { error: 'An account with this email already exists', code: 'EMAIL_EXISTS' },
@@ -125,7 +125,7 @@ export async function POST(req: Request) {
 
     loggers.auth.info('Passkey signup options generated', {
       ip: clientIP,
-      email: normalizedEmail.substring(0, 3) + '***',
+      email: maskEmail(normalizedEmail),
     });
 
     return NextResponse.json({

--- a/apps/web/src/app/api/auth/signup-passkey/route.ts
+++ b/apps/web/src/app/api/auth/signup-passkey/route.ts
@@ -7,7 +7,7 @@ import {
   generateCSRFToken,
   SESSION_DURATION_MS,
 } from '@pagespace/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers, auditRequest, maskEmail } from '@pagespace/lib/server';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
 import {
   checkDistributedRateLimit,
@@ -135,7 +135,7 @@ export async function POST(req: Request) {
       loggers.auth.warn('Passkey signup failed', {
         error: result.error.code,
         ip: clientIP,
-        email: email.substring(0, 3) + '***',
+        email: maskEmail(email),
       });
       auditRequest(req, {
         eventType: 'auth.login.failure',
@@ -168,7 +168,7 @@ export async function POST(req: Request) {
       loggers.auth.error('Failed to insert default AI settings', error as Error, { userId });
     }
 
-    loggers.auth.info('Passkey signup successful', { userId, email: email.substring(0, 3) + '***', name });
+    loggers.auth.info('Passkey signup successful', { userId, email: maskEmail(email) });
 
     // Reset rate limits on successful signup
     await Promise.allSettled([
@@ -282,7 +282,7 @@ export async function POST(req: Request) {
     );
 
   } catch (error) {
-    loggers.auth.error('Passkey signup verification error', error as Error, { email, clientIP });
+    loggers.auth.error('Passkey signup verification error', error as Error, { email: email ? maskEmail(email) : undefined, clientIP });
     return NextResponse.json(
       { error: 'Internal server error' },
       { status: 500 }

--- a/apps/web/src/app/api/integrations/google-calendar/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/callback/__tests__/route.test.ts
@@ -41,16 +41,16 @@ vi.mock('@pagespace/lib/server', async () => {
     '@pagespace/lib/audit/mask-email'
   );
   return {
-  loggers: {
-    auth: {
-      error: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      debug: vi.fn(),
+    loggers: {
+      auth: {
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      },
     },
-  },
-  auditRequest: vi.fn(),
-  maskEmail,
+    auditRequest: vi.fn(),
+    maskEmail,
   };
 });
 

--- a/apps/web/src/app/api/integrations/google-calendar/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/callback/__tests__/route.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Regression test for PII scrubbing in Google Calendar OAuth callback.
+ * Asserts that googleEmail is masked in log metadata.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import crypto from 'crypto';
+
+const mockGetToken = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    tokens: { access_token: 'at', refresh_token: 'rt', expiry_date: Date.now() + 3600_000 },
+  })
+);
+const mockSetCredentials = vi.hoisted(() => vi.fn());
+
+vi.mock('google-auth-library', () => ({
+  OAuth2Client: vi.fn().mockImplementation(() => ({
+    getToken: mockGetToken,
+    setCredentials: mockSetCredentials,
+  })),
+}));
+
+vi.mock('@pagespace/db', () => ({
+  db: {
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+      }),
+    }),
+  },
+  googleCalendarConnections: { userId: 'userId' },
+}));
+
+vi.mock('@pagespace/lib', () => ({
+  encrypt: vi.fn().mockResolvedValue('encrypted'),
+  secureCompare: (a: string, b: string) => a === b,
+}));
+
+vi.mock('@pagespace/lib/server', () => ({
+  loggers: {
+    auth: {
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    },
+  },
+  auditRequest: vi.fn(),
+  maskEmail: (email: string) => {
+    const [local, domain] = email.split('@');
+    if (!local || !domain) return '***@***';
+    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
+  },
+}));
+
+vi.mock('@/lib/integrations/google-calendar/return-url', () => ({
+  GOOGLE_CALENDAR_DEFAULT_RETURN_PATH: '/settings',
+  normalizeGoogleCalendarReturnPath: (p: string) => p,
+}));
+
+import { GET } from '../route';
+import { loggers } from '@pagespace/lib/server';
+
+const SECRET = 'test-oauth-state-secret';
+
+function createSignedState(data: { userId: string; returnUrl: string; timestamp: number }) {
+  const sig = crypto.createHmac('sha256', SECRET).update(JSON.stringify(data)).digest('hex');
+  return Buffer.from(JSON.stringify({ data, sig })).toString('base64');
+}
+
+describe('GET /api/integrations/google-calendar/callback', () => {
+  const originalEnv = process.env;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = {
+      ...originalEnv,
+      WEB_APP_URL: 'https://example.com',
+      GOOGLE_OAUTH_CLIENT_ID: 'cid',
+      GOOGLE_OAUTH_CLIENT_SECRET: 'csec',
+      OAUTH_STATE_SECRET: SECRET,
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    global.fetch = originalFetch;
+  });
+
+  describe('PII scrub', () => {
+    it('masks googleEmail in "email not verified" warn log', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          email: 'jane@example.com',
+          id: 'gid-1',
+          verified_email: false,
+        }),
+      }) as never;
+
+      const state = createSignedState({
+        userId: 'user-1',
+        returnUrl: '/settings',
+        timestamp: Date.now(),
+      });
+      const url = new URL('http://localhost/api/integrations/google-calendar/callback');
+      url.searchParams.set('code', 'auth-code');
+      url.searchParams.set('state', state);
+
+      await GET(new Request(url.toString()));
+
+      expect(loggers.auth.warn).toHaveBeenCalledWith(
+        'Google account email is not verified',
+        { googleEmail: 'ja***@example.com' }
+      );
+    });
+  });
+});

--- a/apps/web/src/app/api/integrations/google-calendar/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/callback/__tests__/route.test.ts
@@ -36,7 +36,11 @@ vi.mock('@pagespace/lib', () => ({
   secureCompare: (a: string, b: string) => a === b,
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
+vi.mock('@pagespace/lib/server', async () => {
+  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
+    '@pagespace/lib/audit/mask-email'
+  );
+  return {
   loggers: {
     auth: {
       error: vi.fn(),
@@ -46,12 +50,9 @@ vi.mock('@pagespace/lib/server', () => ({
     },
   },
   auditRequest: vi.fn(),
-  maskEmail: (email: string) => {
-    const [local, domain] = email.split('@');
-    if (!local || !domain) return '***@***';
-    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
-  },
-}));
+  maskEmail,
+  };
+});
 
 vi.mock('@/lib/integrations/google-calendar/return-url', () => ({
   GOOGLE_CALENDAR_DEFAULT_RETURN_PATH: '/settings',

--- a/apps/web/src/app/api/integrations/google-calendar/callback/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/callback/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { db, googleCalendarConnections } from '@pagespace/db';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers, auditRequest, maskEmail } from '@pagespace/lib/server';
 import { encrypt } from '@pagespace/lib';
 import { OAuth2Client } from 'google-auth-library';
 import crypto from 'crypto';
@@ -143,7 +143,7 @@ export async function GET(req: Request) {
     }
 
     if (!emailVerified) {
-      loggers.auth.warn('Google account email is not verified', { googleEmail });
+      loggers.auth.warn('Google account email is not verified', { googleEmail: maskEmail(googleEmail) });
       return NextResponse.redirect(
         new URL('/settings/integrations/google-calendar?error=email_not_verified', baseUrl)
       );

--- a/apps/web/src/app/api/stripe/webhook/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/webhook/__tests__/route.test.ts
@@ -87,7 +87,11 @@ vi.mock('@pagespace/db', () => {
   };
 });
 
-vi.mock('@pagespace/lib/server', () => ({
+vi.mock('@pagespace/lib/server', async () => {
+  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
+    '@pagespace/lib/audit/mask-email'
+  );
+  return {
   loggers: {
     api: {
       error: vi.fn(),
@@ -101,12 +105,9 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
     },
   },
-  maskEmail: (email: string) => {
-    const [local, domain] = email.split('@');
-    if (!local || !domain) return '***@***';
-    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
-  },
-}));
+  maskEmail,
+  };
+});
 
 // Import after mocks
 import { POST } from '../route';

--- a/apps/web/src/app/api/stripe/webhook/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/webhook/__tests__/route.test.ts
@@ -92,20 +92,20 @@ vi.mock('@pagespace/lib/server', async () => {
     '@pagespace/lib/audit/mask-email'
   );
   return {
-  loggers: {
-    api: {
-      error: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      debug: vi.fn(),
+    loggers: {
+      api: {
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      },
+      auth: {
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+      },
     },
-    auth: {
-      error: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-    },
-  },
-  maskEmail,
+    maskEmail,
   };
 });
 

--- a/apps/web/src/app/api/stripe/webhook/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/webhook/__tests__/route.test.ts
@@ -87,8 +87,30 @@ vi.mock('@pagespace/db', () => {
   };
 });
 
+vi.mock('@pagespace/lib/server', () => ({
+  loggers: {
+    api: {
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    },
+    auth: {
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+    },
+  },
+  maskEmail: (email: string) => {
+    const [local, domain] = email.split('@');
+    if (!local || !domain) return '***@***';
+    return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
+  },
+}));
+
 // Import after mocks
 import { POST } from '../route';
+import { loggers } from '@pagespace/lib/server';
 
 // Helper to create mock Stripe event
 const mockStripeEvent = (type: string, data: unknown) => ({
@@ -571,6 +593,31 @@ describe('POST /api/stripe/webhook', () => {
           stripeCustomerId: 'cus_new123',
         })
       );
+    });
+
+    it('masks customer email in "Linked Stripe customer to user" log', async () => {
+      const session = mockCheckoutSession({
+        mode: 'subscription',
+        customer: 'cus_new123',
+        customerEmail: 'jane@example.com',
+      });
+      const event = mockStripeEvent('checkout.session.completed', session);
+      mockStripeWebhooksConstructEvent.mockReturnValue(event);
+
+      const request = new Request('https://example.com/api/stripe/webhook', {
+        method: 'POST',
+        body: JSON.stringify(event),
+        headers: { 'stripe-signature': 'valid_signature' },
+      }) as unknown as import('next/server').NextRequest;
+
+      await POST(request);
+
+      const call = vi.mocked(loggers.api.info).mock.calls.find(
+        c => c[0] === 'Linked Stripe customer to user'
+      );
+      expect(call).toBeDefined();
+      const meta = call?.[1] as { email?: string };
+      expect(meta.email).toBe('ja***@example.com');
     });
 
     it('should skip non-subscription checkout sessions', async () => {

--- a/apps/web/src/app/api/stripe/webhook/route.ts
+++ b/apps/web/src/app/api/stripe/webhook/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db, eq, subscriptions, stripeEvents, users } from '@pagespace/db';
 import { stripe, Stripe, getTierFromPrice } from '@/lib/stripe';
-import { loggers } from '@pagespace/lib/server';
+import { loggers, maskEmail } from '@pagespace/lib/server';
 
 export async function POST(request: NextRequest) {
   try {
@@ -279,7 +279,7 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session) {
         })
         .where(eq(users.email, customerEmail));
 
-      loggers.api.info('Linked Stripe customer to user', { customerId, email: customerEmail });
+      loggers.api.info('Linked Stripe customer to user', { customerId, email: maskEmail(customerEmail) });
     }
 
     // Bridge to control-plane: trigger tenant provisioning if metadata.slug is present

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -58,6 +58,7 @@ export default defineConfig({
       '@pagespace/lib/email-templates/VerificationEmail': path.resolve(packagesDir, 'lib/src/email-templates/VerificationEmail'),
       '@pagespace/lib/api-utils': path.resolve(packagesDir, 'lib/src/utils/api-utils'),
       '@pagespace/lib/audit/security-audit': path.resolve(packagesDir, 'lib/src/audit/security-audit'),
+      '@pagespace/lib/audit/mask-email': path.resolve(packagesDir, 'lib/src/audit/mask-email'),
       '@pagespace/lib/security': path.resolve(packagesDir, 'lib/src/security'),
       '@pagespace/lib/secure-compare': path.resolve(packagesDir, 'lib/src/auth/secure-compare'),
       '@pagespace/lib/auth': path.resolve(packagesDir, 'lib/src/auth'),

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -104,6 +104,11 @@
       "import": "./dist/audit/security-audit.js",
       "require": "./dist/audit/security-audit.js"
     },
+    "./audit/mask-email": {
+      "types": "./dist/audit/mask-email.d.ts",
+      "import": "./dist/audit/mask-email.js",
+      "require": "./dist/audit/mask-email.js"
+    },
     "./broadcast-auth": {
       "types": "./dist/auth/broadcast-auth.d.ts",
       "import": "./dist/auth/broadcast-auth.js",

--- a/packages/lib/src/audit/__tests__/mask-email.test.ts
+++ b/packages/lib/src/audit/__tests__/mask-email.test.ts
@@ -1,10 +1,6 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 
-// Mock dependencies to avoid resolution errors (maskEmail doesn't need DB)
-vi.mock('@pagespace/db', () => ({}));
-vi.mock('drizzle-orm', () => ({}));
-
-import { maskEmail } from '../index';
+import { maskEmail } from '../mask-email';
 
 describe('maskEmail', () => {
   it('masks standard email addresses', () => {

--- a/packages/lib/src/audit/index.ts
+++ b/packages/lib/src/audit/index.ts
@@ -32,10 +32,4 @@ export {
   type ChainAlertHandler,
 } from './security-audit-alerting';
 
-/** Mask email to prevent PII in audit logs (e.g., john@example.com -> jo***@example.com) */
-export function maskEmail(email: string): string {
-  const [local, domain] = email.split('@');
-  if (!local || !domain) return '***@***';
-  const visibleChars = Math.min(2, local.length);
-  return `${local.slice(0, visibleChars)}***@${domain}`;
-}
+export { maskEmail } from './mask-email';

--- a/packages/lib/src/audit/mask-email.ts
+++ b/packages/lib/src/audit/mask-email.ts
@@ -1,0 +1,18 @@
+/**
+ * Mask an email for PII-safe logging (e.g., john@example.com -> jo***@example.com).
+ *
+ * The domain is intentionally retained. Operational debugging of auth flows
+ * (OAuth provider mismatches, email deliverability, tenant-scoped issues)
+ * requires knowing which provider/domain the user came from. The local part
+ * is the uniquely identifying component and is the one we truncate.
+ *
+ * Kept as a zero-import leaf module so test mocks can pull the real
+ * implementation via `vi.importActual('@pagespace/lib/audit/mask-email')`
+ * without dragging in the DB-bound audit service.
+ */
+export function maskEmail(email: string): string {
+  const [local, domain] = email.split('@');
+  if (!local || !domain) return '***@***';
+  const visibleChars = Math.min(2, local.length);
+  return `${local.slice(0, visibleChars)}***@${domain}`;
+}

--- a/packages/lib/src/auth/__tests__/account-lockout.test.ts
+++ b/packages/lib/src/auth/__tests__/account-lockout.test.ts
@@ -38,6 +38,7 @@ vi.mock('../../logging/logger-config', () => ({
 }));
 
 import { db } from '@pagespace/db';
+import { loggers } from '../../logging/logger-config';
 import {
   getAccountLockoutStatus,
   isAccountLockedByEmail,
@@ -203,6 +204,13 @@ describe('account-lockout', () => {
       expect(result.success).toBe(true);
       expect(result.lockedUntil).toBeDefined();
       expect(result.lockedUntil!.getTime()).toBeGreaterThan(Date.now());
+
+      const warnCall = vi.mocked(loggers.api.warn).mock.calls.find(
+        c => c[0] === 'Account locked due to failed login attempts'
+      );
+      expect(warnCall).toBeDefined();
+      const meta = warnCall?.[1] as { email?: string };
+      expect(meta.email).toBe('te***@example.com');
     });
 
     it('resets counter when lockout has expired', async () => {

--- a/packages/lib/src/auth/account-lockout.ts
+++ b/packages/lib/src/auth/account-lockout.ts
@@ -13,6 +13,7 @@
 import { db, users } from '@pagespace/db';
 import { eq, sql } from 'drizzle-orm';
 import { loggers } from '../logging/logger-config';
+import { maskEmail } from '../audit';
 
 // Lockout thresholds
 const MAX_FAILED_ATTEMPTS = 10;
@@ -150,7 +151,7 @@ export async function recordFailedLoginAttempt(
 
       loggers.api.warn('Account locked due to failed login attempts', {
         userId,
-        email,
+        email: maskEmail(email),
         failedAttempts: failedLoginAttempts,
         lockedUntil: lockedUntil.toISOString(),
       });

--- a/packages/lib/src/auth/account-lockout.ts
+++ b/packages/lib/src/auth/account-lockout.ts
@@ -13,7 +13,7 @@
 import { db, users } from '@pagespace/db';
 import { eq, sql } from 'drizzle-orm';
 import { loggers } from '../logging/logger-config';
-import { maskEmail } from '../audit';
+import { maskEmail } from '../audit/mask-email';
 
 // Lockout thresholds
 const MAX_FAILED_ATTEMPTS = 10;


### PR DESCRIPTION
## Summary
- Mask raw `email` with `maskEmail()` and drop `name`/`targetUserName` from `loggers.auth/api.*` metadata across 13 routes + `packages/lib/src/auth/account-lockout.ts`
- The unified audit chain (`audit()`/`auditRequest()`) is already clean — this fixes the parallel structured logging surface that was still leaking PII subject to GDPR right-to-erasure
- Leaves `authRepository.createUser/updateUser` ORM `name:` params and `trackAuthEvent()` calls untouched (separate scope)

## Scope
**Routes (apps/web):**
- `auth/google/{callback,native,one-tap}`
- `auth/apple/{callback,native}`
- `auth/mobile/oauth/google/exchange`
- `auth/{resend-verification,signup-passkey,signup-passkey/options}`
- `integrations/google-calendar/callback`
- `stripe/webhook`
- `admin/users/[userId]/gift-subscription`

**Packages:**
- `packages/lib/src/auth/account-lockout.ts`

## Tests
TDD: failing test first, then route fix, per `.claude/rules/tdd.mdc`. Added/updated test mocks for `maskEmail` and PII assertions across 14 colocated test files. Created 2 new test files (`google-calendar/callback`, `gift-subscription/route.pii`).

## Test plan
- [x] `pnpm typecheck` — passes (via Turbo build)
- [x] `packages/lib` tests: 153 files, 4024 tests pass
- [x] `apps/web` tests: 367/369 files pass — 2 pre-existing DB integration failures (`admin-role-version.test.ts`, `gift-subscription/route.security.test.ts`) verified failing on baseline before this branch
- [x] Grep sweep for raw `email`/`name` in `loggers.*` metadata: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Logs now mask email addresses and omit user names in authentication, admin, and integration events to reduce PII exposure.

* **Tests**
  * Added/expanded test suites to verify email masking and absence of name fields in log metadata across auth, admin, webhook, and integration flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->