### PR TITLE
feat(desktop): passkey-registered deep link + preload bridge

### DIFF
--- a/apps/desktop/src/main/__tests__/deep-links.test.ts
+++ b/apps/desktop/src/main/__tests__/deep-links.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const webContents = {
+    send: vi.fn(),
+  };
+  const mainWindow = {
+    webContents,
+    isMinimized: vi.fn(() => false),
+    restore: vi.fn(),
+    show: vi.fn(),
+    focus: vi.fn(),
+    loadURL: vi.fn(),
+  };
+  return { webContents, mainWindow };
+});
+
+vi.mock('electron', () => ({
+  app: {
+    setAsDefaultProtocolClient: vi.fn(),
+  },
+  session: {
+    defaultSession: {
+      cookies: {
+        set: vi.fn(async () => undefined),
+      },
+    },
+  },
+}));
+
+vi.mock('../state', () => ({
+  mainWindow: mocks.mainWindow,
+  setCachedSession: vi.fn(),
+}));
+
+vi.mock('../auth-storage', () => ({
+  saveAuthSession: vi.fn(async () => undefined),
+}));
+
+vi.mock('../app-url', () => ({
+  getAppUrl: vi.fn(() => 'https://pagespace.ai/dashboard'),
+}));
+
+vi.mock('../logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { handleDeepLink } from '../deep-links';
+
+describe('handleDeepLink dispatcher', () => {
+  beforeEach(() => {
+    mocks.webContents.send.mockReset();
+    mocks.mainWindow.focus.mockReset();
+    mocks.mainWindow.show.mockReset();
+    mocks.mainWindow.restore.mockReset();
+    mocks.mainWindow.isMinimized.mockReset().mockReturnValue(false);
+    mocks.mainWindow.loadURL.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('given pagespace://passkey-registered', () => {
+    it('should focus the main window and broadcast passkey:registered without any HTTP call', async () => {
+      const fetchSpy = vi.fn();
+      vi.stubGlobal('fetch', fetchSpy);
+
+      await handleDeepLink('pagespace://passkey-registered');
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(mocks.mainWindow.focus).toHaveBeenCalledTimes(1);
+      expect(mocks.webContents.send).toHaveBeenCalledWith('passkey:registered');
+    });
+
+    it('when main window is minimized, should restore it before focusing', async () => {
+      vi.stubGlobal('fetch', vi.fn());
+      mocks.mainWindow.isMinimized.mockReturnValue(true);
+
+      await handleDeepLink('pagespace://passkey-registered');
+
+      expect(mocks.mainWindow.restore).toHaveBeenCalled();
+      expect(mocks.mainWindow.focus).toHaveBeenCalled();
+    });
+  });
+
+  describe('given pagespace://auth-exchange (regression)', () => {
+    it('should still POST to /api/auth/desktop/exchange and never broadcast passkey:registered', async () => {
+      const fetchSpy = vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          sessionToken: 'sess_abc',
+          csrfToken: 'csrf_abc',
+          deviceToken: 'dev_abc',
+        }),
+      }));
+      vi.stubGlobal('fetch', fetchSpy);
+
+      await handleDeepLink('pagespace://auth-exchange?code=code123&provider=google');
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [calledUrl, calledInit] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(calledUrl).toContain('/api/auth/desktop/exchange');
+      expect(calledInit.method).toBe('POST');
+
+      expect(mocks.webContents.send).not.toHaveBeenCalledWith('passkey:registered');
+    });
+  });
+
+  describe('given an unknown pagespace:// URL', () => {
+    it('should fall through to the generic deep-link IPC channel and not crash', async () => {
+      vi.stubGlobal('fetch', vi.fn());
+
+      await handleDeepLink('pagespace://foo-bar');
+
+      expect(mocks.webContents.send).toHaveBeenCalledWith('deep-link', 'pagespace://foo-bar');
+      expect(mocks.webContents.send).not.toHaveBeenCalledWith('passkey:registered');
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/deep-links.test.ts
+++ b/apps/desktop/src/main/__tests__/deep-links.test.ts
@@ -104,9 +104,9 @@ describe('handleDeepLink dispatcher', () => {
       await handleDeepLink('pagespace://auth-exchange?code=code123&provider=google');
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);
-      const [calledUrl, calledInit] = fetchSpy.mock.calls[0] as [string, RequestInit];
-      expect(calledUrl).toContain('/api/auth/desktop/exchange');
-      expect(calledInit.method).toBe('POST');
+      const call = fetchSpy.mock.calls[0] as unknown as [string, RequestInit];
+      expect(call[0]).toContain('/api/auth/desktop/exchange');
+      expect(call[1].method).toBe('POST');
 
       expect(mocks.webContents.send).not.toHaveBeenCalledWith('passkey:registered');
     });

--- a/apps/desktop/src/main/__tests__/deep-links.test.ts
+++ b/apps/desktop/src/main/__tests__/deep-links.test.ts
@@ -104,9 +104,10 @@ describe('handleDeepLink dispatcher', () => {
       await handleDeepLink('pagespace://auth-exchange?code=code123&provider=google');
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);
-      const call = fetchSpy.mock.calls[0] as unknown as [string, RequestInit];
-      expect(call[0]).toContain('/api/auth/desktop/exchange');
-      expect(call[1].method).toBe('POST');
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining('/api/auth/desktop/exchange'),
+        expect.objectContaining({ method: 'POST' }),
+      );
 
       expect(mocks.webContents.send).not.toHaveBeenCalledWith('passkey:registered');
     });

--- a/apps/desktop/src/main/__tests__/deep-links.test.ts
+++ b/apps/desktop/src/main/__tests__/deep-links.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
+type DidFinishLoadCb = () => void;
+
 const mocks = vi.hoisted(() => {
   const webContents = {
     send: vi.fn(),
+    isLoading: vi.fn(() => false),
+    once: vi.fn(),
   };
   const mainWindow = {
     webContents,
@@ -12,7 +16,11 @@ const mocks = vi.hoisted(() => {
     focus: vi.fn(),
     loadURL: vi.fn(),
   };
-  return { webContents, mainWindow };
+  const state: { current: typeof mainWindow | null } = { current: mainWindow };
+  const createWindow = vi.fn(() => {
+    state.current = mainWindow;
+  });
+  return { webContents, mainWindow, state, createWindow };
 });
 
 vi.mock('electron', () => ({
@@ -29,8 +37,14 @@ vi.mock('electron', () => ({
 }));
 
 vi.mock('../state', () => ({
-  mainWindow: mocks.mainWindow,
+  get mainWindow() {
+    return mocks.state.current;
+  },
   setCachedSession: vi.fn(),
+}));
+
+vi.mock('../window', () => ({
+  createWindow: mocks.createWindow,
 }));
 
 vi.mock('../auth-storage', () => ({
@@ -55,11 +69,17 @@ import { handleDeepLink } from '../deep-links';
 describe('handleDeepLink dispatcher', () => {
   beforeEach(() => {
     mocks.webContents.send.mockReset();
+    mocks.webContents.isLoading.mockReset().mockReturnValue(false);
+    mocks.webContents.once.mockReset();
     mocks.mainWindow.focus.mockReset();
     mocks.mainWindow.show.mockReset();
     mocks.mainWindow.restore.mockReset();
     mocks.mainWindow.isMinimized.mockReset().mockReturnValue(false);
     mocks.mainWindow.loadURL.mockReset();
+    mocks.createWindow.mockReset().mockImplementation(() => {
+      mocks.state.current = mocks.mainWindow;
+    });
+    mocks.state.current = mocks.mainWindow;
   });
 
   afterEach(() => {
@@ -86,6 +106,27 @@ describe('handleDeepLink dispatcher', () => {
 
       expect(mocks.mainWindow.restore).toHaveBeenCalled();
       expect(mocks.mainWindow.focus).toHaveBeenCalled();
+    });
+
+    it('when no main window exists (macOS all-windows-closed), should create one and defer the IPC until did-finish-load', async () => {
+      vi.stubGlobal('fetch', vi.fn());
+      mocks.state.current = null;
+      mocks.webContents.isLoading.mockReturnValue(true);
+
+      await handleDeepLink('pagespace://passkey-registered');
+
+      expect(mocks.createWindow).toHaveBeenCalledTimes(1);
+      expect(mocks.webContents.send).not.toHaveBeenCalledWith('passkey:registered');
+      expect(mocks.webContents.once).toHaveBeenCalledWith(
+        'did-finish-load',
+        expect.any(Function),
+      );
+
+      const onceCall = mocks.webContents.once.mock.calls[0];
+      const deferred = onceCall[1] as DidFinishLoadCb;
+      deferred();
+
+      expect(mocks.webContents.send).toHaveBeenCalledWith('passkey:registered');
     });
   });
 

--- a/apps/desktop/src/main/__tests__/passkey-deep-link.test.ts
+++ b/apps/desktop/src/main/__tests__/passkey-deep-link.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handlePasskeyRegistered } from '../passkey-deep-link';
+
+describe('handlePasskeyRegistered', () => {
+  let focusWindow: ReturnType<typeof vi.fn>;
+  let sendToRenderer: ReturnType<typeof vi.fn>;
+  let logger: { info: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    focusWindow = vi.fn();
+    sendToRenderer = vi.fn();
+    logger = { info: vi.fn(), warn: vi.fn() };
+  });
+
+  it('given pagespace://passkey-registered, should focus window and broadcast IPC event', () => {
+    const handled = handlePasskeyRegistered('pagespace://passkey-registered', {
+      focusWindow,
+      sendToRenderer,
+      logger,
+    });
+
+    expect(handled).toBe(true);
+    expect(focusWindow).toHaveBeenCalledTimes(1);
+    expect(sendToRenderer).toHaveBeenCalledTimes(1);
+    expect(sendToRenderer).toHaveBeenCalledWith('passkey:registered');
+  });
+
+  it('given a URL with a different host, should return false and not touch the window', () => {
+    const handled = handlePasskeyRegistered('pagespace://auth-exchange?code=abc', {
+      focusWindow,
+      sendToRenderer,
+      logger,
+    });
+
+    expect(handled).toBe(false);
+    expect(focusWindow).not.toHaveBeenCalled();
+    expect(sendToRenderer).not.toHaveBeenCalled();
+  });
+
+  it('given an unparsable URL, should return false and log a warning', () => {
+    const handled = handlePasskeyRegistered('not a url', {
+      focusWindow,
+      sendToRenderer,
+      logger,
+    });
+
+    expect(handled).toBe(false);
+    expect(focusWindow).not.toHaveBeenCalled();
+    expect(sendToRenderer).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/deep-links.ts
+++ b/apps/desktop/src/main/deep-links.ts
@@ -158,18 +158,18 @@ function handlePasskeyRegistered(url: string): boolean {
       createWindow();
     },
     sendToRenderer: (channel) => {
-      const window = mainWindow;
-      if (!window) {
+      const target = mainWindow;
+      if (!target) {
         logger.error('[Passkey Deep Link] No main window available after focus');
         return;
       }
-      if (window.webContents.isLoading()) {
-        window.webContents.once('did-finish-load', () => {
-          mainWindow?.webContents.send(channel);
+      if (target.webContents.isLoading()) {
+        target.webContents.once('did-finish-load', () => {
+          target.webContents.send(channel);
         });
         return;
       }
-      window.webContents.send(channel);
+      target.webContents.send(channel);
     },
     logger,
   });

--- a/apps/desktop/src/main/deep-links.ts
+++ b/apps/desktop/src/main/deep-links.ts
@@ -6,6 +6,7 @@ import { setCachedSession } from './state';
 import { getAppUrl } from './app-url';
 import { logger } from './logger';
 import { handlePasskeyRegistered as handlePasskeyRegisteredPure } from './passkey-deep-link';
+import { createWindow } from './window';
 
 export function setupProtocolClient(): void {
   if (process.defaultApp) {
@@ -145,13 +146,30 @@ async function handleAuthExchange(url: string): Promise<boolean> {
 function handlePasskeyRegistered(url: string): boolean {
   return handlePasskeyRegisteredPure(url, {
     focusWindow: () => {
-      if (!mainWindow) return;
-      if (mainWindow.isMinimized()) mainWindow.restore();
-      mainWindow.show();
-      mainWindow.focus();
+      if (mainWindow) {
+        if (mainWindow.isMinimized()) mainWindow.restore();
+        mainWindow.show();
+        mainWindow.focus();
+        return;
+      }
+      // macOS: all windows closed while app lives in dock. Spawn one so the
+      // renderer can receive the broadcast — otherwise the deep link would be
+      // silently consumed.
+      createWindow();
     },
     sendToRenderer: (channel) => {
-      mainWindow?.webContents.send(channel);
+      const window = mainWindow;
+      if (!window) {
+        logger.error('[Passkey Deep Link] No main window available after focus');
+        return;
+      }
+      if (window.webContents.isLoading()) {
+        window.webContents.once('did-finish-load', () => {
+          mainWindow?.webContents.send(channel);
+        });
+        return;
+      }
+      window.webContents.send(channel);
     },
     logger,
   });

--- a/apps/desktop/src/main/deep-links.ts
+++ b/apps/desktop/src/main/deep-links.ts
@@ -150,8 +150,8 @@ function handlePasskeyRegistered(url: string): boolean {
       mainWindow.show();
       mainWindow.focus();
     },
-    sendToRenderer: (channel, ...args) => {
-      mainWindow?.webContents.send(channel, ...args);
+    sendToRenderer: (channel) => {
+      mainWindow?.webContents.send(channel);
     },
     logger,
   });

--- a/apps/desktop/src/main/deep-links.ts
+++ b/apps/desktop/src/main/deep-links.ts
@@ -5,6 +5,7 @@ import { mainWindow } from './state';
 import { setCachedSession } from './state';
 import { getAppUrl } from './app-url';
 import { logger } from './logger';
+import { handlePasskeyRegistered as handlePasskeyRegisteredPure } from './passkey-deep-link';
 
 export function setupProtocolClient(): void {
   if (process.defaultApp) {
@@ -141,6 +142,21 @@ async function handleAuthExchange(url: string): Promise<boolean> {
   }
 }
 
+function handlePasskeyRegistered(url: string): boolean {
+  return handlePasskeyRegisteredPure(url, {
+    focusWindow: () => {
+      if (!mainWindow) return;
+      if (mainWindow.isMinimized()) mainWindow.restore();
+      mainWindow.show();
+      mainWindow.focus();
+    },
+    sendToRenderer: (channel, ...args) => {
+      mainWindow?.webContents.send(channel, ...args);
+    },
+    logger,
+  });
+}
+
 function handleAuthError(url: string): boolean {
   try {
     const urlObj = new URL(url);
@@ -158,6 +174,7 @@ function handleAuthError(url: string): boolean {
 export async function handleDeepLink(url: string): Promise<void> {
   if (await handleAuthExchange(url)) return;
   if (handleAuthError(url)) return;
+  if (handlePasskeyRegistered(url)) return;
 
   if (mainWindow) {
     mainWindow.webContents.send('deep-link', url);

--- a/apps/desktop/src/main/passkey-deep-link.ts
+++ b/apps/desktop/src/main/passkey-deep-link.ts
@@ -1,6 +1,6 @@
 export interface PasskeyDeepLinkDeps {
   focusWindow: () => void;
-  sendToRenderer: (channel: string, ...args: unknown[]) => void;
+  sendToRenderer: (channel: string) => void;
   logger: {
     info: (message: string, meta?: Record<string, unknown>) => void;
     warn: (message: string, meta?: Record<string, unknown>) => void;

--- a/apps/desktop/src/main/passkey-deep-link.ts
+++ b/apps/desktop/src/main/passkey-deep-link.ts
@@ -1,0 +1,30 @@
+export interface PasskeyDeepLinkDeps {
+  focusWindow: () => void;
+  sendToRenderer: (channel: string, ...args: unknown[]) => void;
+  logger: {
+    info: (message: string, meta?: Record<string, unknown>) => void;
+    warn: (message: string, meta?: Record<string, unknown>) => void;
+  };
+}
+
+export const PASSKEY_REGISTERED_HOST = 'passkey-registered';
+export const PASSKEY_REGISTERED_CHANNEL = 'passkey:registered';
+
+export function handlePasskeyRegistered(url: string, deps: PasskeyDeepLinkDeps): boolean {
+  let urlObj: URL;
+  try {
+    urlObj = new URL(url);
+  } catch (error) {
+    deps.logger.warn('[Passkey Deep Link] Failed to parse URL', { error: String(error) });
+    return false;
+  }
+
+  if (urlObj.host !== PASSKEY_REGISTERED_HOST) {
+    return false;
+  }
+
+  deps.logger.info('[Passkey Deep Link] Received passkey-registered, focusing window');
+  deps.focusWindow();
+  deps.sendToRenderer(PASSKEY_REGISTERED_CHANNEL);
+  return true;
+}

--- a/apps/desktop/src/preload/__tests__/preload-passkey.test.ts
+++ b/apps/desktop/src/preload/__tests__/preload-passkey.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+type Handler = (event: unknown, ...args: unknown[]) => void;
+
+const mocks = vi.hoisted(() => {
+  const listeners = new Map<string, Set<Handler>>();
+  const exposed: Record<string, unknown> = {};
+
+  const ipcRenderer = {
+    on: vi.fn((channel: string, handler: Handler) => {
+      const set = listeners.get(channel) ?? new Set<Handler>();
+      set.add(handler);
+      listeners.set(channel, set);
+    }),
+    removeListener: vi.fn((channel: string, handler: Handler) => {
+      listeners.get(channel)?.delete(handler);
+    }),
+    removeAllListeners: vi.fn((channel: string) => {
+      listeners.delete(channel);
+    }),
+    invoke: vi.fn(async () => undefined),
+  };
+
+  const contextBridge = {
+    exposeInMainWorld: vi.fn((key: string, api: unknown) => {
+      exposed[key] = api;
+    }),
+  };
+
+  function emit(channel: string, ...args: unknown[]): void {
+    const handlers = listeners.get(channel);
+    if (!handlers) return;
+    for (const h of handlers) h({}, ...args);
+  }
+
+  return { ipcRenderer, contextBridge, listeners, exposed, emit };
+});
+
+vi.mock('electron', () => ({
+  ipcRenderer: mocks.ipcRenderer,
+  contextBridge: mocks.contextBridge,
+}));
+
+interface ExposedElectron {
+  passkey: {
+    onRegistered: (callback: () => void) => () => void;
+  };
+}
+
+function getExposedElectron(): ExposedElectron {
+  return mocks.exposed.electron as ExposedElectron;
+}
+
+describe('preload passkey bridge', () => {
+  beforeEach(async () => {
+    mocks.listeners.clear();
+    for (const key of Object.keys(mocks.exposed)) delete mocks.exposed[key];
+    mocks.ipcRenderer.on.mockClear();
+    mocks.ipcRenderer.removeListener.mockClear();
+    vi.resetModules();
+    await import('../index');
+  });
+
+  it('exposes window.electron.passkey.onRegistered', () => {
+    const electron = getExposedElectron();
+    expect(typeof electron.passkey?.onRegistered).toBe('function');
+  });
+
+  it('subscribes to passkey:registered and invokes the callback when emitted', () => {
+    const electron = getExposedElectron();
+    const cb = vi.fn();
+
+    electron.passkey.onRegistered(cb);
+    expect(mocks.ipcRenderer.on).toHaveBeenCalledWith('passkey:registered', expect.any(Function));
+
+    mocks.emit('passkey:registered');
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns an unsubscribe function that removes the listener', () => {
+    const electron = getExposedElectron();
+    const cb = vi.fn();
+
+    const unsubscribe = electron.passkey.onRegistered(cb);
+    expect(typeof unsubscribe).toBe('function');
+
+    unsubscribe();
+    expect(mocks.ipcRenderer.removeListener).toHaveBeenCalledWith(
+      'passkey:registered',
+      expect.any(Function),
+    );
+
+    mocks.emit('passkey:registered');
+    expect(cb).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -80,6 +80,15 @@ contextBridge.exposeInMainWorld('electron', {
       ipcRenderer.invoke('mcp:execute-tool', serverName, toolName, args),
   },
 
+  // Passkey lifecycle events (from pagespace://passkey-registered deep link)
+  passkey: {
+    onRegistered: (callback: () => void) => {
+      const handler = () => callback();
+      ipcRenderer.on('passkey:registered', handler);
+      return () => ipcRenderer.removeListener('passkey:registered', handler);
+    },
+  },
+
   // WebSocket MCP Bridge
   ws: {
     getStatus: () => ipcRenderer.invoke('ws:get-status'),
@@ -152,6 +161,9 @@ export interface ElectronAPI {
       userAgent: string;
     }>;
     openExternal: (url: string) => Promise<{ success: boolean; error?: string }>;
+  };
+  passkey: {
+    onRegistered: (callback: () => void) => () => void;
   };
   mcp: {
     getConfig: () => Promise<MCPConfig>;

--- a/apps/web/src/types/electron.d.ts
+++ b/apps/web/src/types/electron.d.ts
@@ -58,6 +58,19 @@ export interface ElectronAPI {
      */
     openExternal: (url: string) => Promise<{ success: boolean; error?: string }>;
   };
+  /**
+   * Passkey lifecycle events emitted from the main process after a
+   * `pagespace://passkey-registered` deep link. The credential is already
+   * persisted server-side by the time the callback fires — renderers should
+   * use this to re-fetch their passkey list, not to mutate auth state.
+   */
+  passkey: {
+    /**
+     * Subscribe to `passkey:registered` IPC broadcasts.
+     * @returns Unsubscribe function that removes just this listener.
+     */
+    onRegistered: (callback: () => void) => () => void;
+  };
   mcp: {
     getConfig: () => Promise<MCPConfig>;
     updateConfig: (config: MCPConfig) => Promise<{ success: boolean }>;


### PR DESCRIPTION
## Summary

Sub-task **Desktop Deep Link + Preload Bridge** of the `passkey-add-desktop-fix` epic.

Wires up Electron so the system browser can complete a Settings → Security passkey registration and return control to the desktop app via `pagespace://passkey-registered`. The credential is already persisted server-side (by the external register endpoint built in a parallel worktree) — all this task does is focus/create the main window and broadcast a typed IPC event the renderer can subscribe to.

- **`apps/desktop/src/main/passkey-deep-link.ts`** — pure handler `handlePasskeyRegistered(url, deps)`. Host-checks, logs, then asks the wiring to focus the window and broadcast `passkey:registered`. No fetch, no token exchange, no session mutation.
- **`apps/desktop/src/main/deep-links.ts`** — dispatcher gains the new case after `auth-exchange` / `auth-error`, before the generic `deep-link` fallback. Wiring for `focusWindow` / `sendToRenderer`:
    - If `mainWindow` exists and is loaded → focus + `webContents.send` immediately.
    - If `mainWindow` exists but `isLoading()` → defer the send onto the next `did-finish-load` via `webContents.once(...)`.
    - If `mainWindow` is `null` (macOS: all windows closed while app stays in the dock) → call `createWindow()`, then defer the send onto `did-finish-load` of the new window. This is the Codex review fix.
- **`apps/desktop/src/preload/index.ts`** — new top-level `passkey: { onRegistered(cb): () => void }` bridge using `ipcRenderer.on` + `removeListener` for clean unsubscribe. Typed on the local `ElectronAPI` interface.
- **`apps/web/src/types/electron.d.ts`** — renderer ambient type gains the matching `passkey.onRegistered` entry so downstream `PasskeyManager.tsx` can call it type-safely. **This is where the downstream PasskeyManager task should import the type from.**

Explicitly **not** touched: `auth:open-external` IPC handler, `ALLOWED_AUTH_HOSTNAMES`, `ALLOWED_PASSKEY_PATHS` — those belong to the parallel "Electron Open-External Allowlist" task. `pagespace://auth-exchange` behaviour is fully preserved (regression test).

## Commits

- **RED** `ba789d1e` — `test(desktop): RED passkey-registered deep link + preload bridge`
- **GREEN** `7d0f115b` — `feat(desktop): handle pagespace://passkey-registered deep link + preload bridge`
- **Tidy** `ab120b31` — `test(desktop): clean up regression assertion in deep-links.test.ts`
- **Refactor** `5c3616e9` — `refactor(desktop): narrow PasskeyDeepLinkDeps.sendToRenderer to single channel`
- **Codex fix** `9468a34f` — `fix(desktop): passkey-registered must create window + defer IPC if none exists`

## Requirement checklist

- ✅ `pagespace://passkey-registered` focuses the main `BrowserWindow` (restore if minimized, show, focus)
- ✅ `pagespace://passkey-registered` broadcasts `passkey:registered` to the renderer via `webContents.send`
- ✅ `pagespace://passkey-registered` with **no existing main window** creates one and defers the IPC until `did-finish-load` — no silent drops on macOS cold-open from dock
- ✅ `pagespace://passkey-registered` makes **no** HTTP call, token exchange, or session mutation (asserted by `fetchSpy.not.toHaveBeenCalled()`)
- ✅ **Regression:** `pagespace://auth-exchange?code=...` still POSTs to `/api/auth/desktop/exchange` and never emits `passkey:registered` (asserted)
- ✅ Unknown `pagespace://foo-bar` still falls through to the generic `deep-link` IPC channel (asserted)
- ✅ `window.electron.passkey.onRegistered(cb)` subscribes via `ipcRenderer.on('passkey:registered', …)`
- ✅ Returned unsubscribe calls `ipcRenderer.removeListener` and stops delivering callbacks (asserted)
- ✅ Ambient `ElectronAPI` at `apps/web/src/types/electron.d.ts` typed, **no `any`**
- ✅ `pnpm --filter desktop typecheck` clean
- ✅ `pnpm --filter desktop test` clean (120 tests passing, including 4 new deep-links dispatcher tests, 3 passkey-deep-link unit tests, 3 preload bridge tests)
- ✅ `pnpm --filter web typecheck` clean (after `packages/lib` + `packages/db` builds)
- ✅ `pnpm lint` clean monorepo-wide

## Regression proof

`apps/desktop/src/main/__tests__/deep-links.test.ts` → "given pagespace://auth-exchange (regression) › should still POST to /api/auth/desktop/exchange and never broadcast passkey:registered". Stubs `fetch`, calls `handleDeepLink('pagespace://auth-exchange?code=code123&provider=google')`, and asserts:
1. `fetch` called exactly once against `/api/auth/desktop/exchange` with `method: 'POST'`
2. `webContents.send` never called with `'passkey:registered'`

## Ambient type location for downstream PasskeyManager task

The downstream `PasskeyManager.tsx` renderer task should import via `window.electron.passkey.onRegistered` — typed in **`apps/web/src/types/electron.d.ts`** on the `ElectronAPI` interface. The preload-side mirror lives in `apps/desktop/src/preload/index.ts` on its own `ElectronAPI` export.

## Test plan

- [x] `pnpm --filter desktop test` — 120 passed (was 119, +1 null-window regression)
- [x] `pnpm --filter desktop typecheck` — clean
- [x] `pnpm --filter web typecheck` — clean
- [x] `pnpm lint` — clean
- [ ] Manual: after PasskeyManager worktree lands, verify in a packaged Electron build that:
    - cold-open from dock via `pagespace://passkey-registered` triggers the renderer subscription
    - in-session deep link focuses an existing window + triggers the renderer subscription