### PR TITLE
fix(cron): drop broken network check from auth

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -92,7 +92,7 @@ export async function middleware(req: NextRequest) {
     }
 
     // Public routes that don't require authentication
-    // Note: Cron routes handle their own auth via validateCronRequest (internal network only)
+    // Note: Cron routes handle their own auth via validateSignedCronRequest (HMAC-SHA256 + nonce)
     // Device/mobile auth endpoints authenticate via body tokens (device token, magic link),
     // not session cookies, so they must bypass the cookie check to allow cookie-expired recovery.
     if (

--- a/apps/web/src/app/api/memory/cron/__tests__/route.test.ts
+++ b/apps/web/src/app/api/memory/cron/__tests__/route.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, vi, beforeEach } from 'vitest';
+import { describe, it, vi, beforeEach, afterEach } from 'vitest';
 import { assert } from '@/lib/memory/__tests__/riteway';
+import { computeCronSignature } from '@/lib/auth/cron-auth';
 
 /**
  * Memory Cron Route Tests
@@ -73,10 +74,44 @@ vi.mock('@pagespace/lib/server', () => ({
   },
 }));
 
+// Helper that creates a properly HMAC-signed cron request.
+// The route validates HMAC-SHA256 signatures; tests that exercise non-auth
+// behavior must send signed requests when CRON_SECRET is set in the env.
+const TEST_SECRET = 'test-route-cron-secret';
+
+function createSignedCronRequest(opts: {
+  method?: string;
+  url?: string;
+  extraHeaders?: Record<string, string>;
+} = {}): Request {
+  const method = opts.method ?? 'POST';
+  const url = opts.url ?? 'http://web:3000/api/memory/cron';
+  const parsed = new URL(url);
+  const timestamp = String(Math.floor(Date.now() / 1000));
+  const nonce = `nonce-${Math.random()}`;
+  const signature = computeCronSignature(TEST_SECRET, timestamp, nonce, method, parsed.pathname);
+  return new Request(url, {
+    method,
+    headers: {
+      host: parsed.host,
+      'x-cron-timestamp': timestamp,
+      'x-cron-nonce': nonce,
+      'x-cron-signature': signature,
+      ...opts.extraHeaders,
+    },
+  });
+}
+
 describe('memory cron route', () => {
+  let savedCronSecret: string | undefined;
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
+    // Normalise CRON_SECRET so all tests run against a known secret state.
+    // Tests that need no-secret (dev bypass) must clear it themselves.
+    savedCronSecret = process.env.CRON_SECRET;
+    process.env.CRON_SECRET = TEST_SECRET;
     // Setup default mocks
     mockDbSelect.mockReturnValue({
       from: vi.fn().mockReturnValue({
@@ -90,14 +125,18 @@ describe('memory cron route', () => {
     });
   });
 
+  afterEach(() => {
+    if (savedCronSecret !== undefined) {
+      process.env.CRON_SECRET = savedCronSecret;
+    } else {
+      delete process.env.CRON_SECRET;
+    }
+  });
+
   describe('cron authentication', () => {
     it('should return 403 when cron signature headers are missing', async () => {
+      // CRON_SECRET is set by outer beforeEach; omitting HMAC headers must be rejected.
       const { POST } = await import('../route');
-      // Simulate what happens in non-dev environments: auth requires HMAC headers.
-      // In test mode (no CRON_SECRET) auth is bypassed, so we set a secret to
-      // exercise the rejection path.
-      const originalSecret = process.env.CRON_SECRET;
-      process.env.CRON_SECRET = 'test-secret';
       const request = new Request('https://pagespace.ai/api/memory/cron', {
         method: 'POST',
         headers: { host: 'pagespace.ai' },
@@ -105,12 +144,6 @@ describe('memory cron route', () => {
 
       const response = await POST(request);
       const data = await response.json();
-
-      if (originalSecret !== undefined) {
-        process.env.CRON_SECRET = originalSecret;
-      } else {
-        delete process.env.CRON_SECRET;
-      }
 
       assert({
         given: 'request with CRON_SECRET set but no HMAC headers',
@@ -127,56 +160,34 @@ describe('memory cron route', () => {
       });
     });
 
-    it('should proceed when request has x-forwarded-for set (Next.js 15 behavior)', async () => {
+    it('should pass a valid signed request with x-forwarded-for set (Next.js 15 regression)', async () => {
+      // Next.js 15 unconditionally injects x-forwarded-for; the HMAC auth layer
+      // must not be affected by its presence — only the signature headers matter.
       const { POST } = await import('../route');
-      // x-forwarded-for is injected by Next.js 15 on every request; the auth
-      // layer must not reject on its presence.
-      const request = new Request('http://localhost:3000/api/memory/cron', {
-        method: 'POST',
-        headers: {
-          host: 'localhost:3000',
-          'x-forwarded-for': '172.18.0.1',
-        },
+      const request = createSignedCronRequest({
+        extraHeaders: { 'x-forwarded-for': '172.18.0.1' },
       });
 
       const response = await POST(request);
 
       assert({
-        given: 'request with x-forwarded-for header in test mode',
-        should: 'not return 403 (host check is not a security gate)',
+        given: 'valid signed request with x-forwarded-for header injected',
+        should: 'not return 403 (x-forwarded-for is irrelevant to HMAC auth)',
         actual: response.status !== 403,
         expected: true,
       });
     });
 
-    it('should proceed when request is from localhost', async () => {
+    it('should accept a validly signed request from any origin', async () => {
+      // Origin / host is not part of the HMAC message — only timestamp, nonce,
+      // method, and path are signed.
       const { POST } = await import('../route');
-      const request = new Request('http://localhost:3000/api/memory/cron', {
-        method: 'POST',
-        headers: { host: 'localhost:3000' },
-      });
+      const request = createSignedCronRequest();
 
       const response = await POST(request);
 
       assert({
-        given: 'request from localhost',
-        should: 'not return 403',
-        actual: response.status !== 403,
-        expected: true,
-      });
-    });
-
-    it('should proceed when request is from 127.0.0.1', async () => {
-      const { POST } = await import('../route');
-      const request = new Request('http://127.0.0.1:3000/api/memory/cron', {
-        method: 'POST',
-        headers: { host: '127.0.0.1:3000' },
-      });
-
-      const response = await POST(request);
-
-      assert({
-        given: 'request from 127.0.0.1',
+        given: 'validly signed cron request',
         should: 'not return 403',
         actual: response.status !== 403,
         expected: true,
@@ -197,10 +208,7 @@ describe('memory cron route', () => {
       });
 
       const { POST } = await import('../route');
-      const request = new Request('http://localhost:3000/api/memory/cron', {
-        method: 'POST',
-        headers: { host: 'localhost:3000' },
-      });
+      const request = createSignedCronRequest();
 
       const response = await POST(request);
       const data = await response.json();
@@ -235,10 +243,7 @@ describe('memory cron route', () => {
         });
 
       const { POST } = await import('../route');
-      const request = new Request('http://localhost:3000/api/memory/cron', {
-        method: 'POST',
-        headers: { host: 'localhost:3000' },
-      });
+      const request = createSignedCronRequest();
 
       const response = await POST(request);
       const data = await response.json();
@@ -262,15 +267,12 @@ describe('memory cron route', () => {
   describe('GET support', () => {
     it('should support GET requests for cron services', async () => {
       const { GET } = await import('../route');
-      const request = new Request('http://localhost:3000/api/memory/cron', {
-        method: 'GET',
-        headers: { host: 'localhost:3000' },
-      });
+      const request = createSignedCronRequest({ method: 'GET' });
 
       const response = await GET(request);
 
       assert({
-        given: 'GET request from localhost',
+        given: 'valid signed GET request',
         should: 'return 200 status',
         actual: response.status,
         expected: 200,

--- a/apps/web/src/app/api/memory/cron/__tests__/route.test.ts
+++ b/apps/web/src/app/api/memory/cron/__tests__/route.test.ts
@@ -106,7 +106,11 @@ describe('memory cron route', () => {
       const response = await POST(request);
       const data = await response.json();
 
-      process.env.CRON_SECRET = originalSecret;
+      if (originalSecret !== undefined) {
+        process.env.CRON_SECRET = originalSecret;
+      } else {
+        delete process.env.CRON_SECRET;
+      }
 
       assert({
         given: 'request with CRON_SECRET set but no HMAC headers',

--- a/apps/web/src/app/api/memory/cron/__tests__/route.test.ts
+++ b/apps/web/src/app/api/memory/cron/__tests__/route.test.ts
@@ -11,7 +11,7 @@ import { assert } from '@/lib/memory/__tests__/riteway';
  * 4. Compacts fields if needed
  *
  * Key behaviors to test:
- * 1. Only accessible from internal network (CRON_SECRET + network origin check)
+ * 1. Authentication via HMAC-SHA256 + nonce (see cron-auth.ts)
  * 2. Only processes paying users (pro, founder, business)
  * 3. Skips users with personalization disabled
  * 4. Handles errors for individual users without failing entire job
@@ -90,9 +90,14 @@ describe('memory cron route', () => {
     });
   });
 
-  describe('localhost authentication (zero trust)', () => {
-    it('should return 403 when request comes from external host', async () => {
+  describe('cron authentication', () => {
+    it('should return 403 when cron signature headers are missing', async () => {
       const { POST } = await import('../route');
+      // Simulate what happens in non-dev environments: auth requires HMAC headers.
+      // In test mode (no CRON_SECRET) auth is bypassed, so we set a secret to
+      // exercise the rejection path.
+      const originalSecret = process.env.CRON_SECRET;
+      process.env.CRON_SECRET = 'test-secret';
       const request = new Request('https://pagespace.ai/api/memory/cron', {
         method: 'POST',
         headers: { host: 'pagespace.ai' },
@@ -101,38 +106,42 @@ describe('memory cron route', () => {
       const response = await POST(request);
       const data = await response.json();
 
+      process.env.CRON_SECRET = originalSecret;
+
       assert({
-        given: 'request from external host',
+        given: 'request with CRON_SECRET set but no HMAC headers',
         should: 'return 403 status',
         actual: response.status,
         expected: 403,
       });
 
       assert({
-        given: 'request from external host',
-        should: 'return forbidden error mentioning internal network',
-        actual: data.error.includes('internal network'),
+        given: 'request with CRON_SECRET set but no HMAC headers',
+        should: 'return forbidden error mentioning missing headers',
+        actual: data.error.includes('missing cron authentication headers'),
         expected: true,
       });
     });
 
-    it('should return 403 when x-forwarded-for header is present', async () => {
+    it('should proceed when request has x-forwarded-for set (Next.js 15 behavior)', async () => {
       const { POST } = await import('../route');
+      // x-forwarded-for is injected by Next.js 15 on every request; the auth
+      // layer must not reject on its presence.
       const request = new Request('http://localhost:3000/api/memory/cron', {
         method: 'POST',
         headers: {
           host: 'localhost:3000',
-          'x-forwarded-for': '203.0.113.195',
+          'x-forwarded-for': '172.18.0.1',
         },
       });
 
       const response = await POST(request);
 
       assert({
-        given: 'request with x-forwarded-for header (proxied)',
-        should: 'return 403 status',
-        actual: response.status,
-        expected: 403,
+        given: 'request with x-forwarded-for header in test mode',
+        should: 'not return 403 (host check is not a security gate)',
+        actual: response.status !== 403,
+        expected: true,
       });
     });
 

--- a/apps/web/src/lib/auth/__tests__/cron-auth.test.ts
+++ b/apps/web/src/lib/auth/__tests__/cron-auth.test.ts
@@ -1,7 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
-  isLocalhostRequest,
-  isInternalRequest,
   computeCronSignature,
   checkAndRecordNonce,
   validateSignedCronRequest,
@@ -10,98 +8,6 @@ import {
 } from '../cron-auth';
 
 describe('cron-auth', () => {
-  describe('isInternalRequest', () => {
-    it('should return true for localhost host header', () => {
-      const request = new Request('http://localhost:3000/api/cron/test', {
-        headers: { host: 'localhost:3000' },
-      });
-
-      expect(isInternalRequest(request)).toBe(true);
-    });
-
-    it('should return true for 127.0.0.1 host header', () => {
-      const request = new Request('http://127.0.0.1:3000/api/cron/test', {
-        headers: { host: '127.0.0.1:3000' },
-      });
-
-      expect(isInternalRequest(request)).toBe(true);
-    });
-
-    it('should return true for IPv6 localhost [::1]', () => {
-      const request = new Request('http://[::1]:3000/api/cron/test', {
-        headers: { host: '[::1]:3000' },
-      });
-
-      expect(isInternalRequest(request)).toBe(true);
-    });
-
-    it('should return true for docker internal hostname web:3000', () => {
-      const request = new Request('http://web:3000/api/cron/test', {
-        headers: { host: 'web:3000' },
-      });
-
-      expect(isInternalRequest(request)).toBe(true);
-    });
-
-    it('should return true for docker internal hostname web (no port)', () => {
-      const request = new Request('http://web/api/cron/test', {
-        headers: { host: 'web' },
-      });
-
-      expect(isInternalRequest(request)).toBe(true);
-    });
-
-    it('should return false for external host', () => {
-      const request = new Request('https://pagespace.ai/api/cron/test', {
-        headers: { host: 'pagespace.ai' },
-      });
-
-      expect(isInternalRequest(request)).toBe(false);
-    });
-
-    it('should return false for localhost.evil.com (prefix attack)', () => {
-      const request = new Request('https://localhost.evil.com/api/cron/test', {
-        headers: { host: 'localhost.evil.com' },
-      });
-
-      expect(isInternalRequest(request)).toBe(false);
-    });
-
-    it('should return false when x-forwarded-for header is present', () => {
-      const request = new Request('http://localhost:3000/api/cron/test', {
-        headers: {
-          host: 'localhost:3000',
-          'x-forwarded-for': '203.0.113.195',
-        },
-      });
-
-      expect(isInternalRequest(request)).toBe(false);
-    });
-
-    it('should return false when x-forwarded-for present even with docker host', () => {
-      const request = new Request('http://web:3000/api/cron/test', {
-        headers: {
-          host: 'web:3000',
-          'x-forwarded-for': '203.0.113.195',
-        },
-      });
-
-      expect(isInternalRequest(request)).toBe(false);
-    });
-
-    it('should return false for missing host header', () => {
-      const request = new Request('http://localhost:3000/api/cron/test');
-
-      expect(isInternalRequest(request)).toBe(false);
-    });
-  });
-
-  describe('isLocalhostRequest (alias)', () => {
-    it('should be an alias for isInternalRequest', () => {
-      expect(isLocalhostRequest).toBe(isInternalRequest);
-    });
-  });
-
   describe('computeCronSignature', () => {
     it('given valid inputs, should produce deterministic HMAC', () => {
       const sig1 = computeCronSignature('secret', '1000', 'nonce-1', 'POST', '/api/cron/test');
@@ -199,8 +105,25 @@ describe('cron-auth', () => {
       return new Request(`http://${host}${path}`, { method, headers });
     }
 
-    it('given valid signature + timestamp + nonce + internal, should return null (pass)', () => {
+    it('given valid signature + timestamp + nonce, should return null (pass)', () => {
       const request = createSignedRequest();
+      expect(validateSignedCronRequest(request)).toBeNull();
+    });
+
+    it('given valid signature with x-forwarded-for set (Next.js 15 behavior), should return null', () => {
+      const timestamp = String(Math.floor(Date.now() / 1000));
+      const nonce = `nonce-${Math.random()}`;
+      const signature = computeCronSignature(TEST_SECRET, timestamp, nonce, 'POST', '/api/cron/test');
+      const request = new Request('http://web:3000/api/cron/test', {
+        method: 'POST',
+        headers: {
+          host: 'web:3000',
+          'x-forwarded-for': '172.18.0.1', // Docker bridge peer IP injected by Next.js 15
+          'x-cron-timestamp': timestamp,
+          'x-cron-nonce': nonce,
+          'x-cron-signature': signature,
+        },
+      });
       expect(validateSignedCronRequest(request)).toBeNull();
     });
 
@@ -333,7 +256,21 @@ describe('cron-auth', () => {
         expect(response!.status).toBe(403);
 
         const data = await response!.json();
-        expect(data.error).toContain('CRON_SECRET must be configured in production');
+        expect(data.error).toContain('CRON_SECRET must be configured');
+      });
+
+      it('given staging/unknown NODE_ENV, should reject request (fail-closed)', async () => {
+        (process.env as Record<string, string | undefined>).NODE_ENV = 'staging';
+        const request = new Request('http://localhost:3000/api/cron/test', {
+          headers: { host: 'localhost:3000' },
+        });
+        const response = validateSignedCronRequest(request);
+
+        expect(response).not.toBeNull();
+        expect(response!.status).toBe(403);
+
+        const data = await response!.json();
+        expect(data.error).toContain('CRON_SECRET must be configured');
       });
 
       it('given test mode, should allow all requests with warning', () => {

--- a/apps/web/src/lib/auth/__tests__/cron-auth.test.ts
+++ b/apps/web/src/lib/auth/__tests__/cron-auth.test.ts
@@ -297,14 +297,9 @@ describe('cron-auth', () => {
       expect(data.error).toContain('missing');
     });
 
-    it('given valid signature but external request, should return 403', async () => {
+    it('given valid signature from any host, should return null (host is not security-relevant)', () => {
       const request = createSignedRequest({ host: 'pagespace.ai' });
-      const response = validateSignedCronRequest(request);
-
-      expect(response).not.toBeNull();
-      expect(response!.status).toBe(403);
-      const data = await response!.json();
-      expect(data.error).toContain('internal network');
+      expect(validateSignedCronRequest(request)).toBeNull();
     });
 
     describe('without CRON_SECRET', () => {
@@ -319,7 +314,7 @@ describe('cron-auth', () => {
         (process.env as Record<string, string | undefined>).NODE_ENV = originalNodeEnv;
       });
 
-      it('given development mode, should fall back to internal network check', () => {
+      it('given development mode, should allow all requests with warning', () => {
         (process.env as Record<string, string | undefined>).NODE_ENV = 'development';
         const request = new Request('http://localhost:3000/api/cron/test', {
           headers: { host: 'localhost:3000' },
@@ -341,7 +336,7 @@ describe('cron-auth', () => {
         expect(data.error).toContain('CRON_SECRET must be configured in production');
       });
 
-      it('given test mode, should fall back to internal network check', () => {
+      it('given test mode, should allow all requests with warning', () => {
         (process.env as Record<string, string | undefined>).NODE_ENV = 'test';
         const request = new Request('http://localhost:3000/api/cron/test', {
           headers: { host: 'localhost:3000' },

--- a/apps/web/src/lib/auth/cron-auth.ts
+++ b/apps/web/src/lib/auth/cron-auth.ts
@@ -1,18 +1,14 @@
 /**
  * Cron Authentication Utility
  *
- * Security model:
- *   1. Primary: HMAC-SHA256 signed requests with anti-replay protection
- *   2. Defense-in-depth: Internal network header checks
+ * Security model: HMAC-SHA256 signed requests with anti-replay protection.
  *
  * Production (CRON_SECRET required):
  *   - Requests MUST include valid signed headers (timestamp, nonce, signature)
  *   - Rejects if CRON_SECRET not configured (fail-closed)
- *   - Internal network checks still apply as additional layer
  *
  * Development (CRON_SECRET optional):
- *   - Falls back to internal network checks only
- *   - Logs a warning on first request
+ *   - All requests allowed with a warning on first request
  */
 
 import { createHmac } from 'crypto';
@@ -151,7 +147,6 @@ export function _resetWarningFlag(): void {
  *   3. Reject if timestamp older than 5 minutes (anti-replay)
  *   4. Recompute signature and timing-safe compare
  *   5. Reject if nonce already seen (recorded after signature verified)
- *   6. Defense-in-depth: require internal network origin
  *
  * Returns null on success, 403 NextResponse on failure.
  */
@@ -166,18 +161,12 @@ export function validateSignedCronRequest(request: Request): NextResponse | null
         { status: 403 }
       );
     }
-    // Development fallback: network-only auth
+    // Development fallback: allow all requests with a warning
     if (!cronSecretWarningLogged) {
       console.warn(
-        '[cron-auth] CRON_SECRET is not configured. Falling back to network-only auth. Set CRON_SECRET in production.'
+        '[cron-auth] CRON_SECRET is not configured. All cron requests allowed in development mode. Set CRON_SECRET in production.'
       );
       cronSecretWarningLogged = true;
-    }
-    if (!isInternalRequest(request)) {
-      return NextResponse.json(
-        { error: 'Forbidden - cron endpoints only accessible from internal network' },
-        { status: 403 }
-      );
     }
     return null;
   }
@@ -221,14 +210,6 @@ export function validateSignedCronRequest(request: Request): NextResponse | null
   if (!checkAndRecordNonce(nonce)) {
     return NextResponse.json(
       { error: 'Forbidden - cron request nonce already used' },
-      { status: 403 }
-    );
-  }
-
-  // Defense-in-depth: require internal network origin
-  if (!isInternalRequest(request)) {
-    return NextResponse.json(
-      { error: 'Forbidden - cron endpoints only accessible from internal network' },
       { status: 403 }
     );
   }

--- a/apps/web/src/lib/auth/cron-auth.ts
+++ b/apps/web/src/lib/auth/cron-auth.ts
@@ -3,12 +3,12 @@
  *
  * Security model: HMAC-SHA256 signed requests with anti-replay protection.
  *
- * Production (CRON_SECRET required):
+ * Production / staging (CRON_SECRET required):
  *   - Requests MUST include valid signed headers (timestamp, nonce, signature)
- *   - Rejects if CRON_SECRET not configured (fail-closed)
+ *   - Rejects if CRON_SECRET not configured (fail-closed for any non-dev env)
  *
- * Development (CRON_SECRET optional):
- *   - All requests allowed with a warning on first request
+ * Local development / test (CRON_SECRET optional):
+ *   - All requests allowed with a one-time warning
  */
 
 import { createHmac } from 'crypto';
@@ -16,51 +16,6 @@ import { NextResponse } from 'next/server';
 import { secureCompare } from '@pagespace/lib';
 
 let cronSecretWarningLogged = false;
-
-/**
- * Check if request originates from internal network (not proxied from outside)
- *
- * Returns true if:
- * - No X-Forwarded-For header (not proxied from external source)
- * - Host is localhost, internal docker service name, or IP
- *
- * IMPORTANT: This check is defense-in-depth behind HMAC validation. The host header
- * and absence of x-forwarded-for can be spoofed by attackers connecting directly.
- * Infrastructure (reverse proxy/load balancer) MUST set x-forwarded-for on all
- * inbound requests for this check to be meaningful.
- */
-export function isInternalRequest(request: Request): boolean {
-  const host = request.headers.get('host') ?? '';
-  const forwardedFor = request.headers.get('x-forwarded-for');
-
-  // If there's a forwarded-for header, request came through a proxy/load balancer
-  // from an external source - reject it
-  if (forwardedFor) {
-    return false;
-  }
-
-  // Allow localhost (dev/testing) - anchor to port separator or end-of-string
-  // to prevent matching localhost.evil.com
-  if (
-    /^localhost(:\d+)?$/.test(host) ||
-    /^127\.0\.0\.1(:\d+)?$/.test(host) ||
-    /^\[::1\](:\d+)?$/.test(host)
-  ) {
-    return true;
-  }
-
-  // Allow internal docker service names (e.g., web:3000, web)
-  // These are only reachable from within the docker network
-  if (host.startsWith('web:') || host === 'web') {
-    return true;
-  }
-
-  return false;
-}
-
-// Alias for backward compatibility with tests
-export const isLocalhostRequest = isInternalRequest;
-
 
 // ============================================================
 // HMAC-Signed Request Validation (anti-replay upgrade)
@@ -154,17 +109,18 @@ export function validateSignedCronRequest(request: Request): NextResponse | null
   const cronSecret = process.env.CRON_SECRET;
 
   if (!cronSecret) {
-    // Fail-closed in production: CRON_SECRET must be configured
-    if (process.env.NODE_ENV === 'production') {
+    // Fail-closed for all non-local envs: staging, custom NODE_ENV, etc.
+    const isLocalDev = process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test';
+    if (!isLocalDev) {
       return NextResponse.json(
-        { error: 'Forbidden - CRON_SECRET must be configured in production' },
+        { error: 'Forbidden - CRON_SECRET must be configured' },
         { status: 403 }
       );
     }
-    // Development fallback: allow all requests with a warning
+    // Local dev/test only: allow with a one-time warning
     if (!cronSecretWarningLogged) {
       console.warn(
-        '[cron-auth] CRON_SECRET is not configured. All cron requests allowed in development mode. Set CRON_SECRET in production.'
+        '[cron-auth] CRON_SECRET is not configured. All cron requests allowed in local dev/test. Set CRON_SECRET in all deployed environments.'
       );
       cronSecretWarningLogged = true;
     }

--- a/apps/web/src/lib/auth/cron-auth.ts
+++ b/apps/web/src/lib/auth/cron-auth.ts
@@ -97,7 +97,7 @@ export function _resetWarningFlag(): void {
  *   X-Cron-Signature: HMAC-SHA256(CRON_SECRET, `${timestamp}:${nonce}:${method}:${path}`)
  *
  * Validation:
- *   1. Reject if CRON_SECRET not configured (fail-closed in production)
+ *   1. Reject if CRON_SECRET not configured (fail-closed for any non-development/test env)
  *   2. Reject if any required header is missing
  *   3. Reject if timestamp older than 5 minutes (anti-replay)
  *   4. Recompute signature and timing-safe compare


### PR DESCRIPTION
## Summary

- Next.js 15 unconditionally sets \`x-forwarded-for\` on every inbound request (even direct Docker-internal connections), so \`isInternalRequest()\` always returned \`false\` and \`validateSignedCronRequest\` always rejected with 403 **after** a valid HMAC had already passed — no cron job could ever authenticate
- Removes the \`isInternalRequest\` gate from the signed-request validation path; HMAC-SHA256 + nonce + 5-minute timestamp window is cryptographically complete, and Caddy already blocks \`/api/cron/*\` at the public edge
- Simplifies the dev fallback: \`CRON_SECRET\` absent now fails closed for **any** non-\`development\`/\`test\` \`NODE_ENV\` (staging, unset, custom) — only explicit \`development\` or \`test\` opens the gate with a warning
- Removes dead \`isInternalRequest\`/\`isLocalhostRequest\` exports (no production callers) and their test suite
- Adds regression test: signed request with \`x-forwarded-for\` set (Next.js 15 socket-peer injection) must pass

## Root cause

\`base-server.js\` in Next.js 15:
\`\`\`js
req.headers['x-forwarded-for'] ??= originalRequest.socket.remoteAddress
\`\`\`
This runs before any route handler, populating \`x-forwarded-for\` from the TCP peer address — even for direct internal connections — making the "no forwarded-for = internal" heuristic permanently wrong.

## Test plan

- [ ] \`pnpm --filter web test src/lib/auth/__tests__/cron-auth.test.ts\` passes
- [ ] Send a correctly signed cron request to a \`/api/cron/*\` endpoint → 200
- [ ] Send with wrong signature → 403 \`invalid cron signature\`
- [ ] Send with expired timestamp → 403 \`timestamp expired\`
- [ ] Send with replayed nonce → 403 \`nonce already used\`
- [ ] Send with no headers → 403 \`missing cron authentication headers\`
- [ ] Deploy with \`NODE_ENV=staging\` and no \`CRON_SECRET\` → cron requests rejected (fail-closed)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)