### PR TITLE
refactor(imports): direct subpath imports — PR C: Web Auth + Security

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -6,7 +6,7 @@ import {
   isPublicPageRoute,
   shouldDisableCOEP,
 } from '@/middleware/security-headers';
-import { logSecurityEvent } from '@pagespace/lib/server';
+import { logSecurityEvent } from '@pagespace/lib/logging/logger-config';
 import {
   validateOriginForMiddleware,
   isOriginValidationBlocking,

--- a/apps/web/src/app/api/auth/__tests__/csrf.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/csrf.test.ts
@@ -21,16 +21,16 @@ import { GET } from '../csrf/route';
 
 // Mock dependencies at system boundaries
 vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
-    generateCSRFToken: vi.fn().mockReturnValue('generated-csrf-token'),
+  generateCSRFToken: vi.fn().mockReturnValue('generated-csrf-token'),
 }));
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     validateSession: vi.fn(),
   },
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -38,15 +38,13 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       debug: vi.fn(),
     },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 vi.mock('@/lib/auth/cookie-config', () => ({
   getSessionFromCookies: vi.fn(),
 }));
 
-import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
 import { sessionService } from '@pagespace/lib/auth/session-service';
 import { getSessionFromCookies } from '@/lib/auth/cookie-config';
 

--- a/apps/web/src/app/api/auth/__tests__/csrf.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/csrf.test.ts
@@ -20,15 +20,17 @@ import { GET } from '../csrf/route';
  */
 
 // Mock dependencies at system boundaries
-vi.mock('@pagespace/lib/auth', () => ({
-  generateCSRFToken: vi.fn().mockReturnValue('generated-csrf-token'),
-  sessionService: {
+vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
+    generateCSRFToken: vi.fn().mockReturnValue('generated-csrf-token'),
+}));
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     validateSession: vi.fn(),
   },
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -36,13 +38,16 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 vi.mock('@/lib/auth/cookie-config', () => ({
   getSessionFromCookies: vi.fn(),
 }));
 
-import { generateCSRFToken, sessionService } from '@pagespace/lib/auth';
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { sessionService } from '@pagespace/lib/auth/session-service';
 import { getSessionFromCookies } from '@/lib/auth/cookie-config';
 
 describe('/api/auth/csrf', () => {

--- a/apps/web/src/app/api/auth/__tests__/device-refresh.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/device-refresh.test.ts
@@ -17,13 +17,16 @@ vi.mock('@pagespace/db/transactions/auth-transactions', () => ({
   atomicDeviceTokenRotation: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  validateDeviceToken: vi.fn(),
-  updateDeviceTokenActivity: vi.fn().mockResolvedValue(undefined),
-  // Opaque token generator - now synchronous with no parameters
-  generateDeviceToken: vi.fn().mockReturnValue('ps_dev_mock_token'),
-  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
-  loggers: {
+vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
+    validateDeviceToken: vi.fn(),
+    updateDeviceTokenActivity: vi.fn().mockResolvedValue(undefined),
+    generateDeviceToken: vi.fn().mockReturnValue('ps_dev_mock_token'),
+}));
+vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
+    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -34,7 +37,11 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
     },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
@@ -44,16 +51,19 @@ vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
 vi.mock('@paralleldrive/cuid2', () => ({
   createId: vi.fn().mockReturnValue('mock-cuid'),
   init: vi.fn(() => vi.fn(() => 'test-cuid')),
+  isCuid: vi.fn((id: string) => typeof id === 'string' && id.length > 0),
 }));
 
 vi.mock('cookie', () => ({
   serialize: vi.fn().mockReturnValue('mock-cookie'),
 }));
 
-vi.mock('@pagespace/lib/auth', () => ({
-  hashToken: vi.fn().mockReturnValue('mock-token-hash'),
-  getTokenPrefix: vi.fn().mockReturnValue('mock-prefix'),
-  sessionService: {
+vi.mock('@pagespace/lib/auth/token-utils', () => ({
+    hashToken: vi.fn().mockReturnValue('mock-token-hash'),
+    getTokenPrefix: vi.fn().mockReturnValue('mock-prefix'),
+}));
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock-session-token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'session-123',
@@ -72,17 +82,24 @@ vi.mock('@/lib/auth', () => ({
   appendSessionCookie: vi.fn(),
 }));
 
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+  checkDistributedRateLimit: vi.fn().mockResolvedValue({ allowed: true, remaining: 9 }),
+  resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
+  DISTRIBUTED_RATE_LIMITS: {
+    REFRESH: { windowMs: 300000, maxAttempts: 10 },
+    LOGIN: { windowMs: 900000, maxAttempts: 5 },
+    API: { windowMs: 60000, maxAttempts: 100 },
+  },
+}));
+
 import { authRepository } from '@/lib/repositories/auth-repository';
 import { sessionRepository } from '@/lib/repositories/session-repository';
 import { atomicDeviceTokenRotation } from '@pagespace/db/transactions/auth-transactions';
-import {
-  validateDeviceToken,
-  updateDeviceTokenActivity,
-  auditRequest,
-  loggers,
-} from '@pagespace/lib/server';
+import { validateDeviceToken, updateDeviceTokenActivity } from '@pagespace/lib/auth/device-auth-utils'
+import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
-import { sessionService } from '@pagespace/lib/auth';
+import { sessionService } from '@pagespace/lib/auth/session-service';
 import { appendSessionCookie } from '@/lib/auth';
 
 describe('/api/auth/device/refresh', () => {

--- a/apps/web/src/app/api/auth/__tests__/device-refresh.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/device-refresh.test.ts
@@ -280,8 +280,8 @@ describe('/api/auth/device/refresh', () => {
       const body = await response.json();
 
       // Assert
-      const { hashToken, getTokenPrefix } = await import('@pagespace/lib/auth');
-      const { generateDeviceToken } = await import('@pagespace/lib/server');
+      const { hashToken, getTokenPrefix } = await import('@pagespace/lib/auth/token-utils');
+      const { generateDeviceToken } = await import('@pagespace/lib/auth/device-auth-utils');
       expect(atomicDeviceTokenRotation).toHaveBeenCalledWith(
         'valid-device-token',
         {

--- a/apps/web/src/app/api/auth/__tests__/device-refresh.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/device-refresh.test.ts
@@ -18,15 +18,15 @@ vi.mock('@pagespace/db/transactions/auth-transactions', () => ({
 }));
 
 vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
-    validateDeviceToken: vi.fn(),
-    updateDeviceTokenActivity: vi.fn().mockResolvedValue(undefined),
-    generateDeviceToken: vi.fn().mockReturnValue('ps_dev_mock_token'),
+  validateDeviceToken: vi.fn(),
+  updateDeviceTokenActivity: vi.fn().mockResolvedValue(undefined),
+  generateDeviceToken: vi.fn().mockReturnValue('ps_dev_mock_token'),
 }));
 vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
-    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
 }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -37,11 +37,9 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       warn: vi.fn(),
     },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
@@ -59,11 +57,11 @@ vi.mock('cookie', () => ({
 }));
 
 vi.mock('@pagespace/lib/auth/token-utils', () => ({
-    hashToken: vi.fn().mockReturnValue('mock-token-hash'),
-    getTokenPrefix: vi.fn().mockReturnValue('mock-prefix'),
+  hashToken: vi.fn().mockReturnValue('mock-token-hash'),
+  getTokenPrefix: vi.fn().mockReturnValue('mock-prefix'),
 }));
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock-session-token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'session-123',
@@ -95,8 +93,8 @@ vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
 import { authRepository } from '@/lib/repositories/auth-repository';
 import { sessionRepository } from '@/lib/repositories/session-repository';
 import { atomicDeviceTokenRotation } from '@pagespace/db/transactions/auth-transactions';
-import { validateDeviceToken, updateDeviceTokenActivity } from '@pagespace/lib/auth/device-auth-utils'
-import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { validateDeviceToken, updateDeviceTokenActivity } from '@pagespace/lib/auth/device-auth-utils';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { sessionService } from '@pagespace/lib/auth/session-service';

--- a/apps/web/src/app/api/auth/__tests__/google-callback-redirect.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/google-callback-redirect.test.ts
@@ -44,7 +44,7 @@ vi.mock('@/lib/repositories/auth-repository', () => ({
 
 // Mock session service from @pagespace/lib/auth
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_session_token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -59,16 +59,16 @@ vi.mock('@pagespace/lib/auth/session-service', () => ({
   },
 }));
 vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
-    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
 }));
 vi.mock('@pagespace/lib/auth/exchange-codes', () => ({
-    createExchangeCode: vi.fn().mockResolvedValue('mock-exchange-code'),
+  createExchangeCode: vi.fn().mockResolvedValue('mock-exchange-code'),
 }));
 vi.mock('@pagespace/lib/auth/pkce', () => ({
-    consumePKCEVerifier: vi.fn().mockResolvedValue(null),
+  consumePKCEVerifier: vi.fn().mockResolvedValue(null),
 }));
 vi.mock('@pagespace/lib/auth/constants', () => ({
-    SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
+  SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 
 // Mock cookie utilities
@@ -80,7 +80,7 @@ vi.mock('@/lib/auth/cookie-config', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
       auth: {
         error: vi.fn(),
         info: vi.fn(),
@@ -91,23 +91,21 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
         warn: vi.fn(),
       },
     },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
-    validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
+  validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
       deviceToken: 'mock-device-token',
       deviceTokenRecordId: 'device-record-id',
     }),
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn(),
-    resetDistributedRateLimit: vi.fn(),
-    DISTRIBUTED_RATE_LIMITS: {
+  checkDistributedRateLimit: vi.fn(),
+  resetDistributedRateLimit: vi.fn(),
+  DISTRIBUTED_RATE_LIMITS: {
     LOGIN: {
       maxAttempts: 5,
       windowMs: 900000,

--- a/apps/web/src/app/api/auth/__tests__/google-callback-redirect.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/google-callback-redirect.test.ts
@@ -43,8 +43,8 @@ vi.mock('@/lib/repositories/auth-repository', () => ({
 }));
 
 // Mock session service from @pagespace/lib/auth
-vi.mock('@pagespace/lib/auth', () => ({
-  sessionService: {
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_session_token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -57,10 +57,18 @@ vi.mock('@pagespace/lib/auth', () => ({
     revokeAllUserSessions: vi.fn().mockResolvedValue(0),
     revokeSession: vi.fn().mockResolvedValue(undefined),
   },
-  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
-  createExchangeCode: vi.fn().mockResolvedValue('mock-exchange-code'),
-  consumePKCEVerifier: vi.fn().mockResolvedValue(null),
-  SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
+}));
+vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
+    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+}));
+vi.mock('@pagespace/lib/auth/exchange-codes', () => ({
+    createExchangeCode: vi.fn().mockResolvedValue('mock-exchange-code'),
+}));
+vi.mock('@pagespace/lib/auth/pkce', () => ({
+    consumePKCEVerifier: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@pagespace/lib/auth/constants', () => ({
+    SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 
 // Mock cookie utilities
@@ -71,11 +79,7 @@ vi.mock('@/lib/auth/cookie-config', () => ({
   createDeviceTokenHandoffCookie: vi.fn().mockReturnValue('ps_device_token=mock; Path=/; Max-Age=60'),
 }));
 
-vi.mock('@pagespace/lib/server', async () => {
-  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
-    '@pagespace/lib/audit/mask-email'
-  );
-  return {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
     loggers: {
       auth: {
         error: vi.fn(),
@@ -87,19 +91,23 @@ vi.mock('@pagespace/lib/server', async () => {
         warn: vi.fn(),
       },
     },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
     auditRequest: vi.fn(),
+}));
+vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
     validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
       deviceToken: 'mock-device-token',
       deviceTokenRecordId: 'device-record-id',
     }),
-    maskEmail,
-  };
-});
+}));
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn(),
-  resetDistributedRateLimit: vi.fn(),
-  DISTRIBUTED_RATE_LIMITS: {
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn(),
+    resetDistributedRateLimit: vi.fn(),
+    DISTRIBUTED_RATE_LIMITS: {
     LOGIN: {
       maxAttempts: 5,
       windowMs: 900000,
@@ -137,7 +145,7 @@ vi.mock('@/lib/auth', async () => {
 });
 
 import { authRepository } from '@/lib/repositories/auth-repository';
-import { checkDistributedRateLimit } from '@pagespace/lib/security';
+import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-started-drive';
 
 describe('/api/auth/google/callback redirect', () => {

--- a/apps/web/src/app/api/auth/__tests__/logout.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/logout.test.ts
@@ -15,7 +15,7 @@ import { POST } from '../logout/route';
 
 // Mock session service from @pagespace/lib/auth
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'test-session-id',
       userId: 'test-user-id',
@@ -30,7 +30,7 @@ vi.mock('@pagespace/lib/auth/session-service', () => ({
   },
 }));
 vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
-    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
 }));
 
 // Mock cookie utilities
@@ -46,7 +46,7 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -57,11 +57,9 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       warn: vi.fn(),
     },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({

--- a/apps/web/src/app/api/auth/__tests__/logout.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/logout.test.ts
@@ -14,8 +14,8 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { POST } from '../logout/route';
 
 // Mock session service from @pagespace/lib/auth
-vi.mock('@pagespace/lib/auth', () => ({
-  sessionService: {
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'test-session-id',
       userId: 'test-user-id',
@@ -28,7 +28,9 @@ vi.mock('@pagespace/lib/auth', () => ({
     revokeAllUserSessions: vi.fn().mockResolvedValue(0),
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_session_token'),
   },
-  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+}));
+vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
+    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
 }));
 
 // Mock cookie utilities
@@ -43,8 +45,8 @@ vi.mock('@/lib/auth', () => ({
   getClientIP: vi.fn().mockReturnValue('unknown'),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -55,17 +57,21 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
     },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
   trackAuthEvent: vi.fn(),
 }));
 
-import { sessionService } from '@pagespace/lib/auth';
+import { sessionService } from '@pagespace/lib/auth/session-service';
 import { getSessionFromCookies, appendClearCookies } from '@/lib/auth/cookie-config';
 import { getClientIP } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 
 describe('/api/auth/logout', () => {

--- a/apps/web/src/app/api/auth/__tests__/mcp-tokens.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/mcp-tokens.test.ts
@@ -21,7 +21,7 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -30,16 +30,14 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       warn: vi.fn(),
     },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/auth/token-utils', () => ({
-    generateToken: vi.fn().mockReturnValue({
+  generateToken: vi.fn().mockReturnValue({
     token: 'mcp_randomBase64UrlString',
     hash: 'mockTokenHash123',
     tokenPrefix: 'mcp_randomBas',

--- a/apps/web/src/app/api/auth/__tests__/mcp-tokens.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/mcp-tokens.test.ts
@@ -20,8 +20,8 @@ vi.mock('@/lib/auth', () => ({
   getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -30,12 +30,16 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
     },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/auth', () => ({
-  generateToken: vi.fn().mockReturnValue({
+vi.mock('@pagespace/lib/auth/token-utils', () => ({
+    generateToken: vi.fn().mockReturnValue({
     token: 'mcp_randomBase64UrlString',
     hash: 'mockTokenHash123',
     tokenPrefix: 'mcp_randomBas',

--- a/apps/web/src/app/api/auth/__tests__/mobile-oauth-google-exchange.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/mobile-oauth-google-exchange.test.ts
@@ -14,21 +14,25 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { POST } from '../mobile/oauth/google/exchange/route';
 
 // Mock dependencies
-vi.mock('@pagespace/lib/server', async () => {
-  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
-    '@pagespace/lib/audit/mask-email'
-  );
-  return {
+vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
     generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+}));
+vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
     validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
       deviceToken: 'mock-device-token',
     }),
+}));
+vi.mock('@pagespace/lib/auth/oauth-utils', () => ({
     verifyOAuthIdToken: vi.fn(),
     createOrLinkOAuthUser: vi.fn(),
+}));
+vi.mock('@pagespace/lib/auth/oauth-types', () => ({
     OAuthProvider: {
       GOOGLE: 'google',
       APPLE: 'apple',
     },
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
     loggers: {
       auth: {
         error: vi.fn(),
@@ -40,13 +44,15 @@ vi.mock('@pagespace/lib/server', async () => {
         warn: vi.fn(),
       },
     },
-    auditRequest: vi.fn(),
-    maskEmail,
-  };
-});
 
-vi.mock('@pagespace/lib/auth', () => ({
-  sessionService: {
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_oauth-token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'sfh0haxfpzowht3oi213oas1',
@@ -64,14 +70,14 @@ vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
   trackAuthEvent: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn().mockResolvedValue({
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn().mockResolvedValue({
     allowed: true,
     attemptsRemaining: 4,
     retryAfter: undefined,
   }),
-  resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
-  DISTRIBUTED_RATE_LIMITS: {
+    resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
+    DISTRIBUTED_RATE_LIMITS: {
     LOGIN: { maxAttempts: 5, windowMs: 900000, progressiveDelay: true },
     SIGNUP: { maxAttempts: 3, windowMs: 3600000, progressiveDelay: false },
     REFRESH: { maxAttempts: 10, windowMs: 300000, progressiveDelay: false },
@@ -97,19 +103,16 @@ vi.mock('@/lib/auth', () => ({
   getClientIP: vi.fn().mockReturnValue('192.168.1.1'),
 }));
 
-import {
-  verifyOAuthIdToken,
-  createOrLinkOAuthUser,
-  validateOrCreateDeviceToken,
-  auditRequest,
-  loggers,
-} from '@pagespace/lib/server';
+import { verifyOAuthIdToken, createOrLinkOAuthUser } from '@pagespace/lib/auth/oauth-utils'
+import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils'
+import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import {
   checkDistributedRateLimit,
   resetDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
-} from '@pagespace/lib/security';
-import { sessionService } from '@pagespace/lib/auth';
+} from '@pagespace/lib/security/distributed-rate-limit';
+import { sessionService } from '@pagespace/lib/auth/session-service';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 
 describe('/api/auth/mobile/oauth/google/exchange', () => {

--- a/apps/web/src/app/api/auth/__tests__/mobile-oauth-google-exchange.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/mobile-oauth-google-exchange.test.ts
@@ -15,25 +15,25 @@ import { POST } from '../mobile/oauth/google/exchange/route';
 
 // Mock dependencies
 vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
-    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
 }));
 vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
-    validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
+  validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
       deviceToken: 'mock-device-token',
     }),
 }));
 vi.mock('@pagespace/lib/auth/oauth-utils', () => ({
-    verifyOAuthIdToken: vi.fn(),
-    createOrLinkOAuthUser: vi.fn(),
+  verifyOAuthIdToken: vi.fn(),
+  createOrLinkOAuthUser: vi.fn(),
 }));
 vi.mock('@pagespace/lib/auth/oauth-types', () => ({
-    OAuthProvider: {
+  OAuthProvider: {
       GOOGLE: 'google',
       APPLE: 'apple',
     },
 }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
       auth: {
         error: vi.fn(),
         info: vi.fn(),
@@ -44,15 +44,13 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
         warn: vi.fn(),
       },
     },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_oauth-token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'sfh0haxfpzowht3oi213oas1',
@@ -71,13 +69,13 @@ vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn().mockResolvedValue({
+  checkDistributedRateLimit: vi.fn().mockResolvedValue({
     allowed: true,
     attemptsRemaining: 4,
     retryAfter: undefined,
   }),
-    resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
-    DISTRIBUTED_RATE_LIMITS: {
+  resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
+  DISTRIBUTED_RATE_LIMITS: {
     LOGIN: { maxAttempts: 5, windowMs: 900000, progressiveDelay: true },
     SIGNUP: { maxAttempts: 3, windowMs: 3600000, progressiveDelay: false },
     REFRESH: { maxAttempts: 10, windowMs: 300000, progressiveDelay: false },
@@ -103,9 +101,9 @@ vi.mock('@/lib/auth', () => ({
   getClientIP: vi.fn().mockReturnValue('192.168.1.1'),
 }));
 
-import { verifyOAuthIdToken, createOrLinkOAuthUser } from '@pagespace/lib/auth/oauth-utils'
-import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils'
-import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { verifyOAuthIdToken, createOrLinkOAuthUser } from '@pagespace/lib/auth/oauth-utils';
+import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import {
   checkDistributedRateLimit,

--- a/apps/web/src/app/api/auth/__tests__/mobile-oauth-google-exchange.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/mobile-oauth-google-exchange.test.ts
@@ -714,7 +714,7 @@ describe('/api/auth/mobile/oauth/google/exchange', () => {
     });
 
     it('logs rate limit reset failures', async () => {
-      const { loggers } = await import('@pagespace/lib/server');
+      const { loggers } = await import('@pagespace/lib/logging/logger-config');
       vi.mocked(resetDistributedRateLimit).mockRejectedValueOnce(new Error('Reset failed'));
 
       const request = new Request('http://localhost/api/auth/mobile/oauth/google/exchange', {

--- a/apps/web/src/app/api/auth/__tests__/mobile-refresh.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/mobile-refresh.test.ts
@@ -29,15 +29,15 @@ vi.mock('@pagespace/db/transactions/auth-transactions', () => ({
 }));
 
 vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
-    validateDeviceToken: vi.fn(),
-    updateDeviceTokenActivity: vi.fn().mockResolvedValue(undefined),
-    generateDeviceToken: vi.fn().mockReturnValue('new-device-token'),
+  validateDeviceToken: vi.fn(),
+  updateDeviceTokenActivity: vi.fn().mockResolvedValue(undefined),
+  generateDeviceToken: vi.fn().mockReturnValue('new-device-token'),
 }));
 vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
-    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
 }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -48,11 +48,9 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       warn: vi.fn(),
     },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/security-audit', () => ({
-    securityAudit: {
+  securityAudit: {
     logAuthSuccess: vi.fn().mockResolvedValue(undefined),
     logAuthFailure: vi.fn().mockResolvedValue(undefined),
     logTokenCreated: vi.fn().mockResolvedValue(undefined),
@@ -64,11 +62,11 @@ vi.mock('@pagespace/lib/audit/security-audit', () => ({
 }));
 
 vi.mock('@pagespace/lib/auth/token-utils', () => ({
-    hashToken: vi.fn((token) => `hashed-${token}`),
-    getTokenPrefix: vi.fn((token) => token.substring(0, 8)),
+  hashToken: vi.fn((token) => `hashed-${token}`),
+  getTokenPrefix: vi.fn((token) => token.substring(0, 8)),
 }));
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_refreshed-token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'nfh0haxfpzowht3oi213ses2',
@@ -83,13 +81,13 @@ vi.mock('@pagespace/lib/auth/session-service', () => ({
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn().mockResolvedValue({
+  checkDistributedRateLimit: vi.fn().mockResolvedValue({
     allowed: true,
     attemptsRemaining: 9,
     retryAfter: undefined,
   }),
-    resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
-    DISTRIBUTED_RATE_LIMITS: {
+  resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
+  DISTRIBUTED_RATE_LIMITS: {
     LOGIN: { maxAttempts: 5, windowMs: 900000, progressiveDelay: true },
     SIGNUP: { maxAttempts: 3, windowMs: 3600000, progressiveDelay: false },
     REFRESH: { maxAttempts: 10, windowMs: 300000, progressiveDelay: false },

--- a/apps/web/src/app/api/auth/__tests__/mobile-refresh.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/mobile-refresh.test.ts
@@ -28,12 +28,16 @@ vi.mock('@pagespace/db/transactions/auth-transactions', () => ({
   }),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  validateDeviceToken: vi.fn(),
-  updateDeviceTokenActivity: vi.fn().mockResolvedValue(undefined),
-  generateDeviceToken: vi.fn().mockReturnValue('new-device-token'),
-  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
-  loggers: {
+vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
+    validateDeviceToken: vi.fn(),
+    updateDeviceTokenActivity: vi.fn().mockResolvedValue(undefined),
+    generateDeviceToken: vi.fn().mockReturnValue('new-device-token'),
+}));
+vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
+    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -44,7 +48,11 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
     },
   },
-  securityAudit: {
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/security-audit', () => ({
+    securityAudit: {
     logAuthSuccess: vi.fn().mockResolvedValue(undefined),
     logAuthFailure: vi.fn().mockResolvedValue(undefined),
     logTokenCreated: vi.fn().mockResolvedValue(undefined),
@@ -55,10 +63,12 @@ vi.mock('@pagespace/lib/server', () => ({
   },
 }));
 
-vi.mock('@pagespace/lib/auth', () => ({
-  hashToken: vi.fn((token) => `hashed-${token}`),
-  getTokenPrefix: vi.fn((token) => token.substring(0, 8)),
-  sessionService: {
+vi.mock('@pagespace/lib/auth/token-utils', () => ({
+    hashToken: vi.fn((token) => `hashed-${token}`),
+    getTokenPrefix: vi.fn((token) => token.substring(0, 8)),
+}));
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_refreshed-token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'nfh0haxfpzowht3oi213ses2',
@@ -72,14 +82,14 @@ vi.mock('@pagespace/lib/auth', () => ({
   },
 }));
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn().mockResolvedValue({
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn().mockResolvedValue({
     allowed: true,
     attemptsRemaining: 9,
     retryAfter: undefined,
   }),
-  resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
-  DISTRIBUTED_RATE_LIMITS: {
+    resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
+    DISTRIBUTED_RATE_LIMITS: {
     LOGIN: { maxAttempts: 5, windowMs: 900000, progressiveDelay: true },
     SIGNUP: { maxAttempts: 3, windowMs: 3600000, progressiveDelay: false },
     REFRESH: { maxAttempts: 10, windowMs: 300000, progressiveDelay: false },
@@ -93,16 +103,13 @@ vi.mock('@/lib/auth', () => ({
 
 import { authRepository } from '@/lib/repositories/auth-repository';
 import { atomicDeviceTokenRotation } from '@pagespace/db/transactions/auth-transactions';
-import {
-  validateDeviceToken,
-  updateDeviceTokenActivity,
-} from '@pagespace/lib/server';
+import { validateDeviceToken, updateDeviceTokenActivity } from '@pagespace/lib/auth/device-auth-utils';
 import {
   checkDistributedRateLimit,
   resetDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
-} from '@pagespace/lib/security';
-import { sessionService } from '@pagespace/lib/auth';
+} from '@pagespace/lib/security/distributed-rate-limit';
+import { sessionService } from '@pagespace/lib/auth/session-service';
 import { getClientIP } from '@/lib/auth';
 
 describe('/api/auth/mobile/refresh', () => {

--- a/apps/web/src/app/api/auth/__tests__/mobile-refresh.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/mobile-refresh.test.ts
@@ -243,8 +243,8 @@ describe('/api/auth/mobile/refresh', () => {
       const body = await response.json();
 
       expect(response.status).toBe(200);
-      const { hashToken, getTokenPrefix } = await import('@pagespace/lib/auth');
-      const { generateDeviceToken } = await import('@pagespace/lib/server');
+      const { hashToken, getTokenPrefix } = await import('@pagespace/lib/auth/token-utils');
+      const { generateDeviceToken } = await import('@pagespace/lib/auth/device-auth-utils');
       expect(atomicDeviceTokenRotation).toHaveBeenCalledWith(
         validRefreshPayload.deviceToken,
         {
@@ -563,7 +563,7 @@ describe('/api/auth/mobile/refresh', () => {
     });
 
     it('logs device ID mismatch warning', async () => {
-      const { loggers } = await import('@pagespace/lib/server');
+      const { loggers } = await import('@pagespace/lib/logging/logger-config');
 
       const request = new Request('http://localhost/api/auth/mobile/refresh', {
         method: 'POST',

--- a/apps/web/src/app/api/auth/__tests__/session-fixation.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/session-fixation.test.ts
@@ -21,13 +21,13 @@ describe('Session Fixation Prevention - Service Layer', () => {
   describe('sessionService contract', () => {
     it('createSession returns opaque token with ps_sess_ prefix', async () => {
       // Mock the session service
-      vi.doMock('@pagespace/lib/auth', () => ({
+      vi.doMock('@pagespace/lib/auth/session-service', () => ({
         sessionService: {
           createSession: vi.fn().mockResolvedValue('ps_sess_abc123'),
         },
       }));
 
-      const { sessionService } = await import('@pagespace/lib/auth');
+      const { sessionService } = await import('@pagespace/lib/auth/session-service');
       const token = await sessionService.createSession({
         userId: 'user-123',
         type: 'user',
@@ -47,13 +47,13 @@ describe('Session Fixation Prevention - Service Layer', () => {
         expiresAt: new Date(Date.now() + 1000000),
       };
 
-      vi.doMock('@pagespace/lib/auth', () => ({
+      vi.doMock('@pagespace/lib/auth/session-service', () => ({
         sessionService: {
           validateSession: vi.fn().mockResolvedValue(mockClaims),
         },
       }));
 
-      const { sessionService } = await import('@pagespace/lib/auth');
+      const { sessionService } = await import('@pagespace/lib/auth/session-service');
       const claims = await sessionService.validateSession('ps_sess_valid');
 
       expect(claims).toEqual(mockClaims);
@@ -61,26 +61,26 @@ describe('Session Fixation Prevention - Service Layer', () => {
     });
 
     it('validateSession returns null for invalid token', async () => {
-      vi.doMock('@pagespace/lib/auth', () => ({
+      vi.doMock('@pagespace/lib/auth/session-service', () => ({
         sessionService: {
           validateSession: vi.fn().mockResolvedValue(null),
         },
       }));
 
-      const { sessionService } = await import('@pagespace/lib/auth');
+      const { sessionService } = await import('@pagespace/lib/auth/session-service');
       const claims = await sessionService.validateSession('ps_sess_invalid');
 
       expect(claims).toBeNull();
     });
 
     it('revokeAllUserSessions returns count of revoked sessions', async () => {
-      vi.doMock('@pagespace/lib/auth', () => ({
+      vi.doMock('@pagespace/lib/auth/session-service', () => ({
         sessionService: {
           revokeAllUserSessions: vi.fn().mockResolvedValue(3),
         },
       }));
 
-      const { sessionService } = await import('@pagespace/lib/auth');
+      const { sessionService } = await import('@pagespace/lib/auth/session-service');
       const count = await sessionService.revokeAllUserSessions('user-123', 'new_login');
 
       expect(count).toBe(3);
@@ -91,33 +91,33 @@ describe('Session Fixation Prevention - Service Layer', () => {
     it('generateCSRFToken accepts session ID parameter', async () => {
       const mockCSRFToken = 'csrf.token.signature';
 
-      vi.doMock('@pagespace/lib/auth', () => ({
+      vi.doMock('@pagespace/lib/auth/csrf-utils', () => ({
         generateCSRFToken: vi.fn().mockReturnValue(mockCSRFToken),
       }));
 
-      const { generateCSRFToken } = await import('@pagespace/lib/auth');
+      const { generateCSRFToken } = await import('@pagespace/lib/auth/csrf-utils');
       const token = generateCSRFToken('session-123');
 
       expect(token).toBe(mockCSRFToken);
     });
 
     it('validateCSRFToken validates against session ID', async () => {
-      vi.doMock('@pagespace/lib/auth', () => ({
+      vi.doMock('@pagespace/lib/auth/csrf-utils', () => ({
         validateCSRFToken: vi.fn().mockReturnValue(true),
       }));
 
-      const { validateCSRFToken } = await import('@pagespace/lib/auth');
+      const { validateCSRFToken } = await import('@pagespace/lib/auth/csrf-utils');
       const isValid = validateCSRFToken('csrf.token.signature', 'session-123');
 
       expect(isValid).toBe(true);
     });
 
     it('validateCSRFToken rejects invalid tokens', async () => {
-      vi.doMock('@pagespace/lib/auth', () => ({
+      vi.doMock('@pagespace/lib/auth/csrf-utils', () => ({
         validateCSRFToken: vi.fn().mockReturnValue(false),
       }));
 
-      const { validateCSRFToken } = await import('@pagespace/lib/auth');
+      const { validateCSRFToken } = await import('@pagespace/lib/auth/csrf-utils');
       const isValid = validateCSRFToken('invalid.token', 'session-123');
 
       expect(isValid).toBe(false);
@@ -187,10 +187,12 @@ describe('Session Fixation Prevention - Auth Middleware', () => {
 
   describe('validateSessionToken', () => {
     it('exports validateSessionToken function', async () => {
-      vi.doMock('@pagespace/lib/auth', () => ({
+      vi.doMock('@pagespace/lib/auth/session-service', () => ({
         sessionService: {
           validateSession: vi.fn().mockResolvedValue(null),
         },
+      }));
+      vi.doMock('@pagespace/lib/auth/token-utils', () => ({
         hashToken: vi.fn(),
       }));
 
@@ -206,10 +208,12 @@ describe('Session Fixation Prevention - Auth Middleware', () => {
 
   describe('authenticateSessionRequest', () => {
     it('exports authenticateSessionRequest function', async () => {
-      vi.doMock('@pagespace/lib/auth', () => ({
+      vi.doMock('@pagespace/lib/auth/session-service', () => ({
         sessionService: {
           validateSession: vi.fn(),
         },
+      }));
+      vi.doMock('@pagespace/lib/auth/token-utils', () => ({
         hashToken: vi.fn(),
       }));
 

--- a/apps/web/src/app/api/auth/__tests__/session-fixation.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/session-fixation.test.ts
@@ -270,20 +270,22 @@ describe('Session Fixation Prevention - CSRF Validation', () => {
         getSessionFromCookies: mockGetSession,
       }));
 
-      vi.doMock('@pagespace/lib/auth', () => ({
+      vi.doMock('@pagespace/lib/auth/session-service', () => ({
         sessionService: {
           validateSession: mockValidateSession,
         },
+      }));
+      vi.doMock('@pagespace/lib/auth/csrf-utils', () => ({
         validateCSRFToken: vi.fn().mockReturnValue(true),
       }));
-
-      vi.doMock('@pagespace/lib/server', () => ({
+      vi.doMock('@pagespace/lib/logging/logger-config', () => ({
         loggers: {
           auth: {
             warn: vi.fn(),
             debug: vi.fn(),
           },
         },
+        logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
       }));
 
       const { validateCSRF } = await import('@/lib/auth/csrf-validation');

--- a/apps/web/src/app/api/auth/__tests__/session-fixation.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/session-fixation.test.ts
@@ -285,7 +285,6 @@ describe('Session Fixation Prevention - CSRF Validation', () => {
             debug: vi.fn(),
           },
         },
-        logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
       }));
 
       const { validateCSRF } = await import('@/lib/auth/csrf-validation');

--- a/apps/web/src/app/api/auth/__tests__/verify-email.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/verify-email.test.ts
@@ -8,8 +8,8 @@ vi.mock('@pagespace/lib/auth/verification-utils', () => ({
   markEmailVerified: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -20,8 +20,12 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
     },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
@@ -29,7 +33,7 @@ vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
 }));
 
 import { verifyToken, markEmailVerified } from '@pagespace/lib/auth/verification-utils';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 
 describe('/api/auth/verify-email', () => {

--- a/apps/web/src/app/api/auth/__tests__/verify-email.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/verify-email.test.ts
@@ -9,7 +9,7 @@ vi.mock('@pagespace/lib/auth/verification-utils', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -20,12 +20,10 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       warn: vi.fn(),
     },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({

--- a/apps/web/src/app/api/auth/apple/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/apple/callback/__tests__/route.test.ts
@@ -32,8 +32,8 @@ vi.mock('@/lib/repositories/auth-repository', () => ({
   },
 }));
 
-vi.mock('@pagespace/lib/auth', () => ({
-  sessionService: {
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -46,10 +46,18 @@ vi.mock('@pagespace/lib/auth', () => ({
     }),
     revokeAllUserSessions: vi.fn().mockResolvedValue(0),
   },
-  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
-  createExchangeCode: vi.fn().mockResolvedValue('mock-exchange-code'),
-  SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
-  verifyAppleIdToken: vi.fn().mockResolvedValue({
+}));
+vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
+    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+}));
+vi.mock('@pagespace/lib/auth/exchange-codes', () => ({
+    createExchangeCode: vi.fn().mockResolvedValue('mock-exchange-code'),
+}));
+vi.mock('@pagespace/lib/auth/constants', () => ({
+    SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
+}));
+vi.mock('@pagespace/lib/auth/oauth-utils', () => ({
+    verifyAppleIdToken: vi.fn().mockResolvedValue({
     success: true,
     userInfo: {
       providerId: 'apple-sub-123',
@@ -64,11 +72,7 @@ vi.mock('@paralleldrive/cuid2', () => ({
   init: vi.fn(() => vi.fn(() => 'test-cuid')),
 }));
 
-vi.mock('@pagespace/lib/server', async () => {
-  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
-    '@pagespace/lib/audit/mask-email'
-  );
-  return {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
     loggers: {
       auth: {
         error: vi.fn(),
@@ -80,13 +84,17 @@ vi.mock('@pagespace/lib/server', async () => {
         warn: vi.fn(),
       },
     },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
     auditRequest: vi.fn(),
+}));
+vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
     validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
       deviceToken: 'mock-device-token',
     }),
-    maskEmail,
-  };
-});
+}));
 
 vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
   trackAuthEvent: vi.fn(),
@@ -108,24 +116,27 @@ vi.mock('@/lib/auth/cookie-config', () => ({
   createDeviceTokenHandoffCookie: vi.fn().mockReturnValue('ps_device_token=mock; Path=/; Max-Age=60'),
 }));
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn().mockResolvedValue({
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn().mockResolvedValue({
     allowed: true,
     attemptsRemaining: 4,
     retryAfter: undefined,
   }),
-  resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
-  DISTRIBUTED_RATE_LIMITS: {
+    resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
+    DISTRIBUTED_RATE_LIMITS: {
     LOGIN: { maxAttempts: 5, windowMs: 900000, progressiveDelay: true },
   },
 }));
 
 import { POST } from '../route';
 import { authRepository } from '@/lib/repositories/auth-repository';
-import { sessionService, verifyAppleIdToken } from '@pagespace/lib/auth';
-import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security';
+import { sessionService } from '@pagespace/lib/auth/session-service'
+import { verifyAppleIdToken } from '@pagespace/lib/auth/oauth-utils';
+import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { getClientIP, isSafeReturnUrl } from '@/lib/auth';
-import { loggers, auditRequest, validateOrCreateDeviceToken } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-started-drive';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';

--- a/apps/web/src/app/api/auth/apple/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/apple/callback/__tests__/route.test.ts
@@ -33,7 +33,7 @@ vi.mock('@/lib/repositories/auth-repository', () => ({
 }));
 
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -48,16 +48,16 @@ vi.mock('@pagespace/lib/auth/session-service', () => ({
   },
 }));
 vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
-    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
 }));
 vi.mock('@pagespace/lib/auth/exchange-codes', () => ({
-    createExchangeCode: vi.fn().mockResolvedValue('mock-exchange-code'),
+  createExchangeCode: vi.fn().mockResolvedValue('mock-exchange-code'),
 }));
 vi.mock('@pagespace/lib/auth/constants', () => ({
-    SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
+  SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 vi.mock('@pagespace/lib/auth/oauth-utils', () => ({
-    verifyAppleIdToken: vi.fn().mockResolvedValue({
+  verifyAppleIdToken: vi.fn().mockResolvedValue({
     success: true,
     userInfo: {
       providerId: 'apple-sub-123',
@@ -73,7 +73,7 @@ vi.mock('@paralleldrive/cuid2', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
       auth: {
         error: vi.fn(),
         info: vi.fn(),
@@ -84,14 +84,12 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
         warn: vi.fn(),
       },
     },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
-    validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
+  validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
       deviceToken: 'mock-device-token',
     }),
 }));
@@ -117,25 +115,25 @@ vi.mock('@/lib/auth/cookie-config', () => ({
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn().mockResolvedValue({
+  checkDistributedRateLimit: vi.fn().mockResolvedValue({
     allowed: true,
     attemptsRemaining: 4,
     retryAfter: undefined,
   }),
-    resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
-    DISTRIBUTED_RATE_LIMITS: {
+  resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
+  DISTRIBUTED_RATE_LIMITS: {
     LOGIN: { maxAttempts: 5, windowMs: 900000, progressiveDelay: true },
   },
 }));
 
 import { POST } from '../route';
 import { authRepository } from '@/lib/repositories/auth-repository';
-import { sessionService } from '@pagespace/lib/auth/session-service'
+import { sessionService } from '@pagespace/lib/auth/session-service';
 import { verifyAppleIdToken } from '@pagespace/lib/auth/oauth-utils';
 import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { getClientIP, isSafeReturnUrl } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/logging/logger-config'
-import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-started-drive';

--- a/apps/web/src/app/api/auth/apple/callback/route.ts
+++ b/apps/web/src/app/api/auth/apple/callback/route.ts
@@ -1,12 +1,19 @@
 import { z } from 'zod/v4';
-import { sessionService, generateCSRFToken, createExchangeCode, SESSION_DURATION_MS, verifyAppleIdToken } from '@pagespace/lib/auth';
+import { sessionService } from '@pagespace/lib/auth/session-service'
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { createExchangeCode } from '@pagespace/lib/auth/exchange-codes'
+import { SESSION_DURATION_MS } from '@pagespace/lib/auth/constants'
+import { verifyAppleIdToken } from '@pagespace/lib/auth/oauth-utils';
 import {
   checkDistributedRateLimit,
   resetDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
-} from '@pagespace/lib/security';
+} from '@pagespace/lib/security/distributed-rate-limit';
 import { createId } from '@paralleldrive/cuid2';
-import { loggers, auditRequest, validateOrCreateDeviceToken, maskEmail } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils'
+import { maskEmail } from '@pagespace/lib/audit/mask-email';
 import { revokeSessionsForLogin, createWebDeviceToken } from '@/lib/auth';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { NextResponse } from 'next/server';

--- a/apps/web/src/app/api/auth/apple/callback/route.ts
+++ b/apps/web/src/app/api/auth/apple/callback/route.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod/v4';
-import { sessionService } from '@pagespace/lib/auth/session-service'
-import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
-import { createExchangeCode } from '@pagespace/lib/auth/exchange-codes'
-import { SESSION_DURATION_MS } from '@pagespace/lib/auth/constants'
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
+import { createExchangeCode } from '@pagespace/lib/auth/exchange-codes';
+import { SESSION_DURATION_MS } from '@pagespace/lib/auth/constants';
 import { verifyAppleIdToken } from '@pagespace/lib/auth/oauth-utils';
 import {
   checkDistributedRateLimit,
@@ -10,9 +10,9 @@ import {
   DISTRIBUTED_RATE_LIMITS,
 } from '@pagespace/lib/security/distributed-rate-limit';
 import { createId } from '@paralleldrive/cuid2';
-import { loggers } from '@pagespace/lib/logging/logger-config'
-import { auditRequest } from '@pagespace/lib/audit/audit-log'
-import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils'
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
 import { maskEmail } from '@pagespace/lib/audit/mask-email';
 import { revokeSessionsForLogin, createWebDeviceToken } from '@/lib/auth';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';

--- a/apps/web/src/app/api/auth/apple/native/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/apple/native/__tests__/route.test.ts
@@ -31,7 +31,7 @@ vi.mock('@/lib/repositories/auth-repository', () => ({
 }));
 
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -46,13 +46,13 @@ vi.mock('@pagespace/lib/auth/session-service', () => ({
   },
 }));
 vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
-    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
 }));
 vi.mock('@pagespace/lib/auth/constants', () => ({
-    SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
+  SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 vi.mock('@pagespace/lib/auth/oauth-utils', () => ({
-    verifyAppleIdToken: vi.fn().mockResolvedValue({
+  verifyAppleIdToken: vi.fn().mockResolvedValue({
     success: true,
     userInfo: {
       providerId: 'apple-sub-123',
@@ -68,7 +68,7 @@ vi.mock('@paralleldrive/cuid2', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
       auth: {
         error: vi.fn(),
         info: vi.fn(),
@@ -79,14 +79,12 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
         warn: vi.fn(),
       },
     },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
-    validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
+  validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
       deviceToken: 'mock-device-token',
     }),
 }));
@@ -108,25 +106,25 @@ vi.mock('@/lib/auth/cookie-config', () => ({
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn().mockResolvedValue({
+  checkDistributedRateLimit: vi.fn().mockResolvedValue({
     allowed: true,
     attemptsRemaining: 4,
     retryAfter: undefined,
   }),
-    resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
-    DISTRIBUTED_RATE_LIMITS: {
+  resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
+  DISTRIBUTED_RATE_LIMITS: {
     LOGIN: { maxAttempts: 5, windowMs: 900000, progressiveDelay: true },
   },
 }));
 
 import { POST } from '../route';
 import { authRepository } from '@/lib/repositories/auth-repository';
-import { sessionService } from '@pagespace/lib/auth/session-service'
+import { sessionService } from '@pagespace/lib/auth/session-service';
 import { verifyAppleIdToken } from '@pagespace/lib/auth/oauth-utils';
 import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { getClientIP } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/logging/logger-config'
-import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-started-drive';

--- a/apps/web/src/app/api/auth/apple/native/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/apple/native/__tests__/route.test.ts
@@ -30,8 +30,8 @@ vi.mock('@/lib/repositories/auth-repository', () => ({
   },
 }));
 
-vi.mock('@pagespace/lib/auth', () => ({
-  sessionService: {
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -44,9 +44,15 @@ vi.mock('@pagespace/lib/auth', () => ({
     }),
     revokeAllUserSessions: vi.fn().mockResolvedValue(0),
   },
-  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
-  SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
-  verifyAppleIdToken: vi.fn().mockResolvedValue({
+}));
+vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
+    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+}));
+vi.mock('@pagespace/lib/auth/constants', () => ({
+    SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
+}));
+vi.mock('@pagespace/lib/auth/oauth-utils', () => ({
+    verifyAppleIdToken: vi.fn().mockResolvedValue({
     success: true,
     userInfo: {
       providerId: 'apple-sub-123',
@@ -61,11 +67,7 @@ vi.mock('@paralleldrive/cuid2', () => ({
   init: vi.fn(() => vi.fn(() => 'test-cuid')),
 }));
 
-vi.mock('@pagespace/lib/server', async () => {
-  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
-    '@pagespace/lib/audit/mask-email'
-  );
-  return {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
     loggers: {
       auth: {
         error: vi.fn(),
@@ -77,13 +79,17 @@ vi.mock('@pagespace/lib/server', async () => {
         warn: vi.fn(),
       },
     },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
     auditRequest: vi.fn(),
+}));
+vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
     validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
       deviceToken: 'mock-device-token',
     }),
-    maskEmail,
-  };
-});
+}));
 
 vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
   trackAuthEvent: vi.fn(),
@@ -101,24 +107,27 @@ vi.mock('@/lib/auth/cookie-config', () => ({
   appendSessionCookie: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn().mockResolvedValue({
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn().mockResolvedValue({
     allowed: true,
     attemptsRemaining: 4,
     retryAfter: undefined,
   }),
-  resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
-  DISTRIBUTED_RATE_LIMITS: {
+    resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
+    DISTRIBUTED_RATE_LIMITS: {
     LOGIN: { maxAttempts: 5, windowMs: 900000, progressiveDelay: true },
   },
 }));
 
 import { POST } from '../route';
 import { authRepository } from '@/lib/repositories/auth-repository';
-import { sessionService, verifyAppleIdToken } from '@pagespace/lib/auth';
-import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security';
+import { sessionService } from '@pagespace/lib/auth/session-service'
+import { verifyAppleIdToken } from '@pagespace/lib/auth/oauth-utils';
+import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { getClientIP } from '@/lib/auth';
-import { loggers, auditRequest, validateOrCreateDeviceToken } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-started-drive';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';

--- a/apps/web/src/app/api/auth/apple/native/route.ts
+++ b/apps/web/src/app/api/auth/apple/native/route.ts
@@ -1,11 +1,11 @@
-import { sessionService } from '@pagespace/lib/auth/session-service'
-import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
-import { SESSION_DURATION_MS } from '@pagespace/lib/auth/constants'
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
+import { SESSION_DURATION_MS } from '@pagespace/lib/auth/constants';
 import { verifyAppleIdToken } from '@pagespace/lib/auth/oauth-utils';
 import { createId } from '@paralleldrive/cuid2';
-import { loggers } from '@pagespace/lib/logging/logger-config'
-import { auditRequest } from '@pagespace/lib/audit/audit-log'
-import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils'
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
 import { maskEmail } from '@pagespace/lib/audit/mask-email';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { z } from 'zod/v4';

--- a/apps/web/src/app/api/auth/apple/native/route.ts
+++ b/apps/web/src/app/api/auth/apple/native/route.ts
@@ -1,6 +1,12 @@
-import { sessionService, generateCSRFToken, SESSION_DURATION_MS, verifyAppleIdToken } from '@pagespace/lib/auth';
+import { sessionService } from '@pagespace/lib/auth/session-service'
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { SESSION_DURATION_MS } from '@pagespace/lib/auth/constants'
+import { verifyAppleIdToken } from '@pagespace/lib/auth/oauth-utils';
 import { createId } from '@paralleldrive/cuid2';
-import { loggers, auditRequest, validateOrCreateDeviceToken, maskEmail } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils'
+import { maskEmail } from '@pagespace/lib/audit/mask-email';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { z } from 'zod/v4';
 import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-started-drive';
@@ -10,7 +16,7 @@ import {
   checkDistributedRateLimit,
   resetDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
-} from '@pagespace/lib/security';
+} from '@pagespace/lib/security/distributed-rate-limit';
 import { authRepository } from '@/lib/repositories/auth-repository';
 
 const nativeAuthSchema = z.object({

--- a/apps/web/src/app/api/auth/apple/signin/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/apple/signin/__tests__/route.test.ts
@@ -15,7 +15,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // Mock dependencies BEFORE imports
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -23,17 +23,15 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       debug: vi.fn(),
     },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn().mockResolvedValue({
+  checkDistributedRateLimit: vi.fn().mockResolvedValue({
     allowed: true,
     attemptsRemaining: 4,
     retryAfter: undefined,
   }),
-    DISTRIBUTED_RATE_LIMITS: {
+  DISTRIBUTED_RATE_LIMITS: {
     LOGIN: { maxAttempts: 5, windowMs: 900000, progressiveDelay: true },
   },
 }));

--- a/apps/web/src/app/api/auth/apple/signin/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/apple/signin/__tests__/route.test.ts
@@ -14,8 +14,8 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // Mock dependencies BEFORE imports
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -23,15 +23,17 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn().mockResolvedValue({
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn().mockResolvedValue({
     allowed: true,
     attemptsRemaining: 4,
     retryAfter: undefined,
   }),
-  DISTRIBUTED_RATE_LIMITS: {
+    DISTRIBUTED_RATE_LIMITS: {
     LOGIN: { maxAttempts: 5, windowMs: 900000, progressiveDelay: true },
   },
 }));
@@ -42,9 +44,9 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 import { POST, GET } from '../route';
-import { checkDistributedRateLimit } from '@pagespace/lib/security';
+import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { getClientIP, isSafeReturnUrl } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 const createPostRequest = (body: Record<string, unknown> = {}) =>
   new Request('http://localhost/api/auth/apple/signin', {

--- a/apps/web/src/app/api/auth/apple/signin/route.ts
+++ b/apps/web/src/app/api/auth/apple/signin/route.ts
@@ -1,9 +1,9 @@
 import { z } from 'zod/v4';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import {
   checkDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
-} from '@pagespace/lib/security';
+} from '@pagespace/lib/security/distributed-rate-limit';
 import crypto from 'crypto';
 import { getClientIP, isSafeReturnUrl } from '@/lib/auth';
 

--- a/apps/web/src/app/api/auth/csrf/route.ts
+++ b/apps/web/src/app/api/auth/csrf/route.ts
@@ -1,5 +1,6 @@
-import { generateCSRFToken, sessionService } from '@pagespace/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getSessionFromCookies } from '@/lib/auth/cookie-config';
 
 export async function GET(req: Request) {

--- a/apps/web/src/app/api/auth/csrf/route.ts
+++ b/apps/web/src/app/api/auth/csrf/route.ts
@@ -1,4 +1,4 @@
-import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
 import { sessionService } from '@pagespace/lib/auth/session-service';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getSessionFromCookies } from '@/lib/auth/cookie-config';

--- a/apps/web/src/app/api/auth/desktop/exchange/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/desktop/exchange/__tests__/route.test.ts
@@ -20,12 +20,12 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
  *   - zod/v4: schema validation (real implementation)
  */
 
-vi.mock('@pagespace/lib/auth', () => ({
-  consumeExchangeCode: vi.fn(),
+vi.mock('@pagespace/lib/auth/exchange-codes', () => ({
+    consumeExchangeCode: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -36,16 +36,20 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
     },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 vi.mock('@/lib/auth/cookie-config', () => ({
   createSessionCookie: vi.fn().mockReturnValue('session=mock-session-token; Path=/; HttpOnly'),
 }));
 
-import { consumeExchangeCode } from '@pagespace/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { consumeExchangeCode } from '@pagespace/lib/auth/exchange-codes';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { createSessionCookie } from '@/lib/auth/cookie-config';
 import { POST } from '../route';
 

--- a/apps/web/src/app/api/auth/desktop/exchange/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/desktop/exchange/__tests__/route.test.ts
@@ -21,11 +21,11 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
  */
 
 vi.mock('@pagespace/lib/auth/exchange-codes', () => ({
-    consumeExchangeCode: vi.fn(),
+  consumeExchangeCode: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -36,12 +36,10 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       warn: vi.fn(),
     },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@/lib/auth/cookie-config', () => ({

--- a/apps/web/src/app/api/auth/desktop/exchange/route.ts
+++ b/apps/web/src/app/api/auth/desktop/exchange/route.ts
@@ -17,8 +17,9 @@
  * - Response body is not logged by nginx/proxies
  */
 
-import { consumeExchangeCode } from '@pagespace/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { consumeExchangeCode } from '@pagespace/lib/auth/exchange-codes';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { createSessionCookie } from '@/lib/auth/cookie-config';
 import { z } from 'zod/v4';
 

--- a/apps/web/src/app/api/auth/desktop/exchange/route.ts
+++ b/apps/web/src/app/api/auth/desktop/exchange/route.ts
@@ -18,7 +18,7 @@
  */
 
 import { consumeExchangeCode } from '@pagespace/lib/auth/exchange-codes';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { createSessionCookie } from '@/lib/auth/cookie-config';
 import { z } from 'zod/v4';

--- a/apps/web/src/app/api/auth/device/__tests__/refresh-deviceid.test.ts
+++ b/apps/web/src/app/api/auth/device/__tests__/refresh-deviceid.test.ts
@@ -1,33 +1,43 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('@pagespace/lib/auth', () => ({
-  hashToken: vi.fn((t: string) => `hashed_${t}`),
-  getTokenPrefix: vi.fn((t: string) => t.slice(0, 8)),
-  sessionService: {
+vi.mock('@pagespace/lib/auth/token-utils', () => ({
+    hashToken: vi.fn((t: string) => `hashed_${t}`),
+    getTokenPrefix: vi.fn((t: string) => t.slice(0, 8)),
+}));
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_token'),
     validateSession: vi.fn().mockResolvedValue({ sessionId: 'sid_123' }),
   },
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  validateDeviceToken: vi.fn().mockResolvedValue({
+vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
+    validateDeviceToken: vi.fn().mockResolvedValue({
     id: 'dt_1',
     userId: 'user_1',
     deviceId: 'device_123',
     platform: 'web',
     expiresAt: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
   }),
-  updateDeviceTokenActivity: vi.fn().mockResolvedValue(undefined),
-  generateDeviceToken: vi.fn().mockReturnValue('new_device_token'),
-  generateCSRFToken: vi.fn().mockReturnValue('csrf_token'),
-  loggers: { auth: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } },
-  auditRequest: vi.fn(),
+    updateDeviceTokenActivity: vi.fn().mockResolvedValue(undefined),
+    generateDeviceToken: vi.fn().mockReturnValue('new_device_token'),
+}));
+vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
+    generateCSRFToken: vi.fn().mockReturnValue('csrf_token'),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: { auth: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
-  resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
-  DISTRIBUTED_RATE_LIMITS: { REFRESH: { maxAttempts: 10, windowMs: 60000 } },
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
+    resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
+    DISTRIBUTED_RATE_LIMITS: { REFRESH: { maxAttempts: 10, windowMs: 60000 } },
 }));
 
 vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
@@ -54,8 +64,8 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 import { POST } from '../refresh/route';
-import { validateDeviceToken } from '@pagespace/lib/server';
-import { sessionService } from '@pagespace/lib/auth';
+import { validateDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
+import { sessionService } from '@pagespace/lib/auth/session-service';
 
 function makeRequest(body: Record<string, unknown>): Request {
   return new Request('http://localhost/api/auth/device/refresh', {

--- a/apps/web/src/app/api/auth/device/__tests__/refresh-deviceid.test.ts
+++ b/apps/web/src/app/api/auth/device/__tests__/refresh-deviceid.test.ts
@@ -1,43 +1,41 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('@pagespace/lib/auth/token-utils', () => ({
-    hashToken: vi.fn((t: string) => `hashed_${t}`),
-    getTokenPrefix: vi.fn((t: string) => t.slice(0, 8)),
+  hashToken: vi.fn((t: string) => `hashed_${t}`),
+  getTokenPrefix: vi.fn((t: string) => t.slice(0, 8)),
 }));
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_token'),
     validateSession: vi.fn().mockResolvedValue({ sessionId: 'sid_123' }),
   },
 }));
 
 vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
-    validateDeviceToken: vi.fn().mockResolvedValue({
+  validateDeviceToken: vi.fn().mockResolvedValue({
     id: 'dt_1',
     userId: 'user_1',
     deviceId: 'device_123',
     platform: 'web',
     expiresAt: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
   }),
-    updateDeviceTokenActivity: vi.fn().mockResolvedValue(undefined),
-    generateDeviceToken: vi.fn().mockReturnValue('new_device_token'),
+  updateDeviceTokenActivity: vi.fn().mockResolvedValue(undefined),
+  generateDeviceToken: vi.fn().mockReturnValue('new_device_token'),
 }));
 vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
-    generateCSRFToken: vi.fn().mockReturnValue('csrf_token'),
+  generateCSRFToken: vi.fn().mockReturnValue('csrf_token'),
 }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: { auth: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+  loggers: { auth: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
-    resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
-    DISTRIBUTED_RATE_LIMITS: { REFRESH: { maxAttempts: 10, windowMs: 60000 } },
+  checkDistributedRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
+  resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
+  DISTRIBUTED_RATE_LIMITS: { REFRESH: { maxAttempts: 10, windowMs: 60000 } },
 }));
 
 vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({

--- a/apps/web/src/app/api/auth/device/refresh/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/device/refresh/__tests__/route.test.ts
@@ -41,15 +41,15 @@ vi.mock('@pagespace/db/transactions/auth-transactions', () => ({
 }));
 
 vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
-    validateDeviceToken: vi.fn(),
-    updateDeviceTokenActivity: vi.fn().mockResolvedValue(undefined),
-    generateDeviceToken: vi.fn(),
+  validateDeviceToken: vi.fn(),
+  updateDeviceTokenActivity: vi.fn().mockResolvedValue(undefined),
+  generateDeviceToken: vi.fn(),
 }));
 vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
-    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
 }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -60,17 +60,15 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       warn: vi.fn(),
     },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn(),
-    resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
-    DISTRIBUTED_RATE_LIMITS: {
+  checkDistributedRateLimit: vi.fn(),
+  resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
+  DISTRIBUTED_RATE_LIMITS: {
     REFRESH: {
       maxAttempts: 10,
       windowMs: 300000,
@@ -79,11 +77,11 @@ vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
 }));
 
 vi.mock('@pagespace/lib/auth/token-utils', () => ({
-    hashToken: vi.fn(),
-    getTokenPrefix: vi.fn(),
+  hashToken: vi.fn(),
+  getTokenPrefix: vi.fn(),
 }));
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_session_token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -109,8 +107,8 @@ import { POST } from '../route';
 import { authRepository } from '@/lib/repositories/auth-repository';
 import { sessionRepository } from '@/lib/repositories/session-repository';
 import { atomicDeviceTokenRotation } from '@pagespace/db/transactions/auth-transactions';
-import { validateDeviceToken, updateDeviceTokenActivity } from '@pagespace/lib/auth/device-auth-utils'
-import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { validateDeviceToken, updateDeviceTokenActivity } from '@pagespace/lib/auth/device-auth-utils';
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { sessionService } from '@pagespace/lib/auth/session-service';
 import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';

--- a/apps/web/src/app/api/auth/device/refresh/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/device/refresh/__tests__/route.test.ts
@@ -40,12 +40,16 @@ vi.mock('@pagespace/db/transactions/auth-transactions', () => ({
   atomicDeviceTokenRotation: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  validateDeviceToken: vi.fn(),
-  updateDeviceTokenActivity: vi.fn().mockResolvedValue(undefined),
-  generateDeviceToken: vi.fn(),
-  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
-  loggers: {
+vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
+    validateDeviceToken: vi.fn(),
+    updateDeviceTokenActivity: vi.fn().mockResolvedValue(undefined),
+    generateDeviceToken: vi.fn(),
+}));
+vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
+    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -56,13 +60,17 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
     },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn(),
-  resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
-  DISTRIBUTED_RATE_LIMITS: {
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn(),
+    resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
+    DISTRIBUTED_RATE_LIMITS: {
     REFRESH: {
       maxAttempts: 10,
       windowMs: 300000,
@@ -70,10 +78,12 @@ vi.mock('@pagespace/lib/security', () => ({
   },
 }));
 
-vi.mock('@pagespace/lib/auth', () => ({
-  hashToken: vi.fn(),
-  getTokenPrefix: vi.fn(),
-  sessionService: {
+vi.mock('@pagespace/lib/auth/token-utils', () => ({
+    hashToken: vi.fn(),
+    getTokenPrefix: vi.fn(),
+}));
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_session_token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -99,9 +109,11 @@ import { POST } from '../route';
 import { authRepository } from '@/lib/repositories/auth-repository';
 import { sessionRepository } from '@/lib/repositories/session-repository';
 import { atomicDeviceTokenRotation } from '@pagespace/db/transactions/auth-transactions';
-import { validateDeviceToken, updateDeviceTokenActivity, generateCSRFToken, loggers } from '@pagespace/lib/server';
-import { sessionService } from '@pagespace/lib/auth';
-import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security';
+import { validateDeviceToken, updateDeviceTokenActivity } from '@pagespace/lib/auth/device-auth-utils'
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { getClientIP, appendSessionCookie } from '@/lib/auth';
 

--- a/apps/web/src/app/api/auth/device/refresh/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/device/refresh/__tests__/route.test.ts
@@ -384,8 +384,8 @@ describe('POST /api/auth/device/refresh', () => {
 
       expect(response.status).toBe(200);
       expect(body.deviceToken).toBe('ps_dev_rotated_token');
-      const { hashToken, getTokenPrefix } = await import('@pagespace/lib/auth');
-      const { generateDeviceToken } = await import('@pagespace/lib/server');
+      const { hashToken, getTokenPrefix } = await import('@pagespace/lib/auth/token-utils');
+      const { generateDeviceToken } = await import('@pagespace/lib/auth/device-auth-utils');
       expect(atomicDeviceTokenRotation).toHaveBeenCalledWith(
         'ps_dev_valid_token',
         expect.objectContaining({

--- a/apps/web/src/app/api/auth/device/refresh/route.ts
+++ b/apps/web/src/app/api/auth/device/refresh/route.ts
@@ -2,19 +2,17 @@ import { z } from 'zod/v4';
 import { atomicDeviceTokenRotation } from '@pagespace/db/transactions/auth-transactions';
 import { authRepository } from '@/lib/repositories/auth-repository';
 import { sessionRepository } from '@/lib/repositories/session-repository';
-import {
-  validateDeviceToken,
-  updateDeviceTokenActivity,
-  generateDeviceToken,
-  generateCSRFToken,
-} from '@pagespace/lib/server';
+import { validateDeviceToken, updateDeviceTokenActivity, generateDeviceToken } from '@pagespace/lib/auth/device-auth-utils'
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
 import {
   checkDistributedRateLimit,
   resetDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
-} from '@pagespace/lib/security';
-import { hashToken, getTokenPrefix, sessionService } from '@pagespace/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+} from '@pagespace/lib/security/distributed-rate-limit';
+import { hashToken, getTokenPrefix } from '@pagespace/lib/auth/token-utils'
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { getClientIP, appendSessionCookie } from '@/lib/auth';
 

--- a/apps/web/src/app/api/auth/device/refresh/route.ts
+++ b/apps/web/src/app/api/auth/device/refresh/route.ts
@@ -2,16 +2,16 @@ import { z } from 'zod/v4';
 import { atomicDeviceTokenRotation } from '@pagespace/db/transactions/auth-transactions';
 import { authRepository } from '@/lib/repositories/auth-repository';
 import { sessionRepository } from '@/lib/repositories/session-repository';
-import { validateDeviceToken, updateDeviceTokenActivity, generateDeviceToken } from '@pagespace/lib/auth/device-auth-utils'
+import { validateDeviceToken, updateDeviceTokenActivity, generateDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
 import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
 import {
   checkDistributedRateLimit,
   resetDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
 } from '@pagespace/lib/security/distributed-rate-limit';
-import { hashToken, getTokenPrefix } from '@pagespace/lib/auth/token-utils'
+import { hashToken, getTokenPrefix } from '@pagespace/lib/auth/token-utils';
 import { sessionService } from '@pagespace/lib/auth/session-service';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { getClientIP, appendSessionCookie } from '@/lib/auth';

--- a/apps/web/src/app/api/auth/device/register/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/device/register/__tests__/route.test.ts
@@ -7,14 +7,18 @@ vi.mock('@/lib/auth', () => ({
   createWebDeviceToken: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     security: {
       warn: vi.fn(),
     },
   },
-  securityAudit: {
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/security-audit', () => ({
+    securityAudit: {
     logAuthSuccess: vi.fn().mockResolvedValue(undefined),
     logAuthFailure: vi.fn().mockResolvedValue(undefined),
     logTokenCreated: vi.fn().mockResolvedValue(undefined),
@@ -25,10 +29,10 @@ vi.mock('@pagespace/lib/server', () => ({
   },
 }));
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn(),
-  resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
-  DISTRIBUTED_RATE_LIMITS: {
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn(),
+    resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
+    DISTRIBUTED_RATE_LIMITS: {
     REFRESH: { maxAttempts: 10, windowMs: 300000 },
   },
 }));
@@ -41,7 +45,7 @@ vi.mock('@/lib/repositories/auth-repository', () => ({
 
 import { POST } from '../route';
 import { authenticateRequestWithOptions, createWebDeviceToken } from '@/lib/auth';
-import { checkDistributedRateLimit } from '@pagespace/lib/security';
+import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { authRepository } from '@/lib/repositories/auth-repository';
 
 function createRequest(body: Record<string, unknown>) {

--- a/apps/web/src/app/api/auth/device/register/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/device/register/__tests__/route.test.ts
@@ -8,17 +8,15 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     security: {
       warn: vi.fn(),
     },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/security-audit', () => ({
-    securityAudit: {
+  securityAudit: {
     logAuthSuccess: vi.fn().mockResolvedValue(undefined),
     logAuthFailure: vi.fn().mockResolvedValue(undefined),
     logTokenCreated: vi.fn().mockResolvedValue(undefined),
@@ -30,9 +28,9 @@ vi.mock('@pagespace/lib/audit/security-audit', () => ({
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn(),
-    resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
-    DISTRIBUTED_RATE_LIMITS: {
+  checkDistributedRateLimit: vi.fn(),
+  resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
+  DISTRIBUTED_RATE_LIMITS: {
     REFRESH: { maxAttempts: 10, windowMs: 300000 },
   },
 }));

--- a/apps/web/src/app/api/auth/device/register/route.ts
+++ b/apps/web/src/app/api/auth/device/register/route.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod/v4';
 import { authenticateRequestWithOptions, isAuthError, getClientIP, createWebDeviceToken } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { securityAudit } from '@pagespace/lib/audit/security-audit';
 import {
   checkDistributedRateLimit,

--- a/apps/web/src/app/api/auth/device/register/route.ts
+++ b/apps/web/src/app/api/auth/device/register/route.ts
@@ -1,11 +1,12 @@
 import { z } from 'zod/v4';
 import { authenticateRequestWithOptions, isAuthError, getClientIP, createWebDeviceToken } from '@/lib/auth';
-import { loggers, securityAudit } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { securityAudit } from '@pagespace/lib/audit/security-audit';
 import {
   checkDistributedRateLimit,
   resetDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
-} from '@pagespace/lib/security';
+} from '@pagespace/lib/security/distributed-rate-limit';
 import { authRepository } from '@/lib/repositories/auth-repository';
 
 const registerDeviceSchema = z.object({

--- a/apps/web/src/app/api/auth/google/__tests__/google-callback-redirect.test.ts
+++ b/apps/web/src/app/api/auth/google/__tests__/google-callback-redirect.test.ts
@@ -39,7 +39,7 @@ vi.mock('@/lib/repositories/auth-repository', () => ({
 
 // Mock session service from @pagespace/lib/auth
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_session_token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -54,16 +54,16 @@ vi.mock('@pagespace/lib/auth/session-service', () => ({
   },
 }));
 vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
-    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
 }));
 vi.mock('@pagespace/lib/auth/exchange-codes', () => ({
-    createExchangeCode: vi.fn().mockResolvedValue('mock-exchange-code'),
+  createExchangeCode: vi.fn().mockResolvedValue('mock-exchange-code'),
 }));
 vi.mock('@pagespace/lib/auth/pkce', () => ({
-    consumePKCEVerifier: vi.fn().mockResolvedValue(null),
+  consumePKCEVerifier: vi.fn().mockResolvedValue(null),
 }));
 vi.mock('@pagespace/lib/auth/constants', () => ({
-    SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
+  SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 
 // Mock cookie utilities
@@ -75,7 +75,7 @@ vi.mock('@/lib/auth/cookie-config', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
       auth: {
         error: vi.fn(),
         info: vi.fn(),
@@ -86,23 +86,21 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
         warn: vi.fn(),
       },
     },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
-    validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
+  validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
       deviceToken: 'mock-device-token',
       deviceTokenRecordId: 'device-record-id',
     }),
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn(),
-    resetDistributedRateLimit: vi.fn(),
-    DISTRIBUTED_RATE_LIMITS: {
+  checkDistributedRateLimit: vi.fn(),
+  resetDistributedRateLimit: vi.fn(),
+  DISTRIBUTED_RATE_LIMITS: {
     LOGIN: {
       maxAttempts: 5,
       windowMs: 900000,

--- a/apps/web/src/app/api/auth/google/__tests__/google-callback-redirect.test.ts
+++ b/apps/web/src/app/api/auth/google/__tests__/google-callback-redirect.test.ts
@@ -38,8 +38,8 @@ vi.mock('@/lib/repositories/auth-repository', () => ({
 }));
 
 // Mock session service from @pagespace/lib/auth
-vi.mock('@pagespace/lib/auth', () => ({
-  sessionService: {
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_session_token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -52,10 +52,18 @@ vi.mock('@pagespace/lib/auth', () => ({
     revokeAllUserSessions: vi.fn().mockResolvedValue(0),
     revokeSession: vi.fn().mockResolvedValue(undefined),
   },
-  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
-  createExchangeCode: vi.fn().mockResolvedValue('mock-exchange-code'),
-  consumePKCEVerifier: vi.fn().mockResolvedValue(null),
-  SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
+}));
+vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
+    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+}));
+vi.mock('@pagespace/lib/auth/exchange-codes', () => ({
+    createExchangeCode: vi.fn().mockResolvedValue('mock-exchange-code'),
+}));
+vi.mock('@pagespace/lib/auth/pkce', () => ({
+    consumePKCEVerifier: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@pagespace/lib/auth/constants', () => ({
+    SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 
 // Mock cookie utilities
@@ -66,11 +74,7 @@ vi.mock('@/lib/auth/cookie-config', () => ({
   createDeviceTokenHandoffCookie: vi.fn().mockReturnValue('ps_device_token=mock; Path=/; Max-Age=60'),
 }));
 
-vi.mock('@pagespace/lib/server', async () => {
-  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
-    '@pagespace/lib/audit/mask-email'
-  );
-  return {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
     loggers: {
       auth: {
         error: vi.fn(),
@@ -82,19 +86,23 @@ vi.mock('@pagespace/lib/server', async () => {
         warn: vi.fn(),
       },
     },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
     auditRequest: vi.fn(),
+}));
+vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
     validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
       deviceToken: 'mock-device-token',
       deviceTokenRecordId: 'device-record-id',
     }),
-    maskEmail,
-  };
-});
+}));
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn(),
-  resetDistributedRateLimit: vi.fn(),
-  DISTRIBUTED_RATE_LIMITS: {
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn(),
+    resetDistributedRateLimit: vi.fn(),
+    DISTRIBUTED_RATE_LIMITS: {
     LOGIN: {
       maxAttempts: 5,
       windowMs: 900000,
@@ -147,9 +155,9 @@ vi.mock('crypto', async () => {
 });
 
 import { authRepository } from '@/lib/repositories/auth-repository';
-import { sessionService } from '@pagespace/lib/auth';
+import { sessionService } from '@pagespace/lib/auth/session-service';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';
-import { checkDistributedRateLimit } from '@pagespace/lib/security';
+import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-started-drive';
 
 // Test fixtures

--- a/apps/web/src/app/api/auth/google/__tests__/one-tap.test.ts
+++ b/apps/web/src/app/api/auth/google/__tests__/one-tap.test.ts
@@ -39,8 +39,8 @@ vi.mock('@/lib/repositories/auth-repository', () => ({
 }));
 
 // Mock session service from @pagespace/lib/auth
-vi.mock('@pagespace/lib/auth', () => ({
-  sessionService: {
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_session_token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -53,8 +53,12 @@ vi.mock('@pagespace/lib/auth', () => ({
     revokeAllUserSessions: vi.fn().mockResolvedValue(0),
     revokeSession: vi.fn().mockResolvedValue(undefined),
   },
-  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
-  SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
+}));
+vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
+    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+}));
+vi.mock('@pagespace/lib/auth/constants', () => ({
+    SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 
 // Mock cookie utilities
@@ -64,11 +68,7 @@ vi.mock('@/lib/auth/cookie-config', () => ({
   getSessionFromCookies: vi.fn().mockReturnValue('ps_sess_mock_session_token'),
 }));
 
-vi.mock('@pagespace/lib/server', async () => {
-  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
-    '@pagespace/lib/audit/mask-email'
-  );
-  return {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
     loggers: {
       auth: {
         error: vi.fn(),
@@ -80,15 +80,17 @@ vi.mock('@pagespace/lib/server', async () => {
         warn: vi.fn(),
       },
     },
-    auditRequest: vi.fn(),
-    maskEmail,
-  };
-});
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn(),
-  resetDistributedRateLimit: vi.fn(),
-  DISTRIBUTED_RATE_LIMITS: {
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn(),
+    resetDistributedRateLimit: vi.fn(),
+    DISTRIBUTED_RATE_LIMITS: {
     LOGIN: {
       maxAttempts: 5,
       windowMs: 900000,
@@ -118,9 +120,10 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 import { authRepository } from '@/lib/repositories/auth-repository';
-import { sessionService, generateCSRFToken } from '@pagespace/lib/auth';
+import { sessionService } from '@pagespace/lib/auth/session-service'
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';
-import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security';
+import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-started-drive';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 

--- a/apps/web/src/app/api/auth/google/__tests__/one-tap.test.ts
+++ b/apps/web/src/app/api/auth/google/__tests__/one-tap.test.ts
@@ -40,7 +40,7 @@ vi.mock('@/lib/repositories/auth-repository', () => ({
 
 // Mock session service from @pagespace/lib/auth
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_session_token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -55,10 +55,10 @@ vi.mock('@pagespace/lib/auth/session-service', () => ({
   },
 }));
 vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
-    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
 }));
 vi.mock('@pagespace/lib/auth/constants', () => ({
-    SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
+  SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 
 // Mock cookie utilities
@@ -69,7 +69,7 @@ vi.mock('@/lib/auth/cookie-config', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
       auth: {
         error: vi.fn(),
         info: vi.fn(),
@@ -80,17 +80,15 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
         warn: vi.fn(),
       },
     },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn(),
-    resetDistributedRateLimit: vi.fn(),
-    DISTRIBUTED_RATE_LIMITS: {
+  checkDistributedRateLimit: vi.fn(),
+  resetDistributedRateLimit: vi.fn(),
+  DISTRIBUTED_RATE_LIMITS: {
     LOGIN: {
       maxAttempts: 5,
       windowMs: 900000,
@@ -120,7 +118,7 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 import { authRepository } from '@/lib/repositories/auth-repository';
-import { sessionService } from '@pagespace/lib/auth/session-service'
+import { sessionService } from '@pagespace/lib/auth/session-service';
 import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';
 import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';

--- a/apps/web/src/app/api/auth/google/__tests__/open-redirect-protection.test.ts
+++ b/apps/web/src/app/api/auth/google/__tests__/open-redirect-protection.test.ts
@@ -11,7 +11,7 @@ import { GET } from '../callback/route';
 
 // Mock dependencies for signin
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
       auth: {
         error: vi.fn(),
         info: vi.fn(),
@@ -22,23 +22,21 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
         warn: vi.fn(),
       },
     },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
-    validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
+  validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
       deviceToken: 'mock-device-token',
       deviceTokenRecordId: 'device-record-id',
     }),
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn().mockResolvedValue({ allowed: true, attemptsRemaining: 5 }),
-    resetDistributedRateLimit: vi.fn(),
-    DISTRIBUTED_RATE_LIMITS: {
+  checkDistributedRateLimit: vi.fn().mockResolvedValue({ allowed: true, attemptsRemaining: 5 }),
+  resetDistributedRateLimit: vi.fn(),
+  DISTRIBUTED_RATE_LIMITS: {
     LOGIN: { maxAttempts: 5, windowMs: 900000, blockDurationMs: 900000, progressiveDelay: true },
     REFRESH: { maxAttempts: 10, windowMs: 60000 },
   },
@@ -98,7 +96,7 @@ vi.mock('@/lib/repositories/auth-repository', () => ({
 
 // Mock session service from @pagespace/lib/auth
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_session_token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -113,14 +111,14 @@ vi.mock('@pagespace/lib/auth/session-service', () => ({
   },
 }));
 vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
-    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
 }));
 vi.mock('@pagespace/lib/auth/pkce', () => ({
-    generatePKCE: vi.fn().mockResolvedValue(null),
-    consumePKCEVerifier: vi.fn().mockResolvedValue(null),
+  generatePKCE: vi.fn().mockResolvedValue(null),
+  consumePKCEVerifier: vi.fn().mockResolvedValue(null),
 }));
 vi.mock('@pagespace/lib/auth/constants', () => ({
-    SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
+  SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 
 // Mock cookie utilities

--- a/apps/web/src/app/api/auth/google/__tests__/open-redirect-protection.test.ts
+++ b/apps/web/src/app/api/auth/google/__tests__/open-redirect-protection.test.ts
@@ -10,11 +10,7 @@ import { POST } from '../signin/route';
 import { GET } from '../callback/route';
 
 // Mock dependencies for signin
-vi.mock('@pagespace/lib/server', async () => {
-  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
-    '@pagespace/lib/audit/mask-email'
-  );
-  return {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
     loggers: {
       auth: {
         error: vi.fn(),
@@ -26,19 +22,23 @@ vi.mock('@pagespace/lib/server', async () => {
         warn: vi.fn(),
       },
     },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
     auditRequest: vi.fn(),
+}));
+vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
     validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
       deviceToken: 'mock-device-token',
       deviceTokenRecordId: 'device-record-id',
     }),
-    maskEmail,
-  };
-});
+}));
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn().mockResolvedValue({ allowed: true, attemptsRemaining: 5 }),
-  resetDistributedRateLimit: vi.fn(),
-  DISTRIBUTED_RATE_LIMITS: {
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn().mockResolvedValue({ allowed: true, attemptsRemaining: 5 }),
+    resetDistributedRateLimit: vi.fn(),
+    DISTRIBUTED_RATE_LIMITS: {
     LOGIN: { maxAttempts: 5, windowMs: 900000, blockDurationMs: 900000, progressiveDelay: true },
     REFRESH: { maxAttempts: 10, windowMs: 60000 },
   },
@@ -97,8 +97,8 @@ vi.mock('@/lib/repositories/auth-repository', () => ({
 }));
 
 // Mock session service from @pagespace/lib/auth
-vi.mock('@pagespace/lib/auth', () => ({
-  sessionService: {
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_session_token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -111,10 +111,16 @@ vi.mock('@pagespace/lib/auth', () => ({
     revokeAllUserSessions: vi.fn().mockResolvedValue(0),
     revokeSession: vi.fn().mockResolvedValue(undefined),
   },
-  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
-  generatePKCE: vi.fn().mockResolvedValue(null),
-  consumePKCEVerifier: vi.fn().mockResolvedValue(null),
-  SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
+}));
+vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
+    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+}));
+vi.mock('@pagespace/lib/auth/pkce', () => ({
+    generatePKCE: vi.fn().mockResolvedValue(null),
+    consumePKCEVerifier: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@pagespace/lib/auth/constants', () => ({
+    SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 
 // Mock cookie utilities
@@ -179,7 +185,7 @@ const createSignedState = (data: Record<string, unknown>) => {
   return Buffer.from(JSON.stringify(stateData)).toString('base64');
 };
 
-import { checkDistributedRateLimit } from '@pagespace/lib/security';
+import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 
 describe('Open Redirect Protection', () => {
   const originalEnv = { ...process.env };

--- a/apps/web/src/app/api/auth/google/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/callback/__tests__/route.test.ts
@@ -61,7 +61,7 @@ vi.mock('@/lib/repositories/auth-repository', () => ({
 }));
 
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_session_token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -75,26 +75,26 @@ vi.mock('@pagespace/lib/auth/session-service', () => ({
   },
 }));
 vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
-    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
 }));
 vi.mock('@pagespace/lib/auth/exchange-codes', () => ({
-    createExchangeCode: vi.fn().mockResolvedValue('mock-exchange-code'),
+  createExchangeCode: vi.fn().mockResolvedValue('mock-exchange-code'),
 }));
 vi.mock('@pagespace/lib/auth/pkce', () => ({
-    consumePKCEVerifier: vi.fn().mockResolvedValue(null),
+  consumePKCEVerifier: vi.fn().mockResolvedValue(null),
 }));
 vi.mock('@pagespace/lib/auth/constants', () => ({
-    SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
+  SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 
 vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
-    validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
+  validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
       deviceToken: 'mock-device-token',
       deviceTokenRecordId: 'device-record-id',
     }),
 }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
       auth: {
         error: vi.fn(),
         info: vi.fn(),
@@ -105,17 +105,15 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
         warn: vi.fn(),
       },
     },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn(),
-    resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
-    DISTRIBUTED_RATE_LIMITS: {
+  checkDistributedRateLimit: vi.fn(),
+  resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
+  DISTRIBUTED_RATE_LIMITS: {
     LOGIN: {
       maxAttempts: 5,
       windowMs: 900000,
@@ -156,11 +154,11 @@ vi.mock('@/lib/auth/google-avatar', () => ({
 
 import { GET } from '../route';
 import { authRepository } from '@/lib/repositories/auth-repository';
-import { sessionService } from '@pagespace/lib/auth/session-service'
-import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
 import { createExchangeCode } from '@pagespace/lib/auth/exchange-codes';
-import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils'
-import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';

--- a/apps/web/src/app/api/auth/google/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/callback/__tests__/route.test.ts
@@ -60,8 +60,8 @@ vi.mock('@/lib/repositories/auth-repository', () => ({
   },
 }));
 
-vi.mock('@pagespace/lib/auth', () => ({
-  sessionService: {
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_session_token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -73,21 +73,27 @@ vi.mock('@pagespace/lib/auth', () => ({
     }),
     revokeAllUserSessions: vi.fn().mockResolvedValue(0),
   },
-  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
-  createExchangeCode: vi.fn().mockResolvedValue('mock-exchange-code'),
-  consumePKCEVerifier: vi.fn().mockResolvedValue(null),
-  SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
+}));
+vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
+    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+}));
+vi.mock('@pagespace/lib/auth/exchange-codes', () => ({
+    createExchangeCode: vi.fn().mockResolvedValue('mock-exchange-code'),
+}));
+vi.mock('@pagespace/lib/auth/pkce', () => ({
+    consumePKCEVerifier: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@pagespace/lib/auth/constants', () => ({
+    SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 
-vi.mock('@pagespace/lib/server', async () => {
-  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
-    '@pagespace/lib/audit/mask-email'
-  );
-  return {
+vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
     validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
       deviceToken: 'mock-device-token',
       deviceTokenRecordId: 'device-record-id',
     }),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
     loggers: {
       auth: {
         error: vi.fn(),
@@ -99,15 +105,17 @@ vi.mock('@pagespace/lib/server', async () => {
         warn: vi.fn(),
       },
     },
-    auditRequest: vi.fn(),
-    maskEmail,
-  };
-});
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn(),
-  resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
-  DISTRIBUTED_RATE_LIMITS: {
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn(),
+    resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
+    DISTRIBUTED_RATE_LIMITS: {
     LOGIN: {
       maxAttempts: 5,
       windowMs: 900000,
@@ -148,9 +156,13 @@ vi.mock('@/lib/auth/google-avatar', () => ({
 
 import { GET } from '../route';
 import { authRepository } from '@/lib/repositories/auth-repository';
-import { sessionService, generateCSRFToken, createExchangeCode } from '@pagespace/lib/auth';
-import { validateOrCreateDeviceToken, auditRequest, loggers } from '@pagespace/lib/server';
-import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security';
+import { sessionService } from '@pagespace/lib/auth/session-service'
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { createExchangeCode } from '@pagespace/lib/auth/exchange-codes';
+import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils'
+import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { createId } from '@paralleldrive/cuid2';
 import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-started-drive';

--- a/apps/web/src/app/api/auth/google/callback/route.ts
+++ b/apps/web/src/app/api/auth/google/callback/route.ts
@@ -1,11 +1,17 @@
-import { sessionService, generateCSRFToken, createExchangeCode, SESSION_DURATION_MS } from '@pagespace/lib/auth';
+import { sessionService } from '@pagespace/lib/auth/session-service'
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { createExchangeCode } from '@pagespace/lib/auth/exchange-codes'
+import { SESSION_DURATION_MS } from '@pagespace/lib/auth/constants';
 import {
   checkDistributedRateLimit,
   resetDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
-} from '@pagespace/lib/security';
+} from '@pagespace/lib/security/distributed-rate-limit';
 import { createId } from '@paralleldrive/cuid2';
-import { loggers, auditRequest, validateOrCreateDeviceToken, maskEmail } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils'
+import { maskEmail } from '@pagespace/lib/audit/mask-email';
 import { revokeSessionsForLogin, createWebDeviceToken } from '@/lib/auth';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { OAuth2Client } from 'google-auth-library';
@@ -15,7 +21,7 @@ import { getClientIP, isSafeReturnUrl } from '@/lib/auth';
 import { verifyOAuthState } from '@/lib/auth/oauth-state';
 import { appendSessionCookie, createDeviceTokenHandoffCookie } from '@/lib/auth/cookie-config';
 import { resolveGoogleAvatarImage } from '@/lib/auth/google-avatar';
-import { consumePKCEVerifier } from '@pagespace/lib/auth';
+import { consumePKCEVerifier } from '@pagespace/lib/auth/pkce';
 import { authRepository } from '@/lib/repositories/auth-repository';
 import { buildHandoffBridgeResponse } from '@/app/api/auth/_shared/handoffBridgeResponse';
 

--- a/apps/web/src/app/api/auth/google/callback/route.ts
+++ b/apps/web/src/app/api/auth/google/callback/route.ts
@@ -1,6 +1,6 @@
-import { sessionService } from '@pagespace/lib/auth/session-service'
-import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
-import { createExchangeCode } from '@pagespace/lib/auth/exchange-codes'
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
+import { createExchangeCode } from '@pagespace/lib/auth/exchange-codes';
 import { SESSION_DURATION_MS } from '@pagespace/lib/auth/constants';
 import {
   checkDistributedRateLimit,
@@ -8,9 +8,9 @@ import {
   DISTRIBUTED_RATE_LIMITS,
 } from '@pagespace/lib/security/distributed-rate-limit';
 import { createId } from '@paralleldrive/cuid2';
-import { loggers } from '@pagespace/lib/logging/logger-config'
-import { auditRequest } from '@pagespace/lib/audit/audit-log'
-import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils'
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
 import { maskEmail } from '@pagespace/lib/audit/mask-email';
 import { revokeSessionsForLogin, createWebDeviceToken } from '@/lib/auth';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';

--- a/apps/web/src/app/api/auth/google/native/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/native/__tests__/route.test.ts
@@ -45,8 +45,8 @@ vi.mock('@/lib/repositories/auth-repository', () => ({
   },
 }));
 
-vi.mock('@pagespace/lib/auth', () => ({
-  sessionService: {
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_session_token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -59,19 +59,21 @@ vi.mock('@pagespace/lib/auth', () => ({
     revokeAllUserSessions: vi.fn().mockResolvedValue(0),
     revokeSession: vi.fn().mockResolvedValue(undefined),
   },
-  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
-  SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
+}));
+vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
+    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+}));
+vi.mock('@pagespace/lib/auth/constants', () => ({
+    SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 
-vi.mock('@pagespace/lib/server', async () => {
-  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
-    '@pagespace/lib/audit/mask-email'
-  );
-  return {
+vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
     validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
       deviceToken: 'mock-device-token',
       deviceTokenRecordId: 'device-record-id',
     }),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
     loggers: {
       auth: {
         error: vi.fn(),
@@ -83,15 +85,17 @@ vi.mock('@pagespace/lib/server', async () => {
         warn: vi.fn(),
       },
     },
-    auditRequest: vi.fn(),
-    maskEmail,
-  };
-});
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn(),
-  resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
-  DISTRIBUTED_RATE_LIMITS: {
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn(),
+    resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
+    DISTRIBUTED_RATE_LIMITS: {
     LOGIN: {
       maxAttempts: 5,
       windowMs: 900000,
@@ -127,9 +131,12 @@ vi.mock('@/lib/auth/google-avatar', () => ({
 }));
 
 import { authRepository } from '@/lib/repositories/auth-repository';
-import { sessionService, generateCSRFToken } from '@pagespace/lib/auth';
-import { validateOrCreateDeviceToken, auditRequest, loggers } from '@pagespace/lib/server';
-import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security';
+import { sessionService } from '@pagespace/lib/auth/session-service'
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
+import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils'
+import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-started-drive';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { getClientIP } from '@/lib/auth';

--- a/apps/web/src/app/api/auth/google/native/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/native/__tests__/route.test.ts
@@ -46,7 +46,7 @@ vi.mock('@/lib/repositories/auth-repository', () => ({
 }));
 
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_session_token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -61,20 +61,20 @@ vi.mock('@pagespace/lib/auth/session-service', () => ({
   },
 }));
 vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
-    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
 }));
 vi.mock('@pagespace/lib/auth/constants', () => ({
-    SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
+  SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 
 vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
-    validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
+  validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
       deviceToken: 'mock-device-token',
       deviceTokenRecordId: 'device-record-id',
     }),
 }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
       auth: {
         error: vi.fn(),
         info: vi.fn(),
@@ -85,17 +85,15 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
         warn: vi.fn(),
       },
     },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn(),
-    resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
-    DISTRIBUTED_RATE_LIMITS: {
+  checkDistributedRateLimit: vi.fn(),
+  resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
+  DISTRIBUTED_RATE_LIMITS: {
     LOGIN: {
       maxAttempts: 5,
       windowMs: 900000,
@@ -131,10 +129,10 @@ vi.mock('@/lib/auth/google-avatar', () => ({
 }));
 
 import { authRepository } from '@/lib/repositories/auth-repository';
-import { sessionService } from '@pagespace/lib/auth/session-service'
+import { sessionService } from '@pagespace/lib/auth/session-service';
 import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
-import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils'
-import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-started-drive';

--- a/apps/web/src/app/api/auth/google/native/route.ts
+++ b/apps/web/src/app/api/auth/google/native/route.ts
@@ -1,7 +1,12 @@
 import { OAuth2Client } from 'google-auth-library';
-import { sessionService, generateCSRFToken, SESSION_DURATION_MS } from '@pagespace/lib/auth';
+import { sessionService } from '@pagespace/lib/auth/session-service'
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { SESSION_DURATION_MS } from '@pagespace/lib/auth/constants';
 import { createId } from '@paralleldrive/cuid2';
-import { loggers, auditRequest, validateOrCreateDeviceToken, maskEmail } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils'
+import { maskEmail } from '@pagespace/lib/audit/mask-email';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { z } from 'zod/v4';
 import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-started-drive';
@@ -12,7 +17,7 @@ import {
   checkDistributedRateLimit,
   resetDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
-} from '@pagespace/lib/security';
+} from '@pagespace/lib/security/distributed-rate-limit';
 import { authRepository } from '@/lib/repositories/auth-repository';
 
 const client = new OAuth2Client();

--- a/apps/web/src/app/api/auth/google/native/route.ts
+++ b/apps/web/src/app/api/auth/google/native/route.ts
@@ -1,11 +1,11 @@
 import { OAuth2Client } from 'google-auth-library';
-import { sessionService } from '@pagespace/lib/auth/session-service'
-import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
 import { SESSION_DURATION_MS } from '@pagespace/lib/auth/constants';
 import { createId } from '@paralleldrive/cuid2';
-import { loggers } from '@pagespace/lib/logging/logger-config'
-import { auditRequest } from '@pagespace/lib/audit/audit-log'
-import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils'
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
 import { maskEmail } from '@pagespace/lib/audit/mask-email';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { z } from 'zod/v4';

--- a/apps/web/src/app/api/auth/google/one-tap/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/one-tap/__tests__/route.test.ts
@@ -49,7 +49,7 @@ vi.mock('@/lib/repositories/auth-repository', () => ({
 }));
 
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_session_token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -63,14 +63,14 @@ vi.mock('@pagespace/lib/auth/session-service', () => ({
   },
 }));
 vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
-    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
 }));
 vi.mock('@pagespace/lib/auth/constants', () => ({
-    SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
+  SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
       auth: {
         error: vi.fn(),
         info: vi.fn(),
@@ -81,17 +81,15 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
         warn: vi.fn(),
       },
     },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn(),
-    resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
-    DISTRIBUTED_RATE_LIMITS: {
+  checkDistributedRateLimit: vi.fn(),
+  resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
+  DISTRIBUTED_RATE_LIMITS: {
     LOGIN: {
       maxAttempts: 5,
       windowMs: 900000,
@@ -130,9 +128,9 @@ vi.mock('@/lib/auth/google-avatar', () => ({
 
 import { POST } from '../route';
 import { authRepository } from '@/lib/repositories/auth-repository';
-import { sessionService } from '@pagespace/lib/auth/session-service'
+import { sessionService } from '@pagespace/lib/auth/session-service';
 import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
-import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';

--- a/apps/web/src/app/api/auth/google/one-tap/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/one-tap/__tests__/route.test.ts
@@ -48,8 +48,8 @@ vi.mock('@/lib/repositories/auth-repository', () => ({
   },
 }));
 
-vi.mock('@pagespace/lib/auth', () => ({
-  sessionService: {
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_session_token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -61,15 +61,15 @@ vi.mock('@pagespace/lib/auth', () => ({
     }),
     revokeAllUserSessions: vi.fn().mockResolvedValue(0),
   },
-  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
-  SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
+}));
+vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
+    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+}));
+vi.mock('@pagespace/lib/auth/constants', () => ({
+    SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 
-vi.mock('@pagespace/lib/server', async () => {
-  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
-    '@pagespace/lib/audit/mask-email'
-  );
-  return {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
     loggers: {
       auth: {
         error: vi.fn(),
@@ -81,15 +81,17 @@ vi.mock('@pagespace/lib/server', async () => {
         warn: vi.fn(),
       },
     },
-    auditRequest: vi.fn(),
-    maskEmail,
-  };
-});
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn(),
-  resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
-  DISTRIBUTED_RATE_LIMITS: {
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn(),
+    resetDistributedRateLimit: vi.fn().mockResolvedValue(undefined),
+    DISTRIBUTED_RATE_LIMITS: {
     LOGIN: {
       maxAttempts: 5,
       windowMs: 900000,
@@ -128,9 +130,11 @@ vi.mock('@/lib/auth/google-avatar', () => ({
 
 import { POST } from '../route';
 import { authRepository } from '@/lib/repositories/auth-repository';
-import { sessionService, generateCSRFToken } from '@pagespace/lib/auth';
-import { auditRequest, loggers } from '@pagespace/lib/server';
-import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security';
+import { sessionService } from '@pagespace/lib/auth/session-service'
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
+import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-started-drive';
 import { getClientIP, createDeviceToken } from '@/lib/auth';

--- a/apps/web/src/app/api/auth/google/one-tap/route.ts
+++ b/apps/web/src/app/api/auth/google/one-tap/route.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod/v4';
-import { sessionService } from '@pagespace/lib/auth/session-service'
-import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
 import { SESSION_DURATION_MS } from '@pagespace/lib/auth/constants';
 import { revokeSessionsForLogin, createDeviceToken } from '@/lib/auth';
 import {
@@ -9,8 +9,8 @@ import {
   DISTRIBUTED_RATE_LIMITS,
 } from '@pagespace/lib/security/distributed-rate-limit';
 import { createId } from '@paralleldrive/cuid2';
-import { loggers } from '@pagespace/lib/logging/logger-config'
-import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { maskEmail } from '@pagespace/lib/audit/mask-email';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { OAuth2Client } from 'google-auth-library';

--- a/apps/web/src/app/api/auth/google/one-tap/route.ts
+++ b/apps/web/src/app/api/auth/google/one-tap/route.ts
@@ -1,13 +1,17 @@
 import { z } from 'zod/v4';
-import { sessionService, generateCSRFToken, SESSION_DURATION_MS } from '@pagespace/lib/auth';
+import { sessionService } from '@pagespace/lib/auth/session-service'
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { SESSION_DURATION_MS } from '@pagespace/lib/auth/constants';
 import { revokeSessionsForLogin, createDeviceToken } from '@/lib/auth';
 import {
   checkDistributedRateLimit,
   resetDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
-} from '@pagespace/lib/security';
+} from '@pagespace/lib/security/distributed-rate-limit';
 import { createId } from '@paralleldrive/cuid2';
-import { loggers, auditRequest, maskEmail } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { maskEmail } from '@pagespace/lib/audit/mask-email';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { OAuth2Client } from 'google-auth-library';
 import { NextResponse } from 'next/server';

--- a/apps/web/src/app/api/auth/google/signin/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/signin/__tests__/route.test.ts
@@ -20,8 +20,8 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -29,11 +29,13 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn(),
-  DISTRIBUTED_RATE_LIMITS: {
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn(),
+    DISTRIBUTED_RATE_LIMITS: {
     LOGIN: {
       maxAttempts: 5,
       windowMs: 900000,
@@ -49,8 +51,8 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 import { POST, GET } from '../route';
-import { loggers } from '@pagespace/lib/server';
-import { checkDistributedRateLimit } from '@pagespace/lib/security';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { getClientIP, isSafeReturnUrl } from '@/lib/auth';
 
 const createPostRequest = (

--- a/apps/web/src/app/api/auth/google/signin/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/signin/__tests__/route.test.ts
@@ -21,7 +21,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -29,13 +29,11 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       debug: vi.fn(),
     },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn(),
-    DISTRIBUTED_RATE_LIMITS: {
+  checkDistributedRateLimit: vi.fn(),
+  DISTRIBUTED_RATE_LIMITS: {
     LOGIN: {
       maxAttempts: 5,
       windowMs: 900000,

--- a/apps/web/src/app/api/auth/google/signin/route.ts
+++ b/apps/web/src/app/api/auth/google/signin/route.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod/v4';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import {
   checkDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
-} from '@pagespace/lib/security';
-import { createSignedState } from '@pagespace/lib/integrations';
+} from '@pagespace/lib/security/distributed-rate-limit';
+import { createSignedState } from '@pagespace/lib/integrations/oauth/oauth-state';
 import { getClientIP, isSafeReturnUrl } from '@/lib/auth';
-import { generatePKCE } from '@pagespace/lib/auth';
+import { generatePKCE } from '@pagespace/lib/auth/pkce';
 
 // Length bounds must match verifyOAuthState's oauthStateDataSchema — otherwise
 // the server can mint a signed state it will later reject at the callback,

--- a/apps/web/src/app/api/auth/logout/route.ts
+++ b/apps/web/src/app/api/auth/logout/route.ts
@@ -1,5 +1,6 @@
-import { sessionService } from '@pagespace/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { getClientIP } from '@/lib/auth';
 import { getSessionFromCookies, appendClearCookies } from '@/lib/auth/cookie-config';

--- a/apps/web/src/app/api/auth/logout/route.ts
+++ b/apps/web/src/app/api/auth/logout/route.ts
@@ -1,5 +1,5 @@
 import { sessionService } from '@pagespace/lib/auth/session-service';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { getClientIP } from '@/lib/auth';

--- a/apps/web/src/app/api/auth/magic-link/send/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/send/__tests__/route.test.ts
@@ -15,12 +15,12 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // Mock dependencies BEFORE imports
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn().mockResolvedValue({
+  checkDistributedRateLimit: vi.fn().mockResolvedValue({
     allowed: true,
     attemptsRemaining: 4,
     retryAfter: undefined,
   }),
-    DISTRIBUTED_RATE_LIMITS: {
+  DISTRIBUTED_RATE_LIMITS: {
     MAGIC_LINK: { maxAttempts: 5, windowMs: 900000, progressiveDelay: false },
   },
 }));
@@ -41,7 +41,7 @@ vi.mock('@pagespace/lib/email-templates/MagicLinkEmail', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -49,14 +49,12 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       debug: vi.fn(),
     },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 vi.mock('@pagespace/lib/audit/mask-email', () => ({
-    maskEmail: (email: string) => {
+  maskEmail: (email: string) => {
     const [local, domain] = email.split('@');
     if (!local || !domain) return '***@***';
     return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
@@ -82,7 +80,7 @@ import { POST } from '../route';
 import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { createMagicLinkToken } from '@pagespace/lib/auth/magic-link-service';
 import { sendEmail } from '@pagespace/lib/services/email-service';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { validateLoginCSRFToken, getClientIP } from '@/lib/auth';
 import { parse } from 'cookie';

--- a/apps/web/src/app/api/auth/magic-link/send/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/send/__tests__/route.test.ts
@@ -14,13 +14,13 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // Mock dependencies BEFORE imports
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn().mockResolvedValue({
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn().mockResolvedValue({
     allowed: true,
     attemptsRemaining: 4,
     retryAfter: undefined,
   }),
-  DISTRIBUTED_RATE_LIMITS: {
+    DISTRIBUTED_RATE_LIMITS: {
     MAGIC_LINK: { maxAttempts: 5, windowMs: 900000, progressiveDelay: false },
   },
 }));
@@ -40,8 +40,8 @@ vi.mock('@pagespace/lib/email-templates/MagicLinkEmail', () => ({
   MagicLinkEmail: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -49,8 +49,14 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
-  auditRequest: vi.fn(),
-  maskEmail: (email: string) => {
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
+}));
+vi.mock('@pagespace/lib/audit/mask-email', () => ({
+    maskEmail: (email: string) => {
     const [local, domain] = email.split('@');
     if (!local || !domain) return '***@***';
     return `${local.slice(0, Math.min(2, local.length))}***@${domain}`;
@@ -73,10 +79,11 @@ vi.mock('react', () => ({
 }));
 
 import { POST } from '../route';
-import { checkDistributedRateLimit } from '@pagespace/lib/security';
+import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { createMagicLinkToken } from '@pagespace/lib/auth/magic-link-service';
 import { sendEmail } from '@pagespace/lib/services/email-service';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { validateLoginCSRFToken, getClientIP } from '@/lib/auth';
 import { parse } from 'cookie';
 

--- a/apps/web/src/app/api/auth/magic-link/send/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/send/route.ts
@@ -4,11 +4,13 @@ import React from 'react';
 import {
   checkDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
-} from '@pagespace/lib/security';
+} from '@pagespace/lib/security/distributed-rate-limit';
 import { createMagicLinkToken } from '@pagespace/lib/auth/magic-link-service';
 import { sendEmail } from '@pagespace/lib/services/email-service';
 import { MagicLinkEmail } from '@pagespace/lib/email-templates/MagicLinkEmail';
-import { loggers, auditRequest, maskEmail } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { maskEmail } from '@pagespace/lib/audit/mask-email';
 import { secureCompare } from '@pagespace/lib/auth/secure-compare';
 import { validateLoginCSRFToken, getClientIP } from '@/lib/auth';
 

--- a/apps/web/src/app/api/auth/magic-link/send/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/send/route.ts
@@ -8,8 +8,8 @@ import {
 import { createMagicLinkToken } from '@pagespace/lib/auth/magic-link-service';
 import { sendEmail } from '@pagespace/lib/services/email-service';
 import { MagicLinkEmail } from '@pagespace/lib/email-templates/MagicLinkEmail';
-import { loggers } from '@pagespace/lib/logging/logger-config'
-import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { maskEmail } from '@pagespace/lib/audit/mask-email';
 import { secureCompare } from '@pagespace/lib/auth/secure-compare';
 import { validateLoginCSRFToken, getClientIP } from '@/lib/auth';

--- a/apps/web/src/app/api/auth/magic-link/verify/__tests__/desktop-verify.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/__tests__/desktop-verify.test.ts
@@ -23,8 +23,8 @@ vi.mock('next/server', () => ({
   },
 }));
 
-vi.mock('@pagespace/lib/auth', () => ({
-  sessionService: {
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'mock-sid',
@@ -38,10 +38,18 @@ vi.mock('@pagespace/lib/auth', () => ({
     }),
     revokeAllUserSessions: vi.fn().mockResolvedValue(0),
   },
-  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf'),
-  SESSION_DURATION_MS: 604800000,
-  createExchangeCode: vi.fn().mockResolvedValue('exchange-code-abc'),
-  validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
+}));
+vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
+    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf'),
+}));
+vi.mock('@pagespace/lib/auth/constants', () => ({
+    SESSION_DURATION_MS: 604800000,
+}));
+vi.mock('@pagespace/lib/auth/exchange-codes', () => ({
+    createExchangeCode: vi.fn().mockResolvedValue('exchange-code-abc'),
+}));
+vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
+    validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
     deviceToken: 'ps_dev_desktop',
     deviceTokenRecordId: 'dt-1',
     isNew: true,
@@ -56,14 +64,18 @@ vi.mock('@pagespace/lib/auth/verification-utils', () => ({
   markEmailVerified: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     security: {
       warn: vi.fn(),
     },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
@@ -93,7 +105,7 @@ vi.mock('@/lib/repositories/auth-repository', () => ({
 
 import { GET } from '../route';
 import { verifyMagicLinkToken } from '@pagespace/lib/auth/magic-link-service';
-import { createExchangeCode } from '@pagespace/lib/auth';
+import { createExchangeCode } from '@pagespace/lib/auth/exchange-codes';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';
 import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-started-drive';
 

--- a/apps/web/src/app/api/auth/magic-link/verify/__tests__/desktop-verify.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/__tests__/desktop-verify.test.ts
@@ -24,7 +24,7 @@ vi.mock('next/server', () => ({
 }));
 
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'mock-sid',
@@ -40,16 +40,16 @@ vi.mock('@pagespace/lib/auth/session-service', () => ({
   },
 }));
 vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
-    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf'),
+  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf'),
 }));
 vi.mock('@pagespace/lib/auth/constants', () => ({
-    SESSION_DURATION_MS: 604800000,
+  SESSION_DURATION_MS: 604800000,
 }));
 vi.mock('@pagespace/lib/auth/exchange-codes', () => ({
-    createExchangeCode: vi.fn().mockResolvedValue('exchange-code-abc'),
+  createExchangeCode: vi.fn().mockResolvedValue('exchange-code-abc'),
 }));
 vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
-    validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
+  validateOrCreateDeviceToken: vi.fn().mockResolvedValue({
     deviceToken: 'ps_dev_desktop',
     deviceTokenRecordId: 'dt-1',
     isNew: true,
@@ -65,17 +65,15 @@ vi.mock('@pagespace/lib/auth/verification-utils', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
     security: {
       warn: vi.fn(),
     },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({

--- a/apps/web/src/app/api/auth/magic-link/verify/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/__tests__/route.test.ts
@@ -20,7 +20,7 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 
 // Mock dependencies BEFORE imports
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -35,10 +35,10 @@ vi.mock('@pagespace/lib/auth/session-service', () => ({
   },
 }));
 vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
-    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
 }));
 vi.mock('@pagespace/lib/auth/constants', () => ({
-    SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
+  SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 
 vi.mock('@pagespace/lib/auth/magic-link-service', () => ({
@@ -53,7 +53,7 @@ vi.mock('@pagespace/lib/auth/verification-utils', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -64,11 +64,9 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       warn: vi.fn(),
     },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
@@ -91,7 +89,7 @@ import { GET } from '../route';
 import { sessionService } from '@pagespace/lib/auth/session-service';
 import { verifyMagicLinkToken } from '@pagespace/lib/auth/magic-link-service';
 import { markEmailVerified } from '@pagespace/lib/auth/verification-utils';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { getClientIP } from '@/lib/auth';

--- a/apps/web/src/app/api/auth/magic-link/verify/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/__tests__/route.test.ts
@@ -19,8 +19,8 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 
 // Mock dependencies BEFORE imports
-vi.mock('@pagespace/lib/auth', () => ({
-  sessionService: {
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -33,8 +33,12 @@ vi.mock('@pagespace/lib/auth', () => ({
     }),
     revokeAllUserSessions: vi.fn().mockResolvedValue(0),
   },
-  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
-  SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
+}));
+vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
+    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+}));
+vi.mock('@pagespace/lib/auth/constants', () => ({
+    SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 
 vi.mock('@pagespace/lib/auth/magic-link-service', () => ({
@@ -48,8 +52,8 @@ vi.mock('@pagespace/lib/auth/verification-utils', () => ({
   markEmailVerified: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -60,7 +64,11 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
     },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
@@ -80,10 +88,11 @@ vi.mock('@/lib/onboarding/getting-started-drive', () => ({
 }));
 
 import { GET } from '../route';
-import { sessionService } from '@pagespace/lib/auth';
+import { sessionService } from '@pagespace/lib/auth/session-service';
 import { verifyMagicLinkToken } from '@pagespace/lib/auth/magic-link-service';
 import { markEmailVerified } from '@pagespace/lib/auth/verification-utils';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { getClientIP } from '@/lib/auth';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';

--- a/apps/web/src/app/api/auth/magic-link/verify/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/route.ts
@@ -1,13 +1,13 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod/v4';
-import { sessionService } from '@pagespace/lib/auth/session-service'
-import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
-import { SESSION_DURATION_MS } from '@pagespace/lib/auth/constants'
-import { createExchangeCode } from '@pagespace/lib/auth/exchange-codes'
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
+import { SESSION_DURATION_MS } from '@pagespace/lib/auth/constants';
+import { createExchangeCode } from '@pagespace/lib/auth/exchange-codes';
 import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
 import { verifyMagicLinkToken, type DesktopMagicLinkMetadata } from '@pagespace/lib/auth/magic-link-service';
 import { markEmailVerified } from '@pagespace/lib/auth/verification-utils';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { getClientIP } from '@/lib/auth';

--- a/apps/web/src/app/api/auth/magic-link/verify/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/route.ts
@@ -1,15 +1,14 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod/v4';
-import {
-  sessionService,
-  generateCSRFToken,
-  SESSION_DURATION_MS,
-  createExchangeCode,
-  validateOrCreateDeviceToken,
-} from '@pagespace/lib/auth';
+import { sessionService } from '@pagespace/lib/auth/session-service'
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { SESSION_DURATION_MS } from '@pagespace/lib/auth/constants'
+import { createExchangeCode } from '@pagespace/lib/auth/exchange-codes'
+import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
 import { verifyMagicLinkToken, type DesktopMagicLinkMetadata } from '@pagespace/lib/auth/magic-link-service';
 import { markEmailVerified } from '@pagespace/lib/auth/verification-utils';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { getClientIP } from '@/lib/auth';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';

--- a/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/__tests__/route.test.ts
@@ -31,7 +31,7 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -41,12 +41,10 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       warn: vi.fn(),
     },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({

--- a/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/__tests__/route.test.ts
@@ -30,8 +30,8 @@ vi.mock('@/lib/auth', () => ({
   getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -41,8 +41,12 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
     },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
@@ -53,7 +57,7 @@ vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
 import { DELETE } from '../route';
 import { sessionRepository } from '@/lib/repositories/session-repository';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 
 const createContext = (tokenId = 'token-123') => ({

--- a/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/route.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { sessionRepository } from '@/lib/repositories/session-repository';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { getActorInfo, logTokenActivity } from '@pagespace/lib/monitoring/activity-logger';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/route.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/[tokenId]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { sessionRepository } from '@/lib/repositories/session-repository';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { getActorInfo, logTokenActivity } from '@pagespace/lib/monitoring/activity-logger';
 

--- a/apps/web/src/app/api/auth/mcp-tokens/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/__tests__/route.test.ts
@@ -38,7 +38,7 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -48,16 +48,14 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       warn: vi.fn(),
     },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/auth/token-utils', () => ({
-    generateToken: vi.fn().mockReturnValue({
+  generateToken: vi.fn().mockReturnValue({
     token: 'mcp_randomBase64UrlString',
     hash: 'mockTokenHash123',
     tokenPrefix: 'mcp_randomBas',

--- a/apps/web/src/app/api/auth/mcp-tokens/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/__tests__/route.test.ts
@@ -37,8 +37,8 @@ vi.mock('@/lib/auth', () => ({
   isAuthError: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -48,12 +48,16 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
     },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/auth', () => ({
-  generateToken: vi.fn().mockReturnValue({
+vi.mock('@pagespace/lib/auth/token-utils', () => ({
+    generateToken: vi.fn().mockReturnValue({
     token: 'mcp_randomBase64UrlString',
     hash: 'mockTokenHash123',
     tokenPrefix: 'mcp_randomBas',
@@ -72,10 +76,10 @@ vi.mock('@pagespace/lib/services/drive-service', () => ({
 import { POST, GET } from '../route';
 import { sessionRepository } from '@/lib/repositories/session-repository';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getDriveAccess } from '@pagespace/lib/services/drive-service';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
-import { generateToken } from '@pagespace/lib/auth';
+import { generateToken } from '@pagespace/lib/auth/token-utils';
 
 describe('/api/auth/mcp-tokens (additional coverage)', () => {
   beforeEach(() => {

--- a/apps/web/src/app/api/auth/mcp-tokens/route.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/route.ts
@@ -2,9 +2,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { sessionRepository } from '@/lib/repositories/session-repository';
 import { z } from 'zod/v4';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { getActorInfo, logTokenActivity } from '@pagespace/lib/monitoring/activity-logger';
-import { generateToken } from '@pagespace/lib/auth';
+import { generateToken } from '@pagespace/lib/auth/token-utils';
 import { getDriveAccess } from '@pagespace/lib/services/drive-service';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };

--- a/apps/web/src/app/api/auth/mcp-tokens/route.ts
+++ b/apps/web/src/app/api/auth/mcp-tokens/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { sessionRepository } from '@/lib/repositories/session-repository';
 import { z } from 'zod/v4';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { getActorInfo, logTokenActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { generateToken } from '@pagespace/lib/auth/token-utils';

--- a/apps/web/src/app/api/auth/me/route.ts
+++ b/apps/web/src/app/api/auth/me/route.ts
@@ -1,5 +1,5 @@
 import { requireAuth, isAuthError } from '@/lib/auth/auth-helpers';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authRepository } from '@/lib/repositories/auth-repository';
 import { isExternalHttpUrl } from '@/lib/auth/google-avatar';
 

--- a/apps/web/src/app/api/auth/mobile/oauth/google/exchange/route.ts
+++ b/apps/web/src/app/api/auth/mobile/oauth/google/exchange/route.ts
@@ -47,7 +47,7 @@
  */
 
 import { z } from 'zod/v4';
-import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
 import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
 import { authRepository } from '@/lib/repositories/auth-repository';
 import {
@@ -56,11 +56,11 @@ import {
   DISTRIBUTED_RATE_LIMITS,
 } from '@pagespace/lib/security/distributed-rate-limit';
 import { sessionService } from '@pagespace/lib/auth/session-service';
-import { loggers } from '@pagespace/lib/logging/logger-config'
-import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { maskEmail } from '@pagespace/lib/audit/mask-email';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
-import { verifyOAuthIdToken, createOrLinkOAuthUser } from '@pagespace/lib/auth/oauth-utils'
+import { verifyOAuthIdToken, createOrLinkOAuthUser } from '@pagespace/lib/auth/oauth-utils';
 import { OAuthProvider } from '@pagespace/lib/auth/oauth-types';
 import type { MobileOAuthResponse } from '@pagespace/lib/auth/oauth-types';
 import { getClientIP } from '@/lib/auth';

--- a/apps/web/src/app/api/auth/mobile/oauth/google/exchange/route.ts
+++ b/apps/web/src/app/api/auth/mobile/oauth/google/exchange/route.ts
@@ -47,21 +47,22 @@
  */
 
 import { z } from 'zod/v4';
-import {
-  generateCSRFToken,
-  validateOrCreateDeviceToken,
-} from '@pagespace/lib/server';
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
 import { authRepository } from '@/lib/repositories/auth-repository';
 import {
   checkDistributedRateLimit,
   resetDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
-} from '@pagespace/lib/security';
-import { sessionService } from '@pagespace/lib/auth';
-import { loggers, auditRequest, maskEmail } from '@pagespace/lib/server';
+} from '@pagespace/lib/security/distributed-rate-limit';
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { maskEmail } from '@pagespace/lib/audit/mask-email';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
-import { verifyOAuthIdToken, createOrLinkOAuthUser, OAuthProvider } from '@pagespace/lib/server';
-import type { MobileOAuthResponse } from '@pagespace/lib/server';
+import { verifyOAuthIdToken, createOrLinkOAuthUser } from '@pagespace/lib/auth/oauth-utils'
+import { OAuthProvider } from '@pagespace/lib/auth/oauth-types';
+import type { MobileOAuthResponse } from '@pagespace/lib/auth/oauth-types';
 import { getClientIP } from '@/lib/auth';
 import { createSessionCookie } from '@/lib/auth/cookie-config';
 import { resolveGoogleAvatarImage } from '@/lib/auth/google-avatar';

--- a/apps/web/src/app/api/auth/mobile/refresh/route.ts
+++ b/apps/web/src/app/api/auth/mobile/refresh/route.ts
@@ -1,16 +1,16 @@
 import { authRepository } from '@/lib/repositories/auth-repository';
 import { atomicDeviceTokenRotation } from '@pagespace/db/transactions/auth-transactions';
-import { validateDeviceToken, updateDeviceTokenActivity, generateDeviceToken } from '@pagespace/lib/auth/device-auth-utils'
+import { validateDeviceToken, updateDeviceTokenActivity, generateDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
 import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
 import {
   checkDistributedRateLimit,
   resetDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
 } from '@pagespace/lib/security/distributed-rate-limit';
-import { hashToken, getTokenPrefix } from '@pagespace/lib/auth/token-utils'
+import { hashToken, getTokenPrefix } from '@pagespace/lib/auth/token-utils';
 import { sessionService } from '@pagespace/lib/auth/session-service';
 import { z } from 'zod/v4';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { securityAudit } from '@pagespace/lib/audit/security-audit';
 import { getClientIP, appendSessionCookie } from '@/lib/auth';
 

--- a/apps/web/src/app/api/auth/mobile/refresh/route.ts
+++ b/apps/web/src/app/api/auth/mobile/refresh/route.ts
@@ -1,19 +1,17 @@
 import { authRepository } from '@/lib/repositories/auth-repository';
 import { atomicDeviceTokenRotation } from '@pagespace/db/transactions/auth-transactions';
-import {
-  validateDeviceToken,
-  updateDeviceTokenActivity,
-  generateDeviceToken,
-  generateCSRFToken,
-} from '@pagespace/lib/server';
+import { validateDeviceToken, updateDeviceTokenActivity, generateDeviceToken } from '@pagespace/lib/auth/device-auth-utils'
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
 import {
   checkDistributedRateLimit,
   resetDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
-} from '@pagespace/lib/security';
-import { hashToken, getTokenPrefix, sessionService } from '@pagespace/lib/auth';
+} from '@pagespace/lib/security/distributed-rate-limit';
+import { hashToken, getTokenPrefix } from '@pagespace/lib/auth/token-utils'
+import { sessionService } from '@pagespace/lib/auth/session-service';
 import { z } from 'zod/v4';
-import { loggers, securityAudit } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { securityAudit } from '@pagespace/lib/audit/security-audit';
 import { getClientIP, appendSessionCookie } from '@/lib/auth';
 
 const refreshSchema = z.object({

--- a/apps/web/src/app/api/auth/passkey/[passkeyId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/[passkeyId]/__tests__/route.test.ts
@@ -9,15 +9,15 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // Mock dependencies before imports
 vi.mock('@pagespace/lib/auth/passkey-service', () => ({
-    deletePasskey: vi.fn(),
-    updatePasskeyName: vi.fn(),
+  deletePasskey: vi.fn(),
+  updatePasskeyName: vi.fn(),
 }));
 vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
-    validateCSRFToken: vi.fn(),
+  validateCSRFToken: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -25,11 +25,9 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       debug: vi.fn(),
     },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
@@ -44,9 +42,9 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 import { DELETE, PATCH } from '../route';
-import { deletePasskey, updatePasskeyName } from '@pagespace/lib/auth/passkey-service'
+import { deletePasskey, updatePasskeyName } from '@pagespace/lib/auth/passkey-service';
 import { validateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { authenticateSessionRequest, isAuthError, isSessionAuthResult, getClientIP } from '@/lib/auth';

--- a/apps/web/src/app/api/auth/passkey/[passkeyId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/[passkeyId]/__tests__/route.test.ts
@@ -8,14 +8,16 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // Mock dependencies before imports
-vi.mock('@pagespace/lib/auth', () => ({
-  deletePasskey: vi.fn(),
-  updatePasskeyName: vi.fn(),
-  validateCSRFToken: vi.fn(),
+vi.mock('@pagespace/lib/auth/passkey-service', () => ({
+    deletePasskey: vi.fn(),
+    updatePasskeyName: vi.fn(),
+}));
+vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
+    validateCSRFToken: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -23,7 +25,11 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
@@ -38,8 +44,10 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 import { DELETE, PATCH } from '../route';
-import { deletePasskey, updatePasskeyName, validateCSRFToken } from '@pagespace/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { deletePasskey, updatePasskeyName } from '@pagespace/lib/auth/passkey-service'
+import { validateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { authenticateSessionRequest, isAuthError, isSessionAuthResult, getClientIP } from '@/lib/auth';
 import { NextResponse } from 'next/server';

--- a/apps/web/src/app/api/auth/passkey/[passkeyId]/route.ts
+++ b/apps/web/src/app/api/auth/passkey/[passkeyId]/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod/v4';
-import { deletePasskey, updatePasskeyName } from '@pagespace/lib/auth/passkey-service'
+import { deletePasskey, updatePasskeyName } from '@pagespace/lib/auth/passkey-service';
 import { validateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import {

--- a/apps/web/src/app/api/auth/passkey/[passkeyId]/route.ts
+++ b/apps/web/src/app/api/auth/passkey/[passkeyId]/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod/v4';
-import { deletePasskey, updatePasskeyName, validateCSRFToken } from '@pagespace/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { deletePasskey, updatePasskeyName } from '@pagespace/lib/auth/passkey-service'
+import { validateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import {
   authenticateSessionRequest,

--- a/apps/web/src/app/api/auth/passkey/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/__tests__/route.test.ts
@@ -8,12 +8,12 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // Mock dependencies before imports
-vi.mock('@pagespace/lib/auth', () => ({
-  listUserPasskeys: vi.fn(),
+vi.mock('@pagespace/lib/auth/passkey-service', () => ({
+    listUserPasskeys: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -24,7 +24,11 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
     },
   },
-  securityAudit: {
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/security-audit', () => ({
+    securityAudit: {
     logAuthSuccess: vi.fn().mockResolvedValue(undefined),
     logAuthFailure: vi.fn().mockResolvedValue(undefined),
     logTokenCreated: vi.fn().mockResolvedValue(undefined),
@@ -42,8 +46,8 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 import { GET } from '../route';
-import { listUserPasskeys } from '@pagespace/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { listUserPasskeys } from '@pagespace/lib/auth/passkey-service';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import {
   authenticateSessionRequest,
   isAuthError,

--- a/apps/web/src/app/api/auth/passkey/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/__tests__/route.test.ts
@@ -9,11 +9,11 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // Mock dependencies before imports
 vi.mock('@pagespace/lib/auth/passkey-service', () => ({
-    listUserPasskeys: vi.fn(),
+  listUserPasskeys: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -24,11 +24,9 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       warn: vi.fn(),
     },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/security-audit', () => ({
-    securityAudit: {
+  securityAudit: {
     logAuthSuccess: vi.fn().mockResolvedValue(undefined),
     logAuthFailure: vi.fn().mockResolvedValue(undefined),
     logTokenCreated: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/src/app/api/auth/passkey/authenticate/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/authenticate/__tests__/route.test.ts
@@ -17,9 +17,11 @@ vi.mock('next/server', () => ({
   },
 }));
 
-vi.mock('@pagespace/lib/auth', () => ({
-  verifyAuthentication: vi.fn(),
-  sessionService: {
+vi.mock('@pagespace/lib/auth/passkey-service', () => ({
+    verifyAuthentication: vi.fn(),
+}));
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_session_token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -32,13 +34,19 @@ vi.mock('@pagespace/lib/auth', () => ({
     }),
     revokeAllUserSessions: vi.fn().mockResolvedValue(0),
   },
-  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
-  createExchangeCode: vi.fn().mockResolvedValue('mock-exchange-code'),
-  SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
+}));
+vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
+    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+}));
+vi.mock('@pagespace/lib/auth/exchange-codes', () => ({
+    createExchangeCode: vi.fn().mockResolvedValue('mock-exchange-code'),
+}));
+vi.mock('@pagespace/lib/auth/constants', () => ({
+    SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -46,17 +54,21 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
   trackAuthEvent: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn(),
-  resetDistributedRateLimit: vi.fn(),
-  DISTRIBUTED_RATE_LIMITS: {
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn(),
+    resetDistributedRateLimit: vi.fn(),
+    DISTRIBUTED_RATE_LIMITS: {
     PASSKEY_AUTH: { maxAttempts: 5, windowMs: 300000, progressiveDelay: true },
   },
 }));
@@ -81,15 +93,14 @@ vi.mock('@/lib/repositories/auth-repository', () => ({
 }));
 
 import { POST } from '../route';
-import {
-  verifyAuthentication,
-  sessionService,
-  generateCSRFToken,
-  createExchangeCode,
-} from '@pagespace/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { verifyAuthentication } from '@pagespace/lib/auth/passkey-service'
+import { sessionService } from '@pagespace/lib/auth/session-service'
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { createExchangeCode } from '@pagespace/lib/auth/exchange-codes';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
-import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security';
+import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { validateLoginCSRFToken, getClientIP, createDeviceToken } from '@/lib/auth';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';
 

--- a/apps/web/src/app/api/auth/passkey/authenticate/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/authenticate/__tests__/route.test.ts
@@ -18,10 +18,10 @@ vi.mock('next/server', () => ({
 }));
 
 vi.mock('@pagespace/lib/auth/passkey-service', () => ({
-    verifyAuthentication: vi.fn(),
+  verifyAuthentication: vi.fn(),
 }));
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_session_token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -36,17 +36,17 @@ vi.mock('@pagespace/lib/auth/session-service', () => ({
   },
 }));
 vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
-    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
 }));
 vi.mock('@pagespace/lib/auth/exchange-codes', () => ({
-    createExchangeCode: vi.fn().mockResolvedValue('mock-exchange-code'),
+  createExchangeCode: vi.fn().mockResolvedValue('mock-exchange-code'),
 }));
 vi.mock('@pagespace/lib/auth/constants', () => ({
-    SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
+  SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -54,11 +54,9 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       debug: vi.fn(),
     },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
@@ -66,9 +64,9 @@ vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn(),
-    resetDistributedRateLimit: vi.fn(),
-    DISTRIBUTED_RATE_LIMITS: {
+  checkDistributedRateLimit: vi.fn(),
+  resetDistributedRateLimit: vi.fn(),
+  DISTRIBUTED_RATE_LIMITS: {
     PASSKEY_AUTH: { maxAttempts: 5, windowMs: 300000, progressiveDelay: true },
   },
 }));
@@ -93,11 +91,11 @@ vi.mock('@/lib/repositories/auth-repository', () => ({
 }));
 
 import { POST } from '../route';
-import { verifyAuthentication } from '@pagespace/lib/auth/passkey-service'
-import { sessionService } from '@pagespace/lib/auth/session-service'
-import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { verifyAuthentication } from '@pagespace/lib/auth/passkey-service';
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
 import { createExchangeCode } from '@pagespace/lib/auth/exchange-codes';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';

--- a/apps/web/src/app/api/auth/passkey/authenticate/options/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/authenticate/options/__tests__/route.test.ts
@@ -8,12 +8,12 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // Mock dependencies before imports
-vi.mock('@pagespace/lib/auth', () => ({
-  generateAuthenticationOptions: vi.fn(),
+vi.mock('@pagespace/lib/auth/passkey-service', () => ({
+    generateAuthenticationOptions: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -21,12 +21,16 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn(),
-  DISTRIBUTED_RATE_LIMITS: {
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn(),
+    DISTRIBUTED_RATE_LIMITS: {
     PASSKEY_OPTIONS: { maxAttempts: 10, windowMs: 60000, progressiveDelay: false },
   },
 }));
@@ -37,9 +41,10 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 import { POST } from '../route';
-import { generateAuthenticationOptions } from '@pagespace/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
-import { checkDistributedRateLimit } from '@pagespace/lib/security';
+import { generateAuthenticationOptions } from '@pagespace/lib/auth/passkey-service';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { validateLoginCSRFToken, getClientIP } from '@/lib/auth';
 
 const createRequest = (body: Record<string, unknown>) =>

--- a/apps/web/src/app/api/auth/passkey/authenticate/options/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/authenticate/options/__tests__/route.test.ts
@@ -9,11 +9,11 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // Mock dependencies before imports
 vi.mock('@pagespace/lib/auth/passkey-service', () => ({
-    generateAuthenticationOptions: vi.fn(),
+  generateAuthenticationOptions: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -21,16 +21,14 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       debug: vi.fn(),
     },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn(),
-    DISTRIBUTED_RATE_LIMITS: {
+  checkDistributedRateLimit: vi.fn(),
+  DISTRIBUTED_RATE_LIMITS: {
     PASSKEY_OPTIONS: { maxAttempts: 10, windowMs: 60000, progressiveDelay: false },
   },
 }));
@@ -42,7 +40,7 @@ vi.mock('@/lib/auth', () => ({
 
 import { POST } from '../route';
 import { generateAuthenticationOptions } from '@pagespace/lib/auth/passkey-service';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { validateLoginCSRFToken, getClientIP } from '@/lib/auth';

--- a/apps/web/src/app/api/auth/passkey/authenticate/options/route.ts
+++ b/apps/web/src/app/api/auth/passkey/authenticate/options/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod/v4';
 import { generateAuthenticationOptions } from '@pagespace/lib/auth/passkey-service';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import {
   checkDistributedRateLimit,

--- a/apps/web/src/app/api/auth/passkey/authenticate/options/route.ts
+++ b/apps/web/src/app/api/auth/passkey/authenticate/options/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod/v4';
-import { generateAuthenticationOptions } from '@pagespace/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { generateAuthenticationOptions } from '@pagespace/lib/auth/passkey-service';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import {
   checkDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
-} from '@pagespace/lib/security';
+} from '@pagespace/lib/security/distributed-rate-limit';
 import { validateLoginCSRFToken, getClientIP } from '@/lib/auth';
 
 const optionsSchema = z.object({

--- a/apps/web/src/app/api/auth/passkey/authenticate/route.ts
+++ b/apps/web/src/app/api/auth/passkey/authenticate/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod/v4';
-import { verifyAuthentication } from '@pagespace/lib/auth/passkey-service'
-import { sessionService } from '@pagespace/lib/auth/session-service'
-import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
-import { createExchangeCode } from '@pagespace/lib/auth/exchange-codes'
+import { verifyAuthentication } from '@pagespace/lib/auth/passkey-service';
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
+import { createExchangeCode } from '@pagespace/lib/auth/exchange-codes';
 import { SESSION_DURATION_MS } from '@pagespace/lib/auth/constants';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import {

--- a/apps/web/src/app/api/auth/passkey/authenticate/route.ts
+++ b/apps/web/src/app/api/auth/passkey/authenticate/route.ts
@@ -1,19 +1,18 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod/v4';
-import {
-  verifyAuthentication,
-  sessionService,
-  generateCSRFToken,
-  createExchangeCode,
-  SESSION_DURATION_MS,
-} from '@pagespace/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { verifyAuthentication } from '@pagespace/lib/auth/passkey-service'
+import { sessionService } from '@pagespace/lib/auth/session-service'
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { createExchangeCode } from '@pagespace/lib/auth/exchange-codes'
+import { SESSION_DURATION_MS } from '@pagespace/lib/auth/constants';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import {
   checkDistributedRateLimit,
   resetDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
-} from '@pagespace/lib/security';
+} from '@pagespace/lib/security/distributed-rate-limit';
 import { validateLoginCSRFToken, getClientIP, createDeviceToken } from '@/lib/auth';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';
 import { authRepository } from '@/lib/repositories/auth-repository';

--- a/apps/web/src/app/api/auth/passkey/register/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/register/__tests__/route.test.ts
@@ -9,17 +9,17 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // Mock dependencies before imports
 vi.mock('@pagespace/lib/auth/passkey-service', () => ({
-    verifyRegistration: vi.fn(),
+  verifyRegistration: vi.fn(),
 }));
 vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
-    validateCSRFToken: vi.fn(),
+  validateCSRFToken: vi.fn(),
 }));
 vi.mock('@pagespace/lib/auth/passkey-register-handoff', () => ({
-    consumePasskeyRegisterHandoff: vi.fn(),
+  consumePasskeyRegisterHandoff: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -27,11 +27,9 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       debug: vi.fn(),
     },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
@@ -39,8 +37,8 @@ vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn(),
-    DISTRIBUTED_RATE_LIMITS: {
+  checkDistributedRateLimit: vi.fn(),
+  DISTRIBUTED_RATE_LIMITS: {
     PASSKEY_REGISTER: { maxAttempts: 5, windowMs: 300000, progressiveDelay: false },
   },
 }));
@@ -57,10 +55,10 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 import { POST } from '../route';
-import { verifyRegistration } from '@pagespace/lib/auth/passkey-service'
-import { validateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { verifyRegistration } from '@pagespace/lib/auth/passkey-service';
+import { validateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
 import { consumePasskeyRegisterHandoff } from '@pagespace/lib/auth/passkey-register-handoff';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';

--- a/apps/web/src/app/api/auth/passkey/register/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/register/__tests__/route.test.ts
@@ -8,14 +8,18 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // Mock dependencies before imports
-vi.mock('@pagespace/lib/auth', () => ({
-  verifyRegistration: vi.fn(),
-  validateCSRFToken: vi.fn(),
-  consumePasskeyRegisterHandoff: vi.fn(),
+vi.mock('@pagespace/lib/auth/passkey-service', () => ({
+    verifyRegistration: vi.fn(),
+}));
+vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
+    validateCSRFToken: vi.fn(),
+}));
+vi.mock('@pagespace/lib/auth/passkey-register-handoff', () => ({
+    consumePasskeyRegisterHandoff: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -23,16 +27,20 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
   trackAuthEvent: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn(),
-  DISTRIBUTED_RATE_LIMITS: {
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn(),
+    DISTRIBUTED_RATE_LIMITS: {
     PASSKEY_REGISTER: { maxAttempts: 5, windowMs: 300000, progressiveDelay: false },
   },
 }));
@@ -49,14 +57,13 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 import { POST } from '../route';
-import {
-  verifyRegistration,
-  validateCSRFToken,
-  consumePasskeyRegisterHandoff,
-} from '@pagespace/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { verifyRegistration } from '@pagespace/lib/auth/passkey-service'
+import { validateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { consumePasskeyRegisterHandoff } from '@pagespace/lib/auth/passkey-register-handoff';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
-import { checkDistributedRateLimit } from '@pagespace/lib/security';
+import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { authenticateSessionRequest, isAuthError, isSessionAuthResult, getClientIP } from '@/lib/auth';
 import { NextResponse } from 'next/server';
 

--- a/apps/web/src/app/api/auth/passkey/register/handoff/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/register/handoff/__tests__/route.test.ts
@@ -10,14 +10,14 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 vi.mock('@pagespace/lib/auth/passkey-register-handoff', () => ({
-    createPasskeyRegisterHandoff: vi.fn(),
+  createPasskeyRegisterHandoff: vi.fn(),
 }));
 vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
-    validateCSRFToken: vi.fn(),
+  validateCSRFToken: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -25,16 +25,14 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       debug: vi.fn(),
     },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn(),
-    DISTRIBUTED_RATE_LIMITS: {
+  checkDistributedRateLimit: vi.fn(),
+  DISTRIBUTED_RATE_LIMITS: {
     PASSKEY_REGISTER: { maxAttempts: 5, windowMs: 300000, progressiveDelay: false },
   },
 }));
@@ -51,9 +49,9 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 import { POST } from '../route';
-import { createPasskeyRegisterHandoff } from '@pagespace/lib/auth/passkey-register-handoff'
+import { createPasskeyRegisterHandoff } from '@pagespace/lib/auth/passkey-register-handoff';
 import { validateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import {

--- a/apps/web/src/app/api/auth/passkey/register/handoff/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/register/handoff/__tests__/route.test.ts
@@ -9,13 +9,15 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-vi.mock('@pagespace/lib/auth', () => ({
-  createPasskeyRegisterHandoff: vi.fn(),
-  validateCSRFToken: vi.fn(),
+vi.mock('@pagespace/lib/auth/passkey-register-handoff', () => ({
+    createPasskeyRegisterHandoff: vi.fn(),
+}));
+vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
+    validateCSRFToken: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -23,12 +25,16 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn(),
-  DISTRIBUTED_RATE_LIMITS: {
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn(),
+    DISTRIBUTED_RATE_LIMITS: {
     PASSKEY_REGISTER: { maxAttempts: 5, windowMs: 300000, progressiveDelay: false },
   },
 }));
@@ -45,9 +51,11 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 import { POST } from '../route';
-import { createPasskeyRegisterHandoff, validateCSRFToken } from '@pagespace/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
-import { checkDistributedRateLimit } from '@pagespace/lib/security';
+import { createPasskeyRegisterHandoff } from '@pagespace/lib/auth/passkey-register-handoff'
+import { validateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import {
   authenticateSessionRequest,
   isAuthError,

--- a/apps/web/src/app/api/auth/passkey/register/handoff/route.ts
+++ b/apps/web/src/app/api/auth/passkey/register/handoff/route.ts
@@ -1,13 +1,12 @@
 import { NextResponse } from 'next/server';
-import {
-  createPasskeyRegisterHandoff,
-  validateCSRFToken,
-} from '@pagespace/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { createPasskeyRegisterHandoff } from '@pagespace/lib/auth/passkey-register-handoff'
+import { validateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import {
   checkDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
-} from '@pagespace/lib/security';
+} from '@pagespace/lib/security/distributed-rate-limit';
 import {
   authenticateSessionRequest,
   getBearerToken,

--- a/apps/web/src/app/api/auth/passkey/register/handoff/route.ts
+++ b/apps/web/src/app/api/auth/passkey/register/handoff/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
-import { createPasskeyRegisterHandoff } from '@pagespace/lib/auth/passkey-register-handoff'
+import { createPasskeyRegisterHandoff } from '@pagespace/lib/auth/passkey-register-handoff';
 import { validateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import {
   checkDistributedRateLimit,

--- a/apps/web/src/app/api/auth/passkey/register/options/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/register/options/__tests__/route.test.ts
@@ -8,15 +8,19 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // Mock dependencies before imports
-vi.mock('@pagespace/lib/auth', () => ({
-  generateRegistrationOptions: vi.fn(),
-  validateCSRFToken: vi.fn(),
-  peekPasskeyRegisterHandoff: vi.fn(),
-  markPasskeyRegisterOptionsIssued: vi.fn(),
+vi.mock('@pagespace/lib/auth/passkey-service', () => ({
+    generateRegistrationOptions: vi.fn(),
+}));
+vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
+    validateCSRFToken: vi.fn(),
+}));
+vi.mock('@pagespace/lib/auth/passkey-register-handoff', () => ({
+    peekPasskeyRegisterHandoff: vi.fn(),
+    markPasskeyRegisterOptionsIssued: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -24,12 +28,16 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn(),
-  DISTRIBUTED_RATE_LIMITS: {
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn(),
+    DISTRIBUTED_RATE_LIMITS: {
     PASSKEY_REGISTER: { maxAttempts: 5, windowMs: 300000, progressiveDelay: false },
   },
 }));
@@ -46,14 +54,12 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 import { POST } from '../route';
-import {
-  generateRegistrationOptions,
-  validateCSRFToken,
-  peekPasskeyRegisterHandoff,
-  markPasskeyRegisterOptionsIssued,
-} from '@pagespace/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
-import { checkDistributedRateLimit } from '@pagespace/lib/security';
+import { generateRegistrationOptions } from '@pagespace/lib/auth/passkey-service'
+import { validateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { peekPasskeyRegisterHandoff, markPasskeyRegisterOptionsIssued } from '@pagespace/lib/auth/passkey-register-handoff';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { authenticateSessionRequest, isAuthError, isSessionAuthResult, getClientIP } from '@/lib/auth';
 import { NextResponse } from 'next/server';
 

--- a/apps/web/src/app/api/auth/passkey/register/options/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/register/options/__tests__/route.test.ts
@@ -9,18 +9,18 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // Mock dependencies before imports
 vi.mock('@pagespace/lib/auth/passkey-service', () => ({
-    generateRegistrationOptions: vi.fn(),
+  generateRegistrationOptions: vi.fn(),
 }));
 vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
-    validateCSRFToken: vi.fn(),
+  validateCSRFToken: vi.fn(),
 }));
 vi.mock('@pagespace/lib/auth/passkey-register-handoff', () => ({
-    peekPasskeyRegisterHandoff: vi.fn(),
-    markPasskeyRegisterOptionsIssued: vi.fn(),
+  peekPasskeyRegisterHandoff: vi.fn(),
+  markPasskeyRegisterOptionsIssued: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -28,16 +28,14 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       debug: vi.fn(),
     },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn(),
-    DISTRIBUTED_RATE_LIMITS: {
+  checkDistributedRateLimit: vi.fn(),
+  DISTRIBUTED_RATE_LIMITS: {
     PASSKEY_REGISTER: { maxAttempts: 5, windowMs: 300000, progressiveDelay: false },
   },
 }));
@@ -54,10 +52,10 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 import { POST } from '../route';
-import { generateRegistrationOptions } from '@pagespace/lib/auth/passkey-service'
-import { validateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { generateRegistrationOptions } from '@pagespace/lib/auth/passkey-service';
+import { validateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
 import { peekPasskeyRegisterHandoff, markPasskeyRegisterOptionsIssued } from '@pagespace/lib/auth/passkey-register-handoff';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { authenticateSessionRequest, isAuthError, isSessionAuthResult, getClientIP } from '@/lib/auth';

--- a/apps/web/src/app/api/auth/passkey/register/options/route.ts
+++ b/apps/web/src/app/api/auth/passkey/register/options/route.ts
@@ -1,15 +1,13 @@
 import { NextResponse } from 'next/server';
-import {
-  generateRegistrationOptions,
-  validateCSRFToken,
-  peekPasskeyRegisterHandoff,
-  markPasskeyRegisterOptionsIssued,
-} from '@pagespace/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { generateRegistrationOptions } from '@pagespace/lib/auth/passkey-service'
+import { validateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { peekPasskeyRegisterHandoff, markPasskeyRegisterOptionsIssued } from '@pagespace/lib/auth/passkey-register-handoff';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import {
   checkDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
-} from '@pagespace/lib/security';
+} from '@pagespace/lib/security/distributed-rate-limit';
 import {
   authenticateSessionRequest,
   getBearerToken,

--- a/apps/web/src/app/api/auth/passkey/register/options/route.ts
+++ b/apps/web/src/app/api/auth/passkey/register/options/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
-import { generateRegistrationOptions } from '@pagespace/lib/auth/passkey-service'
-import { validateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { generateRegistrationOptions } from '@pagespace/lib/auth/passkey-service';
+import { validateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
 import { peekPasskeyRegisterHandoff, markPasskeyRegisterOptionsIssued } from '@pagespace/lib/auth/passkey-register-handoff';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import {
   checkDistributedRateLimit,

--- a/apps/web/src/app/api/auth/passkey/register/route.ts
+++ b/apps/web/src/app/api/auth/passkey/register/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod/v4';
-import { verifyRegistration } from '@pagespace/lib/auth/passkey-service'
-import { validateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { verifyRegistration } from '@pagespace/lib/auth/passkey-service';
+import { validateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
 import { consumePasskeyRegisterHandoff } from '@pagespace/lib/auth/passkey-register-handoff';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import {

--- a/apps/web/src/app/api/auth/passkey/register/route.ts
+++ b/apps/web/src/app/api/auth/passkey/register/route.ts
@@ -1,16 +1,15 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod/v4';
-import {
-  verifyRegistration,
-  validateCSRFToken,
-  consumePasskeyRegisterHandoff,
-} from '@pagespace/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { verifyRegistration } from '@pagespace/lib/auth/passkey-service'
+import { validateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { consumePasskeyRegisterHandoff } from '@pagespace/lib/auth/passkey-register-handoff';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import {
   checkDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
-} from '@pagespace/lib/security';
+} from '@pagespace/lib/security/distributed-rate-limit';
 import {
   authenticateSessionRequest,
   getBearerToken,

--- a/apps/web/src/app/api/auth/passkey/route.ts
+++ b/apps/web/src/app/api/auth/passkey/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
-import { listUserPasskeys } from '@pagespace/lib/auth';
-import { loggers, securityAudit } from '@pagespace/lib/server';
+import { listUserPasskeys } from '@pagespace/lib/auth/passkey-service';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { securityAudit } from '@pagespace/lib/audit/security-audit';
 import {
   authenticateSessionRequest,
   isAuthError,

--- a/apps/web/src/app/api/auth/passkey/route.ts
+++ b/apps/web/src/app/api/auth/passkey/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { listUserPasskeys } from '@pagespace/lib/auth/passkey-service';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { securityAudit } from '@pagespace/lib/audit/security-audit';
 import {
   authenticateSessionRequest,

--- a/apps/web/src/app/api/auth/resend-verification/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/resend-verification/__tests__/route.test.ts
@@ -29,8 +29,8 @@ vi.mock('@/lib/repositories/auth-repository', () => ({
   },
 }));
 
-vi.mock('@pagespace/lib', () => ({
-  createVerificationToken: vi.fn().mockResolvedValue('mock-verification-token'),
+vi.mock('@pagespace/lib/auth/verification-utils', () => ({
+    createVerificationToken: vi.fn().mockResolvedValue('mock-verification-token'),
 }));
 
 vi.mock('@pagespace/lib/services/email-service', () => ({
@@ -41,11 +41,7 @@ vi.mock('@pagespace/lib/email-templates/VerificationEmail', () => ({
   VerificationEmail: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', async () => {
-  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
-    '@pagespace/lib/audit/mask-email'
-  );
-  return {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
     loggers: {
       auth: {
         error: vi.fn(),
@@ -57,19 +53,21 @@ vi.mock('@pagespace/lib/server', async () => {
         warn: vi.fn(),
       },
     },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
     audit: vi.fn(),
     auditRequest: vi.fn(),
-    maskEmail,
-  };
-});
+}));
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn().mockResolvedValue({
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn().mockResolvedValue({
     allowed: true,
     attemptsRemaining: 2,
     retryAfter: undefined,
   }),
-  DISTRIBUTED_RATE_LIMITS: {
+    DISTRIBUTED_RATE_LIMITS: {
     EMAIL_RESEND: { maxAttempts: 3, windowMs: 3600000, progressiveDelay: false },
   },
 }));
@@ -83,10 +81,10 @@ vi.mock('react', () => ({
 import { POST } from '../route';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { authRepository } from '@/lib/repositories/auth-repository';
-import { createVerificationToken } from '@pagespace/lib';
+import { createVerificationToken } from '@pagespace/lib/auth/verification-utils';
 import { sendEmail } from '@pagespace/lib/services/email-service';
-import { loggers } from '@pagespace/lib/server';
-import { checkDistributedRateLimit } from '@pagespace/lib/security';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { NextResponse } from 'next/server';
 
 const createResendRequest = () =>

--- a/apps/web/src/app/api/auth/resend-verification/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/resend-verification/__tests__/route.test.ts
@@ -30,7 +30,7 @@ vi.mock('@/lib/repositories/auth-repository', () => ({
 }));
 
 vi.mock('@pagespace/lib/auth/verification-utils', () => ({
-    createVerificationToken: vi.fn().mockResolvedValue('mock-verification-token'),
+  createVerificationToken: vi.fn().mockResolvedValue('mock-verification-token'),
 }));
 
 vi.mock('@pagespace/lib/services/email-service', () => ({
@@ -42,7 +42,7 @@ vi.mock('@pagespace/lib/email-templates/VerificationEmail', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
       auth: {
         error: vi.fn(),
         info: vi.fn(),
@@ -53,21 +53,19 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
         warn: vi.fn(),
       },
     },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn().mockResolvedValue({
+  checkDistributedRateLimit: vi.fn().mockResolvedValue({
     allowed: true,
     attemptsRemaining: 2,
     retryAfter: undefined,
   }),
-    DISTRIBUTED_RATE_LIMITS: {
+  DISTRIBUTED_RATE_LIMITS: {
     EMAIL_RESEND: { maxAttempts: 3, windowMs: 3600000, progressiveDelay: false },
   },
 }));

--- a/apps/web/src/app/api/auth/resend-verification/route.ts
+++ b/apps/web/src/app/api/auth/resend-verification/route.ts
@@ -3,8 +3,8 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { createVerificationToken } from '@pagespace/lib/auth/verification-utils';
 import { sendEmail } from '@pagespace/lib/services/email-service';
 import { VerificationEmail } from '@pagespace/lib/email-templates/VerificationEmail';
-import { loggers } from '@pagespace/lib/logging/logger-config'
-import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { maskEmail } from '@pagespace/lib/audit/mask-email';
 import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security/distributed-rate-limit';
 import React from 'react';

--- a/apps/web/src/app/api/auth/resend-verification/route.ts
+++ b/apps/web/src/app/api/auth/resend-verification/route.ts
@@ -1,10 +1,12 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { createVerificationToken } from '@pagespace/lib';
+import { createVerificationToken } from '@pagespace/lib/auth/verification-utils';
 import { sendEmail } from '@pagespace/lib/services/email-service';
 import { VerificationEmail } from '@pagespace/lib/email-templates/VerificationEmail';
-import { loggers, auditRequest, maskEmail } from '@pagespace/lib/server';
-import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { maskEmail } from '@pagespace/lib/audit/mask-email';
+import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security/distributed-rate-limit';
 import React from 'react';
 import { authRepository } from '@/lib/repositories/auth-repository';
 

--- a/apps/web/src/app/api/auth/signup-passkey/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/signup-passkey/__tests__/route.test.ts
@@ -15,10 +15,10 @@ vi.mock('@/lib/repositories/oauth-repository', () => ({
 }));
 
 vi.mock('@pagespace/lib/auth/passkey-service', () => ({
-    verifySignupRegistration: vi.fn(),
+  verifySignupRegistration: vi.fn(),
 }));
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_session_token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -32,14 +32,14 @@ vi.mock('@pagespace/lib/auth/session-service', () => ({
   },
 }));
 vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
-    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
 }));
 vi.mock('@pagespace/lib/auth/constants', () => ({
-    SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
+  SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
       auth: {
         error: vi.fn(),
         info: vi.fn(),
@@ -50,11 +50,9 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
         warn: vi.fn(),
       },
     },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
@@ -62,9 +60,9 @@ vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn(),
-    resetDistributedRateLimit: vi.fn(),
-    DISTRIBUTED_RATE_LIMITS: {
+  checkDistributedRateLimit: vi.fn(),
+  resetDistributedRateLimit: vi.fn(),
+  DISTRIBUTED_RATE_LIMITS: {
     SIGNUP: { maxAttempts: 3, windowMs: 3600000, progressiveDelay: false },
   },
 }));
@@ -84,10 +82,10 @@ vi.mock('@/lib/onboarding/getting-started-drive', () => ({
 
 import { POST } from '../route';
 import { oauthRepository } from '@/lib/repositories/oauth-repository';
-import { verifySignupRegistration } from '@pagespace/lib/auth/passkey-service'
-import { sessionService } from '@pagespace/lib/auth/session-service'
+import { verifySignupRegistration } from '@pagespace/lib/auth/passkey-service';
+import { sessionService } from '@pagespace/lib/auth/session-service';
 import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';

--- a/apps/web/src/app/api/auth/signup-passkey/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/signup-passkey/__tests__/route.test.ts
@@ -14,9 +14,11 @@ vi.mock('@/lib/repositories/oauth-repository', () => ({
   },
 }));
 
-vi.mock('@pagespace/lib/auth', () => ({
-  verifySignupRegistration: vi.fn(),
-  sessionService: {
+vi.mock('@pagespace/lib/auth/passkey-service', () => ({
+    verifySignupRegistration: vi.fn(),
+}));
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_session_token'),
     validateSession: vi.fn().mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -28,15 +30,15 @@ vi.mock('@pagespace/lib/auth', () => ({
       expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
     }),
   },
-  generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
-  SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
+}));
+vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
+    generateCSRFToken: vi.fn().mockReturnValue('mock-csrf-token'),
+}));
+vi.mock('@pagespace/lib/auth/constants', () => ({
+    SESSION_DURATION_MS: 7 * 24 * 60 * 60 * 1000,
 }));
 
-vi.mock('@pagespace/lib/server', async () => {
-  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
-    '@pagespace/lib/audit/mask-email'
-  );
-  return {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
     loggers: {
       auth: {
         error: vi.fn(),
@@ -48,19 +50,21 @@ vi.mock('@pagespace/lib/server', async () => {
         warn: vi.fn(),
       },
     },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
     auditRequest: vi.fn(),
-    maskEmail,
-  };
-});
+}));
 
 vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
   trackAuthEvent: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn(),
-  resetDistributedRateLimit: vi.fn(),
-  DISTRIBUTED_RATE_LIMITS: {
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn(),
+    resetDistributedRateLimit: vi.fn(),
+    DISTRIBUTED_RATE_LIMITS: {
     SIGNUP: { maxAttempts: 3, windowMs: 3600000, progressiveDelay: false },
   },
 }));
@@ -80,14 +84,13 @@ vi.mock('@/lib/onboarding/getting-started-drive', () => ({
 
 import { POST } from '../route';
 import { oauthRepository } from '@/lib/repositories/oauth-repository';
-import {
-  verifySignupRegistration,
-  sessionService,
-  generateCSRFToken,
-} from '@pagespace/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { verifySignupRegistration } from '@pagespace/lib/auth/passkey-service'
+import { sessionService } from '@pagespace/lib/auth/session-service'
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
-import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security';
+import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { validateLoginCSRFToken, getClientIP } from '@/lib/auth';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';
 import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-started-drive';

--- a/apps/web/src/app/api/auth/signup-passkey/options/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/signup-passkey/options/__tests__/route.test.ts
@@ -8,15 +8,11 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // Mock dependencies before imports
-vi.mock('@pagespace/lib/auth', () => ({
-  generateRegistrationOptionsForSignup: vi.fn(),
+vi.mock('@pagespace/lib/auth/passkey-service', () => ({
+    generateRegistrationOptionsForSignup: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', async () => {
-  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
-    '@pagespace/lib/audit/mask-email'
-  );
-  return {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
     loggers: {
       auth: {
         error: vi.fn(),
@@ -25,14 +21,16 @@ vi.mock('@pagespace/lib/server', async () => {
         debug: vi.fn(),
       },
     },
-    auditRequest: vi.fn(),
-    maskEmail,
-  };
-});
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn(),
-  DISTRIBUTED_RATE_LIMITS: {
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn(),
+    DISTRIBUTED_RATE_LIMITS: {
     SIGNUP: { maxAttempts: 3, windowMs: 3600000, progressiveDelay: false },
   },
 }));
@@ -43,9 +41,10 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 import { POST } from '../route';
-import { generateRegistrationOptionsForSignup } from '@pagespace/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
-import { checkDistributedRateLimit } from '@pagespace/lib/security';
+import { generateRegistrationOptionsForSignup } from '@pagespace/lib/auth/passkey-service';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { validateLoginCSRFToken, getClientIP } from '@/lib/auth';
 
 const validPayload = {

--- a/apps/web/src/app/api/auth/signup-passkey/options/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/signup-passkey/options/__tests__/route.test.ts
@@ -9,11 +9,11 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // Mock dependencies before imports
 vi.mock('@pagespace/lib/auth/passkey-service', () => ({
-    generateRegistrationOptionsForSignup: vi.fn(),
+  generateRegistrationOptionsForSignup: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
       auth: {
         error: vi.fn(),
         info: vi.fn(),
@@ -21,16 +21,14 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
         debug: vi.fn(),
       },
     },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn(),
-    DISTRIBUTED_RATE_LIMITS: {
+  checkDistributedRateLimit: vi.fn(),
+  DISTRIBUTED_RATE_LIMITS: {
     SIGNUP: { maxAttempts: 3, windowMs: 3600000, progressiveDelay: false },
   },
 }));
@@ -42,7 +40,7 @@ vi.mock('@/lib/auth', () => ({
 
 import { POST } from '../route';
 import { generateRegistrationOptionsForSignup } from '@pagespace/lib/auth/passkey-service';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { validateLoginCSRFToken, getClientIP } from '@/lib/auth';

--- a/apps/web/src/app/api/auth/signup-passkey/options/route.ts
+++ b/apps/web/src/app/api/auth/signup-passkey/options/route.ts
@@ -1,11 +1,13 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod/v4';
-import { generateRegistrationOptionsForSignup } from '@pagespace/lib/auth';
-import { loggers, auditRequest, maskEmail } from '@pagespace/lib/server';
+import { generateRegistrationOptionsForSignup } from '@pagespace/lib/auth/passkey-service';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { maskEmail } from '@pagespace/lib/audit/mask-email';
 import {
   checkDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
-} from '@pagespace/lib/security';
+} from '@pagespace/lib/security/distributed-rate-limit';
 import { validateLoginCSRFToken, getClientIP } from '@/lib/auth';
 
 const optionsSchema = z.object({

--- a/apps/web/src/app/api/auth/signup-passkey/options/route.ts
+++ b/apps/web/src/app/api/auth/signup-passkey/options/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod/v4';
 import { generateRegistrationOptionsForSignup } from '@pagespace/lib/auth/passkey-service';
-import { loggers } from '@pagespace/lib/logging/logger-config'
-import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { maskEmail } from '@pagespace/lib/audit/mask-email';
 import {
   checkDistributedRateLimit,

--- a/apps/web/src/app/api/auth/signup-passkey/route.ts
+++ b/apps/web/src/app/api/auth/signup-passkey/route.ts
@@ -1,19 +1,19 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod/v4';
 import { oauthRepository } from '@/lib/repositories/oauth-repository';
-import {
-  verifySignupRegistration,
-  sessionService,
-  generateCSRFToken,
-  SESSION_DURATION_MS,
-} from '@pagespace/lib/auth';
-import { loggers, auditRequest, maskEmail } from '@pagespace/lib/server';
+import { verifySignupRegistration } from '@pagespace/lib/auth/passkey-service'
+import { sessionService } from '@pagespace/lib/auth/session-service'
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { SESSION_DURATION_MS } from '@pagespace/lib/auth/constants';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { maskEmail } from '@pagespace/lib/audit/mask-email';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import {
   checkDistributedRateLimit,
   resetDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
-} from '@pagespace/lib/security';
+} from '@pagespace/lib/security/distributed-rate-limit';
 import { validateLoginCSRFToken, getClientIP, createDeviceToken } from '@/lib/auth';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';
 import { provisionGettingStartedDriveIfNeeded, type ProvisionGettingStartedDriveResult } from '@/lib/onboarding/getting-started-drive';

--- a/apps/web/src/app/api/auth/signup-passkey/route.ts
+++ b/apps/web/src/app/api/auth/signup-passkey/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod/v4';
 import { oauthRepository } from '@/lib/repositories/oauth-repository';
-import { verifySignupRegistration } from '@pagespace/lib/auth/passkey-service'
-import { sessionService } from '@pagespace/lib/auth/session-service'
-import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { verifySignupRegistration } from '@pagespace/lib/auth/passkey-service';
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
 import { SESSION_DURATION_MS } from '@pagespace/lib/auth/constants';
-import { loggers } from '@pagespace/lib/logging/logger-config'
-import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { maskEmail } from '@pagespace/lib/audit/mask-email';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import {

--- a/apps/web/src/app/api/auth/socket-token/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/socket-token/__tests__/route.test.ts
@@ -32,8 +32,8 @@ vi.mock('@/lib/repositories/session-repository', () => ({
   },
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -44,8 +44,12 @@ vi.mock('@pagespace/lib/server', () => ({
       warn: vi.fn(),
     },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 import { requireAuth, isAuthError } from '@/lib/auth/auth-helpers';

--- a/apps/web/src/app/api/auth/socket-token/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/socket-token/__tests__/route.test.ts
@@ -33,7 +33,7 @@ vi.mock('@/lib/repositories/session-repository', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       error: vi.fn(),
       info: vi.fn(),
@@ -44,12 +44,10 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       warn: vi.fn(),
     },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 import { requireAuth, isAuthError } from '@/lib/auth/auth-helpers';

--- a/apps/web/src/app/api/auth/socket-token/route.ts
+++ b/apps/web/src/app/api/auth/socket-token/route.ts
@@ -1,5 +1,5 @@
 import { requireAuth, isAuthError } from '@/lib/auth/auth-helpers';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { sessionRepository } from '@/lib/repositories/session-repository';
 import { hashToken } from '@pagespace/lib/auth';
 import { randomBytes } from 'crypto';

--- a/apps/web/src/app/api/auth/verify-email/route.ts
+++ b/apps/web/src/app/api/auth/verify-email/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyToken, markEmailVerified } from '@pagespace/lib/auth/verification-utils';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 
 export async function GET(request: NextRequest) {

--- a/apps/web/src/app/api/auth/verify-email/route.ts
+++ b/apps/web/src/app/api/auth/verify-email/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyToken, markEmailVerified } from '@pagespace/lib/auth/verification-utils';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 

--- a/apps/web/src/app/api/auth/ws-token/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/ws-token/__tests__/route.test.ts
@@ -23,31 +23,35 @@ vi.mock('@/lib/auth', () => ({
   getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
 }));
 
-vi.mock('@pagespace/lib', () => ({
-  sessionService: {
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_ws_token'),
   },
 }));
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn().mockResolvedValue({
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn().mockResolvedValue({
     allowed: true,
     attemptsRemaining: 9,
   }),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 import { verifyAuth, getClientIP } from '@/lib/auth';
-import { sessionService } from '@pagespace/lib';
-import { checkDistributedRateLimit } from '@pagespace/lib/security';
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { POST } from '../route';
 
 describe('/api/auth/ws-token', () => {

--- a/apps/web/src/app/api/auth/ws-token/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/ws-token/__tests__/route.test.ts
@@ -24,29 +24,27 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_ws_token'),
   },
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn().mockResolvedValue({
+  checkDistributedRateLimit: vi.fn().mockResolvedValue({
     allowed: true,
     attemptsRemaining: 9,
   }),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 import { verifyAuth, getClientIP } from '@/lib/auth';

--- a/apps/web/src/app/api/auth/ws-token/route.ts
+++ b/apps/web/src/app/api/auth/ws-token/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 import { verifyAuth, getClientIP } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
-import { sessionService } from '@pagespace/lib';
-import { checkDistributedRateLimit } from '@pagespace/lib/security';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 
 // WS tokens for desktop/mobile persistent connections need long TTL to match device sessions.
 // The connection is persistent and authenticated - we don't want to kick users mid-interaction.

--- a/apps/web/src/lib/auth/__tests__/admin-audit-coverage.test.ts
+++ b/apps/web/src/lib/auth/__tests__/admin-audit-coverage.test.ts
@@ -18,19 +18,23 @@ vi.mock('../csrf-validation', () => ({
 }));
 
 // Mock security event logging
-vi.mock('@pagespace/lib/server', () => ({
-  logSecurityEvent: vi.fn(),
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    logSecurityEvent: vi.fn(),
+    loggers: {
     security: { warn: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 import { withAdminAuth } from '../auth';
 import { authenticateSessionRequest } from '../index';
 import { validateAdminAccess } from '../admin-role';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const mockAuthenticateRequest = vi.mocked(authenticateSessionRequest);
 const mockValidateAdminAccess = vi.mocked(validateAdminAccess);

--- a/apps/web/src/lib/auth/__tests__/admin-audit-coverage.test.ts
+++ b/apps/web/src/lib/auth/__tests__/admin-audit-coverage.test.ts
@@ -19,16 +19,14 @@ vi.mock('../csrf-validation', () => ({
 
 // Mock security event logging
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    logSecurityEvent: vi.fn(),
-    loggers: {
+  logSecurityEvent: vi.fn(),
+  loggers: {
     security: { warn: vi.fn() },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 import { withAdminAuth } from '../auth';

--- a/apps/web/src/lib/auth/__tests__/admin-role-version.test.ts
+++ b/apps/web/src/lib/auth/__tests__/admin-role-version.test.ts
@@ -5,19 +5,15 @@ import { updateUserRole, validateAdminAccess } from '../admin-role';
 
 // Mock sessionService to avoid race conditions with parallel test execution
 // The real sessionService has a TOCTOU gap between user lookup and session insert
-vi.mock('@pagespace/lib/auth', async () => {
-  const actual = await vi.importActual('@pagespace/lib/auth');
-  return {
-    ...actual,
+vi.mock('@pagespace/lib/auth/session-service', () => ({
     sessionService: {
       createSession: vi.fn(),
       validateSession: vi.fn(),
     },
-  };
-});
+}));
 
 // Import the mocked module after vi.mock declaration
-import { sessionService } from '@pagespace/lib/auth';
+import { sessionService } from '@pagespace/lib/auth/session-service';
 
 describe('Admin Role Versioning', () => {
   let adminUserId: string;

--- a/apps/web/src/lib/auth/__tests__/admin-role-version.test.ts
+++ b/apps/web/src/lib/auth/__tests__/admin-role-version.test.ts
@@ -6,7 +6,7 @@ import { updateUserRole, validateAdminAccess } from '../admin-role';
 // Mock sessionService to avoid race conditions with parallel test execution
 // The real sessionService has a TOCTOU gap between user lookup and session insert
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
       createSession: vi.fn(),
       validateSession: vi.fn(),
     },

--- a/apps/web/src/lib/auth/__tests__/auth-middleware.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth-middleware.test.ts
@@ -13,25 +13,23 @@ import {
 
 // Mock dependencies
 vi.mock('@pagespace/lib/auth/token-utils', () => ({
-    hashToken: vi.fn().mockReturnValue('mocked-hash'),
+  hashToken: vi.fn().mockReturnValue('mocked-hash'),
 }));
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     validateSession: vi.fn(),
   },
 }));
 
 vi.mock('@pagespace/lib/permissions/enforced-context', () => ({
-    EnforcedAuthContext: class EnforcedAuthContext {
+  EnforcedAuthContext: class EnforcedAuthContext {
     static fromSession(sessionClaims: unknown): unknown {
       return sessionClaims;
     }
   },
 }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    logSecurityEvent: vi.fn(),
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+  logSecurityEvent: vi.fn(),
 }));
 
 vi.mock('@pagespace/db', () => ({

--- a/apps/web/src/lib/auth/__tests__/auth-middleware.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth-middleware.test.ts
@@ -12,20 +12,26 @@ import {
 } from '../index';
 
 // Mock dependencies
-vi.mock('@pagespace/lib/auth', () => ({
-  hashToken: vi.fn().mockReturnValue('mocked-hash'),
-  sessionService: {
+vi.mock('@pagespace/lib/auth/token-utils', () => ({
+    hashToken: vi.fn().mockReturnValue('mocked-hash'),
+}));
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     validateSession: vi.fn(),
   },
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  EnforcedAuthContext: class EnforcedAuthContext {
+vi.mock('@pagespace/lib/permissions/enforced-context', () => ({
+    EnforcedAuthContext: class EnforcedAuthContext {
     static fromSession(sessionClaims: unknown): unknown {
       return sessionClaims;
     }
   },
-  logSecurityEvent: vi.fn(),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    logSecurityEvent: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 vi.mock('@pagespace/db', () => ({
@@ -59,8 +65,8 @@ vi.mock('../cookie-config', () => ({
   getSessionFromCookies: vi.fn(),
 }));
 
-import { sessionService } from '@pagespace/lib/auth';
-import { logSecurityEvent } from '@pagespace/lib/server';
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { logSecurityEvent } from '@pagespace/lib/logging/logger-config';
 import { db } from '@pagespace/db';
 import { validateCSRF } from '../csrf-validation';
 import { validateOrigin } from '../origin-validation';

--- a/apps/web/src/lib/auth/__tests__/auth.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.test.ts
@@ -20,13 +20,17 @@ vi.mock('../csrf-validation', () => ({
 }));
 
 // Mock security event logging
-vi.mock('@pagespace/lib/server', () => ({
-  logSecurityEvent: vi.fn(),
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    logSecurityEvent: vi.fn(),
+    loggers: {
     security: { warn: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 import { authenticateSessionRequest } from '../index';

--- a/apps/web/src/lib/auth/__tests__/auth.test.ts
+++ b/apps/web/src/lib/auth/__tests__/auth.test.ts
@@ -21,16 +21,14 @@ vi.mock('../csrf-validation', () => ({
 
 // Mock security event logging
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    logSecurityEvent: vi.fn(),
-    loggers: {
+  logSecurityEvent: vi.fn(),
+  loggers: {
     security: { warn: vi.fn() },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 import { authenticateSessionRequest } from '../index';

--- a/apps/web/src/lib/auth/__tests__/csrf-validation.test.ts
+++ b/apps/web/src/lib/auth/__tests__/csrf-validation.test.ts
@@ -21,28 +21,33 @@ import { validateCSRF, requiresCSRFProtection } from '../csrf-validation';
  */
 
 // Mock dependencies at system boundary
-vi.mock('@pagespace/lib/auth', () => ({
-  validateCSRFToken: vi.fn(),
-  sessionService: {
+vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
+    validateCSRFToken: vi.fn(),
+}));
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     validateSession: vi.fn(),
   },
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       warn: vi.fn(),
       debug: vi.fn(),
       error: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 vi.mock('../cookie-config', () => ({
   getSessionFromCookies: vi.fn(),
 }));
 
-import { validateCSRFToken, sessionService } from '@pagespace/lib/auth';
+import { validateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { sessionService } from '@pagespace/lib/auth/session-service';
 import { getSessionFromCookies } from '../cookie-config';
 
 describe('csrf-validation', () => {

--- a/apps/web/src/lib/auth/__tests__/csrf-validation.test.ts
+++ b/apps/web/src/lib/auth/__tests__/csrf-validation.test.ts
@@ -22,31 +22,29 @@ import { validateCSRF, requiresCSRFProtection } from '../csrf-validation';
 
 // Mock dependencies at system boundary
 vi.mock('@pagespace/lib/auth/csrf-utils', () => ({
-    validateCSRFToken: vi.fn(),
+  validateCSRFToken: vi.fn(),
 }));
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     validateSession: vi.fn(),
   },
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       warn: vi.fn(),
       debug: vi.fn(),
       error: vi.fn(),
     },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 vi.mock('../cookie-config', () => ({
   getSessionFromCookies: vi.fn(),
 }));
 
-import { validateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { validateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
 import { sessionService } from '@pagespace/lib/auth/session-service';
 import { getSessionFromCookies } from '../cookie-config';
 

--- a/apps/web/src/lib/auth/__tests__/device-auth-helpers.test.ts
+++ b/apps/web/src/lib/auth/__tests__/device-auth-helpers.test.ts
@@ -1,21 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     revokeDeviceSessions: vi.fn(),
     revokeAllUserSessions: vi.fn(),
   },
 }));
 
 vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
-    validateOrCreateDeviceToken: vi.fn(),
+  validateOrCreateDeviceToken: vi.fn(),
 }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 import { revokeSessionsForLogin, createWebDeviceToken } from '../device-auth-helpers';

--- a/apps/web/src/lib/auth/__tests__/device-auth-helpers.test.ts
+++ b/apps/web/src/lib/auth/__tests__/device-auth-helpers.test.ts
@@ -1,22 +1,26 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock('@pagespace/lib/auth', () => ({
-  sessionService: {
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     revokeDeviceSessions: vi.fn(),
     revokeAllUserSessions: vi.fn(),
   },
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  validateOrCreateDeviceToken: vi.fn(),
-  loggers: {
+vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
+    validateOrCreateDeviceToken: vi.fn(),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 import { revokeSessionsForLogin, createWebDeviceToken } from '../device-auth-helpers';
-import { sessionService } from '@pagespace/lib/auth';
-import { validateOrCreateDeviceToken } from '@pagespace/lib/server';
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
 
 describe('device-auth-helpers', () => {
   beforeEach(() => {

--- a/apps/web/src/lib/auth/__tests__/enforced-context-csrf.test.ts
+++ b/apps/web/src/lib/auth/__tests__/enforced-context-csrf.test.ts
@@ -2,15 +2,17 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { NextResponse } from 'next/server';
 
 // Mock dependencies at system boundary
-vi.mock('@pagespace/lib/auth', () => ({
-  hashToken: vi.fn().mockReturnValue('mocked-hash'),
-  sessionService: {
+vi.mock('@pagespace/lib/auth/token-utils', () => ({
+    hashToken: vi.fn().mockReturnValue('mocked-hash'),
+}));
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     validateSession: vi.fn(),
   },
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  EnforcedAuthContext: class EnforcedAuthContext {
+vi.mock('@pagespace/lib/permissions/enforced-context', () => ({
+    EnforcedAuthContext: class EnforcedAuthContext {
     userId: string;
     userRole: string;
     constructor(claims: { userId: string; userRole: string }) {
@@ -21,7 +23,11 @@ vi.mock('@pagespace/lib/server', () => ({
       return { ctx: claims };
     }
   },
-  logSecurityEvent: vi.fn(),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    logSecurityEvent: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 vi.mock('@pagespace/db', () => ({
@@ -56,8 +62,8 @@ vi.mock('../cookie-config', () => ({
 }));
 
 import { authenticateWithEnforcedContext, isEnforcedAuthError } from '../index';
-import { sessionService } from '@pagespace/lib/auth';
-import { logSecurityEvent } from '@pagespace/lib/server';
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { logSecurityEvent } from '@pagespace/lib/logging/logger-config';
 import { validateCSRF } from '../csrf-validation';
 import { getSessionFromCookies } from '../cookie-config';
 

--- a/apps/web/src/lib/auth/__tests__/enforced-context-csrf.test.ts
+++ b/apps/web/src/lib/auth/__tests__/enforced-context-csrf.test.ts
@@ -3,16 +3,16 @@ import { NextResponse } from 'next/server';
 
 // Mock dependencies at system boundary
 vi.mock('@pagespace/lib/auth/token-utils', () => ({
-    hashToken: vi.fn().mockReturnValue('mocked-hash'),
+  hashToken: vi.fn().mockReturnValue('mocked-hash'),
 }));
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     validateSession: vi.fn(),
   },
 }));
 
 vi.mock('@pagespace/lib/permissions/enforced-context', () => ({
-    EnforcedAuthContext: class EnforcedAuthContext {
+  EnforcedAuthContext: class EnforcedAuthContext {
     userId: string;
     userRole: string;
     constructor(claims: { userId: string; userRole: string }) {
@@ -25,9 +25,7 @@ vi.mock('@pagespace/lib/permissions/enforced-context', () => ({
   },
 }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    logSecurityEvent: vi.fn(),
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+  logSecurityEvent: vi.fn(),
 }));
 
 vi.mock('@pagespace/db', () => ({

--- a/apps/web/src/lib/auth/__tests__/file-access.test.ts
+++ b/apps/web/src/lib/auth/__tests__/file-access.test.ts
@@ -10,7 +10,7 @@
  * using the same pattern as production, with a structural sync assertion to catch drift.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { canUserAccessFile as productionFn } from '@pagespace/lib/permissions';
+import { canUserAccessFile as productionFn } from '@pagespace/lib/permissions/file-access';
 
 const { mockWhereFn, mockCanUserViewPage, mockIsUserDriveMember } = vi.hoisted(() => ({
   mockWhereFn: vi.fn().mockResolvedValue([]),
@@ -37,14 +37,10 @@ vi.mock('@pagespace/lib/logging/logger-config', () => {
   return { loggers: { api: logger, realtime: logger, security: logger } };
 });
 
-vi.mock('@pagespace/lib', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    parseUserId: vi.fn((v: unknown) => ({ success: true, data: v })),
-    parsePageId: vi.fn((v: unknown) => ({ success: true, data: v })),
-  };
-});
+vi.mock('@pagespace/lib/validators/id-validators', () => ({
+  parseUserId: vi.fn((v: unknown) => ({ success: true, data: v })),
+  parsePageId: vi.fn((v: unknown) => ({ success: true, data: v })),
+}));
 
 describe('canUserAccessFile', () => {
   let canUserAccessFile: (userId: string, fileId: string, driveId: string) => Promise<boolean>;

--- a/apps/web/src/lib/auth/__tests__/google-avatar.test.ts
+++ b/apps/web/src/lib/auth/__tests__/google-avatar.test.ts
@@ -1,18 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@pagespace/lib/services/validated-service-token', () => ({
-    createUserServiceToken: vi.fn().mockResolvedValue({ token: 'service-token' }),
+  createUserServiceToken: vi.fn().mockResolvedValue({ token: 'service-token' }),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       debug: vi.fn(),
       warn: vi.fn(),
     },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 import { createUserServiceToken } from '@pagespace/lib/services/validated-service-token';

--- a/apps/web/src/lib/auth/__tests__/google-avatar.test.ts
+++ b/apps/web/src/lib/auth/__tests__/google-avatar.test.ts
@@ -1,20 +1,22 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('@pagespace/lib', () => ({
-  createUserServiceToken: vi.fn().mockResolvedValue({ token: 'service-token' }),
+vi.mock('@pagespace/lib/services/validated-service-token', () => ({
+    createUserServiceToken: vi.fn().mockResolvedValue({ token: 'service-token' }),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       debug: vi.fn(),
       warn: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
-import { createUserServiceToken } from '@pagespace/lib';
-import { loggers } from '@pagespace/lib/server';
+import { createUserServiceToken } from '@pagespace/lib/services/validated-service-token';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { isExternalHttpUrl, resolveGoogleAvatarImage } from '@/lib/auth/google-avatar';
 
 describe('google-avatar', () => {

--- a/apps/web/src/lib/auth/__tests__/mcp-scope-enforcement.test.ts
+++ b/apps/web/src/lib/auth/__tests__/mcp-scope-enforcement.test.ts
@@ -47,14 +47,20 @@ vi.mock('@pagespace/db', () => ({
   isNull: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/auth', () => ({
-  hashToken: vi.fn(),
-  sessionService: { validateSession: vi.fn() },
+vi.mock('@pagespace/lib/auth/token-utils', () => ({
+    hashToken: vi.fn(),
+}));
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: { validateSession: vi.fn() },
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  EnforcedAuthContext: { fromSession: vi.fn() },
-  logSecurityEvent: vi.fn(),
+vi.mock('@pagespace/lib/permissions/enforced-context', () => ({
+    EnforcedAuthContext: { fromSession: vi.fn() },
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    logSecurityEvent: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 vi.mock('../cookie-config', () => ({

--- a/apps/web/src/lib/auth/__tests__/mcp-scope-enforcement.test.ts
+++ b/apps/web/src/lib/auth/__tests__/mcp-scope-enforcement.test.ts
@@ -48,19 +48,17 @@ vi.mock('@pagespace/db', () => ({
 }));
 
 vi.mock('@pagespace/lib/auth/token-utils', () => ({
-    hashToken: vi.fn(),
+  hashToken: vi.fn(),
 }));
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: { validateSession: vi.fn() },
+  sessionService: { validateSession: vi.fn() },
 }));
 
 vi.mock('@pagespace/lib/permissions/enforced-context', () => ({
-    EnforcedAuthContext: { fromSession: vi.fn() },
+  EnforcedAuthContext: { fromSession: vi.fn() },
 }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    logSecurityEvent: vi.fn(),
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+  logSecurityEvent: vi.fn(),
 }));
 
 vi.mock('../cookie-config', () => ({

--- a/apps/web/src/lib/auth/__tests__/origin-validation.test.ts
+++ b/apps/web/src/lib/auth/__tests__/origin-validation.test.ts
@@ -30,15 +30,13 @@ import {
 
 // Mock dependencies at system boundary
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       warn: vi.fn(),
       debug: vi.fn(),
       error: vi.fn(),
     },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 import { loggers } from '@pagespace/lib/logging/logger-config';

--- a/apps/web/src/lib/auth/__tests__/origin-validation.test.ts
+++ b/apps/web/src/lib/auth/__tests__/origin-validation.test.ts
@@ -29,17 +29,19 @@ import {
  */
 
 // Mock dependencies at system boundary
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       warn: vi.fn(),
       debug: vi.fn(),
       error: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 describe('origin-validation', () => {
   // Store original env values

--- a/apps/web/src/lib/auth/auth.ts
+++ b/apps/web/src/lib/auth/auth.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { authenticateSessionRequest, isAuthError } from './index';
 import { validateAdminAccess, type AdminValidationResult } from './admin-role';
 import { validateCSRF } from './csrf-validation';
-import { logSecurityEvent } from '@pagespace/lib/logging/logger-config'
+import { logSecurityEvent } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 export interface VerifiedUser {

--- a/apps/web/src/lib/auth/auth.ts
+++ b/apps/web/src/lib/auth/auth.ts
@@ -2,7 +2,8 @@ import { NextResponse } from 'next/server';
 import { authenticateSessionRequest, isAuthError } from './index';
 import { validateAdminAccess, type AdminValidationResult } from './admin-role';
 import { validateCSRF } from './csrf-validation';
-import { logSecurityEvent, auditRequest } from '@pagespace/lib/server';
+import { logSecurityEvent } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 export interface VerifiedUser {
   id: string;

--- a/apps/web/src/lib/auth/cron-auth.ts
+++ b/apps/web/src/lib/auth/cron-auth.ts
@@ -13,7 +13,7 @@
 
 import { createHmac } from 'crypto';
 import { NextResponse } from 'next/server';
-import { secureCompare } from '@pagespace/lib';
+import { secureCompare } from '@pagespace/lib/auth/secure-compare';
 
 let cronSecretWarningLogged = false;
 

--- a/apps/web/src/lib/auth/csrf-validation.ts
+++ b/apps/web/src/lib/auth/csrf-validation.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { validateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { validateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
 import { sessionService } from '@pagespace/lib/auth/session-service';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getSessionFromCookies } from './cookie-config';

--- a/apps/web/src/lib/auth/csrf-validation.ts
+++ b/apps/web/src/lib/auth/csrf-validation.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
-import { validateCSRFToken, sessionService } from '@pagespace/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { validateCSRFToken } from '@pagespace/lib/auth/csrf-utils'
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getSessionFromCookies } from './cookie-config';
 
 /**

--- a/apps/web/src/lib/auth/device-auth-helpers.ts
+++ b/apps/web/src/lib/auth/device-auth-helpers.ts
@@ -1,5 +1,6 @@
-import { sessionService } from '@pagespace/lib/auth';
-import { validateOrCreateDeviceToken, loggers } from '@pagespace/lib/server';
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 /**
  * Revoke existing sessions before login, scoped to a specific device when possible.

--- a/apps/web/src/lib/auth/device-auth-helpers.ts
+++ b/apps/web/src/lib/auth/device-auth-helpers.ts
@@ -1,5 +1,5 @@
 import { sessionService } from '@pagespace/lib/auth/session-service';
-import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils'
+import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 
 /**

--- a/apps/web/src/lib/auth/google-avatar.ts
+++ b/apps/web/src/lib/auth/google-avatar.ts
@@ -1,5 +1,5 @@
-import { createUserServiceToken, type ServiceScope } from '@pagespace/lib';
-import { loggers } from '@pagespace/lib/server';
+import { createUserServiceToken, type ServiceScope } from '@pagespace/lib/services/validated-service-token';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 const PROCESSOR_URL = process.env.PROCESSOR_URL || 'http://processor:3003';
 const MAX_AVATAR_BYTES = 5 * 1024 * 1024;

--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from 'next/server';
 import { db, mcpTokens, eq, and, isNull } from '@pagespace/db';
-import { hashToken, sessionService, type SessionClaims } from '@pagespace/lib/auth';
-import { EnforcedAuthContext, logSecurityEvent } from '@pagespace/lib/server';
+import { hashToken } from '@pagespace/lib/auth/token-utils'
+import { sessionService, type SessionClaims } from '@pagespace/lib/auth/session-service';
+import { EnforcedAuthContext } from '@pagespace/lib/permissions/enforced-context'
+import { logSecurityEvent } from '@pagespace/lib/logging/logger-config';
 import { getSessionFromCookies } from './cookie-config';
 
 const BEARER_PREFIX = 'Bearer ';

--- a/apps/web/src/lib/auth/index.ts
+++ b/apps/web/src/lib/auth/index.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 import { db, mcpTokens, eq, and, isNull } from '@pagespace/db';
-import { hashToken } from '@pagespace/lib/auth/token-utils'
+import { hashToken } from '@pagespace/lib/auth/token-utils';
 import { sessionService, type SessionClaims } from '@pagespace/lib/auth/session-service';
-import { EnforcedAuthContext } from '@pagespace/lib/permissions/enforced-context'
+import { EnforcedAuthContext } from '@pagespace/lib/permissions/enforced-context';
 import { logSecurityEvent } from '@pagespace/lib/logging/logger-config';
 import { getSessionFromCookies } from './cookie-config';
 

--- a/apps/web/src/lib/auth/login-csrf-utils.ts
+++ b/apps/web/src/lib/auth/login-csrf-utils.ts
@@ -1,5 +1,5 @@
 import { randomBytes, createHmac } from 'crypto';
-import { secureCompare } from '@pagespace/lib';
+import { secureCompare } from '@pagespace/lib/auth/secure-compare';
 
 // Constants
 export const LOGIN_CSRF_COOKIE_NAME = 'login_csrf';

--- a/apps/web/src/lib/auth/oauth-state.ts
+++ b/apps/web/src/lib/auth/oauth-state.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto';
 import { z } from 'zod/v4';
-import { secureCompare } from '@pagespace/lib';
+import { secureCompare } from '@pagespace/lib/auth/secure-compare';
 
 // State expires after 10 minutes — prevents replay attacks
 const STATE_MAX_AGE_MS = 10 * 60 * 1000;

--- a/apps/web/src/lib/auth/origin-validation.ts
+++ b/apps/web/src/lib/auth/origin-validation.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 /**
  * Origin Header Validation for API Routes (Defense-in-Depth)

--- a/apps/web/src/lib/subscription/rate-limit-middleware.ts
+++ b/apps/web/src/lib/subscription/rate-limit-middleware.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { incrementUsage } from './usage-service';
-import { getTomorrowMidnightUTC } from '@pagespace/lib/services/date-utils'
-import { isBillingEnabled } from '@pagespace/lib/deployment-mode'
+import { getTomorrowMidnightUTC } from '@pagespace/lib/services/date-utils';
+import { isBillingEnabled } from '@pagespace/lib/deployment-mode';
 import type { ProviderType } from '@pagespace/lib/services/rate-limit-cache';
 import { getPageSpaceModelTier } from '@/lib/ai/core/ai-providers-config';
 

--- a/apps/web/src/lib/subscription/rate-limit-middleware.ts
+++ b/apps/web/src/lib/subscription/rate-limit-middleware.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import { incrementUsage } from './usage-service';
-import { getTomorrowMidnightUTC, isBillingEnabled, type ProviderType } from '@pagespace/lib';
+import { getTomorrowMidnightUTC } from '@pagespace/lib/services/date-utils'
+import { isBillingEnabled } from '@pagespace/lib/deployment-mode'
+import type { ProviderType } from '@pagespace/lib/services/rate-limit-cache';
 import { getPageSpaceModelTier } from '@/lib/ai/core/ai-providers-config';
 
 export interface RateLimitResult {

--- a/apps/web/src/lib/subscription/usage-service.ts
+++ b/apps/web/src/lib/subscription/usage-service.ts
@@ -1,8 +1,8 @@
 import { db, eq, users } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/server';
-import { isBillingEnabled } from '@pagespace/lib';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { isBillingEnabled } from '@pagespace/lib/deployment-mode';
 import { maskIdentifier } from '@/lib/logging/mask';
-import { rateLimitCache, type ProviderType, type UsageTrackingResult } from '@pagespace/lib';
+import { rateLimitCache, type ProviderType, type UsageTrackingResult } from '@pagespace/lib/services/rate-limit-cache';
 
 // Re-export types for backwards compatibility
 export type { ProviderType, UsageTrackingResult };


### PR DESCRIPTION
## Summary

Replaces barrel imports with direct subpath imports across the web app's auth and security surface:

- `apps/web/src/app/api/auth/**` — all auth API routes and their tests
- `apps/web/src/lib/auth/**` — auth utilities, session service, admin role, middleware
- `apps/web/middleware.ts` — Next.js edge middleware
- `apps/web/src/lib/subscription/` — rate-limit middleware, usage service

**95 files total — all mechanical import-path swaps. No logic changes.**

## Context

**PR C of 6** in the barrel-import removal series.

**⚠️ Depends on PR A (#1088) `barrel/foundation` being merged first.**
Base branch is `barrel/foundation` so CI resolves the new subpath exports.
After A merges, this PR's base will be updated to `master`.

## Why auth is grouped together

The auth routes, auth lib, and middleware form a coherent security surface. Grouping them lets reviewers verify the entire auth path in one pass — ensuring no session handling, token validation, or permission logic was accidentally altered.

## Changes pattern

```diff
-import { sessionService } from '@pagespace/lib/auth'
-import { checkPermission } from '@pagespace/lib/permissions'
+import { sessionService } from '@pagespace/lib/auth/session-service'
+import { checkPermission } from '@pagespace/lib/permissions/page-permissions'
```

Test mocks are updated in the same PR to match:
```diff
-vi.mock('@pagespace/lib/auth', () => ({ ... }))
+vi.mock('@pagespace/lib/auth/session-service', () => ({ ... }))
```

## Verification

- [ ] `pnpm --filter web typecheck` passes (no auth-related TS errors)
- [ ] Auth test suite passes: `pnpm --filter web exec vitest run src/app/api/auth src/lib/auth`
- [ ] No logic changes — diff shows only import path updates

## Review

Please use `/aidd:review` for AI-assisted review. Key questions:
1. Are all auth symbols routed to the correct subpath? (session-service vs admin-role vs middleware-utils etc.)
2. Are the test mocks aligned with what the source files actually import?
3. Does `apps/web/middleware.ts` still correctly import from the right auth modules?

🤖 Generated with [Claude Code](https://claude.ai/claude-code)