### PR TITLE
feat(desktop): allowlist /auth/passkey-register-external for system-browser handoff

### DIFF
--- a/apps/desktop/src/main/__tests__/ipc-handlers.test.ts
+++ b/apps/desktop/src/main/__tests__/ipc-handlers.test.ts
@@ -300,5 +300,85 @@ describe('IPC Handlers', () => {
         error: expect.stringContaining('not allowed'),
       });
     });
+
+    it('allows /auth/passkey-register-external on the configured app origin', async () => {
+      vi.mocked(shell.openExternal).mockResolvedValue(undefined);
+      vi.mocked(getAppUrl).mockReturnValue('https://pagespace.ai/dashboard');
+
+      const handler = getRegisteredHandler('auth:open-external');
+      const result = await handler(
+        {},
+        'https://pagespace.ai/auth/passkey-register-external?deviceId=d&deviceName=Mac',
+      );
+
+      expect(shell.openExternal).toHaveBeenCalledWith(
+        'https://pagespace.ai/auth/passkey-register-external?deviceId=d&deviceName=Mac',
+      );
+      expect(result).toEqual({ success: true });
+    });
+
+    it('allows /auth/passkey-register-external on a localhost http app origin', async () => {
+      vi.mocked(shell.openExternal).mockResolvedValue(undefined);
+      vi.mocked(getAppUrl).mockReturnValue('http://localhost:3000/dashboard');
+
+      const handler = getRegisteredHandler('auth:open-external');
+      const result = await handler(
+        {},
+        'http://localhost:3000/auth/passkey-register-external?deviceId=d&deviceName=Mac',
+      );
+
+      expect(shell.openExternal).toHaveBeenCalledWith(
+        'http://localhost:3000/auth/passkey-register-external?deviceId=d&deviceName=Mac',
+      );
+      expect(result).toEqual({ success: true });
+    });
+
+    it('rejects /auth/passkey-register-external on a third-party origin', async () => {
+      vi.mocked(getAppUrl).mockReturnValue('https://pagespace.ai/dashboard');
+
+      const handler = getRegisteredHandler('auth:open-external');
+      const result = await handler(
+        {},
+        'https://evil.com/auth/passkey-register-external?deviceId=d',
+      );
+
+      expect(shell.openExternal).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        success: false,
+        error: expect.stringContaining('not allowed'),
+      });
+    });
+
+    it('rejects app-origin lookalike hosts for /auth/passkey-register-external', async () => {
+      vi.mocked(getAppUrl).mockReturnValue('https://pagespace.ai/dashboard');
+
+      const handler = getRegisteredHandler('auth:open-external');
+      const result = await handler(
+        {},
+        'https://pagespace.ai.evil.com/auth/passkey-register-external',
+      );
+
+      expect(shell.openExternal).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        success: false,
+        error: expect.stringContaining('not allowed'),
+      });
+    });
+
+    it('rejects http on non-localhost even for /auth/passkey-register-external', async () => {
+      vi.mocked(getAppUrl).mockReturnValue('https://pagespace.ai/dashboard');
+
+      const handler = getRegisteredHandler('auth:open-external');
+      const result = await handler(
+        {},
+        'http://pagespace.ai/auth/passkey-register-external',
+      );
+
+      expect(shell.openExternal).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        success: false,
+        error: expect.stringContaining('not allowed'),
+      });
+    });
   });
 });

--- a/apps/desktop/src/main/ipc-handlers.ts
+++ b/apps/desktop/src/main/ipc-handlers.ts
@@ -104,10 +104,13 @@ export function registerIPCHandlers(): void {
 
   // Open an auth URL in the system browser. Allows:
   //  - OAuth providers over HTTPS (Google, Apple)
-  //  - The configured PageSpace app origin on the /auth/passkey-external path
-  //    (HTTPS for remote origins, HTTP only for localhost/127.0.0.1 dev builds)
+  //  - The configured PageSpace app origin on an allowlisted passkey-handoff
+  //    path (HTTPS for remote origins, HTTP only for localhost/127.0.0.1 dev)
   const ALLOWED_AUTH_HOSTNAMES = ['accounts.google.com', 'appleid.apple.com'];
-  const PASSKEY_EXTERNAL_PATH = '/auth/passkey-external';
+  const ALLOWED_PASSKEY_PATHS: ReadonlySet<string> = new Set([
+    '/auth/passkey-external',
+    '/auth/passkey-register-external',
+  ]);
 
   const isAppOriginMatch = (parsed: URL): boolean => {
     try {
@@ -130,7 +133,7 @@ export function registerIPCHandlers(): void {
       const isOAuthProvider =
         parsed.protocol === 'https:' && ALLOWED_AUTH_HOSTNAMES.includes(parsed.hostname);
       const isPasskeyHandoff =
-        parsed.pathname === PASSKEY_EXTERNAL_PATH && isAppOriginMatch(parsed);
+        ALLOWED_PASSKEY_PATHS.has(parsed.pathname) && isAppOriginMatch(parsed);
 
       if (!isOAuthProvider && !isPasskeyHandoff) {
         console.warn('[Auth IPC] Blocked open-external for URL not in allowlist:', parsed.hostname, parsed.pathname);


### PR DESCRIPTION
Epic sub-task: **Electron Open-External Allowlist** (`tasks/passkey-add-desktop-fix.md`).

Extends the `auth:open-external` IPC allowlist so the Settings → Security add-passkey flow can hand the ceremony off to the system browser the same way sign-in already does (PRs #1001, #1003, #1004). Converts the one-off `PASSKEY_EXTERNAL_PATH` constant into an `ALLOWED_PASSKEY_PATHS` set so future passkey flows don't require another one-off edit. Origin matching, OAuth provider branch, and `isAppOriginMatch` rules are untouched.

## TDD trail
- RED: 59f50892 — failing tests for `/auth/passkey-register-external`
- GREEN: f7887b55 — refactor constant → set, update check

## Requirement checklist
- ✅ `/auth/passkey-register-external` on app origin (https) → allowed
- ✅ `/auth/passkey-register-external` on localhost http app origin → allowed
- ✅ `/auth/passkey-external` on app origin → still allowed (regression)
- ✅ `/dashboard` and other app-origin paths → blocked (regression)
- ✅ `https://accounts.google.com/...` → still allowed (regression)
- ✅ `https://appleid.apple.com/...` → still allowed (regression)
- ✅ `/auth/passkey-register-external` on third-party origin → blocked
- ✅ Lookalike host `pagespace.ai.evil.com` → blocked
- ✅ `http://` on non-localhost for either passkey path → blocked

## Scope guardrails
- Only `apps/desktop/src/main/ipc-handlers.ts` (+ its colocated test) modified.
- `ALLOWED_AUTH_HOSTNAMES` and `isAppOriginMatch` untouched — regression tests cover Google, Apple, lookalike hosts, http-on-non-localhost, and the existing `/auth/passkey-external` sign-in path to prove it.
- Deep-link / preload bridge intentionally NOT touched (separate parallel worktree task).

## Test plan
- [x] `pnpm --filter desktop typecheck`
- [x] `pnpm --filter desktop test` — 114/114 passing (21 in `ipc-handlers.test.ts`, including 5 new `/auth/passkey-register-external` cases)
- [ ] End-to-end smoke of Settings add-passkey flow — deferred to the follow-up PasskeyManager task in this epic per plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended passkey-based authentication with support for registration flows.

* **Tests**
  * Added unit tests covering passkey authentication paths with origin and protocol validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->