### PR TITLE
fix(gdpr): close Art. 17 right-to-erasure gaps in account deletion

### DIFF
--- a/apps/web/src/app/api/account/__tests__/delete-route.test.ts
+++ b/apps/web/src/app/api/account/__tests__/delete-route.test.ts
@@ -24,6 +24,7 @@ vi.mock('@pagespace/lib/server', () => ({
   },
   audit: vi.fn(),
   auditRequest: vi.fn(),
+  revokeUserIntegrationTokens: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -35,6 +36,15 @@ vi.mock('@pagespace/lib', () => ({
   createUserServiceToken: vi.fn(),
   deleteAiUsageLogsForUser: vi.fn(),
   deleteMonitoringDataForUser: vi.fn(),
+  isCloud: vi.fn(),
+}));
+
+vi.mock('@/lib/stripe/client', () => ({
+  stripe: {
+    customers: {
+      del: vi.fn(),
+    },
+  },
 }));
 
 import { DELETE } from '../route';
@@ -42,9 +52,11 @@ import {
   loggers,
   accountRepository,
   activityLogRepository,
+  revokeUserIntegrationTokens,
 } from '@pagespace/lib/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { createUserServiceToken, deleteMonitoringDataForUser } from '@pagespace/lib';
+import { createUserServiceToken, deleteMonitoringDataForUser, isCloud } from '@pagespace/lib';
+import { stripe } from '@/lib/stripe/client';
 
 // Type the mocked repositories
 const mockAccountRepo = vi.mocked(accountRepository);
@@ -78,11 +90,12 @@ describe('DELETE /api/account', () => {
     );
     vi.mocked(isAuthError).mockReturnValue(false);
 
-    // Arrange: default user exists
+    // Arrange: default user exists (includes stripeCustomerId for #910)
     mockAccountRepo.findById.mockResolvedValue({
       id: mockUserId,
       email: mockUserEmail,
       image: null,
+      stripeCustomerId: null,
     });
 
     // Arrange: default no owned drives
@@ -92,6 +105,12 @@ describe('DELETE /api/account', () => {
     mockAccountRepo.deleteDrive.mockResolvedValue(undefined);
     mockAccountRepo.deleteUser.mockResolvedValue(undefined);
     mockActivityLogRepo.anonymizeForUser.mockResolvedValue({ success: true });
+
+    // Arrange: default non-cloud (no Stripe calls)
+    vi.mocked(isCloud).mockReturnValue(false);
+
+    // Arrange: default successful OAuth revocation (#911)
+    vi.mocked(revokeUserIntegrationTokens).mockResolvedValue({ revoked: 0, failed: 0 });
   });
 
   describe('email confirmation validation', () => {
@@ -284,6 +303,7 @@ describe('DELETE /api/account', () => {
         id: mockUserId,
         email: mockUserEmail,
         image: '/avatars/user_123.jpg',
+        stripeCustomerId: null,
       });
 
       global.fetch = vi.fn().mockResolvedValue({
@@ -317,6 +337,7 @@ describe('DELETE /api/account', () => {
         id: mockUserId,
         email: mockUserEmail,
         image: 'https://example.com/avatar.jpg',
+        stripeCustomerId: null,
       });
 
       global.fetch = vi.fn();
@@ -339,6 +360,7 @@ describe('DELETE /api/account', () => {
         id: mockUserId,
         email: mockUserEmail,
         image: '/avatars/user_123.jpg',
+        stripeCustomerId: null,
       });
 
       vi.mocked(createUserServiceToken).mockRejectedValueOnce(new Error('Token creation failed'));
@@ -492,6 +514,200 @@ describe('DELETE /api/account', () => {
       expect(loggers.auth.error).toHaveBeenCalledWith(
         'Account deletion error:',
         expect.objectContaining({ message: 'Database connection lost' })
+      );
+    });
+  });
+
+  describe('stripe customer deletion (#910)', () => {
+    it('given stripeCustomerId and cloud mode, should delete Stripe customer after account deletion', async () => {
+      // Arrange
+      mockAccountRepo.findById.mockResolvedValue({
+        id: mockUserId,
+        email: mockUserEmail,
+        image: null,
+        stripeCustomerId: 'cus_test123',
+      });
+      vi.mocked(isCloud).mockReturnValue(true);
+      vi.mocked(stripe.customers.del).mockResolvedValue({} as never);
+
+      const request = new Request('https://example.com/api/account', {
+        method: 'DELETE',
+        body: JSON.stringify({ emailConfirmation: mockUserEmail }),
+      });
+
+      // Act
+      const response = await DELETE(request);
+
+      // Assert
+      expect(response.status).toBe(200);
+      expect(stripe.customers.del).toHaveBeenCalledWith('cus_test123');
+    });
+
+    it('given null stripeCustomerId, should not call Stripe delete', async () => {
+      // Arrange — default beforeEach already has stripeCustomerId: null
+      vi.mocked(isCloud).mockReturnValue(true);
+
+      const request = new Request('https://example.com/api/account', {
+        method: 'DELETE',
+        body: JSON.stringify({ emailConfirmation: mockUserEmail }),
+      });
+
+      // Act
+      const response = await DELETE(request);
+
+      // Assert
+      expect(response.status).toBe(200);
+      expect(stripe.customers.del).not.toHaveBeenCalled();
+    });
+
+    it('given non-cloud deployment, should not call Stripe delete even with stripeCustomerId', async () => {
+      // Arrange
+      mockAccountRepo.findById.mockResolvedValue({
+        id: mockUserId,
+        email: mockUserEmail,
+        image: null,
+        stripeCustomerId: 'cus_onprem123',
+      });
+      vi.mocked(isCloud).mockReturnValue(false);
+
+      const request = new Request('https://example.com/api/account', {
+        method: 'DELETE',
+        body: JSON.stringify({ emailConfirmation: mockUserEmail }),
+      });
+
+      // Act
+      const response = await DELETE(request);
+
+      // Assert
+      expect(response.status).toBe(200);
+      expect(stripe.customers.del).not.toHaveBeenCalled();
+    });
+
+    it('given Stripe API failure, should log error but not block deletion', async () => {
+      // Arrange
+      mockAccountRepo.findById.mockResolvedValue({
+        id: mockUserId,
+        email: mockUserEmail,
+        image: null,
+        stripeCustomerId: 'cus_test123',
+      });
+      vi.mocked(isCloud).mockReturnValue(true);
+      vi.mocked(stripe.customers.del).mockRejectedValue(new Error('Stripe API unavailable'));
+
+      const request = new Request('https://example.com/api/account', {
+        method: 'DELETE',
+        body: JSON.stringify({ emailConfirmation: mockUserEmail }),
+      });
+
+      // Act
+      const response = await DELETE(request);
+
+      // Assert — user deleted, Stripe failure only logged
+      expect(response.status).toBe(200);
+      expect(mockAccountRepo.deleteUser).toHaveBeenCalledWith(mockUserId);
+      expect(loggers.auth.error).toHaveBeenCalledWith(
+        'Could not delete Stripe customer during account deletion:',
+        expect.objectContaining({ message: 'Stripe API unavailable' })
+      );
+    });
+
+    it('given Stripe deletion, should call deleteUser BEFORE stripe.customers.del', async () => {
+      // Arrange — right to erasure cannot be gated on Stripe API availability
+      mockAccountRepo.findById.mockResolvedValue({
+        id: mockUserId,
+        email: mockUserEmail,
+        image: null,
+        stripeCustomerId: 'cus_test123',
+      });
+      vi.mocked(isCloud).mockReturnValue(true);
+
+      const callOrder: string[] = [];
+      mockAccountRepo.deleteUser.mockImplementation(async () => {
+        callOrder.push('deleteUser');
+      });
+      vi.mocked(stripe.customers.del).mockImplementation(async () => {
+        callOrder.push('stripeDel');
+        return {} as never;
+      });
+
+      const request = new Request('https://example.com/api/account', {
+        method: 'DELETE',
+        body: JSON.stringify({ emailConfirmation: mockUserEmail }),
+      });
+
+      // Act
+      await DELETE(request);
+
+      // Assert — DB deletion before Stripe
+      expect(callOrder.indexOf('deleteUser')).toBeLessThan(callOrder.indexOf('stripeDel'));
+    });
+  });
+
+  describe('oauth token revocation (#911)', () => {
+    it('given active oauth connections, should revoke tokens before user deletion', async () => {
+      // Arrange
+      const callOrder: string[] = [];
+      vi.mocked(revokeUserIntegrationTokens).mockImplementation(async () => {
+        callOrder.push('revokeTokens');
+        return { revoked: 2, failed: 0 };
+      });
+      mockAccountRepo.deleteUser.mockImplementation(async () => {
+        callOrder.push('deleteUser');
+      });
+
+      const request = new Request('https://example.com/api/account', {
+        method: 'DELETE',
+        body: JSON.stringify({ emailConfirmation: mockUserEmail }),
+      });
+
+      // Act
+      const response = await DELETE(request);
+
+      // Assert — revoke before delete
+      expect(response.status).toBe(200);
+      expect(revokeUserIntegrationTokens).toHaveBeenCalledWith(mockUserId);
+      expect(callOrder.indexOf('revokeTokens')).toBeLessThan(callOrder.indexOf('deleteUser'));
+    });
+
+    it('given oauth revocation failure, should log error but not block deletion', async () => {
+      // Arrange
+      vi.mocked(revokeUserIntegrationTokens).mockRejectedValue(
+        new Error('Revocation service down')
+      );
+
+      const request = new Request('https://example.com/api/account', {
+        method: 'DELETE',
+        body: JSON.stringify({ emailConfirmation: mockUserEmail }),
+      });
+
+      // Act
+      const response = await DELETE(request);
+
+      // Assert
+      expect(response.status).toBe(200);
+      expect(mockAccountRepo.deleteUser).toHaveBeenCalledWith(mockUserId);
+      expect(loggers.auth.error).toHaveBeenCalledWith(
+        'Could not revoke OAuth tokens during account deletion:',
+        expect.objectContaining({ message: 'Revocation service down' })
+      );
+    });
+
+    it('given partial revocation failures, should log the counts and continue', async () => {
+      // Arrange
+      vi.mocked(revokeUserIntegrationTokens).mockResolvedValue({ revoked: 1, failed: 2 });
+
+      const request = new Request('https://example.com/api/account', {
+        method: 'DELETE',
+        body: JSON.stringify({ emailConfirmation: mockUserEmail }),
+      });
+
+      // Act
+      const response = await DELETE(request);
+
+      // Assert
+      expect(response.status).toBe(200);
+      expect(loggers.auth.info).toHaveBeenCalledWith(
+        expect.stringMatching(/revoked=1.*failed=2|OAuth.*1.*2/i)
       );
     });
   });

--- a/apps/web/src/app/api/account/route.ts
+++ b/apps/web/src/app/api/account/route.ts
@@ -1,10 +1,11 @@
 import { users, db, eq } from '@pagespace/db';
 import { z } from 'zod';
-import { loggers, accountRepository, activityLogRepository, auditRequest } from '@pagespace/lib/server';
+import { loggers, accountRepository, activityLogRepository, auditRequest, revokeUserIntegrationTokens } from '@pagespace/lib/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { createUserServiceToken, deleteAiUsageLogsForUser, deleteMonitoringDataForUser, isValidEmail, type ServiceScope } from '@pagespace/lib';
+import { createUserServiceToken, deleteAiUsageLogsForUser, deleteMonitoringDataForUser, isValidEmail, isCloud, type ServiceScope } from '@pagespace/lib';
 import { createAnonymizedActorEmail } from '@pagespace/lib/compliance/anonymize';
 import { getActorInfo, logUserActivity } from '@pagespace/lib/monitoring/activity-logger';
+import { stripe } from '@/lib/stripe/client';
 
 const patchBodySchema = z
   .object({
@@ -268,12 +269,33 @@ export async function DELETE(req: Request) {
       loggers.auth.error('Could not delete monitoring data during account deletion:', error as Error);
     }
 
+    // Revoke all OAuth integration tokens BEFORE user deletion (Art. 17 GDPR — #911)
+    // Best-effort: log failures but never block the right to erasure
+    try {
+      const { revoked, failed } = await revokeUserIntegrationTokens(userId);
+      loggers.auth.info(`OAuth token revocation complete for user ${userId}: revoked=${revoked}, failed=${failed}`);
+    } catch (error) {
+      loggers.auth.error('Could not revoke OAuth tokens during account deletion:', error as Error);
+    }
+
     // Log security audit BEFORE user deletion so the userId FK is still valid.
     // Timeout prevents stalling account deletion if the advisory lock hangs.
     auditRequest(req, { eventType: 'admin.user.deleted', userId, resourceType: 'account', resourceId: userId });
 
     // Delete the user via repository seam (FK set null will preserve activity logs with userId = null)
     await accountRepository.deleteUser(userId);
+
+    // Delete Stripe customer AFTER user deletion (Art. 17 GDPR — #910)
+    // Cloud-only: on-prem and tenant deployments don't use Stripe
+    // Right to erasure cannot be gated on Stripe API availability — log failures only
+    if (user.stripeCustomerId && isCloud()) {
+      try {
+        await stripe.customers.del(user.stripeCustomerId);
+        loggers.auth.info(`Stripe customer deleted: ${user.stripeCustomerId}`);
+      } catch (error) {
+        loggers.auth.error('Could not delete Stripe customer during account deletion:', error as Error);
+      }
+    }
 
     loggers.auth.info(`User account deleted: ${userId}`);
 

--- a/apps/web/src/app/api/admin/users/[userId]/data/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/data/__tests__/route.test.ts
@@ -95,6 +95,7 @@ describe('/api/admin/users/[userId]/data', () => {
       id: 'user-1',
       email: 'target@example.com',
       image: null,
+      stripeCustomerId: null,
     });
 
     const request = new Request('http://localhost/api/admin/users/user-1/data', {
@@ -127,6 +128,7 @@ describe('/api/admin/users/[userId]/data', () => {
       id: 'admin-123',
       email: 'admin@example.com',
       image: null,
+      stripeCustomerId: null,
     });
 
     const request = new Request('http://localhost/api/admin/users/admin-123/data', {
@@ -180,6 +182,7 @@ describe('/api/admin/users/[userId]/data', () => {
       id: 'user-1',
       email: 'target@example.com',
       image: null,
+      stripeCustomerId: null,
     });
 
     const request = new Request('http://localhost/api/admin/users/user-1/data', {
@@ -212,6 +215,7 @@ describe('/api/admin/users/[userId]/data', () => {
       id: 'user-1',
       email: 'target@example.com',
       image: null,
+      stripeCustomerId: null,
     });
     vi.mocked(accountRepository.checkAndDeleteSoloDrives).mockResolvedValue({
       multiMemberDriveNames: ['Shared Drive'],

--- a/apps/web/src/app/api/admin/users/[userId]/data/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/data/__tests__/route.test.ts
@@ -18,6 +18,14 @@ vi.mock('@/lib/auth/csrf-validation', () => ({
   validateCSRF: vi.fn().mockResolvedValue(null),
 }));
 
+vi.mock('@/lib/stripe/client', () => ({
+  stripe: {
+    customers: {
+      del: vi.fn(),
+    },
+  },
+}));
+
 vi.mock('@pagespace/lib/server', () => ({
   loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
@@ -25,6 +33,7 @@ vi.mock('@pagespace/lib/server', () => ({
   },
   logSecurityEvent: vi.fn(),
   auditRequest: vi.fn(),
+  revokeUserIntegrationTokens: vi.fn().mockResolvedValue({ revoked: 0, failed: 0 }),
   accountRepository: {
     findById: vi.fn(),
     getOwnedDrives: vi.fn().mockResolvedValue([]),
@@ -49,6 +58,7 @@ vi.mock('@pagespace/lib', async (importOriginal) => {
     ...(actual as object),
     deleteAiUsageLogsForUser: vi.fn().mockResolvedValue(undefined),
     deleteMonitoringDataForUser: vi.fn().mockResolvedValue({ systemLogs: 0, apiMetrics: 0, errorLogs: 0, userActivities: 0 }),
+    isCloud: vi.fn().mockReturnValue(false),
   };
 });
 
@@ -56,9 +66,10 @@ import { DELETE } from '../route';
 import { authenticateSessionRequest } from '@/lib/auth/index';
 import { validateAdminAccess } from '@/lib/auth/admin-role';
 import { validateCSRF } from '@/lib/auth/csrf-validation';
-import { accountRepository, activityLogRepository, auditRequest } from '@pagespace/lib/server';
+import { accountRepository, activityLogRepository, auditRequest, revokeUserIntegrationTokens } from '@pagespace/lib/server';
 import { logUserActivity } from '@pagespace/lib/monitoring/activity-logger';
-import { deleteAiUsageLogsForUser, deleteMonitoringDataForUser } from '@pagespace/lib';
+import { deleteAiUsageLogsForUser, deleteMonitoringDataForUser, isCloud } from '@pagespace/lib';
+import { stripe } from '@/lib/stripe/client';
 
 const mockAuth = vi.mocked(authenticateSessionRequest);
 const mockAdminValidation = vi.mocked(validateAdminAccess);
@@ -87,6 +98,11 @@ function mockAuthDenied() {
 describe('/api/admin/users/[userId]/data', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(isCloud).mockReturnValue(false);
+    vi.mocked(revokeUserIntegrationTokens).mockResolvedValue({ revoked: 0, failed: 0 });
+    vi.mocked(stripe.customers.del).mockResolvedValue({} as never);
+    // Reset mocks that individual tests override (clearAllMocks preserves implementations)
+    vi.mocked(accountRepository.checkAndDeleteSoloDrives).mockResolvedValue({ multiMemberDriveNames: [] });
   });
 
   it('DELETE_withValidAdmin_anonymizesAndDeletesUserData', async () => {
@@ -234,5 +250,135 @@ describe('/api/admin/users/[userId]/data', () => {
     expect(response.status).toBe(400);
     expect(body.error).toContain('Transfer ownership first');
     expect(body.multiMemberDrives).toContain('Shared Drive');
+  });
+
+  describe('oauth token revocation (#911)', () => {
+    it('given_activeOAuthConnections_shouldRevokeTokensBeforeUserDeletion', async () => {
+      mockAdminAuth();
+      mockFindById.mockResolvedValue({
+        id: 'user-1',
+        email: 'target@example.com',
+        image: null,
+        stripeCustomerId: null,
+      });
+
+      const callOrder: string[] = [];
+      vi.mocked(revokeUserIntegrationTokens).mockImplementation(async () => {
+        callOrder.push('revoke');
+        return { revoked: 2, failed: 0 };
+      });
+      vi.mocked(accountRepository.deleteUser).mockImplementation(async () => {
+        callOrder.push('deleteUser');
+      });
+
+      const request = new Request('http://localhost/api/admin/users/user-1/data', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason: 'DSAR' }),
+      });
+
+      await DELETE(request, { params: Promise.resolve({ userId: 'user-1' }) });
+
+      expect(callOrder.indexOf('revoke')).toBeLessThan(callOrder.indexOf('deleteUser'));
+    });
+
+    it('given_oauthRevocationFailure_shouldLogErrorButNotBlockDeletion', async () => {
+      mockAdminAuth();
+      mockFindById.mockResolvedValue({
+        id: 'user-1',
+        email: 'target@example.com',
+        image: null,
+        stripeCustomerId: null,
+      });
+      vi.mocked(revokeUserIntegrationTokens).mockRejectedValue(new Error('DB connection lost'));
+
+      const request = new Request('http://localhost/api/admin/users/user-1/data', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason: 'DSAR' }),
+      });
+
+      const response = await DELETE(request, { params: Promise.resolve({ userId: 'user-1' }) });
+
+      expect(response.status).toBe(200);
+      expect(accountRepository.deleteUser).toHaveBeenCalledWith('user-1');
+    });
+  });
+
+  describe('stripe customer deletion (#910)', () => {
+    it('given_cloudDeploymentWithStripeCustomer_shouldDeleteStripeCustomerAfterUserDeletion', async () => {
+      mockAdminAuth();
+      mockFindById.mockResolvedValue({
+        id: 'user-1',
+        email: 'target@example.com',
+        image: null,
+        stripeCustomerId: 'cus_abc123',
+      });
+      vi.mocked(isCloud).mockReturnValue(true);
+
+      const callOrder: string[] = [];
+      vi.mocked(accountRepository.deleteUser).mockImplementation(async () => {
+        callOrder.push('deleteUser');
+      });
+      vi.mocked(stripe.customers.del).mockImplementation(async () => {
+        callOrder.push('stripeDelete');
+        return {} as never;
+      });
+
+      const request = new Request('http://localhost/api/admin/users/user-1/data', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason: 'DSAR' }),
+      });
+
+      await DELETE(request, { params: Promise.resolve({ userId: 'user-1' }) });
+
+      expect(stripe.customers.del).toHaveBeenCalledWith('cus_abc123');
+      expect(callOrder.indexOf('deleteUser')).toBeLessThan(callOrder.indexOf('stripeDelete'));
+    });
+
+    it('given_nonCloudDeployment_shouldNotCallStripeEvenWithStripeCustomerId', async () => {
+      mockAdminAuth();
+      mockFindById.mockResolvedValue({
+        id: 'user-1',
+        email: 'target@example.com',
+        image: null,
+        stripeCustomerId: 'cus_abc123',
+      });
+      vi.mocked(isCloud).mockReturnValue(false);
+
+      const request = new Request('http://localhost/api/admin/users/user-1/data', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason: 'DSAR' }),
+      });
+
+      await DELETE(request, { params: Promise.resolve({ userId: 'user-1' }) });
+
+      expect(stripe.customers.del).not.toHaveBeenCalled();
+    });
+
+    it('given_stripeApiFailure_shouldLogErrorButNotBlockDeletion', async () => {
+      mockAdminAuth();
+      mockFindById.mockResolvedValue({
+        id: 'user-1',
+        email: 'target@example.com',
+        image: null,
+        stripeCustomerId: 'cus_abc123',
+      });
+      vi.mocked(isCloud).mockReturnValue(true);
+      vi.mocked(stripe.customers.del).mockRejectedValue(new Error('Stripe API unavailable'));
+
+      const request = new Request('http://localhost/api/admin/users/user-1/data', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason: 'DSAR' }),
+      });
+
+      const response = await DELETE(request, { params: Promise.resolve({ userId: 'user-1' }) });
+
+      expect(response.status).toBe(200);
+      expect(accountRepository.deleteUser).toHaveBeenCalledWith('user-1');
+    });
   });
 });

--- a/apps/web/src/app/api/admin/users/[userId]/data/route.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/data/route.ts
@@ -1,8 +1,9 @@
 import { withAdminAuth } from '@/lib/auth/auth';
-import { loggers, auditRequest, accountRepository, activityLogRepository } from '@pagespace/lib/server';
-import { deleteAiUsageLogsForUser, deleteMonitoringDataForUser } from '@pagespace/lib';
+import { loggers, auditRequest, accountRepository, activityLogRepository, revokeUserIntegrationTokens } from '@pagespace/lib/server';
+import { deleteAiUsageLogsForUser, deleteMonitoringDataForUser, isCloud } from '@pagespace/lib';
 import { createAnonymizedActorEmail } from '@pagespace/lib/compliance/anonymize';
 import { getActorInfo, logUserActivity } from '@pagespace/lib/monitoring/activity-logger';
+import { stripe } from '@/lib/stripe/client';
 
 type DataRouteContext = { params: Promise<{ userId: string }> };
 
@@ -71,8 +72,26 @@ export const DELETE = withAdminAuth<DataRouteContext>(
       // Note: security_audit_log is intentionally NOT deleted — legal retention requirement
       await deleteMonitoringDataForUser(userId);
 
+      // Revoke OAuth integration tokens BEFORE user deletion (Art. 17 GDPR — #911)
+      try {
+        const { revoked, failed } = await revokeUserIntegrationTokens(userId);
+        loggers.api.info(`Admin DSAR: OAuth token revocation for ${userId}: revoked=${revoked}, failed=${failed}`);
+      } catch (error) {
+        loggers.api.error('Admin DSAR: Could not revoke OAuth tokens:', error as Error);
+      }
+
       // Delete user record
       await accountRepository.deleteUser(userId);
+
+      // Delete Stripe customer AFTER user deletion (Art. 17 GDPR — #910)
+      if (user.stripeCustomerId && isCloud()) {
+        try {
+          await stripe.customers.del(user.stripeCustomerId);
+          loggers.api.info(`Admin DSAR: Stripe customer deleted: ${user.stripeCustomerId}`);
+        } catch (error) {
+          loggers.api.error('Admin DSAR: Could not delete Stripe customer:', error as Error);
+        }
+      }
 
       loggers.api.info(`Admin DSAR deletion: admin=${adminUser.id} target=${userId} reason="${reason}"`);
 

--- a/apps/web/src/app/api/cron/purge-trashed-pages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/purge-trashed-pages/__tests__/route.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const { mockPageRepo, mockAudit } = vi.hoisted(() => ({
+  mockPageRepo: { purgeExpiredTrashedPages: vi.fn() },
+  mockAudit: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/cron-auth', () => ({
+  validateSignedCronRequest: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/server', () => ({
+  audit: mockAudit,
+  pageRepository: mockPageRepo,
+}));
+
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: ResponseInit) =>
+      new Response(JSON.stringify(body), {
+        status: init?.status ?? 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+  },
+}));
+
+import { GET, POST } from '../route';
+import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
+
+function makeRequest(): Request {
+  return new Request('http://localhost:3000/api/cron/purge-trashed-pages');
+}
+
+describe('/api/cron/purge-trashed-pages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(validateSignedCronRequest).mockReturnValue(null);
+    mockPageRepo.purgeExpiredTrashedPages.mockResolvedValue(0);
+  });
+
+  it('given valid HMAC, should purge trashed pages older than 30 days', async () => {
+    // Arrange
+    mockPageRepo.purgeExpiredTrashedPages.mockResolvedValue(7);
+
+    // Act
+    const response = await GET(makeRequest());
+    const body = await response.json();
+
+    // Assert
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.pagesPurged).toBe(7);
+    expect(body.timestamp).toBeDefined();
+  });
+
+  it('given valid HMAC, should pass a cutoff date approximately 30 days ago', async () => {
+    // Arrange
+    const before = Date.now();
+
+    // Act
+    await GET(makeRequest());
+
+    // Assert — the cutoff passed to the repo should be ~30 days ago
+    const cutoff: Date = mockPageRepo.purgeExpiredTrashedPages.mock.calls[0][0];
+    const thirtyDaysMs = 30 * 24 * 60 * 60 * 1000;
+    const after = Date.now();
+
+    expect(cutoff.getTime()).toBeGreaterThanOrEqual(before - thirtyDaysMs - 100);
+    expect(cutoff.getTime()).toBeLessThanOrEqual(after - thirtyDaysMs + 100);
+  });
+
+  it('given invalid HMAC, should return auth error and not purge', async () => {
+    // Arrange
+    const authResponse = new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 });
+    vi.mocked(validateSignedCronRequest).mockReturnValue(authResponse as never);
+
+    // Act
+    const response = await GET(makeRequest());
+
+    // Assert
+    expect(response.status).toBe(403);
+    expect(mockPageRepo.purgeExpiredTrashedPages).not.toHaveBeenCalled();
+  });
+
+  it('given zero eligible pages, should return success with zero count', async () => {
+    // Arrange
+    mockPageRepo.purgeExpiredTrashedPages.mockResolvedValue(0);
+
+    // Act
+    const response = await GET(makeRequest());
+    const body = await response.json();
+
+    // Assert
+    expect(response.status).toBe(200);
+    expect(body.pagesPurged).toBe(0);
+  });
+
+  it('should write an audit log entry on successful purge', async () => {
+    // Arrange
+    mockPageRepo.purgeExpiredTrashedPages.mockResolvedValue(3);
+
+    // Act
+    await GET(makeRequest());
+
+    // Assert
+    expect(mockAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'data.delete',
+        userId: 'system',
+        resourceType: 'cron_job',
+        resourceId: 'purge_trashed_pages',
+        details: { pagesPurged: 3 },
+      })
+    );
+  });
+
+  it('given invalid HMAC, should not log audit event', async () => {
+    // Arrange
+    const authResponse = new Response(JSON.stringify({ error: 'Forbidden' }), { status: 403 });
+    vi.mocked(validateSignedCronRequest).mockReturnValue(authResponse as never);
+
+    // Act
+    await GET(makeRequest());
+
+    // Assert
+    expect(mockAudit).not.toHaveBeenCalled();
+  });
+
+  it('given a DB error, should return 500 and not log audit', async () => {
+    // Arrange
+    mockPageRepo.purgeExpiredTrashedPages.mockRejectedValue(new Error('connection refused'));
+
+    // Act
+    const response = await GET(makeRequest());
+    const body = await response.json();
+
+    // Assert
+    expect(response.status).toBe(500);
+    expect(body.success).toBe(false);
+    expect(body.error).toBe('connection refused');
+    expect(mockAudit).not.toHaveBeenCalled();
+  });
+
+  it('POST should delegate to GET', async () => {
+    // Arrange
+    mockPageRepo.purgeExpiredTrashedPages.mockResolvedValue(2);
+
+    // Act
+    const response = await POST(makeRequest());
+    const body = await response.json();
+
+    // Assert
+    expect(body.success).toBe(true);
+    expect(body.pagesPurged).toBe(2);
+  });
+});

--- a/apps/web/src/app/api/cron/purge-trashed-pages/route.ts
+++ b/apps/web/src/app/api/cron/purge-trashed-pages/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+import { audit, pageRepository } from '@pagespace/lib/server';
+import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
+
+/**
+ * Cron endpoint to hard-delete pages that have been in the trash for 30+ days.
+ *
+ * Implements Art. 17 GDPR erasure: trashed pages are soft-deleted immediately,
+ * then permanently removed after the 30-day retention window.
+ *
+ * Authentication: HMAC-signed request with X-Cron-Timestamp, X-Cron-Nonce, X-Cron-Signature headers.
+ */
+export async function GET(request: Request) {
+  const authError = validateSignedCronRequest(request);
+  if (authError) {
+    return authError;
+  }
+
+  try {
+    const now = new Date();
+    const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+
+    const pagesPurged = await pageRepository.purgeExpiredTrashedPages(thirtyDaysAgo);
+
+    console.log(`[Cron] Purged trashed pages: ${pagesPurged}`);
+
+    audit({
+      eventType: 'data.delete',
+      userId: 'system',
+      resourceType: 'cron_job',
+      resourceId: 'purge_trashed_pages',
+      details: { pagesPurged },
+    });
+
+    return NextResponse.json({
+      success: true,
+      pagesPurged,
+      timestamp: now.toISOString(),
+    });
+  } catch (error) {
+    console.error('[Cron] Error purging trashed pages:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  return GET(request);
+}

--- a/docker/cron/crontab
+++ b/docker/cron/crontab
@@ -43,9 +43,13 @@
 # Fires scheduled agent work tied to calendar events
 */2 * * * * cron-curl POST http://web:3000/api/cron/calendar-triggers >> /var/log/cron/calendar-triggers.log 2>&1
 
-# Orphaned file cleanup - Weekly on Sundays at 5am UTC
+# Trashed page purge - Daily at 5am UTC
+# Hard-deletes pages that have been in the trash for 30+ days (GDPR Art. 17 #909)
+0 5 * * * cron-curl GET http://web:3000/api/cron/purge-trashed-pages >> /var/log/cron/purge-trashed-pages.log 2>&1
+
+# Orphaned file cleanup - Weekly on Sundays at 6am UTC
 # Detects and deletes file records with zero references + physical files
-0 5 * * 0 cron-curl GET http://web:3000/api/cron/cleanup-orphaned-files >> /var/log/cron/orphan-cleanup.log 2>&1
+0 6 * * 0 cron-curl GET http://web:3000/api/cron/cleanup-orphaned-files >> /var/log/cron/orphan-cleanup.log 2>&1
 
 # Expired row sweep - Every 15 minutes
 # Reaps expired tombstones from append-with-TTL tables (revoked_service_tokens;

--- a/packages/lib/src/compliance/erasure/revoke-integration-tokens.ts
+++ b/packages/lib/src/compliance/erasure/revoke-integration-tokens.ts
@@ -1,0 +1,71 @@
+import { db, eq, integrationConnections } from '@pagespace/db';
+import { decryptCredentials } from '../../integrations/credentials/encrypt-credentials';
+import type { IntegrationProviderConfig } from '../../integrations/types';
+
+export interface OAuthRevokeResult {
+  revoked: number;
+  failed: number;
+}
+
+/**
+ * Revoke all OAuth tokens for a user before account erasure (Art. 17 GDPR).
+ *
+ * For each user-scoped integration connection:
+ * 1. Attempt to call the upstream revoke endpoint (best-effort, non-fatal)
+ * 2. Mark the DB record as 'revoked' regardless of HTTP result
+ *
+ * Failures are counted but never block account deletion.
+ */
+export async function revokeUserIntegrationTokens(userId: string): Promise<OAuthRevokeResult> {
+  const connections = await db.query.integrationConnections.findMany({
+    where: eq(integrationConnections.userId, userId),
+    with: { provider: true },
+  });
+
+  let revoked = 0;
+  let failed = 0;
+
+  for (const connection of connections) {
+    try {
+      if (connection.provider && connection.credentials) {
+        const providerConfig = connection.provider.config as IntegrationProviderConfig;
+
+        if (providerConfig.authMethod.type === 'oauth2') {
+          const revokeUrl = providerConfig.authMethod.config.revokeUrl;
+
+          if (revokeUrl) {
+            try {
+              const credentials = await decryptCredentials(
+                connection.credentials as Record<string, string>
+              );
+              const accessToken = credentials.accessToken || credentials.access_token;
+
+              if (accessToken) {
+                await fetch(revokeUrl, {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                  body: `token=${encodeURIComponent(accessToken)}`,
+                  signal: AbortSignal.timeout(10_000),
+                });
+              }
+            } catch {
+              // HTTP revoke failure is non-fatal — token may be expired or provider unreachable
+            }
+          }
+        }
+      }
+
+      await db
+        .update(integrationConnections)
+        .set({ status: 'revoked' })
+        .where(eq(integrationConnections.id, connection.id));
+
+      revoked++;
+    } catch {
+      // DB update failure: count as failed, don't block account deletion
+      failed++;
+    }
+  }
+
+  return { revoked, failed };
+}

--- a/packages/lib/src/compliance/file-cleanup/orphan-detector.test.ts
+++ b/packages/lib/src/compliance/file-cleanup/orphan-detector.test.ts
@@ -74,8 +74,9 @@ describe('findOrphanedFileRecords', () => {
     await expect(findOrphanedFileRecords(db as never)).rejects.toThrow('connection refused');
   });
 
-  it('given_contentHashDedupRequired_queryIncludesContentHashGuard', async () => {
+  it('given_sharedStoragePathDedupRequired_queryIncludesStoragePathGuard', async () => {
     // Ensures the SQL excludes blobs shared with a live sibling file record (#905 gap).
+    // Uses storagePath (the actual CAS key in the files schema) — no contentHash column exists.
     const db = {
       execute: vi.fn().mockResolvedValue({ rows: [] }),
     };
@@ -84,7 +85,7 @@ describe('findOrphanedFileRecords', () => {
 
     const sqlArg = db.execute.mock.calls[0][0] as { strings: TemplateStringsArray };
     const fullSql = sqlArg.strings.join('');
-    expect(fullSql).toContain('contentHash');
+    expect(fullSql).toContain('storagePath');
   });
 });
 

--- a/packages/lib/src/compliance/file-cleanup/orphan-detector.test.ts
+++ b/packages/lib/src/compliance/file-cleanup/orphan-detector.test.ts
@@ -73,6 +73,19 @@ describe('findOrphanedFileRecords', () => {
 
     await expect(findOrphanedFileRecords(db as never)).rejects.toThrow('connection refused');
   });
+
+  it('given_contentHashDedupRequired_queryIncludesContentHashGuard', async () => {
+    // Ensures the SQL excludes blobs shared with a live sibling file record (#905 gap).
+    const db = {
+      execute: vi.fn().mockResolvedValue({ rows: [] }),
+    };
+
+    await findOrphanedFileRecords(db as never);
+
+    const sqlArg = db.execute.mock.calls[0][0] as { strings: TemplateStringsArray };
+    const fullSql = sqlArg.strings.join('');
+    expect(fullSql).toContain('contentHash');
+  });
 });
 
 describe('isFileOrphaned', () => {

--- a/packages/lib/src/compliance/file-cleanup/orphan-detector.ts
+++ b/packages/lib/src/compliance/file-cleanup/orphan-detector.ts
@@ -18,11 +18,12 @@ type DB = NodePgDatabase<Record<string, unknown>>;
  * 1. No filePages rows reference it by fileId
  * 2. No channelMessages reference it (via fileId)
  * 3. No pages reference it (via filePath = storagePath pattern)
- * 4. No other live file record shares the same contentHash — protects content-addressed
+ * 4. No other live file record shares the same storagePath — protects content-addressed
  *    blobs that are still needed by a sibling file record referenced via fileId.
  *
- * Content-addressed storage means one physical blob may back multiple file records.
- * We only delete a blob when every record sharing that contentHash is gone.
+ * Content-addressed storage means one physical blob may back multiple file records
+ * (same storagePath). We only treat a record as orphaned when every sibling sharing
+ * that storagePath also has no live references.
  */
 export async function findOrphanedFileRecords(database: DB): Promise<OrphanedFile[]> {
   const result = await database.execute(sql`
@@ -35,10 +36,10 @@ export async function findOrphanedFileRecords(database: DB): Promise<OrphanedFil
       AND cm."fileId" IS NULL
       AND p.id IS NULL
       AND (
-        f."contentHash" IS NULL
+        f."storagePath" IS NULL
         OR NOT EXISTS (
           SELECT 1 FROM files other_f
-          WHERE other_f."contentHash" = f."contentHash"
+          WHERE other_f."storagePath" = f."storagePath"
             AND other_f.id != f.id
             AND (
               EXISTS (SELECT 1 FROM file_pages WHERE "fileId" = other_f.id)

--- a/packages/lib/src/compliance/file-cleanup/orphan-detector.ts
+++ b/packages/lib/src/compliance/file-cleanup/orphan-detector.ts
@@ -15,12 +15,14 @@ type DB = NodePgDatabase<Record<string, unknown>>;
  * Find file records with zero references across filePages, channelMessages, and pages.
  *
  * A file is orphaned when:
- * 1. No filePages rows reference it
+ * 1. No filePages rows reference it by fileId
  * 2. No channelMessages reference it (via fileId)
  * 3. No pages reference it (via filePath = storagePath pattern)
+ * 4. No other live file record shares the same contentHash — protects content-addressed
+ *    blobs that are still needed by a sibling file record referenced via fileId.
  *
- * Content-addressed storage means one physical file may serve multiple pages/drives,
- * so we only consider a file orphaned when ALL references are gone.
+ * Content-addressed storage means one physical blob may back multiple file records.
+ * We only delete a blob when every record sharing that contentHash is gone.
  */
 export async function findOrphanedFileRecords(database: DB): Promise<OrphanedFile[]> {
   const result = await database.execute(sql`
@@ -32,6 +34,18 @@ export async function findOrphanedFileRecords(database: DB): Promise<OrphanedFil
     WHERE fp."fileId" IS NULL
       AND cm."fileId" IS NULL
       AND p.id IS NULL
+      AND (
+        f."contentHash" IS NULL
+        OR NOT EXISTS (
+          SELECT 1 FROM files other_f
+          WHERE other_f."contentHash" = f."contentHash"
+            AND other_f.id != f.id
+            AND (
+              EXISTS (SELECT 1 FROM file_pages WHERE "fileId" = other_f.id)
+              OR EXISTS (SELECT 1 FROM channel_messages WHERE "fileId" = other_f.id)
+            )
+        )
+      )
   `);
 
   return (result.rows as Array<{

--- a/packages/lib/src/repositories/account-repository.ts
+++ b/packages/lib/src/repositories/account-repository.ts
@@ -11,6 +11,7 @@ export interface UserAccount {
   id: string;
   email: string;
   image: string | null;
+  stripeCustomerId: string | null;
 }
 
 export interface OwnedDrive {
@@ -34,6 +35,7 @@ export const accountRepository = {
         id: true,
         email: true,
         image: true,
+        stripeCustomerId: true,
       },
     });
 

--- a/packages/lib/src/repositories/page-repository.ts
+++ b/packages/lib/src/repositories/page-repository.ts
@@ -5,7 +5,7 @@
  * Tests should mock this repository, not the ORM chains.
  */
 
-import { db, pages, eq, and, desc, isNull, inArray, type PageTypeEnum } from '@pagespace/db';
+import { db, pages, eq, and, desc, isNull, inArray, isNotNull, lt, type PageTypeEnum } from '@pagespace/db';
 
 export type PageTypeValue = PageTypeEnum;
 
@@ -262,6 +262,25 @@ export const pageRepository = {
       });
 
     return restoredPage;
+  },
+
+  /**
+   * Hard-delete pages that have been in the trash for longer than the cutoff date.
+   * Returns the count of deleted pages.
+   */
+  purgeExpiredTrashedPages: async (olderThan: Date): Promise<number> => {
+    const result = await db
+      .delete(pages)
+      .where(
+        and(
+          eq(pages.isTrashed, true),
+          isNotNull(pages.trashedAt),
+          lt(pages.trashedAt, olderThan)
+        )
+      )
+      .returning({ id: pages.id });
+
+    return result.length;
   },
 
   /**

--- a/packages/lib/src/server.ts
+++ b/packages/lib/src/server.ts
@@ -52,6 +52,9 @@ export * from './monitoring';
 // Repository seams for testable database access
 export * from './repositories';
 
+// Compliance — erasure (Art. 17 GDPR)
+export { revokeUserIntegrationTokens, type OAuthRevokeResult } from './compliance/erasure/revoke-integration-tokens';
+
 // Notifications
 export * from './notifications';
 


### PR DESCRIPTION
## Triage Summary

| Issue | Status | Finding |
|-------|--------|---------|
| #910 Stripe customer | **CONFIRMED** | `stripeCustomerId` at `auth.ts:30`; no `stripe.customers.del` call anywhere in DELETE handler |
| #911 OAuth token revocation | **CONFIRMED** | `integration_connections` has encrypted credentials; DELETE handler has zero revocation logic |
| #909 Trashed pages purge | **CONFIRMED** | `pages.isTrashed`/`pages.trashedAt` exist; no `purge-trashed-pages` cron in `apps/web/src/app/api/cron/` and no crontab entry |
| #905 File blob dedup | **PARTIAL GAP** | `cleanup-orphaned-files` misses the case where two file records share the same `storagePath` and one is still referenced via `fileId`. Fixed with NOT EXISTS subquery. |

---

## Changes

### #910 — Stripe customer deleted on account erasure
- `packages/lib/src/repositories/account-repository.ts` — `UserAccount` interface + `findById` now include `stripeCustomerId`
- `apps/web/src/app/api/account/route.ts` — after `deleteUser()`, calls `stripe.customers.del(user.stripeCustomerId)` when `isCloud()`. Failure logged, never blocks erasure.
- `apps/web/src/app/api/admin/users/[userId]/data/route.ts` — same fix applied to the admin DSAR endpoint.

### #911 — OAuth tokens revoked before user deletion
- `packages/lib/src/compliance/erasure/revoke-integration-tokens.ts` (new) — `revokeUserIntegrationTokens(userId)`: queries all user `integration_connections` with provider config, decrypts credentials, POSTs to each `revokeUrl`, marks `status='revoked'` in DB regardless of HTTP result. Inner try/catch makes HTTP failures non-fatal.
- `packages/lib/src/server.ts` — exports `revokeUserIntegrationTokens`
- `apps/web/src/app/api/account/route.ts` — calls revocation **before** `deleteUser()`; failure logged, never blocks deletion.
- `apps/web/src/app/api/admin/users/[userId]/data/route.ts` — same fix applied to the admin DSAR endpoint.

### #909 — Trashed pages hard-deleted after 30-day window
- `packages/lib/src/repositories/page-repository.ts` — `purgeExpiredTrashedPages(olderThan: Date)` method (uses `lt(pages.trashedAt, olderThan)`)
- `apps/web/src/app/api/cron/purge-trashed-pages/route.ts` (new) — HMAC-authenticated (`validateSignedCronRequest`), 30-day cutoff, audit-logged, GET+POST export. Mirrors `purge-deleted-messages` exactly.
- `docker/cron/crontab` — schedule entry: daily at 5am UTC. Also shifted orphan-file-cleanup to 6am to avoid collision.

### #905 — Content-addressed blob dedup gap closed
- `packages/lib/src/compliance/file-cleanup/orphan-detector.ts` — `findOrphanedFileRecords` SQL now includes a `NOT EXISTS` subquery that excludes files whose `storagePath` is still referenced by another live file record (via `file_pages` or `channel_messages`). The `files` schema has no `contentHash` column — `storagePath` is the actual content-addressed key.

---

## Test Coverage (TDD — RED before GREEN)

**#910** (self-service) — 5 tests: cloud+stripeCustomerId calls Stripe; null stripeCustomerId skips; non-cloud skips; Stripe failure non-blocking; deleteUser-before-stripeDel ordering.

**#910** (admin DSAR) — 3 tests: cloud+stripeCustomerId calls Stripe after deleteUser; non-cloud skips; Stripe failure non-blocking.

**#911** (self-service) — 3 tests: revoke-before-deleteUser ordering; revocation failure non-blocking; partial failure logging.

**#911** (admin DSAR) — 2 tests: revoke-before-deleteUser ordering; revocation failure non-blocking.

**#909** — 8 tests: valid HMAC purges, 30-day cutoff verified, invalid HMAC rejected, zero-pages case, audit logged, DB error → 500, POST delegates to GET.

**#905** — 1 test: SQL guard verifies `storagePath`-based CAS dedup is present in query.

**Existing tests updated**: all `findById.mockResolvedValue` calls updated to include `stripeCustomerId: null`.

```
packages/lib:  all compliance/erasure/repository tests pass
apps/web:      all account + cron + admin/data tests pass
typecheck:     0 new errors
lint:          0 errors
```

---

Closes #910, Closes #911, Closes #909

🤖 Generated with [Claude Code](https://claude.com/claude-code)