### PR TITLE
feat(auth): delegate desktop passkey ceremony to system browser

### DIFF
--- a/apps/desktop/src/main/__tests__/ipc-handlers.test.ts
+++ b/apps/desktop/src/main/__tests__/ipc-handlers.test.ts
@@ -220,5 +220,85 @@ describe('IPC Handlers', () => {
       expect(shell.openExternal).not.toHaveBeenCalled();
       expect(result).toEqual({ success: false, error: expect.stringContaining('Invalid') });
     });
+
+    it('allows /auth/passkey-external on the configured app origin', async () => {
+      vi.mocked(shell.openExternal).mockResolvedValue(undefined);
+      vi.mocked(getAppUrl).mockReturnValue('https://pagespace.ai/dashboard');
+
+      const handler = getRegisteredHandler('auth:open-external');
+      const result = await handler(
+        {},
+        'https://pagespace.ai/auth/passkey-external?deviceId=d&deviceName=Mac',
+      );
+
+      expect(shell.openExternal).toHaveBeenCalledWith(
+        'https://pagespace.ai/auth/passkey-external?deviceId=d&deviceName=Mac',
+      );
+      expect(result).toEqual({ success: true });
+    });
+
+    it('allows a localhost http app origin in development', async () => {
+      vi.mocked(shell.openExternal).mockResolvedValue(undefined);
+      vi.mocked(getAppUrl).mockReturnValue('http://localhost:3000/dashboard');
+
+      const handler = getRegisteredHandler('auth:open-external');
+      const result = await handler(
+        {},
+        'http://localhost:3000/auth/passkey-external?deviceId=d&deviceName=Mac',
+      );
+
+      expect(shell.openExternal).toHaveBeenCalledWith(
+        'http://localhost:3000/auth/passkey-external?deviceId=d&deviceName=Mac',
+      );
+      expect(result).toEqual({ success: true });
+    });
+
+    it('rejects app-origin URLs whose path is not /auth/passkey-external', async () => {
+      vi.mocked(getAppUrl).mockReturnValue('https://pagespace.ai/dashboard');
+
+      const handler = getRegisteredHandler('auth:open-external');
+      const result = await handler(
+        {},
+        'https://pagespace.ai/dashboard/drive/123',
+      );
+
+      expect(shell.openExternal).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        success: false,
+        error: expect.stringContaining('not allowed'),
+      });
+    });
+
+    it('rejects app-origin lookalike hosts', async () => {
+      vi.mocked(getAppUrl).mockReturnValue('https://pagespace.ai/dashboard');
+
+      const handler = getRegisteredHandler('auth:open-external');
+      const result = await handler(
+        {},
+        'https://pagespace.ai.evil.com/auth/passkey-external',
+      );
+
+      expect(shell.openExternal).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        success: false,
+        error: expect.stringContaining('not allowed'),
+      });
+    });
+
+    it('rejects http on non-localhost even for /auth/passkey-external', async () => {
+      vi.mocked(getAppUrl).mockReturnValue('https://pagespace.ai/dashboard');
+
+      const handler = getRegisteredHandler('auth:open-external');
+      const result = await handler(
+        {},
+        'http://pagespace.ai/auth/passkey-external',
+      );
+
+      expect(shell.openExternal).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        success: false,
+        error: expect.stringContaining('not allowed'),
+      });
+    });
   });
 });

--- a/apps/desktop/src/main/ipc-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers.ts
@@ -102,15 +102,39 @@ export function registerIPCHandlers(): void {
     };
   });
 
-  // Open an OAuth URL in the system browser (allowlisted hostnames only)
+  // Open an auth URL in the system browser. Allows:
+  //  - OAuth providers over HTTPS (Google, Apple)
+  //  - The configured PageSpace app origin on the /auth/passkey-external path
+  //    (HTTPS for remote origins, HTTP only for localhost/127.0.0.1 dev builds)
   const ALLOWED_AUTH_HOSTNAMES = ['accounts.google.com', 'appleid.apple.com'];
+  const PASSKEY_EXTERNAL_PATH = '/auth/passkey-external';
+
+  const isAppOriginMatch = (parsed: URL): boolean => {
+    try {
+      const appUrl = new URL(getAppUrl());
+      if (parsed.hostname !== appUrl.hostname) return false;
+      if (parsed.port !== appUrl.port) return false;
+      const isLocal =
+        parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1';
+      if (parsed.protocol === 'https:') return true;
+      if (parsed.protocol === 'http:' && isLocal) return true;
+      return false;
+    } catch {
+      return false;
+    }
+  };
 
   ipcMain.handle('auth:open-external', async (_event, url: string) => {
     try {
       const parsed = new URL(url);
-      if (parsed.protocol !== 'https:' || !ALLOWED_AUTH_HOSTNAMES.includes(parsed.hostname)) {
-        console.warn('[Auth IPC] Blocked open-external for URL not in allowlist:', parsed.hostname);
-        return { success: false, error: `URL hostname "${parsed.hostname}" is not allowed` };
+      const isOAuthProvider =
+        parsed.protocol === 'https:' && ALLOWED_AUTH_HOSTNAMES.includes(parsed.hostname);
+      const isPasskeyHandoff =
+        parsed.pathname === PASSKEY_EXTERNAL_PATH && isAppOriginMatch(parsed);
+
+      if (!isOAuthProvider && !isPasskeyHandoff) {
+        console.warn('[Auth IPC] Blocked open-external for URL not in allowlist:', parsed.hostname, parsed.pathname);
+        return { success: false, error: `URL "${parsed.hostname}${parsed.pathname}" is not allowed` };
       }
       await shell.openExternal(url);
       return { success: true };

--- a/apps/web/src/app/api/auth/passkey/authenticate/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/authenticate/__tests__/route.test.ts
@@ -33,6 +33,7 @@ vi.mock('@pagespace/lib/auth', () => ({
     revokeAllUserSessions: vi.fn().mockResolvedValue(0),
   },
   generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+  createExchangeCode: vi.fn().mockResolvedValue('mock-exchange-code'),
   SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 
@@ -84,6 +85,7 @@ import {
   verifyAuthentication,
   sessionService,
   generateCSRFToken,
+  createExchangeCode,
 } from '@pagespace/lib/auth';
 import { loggers, auditRequest } from '@pagespace/lib/server';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
@@ -494,6 +496,88 @@ describe('POST /api/auth/passkey/authenticate', () => {
       await POST(createRequest());
 
       expect(createDeviceToken).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('desktop external-browser handoff (desktopExchange flag)', () => {
+    const desktopExchangePayload = {
+      ...validPayload,
+      platform: 'desktop' as const,
+      deviceId: 'device-xyz',
+      deviceName: 'Jono Mac',
+      desktopExchange: true,
+    };
+
+    const createExchangeRequest = () =>
+      new Request('http://localhost/api/auth/passkey/authenticate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(desktopExchangePayload),
+      });
+
+    it('mints an exchange code with the created session, csrf and device tokens', async () => {
+      await POST(createExchangeRequest());
+
+      expect(createExchangeCode).toHaveBeenCalledWith(expect.objectContaining({
+        sessionToken: 'ps_sess_mock_session_token',
+        csrfToken: 'mock-csrf-token',
+        deviceToken: 'ps_dev_mock_token',
+        provider: 'passkey',
+        userId: 'user-1',
+      }));
+    });
+
+    it('returns desktopExchangeCode at the top of the response body', async () => {
+      const response = await POST(createExchangeRequest());
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.desktopExchangeCode).toBe('mock-exchange-code');
+    });
+
+    it('does not return raw session tokens when desktopExchange is set', async () => {
+      const response = await POST(createExchangeRequest());
+      const body = await response.json();
+
+      expect(body.sessionToken).toBeUndefined();
+      expect(body.csrfToken).toBeUndefined();
+      expect(body.deviceToken).toBeUndefined();
+    });
+
+    it('does not set a session cookie on the response when using exchange handoff', async () => {
+      await POST(createExchangeRequest());
+
+      expect(appendSessionCookie).not.toHaveBeenCalled();
+    });
+
+    it('still creates a session and device token (exchange is just the delivery mechanism)', async () => {
+      await POST(createExchangeRequest());
+
+      expect(sessionService.createSession).toHaveBeenCalled();
+      expect(createDeviceToken).toHaveBeenCalledWith(expect.objectContaining({
+        platform: 'desktop',
+        deviceId: 'device-xyz',
+      }));
+    });
+
+    it('returns 400 if desktopExchange is set without deviceId (device token required)', async () => {
+      const response = await POST(
+        new Request('http://localhost/api/auth/passkey/authenticate', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            ...validPayload,
+            platform: 'desktop',
+            desktopExchange: true,
+          }),
+        }),
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toMatch(/device/i);
+      expect(createExchangeCode).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/src/app/api/auth/passkey/authenticate/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/authenticate/__tests__/route.test.ts
@@ -561,6 +561,35 @@ describe('POST /api/auth/passkey/authenticate', () => {
       }));
     });
 
+    it('returns 400 if desktopExchange is set with platform=web (inconsistent request)', async () => {
+      const response = await POST(
+        new Request('http://localhost/api/auth/passkey/authenticate', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            ...validPayload,
+            platform: 'web',
+            deviceId: 'device-xyz',
+            desktopExchange: true,
+          }),
+        }),
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toMatch(/platform/i);
+      expect(createExchangeCode).not.toHaveBeenCalled();
+    });
+
+    it('logs an auth.info entry on successful exchange mint', async () => {
+      await POST(createExchangeRequest());
+
+      expect(loggers.auth.info).toHaveBeenCalledWith(
+        'Desktop passkey exchange mint',
+        expect.objectContaining({ userId: 'user-1', provider: 'passkey' }),
+      );
+    });
+
     it('returns 400 if desktopExchange is set without deviceId (device token required)', async () => {
       const response = await POST(
         new Request('http://localhost/api/auth/passkey/authenticate', {

--- a/apps/web/src/app/api/auth/passkey/authenticate/route.ts
+++ b/apps/web/src/app/api/auth/passkey/authenticate/route.ts
@@ -4,6 +4,7 @@ import {
   verifyAuthentication,
   sessionService,
   generateCSRFToken,
+  createExchangeCode,
   SESSION_DURATION_MS,
 } from '@pagespace/lib/auth';
 import { loggers, auditRequest } from '@pagespace/lib/server';
@@ -24,6 +25,7 @@ const verifySchema = z.object({
   platform: z.enum(['web', 'desktop']).optional().default('web'),
   deviceId: z.string().max(128).optional(),
   deviceName: z.string().optional(),
+  desktopExchange: z.boolean().optional().default(false),
 });
 
 /**
@@ -66,7 +68,14 @@ export async function POST(req: Request) {
       );
     }
 
-    const { response, expectedChallenge, csrfToken, platform, deviceId, deviceName } = validation.data;
+    const { response, expectedChallenge, csrfToken, platform, deviceId, deviceName, desktopExchange } = validation.data;
+
+    if (desktopExchange && !deviceId) {
+      return NextResponse.json(
+        { error: 'deviceId is required for desktop exchange handoff' },
+        { status: 400 }
+      );
+    }
 
     // Verify login CSRF token
     if (!validateLoginCSRFToken(csrfToken)) {
@@ -185,6 +194,37 @@ export async function POST(req: Request) {
           userId, error: error instanceof Error ? error.message : String(error),
         });
       }
+    }
+
+    if (desktopExchange) {
+      if (!deviceTokenValue) {
+        loggers.auth.error('Desktop exchange requested but device token missing', { userId });
+        return NextResponse.json(
+          { error: 'Failed to create device token for desktop exchange' },
+          { status: 500 }
+        );
+      }
+
+      const code = await createExchangeCode({
+        sessionToken,
+        csrfToken: newCsrfToken,
+        deviceToken: deviceTokenValue,
+        provider: 'passkey',
+        userId,
+        createdAt: Date.now(),
+      });
+
+      return NextResponse.json(
+        {
+          success: true,
+          userId,
+          redirectUrl: '/dashboard',
+          desktopExchangeCode: code,
+        },
+        {
+          headers: { 'Cache-Control': 'no-store, no-cache, must-revalidate' },
+        }
+      );
     }
 
     // Build response headers with session cookie

--- a/apps/web/src/app/api/auth/passkey/authenticate/route.ts
+++ b/apps/web/src/app/api/auth/passkey/authenticate/route.ts
@@ -77,6 +77,13 @@ export async function POST(req: Request) {
       );
     }
 
+    if (desktopExchange && platform !== 'desktop') {
+      return NextResponse.json(
+        { error: 'desktopExchange requires platform: desktop' },
+        { status: 400 }
+      );
+    }
+
     // Verify login CSRF token
     if (!validateLoginCSRFToken(csrfToken)) {
       auditRequest(req, {
@@ -213,6 +220,8 @@ export async function POST(req: Request) {
         userId,
         createdAt: Date.now(),
       });
+
+      loggers.auth.info('Desktop passkey exchange mint', { userId, provider: 'passkey' });
 
       return NextResponse.json(
         {

--- a/apps/web/src/app/auth/passkey-external/page.tsx
+++ b/apps/web/src/app/auth/passkey-external/page.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useEffect, useRef, useState } from 'react';
 import { Loader2, ShieldAlert } from 'lucide-react';
-import { AuthShell } from '@/components/auth';
+import { AuthShell } from '@/components/auth/AuthShell';
 import { runPasskeyExternalCeremony } from '@/components/auth/runPasskeyExternalCeremony';
 import { parsePasskeyExternalParams } from '@/components/auth/passkeyExternal';
 

--- a/apps/web/src/app/auth/passkey-external/page.tsx
+++ b/apps/web/src/app/auth/passkey-external/page.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { Suspense, useEffect, useRef, useState } from 'react';
+import { Loader2, ShieldAlert } from 'lucide-react';
+import { AuthShell } from '@/components/auth';
+import { runPasskeyExternalCeremony } from '@/components/auth/runPasskeyExternalCeremony';
+import { parsePasskeyExternalParams } from '@/components/auth/passkeyExternal';
+
+type Status =
+  | { kind: 'running' }
+  | { kind: 'redirecting' }
+  | { kind: 'error'; message: string };
+
+function PasskeyExternalContent() {
+  const [status, setStatus] = useState<Status>({ kind: 'running' });
+  const started = useRef(false);
+
+  useEffect(() => {
+    if (started.current) return;
+    started.current = true;
+
+    const params = parsePasskeyExternalParams(window.location.search);
+    if (!params) {
+      setStatus({ kind: 'error', message: 'Missing desktop device info in the handoff URL.' });
+      return;
+    }
+
+    void runPasskeyExternalCeremony({
+      deviceId: params.deviceId,
+      deviceName: params.deviceName,
+    }).then((result) => {
+      if (result.ok) {
+        setStatus({ kind: 'redirecting' });
+        window.location.href = result.deepLink;
+      } else {
+        setStatus({ kind: 'error', message: result.error });
+      }
+    });
+  }, []);
+
+  return (
+    <AuthShell>
+      <div className="flex flex-col items-center gap-4 py-6 text-center">
+        {status.kind === 'error' ? (
+          <>
+            <ShieldAlert className="h-8 w-8 text-destructive" />
+            <div>
+              <p className="text-sm font-medium text-foreground">Sign-in failed</p>
+              <p className="mt-1 text-xs text-muted-foreground">{status.message}</p>
+              <p className="mt-4 text-xs text-muted-foreground">
+                You can close this window and try again from the desktop app.
+              </p>
+            </div>
+          </>
+        ) : (
+          <>
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            <div>
+              <p className="text-sm font-medium text-foreground">
+                {status.kind === 'redirecting'
+                  ? 'Returning to the desktop app…'
+                  : 'Complete your passkey prompt'}
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Use Touch ID, Windows Hello, or your security key when prompted.
+              </p>
+            </div>
+          </>
+        )}
+      </div>
+    </AuthShell>
+  );
+}
+
+export default function PasskeyExternalPage() {
+  return (
+    <Suspense
+      fallback={
+        <AuthShell>
+          <div className="flex flex-col items-center gap-4 py-6 text-center">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">Preparing passkey prompt…</p>
+          </div>
+        </AuthShell>
+      }
+    >
+      <PasskeyExternalContent />
+    </Suspense>
+  );
+}

--- a/apps/web/src/components/auth/PasskeyLoginButton.tsx
+++ b/apps/web/src/components/auth/PasskeyLoginButton.tsx
@@ -9,7 +9,12 @@ import { cn } from '@/lib/utils';
 import { persistCsrfToken } from '@/lib/utils/persist-csrf-token';
 import { useWebAuthnSupport } from '@/hooks/useWebAuthnSupport';
 import { useAuthStore } from '@/stores/useAuthStore';
-import { getDevicePlatformFields, handleDesktopAuthResponse } from '@/lib/desktop-auth';
+import {
+  getDevicePlatformFields,
+  handleDesktopAuthResponse,
+  isDesktopPlatform,
+} from '@/lib/desktop-auth';
+import { buildPasskeyExternalUrl } from './passkeyExternal';
 
 interface PasskeyLoginButtonProps {
   csrfToken: string;
@@ -40,6 +45,31 @@ export function PasskeyLoginButton({
     setIsAuthenticating(true);
 
     try {
+      // Desktop (Electron): delegate the WebAuthn ceremony to the system
+      // browser via the auth:open-external IPC. Electron's Chromium cannot
+      // drive platform authenticators on macOS without extra entitlements,
+      // so we mirror the OAuth flow: open an external page that runs the
+      // ceremony and hands back a one-time exchange code over the
+      // pagespace:// deep link.
+      if (isDesktopPlatform() && window.electron?.auth?.openExternal) {
+        const fields = await getDevicePlatformFields();
+        if (!('deviceId' in fields) || !fields.deviceId) {
+          toast.error('Could not read desktop device info');
+          return;
+        }
+        const externalUrl = buildPasskeyExternalUrl(window.location.origin, {
+          deviceId: fields.deviceId,
+          deviceName: fields.deviceName,
+        });
+        const result = await window.electron.auth.openExternal(externalUrl);
+        if (!result.success) {
+          toast.error(result.error || 'Failed to open browser for sign-in');
+          return;
+        }
+        toast.info('Complete sign-in in your browser, then return here.');
+        return;
+      }
+
       // Refresh CSRF token to avoid expiry after sitting on the page
       const freshToken = refreshToken ? (await refreshToken() ?? csrfToken) : csrfToken;
 

--- a/apps/web/src/components/auth/__tests__/PasskeyLoginButton.desktop.test.tsx
+++ b/apps/web/src/components/auth/__tests__/PasskeyLoginButton.desktop.test.tsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock('@simplewebauthn/browser', () => ({
+  startAuthentication: vi.fn(),
+}));
+
+vi.mock('@/hooks/useWebAuthnSupport', () => ({
+  useWebAuthnSupport: vi.fn(() => true),
+}));
+
+vi.mock('@/stores/useAuthStore', () => ({
+  useAuthStore: {
+    getState: () => ({ setAuthFailedPermanently: vi.fn() }),
+  },
+}));
+
+vi.mock('@/lib/utils/persist-csrf-token', () => ({
+  persistCsrfToken: vi.fn(),
+}));
+
+vi.mock('@/lib/desktop-auth', () => ({
+  isDesktopPlatform: vi.fn(),
+  getDevicePlatformFields: vi.fn(),
+  handleDesktopAuthResponse: vi.fn(),
+}));
+
+import { PasskeyLoginButton } from '../PasskeyLoginButton';
+import { startAuthentication } from '@simplewebauthn/browser';
+import { isDesktopPlatform, getDevicePlatformFields } from '@/lib/desktop-auth';
+import { toast } from 'sonner';
+
+type ElectronBridge = {
+  isDesktop: boolean;
+  auth: {
+    openExternal: ReturnType<typeof vi.fn>;
+  };
+};
+
+describe('PasskeyLoginButton — desktop external-browser branch', () => {
+  let openExternalMock: ReturnType<typeof vi.fn>;
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(isDesktopPlatform).mockReturnValue(true);
+    vi.mocked(getDevicePlatformFields).mockResolvedValue({
+      platform: 'desktop',
+      deviceId: 'device-xyz',
+      deviceName: 'Jono Mac',
+    });
+
+    openExternalMock = vi.fn().mockResolvedValue({ success: true });
+    const bridge: ElectronBridge = {
+      isDesktop: true,
+      auth: { openExternal: openExternalMock },
+    };
+    (window as unknown as { electron: ElectronBridge }).electron = bridge;
+
+    // Pin origin so the URL assertion is deterministic. jsdom default is
+    // http://localhost:3000 which we still want, but set explicitly.
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: new URL('http://localhost:3000/auth/signin'),
+    });
+
+    fetchSpy = vi.fn();
+    global.fetch = fetchSpy as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    delete (window as unknown as { electron?: ElectronBridge }).electron;
+  });
+
+  it('opens the system browser to /auth/passkey-external with device fields', async () => {
+    render(<PasskeyLoginButton csrfToken="csrf-token-value" />);
+
+    await userEvent.click(screen.getByRole('button', { name: /sign in with passkey/i }));
+
+    expect(openExternalMock).toHaveBeenCalledTimes(1);
+    const [url] = openExternalMock.mock.calls[0];
+    const parsed = new URL(url as string);
+    expect(parsed.pathname).toBe('/auth/passkey-external');
+    expect(parsed.searchParams.get('deviceId')).toBe('device-xyz');
+    expect(parsed.searchParams.get('deviceName')).toBe('Jono Mac');
+  });
+
+  it('does not run the WebAuthn ceremony in the Electron window', async () => {
+    render(<PasskeyLoginButton csrfToken="csrf-token-value" />);
+
+    await userEvent.click(screen.getByRole('button', { name: /sign in with passkey/i }));
+
+    expect(startAuthentication).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch passkey authentication options from the Electron window', async () => {
+    render(<PasskeyLoginButton csrfToken="csrf-token-value" />);
+
+    await userEvent.click(screen.getByRole('button', { name: /sign in with passkey/i }));
+
+    const callsToAuthOptions = fetchSpy.mock.calls.filter(([url]) =>
+      typeof url === 'string' && url.includes('/api/auth/passkey/authenticate/options')
+    );
+    expect(callsToAuthOptions).toHaveLength(0);
+  });
+
+  it('surfaces an error toast if openExternal is rejected by the IPC allowlist', async () => {
+    openExternalMock.mockResolvedValueOnce({
+      success: false,
+      error: 'URL hostname "localhost" is not allowed',
+    });
+
+    render(<PasskeyLoginButton csrfToken="csrf-token-value" />);
+
+    await userEvent.click(screen.getByRole('button', { name: /sign in with passkey/i }));
+
+    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('not allowed'));
+    expect(startAuthentication).not.toHaveBeenCalled();
+  });
+});
+
+describe('PasskeyLoginButton — web path (regression guard)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isDesktopPlatform).mockReturnValue(false);
+    vi.mocked(getDevicePlatformFields).mockResolvedValue({});
+
+    delete (window as unknown as { electron?: ElectronBridge }).electron;
+
+    // Web path still calls fetch; mock it to fail fast after options so the
+    // test does not rely on the full ceremony plumbing.
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: 'Failed to start authentication' }),
+    }) as unknown as typeof fetch;
+  });
+
+  it('still runs the in-browser ceremony path on web (no IPC invoked)', async () => {
+    const { container } = render(<PasskeyLoginButton csrfToken="csrf-token-value" />);
+
+    await userEvent.click(screen.getByRole('button', { name: /sign in with passkey/i }));
+
+    // On web, fetch IS called (for options), and the IPC bridge is never touched.
+    expect((global.fetch as unknown as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith(
+      '/api/auth/passkey/authenticate/options',
+      expect.any(Object),
+    );
+    expect((window as unknown as { electron?: ElectronBridge }).electron).toBeUndefined();
+    // Ensure the component actually mounted (sanity check).
+    expect(container).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/auth/__tests__/passkeyExternal.test.ts
+++ b/apps/web/src/components/auth/__tests__/passkeyExternal.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  buildPasskeyExternalUrl,
+  buildPasskeyExchangeDeepLink,
+  parsePasskeyExternalParams,
+} from '../passkeyExternal';
+
+describe('buildPasskeyExternalUrl', () => {
+  it('builds an /auth/passkey-external URL on the given origin with device fields', () => {
+    const url = buildPasskeyExternalUrl('https://pagespace.ai', {
+      deviceId: 'device-123',
+      deviceName: 'Jono Mac',
+    });
+
+    const parsed = new URL(url);
+    expect(parsed.origin).toBe('https://pagespace.ai');
+    expect(parsed.pathname).toBe('/auth/passkey-external');
+    expect(parsed.searchParams.get('deviceId')).toBe('device-123');
+    expect(parsed.searchParams.get('deviceName')).toBe('Jono Mac');
+  });
+
+  it('encodes device names that contain special characters', () => {
+    const url = buildPasskeyExternalUrl('http://localhost:3000', {
+      deviceId: 'd',
+      deviceName: 'My Mac / Work',
+    });
+
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('deviceName')).toBe('My Mac / Work');
+  });
+
+  it('preserves an http://localhost origin for development builds', () => {
+    const url = buildPasskeyExternalUrl('http://localhost:3000', {
+      deviceId: 'd',
+      deviceName: 'n',
+    });
+
+    expect(url.startsWith('http://localhost:3000/auth/passkey-external')).toBe(true);
+  });
+});
+
+describe('buildPasskeyExchangeDeepLink', () => {
+  it('builds a pagespace://auth-exchange deep link with code and passkey provider', () => {
+    const url = buildPasskeyExchangeDeepLink('abc123');
+
+    expect(url).toContain('pagespace://auth-exchange');
+    expect(url).toContain('code=abc123');
+    expect(url).toContain('provider=passkey');
+  });
+
+  it('uri-encodes exchange codes that contain reserved characters', () => {
+    const url = buildPasskeyExchangeDeepLink('a+b/c=');
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('code')).toBe('a+b/c=');
+    expect(parsed.searchParams.get('provider')).toBe('passkey');
+  });
+});
+
+describe('parsePasskeyExternalParams', () => {
+  it('returns deviceId and deviceName when both are present', () => {
+    expect(parsePasskeyExternalParams('?deviceId=d-1&deviceName=Mac')).toEqual({
+      deviceId: 'd-1',
+      deviceName: 'Mac',
+    });
+  });
+
+  it('returns null when deviceId is missing', () => {
+    expect(parsePasskeyExternalParams('?deviceName=Mac')).toBeNull();
+  });
+
+  it('returns null when deviceName is missing', () => {
+    expect(parsePasskeyExternalParams('?deviceId=d-1')).toBeNull();
+  });
+
+  it('returns null for empty search string', () => {
+    expect(parsePasskeyExternalParams('')).toBeNull();
+  });
+});

--- a/apps/web/src/components/auth/__tests__/runPasskeyExternalCeremony.test.ts
+++ b/apps/web/src/components/auth/__tests__/runPasskeyExternalCeremony.test.ts
@@ -10,7 +10,7 @@ import { runPasskeyExternalCeremony } from '../runPasskeyExternalCeremony';
 const authResponse = { id: 'cred-1', rawId: 'raw', type: 'public-key' };
 
 function mockFetch(handlers: Record<string, () => Response | Promise<Response>>) {
-  return vi.fn(async (input: unknown) => {
+  return vi.fn(async (input: unknown, _init?: unknown) => {
     const url = typeof input === 'string' ? input : (input as Request).url;
     for (const [pattern, handler] of Object.entries(handlers)) {
       if (url.includes(pattern)) return handler();
@@ -71,11 +71,12 @@ describe('runPasskeyExternalCeremony', () => {
       fetchImpl: fetchImpl as unknown as typeof fetch,
     });
 
-    const verifyCall = fetchImpl.mock.calls.find(([url]) =>
-      typeof url === 'string' && url === '/api/auth/passkey/authenticate'
+    const verifyCall = fetchImpl.mock.calls.find(
+      (call) => typeof call[0] === 'string' && call[0] === '/api/auth/passkey/authenticate',
     );
     expect(verifyCall).toBeDefined();
-    const body = JSON.parse((verifyCall![1] as RequestInit).body as string);
+    const init = verifyCall![1] as RequestInit;
+    const body = JSON.parse(init.body as string);
     expect(body).toMatchObject({
       platform: 'desktop',
       deviceId: 'device-xyz',

--- a/apps/web/src/components/auth/__tests__/runPasskeyExternalCeremony.test.ts
+++ b/apps/web/src/components/auth/__tests__/runPasskeyExternalCeremony.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@simplewebauthn/browser', () => ({
+  startAuthentication: vi.fn(),
+}));
+
+import { startAuthentication } from '@simplewebauthn/browser';
+import { runPasskeyExternalCeremony } from '../runPasskeyExternalCeremony';
+
+const authResponse = { id: 'cred-1', rawId: 'raw', type: 'public-key' };
+
+function mockFetch(handlers: Record<string, () => Response | Promise<Response>>) {
+  return vi.fn(async (input: unknown) => {
+    const url = typeof input === 'string' ? input : (input as Request).url;
+    for (const [pattern, handler] of Object.entries(handlers)) {
+      if (url.includes(pattern)) return handler();
+    }
+    throw new Error(`Unmocked fetch: ${url}`);
+  });
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('runPasskeyExternalCeremony', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(startAuthentication).mockResolvedValue(
+      authResponse as unknown as Awaited<ReturnType<typeof startAuthentication>>,
+    );
+  });
+
+  it('runs login-csrf → options → startAuthentication → verify → returns exchange deep link', async () => {
+    const fetchImpl = mockFetch({
+      '/api/auth/login-csrf': () => jsonResponse({ csrfToken: 'csrf-abc' }),
+      '/api/auth/passkey/authenticate/options': () =>
+        jsonResponse({ options: { challenge: 'chal-1', allowCredentials: [] } }),
+      '/api/auth/passkey/authenticate': () =>
+        jsonResponse({ success: true, desktopExchangeCode: 'exchange-xyz' }),
+    });
+
+    const result = await runPasskeyExternalCeremony({
+      deviceId: 'device-xyz',
+      deviceName: 'Jono Mac',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.deepLink).toContain('pagespace://auth-exchange');
+    expect(result.deepLink).toContain('code=exchange-xyz');
+    expect(result.deepLink).toContain('provider=passkey');
+  });
+
+  it('sends desktopExchange=true and device fields to the verify endpoint', async () => {
+    const fetchImpl = mockFetch({
+      '/api/auth/login-csrf': () => jsonResponse({ csrfToken: 'csrf-abc' }),
+      '/api/auth/passkey/authenticate/options': () =>
+        jsonResponse({ options: { challenge: 'chal-1' } }),
+      '/api/auth/passkey/authenticate': () =>
+        jsonResponse({ success: true, desktopExchangeCode: 'code-1' }),
+    });
+
+    await runPasskeyExternalCeremony({
+      deviceId: 'device-xyz',
+      deviceName: 'Jono Mac',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const verifyCall = fetchImpl.mock.calls.find(([url]) =>
+      typeof url === 'string' && url === '/api/auth/passkey/authenticate'
+    );
+    expect(verifyCall).toBeDefined();
+    const body = JSON.parse((verifyCall![1] as RequestInit).body as string);
+    expect(body).toMatchObject({
+      platform: 'desktop',
+      deviceId: 'device-xyz',
+      deviceName: 'Jono Mac',
+      desktopExchange: true,
+      expectedChallenge: 'chal-1',
+      csrfToken: 'csrf-abc',
+    });
+    expect(body.response).toEqual(authResponse);
+  });
+
+  it('returns an error result when the CSRF fetch fails', async () => {
+    const fetchImpl = mockFetch({
+      '/api/auth/login-csrf': () =>
+        jsonResponse({ error: 'server error' }, 500),
+    });
+
+    const result = await runPasskeyExternalCeremony({
+      deviceId: 'd',
+      deviceName: 'n',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected error');
+    expect(result.error).toMatch(/csrf/i);
+    expect(startAuthentication).not.toHaveBeenCalled();
+  });
+
+  it('returns an error result when the options fetch fails', async () => {
+    const fetchImpl = mockFetch({
+      '/api/auth/login-csrf': () => jsonResponse({ csrfToken: 'csrf-abc' }),
+      '/api/auth/passkey/authenticate/options': () =>
+        jsonResponse({ error: 'rate limited' }, 429),
+    });
+
+    const result = await runPasskeyExternalCeremony({
+      deviceId: 'd',
+      deviceName: 'n',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected error');
+    expect(result.error).toMatch(/rate limited/i);
+    expect(startAuthentication).not.toHaveBeenCalled();
+  });
+
+  it('returns an error result when the verify response lacks desktopExchangeCode', async () => {
+    const fetchImpl = mockFetch({
+      '/api/auth/login-csrf': () => jsonResponse({ csrfToken: 'csrf-abc' }),
+      '/api/auth/passkey/authenticate/options': () =>
+        jsonResponse({ options: { challenge: 'c' } }),
+      '/api/auth/passkey/authenticate': () =>
+        jsonResponse({ success: true }),
+    });
+
+    const result = await runPasskeyExternalCeremony({
+      deviceId: 'd',
+      deviceName: 'n',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected error');
+    expect(result.error).toMatch(/exchange/i);
+  });
+
+  it('returns an error result when startAuthentication is cancelled by the user', async () => {
+    vi.mocked(startAuthentication).mockRejectedValueOnce(
+      Object.assign(new Error('The operation either timed out or was not allowed'), {
+        name: 'NotAllowedError',
+      }),
+    );
+
+    const fetchImpl = mockFetch({
+      '/api/auth/login-csrf': () => jsonResponse({ csrfToken: 'csrf-abc' }),
+      '/api/auth/passkey/authenticate/options': () =>
+        jsonResponse({ options: { challenge: 'c' } }),
+    });
+
+    const result = await runPasskeyExternalCeremony({
+      deviceId: 'd',
+      deviceName: 'n',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected error');
+    expect(result.error).toMatch(/cancel/i);
+  });
+});

--- a/apps/web/src/components/auth/passkeyExternal.ts
+++ b/apps/web/src/components/auth/passkeyExternal.ts
@@ -1,0 +1,33 @@
+export interface PasskeyExternalDeviceFields {
+  deviceId: string;
+  deviceName: string;
+}
+
+const PASSKEY_EXTERNAL_PATH = '/auth/passkey-external';
+
+export function buildPasskeyExternalUrl(
+  origin: string,
+  { deviceId, deviceName }: PasskeyExternalDeviceFields,
+): string {
+  const url = new URL(PASSKEY_EXTERNAL_PATH, origin);
+  url.searchParams.set('deviceId', deviceId);
+  url.searchParams.set('deviceName', deviceName);
+  return url.toString();
+}
+
+export function buildPasskeyExchangeDeepLink(exchangeCode: string): string {
+  const url = new URL('pagespace://auth-exchange');
+  url.searchParams.set('code', exchangeCode);
+  url.searchParams.set('provider', 'passkey');
+  return url.toString();
+}
+
+export function parsePasskeyExternalParams(
+  search: string,
+): PasskeyExternalDeviceFields | null {
+  const params = new URLSearchParams(search);
+  const deviceId = params.get('deviceId');
+  const deviceName = params.get('deviceName');
+  if (!deviceId || !deviceName) return null;
+  return { deviceId, deviceName };
+}

--- a/apps/web/src/components/auth/runPasskeyExternalCeremony.ts
+++ b/apps/web/src/components/auth/runPasskeyExternalCeremony.ts
@@ -1,0 +1,82 @@
+import { startAuthentication } from '@simplewebauthn/browser';
+import { buildPasskeyExchangeDeepLink } from './passkeyExternal';
+
+export interface RunPasskeyExternalCeremonyInput {
+  deviceId: string;
+  deviceName: string;
+  fetchImpl?: typeof fetch;
+}
+
+export type RunPasskeyExternalCeremonyResult =
+  | { ok: true; deepLink: string }
+  | { ok: false; error: string };
+
+async function readError(res: Response, fallback: string): Promise<string> {
+  try {
+    const body = (await res.json()) as { error?: string };
+    return body.error || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export async function runPasskeyExternalCeremony(
+  input: RunPasskeyExternalCeremonyInput,
+): Promise<RunPasskeyExternalCeremonyResult> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+
+  const csrfRes = await fetchImpl('/api/auth/login-csrf', { method: 'GET' });
+  if (!csrfRes.ok) {
+    const detail = await readError(csrfRes, 'Failed to fetch CSRF token');
+    return { ok: false, error: `CSRF request failed: ${detail}` };
+  }
+  const { csrfToken } = (await csrfRes.json()) as { csrfToken: string };
+
+  const optionsRes = await fetchImpl('/api/auth/passkey/authenticate/options', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ csrfToken }),
+  });
+  if (!optionsRes.ok) {
+    return { ok: false, error: await readError(optionsRes, 'Failed to fetch passkey options') };
+  }
+  const { options } = (await optionsRes.json()) as {
+    options: { challenge: string; allowCredentials?: unknown[] };
+  };
+
+  let authResponse: Awaited<ReturnType<typeof startAuthentication>>;
+  try {
+    authResponse = await startAuthentication({ optionsJSON: options });
+  } catch (err) {
+    if (err instanceof Error && err.name === 'NotAllowedError') {
+      return { ok: false, error: 'Authentication was cancelled' };
+    }
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : 'Authentication failed',
+    };
+  }
+
+  const verifyRes = await fetchImpl('/api/auth/passkey/authenticate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      response: authResponse,
+      expectedChallenge: options.challenge,
+      csrfToken,
+      platform: 'desktop',
+      deviceId: input.deviceId,
+      deviceName: input.deviceName,
+      desktopExchange: true,
+    }),
+  });
+  if (!verifyRes.ok) {
+    return { ok: false, error: await readError(verifyRes, 'Authentication failed') };
+  }
+  const verifyBody = (await verifyRes.json()) as { desktopExchangeCode?: string };
+  if (!verifyBody.desktopExchangeCode) {
+    return { ok: false, error: 'Missing desktop exchange code in response' };
+  }
+
+  return { ok: true, deepLink: buildPasskeyExchangeDeepLink(verifyBody.desktopExchangeCode) };
+}

--- a/apps/web/src/components/auth/runPasskeyExternalCeremony.ts
+++ b/apps/web/src/components/auth/runPasskeyExternalCeremony.ts
@@ -41,12 +41,14 @@ export async function runPasskeyExternalCeremony(
     return { ok: false, error: await readError(optionsRes, 'Failed to fetch passkey options') };
   }
   const { options } = (await optionsRes.json()) as {
-    options: { challenge: string; allowCredentials?: unknown[] };
+    options: { challenge: string };
   };
 
   let authResponse: Awaited<ReturnType<typeof startAuthentication>>;
   try {
-    authResponse = await startAuthentication({ optionsJSON: options });
+    authResponse = await startAuthentication({
+      optionsJSON: options as unknown as Parameters<typeof startAuthentication>[0]['optionsJSON'],
+    });
   } catch (err) {
     if (err instanceof Error && err.name === 'NotAllowedError') {
       return { ok: false, error: 'Authentication was cancelled' };


### PR DESCRIPTION
## Summary

Electron 33's bundled Chromium silently no-ops the WebAuthn ceremony on macOS (no Touch ID dialog, nothing) and our entitlements plist has no WebAuthn-related entries. PR #833 fixed desktop *session persistence* after a successful ceremony but did not make the ceremony itself fire inside the Electron BrowserWindow.

This PR stops trying to run the ceremony in Electron and **delegates it to the system browser**, mirroring the OAuth flow that already works via `auth:open-external` + `pagespace://auth-exchange`. Safari/Chrome on the user's machine handle platform authenticators correctly, and the existing exchange-code + deep-link infrastructure from PR #833 carries the session back to Electron.

Sub-task 4 of 4 in the passkey signin fix epic (plan: `.claude/plans/distributed-plotting-ritchie.md`). Sub-tasks 1 and 2 land in parallel — this PR deliberately does not touch any files those sub-tasks own.

**Preserves OAuth and magic link desktop flows unchanged — reuses PR #833 infrastructure.**

## Changes

- `apps/web/src/components/auth/passkeyExternal.ts` — pure URL/deep-link helpers (`buildPasskeyExternalUrl`, `buildPasskeyExchangeDeepLink`, `parsePasskeyExternalParams`).
- `apps/web/src/components/auth/runPasskeyExternalCeremony.ts` — pure async helper that runs the CSRF → options → `startAuthentication` → verify → deep-link flow. Takes `fetch` as a dependency for clean unit testing.
- `apps/web/src/app/auth/passkey-external/page.tsx` — thin client route the system browser opens. Calls the ceremony helper and redirects to the returned `pagespace://auth-exchange` deep link on success.
- `apps/web/src/components/auth/PasskeyLoginButton.tsx` — new desktop branch at the top of `handleLogin`: when `isDesktopPlatform()` and the IPC bridge is present, invoke `window.electron.auth.openExternal` with the passkey-external URL and return early, so `startAuthentication` never fires inside Electron. Web behavior is untouched.
- `apps/web/src/app/api/auth/passkey/authenticate/route.ts` — new `desktopExchange` flag. When set (plus `platform: 'desktop'` + `deviceId`), the route mints a one-time `createExchangeCode` and returns only `desktopExchangeCode` — no raw session tokens in the body, no session cookie on the response. Mirrors the Google/Apple OAuth callback desktop path.
- `apps/desktop/src/main/ipc-handlers.ts` — `auth:open-external` allowlist now permits the configured app origin on the `/auth/passkey-external` path. HTTPS always allowed, HTTP only for `localhost`/`127.0.0.1` dev builds. Hostname AND port must match exactly so lookalike hosts (`pagespace.ai.evil.com`) are rejected. Other paths on the app origin and other hostnames remain blocked.
- No change to `deep-links.ts` — the `pagespace://auth-exchange?code=…&provider=…` handler is already generic and accepts any provider tag, so the passkey-origin exchange just piggybacks on it.

## Commit map

Every change landed as a RED test before the GREEN implementation, with one commit per phase.

| RED | GREEN |
| --- | --- |
| `03e05273` passkeyExternal helpers | `d1f6b50b` passkeyExternal helpers |
| `40abe346` desktopExchange on authenticate route | `d48989d2` desktopExchange on authenticate route |
| `2a4ec22a` PasskeyLoginButton desktop branch | `735435d7` PasskeyLoginButton desktop branch |
| `2ff65fd7` runPasskeyExternalCeremony helper | `a9d02eb7` runPasskeyExternalCeremony helper |
| —   | `851f1ffe` /auth/passkey-external route page |
| `c5697b9c` auth:open-external app-origin allowlist | `9cfe9f54` auth:open-external app-origin allowlist |
| —   | `584af539` import AuthShell directly to bypass broken barrel transitive |

## Verification

- `pnpm --filter web test src/components/auth src/app/api/auth/passkey` → **184 / 184 ✅**
- `pnpm --filter web test src/app/api/auth/google src/app/api/auth/magic-link` → **258 / 258 ✅** (OAuth + magic link regression)
- `pnpm --filter desktop test src/main/__tests__/ipc-handlers.test.ts` → **16 / 16 ✅**
- `pnpm --filter desktop typecheck` → clean
- `pnpm --filter web typecheck` — only errors are pre-existing `@pagespace/lib/*` subpath baseline issues present on `master` (unrelated to this PR).
- `pnpm --filter web build` — only errors are pre-existing `@pagespace/lib/client-safe` baseline issues present on `master` (confirmed with a scratch `git stash` + checkout of `master`'s `signin/page.tsx` → same failures). Sub-task 1 will clean the last transitive dep on `signin/page.tsx` as part of its epic work.
- `pnpm --filter web lint` — clean for touched files (only pre-existing warnings in `CalendarView.tsx`).

## Manual test plan

Run after merge (requires a built Electron binary, which is not available inside the agent session):

- [ ] `pnpm dev:desktop` → click **Sign in with Passkey** on the signin page.
- [ ] Default system browser opens at `/auth/passkey-external?deviceId=…&deviceName=…`.
- [ ] Touch ID / Windows Hello prompts.
- [ ] Browser redirects to `pagespace://auth-exchange?code=…&provider=passkey`.
- [ ] Electron picks up the deep link, exchanges the code via `/api/auth/desktop/exchange`, and the main window reloads signed in.
- [ ] Regression: Google OAuth, Apple OAuth, and magic link desktop flows still work unchanged (PR #833 baseline).
- [ ] Regression: web passkey signin still runs the in-browser ceremony with no IPC involvement.

## Out of scope

- Upgrading Electron or adding WebAuthn entitlements to the mac plist. External-browser delegation is the fix.
- Deleting `useConditionalPasskeyUI` / `conditionalPasskeyCeremony` — sub-task 1's territory.
- Adding `hints: ['client-device']` to registration options — sub-task 2's territory.
- Existing passkey row cleanup — sub-task 3 (runbook step after 1+2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)