### PR TITLE
feat(siem): wave 2 — audit AI routes

### DIFF
--- a/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
+++ b/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
@@ -203,4 +203,47 @@ describe('Security Audit Route Coverage', () => {
   it('should discover a reasonable number of routes (sanity check)', () => {
     expect(routes.length).toBeGreaterThanOrEqual(240);
   });
+
+  /**
+   * AI routes are the highest abuse surface in the app: prompt injection,
+   * model abuse, and data exfiltration through agents all probe through
+   * these endpoints before landing. Emitting `authz.access.denied` on the
+   * auth/permission-denial paths is what lets SIEM detect the probing.
+   * Success-only audit coverage is not enough for the AI subset.
+   */
+  const AI_ROUTES_REQUIRING_DENIAL_AUDIT: string[] = [
+    'ai/abort',
+    'ai/chat',
+    'ai/chat/messages',
+    'ai/chat/messages/[messageId]',
+    'ai/chat/messages/[messageId]/undo',
+  ];
+
+  it('AI routes should audit authz.access.denied on auth/permission-failure paths', () => {
+    const routeByPath = new Map(routes.map((r) => [r.path, r.file]));
+    const violations: string[] = [];
+
+    for (const routePath of AI_ROUTES_REQUIRING_DENIAL_AUDIT) {
+      const file = routeByPath.get(routePath);
+      if (!file) {
+        violations.push(`${routePath} (route file not found)`);
+        continue;
+      }
+      const content = readFileSync(file, 'utf-8');
+      if (!/authz\.access\.denied/.test(content)) {
+        violations.push(routePath);
+      }
+    }
+
+    expect(violations).toEqual([]);
+    if (violations.length > 0) {
+      console.error(
+        `\nAI routes missing authz.access.denied audit for ${violations.length} route(s):\n` +
+          violations.map((v) => `  - ${v}`).join('\n') +
+          '\n\nFix: On each early-return path representing an auth/permission' +
+          '\nfailure, call auditRequest(request, { eventType: "authz.access.denied", ... })' +
+          '\nbefore returning the error response so SIEM can detect probing.\n'
+      );
+    }
+  });
 });

--- a/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
+++ b/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
@@ -212,11 +212,30 @@ describe('Security Audit Route Coverage', () => {
    * Success-only audit coverage is not enough for the AI subset.
    */
   const AI_ROUTES_REQUIRING_DENIAL_AUDIT: string[] = [
+    // Chat subset
     'ai/abort',
     'ai/chat',
     'ai/chat/messages',
     'ai/chat/messages/[messageId]',
     'ai/chat/messages/[messageId]/undo',
+    // Settings
+    'ai/settings',
+    // Global assistant
+    'ai/global',
+    'ai/global/active',
+    'ai/global/[id]',
+    'ai/global/[id]/messages',
+    'ai/global/[id]/messages/[messageId]',
+    'ai/global/[id]/usage',
+    // Page agents
+    'ai/page-agents/consult',
+    'ai/page-agents/create',
+    'ai/page-agents/multi-drive',
+    'ai/page-agents/[agentId]/config',
+    'ai/page-agents/[agentId]/conversations',
+    'ai/page-agents/[agentId]/conversations/[conversationId]',
+    'ai/page-agents/[agentId]/conversations/[conversationId]/messages',
+    'ai/page-agents/[agentId]/conversations/[conversationId]/messages/[messageId]',
   ];
 
   it('AI routes should audit authz.access.denied on auth/permission-failure paths', () => {

--- a/apps/web/src/app/api/ai/abort/route.ts
+++ b/apps/web/src/app/api/ai/abort/route.ts
@@ -24,6 +24,7 @@ export async function POST(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
     if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'ai_chat_stream', resourceId: 'abort', details: { reason: 'auth_failed', method: 'POST' }, riskScore: 0.5 });
       return auth.error;
     }
     const userId = auth.userId;
@@ -32,6 +33,7 @@ export async function POST(request: Request) {
     const rateLimit = checkRateLimit(`abort:${userId}`, ABORT_RATE_LIMIT);
     if (!rateLimit.allowed) {
       loggers.api.warn('AI abort rate limited', { userId, retryAfter: rateLimit.retryAfter });
+      auditRequest(request, { eventType: 'authz.access.denied', userId, resourceType: 'ai_chat_stream', resourceId: 'abort', details: { reason: 'rate_limited', method: 'POST' }, riskScore: 0.5 });
       return NextResponse.json(
         { error: 'Too many requests. Please try again later.' },
         {

--- a/apps/web/src/app/api/ai/chat/messages/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/chat/messages/[messageId]/route.ts
@@ -41,7 +41,10 @@ export async function PATCH(
   try {
     // Authenticate
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'message', resourceId: 'edit', details: { reason: 'auth_failed', method: 'PATCH' }, riskScore: 0.5 });
+      return auth.error;
+    }
     const userId = auth.userId;
 
     const { messageId } = await context.params;
@@ -74,6 +77,7 @@ export async function PATCH(
         messageId: maskIdentifier(messageId),
         pageId: maskIdentifier(message.pageId)
       });
+      auditRequest(request, { eventType: 'authz.access.denied', userId, resourceType: 'message', resourceId: messageId, details: { reason: 'no_edit_permission', method: 'PATCH', pageId: message.pageId }, riskScore: 0.5 });
       return NextResponse.json(
         { error: 'You do not have permission to edit messages in this chat' },
         { status: 403 }
@@ -149,7 +153,10 @@ export async function DELETE(
   try {
     // Authenticate
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'message', resourceId: 'delete', details: { reason: 'auth_failed', method: 'DELETE' }, riskScore: 0.5 });
+      return auth.error;
+    }
     const userId = auth.userId;
 
     const { messageId } = await context.params;
@@ -173,6 +180,7 @@ export async function DELETE(
         messageId: maskIdentifier(messageId),
         pageId: maskIdentifier(message.pageId)
       });
+      auditRequest(request, { eventType: 'authz.access.denied', userId, resourceType: 'message', resourceId: messageId, details: { reason: 'no_edit_permission', method: 'DELETE', pageId: message.pageId }, riskScore: 0.5 });
       return NextResponse.json(
         { error: 'You do not have permission to delete messages in this chat' },
         { status: 403 }

--- a/apps/web/src/app/api/ai/chat/messages/[messageId]/undo/route.ts
+++ b/apps/web/src/app/api/ai/chat/messages/[messageId]/undo/route.ts
@@ -22,6 +22,7 @@ const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: tr
  * Returns a NextResponse if permission denied, null if allowed
  */
 async function checkUndoPermissions(
+  request: Request,
   auth: AuthResult,
   userId: string,
   messageId: string,
@@ -35,7 +36,10 @@ async function checkUndoPermissions(
 
     // Check MCP page scope
     const scopeError = await checkMCPPageScope(auth, preview.pageId);
-    if (scopeError) return scopeError;
+    if (scopeError) {
+      auditRequest(request, { eventType: 'authz.access.denied', userId, resourceType: 'ai_chat_undo', resourceId: messageId, details: { reason: 'mcp_page_scope_denied', operationType, pageId: preview.pageId }, riskScore: 0.5 });
+      return scopeError;
+    }
 
     const canEdit = await canUserEditPage(userId, preview.pageId);
     if (!canEdit) {
@@ -44,6 +48,7 @@ async function checkUndoPermissions(
         messageId: maskIdentifier(messageId),
         pageId: maskIdentifier(preview.pageId)
       });
+      auditRequest(request, { eventType: 'authz.access.denied', userId, resourceType: 'ai_chat_undo', resourceId: messageId, details: { reason: 'no_edit_permission', operationType, pageId: preview.pageId }, riskScore: 0.5 });
       return NextResponse.json(
         { error: 'You do not have permission to undo messages in this chat' },
         { status: 403 }
@@ -58,6 +63,7 @@ async function checkUndoPermissions(
         messageId: maskIdentifier(messageId),
         conversationId: maskIdentifier(preview.conversationId)
       });
+      auditRequest(request, { eventType: 'authz.access.denied', userId, resourceType: 'ai_chat_undo', resourceId: messageId, details: { reason: 'conversation_not_owned', operationType, conversationId: preview.conversationId }, riskScore: 0.5 });
       return NextResponse.json(
         { error: 'You do not have permission to undo messages in this chat' },
         { status: 403 }
@@ -78,7 +84,10 @@ export async function GET(
   try {
     // Authenticate
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'ai_chat_undo', resourceId: 'preview', details: { reason: 'auth_failed', method: 'GET' }, riskScore: 0.5 });
+      return auth.error;
+    }
     const userId = auth.userId;
 
     const { messageId } = await context.params;
@@ -100,7 +109,7 @@ export async function GET(
       source: preview.source,
       pageId: preview.pageId ? maskIdentifier(preview.pageId) : null,
     });
-    const permissionError = await checkUndoPermissions(auth, userId, messageId, preview, 'preview');
+    const permissionError = await checkUndoPermissions(request, auth, userId, messageId, preview, 'preview');
     if (permissionError) return permissionError;
 
     loggers.api.debug('[AiUndo:Route] Permission check passed');
@@ -140,7 +149,10 @@ export async function POST(
   try {
     // Authenticate with CSRF
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'ai_chat_undo', resourceId: 'execute', details: { reason: 'auth_failed', method: 'POST' }, riskScore: 0.5 });
+      return auth.error;
+    }
     const userId = auth.userId;
 
     const { messageId } = await context.params;
@@ -172,7 +184,7 @@ export async function POST(
     }
 
     // Check permissions
-    const permissionError = await checkUndoPermissions(auth, userId, messageId, preview, 'execution');
+    const permissionError = await checkUndoPermissions(request, auth, userId, messageId, preview, 'execution');
     if (permissionError) return permissionError;
 
     loggers.api.debug('[AiUndo:Route] Executing undo', {

--- a/apps/web/src/app/api/ai/chat/messages/route.ts
+++ b/apps/web/src/app/api/ai/chat/messages/route.ts
@@ -14,7 +14,10 @@ const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: fal
 export async function GET(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'message', resourceId: 'list', details: { reason: 'auth_failed', method: 'GET' }, riskScore: 0.5 });
+      return auth.error;
+    }
 
     const { searchParams } = new URL(request.url);
     const pageId = searchParams.get('pageId');
@@ -25,11 +28,15 @@ export async function GET(request: Request) {
     }
 
     const mcpScopeError = await checkMCPPageScope(auth, pageId);
-    if (mcpScopeError) return mcpScopeError;
+    if (mcpScopeError) {
+      auditRequest(request, { eventType: 'authz.access.denied', userId: auth.userId, resourceType: 'message', resourceId: pageId, details: { reason: 'mcp_page_scope_denied', method: 'GET' }, riskScore: 0.5 });
+      return mcpScopeError;
+    }
 
     // Check if user has view permission for this page
     const canView = await canUserViewPage(auth.userId, pageId);
     if (!canView) {
+      auditRequest(request, { eventType: 'authz.access.denied', userId: auth.userId, resourceType: 'message', resourceId: pageId, details: { reason: 'no_view_permission', method: 'GET' }, riskScore: 0.5 });
       return NextResponse.json({
         error: 'You need view permission to access this page\'s chat messages',
         details: 'Contact the page owner to request access'

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -103,6 +103,7 @@ export async function POST(request: Request) {
     const authResult = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
     if (isAuthError(authResult)) {
       loggers.ai.warn('AI Chat API: Authentication failed');
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'ai_chat', resourceId: 'post', details: { reason: 'auth_failed', method: 'POST' }, riskScore: 0.5 });
       return authResult.error;
     }
     userId = authResult.userId;
@@ -193,7 +194,10 @@ export async function POST(request: Request) {
     }
 
     const mcpScopeError = await checkMCPPageScope(authResult, chatId);
-    if (mcpScopeError) return mcpScopeError;
+    if (mcpScopeError) {
+      auditRequest(request, { eventType: 'authz.access.denied', userId, resourceType: 'ai_chat', resourceId: chatId, details: { reason: 'mcp_page_scope_denied', method: 'POST' }, riskScore: 0.5 });
+      return mcpScopeError;
+    }
 
     // Ensure userId and chatId are defined
     if (!userId) {
@@ -231,6 +235,7 @@ export async function POST(request: Request) {
         userId: maskedUserId,
         chatId: maskedChatId,
       });
+      auditRequest(request, { eventType: 'authz.access.denied', userId, resourceType: 'ai_chat', resourceId: chatId, details: { reason: 'no_view_permission', method: 'POST' }, riskScore: 0.5 });
       return NextResponse.json({ error: 'You do not have permission to view this AI chat' }, { status: 403 });
     }
 
@@ -246,6 +251,7 @@ export async function POST(request: Request) {
         userId: maskedUserId,
         chatId: maskedChatId,
       });
+      auditRequest(request, { eventType: 'authz.access.denied', userId, resourceType: 'ai_chat', resourceId: chatId, details: { reason: 'no_edit_permission', method: 'POST' }, riskScore: 0.5 });
       return NextResponse.json({ error: 'You do not have permission to send messages in this AI chat' }, { status: 403 });
     }
 
@@ -1220,7 +1226,10 @@ export async function POST(request: Request) {
 export async function GET(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'ai_chat_settings', resourceId: 'get', details: { reason: 'auth_failed', method: 'GET' }, riskScore: 0.5 });
+      return auth.error;
+    }
     const userId = auth.userId;
 
     // Get pageId from query params
@@ -1394,7 +1403,10 @@ async function validateProviderModel(
 export async function PATCH(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'ai_chat_settings', resourceId: 'update', details: { reason: 'auth_failed', method: 'PATCH' }, riskScore: 0.5 });
+      return auth.error;
+    }
 
     const body = await request.json();
 
@@ -1453,6 +1465,7 @@ export async function PATCH(request: Request) {
         userId: auth.userId,
         pageId: sanitizedPageId
       });
+      auditRequest(request, { eventType: 'authz.access.denied', userId: auth.userId, resourceType: 'ai_chat_settings', resourceId: sanitizedPageId, details: { reason: 'no_edit_permission', method: 'PATCH' }, riskScore: 0.5 });
       return NextResponse.json(
         { error: 'You do not have permission to modify this page' },
         { status: 403 }

--- a/apps/web/src/app/api/ai/global/[id]/messages/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/[messageId]/route.ts
@@ -19,7 +19,10 @@ export async function PATCH(
   try {
     // Authenticate
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat_message', resourceId: 'edit', details: { reason: 'auth_failed', method: 'PATCH' }, riskScore: 0.5 });
+      return auth.error;
+    }
     const userId = auth.userId;
 
     const { id: conversationId, messageId } = await context.params;
@@ -112,7 +115,10 @@ export async function DELETE(
   try {
     // Authenticate
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat_message', resourceId: 'delete', details: { reason: 'auth_failed', method: 'DELETE' }, riskScore: 0.5 });
+      return auth.error;
+    }
     const userId = auth.userId;
 
     const { id: conversationId, messageId } = await context.params;

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -69,7 +69,10 @@ export async function GET(
 ) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat_message', resourceId: 'list', details: { reason: 'auth_failed', method: 'GET' }, riskScore: 0.5 });
+      return auth.error;
+    }
     const userId = auth.userId;
 
     const { id } = await context.params;
@@ -204,6 +207,7 @@ export async function POST(
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
     if (isAuthError(auth)) {
       loggers.api.debug('Global Assistant Chat API: Authentication failed', {});
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat_message', resourceId: 'send', details: { reason: 'auth_failed', method: 'POST' }, riskScore: 0.5 });
       return auth.error;
     }
     const userId = auth.userId;

--- a/apps/web/src/app/api/ai/global/[id]/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/route.ts
@@ -15,7 +15,10 @@ export async function GET(
 ) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat', resourceId: 'get', details: { reason: 'auth_failed', method: 'GET' }, riskScore: 0.5 });
+      return auth.error;
+    }
     const userId = auth.userId;
 
     const { id } = await context.params;
@@ -50,7 +53,10 @@ export async function PATCH(
 ) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat', resourceId: 'update', details: { reason: 'auth_failed', method: 'PATCH' }, riskScore: 0.5 });
+      return auth.error;
+    }
     const userId = auth.userId;
 
     const { id } = await context.params;
@@ -91,7 +97,10 @@ export async function DELETE(
 ) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat', resourceId: 'delete', details: { reason: 'auth_failed', method: 'DELETE' }, riskScore: 0.5 });
+      return auth.error;
+    }
     const userId = auth.userId;
 
     const { id } = await context.params;

--- a/apps/web/src/app/api/ai/global/[id]/usage/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/usage/route.ts
@@ -18,7 +18,10 @@ export async function GET(
 ) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat_usage', resourceId: 'get', details: { reason: 'auth_failed', method: 'GET' }, riskScore: 0.5 });
+      return auth.error;
+    }
     const userId = auth.userId;
 
     const { id } = await context.params;

--- a/apps/web/src/app/api/ai/global/active/route.ts
+++ b/apps/web/src/app/api/ai/global/active/route.ts
@@ -12,7 +12,10 @@ const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
 export async function GET(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat', resourceId: 'active', details: { reason: 'auth_failed', method: 'GET' }, riskScore: 0.5 });
+      return auth.error;
+    }
     const userId = auth.userId;
 
     const conversation = await globalConversationRepository.getActiveGlobalConversation(userId);

--- a/apps/web/src/app/api/ai/global/route.ts
+++ b/apps/web/src/app/api/ai/global/route.ts
@@ -25,7 +25,10 @@ const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
 export async function GET(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat', resourceId: 'list', details: { reason: 'auth_failed', method: 'GET' }, riskScore: 0.5 });
+      return auth.error;
+    }
     const userId = auth.userId;
 
     const { searchParams } = new URL(request.url);
@@ -75,7 +78,10 @@ export async function GET(request: Request) {
 export async function POST(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'global_chat', resourceId: 'create', details: { reason: 'auth_failed', method: 'POST' }, riskScore: 0.5 });
+      return auth.error;
+    }
     const userId = auth.userId;
 
     const body = await request.json();

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/config/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/config/route.ts
@@ -20,7 +20,10 @@ export async function PUT(
 ) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent', resourceId: 'config', details: { reason: 'auth_failed', method: 'PUT' }, riskScore: 0.5 });
+      return auth.error;
+    }
     const { userId } = auth;
 
     const { agentId } = await context.params;
@@ -55,11 +58,15 @@ export async function PUT(
 
     // Enforce MCP token scope
     const scopeError = checkMCPDriveScope(auth, agent.driveId);
-    if (scopeError) return scopeError;
+    if (scopeError) {
+      auditRequest(request, { eventType: 'authz.access.denied', userId, resourceType: 'page_agent', resourceId: agentId, details: { reason: 'mcp_drive_scope_denied', driveId: agent.driveId, method: 'PUT' }, riskScore: 0.5 });
+      return scopeError;
+    }
 
     // Check permissions
     const canEdit = await canUserEditPage(userId, agentId);
     if (!canEdit) {
+      auditRequest(request, { eventType: 'authz.access.denied', userId, resourceType: 'page_agent', resourceId: agentId, details: { reason: 'no_edit_permission', method: 'PUT' }, riskScore: 0.5 });
       return NextResponse.json(
         { error: 'Insufficient permissions to update this agent' },
         { status: 403 }

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/[messageId]/route.ts
@@ -20,7 +20,10 @@ export async function PATCH(
 ) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent_message', resourceId: 'edit', details: { reason: 'auth_failed', method: 'PATCH' }, riskScore: 0.5 });
+      return auth.error;
+    }
     const userId = auth.userId;
 
     const { agentId, conversationId, messageId } = await context.params;
@@ -36,7 +39,10 @@ export async function PATCH(
 
     // Check MCP page scope
     const scopeError = await checkMCPPageScope(auth, agentId);
-    if (scopeError) return scopeError;
+    if (scopeError) {
+      auditRequest(request, { eventType: 'authz.access.denied', userId, resourceType: 'page_agent_message', resourceId: messageId, details: { reason: 'mcp_page_scope_denied', agentId, conversationId, method: 'PATCH' }, riskScore: 0.5 });
+      return scopeError;
+    }
 
     // Check if user can edit the page (agent) this message belongs to
     const canEdit = await canUserEditPage(userId, agentId);
@@ -46,6 +52,7 @@ export async function PATCH(
         messageId: maskIdentifier(messageId),
         agentId: maskIdentifier(agentId),
       });
+      auditRequest(request, { eventType: 'authz.access.denied', userId, resourceType: 'page_agent_message', resourceId: messageId, details: { reason: 'no_edit_permission', agentId, conversationId, method: 'PATCH' }, riskScore: 0.5 });
       return NextResponse.json(
         { error: 'You do not have permission to edit messages in this chat' },
         { status: 403 }
@@ -128,14 +135,20 @@ export async function DELETE(
 ) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent_message', resourceId: 'delete', details: { reason: 'auth_failed', method: 'DELETE' }, riskScore: 0.5 });
+      return auth.error;
+    }
     const userId = auth.userId;
 
     const { agentId, conversationId, messageId } = await context.params;
 
     // Check MCP page scope
     const scopeError = await checkMCPPageScope(auth, agentId);
-    if (scopeError) return scopeError;
+    if (scopeError) {
+      auditRequest(request, { eventType: 'authz.access.denied', userId, resourceType: 'page_agent_message', resourceId: messageId, details: { reason: 'mcp_page_scope_denied', agentId, conversationId, method: 'DELETE' }, riskScore: 0.5 });
+      return scopeError;
+    }
 
     // Check if user can edit the page (agent) this message belongs to
     const canEdit = await canUserEditPage(userId, agentId);
@@ -145,6 +158,7 @@ export async function DELETE(
         messageId: maskIdentifier(messageId),
         agentId: maskIdentifier(agentId),
       });
+      auditRequest(request, { eventType: 'authz.access.denied', userId, resourceType: 'page_agent_message', resourceId: messageId, details: { reason: 'no_edit_permission', agentId, conversationId, method: 'DELETE' }, riskScore: 0.5 });
       return NextResponse.json(
         { error: 'You do not have permission to delete messages in this chat' },
         { status: 403 }

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/route.ts
@@ -55,7 +55,10 @@ export async function GET(
 ) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent_message', resourceId: 'list', details: { reason: 'auth_failed', method: 'GET' }, riskScore: 0.5 });
+      return auth.error;
+    }
 
     const { agentId, conversationId } = await context.params;
 
@@ -77,11 +80,15 @@ export async function GET(
 
     // Check MCP page scope
     const scopeError = await checkMCPPageScope(auth, agentId);
-    if (scopeError) return scopeError;
+    if (scopeError) {
+      auditRequest(request, { eventType: 'authz.access.denied', userId: auth.userId, resourceType: 'page_agent_message', resourceId: conversationId, details: { reason: 'mcp_page_scope_denied', agentId, method: 'GET' }, riskScore: 0.5 });
+      return scopeError;
+    }
 
     // Check permissions
     const canView = await canUserViewPage(auth.userId, agentId);
     if (!canView) {
+      auditRequest(request, { eventType: 'authz.access.denied', userId: auth.userId, resourceType: 'page_agent_message', resourceId: conversationId, details: { reason: 'no_view_permission', agentId, method: 'GET' }, riskScore: 0.5 });
       return NextResponse.json(
         { error: 'Insufficient permissions to view this agent\'s conversations' },
         { status: 403 }

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/route.ts
@@ -18,7 +18,10 @@ export async function PATCH(
 ) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent_conversation', resourceId: 'update', details: { reason: 'auth_failed', method: 'PATCH' }, riskScore: 0.5 });
+      return auth.error;
+    }
 
     const { agentId, conversationId } = await context.params;
 
@@ -34,11 +37,15 @@ export async function PATCH(
 
     // Check MCP page scope
     const scopeError = await checkMCPPageScope(auth, agentId);
-    if (scopeError) return scopeError;
+    if (scopeError) {
+      auditRequest(request, { eventType: 'authz.access.denied', userId: auth.userId, resourceType: 'page_agent_conversation', resourceId: conversationId, details: { reason: 'mcp_page_scope_denied', agentId, method: 'PATCH' }, riskScore: 0.5 });
+      return scopeError;
+    }
 
     // Check permissions (need edit to modify conversations)
     const canEdit = await canUserEditPage(auth.userId, agentId);
     if (!canEdit) {
+      auditRequest(request, { eventType: 'authz.access.denied', userId: auth.userId, resourceType: 'page_agent_conversation', resourceId: conversationId, details: { reason: 'no_edit_permission', agentId, method: 'PATCH' }, riskScore: 0.5 });
       return NextResponse.json(
         { error: 'Insufficient permissions to modify this conversation' },
         { status: 403 }
@@ -112,7 +119,10 @@ export async function DELETE(
 ) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent_conversation', resourceId: 'delete', details: { reason: 'auth_failed', method: 'DELETE' }, riskScore: 0.5 });
+      return auth.error;
+    }
 
     const { agentId, conversationId } = await context.params;
 
@@ -128,11 +138,15 @@ export async function DELETE(
 
     // Check MCP page scope
     const scopeError = await checkMCPPageScope(auth, agentId);
-    if (scopeError) return scopeError;
+    if (scopeError) {
+      auditRequest(request, { eventType: 'authz.access.denied', userId: auth.userId, resourceType: 'page_agent_conversation', resourceId: conversationId, details: { reason: 'mcp_page_scope_denied', agentId, method: 'DELETE' }, riskScore: 0.5 });
+      return scopeError;
+    }
 
     // Check permissions (need edit to delete conversations)
     const canEdit = await canUserEditPage(auth.userId, agentId);
     if (!canEdit) {
+      auditRequest(request, { eventType: 'authz.access.denied', userId: auth.userId, resourceType: 'page_agent_conversation', resourceId: conversationId, details: { reason: 'no_edit_permission', agentId, method: 'DELETE' }, riskScore: 0.5 });
       return NextResponse.json(
         { error: 'Insufficient permissions to delete this conversation' },
         { status: 403 }

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/route.ts
@@ -25,7 +25,10 @@ export async function GET(
 ) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent_conversation', resourceId: 'list', details: { reason: 'auth_failed', method: 'GET' }, riskScore: 0.5 });
+      return auth.error;
+    }
 
     const { agentId } = await context.params;
 
@@ -41,11 +44,15 @@ export async function GET(
 
     // Check MCP page scope
     const scopeError = await checkMCPPageScope(auth, agentId);
-    if (scopeError) return scopeError;
+    if (scopeError) {
+      auditRequest(request, { eventType: 'authz.access.denied', userId: auth.userId, resourceType: 'page_agent_conversation', resourceId: agentId, details: { reason: 'mcp_page_scope_denied', method: 'GET' }, riskScore: 0.5 });
+      return scopeError;
+    }
 
     // Check permissions
     const canView = await canUserViewPage(auth.userId, agentId);
     if (!canView) {
+      auditRequest(request, { eventType: 'authz.access.denied', userId: auth.userId, resourceType: 'page_agent_conversation', resourceId: agentId, details: { reason: 'no_view_permission', method: 'GET' }, riskScore: 0.5 });
       return NextResponse.json(
         { error: 'Insufficient permissions to view this agent' },
         { status: 403 }
@@ -131,7 +138,10 @@ export async function POST(
 ) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent_conversation', resourceId: 'create', details: { reason: 'auth_failed', method: 'POST' }, riskScore: 0.5 });
+      return auth.error;
+    }
 
     const { agentId } = await context.params;
 
@@ -147,11 +157,15 @@ export async function POST(
 
     // Check MCP page scope
     const scopeError = await checkMCPPageScope(auth, agentId);
-    if (scopeError) return scopeError;
+    if (scopeError) {
+      auditRequest(request, { eventType: 'authz.access.denied', userId: auth.userId, resourceType: 'page_agent_conversation', resourceId: agentId, details: { reason: 'mcp_page_scope_denied', method: 'POST' }, riskScore: 0.5 });
+      return scopeError;
+    }
 
     // Check permissions
     const canView = await canUserViewPage(auth.userId, agentId);
     if (!canView) {
+      auditRequest(request, { eventType: 'authz.access.denied', userId: auth.userId, resourceType: 'page_agent_conversation', resourceId: agentId, details: { reason: 'no_view_permission', method: 'POST' }, riskScore: 0.5 });
       return NextResponse.json(
         { error: 'Insufficient permissions to create conversations for this agent' },
         { status: 403 }

--- a/apps/web/src/app/api/ai/page-agents/consult/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/route.ts
@@ -146,7 +146,10 @@ async function getConfiguredModel(userId: string, agentConfig: { aiProvider?: st
 export async function POST(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent', resourceId: 'consult', details: { reason: 'auth_failed', method: 'POST' }, riskScore: 0.5 });
+      return auth.error;
+    }
     const userId = auth.userId;
 
     const body = await request.json();
@@ -182,11 +185,15 @@ export async function POST(request: Request) {
 
     // Check MCP page scope
     const scopeError = await checkMCPPageScope(auth, agentId);
-    if (scopeError) return scopeError;
+    if (scopeError) {
+      auditRequest(request, { eventType: 'authz.access.denied', userId, resourceType: 'page_agent', resourceId: agentId, details: { reason: 'mcp_page_scope_denied', action: 'consult', method: 'POST' }, riskScore: 0.5 });
+      return scopeError;
+    }
 
     // Check view permissions
     const canView = await canUserViewPage(userId, agentId);
     if (!canView) {
+      auditRequest(request, { eventType: 'authz.access.denied', userId, resourceType: 'page_agent', resourceId: agentId, details: { reason: 'no_view_permission', action: 'consult', method: 'POST' }, riskScore: 0.5 });
       return NextResponse.json(
         { error: 'Insufficient permissions to consult this agent' },
         { status: 403 }

--- a/apps/web/src/app/api/ai/page-agents/create/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/create/route.ts
@@ -15,7 +15,10 @@ import { pageAgentRepository, type AgentData } from '@/lib/repositories/page-age
 export async function POST(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent', resourceId: 'create', details: { reason: 'auth_failed', method: 'POST' }, riskScore: 0.5 });
+      return auth.error;
+    }
     const { userId } = auth;
 
     const body = await request.json();
@@ -40,7 +43,10 @@ export async function POST(request: Request) {
 
     // Enforce MCP token scope
     const scopeError = checkMCPDriveScope(auth, driveId);
-    if (scopeError) return scopeError;
+    if (scopeError) {
+      auditRequest(request, { eventType: 'authz.access.denied', userId, resourceType: 'page_agent', resourceId: 'create', details: { reason: 'mcp_drive_scope_denied', driveId, method: 'POST' }, riskScore: 0.5 });
+      return scopeError;
+    }
 
     // If parentId is provided, verify it exists and belongs to this drive
     if (parentId) {
@@ -59,6 +65,7 @@ export async function POST(request: Request) {
       // Creating in a folder - check permissions on parent page
       const canEdit = await canUserEditPage(userId, parentId);
       if (!canEdit) {
+        auditRequest(request, { eventType: 'authz.access.denied', userId, resourceType: 'page_agent', resourceId: 'create', details: { reason: 'no_edit_permission_on_parent', parentId, driveId, method: 'POST' }, riskScore: 0.5 });
         return NextResponse.json(
           { error: 'Insufficient permissions to create agents in this folder' },
           { status: 403 }
@@ -67,6 +74,7 @@ export async function POST(request: Request) {
     } else {
       // Creating at root level - check if user owns the drive
       if (drive.ownerId !== userId) {
+        auditRequest(request, { eventType: 'authz.access.denied', userId, resourceType: 'page_agent', resourceId: 'create', details: { reason: 'not_drive_owner', driveId, method: 'POST' }, riskScore: 0.5 });
         return NextResponse.json(
           { error: 'Only drive owners can create agents at the root level' },
           { status: 403 }

--- a/apps/web/src/app/api/ai/page-agents/multi-drive/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/multi-drive/route.ts
@@ -32,7 +32,10 @@ interface AgentSummary {
 export async function GET(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'page_agent', resourceId: 'multi_drive_list', details: { reason: 'auth_failed', method: 'GET' }, riskScore: 0.5 });
+      return auth.error;
+    }
     const { userId } = auth;
 
     const { searchParams } = new URL(request.url);

--- a/apps/web/src/app/api/ai/settings/route.ts
+++ b/apps/web/src/app/api/ai/settings/route.ts
@@ -83,7 +83,10 @@ const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
 export async function GET(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'ai_settings', resourceId: 'get', details: { reason: 'auth_failed', method: 'GET' }, riskScore: 0.5 });
+      return auth.error;
+    }
     const userId = auth.userId;
 
     // Get user's current provider settings via repository
@@ -195,7 +198,10 @@ export async function GET(request: Request) {
 export async function POST(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'ai_settings', resourceId: 'save_api_key', details: { reason: 'auth_failed', method: 'POST' }, riskScore: 0.5 });
+      return auth.error;
+    }
     const userId = auth.userId;
 
     const body = await request.json();
@@ -316,7 +322,10 @@ export async function POST(request: Request) {
 export async function PATCH(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'ai_settings', resourceId: 'update_selection', details: { reason: 'auth_failed', method: 'PATCH' }, riskScore: 0.5 });
+      return auth.error;
+    }
     const userId = auth.userId;
 
     const body = await request.json();
@@ -408,7 +417,10 @@ export async function PATCH(request: Request) {
 export async function DELETE(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
-    if (isAuthError(auth)) return auth.error;
+    if (isAuthError(auth)) {
+      auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'ai_settings', resourceId: 'delete_api_key', details: { reason: 'auth_failed', method: 'DELETE' }, riskScore: 0.5 });
+      return auth.error;
+    }
     const userId = auth.userId;
 
     const body = await request.json();


### PR DESCRIPTION
## Summary

Closes the biggest abuse-surface gap in the SIEM cloud-readiness epic: AI routes now emit `authz.access.denied` audit events on their auth-failure and permission-denial paths, not just on success. In a cloud environment without this, we cannot detect prompt-injection, model-abuse, or data-exfiltration probing against agents. This is the AI subset of wave 2 (wave 1 #898 migrated ~170 routes to the functional audit pipeline).

All 20 AI routes were already emitting a success-path audit event. This PR adds the missing denial-path audit events so SIEM can correlate failed attempts.

## Routes instrumented (20)

**Chat subset (5):**
- `ai/abort` (POST)
- `ai/chat` (POST / GET / PATCH)
- `ai/chat/messages` (GET)
- `ai/chat/messages/[messageId]` (PATCH / DELETE)
- `ai/chat/messages/[messageId]/undo` (GET / POST)

**Settings (1):**
- `ai/settings` (GET / POST / PATCH / DELETE)

**Global assistant (6):**
- `ai/global` (GET / POST)
- `ai/global/active` (GET)
- `ai/global/[id]` (GET / PATCH / DELETE)
- `ai/global/[id]/messages` (GET / POST)
- `ai/global/[id]/messages/[messageId]` (PATCH / DELETE)
- `ai/global/[id]/usage` (GET)

**Page agents (8):**
- `ai/page-agents/consult` (POST)
- `ai/page-agents/create` (POST)
- `ai/page-agents/multi-drive` (GET)
- `ai/page-agents/[agentId]/config` (PUT)
- `ai/page-agents/[agentId]/conversations` (GET / POST)
- `ai/page-agents/[agentId]/conversations/[conversationId]` (PATCH / DELETE)
- `ai/page-agents/[agentId]/conversations/[conversationId]/messages` (GET)
- `ai/page-agents/[agentId]/conversations/[conversationId]/messages/[messageId]` (PATCH / DELETE)

For each route, `auditRequest(request, { eventType: 'authz.access.denied', resourceType, resourceId, details: { reason, method, ... }, riskScore: 0.5 })` is emitted before each early-return representing an auth failure (isAuthError), MCP scope denial (checkMCPPageScope / checkMCPDriveScope), or permission denial (canUserViewPage / canUserEditPage / drive ownership).

## Contract test

Extended `apps/web/src/app/api/__tests__/security-audit-coverage.test.ts` with a new assertion listing the 20 AI routes and requiring each file to contain an `authz.access.denied` event. The skip list did not grow.

## TDD RED → GREEN history

Delivered in two cycles so RED/GREEN are visible in git history:

- **Cycle 1 (5 chat routes)**
  - RED: `431229e5` — `test(siem): RED — require access-denied audit for 5 chat AI routes`
  - GREEN: `9e49c2b0` — `feat(siem): GREEN — audit access-denied on 5 chat AI routes`
- **Cycle 2 (15 remaining routes)**
  - RED: `c1a09375` — `test(siem): RED — require access-denied audit for 15 remaining AI routes`
  - GREEN: `a7b312d1` — `feat(siem): GREEN — audit access-denied on 15 remaining AI routes`

## SecurityEventType changes

None. Uses the existing `authz.access.denied` value from `securityEventTypeEnum` in `packages/db/src/schema/security-audit.ts`. No enum additions required.

## Test plan

- [x] `pnpm --filter web test src/app/api/__tests__/security-audit-coverage.test.ts` — 4/4 passed
- [x] `pnpm --filter web test src/app/api/ai` — 316/316 passed across 18 files
- [x] `pnpm --filter web typecheck` — clean
- [x] `pnpm --filter web build` — clean
- [ ] Verify in staging that denial events land in `security_audit_log` with `event_type='authz.access.denied'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)