### PR TITLE
fix(audit): canonical JSON for hash chains

### DIFF
--- a/apps/processor/src/services/__tests__/siem-chain-hashers.test.ts
+++ b/apps/processor/src/services/__tests__/siem-chain-hashers.test.ts
@@ -166,12 +166,10 @@ describe('recomputeSecurityAuditHash', () => {
     });
   });
 
-  it('null hashable fields round-trip as undefined (JSON-stringify omission)', () => {
-    // At write time, AuditEvent's optional fields are `undefined` when not
-    // passed, so JSON.stringify omits them. The DB stores null. When we read
-    // back, null must be treated as "field was undefined at write time" —
-    // i.e. omitted from the serialized object — otherwise the recomputed hash
-    // would include "riskScore":null etc. and diverge.
+  it('null hashable fields round-trip correctly with stableStringify', () => {
+    // Both sides normalize optional fields to null via `?? null` before
+    // stableStringify — so "riskScore":null is included in the serialized
+    // object on both the write side and the read side, and they match.
     const timestamp = new Date('2026-04-10T00:00:00.000Z');
     const event: AuditEvent = {
       eventType: 'auth.logout',

--- a/apps/processor/src/services/siem-chain-hashers.ts
+++ b/apps/processor/src/services/siem-chain-hashers.ts
@@ -1,15 +1,5 @@
 import { createHash } from 'crypto';
-
-// Mirrors the stableStringify helper in packages/lib — sorts object keys at
-// every depth so key insertion order (e.g. Postgres JSONB round-trip) never
-// changes the serialized output.
-function stableStringify(value: unknown): string {
-  return JSON.stringify(value, (_, v) =>
-    v !== null && typeof v === 'object' && !Array.isArray(v)
-      ? Object.fromEntries(Object.keys(v).sort().map(k => [k, v[k]]))
-      : v
-  );
-}
+import { stableStringify } from '@pagespace/lib/utils/stable-stringify';
 
 /**
  * Per-source hash recomputation strategies for the SIEM delivery preflight.

--- a/apps/processor/src/services/siem-chain-hashers.ts
+++ b/apps/processor/src/services/siem-chain-hashers.ts
@@ -1,5 +1,16 @@
 import { createHash } from 'crypto';
 
+// Mirrors the stableStringify helper in packages/lib — sorts object keys at
+// every depth so key insertion order (e.g. Postgres JSONB round-trip) never
+// changes the serialized output.
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_, v) =>
+    v !== null && typeof v === 'object' && !Array.isArray(v)
+      ? Object.fromEntries(Object.keys(v).sort().map(k => [k, v[k]]))
+      : v
+  );
+}
+
 /**
  * Per-source hash recomputation strategies for the SIEM delivery preflight.
  *
@@ -65,37 +76,27 @@ export interface SecurityAuditHashableFields {
  * Recompute the expected `logHash` for an activity_logs entry.
  *
  * Mirrors serializeLogDataForHash + computeLogHash in activity-logger.ts:
- *   1. Build a hashable object with fields in the exact same key set the
- *      write side uses, coercing undefined → null the same way.
- *   2. JSON.stringify with sorted keys (deterministic output).
+ *   1. Build hashable object with the same field set (PII excluded).
+ *   2. stableStringify — sorts keys at every depth for deterministic output.
  *   3. SHA-256 of `previousHash + serialized`.
- *
- * IMPORTANT: the order of property writes in `hashableObject` does not
- * matter because JSON.stringify is called with a sorted replacer-array
- * argument; it's the sorted-keys guarantee that makes this deterministic.
  */
 export function recomputeActivityLogHash(
   data: ActivityLogHashableFields,
   previousHash: string
 ): string {
-  const hashableObject = {
-    id: data.id,
-    timestamp: data.timestamp.toISOString(),
-    operation: data.operation,
-    resourceType: data.resourceType,
-    resourceId: data.resourceId,
-    driveId: data.driveId,
-    pageId: data.pageId ?? null,
+  const serialized = stableStringify({
     contentSnapshot: data.contentSnapshot ?? null,
-    previousValues: data.previousValues ?? null,
-    newValues: data.newValues ?? null,
+    driveId: data.driveId,
+    id: data.id,
     metadata: data.metadata ?? null,
-  };
-
-  const serialized = JSON.stringify(
-    hashableObject,
-    Object.keys(hashableObject).sort()
-  );
+    newValues: data.newValues ?? null,
+    operation: data.operation,
+    pageId: data.pageId ?? null,
+    previousValues: data.previousValues ?? null,
+    resourceId: data.resourceId,
+    resourceType: data.resourceType,
+    timestamp: data.timestamp.toISOString(),
+  });
 
   return createHash('sha256').update(previousHash + serialized).digest('hex');
 }
@@ -104,31 +105,26 @@ export function recomputeActivityLogHash(
  * Recompute the expected `eventHash` for a security_audit_log entry.
  *
  * Mirrors computeSecurityEventHash in security-audit.ts:
- *   - Flat JSON.stringify (no sorted-keys replacer — V8 insertion order is
- *     relied on by the write side).
+ *   - stableStringify sorts keys at every depth (including inside `details`).
  *   - SHA-256 of the serialized object; `previousHash` is a field INSIDE the
  *     serialized object, not prepended like activity_logs.
- *
- * Nullable fields map back to undefined so JSON.stringify omits them — the
- * write-side AuditEvent uses optional fields, so `undefined` at write time
- * becomes column-null in the DB. Reconstructing as `undefined` restores the
- * original serialized shape. The key order here MUST match the write-side
- * object literal exactly.
+ *   - Nullable DB columns normalize to null (not undefined) — the write side
+ *     uses `?? null` so JSON.stringify includes them explicitly.
  */
 export function recomputeSecurityAuditHash(
   data: SecurityAuditHashableFields,
   previousHash: string
 ): string {
-  const serialized = JSON.stringify({
+  const serialized = stableStringify({
+    anomalyFlags: data.anomalyFlags ?? null,
+    details: data.details ?? null,
     eventType: data.eventType,
-    serviceId: data.serviceId ?? undefined,
-    resourceType: data.resourceType ?? undefined,
-    resourceId: data.resourceId ?? undefined,
-    details: data.details ?? undefined,
-    riskScore: data.riskScore ?? undefined,
-    anomalyFlags: data.anomalyFlags ?? undefined,
-    timestamp: data.timestamp.toISOString(),
     previousHash,
+    resourceId: data.resourceId ?? null,
+    resourceType: data.resourceType ?? null,
+    riskScore: data.riskScore ?? null,
+    serviceId: data.serviceId ?? null,
+    timestamp: data.timestamp.toISOString(),
   });
 
   return createHash('sha256').update(serialized).digest('hex');

--- a/apps/web/src/app/api/track/__tests__/route.test.ts
+++ b/apps/web/src/app/api/track/__tests__/route.test.ts
@@ -94,7 +94,7 @@ describe('/api/track', () => {
         undefined,
         'page_view',
         {
-          metadata: { path: '/home', ip: '127.0.0.1', userAgent: 'unknown', timestamp: frozenDate.toISOString() },
+          metadata: { path: '/home', timestamp: frozenDate.toISOString() },
           ip: '127.0.0.1',
           userAgent: 'unknown',
         }
@@ -108,7 +108,7 @@ describe('/api/track', () => {
       expect(trackFeature).toHaveBeenCalledWith(
         undefined,
         'dark-mode',
-        { feature: 'dark-mode', ip: '127.0.0.1', userAgent: 'unknown', timestamp: frozenDate.toISOString() }
+        { feature: 'dark-mode', timestamp: frozenDate.toISOString() }
       );
     });
 
@@ -123,7 +123,7 @@ describe('/api/track', () => {
         undefined,
         'js',
         'Uncaught TypeError',
-        { type: 'js', message: 'Uncaught TypeError', ip: '127.0.0.1', userAgent: 'unknown', timestamp: frozenDate.toISOString() }
+        { type: 'js', message: 'Uncaught TypeError', timestamp: frozenDate.toISOString() }
       );
     });
 
@@ -136,7 +136,7 @@ describe('/api/track', () => {
         undefined,
         'ui_click',
         {
-          metadata: { label: 'nav-button', ip: '127.0.0.1', userAgent: 'unknown', timestamp: frozenDate.toISOString() },
+          metadata: { label: 'nav-button', timestamp: frozenDate.toISOString() },
           ip: '127.0.0.1',
           userAgent: 'unknown',
         }
@@ -152,7 +152,7 @@ describe('/api/track', () => {
         undefined,
         'search',
         {
-          metadata: { ip: '127.0.0.1', userAgent: 'unknown', timestamp: frozenDate.toISOString() },
+          metadata: { timestamp: frozenDate.toISOString() },
           ip: '127.0.0.1',
           userAgent: 'unknown',
         }

--- a/apps/web/src/app/api/track/route.ts
+++ b/apps/web/src/app/api/track/route.ts
@@ -110,10 +110,11 @@ export async function POST(request: Request) {
 
     const userAgent = request.headers.get('user-agent') || 'unknown';
 
+    // ip and userAgent are passed as top-level fields to logActivity where they
+    // land in dedicated PII columns excluded from the hash chain. Keeping them
+    // out of enrichedData prevents them from entering the hashed metadata JSONB.
     const enrichedData = {
       ...data,
-      ip,
-      userAgent,
       timestamp: new Date().toISOString(),
     };
 

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -189,6 +189,11 @@
       "import": "./dist/utils/language-detection.js",
       "require": "./dist/utils/language-detection.js"
     },
+    "./utils/stable-stringify": {
+      "types": "./dist/utils/stable-stringify.d.ts",
+      "import": "./dist/utils/stable-stringify.js",
+      "require": "./dist/utils/stable-stringify.js"
+    },
     "./pages/circular-reference-guard": {
       "types": "./dist/pages/circular-reference-guard.d.ts",
       "import": "./dist/pages/circular-reference-guard.js",
@@ -385,6 +390,9 @@
       ],
       "utils/language-detection": [
         "./dist/utils/language-detection.d.ts"
+      ],
+      "utils/stable-stringify": [
+        "./dist/utils/stable-stringify.d.ts"
       ],
       "pages/circular-reference-guard": [
         "./dist/pages/circular-reference-guard.d.ts"

--- a/packages/lib/src/audit/__tests__/security-audit-chain-verifier.test.ts
+++ b/packages/lib/src/audit/__tests__/security-audit-chain-verifier.test.ts
@@ -86,6 +86,7 @@ import {
   verifySecurityAuditChain,
   type SecurityChainVerificationResult,
 } from '../security-audit-chain-verifier';
+import { computeSecurityEventHash, type AuditEvent } from '../security-audit';
 
 describe('security-audit-chain-verifier', () => {
   beforeEach(() => {
@@ -223,6 +224,65 @@ describe('security-audit-chain-verifier', () => {
       expect(result.isValid).toBe(true);
       expect(result.entriesVerified).toBe(5);
       expect(result.validEntries).toBe(5);
+      expect(result.invalidEntries).toBe(0);
+      expect(result.breakPoint).toBeNull();
+    });
+
+    // Regression test for the canonical-serialization bug: when Postgres returns a
+    // JSONB column with keys in a different order than they were written, the
+    // verifier must still compute the same hash. stableStringify sorts keys at
+    // every depth, so insertion order must not matter.
+    it('verifies chain when Postgres JSONB round-trip reorders details keys', async () => {
+      const timestamp0 = new Date('2026-01-25T10:00:00.000Z');
+      const timestamp1 = new Date('2026-01-25T10:00:01.000Z');
+
+      const event0 = {
+        eventType: 'auth.login.success' as const,
+        serviceId: 'web',
+        details: { action: 'export', format: 'pdf', count: 3 },
+      } satisfies AuditEvent;
+      const event1 = {
+        eventType: 'data.read' as const,
+        serviceId: 'web',
+        details: { resource: 'page', nested: { z: 1, a: 2 } },
+      } satisfies AuditEvent;
+
+      const hash0 = computeSecurityEventHash(event0, 'genesis', timestamp0);
+      const hash1 = computeSecurityEventHash(event1, hash0, timestamp1);
+
+      // Simulate Postgres JSONB returning keys in a different order than written
+      mockEntries = [
+        {
+          id: 'audit-1',
+          eventType: 'auth.login.success',
+          userId: null, sessionId: null, serviceId: 'web',
+          resourceType: null, resourceId: null,
+          ipAddress: null, userAgent: null, geoLocation: null,
+          details: { count: 3, format: 'pdf', action: 'export' }, // reversed
+          riskScore: null, anomalyFlags: null,
+          timestamp: timestamp0,
+          previousHash: 'genesis',
+          eventHash: hash0,
+        },
+        {
+          id: 'audit-2',
+          eventType: 'data.read',
+          userId: null, sessionId: null, serviceId: 'web',
+          resourceType: null, resourceId: null,
+          ipAddress: null, userAgent: null, geoLocation: null,
+          details: { nested: { a: 2, z: 1 }, resource: 'page' }, // reversed
+          riskScore: null, anomalyFlags: null,
+          timestamp: timestamp1,
+          previousHash: hash0,
+          eventHash: hash1,
+        },
+      ];
+
+      const result = await verifySecurityAuditChain();
+
+      expect(result.isValid).toBe(true);
+      expect(result.entriesVerified).toBe(2);
+      expect(result.validEntries).toBe(2);
       expect(result.invalidEntries).toBe(0);
       expect(result.breakPoint).toBeNull();
     });

--- a/packages/lib/src/audit/__tests__/security-audit.test.ts
+++ b/packages/lib/src/audit/__tests__/security-audit.test.ts
@@ -169,6 +169,48 @@ describe('Security Audit Service', () => {
       expect(hash).toHaveLength(64);
       expect(typeof hash).toBe('string');
     });
+
+    it('produces the same hash regardless of key order in details (canonical JSON)', () => {
+      const timestamp = new Date('2026-01-25T10:00:00Z');
+      const base = {
+        eventType: 'auth.login.success' as const,
+        serviceId: 'web',
+        resourceType: 'page',
+        resourceId: 'page-1',
+      };
+
+      // Simulate write-time key order vs Postgres JSONB read-back with different order
+      const hashA = computeSecurityEventHash(
+        { ...base, details: { action: 'export', format: 'pdf', userId: 'u1' } },
+        'genesis',
+        timestamp
+      );
+      const hashB = computeSecurityEventHash(
+        { ...base, details: { userId: 'u1', format: 'pdf', action: 'export' } },
+        'genesis',
+        timestamp
+      );
+
+      expect(hashA).toBe(hashB);
+    });
+
+    it('produces the same hash regardless of key order in nested details objects', () => {
+      const timestamp = new Date('2026-01-25T10:00:00Z');
+      const base = { eventType: 'data.read' as const };
+
+      const hashA = computeSecurityEventHash(
+        { ...base, details: { meta: { z: 1, a: 2 }, top: 'value' } },
+        'prev',
+        timestamp
+      );
+      const hashB = computeSecurityEventHash(
+        { ...base, details: { top: 'value', meta: { a: 2, z: 1 } } },
+        'prev',
+        timestamp
+      );
+
+      expect(hashA).toBe(hashB);
+    });
   });
 
   describe('initialize', () => {

--- a/packages/lib/src/audit/security-audit.ts
+++ b/packages/lib/src/audit/security-audit.ts
@@ -19,6 +19,7 @@ import { createHash } from 'crypto';
 import { db, securityAuditLog, desc, sql } from '@pagespace/db';
 import type { SecurityEventType, SelectSecurityAuditLog } from '@pagespace/db';
 import { queryAuditEvents } from './audit-query';
+import { stableStringify } from '../utils/stable-stringify';
 
 /**
  * Audit event input structure
@@ -61,17 +62,6 @@ export interface QueryEventsOptions {
  * Included: eventType, serviceId, resourceType, resourceId, details,
  *           riskScore, anomalyFlags, timestamp, previousHash
  */
-
-// Serialize to canonical JSON: every plain object's keys are sorted at every
-// depth so the output is identical regardless of insertion order (e.g. after a
-// Postgres JSONB round-trip re-orders keys in `details`).
-function stableStringify(value: unknown): string {
-  return JSON.stringify(value, (_, v) =>
-    v !== null && typeof v === 'object' && !Array.isArray(v)
-      ? Object.fromEntries(Object.keys(v).sort().map(k => [k, v[k]]))
-      : v
-  );
-}
 
 /**
  * Compute SHA-256 hash for a security event.

--- a/packages/lib/src/audit/security-audit.ts
+++ b/packages/lib/src/audit/security-audit.ts
@@ -62,6 +62,17 @@ export interface QueryEventsOptions {
  *           riskScore, anomalyFlags, timestamp, previousHash
  */
 
+// Serialize to canonical JSON: every plain object's keys are sorted at every
+// depth so the output is identical regardless of insertion order (e.g. after a
+// Postgres JSONB round-trip re-orders keys in `details`).
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_, v) =>
+    v !== null && typeof v === 'object' && !Array.isArray(v)
+      ? Object.fromEntries(Object.keys(v).sort().map(k => [k, v[k]]))
+      : v
+  );
+}
+
 /**
  * Compute SHA-256 hash for a security event.
  * Includes previous hash to create the chain link.
@@ -77,19 +88,19 @@ export function computeSecurityEventHash(
   previousHash: string,
   timestamp: Date
 ): string {
-  const data = JSON.stringify({
+  const payload = {
+    anomalyFlags: event.anomalyFlags ?? null,
+    details: event.details ?? null,
     eventType: event.eventType,
-    serviceId: event.serviceId,
-    resourceType: event.resourceType,
-    resourceId: event.resourceId,
-    details: event.details,
-    riskScore: event.riskScore,
-    anomalyFlags: event.anomalyFlags,
-    timestamp: timestamp.toISOString(),
     previousHash,
-  });
+    resourceId: event.resourceId ?? null,
+    resourceType: event.resourceType ?? null,
+    riskScore: event.riskScore ?? null,
+    serviceId: event.serviceId ?? null,
+    timestamp: timestamp.toISOString(),
+  };
 
-  return createHash('sha256').update(data).digest('hex');
+  return createHash('sha256').update(stableStringify(payload)).digest('hex');
 }
 
 /**

--- a/packages/lib/src/monitoring/__tests__/activity-logger.test.ts
+++ b/packages/lib/src/monitoring/__tests__/activity-logger.test.ts
@@ -253,6 +253,42 @@ describe('activity-logger', () => {
       const parsed = JSON.parse(serializeLogDataForHash(baseHashData));
       expect(parsed.timestamp).toBe(baseHashData.timestamp.toISOString());
     });
+
+    it('includes nested object content in previousValues, newValues, and metadata', () => {
+      const data = {
+        ...baseHashData,
+        previousValues: { title: 'old', count: 5 },
+        newValues: { title: 'new', count: 6 },
+        metadata: { source: 'api', traceId: 'abc' },
+      };
+      const parsed = JSON.parse(serializeLogDataForHash(data));
+
+      expect(parsed.previousValues).toEqual({ title: 'old', count: 5 });
+      expect(parsed.newValues).toEqual({ title: 'new', count: 6 });
+      expect(parsed.metadata).toEqual({ source: 'api', traceId: 'abc' });
+    });
+
+    it('produces the same serialization regardless of key order in nested objects (canonical JSON)', () => {
+      const dataA = {
+        ...baseHashData,
+        previousValues: { z: 1, a: 2 },
+        metadata: { source: 'api', traceId: 'xyz' },
+      };
+      const dataB = {
+        ...baseHashData,
+        previousValues: { a: 2, z: 1 },
+        metadata: { traceId: 'xyz', source: 'api' },
+      };
+
+      expect(serializeLogDataForHash(dataA)).toBe(serializeLogDataForHash(dataB));
+    });
+
+    it('produces different serialization for different nested object values', () => {
+      const dataA = { ...baseHashData, metadata: { source: 'api' } };
+      const dataB = { ...baseHashData, metadata: { source: 'webhook' } };
+
+      expect(serializeLogDataForHash(dataA)).not.toBe(serializeLogDataForHash(dataB));
+    });
   });
 
   // ── computeLogHash ────────────────────────────────────────────────────────

--- a/packages/lib/src/monitoring/activity-logger.ts
+++ b/packages/lib/src/monitoring/activity-logger.ts
@@ -10,6 +10,7 @@ import { db, activityLogs, users, eq } from '@pagespace/db';
 import { createId } from '@paralleldrive/cuid2';
 import { createHash, randomBytes } from 'crypto';
 import { desc, isNotNull, sql } from 'drizzle-orm';
+import { stableStringify } from '../utils/stable-stringify';
 
 /**
  * Advisory lock key for serializing activity log hash chain writes.
@@ -113,17 +114,6 @@ export function computeHash(data: string, previousHash: string): string {
   return createHash('sha256')
     .update(previousHash + data)
     .digest('hex');
-}
-
-// Serialize to canonical JSON: every plain object's keys are sorted at every
-// depth so the output is identical regardless of insertion order (e.g. after a
-// Postgres JSONB round-trip re-orders keys in `previousValues` or `metadata`).
-function stableStringify(value: unknown): string {
-  return JSON.stringify(value, (_, v) =>
-    v !== null && typeof v === 'object' && !Array.isArray(v)
-      ? Object.fromEntries(Object.keys(v).sort().map(k => [k, v[k]]))
-      : v
-  );
 }
 
 /**

--- a/packages/lib/src/monitoring/activity-logger.ts
+++ b/packages/lib/src/monitoring/activity-logger.ts
@@ -115,27 +115,35 @@ export function computeHash(data: string, previousHash: string): string {
     .digest('hex');
 }
 
+// Serialize to canonical JSON: every plain object's keys are sorted at every
+// depth so the output is identical regardless of insertion order (e.g. after a
+// Postgres JSONB round-trip re-orders keys in `previousValues` or `metadata`).
+function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_, v) =>
+    v !== null && typeof v === 'object' && !Array.isArray(v)
+      ? Object.fromEntries(Object.keys(v).sort().map(k => [k, v[k]]))
+      : v
+  );
+}
+
 /**
  * Serialize log entry data for hashing.
- * Creates a deterministic JSON string with sorted keys.
+ * Creates a deterministic canonical JSON string with sorted keys at every depth.
  */
 export function serializeLogDataForHash(data: HashableLogData): string {
-  const hashableObject = {
-    id: data.id,
-    timestamp: data.timestamp.toISOString(),
-    operation: data.operation,
-    resourceType: data.resourceType,
-    resourceId: data.resourceId,
-    driveId: data.driveId,
-    pageId: data.pageId ?? null,
+  return stableStringify({
     contentSnapshot: data.contentSnapshot ?? null,
-    previousValues: data.previousValues ?? null,
-    newValues: data.newValues ?? null,
+    driveId: data.driveId,
+    id: data.id,
     metadata: data.metadata ?? null,
-  };
-
-  // JSON.stringify with sorted keys for deterministic output
-  return JSON.stringify(hashableObject, Object.keys(hashableObject).sort());
+    newValues: data.newValues ?? null,
+    operation: data.operation,
+    pageId: data.pageId ?? null,
+    previousValues: data.previousValues ?? null,
+    resourceId: data.resourceId,
+    resourceType: data.resourceType,
+    timestamp: data.timestamp.toISOString(),
+  });
 }
 
 /**

--- a/packages/lib/src/utils/stable-stringify.ts
+++ b/packages/lib/src/utils/stable-stringify.ts
@@ -1,12 +1,5 @@
-/**
- * Serialize a value to canonical JSON with object keys sorted at every depth.
- *
- * Postgres JSONB does not guarantee key ordering on read-back, so any object
- * stored in a JSONB column can return with a different key order than it was
- * written. Using plain JSON.stringify over such values makes hash chains
- * non-deterministic. This replacer re-emits every plain object with its keys
- * sorted, producing the same output regardless of insertion order.
- */
+// Canonical JSON — sorts object keys at every depth so Postgres JSONB
+// round-trips produce the same hash as the original write.
 export function stableStringify(value: unknown): string {
   return JSON.stringify(value, (_, v) =>
     v !== null && typeof v === 'object' && !Array.isArray(v)

--- a/packages/lib/src/utils/stable-stringify.ts
+++ b/packages/lib/src/utils/stable-stringify.ts
@@ -1,0 +1,16 @@
+/**
+ * Serialize a value to canonical JSON with object keys sorted at every depth.
+ *
+ * Postgres JSONB does not guarantee key ordering on read-back, so any object
+ * stored in a JSONB column can return with a different key order than it was
+ * written. Using plain JSON.stringify over such values makes hash chains
+ * non-deterministic. This replacer re-emits every plain object with its keys
+ * sorted, producing the same output regardless of insertion order.
+ */
+export function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_, v) =>
+    v !== null && typeof v === 'object' && !Array.isArray(v)
+      ? Object.fromEntries(Object.keys(v).sort().map(k => [k, (v as Record<string, unknown>)[k]]))
+      : v
+  );
+}


### PR DESCRIPTION
## Problem

\`computeSecurityEventHash\` used plain \`JSON.stringify({...})\` over the payload, including \`details\` (a Postgres JSONB column). JavaScript object literal key order is deterministic at write time, but Postgres JSONB does not guarantee key ordering on read-back — so the verifier recomputed a different hash and reported \`entriesVerified: 0, invalidEntries: 1\` on the first entry.

\`serializeLogDataForHash\` in the activity logger had a related bug: it used the array-replacer form of \`JSON.stringify\`, which filters nested object keys against the top-level key list. Any content inside \`previousValues\`, \`newValues\`, or \`metadata\` was silently discarded, making tampering of those fields undetectable.

The \`/api/track\` route was also spreading \`ip\` and \`userAgent\` into \`enrichedData\`, which became the \`metadata\` JSONB column — a hashed field. Those are PII fields that must live only in dedicated columns excluded from the hash chain (GDPR #541 design).

## Fix

Replace all serialization calls with \`stableStringify\` — a \`JSON.stringify\` replacer that re-emits every plain object with its keys sorted at every depth. Extracted to a single shared export at \`@pagespace/lib/utils/stable-stringify\` so the write side (lib) and read side (processor SIEM hasher) use the exact same implementation with no risk of drift.

```typescript
export function stableStringify(value: unknown): string {
  return JSON.stringify(value, (_, v) =>
    v !== null && typeof v === 'object' && !Array.isArray(v)
      ? Object.fromEntries(Object.keys(v).sort().map(k => [k, v[k]]))
      : v
  );
}
```

## Files changed

- \`packages/lib/src/utils/stable-stringify.ts\` — new shared canonical-JSON utility
- \`packages/lib/src/audit/security-audit.ts\` — \`computeSecurityEventHash\` imports shared util
- \`packages/lib/src/monitoring/activity-logger.ts\` — \`serializeLogDataForHash\` imports shared util
- \`apps/processor/src/services/siem-chain-hashers.ts\` — read-side imports shared util (eliminates local copy)
- \`packages/lib/package.json\` — exports \`./utils/stable-stringify\`
- \`apps/web/src/app/api/track/route.ts\` — strip ip/userAgent from enrichedData; pass as top-level fields only
- Tests: key-order invariant tests; JSONB round-trip regression; PII exclusion; canonical nested objects

## Impact on existing chains

This is a **new feature** — the hash chain was not producing usable output prior to this PR:
1. The cron container lacked OpenSSL so HMAC signatures were never generated (fixed in `fix(cron)` commit)
2. The JSONB key-reorder bug meant stored hashes diverged from recomputed values immediately

There are no valid historical chains to preserve compatibility with. All entries written after this fix are correctly verifiable.

## Test plan

- [x] \`security-audit.test.ts\`: same hash for \`details: {a,b}\` vs \`{b,a}\` and for deeply nested reversed keys
- [x] \`security-audit-chain-verifier.test.ts\`: chain verifies after simulated JSONB key reordering
- [x] \`activity-logger.test.ts\`: nested object content preserved; canonical order stable; different values → different hash
- [x] \`route.test.ts\`: ip/userAgent absent from metadata, present as top-level call params
- [x] All unit tests pass