### PR TITLE
refactor(security): route magic-link CSRF compare through secureCompare

### DIFF
--- a/apps/web/src/app/api/auth/magic-link/send/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/send/route.ts
@@ -9,6 +9,7 @@ import { createMagicLinkToken } from '@pagespace/lib/auth/magic-link-service';
 import { sendEmail } from '@pagespace/lib/services/email-service';
 import { MagicLinkEmail } from '@pagespace/lib/email-templates/MagicLinkEmail';
 import { loggers, auditRequest, maskEmail } from '@pagespace/lib/server';
+import { secureCompare } from '@pagespace/lib/secure-compare';
 import { validateLoginCSRFToken, getClientIP } from '@/lib/auth';
 
 const sendMagicLinkSchema = z.object({
@@ -47,7 +48,7 @@ export async function POST(req: Request) {
       );
     }
 
-    if (csrfTokenHeader !== csrfTokenCookie) {
+    if (!secureCompare(csrfTokenHeader, csrfTokenCookie)) {
       auditRequest(req, {
         eventType: 'security.suspicious.activity',
         riskScore: 0.6,


### PR DESCRIPTION
## Summary

- Route the double-submit CSRF check in `apps/web/src/app/api/auth/magic-link/send/route.ts` through the canonical timing-safe helper `secureCompare` (defined at `packages/lib/src/auth/secure-compare.ts:25`).
- This was the last credential-material equality check in the codebase still using `!==`. Every other CSRF / session-token / device-token / magic-link-token / OAuth / webhook signature comparison already goes through `secureCompare`.
- Purpose: make the uniform timing-safe pattern literally true end-to-end. Docs on `pu/docs-audit` (#1063) claim *every* secret comparison uses SHA-256 pre-hash + `timingSafeEqual`; this closes the last gap so that claim is accurate.

## Motivation — hygiene, not exploit fix

**This is security-hygiene / tech-debt, not a security-bug.** Both operands at the offending site come from the same request (header + cookie in a double-submit pattern) and the attacker already controls both values. The timing channel is not meaningfully exploitable here today.

The value is uniformity:

- One pattern for every credential-material compare — nobody has to re-argue the threat model when a new comparison lands.
- Inconsistency is where bugs creep in later: a refactor swaps a request-local compare for one involving a stored secret and nobody notices the `!==` is now exposed.
- Matches the claim in docs that every secret comparison is timing-safe.

## Change

One file, two lines:

\`\`\`diff
 import { loggers, auditRequest, maskEmail } from '@pagespace/lib/server';
+import { secureCompare } from '@pagespace/lib/secure-compare';
 import { validateLoginCSRFToken, getClientIP } from '@/lib/auth';
\`\`\`
\`\`\`diff
-    if (csrfTokenHeader !== csrfTokenCookie) {
+    if (!secureCompare(csrfTokenHeader, csrfTokenCookie)) {
\`\`\`

The guard at lines 34–48 already early-returns `LOGIN_CSRF_MISSING` when either value is falsy, so by the comparison site both are narrowed to `string` — no type-narrowing fix needed.

`@pagespace/lib/secure-compare` is already an exported subpath (`packages/lib/package.json:227`) used by device routes, login-csrf-utils, oauth-state, cron-auth, etc.

## Sweep

Ran from repo root:

\`\`\`
grep -rEn "csrf.*(!==|===)" apps/web/src packages/lib/src --include='*.ts'
grep -rEn "(x-csrf-token|csrf_token).{0,80}(!==|===)" apps/web/src packages/lib/src --include='*.ts'
grep -rEn "cookie.*(!==|===).*header|header.*(!==|===).*cookie" apps/web/src packages/lib/src --include='*.ts'
\`\`\`

**No other offenders.** All remaining `===` / `!==` hits are legitimate non-sensitive equality checks (enums, booleans, null checks) or comparisons that already route through `secureCompare`.

## No test changes — and why

The existing CSRF mismatch contract test at `apps/web/src/app/api/auth/magic-link/send/__tests__/route.test.ts:167-186` uses two different real string values (`'different-token'` vs the header value from the test helper) and asserts on the 403 response shape + audit call. `secureCompare('a', 'b')` returns `false` on different strings, so the branch still triggers, the audit still fires, the response is unchanged. Test passes as-is: **22/22**.

The "header missing" and "cookie missing" tests are caught by the untouched guard at line 34, so they're unaffected.

## Verification

- \`pnpm --filter @pagespace/lib build\` — clean
- \`pnpm --filter web typecheck\` — clean
- \`pnpm --filter web test src/app/api/auth/magic-link/send/__tests__/route.test.ts\` — **22/22 pass**
- \`pnpm --filter @pagespace/lib test csrf\` — **62/62 pass** (\`csrf-utils.test.ts\` + \`csrf-integration.test.ts\`)
- \`pnpm --filter web lint\` — only pre-existing \`react-hooks/exhaustive-deps\` warnings on \`CalendarView.tsx\`, unrelated to this PR

## Test plan

- [ ] CI green on the branch.
- [ ] Reviewer eyeballs the diff — it's 2 lines plus an import.

## Follow-up notes (not in scope)

Nothing surfaced during the sweep that would warrant a follow-up. All credential-material comparisons in \`apps/web/src\` and \`packages/lib/src\` now uniformly route through \`secureCompare\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Security**
  * Strengthened login security with enhanced token validation to provide better protection against unauthorized access attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->