### PR TITLE
fix(auth): close CSRF bypass in authenticateWithEnforcedContext

### DIFF
--- a/apps/web/src/lib/auth/__tests__/enforced-context-csrf.test.ts
+++ b/apps/web/src/lib/auth/__tests__/enforced-context-csrf.test.ts
@@ -57,6 +57,7 @@ vi.mock('../cookie-config', () => ({
 
 import { authenticateWithEnforcedContext, isEnforcedAuthError } from '../index';
 import { sessionService } from '@pagespace/lib/auth';
+import { logSecurityEvent } from '@pagespace/lib/server';
 import { validateCSRF } from '../csrf-validation';
 import { getSessionFromCookies } from '../cookie-config';
 
@@ -100,6 +101,9 @@ describe('authenticateWithEnforcedContext CSRF bypass regression', () => {
     if (isEnforcedAuthError(result)) {
       expect(result.error.status).toBe(401);
     }
+    expect(logSecurityEvent).toHaveBeenCalledWith('unauthorized', expect.objectContaining({
+      reason: 'unknown_bearer_format',
+    }));
   });
 
   it('rejects MCP tokens — EnforcedAuthContext requires full session claims', async () => {
@@ -169,6 +173,28 @@ describe('authenticateWithEnforcedContext CSRF bypass regression', () => {
     const request = new Request('https://example.com/api/pages/123/permissions', {
       method: 'POST',
       headers: {
+        cookie: 'session=ps_sess_valid',
+        'x-csrf-token': 'valid-csrf-token',
+      },
+    });
+
+    const result = await authenticateWithEnforcedContext(request);
+
+    expect(isEnforcedAuthError(result)).toBe(false);
+    expect(validateCSRF).toHaveBeenCalledWith(request);
+  });
+
+  it('treats empty Bearer token as no token and falls through to cookie auth', async () => {
+    // `Authorization: Bearer ` (trailing space, no token) — getBearerToken returns ""
+    // which is falsy, so the request should fall through to cookie-based auth + CSRF.
+    vi.mocked(getSessionFromCookies).mockReturnValue('ps_sess_valid');
+    vi.mocked(sessionService.validateSession).mockResolvedValue(mockSessionClaims);
+    vi.mocked(validateCSRF).mockResolvedValue(null);
+
+    const request = new Request('https://example.com/api/pages/123/permissions', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer ',
         cookie: 'session=ps_sess_valid',
         'x-csrf-token': 'valid-csrf-token',
       },

--- a/apps/web/src/lib/auth/__tests__/enforced-context-csrf.test.ts
+++ b/apps/web/src/lib/auth/__tests__/enforced-context-csrf.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+
+// Mock dependencies at system boundary
+vi.mock('@pagespace/lib/auth', () => ({
+  hashToken: vi.fn().mockReturnValue('mocked-hash'),
+  sessionService: {
+    validateSession: vi.fn(),
+  },
+}));
+
+vi.mock('@pagespace/lib/server', () => ({
+  EnforcedAuthContext: class EnforcedAuthContext {
+    userId: string;
+    userRole: string;
+    constructor(claims: { userId: string; userRole: string }) {
+      this.userId = claims.userId;
+      this.userRole = claims.userRole;
+    }
+    static fromSession(claims: unknown): unknown {
+      return { ctx: claims };
+    }
+  },
+  logSecurityEvent: vi.fn(),
+}));
+
+vi.mock('@pagespace/db', () => ({
+  db: {
+    query: {
+      mcpTokens: {
+        findFirst: vi.fn(),
+      },
+    },
+    update: vi.fn().mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      }),
+    }),
+  },
+  mcpTokens: {},
+  eq: vi.fn(),
+  and: vi.fn(),
+  isNull: vi.fn(),
+}));
+
+vi.mock('../csrf-validation', () => ({
+  validateCSRF: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../origin-validation', () => ({
+  validateOrigin: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('../cookie-config', () => ({
+  getSessionFromCookies: vi.fn(),
+}));
+
+import { authenticateWithEnforcedContext, isEnforcedAuthError } from '../index';
+import { sessionService } from '@pagespace/lib/auth';
+import { validateCSRF } from '../csrf-validation';
+import { getSessionFromCookies } from '../cookie-config';
+
+const mockSessionClaims = {
+  sessionId: 'test-session-id',
+  userId: 'test-user-id',
+  userRole: 'user' as const,
+  tokenVersion: 0,
+  adminRoleVersion: 0,
+  type: 'user' as const,
+  scopes: ['*'],
+  expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+};
+
+describe('authenticateWithEnforcedContext CSRF bypass regression', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(sessionService.validateSession).mockResolvedValue(null);
+    vi.mocked(validateCSRF).mockResolvedValue(null);
+    vi.mocked(getSessionFromCookies).mockReturnValue(null);
+  });
+
+  it('rejects unknown Bearer token format even when session cookie is valid', async () => {
+    // CRITICAL REGRESSION: An attacker sends `Authorization: Bearer garbage` to
+    // bypass CSRF. The garbage token doesn't match mcp_ or ps_sess_, falls through
+    // to cookie-based auth, and then CSRF is skipped because bearerToken is truthy.
+    vi.mocked(getSessionFromCookies).mockReturnValue('ps_sess_valid');
+    vi.mocked(sessionService.validateSession).mockResolvedValue(mockSessionClaims);
+
+    const request = new Request('https://example.com/api/pages/123/permissions', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer garbage_token',
+        cookie: 'session=ps_sess_valid',
+      },
+    });
+
+    const result = await authenticateWithEnforcedContext(request);
+
+    expect(isEnforcedAuthError(result)).toBe(true);
+    if (isEnforcedAuthError(result)) {
+      expect(result.error.status).toBe(401);
+    }
+  });
+
+  it('rejects MCP tokens — EnforcedAuthContext requires full session claims', async () => {
+    const request = new Request('https://example.com/api/pages/123/permissions', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer mcp_some_token',
+      },
+    });
+
+    const result = await authenticateWithEnforcedContext(request);
+
+    expect(isEnforcedAuthError(result)).toBe(true);
+    if (isEnforcedAuthError(result)) {
+      expect(result.error.status).toBe(401);
+      const body = await result.error.json();
+      expect(body.error).toContain('MCP tokens are not permitted');
+    }
+  });
+
+  it('authenticates valid ps_sess_ Bearer token without CSRF check', async () => {
+    vi.mocked(sessionService.validateSession).mockResolvedValue(mockSessionClaims);
+
+    const request = new Request('https://example.com/api/pages/123/permissions', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer ps_sess_valid_token',
+      },
+    });
+
+    const result = await authenticateWithEnforcedContext(request);
+
+    expect(isEnforcedAuthError(result)).toBe(false);
+    expect(validateCSRF).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when cookie auth is used without CSRF token', async () => {
+    vi.mocked(getSessionFromCookies).mockReturnValue('ps_sess_valid');
+    vi.mocked(sessionService.validateSession).mockResolvedValue(mockSessionClaims);
+    vi.mocked(validateCSRF).mockResolvedValue(
+      NextResponse.json(
+        { error: 'CSRF token required', code: 'CSRF_TOKEN_MISSING' },
+        { status: 403 }
+      )
+    );
+
+    const request = new Request('https://example.com/api/pages/123/permissions', {
+      method: 'POST',
+      headers: {
+        cookie: 'session=ps_sess_valid',
+      },
+    });
+
+    const result = await authenticateWithEnforcedContext(request);
+
+    expect(isEnforcedAuthError(result)).toBe(true);
+    if (isEnforcedAuthError(result)) {
+      expect(result.error.status).toBe(403);
+    }
+  });
+
+  it('succeeds when cookie auth is used with valid CSRF token', async () => {
+    vi.mocked(getSessionFromCookies).mockReturnValue('ps_sess_valid');
+    vi.mocked(sessionService.validateSession).mockResolvedValue(mockSessionClaims);
+    vi.mocked(validateCSRF).mockResolvedValue(null);
+
+    const request = new Request('https://example.com/api/pages/123/permissions', {
+      method: 'POST',
+      headers: {
+        cookie: 'session=ps_sess_valid',
+        'x-csrf-token': 'valid-csrf-token',
+      },
+    });
+
+    const result = await authenticateWithEnforcedContext(request);
+
+    expect(isEnforcedAuthError(result)).toBe(false);
+    expect(validateCSRF).toHaveBeenCalledWith(request);
+  });
+});

--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -377,6 +377,13 @@ export async function authenticateWithEnforcedContext(
     return { ctx: EnforcedAuthContext.fromSession(sessionClaims) };
   }
 
+  // Reject unknown Bearer token formats — prevents CSRF bypass where an attacker
+  // sends `Authorization: Bearer <garbage>` to skip CSRF validation while still
+  // authenticating via the victim's session cookie.
+  if (bearerToken) {
+    return { error: unauthorized('Invalid token format') };
+  }
+
   // Try session cookie (web browsers)
   const cookieHeader = request.headers.get('cookie');
   const sessionToken = getSessionFromCookies(cookieHeader);
@@ -399,8 +406,8 @@ export async function authenticateWithEnforcedContext(
     }
   }
 
-  // Apply CSRF validation for session-based auth (skip for Bearer token)
-  if (requireCSRF && !bearerToken) {
+  // Apply CSRF validation for cookie-based session auth
+  if (requireCSRF) {
     const { validateCSRF } = await import('./csrf-validation');
     const csrfError = await validateCSRF(request);
     if (csrfError) {

--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -381,6 +381,11 @@ export async function authenticateWithEnforcedContext(
   // sends `Authorization: Bearer <garbage>` to skip CSRF validation while still
   // authenticating via the victim's session cookie.
   if (bearerToken) {
+    logSecurityEvent('unauthorized', {
+      reason: 'unknown_bearer_format',
+      authType: 'bearer',
+      action: 'deny',
+    });
     return { error: unauthorized('Invalid token format') };
   }
 


### PR DESCRIPTION
## Summary

- **CRITICAL security fix**: `authenticateWithEnforcedContext` allowed CSRF bypass when an attacker sent `Authorization: Bearer <garbage>` — the unknown token fell through to cookie auth while the CSRF guard was skipped because `bearerToken` was truthy
- Rejects unknown Bearer token formats after the `ps_sess_` check (matching the safe pattern in `authenticateSessionRequest` line 214)
- Simplifies CSRF guard from `requireCSRF && !bearerToken` to `requireCSRF` — all Bearer paths now return early, so this branch is always cookie-only
- Logs `logSecurityEvent` on unknown Bearer format rejection for incident response visibility

## Impact

Affected endpoints: `/api/pages/[pageId]/permissions` POST and DELETE. An attacker could grant themselves page permissions or revoke others'.

## Test plan

- [x] Regression test: `Bearer garbage` + valid session cookie → 401 (was succeeding without CSRF)
- [x] MCP token rejection still works → 401
- [x] Valid `ps_sess_` Bearer authenticates without CSRF → success
- [x] Cookie auth without CSRF token → 403
- [x] Cookie auth with valid CSRF token → success
- [x] Edge case: empty Bearer token falls through to cookie auth + CSRF → success
- [x] Full auth test suite passes (all non-pre-existing failures)
- [x] `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)