### PR TITLE
fix(auth): don't window.close() passkey external pages on desktop

### DIFF
--- a/apps/web/src/app/auth/passkey-external/page.tsx
+++ b/apps/web/src/app/auth/passkey-external/page.tsx
@@ -44,12 +44,6 @@ function PasskeyExternalContent() {
           settleTimer = setTimeout(() => {
             if (unmounted) return;
             setStatus({ kind: 'complete' });
-            try {
-              window.close();
-            } catch {
-              // Best-effort: many browsers refuse window.close() for tabs
-              // not opened via window.open(). The terminal UI is the fallback.
-            }
           }, HANDOFF_SETTLE_MS);
         } else {
           setStatus({ kind: 'error', message: result.error });

--- a/apps/web/src/app/auth/passkey-register-external/page.tsx
+++ b/apps/web/src/app/auth/passkey-register-external/page.tsx
@@ -57,12 +57,6 @@ function PasskeyRegisterExternalContent() {
           settleTimer = setTimeout(() => {
             if (unmounted) return;
             setStatus({ kind: 'complete' });
-            try {
-              window.close();
-            } catch {
-              // Best-effort: many browsers refuse window.close() for tabs
-              // not opened via window.open(). The terminal UI is the fallback.
-            }
           }, HANDOFF_SETTLE_MS);
         } else {
           setStatus({ kind: 'error', message: result.error, code: result.code });


### PR DESCRIPTION
## Summary

- `window.close()` was firing 600ms after the `pagespace://` deep-link redirect in both `passkey-external` and `passkey-register-external` pages
- On macOS/Chrome the browser holds back the deep-link dispatch until a "Do you want to open PageSpace?" dialog is confirmed — the 600ms window was too narrow, causing the tab to close before Electron received the URL
- These pages are **only** opened via `shell.openExternal` (system browser), so `window.close()` was already a best-effort no-op wrapped in a try/catch; removing it makes `HandoffCompleteCard` the definitive terminal UI
- The settle timer is kept so the user sees "Returning to the desktop app…" briefly before the "You're signed in — you can safely close this window" card appears

## Test plan

- [ ] Desktop: sign in with passkey → system browser opens → Touch ID fires → HandoffCompleteCard appears → Electron main window loads dashboard
- [ ] Desktop: add passkey from Settings → system browser opens → Touch ID fires → HandoffCompleteCard appears → passkey appears in settings list
- [ ] `pnpm test:unit` passes (no test changes expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)