### PR TITLE
fix(ui): unify Files view header — bold title + New Page button

### DIFF
--- a/apps/web/src/components/files/FilesBreadcrumbs.tsx
+++ b/apps/web/src/components/files/FilesBreadcrumbs.tsx
@@ -34,7 +34,7 @@ export function FilesBreadcrumbs({ driveId, driveName, currentPageId, tree }: Fi
   const rootHref = `/dashboard/${driveId}/files`;
 
   return (
-    <nav className="flex items-center gap-1 text-sm text-muted-foreground mb-4" aria-label="Breadcrumb">
+    <nav className="flex items-center gap-1 text-sm text-muted-foreground" aria-label="Breadcrumb">
       {currentPageId ? (
         <Link href={rootHref} className="hover:text-foreground transition-colors">
           {driveName}

--- a/apps/web/src/components/files/FilesBreadcrumbs.tsx
+++ b/apps/web/src/components/files/FilesBreadcrumbs.tsx
@@ -34,7 +34,7 @@ export function FilesBreadcrumbs({ driveId, driveName, currentPageId, tree }: Fi
   const rootHref = `/dashboard/${driveId}/files`;
 
   return (
-    <nav className="flex items-center gap-1 text-sm text-muted-foreground" aria-label="Breadcrumb">
+    <nav className="flex items-center gap-1 text-sm text-muted-foreground min-w-0 overflow-hidden" aria-label="Breadcrumb">
       {currentPageId ? (
         <Link href={rootHref} className="hover:text-foreground transition-colors">
           {driveName}
@@ -49,7 +49,7 @@ export function FilesBreadcrumbs({ driveId, driveName, currentPageId, tree }: Fi
           <span key={crumb.id} className="flex items-center gap-1">
             <ChevronRight className="h-3.5 w-3.5" />
             {isLast ? (
-              <span className="text-foreground font-medium">{crumb.title}</span>
+              <span className="text-foreground font-medium truncate">{crumb.title}</span>
             ) : (
               <Link
                 href={`${rootHref}/${crumb.id}`}

--- a/apps/web/src/components/files/FilesFinderContent.tsx
+++ b/apps/web/src/components/files/FilesFinderContent.tsx
@@ -105,18 +105,20 @@ export function FilesFinderContent({ driveId, currentPageId }: FilesFinderConten
   return (
     <div className="h-full overflow-y-auto">
       <div className="container mx-auto px-4 py-10 sm:px-6 lg:px-10 max-w-5xl">
-        <div className="flex items-center justify-between mb-6">
-          {currentPageId ? (
-            <FilesBreadcrumbs
-              driveId={driveId}
-              driveName={driveName}
-              currentPageId={currentPageId}
-              tree={tree}
-            />
-          ) : (
-            <h1 className="text-2xl font-bold">{driveName}</h1>
-          )}
-          <div className="flex items-center gap-2">
+        <div className="flex items-center justify-between gap-4 mb-6">
+          <div className="min-w-0 flex-1">
+            {currentPageId ? (
+              <FilesBreadcrumbs
+                driveId={driveId}
+                driveName={driveName}
+                currentPageId={currentPageId}
+                tree={tree}
+              />
+            ) : (
+              <h1 className="text-2xl font-bold truncate">{driveName}</h1>
+            )}
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
             <Button variant={viewMode === 'list' ? 'secondary' : 'ghost'} size="icon" onClick={() => setViewMode('list')}>
               <List className="h-4 w-4" />
             </Button>

--- a/apps/web/src/components/files/FilesFinderContent.tsx
+++ b/apps/web/src/components/files/FilesFinderContent.tsx
@@ -2,11 +2,13 @@
 
 import { useState, useMemo } from 'react';
 import Link from 'next/link';
+import { Grip, List, Plus } from 'lucide-react';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Button } from '@/components/ui/button';
 import { usePageTree } from '@/hooks/usePageTree';
 import { useDriveStore } from '@/hooks/useDrive';
 import { findNodeAndParent } from '@/lib/tree/tree-utils';
-import { FolderViewHeader } from '@/components/layout/middle-content/page-views/folder/FolderViewHeader';
+import CreatePageDialog from '@/components/layout/left-sidebar/CreatePageDialog';
 import { FilesBreadcrumbs } from './FilesBreadcrumbs';
 import { FilesGridView } from './FilesGridView';
 import { FilesListView } from './FilesListView';
@@ -26,6 +28,7 @@ export function FilesFinderContent({ driveId, currentPageId }: FilesFinderConten
   const canWrite = drive?.role === 'OWNER' || drive?.role === 'ADMIN';
 
   const [viewMode, setViewMode] = useState<ViewMode>('list');
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [sortKey, setSortKey] = useState<SortKey>('title');
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
 
@@ -102,13 +105,32 @@ export function FilesFinderContent({ driveId, currentPageId }: FilesFinderConten
   return (
     <div className="h-full overflow-y-auto">
       <div className="container mx-auto px-4 py-10 sm:px-6 lg:px-10 max-w-5xl">
-        <FilesBreadcrumbs
-          driveId={driveId}
-          driveName={driveName}
-          currentPageId={currentPageId}
-          tree={tree}
-        />
-        <FolderViewHeader viewMode={viewMode} onViewChange={setViewMode} />
+        <div className="flex items-center justify-between mb-6">
+          {currentPageId ? (
+            <FilesBreadcrumbs
+              driveId={driveId}
+              driveName={driveName}
+              currentPageId={currentPageId}
+              tree={tree}
+            />
+          ) : (
+            <h1 className="text-2xl font-bold">{driveName}</h1>
+          )}
+          <div className="flex items-center gap-2">
+            <Button variant={viewMode === 'list' ? 'secondary' : 'ghost'} size="icon" onClick={() => setViewMode('list')}>
+              <List className="h-4 w-4" />
+            </Button>
+            <Button variant={viewMode === 'grid' ? 'secondary' : 'ghost'} size="icon" onClick={() => setViewMode('grid')}>
+              <Grip className="h-4 w-4" />
+            </Button>
+            {canWrite && (
+              <Button size="sm" onClick={() => setIsDialogOpen(true)}>
+                <Plus className="h-4 w-4 mr-1" />
+                New Page
+              </Button>
+            )}
+          </div>
+        </div>
 
         {sortedItems.length === 0 ? (
           <FilesEmptyState
@@ -130,6 +152,18 @@ export function FilesFinderContent({ driveId, currentPageId }: FilesFinderConten
           />
         )}
       </div>
+      {canWrite && (
+        <CreatePageDialog
+          driveId={driveId}
+          parentId={currentPageId}
+          isOpen={isDialogOpen}
+          setIsOpen={setIsDialogOpen}
+          onPageCreated={() => {
+            handleMutate();
+            setIsDialogOpen(false);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/files/FilesGridView.tsx
+++ b/apps/web/src/components/files/FilesGridView.tsx
@@ -16,15 +16,15 @@ export function FilesGridView({ items, driveId, onMutate }: FilesGridViewProps) 
   const router = useRouter();
 
   return (
-    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
+    <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10 gap-1">
       {items.map((item) => (
         <FileItemContextMenu key={item.id} item={item} driveId={driveId} onMutate={onMutate}>
           <div
-            className="flex flex-col items-center justify-center p-2 border rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors aspect-square cursor-pointer"
+            className="flex flex-col items-center gap-1.5 pt-2 pb-1.5 px-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors cursor-pointer"
             onClick={() => router.push(`/dashboard/${driveId}/files/${item.id}`)}
           >
-            <PageTypeIcon type={item.type as PageType} className="h-10 w-10 mb-2" />
-            <span className="text-sm font-medium text-center truncate w-full">
+            <PageTypeIcon type={item.type as PageType} className="h-12 w-12 shrink-0" />
+            <span className="text-xs text-center line-clamp-2 w-full leading-tight break-words">
               {item.title}
             </span>
           </div>

--- a/apps/web/src/components/layout/middle-content/page-views/folder/GridView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/folder/GridView.tsx
@@ -9,12 +9,12 @@ export function GridView({ items }: GridViewProps) {
   const driveId = params.driveId as string;
 
   return (
-    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8 gap-4">
+    <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10 gap-1">
       {items.map((child) => (
         <Link key={child.id} href={`/dashboard/${driveId}/${child.id}`}>
-          <div className="flex flex-col items-center justify-center p-2 border rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors aspect-square">
-            <PageTypeIcon type={child.type as PageType} className="h-10 w-10 mb-2" />
-            <span className="text-sm font-medium text-center truncate w-full">
+          <div className="flex flex-col items-center gap-1.5 pt-2 pb-1.5 px-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors cursor-pointer">
+            <PageTypeIcon type={child.type as PageType} className="h-12 w-12 shrink-0" />
+            <span className="text-xs text-center line-clamp-2 w-full leading-tight break-words">
               {child.title}
             </span>
           </div>


### PR DESCRIPTION
## Summary

- At drive root, render `h1 text-2xl font-bold {driveName}` matching the Drives page aesthetic — replaces the orphaned small `text-sm` drive name
- Breadcrumbs and view toggles now live in one `flex items-center justify-between` row (previously two disconnected rows)
- Adds **New Page** button for owners/admins in the header, wired to `CreatePageDialog` (previously only in the empty state)
- Removes `mb-4` from `FilesBreadcrumbs` nav — spacing now comes from the parent header div

## Test plan

- [ ] `/dashboard/[driveId]/files/` — bold drive name top-left, view toggles + New Page button on right
- [ ] Navigate into a subfolder — breadcrumb path replaces drive name, controls stay right
- [ ] Click New Page when content exists — dialog opens and creates page
- [ ] Read-only drive — New Page button absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)