### PR TITLE
fix(security): gate cloud-only integrations on isOnPrem() (#944 #960 #964)

### DIFF
--- a/apps/web/src/app/api/ai/settings/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/settings/__tests__/route.test.ts
@@ -5,7 +5,7 @@
  * Database operations are mocked at the repository seam.
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { NextResponse } from 'next/server';
 import { GET, POST, PATCH, DELETE } from '../route';
 import type { SessionAuthResult, AuthError } from '@/lib/auth';
@@ -485,6 +485,30 @@ describe('POST /api/ai/settings', () => {
       expect(response.status).toBe(500);
       expect(body.error).toContain('Failed to save');
       expect(loggers.ai.error).toHaveBeenCalledWith('Failed to save openrouter API key', expect.objectContaining({ message: 'Save failed' }), { provider: 'openrouter' });
+    });
+  });
+
+  describe('deployment mode blocking', () => {
+    const origDeploymentMode = process.env.DEPLOYMENT_MODE;
+
+    beforeEach(() => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockWebAuth(mockUserId));
+      vi.mocked(isAuthError).mockReturnValue(false);
+    });
+
+    afterEach(() => {
+      if (origDeploymentMode === undefined) {
+        delete process.env.DEPLOYMENT_MODE;
+      } else {
+        process.env.DEPLOYMENT_MODE = origDeploymentMode;
+      }
+    });
+
+    it('given cloud mode + external provider, should not return 403 due to mode gate', async () => {
+      delete process.env.DEPLOYMENT_MODE;
+      const request = createPostRequest({ provider: 'openai', apiKey: 'test-key' });
+      const response = await POST(request);
+      expect(response.status).not.toBe(403);
     });
   });
 });

--- a/apps/web/src/app/api/ai/settings/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/settings/__tests__/route.test.ts
@@ -510,6 +510,29 @@ describe('POST /api/ai/settings', () => {
       const response = await POST(request);
       expect(response.status).not.toBe(403);
     });
+
+    it('given onprem mode + external provider, should return 403', async () => {
+      process.env.DEPLOYMENT_MODE = 'onprem';
+      const request = createPostRequest({ provider: 'openai', apiKey: 'test-key' });
+      const response = await POST(request);
+      const body = await response.json();
+      expect(response.status).toBe(403);
+      expect(body.error).toMatch(/not available/i);
+    });
+
+    it('given onprem mode + ollama (allowed), should not return 403', async () => {
+      process.env.DEPLOYMENT_MODE = 'onprem';
+      const request = createPostRequest({ provider: 'ollama', baseUrl: 'http://localhost:11434' });
+      const response = await POST(request);
+      expect(response.status).not.toBe(403);
+    });
+
+    it('given tenant mode + external provider, should not return 403 due to mode gate', async () => {
+      process.env.DEPLOYMENT_MODE = 'tenant';
+      const request = createPostRequest({ provider: 'openai', apiKey: 'test-key' });
+      const response = await POST(request);
+      expect(response.status).not.toBe(403);
+    });
   });
 });
 

--- a/apps/web/src/app/api/integrations/google-calendar/__tests__/deployment-mode-gate.test.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/__tests__/deployment-mode-gate.test.ts
@@ -101,6 +101,7 @@ const assertModeGatePasses = async (response: Response) => {
 
 import { GET as getStatus } from '../status/route';
 import { POST as postConnect } from '../connect/route';
+import { GET as getCallback } from '../callback/route';
 import { POST as postWebhook } from '../webhook/route';
 import { GET as getCalendars } from '../calendars/route';
 import { POST as postDisconnect } from '../disconnect/route';
@@ -236,6 +237,22 @@ describe('Google Calendar routes — deployment mode gate', () => {
         headers: { 'X-Goog-Channel-ID': 'ch-1', 'X-Goog-Resource-ID': 'res-1' },
       });
       await assertModeGateBlocks(await postWebhook(req));
+    });
+  });
+
+  describe('GET /callback', () => {
+    it('given cloud mode, should pass deployment mode gate', async () => {
+      const req = new Request('http://localhost/api/integrations/google-calendar/callback?code=code&state=state');
+      await assertModeGatePasses(await getCallback(req));
+    });
+    it('given tenant mode, should pass deployment mode gate', async () => {
+      const req = new Request('http://localhost/api/integrations/google-calendar/callback?code=code&state=state');
+      await assertModeGatePasses(await getCallback(req));
+    });
+    it('given onprem mode, should return 404 from gate', async () => {
+      mockIsOnPrem.mockReturnValue(true);
+      const req = new Request('http://localhost/api/integrations/google-calendar/callback?code=code&state=state');
+      await assertModeGateBlocks(await getCallback(req));
     });
   });
 });

--- a/apps/web/src/app/api/integrations/google-calendar/__tests__/deployment-mode-gate.test.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/__tests__/deployment-mode-gate.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const mockIsOnPrem = vi.hoisted(() => vi.fn(() => false));
+
+vi.mock('@pagespace/lib', () => ({
+  isOnPrem: mockIsOnPrem,
+  encrypt: vi.fn(),
+  secureCompare: vi.fn(),
+  decrypt: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/server', () => ({
+  loggers: {
+    auth: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+    api: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+  },
+  auditRequest: vi.fn(),
+  maskEmail: (e: string) => e,
+}));
+
+vi.mock('@pagespace/lib/security', () => ({
+  checkDistributedRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
+  DISTRIBUTED_RATE_LIMITS: { LOGIN: {} },
+  validateLocalProviderURL: vi.fn(),
+}));
+
+vi.mock('@pagespace/db', () => ({
+  db: {
+    query: {
+      googleCalendarConnections: { findFirst: vi.fn().mockResolvedValue(null) },
+      users: { findFirst: vi.fn().mockResolvedValue({ id: 'user-1', email: 'test@example.com' }) },
+    },
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue([{ total: 0 }]) }),
+    }),
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({ onConflictDoUpdate: vi.fn() }),
+    }),
+    update: vi.fn().mockReturnValue({ set: vi.fn().mockReturnValue({ where: vi.fn() }) }),
+  },
+  googleCalendarConnections: { userId: 'userId' },
+  calendarEvents: { createdById: 'x', syncedFromGoogle: 'x', isTrashed: 'x' },
+  users: { id: 'id', email: 'email' },
+  eq: vi.fn(),
+  and: vi.fn(),
+  count: vi.fn(() => 'count_agg'),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn().mockResolvedValue({ userId: 'user-1' }),
+  isAuthError: vi.fn().mockReturnValue(false),
+  getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
+  validateLoginCSRFToken: vi.fn().mockReturnValue(true),
+  checkMCPDriveScope: vi.fn(),
+}));
+
+vi.mock('@/lib/integrations/google-calendar/return-url', () => ({
+  normalizeGoogleCalendarReturnPath: (p: string) => p ?? '/settings',
+  GOOGLE_CALENDAR_DEFAULT_RETURN_PATH: '/settings',
+}));
+
+vi.mock('@/lib/integrations/google-calendar/sync-service', () => ({
+  syncGoogleCalendar: vi.fn(),
+  unregisterWebhookChannels: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/integrations/google-calendar/webhook-auth', () => ({
+  validateWebhookAuth: vi.fn().mockReturnValue({ ok: false, status: 401, body: { error: 'test' } }),
+  _resetWarningFlag: vi.fn(),
+}));
+
+vi.mock('@/lib/integrations/google-calendar/token-refresh', () => ({
+  getValidAccessToken: vi.fn().mockResolvedValue('token'),
+}));
+
+vi.mock('@/lib/integrations/google-calendar/api-client', () => ({
+  listCalendars: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('google-auth-library', () => ({
+  OAuth2Client: vi.fn().mockImplementation(() => ({
+    getToken: vi.fn().mockResolvedValue({ tokens: {} }),
+    setCredentials: vi.fn(),
+  })),
+}));
+
+const GATE_ERROR = 'Not available';
+
+const assertModeGateBlocks = async (response: Response) => {
+  expect(response.status).toBe(404);
+  const body = await response.json();
+  expect(body.error).toBe(GATE_ERROR);
+};
+
+const assertModeGatePasses = async (response: Response) => {
+  if (response.status === 404) {
+    const body = await response.json();
+    expect(body.error).not.toBe(GATE_ERROR);
+  }
+};
+
+import { GET as getStatus } from '../status/route';
+import { POST as postConnect } from '../connect/route';
+import { POST as postWebhook } from '../webhook/route';
+import { GET as getCalendars } from '../calendars/route';
+import { POST as postDisconnect } from '../disconnect/route';
+import { GET as getSettings, PATCH as patchSettings } from '../settings/route';
+import { POST as postSync } from '../sync/route';
+
+describe('Google Calendar routes — deployment mode gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsOnPrem.mockReturnValue(false);
+    process.env.GOOGLE_OAUTH_CLIENT_ID = 'cid';
+    process.env.GOOGLE_OAUTH_CLIENT_SECRET = 'csec';
+    process.env.OAUTH_STATE_SECRET = 'secret-32-chars-minimum-length!!';
+    process.env.WEB_APP_URL = 'http://localhost:3000';
+  });
+
+  const makeRequest = (method: string, body?: object) =>
+    new Request('http://localhost/api/integrations/google-calendar/test', {
+      method,
+      ...(body ? { body: JSON.stringify(body), headers: { 'Content-Type': 'application/json' } } : {}),
+    });
+
+  describe('GET /status', () => {
+    it('given cloud mode, should pass deployment mode gate', async () => {
+      await assertModeGatePasses(await getStatus(makeRequest('GET')));
+    });
+    it('given tenant mode, should pass deployment mode gate', async () => {
+      await assertModeGatePasses(await getStatus(makeRequest('GET')));
+    });
+    it('given onprem mode, should return 404 from gate', async () => {
+      mockIsOnPrem.mockReturnValue(true);
+      await assertModeGateBlocks(await getStatus(makeRequest('GET')));
+    });
+  });
+
+  describe('POST /connect', () => {
+    it('given cloud mode, should pass deployment mode gate', async () => {
+      await assertModeGatePasses(await postConnect(makeRequest('POST', {})));
+    });
+    it('given tenant mode, should pass deployment mode gate', async () => {
+      await assertModeGatePasses(await postConnect(makeRequest('POST', {})));
+    });
+    it('given onprem mode, should return 404 from gate', async () => {
+      mockIsOnPrem.mockReturnValue(true);
+      await assertModeGateBlocks(await postConnect(makeRequest('POST', {})));
+    });
+  });
+
+  describe('POST /disconnect', () => {
+    it('given cloud mode, should pass deployment mode gate', async () => {
+      await assertModeGatePasses(await postDisconnect(makeRequest('POST')));
+    });
+    it('given tenant mode, should pass deployment mode gate', async () => {
+      await assertModeGatePasses(await postDisconnect(makeRequest('POST')));
+    });
+    it('given onprem mode, should return 404 from gate', async () => {
+      mockIsOnPrem.mockReturnValue(true);
+      await assertModeGateBlocks(await postDisconnect(makeRequest('POST')));
+    });
+  });
+
+  describe('GET /calendars', () => {
+    it('given cloud mode, should pass deployment mode gate', async () => {
+      await assertModeGatePasses(await getCalendars(makeRequest('GET')));
+    });
+    it('given tenant mode, should pass deployment mode gate', async () => {
+      await assertModeGatePasses(await getCalendars(makeRequest('GET')));
+    });
+    it('given onprem mode, should return 404 from gate', async () => {
+      mockIsOnPrem.mockReturnValue(true);
+      await assertModeGateBlocks(await getCalendars(makeRequest('GET')));
+    });
+  });
+
+  describe('GET /settings', () => {
+    it('given cloud mode, should pass deployment mode gate', async () => {
+      await assertModeGatePasses(await getSettings(makeRequest('GET')));
+    });
+    it('given tenant mode, should pass deployment mode gate', async () => {
+      await assertModeGatePasses(await getSettings(makeRequest('GET')));
+    });
+    it('given onprem mode, should return 404 from gate', async () => {
+      mockIsOnPrem.mockReturnValue(true);
+      await assertModeGateBlocks(await getSettings(makeRequest('GET')));
+    });
+  });
+
+  describe('PATCH /settings', () => {
+    it('given cloud mode, should pass deployment mode gate', async () => {
+      await assertModeGatePasses(await patchSettings(makeRequest('PATCH', {})));
+    });
+    it('given tenant mode, should pass deployment mode gate', async () => {
+      await assertModeGatePasses(await patchSettings(makeRequest('PATCH', {})));
+    });
+    it('given onprem mode, should return 404 from gate', async () => {
+      mockIsOnPrem.mockReturnValue(true);
+      await assertModeGateBlocks(await patchSettings(makeRequest('PATCH', {})));
+    });
+  });
+
+  describe('POST /sync', () => {
+    it('given cloud mode, should pass deployment mode gate', async () => {
+      await assertModeGatePasses(await postSync(makeRequest('POST')));
+    });
+    it('given tenant mode, should pass deployment mode gate', async () => {
+      await assertModeGatePasses(await postSync(makeRequest('POST')));
+    });
+    it('given onprem mode, should return 404 from gate', async () => {
+      mockIsOnPrem.mockReturnValue(true);
+      await assertModeGateBlocks(await postSync(makeRequest('POST')));
+    });
+  });
+
+  describe('POST /webhook', () => {
+    it('given cloud mode, should pass deployment mode gate', async () => {
+      const req = new Request('http://localhost/api/integrations/google-calendar/webhook', {
+        method: 'POST',
+        headers: { 'X-Goog-Channel-ID': 'ch-1', 'X-Goog-Resource-ID': 'res-1', 'X-Goog-Resource-State': 'exists' },
+      });
+      await assertModeGatePasses(await postWebhook(req));
+    });
+    it('given tenant mode, should pass deployment mode gate', async () => {
+      const req = new Request('http://localhost/api/integrations/google-calendar/webhook', {
+        method: 'POST',
+        headers: { 'X-Goog-Channel-ID': 'ch-1', 'X-Goog-Resource-ID': 'res-1', 'X-Goog-Resource-State': 'exists' },
+      });
+      await assertModeGatePasses(await postWebhook(req));
+    });
+    it('given onprem mode, should return 404 from gate', async () => {
+      mockIsOnPrem.mockReturnValue(true);
+      const req = new Request('http://localhost/api/integrations/google-calendar/webhook', {
+        method: 'POST',
+        headers: { 'X-Goog-Channel-ID': 'ch-1', 'X-Goog-Resource-ID': 'res-1' },
+      });
+      await assertModeGateBlocks(await postWebhook(req));
+    });
+  });
+});

--- a/apps/web/src/app/api/integrations/google-calendar/calendars/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/calendars/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { isOnPrem } from '@pagespace/lib';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers, auditRequest } from '@pagespace/lib/server';
 import { getValidAccessToken } from '@/lib/integrations/google-calendar/token-refresh';
@@ -12,6 +13,7 @@ const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
  * Used by the settings UI for calendar selection.
  */
 export async function GET(request: Request) {
+  if (isOnPrem()) return Response.json({ error: 'Not available' }, { status: 404 });
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
     if (isAuthError(auth)) return auth.error;

--- a/apps/web/src/app/api/integrations/google-calendar/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/callback/__tests__/route.test.ts
@@ -32,6 +32,7 @@ vi.mock('@pagespace/db', () => ({
 }));
 
 vi.mock('@pagespace/lib', () => ({
+  isOnPrem: () => false,
   encrypt: vi.fn().mockResolvedValue('encrypted'),
   secureCompare: (a: string, b: string) => a === b,
 }));

--- a/apps/web/src/app/api/integrations/google-calendar/callback/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/callback/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db, googleCalendarConnections } from '@pagespace/db';
 import { loggers, auditRequest, maskEmail } from '@pagespace/lib/server';
-import { encrypt } from '@pagespace/lib';
+import { encrypt, isOnPrem } from '@pagespace/lib';
 import { OAuth2Client } from 'google-auth-library';
 import crypto from 'crypto';
 import { secureCompare } from '@pagespace/lib';
@@ -18,6 +18,7 @@ const STATE_MAX_AGE_MS = 10 * 60 * 1000;
  * Exchanges authorization code for tokens and stores encrypted credentials.
  */
 export async function GET(req: Request) {
+  if (isOnPrem()) return Response.json({ error: 'Not available' }, { status: 404 });
   const baseUrl = process.env.WEB_APP_URL || process.env.NEXTAUTH_URL || 'http://localhost:3000';
 
   try {

--- a/apps/web/src/app/api/integrations/google-calendar/connect/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/connect/route.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod/v4';
 import { db, users, eq } from '@pagespace/db';
+import { isOnPrem } from '@pagespace/lib';
 import { loggers, auditRequest } from '@pagespace/lib/server';
 import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security';
 import { authenticateRequestWithOptions, isAuthError, getClientIP } from '@/lib/auth';
@@ -18,6 +19,7 @@ const connectSchema = z.object({
  * User must be authenticated before connecting calendar.
  */
 export async function POST(req: Request) {
+  if (isOnPrem()) return Response.json({ error: 'Not available' }, { status: 404 });
   try {
     // Validate required OAuth environment variables
     if (

--- a/apps/web/src/app/api/integrations/google-calendar/disconnect/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/disconnect/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db, googleCalendarConnections, eq } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { decrypt } from '@pagespace/lib';
+import { decrypt, isOnPrem } from '@pagespace/lib';
 import { loggers, auditRequest } from '@pagespace/lib/server';
 import { unregisterWebhookChannels } from '@/lib/integrations/google-calendar/sync-service';
 
@@ -13,6 +13,7 @@ const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
  * Revokes OAuth token and updates connection status.
  */
 export async function POST(request: Request) {
+  if (isOnPrem()) return Response.json({ error: 'Not available' }, { status: 404 });
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
     if (isAuthError(auth)) return auth.error;

--- a/apps/web/src/app/api/integrations/google-calendar/settings/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/settings/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod/v4';
 import { db, googleCalendarConnections, calendarEvents, eq, and, count } from '@pagespace/db';
+import { isOnPrem } from '@pagespace/lib';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers, auditRequest } from '@pagespace/lib/server';
 
@@ -18,6 +19,7 @@ const settingsSchema = z.object({
  * Returns the current settings and event statistics.
  */
 export async function GET(request: Request) {
+  if (isOnPrem()) return Response.json({ error: 'Not available' }, { status: 404 });
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
     if (isAuthError(auth)) return auth.error;
@@ -76,6 +78,7 @@ export async function GET(request: Request) {
  * Updates Google Calendar sync settings.
  */
 export async function PATCH(request: Request) {
+  if (isOnPrem()) return Response.json({ error: 'Not available' }, { status: 404 });
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
     if (isAuthError(auth)) return auth.error;

--- a/apps/web/src/app/api/integrations/google-calendar/status/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/status/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { db, googleCalendarConnections, calendarEvents, eq, and, count } from '@pagespace/db';
+import { isOnPrem } from '@pagespace/lib';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers, auditRequest } from '@pagespace/lib/server';
 
@@ -10,6 +11,7 @@ const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
  * Returns the Google Calendar connection status for the authenticated user.
  */
 export async function GET(request: Request) {
+  if (isOnPrem()) return Response.json({ error: 'Not available' }, { status: 404 });
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
     if (isAuthError(auth)) return auth.error;

--- a/apps/web/src/app/api/integrations/google-calendar/sync/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/sync/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { isOnPrem } from '@pagespace/lib';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers, auditRequest } from '@pagespace/lib/server';
 import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security';
@@ -11,6 +12,7 @@ const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
  * Triggers a Google Calendar sync for the authenticated user.
  */
 export async function POST(request: Request) {
+  if (isOnPrem()) return Response.json({ error: 'Not available' }, { status: 404 });
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
     if (isAuthError(auth)) return auth.error;

--- a/apps/web/src/app/api/integrations/google-calendar/webhook/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/webhook/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, after } from 'next/server';
+import { isOnPrem } from '@pagespace/lib';
 import { loggers } from '@pagespace/lib/server';
 import { syncGoogleCalendar } from '@/lib/integrations/google-calendar/sync-service';
 import { validateWebhookAuth } from '@/lib/integrations/google-calendar/webhook-auth';
@@ -22,6 +23,7 @@ import { validateWebhookAuth } from '@/lib/integrations/google-calendar/webhook-
  * - No unauthenticated code paths
  */
 export async function POST(request: Request) {
+  if (isOnPrem()) return Response.json({ error: 'Not available' }, { status: 404 });
   try {
     const channelId = request.headers.get('X-Goog-Channel-ID') || request.headers.get('x-goog-channel-id');
     const resourceId = request.headers.get('X-Goog-Resource-ID') || request.headers.get('x-goog-resource-id');

--- a/apps/web/src/lib/ai/core/__tests__/ai-providers-config.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/ai-providers-config.test.ts
@@ -1,11 +1,13 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import {
   PAGESPACE_MODEL_ALIASES,
+  ONPREM_ALLOWED_PROVIDERS,
   resolvePageSpaceModel,
   isPageSpaceModelAlias,
   getPageSpaceModelTier,
   getDefaultModel,
   getUserFacingModelName,
+  getVisibleProviders,
 } from '../ai-providers-config';
 
 describe('ai-providers-config', () => {
@@ -101,6 +103,46 @@ describe('ai-providers-config', () => {
 
     it('should return glm-4.7 for unknown provider', () => {
       expect(getDefaultModel('unknown-provider')).toBe('glm-4.7');
+    });
+  });
+
+  describe('getVisibleProviders', () => {
+    const origNextPublic = process.env.NEXT_PUBLIC_DEPLOYMENT_MODE;
+    const origServer = process.env.DEPLOYMENT_MODE;
+
+    afterEach(() => {
+      process.env.NEXT_PUBLIC_DEPLOYMENT_MODE = origNextPublic;
+      process.env.DEPLOYMENT_MODE = origServer;
+    });
+
+    it('given cloud mode, should include all external providers', () => {
+      delete process.env.NEXT_PUBLIC_DEPLOYMENT_MODE;
+      delete process.env.DEPLOYMENT_MODE;
+      const providers = getVisibleProviders();
+      expect(providers).toHaveProperty('anthropic');
+      expect(providers).toHaveProperty('openai');
+      expect(providers).toHaveProperty('google');
+      expect(providers).toHaveProperty('xai');
+    });
+
+    it('given onprem mode, should include only ONPREM_ALLOWED_PROVIDERS', () => {
+      process.env.NEXT_PUBLIC_DEPLOYMENT_MODE = 'onprem';
+      process.env.DEPLOYMENT_MODE = 'onprem';
+      const providers = getVisibleProviders();
+      expect(providers).not.toHaveProperty('anthropic');
+      expect(providers).not.toHaveProperty('openai');
+      Object.keys(providers).forEach((key) => {
+        expect(ONPREM_ALLOWED_PROVIDERS.has(key)).toBe(true);
+      });
+    });
+
+    it('given tenant mode, should include all external providers', () => {
+      process.env.NEXT_PUBLIC_DEPLOYMENT_MODE = 'tenant';
+      process.env.DEPLOYMENT_MODE = 'tenant';
+      const providers = getVisibleProviders();
+      expect(providers).toHaveProperty('anthropic');
+      expect(providers).toHaveProperty('openai');
+      expect(providers).toHaveProperty('google');
     });
   });
 

--- a/apps/web/src/lib/ai/core/ai-providers-config.ts
+++ b/apps/web/src/lib/ai/core/ai-providers-config.ts
@@ -497,12 +497,12 @@ export const ONPREM_ALLOWED_PROVIDERS = new Set<string>(['ollama', 'lmstudio', '
  */
 export function getVisibleProviders(): Partial<typeof AI_PROVIDERS> {
   // Client-side check uses NEXT_PUBLIC_ prefix; server-side uses DEPLOYMENT_MODE
-  const isOnPremMode =
+  const mode =
     typeof window !== 'undefined'
-      ? process.env.NEXT_PUBLIC_DEPLOYMENT_MODE === 'onprem'
-      : process.env.DEPLOYMENT_MODE === 'onprem';
+      ? process.env.NEXT_PUBLIC_DEPLOYMENT_MODE
+      : process.env.DEPLOYMENT_MODE;
 
-  if (!isOnPremMode) return AI_PROVIDERS;
+  if (mode !== 'onprem') return AI_PROVIDERS;
 
   return Object.fromEntries(
     Object.entries(AI_PROVIDERS).filter(([key]) => ONPREM_ALLOWED_PROVIDERS.has(key))

--- a/packages/lib/src/deployment-mode.ts
+++ b/packages/lib/src/deployment-mode.ts
@@ -1,15 +1,20 @@
 /**
  * Deployment mode detection utilities (server-side).
  *
- * When DEPLOYMENT_MODE=onprem, the application disables cloud-only features
- * (Stripe billing, OAuth, self-registration) and surfaces password auth,
- * local AI providers, and admin-managed user accounts.
+ * Three modes via DEPLOYMENT_MODE env var:
  *
- * When DEPLOYMENT_MODE=tenant, the application runs as a managed instance
- * where billing is handled by the control plane. All users get business-tier
- * features. Cloud-only routes (Stripe, OAuth) are blocked like on-prem.
+ *   cloud  (default) — SaaS at pagespace.ai. Full feature set.
+ *   tenant           — Dedicated-image cloud deployment (own postgres/realtime/processor
+ *                      per tenant). Identical feature set to cloud; differs only in
+ *                      infrastructure topology and billing path (control plane, not Stripe).
+ *   onprem           — Self-hosted. Restricts cloud integrations: no Google Calendar,
+ *                      no external AI providers (only ollama/lmstudio/azure_openai),
+ *                      no OAuth login, no Stripe, no self-registration. Password auth only.
  *
- * All changes are inert unless the env var is explicitly set.
+ * Guard selection:
+ *   isOnPrem()        — gate cloud integrations (Calendar, AI providers). Tenant keeps them.
+ *   isBillingEnabled() — gate subscription/billing UI. False for both onprem and tenant.
+ *   Never use !isCloud() to gate integrations — it incorrectly restricts tenant.
  */
 
 export function isOnPrem(): boolean {

--- a/packages/lib/src/services/__tests__/email-service.test.ts
+++ b/packages/lib/src/services/__tests__/email-service.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const mockSend = vi.fn();
+const mockIsOnPrem = vi.hoisted(() => vi.fn(() => false));
 
 vi.mock('resend', () => ({
   Resend: vi.fn().mockImplementation(() => ({
@@ -13,6 +14,10 @@ vi.mock('../../auth/rate-limit-utils', () => ({
   RATE_LIMIT_CONFIGS: {},
 }));
 
+vi.mock('../../deployment-mode', () => ({
+  isOnPrem: mockIsOnPrem,
+}));
+
 import { sendEmail } from '../email-service';
 import { checkRateLimit } from '../../auth/rate-limit-utils';
 
@@ -22,6 +27,7 @@ describe('email-service', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsOnPrem.mockReturnValue(false);
     process.env.RESEND_API_KEY = 'test-api-key';
     process.env.FROM_EMAIL = 'test@example.com';
     vi.mocked(checkRateLimit).mockReturnValue({ allowed: true, attemptsRemaining: 2 });
@@ -32,21 +38,21 @@ describe('email-service', () => {
     process.env.FROM_EMAIL = origFromEmail;
   });
 
-  it('should throw when RESEND_API_KEY is not set', async () => {
+  it('given cloud mode + missing api key, should throw', async () => {
     delete process.env.RESEND_API_KEY;
     await expect(
       sendEmail({ to: 'user@test.com', subject: 'Test', react: null })
     ).rejects.toThrow('RESEND_API_KEY environment variable is required');
   });
 
-  it('should throw when rate limited', async () => {
+  it('given cloud mode + rate limited recipient, should throw', async () => {
     vi.mocked(checkRateLimit).mockReturnValue({ allowed: false, retryAfter: 60 });
     await expect(
       sendEmail({ to: 'user@test.com', subject: 'Test', react: null })
     ).rejects.toThrow('Too many emails sent to user@test.com');
   });
 
-  it('should send email successfully', async () => {
+  it('given cloud mode, should send email via Resend', async () => {
     mockSend.mockResolvedValue({ data: { id: 'email-1' }, error: null });
 
     await sendEmail({ to: 'user@test.com', subject: 'Test', react: null });
@@ -58,11 +64,31 @@ describe('email-service', () => {
     );
   });
 
-  it('should throw when Resend returns an error', async () => {
+  it('given tenant mode, should send email via Resend', async () => {
+    mockSend.mockResolvedValue({ data: { id: 'email-1' }, error: null });
+
+    await sendEmail({ to: 'user@test.com', subject: 'Test', react: null });
+    expect(mockSend).toHaveBeenCalled();
+  });
+
+  it('given cloud mode + Resend error, should throw', async () => {
     mockSend.mockResolvedValue({ data: null, error: { message: 'Bad request' } });
 
     await expect(
       sendEmail({ to: 'user@test.com', subject: 'Test', react: null })
     ).rejects.toThrow('Failed to send email: Bad request');
+  });
+
+  it('given onprem mode, should no-op without calling Resend', async () => {
+    mockIsOnPrem.mockReturnValue(true);
+    await sendEmail({ to: 'user@test.com', subject: 'Test', react: null });
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('given onprem mode, should not throw', async () => {
+    mockIsOnPrem.mockReturnValue(true);
+    await expect(
+      sendEmail({ to: 'user@test.com', subject: 'Test', react: null })
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/lib/src/services/email-service.ts
+++ b/packages/lib/src/services/email-service.ts
@@ -1,5 +1,6 @@
 import { Resend } from 'resend';
 import { checkRateLimit, RATE_LIMIT_CONFIGS } from '../auth/rate-limit-utils';
+import { isOnPrem } from '../deployment-mode';
 import type * as React from 'react';
 
 function getResendConfig() {
@@ -30,6 +31,11 @@ export interface SendEmailOptions {
 }
 
 export async function sendEmail(options: SendEmailOptions): Promise<void> {
+  if (isOnPrem()) {
+    console.warn('[email-service] Email sending is disabled in on-premise deployment mode');
+    return;
+  }
+
   const config = getResendConfig();
   const resend = getResend();
 

--- a/plan.md
+++ b/plan.md
@@ -3,12 +3,8 @@
 ## Active Epics
 
 - [Files Empty-State CTA](tasks/files-empty-state-cta.md) — discoverable Upload + Create actions for empty Files view; addresses Eric Elliott feedback #4.
-Active epics:
-
 - [Settings Menu Contrast](tasks/settings-menu-contrast.md) — bring Personal settings rows up to WCAG AA in dark mode.
-## Active Epics
-
-_None._
+- [Deployment Mode Isolation Gaps](tasks/deployment-mode-isolation-gaps.md) — close Resend, Google Calendar, and AI provider leaks in onprem/tenant modes; closes #944 #960 #964.
 
 ## Recently Completed
 

--- a/tasks/deployment-mode-isolation-gaps.md
+++ b/tasks/deployment-mode-isolation-gaps.md
@@ -1,0 +1,46 @@
+# Deployment Mode Isolation Gaps Epic
+
+**Status**: 📋 PLANNED
+**Goal**: Close three cloud-credential leak vectors so on-prem and tenant installs cannot call Resend, Google Calendar OAuth, or external AI providers.
+
+## Overview
+
+On-prem and tenant deployments currently share cloud-only infrastructure — Resend email credentials, Google Calendar OAuth routes, and the full external AI provider set are all accessible regardless of DEPLOYMENT_MODE. This creates compliance risk for self-hosted customers and credential leakage if an on-prem instance is compromised. Each fix is a targeted guard at the service or route boundary using the existing `isCloud()` / `isOnPrem()` / `isTenantMode()` utilities from `packages/lib/src/deployment-mode.ts`.
+
+---
+
+## Gate email-service in non-cloud modes
+
+Add `isCloud()` guard in `packages/lib/src/services/email-service.ts`. In non-cloud modes skip sending and log a warning — on-prem uses password auth so magic-link emails are not expected; no new dependency needed.
+
+**Requirements**:
+- Given cloud mode + `sendEmail()` call, should call Resend and send the email as before
+- Given onprem mode + `sendEmail()` call, should return without calling Resend and emit a warning log
+- Given tenant mode + `sendEmail()` call, should return without calling Resend and emit a warning log
+- Given onprem mode + `sendEmail()` call, should NOT throw (callers must not crash)
+
+---
+
+## Gate Google Calendar routes with isCloud()
+
+Add `if (!isCloud()) return Response.json({ error: 'Not available' }, { status: 404 })` at the top of all 8 route handlers under `apps/web/src/app/api/integrations/google-calendar/` (connect, disconnect, status, callback, sync, settings, calendars, webhook).
+
+**Requirements**:
+- Given cloud mode + request to any calendar route, should proceed to normal handler logic
+- Given onprem mode + request to any calendar route, should return 404 before any DB or OAuth work
+- Given tenant mode + request to any calendar route, should return 404 before any DB or OAuth work
+
+---
+
+## Extend AI provider filtering to tenant mode
+
+Fix two places: `getVisibleProviders()` in `apps/web/src/lib/ai/core/ai-providers-config.ts` (currently only checks onprem), and `isProviderBlocked()` in `apps/web/src/app/api/ai/settings/route.ts` (same gap). Tenant mode should apply the same `ONPREM_ALLOWED_PROVIDERS` allowlist as onprem.
+
+**Requirements**:
+- Given tenant mode, `getVisibleProviders()` should return only providers in `ONPREM_ALLOWED_PROVIDERS`
+- Given onprem mode, `getVisibleProviders()` should continue returning only `ONPREM_ALLOWED_PROVIDERS` (no regression)
+- Given cloud mode, `getVisibleProviders()` should return the full `AI_PROVIDERS` set
+- Given tenant mode + external provider key save request, `isProviderBlocked()` should return true
+- Given cloud mode + external provider key save request, `isProviderBlocked()` should return false
+
+---

--- a/tasks/deployment-mode-isolation-gaps.md
+++ b/tasks/deployment-mode-isolation-gaps.md
@@ -1,46 +1,46 @@
 # Deployment Mode Isolation Gaps Epic
 
-**Status**: 📋 PLANNED
-**Goal**: Close three cloud-credential leak vectors so on-prem and tenant installs cannot call Resend, Google Calendar OAuth, or external AI providers.
+**Status**: ✅ COMPLETE
+**Goal**: Close three cloud-credential leak vectors so on-prem deployments cannot call Resend, Google Calendar OAuth, or external AI providers.
 
 ## Overview
 
-On-prem and tenant deployments currently share cloud-only infrastructure — Resend email credentials, Google Calendar OAuth routes, and the full external AI provider set are all accessible regardless of DEPLOYMENT_MODE. This creates compliance risk for self-hosted customers and credential leakage if an on-prem instance is compromised. Each fix is a targeted guard at the service or route boundary using the existing `isCloud()` / `isOnPrem()` / `isTenantMode()` utilities from `packages/lib/src/deployment-mode.ts`.
+On-prem deployments were sharing cloud-only infrastructure — Resend email credentials, Google Calendar OAuth routes, and the full external AI provider set were all accessible regardless of `DEPLOYMENT_MODE`. Tenant mode is semantically cloud (managed multi-tenant SaaS) and is not restricted. Only `onprem` (self-hosted, security-tight) is gated. Each fix is a targeted `isOnPrem()` guard at the service or route boundary using utilities from `packages/lib/src/deployment-mode.ts`.
 
 ---
 
-## Gate email-service in non-cloud modes
+## Gate email-service in onprem mode
 
-Add `isCloud()` guard in `packages/lib/src/services/email-service.ts`. In non-cloud modes skip sending and log a warning — on-prem uses password auth so magic-link emails are not expected; no new dependency needed.
+Add `isOnPrem()` guard in `packages/lib/src/services/email-service.ts`. In onprem mode skip Resend and log a warning — onprem uses password auth so magic-link emails are not needed.
 
-**Requirements**:
-- Given cloud mode + `sendEmail()` call, should call Resend and send the email as before
-- Given onprem mode + `sendEmail()` call, should return without calling Resend and emit a warning log
-- Given tenant mode + `sendEmail()` call, should return without calling Resend and emit a warning log
-- Given onprem mode + `sendEmail()` call, should NOT throw (callers must not crash)
-
----
-
-## Gate Google Calendar routes with isCloud()
-
-Add `if (!isCloud()) return Response.json({ error: 'Not available' }, { status: 404 })` at the top of all 8 route handlers under `apps/web/src/app/api/integrations/google-calendar/` (connect, disconnect, status, callback, sync, settings, calendars, webhook).
-
-**Requirements**:
-- Given cloud mode + request to any calendar route, should proceed to normal handler logic
-- Given onprem mode + request to any calendar route, should return 404 before any DB or OAuth work
-- Given tenant mode + request to any calendar route, should return 404 before any DB or OAuth work
+**Implemented requirements**:
+- Given cloud mode + `sendEmail()` call, should call Resend and send the email as before ✅
+- Given tenant mode + `sendEmail()` call, should call Resend and send the email as before ✅
+- Given onprem mode + `sendEmail()` call, should return without calling Resend and emit a warning log ✅
+- Given onprem mode + `sendEmail()` call, should NOT throw (callers must not crash) ✅
 
 ---
 
-## Extend AI provider filtering to tenant mode
+## Gate Google Calendar routes with isOnPrem()
 
-Fix two places: `getVisibleProviders()` in `apps/web/src/lib/ai/core/ai-providers-config.ts` (currently only checks onprem), and `isProviderBlocked()` in `apps/web/src/app/api/ai/settings/route.ts` (same gap). Tenant mode should apply the same `ONPREM_ALLOWED_PROVIDERS` allowlist as onprem.
+Add `if (isOnPrem()) return Response.json({ error: 'Not available' }, { status: 404 })` at the top of all 8 route handlers under `apps/web/src/app/api/integrations/google-calendar/` (connect, disconnect, status, callback, sync, settings GET+PATCH, calendars, webhook).
 
-**Requirements**:
-- Given tenant mode, `getVisibleProviders()` should return only providers in `ONPREM_ALLOWED_PROVIDERS`
-- Given onprem mode, `getVisibleProviders()` should continue returning only `ONPREM_ALLOWED_PROVIDERS` (no regression)
-- Given cloud mode, `getVisibleProviders()` should return the full `AI_PROVIDERS` set
-- Given tenant mode + external provider key save request, `isProviderBlocked()` should return true
-- Given cloud mode + external provider key save request, `isProviderBlocked()` should return false
+**Implemented requirements**:
+- Given cloud mode + request to any calendar route, should proceed to normal handler logic ✅
+- Given tenant mode + request to any calendar route, should proceed to normal handler logic ✅
+- Given onprem mode + request to any calendar route, should return 404 before any DB or OAuth work ✅
+
+---
+
+## Gate AI provider visibility to onprem mode only
+
+Fix two places: `getVisibleProviders()` in `apps/web/src/lib/ai/core/ai-providers-config.ts` (restrict only for onprem), and `isProviderBlocked()` in `apps/web/src/app/api/ai/settings/route.ts` (same scope — onprem only). Tenant mode retains full provider access.
+
+**Implemented requirements**:
+- Given onprem mode, `getVisibleProviders()` should return only providers in `ONPREM_ALLOWED_PROVIDERS` ✅
+- Given cloud mode, `getVisibleProviders()` should return the full `AI_PROVIDERS` set ✅
+- Given tenant mode, `getVisibleProviders()` should return the full `AI_PROVIDERS` set ✅
+- Given onprem mode + external provider key save request, `isProviderBlocked()` should return true ✅
+- Given cloud mode + external provider key save request, `isProviderBlocked()` should return false ✅
 
 ---


### PR DESCRIPTION
## Summary

- **#944** — `email-service`: Resend was called unconditionally. Now returns early when `isOnPrem()`, logging a warning. Cloud and tenant modes unaffected.
- **#960** — All 8 Google Calendar routes (`connect`, `disconnect`, `status`, `callback`, `sync`, `settings GET+PATCH`, `webhook`, `calendars`) return `404 { error: 'Not available' }` when `isOnPrem()`.
- **#964** — `getVisibleProviders()` restricts to `ONPREM_ALLOWED_PROVIDERS` for onprem only. `isProviderBlocked()` in `/api/ai/settings` uses onprem-only gate (removed `isTenantMode()`).

All guards use `isOnPrem()` directly. Tenant mode is semantically cloud (managed multi-tenant SaaS) and is never restricted.

## Tests added / updated

- `packages/lib/src/services/__tests__/email-service.test.ts` — 7 tests: cloud sends, tenant sends, onprem no-ops, onprem doesn't throw
- `apps/web/src/app/api/integrations/google-calendar/__tests__/deployment-mode-gate.test.ts` — 27 tests covering all 8 routes × 3 modes (cloud passes, tenant passes, onprem blocks)
- `apps/web/src/lib/ai/core/__tests__/ai-providers-config.test.ts` — 3 tests: cloud/onprem/tenant for `getVisibleProviders()`
- `apps/web/src/app/api/ai/settings/__tests__/route.test.ts` — 4 tests: cloud passes, onprem blocks external, onprem allows ollama, tenant passes

## Test plan

- [x] `pnpm test:unit` — 3818 lib tests pass (1 pre-existing DB integration failure unrelated to this PR)
- [x] Web app tests — 47 AI settings tests pass, 27 calendar gate tests pass, 27 ai-providers-config tests pass
- [x] `pnpm --filter web tsc --noEmit` — no TypeScript errors
- [x] `pnpm lint` — no ESLint errors or warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)