### PR TITLE
fix(auth): pass deviceId in all session-creating auth routes + cookie parser

### DIFF
--- a/apps/web/src/app/api/auth/__tests__/mobile-oauth-google-exchange.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/mobile-oauth-google-exchange.test.ts
@@ -635,6 +635,7 @@ describe('/api/auth/mobile/oauth/google/exchange', () => {
         type: 'user',
         scopes: ['*'],
         expiresInMs: 90 * 24 * 60 * 60 * 1000,
+        deviceId: 'ios-device-789',
         createdByService: 'mobile-oauth-google',
         createdByIp: '192.168.1.1',
       });

--- a/apps/web/src/app/api/auth/__tests__/mobile-refresh.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/mobile-refresh.test.ts
@@ -517,6 +517,7 @@ describe('/api/auth/mobile/refresh', () => {
         type: 'user',
         scopes: ['*'],
         expiresInMs: 90 * 24 * 60 * 60 * 1000,
+        deviceId: 'ios-device-123',
         createdByService: 'mobile-refresh',
         createdByIp: '192.168.1.1',
       });

--- a/apps/web/src/app/api/auth/apple/native/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/apple/native/__tests__/route.test.ts
@@ -500,6 +500,7 @@ describe('POST /api/auth/apple/native', () => {
         type: 'user',
         scopes: ['*'],
         expiresInMs: 7 * 24 * 60 * 60 * 1000,
+        deviceId: 'device-123',
         createdByIp: '192.168.1.1',
       });
     });
@@ -514,6 +515,7 @@ describe('POST /api/auth/apple/native', () => {
         type: 'user',
         scopes: ['*'],
         expiresInMs: 7 * 24 * 60 * 60 * 1000,
+        deviceId: 'device-123',
         createdByIp: undefined,
       });
     });

--- a/apps/web/src/app/api/auth/apple/native/route.ts
+++ b/apps/web/src/app/api/auth/apple/native/route.ts
@@ -158,6 +158,7 @@ export async function POST(req: Request) {
       type: 'user',
       scopes: ['*'],
       expiresInMs: SESSION_DURATION_MS,
+      deviceId,
       createdByIp: clientIP !== 'unknown' ? clientIP : undefined,
     });
 

--- a/apps/web/src/app/api/auth/device/__tests__/refresh-deviceid.test.ts
+++ b/apps/web/src/app/api/auth/device/__tests__/refresh-deviceid.test.ts
@@ -99,7 +99,7 @@ describe('device refresh deviceId propagation', () => {
     );
   });
 
-  it('given device refresh for mobile/desktop platform, should pass deviceId to createSession', async () => {
+  it('given device refresh for non-web platform, should pass deviceId to createSession', async () => {
     vi.mocked(validateDeviceToken).mockResolvedValueOnce({
       id: 'dt_1',
       userId: 'user_1',

--- a/apps/web/src/app/api/auth/device/__tests__/refresh-deviceid.test.ts
+++ b/apps/web/src/app/api/auth/device/__tests__/refresh-deviceid.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@pagespace/lib/auth', () => ({
+  hashToken: vi.fn((t: string) => `hashed_${t}`),
+  getTokenPrefix: vi.fn((t: string) => t.slice(0, 8)),
+  sessionService: {
+    createSession: vi.fn().mockResolvedValue('ps_sess_mock_token'),
+    validateSession: vi.fn().mockResolvedValue({ sessionId: 'sid_123' }),
+  },
+}));
+
+vi.mock('@pagespace/lib/server', () => ({
+  validateDeviceToken: vi.fn().mockResolvedValue({
+    id: 'dt_1',
+    userId: 'user_1',
+    deviceId: 'device_123',
+    platform: 'web',
+    expiresAt: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+  }),
+  updateDeviceTokenActivity: vi.fn().mockResolvedValue(undefined),
+  generateDeviceToken: vi.fn().mockReturnValue('new_device_token'),
+  generateCSRFToken: vi.fn().mockReturnValue('csrf_token'),
+  loggers: { auth: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } },
+  auditRequest: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/security', () => ({
+  checkDistributedRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
+  resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
+  DISTRIBUTED_RATE_LIMITS: { REFRESH: { maxAttempts: 10, windowMs: 60000 } },
+}));
+
+vi.mock('@pagespace/lib/activity-tracker', () => ({
+  trackAuthEvent: vi.fn(),
+}));
+
+vi.mock('@/lib/repositories/auth-repository', () => ({
+  authRepository: {
+    findUserById: vi.fn().mockResolvedValue({ id: 'user_1', email: 'test@example.com' }),
+  },
+}));
+
+vi.mock('@/lib/repositories/session-repository', () => ({
+  sessionRepository: {},
+}));
+
+vi.mock('@pagespace/db/transactions/auth-transactions', () => ({
+  atomicDeviceTokenRotation: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
+  appendSessionCookie: vi.fn(),
+}));
+
+import { POST } from '../refresh/route';
+import { validateDeviceToken } from '@pagespace/lib/server';
+import { sessionService } from '@pagespace/lib/auth';
+
+function makeRequest(body: Record<string, unknown>): Request {
+  return new Request('http://localhost/api/auth/device/refresh', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('device refresh deviceId propagation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(sessionService.createSession).mockResolvedValue('ps_sess_mock_token');
+    vi.mocked(sessionService.validateSession).mockResolvedValue({ sessionId: 'sid_123' } as never);
+  });
+
+  it('given device refresh for web platform, should pass deviceId to createSession', async () => {
+    vi.mocked(validateDeviceToken).mockResolvedValueOnce({
+      id: 'dt_1',
+      userId: 'user_1',
+      deviceId: 'device_123',
+      platform: 'web',
+      expiresAt: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+    } as never);
+
+    const req = makeRequest({
+      deviceToken: 'valid_token',
+      deviceId: 'device_123',
+      userAgent: 'test-agent',
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    expect(sessionService.createSession).toHaveBeenCalledOnce();
+    expect(sessionService.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deviceId: 'device_123',
+        createdByService: 'device-refresh',
+      })
+    );
+  });
+
+  it('given device refresh for mobile/desktop platform, should pass deviceId to createSession', async () => {
+    vi.mocked(validateDeviceToken).mockResolvedValueOnce({
+      id: 'dt_1',
+      userId: 'user_1',
+      deviceId: 'device_456',
+      platform: 'mobile',
+      expiresAt: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+    } as never);
+
+    const req = makeRequest({
+      deviceToken: 'valid_token',
+      deviceId: 'device_456',
+      userAgent: 'mobile-agent',
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    expect(sessionService.createSession).toHaveBeenCalledOnce();
+    expect(sessionService.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deviceId: 'device_456',
+        expiresInMs: 90 * 24 * 60 * 60 * 1000,
+        createdByService: 'device-refresh',
+      })
+    );
+  });
+
+  it('given device refresh with deviceId "device_123", should create session where deviceId equals "device_123"', async () => {
+    vi.mocked(validateDeviceToken).mockResolvedValueOnce({
+      id: 'dt_1',
+      userId: 'user_1',
+      deviceId: 'device_123',
+      platform: 'web',
+      expiresAt: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+    } as never);
+
+    const req = makeRequest({
+      deviceToken: 'valid_token',
+      deviceId: 'device_123',
+    });
+
+    await POST(req);
+
+    const callArgs = vi.mocked(sessionService.createSession).mock.calls[0][0];
+    expect(callArgs.deviceId).toBe('device_123');
+  });
+});

--- a/apps/web/src/app/api/auth/device/refresh/route.ts
+++ b/apps/web/src/app/api/auth/device/refresh/route.ts
@@ -188,6 +188,7 @@ export async function POST(req: Request) {
         type: 'user',
         scopes: ['*'],
         expiresInMs: 7 * 24 * 60 * 60 * 1000, // 7 days
+        deviceId,
         createdByService: 'device-refresh',
         createdByIp: normalizedIP,
       });
@@ -217,6 +218,7 @@ export async function POST(req: Request) {
       type: 'user',
       scopes: ['*'],
       expiresInMs: 90 * 24 * 60 * 60 * 1000, // 90 days for mobile/desktop
+      deviceId,
       createdByService: 'device-refresh',
       createdByIp: normalizedIP,
     });

--- a/apps/web/src/app/api/auth/google/native/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/native/__tests__/route.test.ts
@@ -299,6 +299,7 @@ describe('POST /api/auth/google/native', () => {
         type: 'user',
         scopes: ['*'],
         expiresInMs: 7 * 24 * 60 * 60 * 1000,
+        deviceId: 'device-123',
         createdByIp: '127.0.0.1',
       });
     });

--- a/apps/web/src/app/api/auth/google/native/route.ts
+++ b/apps/web/src/app/api/auth/google/native/route.ts
@@ -182,6 +182,7 @@ export async function POST(req: Request) {
       type: 'user',
       scopes: ['*'],
       expiresInMs: SESSION_DURATION_MS,
+      deviceId,
       createdByIp: clientIP !== 'unknown' ? clientIP : undefined,
     });
 

--- a/apps/web/src/app/api/auth/magic-link/verify/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/route.ts
@@ -98,6 +98,7 @@ export async function GET(req: Request) {
       type: 'user',
       scopes: ['*'],
       expiresInMs: SESSION_DURATION_MS,
+      deviceId: desktopMeta?.deviceId,
       createdByIp: clientIP !== 'unknown' ? clientIP : undefined,
     });
 

--- a/apps/web/src/app/api/auth/mobile/oauth/google/exchange/route.ts
+++ b/apps/web/src/app/api/auth/mobile/oauth/google/exchange/route.ts
@@ -250,6 +250,7 @@ export async function POST(req: Request) {
       type: 'user',
       scopes: ['*'],
       expiresInMs: 90 * 24 * 60 * 60 * 1000, // 90 days for mobile
+      deviceId,
       createdByService: 'mobile-oauth-google',
       createdByIp: clientIP,
     });

--- a/apps/web/src/app/api/auth/mobile/refresh/route.ts
+++ b/apps/web/src/app/api/auth/mobile/refresh/route.ts
@@ -135,6 +135,7 @@ export async function POST(req: Request) {
       type: 'user',
       scopes: ['*'],
       expiresInMs: 90 * 24 * 60 * 60 * 1000, // 90 days for mobile
+      deviceId,
       createdByService: 'mobile-refresh',
       createdByIp: normalizedIP,
     });

--- a/apps/web/src/lib/auth/__tests__/cookie-parser.test.ts
+++ b/apps/web/src/lib/auth/__tests__/cookie-parser.test.ts
@@ -22,4 +22,8 @@ describe('getSessionFromCookies (cookie parser)', () => {
   it('given empty string cookie header, should return null', () => {
     expect(getSessionFromCookies('')).toBeNull();
   });
+
+  it('given session token containing "=" like "session=ps_sess_abc123=", should return full value including "="', () => {
+    expect(getSessionFromCookies('session=ps_sess_abc123=')).toBe('ps_sess_abc123=');
+  });
 });

--- a/apps/web/src/lib/auth/__tests__/cookie-parser.test.ts
+++ b/apps/web/src/lib/auth/__tests__/cookie-parser.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { getSessionFromCookies } from '../cookie-config';
+
+describe('getSessionFromCookies (cookie parser)', () => {
+  it('given cookie header "session=ps_sess_abc123", should return "ps_sess_abc123"', () => {
+    expect(getSessionFromCookies('session=ps_sess_abc123')).toBe('ps_sess_abc123');
+  });
+
+  it('given cookie header with value containing "=" like "other=base64==; session=ps_sess_abc", should parse session correctly', () => {
+    expect(getSessionFromCookies('other=base64==; session=ps_sess_abc')).toBe('ps_sess_abc');
+  });
+
+  it('given duplicate cookie names "session=first; session=second", should return first occurrence', () => {
+    // RFC 6265: when duplicates exist, the first value wins in the cookie library
+    expect(getSessionFromCookies('session=first; session=second')).toBe('first');
+  });
+
+  it('given null cookie header, should return null', () => {
+    expect(getSessionFromCookies(null)).toBeNull();
+  });
+
+  it('given empty string cookie header, should return null', () => {
+    expect(getSessionFromCookies('')).toBeNull();
+  });
+});

--- a/apps/web/src/lib/auth/cookie-config.ts
+++ b/apps/web/src/lib/auth/cookie-config.ts
@@ -13,7 +13,7 @@
  * @module @pagespace/web/lib/auth/cookie-config
  */
 
-import { serialize } from 'cookie';
+import { serialize, parse } from 'cookie';
 
 /**
  * Session duration: 7 days in seconds
@@ -153,12 +153,6 @@ export function appendClearCookies(headers: Headers): void {
  */
 export function getSessionFromCookies(cookieHeader: string | null): string | null {
   if (!cookieHeader) return null;
-
-  const cookies = cookieHeader.split(';').reduce((acc, cookie) => {
-    const [key, value] = cookie.trim().split('=');
-    if (key && value) acc[key] = value;
-    return acc;
-  }, {} as Record<string, string>);
-
+  const cookies = parse(cookieHeader);
   return cookies[COOKIE_CONFIG.session.name] ?? null;
 }


### PR DESCRIPTION
## Summary
- **Fix 1 (MEDIUM):** Device refresh route now passes `deviceId` to both `createSession` calls (web + mobile/desktop). Previously sessions were created with `deviceId=NULL`, causing `revokeForUserDevice` to collaterally revoke all device-refresh sessions when logging in on any device.
- **Fix 2 (MEDIUM):** Five additional auth routes had the same missing `deviceId` bug: `mobile/refresh`, `apple/native`, `google/native`, `mobile/oauth/google/exchange`, and `magic-link/verify` (conditional on desktop metadata). All now pass `deviceId` to `createSession`.
- **Fix 3 (LOW):** Replaced hand-rolled cookie parser in `getSessionFromCookies` with the `parse` function from the already-imported `cookie` library. The old parser truncated cookie values containing `=` and used last-duplicate-wins semantics.

## Changed files
| File | Change |
|------|--------|
| `apps/web/src/app/api/auth/device/refresh/route.ts` | +`deviceId` to both `createSession` calls |
| `apps/web/src/app/api/auth/mobile/refresh/route.ts` | +`deviceId` to `createSession` |
| `apps/web/src/app/api/auth/apple/native/route.ts` | +`deviceId` to `createSession` |
| `apps/web/src/app/api/auth/google/native/route.ts` | +`deviceId` to `createSession` |
| `apps/web/src/app/api/auth/mobile/oauth/google/exchange/route.ts` | +`deviceId` to `createSession` |
| `apps/web/src/app/api/auth/magic-link/verify/route.ts` | +`deviceId: desktopMeta?.deviceId` to `createSession` |
| `apps/web/src/lib/auth/cookie-config.ts` | Replace naive `split('=')` parser with `cookie.parse()` |

## Test plan
- [x] New test: `refresh-deviceid.test.ts` — verifies `deviceId` is passed to `createSession` for web and non-web platforms (3 tests)
- [x] New test: `cookie-parser.test.ts` — verifies correct parsing of `=` in values, duplicate handling, null/empty inputs, and token truncation regression (6 tests)
- [x] Existing `cookie-config.test.ts` still passes (32 tests)
- [x] `pnpm typecheck` passes on all changed files
- [x] Note: `refresh-deviceid.test.ts` is blocked by a pre-existing Vite module resolution issue affecting ALL auth route tests

## CI note
"Dependency Audit" and "Security Summary" failures are pre-existing — npm's audit endpoint returns 410 (retired). Affects all PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)