### PR TITLE
fix(notifications): fix dark mode hover contrast

### DIFF
--- a/apps/web/src/components/notifications/NotificationItem.tsx
+++ b/apps/web/src/components/notifications/NotificationItem.tsx
@@ -71,7 +71,7 @@ export function NotificationItem({
       className={cn(
         'group relative grid grid-cols-[0.5rem_auto_1fr_auto] items-start gap-x-3 gap-y-1 rounded-md border border-transparent bg-card text-card-foreground transition-colors',
         containerClasses[variant],
-        isInteractive && 'cursor-pointer hover:bg-accent focus-visible:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        isInteractive && 'cursor-pointer hover:bg-accent hover:text-accent-foreground focus-visible:bg-accent focus-visible:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
         isUnread && 'bg-accent/40',
       )}
     >
@@ -89,6 +89,7 @@ export function NotificationItem({
           'flex items-center justify-center rounded-full bg-muted text-muted-foreground',
           iconWrapClasses[variant],
           isUnread && 'bg-primary/10 text-primary',
+          isInteractive && 'group-hover:text-accent-foreground',
         )}
       >
         <Icon className="size-4" aria-hidden />
@@ -103,10 +104,10 @@ export function NotificationItem({
         >
           {notification.title}
         </p>
-        <p className="mt-0.5 line-clamp-2 text-sm leading-5 text-muted-foreground">
+        <p className={cn('mt-0.5 line-clamp-2 text-sm leading-5 text-muted-foreground', isInteractive && 'group-hover:text-accent-foreground')}>
           {notification.message}
         </p>
-        <div className="mt-1.5 flex flex-wrap items-center gap-x-1.5 text-xs text-muted-foreground">
+        <div className={cn('mt-1.5 flex flex-wrap items-center gap-x-1.5 text-xs text-muted-foreground', isInteractive && 'group-hover:text-accent-foreground')}>
           <time dateTime={new Date(notification.createdAt).toISOString()}>{timestamp}</time>
           {triggeredByName ? (
             <>


### PR DESCRIPTION
## Summary

- Notification dropdown items showed `hover:bg-accent` (bright blue in dark mode) but message body and timestamp text stayed in `text-muted-foreground`, creating near-invisible text on hover
- Applied the same fix pattern used in `SettingsRow.tsx` (58cbdaf99): pair the background flip with `hover:text-accent-foreground` on the container and `group-hover:text-accent-foreground` on nested muted-text elements
- Only affects interactive items (`isInteractive` guard); non-clickable notification items are unchanged

## Changes

- `apps/web/src/components/notifications/NotificationItem.tsx`
  - Container: added `hover:text-accent-foreground` and `focus-visible:text-accent-foreground`
  - Icon wrapper: added `group-hover:text-accent-foreground`
  - Message body `<p>`: added `group-hover:text-accent-foreground`
  - Timestamp/meta row `<div>`: added `group-hover:text-accent-foreground`

## Test plan

- [ ] Open notifications dropdown in dark mode, hover over a notification — message, timestamp, and icon should now be bright (`accent-foreground`), not dim gray
- [ ] Verify unread items (tinted `bg-accent/40`) also transition cleanly on hover
- [ ] Tab into a notification item — `focus-visible` state should show the same contrast
- [ ] Verify light mode is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)