### PR TITLE
fix(auth): clear error when adding a passkey on a device that already has one

### DIFF
--- a/apps/web/src/app/auth/__tests__/passkey-register-external-page.test.tsx
+++ b/apps/web/src/app/auth/__tests__/passkey-register-external-page.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
-import { PasskeyRegisterExternalView } from '../passkey-register-external/page';
+import { PasskeyRegisterExternalView } from '@/components/auth/PasskeyRegisterExternalView';
 
 describe('PasskeyRegisterExternalView', () => {
   it('renders a loading state while the ceremony is running', () => {

--- a/apps/web/src/app/auth/__tests__/passkey-register-external-page.test.tsx
+++ b/apps/web/src/app/auth/__tests__/passkey-register-external-page.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { PasskeyRegisterExternalView } from '../passkey-register-external/page';
+
+describe('PasskeyRegisterExternalView', () => {
+  it('renders a loading state while the ceremony is running', () => {
+    render(<PasskeyRegisterExternalView status={{ kind: 'running' }} />);
+    expect(screen.getByText(/adding your passkey/i)).toBeInTheDocument();
+  });
+
+  it('renders a redirecting message when the deep link is ready', () => {
+    render(<PasskeyRegisterExternalView status={{ kind: 'redirecting' }} />);
+    expect(screen.getByText(/returning to the desktop app/i)).toBeInTheDocument();
+  });
+
+  it('renders a softer "already set up" header when code=ALREADY_REGISTERED', () => {
+    render(
+      <PasskeyRegisterExternalView
+        status={{
+          kind: 'error',
+          message:
+            'A passkey is already registered on this device. To add another, use a different device, a security key, or iCloud Keychain from another Mac or iPhone.',
+          code: 'ALREADY_REGISTERED',
+        }}
+      />,
+    );
+    expect(screen.getByText(/this device is already set up/i)).toBeInTheDocument();
+    expect(screen.getByText(/already registered on this device/i)).toBeInTheDocument();
+    expect(screen.queryByText(/registration failed/i)).not.toBeInTheDocument();
+  });
+
+  it('renders a "Registration cancelled" header when code=CANCELLED', () => {
+    render(
+      <PasskeyRegisterExternalView
+        status={{
+          kind: 'error',
+          message: 'Registration was cancelled',
+          code: 'CANCELLED',
+        }}
+      />,
+    );
+    expect(screen.getByText(/registration cancelled/i)).toBeInTheDocument();
+    expect(screen.queryByText(/registration failed/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/this device is already set up/i)).not.toBeInTheDocument();
+  });
+
+  it('renders a generic "Registration failed" header for uncoded errors', () => {
+    render(
+      <PasskeyRegisterExternalView
+        status={{ kind: 'error', message: 'network failure' }}
+      />,
+    );
+    expect(screen.getByText(/registration failed/i)).toBeInTheDocument();
+    expect(screen.getByText(/network failure/i)).toBeInTheDocument();
+    expect(screen.queryByText(/this device is already set up/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/registration cancelled/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/auth/passkey-register-external/page.tsx
+++ b/apps/web/src/app/auth/passkey-register-external/page.tsx
@@ -1,101 +1,14 @@
 'use client';
 
 import { Suspense, useEffect, useRef, useState } from 'react';
-import { CheckCircle2, Info, Loader2, ShieldAlert } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 import { AuthShell } from '@/components/auth/AuthShell';
+import { runPasskeyRegisterExternalCeremony } from '@/components/auth/runPasskeyRegisterExternalCeremony';
 import {
-  runPasskeyRegisterExternalCeremony,
-  type PasskeyRegisterExternalErrorCode,
-} from '@/components/auth/runPasskeyRegisterExternalCeremony';
+  PasskeyRegisterExternalView,
+  type PasskeyRegisterExternalStatus,
+} from '@/components/auth/PasskeyRegisterExternalView';
 import { parsePasskeyRegisterExternalParams } from '@/components/auth/passkeyExternal';
-
-export type PasskeyRegisterExternalStatus =
-  | { kind: 'running' }
-  | { kind: 'redirecting' }
-  | { kind: 'error'; message: string; code?: PasskeyRegisterExternalErrorCode };
-
-export function PasskeyRegisterExternalView({
-  status,
-}: {
-  status: PasskeyRegisterExternalStatus;
-}) {
-  return (
-    <AuthShell>
-      <div className="flex flex-col items-center gap-4 py-6 text-center">
-        {status.kind === 'error' ? (
-          <ErrorState status={status} />
-        ) : (
-          <>
-            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-            <div>
-              <p className="text-sm font-medium text-foreground">
-                {status.kind === 'redirecting'
-                  ? 'Returning to the desktop app…'
-                  : 'Adding your passkey…'}
-              </p>
-              <p className="mt-1 text-xs text-muted-foreground">
-                Use Touch ID, Windows Hello, or your security key when prompted.
-              </p>
-            </div>
-          </>
-        )}
-      </div>
-    </AuthShell>
-  );
-}
-
-function ErrorState({
-  status,
-}: {
-  status: Extract<PasskeyRegisterExternalStatus, { kind: 'error' }>;
-}) {
-  if (status.code === 'ALREADY_REGISTERED') {
-    return (
-      <>
-        <CheckCircle2 className="h-8 w-8 text-muted-foreground" />
-        <div>
-          <p className="text-sm font-medium text-foreground">
-            This device is already set up
-          </p>
-          <p className="mt-1 text-xs text-muted-foreground">{status.message}</p>
-          <p className="mt-4 text-xs text-muted-foreground">
-            You can close this window and return to the desktop app.
-          </p>
-        </div>
-      </>
-    );
-  }
-
-  if (status.code === 'CANCELLED') {
-    return (
-      <>
-        <Info className="h-8 w-8 text-muted-foreground" />
-        <div>
-          <p className="text-sm font-medium text-foreground">
-            Registration cancelled
-          </p>
-          <p className="mt-1 text-xs text-muted-foreground">{status.message}</p>
-          <p className="mt-4 text-xs text-muted-foreground">
-            You can close this window and try again from the desktop app.
-          </p>
-        </div>
-      </>
-    );
-  }
-
-  return (
-    <>
-      <ShieldAlert className="h-8 w-8 text-destructive" />
-      <div>
-        <p className="text-sm font-medium text-foreground">Registration failed</p>
-        <p className="mt-1 text-xs text-muted-foreground">{status.message}</p>
-        <p className="mt-4 text-xs text-muted-foreground">
-          You can close this window and try again from the desktop app.
-        </p>
-      </div>
-    </>
-  );
-}
 
 function PasskeyRegisterExternalContent() {
   const [status, setStatus] = useState<PasskeyRegisterExternalStatus>({

--- a/apps/web/src/app/auth/passkey-register-external/page.tsx
+++ b/apps/web/src/app/auth/passkey-register-external/page.tsx
@@ -1,82 +1,29 @@
 'use client';
 
 import { Suspense, useEffect, useRef, useState } from 'react';
-import { Loader2, ShieldAlert } from 'lucide-react';
+import { CheckCircle2, Info, Loader2, ShieldAlert } from 'lucide-react';
 import { AuthShell } from '@/components/auth/AuthShell';
-import { runPasskeyRegisterExternalCeremony } from '@/components/auth/runPasskeyRegisterExternalCeremony';
+import {
+  runPasskeyRegisterExternalCeremony,
+  type PasskeyRegisterExternalErrorCode,
+} from '@/components/auth/runPasskeyRegisterExternalCeremony';
 import { parsePasskeyRegisterExternalParams } from '@/components/auth/passkeyExternal';
 
-type Status =
+export type PasskeyRegisterExternalStatus =
   | { kind: 'running' }
   | { kind: 'redirecting' }
-  | { kind: 'error'; message: string };
+  | { kind: 'error'; message: string; code?: PasskeyRegisterExternalErrorCode };
 
-function PasskeyRegisterExternalContent() {
-  const [status, setStatus] = useState<Status>({ kind: 'running' });
-  const started = useRef(false);
-
-  useEffect(() => {
-    if (started.current) return;
-    started.current = true;
-
-    const params = parsePasskeyRegisterExternalParams(
-      window.location.search,
-      window.location.hash,
-    );
-    if (!params) {
-      setStatus({
-        kind: 'error',
-        message: 'Missing handoff token or device info in the handoff URL.',
-      });
-      return;
-    }
-
-    // Drop the fragment from the visible URL so the capability token is not
-    // left sitting in the browser address bar after consumption.
-    if (window.location.hash) {
-      window.history.replaceState(
-        null,
-        '',
-        window.location.pathname + window.location.search,
-      );
-    }
-
-    runPasskeyRegisterExternalCeremony({
-      handoffToken: params.handoffToken,
-      deviceName: params.deviceName,
-    })
-      .then((result) => {
-        if (result.ok) {
-          setStatus({ kind: 'redirecting' });
-          window.location.href = result.deepLink;
-        } else {
-          setStatus({ kind: 'error', message: result.error });
-        }
-      })
-      .catch((err: unknown) => {
-        setStatus({
-          kind: 'error',
-          message: err instanceof Error ? err.message : 'Unexpected error',
-        });
-      });
-  }, []);
-
+export function PasskeyRegisterExternalView({
+  status,
+}: {
+  status: PasskeyRegisterExternalStatus;
+}) {
   return (
     <AuthShell>
       <div className="flex flex-col items-center gap-4 py-6 text-center">
         {status.kind === 'error' ? (
-          <>
-            <ShieldAlert className="h-8 w-8 text-destructive" />
-            <div>
-              <p className="text-sm font-medium text-foreground">
-                Could not add passkey
-              </p>
-              <p className="mt-1 text-xs text-muted-foreground">{status.message}</p>
-              <p className="mt-4 text-xs text-muted-foreground">
-                You can close this window and try again from the desktop app.
-              </p>
-            </div>
-          </>
+          <ErrorState status={status} />
         ) : (
           <>
             <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
@@ -95,6 +42,112 @@ function PasskeyRegisterExternalContent() {
       </div>
     </AuthShell>
   );
+}
+
+function ErrorState({
+  status,
+}: {
+  status: Extract<PasskeyRegisterExternalStatus, { kind: 'error' }>;
+}) {
+  if (status.code === 'ALREADY_REGISTERED') {
+    return (
+      <>
+        <CheckCircle2 className="h-8 w-8 text-muted-foreground" />
+        <div>
+          <p className="text-sm font-medium text-foreground">
+            This device is already set up
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">{status.message}</p>
+          <p className="mt-4 text-xs text-muted-foreground">
+            You can close this window and return to the desktop app.
+          </p>
+        </div>
+      </>
+    );
+  }
+
+  if (status.code === 'CANCELLED') {
+    return (
+      <>
+        <Info className="h-8 w-8 text-muted-foreground" />
+        <div>
+          <p className="text-sm font-medium text-foreground">
+            Registration cancelled
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">{status.message}</p>
+          <p className="mt-4 text-xs text-muted-foreground">
+            You can close this window and try again from the desktop app.
+          </p>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <ShieldAlert className="h-8 w-8 text-destructive" />
+      <div>
+        <p className="text-sm font-medium text-foreground">Registration failed</p>
+        <p className="mt-1 text-xs text-muted-foreground">{status.message}</p>
+        <p className="mt-4 text-xs text-muted-foreground">
+          You can close this window and try again from the desktop app.
+        </p>
+      </div>
+    </>
+  );
+}
+
+function PasskeyRegisterExternalContent() {
+  const [status, setStatus] = useState<PasskeyRegisterExternalStatus>({
+    kind: 'running',
+  });
+  const started = useRef(false);
+
+  useEffect(() => {
+    if (started.current) return;
+    started.current = true;
+
+    const params = parsePasskeyRegisterExternalParams(
+      window.location.search,
+      window.location.hash,
+    );
+    if (!params) {
+      setStatus({
+        kind: 'error',
+        message: 'Missing handoff token or device info in the handoff URL.',
+      });
+      return;
+    }
+
+    if (window.location.hash) {
+      window.history.replaceState(
+        null,
+        '',
+        window.location.pathname + window.location.search,
+      );
+    }
+
+    runPasskeyRegisterExternalCeremony({
+      handoffToken: params.handoffToken,
+      deviceName: params.deviceName,
+    })
+      .then((result) => {
+        if (result.ok) {
+          setStatus({ kind: 'redirecting' });
+          window.location.href = result.deepLink;
+        } else {
+          setStatus({ kind: 'error', message: result.error, code: result.code });
+        }
+      })
+      .catch((err: unknown) => {
+        setStatus({
+          kind: 'error',
+          message: err instanceof Error ? err.message : 'Unexpected error',
+        });
+      });
+  }, []);
+
+  return <PasskeyRegisterExternalView status={status} />;
 }
 
 export default function PasskeyRegisterExternalPage() {

--- a/apps/web/src/components/auth/PasskeyRegisterExternalView.tsx
+++ b/apps/web/src/components/auth/PasskeyRegisterExternalView.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { CheckCircle2, Info, Loader2, ShieldAlert } from 'lucide-react';
+import { AuthShell } from '@/components/auth/AuthShell';
+import type { PasskeyRegisterExternalErrorCode } from '@/components/auth/runPasskeyRegisterExternalCeremony';
+
+export type PasskeyRegisterExternalStatus =
+  | { kind: 'running' }
+  | { kind: 'redirecting' }
+  | { kind: 'error'; message: string; code?: PasskeyRegisterExternalErrorCode };
+
+export function PasskeyRegisterExternalView({
+  status,
+}: {
+  status: PasskeyRegisterExternalStatus;
+}) {
+  return (
+    <AuthShell>
+      <div className="flex flex-col items-center gap-4 py-6 text-center">
+        {status.kind === 'error' ? (
+          <ErrorState status={status} />
+        ) : (
+          <>
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            <div>
+              <p className="text-sm font-medium text-foreground">
+                {status.kind === 'redirecting'
+                  ? 'Returning to the desktop app…'
+                  : 'Adding your passkey…'}
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Use Touch ID, Windows Hello, or your security key when prompted.
+              </p>
+            </div>
+          </>
+        )}
+      </div>
+    </AuthShell>
+  );
+}
+
+function ErrorState({
+  status,
+}: {
+  status: Extract<PasskeyRegisterExternalStatus, { kind: 'error' }>;
+}) {
+  if (status.code === 'ALREADY_REGISTERED') {
+    return (
+      <>
+        <CheckCircle2 className="h-8 w-8 text-muted-foreground" />
+        <div>
+          <p className="text-sm font-medium text-foreground">
+            This device is already set up
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">{status.message}</p>
+          <p className="mt-4 text-xs text-muted-foreground">
+            You can close this window and return to the desktop app.
+          </p>
+        </div>
+      </>
+    );
+  }
+
+  if (status.code === 'CANCELLED') {
+    return (
+      <>
+        <Info className="h-8 w-8 text-muted-foreground" />
+        <div>
+          <p className="text-sm font-medium text-foreground">
+            Registration cancelled
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">{status.message}</p>
+          <p className="mt-4 text-xs text-muted-foreground">
+            You can close this window and try again from the desktop app.
+          </p>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <ShieldAlert className="h-8 w-8 text-destructive" />
+      <div>
+        <p className="text-sm font-medium text-foreground">Registration failed</p>
+        <p className="mt-1 text-xs text-muted-foreground">{status.message}</p>
+        <p className="mt-4 text-xs text-muted-foreground">
+          You can close this window and try again from the desktop app.
+        </p>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/components/auth/__tests__/runPasskeyRegisterExternalCeremony.test.ts
+++ b/apps/web/src/components/auth/__tests__/runPasskeyRegisterExternalCeremony.test.ts
@@ -129,7 +129,7 @@ describe('runPasskeyRegisterExternalCeremony', () => {
     expect(result.error).toMatch(/verification/i);
   });
 
-  it('returns an error result when startRegistration is cancelled by the user', async () => {
+  it('returns an error result with code=CANCELLED when startRegistration is cancelled by the user', async () => {
     vi.mocked(startRegistration).mockRejectedValueOnce(
       Object.assign(new Error('timed out or not allowed'), { name: 'NotAllowedError' })
     );
@@ -148,5 +148,51 @@ describe('runPasskeyRegisterExternalCeremony', () => {
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected error');
     expect(result.error).toMatch(/cancel/i);
+    expect(result.code).toBe('CANCELLED');
+  });
+
+  it('returns a friendly already-registered error when startRegistration throws InvalidStateError', async () => {
+    vi.mocked(startRegistration).mockRejectedValueOnce(
+      Object.assign(new Error('The authenticator recognized an entry'), {
+        name: 'InvalidStateError',
+      })
+    );
+
+    const fetchImpl = mockFetch({
+      '/api/auth/passkey/register/options': () =>
+        jsonResponse({ options: { challenge: 'c' } }),
+    });
+
+    const result = await runPasskeyRegisterExternalCeremony({
+      handoffToken: 'handoff',
+      deviceName: 'd',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected error');
+    expect(result.code).toBe('ALREADY_REGISTERED');
+    expect(result.error).toMatch(/already registered on this device/i);
+    expect(result.error).toMatch(/different device|security key|iCloud/i);
+  });
+
+  it('surfaces the raw message for unknown errors with no code field', async () => {
+    vi.mocked(startRegistration).mockRejectedValueOnce(new Error('network failure'));
+
+    const fetchImpl = mockFetch({
+      '/api/auth/passkey/register/options': () =>
+        jsonResponse({ options: { challenge: 'c' } }),
+    });
+
+    const result = await runPasskeyRegisterExternalCeremony({
+      handoffToken: 'handoff',
+      deviceName: 'd',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected error');
+    expect(result.error).toBe('network failure');
+    expect(result.code).toBeUndefined();
   });
 });

--- a/apps/web/src/components/auth/runPasskeyRegisterExternalCeremony.ts
+++ b/apps/web/src/components/auth/runPasskeyRegisterExternalCeremony.ts
@@ -9,9 +9,14 @@ export interface RunPasskeyRegisterExternalCeremonyInput {
   fetchImpl?: typeof fetch;
 }
 
+export type PasskeyRegisterExternalErrorCode = 'ALREADY_REGISTERED' | 'CANCELLED';
+
 export type RunPasskeyRegisterExternalCeremonyResult =
   | { ok: true; deepLink: string }
-  | { ok: false; error: string };
+  | { ok: false; error: string; code?: PasskeyRegisterExternalErrorCode };
+
+export const ALREADY_REGISTERED_MESSAGE =
+  'A passkey is already registered on this device. To add another, use a different device, a security key, or iCloud Keychain from another Mac or iPhone.';
 
 async function readError(res: Response, fallback: string): Promise<string> {
   try {
@@ -41,13 +46,20 @@ export async function runPasskeyRegisterExternalCeremony(
   try {
     registrationResponse = await startRegistration({ optionsJSON: options });
   } catch (err) {
-    if (err instanceof Error && err.name === 'NotAllowedError') {
-      return { ok: false, error: 'Registration was cancelled' };
+    if (err instanceof Error) {
+      if (err.name === 'NotAllowedError') {
+        return { ok: false, error: 'Registration was cancelled', code: 'CANCELLED' };
+      }
+      if (err.name === 'InvalidStateError') {
+        return {
+          ok: false,
+          error: ALREADY_REGISTERED_MESSAGE,
+          code: 'ALREADY_REGISTERED',
+        };
+      }
+      return { ok: false, error: err.message };
     }
-    return {
-      ok: false,
-      error: err instanceof Error ? err.message : 'Registration failed',
-    };
+    return { ok: false, error: 'Registration failed' };
   }
 
   const verifyRes = await fetchImpl('/api/auth/passkey/register', {


### PR DESCRIPTION
## Summary

A desktop user on `desktop-v1.0.22` (shipped via #1012) reported:

> "it doesn't work when I have one already"

They have a Touch ID passkey registered on their Mac and tried to add another from Settings → Security. The external register page showed an unhelpful error like "The operation either timed out or was not allowed" with no actionable context, leading them to conclude the feature was broken.

**Root cause is WebAuthn behaving correctly:** the server in `packages/lib/src/auth/passkey-service.ts` populates `excludeCredentials` with the user's existing credential IDs (the spec-recommended pattern), Touch ID sees its own credential in the exclude list, and refuses with `InvalidStateError`. The existing web flow (`PasskeyManager.tsx` line 195) maps this to a friendly toast — but the NEW external register ceremony shipped in #1012 forgot to copy that branch and bubbled the raw message.

**This PR fixes the messaging, not the WebAuthn rule.** To actually register a second passkey, users still need a different authenticator (another Mac, an iPhone, a hardware security key, or iCloud Keychain sync). The message now spells that out.

### What changed

- `runPasskeyRegisterExternalCeremony` now returns `{ ok: false, error, code? }` where `code` is `'ALREADY_REGISTERED'` for `InvalidStateError` and `'CANCELLED'` for `NotAllowedError`. Generic errors surface `err.message` with no code, matching prior behaviour.
- `passkey-register-external/page.tsx` extracts a pure `PasskeyRegisterExternalView` that branches on `code` to render distinct headers with softer icons:
  - `ALREADY_REGISTERED` → "This device is already set up" + `CheckCircle2` (muted)
  - `CANCELLED` → "Registration cancelled" + `Info` (muted)
  - everything else → "Registration failed" + `ShieldAlert` (destructive)

### NOT touched

- `packages/lib/src/auth/passkey-service.ts` — server `excludeCredentials` is correct and stays.
- `apps/web/src/app/api/auth/passkey/register/options/route.ts`, `apps/web/src/app/api/auth/passkey/register/route.ts` — untouched; the parallel rate-limit hot fix (`pu/passkey-register-ratelimit-fix`) owns these.
- `runPasskeyExternalCeremony.ts` (sign-in, not register) — `.get` does not throw `InvalidStateError`.
- `PasskeyManager.tsx` — its web-path `InvalidStateError` toast already works.

### Parallel hot fix

This PR is one of two independent hot fixes flowing from #1012. The rate-limit fix is being handled in a separate worktree / PR.

## Commits

- RED `4dfe5dbd` — test(auth): RED passkey register external existing-credential UX
- GREEN `987bec64` — fix(auth): map InvalidStateError to clear already-registered UX on register-external

## Test plan

Automated (all green locally):
- [x] `pnpm --filter web typecheck`
- [x] `pnpm --filter web lint` (no new warnings)
- [x] `pnpm --filter web exec vitest run src/components/auth/__tests__/runPasskeyRegisterExternalCeremony.test.ts` — 7/7 passing (adds `InvalidStateError`, `CANCELLED`-code, and generic-error cases)
- [x] `pnpm --filter web exec vitest run src/app/auth/__tests__/passkey-register-external-page.test.tsx` — 5/5 passing (asserts each status variant renders its own header)

Manual smoke test (to run against `desktop-v1.0.22`+ once shipped):
- [ ] Sign in as a user who already has one Touch ID passkey registered.
- [ ] Settings → Security → Add Passkey.
- [ ] System browser opens, Touch ID prompt appears. Approve it.
- [ ] macOS refuses (credential already exists on this authenticator).
- [ ] **Expected:** external page shows "This device is already set up" with "A passkey is already registered on this device. To add another, use a different device, a security key, or iCloud Keychain from another Mac or iPhone." — NOT a generic "Registration failed" header.
- [ ] Cancel Touch ID in a separate run. **Expected:** page shows "Registration cancelled" — distinct from the "already set up" case, proves `code` discrimination works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)