### PR TITLE
fix(typecheck): make web app typecheck pass alongside marketing

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -21,6 +21,8 @@
     ],
     "paths": {
       "@/*": ["apps/web/src/*"],
+      "@pagespace/lib/*": ["packages/lib/src/*"],
+      "@pagespace/db/*": ["packages/db/src/*"],
       "@pagespace/*": ["packages/*/src"]
     }
   },

--- a/packages/lib/src/activity-tracker.ts
+++ b/packages/lib/src/activity-tracker.ts
@@ -1,0 +1,1 @@
+export * from "./monitoring/activity-tracker";

--- a/packages/lib/src/ai-context-calculator.ts
+++ b/packages/lib/src/ai-context-calculator.ts
@@ -1,0 +1,1 @@
+export * from "./monitoring/ai-context-calculator";

--- a/packages/lib/src/ai-monitoring.ts
+++ b/packages/lib/src/ai-monitoring.ts
@@ -1,0 +1,1 @@
+export * from "./monitoring/ai-monitoring";

--- a/packages/lib/src/api-utils.ts
+++ b/packages/lib/src/api-utils.ts
@@ -1,0 +1,1 @@
+export * from "./utils/api-utils";

--- a/packages/lib/src/broadcast-auth.ts
+++ b/packages/lib/src/broadcast-auth.ts
@@ -1,0 +1,1 @@
+export * from "./auth/broadcast-auth";

--- a/packages/lib/src/device-auth-utils.ts
+++ b/packages/lib/src/device-auth-utils.ts
@@ -1,0 +1,1 @@
+export * from "./auth/device-auth-utils";

--- a/packages/lib/src/logger-browser.ts
+++ b/packages/lib/src/logger-browser.ts
@@ -1,0 +1,1 @@
+export * from "./logging/logger-browser";

--- a/packages/lib/src/logger-database.ts
+++ b/packages/lib/src/logger-database.ts
@@ -1,0 +1,1 @@
+export * from "./logging/logger-database";

--- a/packages/lib/src/secure-compare.ts
+++ b/packages/lib/src/secure-compare.ts
@@ -1,0 +1,1 @@
+export * from "./auth/secure-compare";

--- a/packages/lib/src/verification-utils.ts
+++ b/packages/lib/src/verification-utils.ts
@@ -1,0 +1,1 @@
+export * from "./auth/verification-utils";


### PR DESCRIPTION
## Summary

- Add `@pagespace/lib/*` and `@pagespace/db/*` specific path entries to `apps/web/tsconfig.json` — the generic `@pagespace/*` wildcard was expanding `@pagespace/lib/server` to `packages/lib/server/src` (wrong directory). This mirrors the same fix already in `apps/marketing/tsconfig.json` from #1051.
- Add 10 barrel re-export files at `packages/lib/src/` root for subpaths whose source lives under a subdirectory (`auth/`, `monitoring/`, `logging/`, `utils/`). This aligns the source layout with the `package.json` exports field and fixes resolution without requiring a build step.

**Result:** 1,222 TypeScript errors across 538 files → 0 errors. Both `pnpm --filter web typecheck` and `pnpm --filter marketing typecheck` pass clean.

## Test plan

- [x] `pnpm --filter web typecheck` — exits clean
- [x] `pnpm --filter marketing typecheck` — exits clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized library package modules with new top-level entry points for authentication, monitoring, logging, and utility services to improve import accessibility.
  * Updated TypeScript path aliases in the web application configuration for streamlined module resolution and cleaner import statements throughout the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->