### PR TITLE
fix(ui): remove bordered cards from file system grid views

### DIFF
--- a/apps/web/src/components/files/FilesGridView.tsx
+++ b/apps/web/src/components/files/FilesGridView.tsx
@@ -16,15 +16,15 @@ export function FilesGridView({ items, driveId, onMutate }: FilesGridViewProps) 
   const router = useRouter();
 
   return (
-    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
+    <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10 gap-1">
       {items.map((item) => (
         <FileItemContextMenu key={item.id} item={item} driveId={driveId} onMutate={onMutate}>
           <div
-            className="flex flex-col items-center justify-center p-2 border rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors aspect-square cursor-pointer"
+            className="flex flex-col items-center gap-1.5 pt-2 pb-1.5 px-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors cursor-pointer"
             onClick={() => router.push(`/dashboard/${driveId}/files/${item.id}`)}
           >
-            <PageTypeIcon type={item.type as PageType} className="h-10 w-10 mb-2" />
-            <span className="text-sm font-medium text-center truncate w-full">
+            <PageTypeIcon type={item.type as PageType} className="h-12 w-12 shrink-0" />
+            <span className="text-xs text-center line-clamp-2 w-full leading-tight break-words">
               {item.title}
             </span>
           </div>

--- a/apps/web/src/components/layout/middle-content/page-views/folder/GridView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/folder/GridView.tsx
@@ -9,12 +9,12 @@ export function GridView({ items }: GridViewProps) {
   const driveId = params.driveId as string;
 
   return (
-    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
+    <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10 gap-1">
       {items.map((child) => (
         <Link key={child.id} href={`/dashboard/${driveId}/${child.id}`}>
-          <div className="flex flex-col items-center justify-center p-2 border rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors aspect-square">
-            <PageTypeIcon type={child.type as PageType} className="h-10 w-10 mb-2" />
-            <span className="text-sm font-medium text-center truncate w-full">
+          <div className="flex flex-col items-center gap-1.5 pt-2 pb-1.5 px-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors cursor-pointer">
+            <PageTypeIcon type={child.type as PageType} className="h-12 w-12 shrink-0" />
+            <span className="text-xs text-center line-clamp-2 w-full leading-tight break-words">
               {child.title}
             </span>
           </div>


### PR DESCRIPTION
## Summary

- Remove bordered `aspect-square` card layout from folder `GridView` and `FilesGridView` inside drives — match the compact OS-style icon+label layout already live in `DrivesBrowser` (no border, `h-12 w-12` icon, denser grid)
- Unify the Files view header: at drive root, render `h1 text-2xl font-bold {driveName}` matching the Drives page; inside a subfolder, breadcrumbs sit inline with controls in one flex row (no more orphaned/disconnected layout)
- Add **New Page** button to the Files header for owners/admins, wired to `CreatePageDialog` (previously only existed in the empty state)

## Test plan

- [ ] Folder grid view inside a drive — confirm no border boxes around icons, icons match drives page aesthetic
- [ ] `/dashboard/[driveId]/files/` — bold drive name in top-left, view toggles + New Page button on right
- [ ] Navigate into a subfolder — breadcrumb path replaces drive name, controls stay on the right
- [ ] Click New Page when content exists — dialog opens and creates page
- [ ] Read-only drive — New Page button absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)