### PR TITLE
feat(auth): prioritize OS authenticator at passkey registration

### DIFF
--- a/docs/1.0-overview/changelog.md
+++ b/docs/1.0-overview/changelog.md
@@ -1,5 +1,13 @@
 ## 2026-04-13
 
+### Passkey Registration: Prefer Platform Authenticator
+
+Passkey enrolment now nudges the browser toward the built-in platform authenticator (Touch ID, Windows Hello, Android biometrics) instead of defaulting to the cross-device QR picker. Users can still choose "use a different device" from the native browser dialog — this is a preference, not a restriction.
+
+#### Changed
+
+- **`hints: ['client-device']` on registration options**: `generateRegistrationOptions` and `generateRegistrationOptionsForSignup` now emit the WebAuthn Level 3 hint so browsers surface the local biometric UI first. `authenticatorAttachment` is deliberately left unset to preserve cross-device enrolment as a fallback.
+
 ### GitHub Import: Connection Resolution Hardened
 
 `import_from_github` now resolves and authorises GitHub connections through the same path as the rest of the integration runtime, fixing a regression where the tool could fail to find a connection that the same chat had successfully used moments earlier.

--- a/packages/lib/src/auth/__tests__/passkey-service.test.ts
+++ b/packages/lib/src/auth/__tests__/passkey-service.test.ts
@@ -189,6 +189,54 @@ describe('passkey-service', () => {
       expect(result.ok).toBe(true);
       if (result.ok) expect(result.data.options.challenge).toBe('challenge123');
     });
+
+    // WebAuthn L3 hint — tells the browser to prefer the OS platform authenticator
+    // (Touch ID / Windows Hello) over the cross-device QR flow, while still allowing
+    // the user to pick "use a different device" in the native picker.
+    it('generateRegistrationOptions_default_includesClientDeviceHint', async () => {
+      mockDb.query.users.findFirst.mockResolvedValueOnce({
+        id: 'user-1', email: 'a@b.com', name: 'Test', suspendedAt: null,
+      });
+      mockDb.query.passkeys.findMany.mockResolvedValueOnce([]);
+      mockGenRegOptions.mockResolvedValueOnce({ challenge: 'challenge123', rp: {} });
+      mockDb.delete.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+      mockDb.insert.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
+
+      const result = await generateRegistrationOptions({ userId: 'user-1' });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect((result.data.options as { hints?: readonly string[] }).hints).toEqual(['client-device']);
+      }
+    });
+
+    // Portability constraint: we must NOT set authenticatorAttachment,
+    // because 'platform' would hard-exclude cross-device registration and
+    // the user has asked to keep that path open as a fallback.
+    it('generateRegistrationOptions_default_omitsAuthenticatorAttachment', async () => {
+      mockDb.query.users.findFirst.mockResolvedValueOnce({
+        id: 'user-1', email: 'a@b.com', name: 'Test', suspendedAt: null,
+      });
+      mockDb.query.passkeys.findMany.mockResolvedValueOnce([]);
+      mockGenRegOptions.mockResolvedValueOnce({ challenge: 'challenge123', rp: {} });
+      mockDb.delete.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+      mockDb.insert.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
+
+      await generateRegistrationOptions({ userId: 'user-1' });
+
+      const simpleWebAuthnArgs = mockGenRegOptions.mock.calls[0]?.[0] as {
+        authenticatorSelection?: {
+          authenticatorAttachment?: string;
+          residentKey?: string;
+          requireResidentKey?: boolean;
+          userVerification?: string;
+        };
+      };
+      expect(simpleWebAuthnArgs.authenticatorSelection?.authenticatorAttachment).toBeUndefined();
+      expect(simpleWebAuthnArgs.authenticatorSelection?.residentKey).toBe('required');
+      expect(simpleWebAuthnArgs.authenticatorSelection?.requireResidentKey).toBe(true);
+      expect(simpleWebAuthnArgs.authenticatorSelection?.userVerification).toBe('required');
+    });
   });
 
   describe('verifyRegistration', () => {
@@ -653,6 +701,46 @@ describe('passkey-service', () => {
         expect(result.data.options.challenge).toBe('signup-challenge');
         expect(result.data.challengeId).toBe('test-cuid');
       }
+    });
+
+    it('generateRegistrationOptionsForSignup_default_includesClientDeviceHint', async () => {
+      mockDb.query.users.findFirst.mockResolvedValueOnce(null);
+      mockGenRegOptions.mockResolvedValueOnce({ challenge: 'signup-challenge' });
+      mockDb.delete.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+      mockDb.insert.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
+
+      const result = await generateRegistrationOptionsForSignup({
+        email: 'new@example.com', name: 'New User',
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect((result.data.options as { hints?: readonly string[] }).hints).toEqual(['client-device']);
+      }
+    });
+
+    it('generateRegistrationOptionsForSignup_default_omitsAuthenticatorAttachment', async () => {
+      mockDb.query.users.findFirst.mockResolvedValueOnce(null);
+      mockGenRegOptions.mockResolvedValueOnce({ challenge: 'signup-challenge' });
+      mockDb.delete.mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) });
+      mockDb.insert.mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) });
+
+      await generateRegistrationOptionsForSignup({
+        email: 'new@example.com', name: 'New User',
+      });
+
+      const simpleWebAuthnArgs = mockGenRegOptions.mock.calls[0]?.[0] as {
+        authenticatorSelection?: {
+          authenticatorAttachment?: string;
+          residentKey?: string;
+          requireResidentKey?: boolean;
+          userVerification?: string;
+        };
+      };
+      expect(simpleWebAuthnArgs.authenticatorSelection?.authenticatorAttachment).toBeUndefined();
+      expect(simpleWebAuthnArgs.authenticatorSelection?.residentKey).toBe('required');
+      expect(simpleWebAuthnArgs.authenticatorSelection?.requireResidentKey).toBe(true);
+      expect(simpleWebAuthnArgs.authenticatorSelection?.userVerification).toBe('required');
     });
   });
 

--- a/packages/lib/src/auth/passkey-service.ts
+++ b/packages/lib/src/auth/passkey-service.ts
@@ -222,10 +222,10 @@ export async function generateRegistrationOptions(
   });
 
   // WebAuthn Level 3: hint browser to prefer the OS platform authenticator
-  // (Touch ID / Windows Hello) over the cross-device QR flow. This is a
-  // preference only — users can still pick "use a different device" in the
-  // browser's native picker. SimpleWebAuthn v13 doesn't accept hints in
-  // generateRegistrationOptions, so we splice it on post-call.
+  // (Touch ID / Windows Hello) while still allowing "use a different device"
+  // as a fallback. SimpleWebAuthn v13's `preferredAuthenticatorType: 'localDevice'`
+  // would also force `authenticatorAttachment: 'platform'`, which hard-excludes
+  // cross-device — so we bypass it and splice `hints` on post-call.
   const options = {
     ...rawOptions,
     hints: ['client-device' as const],

--- a/packages/lib/src/auth/passkey-service.ts
+++ b/packages/lib/src/auth/passkey-service.ts
@@ -103,8 +103,13 @@ export type PasskeyError =
   | { code: 'PASSKEY_NOT_FOUND' }
   | { code: 'EMAIL_EXISTS' };
 
+export type RegistrationOptionsWithHints =
+  Awaited<ReturnType<typeof simpleGenerateRegistrationOptions>> & {
+    hints?: readonly string[];
+  };
+
 export type GenerateRegOptionsResult =
-  | { ok: true; data: { options: Awaited<ReturnType<typeof simpleGenerateRegistrationOptions>> } }
+  | { ok: true; data: { options: RegistrationOptionsWithHints } }
   | { ok: false; error: PasskeyError };
 
 export type VerifyRegistrationResult =
@@ -137,7 +142,7 @@ export type UpdateNameResult =
   | { ok: false; error: PasskeyError };
 
 export type GenerateSignupRegOptionsResult =
-  | { ok: true; data: { options: Awaited<ReturnType<typeof simpleGenerateRegistrationOptions>>; challengeId: string } }
+  | { ok: true; data: { options: RegistrationOptionsWithHints; challengeId: string } }
   | { ok: false; error: PasskeyError };
 
 export type VerifySignupRegistrationResult =
@@ -201,7 +206,7 @@ export async function generateRegistrationOptions(
   }));
 
   // Generate options with discoverable credentials (required for true passwordless)
-  const options = await simpleGenerateRegistrationOptions({
+  const rawOptions = await simpleGenerateRegistrationOptions({
     rpName: PASSKEY_CONFIG.rpName,
     rpID: PASSKEY_CONFIG.rpId,
     userName: user.email,
@@ -215,6 +220,16 @@ export async function generateRegistrationOptions(
     },
     timeout: PASSKEY_CONFIG.timeout,
   });
+
+  // WebAuthn Level 3: hint browser to prefer the OS platform authenticator
+  // (Touch ID / Windows Hello) over the cross-device QR flow. This is a
+  // preference only — users can still pick "use a different device" in the
+  // browser's native picker. SimpleWebAuthn v13 doesn't accept hints in
+  // generateRegistrationOptions, so we splice it on post-call.
+  const options = {
+    ...rawOptions,
+    hints: ['client-device' as const],
+  };
 
   // Clean up old unused challenges
   await db
@@ -725,7 +740,7 @@ export async function generateRegistrationOptionsForSignup(
   }
 
   // Generate options with email as userName (user doesn't exist yet)
-  const options = await simpleGenerateRegistrationOptions({
+  const rawOptions = await simpleGenerateRegistrationOptions({
     rpName: PASSKEY_CONFIG.rpName,
     rpID: PASSKEY_CONFIG.rpId,
     userName: normalizedEmail,
@@ -738,6 +753,12 @@ export async function generateRegistrationOptionsForSignup(
     },
     timeout: PASSKEY_CONFIG.timeout,
   });
+
+  // See generateRegistrationOptions for rationale on the client-device hint.
+  const options = {
+    ...rawOptions,
+    hints: ['client-device' as const],
+  };
 
   // Clean up old unused signup challenges for this email
   // We use a deterministic ID based on email hash to enable cleanup


### PR DESCRIPTION
## Summary

Splice WebAuthn Level 3 `hints: ['client-device']` onto the options returned by `generateRegistrationOptions` (existing-user flow) and `generateRegistrationOptionsForSignup` (new-user signup flow) in `packages/lib/src/auth/passkey-service.ts`. Mirrors the pattern already used on `generateAuthenticationOptions`.

**Why:** PageSpace's passkey users have never seen a Touch ID / Windows Hello prompt during signup or signin — registration never signals any authenticator preference, so Chrome's default UX routes every new credential through the cross-device ("use a phone") QR flow, making them hybrid credentials. Every subsequent signin inherits that and also prefers the QR path. The L3 hint tells the browser to prefer the platform authenticator at registration time, which unblocks the whole chain.

**Preserves cross-device passkey registration as opt-in** — users can still pick "use a different device" in the browser's native picker to register a phone or security-key passkey. `authenticatorAttachment` is deliberately NOT set (that would hard-exclude cross-device), and `authenticatorSelection` (residentKey: required, userVerification: required) is unchanged so true passwordless signin still works.

Sub-task 2 of the passkey signin fix epic at `tasks/passkey-signin-fix.md`.

## Commits

- **RED** `a37c3e7b` — `test(auth): red — registration options must include client-device hint`
- **GREEN** `fbfd51ec` — `feat(auth): prioritize platform authenticator via WebAuthn L3 hints`

## Test plan

- [x] 4 new unit tests added to `packages/lib/src/auth/__tests__/passkey-service.test.ts`:
  - `generateRegistrationOptions_default_includesClientDeviceHint`
  - `generateRegistrationOptions_default_omitsAuthenticatorAttachment` (also asserts `residentKey: 'required'`, `requireResidentKey: true`, `userVerification: 'required'` are unchanged)
  - `generateRegistrationOptionsForSignup_default_includesClientDeviceHint`
  - `generateRegistrationOptionsForSignup_default_omitsAuthenticatorAttachment` (same selection assertions)
- [x] RED commit verified failing against unmodified source (2 "hint" tests fail; "attachment" tests pre-pass since behavior already held)
- [x] GREEN commit turns all 4 new tests green
- [x] `pnpm --filter @pagespace/lib exec vitest run src/auth/__tests__/passkey-service.test.ts` — 47/47 pass
- [x] `pnpm --filter @pagespace/lib exec vitest run` (full lib unit suite) — 154 files, 4034 pass, 3 skipped, 0 fail
- [x] `pnpm --filter @pagespace/lib typecheck` — clean
- [x] `pnpm --filter @pagespace/lib build` — clean
- [ ] Manual: register a new passkey in Chrome on macOS — OS authenticator (Touch ID) should be offered first, with "use a different device" still available in the native picker as a fallback
- [ ] Manual: register a new passkey in Safari on macOS — hint is a progressive enhancement Safari ignores; existing behavior preserved
- [ ] Manual: sign in with a newly-registered passkey — should hit Touch ID, not the QR flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Passkey registration now includes device preference hints, specifying client-device as the preferred authenticator for a streamlined and optimized user authentication experience.

* **Tests**
  * Added test coverage for registration option generation, verifying that device preference hints are correctly included and authenticator selection settings work as expected across registration flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->