### PR TITLE
refactor(imports): direct subpath imports — PR B: Small Apps

### DIFF
--- a/apps/control-plane/src/middleware/api-key-auth.ts
+++ b/apps/control-plane/src/middleware/api-key-auth.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify'
 import fp from 'fastify-plugin'
-import { secureCompare } from '@pagespace/lib'
+import { secureCompare } from '@pagespace/lib/auth/secure-compare'
 
 async function apiKeyAuthPlugin(app: FastifyInstance) {
   app.addHook('onRequest', async (request: FastifyRequest, reply: FastifyReply) => {

--- a/apps/control-plane/src/validation/tenant-validation.ts
+++ b/apps/control-plane/src/validation/tenant-validation.ts
@@ -1,4 +1,4 @@
-import { isValidEmail } from '@pagespace/lib/validators'
+import { isValidEmail } from '@pagespace/lib/validators/email'
 
 export type ValidationResult = {
   valid: boolean

--- a/apps/marketing/src/app/api/contact/__tests__/route.test.ts
+++ b/apps/marketing/src/app/api/contact/__tests__/route.test.ts
@@ -16,14 +16,14 @@ vi.mock('resend', () => ({
   })),
 }));
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn(),
-  DISTRIBUTED_RATE_LIMITS: {
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn(),
+    DISTRIBUTED_RATE_LIMITS: {
     MARKETING_CONTACT_FORM: { maxAttempts: 5, windowMs: 3_600_000 },
   },
 }));
 
-import { checkDistributedRateLimit } from '@pagespace/lib/security';
+import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 
 const validPayload = {
   name: 'John Doe',

--- a/apps/marketing/src/app/api/contact/__tests__/route.test.ts
+++ b/apps/marketing/src/app/api/contact/__tests__/route.test.ts
@@ -17,8 +17,8 @@ vi.mock('resend', () => ({
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn(),
-    DISTRIBUTED_RATE_LIMITS: {
+  checkDistributedRateLimit: vi.fn(),
+  DISTRIBUTED_RATE_LIMITS: {
     MARKETING_CONTACT_FORM: { maxAttempts: 5, windowMs: 3_600_000 },
   },
 }));

--- a/apps/marketing/src/app/api/contact/route.ts
+++ b/apps/marketing/src/app/api/contact/route.ts
@@ -1,5 +1,5 @@
 import { Resend } from "resend";
-import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from "@pagespace/lib/security";
+import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security/distributed-rate-limit';
 
 // Bounded-quantifier RFC 5322 regex — O(N), no ReDoS risk
 const EMAIL_PATTERN = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;

--- a/apps/processor/src/__tests__/cors-validation.test.ts
+++ b/apps/processor/src/__tests__/cors-validation.test.ts
@@ -18,6 +18,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       error: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 import { loggers } from '@pagespace/lib/logging/logger-config';

--- a/apps/processor/src/__tests__/server.test.ts
+++ b/apps/processor/src/__tests__/server.test.ts
@@ -236,6 +236,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       error: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 // ---------------------------------------------------------------------------

--- a/apps/processor/src/api/__tests__/ingest.test.ts
+++ b/apps/processor/src/api/__tests__/ingest.test.ts
@@ -40,6 +40,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
     security: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
     processor: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 import { ingestRouter } from '../ingest';

--- a/apps/processor/src/middleware/__tests__/auth.test.ts
+++ b/apps/processor/src/middleware/__tests__/auth.test.ts
@@ -13,13 +13,13 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 // Mock all external dependencies that auth.ts imports
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     validateSession: vi.fn(),
   },
 }));
 
 vi.mock('@pagespace/lib/permissions/enforced-context', () => ({
-    EnforcedAuthContext: {
+  EnforcedAuthContext: {
     fromSession: vi.fn(),
   },
 }));

--- a/apps/processor/src/middleware/__tests__/auth.test.ts
+++ b/apps/processor/src/middleware/__tests__/auth.test.ts
@@ -12,14 +12,14 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
  */
 
 // Mock all external dependencies that auth.ts imports
-vi.mock('@pagespace/lib/auth', () => ({
-  sessionService: {
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     validateSession: vi.fn(),
   },
 }));
 
-vi.mock('@pagespace/lib/permissions', () => ({
-  EnforcedAuthContext: {
+vi.mock('@pagespace/lib/permissions/enforced-context', () => ({
+    EnforcedAuthContext: {
     fromSession: vi.fn(),
   },
 }));
@@ -28,6 +28,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   loggers: {
     security: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 describe('AUTH_REQUIRED security behavior', () => {

--- a/apps/processor/src/middleware/__tests__/auth.test.ts
+++ b/apps/processor/src/middleware/__tests__/auth.test.ts
@@ -174,16 +174,17 @@ describe('authenticateService - catch block', () => {
 
   it('responds 401 when validateSession throws an error', async () => {
     // Set up mocks before importing the module
-    vi.doMock('@pagespace/lib/auth', () => ({
+    vi.doMock('@pagespace/lib/auth/session-service', () => ({
       sessionService: {
         validateSession: vi.fn().mockRejectedValue(new Error('JWT parsing failed')),
       },
     }));
-    vi.doMock('@pagespace/lib/permissions', () => ({
+    vi.doMock('@pagespace/lib/permissions/enforced-context', () => ({
       EnforcedAuthContext: { fromSession: vi.fn() },
     }));
     vi.doMock('@pagespace/lib/logging/logger-config', () => ({
       loggers: { security: { warn: vi.fn(), info: vi.fn(), error: vi.fn() } },
+      logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
     }));
 
     const { authenticateService } = await import('../auth');
@@ -210,16 +211,17 @@ describe('authenticateService - catch block', () => {
   });
 
   it('responds 401 when validateSession throws a non-Error object', async () => {
-    vi.doMock('@pagespace/lib/auth', () => ({
+    vi.doMock('@pagespace/lib/auth/session-service', () => ({
       sessionService: {
         validateSession: vi.fn().mockRejectedValue('string error'),
       },
     }));
-    vi.doMock('@pagespace/lib/permissions', () => ({
+    vi.doMock('@pagespace/lib/permissions/enforced-context', () => ({
       EnforcedAuthContext: { fromSession: vi.fn() },
     }));
     vi.doMock('@pagespace/lib/logging/logger-config', () => ({
       loggers: { security: { warn: vi.fn(), info: vi.fn(), error: vi.fn() } },
+      logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
     }));
 
     const { authenticateService } = await import('../auth');

--- a/apps/processor/src/middleware/__tests__/resource-binding.test.ts
+++ b/apps/processor/src/middleware/__tests__/resource-binding.test.ts
@@ -12,6 +12,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       error: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 vi.mock('../../cache/content-store', () => ({

--- a/apps/processor/src/middleware/auth.ts
+++ b/apps/processor/src/middleware/auth.ts
@@ -1,6 +1,6 @@
 import type { NextFunction, Request, Response } from 'express';
-import { sessionService, type SessionClaims } from '@pagespace/lib/auth';
-import { EnforcedAuthContext } from '@pagespace/lib/permissions';
+import { sessionService, type SessionClaims } from '@pagespace/lib/auth/session-service';
+import { EnforcedAuthContext } from '@pagespace/lib/permissions/enforced-context';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 
 /**
@@ -153,4 +153,4 @@ export function getUserId(req: Request): string | null {
   return auth.userId;
 }
 
-export { EnforcedAuthContext, type ResourceBinding } from '@pagespace/lib/permissions';
+export { EnforcedAuthContext, type ResourceBinding } from '@pagespace/lib/permissions/enforced-context';

--- a/apps/processor/src/services/__tests__/authorization.test.ts
+++ b/apps/processor/src/services/__tests__/authorization.test.ts
@@ -12,9 +12,11 @@ vi.mock('../file-links', () => ({
   getFileDriveId: (...args: unknown[]) => mockGetFileDriveId(...args),
 }));
 
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    getUserAccessLevel: (...args: unknown[]) => mockGetUserAccessLevel(...args),
+}));
 vi.mock('@pagespace/lib/permissions', () => ({
-  getUserAccessLevel: (...args: unknown[]) => mockGetUserAccessLevel(...args),
-  getUserDrivePermissions: (...args: unknown[]) => mockGetUserDrivePermissions(...args),
+    getUserDrivePermissions: (...args: unknown[]) => mockGetUserDrivePermissions(...args),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
@@ -25,6 +27,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       error: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 import type { EnforcedAuthContext } from '../../middleware/auth';

--- a/apps/processor/src/services/__tests__/authorization.test.ts
+++ b/apps/processor/src/services/__tests__/authorization.test.ts
@@ -14,8 +14,6 @@ vi.mock('../file-links', () => ({
 
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
     getUserAccessLevel: (...args: unknown[]) => mockGetUserAccessLevel(...args),
-}));
-vi.mock('@pagespace/lib/permissions', () => ({
     getUserDrivePermissions: (...args: unknown[]) => mockGetUserDrivePermissions(...args),
 }));
 

--- a/apps/processor/src/services/__tests__/authorization.test.ts
+++ b/apps/processor/src/services/__tests__/authorization.test.ts
@@ -13,8 +13,8 @@ vi.mock('../file-links', () => ({
 }));
 
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
-    getUserAccessLevel: (...args: unknown[]) => mockGetUserAccessLevel(...args),
-    getUserDrivePermissions: (...args: unknown[]) => mockGetUserDrivePermissions(...args),
+  getUserAccessLevel: (...args: unknown[]) => mockGetUserAccessLevel(...args),
+  getUserDrivePermissions: (...args: unknown[]) => mockGetUserDrivePermissions(...args),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({

--- a/apps/processor/src/services/__tests__/rbac-delete.test.ts
+++ b/apps/processor/src/services/__tests__/rbac-delete.test.ts
@@ -15,8 +15,8 @@ vi.mock('../file-links', () => ({
 }));
 
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
-    getUserAccessLevel: (...args: unknown[]) => mockGetUserAccessLevel(...args),
-    getUserDrivePermissions: (...args: unknown[]) => mockGetUserDrivePermissions(...args),
+  getUserAccessLevel: (...args: unknown[]) => mockGetUserAccessLevel(...args),
+  getUserDrivePermissions: (...args: unknown[]) => mockGetUserDrivePermissions(...args),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({

--- a/apps/processor/src/services/__tests__/rbac-delete.test.ts
+++ b/apps/processor/src/services/__tests__/rbac-delete.test.ts
@@ -14,9 +14,11 @@ vi.mock('../file-links', () => ({
   getLinksForFile: (...args: unknown[]) => mockGetLinksForFile(...args),
 }));
 
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    getUserAccessLevel: (...args: unknown[]) => mockGetUserAccessLevel(...args),
+}));
 vi.mock('@pagespace/lib/permissions', () => ({
-  getUserAccessLevel: (...args: unknown[]) => mockGetUserAccessLevel(...args),
-  getUserDrivePermissions: (...args: unknown[]) => mockGetUserDrivePermissions(...args),
+    getUserDrivePermissions: (...args: unknown[]) => mockGetUserDrivePermissions(...args),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
@@ -27,6 +29,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       error: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 vi.mock('@pagespace/db', () => ({

--- a/apps/processor/src/services/__tests__/rbac-delete.test.ts
+++ b/apps/processor/src/services/__tests__/rbac-delete.test.ts
@@ -16,8 +16,6 @@ vi.mock('../file-links', () => ({
 
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
     getUserAccessLevel: (...args: unknown[]) => mockGetUserAccessLevel(...args),
-}));
-vi.mock('@pagespace/lib/permissions', () => ({
     getUserDrivePermissions: (...args: unknown[]) => mockGetUserDrivePermissions(...args),
 }));
 

--- a/apps/processor/src/services/__tests__/siem-adapter.test.ts
+++ b/apps/processor/src/services/__tests__/siem-adapter.test.ts
@@ -66,13 +66,15 @@ vi.mock('dgram', () => ({
   createSocket: mockDgramCreateSocket,
 }));
 
-vi.mock('@pagespace/lib/security', () => ({
-  validateExternalURL: mockValidateExternalURL,
-  resolvePathWithinSync: vi.fn((base: string, ...segs: string[]) => {
+vi.mock('@pagespace/lib/security/path-validator', () => ({
+    resolvePathWithinSync: vi.fn((base: string, ...segs: string[]) => {
     const path = require('path');
     const joined = path.join(base, ...segs);
     return joined.startsWith(base) ? joined : null;
   }),
+}));
+vi.mock('@pagespace/lib/security', () => ({
+    validateExternalURL: mockValidateExternalURL,
 }));
 
 import {

--- a/apps/processor/src/services/__tests__/siem-adapter.test.ts
+++ b/apps/processor/src/services/__tests__/siem-adapter.test.ts
@@ -67,14 +67,14 @@ vi.mock('dgram', () => ({
 }));
 
 vi.mock('@pagespace/lib/security/path-validator', () => ({
-    resolvePathWithinSync: vi.fn((base: string, ...segs: string[]) => {
+  resolvePathWithinSync: vi.fn((base: string, ...segs: string[]) => {
     const path = require('path');
     const joined = path.join(base, ...segs);
     return joined.startsWith(base) ? joined : null;
   }),
 }));
 vi.mock('@pagespace/lib/security/url-validator', () => ({
-    validateExternalURL: mockValidateExternalURL,
+  validateExternalURL: mockValidateExternalURL,
 }));
 
 import {

--- a/apps/processor/src/services/__tests__/siem-adapter.test.ts
+++ b/apps/processor/src/services/__tests__/siem-adapter.test.ts
@@ -73,7 +73,7 @@ vi.mock('@pagespace/lib/security/path-validator', () => ({
     return joined.startsWith(base) ? joined : null;
   }),
 }));
-vi.mock('@pagespace/lib/security', () => ({
+vi.mock('@pagespace/lib/security/url-validator', () => ({
     validateExternalURL: mockValidateExternalURL,
 }));
 

--- a/apps/processor/src/services/__tests__/siem-chain-hashers.test.ts
+++ b/apps/processor/src/services/__tests__/siem-chain-hashers.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'vitest';
-import { computeLogHash } from '@pagespace/lib/monitoring';
-import { computeSecurityEventHash, type AuditEvent } from '@pagespace/lib/audit';
+import { computeLogHash } from '@pagespace/lib/monitoring/activity-logger';
+import { computeSecurityEventHash, type AuditEvent } from '@pagespace/lib/audit/security-audit';
 import { assert } from '../../__tests__/riteway';
 import {
   recomputeActivityLogHash,

--- a/apps/processor/src/services/__tests__/siem-pipeline.e2e.test.ts
+++ b/apps/processor/src/services/__tests__/siem-pipeline.e2e.test.ts
@@ -150,13 +150,15 @@ vi.mock('@pagespace/db', () => {
 });
 
 // ---------------------------------------------------------------------------
-// @pagespace/lib/security — the worker's delivery path calls validateExternalURL
+// @pagespace/lib/security/url-validator — the worker's delivery path calls validateExternalURL
 // against the webhook URL. Localhost would normally be blocked for SSRF, so
 // override to accept any URL in this test.
 // ---------------------------------------------------------------------------
 
-vi.mock('@pagespace/lib/security', () => ({
+vi.mock('@pagespace/lib/security/url-validator', () => ({
   validateExternalURL: mockValidateExternalURL,
+}));
+vi.mock('@pagespace/lib/security/path-validator', () => ({
   resolvePathWithinSync: (base: string, ...segs: string[]): string => {
     return [base, ...segs].join('/');
   },
@@ -270,7 +272,8 @@ vi.mock('../../db', () => {
 // Deferred imports so the vi.mock calls above take effect first.
 // ---------------------------------------------------------------------------
 
-import { audit, securityAudit, type AuditEvent } from '@pagespace/lib/audit';
+import { audit } from '@pagespace/lib/audit/audit-log';
+import { securityAudit, type AuditEvent } from '@pagespace/lib/audit/security-audit';
 import { processSiemDelivery } from '../../workers/siem-delivery-worker';
 
 // ---------------------------------------------------------------------------

--- a/apps/processor/src/services/authorization.ts
+++ b/apps/processor/src/services/authorization.ts
@@ -1,5 +1,5 @@
 import { loggers } from '@pagespace/lib/logging/logger-config';
-import { getUserAccessLevel, getUserDrivePermissions } from '@pagespace/lib/permissions';
+import { getUserAccessLevel, getUserDrivePermissions } from '@pagespace/lib/permissions/permissions';
 import type { EnforcedAuthContext, ResourceBinding } from '../middleware/auth';
 import { getLinksForFile, getFileDriveId, type FileLink } from './file-links';
 

--- a/apps/processor/src/services/rbac.ts
+++ b/apps/processor/src/services/rbac.ts
@@ -1,6 +1,6 @@
 import { db, channelMessages, eq, filePages, files, pages } from '@pagespace/db';
 import { loggers } from '@pagespace/lib/logging/logger-config';
-import { getUserAccessLevel, getUserDrivePermissions } from '@pagespace/lib/permissions';
+import { getUserAccessLevel, getUserDrivePermissions } from '@pagespace/lib/permissions/permissions';
 import type { EnforcedAuthContext } from '../middleware/auth';
 import { getLinksForFile, type FileLink } from './file-links';
 

--- a/apps/processor/src/services/siem-adapter.ts
+++ b/apps/processor/src/services/siem-adapter.ts
@@ -1,7 +1,7 @@
 import { createHash, createHmac } from 'crypto';
 import * as net from 'net';
 import * as dgram from 'dgram';
-import { validateExternalURL } from '@pagespace/lib/security';
+import { validateExternalURL } from '@pagespace/lib/security/url-validator';
 
 // Sources the SIEM worker can read from. Each source has its own cursor row
 // in siem_delivery_cursors and its own pure-function row mapper. The canonical

--- a/apps/processor/src/utils/__tests__/security.test.ts
+++ b/apps/processor/src/utils/__tests__/security.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 // Mock the underlying lib security module
-vi.mock('@pagespace/lib/security', () => ({
-  validateExternalURL: vi.fn().mockResolvedValue({ valid: true }),
-  resolvePathWithinSync: vi.fn((base: string, ...segs: string[]) => {
+vi.mock('@pagespace/lib/security/path-validator', () => ({
+    resolvePathWithinSync: vi.fn((base: string, ...segs: string[]) => {
     const path = require('path');
     const joined = path.join(base, ...segs);
     if (
@@ -13,6 +12,9 @@ vi.mock('@pagespace/lib/security', () => ({
     }
     return joined;
   }),
+}));
+vi.mock('@pagespace/lib/security', () => ({
+    validateExternalURL: vi.fn().mockResolvedValue({ valid: true }),
 }));
 
 import {

--- a/apps/processor/src/utils/__tests__/security.test.ts
+++ b/apps/processor/src/utils/__tests__/security.test.ts
@@ -2,19 +2,14 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 // Mock the underlying lib security module
 vi.mock('@pagespace/lib/security/path-validator', () => ({
-    resolvePathWithinSync: vi.fn((base: string, ...segs: string[]) => {
+  resolvePathWithinSync: vi.fn((base: string, ...segs: string[]) => {
     const path = require('path');
     const joined = path.join(base, ...segs);
-    if (
-      segs.some(s => s.includes('..') || s.includes('\0'))
-    ) {
+    if (segs.some(s => s.includes('..') || s.includes('\0'))) {
       return null;
     }
     return joined;
   }),
-}));
-vi.mock('@pagespace/lib/security', () => ({
-    validateExternalURL: vi.fn().mockResolvedValue({ valid: true }),
 }));
 
 import {

--- a/apps/processor/src/utils/security.ts
+++ b/apps/processor/src/utils/security.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { resolvePathWithinSync as libResolvePathWithinSync } from '@pagespace/lib/security';
+import { resolvePathWithinSync as libResolvePathWithinSync } from '@pagespace/lib/security/path-validator';
 
 export const SAFE_EXTENSION_PATTERN = /^[a-z0-9]{1,8}$/i;
 export const DEFAULT_EXTENSION = '.bin';

--- a/apps/processor/src/workers/__tests__/siem-delivery-worker.test.ts
+++ b/apps/processor/src/workers/__tests__/siem-delivery-worker.test.ts
@@ -59,7 +59,7 @@ vi.mock('../siem-delivery-preflight', () => ({
   runChainPreflight: mockRunChainPreflight,
 }));
 
-vi.mock('@pagespace/lib/audit', () => ({
+vi.mock('@pagespace/lib/audit/security-audit-alerting', () => ({
     notifyChainPreflightFailure: mockNotifyChainPreflightFailure,
 }));
 

--- a/apps/processor/src/workers/__tests__/siem-delivery-worker.test.ts
+++ b/apps/processor/src/workers/__tests__/siem-delivery-worker.test.ts
@@ -60,7 +60,7 @@ vi.mock('../siem-delivery-preflight', () => ({
 }));
 
 vi.mock('@pagespace/lib/audit/security-audit-alerting', () => ({
-    notifyChainPreflightFailure: mockNotifyChainPreflightFailure,
+  notifyChainPreflightFailure: mockNotifyChainPreflightFailure,
 }));
 
 import { processSiemDelivery } from '../siem-delivery-worker';

--- a/apps/processor/src/workers/__tests__/siem-delivery-worker.test.ts
+++ b/apps/processor/src/workers/__tests__/siem-delivery-worker.test.ts
@@ -60,7 +60,7 @@ vi.mock('../siem-delivery-preflight', () => ({
 }));
 
 vi.mock('@pagespace/lib/audit', () => ({
-  notifyChainPreflightFailure: mockNotifyChainPreflightFailure,
+    notifyChainPreflightFailure: mockNotifyChainPreflightFailure,
 }));
 
 import { processSiemDelivery } from '../siem-delivery-worker';

--- a/apps/processor/src/workers/siem-delivery-worker.ts
+++ b/apps/processor/src/workers/siem-delivery-worker.ts
@@ -18,7 +18,7 @@ import { buildReceipts } from '../services/siem-receipt-builder';
 import { writeReceipts } from './siem-receipt-writer';
 import { runChainPreflight } from './siem-delivery-preflight';
 import { SIEM_SOURCES, CURSOR_INIT_SENTINEL } from '../services/siem-sources';
-import { notifyChainPreflightFailure } from '@pagespace/lib/audit';
+import { notifyChainPreflightFailure } from '@pagespace/lib/audit/security-audit-alerting';
 import { getPoolForWorker } from '../db';
 
 const DEFAULT_BATCH_SIZE = 100;

--- a/apps/processor/tests/auth-middleware.test.ts
+++ b/apps/processor/tests/auth-middleware.test.ts
@@ -8,14 +8,14 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   },
 }));
 
-vi.mock('@pagespace/lib/auth', () => ({
-  sessionService: {
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     validateSession: vi.fn(),
   },
 }));
 
-vi.mock('@pagespace/lib/permissions', () => ({
-  EnforcedAuthContext: {
+vi.mock('@pagespace/lib/permissions/enforced-context', () => ({
+    EnforcedAuthContext: {
     fromSession: vi.fn((claims) => ({
       userId: claims.userId,
       userRole: claims.userRole,
@@ -35,7 +35,7 @@ vi.mock('@pagespace/lib/permissions', () => ({
   },
 }));
 
-import { sessionService } from '@pagespace/lib/auth';
+import { sessionService } from '@pagespace/lib/auth/session-service';
 
 function createMockRequest(overrides: Partial<Request> = {}): Request {
   return {

--- a/apps/processor/tests/auth-middleware.test.ts
+++ b/apps/processor/tests/auth-middleware.test.ts
@@ -9,13 +9,13 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
 }));
 
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     validateSession: vi.fn(),
   },
 }));
 
 vi.mock('@pagespace/lib/permissions/enforced-context', () => ({
-    EnforcedAuthContext: {
+  EnforcedAuthContext: {
     fromSession: vi.fn((claims) => ({
       userId: claims.userId,
       userRole: claims.userRole,

--- a/apps/realtime/src/__tests__/index.test.ts
+++ b/apps/realtime/src/__tests__/index.test.ts
@@ -38,6 +38,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       error: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 // broadcast-auth mock
@@ -46,14 +48,14 @@ vi.mock('@pagespace/lib/auth/broadcast-auth', () => ({
 }));
 
 // permissions mock
-vi.mock('@pagespace/lib/permissions', () => ({
-  getUserAccessLevel: vi.fn(),
-  getUserDriveAccess: vi.fn(),
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    getUserAccessLevel: vi.fn(),
+    getUserDriveAccess: vi.fn(),
 }));
 
 // auth/session mock
-vi.mock('@pagespace/lib/auth', () => ({
-  sessionService: {
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     validateSession: vi.fn(),
   },
   hashToken: (token: string) => {
@@ -227,8 +229,8 @@ vi.mock('socket.io', () => ({
 // ---------------------------------------------------------------------------
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { verifyBroadcastSignature } from '@pagespace/lib/auth/broadcast-auth';
-import { getUserAccessLevel, getUserDriveAccess } from '@pagespace/lib/permissions';
-import { sessionService } from '@pagespace/lib/auth';
+import { getUserAccessLevel, getUserDriveAccess } from '@pagespace/lib/permissions/permissions';
+import { sessionService } from '@pagespace/lib/auth/session-service';
 import { emitValidationError } from '../validation';
 
 // ---------------------------------------------------------------------------

--- a/apps/realtime/src/__tests__/index.test.ts
+++ b/apps/realtime/src/__tests__/index.test.ts
@@ -49,13 +49,13 @@ vi.mock('@pagespace/lib/auth/broadcast-auth', () => ({
 
 // permissions mock
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
-    getUserAccessLevel: vi.fn(),
-    getUserDriveAccess: vi.fn(),
+  getUserAccessLevel: vi.fn(),
+  getUserDriveAccess: vi.fn(),
 }));
 
 // auth/session mock
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     validateSession: vi.fn(),
   },
   hashToken: (token: string) => {

--- a/apps/realtime/src/__tests__/kick-api.test.ts
+++ b/apps/realtime/src/__tests__/kick-api.test.ts
@@ -21,6 +21,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       error: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 describe('Kick API', () => {

--- a/apps/realtime/src/__tests__/kick-handler.test.ts
+++ b/apps/realtime/src/__tests__/kick-handler.test.ts
@@ -18,6 +18,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       error: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 // Mock the socket-registry module

--- a/apps/realtime/src/__tests__/origin-validation.test.ts
+++ b/apps/realtime/src/__tests__/origin-validation.test.ts
@@ -31,6 +31,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       error: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 import { loggers } from '@pagespace/lib/logging/logger-config';

--- a/apps/realtime/src/__tests__/per-event-auth.test.ts
+++ b/apps/realtime/src/__tests__/per-event-auth.test.ts
@@ -15,11 +15,11 @@ vi.mock('@pagespace/lib/logging/logger-config', () => {
   return { loggers: { realtime: logger, api: logger, security: logger } };
 });
 
-vi.mock('@pagespace/lib/permissions', () => ({
-  getUserAccessLevel: vi.fn(),
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    getUserAccessLevel: vi.fn(),
 }));
 
-import { getUserAccessLevel } from '@pagespace/lib/permissions';
+import { getUserAccessLevel } from '@pagespace/lib/permissions/permissions';
 
 describe('Per-Event Authorization', () => {
   describe('isSensitiveEvent', () => {

--- a/apps/realtime/src/__tests__/per-event-auth.test.ts
+++ b/apps/realtime/src/__tests__/per-event-auth.test.ts
@@ -16,7 +16,7 @@ vi.mock('@pagespace/lib/logging/logger-config', () => {
 });
 
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
-    getUserAccessLevel: vi.fn(),
+  getUserAccessLevel: vi.fn(),
 }));
 
 import { getUserAccessLevel } from '@pagespace/lib/permissions/permissions';

--- a/apps/realtime/src/__tests__/rooms.test.ts
+++ b/apps/realtime/src/__tests__/rooms.test.ts
@@ -21,9 +21,9 @@
 import { describe, it, expect, beforeEach, vi, MockedFunction } from 'vitest';
 
 // Mock the permission functions
-vi.mock('@pagespace/lib/permissions', () => ({
-  getUserAccessLevel: vi.fn(),
-  getUserDriveAccess: vi.fn(),
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    getUserAccessLevel: vi.fn(),
+    getUserDriveAccess: vi.fn(),
 }));
 
 // Mock the database
@@ -49,9 +49,11 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       error: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
-import { getUserAccessLevel, getUserDriveAccess } from '@pagespace/lib/permissions';
+import { getUserAccessLevel, getUserDriveAccess } from '@pagespace/lib/permissions/permissions';
 import { db } from '@pagespace/db';
 
 // Create a mock socket that tracks room joins/leaves

--- a/apps/realtime/src/__tests__/rooms.test.ts
+++ b/apps/realtime/src/__tests__/rooms.test.ts
@@ -22,8 +22,8 @@ import { describe, it, expect, beforeEach, vi, MockedFunction } from 'vitest';
 
 // Mock the permission functions
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
-    getUserAccessLevel: vi.fn(),
-    getUserDriveAccess: vi.fn(),
+  getUserAccessLevel: vi.fn(),
+  getUserDriveAccess: vi.fn(),
 }));
 
 // Mock the database

--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -1,7 +1,8 @@
 import { createServer, IncomingMessage, ServerResponse } from 'http';
 import { Server, Socket } from 'socket.io';
-import { getUserAccessLevel, getUserDriveAccess } from '@pagespace/lib/permissions';
-import { sessionService, hashToken } from '@pagespace/lib/auth';
+import { getUserAccessLevel, getUserDriveAccess } from '@pagespace/lib/permissions/permissions';
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { hashToken } from '@pagespace/lib/auth/token-utils';
 import { verifyBroadcastSignature } from '@pagespace/lib/auth/broadcast-auth';
 import * as dotenv from 'dotenv';
 import { db, eq, gt, and, or, dmConversations, socketTokens, users, userProfiles, pages } from '@pagespace/db';

--- a/apps/realtime/src/per-event-auth.ts
+++ b/apps/realtime/src/per-event-auth.ts
@@ -13,7 +13,7 @@
  * - Room joins: immediate at kick time (kick handler evicts sockets)
  */
 
-import { getUserAccessLevel } from '@pagespace/lib/permissions';
+import { getUserAccessLevel } from '@pagespace/lib/permissions/permissions';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import type { Socket } from 'socket.io';
 

--- a/apps/realtime/src/presence-tracker.ts
+++ b/apps/realtime/src/presence-tracker.ts
@@ -9,7 +9,7 @@
  * "who is viewing what" with display metadata.
  */
 
-import type { PresenceViewer } from '@pagespace/lib/client-safe';
+import type { PresenceViewer } from '@pagespace/lib/types';
 
 // Re-export for convenience
 export type { PresenceViewer };


### PR DESCRIPTION
## Summary

Replaces barrel imports (`@pagespace/lib/server`, `@pagespace/lib/auth`, `@pagespace/lib/permissions`, etc.) with direct subpath imports in:
- `apps/processor/` — 19 files (source + tests)
- `apps/realtime/` — 9 files (source + tests)
- `apps/control-plane/` — 2 files
- `apps/marketing/` — 2 files (source + test)

**All source-file changes are mechanical import-path swaps. No logic changes.**

## Context

**PR B of 6** in the barrel-import removal series.

**⚠️ Depends on PR A (#1088) `barrel/foundation` being merged first.**
Base branch is `barrel/foundation` so CI resolves the new subpath exports.
After A merges, this PR's base will be updated to `master`.

## Changes pattern

Every source change is a variant of:
```diff
-import { sessionService } from '@pagespace/lib/auth'
+import { sessionService } from '@pagespace/lib/auth/session-service'
```

## Non-mechanical changes (documented)

Two categories of test changes accompany the import swaps:

**1. Logger mock contract expansion** — 12 test files add `logger: { child: vi.fn(...) }` to existing `@pagespace/lib/logging/logger-config` mocks. Required because `logger-config` added a root `logger` export that tests were not mocking, causing failures unrelated to this refactor.

**2. `presence-tracker.ts` — `client-safe` → `types`** — `PresenceViewer` is defined in `packages/lib/src/types.ts` (exported at `@pagespace/lib/types`) and only re-exported from `client-safe`. The import is redirected to the canonical source. It is `import type` only — zero runtime impact.

## Verification

- [ ] `pnpm --filter processor typecheck`
- [ ] `pnpm --filter realtime typecheck`
- [ ] No logic changes — only import paths updated

## Review

Please use `/aidd:review` for AI-assisted review. Focus: are the import targets correct for each symbol (right module, not just right package)?

🤖 Generated with [Claude Code](https://claude.ai/claude-code)