### PR TITLE
fix(canvas): predictable sandbox rendering for AI-generated HTML

### DIFF
--- a/apps/web/src/components/canvas/ShadowCanvas.tsx
+++ b/apps/web/src/components/canvas/ShadowCanvas.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useRef } from 'react';
 import DOMPurify from 'dompurify';
 import { sanitizeCSS } from '@/lib/canvas/css-sanitizer';
+import { remapDocumentSelectors } from '@/lib/canvas/remap-document-selectors';
 
 interface ShadowCanvasProps {
   html: string;
@@ -13,24 +14,23 @@ export function ShadowCanvas({ html, onNavigate }: ShadowCanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const shadowRef = useRef<ShadowRoot | null>(null);
 
-  // Extract styles from HTML
   const extractStylesFromHTML = (htmlContent: string): { html: string; css: string } => {
-    // Create a temporary container to parse HTML
     const temp = document.createElement('div');
     temp.innerHTML = htmlContent;
 
-    // Find all style tags
     const styleTags = temp.querySelectorAll('style');
     let extractedCSS = '';
 
-    // Extract CSS content and remove style tags from HTML
     styleTags.forEach(styleTag => {
       extractedCSS += styleTag.textContent || '';
       styleTag.remove();
     });
 
+    const body = temp.querySelector('body');
+    const content = body ? body.innerHTML : temp.innerHTML;
+
     return {
-      html: temp.innerHTML,
+      html: content,
       css: extractedCSS
     };
   };
@@ -56,51 +56,31 @@ export function ShadowCanvas({ html, onNavigate }: ShadowCanvasProps) {
       ADD_ATTR: ['target', 'data-href', 'data-navigate'], // Allow navigation attributes
     });
 
-    // Sanitize CSS - remove JavaScript execution
-    const sanitizedCSS = sanitizeCSS(extractedCSS);
+    const sanitizedCSS = remapDocumentSelectors(sanitizeCSS(extractedCSS));
 
     // Build shadow DOM content with extracted styles
     shadow.innerHTML = `
       <style>
-        /* Reset styles for complete theme independence */
         :host {
           display: block;
           width: 100%;
           height: 100%;
-          /* Isolate from parent theme */
-          color-scheme: light;
         }
 
-        /* Canvas root with explicit defaults */
         .canvas-root {
-          /* Always white background unless user overrides */
-          background: white;
-          color: black;
+          background: transparent;
+          color: inherit;
           min-height: 100%;
           width: 100%;
-
-          /* Standard font stack */
           font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
           line-height: 1.6;
-
-          /* Ensure no bleed-through from parent */
           isolation: isolate;
         }
 
-        /* Reset common elements to predictable defaults */
-        .canvas-root * {
-          /* Ensure inheritance from canvas-root, not parent page */
-          color: inherit;
-          font-family: inherit;
-          line-height: inherit;
-        }
-
-        /* Box sizing for all elements */
         *, *::before, *::after {
           box-sizing: border-box;
         }
 
-        /* User styles come after reset */
         ${sanitizedCSS}
       </style>
       <div class="canvas-root">

--- a/apps/web/src/lib/ai/core/inline-instructions.ts
+++ b/apps/web/src/lib/ai/core/inline-instructions.ts
@@ -48,7 +48,7 @@ PAGE TYPES:
 • FOLDER: Container with list/icon view of children. Accepts file uploads via drag-drop.
 • DOCUMENT: Rich text stored as HTML. Use replace_lines for content changes.
 • SHEET: Spreadsheet stored as TOML. Use edit_sheet_cells for cell-level edits.
-• CANVAS: Raw HTML/CSS for dashboards and custom visual layouts. Edit as HTML.
+• CANVAS: Raw HTML/CSS rendered in an isolated sandbox. body/html/:root styles auto-remap to the sandbox root. Edit as HTML.
 • TASK_LIST: Task manager where each task auto-creates a linked child DOCUMENT page.
 • AI_CHAT: Custom AI agent with configurable system prompt and tool permissions.
 • CHANNEL: Team discussion thread with real-time messaging.
@@ -98,7 +98,7 @@ PAGE TYPES:
 • FOLDER: Container with list/icon view of children. Accepts file uploads via drag-drop.
 • DOCUMENT: Rich text stored as HTML. Use replace_lines for content changes.
 • SHEET: Spreadsheet stored as TOML. Use edit_sheet_cells for cell-level edits.
-• CANVAS: Raw HTML/CSS for dashboards and custom visual layouts. Edit as HTML.
+• CANVAS: Raw HTML/CSS rendered in an isolated sandbox. body/html/:root styles auto-remap to the sandbox root. Edit as HTML.
 • TASK_LIST: Task manager where each task auto-creates a linked child DOCUMENT page.
 • AI_CHAT: Custom AI agent with configurable system prompt and tool permissions.
 • CHANNEL: Team discussion thread with real-time messaging.

--- a/apps/web/src/lib/canvas/__tests__/remap-document-selectors.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/remap-document-selectors.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { remapDocumentSelectors } from '../remap-document-selectors';
+
+describe('remapDocumentSelectors', () => {
+  it('remaps body selector to .canvas-root', () => {
+    expect(remapDocumentSelectors('body { background: #000; }'))
+      .toBe('.canvas-root { background: #000; }');
+  });
+
+  it('remaps html selector to .canvas-root', () => {
+    expect(remapDocumentSelectors('html { margin: 0; }'))
+      .toBe('.canvas-root { margin: 0; }');
+  });
+
+  it('remaps :root selector to .canvas-root', () => {
+    expect(remapDocumentSelectors(':root { --bg: #000; }'))
+      .toBe('.canvas-root { --bg: #000; }');
+  });
+
+  it('remaps body with descendant selector', () => {
+    expect(remapDocumentSelectors('body * { color: #fff; }'))
+      .toBe('.canvas-root * { color: #fff; }');
+  });
+
+  it('remaps body with class descendant', () => {
+    expect(remapDocumentSelectors('body .wrap { padding: 10px; }'))
+      .toBe('.canvas-root .wrap { padding: 10px; }');
+  });
+
+  it('remaps body in comma-separated selectors', () => {
+    expect(remapDocumentSelectors('body, .foo { margin: 0; }'))
+      .toBe('.canvas-root, .foo { margin: 0; }');
+  });
+
+  it('remaps body with child combinator', () => {
+    expect(remapDocumentSelectors('body > div { display: flex; }'))
+      .toBe('.canvas-root > div { display: flex; }');
+  });
+
+  it('does not match partial words like .somebody', () => {
+    const input = '.somebody { color: red; }';
+    expect(remapDocumentSelectors(input)).toBe(input);
+  });
+
+  it('does not match partial words like .html-content', () => {
+    const input = '.html-content { color: red; }';
+    expect(remapDocumentSelectors(input)).toBe(input);
+  });
+
+  it('remaps multiple document selectors in one stylesheet', () => {
+    const input = `
+:root { --bg: #000; --fg: #fff; }
+html { margin: 0; min-height: 100%; }
+body { background: var(--bg); color: var(--fg); }
+body * { color: inherit; }
+.card { border: 1px solid #333; }`;
+
+    const result = remapDocumentSelectors(input);
+    expect(result).toContain('.canvas-root { --bg: #000;');
+    expect(result).toContain('.canvas-root { margin: 0;');
+    expect(result).toContain('.canvas-root { background: var(--bg);');
+    expect(result).toContain('.canvas-root * { color: inherit;');
+    expect(result).toContain('.card { border: 1px solid #333; }');
+  });
+
+  it('handles body with pseudo-selectors', () => {
+    expect(remapDocumentSelectors('body::before { content: ""; }'))
+      .toBe('.canvas-root::before { content: ""; }');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(remapDocumentSelectors('')).toBe('');
+  });
+
+  it('leaves class-only selectors untouched', () => {
+    const input = '.wrap { max-width: 1440px; }';
+    expect(remapDocumentSelectors(input)).toBe(input);
+  });
+
+  it('handles selector after closing brace', () => {
+    const input = '.foo { color: red; }\nbody { color: white; }';
+    const result = remapDocumentSelectors(input);
+    expect(result).toContain('.canvas-root { color: white; }');
+    expect(result).toContain('.foo { color: red; }');
+  });
+
+  it('remaps body with attribute selector', () => {
+    expect(remapDocumentSelectors('body[data-theme="dark"] { background: #000; }'))
+      .toBe('.canvas-root[data-theme="dark"] { background: #000; }');
+  });
+
+  it('remaps body inside @media block', () => {
+    const input = '@media (max-width: 768px) {\n  body { padding: 16px; }\n}';
+    const result = remapDocumentSelectors(input);
+    expect(result).toContain('.canvas-root { padding: 16px; }');
+  });
+});

--- a/apps/web/src/lib/canvas/__tests__/remap-document-selectors.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/remap-document-selectors.test.ts
@@ -94,4 +94,64 @@ body * { color: inherit; }
     const result = remapDocumentSelectors(input);
     expect(result).toContain('.canvas-root { padding: 16px; }');
   });
+
+  // ID selectors (#) — previously missed from all lookaheads
+  it('remaps body#id selector', () => {
+    expect(remapDocumentSelectors('body#main { background: red; }'))
+      .toBe('.canvas-root#main { background: red; }');
+  });
+
+  it('remaps html#id selector', () => {
+    expect(remapDocumentSelectors('html#app { margin: 0; }'))
+      .toBe('.canvas-root#app { margin: 0; }');
+  });
+
+  it('remaps :root#id selector', () => {
+    expect(remapDocumentSelectors(':root#theme { --bg: #000; }'))
+      .toBe('.canvas-root#theme { --bg: #000; }');
+  });
+
+  // :root with attribute, class, and pseudo selectors —
+  // previously missed because :root had a narrower lookahead
+  it('remaps :root with attribute selector', () => {
+    expect(remapDocumentSelectors(':root[data-theme="dark"] { color: #fff; }'))
+      .toBe('.canvas-root[data-theme="dark"] { color: #fff; }');
+  });
+
+  it('remaps :root with class', () => {
+    expect(remapDocumentSelectors(':root.dark { background: #000; }'))
+      .toBe('.canvas-root.dark { background: #000; }');
+  });
+
+  it('remaps :root with pseudo-selector', () => {
+    expect(remapDocumentSelectors(':root::before { content: ""; }'))
+      .toBe('.canvas-root::before { content: ""; }');
+  });
+
+  // Compound html+body selectors — collapse to single .canvas-root
+  // to prevent .canvas-root .canvas-root (which matches nothing)
+  it('collapses html body descendant into single .canvas-root', () => {
+    expect(remapDocumentSelectors('html body { margin: 0; }'))
+      .toBe('.canvas-root { margin: 0; }');
+  });
+
+  it('collapses html > body child combinator into single .canvas-root', () => {
+    expect(remapDocumentSelectors('html > body { margin: 0; }'))
+      .toBe('.canvas-root { margin: 0; }');
+  });
+
+  it('collapses html body with class into .canvas-root.class', () => {
+    expect(remapDocumentSelectors('html body.dark { color: #fff; }'))
+      .toBe('.canvas-root.dark { color: #fff; }');
+  });
+
+  it('collapses html > body with descendant', () => {
+    expect(remapDocumentSelectors('html > body > .wrap { padding: 10px; }'))
+      .toBe('.canvas-root > .wrap { padding: 10px; }');
+  });
+
+  it('keeps html, body comma-separated as two .canvas-root', () => {
+    expect(remapDocumentSelectors('html, body { margin: 0; }'))
+      .toBe('.canvas-root, .canvas-root { margin: 0; }');
+  });
 });

--- a/apps/web/src/lib/canvas/remap-document-selectors.ts
+++ b/apps/web/src/lib/canvas/remap-document-selectors.ts
@@ -1,0 +1,8 @@
+export function remapDocumentSelectors(css: string): string {
+  if (!css) return '';
+
+  return css
+    .replace(/(^|[{},;\s])body(?=\s*[{,\s*>+~:[.])/gm, '$1.canvas-root')
+    .replace(/(^|[{},;\s])html(?=\s*[{,\s*>+~:[.])/gm, '$1.canvas-root')
+    .replace(/(^|[{},;\s]):root(?=\s*[{,\s])/gm, '$1.canvas-root');
+}

--- a/apps/web/src/lib/canvas/remap-document-selectors.ts
+++ b/apps/web/src/lib/canvas/remap-document-selectors.ts
@@ -1,8 +1,21 @@
+const SELECTOR_LOOKAHEAD = '(?=\\s*[{,\\s*>+~:[.#])';
+const SELECTOR_LOOKBEHIND = '(^|[{},;\\s])';
+
 export function remapDocumentSelectors(css: string): string {
   if (!css) return '';
 
+  // Collapse compound html+body selectors first to prevent
+  // .canvas-root .canvas-root (which matches nothing in the shadow DOM)
+  const compoundBody = new RegExp(`${SELECTOR_LOOKBEHIND}html\\s*>\\s*body${SELECTOR_LOOKAHEAD}`, 'gm');
+  const descendantBody = new RegExp(`${SELECTOR_LOOKBEHIND}html\\s+body${SELECTOR_LOOKAHEAD}`, 'gm');
+  const body = new RegExp(`${SELECTOR_LOOKBEHIND}body${SELECTOR_LOOKAHEAD}`, 'gm');
+  const html = new RegExp(`${SELECTOR_LOOKBEHIND}html${SELECTOR_LOOKAHEAD}`, 'gm');
+  const root = new RegExp(`${SELECTOR_LOOKBEHIND}:root${SELECTOR_LOOKAHEAD}`, 'gm');
+
   return css
-    .replace(/(^|[{},;\s])body(?=\s*[{,\s*>+~:[.])/gm, '$1.canvas-root')
-    .replace(/(^|[{},;\s])html(?=\s*[{,\s*>+~:[.])/gm, '$1.canvas-root')
-    .replace(/(^|[{},;\s]):root(?=\s*[{,\s])/gm, '$1.canvas-root');
+    .replace(compoundBody, '$1.canvas-root')
+    .replace(descendantBody, '$1.canvas-root')
+    .replace(body, '$1.canvas-root')
+    .replace(html, '$1.canvas-root')
+    .replace(root, '$1.canvas-root');
 }


### PR DESCRIPTION
## Summary
- Remove forced `background: white; color: black; color-scheme: light` from Canvas shadow DOM — canvas now inherits the app theme (transparent bg, inherited text color)
- Remove destructive `.canvas-root * { color: inherit }` wildcard that defeated all element-level color/font overrides
- Auto-detect full HTML documents: extract `<body>` content and remap `body/html/:root` CSS selectors to `.canvas-root`
- Unify all selector regex lookaheads (`:root` previously used a narrower pattern), add `#` for ID selectors, and collapse compound `html body` / `html > body` to prevent unreachable `.canvas-root .canvas-root`
- Update AI inline instructions with minimal sandbox hint

## Test plan
- [x] 27 unit tests for selector remapping (body, html, :root, ID selectors, attribute selectors, pseudo-selectors, compound collapse, combinators, edge cases)
- [x] Lint & TypeScript checks passing
- [ ] Manual: paste a full dark-themed HTML document into a Canvas page — should render with dark background
- [ ] Manual: empty Canvas page should inherit app theme, not force white

## Changes by commit
1. `e4d3e33` — Remove forced light-mode defaults, add `remapDocumentSelectors` utility, extract `<body>` content, update AI instructions
2. `8b00cee` — Unify `:root` lookahead with `body`/`html`, add `#` to all lookaheads, collapse compound `html body` selectors, add 12 regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)