### PR TITLE
fix(auth): tighten passkey desktop path — remove legacy raw-token branch, bound deviceName

### DIFF
--- a/apps/web/src/app/api/auth/passkey/authenticate/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/authenticate/__tests__/route.test.ts
@@ -609,4 +609,70 @@ describe('POST /api/auth/passkey/authenticate', () => {
       expect(createExchangeCode).not.toHaveBeenCalled();
     });
   });
+
+  describe('platform=desktop requires desktopExchange (legacy raw-token path removed)', () => {
+    it('returns 400 when platform=desktop is sent without desktopExchange=true', async () => {
+      const response = await POST(
+        new Request('http://localhost/api/auth/passkey/authenticate', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            ...validPayload,
+            platform: 'desktop',
+            deviceId: 'device-xyz',
+            deviceName: 'My Mac',
+          }),
+        }),
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toMatch(/desktopExchange/i);
+      expect(sessionService.createSession).not.toHaveBeenCalled();
+      expect(appendSessionCookie).not.toHaveBeenCalled();
+      expect(createExchangeCode).not.toHaveBeenCalled();
+    });
+
+    it('never returns a raw sessionToken in the response body for any desktop request', async () => {
+      const response = await POST(
+        new Request('http://localhost/api/auth/passkey/authenticate', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            ...validPayload,
+            platform: 'desktop',
+            deviceId: 'device-xyz',
+            deviceName: 'My Mac',
+            desktopExchange: true,
+          }),
+        }),
+      );
+      const body = await response.json();
+
+      expect(body.sessionToken).toBeUndefined();
+      expect(body.deviceToken).toBeUndefined();
+    });
+  });
+
+  describe('deviceName input bounds', () => {
+    it('returns 400 when deviceName exceeds 256 characters', async () => {
+      const response = await POST(
+        new Request('http://localhost/api/auth/passkey/authenticate', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            ...validPayload,
+            platform: 'desktop',
+            deviceId: 'device-xyz',
+            deviceName: 'x'.repeat(257),
+            desktopExchange: true,
+          }),
+        }),
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toBeDefined();
+    });
+  });
 });

--- a/apps/web/src/app/api/auth/passkey/authenticate/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/authenticate/__tests__/route.test.ts
@@ -440,58 +440,7 @@ describe('POST /api/auth/passkey/authenticate', () => {
     });
   });
 
-  describe('desktop platform handling (unified path)', () => {
-    const desktopPayload = {
-      ...validPayload,
-      platform: 'desktop',
-      deviceId: 'device-123',
-      deviceName: 'My Mac',
-    };
-
-    const createDesktopRequest = (body: Record<string, unknown> = desktopPayload) =>
-      new Request('http://localhost/api/auth/passkey/authenticate', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      });
-
-    it('returns sessionToken, csrfToken, deviceToken at top level for desktop', async () => {
-      const response = await POST(createDesktopRequest());
-      const body = await response.json();
-
-      expect(response.status).toBe(200);
-      expect(body.success).toBe(true);
-      expect(body.sessionToken).toBe('ps_sess_mock_session_token');
-      expect(body.csrfToken).toBe('mock-csrf-token');
-      expect(body.deviceToken).toBe('ps_dev_mock_token');
-      // Should NOT have nested desktopTokens
-      expect(body.desktopTokens).toBeUndefined();
-    });
-
-    it('uses revokeAllUserSessions (hardest reset) for passkey', async () => {
-      await POST(createDesktopRequest());
-
-      expect(sessionService.revokeAllUserSessions).toHaveBeenCalledWith('user-1', 'passkey_login');
-    });
-
-    it('calls createDeviceToken with platform desktop', async () => {
-      await POST(createDesktopRequest());
-
-      expect(createDeviceToken).toHaveBeenCalledWith(expect.objectContaining({
-        userId: 'user-1',
-        deviceId: 'device-123',
-        platform: 'desktop',
-        deviceName: 'My Mac',
-        tokenVersion: 5,
-      }));
-    });
-
-    it('sets session cookies even for desktop platform', async () => {
-      await POST(createDesktopRequest());
-
-      expect(appendSessionCookie).toHaveBeenCalled();
-    });
-
+  describe('device token creation', () => {
     it('does not create device token without deviceId', async () => {
       await POST(createRequest());
 

--- a/apps/web/src/app/api/auth/passkey/authenticate/route.ts
+++ b/apps/web/src/app/api/auth/passkey/authenticate/route.ts
@@ -24,7 +24,7 @@ const verifySchema = z.object({
   csrfToken: z.string().min(1),
   platform: z.enum(['web', 'desktop']).optional().default('web'),
   deviceId: z.string().max(128).optional(),
-  deviceName: z.string().optional(),
+  deviceName: z.string().max(256).optional(),
   desktopExchange: z.boolean().optional().default(false),
 });
 
@@ -80,6 +80,17 @@ export async function POST(req: Request) {
     if (desktopExchange && platform !== 'desktop') {
       return NextResponse.json(
         { error: 'desktopExchange requires platform: desktop' },
+        { status: 400 }
+      );
+    }
+
+    // Desktop auth must go through the external-browser exchange flow. The
+    // legacy path that returned a raw sessionToken in the response body for
+    // platform=desktop is removed — it's dead code after #1001 and leaking
+    // raw tokens in JSON is strictly worse than the opaque exchange code.
+    if (platform === 'desktop' && !desktopExchange) {
+      return NextResponse.json(
+        { error: 'platform=desktop requires desktopExchange=true' },
         { status: 400 }
       );
     }
@@ -255,7 +266,6 @@ export async function POST(req: Request) {
         userId,
         redirectUrl: '/dashboard',
         csrfToken: newCsrfToken,
-        ...(platform === 'desktop' && { sessionToken }),
         ...(deviceTokenValue && { deviceToken: deviceTokenValue }),
       },
       { headers }


### PR DESCRIPTION
## Summary

Follow-up to #1001. Cleans up two issues flagged in a post-merge review of the desktop passkey external-browser flow:

1. **Legacy raw-token desktop path removed.** Before #1001, `POST /api/auth/passkey/authenticate` had a branch that returned a raw `sessionToken` in the JSON response body when `platform: 'desktop'` was sent. #1001 introduced the correct path (`desktopExchange: true` → opaque exchange code, no raw tokens in the body, ceremony handed back via `pagespace://auth-exchange`) but left the legacy branch in place as dead code. No caller in the repo hits the legacy path — verified by grep across `apps/` and `packages/`. This PR rejects `platform: 'desktop'` without `desktopExchange: true` at validation (400) and removes the `...(platform === 'desktop' && { sessionToken })` spread from the standard response.
2. **`deviceName` length bounded.** The `/auth/passkey-external` ceremony page receives `deviceId` and `deviceName` via URL query string from the Electron main process (see `passkeyExternal.ts:25-33`). An attacker-crafted link could stuff an arbitrarily long `deviceName` into device tracker metadata. The exchange-code architecture already prevents session hijack (deep link target is local-only, codes are one-time use), so this is a defensive bound — cosmetic impact only, but worth closing. `deviceId` already had `max(128)`; this PR adds `max(256)` to `deviceName`.

## Commits

- \`f67a5445\` **RED** — failing tests: \`platform=desktop\` without \`desktopExchange\` is rejected, \`deviceName > 256\` is rejected.
- \`9fa2d06e\` **GREEN** — route rejects platform=desktop without desktopExchange, deletes legacy response branch, bounds deviceName, removes stale \`desktop platform handling (unified path)\` test describe block that asserted the removed shape.

## Not changed

- The exchange-code path (\`desktopExchange: true\`) is exactly as #1001 shipped it.
- Web passkey sign-in is untouched.
- No changes to \`PasskeyLoginButton.tsx\`, \`runPasskeyExternalCeremony.ts\`, \`passkeyExternal.ts\`, or the Electron IPC allowlist.

## Verification

- \`pnpm --filter web exec vitest run src/components/auth src/app/api/auth\` → **843 / 843 ✅** (including 258 OAuth/magic-link regression tests)
- \`pnpm --filter web exec vitest run src/app/api/auth/passkey/authenticate\` → **43 / 43 ✅**
- Pre-existing master typecheck baseline errors (\`auditRequest\` export from \`@pagespace/lib/server\`, \`SessionService.revokeDeviceSessions\`) are unrelated to this PR; confirmed unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)