### PR TITLE
fix(auth): PasskeyLoginButton must surface error when desktop IPC bridge is missing

### DIFF
--- a/apps/web/src/components/auth/PasskeyLoginButton.tsx
+++ b/apps/web/src/components/auth/PasskeyLoginButton.tsx
@@ -51,7 +51,20 @@ export function PasskeyLoginButton({
       // so we mirror the OAuth flow: open an external page that runs the
       // ceremony and hands back a one-time exchange code over the
       // pagespace:// deep link.
-      if (isDesktopPlatform() && window.electron?.auth?.openExternal) {
+      if (isDesktopPlatform()) {
+        // The server rejects platform=desktop without desktopExchange, and
+        // Chromium inside the Electron BrowserWindow cannot drive platform
+        // authenticators without entitlements we don't ship — so an older
+        // desktop bridge that lacks the openExternal IPC has no working
+        // sign-in path. Surface a clear update prompt instead of silently
+        // falling through to a request the server will reject with 400.
+        if (!window.electron?.auth?.openExternal) {
+          toast.error(
+            'Your desktop app needs to be updated to sign in with a passkey. Please update the app and try again.'
+          );
+          return;
+        }
+
         const fields = await getDevicePlatformFields();
         if (!('deviceId' in fields) || !fields.deviceId) {
           toast.error('Could not read desktop device info');

--- a/apps/web/src/components/auth/__tests__/PasskeyLoginButton.desktop.test.tsx
+++ b/apps/web/src/components/auth/__tests__/PasskeyLoginButton.desktop.test.tsx
@@ -125,6 +125,58 @@ describe('PasskeyLoginButton — desktop external-browser branch', () => {
   });
 });
 
+describe('PasskeyLoginButton — desktop without IPC bridge', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(isDesktopPlatform).mockReturnValue(true);
+    vi.mocked(getDevicePlatformFields).mockResolvedValue({
+      platform: 'desktop',
+      deviceId: 'device-xyz',
+      deviceName: 'Jono Mac',
+    });
+
+    delete (window as unknown as { electron?: ElectronBridge }).electron;
+
+    fetchSpy = vi.fn();
+    global.fetch = fetchSpy as unknown as typeof fetch;
+  });
+
+  it('surfaces an update-app error and posts nothing when openExternal is missing', async () => {
+    render(<PasskeyLoginButton csrfToken="csrf-token-value" />);
+
+    await userEvent.click(screen.getByRole('button', { name: /sign in with passkey/i }));
+
+    expect(toast.error).toHaveBeenCalledWith(expect.stringMatching(/desktop app/i));
+
+    const passkeyFetchCalls = fetchSpy.mock.calls.filter(([url]) =>
+      typeof url === 'string' && url.includes('/api/auth/passkey/authenticate')
+    );
+    expect(passkeyFetchCalls).toHaveLength(0);
+
+    expect(startAuthentication).not.toHaveBeenCalled();
+  });
+
+  it('does not fall through to the web ceremony when IPC bridge is missing', async () => {
+    (window as unknown as { electron: { isDesktop: boolean; auth: Record<string, never> } }).electron = {
+      isDesktop: true,
+      auth: {},
+    };
+
+    render(<PasskeyLoginButton csrfToken="csrf-token-value" />);
+
+    await userEvent.click(screen.getByRole('button', { name: /sign in with passkey/i }));
+
+    expect(toast.error).toHaveBeenCalledWith(expect.stringMatching(/desktop app/i));
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(startAuthentication).not.toHaveBeenCalled();
+
+    delete (window as unknown as { electron?: ElectronBridge }).electron;
+  });
+});
+
 describe('PasskeyLoginButton — web path (regression guard)', () => {
   beforeEach(() => {
     vi.clearAllMocks();


### PR DESCRIPTION
## Summary

Sister PR to #1003. Fixes a client-side regression that #1003 would otherwise introduce: after #1003 tightens `POST /api/auth/passkey/authenticate` to reject `platform: 'desktop'` without `desktopExchange: true`, any Electron build whose preload lacks `window.electron.auth.openExternal` will hard-400 on passkey sign-in, because `PasskeyLoginButton` currently silently falls through to the web ceremony when the IPC bridge is unavailable.

The fix lives entirely on the client. The server guard added in #1003 is correct and stays as-is; the legacy raw-token server branch is NOT restored.

Prior fallthrough site — `apps/web/src/components/auth/PasskeyLoginButton.tsx:54` (pre-fix):

```ts
if (isDesktopPlatform() && window.electron?.auth?.openExternal) {
  // … delegate to system browser, return …
}
// falls through to in-window startAuthentication + POST with platform: 'desktop'
// → 400 under #1003's new validation
```

## Invariant

**The client must never POST `platform: 'desktop'` to `/api/auth/passkey/authenticate` unless it is also using `desktopExchange: true` via the external-browser ceremony path.** If the IPC bridge that enables the external-browser path is unavailable, the client must surface a clear error to the user — not silently fall through to a code path that will be rejected by the server.

## The fix

`handleLogin` in `PasskeyLoginButton.tsx` now gates on `isDesktopPlatform()` **first**, before reading `csrfToken` or calling `startAuthentication`. Inside the desktop branch:

- If `window.electron?.auth?.openExternal` is missing → toast `"Your desktop app needs to be updated to sign in with a passkey. Please update the app and try again."` and return early. No network call is made.
- If the IPC bridge is present → the existing external-browser delegation block runs unchanged.

Web path is untouched.

## Commits

- **RED** `83dadc4a` — test(auth): red — PasskeyLoginButton must error when desktop bridge missing
- **GREEN** `0c4da27b` — fix(auth): PasskeyLoginButton requires openExternal IPC for desktop sign-in

Two failing test cases were added to `PasskeyLoginButton.desktop.test.tsx`:

1. Desktop + `window.electron` absent → asserts `toast.error` matches `/desktop app/i`, no `fetch` to any `/api/auth/passkey/authenticate*`, and `startAuthentication` not called.
2. Desktop + `window.electron.auth = {}` (bridge exists but `openExternal` missing) → same assertions.

Both failed against the pre-fix component and pass after.

## Relationship to #1003

This PR is intended to ship **together with** #1003 in the same release. Default is to land them as two separate PRs; the orchestrator can fold this into #1003 if that's cleaner.

## Test plan

- [x] New RED cases fail against pre-fix code
- [x] All 7 cases in `PasskeyLoginButton.desktop.test.tsx` green after fix
- [x] `pnpm --filter web exec vitest run src/components/auth` — 24/24 passing
- [x] `pnpm --filter web typecheck` — clean
- [x] `pnpm --filter web lint` — no new warnings (pre-existing CalendarView warnings only)
- [x] `pnpm --filter web build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)