### PR TITLE
fix(files): add empty-state CTAs + drag-drop upload for Files view

### DIFF
--- a/apps/web/src/components/files/FilesEmptyState.tsx
+++ b/apps/web/src/components/files/FilesEmptyState.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+import { FolderOpen, Plus, Upload } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import CreatePageDialog from '@/components/layout/left-sidebar/CreatePageDialog';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { useEditingStore } from '@/stores/useEditingStore';
+
+interface FilesEmptyStateProps {
+  driveId: string;
+  parentId: string | null;
+  canWrite: boolean;
+  onMutate: () => void;
+}
+
+const uploadOne = async (file: File, driveId: string, parentId: string | null) => {
+  const formData = new FormData();
+  formData.append('file', file);
+  formData.append('driveId', driveId);
+  if (parentId) {
+    formData.append('parentId', parentId);
+  }
+  const response = await fetchWithAuth('/api/upload', { method: 'POST', body: formData });
+  if (!response.ok) {
+    const err = (await response.json().catch(() => ({}))) as { error?: string };
+    throw new Error(err.error ?? `Failed to upload ${file.name}`);
+  }
+};
+
+export function FilesEmptyState({ driveId, parentId, canWrite, onMutate }: FilesEmptyStateProps) {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isDropActive, setIsDropActive] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const headline = parentId ? 'No child pages' : 'No pages in this drive';
+
+  const uploadBatch = useCallback(
+    async (files: File[]) => {
+      if (files.length === 0) return;
+      const sessionId = `files-empty-upload-${Date.now()}`;
+      useEditingStore.getState().startEditing(sessionId, 'form', { componentName: 'FilesEmptyState' });
+      try {
+        for (const file of files) {
+          try {
+            await uploadOne(file, driveId, parentId);
+          } catch (error) {
+            toast.error((error as Error).message);
+          }
+        }
+        onMutate();
+      } finally {
+        useEditingStore.getState().endEditing(sessionId);
+      }
+    },
+    [driveId, parentId, onMutate]
+  );
+
+  if (!canWrite) {
+    return (
+      <div
+        data-testid="files-empty-state-readonly"
+        className="flex flex-col items-center justify-center py-16 text-center"
+      >
+        <FolderOpen className="h-12 w-12 text-muted-foreground/50 mb-4" aria-hidden="true" />
+        <p className="text-muted-foreground mb-1">{headline}</p>
+        <p className="text-sm text-muted-foreground/70">
+          You have view-only access to this drive.
+        </p>
+      </div>
+    );
+  }
+
+  const handleDragEnter = (event: React.DragEvent<HTMLDivElement>) => {
+    if (!event.dataTransfer.types.includes('Files')) return;
+    event.preventDefault();
+    setIsDropActive(true);
+  };
+
+  const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+    if (!event.dataTransfer.types.includes('Files')) return;
+    event.preventDefault();
+    setIsDropActive(true);
+  };
+
+  const handleDragLeave = () => setIsDropActive(false);
+
+  const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    setIsDropActive(false);
+    const files = Array.from(event.dataTransfer.files ?? []);
+    void uploadBatch(files);
+  };
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(event.target.files ?? []);
+    event.target.value = '';
+    void uploadBatch(files);
+  };
+
+  return (
+    <>
+      <div
+        data-testid="files-empty-state"
+        data-drop-active={isDropActive ? 'true' : 'false'}
+        onDragEnter={handleDragEnter}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        className={`flex flex-col items-center justify-center py-16 text-center rounded-lg border-2 border-dashed transition-colors ${
+          isDropActive ? 'border-primary bg-primary/5' : 'border-transparent'
+        }`}
+      >
+        <FolderOpen className="h-12 w-12 text-muted-foreground/50 mb-4" aria-hidden="true" />
+        <p className="text-muted-foreground mb-2">{headline}</p>
+        <p className="text-sm text-muted-foreground/70 mb-6">
+          Upload files or create a page to get started
+        </p>
+        <div className="flex gap-2">
+          <Button onClick={() => fileInputRef.current?.click()}>
+            <Upload className="mr-2 h-4 w-4" />
+            Upload files
+          </Button>
+          <Button variant="outline" onClick={() => setIsDialogOpen(true)}>
+            <Plus className="mr-2 h-4 w-4" />
+            Create page
+          </Button>
+        </div>
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          data-testid="files-upload-input"
+          className="hidden"
+          onChange={handleInputChange}
+        />
+      </div>
+      <CreatePageDialog
+        driveId={driveId}
+        parentId={parentId}
+        isOpen={isDialogOpen}
+        setIsOpen={setIsDialogOpen}
+        onPageCreated={() => {
+          onMutate();
+          setIsDialogOpen(false);
+        }}
+      />
+    </>
+  );
+}

--- a/apps/web/src/components/files/FilesEmptyState.tsx
+++ b/apps/web/src/components/files/FilesEmptyState.tsx
@@ -84,7 +84,11 @@ export function FilesEmptyState({ driveId, parentId, canWrite, onMutate }: Files
     setIsDropActive(true);
   };
 
-  const handleDragLeave = () => setIsDropActive(false);
+  const handleDragLeave = (event: React.DragEvent<HTMLDivElement>) => {
+    const next = event.relatedTarget as Node | null;
+    if (next && event.currentTarget.contains(next)) return;
+    setIsDropActive(false);
+  };
 
   const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
     event.preventDefault();

--- a/apps/web/src/components/files/FilesFinderContent.tsx
+++ b/apps/web/src/components/files/FilesFinderContent.tsx
@@ -23,7 +23,7 @@ export function FilesFinderContent({ driveId, currentPageId }: FilesFinderConten
   const drives = useDriveStore((state) => state.drives);
   const drive = drives.find((d) => d.id === driveId);
   const driveName = drive?.name ?? 'Files';
-  const canWrite = Boolean(drive?.role);
+  const canWrite = drive?.role === 'OWNER' || drive?.role === 'ADMIN';
 
   const [viewMode, setViewMode] = useState<ViewMode>('list');
   const [sortKey, setSortKey] = useState<SortKey>('title');

--- a/apps/web/src/components/files/FilesFinderContent.tsx
+++ b/apps/web/src/components/files/FilesFinderContent.tsx
@@ -10,8 +10,8 @@ import { FolderViewHeader } from '@/components/layout/middle-content/page-views/
 import { FilesBreadcrumbs } from './FilesBreadcrumbs';
 import { FilesGridView } from './FilesGridView';
 import { FilesListView } from './FilesListView';
+import { FilesEmptyState } from './FilesEmptyState';
 import type { ViewMode, SortKey, SortDirection } from '@/components/layout/middle-content/page-views/folder/types';
-import { FolderOpen } from 'lucide-react';
 
 interface FilesFinderContentProps {
   driveId: string;
@@ -23,6 +23,7 @@ export function FilesFinderContent({ driveId, currentPageId }: FilesFinderConten
   const drives = useDriveStore((state) => state.drives);
   const drive = drives.find((d) => d.id === driveId);
   const driveName = drive?.name ?? 'Files';
+  const canWrite = Boolean(drive?.role);
 
   const [viewMode, setViewMode] = useState<ViewMode>('list');
   const [sortKey, setSortKey] = useState<SortKey>('title');
@@ -110,12 +111,12 @@ export function FilesFinderContent({ driveId, currentPageId }: FilesFinderConten
         <FolderViewHeader viewMode={viewMode} onViewChange={setViewMode} />
 
         {sortedItems.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-16 text-center">
-            <FolderOpen className="h-12 w-12 text-muted-foreground/50 mb-4" />
-            <p className="text-muted-foreground">
-              {currentPageId ? 'No child pages' : 'No pages in this drive'}
-            </p>
-          </div>
+          <FilesEmptyState
+            driveId={driveId}
+            parentId={currentPageId}
+            canWrite={canWrite}
+            onMutate={handleMutate}
+          />
         ) : viewMode === 'grid' ? (
           <FilesGridView items={sortedItems} driveId={driveId} onMutate={handleMutate} />
         ) : (

--- a/apps/web/src/components/files/__tests__/FilesEmptyState.test.tsx
+++ b/apps/web/src/components/files/__tests__/FilesEmptyState.test.tsx
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { FilesEmptyState } from '../FilesEmptyState';
+
+const hoisted = vi.hoisted(() => ({
+  fetchWithAuth: vi.fn(),
+  toastError: vi.fn(),
+  startEditing: vi.fn(),
+  endEditing: vi.fn(),
+}));
+
+vi.mock('@/components/layout/left-sidebar/CreatePageDialog', () => ({
+  default: vi.fn(({ isOpen, driveId, parentId }: { isOpen: boolean; driveId: string; parentId: string | null }) =>
+    isOpen ? (
+      <div
+        data-testid="create-page-dialog"
+        data-drive={driveId}
+        data-parent={parentId ?? ''}
+      />
+    ) : null
+  ),
+}));
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: hoisted.fetchWithAuth,
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: hoisted.toastError,
+    success: vi.fn(),
+  },
+}));
+
+vi.mock('@/stores/useEditingStore', () => ({
+  useEditingStore: {
+    getState: () => ({
+      startEditing: hoisted.startEditing,
+      endEditing: hoisted.endEditing,
+    }),
+  },
+}));
+
+const okResponse = () =>
+  ({ ok: true, json: async () => ({ page: { id: 'new-page' } }) }) as Response;
+
+const errorResponse = (message: string) =>
+  ({ ok: false, json: async () => ({ error: message }) }) as Response;
+
+describe('FilesEmptyState', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.fetchWithAuth.mockResolvedValue(okResponse());
+  });
+
+  it('renders read-only message and no CTAs when user has no drive role', () => {
+    render(
+      <FilesEmptyState driveId="drive-1" parentId={null} canWrite={false} onMutate={vi.fn()} />
+    );
+
+    expect(screen.getByText(/view-only access/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /upload files/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /create page/i })).not.toBeInTheDocument();
+  });
+
+  it('renders both CTAs and onboarding subheadline when user can write', () => {
+    render(
+      <FilesEmptyState driveId="drive-1" parentId={null} canWrite={true} onMutate={vi.fn()} />
+    );
+
+    expect(screen.getByText('No pages in this drive')).toBeInTheDocument();
+    expect(screen.getByText(/upload files or create a page to get started/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /upload files/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /create page/i })).toBeInTheDocument();
+  });
+
+  it('uses nested-folder headline when parentId is provided', () => {
+    render(
+      <FilesEmptyState driveId="drive-1" parentId="page-42" canWrite={true} onMutate={vi.fn()} />
+    );
+
+    expect(screen.getByText('No child pages')).toBeInTheDocument();
+  });
+
+  it('opens CreatePageDialog seeded with driveId and parentId when Create page is clicked', async () => {
+    const user = userEvent.setup();
+    render(
+      <FilesEmptyState driveId="drive-1" parentId="page-42" canWrite={true} onMutate={vi.fn()} />
+    );
+
+    await user.click(screen.getByRole('button', { name: /create page/i }));
+
+    const dialog = await screen.findByTestId('create-page-dialog');
+    expect(dialog.dataset.drive).toBe('drive-1');
+    expect(dialog.dataset.parent).toBe('page-42');
+  });
+
+  it('triggers the hidden file picker when Upload files is clicked', async () => {
+    const user = userEvent.setup();
+    render(
+      <FilesEmptyState driveId="drive-1" parentId={null} canWrite={true} onMutate={vi.fn()} />
+    );
+
+    const fileInput = screen.getByTestId('files-upload-input') as HTMLInputElement;
+    const clickSpy = vi.spyOn(fileInput, 'click');
+
+    await user.click(screen.getByRole('button', { name: /upload files/i }));
+
+    expect(clickSpy).toHaveBeenCalledOnce();
+  });
+
+  it('shows a drop-zone cue while a file is dragged over the panel', () => {
+    render(
+      <FilesEmptyState driveId="drive-1" parentId={null} canWrite={true} onMutate={vi.fn()} />
+    );
+
+    const panel = screen.getByTestId('files-empty-state');
+    expect(panel.getAttribute('data-drop-active')).toBe('false');
+
+    fireEvent.dragEnter(panel, { dataTransfer: { types: ['Files'] } });
+    fireEvent.dragOver(panel, { dataTransfer: { types: ['Files'] } });
+    expect(panel.getAttribute('data-drop-active')).toBe('true');
+
+    fireEvent.dragLeave(panel);
+    expect(panel.getAttribute('data-drop-active')).toBe('false');
+  });
+
+  it('uploads each dropped file via POST /api/upload with driveId and parentId', async () => {
+    const onMutate = vi.fn();
+    render(
+      <FilesEmptyState driveId="drive-7" parentId="page-42" canWrite={true} onMutate={onMutate} />
+    );
+
+    const panel = screen.getByTestId('files-empty-state');
+    const file1 = new File(['one'], 'one.txt', { type: 'text/plain' });
+    const file2 = new File(['two'], 'two.md', { type: 'text/markdown' });
+
+    await act(async () => {
+      fireEvent.drop(panel, { dataTransfer: { files: [file1, file2], types: ['Files'] } });
+    });
+
+    await waitFor(() => {
+      expect(hoisted.fetchWithAuth).toHaveBeenCalledTimes(2);
+    });
+
+    const [firstCall, secondCall] = hoisted.fetchWithAuth.mock.calls;
+    expect(firstCall[0]).toBe('/api/upload');
+    const firstBody = firstCall[1].body as FormData;
+    expect(firstBody.get('driveId')).toBe('drive-7');
+    expect(firstBody.get('parentId')).toBe('page-42');
+    expect((firstBody.get('file') as File).name).toBe('one.txt');
+
+    const secondBody = secondCall[1].body as FormData;
+    expect((secondBody.get('file') as File).name).toBe('two.md');
+    expect(onMutate).toHaveBeenCalled();
+  });
+
+  it('uploads files selected via the hidden file picker', async () => {
+    render(
+      <FilesEmptyState driveId="drive-7" parentId={null} canWrite={true} onMutate={vi.fn()} />
+    );
+
+    const fileInput = screen.getByTestId('files-upload-input') as HTMLInputElement;
+    const file = new File(['hi'], 'hi.txt', { type: 'text/plain' });
+
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files: [file] } });
+    });
+
+    await waitFor(() => {
+      expect(hoisted.fetchWithAuth).toHaveBeenCalledTimes(1);
+    });
+    const body = hoisted.fetchWithAuth.mock.calls[0][1].body as FormData;
+    expect((body.get('file') as File).name).toBe('hi.txt');
+    expect(body.get('driveId')).toBe('drive-7');
+    expect(body.get('parentId')).toBeNull();
+  });
+
+  it('ignores drops when the user lacks drive role', async () => {
+    render(
+      <FilesEmptyState driveId="drive-7" parentId={null} canWrite={false} onMutate={vi.fn()} />
+    );
+
+    expect(screen.queryByTestId('files-empty-state')).not.toBeInTheDocument();
+    const panel = screen.getByTestId('files-empty-state-readonly');
+    const file = new File(['one'], 'one.txt', { type: 'text/plain' });
+
+    await act(async () => {
+      fireEvent.drop(panel, { dataTransfer: { files: [file], types: ['Files'] } });
+    });
+
+    expect(hoisted.fetchWithAuth).not.toHaveBeenCalled();
+  });
+
+  it('registers and releases an editing-store session around the upload batch', async () => {
+    render(
+      <FilesEmptyState driveId="drive-7" parentId={null} canWrite={true} onMutate={vi.fn()} />
+    );
+
+    const panel = screen.getByTestId('files-empty-state');
+    const file = new File(['x'], 'x.txt', { type: 'text/plain' });
+
+    await act(async () => {
+      fireEvent.drop(panel, { dataTransfer: { files: [file], types: ['Files'] } });
+    });
+
+    await waitFor(() => {
+      expect(hoisted.startEditing).toHaveBeenCalledTimes(1);
+      expect(hoisted.endEditing).toHaveBeenCalledTimes(1);
+    });
+    const [startId, startType] = hoisted.startEditing.mock.calls[0];
+    const [endId] = hoisted.endEditing.mock.calls[0];
+    expect(startType).toBe('form');
+    expect(endId).toBe(startId);
+  });
+
+  it('shows a toast.error for a failed upload but continues the batch', async () => {
+    hoisted.fetchWithAuth
+      .mockResolvedValueOnce(errorResponse('too large'))
+      .mockResolvedValueOnce(okResponse());
+
+    render(
+      <FilesEmptyState driveId="drive-7" parentId={null} canWrite={true} onMutate={vi.fn()} />
+    );
+
+    const panel = screen.getByTestId('files-empty-state');
+    const bad = new File(['big'], 'big.bin', { type: 'application/octet-stream' });
+    const good = new File(['ok'], 'ok.txt', { type: 'text/plain' });
+
+    await act(async () => {
+      fireEvent.drop(panel, { dataTransfer: { files: [bad, good], types: ['Files'] } });
+    });
+
+    await waitFor(() => {
+      expect(hoisted.fetchWithAuth).toHaveBeenCalledTimes(2);
+    });
+    expect(hoisted.toastError).toHaveBeenCalledWith(expect.stringContaining('too large'));
+  });
+});

--- a/apps/web/src/components/files/__tests__/FilesEmptyState.test.tsx
+++ b/apps/web/src/components/files/__tests__/FilesEmptyState.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { render, screen, fireEvent, createEvent, waitFor, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { FilesEmptyState } from '../FilesEmptyState';
 
@@ -122,8 +122,26 @@ describe('FilesEmptyState', () => {
     fireEvent.dragOver(panel, { dataTransfer: { types: ['Files'] } });
     expect(panel.getAttribute('data-drop-active')).toBe('true');
 
-    fireEvent.dragLeave(panel);
+    fireEvent.dragLeave(panel, { relatedTarget: document.body });
     expect(panel.getAttribute('data-drop-active')).toBe('false');
+  });
+
+  it('keeps the drop-zone cue active when the drag moves to a child element', () => {
+    render(
+      <FilesEmptyState driveId="drive-1" parentId={null} canWrite={true} onMutate={vi.fn()} />
+    );
+
+    const panel = screen.getByTestId('files-empty-state');
+    const childButton = screen.getByRole('button', { name: /upload files/i });
+
+    fireEvent.dragEnter(panel, { dataTransfer: { types: ['Files'] } });
+    fireEvent.dragOver(panel, { dataTransfer: { types: ['Files'] } });
+    expect(panel.getAttribute('data-drop-active')).toBe('true');
+
+    const leaveEvent = createEvent.dragLeave(panel);
+    Object.defineProperty(leaveEvent, 'relatedTarget', { value: childButton });
+    fireEvent(panel, leaveEvent);
+    expect(panel.getAttribute('data-drop-active')).toBe('true');
   });
 
   it('uploads each dropped file via POST /api/upload with driveId and parentId', async () => {

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,5 @@
+# Plan
+
+## Active Epics
+
+- [Files Empty-State CTA](tasks/files-empty-state-cta.md) — discoverable Upload + Create actions for empty Files view; addresses Eric Elliott feedback #4.

--- a/tasks/files-empty-state-cta.md
+++ b/tasks/files-empty-state-cta.md
@@ -1,0 +1,44 @@
+# Files Empty-State CTA Epic
+
+**Status**: 📋 PLANNED
+**Goal**: Give users a discoverable path to upload or create content when the Files view is empty.
+
+## Overview
+
+Landing on an empty Files view with only a folder icon and "No pages in this drive" leaves first-run users stranded — the only affordance is the tiny '+' in the sidebar, which Eric Elliott's feedback flagged as invisible. This epic replaces the inert block in `FilesFinderContent` with a drop zone plus primary Upload and Create actions (reusing `CreatePageDialog`), gates CTAs on the user's drive role so non-members see an explanatory read-only state, and adds co-located tests for rendering, handler wiring, and permission gating.
+
+---
+
+## Empty-State CTA Panel
+
+Replace the empty block in `FilesFinderContent.tsx` with an icon + headline + subheadline + Upload/Create CTA pair, reusing `CreatePageDialog`.
+
+**Requirements**:
+- Given a drive role of OWNER/ADMIN/MEMBER, should render a primary "Upload files" and secondary "Create page" CTA with the subheadline "Upload files or create a page to get started"
+- Given the current user has no role on the drive, should render a read-only message explaining they can view but not modify, and no CTAs
+- Given the Create page button is clicked, should open `CreatePageDialog` seeded with the current driveId and `currentPageId` as parentId
+- Given a nested folder is the current location, should pass `currentPageId` through as `parentId` so new pages land in the right parent
+
+---
+
+## Drag-and-Drop Upload Zone
+
+Make the empty panel itself a drop target, wired to `POST /api/upload`.
+
+**Requirements**:
+- Given a file is dragged over the empty panel, should show a dashed-outline drop-zone cue
+- Given files are dropped, should upload each one via `POST /api/upload` with the current driveId and parentId, and refresh the tree on success
+- Given the user has no drive role, should not accept drops and the read-only message should remain
+- Given an upload is in flight, should register a `form`-type session with `useEditingStore` to prevent SWR from clobbering, and end the session on settle
+- Given an upload fails, should surface the server error via `toast.error` without dropping the rest of the batch
+
+---
+
+## Test Coverage
+
+Co-located `__tests__` alongside `FilesFinderContent.tsx` covering the three branches.
+
+**Requirements**:
+- Given a drive without a role for the current user, should render the read-only message and neither CTA
+- Given an OWNER/ADMIN/MEMBER role, should render both CTAs, wire Create to dialog open state, and wire Upload to the hidden file input
+- Given a drop event with two files, should call the upload handler twice with the expected driveId and parentId

--- a/tasks/files-empty-state-cta.md
+++ b/tasks/files-empty-state-cta.md
@@ -1,6 +1,6 @@
 # Files Empty-State CTA Epic
 
-**Status**: 📋 PLANNED
+**Status**: ✅ COMPLETED (2026-04-17)
 **Goal**: Give users a discoverable path to upload or create content when the Files view is empty.
 
 ## Overview

--- a/tasks/files-empty-state-cta.md
+++ b/tasks/files-empty-state-cta.md
@@ -14,8 +14,8 @@ Landing on an empty Files view with only a folder icon and "No pages in this dri
 Replace the empty block in `FilesFinderContent.tsx` with an icon + headline + subheadline + Upload/Create CTA pair, reusing `CreatePageDialog`.
 
 **Requirements**:
-- Given a drive role of OWNER/ADMIN/MEMBER, should render a primary "Upload files" and secondary "Create page" CTA with the subheadline "Upload files or create a page to get started"
-- Given the current user has no role on the drive, should render a read-only message explaining they can view but not modify, and no CTAs
+- Given a drive role of OWNER or ADMIN (matching the server-side `/api/pages` gate), should render a primary "Upload files" and secondary "Create page" CTA with the subheadline "Upload files or create a page to get started"
+- Given a non-owner/non-admin role (MEMBER, or the MEMBER fallback that `drive-service.ts` applies to page-level collaborators), should render a read-only message instead of CTAs that would 403
 - Given the Create page button is clicked, should open `CreatePageDialog` seeded with the current driveId and `currentPageId` as parentId
 - Given a nested folder is the current location, should pass `currentPageId` through as `parentId` so new pages land in the right parent
 
@@ -28,7 +28,7 @@ Make the empty panel itself a drop target, wired to `POST /api/upload`.
 **Requirements**:
 - Given a file is dragged over the empty panel, should show a dashed-outline drop-zone cue
 - Given files are dropped, should upload each one via `POST /api/upload` with the current driveId and parentId, and refresh the tree on success
-- Given the user has no drive role, should not accept drops and the read-only message should remain
+- Given the user is not OWNER/ADMIN on the drive, should not accept drops and the read-only message should remain
 - Given an upload is in flight, should register a `form`-type session with `useEditingStore` to prevent SWR from clobbering, and end the session on settle
 - Given an upload fails, should surface the server error via `toast.error` without dropping the rest of the batch
 
@@ -39,6 +39,6 @@ Make the empty panel itself a drop target, wired to `POST /api/upload`.
 Co-located `__tests__` alongside `FilesFinderContent.tsx` covering the three branches.
 
 **Requirements**:
-- Given a drive without a role for the current user, should render the read-only message and neither CTA
-- Given an OWNER/ADMIN/MEMBER role, should render both CTAs, wire Create to dialog open state, and wire Upload to the hidden file input
+- Given a non-writable drive role for the current user, should render the read-only message and neither CTA
+- Given an OWNER or ADMIN role, should render both CTAs, wire Create to dialog open state, and wire Upload to the hidden file input
 - Given a drop event with two files, should call the upload handler twice with the expected driveId and parentId


### PR DESCRIPTION
## Summary
- Replaces the inert `No pages in this drive` empty state with a discoverable Upload + Create CTA pair, reusing the existing `CreatePageDialog` (no duplicated create/upload code paths)
- Makes the empty panel a drag-drop target that uploads each dropped file via `POST /api/upload` with the current `driveId` + `parentId`, wrapping the batch in a `useEditingStore` `form` session so in-flight uploads don't get clobbered by SWR revalidation
- Role-aware gating: CTAs render only for `OWNER` or `ADMIN` (matching the `/api/pages` server gate — `isDriveOwnerOrAdmin`). All other roles — including the `MEMBER` fallback that `drive-service.ts` assigns to page-level collaborators — see a read-only message instead. Server enforcement in `POST /api/pages` and `POST /api/upload` is unchanged

Addresses Eric Elliott onboarding feedback #4 — empty Files view previously gave first-run users no discoverable path to upload or create content.

## Test plan
- [x] `pnpm --filter web test src/components/files/__tests__/FilesEmptyState.test.tsx` — 11/11 pass, covering: read-only branch when user can't write, both CTAs when user can write, nested-folder headline, `CreatePageDialog` seeded with correct `driveId` + `parentId`, file picker trigger, drag-over cue state, two-file drop upload, file-picker upload, drop ignored for non-writable roles, `useEditingStore` session start/end around batch, per-file error toast without dropping the rest of the batch
- [x] `pnpm --filter web lint` — clean (pre-existing unrelated `CalendarView.tsx` warnings only)
- [x] `pnpm --filter web typecheck` — no new errors for touched files (pre-existing `@pagespace/lib/*` module-resolution errors on master baseline are untouched)
- [ ] Manual: start dev server, empty drive → confirm CTAs render, drop files, verify drop-zone cue + per-file toast on rejection
- [ ] Before / after screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Empty-state UI in Files now shows "Upload files" and "Create page" for writable users, supports multiple-file uploads, drag-and-drop with visual drop state, and opens a Create Page dialog for new pages.
* **Behavior**
  * Read-only users see a view-only message; upload/create CTAs are hidden.
* **Tests**
  * Added unit tests covering role-based rendering, drag/drop and file-upload flows.
* **Documentation**
  * Added a spec describing the empty-state CTA and upload behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->