### PR TITLE
fix(marketing): repair contact route import

### DIFF
--- a/apps/marketing/tsconfig.json
+++ b/apps/marketing/tsconfig.json
@@ -21,6 +21,7 @@
     ],
     "paths": {
       "@/*": ["apps/marketing/src/*"],
+      "@pagespace/lib/*": ["packages/lib/src/*"],
       "@pagespace/*": ["packages/*/src"]
     }
   },


### PR DESCRIPTION
## Summary

\`pnpm --filter marketing typecheck\` fails in a clean tree:

\`\`\`
src/app/api/contact/__tests__/route.test.ts(26,43): error TS2307:
  Cannot find module '@pagespace/lib/security' or its corresponding type declarations.
src/app/api/contact/route.ts(2,68): error TS2307:
  Cannot find module '@pagespace/lib/security' or its corresponding type declarations.
\`\`\`

## Root cause

\`apps/marketing/tsconfig.json\` has a single \`@pagespace/*\` paths entry mapping to \`packages/*/src\`. TypeScript treats \`*\` as one greedy match, so:

- \`@pagespace/lib\` → \`packages/lib/src\` ✓
- \`@pagespace/lib/security\` → \`packages/lib/**security**/src\` ✗ (does not exist)

The symbols (\`checkDistributedRateLimit\`, \`DISTRIBUTED_RATE_LIMITS\`) do live at \`packages/lib/src/security/index.ts\` and are re-exported via package.json \`"./security"\` — but that export points at \`./dist/security/...\`, which only exists after \`pnpm --filter @pagespace/lib build\`. On a clean checkout there is no dist, and the greedy \`*\` match doesn't fall through to exports.

## What changed

One line in \`apps/marketing/tsconfig.json\` — a more specific paths entry:

\`\`\`diff
     "paths": {
       "@/*": ["apps/marketing/src/*"],
+      "@pagespace/lib/*": ["packages/lib/src/*"],
       "@pagespace/*": ["packages/*/src"]
     }
\`\`\`

TypeScript picks the more specific prefix, so \`@pagespace/lib/security\` now resolves to \`packages/lib/src/security\` directly from source. No code, import, or test changes needed; \`vitest.config.ts\` already has an equivalent alias for the test runner.

## Scope

Only \`apps/marketing/tsconfig.json\`. No \`packages/lib\` change was needed — the export surface is already correct; the consumer's path mapping was incomplete. The original commit that added the \`@pagespace/*\` mapping (#842/#852) didn't account for subpath imports.

## Verification

Reproduced on a clean tree (no \`packages/lib/dist\` or \`packages/db/dist\`):

**Before:**
\`\`\`
$ pnpm --filter marketing typecheck
src/app/api/contact/__tests__/route.test.ts(26,43): error TS2307: Cannot find module '@pagespace/lib/security'...
src/app/api/contact/route.ts(2,68): error TS2307: Cannot find module '@pagespace/lib/security'...
Exit status 2
\`\`\`

**After:**
\`\`\`
$ pnpm --filter marketing typecheck
> marketing@0.1.0 typecheck
> tsc --noEmit
(clean)
\`\`\`

\`pnpm --filter marketing exec vitest run src/app/api/contact\` — 3/3 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)