### PR TITLE
[codex] Escape HTML in user chat messages

### DIFF
--- a/apps/web/src/components/ai/shared/__tests__/StreamingMarkdown.test.tsx
+++ b/apps/web/src/components/ai/shared/__tests__/StreamingMarkdown.test.tsx
@@ -127,6 +127,40 @@ describe('preprocessMentions', () => {
   });
 });
 
+describe('HTML escaping', () => {
+  it('should escape HTML-like user content before passing it to Streamdown', () => {
+    render(
+      React.createElement(
+        StreamingMarkdown as React.ComponentType<{ content: string; escapeHtml?: boolean }>,
+        {
+          content: 'Write a <style> block inside <html>',
+          escapeHtml: true,
+        }
+      )
+    );
+
+    const streamdown = screen.getByTestId('streamdown');
+    expect(streamdown.textContent).toBe('Write a &lt;style&gt; block inside &lt;html&gt;');
+  });
+
+  it('should preserve mention preprocessing when HTML escaping is enabled', () => {
+    render(
+      React.createElement(
+        StreamingMarkdown as React.ComponentType<{ content: string; escapeHtml?: boolean }>,
+        {
+          content: 'See <style> and @[Project](proj123:page)',
+          escapeHtml: true,
+        }
+      )
+    );
+
+    const streamdown = screen.getByTestId('streamdown');
+    expect(streamdown.textContent).toBe(
+      'See &lt;style&gt; and [mention:Project](mention://proj123/page)'
+    );
+  });
+});
+
 describe('memoization', () => {
   it('should re-render when content changes', () => {
     const { rerender } = render(<StreamingMarkdown content="First" />);

--- a/apps/web/src/components/ai/shared/__tests__/StreamingMarkdown.test.tsx
+++ b/apps/web/src/components/ai/shared/__tests__/StreamingMarkdown.test.tsx
@@ -2,15 +2,58 @@ import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
+const { streamdownSpy } = vi.hoisted(() => ({
+  streamdownSpy: vi.fn(),
+}));
+
 // Mock Streamdown with a simple implementation that passes children through
 vi.mock('streamdown', () => ({
-  Streamdown: ({ children, mode, className }: { children: string; mode: string; className?: string }) => (
-    React.createElement('div', { 'data-testid': 'streamdown', 'data-mode': mode, className }, children)
-  ),
+  defaultRemarkPlugins: {
+    gfm: () => undefined,
+  },
+  Streamdown: ({
+    children,
+    mode,
+    className,
+    remarkPlugins,
+  }: {
+    children: string;
+    mode: string;
+    className?: string;
+    remarkPlugins?: unknown[];
+  }) => {
+    streamdownSpy({ children, mode, className, remarkPlugins });
+    return React.createElement('div', { 'data-testid': 'streamdown', 'data-mode': mode, className }, children);
+  },
 }));
 
 // Import after mocking
 import { StreamingMarkdown } from '../chat/StreamingMarkdown';
+
+interface MarkdownNode {
+  type: string;
+  value?: string;
+  url?: string;
+  children?: MarkdownNode[];
+}
+
+type RemarkTransformer = (tree: MarkdownNode) => void;
+type RemarkPlugin = () => RemarkTransformer;
+
+function getLastRemarkPlugins(): RemarkPlugin[] {
+  const lastCall = streamdownSpy.mock.lastCall as [{ remarkPlugins?: RemarkPlugin[] }] | undefined;
+  return lastCall?.[0].remarkPlugins ?? [];
+}
+
+function applyUserHtmlTextPlugin(tree: MarkdownNode): void {
+  const remarkPlugins = getLastRemarkPlugins();
+  const rawHtmlTextPlugin = remarkPlugins[remarkPlugins.length - 1];
+
+  expect(rawHtmlTextPlugin).toBeTypeOf('function');
+
+  const transform = rawHtmlTextPlugin();
+  transform(tree);
+}
 
 /**
  * Tests for StreamingMarkdown component
@@ -127,37 +170,97 @@ describe('preprocessMentions', () => {
   });
 });
 
-describe('HTML escaping', () => {
-  it('should escape HTML-like user content before passing it to Streamdown', () => {
+describe('raw HTML rendering', () => {
+  it('should keep raw user markdown source intact while installing an HTML-to-text remark plugin', () => {
     render(
       React.createElement(
-        StreamingMarkdown as React.ComponentType<{ content: string; escapeHtml?: boolean }>,
+        StreamingMarkdown as React.ComponentType<{ content: string; renderHtmlAsText?: boolean }>,
         {
           content: 'Write a <style> block inside <html>',
-          escapeHtml: true,
+          renderHtmlAsText: true,
         }
       )
     );
 
     const streamdown = screen.getByTestId('streamdown');
-    expect(streamdown.textContent).toBe('Write a &lt;style&gt; block inside &lt;html&gt;');
+    expect(streamdown.textContent).toBe('Write a <style> block inside <html>');
+
+    const tree: MarkdownNode = {
+      type: 'root',
+      children: [
+        { type: 'text', value: 'Write a ' },
+        { type: 'html', value: '<style>' },
+        { type: 'text', value: ' block inside ' },
+        { type: 'html', value: '<html>' },
+      ],
+    };
+
+    applyUserHtmlTextPlugin(tree);
+
+    expect(tree.children).toEqual([
+      { type: 'text', value: 'Write a ' },
+      { type: 'text', value: '<style>' },
+      { type: 'text', value: ' block inside ' },
+      { type: 'text', value: '<html>' },
+    ]);
   });
 
-  it('should preserve mention preprocessing when HTML escaping is enabled', () => {
+  it('should preserve mention preprocessing without escaping the raw markdown source', () => {
     render(
       React.createElement(
-        StreamingMarkdown as React.ComponentType<{ content: string; escapeHtml?: boolean }>,
+        StreamingMarkdown as React.ComponentType<{ content: string; renderHtmlAsText?: boolean }>,
         {
           content: 'See <style> and @[Project](proj123:page)',
-          escapeHtml: true,
+          renderHtmlAsText: true,
         }
       )
     );
 
     const streamdown = screen.getByTestId('streamdown');
     expect(streamdown.textContent).toBe(
-      'See &lt;style&gt; and [mention:Project](mention://proj123/page)'
+      'See <style> and [mention:Project](mention://proj123/page)'
     );
+  });
+
+  it('should leave inline code and autolink nodes untouched when converting raw HTML nodes to text', () => {
+    render(
+      React.createElement(
+        StreamingMarkdown as React.ComponentType<{ content: string; renderHtmlAsText?: boolean }>,
+        {
+          content: '`<div>` <https://example.com> <style>',
+          renderHtmlAsText: true,
+        }
+      )
+    );
+
+    const tree: MarkdownNode = {
+      type: 'root',
+      children: [
+        { type: 'inlineCode', value: '<div>' },
+        { type: 'text', value: ' ' },
+        {
+          type: 'link',
+          url: 'https://example.com',
+          children: [{ type: 'text', value: 'https://example.com' }],
+        },
+        { type: 'text', value: ' ' },
+        { type: 'html', value: '<style>' },
+      ],
+    };
+
+    applyUserHtmlTextPlugin(tree);
+
+    expect(tree.children).toEqual([
+      { type: 'inlineCode', value: '<div>' },
+      { type: 'text', value: ' ' },
+      {
+        type: 'link',
+        url: 'https://example.com',
+        children: [{ type: 'text', value: 'https://example.com' }],
+      },
+      { type: 'text', value: ' ' },
+      { type: 'text', value: '<style>' },
+    ]);
   });
 });
 
@@ -176,5 +279,23 @@ describe('memoization', () => {
 
     rerender(<StreamingMarkdown content="Test" isStreaming={true} />);
     expect(screen.getByTestId('streamdown')).toHaveAttribute('data-mode', 'streaming');
+  });
+
+  it('should re-render when renderHtmlAsText changes', () => {
+    const { rerender } = render(
+      React.createElement(
+        StreamingMarkdown as React.ComponentType<{ content: string; renderHtmlAsText?: boolean }>,
+        { content: 'Test', renderHtmlAsText: false }
+      )
+    );
+    expect(getLastRemarkPlugins()).toHaveLength(0);
+
+    rerender(
+      React.createElement(
+        StreamingMarkdown as React.ComponentType<{ content: string; renderHtmlAsText?: boolean }>,
+        { content: 'Test', renderHtmlAsText: true }
+      )
+    );
+    expect(getLastRemarkPlugins().length).toBeGreaterThan(0);
   });
 });

--- a/apps/web/src/components/ai/shared/chat/CompactMessageRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/CompactMessageRenderer.tsx
@@ -79,7 +79,11 @@ const CompactTextBlock: React.FC<CompactTextBlockProps> = React.memo(({
       ) : (
         <>
           <div className={`text-gray-900 dark:text-gray-100 prose prose-xs dark:prose-invert min-w-0 max-w-full break-words ${styles.compactProseContent}`}>
-            <StreamingMarkdown content={content} isStreaming={isStreaming} />
+            <StreamingMarkdown
+              content={content}
+              isStreaming={isStreaming}
+              escapeHtml={role === 'user'}
+            />
           </div>
           {/* Always show footer with buttons; timestamp only when createdAt exists */}
           <div className="flex items-center justify-between mt-1">

--- a/apps/web/src/components/ai/shared/chat/CompactMessageRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/CompactMessageRenderer.tsx
@@ -82,7 +82,7 @@ const CompactTextBlock: React.FC<CompactTextBlockProps> = React.memo(({
             <StreamingMarkdown
               content={content}
               isStreaming={isStreaming}
-              escapeHtml={role === 'user'}
+              renderHtmlAsText={role === 'user'}
             />
           </div>
           {/* Always show footer with buttons; timestamp only when createdAt exists */}

--- a/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
@@ -76,7 +76,11 @@ const TextBlock: React.FC<TextBlockProps> = React.memo(({
         <>
           <div className="text-gray-900 dark:text-gray-100 prose prose-sm dark:prose-invert max-w-full prose-pre:bg-gray-100 dark:prose-pre:bg-gray-800">
             <div className="[overflow-wrap:break-word] [hyphens:auto] [text-wrap:pretty]">
-              <StreamingMarkdown content={content} isStreaming={isStreaming} />
+              <StreamingMarkdown
+                content={content}
+                isStreaming={isStreaming}
+                escapeHtml={role === 'user'}
+              />
             </div>
           </div>
           {/* Always show footer with buttons; timestamp only when createdAt exists */}

--- a/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
@@ -79,7 +79,7 @@ const TextBlock: React.FC<TextBlockProps> = React.memo(({
               <StreamingMarkdown
                 content={content}
                 isStreaming={isStreaming}
-                escapeHtml={role === 'user'}
+                renderHtmlAsText={role === 'user'}
               />
             </div>
           </div>

--- a/apps/web/src/components/ai/shared/chat/StreamingMarkdown.tsx
+++ b/apps/web/src/components/ai/shared/chat/StreamingMarkdown.tsx
@@ -12,7 +12,7 @@
 'use client';
 
 import { memo, useMemo, useState, useRef, useEffect, useCallback, AnchorHTMLAttributes, HTMLAttributes, TableHTMLAttributes, ReactNode, MouseEvent } from 'react';
-import { Streamdown } from 'streamdown';
+import { Streamdown, defaultRemarkPlugins } from 'streamdown';
 import { useRouter } from 'next/navigation';
 import { isInternalUrl, openExternalUrl } from '@/lib/navigation/app-navigation';
 import { CheckIcon, CopyIcon } from 'lucide-react';
@@ -34,11 +34,39 @@ function preprocessMentions(content: string): string {
   });
 }
 
-function escapeHtmlChars(content: string): string {
-  return content
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
+interface MarkdownNode {
+  type: string;
+  value?: string;
+  children?: MarkdownNode[];
+  [key: string]: unknown;
+}
+
+function isMarkdownParent(node: MarkdownNode): node is MarkdownNode & { children: MarkdownNode[] } {
+  return Array.isArray(node.children);
+}
+
+function renderRawHtmlNodesAsText(tree: MarkdownNode): void {
+  if (!isMarkdownParent(tree)) {
+    return;
+  }
+
+  tree.children = tree.children.map((child) => {
+    if (child.type === 'html') {
+      return {
+        ...child,
+        type: 'text',
+      };
+    }
+
+    renderRawHtmlNodesAsText(child);
+    return child;
+  });
+}
+
+function renderHtmlAsTextRemarkPlugin() {
+  return (tree: MarkdownNode) => {
+    renderRawHtmlNodesAsText(tree);
+  };
 }
 
 /**
@@ -273,8 +301,8 @@ interface StreamingMarkdownProps {
   content: string;
   /** Whether to use streaming mode (progressive formatting) or static mode */
   isStreaming?: boolean;
-  /** Escape HTML-shaped text before markdown processing */
-  escapeHtml?: boolean;
+  /** Render parsed raw HTML nodes as literal text while preserving markdown syntax */
+  renderHtmlAsText?: boolean;
   /** Additional CSS class */
   className?: string;
 }
@@ -290,23 +318,28 @@ interface StreamingMarkdownProps {
  * - Mobile-aware link handling (internal links use router.push on Capacitor)
  */
 export const StreamingMarkdown = memo(
-  ({ content, isStreaming = false, escapeHtml = false, className }: StreamingMarkdownProps) => {
+  ({ content, isStreaming = false, renderHtmlAsText = false, className }: StreamingMarkdownProps) => {
     const router = useRouter();
 
     // Pre-process mentions before rendering
-    const processedContent = useMemo(() => {
-      const safeContent = escapeHtml ? escapeHtmlChars(content) : content;
-      return preprocessMentions(safeContent);
-    }, [content, escapeHtml]);
+    const processedContent = useMemo(() => preprocessMentions(content), [content]);
 
     // Create components with router for mobile-aware navigation
     // Memoize to avoid recreating on every render
     const streamdownComponents = useMemo(() => createStreamdownComponents(router), [router]);
+    const remarkPlugins = useMemo(() => {
+      if (!renderHtmlAsText) {
+        return undefined;
+      }
+
+      return [...Object.values(defaultRemarkPlugins), renderHtmlAsTextRemarkPlugin];
+    }, [renderHtmlAsText]);
 
     return (
       <Streamdown
         mode={isStreaming ? 'streaming' : 'static'}
         components={streamdownComponents}
+        remarkPlugins={remarkPlugins}
         className={className}
         // Disable controls for chat messages (copy/download buttons on code blocks)
         controls={false}
@@ -319,7 +352,7 @@ export const StreamingMarkdown = memo(
     // Custom equality check for better memoization
     return prevProps.content === nextProps.content &&
            prevProps.isStreaming === nextProps.isStreaming &&
-           prevProps.escapeHtml === nextProps.escapeHtml &&
+           prevProps.renderHtmlAsText === nextProps.renderHtmlAsText &&
            prevProps.className === nextProps.className;
   }
 );

--- a/apps/web/src/components/ai/shared/chat/StreamingMarkdown.tsx
+++ b/apps/web/src/components/ai/shared/chat/StreamingMarkdown.tsx
@@ -34,6 +34,13 @@ function preprocessMentions(content: string): string {
   });
 }
 
+function escapeHtmlChars(content: string): string {
+  return content
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
 /**
  * Extract text content from React children recursively
  * Used to get the code content for copy functionality
@@ -266,6 +273,8 @@ interface StreamingMarkdownProps {
   content: string;
   /** Whether to use streaming mode (progressive formatting) or static mode */
   isStreaming?: boolean;
+  /** Escape HTML-shaped text before markdown processing */
+  escapeHtml?: boolean;
   /** Additional CSS class */
   className?: string;
 }
@@ -281,11 +290,14 @@ interface StreamingMarkdownProps {
  * - Mobile-aware link handling (internal links use router.push on Capacitor)
  */
 export const StreamingMarkdown = memo(
-  ({ content, isStreaming = false, className }: StreamingMarkdownProps) => {
+  ({ content, isStreaming = false, escapeHtml = false, className }: StreamingMarkdownProps) => {
     const router = useRouter();
 
     // Pre-process mentions before rendering
-    const processedContent = useMemo(() => preprocessMentions(content), [content]);
+    const processedContent = useMemo(() => {
+      const safeContent = escapeHtml ? escapeHtmlChars(content) : content;
+      return preprocessMentions(safeContent);
+    }, [content, escapeHtml]);
 
     // Create components with router for mobile-aware navigation
     // Memoize to avoid recreating on every render
@@ -307,6 +319,7 @@ export const StreamingMarkdown = memo(
     // Custom equality check for better memoization
     return prevProps.content === nextProps.content &&
            prevProps.isStreaming === nextProps.isStreaming &&
+           prevProps.escapeHtml === nextProps.escapeHtml &&
            prevProps.className === nextProps.className;
   }
 );

--- a/tasks/ai-chat-user-message-html-escaping-epic.md
+++ b/tasks/ai-chat-user-message-html-escaping-epic.md
@@ -1,0 +1,8 @@
+# AI Chat User Message HTML Escaping
+
+**Status**: IN PROGRESS
+
+## Requirements
+
+- Given a user-authored AI chat message that contains tag-shaped text such as `<style>`, `<html>`, or `<iframe>`, should render those characters literally in the message bubble instead of truncating or interpreting them as HTML.
+- Given a user-authored AI chat message that contains markdown formatting or page mentions alongside tag-shaped text, should preserve that formatting and mention rendering while still displaying the tag-shaped text literally.


### PR DESCRIPTION
## Summary
- escape HTML-shaped text before markdown processing when rendering user-authored chat messages
- keep assistant message rendering unchanged while preserving user markdown and mention preprocessing
- apply the same user-only escaping in both the main chat bubble and compact message view

## Root Cause
User messages were passed directly into `StreamingMarkdown`, which forwards content to `streamdown`. The installed `streamdown` pipeline treats raw HTML as HTML, so literal strings like `<style>` opened real DOM elements and made the remaining message appear truncated.

## Validation
- `pnpm --filter web exec vitest run src/components/ai/shared/__tests__/StreamingMarkdown.test.tsx`
- `pnpm --filter web lint`

## Notes
- `pnpm --filter web typecheck` is currently failing in this workspace due broad pre-existing `@pagespace/lib/*` and `@pagespace/db/*` resolution errors unrelated to this fix.
