### PR TITLE
fix(docker): pin processor image to linux/amd64 for Apple Silicon

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,9 +105,15 @@ services:
       - internal
 
   processor:
+    # @tensorflow/tfjs-node has no Linux-arm64 prebuild. CI + prod build on
+    # ubuntu-latest (amd64); pin here so local builds on Apple Silicon
+    # produce an amd64 image (runs via Rosetta 2). No-op on amd64 hosts.
+    platform: linux/amd64
     build:
       context: .
       dockerfile: apps/processor/Dockerfile
+      platforms:
+        - linux/amd64
     ports:
       - "3003:3003"
     depends_on:


### PR DESCRIPTION
## Summary

- Pin processor service to `linux/amd64` in `docker-compose.yml` (root, shared by dev workflows).
- Adds `platform: linux/amd64` (runtime) + `build.platforms: [linux/amd64]` (build-time).

## Why

`@tensorflow/tfjs-node` has no Linux-arm64 prebuild. Its postinstall script silently exits 0 on arm64 Linux without downloading the native binding, so `require('@tensorflow/tfjs-node')` fails at runtime with `ERR_DLOPEN_FAILED`:

```
Error: /app/node_modules/.pnpm/@tensorflow+tfjs-node@4.22.0_.../tfjs_binding.node: cannot open shared object file: No such file or directory
```

This broke `apps/processor/src/services/content-detector.ts` (magika/node → tfjs-node) any time the image was rebuilt on an Apple Silicon machine — i.e. every dev working locally.

CI + prod build on ubuntu-latest (amd64) where the binding exists, so prod was fine. Only surfaced locally.

## Impact

- **amd64 hosts** (CI runners, Linux servers, Intel Macs): both fields are no-ops.
- **arm64 hosts** (Apple Silicon): build produces amd64 image; Rosetta 2 runs it. This is the exact strategy the original magika PR (#983) verified with (`docker build --platform linux/amd64`).
- `PageSpace-Deploy/docker-compose.prod.yml` is unchanged — prod keeps building native amd64 in CI.

## Verified locally (Apple Silicon M-series)

- `docker image inspect pagespace-processor:latest --format '{{.Architecture}}'` → `amd64`
- Container startup log shows `TensorFlow binary is optimized ... AVX2 FMA`, confirming `libtensorflow.so` opened.
- `content-detector.ts` loads, processor healthcheck passes, `/health` returns 200.
- Survives `docker compose build --no-cache` without reverting to arm64.

## Test plan

- [ ] Fresh clone on Apple Silicon + `pnpm dev:services` → processor healthy.
- [ ] `docker compose build --no-cache processor` on Apple Silicon → image arch is amd64.
- [ ] CI docker-images workflow still green (no workflow changes; should be inert for CI since it runs on amd64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated processor service platform configuration to explicitly target the linux/amd64 architecture, ensuring consistent behavior and reliable execution across diverse system environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->