### PR TITLE
fix(sw): stop owning top-level navigations — restores desktop OAuth callback

### DIFF
--- a/apps/web/public/sw-router.js
+++ b/apps/web/public/sw-router.js
@@ -1,0 +1,89 @@
+/**
+ * PageSpace service worker routing classifier.
+ *
+ * Pure decision function extracted from sw.js so it can be unit-tested
+ * without faking FetchEvent. Consumed two ways:
+ *   - In the service worker via importScripts('/sw-router.js'), which
+ *     attaches classifyRequest to `self`.
+ *   - In vitest via `import { classifyRequest } from '../../public/sw-router.js'`,
+ *     which reads the CommonJS module.exports assignment below.
+ *
+ * The classifier encodes three layered invariants, in order of strength:
+ *   1. The service worker must not own top-level navigations. Requests
+ *      with `request.mode === 'navigate'` are the browser's business —
+ *      OAuth callbacks, redirects to custom schemes like pagespace://,
+ *      and normal page loads must remain browser-owned so native scheme
+ *      dispatch and redirect following work correctly.
+ *   2. Service workers must not sit in the credential-exchange redirect
+ *      path. Auth routes redirect to custom schemes; rule 1 keeps them
+ *      browser-owned mechanically rather than via a path allowlist.
+ *   3. "API" to the SW means XHR/fetch from the running SPA, not a
+ *      top-level navigation. Encoded via request mode, not path prefix.
+ */
+
+/**
+ * @typedef {(
+ *   | 'not-intercepted'
+ *   | 'native-pass-through'
+ *   | 'api-network-first'
+ *   | 'cache-first'
+ *   | 'network-first'
+ * )} RouteClassification
+ */
+
+/**
+ * @param {string} pathname
+ * @returns {boolean}
+ */
+function isStaticAssetPath(pathname) {
+  const staticExtensions = [
+    '.png',
+    '.jpg',
+    '.jpeg',
+    '.gif',
+    '.svg',
+    '.ico',
+    '.woff',
+    '.woff2',
+    '.ttf',
+    '.eot',
+  ];
+  return staticExtensions.some((ext) => pathname.endsWith(ext));
+}
+
+/**
+ * @param {{ mode: string, method: string, url: string }} input
+ * @returns {RouteClassification}
+ */
+function classifyRequest(input) {
+  const { mode, method, url } = input;
+
+  if (method !== 'GET') return 'not-intercepted';
+
+  // Rule 1 enforcement: top-level navigations bypass the SW entirely.
+  // A path-based allowlist would silently break future non-auth
+  // navigations under /api/; mode is the semantic boundary.
+  if (mode === 'navigate') return 'native-pass-through';
+
+  const parsed = new URL(url, 'http://localhost');
+
+  // Next.js runtime chunks: let the browser fetch directly to avoid
+  // stale bundle mismatches after deploys.
+  if (parsed.pathname.startsWith('/_next/')) return 'native-pass-through';
+
+  // Rule 3: any remaining /api/ request is an in-app XHR, safe for
+  // network-first-with-cache. Navigations were peeled off above.
+  if (parsed.pathname.startsWith('/api/')) return 'api-network-first';
+
+  if (isStaticAssetPath(parsed.pathname)) return 'cache-first';
+
+  return 'network-first';
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { classifyRequest, isStaticAssetPath };
+}
+if (typeof self !== 'undefined') {
+  self.classifyRequest = classifyRequest;
+  self.isStaticAssetPath = isStaticAssetPath;
+}

--- a/apps/web/public/sw-router.js
+++ b/apps/web/public/sw-router.js
@@ -65,6 +65,8 @@ function classifyRequest(input) {
   // navigations under /api/; mode is the semantic boundary.
   if (mode === 'navigate') return 'native-pass-through';
 
+  // Base is only consulted by unit tests that pass relative-ish URLs;
+  // production SW callers always pass absolute same-origin URLs.
   const parsed = new URL(url, 'http://localhost');
 
   // Next.js runtime chunks: let the browser fetch directly to avoid
@@ -77,6 +79,8 @@ function classifyRequest(input) {
 
   if (isStaticAssetPath(parsed.pathname)) return 'cache-first';
 
+  // Next.js RSC/prefetch headers are handled inside sw.js's
+  // network-first branch, not here — the classifier is header-agnostic.
   return 'network-first';
 }
 
@@ -85,5 +89,4 @@ if (typeof module !== 'undefined' && module.exports) {
 }
 if (typeof self !== 'undefined') {
   self.classifyRequest = classifyRequest;
-  self.isStaticAssetPath = isStaticAssetPath;
 }

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -3,10 +3,17 @@
  *
  * Provides offline caching for recently viewed pages and static assets.
  * Uses network-first strategy for API data, cache-first for static assets.
+ *
+ * Routing is delegated to classifyRequest in sw-router.js so the decision
+ * logic can be unit-tested in isolation. See that file for the layered
+ * invariants this SW enforces — in particular, the rule that top-level
+ * navigations must not be owned by the service worker.
  */
 
-const CACHE_NAME = 'pagespace-v2';
-const STATIC_CACHE_NAME = 'pagespace-static-v2';
+importScripts('/sw-router.js');
+
+const CACHE_NAME = 'pagespace-v3';
+const STATIC_CACHE_NAME = 'pagespace-static-v3';
 
 // Core pages to cache for offline access
 const OFFLINE_URLS = ['/', '/offline'];
@@ -48,53 +55,70 @@ self.addEventListener('activate', (event) => {
 // Fetch event - handle requests
 self.addEventListener('fetch', (event) => {
   const { request } = event;
-  const url = new URL(request.url);
 
   // Only handle GET requests
   if (request.method !== 'GET') return;
 
   // Skip cross-origin requests
+  const url = new URL(request.url);
   if (url.origin !== self.location.origin) return;
 
-  // Let the browser handle Next.js build assets directly.
-  // Avoid SW-managed cache for runtime chunks to prevent stale bundle mismatches.
-  if (url.pathname.startsWith('/_next/')) return;
+  const classification = self.classifyRequest({
+    mode: request.mode,
+    method: request.method,
+    url: request.url,
+  });
 
-  // API requests: network-first with cache fallback
-  if (url.pathname.startsWith('/api/')) {
-    event.respondWith(networkFirstWithCache(request));
-    return;
+  switch (classification) {
+    case 'not-intercepted':
+    case 'native-pass-through':
+      // Returning without calling event.respondWith hands the request
+      // back to the browser. This is operationally different from
+      // event.respondWith(fetch(request)): that would move redirect
+      // following into the fetch API, which cannot dispatch to custom
+      // schemes like pagespace:// and would break desktop OAuth.
+      return;
+
+    case 'api-network-first':
+      event.respondWith(networkFirstWithCache(request));
+      return;
+
+    case 'cache-first':
+      event.respondWith(cacheFirstWithNetwork(request));
+      return;
+
+    case 'network-first': {
+      // Next.js RSC (React Server Component) flight data and prefetch
+      // requests must NEVER be cache-first — same URL serves different
+      // content based on headers, and payloads become stale after
+      // deploys.
+      if (
+        request.headers.get('rsc') ||
+        request.headers.get('next-router-prefetch') ||
+        request.headers.get('next-router-state-tree') ||
+        request.headers.get('next-url')
+      ) {
+        event.respondWith(
+          fetch(request).catch(
+            () => new Response('', { status: 503, statusText: 'Service Unavailable' })
+          )
+        );
+        return;
+      }
+
+      // HTML pages with network-first + offline fallback. Note that
+      // top-level HTML navigations never reach this branch — they are
+      // classified 'native-pass-through' by rule 1 above. This branch
+      // handles non-navigate HTML sub-requests (e.g. iframe loads).
+      if (request.headers.get('accept')?.includes('text/html')) {
+        event.respondWith(networkFirstWithOfflineFallback(request));
+        return;
+      }
+
+      event.respondWith(networkFirstWithCache(request));
+      return;
+    }
   }
-
-  // Next.js RSC (React Server Component) flight data and prefetch requests
-  // must NEVER be cache-first — same URL serves different content based on
-  // headers, and payloads become stale after deploys.
-  if (request.headers.get('rsc') ||
-      request.headers.get('next-router-prefetch') ||
-      request.headers.get('next-router-state-tree') ||
-      request.headers.get('next-url')) {
-    event.respondWith(
-      fetch(request).catch(() =>
-        new Response('', { status: 503, statusText: 'Service Unavailable' })
-      )
-    );
-    return;
-  }
-
-  // Static assets (fonts, images): cache-first
-  if (isStaticAsset(url.pathname)) {
-    event.respondWith(cacheFirstWithNetwork(request));
-    return;
-  }
-
-  // HTML pages: network-first, fallback to offline page
-  if (request.headers.get('accept')?.includes('text/html')) {
-    event.respondWith(networkFirstWithOfflineFallback(request));
-    return;
-  }
-
-  // Everything else: network-first to avoid serving stale dynamic content
-  event.respondWith(networkFirstWithCache(request));
 });
 
 /**
@@ -168,25 +192,6 @@ async function networkFirstWithOfflineFallback(request) {
       headers: { 'Content-Type': 'text/plain' },
     });
   }
-}
-
-/**
- * Check if URL is a static asset.
- */
-function isStaticAsset(pathname) {
-  const staticExtensions = [
-    '.png',
-    '.jpg',
-    '.jpeg',
-    '.gif',
-    '.svg',
-    '.ico',
-    '.woff',
-    '.woff2',
-    '.ttf',
-    '.eot',
-  ];
-  return staticExtensions.some((ext) => pathname.endsWith(ext));
 }
 
 // Listen for messages from the app with origin verification

--- a/apps/web/src/__tests__/fetch-custom-scheme-redirect.test.ts
+++ b/apps/web/src/__tests__/fetch-custom-scheme-redirect.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @mechanism-evidence
+ *
+ * Documents the runtime behavior the sw-router fix relies on: when
+ * fetch() encounters a 3xx Location pointing at a custom scheme like
+ * pagespace://, the returned response is not a normal 2xx that a
+ * service worker could hand back as the result of a top-level
+ * navigation. This is the reason desktop Google OAuth was landing on a
+ * synthetic `{"error":"offline"}` JSON body: sw.js was catching the
+ * resulting error and returning that response from its /api/* handler.
+ *
+ * The navigation-mode invariant in sw-router.js is robust regardless of
+ * exactly how fetch fails here — Chrome/Firefox tend to reject with
+ * TypeError, other runtimes may return opaqueredirect. Both fail the
+ * needs of a service worker trying to synthesize a navigation result.
+ * This test records what we actually observe in the test runtime.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+describe('@mechanism-evidence: fetch() redirecting to a custom scheme', () => {
+  let server: Server;
+  let port: number;
+
+  beforeAll(async () => {
+    server = createServer((_req, res) => {
+      res.writeHead(302, { Location: 'pagespace://auth-exchange?code=test' });
+      res.end();
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', () => resolve());
+    });
+    const address = server.address() as AddressInfo;
+    port = address.port;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  test('fetch() cannot produce a follow-through 2xx response', async () => {
+    let result: 'threw' | 'ok-2xx' | 'other-status' = 'other-status';
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/`);
+      if (res.ok) {
+        result = 'ok-2xx';
+      }
+    } catch {
+      result = 'threw';
+    }
+
+    // Whether the runtime throws or returns a non-ok response, the
+    // invariant holds: a service worker cannot obtain a normal 2xx
+    // response to hand back as the navigation result. The sw-router
+    // fix therefore routes navigations around fetch() entirely.
+    expect(result).not.toBe('ok-2xx');
+  });
+});

--- a/apps/web/src/__tests__/sw-router.test.ts
+++ b/apps/web/src/__tests__/sw-router.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Service worker routing classifier tests.
+ *
+ * These tests exercise the pure decision function that the SW's fetch
+ * handler delegates to. They prove three layered invariants, in order of
+ * strength:
+ *
+ *   1. The service worker must not own top-level navigations. Requests
+ *      with `request.mode === 'navigate'` are the browser's business —
+ *      OAuth callbacks, redirects to custom schemes, normal page loads.
+ *   2. Service workers must not sit in the credential-exchange redirect
+ *      path. Auth routes redirect to custom schemes; they must always
+ *      remain browser-owned. Rule 1 enforces this mechanically.
+ *   3. "API" to the SW means XHR/fetch from the running SPA, not a
+ *      top-level navigation. Encoded via request mode, not path prefix.
+ */
+
+import { describe, test, expect } from 'vitest';
+import { classifyRequest } from '../../public/sw-router.js';
+
+describe('sw-router classifyRequest', () => {
+  test('rule 1: top-level navigation to an OAuth callback is native-pass-through', () => {
+    // Given a top-level navigation to /api/auth/google/callback?code=x,
+    // should be classified as native-pass-through so the browser can
+    // natively follow the redirect to pagespace://auth-exchange.
+    expect(
+      classifyRequest({
+        mode: 'navigate',
+        method: 'GET',
+        url: 'http://localhost/api/auth/google/callback?code=x',
+      })
+    ).toBe('native-pass-through');
+  });
+
+  test('rule 1 generalizes beyond auth: any navigation is native-pass-through', () => {
+    // Given a top-level navigation to /dashboard, should be
+    // native-pass-through. The invariant is mode-based, not path-based —
+    // a path-based fix would silently break future non-auth navigations
+    // that happen to land on a path under /api/.
+    expect(
+      classifyRequest({
+        mode: 'navigate',
+        method: 'GET',
+        url: 'http://localhost/dashboard',
+      })
+    ).toBe('native-pass-through');
+  });
+
+  test('rule 3: SPA XHR to /api/pages is still api-network-first', () => {
+    // Given a CORS-mode GET to /api/pages/123 (an XHR from the running
+    // app), should still use the api-network-first strategy — SPA data
+    // fetches remain network-first with cache fallback.
+    expect(
+      classifyRequest({
+        mode: 'cors',
+        method: 'GET',
+        url: 'http://localhost/api/pages/123',
+      })
+    ).toBe('api-network-first');
+  });
+
+  test('/_next/ requests remain native pass-through', () => {
+    // Given a GET to /_next/static/chunks/main.js, should be
+    // native-pass-through. Preserved behavior: SW-managed cache on
+    // runtime chunks causes stale bundle mismatches after deploys.
+    expect(
+      classifyRequest({
+        mode: 'no-cors',
+        method: 'GET',
+        url: 'http://localhost/_next/static/chunks/main.js',
+      })
+    ).toBe('native-pass-through');
+  });
+
+  test('static asset GETs are cache-first', () => {
+    // Given a GET to /favicon-32x32.png, should be cache-first —
+    // images, fonts, icons rarely change and are safe to serve from
+    // cache before the network.
+    expect(
+      classifyRequest({
+        mode: 'no-cors',
+        method: 'GET',
+        url: 'http://localhost/favicon-32x32.png',
+      })
+    ).toBe('cache-first');
+  });
+
+  test('other same-origin GETs fall through to network-first', () => {
+    // Given a CORS-mode GET to /some-page (not /api/, not /_next/, not a
+    // static asset), should be network-first so the SW still provides an
+    // offline cache for pages and dynamic assets.
+    expect(
+      classifyRequest({
+        mode: 'cors',
+        method: 'GET',
+        url: 'http://localhost/some-page',
+      })
+    ).toBe('network-first');
+  });
+
+  test('non-GET is never intercepted', () => {
+    // Given a POST to /api/auth/passkey/authenticate, should be
+    // not-intercepted. The fetch handler itself skips non-GET before
+    // reaching the classifier; we encode the rule here so the full
+    // decision surface is testable and future code can trust it.
+    expect(
+      classifyRequest({
+        mode: 'cors',
+        method: 'POST',
+        url: 'http://localhost/api/auth/passkey/authenticate',
+      })
+    ).toBe('not-intercepted');
+  });
+});


### PR DESCRIPTION
## Summary

Desktop Google OAuth was rendering `{"error":"offline","message":"You are offline"}` as a JSON page body after completing sign-in at Google. The service worker was intercepting the top-level callback navigation, attempting to `fetch()` the redirect, and returning a synthetic 503 JSON body because the server's response is a redirect to a `pagespace://` custom-scheme URL that `fetch()` cannot follow.

This is one instance of a broader class of bug: the SW assumed every `GET /api/*` is an XHR from the running SPA, when the browser can also perform a **top-level navigation** through those paths as part of an OAuth redirect chain. That's the browser's business, not the SW's.

## Observed vs hypothesis

### Observed (verified by code reading)
- The offline JSON exists in exactly one place: `apps/web/public/sw.js` inside the `catch` of `networkFirstWithCache`.
- `networkFirstWithCache` is selected for every same-origin GET whose pathname starts with `/api/`.
- The OAuth callback at `apps/web/src/app/api/auth/google/callback/route.ts:304` returns `NextResponse.redirect('pagespace://auth-exchange?code=...')` on the desktop branch. No code path returns JSON.

### Hypothesis (documented, not yet verified in a real desktop browser)
- When `fetch()` with `redirect: 'follow'` encounters a 3xx `Location: pagespace://...`, it throws instead of returning an opaque redirect. The mechanism-evidence test records what we observe in the Node test runtime; real-browser behavior is a follow-up.

### The invariant holds even if the mechanism hypothesis is wrong
The right fix is not \"catch the specific fetch error\" or \"bypass `/api/auth/` paths.\" The right fix is: **the service worker must not own top-level navigations**. `request.mode === 'navigate'` is the semantic boundary — this makes the fix robust regardless of whether fetch throws or returns opaque on custom-scheme redirects.

## Invariants (system rules, encoded in code and test names)

1. **The service worker must not own top-level navigations.** Requests with `request.mode === 'navigate'` are the browser's business. The SW must not call `event.respondWith` with a synthetic body that replaces the browser's native navigation result.
2. **Service workers must not sit in the credential-exchange redirect path.** Auth routes redirect to custom schemes; rule 1 keeps them browser-owned mechanically rather than via a path allowlist.
3. **\"API\" to the SW means XHR/fetch from the running SPA, not top-level navigation.** Encoded in the SW routing via request mode, not as an implicit assumption.

## The fix

- New `apps/web/public/sw-router.js` extracts routing to a pure `classifyRequest({ mode, method, url })` function that returns one of `not-intercepted | native-pass-through | api-network-first | cache-first | network-first`.
- `apps/web/public/sw.js` loads it via `importScripts('/sw-router.js')` and switches on the classifier result. `native-pass-through` **returns without calling `event.respondWith`** — operationally different from `event.respondWith(fetch(request))`, which would still break custom-scheme dispatch.
- Cache version bumped to `pagespace-v3` / `pagespace-static-v3` so every user gets the fixed SW on their next visit without needing to clear site data.
- A path-based allowlist (`/api/auth/`) was deliberately rejected: it would silently break any future non-auth navigation that happens to land on a path under `/api/`. Mode is the semantic boundary.

## Test taxonomy

### Level 1 — classifier unit tests (`apps/web/src/__tests__/sw-router.test.ts`)
Seven tests covering all five classifications and the three invariants by name:
- Rule 1: navigation to `/api/auth/google/callback?code=x` → `native-pass-through`
- Rule 1 generalizes: navigation to `/dashboard` → `native-pass-through` (invariant is mode-based, not path-based)
- Rule 3: CORS-mode GET to `/api/pages/123` → `api-network-first`
- `/_next/` GET → `native-pass-through` (preserves existing behavior)
- Static asset GET → `cache-first`
- Other same-origin GET → `network-first`
- POST → `not-intercepted`

Tests name behaviors, not implementation details. They would still pass if `sw.js` internals were reorganized, as long as classifier output is stable.

### Level 2 — fetch redirect behavior evidence (`apps/web/src/__tests__/fetch-custom-scheme-redirect.test.ts`)
A `@mechanism-evidence` test that spins up a local `http.createServer` returning `302 Location: pagespace://auth-exchange?code=test` and asserts that `fetch()` does not produce a follow-through 2xx response. The assertion is intentionally loose — the important claim is \"fetch cannot materialize a normal 2xx we could hand back as a navigation result,\" not the specific failure mode.

### Level 3 — Playwright real-browser repro
**Not in this PR.** A Playwright test that registers the SW, visits a route that redirects to `pagespace://`, and asserts no synthetic offline JSON is rendered would be the only test that proves the interaction end-to-end. Filed as a follow-up.

## Failure modes after the fix

- **Stale SW still active.** Bumping `CACHE_NAME` forces a fresh activation, but users on an old SW will see the bug until their browser updates.
- **Branded `/offline` page no longer renders on top-level navigation.** Intentional: this is the operational consequence of rule 1. Users see the native browser offline UI instead for top-level page loads. Non-navigate HTML sub-requests still hit the offline-fallback branch.
- **Server-side OAuth callback could still be broken.** The SW fix assumes the server returns a well-formed `pagespace://auth-exchange` redirect. If the server is broken, the SW fix won't help. Verify with `curl -v` against the real callback after merge.
- **`fetch` redirect behavior differs from hypothesis.** The navigation-mode fix still holds; only the Level 2 evidence test needs updating to reflect observed behavior.

## Verification

- `pnpm --filter web exec vitest run src/__tests__/sw-router.test.ts` — 7/7 pass
- `pnpm --filter web exec vitest run src/__tests__/fetch-custom-scheme-redirect.test.ts` — 1/1 pass
- `pnpm --filter web lint` — no new warnings (three pre-existing `react-hooks/exhaustive-deps` in `CalendarView.tsx`)
- `pnpm --filter web typecheck` — no new errors; pre-existing `@pagespace/lib/*` subpath resolution errors on base are unchanged
- `pnpm --filter web build` — pre-existing webpack `@pagespace/lib/client-safe` module-not-found on base is unchanged

**Manual verification (post-merge, do not run from the agent):**
- [ ] Hard refresh a browser where PageSpace is loaded. Confirm the new SW version (`pagespace-v3`) shows up in DevTools → Application → Service Workers.
- [ ] Click Google sign-in on desktop. Confirm the OAuth callback redirect reaches `pagespace://auth-exchange` and Electron lands signed-in. No JSON blob rendered as page content.

## Scope

One file is the whole feature: `apps/web/public/sw.js` plus the new `apps/web/public/sw-router.js` plus the two new test files. **No changes** to `PasskeyLoginButton.tsx`, `passkey-service.ts`, any OAuth route handler, the Electron main process, or anything outside the service worker and its tests. This is independent of and does not block desktop passkey work.

## Test plan
- [x] Level 1 classifier unit tests pass
- [x] Level 2 fetch-custom-scheme-redirect evidence test passes
- [x] Lint and typecheck show no regressions vs base
- [ ] Manual: `pagespace-v3` shows up in DevTools after hard refresh
- [ ] Manual: desktop Google sign-in reaches `pagespace://auth-exchange`, no offline JSON body
- [ ] Follow-up: Playwright test for the real-browser interaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated service worker cache versioning to optimize caching strategy.
  * Enhanced service worker request routing logic for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->