### PR TITLE
fix(security-headers): allow payment for Stripe iframe on billing pages

### DIFF
--- a/apps/web/src/middleware/__tests__/security-headers.test.ts
+++ b/apps/web/src/middleware/__tests__/security-headers.test.ts
@@ -253,7 +253,7 @@ describe('Security Headers', () => {
       applySecurityHeaders(response, { nonce: 'test', isProduction: false });
 
       expect(response.headers.get('Permissions-Policy')).toBe(
-        'geolocation=(), microphone=(), camera=()'
+        'geolocation=(), microphone=(), camera=(), payment=(self "https://js.stripe.com")'
       );
     });
 

--- a/apps/web/src/middleware/__tests__/security-headers.test.ts
+++ b/apps/web/src/middleware/__tests__/security-headers.test.ts
@@ -401,6 +401,9 @@ describe('Security Headers', () => {
       expect(response.headers.get('Referrer-Policy')).toBe(
         'strict-origin-when-cross-origin'
       );
+      expect(response.headers.get('Permissions-Policy')).toBe(
+        'geolocation=(), microphone=(), camera=(), payment=(self "https://js.stripe.com")'
+      );
     });
 
     it('includes HSTS in production', () => {

--- a/apps/web/src/middleware/security-headers.ts
+++ b/apps/web/src/middleware/security-headers.ts
@@ -115,7 +115,7 @@ export const applySecurityHeaders = (
   response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
   response.headers.set(
     'Permissions-Policy',
-    'geolocation=(), microphone=(), camera=()'
+    'geolocation=(), microphone=(), camera=(), payment=(self "https://js.stripe.com")'
   );
   // COEP 'credentialless' is set for all page routes except Stripe-dependent
   // paths (/settings/plan, /settings/billing) where it blocks Stripe.js loading

--- a/apps/web/src/middleware/security-headers.ts
+++ b/apps/web/src/middleware/security-headers.ts
@@ -2,13 +2,16 @@ import { NextResponse } from 'next/server';
 
 export const NONCE_HEADER = 'x-nonce';
 
+const PERMISSIONS_POLICY =
+  'geolocation=(), microphone=(), camera=(), payment=(self "https://js.stripe.com")';
+
 // Security headers for error responses (API routes)
 const ERROR_RESPONSE_HEADERS: Record<string, string> = {
   'Content-Security-Policy': "default-src 'none'; frame-ancestors 'none'",
   'X-Frame-Options': 'DENY',
   'X-Content-Type-Options': 'nosniff',
   'Referrer-Policy': 'strict-origin-when-cross-origin',
-  'Permissions-Policy': 'geolocation=(), microphone=(), camera=()',
+  'Permissions-Policy': PERMISSIONS_POLICY,
 };
 
 export const createSecureErrorResponse = (
@@ -113,10 +116,7 @@ export const applySecurityHeaders = (
   response.headers.set('X-Frame-Options', 'DENY');
   response.headers.set('X-Content-Type-Options', 'nosniff');
   response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
-  response.headers.set(
-    'Permissions-Policy',
-    'geolocation=(), microphone=(), camera=(), payment=(self "https://js.stripe.com")'
-  );
+  response.headers.set('Permissions-Policy', PERMISSIONS_POLICY);
   // COEP 'credentialless' is set for all page routes except Stripe-dependent
   // paths (/settings/plan, /settings/billing) where it blocks Stripe.js loading
   // via no-cors without Cross-Origin-Resource-Policy headers.


### PR DESCRIPTION
## Summary

- Add `payment=(self "https://js.stripe.com")` to the `Permissions-Policy` response header so Stripe's `PaymentElement` (cross-origin iframe from `js.stripe.com`) can use the Payment Request API. Previously the directive was omitted, so browsers defaulted to `self` — which blocks the API inside cross-origin iframes and spammed the console with "payment is not allowed" violations on `/settings/plan` and `/settings/billing`.
- Refactor: extract a shared `PERMISSIONS_POLICY` constant at the top of `security-headers.ts` and reference it from both `ERROR_RESPONSE_HEADERS` and `applySecurityHeaders` so API error responses and page responses advertise the same value — no drift between the two.
- Tests: update the `applySecurityHeaders` assertion to match the new header; add a parallel assertion in the `createSecureErrorResponse` `'includes security headers'` test so future divergence is caught automatically.

Companion Caddyfile change in `PageSpace-Deploy` (https://github.com/2witstudios/PageSpace-Deploy/pull/2) is already merged — both were required for the production effect (Caddy's global `Permissions-Policy` header would otherwise override whatever the upstream app sends).

## Test plan

- [x] `pnpm --filter web typecheck` — no regressions
- [x] `pnpm --filter web test src/middleware/__tests__/security-headers.test.ts` — 49/49 tests pass (original + new `createSecureErrorResponse` assertion)
- [ ] Manual: `pnpm dev`, open `/settings/plan`, confirm the console no longer logs the "payment is not allowed" violation
- [ ] Manual: Stripe PaymentElement still renders and accepts card input on `/settings/plan` and `/settings/billing`
- [ ] Post-prod (Caddyfile change already merged): on a supported browser/device, wallet buttons (Apple Pay / Google Pay) appear inside Stripe's PaymentElement

🤖 Generated with [Claude Code](https://claude.com/claude-code)