### PR TITLE
docs(readme): fix tool count and add mobile apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Native desktop apps that connect to your PageSpace cloud workspace.
 - [Download DEB](https://github.com/2witstudios/PageSpace/releases/latest/download/PageSpace.deb) — Debian/Ubuntu
 - [Download RPM](https://github.com/2witstudios/PageSpace/releases/latest/download/PageSpace.rpm) — Fedora/RHEL
 
+**Mobile**
+- **iOS** — Available via [TestFlight](https://www.pagespace.ai/downloads)
+- **Android** — In progress
+
 **Features:**
 - Native desktop integration with system tray
 - Minimize to tray, deep linking support
@@ -125,7 +129,7 @@ PageSpace includes an MCP server that lets Claude Desktop and other AI tools dir
 ## Core Features
 
 ### AI Agent Infrastructure
-- **33 workspace tools** for AI to manipulate content directly
+- **37 workspace tools** for AI to manipulate content directly
 - **Tool permissions**: Control what each AI can do in your workspace
 - **MCP protocol support**: Connect external AI tools like Claude Desktop and Cursor
 


### PR DESCRIPTION
## Summary

- Corrects workspace tool count: `33` → `37` (counted all exported tool functions across `apps/web/src/lib/ai/tools/`)
- Adds **Mobile** subsection under Desktop Apps listing iOS (TestFlight) and Android (in progress) — both native app targets exist in the repo but were completely absent from the README

## Verified accurate (no change needed)
Page types list, plan prices, auth methods, AI provider list, desktop platforms, Google Calendar sync, GitHub integration, AES-256-GCM encryption — all confirmed against source code.

## Test plan
- [ ] README renders correctly on GitHub with no broken markdown
- [ ] Mobile section links resolve to `/downloads`

🤖 Generated with [Claude Code](https://claude.com/claude-code)