### PR TITLE
fix(security): zod-narrow verifyOAuthState to close CodeQL #163

### DIFF
--- a/apps/web/src/lib/auth/__tests__/oauth-state.test.ts
+++ b/apps/web/src/lib/auth/__tests__/oauth-state.test.ts
@@ -73,22 +73,76 @@ describe('verifyOAuthState', () => {
     expect(result.status).toBe('valid');
   });
 
-  it('returns expired for state without timestamp', () => {
+  it('returns malformed for state without timestamp', () => {
     const state = createState({ returnUrl: '/dashboard', platform: 'web' });
     const result = verifyOAuthState(state);
-    expect(result.status).toBe('expired');
+    expect(result.status).toBe('malformed');
   });
 
-  it('returns expired for state with NaN timestamp', () => {
+  it('returns malformed for state with NaN timestamp', () => {
     const state = createState({ returnUrl: '/dashboard', platform: 'web', timestamp: NaN });
     const result = verifyOAuthState(state);
-    expect(result.status).toBe('expired');
+    expect(result.status).toBe('malformed');
   });
 
-  it('returns expired for state with Infinity timestamp', () => {
+  it('returns malformed for state with Infinity timestamp', () => {
     const state = createState({ returnUrl: '/dashboard', platform: 'web', timestamp: Infinity });
     const result = verifyOAuthState(state);
-    expect(result.status).toBe('expired');
+    expect(result.status).toBe('malformed');
+  });
+
+  it('returns malformed for state with unknown platform value', () => {
+    const state = createState({
+      returnUrl: '/dashboard',
+      platform: 'android',
+      timestamp: Date.now(),
+    });
+    const result = verifyOAuthState(state);
+    expect(result.status).toBe('malformed');
+  });
+
+  it('returns malformed for state with deviceId longer than 128 chars', () => {
+    const state = createState({
+      returnUrl: '/dashboard',
+      platform: 'desktop',
+      deviceId: 'x'.repeat(129),
+      timestamp: Date.now(),
+    });
+    const result = verifyOAuthState(state);
+    expect(result.status).toBe('malformed');
+  });
+
+  it('returns malformed for state with returnUrl longer than 2048 chars', () => {
+    const state = createState({
+      returnUrl: '/' + 'a'.repeat(2048),
+      platform: 'web',
+      timestamp: Date.now(),
+    });
+    const result = verifyOAuthState(state);
+    expect(result.status).toBe('malformed');
+  });
+
+  it('returns malformed for state with deviceName longer than 255 chars', () => {
+    const state = createState({
+      returnUrl: '/dashboard',
+      platform: 'desktop',
+      deviceId: 'dev-1',
+      deviceName: 'n'.repeat(256),
+      timestamp: Date.now(),
+    });
+    const result = verifyOAuthState(state);
+    expect(result.status).toBe('malformed');
+  });
+
+  it('returns malformed for state with empty deviceId string', () => {
+    const state = createState({
+      returnUrl: '/dashboard',
+      platform: 'desktop',
+      deviceId: '',
+      timestamp: Date.now(),
+    });
+    const result = verifyOAuthState(state);
+    expect(result.status).toBe('malformed');
   });
 
   it('extracts data fields from valid state', () => {

--- a/apps/web/src/lib/auth/oauth-state.ts
+++ b/apps/web/src/lib/auth/oauth-state.ts
@@ -1,16 +1,19 @@
 import crypto from 'crypto';
+import { z } from 'zod';
 import { secureCompare } from '@pagespace/lib';
 
 // State expires after 10 minutes — prevents replay attacks
 const STATE_MAX_AGE_MS = 10 * 60 * 1000;
 
-export interface OAuthStateData {
-  returnUrl?: string;
-  platform?: 'web' | 'desktop' | 'ios';
-  deviceId?: string;
-  deviceName?: string;
-  timestamp?: number;
-}
+const oauthStateDataSchema = z.object({
+  returnUrl: z.string().max(2048).optional(),
+  platform: z.enum(['web', 'desktop', 'ios']).optional(),
+  deviceId: z.string().min(1).max(128).optional(),
+  deviceName: z.string().max(255).optional(),
+  timestamp: z.number().finite(),
+});
+
+export type OAuthStateData = z.infer<typeof oauthStateDataSchema>;
 
 export type VerifyOAuthStateResult =
   | { status: 'valid'; data: OAuthStateData }
@@ -22,10 +25,10 @@ export type VerifyOAuthStateResult =
 /**
  * Verify an HMAC-signed OAuth state parameter.
  * Returns a discriminated result so callers can handle each case appropriately:
- * - 'valid': signature verified, data is trustworthy
+ * - 'valid': signature verified AND payload matches the expected schema
  * - 'invalid_signature': sig field present but doesn't match (reject)
  * - 'unsigned': parseable JSON but no sig field (safe defaults)
- * - 'malformed': unparseable (safe defaults)
+ * - 'malformed': unparseable, or HMAC-verified payload that fails schema narrowing
  *
  * Uses timing-safe comparison to prevent timing attacks.
  */
@@ -54,17 +57,19 @@ export function verifyOAuthState(stateBase64: string): VerifyOAuthStateResult {
       return { status: 'invalid_signature' };
     }
 
-    // Reject state with missing or invalid timestamp
-    if (typeof data.timestamp !== 'number' || !Number.isFinite(data.timestamp)) {
+    // Schema validation AFTER HMAC verification — the HMAC proves authenticity
+    // but not shape. Narrow to an explicit Zod schema so every caller (and
+    // CodeQL's dataflow engine) sees a sanitized trust boundary.
+    const parsedResult = oauthStateDataSchema.safeParse(data);
+    if (!parsedResult.success) {
+      return { status: 'malformed' };
+    }
+
+    if (Date.now() - parsedResult.data.timestamp > STATE_MAX_AGE_MS) {
       return { status: 'expired' };
     }
 
-    // Reject expired state
-    if (Date.now() - data.timestamp > STATE_MAX_AGE_MS) {
-      return { status: 'expired' };
-    }
-
-    return { status: 'valid', data };
+    return { status: 'valid', data: parsedResult.data };
   } catch {
     return { status: 'malformed' };
   }

--- a/docs/security/CODEQL_ALERT_LOG.md
+++ b/docs/security/CODEQL_ALERT_LOG.md
@@ -253,3 +253,29 @@ CodeQL's `js/shell-command-injection-from-environment` rule flags shell commands
 - `infrastructure/__tests__/tenant-stack.test.ts` — `execSync` → `execFileSync` with array args
 - `infrastructure/__tests__/generate-tenant-env.test.ts` — `execSync` → `execFileSync` with array args
 - `infrastructure/scripts/__tests__/image-runtime.test.ts` — Refactored `run()`/`composeCmd()` to `composeRun()`/`composeArgs()` using `execFileSync`
+
+## Batch 9: Zero-Trust Narrowing of OAuth State (1 alert fixed)
+
+**Branch**: `pu/oauth-state-zod`
+**Date**: 2026-04-13
+**Total Alerts**: 1 (`js/user-controlled-bypass` HIGH)
+**Disposition**: Fixed via Zod schema narrowing in `verifyOAuthState`
+
+### Analysis
+
+Alert #163 traces taint from `req.url` → `searchParams.get('state')` → `verifiedState.deviceId` → `if (!deviceId)` at `google/callback/route.ts:242`. The HMAC in `verifyOAuthState` proves the state was minted with the server secret, but the `'valid'` branch previously returned `JSON.parse` output untouched — no shape validation on `platform`, `deviceId`, `deviceName`, or `returnUrl`. HMAC proves authenticity, not shape. Any holder of `OAUTH_STATE_SECRET` (legacy state, internal mint, future key-compromise) could hand raw JSON straight into branch selection and redirects.
+
+The signin endpoints already Zod-validate the same fields before signing; the callback side re-consumed the signed blob without re-validating. Fix is to put a single Zod schema boundary inside `verifyOAuthState` — every OAuth provider (Google, Apple, future) benefits without per-route duplication, and CodeQL's dataflow engine sees a canonical `safeParse` sanitizer.
+
+**Rating: S2 (Should Fix)** — Not directly exploitable today, but the HMAC-only trust boundary is a real latent weakness and the house style (per Batch 1 precedent) is to fix false positives with real hardening rather than inline suppressions.
+
+### Alert Disposition
+
+| Alert | Rule | Severity | File | CWE | Fix Summary | Status |
+|-------|------|----------|------|-----|-------------|--------|
+| #163 | js/user-controlled-bypass | high | google/callback/route.ts:242 | CWE-807 | `verifyOAuthState` now `safeParse`s HMAC-verified data against `oauthStateDataSchema` (enum `platform`, length-bounded `deviceId`/`deviceName`/`returnUrl`, required finite `timestamp`); shape failures collapse to `'malformed'`; age check moved after parse. Apple callback benefits automatically. | FIXED |
+
+### Files Modified (2 files)
+
+- `apps/web/src/lib/auth/oauth-state.ts` — Added `oauthStateDataSchema`; `verifyOAuthState` returns the parsed shape on the `'valid'` branch; hand-written `OAuthStateData` interface replaced with `z.infer<typeof oauthStateDataSchema>`
+- `apps/web/src/lib/auth/__tests__/oauth-state.test.ts` — Added coverage for unknown `platform`, oversized `deviceId`/`returnUrl`/`deviceName`, empty `deviceId`; updated missing/NaN/Infinity `timestamp` cases to expect `'malformed'` (previously `'expired'`)


### PR DESCRIPTION
## Summary

Closes CodeQL alert [#163 (`js/user-controlled-bypass`, high)](https://github.com/2witstudios/PageSpace/security/code-scanning/163) via **zero-trust shape narrowing** at the OAuth state verification boundary.

## Trust-boundary argument

`verifyOAuthState` previously returned raw `JSON.parse` output on the `'valid'` branch after passing the HMAC check. HMAC proves **authenticity** (the state was minted with `OAUTH_STATE_SECRET`), not **shape** — `platform`, `deviceId`, `deviceName`, and `returnUrl` flowed untouched into callback branch selection and redirects. Any holder of the secret (legacy state, internal mint, future key-compromise) could hand arbitrary JSON to the callback.

The zero-trust fix is to treat the HMAC-verified blob as still-untrusted until it matches an explicit schema. This PR adds `oauthStateDataSchema` inside `apps/web/src/lib/auth/oauth-state.ts` and runs `safeParse` **after** HMAC verification — shape failures collapse to `'malformed'`, and the `timestamp` age check moves after the parse so it runs on the validated shape.

Schema bounds:
- `platform` — `z.enum(['web', 'desktop', 'ios'])` (the field CodeQL actually cares about — it controls branch selection at callback lines 241/308)
- `deviceId` — `z.string().min(1).max(128)` (matches `device/register/route.ts`)
- `deviceName` — `z.string().max(255)`
- `returnUrl` — `z.string().max(2048)` (semantic URL safety stays with `isSafeReturnUrl` downstream)
- `timestamp` — `z.number().finite()` (required; subsumes the old `Number.isFinite` guard and also rejects `NaN`/`Infinity`)

This is the canonical sanitizer shape CodeQL's JS dataflow engine recognizes, so #163 should auto-close on re-scan. **Both Google and Apple callbacks benefit from one change** — no per-route duplication, no inline suppressions.

## Why not inline suppression

House style per `docs/security/CODEQL_ALERT_LOG.md` (and PR #844) is to fix CodeQL false positives with real hardening rather than `// lgtm` / `// codeql-disable`. The schema boundary is textual, co-located with the HMAC check, and makes the trust boundary visible in the dataflow graph.

## Test coverage

`apps/web/src/lib/auth/__tests__/oauth-state.test.ts` — 16 tests, all passing:

**Pin tests (existing behavior preserved):**
- Valid HMAC + well-formed payload → `'valid'`
- Tampered signature → `'invalid_signature'`
- Missing `sig` field → `'unsigned'`
- Unparseable base64 → `'malformed'`
- Missing `OAUTH_STATE_SECRET` → `'invalid_signature'`
- Expired `timestamp` → `'expired'`
- Fresh `timestamp` → `'valid'`
- Data field extraction on valid state

**New schema tests (added in this PR):**
- Unknown `platform` value (`'android'`) → `'malformed'`
- `deviceId` longer than 128 chars → `'malformed'`
- `returnUrl` longer than 2048 chars → `'malformed'`
- `deviceName` longer than 255 chars → `'malformed'`
- Empty `deviceId` string → `'malformed'`

**Behavior-change tests (updated in this PR):**
- Missing `timestamp` → `'malformed'` (previously `'expired'`)
- `NaN` `timestamp` → `'malformed'` (previously `'expired'`)
- `Infinity` `timestamp` → `'malformed'` (previously `'expired'`)

## Apple callback benefits automatically

`apps/web/src/app/api/auth/apple/callback/route.ts` reads `verifiedState.platform`, `deviceId`, `deviceName`, `returnUrl` — all still optional on the narrowed type. No code change required there; verified via `pnpm typecheck`. The same applies to `google/callback/route.ts`.

## Test plan

- [x] `pnpm typecheck` — green (full monorepo)
- [x] `pnpm --filter web test oauth-state --run` — 16/16 passing
- [ ] Manual: Google OAuth web signin → dashboard
- [ ] Manual: Google OAuth desktop signin via Electron → deep-link handoff
- [ ] Manual: Apple OAuth web signin → dashboard
- [ ] Manual: Apple OAuth desktop signin via Electron → deep-link handoff
- [ ] Confirm alert #163 auto-closes on next CodeQL scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)