### PR TITLE
fix(auth): close HIPAA idle timeout bypass when lastUsedAt is NULL

### DIFF
--- a/packages/lib/src/auth/__tests__/session-idle-timeout.test.ts
+++ b/packages/lib/src/auth/__tests__/session-idle-timeout.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../session-repository', () => ({
+  sessionRepository: {
+    findUserById: vi.fn(),
+    findActiveSession: vi.fn(),
+    insertSession: vi.fn(),
+    touchSession: vi.fn(),
+    revokeByHash: vi.fn(),
+    revokeAllForUser: vi.fn(),
+    revokeForUserDevice: vi.fn(),
+    deleteExpired: vi.fn(),
+  },
+}));
+
+vi.mock('../opaque-tokens', () => ({
+  generateOpaqueToken: vi.fn(() => ({
+    token: 'ps_sess_testtoken123456789012345678901234567890a',
+    tokenHash: 'hashed_token',
+    tokenPrefix: 'ps_sess_test',
+  })),
+  isValidTokenFormat: vi.fn((t: string) => typeof t === 'string' && t.startsWith('ps_')),
+}));
+
+vi.mock('../token-utils', () => ({
+  hashToken: vi.fn((t: string) => `hashed_${t}`),
+}));
+
+// 15-minute idle timeout for these tests
+vi.mock('../constants', () => ({
+  IDLE_TIMEOUT_MS: 15 * 60 * 1000,
+}));
+
+import { SessionService } from '../session-service';
+import { sessionRepository } from '../session-repository';
+import type { SessionRecord } from '../session-repository';
+
+function makeSession(overrides: Partial<SessionRecord> = {}): SessionRecord {
+  return {
+    id: 'sess-1',
+    userId: 'user-1',
+    tokenHash: 'h',
+    tokenVersion: 1,
+    adminRoleVersion: 0,
+    type: 'user',
+    scopes: ['read'],
+    expiresAt: new Date(Date.now() + 3600000),
+    lastUsedAt: null,
+    createdAt: new Date(),
+    resourceType: null,
+    resourceId: null,
+    driveId: null,
+    user: {
+      id: 'user-1',
+      tokenVersion: 1,
+      role: 'user',
+      adminRoleVersion: 0,
+      suspendedAt: null,
+    },
+    ...overrides,
+  };
+}
+
+describe('SessionService HIPAA idle timeout', () => {
+  let service: SessionService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new SessionService();
+  });
+
+  describe('when lastUsedAt is NULL (createdAt fallback)', () => {
+    it('allows session when createdAt is within idle timeout', async () => {
+      vi.mocked(sessionRepository.findActiveSession).mockResolvedValue(
+        makeSession({
+          lastUsedAt: null,
+          createdAt: new Date(Date.now() - 5 * 60 * 1000), // 5 min ago
+        }),
+      );
+
+      const result = await service.validateSession('ps_sess_valid');
+
+      expect(result).not.toBeNull();
+      expect(result?.sessionId).toBe('sess-1');
+      expect(sessionRepository.revokeByHash).not.toHaveBeenCalled();
+    });
+
+    it('revokes session when createdAt exceeds idle timeout', async () => {
+      vi.mocked(sessionRepository.findActiveSession).mockResolvedValue(
+        makeSession({
+          lastUsedAt: null,
+          createdAt: new Date(Date.now() - 20 * 60 * 1000), // 20 min ago
+        }),
+      );
+      vi.mocked(sessionRepository.revokeByHash).mockResolvedValue(undefined);
+
+      const result = await service.validateSession('ps_sess_valid');
+
+      expect(result).toBeNull();
+      expect(sessionRepository.revokeByHash).toHaveBeenCalledWith(
+        'hashed_ps_sess_valid',
+        'idle_timeout',
+      );
+    });
+  });
+
+  describe('when lastUsedAt is present', () => {
+    it('allows session when lastUsedAt is within idle timeout', async () => {
+      vi.mocked(sessionRepository.findActiveSession).mockResolvedValue(
+        makeSession({
+          lastUsedAt: new Date(Date.now() - 5 * 60 * 1000), // 5 min ago
+          createdAt: new Date(Date.now() - 60 * 60 * 1000), // created 1hr ago
+        }),
+      );
+
+      const result = await service.validateSession('ps_sess_valid');
+
+      expect(result).not.toBeNull();
+      expect(sessionRepository.revokeByHash).not.toHaveBeenCalled();
+    });
+
+    it('revokes session when lastUsedAt exceeds idle timeout', async () => {
+      vi.mocked(sessionRepository.findActiveSession).mockResolvedValue(
+        makeSession({
+          lastUsedAt: new Date(Date.now() - 20 * 60 * 1000), // 20 min ago
+          createdAt: new Date(Date.now() - 60 * 60 * 1000),
+        }),
+      );
+      vi.mocked(sessionRepository.revokeByHash).mockResolvedValue(undefined);
+
+      const result = await service.validateSession('ps_sess_valid');
+
+      expect(result).toBeNull();
+      expect(sessionRepository.revokeByHash).toHaveBeenCalledWith(
+        'hashed_ps_sess_valid',
+        'idle_timeout',
+      );
+    });
+  });
+});

--- a/packages/lib/src/auth/__tests__/session-repository-logging.test.ts
+++ b/packages/lib/src/auth/__tests__/session-repository-logging.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@pagespace/db', () => ({
+  db: {
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => Promise.resolve()),
+      })),
+    })),
+    query: { users: {}, sessions: {} },
+    insert: vi.fn(),
+    delete: vi.fn(),
+  },
+  sessions: { tokenHash: 'tokenHash' },
+  users: {},
+  eq: vi.fn(),
+  and: vi.fn(),
+  or: vi.fn(),
+  isNull: vi.fn(),
+  gt: vi.fn(),
+  lt: vi.fn(),
+}));
+
+import { db } from '@pagespace/db';
+import { sessionRepository } from '../session-repository';
+
+describe('sessionRepository.touchSession error handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('logs error to console when database write fails', async () => {
+    const dbError = new Error('connection reset by peer');
+    const mockWhere = vi.fn().mockRejectedValueOnce(dbError);
+    const mockSet = vi.fn(() => ({ where: mockWhere }));
+    vi.mocked(db.update).mockReturnValue({ set: mockSet } as never);
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    sessionRepository.touchSession('some-token-hash');
+
+    // Let the microtask (catch handler) execute
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      '[auth] Failed to update session lastUsedAt',
+      dbError,
+    );
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/packages/lib/src/auth/__tests__/session-service-unit.test.ts
+++ b/packages/lib/src/auth/__tests__/session-service-unit.test.ts
@@ -149,7 +149,7 @@ describe('SessionService', () => {
       vi.mocked(sessionRepository.findActiveSession).mockResolvedValue({
         id: 'sess-1', userId: 'user-1', tokenHash: 'h', tokenVersion: 1,
         adminRoleVersion: 0, type: 'user', scopes: ['read'],
-        expiresAt: new Date(Date.now() + 60000), lastUsedAt: null,
+        expiresAt: new Date(Date.now() + 60000), lastUsedAt: null, createdAt: new Date(),
         resourceType: null, resourceId: null, driveId: null,
         user: null,
       });
@@ -164,7 +164,7 @@ describe('SessionService', () => {
       vi.mocked(sessionRepository.findActiveSession).mockResolvedValue({
         id: 'sess-1', userId: 'user-1', tokenHash: 'h', tokenVersion: 1,
         adminRoleVersion: 0, type: 'user', scopes: ['read'],
-        expiresAt: new Date(Date.now() + 60000), lastUsedAt: null,
+        expiresAt: new Date(Date.now() + 60000), lastUsedAt: null, createdAt: new Date(),
         resourceType: null, resourceId: null, driveId: null,
         user: { id: 'user-1', tokenVersion: 1, role: 'user', adminRoleVersion: 0, suspendedAt: new Date() },
       });
@@ -184,7 +184,7 @@ describe('SessionService', () => {
       vi.mocked(sessionRepository.findActiveSession).mockResolvedValue({
         id: 'sess-1', userId: 'user-1', tokenHash: 'h', tokenVersion: 1,
         adminRoleVersion: 0, type: 'user', scopes: ['read'],
-        expiresAt: new Date(Date.now() + 60000), lastUsedAt: null,
+        expiresAt: new Date(Date.now() + 60000), lastUsedAt: null, createdAt: new Date(),
         resourceType: null, resourceId: null, driveId: null,
         user: { id: 'user-1', tokenVersion: 2, role: 'user', adminRoleVersion: 0, suspendedAt: null },
       });
@@ -205,7 +205,7 @@ describe('SessionService', () => {
       vi.mocked(sessionRepository.findActiveSession).mockResolvedValue({
         id: 'sess-1', userId: 'user-1', tokenHash: 'h', tokenVersion: 1,
         adminRoleVersion: 0, type: 'user', scopes: ['read', 'write'],
-        expiresAt, lastUsedAt: null,
+        expiresAt, lastUsedAt: null, createdAt: new Date(),
         resourceType: null, resourceId: null, driveId: null,
         user: { id: 'user-1', tokenVersion: 1, role: 'admin', adminRoleVersion: 0, suspendedAt: null },
       });

--- a/packages/lib/src/auth/session-repository.ts
+++ b/packages/lib/src/auth/session-repository.ts
@@ -22,6 +22,7 @@ export interface SessionRecord {
   scopes: string[];
   expiresAt: Date;
   lastUsedAt: Date | null;
+  createdAt: Date;
   resourceType: string | null;
   resourceId: string | null;
   driveId: string | null;
@@ -65,7 +66,7 @@ export const sessionRepository = {
     db.update(sessions)
       .set({ lastUsedAt: new Date() })
       .where(eq(sessions.tokenHash, tokenHash))
-      .catch(() => {});
+      .catch((err) => { console.error('[auth] Failed to update session lastUsedAt', err); });
   },
 
   revokeByHash: async (tokenHash: string, reason: string): Promise<void> => {

--- a/packages/lib/src/auth/session-service.ts
+++ b/packages/lib/src/auth/session-service.ts
@@ -97,8 +97,10 @@ export class SessionService {
     }
 
     // HIPAA idle timeout: revoke session if idle too long
-    if (IDLE_TIMEOUT_MS > 0 && session.lastUsedAt) {
-      const lastUsed = session.lastUsedAt instanceof Date ? session.lastUsedAt : new Date(session.lastUsedAt);
+    // Falls back to createdAt when lastUsedAt is NULL (new session or failed touchSession)
+    if (IDLE_TIMEOUT_MS > 0) {
+      const lastActivity = session.lastUsedAt ?? session.createdAt;
+      const lastUsed = lastActivity instanceof Date ? lastActivity : new Date(lastActivity);
       const idleDuration = Date.now() - lastUsed.getTime();
       if (idleDuration > IDLE_TIMEOUT_MS) {
         await this.revokeSession(token, 'idle_timeout');


### PR DESCRIPTION
## Summary
- **Security fix**: Sessions with NULL `lastUsedAt` (new sessions or failed `touchSession` DB writes) previously bypassed the idle timeout check entirely, allowing indefinite session persistence on HIPAA deployments
- **Fix**: Falls back to `createdAt` for the idle timeout calculation when `lastUsedAt` is NULL
- **Improvement**: `touchSession` now logs DB errors via `console.error` instead of silently swallowing with `.catch(() => {})`

## Changes
- `session-service.ts`: Idle timeout check no longer requires `lastUsedAt` to be truthy — uses `session.lastUsedAt ?? session.createdAt`
- `session-repository.ts`: Added `createdAt: Date` to `SessionRecord` interface; `touchSession` errors are now logged
- `session-service-unit.test.ts`: Updated mock data to include `createdAt`
- **New**: `session-idle-timeout.test.ts` — 4 tests covering createdAt fallback and lastUsedAt behavior under active idle timeout
- **New**: `session-repository-logging.test.ts` — 1 test verifying touchSession error logging

## Test plan
- [x] All 4068 unit tests pass (0 failures)
- [x] TypeScript typecheck passes (12/12 packages)
- [ ] Verify on-prem HIPAA deployment: new sessions without activity are revoked after idle timeout
- [ ] Verify cloud deployment (IDLE_TIMEOUT_MS=0): no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)