### PR TITLE
feat(siem): dual-source worker — interleave activity_logs and security_audit_log

### DIFF
--- a/apps/processor/src/services/__tests__/siem-adapter.test.ts
+++ b/apps/processor/src/services/__tests__/siem-adapter.test.ts
@@ -1024,4 +1024,61 @@ describe('deliverToSiemWithRetry', () => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
   });
+
+  it('retries only the undelivered tail after a partial batched failure', async () => {
+    vi.useFakeTimers();
+    const config: SiemConfig = {
+      enabled: true,
+      type: 'webhook',
+      // batchSize: 1 so each entry maps to its own fetch call — lets us
+      // observe exactly which entries get re-sent across retries
+      webhook: { url: 'https://example.com', secret: 'sec', batchSize: 1, retryAttempts: 3 },
+    };
+
+    const fetchMock = vi
+      .fn()
+      // Attempt 1: e1 ok, e2 fails retryable → batched returns entriesDelivered=1
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: vi.fn().mockResolvedValue('Server Error'),
+      })
+      // Attempt 2 begins with slice(1) = [e2, e3]: e2 ok, e3 ok → full success
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const entries = [
+      makeEntry({ id: 'e1' }),
+      makeEntry({ id: 'e2' }),
+      makeEntry({ id: 'e3' }),
+    ];
+
+    const resultPromise = deliverToSiemWithRetry(config, entries, 3);
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result.success).toBe(true);
+    expect(result.entriesDelivered).toBe(3);
+
+    // Exactly 4 fetch calls total — not 5. The old behavior would have
+    // re-sent e1 on attempt 2, which is the duplication this test pins against.
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+
+    // Confirm e1 was sent exactly once by inspecting request bodies
+    const bodies = fetchMock.mock.calls.map(
+      (call) => (call[1] as { body: string }).body
+    );
+    const e1Count = bodies.filter((body) => body.includes('"id":"e1"')).length;
+    const e2Count = bodies.filter((body) => body.includes('"id":"e2"')).length;
+    const e3Count = bodies.filter((body) => body.includes('"id":"e3"')).length;
+
+    expect(e1Count).toBe(1);
+    expect(e2Count).toBe(2); // failed on attempt 1, re-sent on attempt 2
+    expect(e3Count).toBe(1);
+
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
 });

--- a/apps/processor/src/services/siem-adapter.ts
+++ b/apps/processor/src/services/siem-adapter.ts
@@ -644,6 +644,14 @@ export function calculateBackoffDelay(attempt: number, baseDelay: number = 1000)
 
 /**
  * Deliver with retry logic
+ *
+ * Retries the *undelivered tail*, not the full batch. Transports that support
+ * partial delivery (syslog TCP/UDP mid-batch failure, webhook batched sub-batch
+ * failure) return `entriesDelivered` as a contiguous prefix count; on a
+ * retryable failure we slice past that prefix so the receiver never sees the
+ * already-delivered rows twice. The returned `entriesDelivered` is the
+ * cumulative total across all attempts, which keeps the caller's cursor walk
+ * (`merged.slice(0, entriesDelivered)`) correct.
  */
 export async function deliverToSiemWithRetry(
   config: SiemConfig,
@@ -651,16 +659,27 @@ export async function deliverToSiemWithRetry(
   maxRetries?: number
 ): Promise<SiemDeliveryResult> {
   const retries = maxRetries ?? config.webhook?.retryAttempts ?? 3;
+  let cumulativeDelivered = 0;
 
   for (let attempt = 0; attempt <= retries; attempt++) {
-    const result = await deliverToSiemBatched(config, entries);
+    const remaining = entries.slice(cumulativeDelivered);
+    const result = await deliverToSiemBatched(config, remaining);
+    cumulativeDelivered += result.entriesDelivered;
 
     if (result.success) {
-      return result;
+      return {
+        success: true,
+        entriesDelivered: cumulativeDelivered,
+      };
     }
 
     if (!result.retryable || attempt === retries) {
-      return result;
+      return {
+        success: false,
+        entriesDelivered: cumulativeDelivered,
+        error: result.error,
+        retryable: result.retryable,
+      };
     }
 
     // Wait before retry
@@ -670,7 +689,7 @@ export async function deliverToSiemWithRetry(
 
   return {
     success: false,
-    entriesDelivered: 0,
+    entriesDelivered: cumulativeDelivered,
     error: 'Max retries exceeded',
     retryable: false,
   };

--- a/apps/processor/src/workers/__tests__/siem-delivery-worker.test.ts
+++ b/apps/processor/src/workers/__tests__/siem-delivery-worker.test.ts
@@ -978,6 +978,77 @@ describe('processSiemDelivery', () => {
     });
   });
 
+  it('recordError UPSERT does not overwrite advanced cursor state on partial delivery', async () => {
+    // Regression pin: Phase 6 in the worker runs recordError() AFTER
+    // advanceCursor() for partial deliveries, and depends on recordError's
+    // UPDATE SET clause touching ONLY lastError/lastErrorAt/updatedAt. If a
+    // future refactor adds lastDeliveredId/lastDeliveredAt/deliveryCount to
+    // that SET clause, the just-advanced cursor state for sources that made
+    // partial progress would be clobbered.
+    mockLoadSiemConfig.mockReturnValue(WEBHOOK_CONFIG);
+    mockValidateSiemConfig.mockReturnValue({ valid: true, errors: [] });
+
+    stubLockAcquired();
+    stubCursorRow('log_prev', new Date('2026-04-10T00:00:00Z'), 0);
+    stubSourceRows([
+      makeActivityRow('log_a', new Date('2026-04-10T00:00:10Z')),
+      makeActivityRow('log_b', new Date('2026-04-10T00:00:30Z')),
+    ]);
+    stubCursorRow('sec_prev', new Date('2026-04-10T00:00:00Z'), 0);
+    stubSourceRows([makeSecurityRow('sec_a', new Date('2026-04-10T00:00:20Z'))]);
+
+    mockDeliverToSiemWithRetry.mockResolvedValue({
+      success: false,
+      entriesDelivered: 2, // log_a + sec_a delivered, log_b remains
+      error: 'HTTP 503',
+    });
+
+    stubCursorAdvance(); // activity_logs advance
+    stubCursorAdvance(); // security_audit_log advance
+    stubErrorUpsert(); // activity_logs error
+    stubErrorUpsert(); // security_audit_log error
+    stubLockRelease();
+
+    await processSiemDelivery();
+
+    const errorUpsertCalls = mockQuery.mock.calls.filter(
+      (call) =>
+        typeof call[0] === 'string' && (call[0] as string).includes('"lastError" = $2')
+    );
+
+    assert({
+      given: 'a partial-delivery failure after per-source advance',
+      should: 'emit a recordError UPSERT for each source',
+      actual: errorUpsertCalls.length,
+      expected: 2,
+    });
+
+    for (const call of errorUpsertCalls) {
+      const sql = call[0] as string;
+
+      assert({
+        given: 'the recordError UPSERT SQL',
+        should: 'not overwrite lastDeliveredId (would clobber the advance)',
+        actual: sql.includes('"lastDeliveredId" ='),
+        expected: false,
+      });
+
+      assert({
+        given: 'the recordError UPSERT SQL',
+        should: 'not overwrite lastDeliveredAt (would clobber the advance)',
+        actual: sql.includes('"lastDeliveredAt" ='),
+        expected: false,
+      });
+
+      assert({
+        given: 'the recordError UPSERT SQL',
+        should: 'not overwrite deliveryCount (would reset the counter)',
+        actual: sql.includes('"deliveryCount" ='),
+        expected: false,
+      });
+    }
+  });
+
   it('delivery failure records error on both source cursors', async () => {
     mockLoadSiemConfig.mockReturnValue(WEBHOOK_CONFIG);
     mockValidateSiemConfig.mockReturnValue({ valid: true, errors: [] });

--- a/apps/processor/src/workers/__tests__/siem-delivery-worker.test.ts
+++ b/apps/processor/src/workers/__tests__/siem-delivery-worker.test.ts
@@ -17,11 +17,17 @@ const { mockLoadSiemConfig, mockValidateSiemConfig, mockDeliverToSiemWithRetry, 
   };
 });
 
-vi.mock('../../services/siem-adapter', () => ({
-  loadSiemConfig: mockLoadSiemConfig,
-  validateSiemConfig: mockValidateSiemConfig,
-  deliverToSiemWithRetry: mockDeliverToSiemWithRetry,
-}));
+vi.mock('../../services/siem-adapter', async () => {
+  const actual = await vi.importActual<typeof import('../../services/siem-adapter')>(
+    '../../services/siem-adapter'
+  );
+  return {
+    ...actual,
+    loadSiemConfig: mockLoadSiemConfig,
+    validateSiemConfig: mockValidateSiemConfig,
+    deliverToSiemWithRetry: mockDeliverToSiemWithRetry,
+  };
+});
 
 vi.mock('../../db', () => ({
   getPoolForWorker: vi.fn(() => ({
@@ -32,16 +38,118 @@ vi.mock('../../db', () => ({
   })),
 }));
 
-import { processSiemDelivery } from '../siem-delivery-worker';
+import { processSiemDelivery, SOURCES } from '../siem-delivery-worker';
+import type { AuditLogSource } from '../../services/siem-adapter';
 
-/** Stub the advisory lock as acquired (default path for most tests) */
+const WEBHOOK_CONFIG = {
+  enabled: true,
+  type: 'webhook' as const,
+  webhook: { url: 'https://siem.example.com', secret: 's3cret', batchSize: 100, retryAttempts: 3 },
+};
+
+// --- Mock query helpers ---------------------------------------------------
+
 function stubLockAcquired() {
   mockQuery.mockResolvedValueOnce({ rows: [{ acquired: true }], rowCount: 1 });
 }
 
-/** Stub the advisory unlock (resolves at end of every successful path) */
 function stubLockRelease() {
   mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+}
+
+/** Cursor row returned from SELECT — pre-seeded, ready to poll */
+function stubCursorRow(lastDeliveredId: string, lastDeliveredAt: Date, deliveryCount = 0) {
+  mockQuery.mockResolvedValueOnce({
+    rows: [{ lastDeliveredId, lastDeliveredAt, deliveryCount }],
+    rowCount: 1,
+  });
+}
+
+/** Cursor row missing — triggers init INSERT in worker */
+function stubCursorMissing() {
+  mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+}
+
+/** Response for the init INSERT (ON CONFLICT DO NOTHING) */
+function stubCursorInit() {
+  mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+}
+
+/** Response for a source rows SELECT */
+function stubSourceRows<T>(rows: T[]) {
+  mockQuery.mockResolvedValueOnce({ rows, rowCount: rows.length });
+}
+
+/** Response for cursor advance UPSERT */
+function stubCursorAdvance() {
+  mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+}
+
+/** Response for error UPSERT */
+function stubErrorUpsert() {
+  mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+}
+
+// --- Row factories --------------------------------------------------------
+
+function makeActivityRow(id: string, timestamp: Date, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    timestamp,
+    userId: 'u1',
+    actorEmail: 'a@b.com',
+    actorDisplayName: 'A',
+    isAiGenerated: false,
+    aiProvider: null,
+    aiModel: null,
+    aiConversationId: null,
+    operation: 'page.create',
+    resourceType: 'page',
+    resourceId: 'p1',
+    resourceTitle: null,
+    driveId: null,
+    pageId: null,
+    metadata: null,
+    previousLogHash: null,
+    logHash: null,
+    ...overrides,
+  };
+}
+
+function makeSecurityRow(id: string, timestamp: Date, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    timestamp,
+    eventType: 'auth.login.success',
+    userId: 'u1',
+    sessionId: 'sess_1',
+    serviceId: null,
+    resourceType: 'user',
+    resourceId: 'u1',
+    ipAddress: '10.0.0.1',
+    userAgent: 'Mozilla/5.0',
+    geoLocation: null,
+    details: null,
+    riskScore: null,
+    anomalyFlags: null,
+    previousHash: 'prev_hash',
+    eventHash: 'event_hash',
+    ...overrides,
+  };
+}
+
+// --- Assertion helpers ----------------------------------------------------
+
+/** Find the index of the first mockQuery call whose SQL includes the needle */
+function findCallContaining(needle: string): number {
+  return mockQuery.mock.calls.findIndex((call) => typeof call[0] === 'string' && (call[0] as string).includes(needle));
+}
+
+/** Find all mockQuery calls whose SQL includes the needle */
+function findAllCallsContaining(needle: string): unknown[][] {
+  return mockQuery.mock.calls.filter(
+    (call) => typeof call[0] === 'string' && (call[0] as string).includes(needle)
+  );
 }
 
 describe('processSiemDelivery', () => {
@@ -84,15 +192,9 @@ describe('processSiemDelivery', () => {
   });
 
   it('skips processing when advisory lock is not acquired', async () => {
-    const config = {
-      enabled: true,
-      type: 'webhook' as const,
-      webhook: { url: 'https://siem.example.com', secret: 's3cret', batchSize: 100, retryAttempts: 3 },
-    };
-    mockLoadSiemConfig.mockReturnValue(config);
+    mockLoadSiemConfig.mockReturnValue(WEBHOOK_CONFIG);
     mockValidateSiemConfig.mockReturnValue({ valid: true, errors: [] });
 
-    // Lock NOT acquired (another worker holds it)
     mockQuery.mockResolvedValueOnce({ rows: [{ acquired: false }], rowCount: 1 });
 
     await processSiemDelivery();
@@ -113,48 +215,24 @@ describe('processSiemDelivery', () => {
   });
 
   it('successful delivery updates cursor', async () => {
-    const config = {
-      enabled: true,
-      type: 'webhook' as const,
-      webhook: { url: 'https://siem.example.com', secret: 's3cret', batchSize: 100, retryAttempts: 3 },
-    };
-    mockLoadSiemConfig.mockReturnValue(config);
+    mockLoadSiemConfig.mockReturnValue(WEBHOOK_CONFIG);
     mockValidateSiemConfig.mockReturnValue({ valid: true, errors: [] });
 
-    // 1. Lock acquired
     stubLockAcquired();
-
-    // 2. Cursor query returns no previous cursor
-    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
-
-    // 3. Activity logs query returns 2 rows
-    const rows = [
-      {
-        id: 'log_1', timestamp: new Date('2026-04-10T12:00:00Z'),
-        userId: 'u1', actorEmail: 'a@b.com', actorDisplayName: 'A',
-        isAiGenerated: false, aiProvider: null, aiModel: null, aiConversationId: null,
-        operation: 'page.create', resourceType: 'page', resourceId: 'p1',
-        resourceTitle: 'Title', driveId: 'd1', pageId: 'p1',
-        metadata: null, previousLogHash: null, logHash: 'h1',
-      },
-      {
-        id: 'log_2', timestamp: new Date('2026-04-10T12:01:00Z'),
-        userId: 'u1', actorEmail: 'a@b.com', actorDisplayName: 'A',
-        isAiGenerated: false, aiProvider: null, aiModel: null, aiConversationId: null,
-        operation: 'page.update', resourceType: 'page', resourceId: 'p1',
-        resourceTitle: 'Title', driveId: 'd1', pageId: 'p1',
-        metadata: null, previousLogHash: 'h1', logHash: 'h2',
-      },
+    // activity_logs cursor pre-seeded so it polls normally
+    stubCursorRow('log_prev', new Date('2026-04-10T10:00:00Z'), 10);
+    const activityRows = [
+      makeActivityRow('log_1', new Date('2026-04-10T12:00:00Z'), { logHash: 'h1' }),
+      makeActivityRow('log_2', new Date('2026-04-10T12:01:00Z'), { previousLogHash: 'h1', logHash: 'h2' }),
     ];
-    mockQuery.mockResolvedValueOnce({ rows, rowCount: 2 });
+    stubSourceRows(activityRows);
+    // security_audit_log cursor pre-seeded, empty rows
+    stubCursorRow('sec_prev', new Date('2026-04-10T10:00:00Z'), 5);
+    stubSourceRows([]);
 
-    // Delivery succeeds
     mockDeliverToSiemWithRetry.mockResolvedValue({ success: true, entriesDelivered: 2 });
 
-    // 4. Cursor upsert
-    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
-
-    // 5. Advisory unlock in finally
+    stubCursorAdvance();
     stubLockRelease();
 
     await processSiemDelivery();
@@ -170,7 +248,7 @@ describe('processSiemDelivery', () => {
       given: 'successful delivery',
       should: 'pass the config to delivery',
       actual: mockDeliverToSiemWithRetry.mock.calls[0][0],
-      expected: config,
+      expected: WEBHOOK_CONFIG,
     });
 
     assert({
@@ -180,86 +258,92 @@ describe('processSiemDelivery', () => {
       expected: 2,
     });
 
-    // The 4th query call (index 3) is the cursor advance (after lock, cursor read, logs read)
-    const upsertCall = mockQuery.mock.calls[3];
-    const upsertSql = upsertCall[0] as string;
+    const upsertCalls = findAllCallsContaining('ON CONFLICT (id) DO UPDATE');
+    const advanceCall = upsertCalls.find(
+      (c) => Array.isArray(c[1]) && (c[1] as unknown[])[1] === 'log_2'
+    );
 
     assert({
       given: 'successful delivery',
       should: 'upsert cursor with last delivered id',
-      actual: (upsertCall[1] as unknown[])[1],
+      actual: advanceCall ? (advanceCall[1] as unknown[])[1] : null,
       expected: 'log_2',
     });
 
     assert({
       given: 'successful delivery',
-      should: 'clear lastError on success',
-      actual: upsertSql.includes('"lastError" = NULL'),
-      expected: true,
+      should: 'advance delivery count by the number of delivered entries',
+      actual: advanceCall ? (advanceCall[1] as unknown[])[3] : null,
+      expected: 12,
     });
 
     assert({
       given: 'successful delivery',
-      should: 'clear lastErrorAt on success',
-      actual: upsertSql.includes('"lastErrorAt" = NULL'),
+      should: 'clear lastError on success',
+      actual: advanceCall ? (advanceCall[0] as string).includes('"lastError" = NULL') : false,
       expected: true,
     });
   });
 
   it('failed delivery with zero entries records error without advancing cursor', async () => {
-    const config = {
-      enabled: true,
-      type: 'webhook' as const,
-      webhook: { url: 'https://siem.example.com', secret: 's3cret', batchSize: 100, retryAttempts: 3 },
-    };
-    mockLoadSiemConfig.mockReturnValue(config);
+    mockLoadSiemConfig.mockReturnValue(WEBHOOK_CONFIG);
     mockValidateSiemConfig.mockReturnValue({ valid: true, errors: [] });
 
-    // 1. Lock acquired
     stubLockAcquired();
+    stubCursorRow('log_prev', new Date('2026-04-10T10:00:00Z'), 0);
+    stubSourceRows([makeActivityRow('log_1', new Date('2026-04-10T12:00:00Z'))]);
+    stubCursorRow('sec_prev', new Date('2026-04-10T10:00:00Z'), 0);
+    stubSourceRows([]);
 
-    // 2. Cursor query returns no previous cursor
-    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
-
-    // 3. Activity logs query returns 1 row
-    mockQuery.mockResolvedValueOnce({
-      rows: [{
-        id: 'log_1', timestamp: new Date('2026-04-10T12:00:00Z'),
-        userId: 'u1', actorEmail: 'a@b.com', actorDisplayName: 'A',
-        isAiGenerated: false, aiProvider: null, aiModel: null, aiConversationId: null,
-        operation: 'page.create', resourceType: 'page', resourceId: 'p1',
-        resourceTitle: null, driveId: null, pageId: null,
-        metadata: null, previousLogHash: null, logHash: null,
-      }],
-      rowCount: 1,
-    });
-
-    // Delivery fails with zero delivered
     mockDeliverToSiemWithRetry.mockResolvedValue({
-      success: false, entriesDelivered: 0, error: 'HTTP 502: Bad Gateway',
+      success: false,
+      entriesDelivered: 0,
+      error: 'HTTP 502: Bad Gateway',
     });
 
-    // 4. Error cursor upsert (only query after the 3 reads — no cursor advance)
-    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
-
-    // 5. Advisory unlock
+    // Two error upserts — one per source
+    stubErrorUpsert();
+    stubErrorUpsert();
     stubLockRelease();
 
     await processSiemDelivery();
 
-    // 5 queries: lock, cursor read, logs read, error upsert, unlock
+    const advanceCalls = findAllCallsContaining('ON CONFLICT (id) DO UPDATE\n           SET');
     assert({
       given: 'failed delivery with 0 entries delivered',
-      should: 'issue exactly 5 queries (lock + cursor + logs + error + unlock)',
-      actual: mockQuery.mock.calls.length,
-      expected: 5,
+      should: 'not issue any cursor-advance upserts',
+      actual: advanceCalls.length,
+      expected: 0,
     });
 
-    const errorUpdateCall = mockQuery.mock.calls[3];
+    const errorCalls = mockQuery.mock.calls.filter(
+      (call) => typeof call[0] === 'string' && (call[0] as string).includes('"lastError" = $2')
+    );
+    assert({
+      given: 'failed delivery with 0 entries delivered',
+      should: 'record the error on both source cursors',
+      actual: errorCalls.length,
+      expected: 2,
+    });
+
+    assert({
+      given: 'failed delivery with 0 entries delivered',
+      should: 'include the activity_logs source in the error writes',
+      actual: errorCalls.some((c) => (c[1] as unknown[])[0] === 'activity_logs'),
+      expected: true,
+    });
+
+    assert({
+      given: 'failed delivery with 0 entries delivered',
+      should: 'include the security_audit_log source in the error writes',
+      actual: errorCalls.some((c) => (c[1] as unknown[])[0] === 'security_audit_log'),
+      expected: true,
+    });
+
     assert({
       given: 'failed delivery with 0 entries delivered',
       should: 'record the error message',
-      actual: (errorUpdateCall[1] as unknown[])[1],
+      actual: (errorCalls[0][1] as unknown[])[1],
       expected: 'HTTP 502: Bad Gateway',
     });
   });
@@ -273,110 +357,76 @@ describe('processSiemDelivery', () => {
     mockLoadSiemConfig.mockReturnValue(config);
     mockValidateSiemConfig.mockReturnValue({ valid: true, errors: [] });
 
-    // 1. Lock acquired
     stubLockAcquired();
-
-    // 2. No existing cursor
-    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
-
-    // 3. Activity logs returns 3 rows
+    stubCursorRow('log_prev', new Date('2026-04-10T10:00:00Z'), 0);
     const rows = [
-      {
-        id: 'log_1', timestamp: new Date('2026-04-10T12:00:00Z'),
-        userId: 'u1', actorEmail: 'a@b.com', actorDisplayName: 'A',
-        isAiGenerated: false, aiProvider: null, aiModel: null, aiConversationId: null,
-        operation: 'page.create', resourceType: 'page', resourceId: 'p1',
-        resourceTitle: null, driveId: null, pageId: null,
-        metadata: null, previousLogHash: null, logHash: null,
-      },
-      {
-        id: 'log_2', timestamp: new Date('2026-04-10T12:01:00Z'),
-        userId: 'u1', actorEmail: 'a@b.com', actorDisplayName: 'A',
-        isAiGenerated: false, aiProvider: null, aiModel: null, aiConversationId: null,
-        operation: 'page.update', resourceType: 'page', resourceId: 'p1',
-        resourceTitle: null, driveId: null, pageId: null,
-        metadata: null, previousLogHash: null, logHash: null,
-      },
-      {
-        id: 'log_3', timestamp: new Date('2026-04-10T12:02:00Z'),
-        userId: 'u1', actorEmail: 'a@b.com', actorDisplayName: 'A',
-        isAiGenerated: false, aiProvider: null, aiModel: null, aiConversationId: null,
-        operation: 'page.delete', resourceType: 'page', resourceId: 'p1',
-        resourceTitle: null, driveId: null, pageId: null,
-        metadata: null, previousLogHash: null, logHash: null,
-      },
+      makeActivityRow('log_1', new Date('2026-04-10T12:00:00Z')),
+      makeActivityRow('log_2', new Date('2026-04-10T12:01:00Z'), { operation: 'page.update' }),
+      makeActivityRow('log_3', new Date('2026-04-10T12:02:00Z'), { operation: 'page.delete' }),
     ];
-    mockQuery.mockResolvedValueOnce({ rows, rowCount: 3 });
+    stubSourceRows(rows);
+    stubCursorRow('sec_prev', new Date('2026-04-10T10:00:00Z'), 0);
+    stubSourceRows([]);
 
-    // Syslog delivers 2 of 3 then fails mid-batch
     mockDeliverToSiemWithRetry.mockResolvedValue({
-      success: false, entriesDelivered: 2, error: 'TCP connection reset',
+      success: false,
+      entriesDelivered: 2,
+      error: 'TCP connection reset',
     });
 
-    // 4. Cursor advance upsert
-    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
-    // 5. Error upsert
-    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
-    // 6. Advisory unlock
+    stubCursorAdvance(); // activity_logs advance
+    stubErrorUpsert(); // activity_logs error
+    stubErrorUpsert(); // security_audit_log error
     stubLockRelease();
 
     await processSiemDelivery();
 
-    // 6 queries: lock, cursor read, logs read, cursor advance, error upsert, unlock
-    assert({
-      given: 'partial delivery (2 of 3)',
-      should: 'issue 6 queries (lock + cursor + logs + advance + error + unlock)',
-      actual: mockQuery.mock.calls.length,
-      expected: 6,
-    });
+    const advanceCalls = mockQuery.mock.calls.filter(
+      (call) =>
+        typeof call[0] === 'string' &&
+        (call[0] as string).includes('"deliveryCount" = $4')
+    );
 
-    // Cursor advance is at index 3 — should point to log_2 (2nd row, index 1)
-    const advanceCall = mockQuery.mock.calls[3];
     assert({
-      given: 'partial delivery of 2 entries',
-      should: 'advance cursor to the last delivered entry (log_2)',
-      actual: (advanceCall[1] as unknown[])[1],
+      given: 'partial delivery (2 of 3 activity_logs rows)',
+      should: 'advance the activity_logs cursor to log_2',
+      actual: (advanceCalls[0][1] as unknown[])[1],
       expected: 'log_2',
     });
 
-    // Error upsert is at index 4
-    const errorCall = mockQuery.mock.calls[4];
+    assert({
+      given: 'partial delivery (2 of 3)',
+      should: 'advance only the source that had delivered entries',
+      actual: advanceCalls.length,
+      expected: 1,
+    });
+
+    const errorCalls = mockQuery.mock.calls.filter(
+      (call) => typeof call[0] === 'string' && (call[0] as string).includes('"lastError" = $2')
+    );
     assert({
       given: 'partial delivery failure',
-      should: 'record the error message',
-      actual: (errorCall[1] as unknown[])[1],
-      expected: 'TCP connection reset',
+      should: 'record the error on both sources',
+      actual: errorCalls.map((c) => (c[1] as unknown[])[1]),
+      expected: ['TCP connection reset', 'TCP connection reset'],
     });
   });
 
   it('no new rows means no delivery', async () => {
-    const config = {
-      enabled: true,
-      type: 'webhook' as const,
-      webhook: { url: 'https://siem.example.com', secret: 's3cret', batchSize: 100, retryAttempts: 3 },
-    };
-    mockLoadSiemConfig.mockReturnValue(config);
+    mockLoadSiemConfig.mockReturnValue(WEBHOOK_CONFIG);
     mockValidateSiemConfig.mockReturnValue({ valid: true, errors: [] });
 
-    // 1. Lock acquired
     stubLockAcquired();
-
-    // 2. Cursor with existing position
-    mockQuery.mockResolvedValueOnce({
-      rows: [{ lastDeliveredId: 'log_99', lastDeliveredAt: new Date('2026-04-10T11:00:00Z'), deliveryCount: 50 }],
-      rowCount: 1,
-    });
-
-    // 3. Activity logs returns nothing new
-    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
-
-    // 4. Advisory unlock
+    stubCursorRow('log_99', new Date('2026-04-10T11:00:00Z'), 50);
+    stubSourceRows([]);
+    stubCursorRow('sec_99', new Date('2026-04-10T11:00:00Z'), 30);
+    stubSourceRows([]);
     stubLockRelease();
 
     await processSiemDelivery();
 
     assert({
-      given: 'no new activity_logs rows',
+      given: 'no new rows from either source',
       should: 'not attempt delivery',
       actual: mockDeliverToSiemWithRetry.mock.calls.length,
       expected: 0,
@@ -384,36 +434,23 @@ describe('processSiemDelivery', () => {
   });
 
   it('uses timestamp-only cursor to resume after last delivered position', async () => {
-    const config = {
-      enabled: true,
-      type: 'webhook' as const,
-      webhook: { url: 'https://siem.example.com', secret: 's3cret', batchSize: 100, retryAttempts: 3 },
-    };
-    mockLoadSiemConfig.mockReturnValue(config);
+    mockLoadSiemConfig.mockReturnValue(WEBHOOK_CONFIG);
     mockValidateSiemConfig.mockReturnValue({ valid: true, errors: [] });
 
-    // 1. Lock acquired
     stubLockAcquired();
-
-    // 2. Existing cursor
     const cursorTimestamp = new Date('2026-04-10T11:00:00Z');
-    mockQuery.mockResolvedValueOnce({
-      rows: [{ lastDeliveredId: 'log_99', lastDeliveredAt: cursorTimestamp, deliveryCount: 50 }],
-      rowCount: 1,
-    });
-
-    // 3. No new logs
-    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
-
-    // 4. Advisory unlock
+    stubCursorRow('log_99', cursorTimestamp, 50);
+    stubSourceRows([]);
+    stubCursorRow('sec_99', new Date('2026-04-10T11:00:00Z'), 30);
+    stubSourceRows([]);
     stubLockRelease();
 
     await processSiemDelivery();
 
-    // The 3rd query (index 2) is the activity_logs fetch
-    const logsQuery = mockQuery.mock.calls[2];
-    const sql = logsQuery[0] as string;
-    const params = logsQuery[1] as unknown[];
+    const activityLogsQueryIndex = findCallContaining('FROM activity_logs');
+    const activityLogsQuery = mockQuery.mock.calls[activityLogsQueryIndex];
+    const sql = activityLogsQuery[0] as string;
+    const params = activityLogsQuery[1] as unknown[];
 
     assert({
       given: 'an existing cursor',
@@ -438,26 +475,17 @@ describe('processSiemDelivery', () => {
   });
 
   it('releases pool client and advisory lock even on error', async () => {
-    mockLoadSiemConfig.mockReturnValue({
-      enabled: true,
-      type: 'webhook',
-      webhook: { url: 'https://siem.example.com', secret: 's3cret', batchSize: 100, retryAttempts: 3 },
-    });
+    mockLoadSiemConfig.mockReturnValue(WEBHOOK_CONFIG);
     mockValidateSiemConfig.mockReturnValue({ valid: true, errors: [] });
 
-    // Lock acquired
     stubLockAcquired();
-
-    // Cursor query throws
     mockQuery.mockRejectedValueOnce(new Error('connection reset'));
 
-    // Best-effort error upsert (in catch block)
-    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
-
-    // Advisory unlock in finally
+    // Catch block writes error to both sources
+    stubErrorUpsert();
+    stubErrorUpsert();
     stubLockRelease();
 
-    // Worker now rethrows — expect the error to propagate
     let thrownError: Error | null = null;
     try {
       await processSiemDelivery();
@@ -479,36 +507,31 @@ describe('processSiemDelivery', () => {
       expected: 1,
     });
 
-    // Verify best-effort error upsert was attempted (index 2 = after lock + failed cursor)
-    const errorUpsertCall = mockQuery.mock.calls[2];
+    const errorCalls = mockQuery.mock.calls.filter(
+      (call) => typeof call[0] === 'string' && (call[0] as string).includes('siem_delivery_cursors') && (call[0] as string).includes('"lastError" = $2')
+    );
+
     assert({
       given: 'a database error',
-      should: 'attempt best-effort error persistence',
-      actual: (errorUpsertCall[0] as string).includes('siem_delivery_cursors'),
-      expected: true,
+      should: 'attempt best-effort error persistence on both sources',
+      actual: errorCalls.length,
+      expected: 2,
     });
   });
 
   it('acquires advisory lock before reading cursor', async () => {
-    const config = {
-      enabled: true,
-      type: 'webhook' as const,
-      webhook: { url: 'https://siem.example.com', secret: 's3cret', batchSize: 100, retryAttempts: 3 },
-    };
-    mockLoadSiemConfig.mockReturnValue(config);
+    mockLoadSiemConfig.mockReturnValue(WEBHOOK_CONFIG);
     mockValidateSiemConfig.mockReturnValue({ valid: true, errors: [] });
 
-    // Lock acquired
     stubLockAcquired();
-
-    // Cursor + no rows + unlock
-    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
-    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    stubCursorRow('log_99', new Date('2026-04-10T11:00:00Z'), 50);
+    stubSourceRows([]);
+    stubCursorRow('sec_99', new Date('2026-04-10T11:00:00Z'), 30);
+    stubSourceRows([]);
     stubLockRelease();
 
     await processSiemDelivery();
 
-    // First query should be the advisory lock
     const lockQuery = mockQuery.mock.calls[0];
     assert({
       given: 'a valid SIEM config',
@@ -519,9 +542,495 @@ describe('processSiemDelivery', () => {
 
     assert({
       given: 'a valid SIEM config',
-      should: 'use CURSOR_ID as lock key via hashtext',
+      should: 'use activity_logs as the single backward-compatible lock key',
       actual: (lockQuery[1] as unknown[])[0],
       expected: 'activity_logs',
+    });
+  });
+
+  // ---------- New dual-source tests (wave 2) ----------
+
+  it('polls both sources when both have new rows and delivers a single merged batch', async () => {
+    mockLoadSiemConfig.mockReturnValue(WEBHOOK_CONFIG);
+    mockValidateSiemConfig.mockReturnValue({ valid: true, errors: [] });
+
+    stubLockAcquired();
+    stubCursorRow('log_prev', new Date('2026-04-10T10:00:00Z'), 0);
+    stubSourceRows([
+      makeActivityRow('log_1', new Date('2026-04-10T12:00:00Z')),
+      makeActivityRow('log_2', new Date('2026-04-10T12:02:00Z')),
+    ]);
+    stubCursorRow('sec_prev', new Date('2026-04-10T10:00:00Z'), 0);
+    stubSourceRows([
+      makeSecurityRow('sec_1', new Date('2026-04-10T12:01:00Z')),
+      makeSecurityRow('sec_2', new Date('2026-04-10T12:03:00Z')),
+    ]);
+
+    mockDeliverToSiemWithRetry.mockResolvedValue({ success: true, entriesDelivered: 4 });
+
+    stubCursorAdvance();
+    stubCursorAdvance();
+    stubLockRelease();
+
+    await processSiemDelivery();
+
+    assert({
+      given: 'both sources have new rows',
+      should: 'issue exactly one delivery call',
+      actual: mockDeliverToSiemWithRetry.mock.calls.length,
+      expected: 1,
+    });
+
+    const batch = mockDeliverToSiemWithRetry.mock.calls[0][1] as { source: AuditLogSource }[];
+
+    assert({
+      given: 'both sources have new rows',
+      should: 'pass a merged batch containing all 4 entries',
+      actual: batch.length,
+      expected: 4,
+    });
+
+    assert({
+      given: 'both sources have new rows',
+      should: 'include entries from activity_logs',
+      actual: batch.filter((e) => e.source === 'activity_logs').length,
+      expected: 2,
+    });
+
+    assert({
+      given: 'both sources have new rows',
+      should: 'include entries from security_audit_log',
+      actual: batch.filter((e) => e.source === 'security_audit_log').length,
+      expected: 2,
+    });
+  });
+
+  it('interleaves entries from both sources by timestamp', async () => {
+    mockLoadSiemConfig.mockReturnValue(WEBHOOK_CONFIG);
+    mockValidateSiemConfig.mockReturnValue({ valid: true, errors: [] });
+
+    stubLockAcquired();
+    stubCursorRow('log_prev', new Date('2026-04-10T00:00:00Z'), 0);
+    stubSourceRows([
+      makeActivityRow('log_a', new Date('2026-04-10T00:00:10Z')),
+      makeActivityRow('log_b', new Date('2026-04-10T00:00:30Z')),
+    ]);
+    stubCursorRow('sec_prev', new Date('2026-04-10T00:00:00Z'), 0);
+    stubSourceRows([
+      makeSecurityRow('sec_a', new Date('2026-04-10T00:00:20Z')),
+      makeSecurityRow('sec_b', new Date('2026-04-10T00:00:40Z')),
+    ]);
+
+    mockDeliverToSiemWithRetry.mockResolvedValue({ success: true, entriesDelivered: 4 });
+
+    stubCursorAdvance();
+    stubCursorAdvance();
+    stubLockRelease();
+
+    await processSiemDelivery();
+
+    const batch = mockDeliverToSiemWithRetry.mock.calls[0][1] as {
+      id: string;
+      source: AuditLogSource;
+      timestamp: Date;
+    }[];
+
+    assert({
+      given: 'activity_logs at t=10,30 and security_audit_log at t=20,40',
+      should: 'interleave the merged batch by timestamp',
+      actual: batch.map((e) => e.id),
+      expected: ['log_a', 'sec_a', 'log_b', 'sec_b'],
+    });
+  });
+
+  it('initializes a new security_audit_log cursor to NOW() and delivers zero security entries', async () => {
+    mockLoadSiemConfig.mockReturnValue(WEBHOOK_CONFIG);
+    mockValidateSiemConfig.mockReturnValue({ valid: true, errors: [] });
+
+    stubLockAcquired();
+    // activity_logs cursor pre-seeded and empty
+    stubCursorRow('log_prev', new Date('2026-04-10T10:00:00Z'), 0);
+    stubSourceRows([]);
+    // security_audit_log cursor missing → init path
+    stubCursorMissing();
+    stubCursorInit();
+    stubLockRelease();
+
+    await processSiemDelivery();
+
+    assert({
+      given: 'a missing security_audit_log cursor',
+      should: 'not attempt delivery (merged batch is empty after init)',
+      actual: mockDeliverToSiemWithRetry.mock.calls.length,
+      expected: 0,
+    });
+
+    const initInserts = mockQuery.mock.calls.filter(
+      (call) =>
+        typeof call[0] === 'string' &&
+        (call[0] as string).includes('ON CONFLICT (id) DO NOTHING')
+    );
+
+    assert({
+      given: 'a missing security_audit_log cursor',
+      should: 'INSERT a sentinel cursor row for security_audit_log with NOW() timestamp',
+      actual: initInserts.length,
+      expected: 1,
+    });
+
+    const initParams = initInserts[0][1] as unknown[];
+    assert({
+      given: 'a missing security_audit_log cursor',
+      should: 'target the security_audit_log source',
+      actual: initParams[0],
+      expected: 'security_audit_log',
+    });
+
+    assert({
+      given: 'a missing security_audit_log cursor',
+      should: 'plant the cursor timestamp at approximately now (within 10s)',
+      actual: (initParams[2] as Date).getTime() >= Date.now() - 10_000,
+      expected: true,
+    });
+
+    // Crucially: no security_audit_log SELECT happened — zero historical delivery
+    const securityQueryCount = findAllCallsContaining('FROM security_audit_log').length;
+    assert({
+      given: 'a missing security_audit_log cursor',
+      should: 'skip the security_audit_log rows query on init run (no backfill)',
+      actual: securityQueryCount,
+      expected: 0,
+    });
+  });
+
+  it('subsequent run after cursor init proceeds normally', async () => {
+    mockLoadSiemConfig.mockReturnValue(WEBHOOK_CONFIG);
+    mockValidateSiemConfig.mockReturnValue({ valid: true, errors: [] });
+
+    stubLockAcquired();
+    stubCursorRow('log_prev', new Date('2026-04-10T10:00:00Z'), 0);
+    stubSourceRows([]);
+    // security cursor exists from a prior init run
+    const initTimestamp = new Date('2026-04-10T09:00:00Z');
+    stubCursorRow('__cursor_init__', initTimestamp, 0);
+    stubSourceRows([makeSecurityRow('sec_1', new Date('2026-04-10T11:00:00Z'))]);
+
+    mockDeliverToSiemWithRetry.mockResolvedValue({ success: true, entriesDelivered: 1 });
+
+    stubCursorAdvance();
+    stubLockRelease();
+
+    await processSiemDelivery();
+
+    assert({
+      given: 'a pre-initialized security_audit_log cursor',
+      should: 'query security_audit_log after the cursor timestamp',
+      actual: findAllCallsContaining('FROM security_audit_log').length,
+      expected: 1,
+    });
+
+    const securityQuery = mockQuery.mock.calls.find(
+      (call) => typeof call[0] === 'string' && (call[0] as string).includes('FROM security_audit_log')
+    );
+    assert({
+      given: 'a pre-initialized security_audit_log cursor',
+      should: 'use the cursor timestamp as the query predicate',
+      actual: (securityQuery?.[1] as unknown[])[0],
+      expected: initTimestamp,
+    });
+
+    assert({
+      given: 'a pre-initialized security_audit_log cursor with one new row',
+      should: 'deliver the single security entry',
+      actual: mockDeliverToSiemWithRetry.mock.calls[0][1].length,
+      expected: 1,
+    });
+  });
+
+  it('empty security_audit_log does not break activity_logs delivery', async () => {
+    mockLoadSiemConfig.mockReturnValue(WEBHOOK_CONFIG);
+    mockValidateSiemConfig.mockReturnValue({ valid: true, errors: [] });
+
+    stubLockAcquired();
+    stubCursorRow('log_prev', new Date('2026-04-10T10:00:00Z'), 7);
+    stubSourceRows([makeActivityRow('log_1', new Date('2026-04-10T12:00:00Z'))]);
+    stubCursorRow('sec_prev', new Date('2026-04-10T10:00:00Z'), 3);
+    stubSourceRows([]);
+
+    mockDeliverToSiemWithRetry.mockResolvedValue({ success: true, entriesDelivered: 1 });
+
+    stubCursorAdvance(); // activity_logs advance only
+    stubLockRelease();
+
+    await processSiemDelivery();
+
+    assert({
+      given: 'activity_logs has rows and security_audit_log is empty',
+      should: 'deliver the activity_logs entry',
+      actual: mockDeliverToSiemWithRetry.mock.calls[0][1].length,
+      expected: 1,
+    });
+
+    const advanceCalls = mockQuery.mock.calls.filter(
+      (call) =>
+        typeof call[0] === 'string' &&
+        (call[0] as string).includes('"deliveryCount" = $4')
+    );
+
+    assert({
+      given: 'activity_logs has rows and security_audit_log is empty',
+      should: 'only advance the activity_logs cursor',
+      actual: advanceCalls.length,
+      expected: 1,
+    });
+
+    assert({
+      given: 'activity_logs has rows and security_audit_log is empty',
+      should: 'advance cursor for activity_logs',
+      actual: (advanceCalls[0][1] as unknown[])[0],
+      expected: 'activity_logs',
+    });
+  });
+
+  it('both sources empty → no delivery call, cursors unchanged', async () => {
+    mockLoadSiemConfig.mockReturnValue(WEBHOOK_CONFIG);
+    mockValidateSiemConfig.mockReturnValue({ valid: true, errors: [] });
+
+    stubLockAcquired();
+    stubCursorRow('log_prev', new Date('2026-04-10T10:00:00Z'), 0);
+    stubSourceRows([]);
+    stubCursorRow('sec_prev', new Date('2026-04-10T10:00:00Z'), 0);
+    stubSourceRows([]);
+    stubLockRelease();
+
+    await processSiemDelivery();
+
+    assert({
+      given: 'both sources empty',
+      should: 'not issue a delivery',
+      actual: mockDeliverToSiemWithRetry.mock.calls.length,
+      expected: 0,
+    });
+
+    const advanceCalls = mockQuery.mock.calls.filter(
+      (call) =>
+        typeof call[0] === 'string' &&
+        (call[0] as string).includes('"deliveryCount" = $4')
+    );
+    assert({
+      given: 'both sources empty',
+      should: 'not advance any cursor',
+      actual: advanceCalls.length,
+      expected: 0,
+    });
+  });
+
+  it('per-source cursor advancement after full delivery', async () => {
+    mockLoadSiemConfig.mockReturnValue(WEBHOOK_CONFIG);
+    mockValidateSiemConfig.mockReturnValue({ valid: true, errors: [] });
+
+    stubLockAcquired();
+    stubCursorRow('log_prev', new Date('2026-04-10T00:00:00Z'), 4);
+    stubSourceRows([
+      makeActivityRow('log_a', new Date('2026-04-10T00:00:10Z')),
+      makeActivityRow('log_b', new Date('2026-04-10T00:00:30Z')),
+    ]);
+    stubCursorRow('sec_prev', new Date('2026-04-10T00:00:00Z'), 2);
+    stubSourceRows([
+      makeSecurityRow('sec_a', new Date('2026-04-10T00:00:20Z')),
+      makeSecurityRow('sec_b', new Date('2026-04-10T00:00:40Z')),
+    ]);
+
+    mockDeliverToSiemWithRetry.mockResolvedValue({ success: true, entriesDelivered: 4 });
+
+    stubCursorAdvance();
+    stubCursorAdvance();
+    stubLockRelease();
+
+    await processSiemDelivery();
+
+    const advanceCalls = mockQuery.mock.calls.filter(
+      (call) =>
+        typeof call[0] === 'string' &&
+        (call[0] as string).includes('"deliveryCount" = $4')
+    );
+
+    assert({
+      given: 'full delivery of 2 rows per source',
+      should: 'advance both cursors',
+      actual: advanceCalls.length,
+      expected: 2,
+    });
+
+    const byId = new Map<string, unknown[]>();
+    for (const call of advanceCalls) {
+      const params = call[1] as unknown[];
+      byId.set(params[0] as string, params);
+    }
+
+    assert({
+      given: 'full delivery',
+      should: 'advance activity_logs cursor to log_b',
+      actual: byId.get('activity_logs')?.[1],
+      expected: 'log_b',
+    });
+
+    assert({
+      given: 'full delivery',
+      should: 'advance activity_logs deliveryCount by 2',
+      actual: byId.get('activity_logs')?.[3],
+      expected: 6,
+    });
+
+    assert({
+      given: 'full delivery',
+      should: 'advance security_audit_log cursor to sec_b',
+      actual: byId.get('security_audit_log')?.[1],
+      expected: 'sec_b',
+    });
+
+    assert({
+      given: 'full delivery',
+      should: 'advance security_audit_log deliveryCount by 2',
+      actual: byId.get('security_audit_log')?.[3],
+      expected: 4,
+    });
+  });
+
+  it('partial delivery walks the merged batch correctly across sources', async () => {
+    mockLoadSiemConfig.mockReturnValue(WEBHOOK_CONFIG);
+    mockValidateSiemConfig.mockReturnValue({ valid: true, errors: [] });
+
+    stubLockAcquired();
+    stubCursorRow('log_prev', new Date('2026-04-10T00:00:00Z'), 0);
+    stubSourceRows([
+      makeActivityRow('log_a', new Date('2026-04-10T00:00:10Z')),
+      makeActivityRow('log_b', new Date('2026-04-10T00:00:30Z')),
+    ]);
+    stubCursorRow('sec_prev', new Date('2026-04-10T00:00:00Z'), 0);
+    stubSourceRows([
+      makeSecurityRow('sec_a', new Date('2026-04-10T00:00:20Z')),
+      makeSecurityRow('sec_b', new Date('2026-04-10T00:00:40Z')),
+    ]);
+
+    // Merged: [log_a(10), sec_a(20), log_b(30), sec_b(40)]
+    // Delivered prefix: 3 → log_a, sec_a, log_b. sec_b stays behind.
+    mockDeliverToSiemWithRetry.mockResolvedValue({
+      success: false,
+      entriesDelivered: 3,
+      error: 'HTTP 503: timeout',
+    });
+
+    // activity_logs advance, security_audit_log advance, then 2 error upserts
+    stubCursorAdvance();
+    stubCursorAdvance();
+    stubErrorUpsert();
+    stubErrorUpsert();
+    stubLockRelease();
+
+    await processSiemDelivery();
+
+    const advanceCalls = mockQuery.mock.calls.filter(
+      (call) =>
+        typeof call[0] === 'string' &&
+        (call[0] as string).includes('"deliveryCount" = $4')
+    );
+
+    const byId = new Map<string, unknown[]>();
+    for (const call of advanceCalls) {
+      const params = call[1] as unknown[];
+      byId.set(params[0] as string, params);
+    }
+
+    assert({
+      given: 'partial delivery of 3 of 4 merged entries',
+      should: 'advance activity_logs cursor over both of its delivered entries (log_a, log_b → log_b)',
+      actual: byId.get('activity_logs')?.[1],
+      expected: 'log_b',
+    });
+
+    assert({
+      given: 'partial delivery of 3 of 4 merged entries',
+      should: 'advance security_audit_log cursor only to sec_a (sec_b un-delivered)',
+      actual: byId.get('security_audit_log')?.[1],
+      expected: 'sec_a',
+    });
+
+    assert({
+      given: 'partial delivery of 3 of 4 merged entries',
+      should: 'advance activity_logs count by 2',
+      actual: byId.get('activity_logs')?.[3],
+      expected: 2,
+    });
+
+    assert({
+      given: 'partial delivery of 3 of 4 merged entries',
+      should: 'advance security_audit_log count by 1',
+      actual: byId.get('security_audit_log')?.[3],
+      expected: 1,
+    });
+  });
+
+  it('delivery failure records error on both source cursors', async () => {
+    mockLoadSiemConfig.mockReturnValue(WEBHOOK_CONFIG);
+    mockValidateSiemConfig.mockReturnValue({ valid: true, errors: [] });
+
+    stubLockAcquired();
+    stubCursorRow('log_prev', new Date('2026-04-10T00:00:00Z'), 0);
+    stubSourceRows([makeActivityRow('log_1', new Date('2026-04-10T01:00:00Z'))]);
+    stubCursorRow('sec_prev', new Date('2026-04-10T00:00:00Z'), 0);
+    stubSourceRows([makeSecurityRow('sec_1', new Date('2026-04-10T01:00:01Z'))]);
+
+    mockDeliverToSiemWithRetry.mockResolvedValue({
+      success: false,
+      entriesDelivered: 0,
+      error: 'webhook unreachable',
+    });
+
+    stubErrorUpsert();
+    stubErrorUpsert();
+    stubLockRelease();
+
+    await processSiemDelivery();
+
+    const errorCalls = mockQuery.mock.calls.filter(
+      (call) => typeof call[0] === 'string' && (call[0] as string).includes('"lastError" = $2')
+    );
+
+    assert({
+      given: 'a total delivery failure',
+      should: 'write lastError to both source cursors',
+      actual: errorCalls.map((c) => (c[1] as unknown[])[0]).sort(),
+      expected: ['activity_logs', 'security_audit_log'],
+    });
+
+    assert({
+      given: 'a total delivery failure',
+      should: 'propagate the error message to every cursor',
+      actual: errorCalls.every((c) => (c[1] as unknown[])[1] === 'webhook unreachable'),
+      expected: true,
+    });
+
+    const advanceCalls = mockQuery.mock.calls.filter(
+      (call) =>
+        typeof call[0] === 'string' &&
+        (call[0] as string).includes('"deliveryCount" = $4')
+    );
+    assert({
+      given: 'a total delivery failure',
+      should: 'not advance either cursor',
+      actual: advanceCalls.length,
+      expected: 0,
+    });
+  });
+
+  it('SOURCES constant is typed as AuditLogSource[] and contains both sources', () => {
+    const expected: AuditLogSource[] = ['activity_logs', 'security_audit_log'];
+    assert({
+      given: 'the exported SOURCES constant',
+      should: 'equal the two known AuditLogSource values in order',
+      actual: [...SOURCES],
+      expected,
     });
   });
 });

--- a/apps/processor/src/workers/__tests__/siem-delivery-worker.test.ts
+++ b/apps/processor/src/workers/__tests__/siem-delivery-worker.test.ts
@@ -433,7 +433,7 @@ describe('processSiemDelivery', () => {
     });
   });
 
-  it('uses timestamp-only cursor to resume after last delivered position', async () => {
+  it('uses tuple (timestamp, id) cursor to resume after last delivered position', async () => {
     mockLoadSiemConfig.mockReturnValue(WEBHOOK_CONFIG);
     mockValidateSiemConfig.mockReturnValue({ valid: true, errors: [] });
 
@@ -454,8 +454,8 @@ describe('processSiemDelivery', () => {
 
     assert({
       given: 'an existing cursor',
-      should: 'use timestamp-only comparison (not composite with non-monotonic IDs)',
-      actual: sql.includes('WHERE timestamp > $1'),
+      should: 'use tuple (timestamp, id) > ($1, $2) cursor so same-timestamp siblings are not dropped',
+      actual: sql.includes('(timestamp, id) > ($1, $2)'),
       expected: true,
     });
 
@@ -468,8 +468,15 @@ describe('processSiemDelivery', () => {
 
     assert({
       given: 'an existing cursor',
-      should: 'pass batchSize as second param',
+      should: 'pass cursor id as second param',
       actual: params[1],
+      expected: 'log_99',
+    });
+
+    assert({
+      given: 'an existing cursor',
+      should: 'pass batchSize as third param',
+      actual: params[2],
       expected: 100,
     });
   });
@@ -1020,6 +1027,130 @@ describe('processSiemDelivery', () => {
       given: 'a total delivery failure',
       should: 'not advance either cursor',
       actual: advanceCalls.length,
+      expected: 0,
+    });
+  });
+
+  it('cursor row with null lastDeliveredAt is treated as uninitialized and re-initialized', async () => {
+    mockLoadSiemConfig.mockReturnValue(WEBHOOK_CONFIG);
+    mockValidateSiemConfig.mockReturnValue({ valid: true, errors: [] });
+
+    stubLockAcquired();
+    // activity_logs cursor is healthy and empty
+    stubCursorRow('log_prev', new Date('2026-04-10T10:00:00Z'), 0);
+    stubSourceRows([]);
+    // security_audit_log cursor exists but with null timestamps — created by a
+    // prior error-path recordError() that ran before the cursor was ever
+    // initialized. The schema check constraint allows (null, null), so the
+    // worker must NOT skip this source forever — it must re-init it.
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ lastDeliveredId: null, lastDeliveredAt: null, deliveryCount: 0 }],
+      rowCount: 1,
+    });
+    stubCursorInit(); // worker should now initCursor for security_audit_log
+    stubLockRelease();
+
+    await processSiemDelivery();
+
+    const initInserts = mockQuery.mock.calls.filter(
+      (call) =>
+        typeof call[0] === 'string' &&
+        (call[0] as string).includes('ON CONFLICT (id) DO NOTHING')
+    );
+
+    assert({
+      given: 'a security_audit_log cursor row with null lastDeliveredAt',
+      should: 'INSERT a fresh sentinel cursor row with NOW() (re-initialize)',
+      actual: initInserts.length,
+      expected: 1,
+    });
+
+    assert({
+      given: 'a security_audit_log cursor row with null lastDeliveredAt',
+      should: 'target the security_audit_log source for re-init',
+      actual: (initInserts[0][1] as unknown[])[0],
+      expected: 'security_audit_log',
+    });
+
+    // Crucially: NO security_audit_log SELECT happened — same as a brand-new
+    // source (no historical backfill, no permanent skip).
+    const securityQueryCount = findAllCallsContaining('FROM security_audit_log').length;
+    assert({
+      given: 'a security_audit_log cursor row with null lastDeliveredAt',
+      should: 'not query security_audit_log on the re-init run',
+      actual: securityQueryCount,
+      expected: 0,
+    });
+  });
+
+  it('returns rows whose timestamp ties the cursor timestamp (no same-microsecond drop)', async () => {
+    mockLoadSiemConfig.mockReturnValue(WEBHOOK_CONFIG);
+    mockValidateSiemConfig.mockReturnValue({ valid: true, errors: [] });
+
+    stubLockAcquired();
+    const tieTimestamp = new Date('2026-04-10T12:00:00.000Z');
+    // activity_logs cursor sits exactly at tieTimestamp with id 'log_a' delivered
+    stubCursorRow('log_a', tieTimestamp, 1);
+    stubSourceRows([]);
+    stubCursorRow('sec_prev', new Date('2026-04-10T10:00:00Z'), 0);
+    stubSourceRows([]);
+    stubLockRelease();
+
+    await processSiemDelivery();
+
+    const activityQuery = mockQuery.mock.calls.find(
+      (call) => typeof call[0] === 'string' && (call[0] as string).includes('FROM activity_logs')
+    );
+
+    assert({
+      given: 'a cursor sitting on a row that may have same-timestamp siblings',
+      should: 'use a tuple (timestamp, id) > ($1, $2) cursor, not a strict timestamp >',
+      actual:
+        typeof activityQuery?.[0] === 'string' &&
+        (activityQuery[0] as string).includes('(timestamp, id) > ($1, $2)'),
+      expected: true,
+    });
+
+    assert({
+      given: 'a cursor sitting on a row that may have same-timestamp siblings',
+      should: 'pass the cursor timestamp as the first param',
+      actual: (activityQuery?.[1] as unknown[])[0],
+      expected: tieTimestamp,
+    });
+
+    assert({
+      given: 'a cursor sitting on a row that may have same-timestamp siblings',
+      should: 'pass the cursor id as the second param so same-timestamp rows with id > cursor id still match',
+      actual: (activityQuery?.[1] as unknown[])[1],
+      expected: 'log_a',
+    });
+  });
+
+  it('does not log the polled-rows line when both sources are empty', async () => {
+    mockLoadSiemConfig.mockReturnValue(WEBHOOK_CONFIG);
+    mockValidateSiemConfig.mockReturnValue({ valid: true, errors: [] });
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    stubLockAcquired();
+    stubCursorRow('log_prev', new Date('2026-04-10T10:00:00Z'), 0);
+    stubSourceRows([]);
+    stubCursorRow('sec_prev', new Date('2026-04-10T10:00:00Z'), 0);
+    stubSourceRows([]);
+    stubLockRelease();
+
+    await processSiemDelivery();
+
+    const polledLogCalls = consoleSpy.mock.calls.filter(
+      (call) => typeof call[0] === 'string' && (call[0] as string).includes('Polled')
+    );
+
+    consoleSpy.mockRestore();
+
+    assert({
+      given: 'a polling cycle where both sources returned zero rows',
+      should: 'not emit the [siem-delivery] Polled info log',
+      actual: polledLogCalls.length,
       expected: 0,
     });
   });

--- a/apps/processor/src/workers/__tests__/siem-delivery-worker.test.ts
+++ b/apps/processor/src/workers/__tests__/siem-delivery-worker.test.ts
@@ -70,9 +70,19 @@ function stubCursorMissing() {
   mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 0 });
 }
 
-/** Response for the init INSERT (ON CONFLICT DO NOTHING) */
-function stubCursorInit() {
-  mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+/** Response for the init INSERT (UPSERT with RETURNING) — returns the
+ *  planted row so the worker can use the DB-side statement_timestamp. */
+function stubCursorInit(plantedAt: Date = new Date()) {
+  mockQuery.mockResolvedValueOnce({
+    rows: [
+      {
+        lastDeliveredId: '__cursor_init__',
+        lastDeliveredAt: plantedAt,
+        deliveryCount: 0,
+      },
+    ],
+    rowCount: 1,
+  });
 }
 
 /** Response for a source rows SELECT */
@@ -675,14 +685,30 @@ describe('processSiemDelivery', () => {
     const initInserts = mockQuery.mock.calls.filter(
       (call) =>
         typeof call[0] === 'string' &&
-        (call[0] as string).includes('ON CONFLICT (id) DO NOTHING')
+        (call[0] as string).includes('statement_timestamp()') &&
+        (call[0] as string).includes('RETURNING')
     );
 
     assert({
       given: 'a missing security_audit_log cursor',
-      should: 'INSERT a sentinel cursor row for security_audit_log with NOW() timestamp',
+      should: 'INSERT a sentinel cursor row planted at the DB clock (statement_timestamp)',
       actual: initInserts.length,
       expected: 1,
+    });
+
+    const initSql = initInserts[0][0] as string;
+    assert({
+      given: 'the init INSERT',
+      should: 'not pass a JS Date for the timestamp — must let Postgres stamp it',
+      actual: (initInserts[0][1] as unknown[]).some((p) => p instanceof Date),
+      expected: false,
+    });
+
+    assert({
+      given: 'the init INSERT',
+      should: 'upsert via ON CONFLICT DO UPDATE so error-only rows are repaired',
+      actual: initSql.includes('ON CONFLICT (id) DO UPDATE'),
+      expected: true,
     });
 
     const initParams = initInserts[0][1] as unknown[];
@@ -691,13 +717,6 @@ describe('processSiemDelivery', () => {
       should: 'target the security_audit_log source',
       actual: initParams[0],
       expected: 'security_audit_log',
-    });
-
-    assert({
-      given: 'a missing security_audit_log cursor',
-      should: 'plant the cursor timestamp at approximately now (within 10s)',
-      actual: (initParams[2] as Date).getTime() >= Date.now() - 10_000,
-      expected: true,
     });
 
     // Crucially: no security_audit_log SELECT happened — zero historical delivery
@@ -1126,12 +1145,13 @@ describe('processSiemDelivery', () => {
     const initInserts = mockQuery.mock.calls.filter(
       (call) =>
         typeof call[0] === 'string' &&
-        (call[0] as string).includes('ON CONFLICT (id) DO NOTHING')
+        (call[0] as string).includes('statement_timestamp()') &&
+        (call[0] as string).includes('ON CONFLICT (id) DO UPDATE')
     );
 
     assert({
       given: 'a security_audit_log cursor row with null lastDeliveredAt',
-      should: 'INSERT a fresh sentinel cursor row with NOW() (re-initialize)',
+      should: 'UPSERT a fresh sentinel cursor row with statement_timestamp (re-initialize)',
       actual: initInserts.length,
       expected: 1,
     });
@@ -1223,6 +1243,91 @@ describe('processSiemDelivery', () => {
       should: 'not emit the [siem-delivery] Polled info log',
       actual: polledLogCalls.length,
       expected: 0,
+    });
+  });
+
+  it('backlogged source caps delivery watermark so newer cross-source rows are deferred', async () => {
+    // Scenario from Codex P2 review: activity_logs has a big historical
+    // backlog (Jan rows), security_audit_log has a few fresh rows (Apr). If we
+    // naively ship every polled row in one batch, the Apr security rows go out
+    // BEFORE most of the Jan activity rows, then the next run ships more Jan
+    // rows — the SIEM receiver's delivery order no longer matches event order.
+    //
+    // Expected behavior: because activity_logs hit its LIMIT (backlog still
+    // pending past the tail), the delivery watermark caps at the activity
+    // batch's last timestamp. Newer security rows past that watermark are
+    // held back — NOT delivered, NOT advanced — until the activity backlog
+    // drains in subsequent runs.
+    const smallBatchConfig = {
+      enabled: true,
+      type: 'webhook' as const,
+      webhook: {
+        url: 'https://siem.example.com',
+        secret: 's3cret',
+        batchSize: 3,
+        retryAttempts: 3,
+      },
+    };
+    mockLoadSiemConfig.mockReturnValue(smallBatchConfig);
+    mockValidateSiemConfig.mockReturnValue({ valid: true, errors: [] });
+
+    stubLockAcquired();
+    // activity_logs has a backlog — returns LIMIT=3 old rows from Jan
+    stubCursorRow('log_prev', new Date('2026-01-01T00:00:00Z'), 10);
+    stubSourceRows([
+      makeActivityRow('log_jan1', new Date('2026-01-01T01:00:00Z')),
+      makeActivityRow('log_jan2', new Date('2026-01-01T02:00:00Z')),
+      makeActivityRow('log_jan3', new Date('2026-01-01T03:00:00Z')),
+    ]);
+    // security_audit_log is caught up except for 2 fresh rows from April
+    stubCursorRow('sec_prev', new Date('2026-04-10T00:00:00Z'), 5);
+    stubSourceRows([
+      makeSecurityRow('sec_apr1', new Date('2026-04-10T10:00:00Z')),
+      makeSecurityRow('sec_apr2', new Date('2026-04-10T10:05:00Z')),
+    ]);
+
+    mockDeliverToSiemWithRetry.mockResolvedValue({ success: true, entriesDelivered: 3 });
+
+    stubCursorAdvance(); // only activity_logs advances
+    stubLockRelease();
+
+    await processSiemDelivery();
+
+    const deliveredBatch = mockDeliverToSiemWithRetry.mock.calls[0][1] as { source: AuditLogSource }[];
+
+    assert({
+      given: 'activity_logs has backlog and security has newer rows',
+      should: 'only deliver the activity (backlogged) prefix, not the newer security rows',
+      actual: deliveredBatch.length,
+      expected: 3,
+    });
+
+    assert({
+      given: 'the delivery watermark cap',
+      should: 'include all three activity_logs rows',
+      actual: deliveredBatch.every((e) => e.source === 'activity_logs'),
+      expected: true,
+    });
+
+    const advanceCalls = mockQuery.mock.calls.filter(
+      (call) =>
+        typeof call[0] === 'string' &&
+        (call[0] as string).includes('"lastDeliveredId" = $2') &&
+        (call[0] as string).includes('"lastDeliveredAt" = $3')
+    );
+
+    assert({
+      given: 'security rows were held back by the watermark',
+      should: 'only issue a cursor advance for activity_logs, not security_audit_log',
+      actual: advanceCalls.length,
+      expected: 1,
+    });
+
+    assert({
+      given: 'the single advance call',
+      should: 'target the activity_logs source',
+      actual: (advanceCalls[0][1] as unknown[])[0],
+      expected: 'activity_logs',
     });
   });
 

--- a/apps/processor/src/workers/siem-delivery-worker.ts
+++ b/apps/processor/src/workers/siem-delivery-worker.ts
@@ -1,22 +1,189 @@
-import { loadSiemConfig, validateSiemConfig, deliverToSiemWithRetry } from '../services/siem-adapter';
-import { mapActivityLogsToSiemEntries, type ActivityLogSiemRow } from '../services/siem-event-mapper';
+import {
+  loadSiemConfig,
+  validateSiemConfig,
+  deliverToSiemWithRetry,
+  type AuditLogEntry,
+  type AuditLogSource,
+} from '../services/siem-adapter';
+import {
+  mapActivityLogsToSiemEntries,
+  type ActivityLogSiemRow,
+} from '../services/siem-event-mapper';
+import {
+  mapSecurityAuditEventsToSiemEntries,
+  type SecurityAuditSiemRow,
+} from '../services/security-audit-event-mapper';
 import { getPoolForWorker } from '../db';
 
-const CURSOR_ID = 'activity_logs';
+export const SOURCES: readonly AuditLogSource[] = ['activity_logs', 'security_audit_log'] as const;
 const DEFAULT_BATCH_SIZE = 100;
+
+// One advisory lock guards the whole worker run — not per-source. Key is kept
+// as 'activity_logs' for backward compatibility: renaming it would hash to a
+// different lock slot, so during a rolling deploy old/new workers would stop
+// serializing against each other and could race on cursor upserts.
+const ADVISORY_LOCK_KEY = 'activity_logs';
+
+// Stored in siem_delivery_cursors.lastDeliveredId when a cursor is first
+// initialized for a new source. The table has a CHECK constraint requiring
+// lastDeliveredId and lastDeliveredAt to be both null or both non-null. Phase 7
+// of the dual-read plan requires the cursor to plant at NOW() with zero backfill,
+// so we need a non-null placeholder until the first real row is delivered. Real
+// row ids are cuids and cannot collide with this sentinel.
+const CURSOR_INIT_SENTINEL = '__cursor_init__';
 
 const ACTIVITY_LOG_COLUMNS = `id, timestamp, "userId", "actorEmail", "actorDisplayName",
         "isAiGenerated", "aiProvider", "aiModel", "aiConversationId",
         operation, "resourceType", "resourceId", "resourceTitle",
         "driveId", "pageId", metadata, "previousLogHash", "logHash"`;
 
+const SECURITY_AUDIT_COLUMNS = `id, timestamp,
+        event_type AS "eventType",
+        user_id AS "userId",
+        session_id AS "sessionId",
+        service_id AS "serviceId",
+        resource_type AS "resourceType",
+        resource_id AS "resourceId",
+        ip_address AS "ipAddress",
+        user_agent AS "userAgent",
+        geo_location AS "geoLocation",
+        details,
+        risk_score AS "riskScore",
+        anomaly_flags AS "anomalyFlags",
+        previous_hash AS "previousHash",
+        event_hash AS "eventHash"`;
+
+// Minimal subset of pg's PoolClient API that this worker uses — defined
+// locally because @types/pg is not installed in this workspace.
+interface PgClient {
+  query(text: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[]; rowCount: number | null }>;
+  release(): void;
+}
+
+interface CursorRow {
+  lastDeliveredId: string | null;
+  lastDeliveredAt: Date | null;
+  deliveryCount: number;
+}
+
+interface SourceState {
+  source: AuditLogSource;
+  cursor: CursorRow;
+  entries: AuditLogEntry[];
+}
+
+async function loadCursor(client: PgClient, source: AuditLogSource): Promise<CursorRow | undefined> {
+  const result = await client.query(
+    'SELECT "lastDeliveredId", "lastDeliveredAt", "deliveryCount" FROM siem_delivery_cursors WHERE id = $1',
+    [source]
+  );
+  return result.rows[0] as unknown as CursorRow | undefined;
+}
+
+async function initCursor(client: PgClient, source: AuditLogSource): Promise<CursorRow> {
+  const now = new Date();
+  await client.query(
+    `INSERT INTO siem_delivery_cursors (id, "lastDeliveredId", "lastDeliveredAt", "deliveryCount", "lastError", "lastErrorAt", "updatedAt")
+     VALUES ($1, $2, $3, 0, NULL, NULL, NOW())
+     ON CONFLICT (id) DO NOTHING`,
+    [source, CURSOR_INIT_SENTINEL, now]
+  );
+  console.log(
+    `[siem-delivery] Initialized cursor for source=${source} at ${now.toISOString()} (no backfill)`
+  );
+  return { lastDeliveredId: CURSOR_INIT_SENTINEL, lastDeliveredAt: now, deliveryCount: 0 };
+}
+
+async function queryActivityLogs(
+  client: PgClient,
+  afterTimestamp: Date,
+  batchSize: number
+): Promise<AuditLogEntry[]> {
+  const result = await client.query(
+    `SELECT ${ACTIVITY_LOG_COLUMNS}
+     FROM activity_logs
+     WHERE timestamp > $1
+     ORDER BY timestamp ASC
+     LIMIT $2`,
+    [afterTimestamp, batchSize]
+  );
+  return mapActivityLogsToSiemEntries(result.rows as unknown as ActivityLogSiemRow[]);
+}
+
+async function querySecurityAuditLog(
+  client: PgClient,
+  afterTimestamp: Date,
+  batchSize: number
+): Promise<AuditLogEntry[]> {
+  const result = await client.query(
+    `SELECT ${SECURITY_AUDIT_COLUMNS}
+     FROM security_audit_log
+     WHERE timestamp > $1
+     ORDER BY timestamp ASC
+     LIMIT $2`,
+    [afterTimestamp, batchSize]
+  );
+  return mapSecurityAuditEventsToSiemEntries(result.rows as unknown as SecurityAuditSiemRow[]);
+}
+
+async function queryRowsForSource(
+  client: PgClient,
+  source: AuditLogSource,
+  afterTimestamp: Date,
+  batchSize: number
+): Promise<AuditLogEntry[]> {
+  if (source === 'activity_logs') {
+    return queryActivityLogs(client, afterTimestamp, batchSize);
+  }
+  return querySecurityAuditLog(client, afterTimestamp, batchSize);
+}
+
+async function recordError(
+  client: PgClient,
+  source: AuditLogSource,
+  message: string
+): Promise<void> {
+  await client.query(
+    `INSERT INTO siem_delivery_cursors (id, "lastError", "lastErrorAt", "updatedAt")
+     VALUES ($1, $2, NOW(), NOW())
+     ON CONFLICT (id) DO UPDATE SET
+       "lastError" = $2,
+       "lastErrorAt" = NOW(),
+       "updatedAt" = NOW()`,
+    [source, message]
+  );
+}
+
+async function advanceCursor(
+  client: PgClient,
+  source: AuditLogSource,
+  lastDeliveredId: string,
+  lastDeliveredAt: Date,
+  newDeliveryCount: number
+): Promise<void> {
+  await client.query(
+    `INSERT INTO siem_delivery_cursors (id, "lastDeliveredId", "lastDeliveredAt", "deliveryCount", "lastError", "lastErrorAt", "updatedAt")
+     VALUES ($1, $2, $3, $4, NULL, NULL, NOW())
+     ON CONFLICT (id) DO UPDATE SET
+       "lastDeliveredId" = $2,
+       "lastDeliveredAt" = $3,
+       "deliveryCount" = $4,
+       "lastError" = NULL,
+       "lastErrorAt" = NULL,
+       "updatedAt" = NOW()`,
+    [source, lastDeliveredId, lastDeliveredAt, newDeliveryCount]
+  );
+}
+
 /**
- * SIEM delivery worker — polls activity_logs for new entries and delivers
- * them to the configured SIEM endpoint via the existing siem-adapter.
+ * SIEM delivery worker — polls every configured audit source for new entries,
+ * interleaves them by timestamp, and delivers a single unified batch to the
+ * configured SIEM endpoint via the existing siem-adapter.
  *
  * Scheduled by pg-boss every 30s. Expected max duration: ~4 minutes
  * (3 retries x 60s backoff cap + network time). The schedule uses
- * retryLimit: 0 so overlapping runs won't stack.
+ * retryLimit: 0 so overlapping runs won't stack, and a single advisory lock
+ * keeps overlapping invocations serialized across every source.
  */
 export async function processSiemDelivery(): Promise<void> {
   const config = loadSiemConfig();
@@ -36,11 +203,9 @@ export async function processSiemDelivery(): Promise<void> {
   let lockAcquired = false;
 
   try {
-    // Acquire advisory lock to serialize cursor processing — prevents duplicate
-    // delivery when overlapping pg-boss invocations race on the same cursor.
     const lockResult = await client.query(
       'SELECT pg_try_advisory_lock(hashtext($1)) AS acquired',
-      [CURSOR_ID]
+      [ADVISORY_LOCK_KEY]
     );
     lockAcquired = Boolean(lockResult.rows[0]?.acquired);
 
@@ -48,102 +213,119 @@ export async function processSiemDelivery(): Promise<void> {
       return;
     }
 
-    // Read cursor position
-    const cursorResult = await client.query(
-      'SELECT "lastDeliveredId", "lastDeliveredAt", "deliveryCount" FROM siem_delivery_cursors WHERE id = $1',
-      [CURSOR_ID]
-    );
-    const cursor = cursorResult.rows[0] as {
-      lastDeliveredId: string | null;
-      lastDeliveredAt: Date | null;
-      deliveryCount: number;
-    } | undefined;
-
-    // Query new activity_logs after the cursor position.
-    // Uses timestamp-only comparison because activity_logs.timestamp has
-    // microsecond precision (PostgreSQL NOW()) and each event comes from a
-    // separate HTTP request/transaction, making same-timestamp collision
-    // effectively impossible. CUID2 IDs are non-monotonic so cannot be used
-    // for reliable cursor ordering.
     const batchSize = config.webhook?.batchSize ?? DEFAULT_BATCH_SIZE;
-    let logsResult;
 
-    if (cursor?.lastDeliveredAt) {
-      logsResult = await client.query(
-        `SELECT ${ACTIVITY_LOG_COLUMNS}
-         FROM activity_logs
-         WHERE timestamp > $1
-         ORDER BY timestamp ASC
-         LIMIT $2`,
-        [cursor.lastDeliveredAt, batchSize]
-      );
-    } else {
-      logsResult = await client.query(
-        `SELECT ${ACTIVITY_LOG_COLUMNS}
-         FROM activity_logs
-         ORDER BY timestamp ASC
-         LIMIT $1`,
-        [batchSize]
-      );
+    // Phase 1: load (or initialize) each source's cursor and query its new rows.
+    // Cursor queries use timestamp-only comparison because both tables have
+    // microsecond-precision timestamps and each event comes from a separate
+    // transaction, making same-timestamp collisions effectively impossible.
+    // CUID2 ids are non-monotonic so cannot be used for reliable cursor ordering.
+    const states: SourceState[] = [];
+    for (const source of SOURCES) {
+      let cursor = await loadCursor(client, source);
+
+      if (!cursor) {
+        // Phase 7: new source — plant cursor at NOW() and deliver zero historical
+        // rows. Backfilling would break temporal audit semantics (customers would
+        // see events from months ago appearing today). If historical events are
+        // needed they must be exported out-of-band.
+        cursor = await initCursor(client, source);
+        states.push({ source, cursor, entries: [] });
+        continue;
+      }
+
+      if (!cursor.lastDeliveredAt) {
+        // Defensive: the CHECK constraint on siem_delivery_cursors makes this
+        // impossible in practice, but avoid querying with a null timestamp.
+        states.push({ source, cursor, entries: [] });
+        continue;
+      }
+
+      const entries = await queryRowsForSource(client, source, cursor.lastDeliveredAt, batchSize);
+      states.push({ source, cursor, entries });
     }
 
-    if (logsResult.rows.length === 0) {
+    const pollCounts = states.map((s) => `${s.source}=${s.entries.length}`).join(', ');
+    console.log(`[siem-delivery] Polled ${pollCounts} rows`);
+
+    // Phase 2: interleave by timestamp. Preserving global temporal ordering
+    // across sources is critical for SIEM correctness — a receiver that sees
+    // a login after the resource access it authorized would flag false anomalies.
+    const merged = states
+      .flatMap((s) => s.entries)
+      .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+
+    if (merged.length === 0) {
       return;
     }
 
-    // Map and deliver
-    const entries = mapActivityLogsToSiemEntries(logsResult.rows as unknown as ActivityLogSiemRow[]);
-    const result = await deliverToSiemWithRetry(config, entries);
+    // Phase 3: single delivery call for the merged, time-ordered batch.
+    const result = await deliverToSiemWithRetry(config, merged);
 
-    // Advance cursor past any delivered entries (handles both full and partial delivery)
-    if (result.entriesDelivered > 0) {
-      const lastDeliveredRow = logsResult.rows[result.entriesDelivered - 1] as unknown as ActivityLogSiemRow;
-      const newCount = (cursor?.deliveryCount ?? 0) + result.entriesDelivered;
-
-      await client.query(
-        `INSERT INTO siem_delivery_cursors (id, "lastDeliveredId", "lastDeliveredAt", "deliveryCount", "lastError", "lastErrorAt", "updatedAt")
-         VALUES ($1, $2, $3, $4, NULL, NULL, NOW())
-         ON CONFLICT (id) DO UPDATE SET
-           "lastDeliveredId" = $2,
-           "lastDeliveredAt" = $3,
-           "deliveryCount" = $4,
-           "lastError" = NULL,
-           "lastErrorAt" = NULL,
-           "updatedAt" = NOW()`,
-        [CURSOR_ID, lastDeliveredRow.id, lastDeliveredRow.timestamp, newCount]
+    // Phase 4: walk the delivered prefix and track per-source progress. The
+    // adapter reports entriesDelivered as the count of the merged batch that
+    // made it through — because entries are interleaved, a single source may
+    // advance over a non-contiguous sub-slice of its own rows, but each source's
+    // OWN rows remain in timestamp order inside that prefix.
+    const delivered = merged.slice(0, result.entriesDelivered);
+    const perSourceLastDelivered = new Map<AuditLogSource, AuditLogEntry>();
+    const perSourceDeliveredCount = new Map<AuditLogSource, number>();
+    for (const entry of delivered) {
+      perSourceLastDelivered.set(entry.source, entry);
+      perSourceDeliveredCount.set(
+        entry.source,
+        (perSourceDeliveredCount.get(entry.source) ?? 0) + 1
       );
     }
 
-    if (result.success) {
-      console.log(`[siem-delivery] Delivered ${result.entriesDelivered} entries`);
-    } else {
-      // Record the error — cursor was already advanced past any partial delivery above
-      await client.query(
-        `INSERT INTO siem_delivery_cursors (id, "lastError", "lastErrorAt", "updatedAt")
-         VALUES ($1, $2, NOW(), NOW())
-         ON CONFLICT (id) DO UPDATE SET
-           "lastError" = $2,
-           "lastErrorAt" = NOW(),
-           "updatedAt" = NOW()`,
-        [CURSOR_ID, result.error ?? 'Unknown delivery error']
-      );
+    // Phase 5: advance cursors for sources whose entries were actually delivered.
+    // Sources with zero progress keep their cursor exactly where it was.
+    for (const state of states) {
+      const lastDelivered = perSourceLastDelivered.get(state.source);
+      if (!lastDelivered) continue;
 
-      console.error(`[siem-delivery] Delivery failed: ${result.error}${result.entriesDelivered > 0 ? ` (${result.entriesDelivered} entries delivered before failure)` : ''}`);
+      const count = perSourceDeliveredCount.get(state.source) ?? 0;
+      const newCount = state.cursor.deliveryCount + count;
+      await advanceCursor(
+        client,
+        state.source,
+        lastDelivered.id,
+        lastDelivered.timestamp,
+        newCount
+      );
+    }
+
+    // Phase 6: result logging + failure handling.
+    if (result.success) {
+      const breakdown =
+        Array.from(perSourceDeliveredCount.entries())
+          .map(([src, n]) => `${n} from ${src}`)
+          .join(', ') || 'none';
+      console.log(
+        `[siem-delivery] Delivered ${result.entriesDelivered} entries (${breakdown})`
+      );
+    } else {
+      // A unified delivery failure means both sources are blocked on the same
+      // network/webhook issue, so record the error on every source cursor. The
+      // error write runs after the cursor advance above, so sources that made
+      // partial progress still show lastError in /health.
+      const errorMessage = result.error ?? 'Unknown delivery error';
+      for (const source of SOURCES) {
+        await recordError(client, source, errorMessage);
+      }
+      const partial =
+        result.entriesDelivered > 0
+          ? ` (${result.entriesDelivered} entries delivered before failure)`
+          : '';
+      console.error(`[siem-delivery] Delivery failed: ${errorMessage}${partial}`);
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
 
-    // Best-effort: persist the error so /health reflects the failure
     try {
-      await client.query(
-        `INSERT INTO siem_delivery_cursors (id, "lastError", "lastErrorAt", "updatedAt")
-         VALUES ($1, $2, NOW(), NOW())
-         ON CONFLICT (id) DO UPDATE SET
-           "lastError" = $2,
-           "lastErrorAt" = NOW(),
-           "updatedAt" = NOW()`,
-        [CURSOR_ID, message]
-      );
+      for (const source of SOURCES) {
+        await recordError(client, source, message);
+      }
     } catch {
       // best-effort only — don't mask the original error
     }
@@ -152,7 +334,9 @@ export async function processSiemDelivery(): Promise<void> {
     throw error;
   } finally {
     if (lockAcquired) {
-      await client.query('SELECT pg_advisory_unlock(hashtext($1))', [CURSOR_ID]).catch(() => undefined);
+      await client
+        .query('SELECT pg_advisory_unlock(hashtext($1))', [ADVISORY_LOCK_KEY])
+        .catch(() => undefined);
     }
     client.release();
   }

--- a/apps/processor/src/workers/siem-delivery-worker.ts
+++ b/apps/processor/src/workers/siem-delivery-worker.ts
@@ -81,17 +81,37 @@ async function loadCursor(client: PgClient, source: AuditLogSource): Promise<Cur
 }
 
 async function initCursor(client: PgClient, source: AuditLogSource): Promise<CursorRow> {
-  const now = new Date();
-  await client.query(
+  // Plant the cursor at the DATABASE clock, not `new Date()`. If the worker
+  // host clock runs ahead of Postgres, any rows whose server-side `timestamp`
+  // defaults landed between DB-now and app-now would be silently skipped on
+  // first init — the tuple cursor `(ts, id) > (app-now, sentinel)` would
+  // exclude them. Read the planted timestamp back via RETURNING so the
+  // in-memory cursor and the row actually match.
+  //
+  // The caller only reaches this path while holding the worker advisory lock
+  // AND after seeing `loadCursor` return either no row or a row with null
+  // cursor fields (an error-only row from `recordError`). Under the lock both
+  // conditions imply we're the unique writer, so DO UPDATE unconditionally
+  // overwrites the planted state without clobbering progress that isn't
+  // there.
+  const result = await client.query(
     `INSERT INTO siem_delivery_cursors (id, "lastDeliveredId", "lastDeliveredAt", "deliveryCount", "lastError", "lastErrorAt", "updatedAt")
-     VALUES ($1, $2, $3, 0, NULL, NULL, NOW())
-     ON CONFLICT (id) DO NOTHING`,
-    [source, CURSOR_INIT_SENTINEL, now]
+     VALUES ($1, $2, statement_timestamp(), 0, NULL, NULL, NOW())
+     ON CONFLICT (id) DO UPDATE SET
+       "lastDeliveredId" = EXCLUDED."lastDeliveredId",
+       "lastDeliveredAt" = EXCLUDED."lastDeliveredAt",
+       "deliveryCount" = 0,
+       "lastError" = NULL,
+       "lastErrorAt" = NULL,
+       "updatedAt" = NOW()
+     RETURNING "lastDeliveredId", "lastDeliveredAt", "deliveryCount"`,
+    [source, CURSOR_INIT_SENTINEL]
   );
+  const row = result.rows[0] as unknown as CursorRow;
   console.log(
-    `[siem-delivery] Initialized cursor for source=${source} at ${now.toISOString()} (no backfill)`
+    `[siem-delivery] Initialized cursor for source=${source} at ${row.lastDeliveredAt?.toISOString()} (no backfill)`
   );
-  return { lastDeliveredId: CURSOR_INIT_SENTINEL, lastDeliveredAt: now, deliveryCount: 0 };
+  return row;
 }
 
 async function queryActivityLogs(
@@ -261,12 +281,38 @@ export async function processSiemDelivery(): Promise<void> {
       states.push({ source, cursor, entries });
     }
 
-    // Phase 2: interleave by timestamp. Preserving global temporal ordering
+    // Phase 2a: compute a safety watermark so a skewed backlog in one source
+    // doesn't cause out-of-order cross-source delivery across runs. If source A
+    // has 10k old rows (Jan) and source B has 5 new rows (Apr), polling each
+    // with LIMIT=batchSize returns A's oldest 100 + all 5 of B's. Naively
+    // merging and shipping would send the 5 Apr rows while 9900 Jan rows from
+    // A are still in the queue — a future run would then ship Jan rows AFTER
+    // Apr rows, violating global chronological order. The fix: if any source
+    // returned a full batch (meaning "more rows may exist after this tail"),
+    // only ship rows with timestamp <= min(backlogged-tail-timestamps). Rows
+    // from other sources past that watermark wait until the next run, when
+    // the backlogged source's cursor has advanced. A source that returned
+    // fewer than batchSize rows is fully drained, contributes no bound, and
+    // its rows are free to ship unconditionally.
+    const backloggedTails = states
+      .filter((s) => s.entries.length === batchSize)
+      .map((s) => s.entries[s.entries.length - 1].timestamp);
+
+    const safeUntil =
+      backloggedTails.length > 0
+        ? new Date(Math.min(...backloggedTails.map((d) => d.getTime())))
+        : null;
+
+    // Phase 2b: interleave by timestamp. Preserving global temporal ordering
     // across sources is critical for SIEM correctness — a receiver that sees
     // a login after the resource access it authorized would flag false anomalies.
-    const merged = states
+    const allEntries = states
       .flatMap((s) => s.entries)
       .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+
+    const merged = safeUntil
+      ? allEntries.filter((e) => e.timestamp.getTime() <= safeUntil.getTime())
+      : allEntries;
 
     if (merged.length === 0) {
       // Idle poll — no log line. The worker runs every 30s and the vast

--- a/apps/processor/src/workers/siem-delivery-worker.ts
+++ b/apps/processor/src/workers/siem-delivery-worker.ts
@@ -97,15 +97,22 @@ async function initCursor(client: PgClient, source: AuditLogSource): Promise<Cur
 async function queryActivityLogs(
   client: PgClient,
   afterTimestamp: Date,
+  afterId: string,
   batchSize: number
 ): Promise<AuditLogEntry[]> {
+  // Tuple cursor: (timestamp, id) > (lastDeliveredAt, lastDeliveredId).
+  // Strict timestamp > would silently drop rows that share a microsecond with
+  // the last delivered row — possible under load when multiple transactions
+  // commit in the same microsecond. CUID2 ids sort lexicographically, which is
+  // sufficient as a tie-breaker (we don't need them to be time-ordered, only
+  // to give same-timestamp rows a stable order).
   const result = await client.query(
     `SELECT ${ACTIVITY_LOG_COLUMNS}
      FROM activity_logs
-     WHERE timestamp > $1
-     ORDER BY timestamp ASC
-     LIMIT $2`,
-    [afterTimestamp, batchSize]
+     WHERE (timestamp, id) > ($1, $2)
+     ORDER BY timestamp ASC, id ASC
+     LIMIT $3`,
+    [afterTimestamp, afterId, batchSize]
   );
   return mapActivityLogsToSiemEntries(result.rows as unknown as ActivityLogSiemRow[]);
 }
@@ -113,15 +120,16 @@ async function queryActivityLogs(
 async function querySecurityAuditLog(
   client: PgClient,
   afterTimestamp: Date,
+  afterId: string,
   batchSize: number
 ): Promise<AuditLogEntry[]> {
   const result = await client.query(
     `SELECT ${SECURITY_AUDIT_COLUMNS}
      FROM security_audit_log
-     WHERE timestamp > $1
-     ORDER BY timestamp ASC
-     LIMIT $2`,
-    [afterTimestamp, batchSize]
+     WHERE (timestamp, id) > ($1, $2)
+     ORDER BY timestamp ASC, id ASC
+     LIMIT $3`,
+    [afterTimestamp, afterId, batchSize]
   );
   return mapSecurityAuditEventsToSiemEntries(result.rows as unknown as SecurityAuditSiemRow[]);
 }
@@ -130,12 +138,13 @@ async function queryRowsForSource(
   client: PgClient,
   source: AuditLogSource,
   afterTimestamp: Date,
+  afterId: string,
   batchSize: number
 ): Promise<AuditLogEntry[]> {
   if (source === 'activity_logs') {
-    return queryActivityLogs(client, afterTimestamp, batchSize);
+    return queryActivityLogs(client, afterTimestamp, afterId, batchSize);
   }
-  return querySecurityAuditLog(client, afterTimestamp, batchSize);
+  return querySecurityAuditLog(client, afterTimestamp, afterId, batchSize);
 }
 
 async function recordError(
@@ -216,37 +225,41 @@ export async function processSiemDelivery(): Promise<void> {
     const batchSize = config.webhook?.batchSize ?? DEFAULT_BATCH_SIZE;
 
     // Phase 1: load (or initialize) each source's cursor and query its new rows.
-    // Cursor queries use timestamp-only comparison because both tables have
-    // microsecond-precision timestamps and each event comes from a separate
-    // transaction, making same-timestamp collisions effectively impossible.
-    // CUID2 ids are non-monotonic so cannot be used for reliable cursor ordering.
+    // Cursor queries use a (timestamp, id) tuple so that rows sharing a
+    // microsecond with the last delivered row are still picked up. CUID ids
+    // are not time-monotonic, but they sort lexicographically and that is all
+    // we need from them as a tie-breaker — same-timestamp rows just need
+    // *some* stable order so neither side gets dropped.
     const states: SourceState[] = [];
     for (const source of SOURCES) {
       let cursor = await loadCursor(client, source);
 
-      if (!cursor) {
-        // Phase 7: new source — plant cursor at NOW() and deliver zero historical
-        // rows. Backfilling would break temporal audit semantics (customers would
-        // see events from months ago appearing today). If historical events are
-        // needed they must be exported out-of-band.
+      // Treat a null-timestamp row as uninitialized. The schema CHECK constraint
+      // permits (lastDeliveredId, lastDeliveredAt) = (null, null), and the
+      // recordError() insert path can create exactly that state if an error
+      // fires before the cursor was ever initialized. Without this branch the
+      // worker would skip the source forever on the next run. Re-initializing
+      // is safe — we lose at most a handful of seconds' worth of events that
+      // arrived during the failure window, which is the same exposure as a
+      // brand-new source per Phase 7's no-backfill rule.
+      if (!cursor || !cursor.lastDeliveredAt || !cursor.lastDeliveredId) {
+        // Phase 7: plant cursor at NOW() and deliver zero historical rows.
+        // Backfilling would break temporal audit semantics (customers would
+        // see events from months ago appearing today).
         cursor = await initCursor(client, source);
         states.push({ source, cursor, entries: [] });
         continue;
       }
 
-      if (!cursor.lastDeliveredAt) {
-        // Defensive: the CHECK constraint on siem_delivery_cursors makes this
-        // impossible in practice, but avoid querying with a null timestamp.
-        states.push({ source, cursor, entries: [] });
-        continue;
-      }
-
-      const entries = await queryRowsForSource(client, source, cursor.lastDeliveredAt, batchSize);
+      const entries = await queryRowsForSource(
+        client,
+        source,
+        cursor.lastDeliveredAt,
+        cursor.lastDeliveredId,
+        batchSize
+      );
       states.push({ source, cursor, entries });
     }
-
-    const pollCounts = states.map((s) => `${s.source}=${s.entries.length}`).join(', ');
-    console.log(`[siem-delivery] Polled ${pollCounts} rows`);
 
     // Phase 2: interleave by timestamp. Preserving global temporal ordering
     // across sources is critical for SIEM correctness — a receiver that sees
@@ -256,8 +269,14 @@ export async function processSiemDelivery(): Promise<void> {
       .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
 
     if (merged.length === 0) {
+      // Idle poll — no log line. The worker runs every 30s and the vast
+      // majority of cycles are idle; logging here would emit ~2880 no-op
+      // lines per day per instance.
       return;
     }
+
+    const pollCounts = states.map((s) => `${s.source}=${s.entries.length}`).join(', ');
+    console.log(`[siem-delivery] Polled ${pollCounts} rows`);
 
     // Phase 3: single delivery call for the merged, time-ordered batch.
     const result = await deliverToSiemWithRetry(config, merged);

--- a/docs/security/gdpr-audit/04-minimization-breach.md
+++ b/docs/security/gdpr-audit/04-minimization-breach.md
@@ -428,7 +428,7 @@ The structured logger at `packages/lib/src/logging/logger.ts:130–165` redacts 
 
 **Evidence:**
 - `find docs/ -iname "*incident*" -o -iname "*breach*" -o -iname "*runbook*"` returns only `docs/runbooks/tenant-migration.md`. The runbook directory exists but contains exactly one runbook, and it is for tenant migrations — not incident response, not breach response.
-- No "notify users" code path. Generic email infrastructure exists (`packages/lib/services/email-service.ts`), but no breach-specific template, no batch sender, no admin action gated on a "breach declared" event.
+- No "notify users" code path. Generic email infrastructure exists (`packages/lib/src/services/email-service.ts`), but no breach-specific template, no batch sender, no admin action gated on a "breach declared" event.
 - No DPA / DPO contact mechanism in the codebase (legal contact may live outside the repo, but nothing in code routes a breach notification to a DPO mailbox).
 - No mechanism to compute the *scope* of a breach by data category — see F16 on the missing data-classification field.
 

--- a/docs/security/gdpr-audit/INDEX.md
+++ b/docs/security/gdpr-audit/INDEX.md
@@ -21,13 +21,13 @@ produce these docs. Spec at [`tasks/gdpr-audit.md`](../../../tasks/gdpr-audit.md
 | 1 — DSR/retention | 5 | 6 | ~12 | — |
 | 2 — Consent/legal | — | 6 | 8 | 5 |
 | 3 — Processors | 3 | 10 | 9 | 2 |
-| 4 — Minimization/breach | 5 | 5 | 5 | — |
+| 4 — Minimization/breach | 4 | 5 | 5 | — |
 
 ## Load-bearing findings
 
 Four finding clusters block lawful EU operation today:
 
-1. **F4.13 + F4.15** — No breach detection, no incident model, no
+1. **Stream 4 F13 + F15** — No breach detection, no incident model, no
    notification runbook. A GDPR breach today could not be reported within
    72h as Art 33 requires.
 2. **F-17-2 + F-17-2-1..4** — Erasure cannot complete without manual
@@ -36,7 +36,7 @@ Four finding clusters block lawful EU operation today:
    (Art 17(2) violation).
 3. **F3.9 + F3.11** — No DPA register and no Art 30 record of processing
    exist anywhere in the repo or deploy repo.
-4. **F4.5b + F4.2** — Internal service-to-service traffic is plaintext
+4. **Stream 4 F5b + F2** — Internal service-to-service traffic is plaintext
    HTTP; onprem/tenant file storage has no application-layer encryption at
    rest.
 


### PR DESCRIPTION
## Summary

Wave 2 of 3 in the SIEM dual-read plan (`~/.claude/plans/giggly-hopping-church.md`). Wave 1 (#899) built the mapper and unified output shape. **Wave 3** (chain verification preflight, delivery receipts, health endpoint multi-source status) is unblocked by this merging.

- Refactors `siem-delivery-worker.ts` from single-source polling to dual-source polling across `activity_logs` and `security_audit_log`, interleaved by timestamp into one merged delivery batch.
- Each source has its own cursor row in `siem_delivery_cursors`. A new source initializes its cursor to the database clock via `statement_timestamp()` with a sentinel `lastDeliveredId` (satisfies the existing `CHECK` constraint) and delivers **zero** historical rows — Phase 7 of the plan, no backfill.
- Single advisory lock (key preserved as `activity_logs` for backward compat so rolling deploys stay serialized), single delivery call, per-source cursor advancement by walking the delivered prefix.

## Why dual-read

After PRs #896–#898, ~170 routes write security events to `security_audit_log` via the unified `audit()` / `auditRequest()` pipeline. The previous worker only polled `activity_logs`, so every security event flowing through the new pipeline was invisible to the SIEM. Unifying on the read side keeps both hash chains semantically pure and leaves the write path untouched.

## Key behaviors

- **Interleaving by timestamp**: global temporal ordering across sources — critical for SIEM correctness (a login must be delivered before the resource access it authorized).
- **Per-source batch budget**: each source gets up to `batchSize` rows, so the merged batch is bounded by `2 × batchSize` — neither source can starve the other.
- **Backlog safety watermark**: if any source returned a full `LIMIT=batchSize` batch (backlog still pending), delivery is capped at `min(backlogged-tail-timestamps)` so a skewed backlog in one source can never cause out-of-order cross-source delivery across runs.
- **Tuple cursor `(timestamp, id) > ($1, $2)`**: rows sharing a microsecond with the last delivered row are not silently dropped — JavaScript `Date` only has millisecond precision, so strict `timestamp >` with a `Date` parameter would lose microsecond-tied rows.
- **DB-clock cursor init**: `initCursor` plants `lastDeliveredAt` via `statement_timestamp()` in the INSERT and reads it back via `RETURNING`, so the in-memory cursor matches the row on disk exactly. No dependency on the worker host clock.
- **Null-cursor repair**: `recordError` can plant a row with null cursor fields if it fires before `initCursor`. The worker treats a null-field row as uninitialized and re-runs `initCursor`, which UPSERTs the sentinel state in place — the source can never become permanently stuck.
- **Partial delivery walk**: if `entriesDelivered < merged.length`, each source's cursor advances only over the entries in the delivered prefix that belong to it. Sources with zero progress keep their cursor exactly where it was.
- **Retry the undelivered tail, not the full batch**: `deliverToSiemWithRetry` slices past the cumulative delivered count on each retry attempt, so partial-delivery transports (syslog TCP/UDP mid-batch, webhook batched sub-batch) never see duplicate rows at the receiver.
- **Unified-failure error recording**: a network/webhook failure writes `lastError` to **both** source cursors. After cursor-advance on partial delivery, the error upsert restores `lastError` on advanced cursors too — `recordError`'s `SET` clause is deliberately scoped to `lastError / lastErrorAt / updatedAt` so it cannot clobber the just-advanced cursor state.

## Post-review fixes

- **Codex P1** (null cursor repair) and **CodeRabbit critical** (error-only row skip): fix commit repairs rows with null cursor fields on the spot.
- **CodeRabbit critical** (tuple cursor): both source queries switched to `(timestamp, id) > ($1, $2) ORDER BY timestamp ASC, id ASC` to eliminate microsecond-tie row drops.
- **CodeRabbit critical** (DB clock): `initCursor` switched to `statement_timestamp()` + `RETURNING` so worker clock drift can't skip rows on first init.
- **Codex P2** (global ordering with backlog): added the backlog safety watermark described above.
- **Uncommitted correctness fix surfaced during review loop** (partial-delivery retry): `deliverToSiemWithRetry` now slices past cumulative delivered count on retry.
- **CodeRabbit minor docs**: fixed `04-minimization-breach.md` F15 email-service path, fixed `INDEX.md` Stream 4 headline count and load-bearing finding IDs.

## Test plan

- [x] `apps/processor/src/workers/__tests__/siem-delivery-worker.test.ts` — dual-source coverage with regression pins for every behavior above.
- [x] `apps/processor/src/services/__tests__/siem-adapter.test.ts` — partial-delivery retry regression pinned (4 fetch calls, not 5; e1 sent once; e2 twice).
- [x] `pnpm --filter @pagespace/processor typecheck` — clean.
- [x] `pnpm --filter @pagespace/processor test -- --run` — **804 / 804 passing** locally.
- [ ] Smoke test in dev once wave 3 lands (chain preflight, receipts, health).

## Out of scope (wave 3)

- Chain verification preflight on the merged batch
- Delivery receipts table + `delivery_id` round-trip
- `/health` endpoint multi-source status
- Backfilling historical events (explicitly rejected per Phase 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)