### PR TITLE
feat(auth): passkey register handoff Redis module

### DIFF
--- a/packages/lib/src/auth/__tests__/passkey-register-handoff.test.ts
+++ b/packages/lib/src/auth/__tests__/passkey-register-handoff.test.ts
@@ -175,6 +175,14 @@ describe('passkey-register-handoff', () => {
 
       process.env.NODE_ENV = origEnv;
     });
+
+    it('should return null when redis.get rejects (transient connection error)', async () => {
+      vi.mocked(tryGetSecurityRedisClient).mockResolvedValue(mockRedis as never);
+      mockRedis.get.mockRejectedValueOnce(new Error('ECONNRESET'));
+
+      const result = await peekPasskeyRegisterHandoff('some-token');
+      expect(result).toBeNull();
+    });
   });
 
   describe('consumePasskeyRegisterHandoff', () => {
@@ -258,6 +266,14 @@ describe('passkey-register-handoff', () => {
       expect(result).toBeNull();
 
       process.env.NODE_ENV = origEnv;
+    });
+
+    it('should return null when redis.eval rejects (transient connection error)', async () => {
+      vi.mocked(tryGetSecurityRedisClient).mockResolvedValue(mockRedis as never);
+      mockRedis.eval.mockRejectedValueOnce(new Error('Connection lost'));
+
+      const result = await consumePasskeyRegisterHandoff('some-token');
+      expect(result).toBeNull();
     });
   });
 

--- a/packages/lib/src/auth/__tests__/passkey-register-handoff.test.ts
+++ b/packages/lib/src/auth/__tests__/passkey-register-handoff.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../token-utils', () => ({
+  hashToken: vi.fn((t: string) => `hashed_${t}`),
+}));
+
+vi.mock('../../security/security-redis', () => ({
+  tryGetSecurityRedisClient: vi.fn(),
+}));
+
+vi.mock('../../logging/logger-config', () => ({
+  loggers: {
+    auth: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  },
+}));
+
+import {
+  createPasskeyRegisterHandoff,
+  peekPasskeyRegisterHandoff,
+  consumePasskeyRegisterHandoff,
+  type PasskeyRegisterHandoffData,
+} from '../passkey-register-handoff';
+import { tryGetSecurityRedisClient } from '../../security/security-redis';
+
+interface MockRedis {
+  setex: ReturnType<typeof vi.fn>;
+  get: ReturnType<typeof vi.fn>;
+  eval: ReturnType<typeof vi.fn>;
+  store: Map<string, string>;
+}
+
+function makeMockRedis(): MockRedis {
+  const store = new Map<string, string>();
+  const redis: MockRedis = {
+    store,
+    setex: vi.fn(async (key: string, _ttl: number, value: string) => {
+      store.set(key, value);
+      return 'OK';
+    }),
+    get: vi.fn(async (key: string) => store.get(key) ?? null),
+    eval: vi.fn(async (_script: string, _numKeys: number, key: string) => {
+      const value = store.get(key) ?? null;
+      if (value !== null) {
+        store.delete(key);
+      }
+      return value;
+    }),
+  };
+  return redis;
+}
+
+describe('passkey-register-handoff', () => {
+  let mockRedis: MockRedis;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRedis = makeMockRedis();
+  });
+
+  describe('createPasskeyRegisterHandoff', () => {
+    it('should create a base64url token and store hashed key with 300s TTL', async () => {
+      vi.mocked(tryGetSecurityRedisClient).mockResolvedValue(mockRedis as never);
+
+      const token = await createPasskeyRegisterHandoff({ userId: 'user-1' });
+
+      expect(typeof token).toBe('string');
+      expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(token.length).toBeGreaterThanOrEqual(42);
+      expect(mockRedis.setex).toHaveBeenCalledTimes(1);
+      const [key, ttl, value] = mockRedis.setex.mock.calls[0];
+      expect(key).toMatch(/^auth:passkey-register-handoff:/);
+      expect(ttl).toBe(300);
+      const parsed = JSON.parse(value as string);
+      expect(parsed.userId).toBe('user-1');
+      expect(typeof parsed.createdAt).toBe('number');
+    });
+
+    it('should generate a unique token on each call', async () => {
+      vi.mocked(tryGetSecurityRedisClient).mockResolvedValue(mockRedis as never);
+
+      const a = await createPasskeyRegisterHandoff({ userId: 'user-1' });
+      const b = await createPasskeyRegisterHandoff({ userId: 'user-1' });
+
+      expect(a).not.toBe(b);
+    });
+
+    it('should throw in production when Redis is unavailable', async () => {
+      const origEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+      vi.mocked(tryGetSecurityRedisClient).mockResolvedValue(null);
+
+      await expect(createPasskeyRegisterHandoff({ userId: 'user-1' })).rejects.toThrow(
+        /Redis unavailable in production/
+      );
+
+      process.env.NODE_ENV = origEnv;
+    });
+
+    it('should throw in development when Redis is unavailable', async () => {
+      const origEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'development';
+      vi.mocked(tryGetSecurityRedisClient).mockResolvedValue(null);
+
+      await expect(createPasskeyRegisterHandoff({ userId: 'user-1' })).rejects.toThrow(
+        /Redis required/
+      );
+
+      process.env.NODE_ENV = origEnv;
+    });
+  });
+
+  describe('peekPasskeyRegisterHandoff', () => {
+    it('should return the stored data without deleting the key', async () => {
+      vi.mocked(tryGetSecurityRedisClient).mockResolvedValue(mockRedis as never);
+
+      const token = await createPasskeyRegisterHandoff({ userId: 'user-42' });
+      const peeked = await peekPasskeyRegisterHandoff(token);
+
+      expect(peeked).not.toBeNull();
+      expect(peeked?.userId).toBe('user-42');
+      expect(typeof peeked?.createdAt).toBe('number');
+      expect(mockRedis.store.size).toBe(1);
+
+      const consumed = await consumePasskeyRegisterHandoff(token);
+      expect(consumed).not.toBeNull();
+      expect(consumed?.userId).toBe('user-42');
+    });
+
+    it('should return null for an unknown token', async () => {
+      vi.mocked(tryGetSecurityRedisClient).mockResolvedValue(mockRedis as never);
+
+      const result = await peekPasskeyRegisterHandoff('never-issued');
+      expect(result).toBeNull();
+    });
+
+    it('should return null for empty token', async () => {
+      vi.mocked(tryGetSecurityRedisClient).mockResolvedValue(mockRedis as never);
+
+      expect(await peekPasskeyRegisterHandoff('')).toBeNull();
+      expect(
+        await peekPasskeyRegisterHandoff(null as unknown as string)
+      ).toBeNull();
+    });
+
+    it('should return null without throwing when stored data is malformed JSON', async () => {
+      vi.mocked(tryGetSecurityRedisClient).mockResolvedValue(mockRedis as never);
+      mockRedis.store.set('auth:passkey-register-handoff:hashed_bad', 'not-json{');
+
+      const result = await peekPasskeyRegisterHandoff('bad');
+      expect(result).toBeNull();
+    });
+
+    it('should return null when Redis is unavailable in production (no throw)', async () => {
+      const origEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+      vi.mocked(tryGetSecurityRedisClient).mockResolvedValue(null);
+
+      const result = await peekPasskeyRegisterHandoff('any');
+      expect(result).toBeNull();
+
+      process.env.NODE_ENV = origEnv;
+    });
+
+    it('should return null when Redis is unavailable in development (no throw)', async () => {
+      const origEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'development';
+      vi.mocked(tryGetSecurityRedisClient).mockResolvedValue(null);
+
+      const result = await peekPasskeyRegisterHandoff('any');
+      expect(result).toBeNull();
+
+      process.env.NODE_ENV = origEnv;
+    });
+  });
+
+  describe('consumePasskeyRegisterHandoff', () => {
+    it('should return parsed data and delete the key on first call', async () => {
+      vi.mocked(tryGetSecurityRedisClient).mockResolvedValue(mockRedis as never);
+
+      const token = await createPasskeyRegisterHandoff({ userId: 'user-7' });
+      expect(mockRedis.store.size).toBe(1);
+
+      const result = await consumePasskeyRegisterHandoff(token);
+      expect(result).not.toBeNull();
+      expect(result?.userId).toBe('user-7');
+      expect(mockRedis.store.size).toBe(0);
+    });
+
+    it('should be one-time-use: second consume returns null', async () => {
+      vi.mocked(tryGetSecurityRedisClient).mockResolvedValue(mockRedis as never);
+
+      const token = await createPasskeyRegisterHandoff({ userId: 'user-9' });
+
+      const first = await consumePasskeyRegisterHandoff(token);
+      const second = await consumePasskeyRegisterHandoff(token);
+
+      expect(first?.userId).toBe('user-9');
+      expect(second).toBeNull();
+    });
+
+    it('should use an atomic Lua GET+DEL script (not a plain get/del pair)', async () => {
+      vi.mocked(tryGetSecurityRedisClient).mockResolvedValue(mockRedis as never);
+
+      const token = await createPasskeyRegisterHandoff({ userId: 'user-atomic' });
+      await consumePasskeyRegisterHandoff(token);
+
+      expect(mockRedis.eval).toHaveBeenCalledTimes(1);
+      const [script] = mockRedis.eval.mock.calls[0];
+      expect(script).toContain('GET');
+      expect(script).toContain('DEL');
+    });
+
+    it('should return null for empty or non-string token', async () => {
+      vi.mocked(tryGetSecurityRedisClient).mockResolvedValue(mockRedis as never);
+
+      expect(await consumePasskeyRegisterHandoff('')).toBeNull();
+      expect(
+        await consumePasskeyRegisterHandoff(null as unknown as string)
+      ).toBeNull();
+    });
+
+    it('should return null for an unknown/expired token', async () => {
+      vi.mocked(tryGetSecurityRedisClient).mockResolvedValue(mockRedis as never);
+
+      const result = await consumePasskeyRegisterHandoff('never-issued');
+      expect(result).toBeNull();
+    });
+
+    it('should return null without throwing when stored JSON is malformed', async () => {
+      vi.mocked(tryGetSecurityRedisClient).mockResolvedValue(mockRedis as never);
+      mockRedis.store.set('auth:passkey-register-handoff:hashed_bad', 'not-json{');
+
+      const result = await consumePasskeyRegisterHandoff('bad');
+      expect(result).toBeNull();
+    });
+
+    it('should return null when Redis is unavailable in production (no throw)', async () => {
+      const origEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+      vi.mocked(tryGetSecurityRedisClient).mockResolvedValue(null);
+
+      const result = await consumePasskeyRegisterHandoff('any');
+      expect(result).toBeNull();
+
+      process.env.NODE_ENV = origEnv;
+    });
+
+    it('should return null when Redis is unavailable in development (no throw)', async () => {
+      const origEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'development';
+      vi.mocked(tryGetSecurityRedisClient).mockResolvedValue(null);
+
+      const result = await consumePasskeyRegisterHandoff('any');
+      expect(result).toBeNull();
+
+      process.env.NODE_ENV = origEnv;
+    });
+  });
+
+  describe('type shape', () => {
+    it('should expose the expected interface', () => {
+      const data: PasskeyRegisterHandoffData = {
+        userId: 'u',
+        createdAt: 1,
+      };
+      expect(data.userId).toBe('u');
+    });
+  });
+});

--- a/packages/lib/src/auth/index.ts
+++ b/packages/lib/src/auth/index.ts
@@ -19,6 +19,7 @@ export * from './token-lookup';
 export * from './token-utils';
 export * from './verification-utils';
 export * from './exchange-codes';
+export * from './passkey-register-handoff';
 export * from './magic-link-service';
 export { generatePKCE, consumePKCEVerifier } from './pkce';
 export * from './passkey-client-constants';

--- a/packages/lib/src/auth/passkey-register-handoff.ts
+++ b/packages/lib/src/auth/passkey-register-handoff.ts
@@ -112,7 +112,17 @@ export async function peekPasskeyRegisterHandoff(
   }
 
   const key = keyFor(token);
-  const raw = (await redis.get(key)) as string | null;
+
+  let raw: string | null;
+  try {
+    raw = (await redis.get(key)) as string | null;
+  } catch (error) {
+    loggers.auth.error(
+      'Passkey register handoff peek Redis error',
+      error as Error
+    );
+    return null;
+  }
 
   if (!raw) {
     loggers.auth.warn('Passkey register handoff peek miss', {
@@ -167,7 +177,16 @@ export async function consumePasskeyRegisterHandoff(
     return data
   `;
 
-  const raw = (await redis.eval(luaScript, 1, key)) as string | null;
+  let raw: string | null;
+  try {
+    raw = (await redis.eval(luaScript, 1, key)) as string | null;
+  } catch (error) {
+    loggers.auth.error(
+      'Passkey register handoff consume Redis error',
+      error as Error
+    );
+    return null;
+  }
 
   if (!raw) {
     loggers.auth.warn('Passkey register handoff invalid or already consumed', {

--- a/packages/lib/src/auth/passkey-register-handoff.ts
+++ b/packages/lib/src/auth/passkey-register-handoff.ts
@@ -1,0 +1,192 @@
+/**
+ * Passkey Register Handoff Tokens
+ *
+ * Short-lived, one-time tokens that hand an authenticated PageSpace user's
+ * identity from the desktop (Electron) renderer to the system browser so the
+ * external `/auth/external-register/*` endpoints can authorise a passkey
+ * registration ceremony without a PageSpace session cookie.
+ *
+ * Flow:
+ * 1. Authenticated Electron renderer POSTs to a mint endpoint, which calls
+ *    `createPasskeyRegisterHandoff({ userId })` and receives the plaintext
+ *    token.
+ * 2. Renderer opens the system browser via `shell.openExternal` with the
+ *    token in the URL.
+ * 3. External options endpoint calls `peekPasskeyRegisterHandoff` (no delete
+ *    — the verify step still needs it).
+ * 4. External verify endpoint calls `consumePasskeyRegisterHandoff` which
+ *    atomically reads and deletes (one-time use).
+ *
+ * Matches the security posture of `./exchange-codes`:
+ * - 32-byte base64url token, SHA-256 hashed at rest
+ * - 300s TTL
+ * - Lua GET+DEL for atomic consume
+ * - Fail-closed on create when Redis is unavailable; log-and-return-null on
+ *   read paths.
+ *
+ * @module @pagespace/lib/auth/passkey-register-handoff
+ */
+
+import { randomBytes } from 'crypto';
+import { hashToken } from './token-utils';
+import { tryGetSecurityRedisClient } from '../security/security-redis';
+import { loggers } from '../logging/logger-config';
+
+const PASSKEY_REGISTER_HANDOFF_PREFIX = 'auth:passkey-register-handoff:';
+const PASSKEY_REGISTER_HANDOFF_TTL_SECONDS = 300;
+
+export interface PasskeyRegisterHandoffData {
+  userId: string;
+  createdAt: number;
+}
+
+function keyFor(token: string): string {
+  return `${PASSKEY_REGISTER_HANDOFF_PREFIX}${hashToken(token)}`;
+}
+
+/**
+ * Create a one-time passkey register handoff token and store the associated
+ * user identity in Redis.
+ *
+ * @throws if Redis is unavailable (in any environment — fail fast)
+ */
+export async function createPasskeyRegisterHandoff(
+  input: { userId: string }
+): Promise<string> {
+  const redis = await tryGetSecurityRedisClient();
+
+  if (!redis) {
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error(
+        'Cannot create passkey register handoff: Redis unavailable in production'
+      );
+    }
+    throw new Error('Redis required for passkey register handoff');
+  }
+
+  const token = randomBytes(32).toString('base64url');
+  const key = keyFor(token);
+  const data: PasskeyRegisterHandoffData = {
+    userId: input.userId,
+    createdAt: Date.now(),
+  };
+
+  await redis.setex(
+    key,
+    PASSKEY_REGISTER_HANDOFF_TTL_SECONDS,
+    JSON.stringify(data)
+  );
+
+  loggers.auth.info('Passkey register handoff created', {
+    userId: input.userId,
+    ttlSeconds: PASSKEY_REGISTER_HANDOFF_TTL_SECONDS,
+  });
+
+  return token;
+}
+
+/**
+ * Non-destructive lookup. Returns the stored handoff data without deleting
+ * the key. Used by the external options endpoint so the verify call still
+ * finds a live token.
+ *
+ * Returns `null` for missing / expired / malformed tokens or when Redis is
+ * unavailable — never throws.
+ */
+export async function peekPasskeyRegisterHandoff(
+  token: string
+): Promise<PasskeyRegisterHandoffData | null> {
+  if (!token || typeof token !== 'string') {
+    return null;
+  }
+
+  const redis = await tryGetSecurityRedisClient();
+
+  if (!redis) {
+    if (process.env.NODE_ENV === 'production') {
+      loggers.auth.error(
+        'Cannot peek passkey register handoff: Redis unavailable in production'
+      );
+    }
+    return null;
+  }
+
+  const key = keyFor(token);
+  const raw = (await redis.get(key)) as string | null;
+
+  if (!raw) {
+    loggers.auth.warn('Passkey register handoff peek miss', {
+      tokenPrefix: token.substring(0, 8),
+    });
+    return null;
+  }
+
+  try {
+    return JSON.parse(raw) as PasskeyRegisterHandoffData;
+  } catch (error) {
+    loggers.auth.error(
+      'Failed to parse passkey register handoff data (peek)',
+      error as Error
+    );
+    return null;
+  }
+}
+
+/**
+ * Atomically read and delete a passkey register handoff token. One-time use —
+ * a second call returns `null`.
+ *
+ * Returns `null` for missing / expired / malformed tokens or when Redis is
+ * unavailable — never throws.
+ */
+export async function consumePasskeyRegisterHandoff(
+  token: string
+): Promise<PasskeyRegisterHandoffData | null> {
+  if (!token || typeof token !== 'string') {
+    return null;
+  }
+
+  const redis = await tryGetSecurityRedisClient();
+
+  if (!redis) {
+    if (process.env.NODE_ENV === 'production') {
+      loggers.auth.error(
+        'Cannot consume passkey register handoff: Redis unavailable in production'
+      );
+    }
+    return null;
+  }
+
+  const key = keyFor(token);
+
+  const luaScript = `
+    local data = redis.call('GET', KEYS[1])
+    if data then
+      redis.call('DEL', KEYS[1])
+    end
+    return data
+  `;
+
+  const raw = (await redis.eval(luaScript, 1, key)) as string | null;
+
+  if (!raw) {
+    loggers.auth.warn('Passkey register handoff invalid or already consumed', {
+      tokenPrefix: token.substring(0, 8),
+    });
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as PasskeyRegisterHandoffData;
+    loggers.auth.info('Passkey register handoff consumed', {
+      userId: parsed.userId,
+    });
+    return parsed;
+  } catch (error) {
+    loggers.auth.error(
+      'Failed to parse passkey register handoff data (consume)',
+      error as Error
+    );
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Epic: `tasks/passkey-add-desktop-fix.md` — sub-task **Server Register Handoff Token Module** (task 1 of 4).

Adds `packages/lib/src/auth/passkey-register-handoff.ts`: a Redis-backed, short-lived, one-time token that lets the authenticated Electron renderer hand the user's identity to the system browser so the external passkey-add ceremony can authorize without a PageSpace session cookie. Foundation only — no routes, no callers, no UI wire-up. Those are the other three epic sub-tasks running in parallel worktrees.

Mirrors `auth/exchange-codes` exactly:
- 32-byte base64url plaintext token
- SHA-256 hashed key at rest (`auth:passkey-register-handoff:<hash>`)
- 300s TTL
- Atomic Lua `GET` + `DEL` on consume (no race on double-use)
- Fail-closed on create when Redis is unavailable (throws, both prod and dev)
- Log-and-return-`null` on peek/consume when Redis is unavailable

`peek` (non-destructive) is the new piece vs. exchange-codes: the external options endpoint needs to validate the token without deleting it, since the verify endpoint must still find it.

## TDD commits
- **RED**: `4a90d57a` — `test(auth): RED passkey-register-handoff module`
- **GREEN**: `98174e20` — `feat(auth): passkey-register-handoff Redis module`

## Epic requirement checklist
- ✅ `create`: generates 32-byte base64url token, SHA-256 hashed key, stores `{ userId, createdAt }` with 300s TTL
- ✅ `peek`: non-destructive GET, returns data or `null`, never throws on bad input
- ✅ `consume`: atomic Lua GET+DEL, one-time use, returns data or `null`
- ✅ Create + peek round-trip returns `{ userId }`
- ✅ Create + consume round-trip returns `{ userId }` and deletes the key
- ✅ Peek does NOT delete (verified by consuming afterwards)
- ✅ Second consume on the same token returns `null`
- ✅ Unknown / empty / malformed token → peek and consume return `null` without throwing
- ✅ Redis unavailable in production → create throws, peek/consume return `null`
- ✅ Redis unavailable in development → create throws, peek/consume return `null`
- ✅ Re-exported from `packages/lib/src/auth/index.ts` barrel
- ✅ No existing files modified except the auth barrel
- ✅ No `any` types; no new Redis key prefix, TTL, or hashing scheme invented

## Test plan
- [x] `pnpm --filter @pagespace/lib test passkey-register-handoff` — 19/19 passing
- [x] `pnpm --filter @pagespace/lib typecheck` — clean
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)