### PR TITLE
fix(ui): tighten icon view layout and refresh page-type icons

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -7,6 +7,10 @@
 
 @custom-variant dark (&:is(.dark *));
 
+svg.lucide {
+  stroke-width: 1.5;
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);

--- a/apps/web/src/components/common/PageTypeIcon.tsx
+++ b/apps/web/src/components/common/PageTypeIcon.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import {
+  File,
+  FileCheck2,
+  FileCode,
+  FileImage,
+  FileSpreadsheet,
   FileText,
-  FileCheck,
   Folder,
-  MessageSquare,
-  Sparkles,
-  Palette,
-  FileIcon,
-  Table,
-  CheckSquare,
-  Code,
-  Terminal,
+  BotMessageSquare,
+  MessagesSquare,
+  SquareCheckBig,
+  SquareTerminal,
 } from 'lucide-react';
 import { PageType, getPageTypeIconName } from '@pagespace/lib/client-safe';
 
@@ -20,27 +20,24 @@ interface PageTypeIconProps {
   isTaskLinked?: boolean;
 }
 
-// Map icon names to actual icon components
 const iconMap = {
   Folder,
   FileText,
-  FileCheck,
-  MessageSquare,
-  Sparkles,
-  Palette,
-  FileIcon,
-  Table,
-  CheckSquare,
-  Code,
-  Terminal,
+  FileCheck2,
+  FileCode,
+  FileImage,
+  FileSpreadsheet,
+  File,
+  MessagesSquare,
+  BotMessageSquare,
+  SquareTerminal,
 } as const;
 
 export function PageTypeIcon({ type, className, isTaskLinked }: PageTypeIconProps) {
   const iconName = getPageTypeIconName(type);
 
-  // Use FileCheck icon for task-linked documents
   if (type === 'DOCUMENT' && isTaskLinked) {
-    return <FileCheck className={className} />;
+    return <SquareCheckBig className={className} />;
   }
 
   const Icon = iconMap[iconName as keyof typeof iconMap] || FileText;

--- a/apps/web/src/components/drives/DrivesBrowser.tsx
+++ b/apps/web/src/components/drives/DrivesBrowser.tsx
@@ -44,9 +44,9 @@ export function DrivesSkeleton() {
               <Skeleton className="h-9 w-28" />
             </div>
           </div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+          <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10 gap-1">
             {Array.from({ length: 6 }).map((_, i) => (
-              <Skeleton key={i} className="aspect-square rounded-lg" />
+              <Skeleton key={i} className="h-20 rounded-lg" />
             ))}
           </div>
         </div>
@@ -179,24 +179,24 @@ export default function DrivesBrowser() {
   );
 
   const renderDriveGrid = (driveList: Drive[]) => (
-    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+    <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10 gap-1">
       {driveList.map((drive) => (
         <DriveContextMenu key={drive.id} drive={drive}>
           <button
             onClick={() => handleDriveClick(drive)}
-            className="flex flex-col items-center justify-center p-4 border rounded-lg hover:bg-accent transition-colors aspect-square w-full text-left"
+            className="flex flex-col items-center gap-1.5 pt-2 pb-1.5 px-1 rounded-lg hover:bg-accent transition-colors w-full text-left cursor-pointer"
           >
-            <Folder className="h-10 w-10 mb-2 text-primary" />
-            <span className="text-sm font-medium text-center truncate w-full">
+            <Folder className="h-12 w-12 shrink-0 text-primary" />
+            <span className="text-xs text-center line-clamp-2 w-full leading-tight break-words">
               {drive.name}
             </span>
             {drive.role && drive.role !== "OWNER" && (
-              <span className="text-xs text-muted-foreground mt-1">
+              <span className="text-xs text-muted-foreground">
                 {formatRole(drive.role)}
               </span>
             )}
             {isFavorite(drive.id, "drive") && (
-              <Star className="h-3 w-3 fill-yellow-500 text-yellow-500 mt-1" />
+              <Star className="h-3 w-3 fill-yellow-500 text-yellow-500" />
             )}
           </button>
         </DriveContextMenu>

--- a/apps/web/src/components/layout/middle-content/page-views/folder/GridView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/folder/GridView.tsx
@@ -9,12 +9,12 @@ export function GridView({ items }: GridViewProps) {
   const driveId = params.driveId as string;
 
   return (
-    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
+    <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10 gap-1">
       {items.map((child) => (
         <Link key={child.id} href={`/dashboard/${driveId}/${child.id}`}>
-          <div className="flex flex-col items-center justify-center p-2 border rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors aspect-square">
-            <PageTypeIcon type={child.type as PageType} className="h-10 w-10 mb-2" />
-            <span className="text-sm font-medium text-center truncate w-full">
+          <div className="flex flex-col items-center gap-1.5 pt-2 pb-1.5 px-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors cursor-pointer">
+            <PageTypeIcon type={child.type as PageType} className="h-12 w-12 shrink-0" />
+            <span className="text-xs text-center line-clamp-2 w-full leading-tight break-words">
               {child.title}
             </span>
           </div>

--- a/packages/lib/src/content/page-types.config.ts
+++ b/packages/lib/src/content/page-types.config.ts
@@ -19,7 +19,7 @@ export interface PageTypeConfig {
   type: PageType;
   displayName: string;
   description: string;
-  iconName: 'Folder' | 'FileText' | 'MessageSquare' | 'Sparkles' | 'Palette' | 'FileIcon' | 'Table' | 'CheckSquare' | 'Code' | 'Terminal';
+  iconName: 'Folder' | 'FileText' | 'MessagesSquare' | 'BotMessageSquare' | 'FileImage' | 'File' | 'FileSpreadsheet' | 'FileCheck2' | 'FileCode' | 'SquareTerminal';
   emoji: string;
   capabilities: PageTypeCapabilities;
   defaultContent: () => string | Record<string, unknown>;
@@ -68,7 +68,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
     type: PageType.CHANNEL,
     displayName: 'Channel',
     description: 'Team discussion channel',
-    iconName: 'MessageSquare',
+    iconName: 'MessagesSquare',
     emoji: '💬',
     capabilities: {
       canAcceptUploads: false,
@@ -85,7 +85,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
     type: PageType.AI_CHAT,
     displayName: 'AI Chat',
     description: 'AI-powered conversation space',
-    iconName: 'Sparkles',
+    iconName: 'BotMessageSquare',
     emoji: '🤖',
     capabilities: {
       canAcceptUploads: false,
@@ -105,7 +105,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
     type: PageType.CANVAS,
     displayName: 'Canvas',
     description: 'Custom HTML/CSS page',
-    iconName: 'Palette',
+    iconName: 'FileImage',
     emoji: '🎨',
     capabilities: {
       canAcceptUploads: false,
@@ -122,7 +122,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
     type: PageType.FILE,
     displayName: 'File',
     description: 'Uploaded file with metadata',
-    iconName: 'FileIcon',
+    iconName: 'File',
     emoji: '📎',
     capabilities: {
       canAcceptUploads: false,
@@ -139,7 +139,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
     type: PageType.SHEET,
     displayName: 'Sheet',
     description: 'Interactive spreadsheet with formulas',
-    iconName: 'Table',
+    iconName: 'FileSpreadsheet',
     emoji: '📊',
     capabilities: {
       canAcceptUploads: false,
@@ -156,7 +156,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
     type: PageType.TASK_LIST,
     displayName: 'Task List',
     description: 'Table-based task management',
-    iconName: 'CheckSquare',
+    iconName: 'FileCheck2',
     emoji: '✅',
     capabilities: {
       canAcceptUploads: false,
@@ -173,7 +173,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
     type: PageType.CODE,
     displayName: 'Code',
     description: 'Code editor with syntax highlighting',
-    iconName: 'Code',
+    iconName: 'FileCode',
     emoji: '💻',
     capabilities: {
       canAcceptUploads: false,
@@ -190,7 +190,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
     type: PageType.TERMINAL,
     displayName: 'Terminal',
     description: 'Interactive terminal with shell access',
-    iconName: 'Terminal',
+    iconName: 'SquareTerminal',
     emoji: '🖥️',
     capabilities: {
       canAcceptUploads: false,


### PR DESCRIPTION
## Summary

- Replace bordered square cards in drives and folder grid views with compact OS-style icon+label layout — no border, content-driven height, denser column grid (3→10 cols across breakpoints)
- Swap all generic Lucide icons for semantic file-type equivalents (`FileText`, `FileCode`, `FileSpreadsheet`, `FileImage`, `FileCheck2`, `MessagesSquare`, `BotMessageSquare`, `SquareTerminal`, etc.)
- Task-linked document pages now use `SquareCheckBig`
- Sidebar page tree and recents/favorites update automatically via the shared `PageTypeIcon` component
- Thin all Lucide icon stroke widths to 1.5 site-wide via `svg.lucide { stroke-width: 1.5 }` in globals.css

## Test plan

- [ ] Open `/dashboard/drives` — drives render as compact icon+label pairs, no card borders, more items per row
- [ ] Open a folder page, switch to icon/grid view — same compact layout, correct file-type icons per page type
- [ ] Hover items — subtle rounded background only, no border
- [ ] Long names wrap to 2 lines then ellipsis
- [ ] Sidebar page tree shows updated icons for all page types
- [ ] List views on drives and folder pages are unaffected
- [ ] Lucide icons across the app appear with thinner strokes

🤖 Generated with [Claude Code](https://claude.com/claude-code)