### PR TITLE
docs(audit): align agent + rate-limit copy with code (closes #1057, #1058)

### DIFF
--- a/apps/marketing/src/app/docs/ai/agents/page.tsx
+++ b/apps/marketing/src/app/docs/ai/agents/page.tsx
@@ -121,7 +121,7 @@ ask_agent({
 
 Agent communication includes depth tracking to prevent infinite loops:
 
-- Maximum depth: **3 levels** (Agent A → Agent B → Agent C)
+- Maximum depth: **2 levels** (Agent A → Agent B)
 - Each nested call increments a depth counter
 - Exceeding the limit returns an error instead of making another call
 

--- a/apps/marketing/src/app/docs/ai/tool-calling/page.tsx
+++ b/apps/marketing/src/app/docs/ai/tool-calling/page.tsx
@@ -208,7 +208,7 @@ Tool errors are captured and reported back to the AI, which can retry or adjust 
 
 - **Permission denied**: AI explains the permission requirement to the user
 - **Page not found**: AI suggests alternative actions
-- **Rate limited**: Built-in retry with up to 20 retries for rate limit errors
+- **Rate limited**: Built-in retry with up to 3 retries for rate limit errors
 - **Validation errors**: AI adjusts parameters and retries
 
 ## Real-Time Broadcasting

--- a/apps/web/src/lib/ai/tools/agent-communication-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-communication-tools.ts
@@ -25,7 +25,9 @@ import { taskManagementTools } from './task-management-tools';
 import { agentTools } from './agent-tools';
 import { loggers } from '@pagespace/lib/server';
 
-// Constants
+// Nesting cap. Intent is 3+ for richer agent-to-agent composition, but held at 2
+// until inner stepCountIs budget is reworked — see PR #713. Raising this without
+// also lowering stepCountIs risks 10k+ tool executions per top-level call.
 const MAX_AGENT_DEPTH = 2;
 
 /**

--- a/apps/web/src/lib/subscription/rate-limit-middleware.ts
+++ b/apps/web/src/lib/subscription/rate-limit-middleware.ts
@@ -66,7 +66,7 @@ export function createRateLimitResponse(
 
   const errorMessage = providerType === 'pro'
     ? `Pro AI calls limited to ${limit} per day. Upgrade to Pro or Business for more access.`
-    : `Standard AI calls limited to ${limit} per day. Upgrade to Pro (100/day) or Business (500/day) for more calls.`;
+    : `Standard AI calls limited to ${limit} per day. Upgrade to Pro (200/day) or Business (1000/day) for more calls.`;
 
   return NextResponse.json(
     {


### PR DESCRIPTION
## Summary

- **#1057 (docs → code)**: marketing claimed agents nest **3 levels** with **20 retries**; source caps depth at **2** (`apps/web/src/lib/ai/tools/agent-communication-tools.ts:29`) and retries at **3** (`:555`, `:570`). Update marketing copy to match, and leave a WHY comment at `MAX_AGENT_DEPTH` explaining the 2-cap is a temporary safety hold (per PR #713) — so future bumps also address the `stepCountIs` step-budget.
- **#1058 (code bug spotted)**: free-tier quotas (500 MB / 50 AI calls) already match code (`packages/lib/src/services/subscription-utils.ts:38`, `apps/web/src/lib/subscription/usage-service.ts:25`), nothing to fix there. But the rate-limit error string at `apps/web/src/lib/subscription/rate-limit-middleware.ts:69` hard-coded the **wrong** upgrade numbers (Pro 100/day, Business 500/day) — actual per `usage-service.ts:22-25` is Pro 200, Business 1000. Fixed.

Research trail: [comment on #1057](https://github.com/2witstudios/PageSpace/issues/1057#issuecomment-4289568815) · [comment on #1058](https://github.com/2witstudios/PageSpace/issues/1058#issuecomment-4289572851).

## Files changed

- `apps/marketing/src/app/docs/ai/agents/page.tsx` — "3 levels (A→B→C)" → "2 levels (A→B)"
- `apps/marketing/src/app/docs/ai/tool-calling/page.tsx` — "20 retries" → "3 retries"
- `apps/web/src/lib/ai/tools/agent-communication-tools.ts` — added WHY comment on `MAX_AGENT_DEPTH`
- `apps/web/src/lib/subscription/rate-limit-middleware.ts` — corrected Pro/Business upgrade caps in error string

## Test plan

- [ ] `pnpm --filter marketing build` — marketing docs pages compile
- [ ] `pnpm --filter web typecheck` — no type regressions
- [ ] Visual: `/docs/ai/agents` renders "2 levels (Agent A → Agent B)" at the Depth Control section
- [ ] Visual: `/docs/ai/tool-calling` renders "up to 3 retries" in the Error Handling list
- [ ] Trigger a free-tier rate-limit 429 locally, confirm the message references Pro (200/day) / Business (1000/day)

Closes #1057
Closes #1058

🤖 Generated with [Claude Code](https://claude.com/claude-code)