### PR TITLE
fix(ai/github-import): unify connection auth path

### DIFF
--- a/apps/web/src/lib/ai/tools/__tests__/github-import-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/github-import-tools.test.ts
@@ -39,9 +39,11 @@ vi.mock('@pagespace/lib/monitoring', () => ({
 vi.mock('@pagespace/lib/integrations', () => ({
   getConnectionWithProvider: vi.fn(),
   decryptCredentials: vi.fn(),
+  listGrantsByAgent: vi.fn().mockResolvedValue([]),
   listUserConnections: vi.fn().mockResolvedValue([]),
   listDriveConnections: vi.fn().mockResolvedValue([]),
   getConfig: vi.fn().mockResolvedValue(null),
+  resolveAgentIntegrations: vi.fn().mockResolvedValue([]),
   resolveGlobalAssistantIntegrations: vi.fn().mockResolvedValue([]),
 }));
 
@@ -71,8 +73,10 @@ import {
 import {
   getConnectionWithProvider,
   decryptCredentials,
+  resolveAgentIntegrations,
   resolveGlobalAssistantIntegrations,
 } from '@pagespace/lib/integrations';
+import { getDriveAccess } from '@pagespace/lib/services/drive-service';
 import type { ToolExecutionContext } from '../../core';
 
 const mockCanUserEditPage = vi.mocked(canUserEditPage);
@@ -81,12 +85,26 @@ const mockDriveRepo = vi.mocked(driveRepository);
 const mockGetConnection = vi.mocked(getConnectionWithProvider);
 const mockDecryptCredentials = vi.mocked(decryptCredentials);
 const mockResolveIntegrations = vi.mocked(resolveGlobalAssistantIntegrations);
+const mockResolveAgentIntegrations = vi.mocked(resolveAgentIntegrations);
+const mockGetDriveAccess = vi.mocked(getDriveAccess);
 
-function makeContext(userId?: string) {
+function makeContext(
+  userId?: string,
+  options?: {
+    chatSource?: ToolExecutionContext['chatSource'];
+    locationContext?: ToolExecutionContext['locationContext'];
+  }
+) {
   return {
     toolCallId: '1',
     messages: [],
-    experimental_context: userId ? { userId } as ToolExecutionContext : {},
+    experimental_context: userId
+      ? ({
+          userId,
+          chatSource: options?.chatSource,
+          locationContext: options?.locationContext,
+        } as ToolExecutionContext)
+      : {},
   };
 }
 
@@ -258,41 +276,9 @@ describe('github-import-tools', () => {
   });
 
   describe('connection validation', () => {
-    it('throws when connection belongs to a different user', async () => {
-      mockDriveRepo.findByIdBasic.mockResolvedValue({
-        id: 'drive-1',
-        ownerId: 'user-123',
-      } as never);
-      mockGetConnection.mockResolvedValue({
-        id: 'conn-1',
-        providerId: 'github',
-        name: 'GitHub',
-        status: 'active',
-        userId: 'other-user',
-        driveId: null,
-        credentials: {},
-      } as never);
-
-      await expect(
-        githubImportTools.import_from_github.execute!(
-          {
-            connectionId: 'conn-1',
-            mode: 'file',
-            owner: 'octocat',
-            repo: 'hello',
-            driveId: 'drive-1',
-            path: 'README.md',
-          },
-          makeContext('user-123')
-        )
-      ).rejects.toThrow('does not belong');
-    });
+    beforeEach(setupAuthMocks);
 
     it('throws when connection is inactive', async () => {
-      mockDriveRepo.findByIdBasic.mockResolvedValue({
-        id: 'drive-1',
-        ownerId: 'user-123',
-      } as never);
       mockGetConnection.mockResolvedValue({
         id: 'conn-1',
         providerId: 'github',
@@ -316,6 +302,80 @@ describe('github-import-tools', () => {
           makeContext('user-123')
         )
       ).rejects.toThrow('expired');
+    });
+
+    it('throws when access token is missing from credentials', async () => {
+      mockDecryptCredentials.mockResolvedValue({});
+
+      await expect(
+        githubImportTools.import_from_github.execute!(
+          {
+            connectionId: 'conn-1',
+            mode: 'file',
+            owner: 'octocat',
+            repo: 'hello',
+            driveId: 'drive-1',
+            path: 'README.md',
+          },
+          makeContext('user-123')
+        )
+      ).rejects.toThrow('access token not found');
+    });
+
+    it('allows a page-agent grant whose connection is scoped to a different drive than the import target', async () => {
+      mockResolveAgentIntegrations.mockResolvedValue([
+        {
+          id: 'grant-1',
+          agentId: 'agent-page-1',
+          connectionId: 'conn-cross-drive',
+          allowedTools: null,
+          deniedTools: null,
+          readOnly: false,
+          rateLimitOverride: null,
+          connection: {
+            id: 'conn-cross-drive',
+            name: 'GitHub',
+            status: 'active',
+            providerId: 'github-provider',
+            provider: { id: 'github-provider', slug: 'github', name: 'GitHub', config: {} },
+          },
+        },
+      ] as never);
+      mockGetConnection.mockResolvedValue({
+        id: 'conn-cross-drive',
+        providerId: 'github',
+        name: 'GitHub',
+        status: 'active',
+        userId: null,
+        driveId: 'drive-source',
+        credentials: { accessToken: 'encrypted' },
+      } as never);
+      mockFetch.mockResolvedValueOnce(
+        mockGitHubResponse({
+          name: 'README.md',
+          path: 'README.md',
+          sha: 'abc',
+          size: 5,
+          content: base64Encode('hello'),
+          encoding: 'base64',
+          html_url: '',
+        })
+      );
+
+      const result = await githubImportTools.import_from_github.execute!(
+        {
+          mode: 'file',
+          owner: 'octocat',
+          repo: 'hello',
+          driveId: 'drive-1',
+          path: 'README.md',
+        },
+        makeContext('user-123', {
+          chatSource: { type: 'page', agentPageId: 'agent-page-1' },
+        })
+      );
+
+      expect(result).toMatchObject({ success: true });
     });
   });
 
@@ -366,6 +426,410 @@ describe('github-import-tools', () => {
           makeContext('user-123')
         )
       ).rejects.toThrow('No active GitHub connection found');
+    });
+
+    it('resolves connection from chat-context drive (not import-target drive) for global assistant', async () => {
+      // User chats from drive-A (where they are owner). Import targets drive-1.
+      // findGitHubConnectionId should call getDriveAccess on drive-A (the chat context),
+      // not drive-1 (the tool-parameter import target).
+      mockGetDriveAccess.mockResolvedValue({
+        isMember: true,
+        role: 'OWNER',
+        isOwner: true,
+        isAdmin: true,
+      } as never);
+
+      mockFetch.mockResolvedValueOnce(
+        mockGitHubResponse({
+          name: 'README.md',
+          path: 'README.md',
+          sha: 'abc',
+          size: 5,
+          content: base64Encode('hello'),
+          encoding: 'base64',
+          html_url: '',
+        })
+      );
+
+      const result = await githubImportTools.import_from_github.execute!(
+        {
+          mode: 'file',
+          owner: 'octocat',
+          repo: 'hello',
+          driveId: 'drive-1',
+          path: 'README.md',
+        },
+        makeContext('user-123', {
+          locationContext: {
+            currentDrive: { id: 'drive-A', name: 'A', slug: 'a' },
+          },
+        })
+      );
+
+      expect(result).toMatchObject({ success: true });
+      expect(mockGetDriveAccess).toHaveBeenCalledWith('drive-A', 'user-123');
+      // Resolver receives the chat-context drive id, not the tool-param drive id.
+      expect(mockResolveIntegrations).toHaveBeenCalledWith(
+        expect.anything(),
+        'user-123',
+        'drive-A',
+        'OWNER'
+      );
+    });
+
+    it('nulls chat drive when user is not a member, allowing visibility filter to be skipped', async () => {
+      // User chats from drive-X where they're not a member (e.g. via stale UI state).
+      // Mirroring the global assistant route, findGitHubConnectionId should pass
+      // driveId=null to the resolver so visibility filtering is bypassed.
+      mockGetDriveAccess.mockResolvedValue({
+        isMember: false,
+        role: null,
+        isOwner: false,
+        isAdmin: false,
+      } as never);
+
+      mockFetch.mockResolvedValueOnce(
+        mockGitHubResponse({
+          name: 'README.md',
+          path: 'README.md',
+          sha: 'abc',
+          size: 5,
+          content: base64Encode('hello'),
+          encoding: 'base64',
+          html_url: '',
+        })
+      );
+
+      await githubImportTools.import_from_github.execute!(
+        {
+          mode: 'file',
+          owner: 'octocat',
+          repo: 'hello',
+          driveId: 'drive-1',
+          path: 'README.md',
+        },
+        makeContext('user-123', {
+          locationContext: {
+            currentDrive: { id: 'drive-X', name: 'X', slug: 'x' },
+          },
+        })
+      );
+
+      expect(mockResolveIntegrations).toHaveBeenCalledWith(
+        expect.anything(),
+        'user-123',
+        null,
+        null
+      );
+    });
+
+    it('passes driveId=null when chatting from dashboard (no current drive)', async () => {
+      // This is the user's reported failing case: global assistant in dashboard,
+      // import target is a specific drive. Connection resolution must not run
+      // the visibility filter against the import-target drive.
+      mockFetch.mockResolvedValueOnce(
+        mockGitHubResponse({
+          name: 'README.md',
+          path: 'README.md',
+          sha: 'abc',
+          size: 5,
+          content: base64Encode('hello'),
+          encoding: 'base64',
+          html_url: '',
+        })
+      );
+
+      await githubImportTools.import_from_github.execute!(
+        {
+          mode: 'file',
+          owner: 'octocat',
+          repo: 'hello',
+          driveId: 'drive-1',
+          path: 'README.md',
+        },
+        makeContext('user-123') // no locationContext
+      );
+
+      expect(mockGetDriveAccess).not.toHaveBeenCalled();
+      expect(mockResolveIntegrations).toHaveBeenCalledWith(
+        expect.anything(),
+        'user-123',
+        null,
+        null
+      );
+    });
+
+    it('resolves via grants for a page agent, ignoring global-assistant config', async () => {
+      mockResolveAgentIntegrations.mockResolvedValue([
+        {
+          id: 'grant-1',
+          agentId: 'agent-page-1',
+          connectionId: 'conn-1',
+          allowedTools: null,
+          deniedTools: null,
+          readOnly: false,
+          rateLimitOverride: null,
+          connection: {
+            id: 'conn-1',
+            name: 'GitHub',
+            status: 'active',
+            providerId: 'github-provider',
+            provider: { id: 'github-provider', slug: 'github', name: 'GitHub', config: {} },
+          },
+        },
+      ] as never);
+
+      mockFetch.mockResolvedValueOnce(
+        mockGitHubResponse({
+          name: 'README.md',
+          path: 'README.md',
+          sha: 'abc',
+          size: 5,
+          content: base64Encode('hello'),
+          encoding: 'base64',
+          html_url: '',
+        })
+      );
+
+      const result = await githubImportTools.import_from_github.execute!(
+        {
+          mode: 'file',
+          owner: 'octocat',
+          repo: 'hello',
+          driveId: 'drive-1',
+          path: 'README.md',
+        },
+        makeContext('user-123', {
+          chatSource: { type: 'page', agentPageId: 'agent-page-1' },
+        })
+      );
+
+      expect(result).toMatchObject({ success: true });
+      expect(mockResolveAgentIntegrations).toHaveBeenCalledWith(
+        expect.anything(),
+        'agent-page-1'
+      );
+      // Page agent path must not consult the global-assistant resolver.
+      expect(mockResolveIntegrations).not.toHaveBeenCalled();
+    });
+
+    it('throws page-agent-specific error when agent has no GitHub grant', async () => {
+      mockResolveAgentIntegrations.mockResolvedValue([]);
+
+      await expect(
+        githubImportTools.import_from_github.execute!(
+          {
+            mode: 'file',
+            owner: 'octocat',
+            repo: 'hello',
+            driveId: 'drive-1',
+            path: 'README.md',
+          },
+          makeContext('user-123', {
+            chatSource: { type: 'page', agentPageId: 'agent-page-1' },
+          })
+        )
+      ).rejects.toThrow('does not have a GitHub integration grant');
+    });
+  });
+
+  // Given a page agent calls import_from_github with an explicit connectionId
+  // that is NOT among the agent's grants, should reject (authorization boundary).
+  // Given global assistant calls with an explicit connectionId not in the resolved
+  // set, should reject. Given the explicit id IS in the allowed set, should accept.
+  describe('explicit connectionId enforcement', () => {
+    beforeEach(setupAuthMocks);
+
+    it('rejects explicit connectionId not granted to the page agent', async () => {
+      mockResolveAgentIntegrations.mockResolvedValue([
+        {
+          id: 'grant-1',
+          agentId: 'agent-page-1',
+          connectionId: 'conn-granted',
+          allowedTools: null,
+          deniedTools: null,
+          readOnly: false,
+          rateLimitOverride: null,
+          connection: {
+            id: 'conn-granted',
+            name: 'GitHub',
+            status: 'active',
+            providerId: 'github-provider',
+            provider: { id: 'github-provider', slug: 'github', name: 'GitHub', config: {} },
+          },
+        },
+      ] as never);
+
+      await expect(
+        githubImportTools.import_from_github.execute!(
+          {
+            connectionId: 'conn-attacker',
+            mode: 'file',
+            owner: 'octocat',
+            repo: 'hello',
+            driveId: 'drive-1',
+            path: 'README.md',
+          },
+          makeContext('user-123', {
+            chatSource: { type: 'page', agentPageId: 'agent-page-1' },
+          })
+        )
+      ).rejects.toThrow('not granted to this agent');
+    });
+
+    it('accepts explicit connectionId that matches a page agent grant', async () => {
+      mockResolveAgentIntegrations.mockResolvedValue([
+        {
+          id: 'grant-1',
+          agentId: 'agent-page-1',
+          connectionId: 'conn-granted',
+          allowedTools: null,
+          deniedTools: null,
+          readOnly: false,
+          rateLimitOverride: null,
+          connection: {
+            id: 'conn-granted',
+            name: 'GitHub',
+            status: 'active',
+            providerId: 'github-provider',
+            provider: { id: 'github-provider', slug: 'github', name: 'GitHub', config: {} },
+          },
+        },
+      ] as never);
+
+      mockGetConnection.mockResolvedValue({
+        id: 'conn-granted',
+        providerId: 'github',
+        name: 'GitHub',
+        status: 'active',
+        userId: null,
+        driveId: 'drive-source',
+        credentials: { accessToken: 'encrypted' },
+      } as never);
+
+      mockFetch.mockResolvedValueOnce(
+        mockGitHubResponse({
+          name: 'README.md',
+          path: 'README.md',
+          sha: 'abc',
+          size: 5,
+          content: base64Encode('hello'),
+          encoding: 'base64',
+          html_url: '',
+        })
+      );
+
+      const result = await githubImportTools.import_from_github.execute!(
+        {
+          connectionId: 'conn-granted',
+          mode: 'file',
+          owner: 'octocat',
+          repo: 'hello',
+          driveId: 'drive-1',
+          path: 'README.md',
+        },
+        makeContext('user-123', {
+          chatSource: { type: 'page', agentPageId: 'agent-page-1' },
+        })
+      );
+
+      expect(result).toMatchObject({ success: true });
+    });
+
+    it('rejects explicit connectionId not in the global-assistant resolved set', async () => {
+      // mockResolveIntegrations from setupAuthMocks returns conn-1
+      await expect(
+        githubImportTools.import_from_github.execute!(
+          {
+            connectionId: 'conn-attacker',
+            mode: 'file',
+            owner: 'octocat',
+            repo: 'hello',
+            driveId: 'drive-1',
+            path: 'README.md',
+          },
+          makeContext('user-123')
+        )
+      ).rejects.toThrow('not available in this chat');
+    });
+
+    it('accepts explicit connectionId that matches the global-assistant resolved set', async () => {
+      mockFetch.mockResolvedValueOnce(
+        mockGitHubResponse({
+          name: 'README.md',
+          path: 'README.md',
+          sha: 'abc',
+          size: 5,
+          content: base64Encode('hello'),
+          encoding: 'base64',
+          html_url: '',
+        })
+      );
+
+      const result = await githubImportTools.import_from_github.execute!(
+        {
+          connectionId: 'conn-1',
+          mode: 'file',
+          owner: 'octocat',
+          repo: 'hello',
+          driveId: 'drive-1',
+          path: 'README.md',
+        },
+        makeContext('user-123')
+      );
+
+      expect(result).toMatchObject({ success: true });
+    });
+  });
+
+  // Given user is in a drive chat context with no resolvable GitHub connection,
+  // should hint that the connection should be drive-scoped. Given dashboard
+  // context, should use the generic message.
+  describe('drive-aware error messages', () => {
+    beforeEach(setupAuthMocks);
+
+    it('mentions the drive in the error when chatting from a drive context', async () => {
+      mockResolveIntegrations.mockResolvedValue([]);
+      mockGetDriveAccess.mockResolvedValue({
+        isMember: true,
+        role: 'OWNER',
+        isOwner: true,
+        isAdmin: true,
+      } as never);
+
+      await expect(
+        githubImportTools.import_from_github.execute!(
+          {
+            mode: 'file',
+            owner: 'octocat',
+            repo: 'hello',
+            driveId: 'drive-1',
+            path: 'README.md',
+          },
+          makeContext('user-123', {
+            locationContext: {
+              currentDrive: { id: 'drive-A', name: 'A', slug: 'a' },
+            },
+          })
+        )
+      ).rejects.toThrow('for this drive');
+    });
+
+    it('uses the generic error in dashboard context', async () => {
+      mockResolveIntegrations.mockResolvedValue([]);
+
+      await expect(
+        githubImportTools.import_from_github.execute!(
+          {
+            mode: 'file',
+            owner: 'octocat',
+            repo: 'hello',
+            driveId: 'drive-1',
+            path: 'README.md',
+          },
+          makeContext('user-123')
+        )
+      ).rejects.toThrow(/^No active GitHub connection found\. Connect/);
     });
   });
 

--- a/apps/web/src/lib/ai/tools/github-import-tools.ts
+++ b/apps/web/src/lib/ai/tools/github-import-tools.ts
@@ -16,7 +16,9 @@ import { createChangeGroupId } from '@pagespace/lib/monitoring';
 import {
   getConnectionWithProvider,
   decryptCredentials,
+  resolveAgentIntegrations,
   resolveGlobalAssistantIntegrations,
+  listGrantsByAgent,
   listUserConnections,
   listDriveConnections,
   getConfig,
@@ -106,77 +108,101 @@ async function githubFetch(
   return response.json();
 }
 
-async function resolveGitHubToken(
-  connectionId: string,
-  userId: string,
-  driveId: string
-): Promise<string> {
+async function loadGitHubToken(connectionId: string): Promise<string> {
   const connection = await getConnectionWithProvider(db, connectionId);
   if (!connection) {
-    throw new Error(
-      'GitHub connection not found. Connect your GitHub account in Settings > Integrations.'
-    );
+    throw new Error('GitHub connection not found. Connect your GitHub account in Settings > Integrations.');
   }
-
-  // Verify the connection belongs to the caller (user-scoped) or their drive (drive-scoped)
-  if (connection.userId && connection.userId !== userId) {
-    throw new Error('GitHub connection does not belong to this user.');
-  }
-  if (connection.driveId && connection.driveId !== driveId) {
-    throw new Error('GitHub connection does not belong to this drive.');
-  }
-
   if (connection.status !== 'active') {
-    throw new Error(
-      `GitHub connection is ${connection.status}. Please reconnect in Settings > Integrations.`
-    );
+    throw new Error(`GitHub connection is ${connection.status}. Please reconnect in Settings > Integrations.`);
   }
 
   const credentials = (await decryptCredentials(
     connection.credentials as Record<string, string>
   )) as { accessToken?: string; token?: string };
 
-  const token = credentials.accessToken || credentials.token;
+  const token = credentials.accessToken ?? credentials.token;
   if (!token) {
     throw new Error('GitHub access token not found in connection credentials.');
   }
-
   return token;
 }
 
-async function findGitHubConnectionId(
-  userId: string,
-  driveId: string
-): Promise<string> {
-  // Resolve connections through the same path the global assistant uses,
-  // applying visibility, assistant-config, and drive-scoping filters.
-  const driveAccess = await getDriveAccess(driveId, userId);
-  const userDriveRole: DriveRole | null = driveAccess.isMember
-    ? (driveAccess.role as DriveRole)
-    : null;
-
-  const deps: ResolutionDependencies = {
-    listGrantsByAgent: async () => [] as GrantWithConnectionAndProvider[],
+function buildResolutionDeps(): ResolutionDependencies {
+  return {
+    listGrantsByAgent: (agentId) =>
+      listGrantsByAgent(db, agentId) as Promise<GrantWithConnectionAndProvider[]>,
     listUserConnections: (uid) => listUserConnections(db, uid),
     listDriveConnections: (did) => listDriveConnections(db, did),
-    getAssistantConfig: (uid) => getConfig(db, uid) as Promise<GlobalAssistantConfigData | null>,
+    getAssistantConfig: (uid) =>
+      getConfig(db, uid) as Promise<GlobalAssistantConfigData | null>,
   };
+}
 
-  const grants = await resolveGlobalAssistantIntegrations(
-    deps, userId, driveId, userDriveRole
-  );
+interface AllowedConnections {
+  ids: readonly string[];
+  noneFoundMessage: string;
+  notAllowedMessage: string;
+}
 
-  const githubGrant = grants.find(
-    (g) => g.connection?.provider?.slug === 'github'
-  );
+async function resolveChatContextDrive(
+  ctx: ToolExecutionContext
+): Promise<{ driveId: string | null; role: DriveRole | null }> {
+  const chatDriveId = ctx.locationContext?.currentDrive?.id ?? null;
+  if (!chatDriveId) return { driveId: null, role: null };
+  const access = await getDriveAccess(chatDriveId, ctx.userId);
+  if (!access.isMember) return { driveId: null, role: null };
+  return { driveId: chatDriveId, role: access.role as DriveRole };
+}
 
-  if (!githubGrant) {
-    throw new Error(
-      'No active GitHub connection found for this drive. Connect your GitHub account in Settings > Integrations.'
-    );
+const githubGrantIds = (grants: readonly GrantWithConnectionAndProvider[]): readonly string[] =>
+  grants.filter((g) => g.connection?.provider?.slug === 'github').map((g) => g.connectionId);
+
+async function listAllowedGitHubConnections(
+  ctx: ToolExecutionContext
+): Promise<AllowedConnections> {
+  const deps = buildResolutionDeps();
+  const chatSource = ctx.chatSource;
+
+  if (chatSource?.type === 'page' && chatSource.agentPageId) {
+    const grants = await resolveAgentIntegrations(deps, chatSource.agentPageId);
+    return {
+      ids: githubGrantIds(grants),
+      noneFoundMessage:
+        "This page agent does not have a GitHub integration grant. Add it from the agent's Integrations panel.",
+      notAllowedMessage:
+        'The supplied connectionId is not granted to this agent. Pass an id from the agent\'s GitHub grants, or omit it for auto-detection.',
+    };
   }
 
-  return githubGrant.connectionId;
+  const { driveId, role } = await resolveChatContextDrive(ctx);
+  const grants = await resolveGlobalAssistantIntegrations(deps, ctx.userId, driveId, role);
+  const inDriveContext = driveId !== null;
+  return {
+    ids: githubGrantIds(grants),
+    noneFoundMessage: inDriveContext
+      ? 'No active GitHub connection found for this drive. Connect your GitHub account in Settings > Integrations.'
+      : 'No active GitHub connection found. Connect your GitHub account in Settings > Integrations.',
+    notAllowedMessage:
+      'The supplied connectionId is not available in this chat. Omit it for auto-detection.',
+  };
+}
+
+async function findGitHubConnectionId(
+  ctx: ToolExecutionContext,
+  explicitConnectionId?: string
+): Promise<string> {
+  const allowed = await listAllowedGitHubConnections(ctx);
+  if (allowed.ids.length === 0) {
+    throw new Error(allowed.noneFoundMessage);
+  }
+  if (explicitConnectionId !== undefined) {
+    if (!allowed.ids.includes(explicitConnectionId)) {
+      throw new Error(allowed.notAllowedMessage);
+    }
+    return explicitConnectionId;
+  }
+  return allowed.ids[0];
 }
 
 async function createCodePage(params: {
@@ -435,10 +461,11 @@ export const githubImportTools = {
         .describe(`Maximum files to import (default ${DEFAULT_MAX_FILES}, max ${MAX_FILES_LIMIT})`),
     }),
     execute: async (params, { experimental_context: context }) => {
-      const userId = (context as ToolExecutionContext)?.userId;
-      if (!userId) {
+      const ctx = context as ToolExecutionContext | undefined;
+      if (!ctx?.userId) {
         throw new Error('User authentication required');
       }
+      const userId = ctx.userId;
 
       const {
         connectionId: explicitConnectionId,
@@ -476,11 +503,8 @@ export const githubImportTools = {
         throw new Error('Only drive owners can create pages at the root level');
       }
 
-      // Resolve GitHub connection (after drive/permission validation)
-      const connectionId = explicitConnectionId ?? await findGitHubConnectionId(userId, driveId);
-
-      // Resolve GitHub credentials (scoped to calling user + drive)
-      const token = await resolveGitHubToken(connectionId, userId, driveId);
+      const connectionId = await findGitHubConnectionId(ctx, explicitConnectionId);
+      const token = await loadGitHubToken(connectionId);
 
       try {
         switch (mode) {

--- a/docs/1.0-overview/changelog.md
+++ b/docs/1.0-overview/changelog.md
@@ -1,3 +1,23 @@
+## 2026-04-13
+
+### GitHub Import: Connection Resolution Hardened
+
+`import_from_github` now resolves and authorises GitHub connections through the same path as the rest of the integration runtime, fixing a regression where the tool could fail to find a connection that the same chat had successfully used moments earlier.
+
+#### Fixed
+
+- **Dashboard imports could not find the user's GitHub connection**: the tool resolved against the import-target `driveId` (which always triggered the visibility filter), not the chat-context drive. It now mirrors the global-assistant chat route (`messages/route.ts`) and uses `locationContext.currentDrive`, with the same `!isMember → driveId=null` nullification, so the connection set matches what `github_list_repositories` already sees.
+- **Page agents could not use granted GitHub connections**: the tool only consulted the global-assistant resolution path. It now branches on `chatSource.type` and resolves via `resolveAgentIntegrations` for page-agent chats, mirroring `resolvePageAgentIntegrationTools`.
+
+#### Security
+
+- **Authorisation bypass via `connectionId` parameter**: an LLM-supplied `connectionId` previously skipped grant validation entirely and was accepted by the token loader as long as it satisfied a permissive drive-scope check. A page-agent session could obtain a token for a drive-scoped GitHub connection that the agent held no grant for. Resolution and authorisation are now collapsed into a single `findGitHubConnectionId(ctx, explicitConnectionId?)` function that always validates explicit ids against the resolved allowed set; `loadGitHubToken` is now a pure load-and-decrypt step with no defence-in-depth scoping checks (those are now upstream and stronger).
+
+#### Errors
+
+- "GitHub connection not found" now branches on whether the chat is in a drive context (`...for this drive...`) or the dashboard, matching pre-fix behaviour.
+- Page-agent and global-assistant rejection messages distinguish between "no connection at all" and "explicit id not allowed".
+
 ## 2026-04-10
 
 ### Task-Triggered Workflows


### PR DESCRIPTION
## Summary

- Collapse `import_from_github`'s two connection-resolution paths into a single `findGitHubConnectionId(ctx, explicitConnectionId?)` that resolves *and* authorises in one place. An LLM-supplied `connectionId` now must belong to the resolved allowed set (page-agent grants for page chats, global-assistant resolution for global chats).
- Resolve against the **chat-context drive** (`locationContext.currentDrive`), not the tool-parameter import target. Mirrors `apps/web/src/app/api/ai/global/[id]/messages/route.ts:700-715` (with `!isMember → driveId=null`), so the connection set matches what `github_list_repositories` already sees in the same chat.
- `loadGitHubToken` is now a pure load-and-decrypt step. Defence-in-depth scoping checks were redundant once upstream resolution is correct, and the bug class (two paths to keep in sync) is gone.

## Why

Two reviews independently flagged the same shape of issue:

1. **User-reported regression**: in the global assistant from the dashboard, `github_list_repositories` worked but `import_from_github` immediately failed with "GitHub connection not found." The chat route resolved with `driveId=null` (skipping the visibility filter); the tool resolved with the import-target `driveId` (always running it).
2. **Authorization bypass**: `explicitConnectionId` previously skipped grant validation entirely. With a permissive drive-scope check in `resolveGitHubToken`, a page-agent session could obtain a token for a drive-scoped GitHub connection the agent held no grant for. Pre-existing weakness, made materially worse by the first iteration's relaxation. Now closed: `findGitHubConnectionId` is the single gate and explicit ids are always validated against the resolved allowed set.

## Test plan

- [x] `pnpm --filter web exec vitest run github-import-tools` — 40/40 (6 new cases covering the explicit-id grant boundary in both branches, drive-aware error messages, dashboard chat, !isMember nulling, page-agent grant path)
- [x] `pnpm --filter web exec vitest run integration-tool-resolver` — 3/3 (regression check on the related resolver)
- [x] `pnpm --filter web typecheck` — clean
- [x] `pnpm --filter web exec next lint --file src/lib/ai/tools/github-import-tools.ts` — clean
- [ ] Manual: global assistant from dashboard → `list my repos`, then `import the README from <owner>/<repo> into <drive>` → both succeed
- [ ] Manual: global assistant inside a drive you own → same
- [ ] Manual: AI_CHAT page with a granted GitHub connection → import succeeds via grant path
- [ ] Manual: confirm `github_list_repositories` (and other integration GitHub tools) still work in all three chats

🤖 Generated with [Claude Code](https://claude.com/claude-code)