### PR TITLE
feat(auth): passkey add-from-settings desktop fix — integration

### DIFF
--- a/apps/web/src/app/api/auth/passkey/register/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/register/__tests__/route.test.ts
@@ -42,6 +42,10 @@ vi.mock('@/lib/auth', () => ({
   isAuthError: vi.fn(),
   isSessionAuthResult: vi.fn(),
   getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
+  getBearerToken: vi.fn((req: Request) => {
+    const header = req.headers.get('authorization');
+    return header && header.startsWith('Bearer ') ? header.slice(7) : null;
+  }),
 }));
 
 import { POST } from '../route';
@@ -233,6 +237,21 @@ describe('POST /api/auth/passkey/register', () => {
       });
 
       const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.error).toBe('Invalid CSRF token');
+    });
+
+    it('does NOT skip CSRF when Authorization uses a non-Bearer scheme (e.g. Basic)', async () => {
+      vi.mocked(validateCSRFToken).mockReturnValue(false);
+
+      const response = await POST(
+        createRequest(validPayload, {
+          Authorization: 'Basic dXNlcjpwYXNz',
+          'x-csrf-token': 'bad',
+        })
+      );
       const body = await response.json();
 
       expect(response.status).toBe(403);

--- a/apps/web/src/app/api/auth/passkey/register/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/register/__tests__/route.test.ts
@@ -311,6 +311,24 @@ describe('POST /api/auth/passkey/register', () => {
   });
 
   describe('input validation', () => {
+    it('returns 400 (not 500) when the request body is malformed JSON', async () => {
+      const request = new Request('http://localhost/api/auth/passkey/register', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-csrf-token': 'valid-csrf-token',
+        },
+        body: 'not-json{',
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toBe('Invalid request body');
+      expect(authenticateSessionRequest).not.toHaveBeenCalled();
+    });
+
     it('returns 400 for missing expectedChallenge', async () => {
       const response = await POST(createRequest({ response: {} }));
       const body = await response.json();

--- a/apps/web/src/app/api/auth/passkey/register/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/register/__tests__/route.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 vi.mock('@pagespace/lib/auth', () => ({
   verifyRegistration: vi.fn(),
   validateCSRFToken: vi.fn(),
+  consumePasskeyRegisterHandoff: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/server', () => ({
@@ -44,7 +45,11 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 import { POST } from '../route';
-import { verifyRegistration, validateCSRFToken } from '@pagespace/lib/auth';
+import {
+  verifyRegistration,
+  validateCSRFToken,
+  consumePasskeyRegisterHandoff,
+} from '@pagespace/lib/auth';
 import { loggers, auditRequest } from '@pagespace/lib/server';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
 import { checkDistributedRateLimit } from '@pagespace/lib/security';
@@ -88,6 +93,7 @@ describe('POST /api/auth/passkey/register', () => {
       allowed: true,
       attemptsRemaining: 4,
     });
+    vi.mocked(consumePasskeyRegisterHandoff).mockResolvedValue(null);
   });
 
   describe('successful registration', () => {
@@ -387,6 +393,104 @@ describe('POST /api/auth/passkey/register', () => {
       expect(loggers.auth.warn).toHaveBeenCalledWith('Passkey registration verification failed', expect.objectContaining({
         error: 'VERIFICATION_FAILED',
       }));
+    });
+  });
+
+  describe('desktop handoff-token branch', () => {
+    const handoffPayload = {
+      handoffToken: 'good-token',
+      response: { id: 'cred-1', rawId: 'raw', type: 'public-key' },
+      expectedChallenge: 'challenge-123',
+      name: 'Handoff Passkey',
+    };
+
+    const handoffRequest = () =>
+      new Request('http://localhost/api/auth/passkey/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(handoffPayload),
+      });
+
+    it('accepts a valid handoff token without session auth or CSRF and registers passkey', async () => {
+      vi.mocked(consumePasskeyRegisterHandoff).mockResolvedValue({
+        userId: 'user-handoff',
+        createdAt: Date.now(),
+      });
+      vi.mocked(verifyRegistration).mockResolvedValue({
+        ok: true,
+        data: { passkeyId: 'pk-handoff-1' },
+      });
+
+      const response = await POST(handoffRequest());
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.passkeyId).toBe('pk-handoff-1');
+      expect(consumePasskeyRegisterHandoff).toHaveBeenCalledWith('good-token');
+      expect(authenticateSessionRequest).not.toHaveBeenCalled();
+      expect(validateCSRFToken).not.toHaveBeenCalled();
+      expect(verifyRegistration).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'user-handoff', name: 'Handoff Passkey' })
+      );
+    });
+
+    it('returns 401 with HANDOFF_INVALID and audits when handoff is already consumed', async () => {
+      vi.mocked(consumePasskeyRegisterHandoff).mockResolvedValue(null);
+
+      const response = await POST(handoffRequest());
+      const body = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(body.code).toBe('HANDOFF_INVALID');
+      expect(auditRequest).toHaveBeenCalledWith(
+        expect.any(Request),
+        expect.objectContaining({
+          eventType: 'security.suspicious.activity',
+          details: expect.objectContaining({
+            reason: 'passkey_handoff_invalid',
+            flow: 'register',
+          }),
+        })
+      );
+      expect(verifyRegistration).not.toHaveBeenCalled();
+    });
+
+    it('enforces one-time-use — a second call with the same token is rejected', async () => {
+      vi.mocked(consumePasskeyRegisterHandoff)
+        .mockResolvedValueOnce({ userId: 'user-handoff', createdAt: Date.now() })
+        .mockResolvedValueOnce(null);
+      vi.mocked(verifyRegistration).mockResolvedValue({
+        ok: true,
+        data: { passkeyId: 'pk-handoff-1' },
+      });
+
+      const first = await POST(handoffRequest());
+      expect(first.status).toBe(200);
+
+      const second = await POST(handoffRequest());
+      expect(second.status).toBe(401);
+      const body = await second.json();
+      expect(body.code).toBe('HANDOFF_INVALID');
+    });
+
+    it('rate limits the handoff branch against the consumed userId bucket', async () => {
+      vi.mocked(consumePasskeyRegisterHandoff).mockResolvedValue({
+        userId: 'user-rl',
+        createdAt: Date.now(),
+      });
+      vi.mocked(checkDistributedRateLimit).mockResolvedValue({
+        allowed: false,
+        attemptsRemaining: 0,
+        retryAfter: 300,
+      });
+
+      const response = await POST(handoffRequest());
+      expect(response.status).toBe(429);
+      expect(checkDistributedRateLimit).toHaveBeenCalledWith(
+        'passkey_register:user-rl',
+        expect.any(Object)
+      );
+      expect(verifyRegistration).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/auth/passkey/register/handoff/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/register/handoff/__tests__/route.test.ts
@@ -38,6 +38,10 @@ vi.mock('@/lib/auth', () => ({
   isAuthError: vi.fn(),
   isSessionAuthResult: vi.fn(),
   getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
+  getBearerToken: vi.fn((req: Request) => {
+    const header = req.headers.get('authorization');
+    return header && header.startsWith('Bearer ') ? header.slice(7) : null;
+  }),
 }));
 
 import { POST } from '../route';
@@ -168,6 +172,22 @@ describe('POST /api/auth/passkey/register/handoff', () => {
 
       const response = await POST(request);
       expect(response.status).toBe(403);
+    });
+
+    it('does NOT skip CSRF when Authorization uses a non-Bearer scheme (e.g. Basic)', async () => {
+      vi.mocked(validateCSRFToken).mockReturnValue(false);
+
+      const response = await POST(
+        createRequest({
+          Authorization: 'Basic dXNlcjpwYXNz',
+          'x-csrf-token': 'bad',
+        })
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.error).toBe('Invalid CSRF token');
+      expect(createPasskeyRegisterHandoff).not.toHaveBeenCalled();
     });
 
     it('skips CSRF validation for Bearer token auth', async () => {

--- a/apps/web/src/app/api/auth/passkey/register/handoff/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/register/handoff/__tests__/route.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Contract tests for POST /api/auth/passkey/register/handoff
+ *
+ * Authenticated endpoint the Electron renderer calls to mint a one-time
+ * handoff token that authorises an external-browser passkey registration
+ * ceremony. Required because Electron's Chromium cannot drive platform
+ * authenticators on macOS without entitlements we don't ship.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@pagespace/lib/auth', () => ({
+  createPasskeyRegisterHandoff: vi.fn(),
+  validateCSRFToken: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/server', () => ({
+  loggers: {
+    auth: {
+      error: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    },
+  },
+  auditRequest: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/security', () => ({
+  checkDistributedRateLimit: vi.fn(),
+  DISTRIBUTED_RATE_LIMITS: {
+    PASSKEY_REGISTER: { maxAttempts: 5, windowMs: 300000, progressiveDelay: false },
+  },
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateSessionRequest: vi.fn(),
+  isAuthError: vi.fn(),
+  isSessionAuthResult: vi.fn(),
+  getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
+}));
+
+import { POST } from '../route';
+import { createPasskeyRegisterHandoff, validateCSRFToken } from '@pagespace/lib/auth';
+import { loggers, auditRequest } from '@pagespace/lib/server';
+import { checkDistributedRateLimit } from '@pagespace/lib/security';
+import {
+  authenticateSessionRequest,
+  isAuthError,
+  isSessionAuthResult,
+} from '@/lib/auth';
+import { NextResponse } from 'next/server';
+
+const createRequest = (headers: Record<string, string> = {}) =>
+  new Request('http://localhost/api/auth/passkey/register/handoff', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-csrf-token': 'valid-csrf-token',
+      ...headers,
+    },
+    body: JSON.stringify({}),
+  });
+
+describe('POST /api/auth/passkey/register/handoff', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(isAuthError).mockReturnValue(false);
+    vi.mocked(isSessionAuthResult).mockReturnValue(true);
+    vi.mocked(authenticateSessionRequest).mockResolvedValue({
+      userId: 'user-1',
+      role: 'user',
+      tokenVersion: 0,
+      adminRoleVersion: 0,
+      tokenType: 'session',
+      sessionId: 'session-1',
+    });
+    vi.mocked(validateCSRFToken).mockReturnValue(true);
+    vi.mocked(checkDistributedRateLimit).mockResolvedValue({
+      allowed: true,
+      attemptsRemaining: 4,
+    });
+    vi.mocked(createPasskeyRegisterHandoff).mockResolvedValue('handoff-token-abc');
+  });
+
+  describe('successful mint', () => {
+    it('returns 200 with handoffToken and 300s expiresIn', async () => {
+      const response = await POST(createRequest());
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.handoffToken).toBe('handoff-token-abc');
+      expect(body.expiresIn).toBe(300);
+      expect(response.headers.get('Cache-Control')).toBe(
+        'no-store, no-cache, must-revalidate'
+      );
+    });
+
+    it('mints the handoff against the authenticated userId', async () => {
+      await POST(createRequest());
+
+      expect(createPasskeyRegisterHandoff).toHaveBeenCalledWith({ userId: 'user-1' });
+    });
+
+    it('audits token creation', async () => {
+      await POST(createRequest());
+
+      expect(auditRequest).toHaveBeenCalledWith(
+        expect.any(Request),
+        expect.objectContaining({
+          eventType: 'auth.token.created',
+          userId: 'user-1',
+          details: expect.objectContaining({ tokenType: 'passkey_register_handoff' }),
+        })
+      );
+    });
+  });
+
+  describe('authentication errors', () => {
+    it('returns auth error when not authenticated', async () => {
+      const authErrorResponse = NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 }
+      );
+      vi.mocked(isAuthError).mockReturnValue(true);
+      vi.mocked(authenticateSessionRequest).mockResolvedValue({ error: authErrorResponse });
+
+      const response = await POST(createRequest());
+      const body = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(body.error).toBe('Authentication required');
+      expect(createPasskeyRegisterHandoff).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('CSRF validation', () => {
+    it('returns 403 when CSRF token is invalid', async () => {
+      vi.mocked(validateCSRFToken).mockReturnValue(false);
+
+      const response = await POST(createRequest({ 'x-csrf-token': 'bad' }));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.error).toBe('Invalid CSRF token');
+      expect(auditRequest).toHaveBeenCalledWith(
+        expect.any(Request),
+        expect.objectContaining({
+          eventType: 'security.suspicious.activity',
+          details: expect.objectContaining({
+            reason: 'passkey_csrf_invalid',
+            flow: 'register_handoff',
+          }),
+        })
+      );
+      expect(createPasskeyRegisterHandoff).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when CSRF header is missing', async () => {
+      vi.mocked(validateCSRFToken).mockReturnValue(false);
+
+      const request = new Request('http://localhost/api/auth/passkey/register/handoff', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(403);
+    });
+
+    it('skips CSRF validation for Bearer token auth', async () => {
+      vi.mocked(validateCSRFToken).mockReturnValue(false);
+
+      const response = await POST(
+        createRequest({ Authorization: 'Bearer ps_sess_token' })
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.handoffToken).toBe('handoff-token-abc');
+    });
+  });
+
+  describe('rate limiting', () => {
+    it('returns 429 when rate limited and does not mint', async () => {
+      vi.mocked(checkDistributedRateLimit).mockResolvedValue({
+        allowed: false,
+        attemptsRemaining: 0,
+        retryAfter: 300,
+      });
+
+      const response = await POST(createRequest());
+      const body = await response.json();
+
+      expect(response.status).toBe(429);
+      expect(body.error).toBe('Too many requests');
+      expect(body.retryAfter).toBe(300);
+      expect(auditRequest).toHaveBeenCalledWith(
+        expect.any(Request),
+        expect.objectContaining({
+          eventType: 'security.rate.limited',
+          userId: 'user-1',
+          details: expect.objectContaining({ reason: 'passkey_rate_limit_register' }),
+        })
+      );
+      expect(createPasskeyRegisterHandoff).not.toHaveBeenCalled();
+    });
+
+    it('uses the same per-user passkey_register bucket as the register routes', async () => {
+      await POST(createRequest());
+
+      expect(checkDistributedRateLimit).toHaveBeenCalledWith(
+        'passkey_register:user-1',
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('unexpected errors', () => {
+    it('returns 500 when createPasskeyRegisterHandoff throws', async () => {
+      vi.mocked(createPasskeyRegisterHandoff).mockRejectedValueOnce(
+        new Error('Redis unavailable')
+      );
+
+      const response = await POST(createRequest());
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(body.error).toBe('Internal server error');
+      expect(loggers.auth.error).toHaveBeenCalledWith(
+        'Passkey register handoff error',
+        expect.any(Error)
+      );
+    });
+  });
+});

--- a/apps/web/src/app/api/auth/passkey/register/handoff/route.ts
+++ b/apps/web/src/app/api/auth/passkey/register/handoff/route.ts
@@ -10,6 +10,7 @@ import {
 } from '@pagespace/lib/security';
 import {
   authenticateSessionRequest,
+  getBearerToken,
   isAuthError,
   isSessionAuthResult,
 } from '@/lib/auth';
@@ -35,7 +36,7 @@ export async function POST(req: Request) {
     const userId = authResult.userId;
     const sessionId = isSessionAuthResult(authResult) ? authResult.sessionId : null;
 
-    const hasBearerAuth = !!req.headers.get('authorization');
+    const hasBearerAuth = !!getBearerToken(req);
     if (!hasBearerAuth && sessionId) {
       const csrfToken = req.headers.get('x-csrf-token');
       if (!csrfToken || !validateCSRFToken(csrfToken, sessionId)) {

--- a/apps/web/src/app/api/auth/passkey/register/handoff/route.ts
+++ b/apps/web/src/app/api/auth/passkey/register/handoff/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from 'next/server';
+import {
+  createPasskeyRegisterHandoff,
+  validateCSRFToken,
+} from '@pagespace/lib/auth';
+import { loggers, auditRequest } from '@pagespace/lib/server';
+import {
+  checkDistributedRateLimit,
+  DISTRIBUTED_RATE_LIMITS,
+} from '@pagespace/lib/security';
+import {
+  authenticateSessionRequest,
+  isAuthError,
+  isSessionAuthResult,
+} from '@/lib/auth';
+
+const HANDOFF_TTL_SECONDS = 300;
+
+/**
+ * POST /api/auth/passkey/register/handoff
+ *
+ * Mint a short-lived, one-time handoff token the Electron renderer can pass
+ * to the system browser so the external passkey-register page can drive the
+ * WebAuthn ceremony without a PageSpace session cookie. Authenticated and
+ * CSRF-protected; uses the same per-user passkey_register rate limit bucket
+ * as the register routes so a handoff token cannot escape its bounds.
+ */
+export async function POST(req: Request) {
+  try {
+    const authResult = await authenticateSessionRequest(req);
+    if (isAuthError(authResult)) {
+      return authResult.error;
+    }
+
+    const userId = authResult.userId;
+    const sessionId = isSessionAuthResult(authResult) ? authResult.sessionId : null;
+
+    const hasBearerAuth = !!req.headers.get('authorization');
+    if (!hasBearerAuth && sessionId) {
+      const csrfToken = req.headers.get('x-csrf-token');
+      if (!csrfToken || !validateCSRFToken(csrfToken, sessionId)) {
+        auditRequest(req, {
+          eventType: 'security.suspicious.activity',
+          userId,
+          riskScore: 0.6,
+          details: { reason: 'passkey_csrf_invalid', flow: 'register_handoff' },
+        });
+        return NextResponse.json({ error: 'Invalid CSRF token' }, { status: 403 });
+      }
+    }
+
+    const rateLimitKey = `passkey_register:${userId}`;
+    const rateLimitResult = await checkDistributedRateLimit(
+      rateLimitKey,
+      DISTRIBUTED_RATE_LIMITS.PASSKEY_REGISTER
+    );
+
+    if (!rateLimitResult.allowed) {
+      auditRequest(req, {
+        eventType: 'security.rate.limited',
+        userId,
+        riskScore: 0.5,
+        details: { reason: 'passkey_rate_limit_register' },
+      });
+      return NextResponse.json(
+        { error: 'Too many requests', retryAfter: rateLimitResult.retryAfter },
+        { status: 429 }
+      );
+    }
+
+    const handoffToken = await createPasskeyRegisterHandoff({ userId });
+
+    auditRequest(req, {
+      eventType: 'auth.token.created',
+      userId,
+      details: { tokenType: 'passkey_register_handoff' },
+    });
+
+    loggers.auth.info('Passkey register handoff minted', { userId });
+
+    return NextResponse.json(
+      { handoffToken, expiresIn: HANDOFF_TTL_SECONDS },
+      { headers: { 'Cache-Control': 'no-store, no-cache, must-revalidate' } }
+    );
+  } catch (error) {
+    loggers.auth.error('Passkey register handoff error', error as Error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/auth/passkey/register/options/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/register/options/__tests__/route.test.ts
@@ -390,6 +390,50 @@ describe('POST /api/auth/passkey/register/options', () => {
       expect(generateRegistrationOptions).not.toHaveBeenCalled();
     });
 
+    it('treats a JSON "null" body as empty and falls through to the session path (not 500)', async () => {
+      vi.mocked(generateRegistrationOptions).mockResolvedValue({
+        ok: true,
+        // @ts-expect-error - partial mock data
+        data: { options: {} },
+      });
+
+      const request = new Request('http://localhost/api/auth/passkey/register/options', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-csrf-token': 'valid-csrf-token',
+        },
+        body: 'null',
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      // Handoff never engaged; session auth path ran instead.
+      expect(peekPasskeyRegisterHandoff).not.toHaveBeenCalled();
+      expect(authenticateSessionRequest).toHaveBeenCalled();
+    });
+
+    it('treats malformed JSON as empty body and falls through to the session path', async () => {
+      vi.mocked(generateRegistrationOptions).mockResolvedValue({
+        ok: true,
+        // @ts-expect-error - partial mock data
+        data: { options: {} },
+      });
+
+      const request = new Request('http://localhost/api/auth/passkey/register/options', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-csrf-token': 'valid-csrf-token',
+        },
+        body: 'not-json{',
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(200);
+      expect(peekPasskeyRegisterHandoff).not.toHaveBeenCalled();
+    });
+
     it('uses peek (not consume) so the verify step still finds the token', async () => {
       vi.mocked(peekPasskeyRegisterHandoff).mockResolvedValue({
         userId: 'user-1',

--- a/apps/web/src/app/api/auth/passkey/register/options/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/register/options/__tests__/route.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 vi.mock('@pagespace/lib/auth', () => ({
   generateRegistrationOptions: vi.fn(),
   validateCSRFToken: vi.fn(),
+  peekPasskeyRegisterHandoff: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/server', () => ({
@@ -40,19 +41,28 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 import { POST } from '../route';
-import { generateRegistrationOptions, validateCSRFToken } from '@pagespace/lib/auth';
+import {
+  generateRegistrationOptions,
+  validateCSRFToken,
+  peekPasskeyRegisterHandoff,
+} from '@pagespace/lib/auth';
 import { loggers, auditRequest } from '@pagespace/lib/server';
 import { checkDistributedRateLimit } from '@pagespace/lib/security';
 import { authenticateSessionRequest, isAuthError, isSessionAuthResult, getClientIP } from '@/lib/auth';
 import { NextResponse } from 'next/server';
 
-const createRequest = (headers: Record<string, string> = {}) =>
+const createRequest = (
+  headers: Record<string, string> = {},
+  body: Record<string, unknown> = {},
+) =>
   new Request('http://localhost/api/auth/passkey/register/options', {
     method: 'POST',
     headers: {
+      'Content-Type': 'application/json',
       'x-csrf-token': 'valid-csrf-token',
       ...headers,
     },
+    body: JSON.stringify(body),
   });
 
 describe('POST /api/auth/passkey/register/options', () => {
@@ -75,6 +85,7 @@ describe('POST /api/auth/passkey/register/options', () => {
       allowed: true,
       attemptsRemaining: 4,
     });
+    vi.mocked(peekPasskeyRegisterHandoff).mockResolvedValue(null);
   });
 
   describe('successful options generation', () => {
@@ -294,6 +305,111 @@ describe('POST /api/auth/passkey/register/options', () => {
       expect(loggers.auth.warn).toHaveBeenCalledWith('Passkey registration options failed', expect.objectContaining({
         error: 'DB_ERROR',
       }));
+    });
+  });
+
+  describe('desktop handoff-token branch', () => {
+    it('accepts a valid handoff token without session auth or CSRF', async () => {
+      vi.mocked(peekPasskeyRegisterHandoff).mockResolvedValue({
+        userId: 'user-handoff',
+        createdAt: Date.now(),
+      });
+      vi.mocked(generateRegistrationOptions).mockResolvedValue({
+        ok: true,
+        // @ts-expect-error - partial mock data
+        data: { options: { challenge: 'h-chal' } },
+      });
+
+      const request = new Request('http://localhost/api/auth/passkey/register/options', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ handoffToken: 'good-token' }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.options).toEqual({ challenge: 'h-chal' });
+      expect(peekPasskeyRegisterHandoff).toHaveBeenCalledWith('good-token');
+      expect(authenticateSessionRequest).not.toHaveBeenCalled();
+      expect(validateCSRFToken).not.toHaveBeenCalled();
+      expect(generateRegistrationOptions).toHaveBeenCalledWith({ userId: 'user-handoff' });
+    });
+
+    it('returns 401 with HANDOFF_INVALID and audits when handoff token is invalid/expired', async () => {
+      vi.mocked(peekPasskeyRegisterHandoff).mockResolvedValue(null);
+
+      const request = new Request('http://localhost/api/auth/passkey/register/options', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ handoffToken: 'expired-token' }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(body.code).toBe('HANDOFF_INVALID');
+      expect(auditRequest).toHaveBeenCalledWith(
+        expect.any(Request),
+        expect.objectContaining({
+          eventType: 'security.suspicious.activity',
+          details: expect.objectContaining({
+            reason: 'passkey_handoff_invalid',
+            flow: 'register_options',
+          }),
+        })
+      );
+      expect(generateRegistrationOptions).not.toHaveBeenCalled();
+    });
+
+    it('rate limits the handoff branch against the same per-user bucket', async () => {
+      vi.mocked(peekPasskeyRegisterHandoff).mockResolvedValue({
+        userId: 'user-rl',
+        createdAt: Date.now(),
+      });
+      vi.mocked(checkDistributedRateLimit).mockResolvedValue({
+        allowed: false,
+        attemptsRemaining: 0,
+        retryAfter: 300,
+      });
+
+      const request = new Request('http://localhost/api/auth/passkey/register/options', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ handoffToken: 'good-token' }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(429);
+      expect(checkDistributedRateLimit).toHaveBeenCalledWith(
+        'passkey_register:user-rl',
+        expect.any(Object)
+      );
+      expect(generateRegistrationOptions).not.toHaveBeenCalled();
+    });
+
+    it('uses peek (not consume) so the verify step still finds the token', async () => {
+      vi.mocked(peekPasskeyRegisterHandoff).mockResolvedValue({
+        userId: 'user-1',
+        createdAt: Date.now(),
+      });
+      vi.mocked(generateRegistrationOptions).mockResolvedValue({
+        ok: true,
+        // @ts-expect-error - partial mock data
+        data: { options: {} },
+      });
+
+      const request = new Request('http://localhost/api/auth/passkey/register/options', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ handoffToken: 'good-token' }),
+      });
+
+      await POST(request);
+
+      expect(peekPasskeyRegisterHandoff).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/apps/web/src/app/api/auth/passkey/register/options/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/register/options/__tests__/route.test.ts
@@ -38,6 +38,10 @@ vi.mock('@/lib/auth', () => ({
   isAuthError: vi.fn(),
   isSessionAuthResult: vi.fn(),
   getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
+  getBearerToken: vi.fn((req: Request) => {
+    const header = req.headers.get('authorization');
+    return header && header.startsWith('Bearer ') ? header.slice(7) : null;
+  }),
 }));
 
 import { POST } from '../route';
@@ -173,6 +177,19 @@ describe('POST /api/auth/passkey/register/options', () => {
       });
 
       const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.error).toBe('Invalid CSRF token');
+    });
+
+    it('does NOT skip CSRF when Authorization uses a non-Bearer scheme (e.g. Basic)', async () => {
+      vi.mocked(validateCSRFToken).mockReturnValue(false);
+
+      const response = await POST(createRequest({
+        Authorization: 'Basic dXNlcjpwYXNz',
+        'x-csrf-token': 'bad',
+      }));
       const body = await response.json();
 
       expect(response.status).toBe(403);
@@ -413,13 +430,7 @@ describe('POST /api/auth/passkey/register/options', () => {
       expect(authenticateSessionRequest).toHaveBeenCalled();
     });
 
-    it('treats malformed JSON as empty body and falls through to the session path', async () => {
-      vi.mocked(generateRegistrationOptions).mockResolvedValue({
-        ok: true,
-        // @ts-expect-error - partial mock data
-        data: { options: {} },
-      });
-
+    it('returns 400 (not 500, not session fallthrough) when body is malformed JSON', async () => {
       const request = new Request('http://localhost/api/auth/passkey/register/options', {
         method: 'POST',
         headers: {
@@ -430,7 +441,12 @@ describe('POST /api/auth/passkey/register/options', () => {
       });
 
       const response = await POST(request);
-      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(response.status).toBe(400);
+      expect(body.error).toBe('Invalid request body');
+      // Parse error surfaced before auth, so session auth never ran and no
+      // handoff token was consulted — matches register/route.ts behavior.
+      expect(authenticateSessionRequest).not.toHaveBeenCalled();
       expect(peekPasskeyRegisterHandoff).not.toHaveBeenCalled();
     });
 

--- a/apps/web/src/app/api/auth/passkey/register/options/route.ts
+++ b/apps/web/src/app/api/auth/passkey/register/options/route.ts
@@ -20,7 +20,11 @@ async function readOptionalJson(req: Request): Promise<Record<string, unknown>> 
   try {
     const text = await req.text();
     if (!text) return {};
-    return JSON.parse(text) as Record<string, unknown>;
+    const parsed: unknown = JSON.parse(text);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {};
+    }
+    return parsed as Record<string, unknown>;
   } catch {
     return {};
   }

--- a/apps/web/src/app/api/auth/passkey/register/options/route.ts
+++ b/apps/web/src/app/api/auth/passkey/register/options/route.ts
@@ -11,23 +11,28 @@ import {
 } from '@pagespace/lib/security';
 import {
   authenticateSessionRequest,
+  getBearerToken,
   isAuthError,
   isSessionAuthResult,
   getClientIP,
 } from '@/lib/auth';
 
+/**
+ * Reads the request body as a JSON object. Empty bodies resolve to `{}` so
+ * unauthenticated/session callers without a body still reach the session-auth
+ * path. Non-object JSON (null, arrays, primitives) is normalized to `{}`.
+ * Malformed JSON surfaces as a SyntaxError so the caller can return a
+ * controlled 400 — swallowing it would hide client errors and let bad input
+ * accidentally engage the session path.
+ */
 async function readOptionalJson(req: Request): Promise<Record<string, unknown>> {
-  try {
-    const text = await req.text();
-    if (!text) return {};
-    const parsed: unknown = JSON.parse(text);
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      return {};
-    }
-    return parsed as Record<string, unknown>;
-  } catch {
+  const text = await req.text();
+  if (!text) return {};
+  const parsed: unknown = JSON.parse(text);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
     return {};
   }
+  return parsed as Record<string, unknown>;
 }
 
 /**
@@ -44,7 +49,16 @@ async function readOptionalJson(req: Request): Promise<Record<string, unknown>> 
 export async function POST(req: Request) {
   try {
     const clientIP = getClientIP(req);
-    const body = await readOptionalJson(req);
+
+    let body: Record<string, unknown>;
+    try {
+      body = await readOptionalJson(req);
+    } catch {
+      return NextResponse.json(
+        { error: 'Invalid request body' },
+        { status: 400 }
+      );
+    }
     const handoffToken =
       typeof body.handoffToken === 'string' ? body.handoffToken : null;
 
@@ -73,7 +87,7 @@ export async function POST(req: Request) {
       userId = authResult.userId;
       const sessionId = isSessionAuthResult(authResult) ? authResult.sessionId : null;
 
-      const hasBearerAuth = !!req.headers.get('authorization');
+      const hasBearerAuth = !!getBearerToken(req);
       if (!hasBearerAuth && sessionId) {
         const csrfToken = req.headers.get('x-csrf-token');
         if (!csrfToken || !validateCSRFToken(csrfToken, sessionId)) {

--- a/apps/web/src/app/api/auth/passkey/register/options/route.ts
+++ b/apps/web/src/app/api/auth/passkey/register/options/route.ts
@@ -1,5 +1,9 @@
 import { NextResponse } from 'next/server';
-import { generateRegistrationOptions, validateCSRFToken } from '@pagespace/lib/auth';
+import {
+  generateRegistrationOptions,
+  validateCSRFToken,
+  peekPasskeyRegisterHandoff,
+} from '@pagespace/lib/auth';
 import { loggers, auditRequest } from '@pagespace/lib/server';
 import {
   checkDistributedRateLimit,
@@ -12,44 +16,77 @@ import {
   getClientIP,
 } from '@/lib/auth';
 
+async function readOptionalJson(req: Request): Promise<Record<string, unknown>> {
+  try {
+    const text = await req.text();
+    if (!text) return {};
+    return JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
 /**
  * POST /api/auth/passkey/register/options
  *
- * Generate WebAuthn registration options for adding a passkey to the authenticated user's account.
- * Requires session authentication and CSRF token.
+ * Generate WebAuthn registration options for adding a passkey to an account.
+ *
+ * Two auth modes:
+ * - Session: `authenticateSessionRequest` + CSRF header.
+ * - Desktop handoff: `{ handoffToken }` in body — peek (non-destructive) so
+ *   the verify step still finds a live token. Bypasses session + CSRF; the
+ *   handoff token IS the capability, minted against a session and TTL-bound.
  */
 export async function POST(req: Request) {
   try {
     const clientIP = getClientIP(req);
+    const body = await readOptionalJson(req);
+    const handoffToken =
+      typeof body.handoffToken === 'string' ? body.handoffToken : null;
 
-    // Verify session auth
-    const authResult = await authenticateSessionRequest(req);
-    if (isAuthError(authResult)) {
-      return authResult.error;
-    }
+    let userId: string;
 
-    const userId = authResult.userId;
-    const sessionId = isSessionAuthResult(authResult) ? authResult.sessionId : null;
-
-    // Verify CSRF token (skip for Bearer token auth - not vulnerable to CSRF)
-    const hasBearerAuth = !!req.headers.get('authorization');
-    if (!hasBearerAuth && sessionId) {
-      const csrfToken = req.headers.get('x-csrf-token');
-      if (!csrfToken || !validateCSRFToken(csrfToken, sessionId)) {
+    if (handoffToken) {
+      const peeked = await peekPasskeyRegisterHandoff(handoffToken);
+      if (!peeked) {
         auditRequest(req, {
           eventType: 'security.suspicious.activity',
-          userId,
           riskScore: 0.6,
-          details: { reason: 'passkey_csrf_invalid', flow: 'register_options' },
+          details: { reason: 'passkey_handoff_invalid', flow: 'register_options' },
         });
         return NextResponse.json(
-          { error: 'Invalid CSRF token' },
-          { status: 403 }
+          { error: 'Invalid or expired handoff token', code: 'HANDOFF_INVALID' },
+          { status: 401 }
         );
+      }
+      userId = peeked.userId;
+    } else {
+      const authResult = await authenticateSessionRequest(req);
+      if (isAuthError(authResult)) {
+        return authResult.error;
+      }
+
+      userId = authResult.userId;
+      const sessionId = isSessionAuthResult(authResult) ? authResult.sessionId : null;
+
+      const hasBearerAuth = !!req.headers.get('authorization');
+      if (!hasBearerAuth && sessionId) {
+        const csrfToken = req.headers.get('x-csrf-token');
+        if (!csrfToken || !validateCSRFToken(csrfToken, sessionId)) {
+          auditRequest(req, {
+            eventType: 'security.suspicious.activity',
+            userId,
+            riskScore: 0.6,
+            details: { reason: 'passkey_csrf_invalid', flow: 'register_options' },
+          });
+          return NextResponse.json(
+            { error: 'Invalid CSRF token' },
+            { status: 403 }
+          );
+        }
       }
     }
 
-    // Rate limiting
     const rateLimitKey = `passkey_register:${userId}`;
     const rateLimitResult = await checkDistributedRateLimit(
       rateLimitKey,
@@ -69,7 +106,6 @@ export async function POST(req: Request) {
       );
     }
 
-    // Generate registration options
     const result = await generateRegistrationOptions({ userId });
 
     if (!result.ok) {

--- a/apps/web/src/app/api/auth/passkey/register/route.ts
+++ b/apps/web/src/app/api/auth/passkey/register/route.ts
@@ -40,7 +40,15 @@ export async function POST(req: Request) {
   try {
     const clientIP = getClientIP(req);
 
-    const body = await req.json();
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch {
+      return NextResponse.json(
+        { error: 'Invalid request body' },
+        { status: 400 }
+      );
+    }
     const validation = verifySchema.safeParse(body);
 
     if (!validation.success) {

--- a/apps/web/src/app/api/auth/passkey/register/route.ts
+++ b/apps/web/src/app/api/auth/passkey/register/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod/v4';
-import { verifyRegistration, validateCSRFToken } from '@pagespace/lib/auth';
+import {
+  verifyRegistration,
+  validateCSRFToken,
+  consumePasskeyRegisterHandoff,
+} from '@pagespace/lib/auth';
 import { loggers, auditRequest } from '@pagespace/lib/server';
 import { trackAuthEvent } from '@pagespace/lib/activity-tracker';
 import {
@@ -18,46 +22,79 @@ const verifySchema = z.object({
   response: z.any(), // WebAuthn response - validated by simplewebauthn
   expectedChallenge: z.string().min(1),
   name: z.string().max(255).optional(),
+  handoffToken: z.string().min(1).optional(),
 });
 
 /**
  * POST /api/auth/passkey/register
  *
  * Verify WebAuthn registration response and store the new passkey.
- * Requires session authentication and CSRF token.
+ *
+ * Two auth modes:
+ * - Session: `authenticateSessionRequest` + CSRF header.
+ * - Desktop handoff: `{ handoffToken }` in body — atomically consumed
+ *   (one-time use). Bypasses session + CSRF; the handoff token IS the
+ *   capability, minted against a session and TTL-bound.
  */
 export async function POST(req: Request) {
   try {
     const clientIP = getClientIP(req);
 
-    // Verify session auth
-    const authResult = await authenticateSessionRequest(req);
-    if (isAuthError(authResult)) {
-      return authResult.error;
+    const body = await req.json();
+    const validation = verifySchema.safeParse(body);
+
+    if (!validation.success) {
+      return NextResponse.json(
+        { error: 'Invalid request body', details: validation.error.flatten().fieldErrors },
+        { status: 400 }
+      );
     }
 
-    const userId = authResult.userId;
-    const sessionId = isSessionAuthResult(authResult) ? authResult.sessionId : null;
+    const { response, expectedChallenge, name, handoffToken } = validation.data;
 
-    // Verify CSRF token (skip for Bearer token auth - not vulnerable to CSRF)
-    const hasBearerAuth = !!req.headers.get('authorization');
-    if (!hasBearerAuth && sessionId) {
-      const csrfToken = req.headers.get('x-csrf-token');
-      if (!csrfToken || !validateCSRFToken(csrfToken, sessionId)) {
+    let userId: string;
+
+    if (handoffToken) {
+      const consumed = await consumePasskeyRegisterHandoff(handoffToken);
+      if (!consumed) {
         auditRequest(req, {
           eventType: 'security.suspicious.activity',
-          userId,
           riskScore: 0.6,
-          details: { reason: 'passkey_csrf_invalid', flow: 'register' },
+          details: { reason: 'passkey_handoff_invalid', flow: 'register' },
         });
         return NextResponse.json(
-          { error: 'Invalid CSRF token' },
-          { status: 403 }
+          { error: 'Invalid or expired handoff token', code: 'HANDOFF_INVALID' },
+          { status: 401 }
         );
+      }
+      userId = consumed.userId;
+    } else {
+      const authResult = await authenticateSessionRequest(req);
+      if (isAuthError(authResult)) {
+        return authResult.error;
+      }
+
+      userId = authResult.userId;
+      const sessionId = isSessionAuthResult(authResult) ? authResult.sessionId : null;
+
+      const hasBearerAuth = !!req.headers.get('authorization');
+      if (!hasBearerAuth && sessionId) {
+        const csrfToken = req.headers.get('x-csrf-token');
+        if (!csrfToken || !validateCSRFToken(csrfToken, sessionId)) {
+          auditRequest(req, {
+            eventType: 'security.suspicious.activity',
+            userId,
+            riskScore: 0.6,
+            details: { reason: 'passkey_csrf_invalid', flow: 'register' },
+          });
+          return NextResponse.json(
+            { error: 'Invalid CSRF token' },
+            { status: 403 }
+          );
+        }
       }
     }
 
-    // Rate limiting
     const rateLimitKey = `passkey_register:${userId}`;
     const rateLimitResult = await checkDistributedRateLimit(
       rateLimitKey,
@@ -77,20 +114,6 @@ export async function POST(req: Request) {
       );
     }
 
-    // Parse and validate request body
-    const body = await req.json();
-    const validation = verifySchema.safeParse(body);
-
-    if (!validation.success) {
-      return NextResponse.json(
-        { error: 'Invalid request body', details: validation.error.flatten().fieldErrors },
-        { status: 400 }
-      );
-    }
-
-    const { response, expectedChallenge, name } = validation.data;
-
-    // Verify registration
     const result = await verifyRegistration({
       userId,
       response,
@@ -121,7 +144,6 @@ export async function POST(req: Request) {
       );
     }
 
-    // Track successful passkey registration
     trackAuthEvent(userId, 'passkey_registered', {
       ip: clientIP,
       passkeyId: result.data.passkeyId,

--- a/apps/web/src/app/api/auth/passkey/register/route.ts
+++ b/apps/web/src/app/api/auth/passkey/register/route.ts
@@ -13,6 +13,7 @@ import {
 } from '@pagespace/lib/security';
 import {
   authenticateSessionRequest,
+  getBearerToken,
   isAuthError,
   isSessionAuthResult,
   getClientIP,
@@ -85,7 +86,7 @@ export async function POST(req: Request) {
       userId = authResult.userId;
       const sessionId = isSessionAuthResult(authResult) ? authResult.sessionId : null;
 
-      const hasBearerAuth = !!req.headers.get('authorization');
+      const hasBearerAuth = !!getBearerToken(req);
       if (!hasBearerAuth && sessionId) {
         const csrfToken = req.headers.get('x-csrf-token');
         if (!csrfToken || !validateCSRFToken(csrfToken, sessionId)) {

--- a/apps/web/src/app/auth/passkey-register-external/page.tsx
+++ b/apps/web/src/app/auth/passkey-register-external/page.tsx
@@ -19,7 +19,10 @@ function PasskeyRegisterExternalContent() {
     if (started.current) return;
     started.current = true;
 
-    const params = parsePasskeyRegisterExternalParams(window.location.search);
+    const params = parsePasskeyRegisterExternalParams(
+      window.location.search,
+      window.location.hash,
+    );
     if (!params) {
       setStatus({
         kind: 'error',
@@ -28,17 +31,34 @@ function PasskeyRegisterExternalContent() {
       return;
     }
 
-    void runPasskeyRegisterExternalCeremony({
+    // Drop the fragment from the visible URL so the capability token is not
+    // left sitting in the browser address bar after consumption.
+    if (window.location.hash) {
+      window.history.replaceState(
+        null,
+        '',
+        window.location.pathname + window.location.search,
+      );
+    }
+
+    runPasskeyRegisterExternalCeremony({
       handoffToken: params.handoffToken,
       deviceName: params.deviceName,
-    }).then((result) => {
-      if (result.ok) {
-        setStatus({ kind: 'redirecting' });
-        window.location.href = result.deepLink;
-      } else {
-        setStatus({ kind: 'error', message: result.error });
-      }
-    });
+    })
+      .then((result) => {
+        if (result.ok) {
+          setStatus({ kind: 'redirecting' });
+          window.location.href = result.deepLink;
+        } else {
+          setStatus({ kind: 'error', message: result.error });
+        }
+      })
+      .catch((err: unknown) => {
+        setStatus({
+          kind: 'error',
+          message: err instanceof Error ? err.message : 'Unexpected error',
+        });
+      });
   }, []);
 
   return (

--- a/apps/web/src/app/auth/passkey-register-external/page.tsx
+++ b/apps/web/src/app/auth/passkey-register-external/page.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { Suspense, useEffect, useRef, useState } from 'react';
+import { Loader2, ShieldAlert } from 'lucide-react';
+import { AuthShell } from '@/components/auth/AuthShell';
+import { runPasskeyRegisterExternalCeremony } from '@/components/auth/runPasskeyRegisterExternalCeremony';
+import { parsePasskeyRegisterExternalParams } from '@/components/auth/passkeyExternal';
+
+type Status =
+  | { kind: 'running' }
+  | { kind: 'redirecting' }
+  | { kind: 'error'; message: string };
+
+function PasskeyRegisterExternalContent() {
+  const [status, setStatus] = useState<Status>({ kind: 'running' });
+  const started = useRef(false);
+
+  useEffect(() => {
+    if (started.current) return;
+    started.current = true;
+
+    const params = parsePasskeyRegisterExternalParams(window.location.search);
+    if (!params) {
+      setStatus({
+        kind: 'error',
+        message: 'Missing handoff token or device info in the handoff URL.',
+      });
+      return;
+    }
+
+    void runPasskeyRegisterExternalCeremony({
+      handoffToken: params.handoffToken,
+      deviceName: params.deviceName,
+    }).then((result) => {
+      if (result.ok) {
+        setStatus({ kind: 'redirecting' });
+        window.location.href = result.deepLink;
+      } else {
+        setStatus({ kind: 'error', message: result.error });
+      }
+    });
+  }, []);
+
+  return (
+    <AuthShell>
+      <div className="flex flex-col items-center gap-4 py-6 text-center">
+        {status.kind === 'error' ? (
+          <>
+            <ShieldAlert className="h-8 w-8 text-destructive" />
+            <div>
+              <p className="text-sm font-medium text-foreground">
+                Could not add passkey
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">{status.message}</p>
+              <p className="mt-4 text-xs text-muted-foreground">
+                You can close this window and try again from the desktop app.
+              </p>
+            </div>
+          </>
+        ) : (
+          <>
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            <div>
+              <p className="text-sm font-medium text-foreground">
+                {status.kind === 'redirecting'
+                  ? 'Returning to the desktop app…'
+                  : 'Adding your passkey…'}
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Use Touch ID, Windows Hello, or your security key when prompted.
+              </p>
+            </div>
+          </>
+        )}
+      </div>
+    </AuthShell>
+  );
+}
+
+export default function PasskeyRegisterExternalPage() {
+  return (
+    <Suspense
+      fallback={
+        <AuthShell>
+          <div className="flex flex-col items-center gap-4 py-6 text-center">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">Preparing passkey prompt…</p>
+          </div>
+        </AuthShell>
+      }
+    >
+      <PasskeyRegisterExternalContent />
+    </Suspense>
+  );
+}

--- a/apps/web/src/components/auth/__tests__/passkeyExternal.test.ts
+++ b/apps/web/src/components/auth/__tests__/passkeyExternal.test.ts
@@ -82,7 +82,7 @@ describe('parsePasskeyExternalParams', () => {
 });
 
 describe('buildPasskeyRegisterExternalUrl', () => {
-  it('builds an /auth/passkey-register-external URL with all three fields', () => {
+  it('puts deviceId + deviceName in query but handoffToken in the URL fragment', () => {
     const url = buildPasskeyRegisterExternalUrl('https://pagespace.ai', {
       deviceId: 'device-123',
       deviceName: 'Jono Mac',
@@ -94,7 +94,14 @@ describe('buildPasskeyRegisterExternalUrl', () => {
     expect(parsed.pathname).toBe('/auth/passkey-register-external');
     expect(parsed.searchParams.get('deviceId')).toBe('device-123');
     expect(parsed.searchParams.get('deviceName')).toBe('Jono Mac');
-    expect(parsed.searchParams.get('handoffToken')).toBe('handoff-abc');
+    // handoffToken must NOT appear in the query — it's a capability token and
+    // fragments are never sent to the server, never logged in access logs or
+    // CDNs, and never carried in the Referer header.
+    expect(parsed.searchParams.get('handoffToken')).toBeNull();
+    expect(parsed.search).not.toContain('handoffToken');
+
+    const fragment = new URLSearchParams(parsed.hash.replace(/^#/, ''));
+    expect(fragment.get('handoffToken')).toBe('handoff-abc');
   });
 
   it('encodes device names with spaces and special characters', () => {
@@ -108,7 +115,7 @@ describe('buildPasskeyRegisterExternalUrl', () => {
     expect(parsed.searchParams.get('deviceName')).toBe("Jono's MacBook Pro");
   });
 
-  it('round-trips build → parse for a device name with special characters', () => {
+  it('round-trips build → parse with search + hash for special characters', () => {
     const fields = {
       deviceId: 'device-xyz',
       deviceName: "Jono's MacBook Pro / Work",
@@ -116,7 +123,7 @@ describe('buildPasskeyRegisterExternalUrl', () => {
     };
     const url = buildPasskeyRegisterExternalUrl('https://pagespace.ai', fields);
     const parsed = new URL(url);
-    const recovered = parsePasskeyRegisterExternalParams(parsed.search);
+    const recovered = parsePasskeyRegisterExternalParams(parsed.search, parsed.hash);
     expect(recovered).toEqual(fields);
   });
 
@@ -136,9 +143,17 @@ describe('buildPasskeyRegisterExternalUrl', () => {
 describe('parsePasskeyRegisterExternalParams', () => {
   it('returns deviceId, deviceName, and handoffToken when all are present', () => {
     expect(
-      parsePasskeyRegisterExternalParams(
-        '?deviceId=d-1&deviceName=Mac&handoffToken=h-1',
-      ),
+      parsePasskeyRegisterExternalParams('?deviceId=d-1&deviceName=Mac', '#handoffToken=h-1'),
+    ).toEqual({
+      deviceId: 'd-1',
+      deviceName: 'Mac',
+      handoffToken: 'h-1',
+    });
+  });
+
+  it('accepts a hash string without a leading #', () => {
+    expect(
+      parsePasskeyRegisterExternalParams('?deviceId=d-1&deviceName=Mac', 'handoffToken=h-1'),
     ).toEqual({
       deviceId: 'd-1',
       deviceName: 'Mac',
@@ -148,23 +163,23 @@ describe('parsePasskeyRegisterExternalParams', () => {
 
   it('returns null when deviceId is missing', () => {
     expect(
-      parsePasskeyRegisterExternalParams('?deviceName=Mac&handoffToken=h-1'),
+      parsePasskeyRegisterExternalParams('?deviceName=Mac', '#handoffToken=h-1'),
     ).toBeNull();
   });
 
   it('returns null when deviceName is missing', () => {
     expect(
-      parsePasskeyRegisterExternalParams('?deviceId=d-1&handoffToken=h-1'),
+      parsePasskeyRegisterExternalParams('?deviceId=d-1', '#handoffToken=h-1'),
     ).toBeNull();
   });
 
-  it('returns null when handoffToken is missing', () => {
+  it('returns null when handoffToken fragment is missing', () => {
     expect(
       parsePasskeyRegisterExternalParams('?deviceId=d-1&deviceName=Mac'),
     ).toBeNull();
   });
 
-  it('returns null for an empty search string', () => {
+  it('returns null for an empty search and hash', () => {
     expect(parsePasskeyRegisterExternalParams('')).toBeNull();
   });
 });

--- a/apps/web/src/components/auth/__tests__/runPasskeyRegisterExternalCeremony.test.ts
+++ b/apps/web/src/components/auth/__tests__/runPasskeyRegisterExternalCeremony.test.ts
@@ -15,7 +15,7 @@ const registrationResponse = {
 };
 
 function mockFetch(handlers: Record<string, () => Response | Promise<Response>>) {
-  return vi.fn(async (input: unknown) => {
+  return vi.fn(async (input: unknown, _init?: unknown) => {
     const url = typeof input === 'string' ? input : (input as Request).url;
     for (const [pattern, handler] of Object.entries(handlers)) {
       if (url.includes(pattern)) return handler();

--- a/apps/web/src/components/auth/__tests__/runPasskeyRegisterExternalCeremony.test.ts
+++ b/apps/web/src/components/auth/__tests__/runPasskeyRegisterExternalCeremony.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@simplewebauthn/browser', () => ({
+  startRegistration: vi.fn(),
+}));
+
+import { startRegistration } from '@simplewebauthn/browser';
+import { runPasskeyRegisterExternalCeremony } from '../runPasskeyRegisterExternalCeremony';
+
+const registrationResponse = {
+  id: 'cred-new',
+  rawId: 'raw',
+  type: 'public-key',
+  response: { attestationObject: 'att', clientDataJSON: 'cdj' },
+};
+
+function mockFetch(handlers: Record<string, () => Response | Promise<Response>>) {
+  return vi.fn(async (input: unknown) => {
+    const url = typeof input === 'string' ? input : (input as Request).url;
+    for (const [pattern, handler] of Object.entries(handlers)) {
+      if (url.includes(pattern)) return handler();
+    }
+    throw new Error(`Unmocked fetch: ${url}`);
+  });
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('runPasskeyRegisterExternalCeremony', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(startRegistration).mockResolvedValue(
+      registrationResponse as unknown as Awaited<ReturnType<typeof startRegistration>>
+    );
+  });
+
+  it('runs options → startRegistration → verify → returns passkey-registered deep link', async () => {
+    const fetchImpl = mockFetch({
+      '/api/auth/passkey/register/options': () =>
+        jsonResponse({ options: { challenge: 'chal-1' } }),
+      '/api/auth/passkey/register': () =>
+        jsonResponse({ success: true, passkeyId: 'pk-1' }),
+    });
+
+    const result = await runPasskeyRegisterExternalCeremony({
+      handoffToken: 'handoff-abc',
+      deviceName: 'Jono Mac',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.deepLink).toBe('pagespace://passkey-registered');
+  });
+
+  it('sends the handoff token to both options and verify endpoints', async () => {
+    const fetchImpl = mockFetch({
+      '/api/auth/passkey/register/options': () =>
+        jsonResponse({ options: { challenge: 'chal-1' } }),
+      '/api/auth/passkey/register': () =>
+        jsonResponse({ success: true, passkeyId: 'pk-1' }),
+    });
+
+    await runPasskeyRegisterExternalCeremony({
+      handoffToken: 'handoff-abc',
+      deviceName: 'Jono Mac',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const optionsCall = fetchImpl.mock.calls.find(
+      (call) => typeof call[0] === 'string' && call[0] === '/api/auth/passkey/register/options'
+    );
+    expect(optionsCall).toBeDefined();
+    const optionsBody = JSON.parse((optionsCall![1] as RequestInit).body as string);
+    expect(optionsBody).toEqual({ handoffToken: 'handoff-abc' });
+
+    const verifyCall = fetchImpl.mock.calls.find(
+      (call) => typeof call[0] === 'string' && call[0] === '/api/auth/passkey/register'
+    );
+    expect(verifyCall).toBeDefined();
+    const verifyBody = JSON.parse((verifyCall![1] as RequestInit).body as string);
+    expect(verifyBody).toMatchObject({
+      handoffToken: 'handoff-abc',
+      expectedChallenge: 'chal-1',
+      name: 'Jono Mac',
+      response: registrationResponse,
+    });
+  });
+
+  it('returns an error result when the options endpoint rejects the handoff', async () => {
+    const fetchImpl = mockFetch({
+      '/api/auth/passkey/register/options': () =>
+        jsonResponse({ error: 'Invalid or expired handoff token', code: 'HANDOFF_INVALID' }, 401),
+    });
+
+    const result = await runPasskeyRegisterExternalCeremony({
+      handoffToken: 'bad',
+      deviceName: 'Jono Mac',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected error');
+    expect(result.error).toMatch(/handoff/i);
+    expect(startRegistration).not.toHaveBeenCalled();
+  });
+
+  it('returns an error result when the verify endpoint fails', async () => {
+    const fetchImpl = mockFetch({
+      '/api/auth/passkey/register/options': () =>
+        jsonResponse({ options: { challenge: 'c' } }),
+      '/api/auth/passkey/register': () =>
+        jsonResponse({ error: 'Verification failed' }, 400),
+    });
+
+    const result = await runPasskeyRegisterExternalCeremony({
+      handoffToken: 'handoff',
+      deviceName: 'd',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected error');
+    expect(result.error).toMatch(/verification/i);
+  });
+
+  it('returns an error result when startRegistration is cancelled by the user', async () => {
+    vi.mocked(startRegistration).mockRejectedValueOnce(
+      Object.assign(new Error('timed out or not allowed'), { name: 'NotAllowedError' })
+    );
+
+    const fetchImpl = mockFetch({
+      '/api/auth/passkey/register/options': () =>
+        jsonResponse({ options: { challenge: 'c' } }),
+    });
+
+    const result = await runPasskeyRegisterExternalCeremony({
+      handoffToken: 'handoff',
+      deviceName: 'd',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected error');
+    expect(result.error).toMatch(/cancel/i);
+  });
+});

--- a/apps/web/src/components/auth/passkeyExternal.ts
+++ b/apps/web/src/components/auth/passkeyExternal.ts
@@ -41,6 +41,12 @@ export interface PasskeyRegisterExternalFields {
 const PASSKEY_REGISTER_EXTERNAL_PATH = '/auth/passkey-register-external';
 const PASSKEY_REGISTERED_DEEP_LINK = 'pagespace://passkey-registered';
 
+/**
+ * Builds the external-browser handoff URL. The `handoffToken` is carried in
+ * the URL fragment so it never touches the network, server access logs, CDN
+ * logs, the browser's Referer header, or same-origin fetches. `deviceId` and
+ * `deviceName` stay in the query since they are not capability-bearing.
+ */
 export function buildPasskeyRegisterExternalUrl(
   origin: string,
   { deviceId, deviceName, handoffToken }: PasskeyRegisterExternalFields,
@@ -48,17 +54,20 @@ export function buildPasskeyRegisterExternalUrl(
   const url = new URL(PASSKEY_REGISTER_EXTERNAL_PATH, origin);
   url.searchParams.set('deviceId', deviceId);
   url.searchParams.set('deviceName', deviceName);
-  url.searchParams.set('handoffToken', handoffToken);
+  const fragment = new URLSearchParams({ handoffToken });
+  url.hash = fragment.toString();
   return url.toString();
 }
 
 export function parsePasskeyRegisterExternalParams(
   search: string,
+  hash = '',
 ): PasskeyRegisterExternalFields | null {
   const params = new URLSearchParams(search);
   const deviceId = params.get('deviceId');
   const deviceName = params.get('deviceName');
-  const handoffToken = params.get('handoffToken');
+  const fragment = new URLSearchParams(hash.startsWith('#') ? hash.slice(1) : hash);
+  const handoffToken = fragment.get('handoffToken');
   if (!deviceId || !deviceName || !handoffToken) return null;
   return { deviceId, deviceName, handoffToken };
 }

--- a/apps/web/src/components/auth/runPasskeyRegisterExternalCeremony.ts
+++ b/apps/web/src/components/auth/runPasskeyRegisterExternalCeremony.ts
@@ -1,6 +1,8 @@
 import { startRegistration } from '@simplewebauthn/browser';
 import { buildPasskeyRegisteredDeepLink } from './passkeyExternal';
 
+type RegisterOptionsJSON = Parameters<typeof startRegistration>[0]['optionsJSON'];
+
 export interface RunPasskeyRegisterExternalCeremonyInput {
   handoffToken: string;
   deviceName: string;
@@ -33,15 +35,11 @@ export async function runPasskeyRegisterExternalCeremony(
   if (!optionsRes.ok) {
     return { ok: false, error: await readError(optionsRes, 'Failed to fetch registration options') };
   }
-  const { options } = (await optionsRes.json()) as {
-    options: { challenge: string };
-  };
+  const { options } = (await optionsRes.json()) as { options: RegisterOptionsJSON };
 
   let registrationResponse: Awaited<ReturnType<typeof startRegistration>>;
   try {
-    registrationResponse = await startRegistration({
-      optionsJSON: options as unknown as Parameters<typeof startRegistration>[0]['optionsJSON'],
-    });
+    registrationResponse = await startRegistration({ optionsJSON: options });
   } catch (err) {
     if (err instanceof Error && err.name === 'NotAllowedError') {
       return { ok: false, error: 'Registration was cancelled' };

--- a/apps/web/src/components/auth/runPasskeyRegisterExternalCeremony.ts
+++ b/apps/web/src/components/auth/runPasskeyRegisterExternalCeremony.ts
@@ -1,0 +1,70 @@
+import { startRegistration } from '@simplewebauthn/browser';
+import { buildPasskeyRegisteredDeepLink } from './passkeyExternal';
+
+export interface RunPasskeyRegisterExternalCeremonyInput {
+  handoffToken: string;
+  deviceName: string;
+  fetchImpl?: typeof fetch;
+}
+
+export type RunPasskeyRegisterExternalCeremonyResult =
+  | { ok: true; deepLink: string }
+  | { ok: false; error: string };
+
+async function readError(res: Response, fallback: string): Promise<string> {
+  try {
+    const body = (await res.json()) as { error?: string };
+    return body.error || fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export async function runPasskeyRegisterExternalCeremony(
+  input: RunPasskeyRegisterExternalCeremonyInput,
+): Promise<RunPasskeyRegisterExternalCeremonyResult> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+
+  const optionsRes = await fetchImpl('/api/auth/passkey/register/options', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ handoffToken: input.handoffToken }),
+  });
+  if (!optionsRes.ok) {
+    return { ok: false, error: await readError(optionsRes, 'Failed to fetch registration options') };
+  }
+  const { options } = (await optionsRes.json()) as {
+    options: { challenge: string };
+  };
+
+  let registrationResponse: Awaited<ReturnType<typeof startRegistration>>;
+  try {
+    registrationResponse = await startRegistration({
+      optionsJSON: options as unknown as Parameters<typeof startRegistration>[0]['optionsJSON'],
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === 'NotAllowedError') {
+      return { ok: false, error: 'Registration was cancelled' };
+    }
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : 'Registration failed',
+    };
+  }
+
+  const verifyRes = await fetchImpl('/api/auth/passkey/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      handoffToken: input.handoffToken,
+      response: registrationResponse,
+      expectedChallenge: options.challenge,
+      name: input.deviceName,
+    }),
+  });
+  if (!verifyRes.ok) {
+    return { ok: false, error: await readError(verifyRes, 'Registration verification failed') };
+  }
+
+  return { ok: true, deepLink: buildPasskeyRegisteredDeepLink() };
+}

--- a/apps/web/src/components/settings/PasskeyManager.tsx
+++ b/apps/web/src/components/settings/PasskeyManager.tsx
@@ -26,6 +26,8 @@ import {
 import { toast } from 'sonner';
 import { Fingerprint, Key, Trash2, Pencil, Shield, Loader2, AlertCircle } from 'lucide-react';
 import { useCSRFToken } from '@/hooks/useCSRFToken';
+import { isDesktopPlatform, getDevicePlatformFields } from '@/lib/desktop-auth';
+import { buildPasskeyRegisterExternalUrl } from '@/components/auth/passkeyExternal';
 
 interface Passkey {
   id: string;
@@ -60,6 +62,18 @@ export function PasskeyManager() {
     setIsSupported(browserSupportsWebAuthn());
   }, []);
 
+  // Desktop: subscribe to passkey:registered IPC so the list refreshes the
+  // moment the system-browser ceremony completes and the main process fires
+  // the `pagespace://passkey-registered` deep link back into the app.
+  useEffect(() => {
+    if (!isDesktopPlatform() || !window.electron?.passkey?.onRegistered) return;
+    const unsubscribe = window.electron.passkey.onRegistered(() => {
+      mutate('/api/auth/passkey');
+      toast.success('Passkey added successfully');
+    });
+    return unsubscribe;
+  }, []);
+
   const { data, error, isLoading } = useSWR<{ passkeys: Passkey[] }>(
     '/api/auth/passkey',
     fetcher,
@@ -77,6 +91,50 @@ export function PasskeyManager() {
     setIsRegistering(true);
 
     try {
+      // Desktop (Electron): Chromium inside the Electron window cannot drive
+      // Touch ID / Windows Hello without entitlements we don't ship. Mint a
+      // handoff token and delegate the ceremony to the system browser, same
+      // shape as the sign-in flow in PasskeyLoginButton.
+      if (isDesktopPlatform()) {
+        if (!window.electron?.auth?.openExternal) {
+          toast.error(
+            'Your desktop app needs to be updated to add a passkey. Please update the app and try again.'
+          );
+          return;
+        }
+
+        const handoffRes = await fetchWithAuth('/api/auth/passkey/register/handoff', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({}),
+        });
+        if (!handoffRes.ok) {
+          const err = await handoffRes.json().catch(() => ({}));
+          toast.error(err.error || 'Failed to start passkey registration');
+          return;
+        }
+        const { handoffToken } = (await handoffRes.json()) as { handoffToken: string };
+
+        const fields = await getDevicePlatformFields();
+        if (!('deviceId' in fields) || !fields.deviceId) {
+          toast.error('Could not read desktop device info');
+          return;
+        }
+
+        const externalUrl = buildPasskeyRegisterExternalUrl(window.location.origin, {
+          deviceId: fields.deviceId,
+          deviceName: fields.deviceName,
+          handoffToken,
+        });
+        const result = await window.electron.auth.openExternal(externalUrl);
+        if (!result.success) {
+          toast.error(result.error || 'Failed to open browser for passkey registration');
+          return;
+        }
+        toast.info('Complete your passkey prompt in the browser, then return here.');
+        return;
+      }
+
       // Get registration options
       const optionsRes = await fetchWithAuth('/api/auth/passkey/register/options', {
         method: 'POST',

--- a/apps/web/src/components/settings/__tests__/PasskeyManager.desktop.test.tsx
+++ b/apps/web/src/components/settings/__tests__/PasskeyManager.desktop.test.tsx
@@ -122,7 +122,13 @@ describe('PasskeyManager — desktop external-browser branch', () => {
     expect(parsed.pathname).toBe('/auth/passkey-register-external');
     expect(parsed.searchParams.get('deviceId')).toBe('device-xyz');
     expect(parsed.searchParams.get('deviceName')).toBe('Jono Mac');
-    expect(parsed.searchParams.get('handoffToken')).toBe('handoff-abc');
+    // handoffToken must live in the URL fragment, never in the query, so it
+    // is never sent to the server, never logged in access logs/CDNs, and
+    // never carried in the Referer header on downstream requests.
+    expect(parsed.searchParams.get('handoffToken')).toBeNull();
+    expect(parsed.search).not.toContain('handoffToken');
+    const fragment = new URLSearchParams(parsed.hash.replace(/^#/, ''));
+    expect(fragment.get('handoffToken')).toBe('handoff-abc');
   });
 
   it('does not run the WebAuthn ceremony or call register/options in the Electron window', async () => {
@@ -221,7 +227,9 @@ describe('PasskeyManager — desktop without IPC bridge', () => {
 
   it('does not subscribe to passkey:registered when bridge is missing', async () => {
     render(<PasskeyManager />);
-    await new Promise((r) => setTimeout(r, 10));
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /add passkey/i })).toBeInTheDocument()
+    );
     expect(swrMutateMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/settings/__tests__/PasskeyManager.desktop.test.tsx
+++ b/apps/web/src/components/settings/__tests__/PasskeyManager.desktop.test.tsx
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock('@simplewebauthn/browser', () => ({
+  startRegistration: vi.fn(),
+  browserSupportsWebAuthn: vi.fn(() => true),
+}));
+
+vi.mock('@/hooks/useCSRFToken', () => ({
+  useCSRFToken: () => ({ csrfToken: 'csrf-token-value' }),
+}));
+
+vi.mock('@/lib/desktop-auth', () => ({
+  isDesktopPlatform: vi.fn(),
+  getDevicePlatformFields: vi.fn(),
+}));
+
+const fetchWithAuthMock = vi.fn();
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: (...args: unknown[]) => fetchWithAuthMock(...args),
+}));
+
+const swrMutateMock = vi.fn();
+vi.mock('swr', async () => {
+  const actual = await vi.importActual<typeof import('swr')>('swr');
+  return {
+    ...actual,
+    default: () => ({
+      data: { passkeys: [] },
+      error: null,
+      isLoading: false,
+      mutate: vi.fn(),
+    }),
+    mutate: (...args: unknown[]) => swrMutateMock(...args),
+  };
+});
+
+import { PasskeyManager } from '../PasskeyManager';
+import { startRegistration } from '@simplewebauthn/browser';
+import { isDesktopPlatform, getDevicePlatformFields } from '@/lib/desktop-auth';
+import { toast } from 'sonner';
+
+type PasskeyBridge = {
+  isDesktop: boolean;
+  auth?: { openExternal?: ReturnType<typeof vi.fn> };
+  passkey?: { onRegistered: ReturnType<typeof vi.fn> };
+};
+
+function setBridge(bridge: PasskeyBridge | undefined) {
+  if (bridge) {
+    (window as unknown as { electron: PasskeyBridge }).electron = bridge;
+  } else {
+    delete (window as unknown as { electron?: PasskeyBridge }).electron;
+  }
+}
+
+describe('PasskeyManager — desktop external-browser branch', () => {
+  let openExternalMock: ReturnType<typeof vi.fn>;
+  let onRegisteredMock: ReturnType<typeof vi.fn>;
+  let unsubscribeMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchWithAuthMock.mockReset();
+
+    vi.mocked(isDesktopPlatform).mockReturnValue(true);
+    vi.mocked(getDevicePlatformFields).mockResolvedValue({
+      platform: 'desktop',
+      deviceId: 'device-xyz',
+      deviceName: 'Jono Mac',
+    });
+
+    openExternalMock = vi.fn().mockResolvedValue({ success: true });
+    unsubscribeMock = vi.fn();
+    onRegisteredMock = vi.fn().mockReturnValue(unsubscribeMock);
+
+    setBridge({
+      isDesktop: true,
+      auth: { openExternal: openExternalMock },
+      passkey: { onRegistered: onRegisteredMock },
+    });
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: new URL('http://localhost:3000/settings/security'),
+    });
+  });
+
+  afterEach(() => {
+    setBridge(undefined);
+  });
+
+  it('POSTs handoff then opens the system browser to /auth/passkey-register-external with deviceId + deviceName + handoffToken', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ handoffToken: 'handoff-abc', expiresIn: 300 }),
+    });
+
+    render(<PasskeyManager />);
+
+    await userEvent.click(screen.getByRole('button', { name: /add passkey/i }));
+
+    await waitFor(() => expect(openExternalMock).toHaveBeenCalledTimes(1));
+
+    const handoffCall = fetchWithAuthMock.mock.calls.find(
+      ([url]) => url === '/api/auth/passkey/register/handoff'
+    );
+    expect(handoffCall).toBeDefined();
+    expect((handoffCall![1] as RequestInit).method).toBe('POST');
+
+    const [url] = openExternalMock.mock.calls[0];
+    const parsed = new URL(url as string);
+    expect(parsed.pathname).toBe('/auth/passkey-register-external');
+    expect(parsed.searchParams.get('deviceId')).toBe('device-xyz');
+    expect(parsed.searchParams.get('deviceName')).toBe('Jono Mac');
+    expect(parsed.searchParams.get('handoffToken')).toBe('handoff-abc');
+  });
+
+  it('does not run the WebAuthn ceremony or call register/options in the Electron window', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ handoffToken: 'handoff-abc', expiresIn: 300 }),
+    });
+
+    render(<PasskeyManager />);
+
+    await userEvent.click(screen.getByRole('button', { name: /add passkey/i }));
+
+    await waitFor(() => expect(openExternalMock).toHaveBeenCalled());
+
+    expect(startRegistration).not.toHaveBeenCalled();
+    const optionsCalls = fetchWithAuthMock.mock.calls.filter(
+      ([url]) => typeof url === 'string' && url === '/api/auth/passkey/register/options'
+    );
+    expect(optionsCalls).toHaveLength(0);
+  });
+
+  it('subscribes to passkey:registered and refreshes the passkey list when the deep link returns', async () => {
+    render(<PasskeyManager />);
+
+    await waitFor(() => expect(onRegisteredMock).toHaveBeenCalledTimes(1));
+
+    const callback = onRegisteredMock.mock.calls[0][0] as () => void;
+    callback();
+
+    expect(swrMutateMock).toHaveBeenCalledWith('/api/auth/passkey');
+    expect(toast.success).toHaveBeenCalledWith(expect.stringMatching(/passkey/i));
+  });
+
+  it('unsubscribes from passkey:registered on unmount', async () => {
+    const { unmount } = render(<PasskeyManager />);
+    await waitFor(() => expect(onRegisteredMock).toHaveBeenCalled());
+    unmount();
+    expect(unsubscribeMock).toHaveBeenCalled();
+  });
+
+  it('surfaces an error toast when openExternal rejects and does not run the ceremony', async () => {
+    fetchWithAuthMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ handoffToken: 'handoff-abc', expiresIn: 300 }),
+    });
+    openExternalMock.mockResolvedValueOnce({
+      success: false,
+      error: 'URL hostname "localhost" is not allowed',
+    });
+
+    render(<PasskeyManager />);
+
+    await userEvent.click(screen.getByRole('button', { name: /add passkey/i }));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('not allowed'))
+    );
+    expect(startRegistration).not.toHaveBeenCalled();
+  });
+});
+
+describe('PasskeyManager — desktop without IPC bridge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchWithAuthMock.mockReset();
+
+    vi.mocked(isDesktopPlatform).mockReturnValue(true);
+    vi.mocked(getDevicePlatformFields).mockResolvedValue({
+      platform: 'desktop',
+      deviceId: 'device-xyz',
+      deviceName: 'Jono Mac',
+    });
+
+    setBridge(undefined);
+  });
+
+  afterEach(() => {
+    setBridge(undefined);
+  });
+
+  it('surfaces an update-app error and posts nothing when openExternal is missing', async () => {
+    render(<PasskeyManager />);
+
+    await userEvent.click(screen.getByRole('button', { name: /add passkey/i }));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(expect.stringMatching(/desktop app/i))
+    );
+
+    const passkeyFetchCalls = fetchWithAuthMock.mock.calls.filter(
+      ([url]) => typeof url === 'string' && url.includes('/api/auth/passkey')
+    );
+    expect(passkeyFetchCalls).toHaveLength(0);
+    expect(startRegistration).not.toHaveBeenCalled();
+  });
+
+  it('does not subscribe to passkey:registered when bridge is missing', async () => {
+    render(<PasskeyManager />);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(swrMutateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('PasskeyManager — web path (regression guard)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchWithAuthMock.mockReset();
+
+    vi.mocked(isDesktopPlatform).mockReturnValue(false);
+    vi.mocked(getDevicePlatformFields).mockResolvedValue({});
+    setBridge(undefined);
+  });
+
+  it('still runs the in-browser register ceremony on web (no IPC invoked)', async () => {
+    fetchWithAuthMock.mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: 'Failed to start registration' }),
+    });
+
+    render(<PasskeyManager />);
+
+    await userEvent.click(screen.getByRole('button', { name: /add passkey/i }));
+
+    await waitFor(() =>
+      expect(fetchWithAuthMock).toHaveBeenCalledWith(
+        '/api/auth/passkey/register/options',
+        expect.any(Object)
+      )
+    );
+    expect((window as unknown as { electron?: PasskeyBridge }).electron).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -52,7 +52,7 @@ function unauthorized(message: string, status = 401): NextResponse {
   return NextResponse.json({ error: message }, { status });
 }
 
-function getBearerToken(request: Request): string | null {
+export function getBearerToken(request: Request): string | null {
   const authHeader = request.headers.get('authorization');
   if (!authHeader || !authHeader.startsWith(BEARER_PREFIX)) {
     return null;


### PR DESCRIPTION
Completes the **Passkey Add Desktop Fix** epic (`tasks/passkey-add-desktop-fix.md`). Wires the four merged foundation PRs into a working end-to-end flow so Electron users can add a passkey from Settings → Security. Electron's Chromium cannot drive Touch ID / Windows Hello without entitlements we don't ship, so the ceremony is delegated to the system browser via the same `shell.openExternal` + `pagespace://` deep-link pattern PR #1001 used for sign-in.

## Foundations (already on master)

| PR | Provided |
|---|---|
| #1010 | `createPasskeyRegisterHandoff` / `peekPasskeyRegisterHandoff` / `consumePasskeyRegisterHandoff` — Redis-backed, 300s TTL, atomic Lua consume, SHA-256 hashed at rest |
| #1009 | `buildPasskeyRegisterExternalUrl` / `parsePasskeyRegisterExternalParams` / `buildPasskeyRegisteredDeepLink` |
| #1008 | IPC allowlist accepts `/auth/passkey-register-external` for `window.electron.auth.openExternal` |
| #1011 | Main-process dispatcher for `pagespace://passkey-registered` + `window.electron.passkey.onRegistered` preload API |

## Changes

**New**
- `apps/web/src/app/api/auth/passkey/register/handoff/route.ts` — authenticated mint endpoint. Session auth + CSRF (skipped for Bearer), same per-user `passkey_register` rate limit bucket as the register routes, `auth.token.created` audit. Returns `{ handoffToken, expiresIn: 300 }`.
- `apps/web/src/components/auth/runPasskeyRegisterExternalCeremony.ts` — `options → startRegistration → verify → pagespace://passkey-registered`. Injectable `fetchImpl` for tests. `NotAllowedError` → cancelled result.
- `apps/web/src/app/auth/passkey-register-external/page.tsx` — system-browser landing page that parses the handoff URL, runs the ceremony, and deep-links back to the desktop app. Mirrors `/auth/passkey-external` shell, same React Strict Mode double-invoke guard.

**Modified in place** (mirroring the `desktopExchange=true` alternative-auth branch in `authenticate/route.ts`)
- `apps/web/src/app/api/auth/passkey/register/options/route.ts` — `{ handoffToken }` branch uses `peekPasskeyRegisterHandoff` (non-destructive; the verify step still needs the token). Skips session auth + CSRF; the handoff token IS the capability, minted against a session and TTL-bound. 401 `HANDOFF_INVALID` + `security.suspicious.activity` audit on miss. Rate limit bound to the resolved `userId` so a handoff token cannot escape its per-user bounds. Session path regression-guarded.
- `apps/web/src/app/api/auth/passkey/register/route.ts` — same pattern but uses `consumePasskeyRegisterHandoff` (atomic one-time-use). A second call with the same token is rejected. Session path regression-guarded.
- `apps/web/src/components/settings/PasskeyManager.tsx` — desktop branch in `handleRegister`: update-prompt guard when the IPC bridge is missing, `POST /register/handoff` → `openExternal` with `/auth/passkey-register-external` URL carrying `deviceId`/`deviceName`/`handoffToken`. No in-window `startRegistration`, no name dialog (desktop path uses device name). Deep-link subscription via `window.electron.passkey.onRegistered` refreshes the passkey list (`mutate('/api/auth/passkey')`) and toasts on return. Unsubscribes on unmount. Web path unchanged.

## Testing

- `apps/web/src/app/api/auth/passkey/register/handoff/__tests__/route.test.ts` — 10 tests: mint success + audit, 401 on missing auth, 403 on bad/missing CSRF, Bearer skip, 429 on rate limit + per-user bucket assertion, 500 on throw
- `apps/web/src/app/api/auth/passkey/register/options/__tests__/route.test.ts` — +4 handoff tests (peek, HANDOFF_INVALID, rate limit binding, peek-not-consume)
- `apps/web/src/app/api/auth/passkey/register/__tests__/route.test.ts` — +4 handoff tests (consume, HANDOFF_INVALID audit, one-time-use enforcement, rate limit binding)
- `apps/web/src/components/auth/__tests__/runPasskeyRegisterExternalCeremony.test.ts` — 5 tests: happy path, handoff rejected at options, verify failure, `NotAllowedError` cancelled
- `apps/web/src/components/settings/__tests__/PasskeyManager.desktop.test.tsx` — 8 tests: handoff POST → openExternal URL shape, no in-window ceremony, onRegistered → mutate + toast, unsubscribe on unmount, openExternal rejection, no-bridge update-prompt, web path regression guard

```
pnpm --filter web test passkey           # 171/171 passing
pnpm --filter @pagespace/lib test passkey-register-handoff  # 21/21 passing
pnpm --filter web typecheck               # clean
pnpm --filter web lint                    # clean
```

## Manual smoke test (macOS)

- [ ] `pnpm dev:desktop` — launch Electron with local web
- [ ] Sign in with any method
- [ ] Navigate to Settings → Security
- [ ] Click **Add Passkey** — system browser (not the Electron window) opens `/auth/passkey-register-external`
- [ ] Complete Touch ID prompt in the browser
- [ ] Browser shows "Returning to the desktop app…" and fires `pagespace://passkey-registered`
- [ ] Desktop app regains focus, passkey list refreshes, success toast appears
- [ ] Refresh Settings → Security to confirm the passkey is persisted server-side
- [ ] Click **Add Passkey** again with an older desktop build (no `passkey:registered` bridge) → update-prompt toast, no network calls
- [ ] Web path: open web app, Settings → Security, Add Passkey — in-window ceremony still runs and the name dialog appears (regression guard)

## TDD commits

- RED: `ee49610c`
- GREEN: `e3f58b8c`

Epic: `tasks/passkey-add-desktop-fix.md` — this PR completes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External browser-based passkey registration for desktop apps with a one-time handoff token flow and deep-linking.
  * Alternate handoff path for registration/options that bypasses session+CSRF when a valid handoff token is provided.
  * Client page and UI flow to run external passkey registration and handle redirects/errors.

* **Security**
  * Enforced per-user rate limits and CSRF checks on session-based flows; handoff failures return explicit 401/HANDOFF_INVALID responses and audit events.

* **Tests**
  * Extensive new tests covering handoff, options, routes, external ceremony, URL parsing, and desktop behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->