### PR TITLE
fix(gdpr): complete GDPR Art. 15 data export coverage

### DIFF
--- a/apps/web/src/app/api/account/export/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/export/__tests__/route.test.ts
@@ -205,6 +205,21 @@ describe('GET /api/account/export', () => {
       expect(appendCalls.some((n: string) => n.includes('display-preferences.json'))).toBe(true);
     });
 
+    it('appends personalization.json when personalization data exists', async () => {
+      vi.mocked(collectAllUserData).mockResolvedValue({
+        ...mockUserData,
+        personalization: { bio: 'test', writingStyle: null, rules: null, enabled: true, createdAt: new Date(), updatedAt: new Date() },
+      } as never);
+
+      await GET(createRequest());
+
+      expect(mockArchive.append).toHaveBeenCalledTimes(12);
+      const appendCalls = mockArchive.append.mock.calls.map(
+        (call: unknown[]) => (call[1] as { name: string }).name
+      );
+      expect(appendCalls.some((n: string) => n.includes('personalization.json'))).toBe(true);
+    });
+
     it('calls archive.finalize()', async () => {
       vi.mocked(collectAllUserData).mockResolvedValue(mockUserData as never);
 

--- a/apps/web/src/app/api/account/export/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/export/__tests__/route.test.ts
@@ -83,6 +83,10 @@ const mockUserData = {
   activity: [],
   aiUsage: [],
   tasks: [],
+  sessions: [],
+  notifications: [],
+  displayPreferences: [],
+  personalization: null,
 };
 
 describe('GET /api/account/export', () => {
@@ -182,8 +186,8 @@ describe('GET /api/account/export', () => {
 
       await GET(createRequest());
 
-      // Should append 8 JSON files
-      expect(mockArchive.append).toHaveBeenCalledTimes(8);
+      // Should append 11 JSON files (sessions, notifications, displayPreferences added; personalization omitted when null)
+      expect(mockArchive.append).toHaveBeenCalledTimes(11);
       // Verify each data category name pattern
       const appendCalls = mockArchive.append.mock.calls.map(
         (call: unknown[]) => (call[1] as { name: string }).name
@@ -196,6 +200,9 @@ describe('GET /api/account/export', () => {
       expect(appendCalls.some((n: string) => n.includes('activity.json'))).toBe(true);
       expect(appendCalls.some((n: string) => n.includes('ai-usage.json'))).toBe(true);
       expect(appendCalls.some((n: string) => n.includes('tasks.json'))).toBe(true);
+      expect(appendCalls.some((n: string) => n.includes('sessions.json'))).toBe(true);
+      expect(appendCalls.some((n: string) => n.includes('notifications.json'))).toBe(true);
+      expect(appendCalls.some((n: string) => n.includes('display-preferences.json'))).toBe(true);
     });
 
     it('calls archive.finalize()', async () => {

--- a/apps/web/src/app/api/account/export/route.ts
+++ b/apps/web/src/app/api/account/export/route.ts
@@ -81,6 +81,12 @@ export async function GET(request: Request) {
     archive.append(JSON.stringify(data.activity, null, 2), { name: `pagespace-export-${dateStr}/activity.json` });
     archive.append(JSON.stringify(data.aiUsage, null, 2), { name: `pagespace-export-${dateStr}/ai-usage.json` });
     archive.append(JSON.stringify(data.tasks, null, 2), { name: `pagespace-export-${dateStr}/tasks.json` });
+    archive.append(JSON.stringify(data.sessions, null, 2), { name: `pagespace-export-${dateStr}/sessions.json` });
+    archive.append(JSON.stringify(data.notifications, null, 2), { name: `pagespace-export-${dateStr}/notifications.json` });
+    archive.append(JSON.stringify(data.displayPreferences, null, 2), { name: `pagespace-export-${dateStr}/display-preferences.json` });
+    if (data.personalization) {
+      archive.append(JSON.stringify(data.personalization, null, 2), { name: `pagespace-export-${dateStr}/personalization.json` });
+    }
 
     // Finalize the archive (must be called after all data is appended)
     archive.finalize();

--- a/apps/web/src/app/api/activities/export/__tests__/route.test.ts
+++ b/apps/web/src/app/api/activities/export/__tests__/route.test.ts
@@ -1,36 +1,53 @@
 /**
  * Security audit tests for /api/activities/export
  * Verifies auditRequest is called for GET (export).
+ * Also verifies all activities are exported without truncation.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// vi.hoisted ensures mockFindMany is defined before vi.mock factories run
+const mockFindMany = vi.hoisted(() => vi.fn().mockResolvedValue([]));
+
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json: vi.fn((data: unknown, init?: ResponseInit) => new Response(JSON.stringify(data), {
+      status: init?.status ?? 200,
+      headers: { 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
+    })),
+  },
+}));
 
 vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
   isAuthError: vi.fn((result: unknown) => result && typeof result === 'object' && 'error' in result),
   checkMCPDriveScope: vi.fn().mockReturnValue(null),
   checkMCPPageScope: vi.fn().mockResolvedValue(null),
-  getAllowedDriveIds: vi.fn().mockReturnValue(null),
+  getAllowedDriveIds: vi.fn().mockReturnValue([]),
 }));
 
 vi.mock('@pagespace/db', () => ({
   db: {
-    select: vi.fn().mockReturnValue({
-      from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          orderBy: vi.fn().mockReturnValue({
-            limit: vi.fn().mockResolvedValue([]),
-          }),
-        }),
-      }),
-    }),
+    query: {
+      activityLogs: {
+        findMany: mockFindMany,
+      },
+    },
   },
-  activityLogs: {},
-  eq: vi.fn(),
-  and: vi.fn(),
-  desc: vi.fn(),
-  gte: vi.fn(),
-  lt: vi.fn(),
-  inArray: vi.fn(),
+  activityLogs: {
+    timestamp: 'activityLogs.timestamp',
+    userId: 'activityLogs.userId',
+    isArchived: 'activityLogs.isArchived',
+    driveId: 'activityLogs.driveId',
+    pageId: 'activityLogs.pageId',
+    operation: 'activityLogs.operation',
+    resourceType: 'activityLogs.resourceType',
+  },
+  eq: vi.fn().mockReturnValue({}),
+  and: vi.fn().mockReturnValue({}),
+  desc: vi.fn().mockReturnValue({}),
+  gte: vi.fn().mockReturnValue({}),
+  lt: vi.fn().mockReturnValue({}),
+  inArray: vi.fn().mockReturnValue({}),
 }));
 
 vi.mock('@pagespace/lib/server', () => ({
@@ -44,7 +61,7 @@ vi.mock('@pagespace/lib/server', () => ({
 vi.mock('@pagespace/lib', () => ({
   canUserViewPage: vi.fn().mockResolvedValue(true),
   isUserDriveMember: vi.fn().mockResolvedValue(true),
-  generateCSV: vi.fn().mockReturnValue('col1,col2\nval1,val2'),
+  generateCSV: vi.fn((rows: string[][]) => rows.map(r => r.join(',')).join('\n')),
 }));
 
 vi.mock('date-fns', () => ({
@@ -68,10 +85,28 @@ const mockAuth = () => {
   });
 };
 
+function makeActivity(i: number) {
+  return {
+    id: `act-${i}`,
+    timestamp: new Date(),
+    actorDisplayName: null,
+    actorEmail: null,
+    operation: 'create',
+    resourceType: 'page',
+    resourceTitle: null,
+    isAiGenerated: false,
+    aiProvider: null,
+    aiModel: null,
+    updatedFields: null,
+    user: { id: mockUserId, name: 'Test User', email: 'test@example.com' },
+  };
+}
+
 describe('GET /api/activities/export audit', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockAuth();
+    mockFindMany.mockResolvedValue([]);
   });
 
   it('logs export audit event on successful activities export', async () => {
@@ -81,5 +116,67 @@ describe('GET /api/activities/export audit', () => {
       expect.any(Request),
       expect.objectContaining({ eventType: 'data.export', userId: mockUserId, resourceType: 'activities', resourceId: 'self' })
     );
+  });
+});
+
+describe('GET /api/activities/export pagination', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth();
+  });
+
+  it('given_moreThanOneBatchOfActivities_allAreExported', async () => {
+    const batch1 = Array.from({ length: 1000 }, (_, i) => makeActivity(i));
+    const batch2 = Array.from({ length: 500 }, (_, i) => makeActivity(i + 1000));
+
+    // First call (offset 0) returns full batch; second call (offset 1000) returns partial batch
+    mockFindMany
+      .mockResolvedValueOnce(batch1)
+      .mockResolvedValueOnce(batch2);
+
+    const response = await GET(new Request('http://localhost/api/activities/export?context=user'));
+    const csv = await response.text();
+
+    // 1 header row + 1500 data rows
+    const rows = csv.split('\n').filter(r => r.trim().length > 0);
+    expect(rows).toHaveLength(1501);
+
+    // Verify findMany was called twice (two batches)
+    expect(mockFindMany).toHaveBeenCalledTimes(2);
+    expect(mockFindMany).toHaveBeenNthCalledWith(1, expect.objectContaining({ limit: 1000, offset: 0 }));
+    expect(mockFindMany).toHaveBeenNthCalledWith(2, expect.objectContaining({ limit: 1000, offset: 1000 }));
+  });
+
+  it('given_exactlyOneBatch_stopsAfterOneFetch', async () => {
+    const batch = Array.from({ length: 500 }, (_, i) => makeActivity(i));
+    mockFindMany.mockResolvedValueOnce(batch);
+
+    await GET(new Request('http://localhost/api/activities/export?context=user'));
+
+    expect(mockFindMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('given_no_activities_returns_csv_with_only_header', async () => {
+    mockFindMany.mockResolvedValueOnce([]);
+
+    const response = await GET(new Request('http://localhost/api/activities/export?context=user'));
+    const csv = await response.text();
+
+    // only the header row
+    const rows = csv.split('\n').filter(r => r.trim().length > 0);
+    expect(rows).toHaveLength(1);
+    expect(mockFindMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('response_does_not_include_X_Truncated_header', async () => {
+    // Build 1000 activities to trigger what the old code would have truncated
+    const batch = Array.from({ length: 1000 }, (_, i) => makeActivity(i));
+    mockFindMany
+      .mockResolvedValueOnce(batch)
+      .mockResolvedValueOnce([]); // second fetch comes back empty
+
+    const response = await GET(new Request('http://localhost/api/activities/export?context=user'));
+
+    expect(response.headers.get('X-Truncated')).toBeNull();
   });
 });

--- a/apps/web/src/app/api/activities/export/__tests__/route.test.ts
+++ b/apps/web/src/app/api/activities/export/__tests__/route.test.ts
@@ -34,6 +34,7 @@ vi.mock('@pagespace/db', () => ({
     },
   },
   activityLogs: {
+    id: 'activityLogs.id',
     timestamp: 'activityLogs.timestamp',
     userId: 'activityLogs.userId',
     isArchived: 'activityLogs.isArchived',
@@ -61,7 +62,6 @@ vi.mock('@pagespace/lib/server', () => ({
 vi.mock('@pagespace/lib', () => ({
   canUserViewPage: vi.fn().mockResolvedValue(true),
   isUserDriveMember: vi.fn().mockResolvedValue(true),
-  generateCSV: vi.fn((rows: string[][]) => rows.map(r => r.join(',')).join('\n')),
 }));
 
 vi.mock('date-fns', () => ({

--- a/apps/web/src/app/api/activities/export/route.ts
+++ b/apps/web/src/app/api/activities/export/route.ts
@@ -2,7 +2,6 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod/v4';
 import { db, activityLogs, eq, and, desc, gte, lt, inArray } from '@pagespace/db';
 import { loggers, auditRequest } from '@pagespace/lib/server';
-import { generateCSV } from '@pagespace/lib';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope, checkMCPPageScope, getAllowedDriveIds } from '@/lib/auth';
 import { canUserViewPage, isUserDriveMember } from '@pagespace/lib';
 import { format } from 'date-fns';
@@ -21,6 +20,17 @@ const querySchema = z.object({
   operation: z.string().optional(),
   resourceType: z.string().optional(),
 });
+
+function escapeCsvField(value: string): string {
+  if (value.includes(',') || value.includes('"') || value.includes('\n') || value.includes('\r')) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function toCsvLine(fields: string[]): string {
+  return fields.map(escapeCsvField).join(',') + '\n';
+}
 
 /**
  * GET /api/activities/export
@@ -186,57 +196,6 @@ export async function GET(request: Request) {
       ? and(...filterConditions)
       : undefined;
 
-    // Fetch all activities in batches to avoid loading millions of rows into
-    // memory at once. Build CSV rows as we go rather than accumulating objects.
-    const BATCH_SIZE = 1000;
-    const headers = [
-      'Timestamp',
-      'Actor Name',
-      'Actor Email',
-      'Operation',
-      'Resource Type',
-      'Resource Title',
-      'AI Generated',
-      'AI Model',
-      'Changed Fields',
-    ];
-    const rows: string[][] = [];
-    let batchOffset = 0;
-
-    for (;;) {
-      const batch = await db.query.activityLogs.findMany({
-        where: finalWhereCondition,
-        with: {
-          user: {
-            columns: { id: true, name: true, email: true },
-          },
-        },
-        orderBy: [desc(activityLogs.timestamp)],
-        limit: BATCH_SIZE,
-        offset: batchOffset,
-      });
-
-      for (const activity of batch) {
-        rows.push([
-          format(new Date(activity.timestamp), 'yyyy-MM-dd HH:mm:ss'),
-          activity.actorDisplayName || activity.user?.name || '',
-          activity.actorEmail || activity.user?.email || '',
-          activity.operation,
-          activity.resourceType,
-          activity.resourceTitle || '',
-          activity.isAiGenerated ? 'Yes' : 'No',
-          activity.isAiGenerated ? [activity.aiProvider, activity.aiModel].filter(Boolean).join('/') : '',
-          activity.updatedFields ? activity.updatedFields.join(', ') : '',
-        ]);
-      }
-
-      if (batch.length < BATCH_SIZE) break;
-      batchOffset += BATCH_SIZE;
-    }
-
-    const csvData = [headers, ...rows];
-    const csvContent = generateCSV(csvData);
-
     // Generate filename with date range
     let filename = 'activity-export';
     if (params.startDate && params.endDate) {
@@ -250,12 +209,80 @@ export async function GET(request: Request) {
     }
     filename += '.csv';
 
-    auditRequest(request, { eventType: 'data.export', userId, resourceType: 'activity', resourceId: params.driveId ?? params.pageId ?? '*', details: {
-      context: params.context,
-      exportedCount: rows.length,
-    } });
+    const CSV_HEADERS = [
+      'Timestamp',
+      'Actor Name',
+      'Actor Email',
+      'Operation',
+      'Resource Type',
+      'Resource Title',
+      'AI Generated',
+      'AI Model',
+      'Changed Fields',
+    ];
 
-    return new Response(csvContent, {
+    const BATCH_SIZE = 1000;
+    const encoder = new TextEncoder();
+
+    // Stream CSV rows directly to the response to avoid buffering the entire
+    // dataset in memory. Uses (timestamp, id) as the sort key pair so that
+    // offset pagination is stable even when many rows share the same timestamp.
+    const stream = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        let exportedCount = 0;
+        try {
+          controller.enqueue(encoder.encode(toCsvLine(CSV_HEADERS)));
+
+          let batchOffset = 0;
+          for (;;) {
+            const batch = await db.query.activityLogs.findMany({
+              where: finalWhereCondition,
+              with: {
+                user: {
+                  columns: { id: true, name: true, email: true },
+                },
+              },
+              orderBy: [desc(activityLogs.timestamp), desc(activityLogs.id)],
+              limit: BATCH_SIZE,
+              offset: batchOffset,
+            });
+
+            for (const activity of batch) {
+              controller.enqueue(encoder.encode(toCsvLine([
+                format(new Date(activity.timestamp), 'yyyy-MM-dd HH:mm:ss'),
+                activity.actorDisplayName || activity.user?.name || '',
+                activity.actorEmail || activity.user?.email || '',
+                activity.operation,
+                activity.resourceType,
+                activity.resourceTitle || '',
+                activity.isAiGenerated ? 'Yes' : 'No',
+                activity.isAiGenerated ? [activity.aiProvider, activity.aiModel].filter(Boolean).join('/') : '',
+                activity.updatedFields ? activity.updatedFields.join(', ') : '',
+              ])));
+              exportedCount++;
+            }
+
+            if (batch.length < BATCH_SIZE) break;
+            batchOffset += BATCH_SIZE;
+          }
+
+          auditRequest(request, {
+            eventType: 'data.export',
+            userId,
+            resourceType: 'activity',
+            resourceId: params.driveId ?? params.pageId ?? '*',
+            details: { context: params.context, exportedCount },
+          });
+
+          controller.close();
+        } catch (err) {
+          loggers.api.error('Error streaming activities export:', err as Error);
+          controller.error(err);
+        }
+      },
+    });
+
+    return new Response(stream, {
       headers: {
         'Content-Type': 'text/csv; charset=utf-8',
         'Content-Disposition': `attachment; filename="${filename}"`,

--- a/apps/web/src/app/api/activities/export/route.ts
+++ b/apps/web/src/app/api/activities/export/route.ts
@@ -186,19 +186,9 @@ export async function GET(request: Request) {
       ? and(...filterConditions)
       : undefined;
 
-    // Fetch all activities (no pagination for export)
-    const activities = await db.query.activityLogs.findMany({
-      where: finalWhereCondition,
-      with: {
-        user: {
-          columns: { id: true, name: true, email: true },
-        },
-      },
-      orderBy: [desc(activityLogs.timestamp)],
-      limit: 10000, // Safety limit
-    });
-
-    // Build CSV data
+    // Fetch all activities in batches to avoid loading millions of rows into
+    // memory at once. Build CSV rows as we go rather than accumulating objects.
+    const BATCH_SIZE = 1000;
     const headers = [
       'Timestamp',
       'Actor Name',
@@ -210,18 +200,39 @@ export async function GET(request: Request) {
       'AI Model',
       'Changed Fields',
     ];
+    const rows: string[][] = [];
+    let batchOffset = 0;
 
-    const rows = activities.map(activity => [
-      format(new Date(activity.timestamp), 'yyyy-MM-dd HH:mm:ss'),
-      activity.actorDisplayName || activity.user?.name || '',
-      activity.actorEmail || activity.user?.email || '',
-      activity.operation,
-      activity.resourceType,
-      activity.resourceTitle || '',
-      activity.isAiGenerated ? 'Yes' : 'No',
-      activity.isAiGenerated ? [activity.aiProvider, activity.aiModel].filter(Boolean).join('/') : '',
-      activity.updatedFields ? activity.updatedFields.join(', ') : '',
-    ]);
+    for (;;) {
+      const batch = await db.query.activityLogs.findMany({
+        where: finalWhereCondition,
+        with: {
+          user: {
+            columns: { id: true, name: true, email: true },
+          },
+        },
+        orderBy: [desc(activityLogs.timestamp)],
+        limit: BATCH_SIZE,
+        offset: batchOffset,
+      });
+
+      for (const activity of batch) {
+        rows.push([
+          format(new Date(activity.timestamp), 'yyyy-MM-dd HH:mm:ss'),
+          activity.actorDisplayName || activity.user?.name || '',
+          activity.actorEmail || activity.user?.email || '',
+          activity.operation,
+          activity.resourceType,
+          activity.resourceTitle || '',
+          activity.isAiGenerated ? 'Yes' : 'No',
+          activity.isAiGenerated ? [activity.aiProvider, activity.aiModel].filter(Boolean).join('/') : '',
+          activity.updatedFields ? activity.updatedFields.join(', ') : '',
+        ]);
+      }
+
+      if (batch.length < BATCH_SIZE) break;
+      batchOffset += BATCH_SIZE;
+    }
 
     const csvData = [headers, ...rows];
     const csvContent = generateCSV(csvData);
@@ -239,20 +250,15 @@ export async function GET(request: Request) {
     }
     filename += '.csv';
 
-    // Check if results were truncated
-    const isTruncated = activities.length === 10000;
-
     auditRequest(request, { eventType: 'data.export', userId, resourceType: 'activity', resourceId: params.driveId ?? params.pageId ?? '*', details: {
       context: params.context,
-      exportedCount: activities.length,
-      isTruncated,
+      exportedCount: rows.length,
     } });
 
     return new Response(csvContent, {
       headers: {
         'Content-Type': 'text/csv; charset=utf-8',
         'Content-Disposition': `attachment; filename="${filename}"`,
-        ...(isTruncated && { 'X-Truncated': 'true', 'X-Truncated-At': '10000' }),
       },
     });
   } catch (error) {

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,10 +1,47 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'path'
+import fs from 'fs'
 // Note: vite-tsconfig-paths removed due to ESM compatibility issue
 // Using manual path alias instead
 
 const packagesDir = path.resolve(__dirname, '../../packages')
+
+// In pnpm git worktrees the local node_modules may be empty (no pnpm install
+// was run in the worktree). Walk up the directory tree to find the workspace
+// root's .pnpm/node_modules so that Next.js and other packages can be resolved
+// by Vite during test collection.
+function findPnpmNodeModules(startDir: string): string | null {
+  let dir = startDir;
+  for (let i = 0; i < 10; i++) {
+    const candidate = path.join(dir, 'node_modules', '.pnpm', 'node_modules');
+    if (fs.existsSync(path.join(candidate, 'next'))) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+const workspaceNodeModules = findPnpmNodeModules(__dirname)
+
+// Build a Vite alias entry for a package from the shared pnpm store.
+// Only used when local node_modules are absent (git worktree scenario).
+function pnpmAlias(pkg: string, subpath: string, pnpmModules: string): Record<string, string> {
+  const fullPath = path.join(pnpmModules, subpath);
+  return fs.existsSync(fullPath) ? { [pkg]: fullPath } : {};
+}
+
+const worktreeAliases = workspaceNodeModules ? {
+  'next/server': path.join(workspaceNodeModules, 'next', 'server.js'),
+  'next/headers': path.join(workspaceNodeModules, 'next', 'headers.js'),
+  'next/navigation': path.join(workspaceNodeModules, 'next', 'navigation.js'),
+  'next/cache': path.join(workspaceNodeModules, 'next', 'cache.js'),
+  'next': path.join(workspaceNodeModules, 'next', 'dist', 'index.js'),
+  ...pnpmAlias('date-fns', 'date-fns/index.js', workspaceNodeModules),
+  ...pnpmAlias('zod/v4', 'zod/v4/index.js', workspaceNodeModules),
+  ...pnpmAlias('zod', 'zod/index.js', workspaceNodeModules),
+} : {}
 
 export default defineConfig({
   plugins: [react()],
@@ -38,6 +75,9 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      // Worktree fallback: resolves packages from the shared pnpm store when
+      // local node_modules are empty. Has no effect in CI or full installs.
+      ...worktreeAliases,
       '@': path.resolve(__dirname, './src'),
       // Workspace package aliases for testing
       '@pagespace/db/test/factories': path.resolve(packagesDir, 'db/src/test/factories'),

--- a/packages/lib/src/compliance/export/gdpr-export.test.ts
+++ b/packages/lib/src/compliance/export/gdpr-export.test.ts
@@ -49,6 +49,29 @@ vi.mock('@pagespace/db', () => {
     priority: `${name}.priority`,
     taskListId: `${name}.taskListId`,
     senderId: `${name}.senderId`,
+    // DM conversation participant fields
+    participant1Id: `${name}.participant1Id`,
+    participant2Id: `${name}.participant2Id`,
+    // Notification fields
+    isRead: `${name}.isRead`,
+    readAt: `${name}.readAt`,
+    message: `${name}.message`,
+    // Display preference fields
+    preferenceType: `${name}.preferenceType`,
+    enabled: `${name}.enabled`,
+    // Personalization fields
+    bio: `${name}.bio`,
+    writingStyle: `${name}.writingStyle`,
+    rules: `${name}.rules`,
+    // Session fields
+    scopes: `${name}.scopes`,
+    deviceId: `${name}.deviceId`,
+    createdByIp: `${name}.createdByIp`,
+    lastUsedAt: `${name}.lastUsedAt`,
+    lastUsedIp: `${name}.lastUsedIp`,
+    expiresAt: `${name}.expiresAt`,
+    revokedAt: `${name}.revokedAt`,
+    revokedReason: `${name}.revokedReason`,
   });
 
   return {
@@ -68,12 +91,19 @@ vi.mock('@pagespace/db', () => {
     aiUsageLogs: mockTable('aiUsageLogs'),
     taskLists: mockTable('taskLists'),
     taskItems: mockTable('taskItems'),
+    sessions: mockTable('sessions'),
+    notifications: mockTable('notifications'),
+    displayPreferences: mockTable('displayPreferences'),
+    userPersonalization: mockTable('userPersonalization'),
   };
 });
 
 vi.mock('drizzle-orm', () => ({
   eq: (col: unknown, val: unknown) => ({ _op: 'eq', col, val }),
   inArray: (col: unknown, vals: unknown[]) => ({ _op: 'inArray', col, vals }),
+  or: (...conditions: unknown[]) => ({ _op: 'or', conditions }),
+  and: (...conditions: unknown[]) => ({ _op: 'and', conditions }),
+  ne: (col: unknown, val: unknown) => ({ _op: 'ne', col, val }),
 }));
 
 import {
@@ -85,6 +115,10 @@ import {
   collectUserActivity,
   collectUserAiUsage,
   collectUserTasks,
+  collectUserSessions,
+  collectUserNotifications,
+  collectUserDisplayPreferences,
+  collectUserPersonalization,
   collectAllUserData,
 } from './gdpr-export';
 
@@ -207,7 +241,8 @@ describe('collectUserMessages', () => {
     const channelMsg = { id: 'm2', content: 'Channel msg', pageId: 'p2', createdAt: new Date() };
     const convMsg = { id: 'm3', content: 'Conv msg', role: 'user', conversationId: 'c2', createdAt: new Date() };
     const dmMsg = { id: 'm4', content: 'DM msg', conversationId: 'c3', createdAt: new Date() };
-    const db = createChainDb([[aiMsg], [channelMsg], [convMsg], [dmMsg]]);
+    // 5th call: dmConversations lookup returns [] so no 6th call for received DMs
+    const db = createChainDb([[aiMsg], [channelMsg], [convMsg], [dmMsg], []]);
 
     const result = await collectUserMessages(db as never, 'user-1');
 
@@ -218,11 +253,53 @@ describe('collectUserMessages', () => {
   });
 
   it('given_noMessages_returnsEmptyArray', async () => {
-    const db = createChainDb([[], [], [], []]);
+    // 5 calls: ai, channel, conv, sentDms, dmConversations
+    const db = createChainDb([[], [], [], [], []]);
 
     const result = await collectUserMessages(db as never, 'user-1');
 
     expect(result).toEqual([]);
+  });
+
+  it('given_userHasSentDMs_setsDirectionSent', async () => {
+    const sentDm = { id: 'm4', content: 'Sent DM', conversationId: 'conv-1', createdAt: new Date() };
+    // ai=[], channel=[], conv=[], sentDms=[sentDm], dmConvIds=[] (no received)
+    const db = createChainDb([[], [], [], [sentDm], []]);
+
+    const result = await collectUserMessages(db as never, 'user-1');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe('direct_message');
+    expect(result[0].direction).toBe('sent');
+  });
+
+  it('given_userHasReceivedDMs_includesThemWithDirectionReceived', async () => {
+    const convId = { id: 'conv-1' };
+    const receivedDm = { id: 'm5', content: 'Received DM', conversationId: 'conv-1', createdAt: new Date() };
+    // ai=[], channel=[], conv=[], sentDms=[], dmConvIds=[convId], receivedDms=[receivedDm]
+    const db = createChainDb([[], [], [], [], [convId], [receivedDm]]);
+
+    const result = await collectUserMessages(db as never, 'user-1');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe('direct_message');
+    expect(result[0].direction).toBe('received');
+    expect(result[0].content).toBe('Received DM');
+  });
+
+  it('given_userHasBothSentAndReceivedDMs_includesBothWithCorrectDirections', async () => {
+    const sentDm = { id: 'm4', content: 'Sent DM', conversationId: 'conv-1', createdAt: new Date() };
+    const convId = { id: 'conv-1' };
+    const receivedDm = { id: 'm5', content: 'Received DM', conversationId: 'conv-1', createdAt: new Date() };
+    // ai=[], channel=[], conv=[], sentDms=[sentDm], dmConvIds=[convId], receivedDms=[receivedDm]
+    const db = createChainDb([[], [], [], [sentDm], [convId], [receivedDm]]);
+
+    const result = await collectUserMessages(db as never, 'user-1');
+
+    expect(result).toHaveLength(2);
+    const directions = result.map(r => r.direction);
+    expect(directions).toContain('sent');
+    expect(directions).toContain('received');
   });
 });
 
@@ -303,6 +380,124 @@ describe('collectUserTasks', () => {
   });
 });
 
+describe('collectUserSessions', () => {
+  it('given_userHasSessions_returnsSessionsWithoutCredentialFields', async () => {
+    const session = {
+      id: 'sess-1',
+      type: 'user',
+      deviceId: 'device-abc',
+      scopes: [],
+      createdByIp: '1.2.3.4',
+      lastUsedAt: new Date(),
+      lastUsedIp: '1.2.3.4',
+      expiresAt: new Date(),
+      revokedAt: null,
+      revokedReason: null,
+      createdAt: new Date(),
+    };
+    const db = createChainDb([[session]]);
+
+    const result = await collectUserSessions(db as never, 'user-1');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('sess-1');
+    expect(result[0].type).toBe('user');
+    expect(result[0].createdByIp).toBe('1.2.3.4');
+  });
+
+  it('given_userHasNoSessions_returnsEmptyArray', async () => {
+    const db = createChainDb([[]]);
+
+    const result = await collectUserSessions(db as never, 'user-1');
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe('collectUserNotifications', () => {
+  it('given_userHasNotifications_returnsNotificationHistory', async () => {
+    const notification = {
+      id: 'notif-1',
+      type: 'MENTION',
+      title: 'You were mentioned',
+      message: 'Alice mentioned you in a page',
+      metadata: null,
+      isRead: true,
+      createdAt: new Date(),
+      readAt: new Date(),
+    };
+    const db = createChainDb([[notification]]);
+
+    const result = await collectUserNotifications(db as never, 'user-1');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('MENTION');
+    expect(result[0].isRead).toBe(true);
+  });
+
+  it('given_userHasNoNotifications_returnsEmptyArray', async () => {
+    const db = createChainDb([[]]);
+
+    const result = await collectUserNotifications(db as never, 'user-1');
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe('collectUserDisplayPreferences', () => {
+  it('given_userHasDisplayPreferences_returnsAllPreferences', async () => {
+    const pref = {
+      preferenceType: 'SHOW_TOKEN_COUNTS',
+      enabled: true,
+      updatedAt: new Date(),
+    };
+    const db = createChainDb([[pref]]);
+
+    const result = await collectUserDisplayPreferences(db as never, 'user-1');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].preferenceType).toBe('SHOW_TOKEN_COUNTS');
+    expect(result[0].enabled).toBe(true);
+  });
+
+  it('given_userHasNoDisplayPreferences_returnsEmptyArray', async () => {
+    const db = createChainDb([[]]);
+
+    const result = await collectUserDisplayPreferences(db as never, 'user-1');
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe('collectUserPersonalization', () => {
+  it('given_userHasPersonalization_returnsPersonalizationData', async () => {
+    const personalization = {
+      bio: 'I am a software engineer',
+      writingStyle: 'concise and technical',
+      rules: 'always use TypeScript',
+      enabled: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const db = createLimitDb([personalization]);
+
+    const result = await collectUserPersonalization(db as never, 'user-1');
+
+    expect(result).not.toBeNull();
+    expect(result!.bio).toBe('I am a software engineer');
+    expect(result!.writingStyle).toBe('concise and technical');
+    expect(result!.rules).toBe('always use TypeScript');
+  });
+
+  it('given_userHasNoPersonalization_returnsNull', async () => {
+    const db = createLimitDb([]);
+
+    const result = await collectUserPersonalization(db as never, 'user-1');
+
+    expect(result).toBeNull();
+  });
+});
+
 describe('collectAllUserData', () => {
   it('given_userDoesNotExist_returnsNull', async () => {
     const db = createLimitDb([]);
@@ -318,6 +513,11 @@ describe('collectAllUserData', () => {
       image: null, timezone: 'UTC', createdAt: new Date(), updatedAt: new Date(),
     };
 
+    // Returns an empty array that also has a .limit() method so both
+    // callers that chain .limit() (profile, personalization) and callers
+    // that use the array directly (drives, messages, etc.) both work.
+    const emptyWithLimit = () => Object.assign([], { limit: vi.fn().mockReturnValue([]) });
+
     let callCount = 0;
     const db = {
       select: vi.fn().mockReturnThis(),
@@ -325,9 +525,9 @@ describe('collectAllUserData', () => {
       where: vi.fn(() => {
         callCount++;
         if (callCount === 1) {
-          return { limit: vi.fn().mockReturnValue([profile]) };
+          return Object.assign([], { limit: vi.fn().mockReturnValue([profile]) });
         }
-        return [];
+        return emptyWithLimit();
       }),
       innerJoin: vi.fn().mockReturnThis(),
     };
@@ -344,5 +544,9 @@ describe('collectAllUserData', () => {
     expect(Array.isArray(result!.activity)).toBe(true);
     expect(Array.isArray(result!.aiUsage)).toBe(true);
     expect(Array.isArray(result!.tasks)).toBe(true);
+    expect(Array.isArray(result!.sessions)).toBe(true);
+    expect(Array.isArray(result!.notifications)).toBe(true);
+    expect(Array.isArray(result!.displayPreferences)).toBe(true);
+    expect(result!.personalization).toBeNull();
   });
 });

--- a/packages/lib/src/compliance/export/gdpr-export.ts
+++ b/packages/lib/src/compliance/export/gdpr-export.ts
@@ -1,4 +1,4 @@
-import { eq, inArray } from 'drizzle-orm';
+import { eq, inArray, or, and, ne } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import {
   users,
@@ -15,6 +15,10 @@ import { channelMessages } from '@pagespace/db';
 import { conversations, messages } from '@pagespace/db';
 import { directMessages, dmConversations } from '@pagespace/db';
 import { taskLists, taskItems } from '@pagespace/db';
+import { sessions } from '@pagespace/db';
+import { notifications } from '@pagespace/db';
+import { displayPreferences } from '@pagespace/db';
+import { userPersonalization } from '@pagespace/db';
 
 type DB = NodePgDatabase<Record<string, unknown>>;
 
@@ -50,6 +54,7 @@ export interface UserMessageExport {
   id: string;
   source: 'ai_chat' | 'channel' | 'conversation' | 'direct_message';
   content: string;
+  direction?: 'sent' | 'received';
   role?: string;
   pageId?: string;
   conversationId?: string;
@@ -96,6 +101,46 @@ export interface UserTaskExport {
   }>;
 }
 
+export interface UserSessionExport {
+  id: string;
+  type: string;
+  deviceId: string | null;
+  scopes: string[];
+  createdByIp: string | null;
+  lastUsedAt: Date | null;
+  lastUsedIp: string | null;
+  expiresAt: Date;
+  revokedAt: Date | null;
+  revokedReason: string | null;
+  createdAt: Date;
+}
+
+export interface UserNotificationExport {
+  id: string;
+  type: string;
+  title: string;
+  message: string;
+  metadata: Record<string, unknown> | null;
+  isRead: boolean;
+  createdAt: Date;
+  readAt: Date | null;
+}
+
+export interface UserDisplayPreferenceExport {
+  preferenceType: string;
+  enabled: boolean;
+  updatedAt: Date;
+}
+
+export interface UserPersonalizationExport {
+  bio: string | null;
+  writingStyle: string | null;
+  rules: string | null;
+  enabled: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
 export interface AllUserData {
   profile: UserProfileExport;
   drives: UserDriveExport[];
@@ -105,6 +150,10 @@ export interface AllUserData {
   activity: UserActivityExport[];
   aiUsage: UserAiUsageExport[];
   tasks: UserTaskExport[];
+  sessions: UserSessionExport[];
+  notifications: UserNotificationExport[];
+  displayPreferences: UserDisplayPreferenceExport[];
+  personalization: UserPersonalizationExport | null;
 }
 
 export async function collectUserProfile(database: DB, userId: string): Promise<UserProfileExport | null> {
@@ -270,8 +319,8 @@ export async function collectUserMessages(database: DB, userId: string): Promise
     });
   }
 
-  // Direct messages
-  const dms = await database
+  // Sent direct messages
+  const sentDms = await database
     .select({
       id: directMessages.id,
       content: directMessages.content,
@@ -281,14 +330,55 @@ export async function collectUserMessages(database: DB, userId: string): Promise
     .from(directMessages)
     .where(eq(directMessages.senderId, userId));
 
-  for (const msg of dms) {
+  for (const msg of sentDms) {
     result.push({
       id: msg.id,
       source: 'direct_message',
       content: msg.content,
+      direction: 'sent',
       conversationId: msg.conversationId,
       createdAt: msg.createdAt,
     });
+  }
+
+  // Received direct messages — find conversations where user is a participant but not the sender
+  const userDmConversations = await database
+    .select({ id: dmConversations.id })
+    .from(dmConversations)
+    .where(
+      or(
+        eq(dmConversations.participant1Id, userId),
+        eq(dmConversations.participant2Id, userId),
+      )
+    );
+
+  if (userDmConversations.length > 0) {
+    const conversationIds = userDmConversations.map(c => c.id);
+    const receivedDms = await database
+      .select({
+        id: directMessages.id,
+        content: directMessages.content,
+        conversationId: directMessages.conversationId,
+        createdAt: directMessages.createdAt,
+      })
+      .from(directMessages)
+      .where(
+        and(
+          inArray(directMessages.conversationId, conversationIds),
+          ne(directMessages.senderId, userId),
+        )
+      );
+
+    for (const msg of receivedDms) {
+      result.push({
+        id: msg.id,
+        source: 'direct_message',
+        content: msg.content,
+        direction: 'received',
+        conversationId: msg.conversationId,
+        createdAt: msg.createdAt,
+      });
+    }
   }
 
   return result;
@@ -387,6 +477,69 @@ export async function collectUserTasks(database: DB, userId: string): Promise<Us
   }));
 }
 
+export async function collectUserSessions(database: DB, userId: string): Promise<UserSessionExport[]> {
+  return database
+    .select({
+      id: sessions.id,
+      type: sessions.type,
+      deviceId: sessions.deviceId,
+      scopes: sessions.scopes,
+      createdByIp: sessions.createdByIp,
+      lastUsedAt: sessions.lastUsedAt,
+      lastUsedIp: sessions.lastUsedIp,
+      expiresAt: sessions.expiresAt,
+      revokedAt: sessions.revokedAt,
+      revokedReason: sessions.revokedReason,
+      createdAt: sessions.createdAt,
+    })
+    .from(sessions)
+    .where(eq(sessions.userId, userId));
+}
+
+export async function collectUserNotifications(database: DB, userId: string): Promise<UserNotificationExport[]> {
+  return database
+    .select({
+      id: notifications.id,
+      type: notifications.type,
+      title: notifications.title,
+      message: notifications.message,
+      metadata: notifications.metadata,
+      isRead: notifications.isRead,
+      createdAt: notifications.createdAt,
+      readAt: notifications.readAt,
+    })
+    .from(notifications)
+    .where(eq(notifications.userId, userId));
+}
+
+export async function collectUserDisplayPreferences(database: DB, userId: string): Promise<UserDisplayPreferenceExport[]> {
+  return database
+    .select({
+      preferenceType: displayPreferences.preferenceType,
+      enabled: displayPreferences.enabled,
+      updatedAt: displayPreferences.updatedAt,
+    })
+    .from(displayPreferences)
+    .where(eq(displayPreferences.userId, userId));
+}
+
+export async function collectUserPersonalization(database: DB, userId: string): Promise<UserPersonalizationExport | null> {
+  const result = await database
+    .select({
+      bio: userPersonalization.bio,
+      writingStyle: userPersonalization.writingStyle,
+      rules: userPersonalization.rules,
+      enabled: userPersonalization.enabled,
+      createdAt: userPersonalization.createdAt,
+      updatedAt: userPersonalization.updatedAt,
+    })
+    .from(userPersonalization)
+    .where(eq(userPersonalization.userId, userId))
+    .limit(1);
+
+  return result[0] ?? null;
+}
+
 export async function collectAllUserData(database: DB, userId: string): Promise<AllUserData | null> {
   const profile = await collectUserProfile(database, userId);
   if (!profile) return null;
@@ -394,13 +547,17 @@ export async function collectAllUserData(database: DB, userId: string): Promise<
   const userDrives = await collectUserDrives(database, userId);
   const driveIds = userDrives.map(d => d.id);
 
-  const [userPages, userMessages, userFiles, activity, aiUsage, tasks] = await Promise.all([
+  const [userPages, userMessages, userFiles, activity, aiUsage, tasks, userSessions, userNotifications, userDisplayPreferences, userPersonalizationData] = await Promise.all([
     collectUserPages(database, userId, driveIds),
     collectUserMessages(database, userId),
     collectUserFiles(database, userId),
     collectUserActivity(database, userId),
     collectUserAiUsage(database, userId),
     collectUserTasks(database, userId),
+    collectUserSessions(database, userId),
+    collectUserNotifications(database, userId),
+    collectUserDisplayPreferences(database, userId),
+    collectUserPersonalization(database, userId),
   ]);
 
   return {
@@ -412,5 +569,9 @@ export async function collectAllUserData(database: DB, userId: string): Promise<
     activity,
     aiUsage,
     tasks,
+    sessions: userSessions,
+    notifications: userNotifications,
+    displayPreferences: userDisplayPreferences,
+    personalization: userPersonalizationData,
   };
 }

--- a/packages/lib/src/compliance/export/gdpr-export.ts
+++ b/packages/lib/src/compliance/export/gdpr-export.ts
@@ -497,7 +497,7 @@ export async function collectUserSessions(database: DB, userId: string): Promise
 }
 
 export async function collectUserNotifications(database: DB, userId: string): Promise<UserNotificationExport[]> {
-  return database
+  const result = await database
     .select({
       id: notifications.id,
       type: notifications.type,
@@ -510,6 +510,11 @@ export async function collectUserNotifications(database: DB, userId: string): Pr
     })
     .from(notifications)
     .where(eq(notifications.userId, userId));
+
+  return result.map(n => ({
+    ...n,
+    metadata: n.metadata as Record<string, unknown> | null,
+  }));
 }
 
 export async function collectUserDisplayPreferences(database: DB, userId: string): Promise<UserDisplayPreferenceExport[]> {


### PR DESCRIPTION
## Summary

- **#902 — Received DMs missing from export**: \`collectUserMessages()\` previously only exported sent DMs (\`WHERE senderId = userId\`). Now also finds all DM conversations where the user is a participant (\`participant1Id\` or \`participant2Id\`), then fetches messages in those conversations where \`senderId != userId\`. Adds \`direction: 'sent' | 'received'\` to \`UserMessageExport\` so consumers can differentiate.

- **#903 — Activities export silent truncation**: Removed hardcoded \`limit: 10000\` from \`/api/activities/export\`. Replaced with \`BATCH_SIZE = 1000\` offset pagination loop with a stable sort key (\`timestamp DESC, id DESC\`) to avoid row skips at page boundaries. Streaming via \`ReadableStream<Uint8Array>\` avoids buffering the full dataset in memory. Removes the \`X-Truncated\` response header entirely.

- **#901 — Missing data categories**: Added export of sessions (token metadata, no credential hashes), notifications, display preferences, and AI personalization settings. All four are included in the GDPR ZIP archive from \`/api/account/export\`.

- **Worktree test infrastructure**: Added \`findPnpmNodeModules()\` to \`apps/web/vitest.config.ts\` to resolve \`next/*\`, \`date-fns\`, and \`zod\` from the shared \`.pnpm\` store when running tests in git worktrees without local \`node_modules\`.

## Test plan

- [x] \`pnpm --filter @pagespace/lib exec vitest run src/compliance/export/gdpr-export.test.ts\` — 28 tests, all pass
- [x] \`pnpm --filter web exec vitest run src/app/api/activities/export/__tests__/route.test.ts\` — 5 tests, all pass
- [x] \`apps/web/src/app/api/account/export/__tests__/route.test.ts\` updated: expects 11 \`archive.append\` calls (up from 8) and asserts presence of \`sessions.json\`, \`notifications.json\`, \`display-preferences.json\`
- [ ] Verify exported ZIP contains \`sessions.json\`, \`notifications.json\`, \`display-preferences.json\`, \`personalization.json\`
- [ ] Verify activities export with >10,000 rows returns all rows without truncation

Closes #901, #902, #903

🤖 Generated with [Claude Code](https://claude.com/claude-code)