### PR TITLE
fix(auth): remove duplicate rate-limit debits on handoff register path

### DIFF
--- a/apps/web/src/app/api/auth/passkey/register/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/register/__tests__/route.test.ts
@@ -327,6 +327,21 @@ describe('POST /api/auth/passkey/register', () => {
         })
       );
     });
+
+    it('session-authed path calls checkDistributedRateLimit exactly once with passkey_register:<userId>', async () => {
+      vi.mocked(verifyRegistration).mockResolvedValue({
+        ok: true,
+        data: { passkeyId: 'pk-new-1' },
+      });
+
+      await POST(createRequest());
+
+      expect(checkDistributedRateLimit).toHaveBeenCalledTimes(1);
+      expect(checkDistributedRateLimit).toHaveBeenCalledWith(
+        'passkey_register:user-1',
+        expect.any(Object)
+      );
+    });
   });
 
   describe('input validation', () => {
@@ -510,24 +525,59 @@ describe('POST /api/auth/passkey/register', () => {
       expect(body.code).toBe('HANDOFF_INVALID');
     });
 
-    it('rate limits the handoff branch against the consumed userId bucket', async () => {
+    it('does NOT call checkDistributedRateLimit on the handoff path (consume + TTL + one-time-use is the rate bound)', async () => {
       vi.mocked(consumePasskeyRegisterHandoff).mockResolvedValue({
-        userId: 'user-rl',
+        userId: 'user-handoff',
         createdAt: Date.now(),
       });
-      vi.mocked(checkDistributedRateLimit).mockResolvedValue({
-        allowed: false,
-        attemptsRemaining: 0,
-        retryAfter: 300,
+      vi.mocked(verifyRegistration).mockResolvedValue({
+        ok: true,
+        data: { passkeyId: 'pk-handoff-1' },
       });
 
       const response = await POST(handoffRequest());
-      expect(response.status).toBe(429);
-      expect(checkDistributedRateLimit).toHaveBeenCalledWith(
-        'passkey_register:user-rl',
-        expect.any(Object)
-      );
-      expect(verifyRegistration).not.toHaveBeenCalled();
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.passkeyId).toBe('pk-handoff-1');
+      expect(checkDistributedRateLimit).not.toHaveBeenCalled();
+    });
+
+    it('three back-to-back handoff verifies for the same user all return 200 — the bucket no longer gates desktop', async () => {
+      vi.mocked(consumePasskeyRegisterHandoff)
+        .mockResolvedValueOnce({ userId: 'user-handoff', createdAt: Date.now() })
+        .mockResolvedValueOnce({ userId: 'user-handoff', createdAt: Date.now() })
+        .mockResolvedValueOnce({ userId: 'user-handoff', createdAt: Date.now() });
+      vi.mocked(verifyRegistration).mockResolvedValue({
+        ok: true,
+        data: { passkeyId: 'pk-handoff' },
+      });
+
+      const req1 = new Request('http://localhost/api/auth/passkey/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...handoffPayload, handoffToken: 'token-1' }),
+      });
+      const req2 = new Request('http://localhost/api/auth/passkey/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...handoffPayload, handoffToken: 'token-2' }),
+      });
+      const req3 = new Request('http://localhost/api/auth/passkey/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...handoffPayload, handoffToken: 'token-3' }),
+      });
+
+      const r1 = await POST(req1);
+      const r2 = await POST(req2);
+      const r3 = await POST(req3);
+
+      expect(r1.status).toBe(200);
+      expect(r2.status).toBe(200);
+      expect(r3.status).toBe(200);
+      expect(checkDistributedRateLimit).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/auth/passkey/register/handoff/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/register/handoff/__tests__/route.test.ts
@@ -236,6 +236,31 @@ describe('POST /api/auth/passkey/register/handoff', () => {
         expect.any(Object)
       );
     });
+
+    it('five back-to-back mint calls succeed and the sixth returns 429 — mint is the real rate gate', async () => {
+      vi.mocked(checkDistributedRateLimit)
+        .mockResolvedValueOnce({ allowed: true, attemptsRemaining: 4 })
+        .mockResolvedValueOnce({ allowed: true, attemptsRemaining: 3 })
+        .mockResolvedValueOnce({ allowed: true, attemptsRemaining: 2 })
+        .mockResolvedValueOnce({ allowed: true, attemptsRemaining: 1 })
+        .mockResolvedValueOnce({ allowed: true, attemptsRemaining: 0 })
+        .mockResolvedValueOnce({ allowed: false, attemptsRemaining: 0, retryAfter: 300 });
+
+      const r1 = await POST(createRequest());
+      const r2 = await POST(createRequest());
+      const r3 = await POST(createRequest());
+      const r4 = await POST(createRequest());
+      const r5 = await POST(createRequest());
+      const r6 = await POST(createRequest());
+
+      expect(r1.status).toBe(200);
+      expect(r2.status).toBe(200);
+      expect(r3.status).toBe(200);
+      expect(r4.status).toBe(200);
+      expect(r5.status).toBe(200);
+      expect(r6.status).toBe(429);
+      expect(createPasskeyRegisterHandoff).toHaveBeenCalledTimes(5);
+    });
   });
 
   describe('unexpected errors', () => {

--- a/apps/web/src/app/api/auth/passkey/register/options/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/register/options/__tests__/route.test.ts
@@ -268,6 +268,22 @@ describe('POST /api/auth/passkey/register/options', () => {
         })
       );
     });
+
+    it('session-authed path calls checkDistributedRateLimit exactly once with passkey_register:<userId>', async () => {
+      vi.mocked(generateRegistrationOptions).mockResolvedValue({
+        ok: true,
+        // @ts-expect-error - partial mock data
+        data: { options: {} },
+      });
+
+      await POST(createRequest());
+
+      expect(checkDistributedRateLimit).toHaveBeenCalledTimes(1);
+      expect(checkDistributedRateLimit).toHaveBeenCalledWith(
+        'passkey_register:user-1',
+        expect.any(Object)
+      );
+    });
   });
 
   describe('service errors', () => {
@@ -381,15 +397,15 @@ describe('POST /api/auth/passkey/register/options', () => {
       expect(generateRegistrationOptions).not.toHaveBeenCalled();
     });
 
-    it('rate limits the handoff branch against the same per-user bucket', async () => {
+    it('does NOT call checkDistributedRateLimit on the handoff path (mint + TTL + one-time-use is the rate bound)', async () => {
       vi.mocked(peekPasskeyRegisterHandoff).mockResolvedValue({
-        userId: 'user-rl',
+        userId: 'user-handoff',
         createdAt: Date.now(),
       });
-      vi.mocked(checkDistributedRateLimit).mockResolvedValue({
-        allowed: false,
-        attemptsRemaining: 0,
-        retryAfter: 300,
+      vi.mocked(generateRegistrationOptions).mockResolvedValue({
+        ok: true,
+        // @ts-expect-error - partial mock data
+        data: { options: {} },
       });
 
       const request = new Request('http://localhost/api/auth/passkey/register/options', {
@@ -399,12 +415,26 @@ describe('POST /api/auth/passkey/register/options', () => {
       });
 
       const response = await POST(request);
-      expect(response.status).toBe(429);
-      expect(checkDistributedRateLimit).toHaveBeenCalledWith(
-        'passkey_register:user-rl',
-        expect.any(Object)
-      );
-      expect(generateRegistrationOptions).not.toHaveBeenCalled();
+
+      expect(response.status).toBe(200);
+      expect(checkDistributedRateLimit).not.toHaveBeenCalled();
+    });
+
+    it('does NOT call checkDistributedRateLimit when handoff token is invalid', async () => {
+      vi.mocked(peekPasskeyRegisterHandoff).mockResolvedValue(null);
+
+      const request = new Request('http://localhost/api/auth/passkey/register/options', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ handoffToken: 'expired-token' }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(body.code).toBe('HANDOFF_INVALID');
+      expect(checkDistributedRateLimit).not.toHaveBeenCalled();
     });
 
     it('treats a JSON "null" body as empty and falls through to the session path (not 500)', async () => {

--- a/apps/web/src/app/api/auth/passkey/register/options/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/register/options/__tests__/route.test.ts
@@ -12,6 +12,7 @@ vi.mock('@pagespace/lib/auth', () => ({
   generateRegistrationOptions: vi.fn(),
   validateCSRFToken: vi.fn(),
   peekPasskeyRegisterHandoff: vi.fn(),
+  markPasskeyRegisterOptionsIssued: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/server', () => ({
@@ -49,6 +50,7 @@ import {
   generateRegistrationOptions,
   validateCSRFToken,
   peekPasskeyRegisterHandoff,
+  markPasskeyRegisterOptionsIssued,
 } from '@pagespace/lib/auth';
 import { loggers, auditRequest } from '@pagespace/lib/server';
 import { checkDistributedRateLimit } from '@pagespace/lib/security';
@@ -90,6 +92,7 @@ describe('POST /api/auth/passkey/register/options', () => {
       attemptsRemaining: 4,
     });
     vi.mocked(peekPasskeyRegisterHandoff).mockResolvedValue(null);
+    vi.mocked(markPasskeyRegisterOptionsIssued).mockResolvedValue(true);
   });
 
   describe('successful options generation', () => {
@@ -500,6 +503,104 @@ describe('POST /api/auth/passkey/register/options', () => {
       await POST(request);
 
       expect(peekPasskeyRegisterHandoff).toHaveBeenCalledTimes(1);
+    });
+
+    it('marks the handoff token as options-issued on the happy path', async () => {
+      vi.mocked(peekPasskeyRegisterHandoff).mockResolvedValue({
+        userId: 'user-handoff',
+        createdAt: Date.now(),
+      });
+      vi.mocked(generateRegistrationOptions).mockResolvedValue({
+        ok: true,
+        // @ts-expect-error - partial mock data
+        data: { options: {} },
+      });
+
+      const request = new Request('http://localhost/api/auth/passkey/register/options', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ handoffToken: 'good-token' }),
+      });
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      expect(markPasskeyRegisterOptionsIssued).toHaveBeenCalledWith('good-token');
+    });
+
+    it('returns 401 OPTIONS_ALREADY_ISSUED when marker indicates replay', async () => {
+      vi.mocked(peekPasskeyRegisterHandoff).mockResolvedValue({
+        userId: 'user-handoff',
+        createdAt: Date.now(),
+      });
+      vi.mocked(markPasskeyRegisterOptionsIssued).mockResolvedValue(false);
+
+      const request = new Request('http://localhost/api/auth/passkey/register/options', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ handoffToken: 'replayed-token' }),
+      });
+
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(body.code).toBe('OPTIONS_ALREADY_ISSUED');
+      expect(generateRegistrationOptions).not.toHaveBeenCalled();
+      expect(auditRequest).toHaveBeenCalledWith(
+        expect.any(Request),
+        expect.objectContaining({
+          eventType: 'security.suspicious.activity',
+          userId: 'user-handoff',
+          details: expect.objectContaining({
+            reason: 'passkey_handoff_options_replayed',
+            flow: 'register_options',
+          }),
+        })
+      );
+    });
+
+    it('two calls with the same handoff token: first 200, second 401 OPTIONS_ALREADY_ISSUED', async () => {
+      vi.mocked(peekPasskeyRegisterHandoff).mockResolvedValue({
+        userId: 'user-handoff',
+        createdAt: Date.now(),
+      });
+      vi.mocked(markPasskeyRegisterOptionsIssued)
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false);
+      vi.mocked(generateRegistrationOptions).mockResolvedValue({
+        ok: true,
+        // @ts-expect-error - partial mock data
+        data: { options: { challenge: 'c1' } },
+      });
+
+      const makeReq = () =>
+        new Request('http://localhost/api/auth/passkey/register/options', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ handoffToken: 'replay-target' }),
+        });
+
+      const first = await POST(makeReq());
+      const second = await POST(makeReq());
+
+      expect(first.status).toBe(200);
+      expect(second.status).toBe(401);
+      const body = await second.json();
+      expect(body.code).toBe('OPTIONS_ALREADY_ISSUED');
+      expect(generateRegistrationOptions).toHaveBeenCalledTimes(1);
+    });
+
+    it('session-authed path does NOT call markPasskeyRegisterOptionsIssued', async () => {
+      vi.mocked(generateRegistrationOptions).mockResolvedValue({
+        ok: true,
+        // @ts-expect-error - partial mock data
+        data: { options: {} },
+      });
+
+      await POST(createRequest());
+
+      expect(markPasskeyRegisterOptionsIssued).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/auth/passkey/register/options/route.ts
+++ b/apps/web/src/app/api/auth/passkey/register/options/route.ts
@@ -103,25 +103,25 @@ export async function POST(req: Request) {
           );
         }
       }
-    }
 
-    const rateLimitKey = `passkey_register:${userId}`;
-    const rateLimitResult = await checkDistributedRateLimit(
-      rateLimitKey,
-      DISTRIBUTED_RATE_LIMITS.PASSKEY_REGISTER
-    );
-
-    if (!rateLimitResult.allowed) {
-      auditRequest(req, {
-        eventType: 'security.rate.limited',
-        userId,
-        riskScore: 0.5,
-        details: { reason: 'passkey_rate_limit_register' },
-      });
-      return NextResponse.json(
-        { error: 'Too many requests', retryAfter: rateLimitResult.retryAfter },
-        { status: 429 }
+      const rateLimitKey = `passkey_register:${userId}`;
+      const rateLimitResult = await checkDistributedRateLimit(
+        rateLimitKey,
+        DISTRIBUTED_RATE_LIMITS.PASSKEY_REGISTER
       );
+
+      if (!rateLimitResult.allowed) {
+        auditRequest(req, {
+          eventType: 'security.rate.limited',
+          userId,
+          riskScore: 0.5,
+          details: { reason: 'passkey_rate_limit_register' },
+        });
+        return NextResponse.json(
+          { error: 'Too many requests', retryAfter: rateLimitResult.retryAfter },
+          { status: 429 }
+        );
+      }
     }
 
     const result = await generateRegistrationOptions({ userId });

--- a/apps/web/src/app/api/auth/passkey/register/options/route.ts
+++ b/apps/web/src/app/api/auth/passkey/register/options/route.ts
@@ -3,6 +3,7 @@ import {
   generateRegistrationOptions,
   validateCSRFToken,
   peekPasskeyRegisterHandoff,
+  markPasskeyRegisterOptionsIssued,
 } from '@pagespace/lib/auth';
 import { loggers, auditRequest } from '@pagespace/lib/server';
 import {
@@ -78,6 +79,26 @@ export async function POST(req: Request) {
         );
       }
       userId = peeked.userId;
+
+      const issued = await markPasskeyRegisterOptionsIssued(handoffToken);
+      if (!issued) {
+        auditRequest(req, {
+          eventType: 'security.suspicious.activity',
+          userId,
+          riskScore: 0.6,
+          details: {
+            reason: 'passkey_handoff_options_replayed',
+            flow: 'register_options',
+          },
+        });
+        return NextResponse.json(
+          {
+            error: 'Registration options already issued for this handoff',
+            code: 'OPTIONS_ALREADY_ISSUED',
+          },
+          { status: 401 }
+        );
+      }
     } else {
       const authResult = await authenticateSessionRequest(req);
       if (isAuthError(authResult)) {

--- a/apps/web/src/app/api/auth/passkey/register/route.ts
+++ b/apps/web/src/app/api/auth/passkey/register/route.ts
@@ -102,25 +102,25 @@ export async function POST(req: Request) {
           );
         }
       }
-    }
 
-    const rateLimitKey = `passkey_register:${userId}`;
-    const rateLimitResult = await checkDistributedRateLimit(
-      rateLimitKey,
-      DISTRIBUTED_RATE_LIMITS.PASSKEY_REGISTER
-    );
-
-    if (!rateLimitResult.allowed) {
-      auditRequest(req, {
-        eventType: 'security.rate.limited',
-        userId,
-        riskScore: 0.5,
-        details: { reason: 'passkey_rate_limit_register' },
-      });
-      return NextResponse.json(
-        { error: 'Too many requests', retryAfter: rateLimitResult.retryAfter },
-        { status: 429 }
+      const rateLimitKey = `passkey_register:${userId}`;
+      const rateLimitResult = await checkDistributedRateLimit(
+        rateLimitKey,
+        DISTRIBUTED_RATE_LIMITS.PASSKEY_REGISTER
       );
+
+      if (!rateLimitResult.allowed) {
+        auditRequest(req, {
+          eventType: 'security.rate.limited',
+          userId,
+          riskScore: 0.5,
+          details: { reason: 'passkey_rate_limit_register' },
+        });
+        return NextResponse.json(
+          { error: 'Too many requests', retryAfter: rateLimitResult.retryAfter },
+          { status: 429 }
+        );
+      }
     }
 
     const result = await verifyRegistration({

--- a/docs/1.0-overview/changelog.md
+++ b/docs/1.0-overview/changelog.md
@@ -1,3 +1,17 @@
+## 2026-04-14
+
+### Passkey Desktop Handoff: Register Rate-Limit + Replay Hardening
+
+Fixes a production incident where desktop-v1.0.22 users were blocked from adding a second passkey in the same 15-minute window: the post-#1012 ceremony burned three tokens from the per-user `PASSKEY_REGISTER` bucket (mint + options + verify) against a bucket sized for two. Also closes a correctness gap that two independent review bots (CodeRabbit, Codex) caught during PR review: because `/register/options` uses non-destructive `peek`, a minted handoff token could drive unbounded `generateRegistrationOptions` calls within its 300s TTL.
+
+#### Fixed
+
+- **Double-debit on passkey-add from desktop**: the per-user rate-limit blocks on `/api/auth/passkey/register/options` and `/api/auth/passkey/register` now run only in the session-auth path. The desktop handoff path is bounded by the existing mint endpoint (session-authed + rate-limited, 5/15min/user), the 300s handoff TTL, and the new per-token options guard below. A successful ceremony is now a single token debit on the mint path, not three.
+
+#### Security
+
+- **One-options-per-handoff-token guard**: new `markPasskeyRegisterOptionsIssued` helper in `@pagespace/lib/auth/passkey-register-handoff` uses Redis `SET NX EX 300` keyed by `auth:passkey-register-handoff-options-issued:<sha256(token)>`. The first `/register/options` call for a minted handoff sets the marker; any replay within the TTL returns `401 OPTIONS_ALREADY_ISSUED` with a `security.suspicious.activity` audit event (`reason: passkey_handoff_options_replayed`). Matches the legitimate ceremony (client calls options exactly once per minted token) and is a tighter bound than the pre-#1012 bucket. Fails closed on Redis unavailability or error — clients must re-mint.
+
 ## 2026-04-13
 
 ### Passkey Registration: Prefer Platform Authenticator

--- a/packages/lib/src/auth/__tests__/passkey-register-handoff.test.ts
+++ b/packages/lib/src/auth/__tests__/passkey-register-handoff.test.ts
@@ -22,6 +22,7 @@ import {
   createPasskeyRegisterHandoff,
   peekPasskeyRegisterHandoff,
   consumePasskeyRegisterHandoff,
+  markPasskeyRegisterOptionsIssued,
   type PasskeyRegisterHandoffData,
 } from '../passkey-register-handoff';
 import { tryGetSecurityRedisClient } from '../../security/security-redis';
@@ -30,6 +31,7 @@ interface MockRedis {
   setex: ReturnType<typeof vi.fn>;
   get: ReturnType<typeof vi.fn>;
   eval: ReturnType<typeof vi.fn>;
+  set: ReturnType<typeof vi.fn>;
   store: Map<string, string>;
 }
 
@@ -49,6 +51,20 @@ function makeMockRedis(): MockRedis {
       }
       return value;
     }),
+    set: vi.fn(
+      async (
+        key: string,
+        value: string,
+        ..._flags: unknown[]
+      ): Promise<'OK' | null> => {
+        const hasNX = _flags.includes('NX');
+        if (hasNX && store.has(key)) {
+          return null;
+        }
+        store.set(key, value);
+        return 'OK';
+      }
+    ),
   };
   return redis;
 }
@@ -274,6 +290,91 @@ describe('passkey-register-handoff', () => {
 
       const result = await consumePasskeyRegisterHandoff('some-token');
       expect(result).toBeNull();
+    });
+  });
+
+  describe('markPasskeyRegisterOptionsIssued', () => {
+    it('first call sets the marker via SET NX EX 300 and returns true', async () => {
+      vi.mocked(tryGetSecurityRedisClient).mockResolvedValue(mockRedis as never);
+
+      const result = await markPasskeyRegisterOptionsIssued('token-1');
+
+      expect(result).toBe(true);
+      expect(mockRedis.set).toHaveBeenCalledTimes(1);
+      const [key, value, ...flags] = mockRedis.set.mock.calls[0];
+      expect(key).toMatch(/^auth:passkey-register-handoff-options-issued:/);
+      expect(value).toBe('1');
+      expect(flags).toContain('EX');
+      expect(flags).toContain(300);
+      expect(flags).toContain('NX');
+    });
+
+    it('uses hashToken for the marker key (at-rest protection)', async () => {
+      vi.mocked(tryGetSecurityRedisClient).mockResolvedValue(mockRedis as never);
+
+      await markPasskeyRegisterOptionsIssued('raw-token');
+
+      const [key] = mockRedis.set.mock.calls[0];
+      expect(key).toBe(
+        'auth:passkey-register-handoff-options-issued:hashed_raw-token'
+      );
+    });
+
+    it('second call with the same token returns false (marker already exists)', async () => {
+      vi.mocked(tryGetSecurityRedisClient).mockResolvedValue(mockRedis as never);
+
+      const first = await markPasskeyRegisterOptionsIssued('token-2');
+      const second = await markPasskeyRegisterOptionsIssued('token-2');
+
+      expect(first).toBe(true);
+      expect(second).toBe(false);
+    });
+
+    it('different tokens both succeed', async () => {
+      vi.mocked(tryGetSecurityRedisClient).mockResolvedValue(mockRedis as never);
+
+      expect(await markPasskeyRegisterOptionsIssued('token-a')).toBe(true);
+      expect(await markPasskeyRegisterOptionsIssued('token-b')).toBe(true);
+    });
+
+    it('returns false for empty or non-string token', async () => {
+      vi.mocked(tryGetSecurityRedisClient).mockResolvedValue(mockRedis as never);
+
+      expect(await markPasskeyRegisterOptionsIssued('')).toBe(false);
+      expect(
+        await markPasskeyRegisterOptionsIssued(null as unknown as string)
+      ).toBe(false);
+      expect(mockRedis.set).not.toHaveBeenCalled();
+    });
+
+    it('fails closed when Redis is unavailable in production (returns false)', async () => {
+      const origEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'production';
+      vi.mocked(tryGetSecurityRedisClient).mockResolvedValue(null);
+
+      const result = await markPasskeyRegisterOptionsIssued('token');
+      expect(result).toBe(false);
+
+      process.env.NODE_ENV = origEnv;
+    });
+
+    it('fails closed when Redis is unavailable in development (returns false)', async () => {
+      const origEnv = process.env.NODE_ENV;
+      process.env.NODE_ENV = 'development';
+      vi.mocked(tryGetSecurityRedisClient).mockResolvedValue(null);
+
+      const result = await markPasskeyRegisterOptionsIssued('token');
+      expect(result).toBe(false);
+
+      process.env.NODE_ENV = origEnv;
+    });
+
+    it('fails closed when redis.set rejects (transient connection error)', async () => {
+      vi.mocked(tryGetSecurityRedisClient).mockResolvedValue(mockRedis as never);
+      mockRedis.set.mockRejectedValueOnce(new Error('ECONNRESET'));
+
+      const result = await markPasskeyRegisterOptionsIssued('token');
+      expect(result).toBe(false);
     });
   });
 

--- a/packages/lib/src/auth/passkey-register-handoff.ts
+++ b/packages/lib/src/auth/passkey-register-handoff.ts
@@ -33,6 +33,8 @@ import { tryGetSecurityRedisClient } from '../security/security-redis';
 import { loggers } from '../logging/logger-config';
 
 const PASSKEY_REGISTER_HANDOFF_PREFIX = 'auth:passkey-register-handoff:';
+const PASSKEY_REGISTER_HANDOFF_OPTIONS_PREFIX =
+  'auth:passkey-register-handoff-options-issued:';
 const PASSKEY_REGISTER_HANDOFF_TTL_SECONDS = 300;
 
 export interface PasskeyRegisterHandoffData {
@@ -42,6 +44,10 @@ export interface PasskeyRegisterHandoffData {
 
 function keyFor(token: string): string {
   return `${PASSKEY_REGISTER_HANDOFF_PREFIX}${hashToken(token)}`;
+}
+
+function optionsMarkerKeyFor(token: string): string {
+  return `${PASSKEY_REGISTER_HANDOFF_OPTIONS_PREFIX}${hashToken(token)}`;
 }
 
 /**
@@ -207,5 +213,59 @@ export async function consumePasskeyRegisterHandoff(
       error as Error
     );
     return null;
+  }
+}
+
+/**
+ * One-options-per-handoff-token guard. Sets a short-lived marker the first
+ * time a handoff token is used to issue WebAuthn registration options.
+ * Returns `true` if the marker was set (first call — caller should proceed)
+ * or `false` if the marker already existed (replay — caller should reject).
+ *
+ * Required because the options endpoint uses `peek` (non-destructive), so
+ * without this guard a single minted handoff token could drive unbounded
+ * `generateRegistrationOptions` calls within its TTL. The legitimate
+ * ceremony calls options exactly once per minted token.
+ *
+ * Fails closed: any Redis unavailability or error returns `false`. A
+ * transient Redis blip forces the client to re-mint, which is acceptable
+ * (mint is session-authed + rate-limited) and strictly safer than opening
+ * the replay window.
+ */
+export async function markPasskeyRegisterOptionsIssued(
+  token: string
+): Promise<boolean> {
+  if (!token || typeof token !== 'string') {
+    return false;
+  }
+
+  const redis = await tryGetSecurityRedisClient();
+
+  if (!redis) {
+    if (process.env.NODE_ENV === 'production') {
+      loggers.auth.error(
+        'Cannot mark passkey register options issued: Redis unavailable in production'
+      );
+    }
+    return false;
+  }
+
+  const key = optionsMarkerKeyFor(token);
+
+  try {
+    const result = await redis.set(
+      key,
+      '1',
+      'EX',
+      PASSKEY_REGISTER_HANDOFF_TTL_SECONDS,
+      'NX'
+    );
+    return result === 'OK';
+  } catch (error) {
+    loggers.auth.error(
+      'Passkey register options marker Redis error',
+      error as Error
+    );
+    return false;
   }
 }


### PR DESCRIPTION
## Incident

Shipped `desktop-v1.0.22` with #1012 (Passkey Add Desktop Fix). Immediately after install, a real desktop user hit a production 429:

> `security.rate.limited` / `reason: passkey_rate_limit_register`
> user-agent: `desktop/1.0.22 ... Electron/33.4.11`

The user was locked out of adding passkeys. Hot fix.

## Root cause

`DISTRIBUTED_RATE_LIMITS.PASSKEY_REGISTER` is `{ maxAttempts: 5, windowMs: 15min }` — sized for the pre-#1012 ceremony which burned **2** bucket tokens per attempt (options + verify).

#1012 added a new mint-handoff step that also rate-limited under the same `passkey_register:${userId}` key, turning every ceremony into a **3-hit** operation against a 5-token bucket. One successful ceremony now consumes 3 of 5 tokens → the second attempt 429s at the mint step. Cancelled attempts (Touch ID rejected, network hiccup) also burn tokens.

## Fix, part 1 — scope the per-user rate limit to the session path

The handoff path is already gated by the mint endpoint (session-authed + rate-limited against the same per-user bucket, 5/15min), so rate-limiting `/register/options` and `/register` **again** on the handoff path is double-counting. Moved those two `checkDistributedRateLimit` blocks inside the session-auth else branches so they never fire on the handoff path. The mint endpoint is untouched — it remains the real ceremony-start gate.

## Fix, part 2 — one-options-per-token guard (review follow-up)

Both CodeRabbit and Codex independently caught a correctness gap in part 1: because `/register/options` uses `peekPasskeyRegisterHandoff` (non-destructive Redis `GET`, not atomic `GET+DEL`), a minted handoff token could drive unbounded `generateRegistrationOptions` calls within its 300s TTL. Each call churns the `verificationTokens` table (`DELETE` unused + `INSERT` fresh).

The original framing ("mint + TTL + one-time-use bounds everything") held for `/register` (which `consume`s) but **not** for `/register/options` (which `peek`s). That was a real regression, not theoretical.

Added `markPasskeyRegisterOptionsIssued` alongside `peek`/`consume` in `packages/lib/src/auth/passkey-register-handoff.ts`. First `/register/options` call for a minted handoff sets a Redis marker via `SET NX EX 300`, keyed by `auth:passkey-register-handoff-options-issued:<sha256(token)>`. Replay within the TTL returns `401 OPTIONS_ALREADY_ISSUED` with a `security.suspicious.activity` audit event (`reason: passkey_handoff_options_replayed`).

Chose a one-shot marker over a second sliding-window bucket because the legitimate ceremony calls options exactly once per minted token. N=1 is the correct contract, and `SET NX EX` is a single atomic round-trip. Fails closed on Redis unavailability or error — clients must re-mint, which is strictly safer than opening the replay window and costs at most one token from the mint bucket.

`/register` is unchanged — `consume` already gives it exactly-once semantics.

## Corrected post-fix budget

| Path | Options-call bound | Verify-call bound | Ceremony-start bound |
|---|---|---|---|
| Desktop (handoff) | **1 per minted token** (`SET NX EX 300` marker) | 1 per minted token (existing `consume` atomic `GET+DEL`) | 5/15min/user (existing mint bucket) |
| Web (session)     | Per-user `PASSKEY_REGISTER` bucket (5/15min) | Per-user `PASSKEY_REGISTER` bucket (5/15min) | n/a |

## Retry semantics

If `/register/options` succeeds but the WebAuthn ceremony then fails (Touch ID cancelled, network blip, etc.), the client must re-mint rather than retry with the same handoff token. The mint bucket is 5/15min/user, which is plenty for legitimate retries, and re-mint produces a fresh auditable ceremony.

## TDD — two RED/GREEN pairs

- `1a556acf` **RED** `test(auth): RED passkey register ratelimit fix` — encodes the contract that the handoff path must not debit the per-user `PASSKEY_REGISTER` bucket. Three expected failures against pre-fix code (handoff options, handoff verify, three back-to-back handoff verifies as per the desktop-v1.0.22 incident shape).
- `695818d6` **GREEN** `fix(auth): remove duplicate rate-limit on handoff register path` — moves the two rate-limit blocks inside the session-auth else branches.
- `9dc3fef8` **RED** `test(auth): RED passkey options one-per-handoff guard` — 8 new unit tests for `markPasskeyRegisterOptionsIssued` in `packages/lib/src/auth/__tests__/passkey-register-handoff.test.ts` + 3 new contract tests for the `/register/options` handoff replay path.
- `125aa05a` **GREEN** `fix(auth): one-options-per-token guard on passkey handoff path` — adds the helper and wires it into `options/route.ts` after `peek` succeeds.
- `b4a08760` **docs** `docs(changelog): note passkey handoff register rate-limit + options replay guard` — adds a 2026-04-14 entry in `docs/1.0-overview/changelog.md` covering both fixes.

## Verification

```
pnpm --filter @pagespace/lib test passkey-register-handoff   → 29/29 ✅ (21 existing + 8 new)
pnpm --filter web exec vitest run src/app/api/auth/passkey/register
                                                             → 72/72 ✅ across options/register/handoff
pnpm --filter web typecheck                                  → ✅
pnpm --filter web lint                                       → ✅ (no new warnings)
```

CI: all 12 required checks green.

## Manual smoke test

- [ ] Open desktop app, sign in, add a passkey via Settings → Security → Add passkey. Expect ceremony success.
- [ ] **Immediately** add a second passkey. Before this fix, step 2 returns 429. After this fix, step 2 succeeds.
- [ ] From web session, add a passkey from settings — still works.
- [ ] From web session, rapidly trigger >5 register-options POSTs in 15 min — 6th returns 429 (session bucket unchanged).
- [ ] Replay guard: observe a handoff URL, `curl` `/register/options` twice with the same `handoffToken` — first returns 200, second returns 401 `OPTIONS_ALREADY_ISSUED`.

## Scope guardrails

- `packages/lib/src/security/distributed-rate-limit.ts` — bucket size **not** changed. The bucket is correctly sized; the fix removes the over-debit.
- `/register/handoff` (mint) — keeps its session-path rate limit, it is the real ceremony-start gate.
- `PasskeyManager.tsx` — no UI change.
- Passkey authenticate / sign-in routes — unaffected (separate per-IP buckets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)