### PR TITLE
feat(auth): passkey register external URL helpers

### DIFF
--- a/apps/web/src/components/auth/__tests__/passkeyExternal.test.ts
+++ b/apps/web/src/components/auth/__tests__/passkeyExternal.test.ts
@@ -4,6 +4,9 @@ import {
   buildPasskeyExternalUrl,
   buildPasskeyExchangeDeepLink,
   parsePasskeyExternalParams,
+  buildPasskeyRegisterExternalUrl,
+  parsePasskeyRegisterExternalParams,
+  buildPasskeyRegisteredDeepLink,
 } from '../passkeyExternal';
 
 describe('buildPasskeyExternalUrl', () => {
@@ -75,5 +78,99 @@ describe('parsePasskeyExternalParams', () => {
 
   it('returns null for empty search string', () => {
     expect(parsePasskeyExternalParams('')).toBeNull();
+  });
+});
+
+describe('buildPasskeyRegisterExternalUrl', () => {
+  it('builds an /auth/passkey-register-external URL with all three fields', () => {
+    const url = buildPasskeyRegisterExternalUrl('https://pagespace.ai', {
+      deviceId: 'device-123',
+      deviceName: 'Jono Mac',
+      handoffToken: 'handoff-abc',
+    });
+
+    const parsed = new URL(url);
+    expect(parsed.origin).toBe('https://pagespace.ai');
+    expect(parsed.pathname).toBe('/auth/passkey-register-external');
+    expect(parsed.searchParams.get('deviceId')).toBe('device-123');
+    expect(parsed.searchParams.get('deviceName')).toBe('Jono Mac');
+    expect(parsed.searchParams.get('handoffToken')).toBe('handoff-abc');
+  });
+
+  it('encodes device names with spaces and special characters', () => {
+    const url = buildPasskeyRegisterExternalUrl('http://localhost:3000', {
+      deviceId: 'd',
+      deviceName: "Jono's MacBook Pro",
+      handoffToken: 't',
+    });
+
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get('deviceName')).toBe("Jono's MacBook Pro");
+  });
+
+  it('round-trips build → parse for a device name with special characters', () => {
+    const fields = {
+      deviceId: 'device-xyz',
+      deviceName: "Jono's MacBook Pro / Work",
+      handoffToken: 'token+slash/equals=',
+    };
+    const url = buildPasskeyRegisterExternalUrl('https://pagespace.ai', fields);
+    const parsed = new URL(url);
+    const recovered = parsePasskeyRegisterExternalParams(parsed.search);
+    expect(recovered).toEqual(fields);
+  });
+
+  it('preserves an http://localhost origin for development builds', () => {
+    const url = buildPasskeyRegisterExternalUrl('http://localhost:3000', {
+      deviceId: 'd',
+      deviceName: 'n',
+      handoffToken: 't',
+    });
+
+    expect(
+      url.startsWith('http://localhost:3000/auth/passkey-register-external'),
+    ).toBe(true);
+  });
+});
+
+describe('parsePasskeyRegisterExternalParams', () => {
+  it('returns deviceId, deviceName, and handoffToken when all are present', () => {
+    expect(
+      parsePasskeyRegisterExternalParams(
+        '?deviceId=d-1&deviceName=Mac&handoffToken=h-1',
+      ),
+    ).toEqual({
+      deviceId: 'd-1',
+      deviceName: 'Mac',
+      handoffToken: 'h-1',
+    });
+  });
+
+  it('returns null when deviceId is missing', () => {
+    expect(
+      parsePasskeyRegisterExternalParams('?deviceName=Mac&handoffToken=h-1'),
+    ).toBeNull();
+  });
+
+  it('returns null when deviceName is missing', () => {
+    expect(
+      parsePasskeyRegisterExternalParams('?deviceId=d-1&handoffToken=h-1'),
+    ).toBeNull();
+  });
+
+  it('returns null when handoffToken is missing', () => {
+    expect(
+      parsePasskeyRegisterExternalParams('?deviceId=d-1&deviceName=Mac'),
+    ).toBeNull();
+  });
+
+  it('returns null for an empty search string', () => {
+    expect(parsePasskeyRegisterExternalParams('')).toBeNull();
+  });
+});
+
+describe('buildPasskeyRegisteredDeepLink', () => {
+  it('returns exactly pagespace://passkey-registered with no params or trailing punctuation', () => {
+    expect(buildPasskeyRegisteredDeepLink()).toBe('pagespace://passkey-registered');
   });
 });

--- a/apps/web/src/components/auth/passkeyExternal.ts
+++ b/apps/web/src/components/auth/passkeyExternal.ts
@@ -31,3 +31,38 @@ export function parsePasskeyExternalParams(
   if (!deviceId || !deviceName) return null;
   return { deviceId, deviceName };
 }
+
+export interface PasskeyRegisterExternalFields {
+  deviceId: string;
+  deviceName: string;
+  handoffToken: string;
+}
+
+const PASSKEY_REGISTER_EXTERNAL_PATH = '/auth/passkey-register-external';
+const PASSKEY_REGISTERED_DEEP_LINK = 'pagespace://passkey-registered';
+
+export function buildPasskeyRegisterExternalUrl(
+  origin: string,
+  { deviceId, deviceName, handoffToken }: PasskeyRegisterExternalFields,
+): string {
+  const url = new URL(PASSKEY_REGISTER_EXTERNAL_PATH, origin);
+  url.searchParams.set('deviceId', deviceId);
+  url.searchParams.set('deviceName', deviceName);
+  url.searchParams.set('handoffToken', handoffToken);
+  return url.toString();
+}
+
+export function parsePasskeyRegisterExternalParams(
+  search: string,
+): PasskeyRegisterExternalFields | null {
+  const params = new URLSearchParams(search);
+  const deviceId = params.get('deviceId');
+  const deviceName = params.get('deviceName');
+  const handoffToken = params.get('handoffToken');
+  if (!deviceId || !deviceName || !handoffToken) return null;
+  return { deviceId, deviceName, handoffToken };
+}
+
+export function buildPasskeyRegisteredDeepLink(): string {
+  return PASSKEY_REGISTERED_DEEP_LINK;
+}


### PR DESCRIPTION
## Epic sub-task

**Passkey Add Desktop Fix** → *Passkey External URL Helpers* (`tasks/passkey-add-desktop-fix.md`)

Thin foundation piece for the desktop Settings add-passkey flow: three pure helpers that build and parse the URLs used by the register-external ceremony page and the deep link back into Electron. Downstream ceremony/component tasks depend on this URL shape.

## Changes

Scoped to a single file + its test file:

- `apps/web/src/components/auth/passkeyExternal.ts`
- `apps/web/src/components/auth/__tests__/passkeyExternal.test.ts`

New exports:

- `PasskeyRegisterExternalFields` — `{ deviceId, deviceName, handoffToken }`
- `buildPasskeyRegisterExternalUrl(origin, fields)` — `<origin>/auth/passkey-register-external?deviceId=…&deviceName=…&handoffToken=…` using `URL` + `searchParams.set` (same style as `buildPasskeyExternalUrl`)
- `parsePasskeyRegisterExternalParams(search)` — returns the struct, or `null` if any of the three params are missing
- `buildPasskeyRegisteredDeepLink()` — returns the literal `pagespace://passkey-registered` (no query params, no code — registration state is already persisted server-side when the deep link fires)

## TDD trail

- **RED**: 6cbe38bb9ce7a14b5dd12d2475c43d59da740641 — `test(auth): RED passkey register external url helpers`
- **GREEN**: 3f0e78f80a4114f01ad1382e34d272f5b3c8f969 — `feat(auth): GREEN passkey register external url helpers`

## Requirement checklist

- ✅ Origin + all three fields → URL has path `/auth/passkey-register-external` and all three query params URL-encoded
- ✅ Missing `deviceId` → parser returns `null`
- ✅ Missing `deviceName` → parser returns `null`
- ✅ Missing `handoffToken` → parser returns `null`
- ✅ Empty search string → parser returns `null`
- ✅ All three present → parser returns the struct with exact values
- ✅ Device name with spaces + special chars (`"Jono's MacBook Pro / Work"`, `token+slash/equals=`) round-trips build → parse
- ✅ `buildPasskeyRegisteredDeepLink()` returns exactly `pagespace://passkey-registered` — no trailing `?`, no params
- ✅ `http://localhost:3000` origin preserved for dev builds
- ✅ **Regression**: existing `buildPasskeyExternalUrl`, `parsePasskeyExternalParams`, `buildPasskeyExchangeDeepLink` tests remain untouched and passing — sign-in path is unaffected

## Sign-in exports untouched

The existing `buildPasskeyExternalUrl` / `parsePasskeyExternalParams` / `buildPasskeyExchangeDeepLink` functions and their test suites were not modified. All 15 pre-existing tests in `passkeyExternal.test.ts` still pass alongside the 10 new tests (25 total, plus 6 in `runPasskeyExternalCeremony.test.ts`).

## Verification

\`\`\`
pnpm --filter web test passkeyExternal
\`\`\`

→ 25/25 passing in `passkeyExternal.test.ts`, 6/6 in `runPasskeyExternalCeremony.test.ts`.

`pnpm --filter web typecheck` and `pnpm --filter web lint` surface only pre-existing unrelated diagnostics (module-resolution errors in `services/api/*`, `stores/*`, and `packages/lib/src/auth/device-auth-utils.ts`; react-hooks warnings in `CalendarView.tsx`). None touch the files changed in this PR.

## Test plan

- [x] `pnpm --filter web test passkeyExternal` green
- [ ] CI green on PR
- [ ] Downstream register-external ceremony task consumes these helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)