### PR TITLE
refactor(imports): direct subpath imports — PR D: Web AI + Integrations

### DIFF
--- a/apps/web/src/app/api/agents/[agentId]/integrations/[grantId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agents/[agentId]/integrations/[grantId]/__tests__/route.test.ts
@@ -14,19 +14,23 @@ vi.mock('@/lib/auth', () => ({
 
 vi.mock('@pagespace/db', () => ({ db: {} }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/permissions', () => ({
-  canUserEditPage: vi.fn().mockResolvedValue(true),
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    canUserEditPage: vi.fn().mockResolvedValue(true),
 }));
 
-vi.mock('@pagespace/lib/integrations', () => ({
+vi.mock('@pagespace/lib/integrations/repositories/grant-repository', () => ({
   getGrantById: mockGetGrantById,
   updateGrant: vi.fn(),
   deleteGrant: mockDeleteGrant,
@@ -34,7 +38,7 @@ vi.mock('@pagespace/lib/integrations', () => ({
 
 import { DELETE } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const mockUserId = 'user_123';
 const mockAgentId = 'agent-1';

--- a/apps/web/src/app/api/agents/[agentId]/integrations/[grantId]/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/integrations/[grantId]/route.ts
@@ -2,9 +2,10 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db } from '@pagespace/db';
-import { loggers, auditRequest } from '@pagespace/lib/server';
-import { canUserEditPage } from '@pagespace/lib/permissions';
-import { getGrantById, updateGrant, deleteGrant } from '@pagespace/lib/integrations';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
+import { getGrantById, updateGrant, deleteGrant } from '@pagespace/lib/integrations/repositories/grant-repository';
 
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
 

--- a/apps/web/src/app/api/agents/[agentId]/integrations/[grantId]/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/integrations/[grantId]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { getGrantById, updateGrant, deleteGrant } from '@pagespace/lib/integrations/repositories/grant-repository';

--- a/apps/web/src/app/api/agents/[agentId]/integrations/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agents/[agentId]/integrations/__tests__/route.test.ts
@@ -34,14 +34,12 @@ vi.mock('@pagespace/lib/services/drive-service', () => ({
 }));
 
 vi.mock('@pagespace/lib/integrations/repositories/grant-repository', () => ({
-    listGrantsByAgent: mockListGrantsByAgent,
+  listGrantsByAgent: mockListGrantsByAgent,
+  createGrant: vi.fn(),
+  findGrant: vi.fn(),
 }));
 vi.mock('@pagespace/lib/integrations/repositories/connection-repository', () => ({
-    getConnectionById: vi.fn(),
-}));
-vi.mock('@pagespace/lib/integrations', () => ({
-    createGrant: vi.fn(),
-    findGrant: vi.fn(),
+  getConnectionById: vi.fn(),
 }));
 
 import { GET } from '../route';

--- a/apps/web/src/app/api/agents/[agentId]/integrations/__tests__/route.test.ts
+++ b/apps/web/src/app/api/agents/[agentId]/integrations/__tests__/route.test.ts
@@ -13,32 +13,40 @@ vi.mock('@/lib/auth', () => ({
 
 vi.mock('@pagespace/db', () => ({ db: {} }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/permissions', () => ({
-  canUserEditPage: vi.fn().mockResolvedValue(true),
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    canUserEditPage: vi.fn().mockResolvedValue(true),
 }));
 
 vi.mock('@pagespace/lib/services/drive-service', () => ({
   getDriveAccess: vi.fn(),
 }));
 
+vi.mock('@pagespace/lib/integrations/repositories/grant-repository', () => ({
+    listGrantsByAgent: mockListGrantsByAgent,
+}));
+vi.mock('@pagespace/lib/integrations/repositories/connection-repository', () => ({
+    getConnectionById: vi.fn(),
+}));
 vi.mock('@pagespace/lib/integrations', () => ({
-  listGrantsByAgent: mockListGrantsByAgent,
-  createGrant: vi.fn(),
-  getConnectionById: vi.fn(),
-  findGrant: vi.fn(),
+    createGrant: vi.fn(),
+    findGrant: vi.fn(),
 }));
 
 import { GET } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const mockUserId = 'user_123';
 const mockAgentId = 'agent-1';

--- a/apps/web/src/app/api/agents/[agentId]/integrations/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/integrations/route.ts
@@ -2,11 +2,11 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { getDriveAccess } from '@pagespace/lib/services/drive-service';
-import { listGrantsByAgent, createGrant, findGrant } from '@pagespace/lib/integrations/repositories/grant-repository'
+import { listGrantsByAgent, createGrant, findGrant } from '@pagespace/lib/integrations/repositories/grant-repository';
 import { getConnectionById } from '@pagespace/lib/integrations/repositories/connection-repository';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const };

--- a/apps/web/src/app/api/agents/[agentId]/integrations/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/integrations/route.ts
@@ -2,15 +2,12 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db } from '@pagespace/db';
-import { loggers, auditRequest } from '@pagespace/lib/server';
-import { canUserEditPage } from '@pagespace/lib/permissions';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { getDriveAccess } from '@pagespace/lib/services/drive-service';
-import {
-  listGrantsByAgent,
-  createGrant,
-  getConnectionById,
-  findGrant,
-} from '@pagespace/lib/integrations';
+import { listGrantsByAgent, createGrant, findGrant } from '@pagespace/lib/integrations/repositories/grant-repository'
+import { getConnectionById } from '@pagespace/lib/integrations/repositories/connection-repository';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/ai/abort/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/abort/__tests__/route.test.ts
@@ -22,30 +22,29 @@ vi.mock('@/lib/ai/core/stream-abort-registry', () => ({
 }));
 
 // Mock logger (boundary)
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: {
       info: vi.fn(),
       error: vi.fn(),
       warn: vi.fn(),
     },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
-// Mock rate limit (boundary) - note: checkRateLimit is exported from @pagespace/lib/auth
-vi.mock('@pagespace/lib/auth', async () => {
-  const actual = await vi.importActual('@pagespace/lib/auth');
-  return {
-    ...actual,
-    checkRateLimit: vi.fn(),
-  };
-});
+vi.mock('@pagespace/lib/auth/rate-limit-utils', () => ({
+  checkRateLimit: vi.fn(),
+}));
 
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { abortStream } from '@/lib/ai/core/stream-abort-registry';
-import { loggers } from '@pagespace/lib/server';
-import { checkRateLimit } from '@pagespace/lib/auth';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { checkRateLimit } from '@pagespace/lib/auth/rate-limit-utils';
 
 // Test fixtures
 const mockUserId = 'user-123';

--- a/apps/web/src/app/api/ai/abort/route.ts
+++ b/apps/web/src/app/api/ai/abort/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { abortStream } from '@/lib/ai/core/stream-abort-registry';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { checkRateLimit } from '@pagespace/lib/auth/rate-limit-utils';
 

--- a/apps/web/src/app/api/ai/abort/route.ts
+++ b/apps/web/src/app/api/ai/abort/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { abortStream } from '@/lib/ai/core/stream-abort-registry';
-import { loggers, auditRequest } from '@pagespace/lib/server';
-import { checkRateLimit } from '@pagespace/lib/auth';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { checkRateLimit } from '@pagespace/lib/auth/rate-limit-utils';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 

--- a/apps/web/src/app/api/ai/chat/__tests__/mcp-scope.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/mcp-scope.test.ts
@@ -19,11 +19,15 @@ vi.mock('@/lib/auth', () => ({
   checkMCPPageScope: vi.fn().mockResolvedValue(null),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  canUserViewPage: vi.fn().mockResolvedValue(true),
-  canUserEditPage: vi.fn().mockResolvedValue(true),
-  getActorInfo: vi.fn().mockResolvedValue({ actorEmail: 'test@test.com', actorDisplayName: 'Test' }),
-  loggers: {
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    canUserViewPage: vi.fn().mockResolvedValue(true),
+    canUserEditPage: vi.fn().mockResolvedValue(true),
+}));
+vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
+    getActorInfo: vi.fn().mockResolvedValue({ actorEmail: 'test@test.com', actorDisplayName: 'Test' }),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     ai: {
       info: vi.fn(),
       error: vi.fn(),
@@ -36,10 +40,14 @@ vi.mock('@pagespace/lib/server', () => ({
         warn: vi.fn(),
         debug: vi.fn(),
         trace: vi.fn(),
-      })),
+      
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+})),
     },
   },
-  auditRequest: vi.fn(),
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/db', () => ({

--- a/apps/web/src/app/api/ai/chat/__tests__/mcp-scope.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/mcp-scope.test.ts
@@ -27,7 +27,7 @@ vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
     getActorInfo: vi.fn().mockResolvedValue({ actorEmail: 'test@test.com', actorDisplayName: 'Test' }),
 }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     ai: {
       info: vi.fn(),
       error: vi.fn(),
@@ -40,11 +40,10 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
         warn: vi.fn(),
         debug: vi.fn(),
         trace: vi.fn(),
-      
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
-})),
+      })),
     },
   },
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
     auditRequest: vi.fn(),

--- a/apps/web/src/app/api/ai/chat/messages/[messageId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/chat/messages/[messageId]/__tests__/route.test.ts
@@ -28,12 +28,18 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock permissions (boundary)
-vi.mock('@pagespace/lib/server', () => ({
-  canUserEditPage: vi.fn(),
-  loggers: {
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    canUserEditPage: vi.fn(),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
 // Mock logging mask (boundary)
@@ -64,7 +70,8 @@ import { chatMessageRepository } from '@/lib/repositories/chat-message-repositor
 import { getActorInfo, logMessageActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { db } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
-import { canUserEditPage, loggers } from '@pagespace/lib/server';
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 // Type for page lookup mock (matches Drizzle schema)
 type PageType = 'DOCUMENT' | 'FOLDER' | 'CHANNEL' | 'AI_CHAT' | 'CANVAS' | 'FILE' | 'SHEET' | 'TASK_LIST' | 'CODE';

--- a/apps/web/src/app/api/ai/chat/messages/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/chat/messages/[messageId]/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
-import { canUserEditPage, loggers, auditRequest } from '@pagespace/lib/server';
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions'
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { maskIdentifier } from '@/lib/logging/mask';
 import {
   chatMessageRepository,

--- a/apps/web/src/app/api/ai/chat/messages/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/chat/messages/[messageId]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
-import { canUserEditPage } from '@pagespace/lib/permissions/permissions'
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { maskIdentifier } from '@/lib/logging/mask';
 import {

--- a/apps/web/src/app/api/ai/chat/messages/[messageId]/undo/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/chat/messages/[messageId]/undo/__tests__/route.test.ts
@@ -34,9 +34,11 @@ vi.mock('@/lib/repositories/global-conversation-repository', () => ({
 }));
 
 // Mock permissions
-vi.mock('@pagespace/lib/server', () => ({
-  canUserEditPage: vi.fn(),
-  loggers: {
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    canUserEditPage: vi.fn(),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: {
       info: vi.fn(),
       error: vi.fn(),
@@ -44,7 +46,11 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
 // Mock websocket broadcasts
@@ -66,7 +72,7 @@ vi.mock('@/lib/logging/mask', () => ({
 import { previewAiUndo, executeAiUndo, type AiUndoPreview } from '@/services/api';
 import { authenticateRequestWithOptions, checkMCPPageScope } from '@/lib/auth';
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
-import { canUserEditPage } from '@pagespace/lib/server';
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 
 const mockAuth = vi.mocked(authenticateRequestWithOptions);
 const mockCheckMCPPageScope = vi.mocked(checkMCPPageScope);

--- a/apps/web/src/app/api/ai/chat/messages/[messageId]/undo/route.ts
+++ b/apps/web/src/app/api/ai/chat/messages/[messageId]/undo/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope, type AuthResult } from '@/lib/auth';
-import { canUserEditPage } from '@pagespace/lib/permissions/permissions'
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { maskIdentifier } from '@/lib/logging/mask';
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';

--- a/apps/web/src/app/api/ai/chat/messages/[messageId]/undo/route.ts
+++ b/apps/web/src/app/api/ai/chat/messages/[messageId]/undo/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope, type AuthResult } from '@/lib/auth';
-import { canUserEditPage, loggers, auditRequest } from '@pagespace/lib/server';
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions'
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { maskIdentifier } from '@/lib/logging/mask';
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 import { previewAiUndo, executeAiUndo, type AiUndoPreview } from '@/services/api';

--- a/apps/web/src/app/api/ai/chat/messages/__tests__/mcp-scope.test.ts
+++ b/apps/web/src/app/api/ai/chat/messages/__tests__/mcp-scope.test.ts
@@ -26,12 +26,18 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock permissions (boundary)
-vi.mock('@pagespace/lib/server', () => ({
-  canUserViewPage: vi.fn().mockResolvedValue(true),
-  loggers: {
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    canUserViewPage: vi.fn().mockResolvedValue(true),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     ai: { info: vi.fn(), error: vi.fn() },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
 // Mock message converter (boundary)
@@ -44,7 +50,7 @@ vi.mock('@/lib/ai/core', () => ({
 }));
 
 import { authenticateRequestWithOptions, checkMCPPageScope } from '@/lib/auth';
-import { canUserViewPage } from '@pagespace/lib/server';
+import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
 import { chatMessageRepository } from '@/lib/repositories/chat-message-repository';
 
 // ============================================================================

--- a/apps/web/src/app/api/ai/chat/messages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/chat/messages/__tests__/route.test.ts
@@ -26,12 +26,18 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock permissions (boundary)
-vi.mock('@pagespace/lib/server', () => ({
-  canUserViewPage: vi.fn(),
-  loggers: {
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    canUserViewPage: vi.fn(),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     ai: { info: vi.fn(), error: vi.fn() },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
 // Mock message converter (boundary)
@@ -45,7 +51,8 @@ vi.mock('@/lib/ai/core', () => ({
 
 import { chatMessageRepository } from '@/lib/repositories/chat-message-repository';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { canUserViewPage, loggers } from '@pagespace/lib/server';
+import { canUserViewPage } from '@pagespace/lib/permissions/permissions'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { convertDbMessageToUIMessage } from '@/lib/ai/core';
 
 // Test fixtures

--- a/apps/web/src/app/api/ai/chat/messages/route.ts
+++ b/apps/web/src/app/api/ai/chat/messages/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
 import { convertDbMessageToUIMessage } from '@/lib/ai/core';
-import { loggers, auditRequest, canUserViewPage } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
 import { chatMessageRepository } from '@/lib/repositories/chat-message-repository';
 
 // Auth options: GET is read-only operation

--- a/apps/web/src/app/api/ai/chat/messages/route.ts
+++ b/apps/web/src/app/api/ai/chat/messages/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
 import { convertDbMessageToUIMessage } from '@/lib/ai/core';
-import { loggers } from '@pagespace/lib/logging/logger-config'
-import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
 import { chatMessageRepository } from '@/lib/repositories/chat-message-repository';
 

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -21,7 +21,8 @@ import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
-import { canUserViewPage, canUserEditPage, getActorInfo } from '@pagespace/lib/server';
+import { canUserViewPage, canUserEditPage } from '@pagespace/lib/permissions/permissions'
+import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import {
   createAIProvider,
   updateUserProviderSettings,
@@ -60,7 +61,8 @@ import {
 } from '@/lib/ai/core';
 import { db, users, chatMessages, pages, drives, eq, and } from '@pagespace/db';
 import { createId } from '@paralleldrive/cuid2';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { maskIdentifier } from '@/lib/logging/mask';
 import { trackFeature } from '@pagespace/lib/monitoring/activity-tracker';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -21,7 +21,7 @@ import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
-import { canUserViewPage, canUserEditPage } from '@pagespace/lib/permissions/permissions'
+import { canUserViewPage, canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import {
   createAIProvider,
@@ -61,7 +61,7 @@ import {
 } from '@/lib/ai/core';
 import { db, users, chatMessages, pages, drives, eq, and } from '@pagespace/db';
 import { createId } from '@paralleldrive/cuid2';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { maskIdentifier } from '@/lib/logging/mask';
 import { trackFeature } from '@pagespace/lib/monitoring/activity-tracker';

--- a/apps/web/src/app/api/ai/global/[id]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/__tests__/route.test.ts
@@ -26,20 +26,24 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock logging (boundary)
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: {
       info: vi.fn(),
       error: vi.fn(),
       warn: vi.fn(),
     },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 // Test fixtures
 const mockUserId = 'user_123';

--- a/apps/web/src/app/api/ai/global/[id]/messages/[messageId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/[messageId]/__tests__/route.test.ts
@@ -32,15 +32,19 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock logging (boundary)
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: {
       info: vi.fn(),
       error: vi.fn(),
       warn: vi.fn(),
     },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
 // Mock logging mask (boundary)
@@ -58,7 +62,7 @@ vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 import { getActorInfo, logMessageActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 // Test fixtures
 const mockUserId = 'user_123';

--- a/apps/web/src/app/api/ai/global/[id]/messages/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/[messageId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { maskIdentifier } from '@/lib/logging/mask';
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 import { processMessageContentUpdate } from '@/lib/repositories/chat-message-repository';

--- a/apps/web/src/app/api/ai/global/[id]/messages/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/[messageId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { maskIdentifier } from '@/lib/logging/mask';
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -39,7 +39,8 @@ import {
 import { db, conversations, messages, drives, eq, and, desc, gt, lt } from '@pagespace/db';
 import { createId } from '@paralleldrive/cuid2';
 import { getMCPBridge } from '@/lib/mcp';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { maskIdentifier } from '@/lib/logging/mask';
 import type { MCPTool } from '@/types/mcp';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -39,7 +39,7 @@ import {
 import { db, conversations, messages, drives, eq, and, desc, gt, lt } from '@pagespace/db';
 import { createId } from '@paralleldrive/cuid2';
 import { getMCPBridge } from '@/lib/mcp';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { maskIdentifier } from '@/lib/logging/mask';
 import type { MCPTool } from '@/types/mcp';

--- a/apps/web/src/app/api/ai/global/[id]/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };

--- a/apps/web/src/app/api/ai/global/[id]/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 

--- a/apps/web/src/app/api/ai/global/[id]/usage/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/usage/__tests__/route.test.ts
@@ -27,15 +27,19 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock logging (boundary)
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: {
       info: vi.fn(),
       error: vi.fn(),
       warn: vi.fn(),
     },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
 // Mock AI monitoring (boundary)
@@ -48,7 +52,7 @@ import {
   calculateUsageSummary as mockedCalculateUsageSummary,
 } from '@/lib/repositories/global-conversation-repository';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getContextWindow } from '@pagespace/lib/monitoring/ai-monitoring';
 
 // Test fixtures

--- a/apps/web/src/app/api/ai/global/[id]/usage/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/usage/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { getContextWindow } from '@pagespace/lib/monitoring/ai-monitoring';
 import {

--- a/apps/web/src/app/api/ai/global/[id]/usage/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/usage/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { getContextWindow } from '@pagespace/lib/monitoring/ai-monitoring';
 import {
   globalConversationRepository,

--- a/apps/web/src/app/api/ai/global/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/global/__tests__/route.test.ts
@@ -25,20 +25,24 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock logging (boundary)
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: {
       info: vi.fn(),
       error: vi.fn(),
       warn: vi.fn(),
     },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 // Test fixtures
 const mockUserId = 'user_123';

--- a/apps/web/src/app/api/ai/global/active/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/global/active/__tests__/route.test.ts
@@ -24,20 +24,24 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock logging (boundary)
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: {
       info: vi.fn(),
       error: vi.fn(),
       warn: vi.fn(),
     },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 // Test fixtures
 const mockUserId = 'user_123';

--- a/apps/web/src/app/api/ai/global/active/route.ts
+++ b/apps/web/src/app/api/ai/global/active/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };

--- a/apps/web/src/app/api/ai/global/active/route.ts
+++ b/apps/web/src/app/api/ai/global/active/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 

--- a/apps/web/src/app/api/ai/global/route.ts
+++ b/apps/web/src/app/api/ai/global/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
 

--- a/apps/web/src/app/api/ai/global/route.ts
+++ b/apps/web/src/app/api/ai/global/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';

--- a/apps/web/src/app/api/ai/lmstudio/models/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/lmstudio/models/__tests__/route.test.ts
@@ -4,8 +4,8 @@ import { GET } from '../route';
 import type { SessionAuthResult, AuthError } from '@/lib/auth';
 
 // Mock dependencies
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     ai: {
       info: vi.fn(),
       error: vi.fn(),
@@ -13,6 +13,8 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -24,11 +26,11 @@ vi.mock('@/lib/ai/core', () => ({
   getUserLMStudioSettings: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/security', () => ({
+vi.mock('@pagespace/lib/security/url-validator', () => ({
   validateLocalProviderURL: vi.fn().mockResolvedValue({ valid: true, resolvedIPs: ['127.0.0.1'] }),
 }));
 
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { authenticateSessionRequest, isAuthError } from '@/lib/auth';
 import { getUserLMStudioSettings } from '@/lib/ai/core';
 

--- a/apps/web/src/app/api/ai/lmstudio/models/route.ts
+++ b/apps/web/src/app/api/ai/lmstudio/models/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 import { authenticateSessionRequest, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getUserLMStudioSettings } from '@/lib/ai/core';
-import { validateLocalProviderURL } from '@pagespace/lib/security';
+import { validateLocalProviderURL } from '@pagespace/lib/security/url-validator';
 
 /**
  * GET /api/ai/lmstudio/models

--- a/apps/web/src/app/api/ai/ollama/models/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/ollama/models/__tests__/route.test.ts
@@ -4,8 +4,8 @@ import { GET } from '../route';
 import type { SessionAuthResult, AuthError } from '@/lib/auth';
 
 // Mock dependencies
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     ai: {
       info: vi.fn(),
       error: vi.fn(),
@@ -13,6 +13,8 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -25,10 +27,10 @@ vi.mock('@/lib/ai/core', () => ({
 }));
 
 vi.mock('@pagespace/lib/security', () => ({
-  validateLocalProviderURL: vi.fn().mockResolvedValue({ valid: true, resolvedIPs: ['127.0.0.1'] }),
+    validateLocalProviderURL: vi.fn().mockResolvedValue({ valid: true, resolvedIPs: ['127.0.0.1'] }),
 }));
 
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { authenticateSessionRequest, isAuthError } from '@/lib/auth';
 import { getUserOllamaSettings } from '@/lib/ai/core';
 

--- a/apps/web/src/app/api/ai/ollama/models/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/ollama/models/__tests__/route.test.ts
@@ -26,8 +26,8 @@ vi.mock('@/lib/ai/core', () => ({
   getUserOllamaSettings: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/security', () => ({
-    validateLocalProviderURL: vi.fn().mockResolvedValue({ valid: true, resolvedIPs: ['127.0.0.1'] }),
+vi.mock('@pagespace/lib/security/url-validator', () => ({
+  validateLocalProviderURL: vi.fn().mockResolvedValue({ valid: true, resolvedIPs: ['127.0.0.1'] }),
 }));
 
 import { loggers } from '@pagespace/lib/logging/logger-config';

--- a/apps/web/src/app/api/ai/ollama/models/route.ts
+++ b/apps/web/src/app/api/ai/ollama/models/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 import { authenticateSessionRequest, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getUserOllamaSettings } from '@/lib/ai/core';
-import { validateLocalProviderURL } from '@pagespace/lib/security';
+import { validateLocalProviderURL } from '@pagespace/lib/security/url-validator';
 
 /**
  * GET /api/ai/ollama/models

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/config/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/config/__tests__/route.test.ts
@@ -26,15 +26,21 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock permissions (boundary)
-vi.mock('@pagespace/lib/server', () => ({
-  canUserEditPage: vi.fn(),
-  loggers: {
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    canUserEditPage: vi.fn(),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: {
       info: vi.fn(),
       error: vi.fn(),
     },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
 // Mock websocket broadcast (boundary)
@@ -84,7 +90,7 @@ vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
 
 import { pageAgentRepository } from '@/lib/repositories/page-agent-repository';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope } from '@/lib/auth';
-import { canUserEditPage } from '@pagespace/lib/server';
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { applyPageMutation } from '@/services/api/page-mutation-service';
 

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/config/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/config/route.ts
@@ -2,10 +2,11 @@ import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope } from '@/lib/auth';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
-import { canUserEditPage } from '@pagespace/lib/server';
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { pageSpaceTools } from '@/lib/ai/core';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { pageAgentRepository, type AgentConfigUpdate } from '@/lib/repositories/page-agent-repository';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import { applyPageMutation, PageRevisionMismatchError } from '@/services/api/page-mutation-service';

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/config/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/config/route.ts
@@ -5,7 +5,7 @@ const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { pageSpaceTools } from '@/lib/ai/core';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { pageAgentRepository, type AgentConfigUpdate } from '@/lib/repositories/page-agent-repository';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/__tests__/route.test.ts
@@ -30,20 +30,27 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock permissions (boundary)
-vi.mock('@pagespace/lib/server', () => ({
-  canUserEditPage: vi.fn(),
-  loggers: {
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    canUserEditPage: vi.fn(),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     ai: {
       info: vi.fn(),
       error: vi.fn(),
     },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
-import { canUserEditPage, loggers } from '@pagespace/lib/server';
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 // Test fixtures
 const mockUserId = 'user_123';

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/[messageId]/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
-import { canUserEditPage, loggers, auditRequest } from '@pagespace/lib/server';
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions'
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { maskIdentifier } from '@/lib/logging/mask';
 import {
   chatMessageRepository,

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/[messageId]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
-import { canUserEditPage } from '@pagespace/lib/permissions/permissions'
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { maskIdentifier } from '@/lib/logging/mask';
 import {

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
 import { db, chatMessages, pages, eq, and, desc, sql } from '@pagespace/db';
-import { canUserViewPage, loggers, auditRequest } from '@pagespace/lib/server';
+import { canUserViewPage } from '@pagespace/lib/permissions/permissions'
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { convertDbMessageToUIMessage } from '@/lib/ai/core';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
 

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
 import { db, chatMessages, pages, eq, and, desc, sql } from '@pagespace/db';
-import { canUserViewPage } from '@pagespace/lib/permissions/permissions'
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { convertDbMessageToUIMessage } from '@/lib/ai/core';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
-import { canUserEditPage, loggers, auditRequest } from '@pagespace/lib/server';
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions'
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
 
 // Auth options: PATCH and DELETE are write operations requiring CSRF protection

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
-import { canUserEditPage } from '@pagespace/lib/permissions/permissions'
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
 

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/__tests__/route.test.ts
@@ -43,15 +43,21 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock permissions (boundary)
-vi.mock('@pagespace/lib/server', () => ({
-  canUserViewPage: vi.fn(),
-  loggers: {
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    canUserViewPage: vi.fn(),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     ai: {
       info: vi.fn(),
       error: vi.fn(),
     },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
 // Mock ID generation
@@ -62,7 +68,8 @@ vi.mock('@paralleldrive/cuid2', () => ({
 
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
-import { canUserViewPage, loggers } from '@pagespace/lib/server';
+import { canUserViewPage } from '@pagespace/lib/permissions/permissions'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 // Test fixtures
 const mockUserId = 'user_123';

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 import { createId } from '@paralleldrive/cuid2';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
-import { canUserViewPage } from '@pagespace/lib/permissions/permissions'
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import {
   conversationRepository,

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from 'next/server';
 import { createId } from '@paralleldrive/cuid2';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
-import { canUserViewPage, loggers, auditRequest } from '@pagespace/lib/server';
+import { canUserViewPage } from '@pagespace/lib/permissions/permissions'
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import {
   conversationRepository,
   extractPreviewText,

--- a/apps/web/src/app/api/ai/page-agents/consult/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/route.ts
@@ -16,7 +16,7 @@ import {
   type ToolExecutionContext,
 } from '@/lib/ai/core';
 import { db, pages, drives, eq, chatMessages } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 /**

--- a/apps/web/src/app/api/ai/page-agents/consult/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { convertToModelMessages, generateText, stepCountIs, hasToolCall } from 'ai';
 import { finishTool, FINISH_TOOL_NAME } from '@/lib/ai/tools/finish-tool';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
-import { canUserViewPage } from '@pagespace/lib/server';
+import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
@@ -16,7 +16,8 @@ import {
   type ToolExecutionContext,
 } from '@/lib/ai/core';
 import { db, pages, drives, eq, chatMessages } from '@pagespace/db';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 /**
  * Format tool execution results into human-readable text

--- a/apps/web/src/app/api/ai/page-agents/create/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/create/__tests__/route.test.ts
@@ -28,15 +28,21 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock permissions (boundary)
-vi.mock('@pagespace/lib/server', () => ({
-  canUserEditPage: vi.fn(),
-  loggers: {
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    canUserEditPage: vi.fn(),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: {
       info: vi.fn(),
       error: vi.fn(),
     },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
 // Mock websocket broadcast (boundary)
@@ -63,7 +69,7 @@ vi.mock('@/lib/ai/core', () => ({
 
 import { pageAgentRepository } from '@/lib/repositories/page-agent-repository';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope } from '@/lib/auth';
-import { canUserEditPage } from '@pagespace/lib/server';
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 
 // Test fixtures

--- a/apps/web/src/app/api/ai/page-agents/create/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/create/route.ts
@@ -5,7 +5,7 @@ const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { pageSpaceTools } from '@/lib/ai/core';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { pageAgentRepository, type AgentData } from '@/lib/repositories/page-agent-repository';
 

--- a/apps/web/src/app/api/ai/page-agents/create/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/create/route.ts
@@ -2,10 +2,11 @@ import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope } from '@/lib/auth';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
-import { canUserEditPage } from '@pagespace/lib/server';
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { pageSpaceTools } from '@/lib/ai/core';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { pageAgentRepository, type AgentData } from '@/lib/repositories/page-agent-repository';
 
 /**

--- a/apps/web/src/app/api/ai/page-agents/multi-drive/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/multi-drive/route.ts
@@ -3,7 +3,9 @@ import { authenticateRequestWithOptions, isAuthError, getAllowedDriveIds } from 
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const };
 import { db, pages, drives, eq, and } from '@pagespace/db';
-import { getUserDriveAccess, canUserViewPage, loggers, auditRequest } from '@pagespace/lib/server';
+import { getUserDriveAccess, canUserViewPage } from '@pagespace/lib/permissions/permissions'
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 interface AgentSummary {
   id: string;

--- a/apps/web/src/app/api/ai/page-agents/multi-drive/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/multi-drive/route.ts
@@ -3,8 +3,8 @@ import { authenticateRequestWithOptions, isAuthError, getAllowedDriveIds } from 
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const };
 import { db, pages, drives, eq, and } from '@pagespace/db';
-import { getUserDriveAccess, canUserViewPage } from '@pagespace/lib/permissions/permissions'
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { getUserDriveAccess, canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 interface AgentSummary {

--- a/apps/web/src/app/api/ai/settings/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/settings/__tests__/route.test.ts
@@ -25,8 +25,8 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock logging (boundary)
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     ai: {
       info: vi.fn(),
       error: vi.fn(),
@@ -34,7 +34,11 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
 // Mock AI provider settings functions (boundary)
@@ -79,7 +83,7 @@ vi.mock('@/lib/subscription/rate-limit-middleware', () => ({
 
 import { aiSettingsRepository } from '@/lib/repositories/ai-settings-repository';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import {
   getDefaultPageSpaceSettings,
   getUserOpenRouterSettings,

--- a/apps/web/src/app/api/ai/settings/route.ts
+++ b/apps/web/src/app/api/ai/settings/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import {
   getUserOpenRouterSettings,
   createOpenRouterSettings,
@@ -37,7 +38,7 @@ import {
 import { ONPREM_ALLOWED_PROVIDERS } from '@/lib/ai/core/ai-providers-config';
 import { aiSettingsRepository } from '@/lib/repositories/ai-settings-repository';
 import { requiresProSubscription } from '@/lib/subscription/rate-limit-middleware';
-import { isOnPrem } from '@pagespace/lib';
+import { isOnPrem } from '@pagespace/lib/deployment-mode';
 
 function isProviderBlocked(provider: string): boolean {
   return isOnPrem() && !ONPREM_ALLOWED_PROVIDERS.has(provider);

--- a/apps/web/src/app/api/ai/settings/route.ts
+++ b/apps/web/src/app/api/ai/settings/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import {
   getUserOpenRouterSettings,

--- a/apps/web/src/app/api/integrations/connections/[connectionId]/grants/route.ts
+++ b/apps/web/src/app/api/integrations/connections/[connectionId]/grants/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
-import { getConnectionById } from '@pagespace/lib/integrations/repositories/connection-repository'
+import { getConnectionById } from '@pagespace/lib/integrations/repositories/connection-repository';
 import { listGrantsByConnection } from '@pagespace/lib/integrations/repositories/grant-repository';
 import { getDriveAccess } from '@pagespace/lib/services/drive-service';
 

--- a/apps/web/src/app/api/integrations/connections/[connectionId]/grants/route.ts
+++ b/apps/web/src/app/api/integrations/connections/[connectionId]/grants/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db } from '@pagespace/db';
-import { loggers, auditRequest } from '@pagespace/lib/server';
-import { getConnectionById, listGrantsByConnection } from '@pagespace/lib/integrations';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { getConnectionById } from '@pagespace/lib/integrations/repositories/connection-repository'
+import { listGrantsByConnection } from '@pagespace/lib/integrations/repositories/grant-repository';
 import { getDriveAccess } from '@pagespace/lib/services/drive-service';
 
 const AUTH_OPTIONS = { allow: ['session'] as const };

--- a/apps/web/src/app/api/integrations/google-calendar/calendars/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/calendars/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { isOnPrem } from '@pagespace/lib';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { getValidAccessToken } from '@/lib/integrations/google-calendar/token-refresh';
 import { listCalendars } from '@/lib/integrations/google-calendar/api-client';
 

--- a/apps/web/src/app/api/integrations/google-calendar/calendars/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/calendars/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { isOnPrem } from '@pagespace/lib';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { getValidAccessToken } from '@/lib/integrations/google-calendar/token-refresh';
 import { listCalendars } from '@/lib/integrations/google-calendar/api-client';

--- a/apps/web/src/app/api/integrations/google-calendar/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/callback/__tests__/route.test.ts
@@ -31,17 +31,17 @@ vi.mock('@pagespace/db', () => ({
   googleCalendarConnections: { userId: 'userId' },
 }));
 
-vi.mock('@pagespace/lib', () => ({
-  isOnPrem: () => false,
+vi.mock('@pagespace/lib/deployment-mode', () => ({
+  isOnPrem: vi.fn().mockReturnValue(false),
+}));
+vi.mock('@pagespace/lib/encryption', () => ({
   encrypt: vi.fn().mockResolvedValue('encrypted'),
+}));
+vi.mock('@pagespace/lib/auth/secure-compare', () => ({
   secureCompare: (a: string, b: string) => a === b,
 }));
 
-vi.mock('@pagespace/lib/server', async () => {
-  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
-    '@pagespace/lib/audit/mask-email'
-  );
-  return {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
     loggers: {
       auth: {
         error: vi.fn(),
@@ -50,10 +50,12 @@ vi.mock('@pagespace/lib/server', async () => {
         debug: vi.fn(),
       },
     },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
     auditRequest: vi.fn(),
-    maskEmail,
-  };
-});
+}));
 
 vi.mock('@/lib/integrations/google-calendar/return-url', () => ({
   GOOGLE_CALENDAR_DEFAULT_RETURN_PATH: '/settings',
@@ -61,7 +63,7 @@ vi.mock('@/lib/integrations/google-calendar/return-url', () => ({
 }));
 
 import { GET } from '../route';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 const SECRET = 'test-oauth-state-secret';
 

--- a/apps/web/src/app/api/integrations/google-calendar/callback/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/callback/route.ts
@@ -1,10 +1,13 @@
 import { NextResponse } from 'next/server';
 import { db, googleCalendarConnections } from '@pagespace/db';
-import { loggers, auditRequest, maskEmail } from '@pagespace/lib/server';
-import { encrypt, isOnPrem } from '@pagespace/lib';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { maskEmail } from '@pagespace/lib/audit/mask-email';
+import { encrypt } from '@pagespace/lib/encryption';
+import { isOnPrem } from '@pagespace/lib/deployment-mode';
 import { OAuth2Client } from 'google-auth-library';
 import crypto from 'crypto';
-import { secureCompare } from '@pagespace/lib';
+import { secureCompare } from '@pagespace/lib/auth/secure-compare';
 import {
   GOOGLE_CALENDAR_DEFAULT_RETURN_PATH,
   normalizeGoogleCalendarReturnPath,

--- a/apps/web/src/app/api/integrations/google-calendar/callback/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/callback/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db, googleCalendarConnections } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/logging/logger-config'
-import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { maskEmail } from '@pagespace/lib/audit/mask-email';
 import { encrypt } from '@pagespace/lib/encryption';
 import { isOnPrem } from '@pagespace/lib/deployment-mode';

--- a/apps/web/src/app/api/integrations/google-calendar/connect/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/connect/route.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod/v4';
 import { db, users, eq } from '@pagespace/db';
 import { isOnPrem } from '@pagespace/lib/deployment-mode';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security/distributed-rate-limit';
 import { authenticateRequestWithOptions, isAuthError, getClientIP } from '@/lib/auth';

--- a/apps/web/src/app/api/integrations/google-calendar/connect/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/connect/route.ts
@@ -1,8 +1,9 @@
 import { z } from 'zod/v4';
 import { db, users, eq } from '@pagespace/db';
-import { isOnPrem } from '@pagespace/lib';
-import { loggers, auditRequest } from '@pagespace/lib/server';
-import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security';
+import { isOnPrem } from '@pagespace/lib/deployment-mode';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security/distributed-rate-limit';
 import { authenticateRequestWithOptions, isAuthError, getClientIP } from '@/lib/auth';
 import crypto from 'crypto';
 import { normalizeGoogleCalendarReturnPath } from '@/lib/integrations/google-calendar/return-url';

--- a/apps/web/src/app/api/integrations/google-calendar/disconnect/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/disconnect/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from 'next/server';
 import { db, googleCalendarConnections, eq } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { decrypt, isOnPrem } from '@pagespace/lib';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { decrypt } from '@pagespace/lib/encryption';
+import { isOnPrem } from '@pagespace/lib/deployment-mode';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { unregisterWebhookChannels } from '@/lib/integrations/google-calendar/sync-service';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/integrations/google-calendar/disconnect/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/disconnect/route.ts
@@ -3,7 +3,7 @@ import { db, googleCalendarConnections, eq } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { decrypt } from '@pagespace/lib/encryption';
 import { isOnPrem } from '@pagespace/lib/deployment-mode';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { unregisterWebhookChannels } from '@/lib/integrations/google-calendar/sync-service';
 

--- a/apps/web/src/app/api/integrations/google-calendar/settings/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/settings/route.ts
@@ -3,7 +3,8 @@ import { z } from 'zod/v4';
 import { db, googleCalendarConnections, calendarEvents, eq, and, count } from '@pagespace/db';
 import { isOnPrem } from '@pagespace/lib';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/integrations/google-calendar/settings/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/settings/route.ts
@@ -3,7 +3,7 @@ import { z } from 'zod/v4';
 import { db, googleCalendarConnections, calendarEvents, eq, and, count } from '@pagespace/db';
 import { isOnPrem } from '@pagespace/lib';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };

--- a/apps/web/src/app/api/integrations/google-calendar/status/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/status/route.ts
@@ -2,7 +2,8 @@ import { NextResponse } from 'next/server';
 import { db, googleCalendarConnections, calendarEvents, eq, and, count } from '@pagespace/db';
 import { isOnPrem } from '@pagespace/lib';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
 

--- a/apps/web/src/app/api/integrations/google-calendar/status/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/status/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { db, googleCalendarConnections, calendarEvents, eq, and, count } from '@pagespace/db';
 import { isOnPrem } from '@pagespace/lib';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };

--- a/apps/web/src/app/api/integrations/google-calendar/sync/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/sync/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from 'next/server';
 import { isOnPrem } from '@pagespace/lib';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
-import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security/distributed-rate-limit';
 import { syncGoogleCalendar } from '@/lib/integrations/google-calendar/sync-service';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/integrations/google-calendar/sync/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/sync/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { isOnPrem } from '@pagespace/lib';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security/distributed-rate-limit';
 import { syncGoogleCalendar } from '@/lib/integrations/google-calendar/sync-service';

--- a/apps/web/src/app/api/integrations/google-calendar/webhook/__tests__/route.test.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/webhook/__tests__/route.test.ts
@@ -9,14 +9,16 @@ vi.mock('@/lib/integrations/google-calendar/sync-service', () => ({
 }));
 
 // Mock loggers
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: {
       info: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 // Mock next/server after() - it executes the callback synchronously in tests

--- a/apps/web/src/app/api/integrations/google-calendar/webhook/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/webhook/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse, after } from 'next/server';
-import { isOnPrem } from '@pagespace/lib';
-import { loggers } from '@pagespace/lib/server';
+import { isOnPrem } from '@pagespace/lib/deployment-mode';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { syncGoogleCalendar } from '@/lib/integrations/google-calendar/sync-service';
 import { validateWebhookAuth } from '@/lib/integrations/google-calendar/webhook-auth';
 

--- a/apps/web/src/app/api/integrations/providers/[providerId]/route.ts
+++ b/apps/web/src/app/api/integrations/providers/[providerId]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authenticateRequestWithOptions, isAuthError, verifyAdminAuth } from '@/lib/auth';
 import { db } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { getProviderById, updateProvider, deleteProvider, countProviderConnections } from '@pagespace/lib/integrations/repositories/provider-repository';
 

--- a/apps/web/src/app/api/integrations/providers/[providerId]/route.ts
+++ b/apps/web/src/app/api/integrations/providers/[providerId]/route.ts
@@ -2,13 +2,9 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authenticateRequestWithOptions, isAuthError, verifyAdminAuth } from '@/lib/auth';
 import { db } from '@pagespace/db';
-import { loggers, auditRequest } from '@pagespace/lib/server';
-import {
-  getProviderById,
-  updateProvider,
-  deleteProvider,
-  countProviderConnections,
-} from '@pagespace/lib/integrations';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { getProviderById, updateProvider, deleteProvider, countProviderConnections } from '@pagespace/lib/integrations/repositories/provider-repository';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/integrations/providers/available/route.ts
+++ b/apps/web/src/app/api/integrations/providers/available/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db } from '@pagespace/db';
-import { loggers, auditRequest } from '@pagespace/lib/server';
-import { builtinProviderList, listEnabledProviders } from '@pagespace/lib/integrations';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { builtinProviderList } from '@pagespace/lib/integrations/providers'
+import { listEnabledProviders } from '@pagespace/lib/integrations/repositories/provider-repository';
 
 const AUTH_OPTIONS = { allow: ['session'] as const };
 

--- a/apps/web/src/app/api/integrations/providers/available/route.ts
+++ b/apps/web/src/app/api/integrations/providers/available/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
-import { builtinProviderList } from '@pagespace/lib/integrations/providers'
+import { builtinProviderList } from '@pagespace/lib/integrations/providers';
 import { listEnabledProviders } from '@pagespace/lib/integrations/repositories/provider-repository';
 
 const AUTH_OPTIONS = { allow: ['session'] as const };

--- a/apps/web/src/app/api/integrations/providers/import-openapi/route.ts
+++ b/apps/web/src/app/api/integrations/providers/import-openapi/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authenticateRequestWithOptions, isAuthError, verifyAdminAuth } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { importOpenAPISpec } from '@pagespace/lib/integrations/converter/openapi';
 

--- a/apps/web/src/app/api/integrations/providers/import-openapi/route.ts
+++ b/apps/web/src/app/api/integrations/providers/import-openapi/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authenticateRequestWithOptions, isAuthError, verifyAdminAuth } from '@/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
-import { importOpenAPISpec } from '@pagespace/lib/integrations';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { importOpenAPISpec } from '@pagespace/lib/integrations/converter/openapi';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 

--- a/apps/web/src/app/api/integrations/providers/install/route.ts
+++ b/apps/web/src/app/api/integrations/providers/install/route.ts
@@ -2,12 +2,10 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { verifyAdminAuth, isAdminAuthError } from '@/lib/auth';
 import { db } from '@pagespace/db';
-import { loggers, auditRequest } from '@pagespace/lib/server';
-import {
-  getBuiltinProvider,
-  getProviderBySlug,
-  createProvider,
-} from '@pagespace/lib/integrations';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { getBuiltinProvider } from '@pagespace/lib/integrations/providers'
+import { getProviderBySlug, createProvider } from '@pagespace/lib/integrations/repositories/provider-repository';
 
 const installSchema = z.object({
   builtinId: z.string().min(1),

--- a/apps/web/src/app/api/integrations/providers/install/route.ts
+++ b/apps/web/src/app/api/integrations/providers/install/route.ts
@@ -2,9 +2,9 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { verifyAdminAuth, isAdminAuthError } from '@/lib/auth';
 import { db } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
-import { getBuiltinProvider } from '@pagespace/lib/integrations/providers'
+import { getBuiltinProvider } from '@pagespace/lib/integrations/providers';
 import { getProviderBySlug, createProvider } from '@pagespace/lib/integrations/repositories/provider-repository';
 
 const installSchema = z.object({

--- a/apps/web/src/app/api/integrations/providers/route.ts
+++ b/apps/web/src/app/api/integrations/providers/route.ts
@@ -2,9 +2,9 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authenticateRequestWithOptions, isAuthError, verifyAdminAuth } from '@/lib/auth';
 import { db } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
-import { listEnabledProviders, createProvider, seedBuiltinProviders, refreshBuiltinProviders } from '@pagespace/lib/integrations/repositories/provider-repository'
+import { listEnabledProviders, createProvider, seedBuiltinProviders, refreshBuiltinProviders } from '@pagespace/lib/integrations/repositories/provider-repository';
 import { builtinProviderList } from '@pagespace/lib/integrations/providers';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const };

--- a/apps/web/src/app/api/integrations/providers/route.ts
+++ b/apps/web/src/app/api/integrations/providers/route.ts
@@ -2,8 +2,10 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authenticateRequestWithOptions, isAuthError, verifyAdminAuth } from '@/lib/auth';
 import { db } from '@pagespace/db';
-import { loggers, auditRequest } from '@pagespace/lib/server';
-import { listEnabledProviders, createProvider, seedBuiltinProviders, refreshBuiltinProviders, builtinProviderList } from '@pagespace/lib/integrations';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { listEnabledProviders, createProvider, seedBuiltinProviders, refreshBuiltinProviders } from '@pagespace/lib/integrations/repositories/provider-repository'
+import { builtinProviderList } from '@pagespace/lib/integrations/providers';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/lib/ai/core/__tests__/integration-tool-resolver.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/integration-tool-resolver.test.ts
@@ -12,26 +12,40 @@ vi.mock('@pagespace/db', () => ({
   db: {},
 }));
 
-vi.mock('@pagespace/lib/integrations', () => ({
+vi.mock('@pagespace/lib/integrations/resolution/resolve-agent-integrations', () => ({
   resolveAgentIntegrations: vi.fn(),
   resolveGlobalAssistantIntegrations: vi.fn(),
+}));
+vi.mock('@pagespace/lib/integrations/converter/ai-sdk', () => ({
   convertIntegrationToolsToAISDK: vi.fn(),
+}));
+vi.mock('@pagespace/lib/integrations/saga/execute-tool', () => ({
   createToolExecutor: vi.fn(),
+}));
+vi.mock('@pagespace/lib/integrations/repositories/connection-repository', () => ({
   getConnectionWithProvider: vi.fn(),
-  logAuditEntry: vi.fn(),
-  listGrantsByAgent: vi.fn(),
   listUserConnections: vi.fn(),
   listDriveConnections: vi.fn(),
+}));
+vi.mock('@pagespace/lib/integrations/repositories/audit-repository', () => ({
+  logAuditEntry: vi.fn(),
+}));
+vi.mock('@pagespace/lib/integrations/repositories/grant-repository', () => ({
+  listGrantsByAgent: vi.fn(),
+}));
+vi.mock('@pagespace/lib/integrations/repositories/config-repository', () => ({
   getConfig: vi.fn(),
 }));
 
 import {
   resolveAgentIntegrations,
   resolveGlobalAssistantIntegrations,
+} from '@pagespace/lib/integrations/resolution/resolve-agent-integrations';
+import {
   convertIntegrationToolsToAISDK,
-  createToolExecutor,
   type GrantWithConnectionAndProvider,
-} from '@pagespace/lib/integrations';
+} from '@pagespace/lib/integrations/converter/ai-sdk';
+import { createToolExecutor } from '@pagespace/lib/integrations/saga/execute-tool';
 import { resolvePageAgentIntegrationTools, resolveGlobalAssistantIntegrationTools } from '../integration-tool-resolver';
 
 const mockResolveAgentIntegrations = vi.mocked(resolveAgentIntegrations);

--- a/apps/web/src/lib/ai/core/__tests__/mention-processor.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/mention-processor.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     ai: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 import {

--- a/apps/web/src/lib/ai/core/__tests__/provider-factory.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/provider-factory.test.ts
@@ -64,7 +64,7 @@ vi.mock('ollama-ai-provider-v2', () => ({
 }));
 
 // Mock security validation
-vi.mock('@pagespace/lib/security', () => ({
+vi.mock('@pagespace/lib/security/url-validator', () => ({
   validateLocalProviderURL: vi.fn(),
 }));
 
@@ -128,7 +128,7 @@ import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createXai } from '@ai-sdk/xai';
 import { createOllama } from 'ollama-ai-provider-v2';
-import { validateLocalProviderURL } from '@pagespace/lib/security';
+import { validateLocalProviderURL } from '@pagespace/lib/security/url-validator';
 
 const mockDb = vi.mocked(db);
 const mockDbMock = mockDb as unknown as MockDb;

--- a/apps/web/src/lib/ai/core/agent-awareness.ts
+++ b/apps/web/src/lib/ai/core/agent-awareness.ts
@@ -6,7 +6,8 @@
  */
 
 import { db, pages, drives, eq, and } from '@pagespace/db';
-import { getUserDriveAccess, canUserViewPage, loggers } from '@pagespace/lib/server';
+import { getUserDriveAccess, canUserViewPage } from '@pagespace/lib/permissions/permissions'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 interface DriveAgent {
   id: string;

--- a/apps/web/src/lib/ai/core/agent-awareness.ts
+++ b/apps/web/src/lib/ai/core/agent-awareness.ts
@@ -6,7 +6,7 @@
  */
 
 import { db, pages, drives, eq, and } from '@pagespace/db';
-import { getUserDriveAccess, canUserViewPage } from '@pagespace/lib/permissions/permissions'
+import { getUserDriveAccess, canUserViewPage } from '@pagespace/lib/permissions/permissions';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 
 interface DriveAgent {

--- a/apps/web/src/lib/ai/core/ai-utils.ts
+++ b/apps/web/src/lib/ai/core/ai-utils.ts
@@ -1,7 +1,7 @@
 import { db, userAiSettings, eq, and } from '@pagespace/db';
-import { decrypt } from '@pagespace/lib/server';
+import { decrypt } from '@pagespace/lib/encryption';
 import { createId } from '@paralleldrive/cuid2';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { maskIdentifier } from '@/lib/logging/mask';
 
 const aiLogger = loggers.ai.child({ module: 'ai-utils' });

--- a/apps/web/src/lib/ai/core/integration-tool-resolver.ts
+++ b/apps/web/src/lib/ai/core/integration-tool-resolver.ts
@@ -9,21 +9,26 @@ import { db } from '@pagespace/db';
 import {
   resolveAgentIntegrations,
   resolveGlobalAssistantIntegrations,
+  type ResolutionDependencies,
+} from '@pagespace/lib/integrations/resolution/resolve-agent-integrations';
+import {
   convertIntegrationToolsToAISDK,
+  type CoreTool,
+  type GrantWithConnectionAndProvider,
+} from '@pagespace/lib/integrations/converter/ai-sdk';
+import {
   createToolExecutor,
+  type ExecuteToolDependencies,
+} from '@pagespace/lib/integrations/saga/execute-tool';
+import {
   getConnectionWithProvider,
-  logAuditEntry,
-  listGrantsByAgent,
   listUserConnections,
   listDriveConnections,
-  getConfig,
-  type CoreTool,
-  type DriveRole,
-  type ResolutionDependencies,
-  type ExecuteToolDependencies,
-  type GrantWithConnectionAndProvider,
-  type GlobalAssistantConfigData,
-} from '@pagespace/lib/integrations';
+} from '@pagespace/lib/integrations/repositories/connection-repository';
+import { logAuditEntry } from '@pagespace/lib/integrations/repositories/audit-repository';
+import { listGrantsByAgent } from '@pagespace/lib/integrations/repositories/grant-repository';
+import { getConfig } from '@pagespace/lib/integrations/repositories/config-repository';
+import { type DriveRole, type GlobalAssistantConfigData } from '@pagespace/lib/integrations/types';
 
 /** The connection type expected by the tool executor's loadConnection dependency. */
 type LoadConnectionResult = ExecuteToolDependencies['loadConnection'] extends

--- a/apps/web/src/lib/ai/core/mention-processor.ts
+++ b/apps/web/src/lib/ai/core/mention-processor.ts
@@ -6,7 +6,7 @@
  * mention format: @[Label](id:type) and returns the IDs for processing.
  */
 
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 export interface ProcessedMention {
   id: string;

--- a/apps/web/src/lib/ai/core/message-utils.ts
+++ b/apps/web/src/lib/ai/core/message-utils.ts
@@ -5,7 +5,7 @@ import {
   type DynamicToolUIPart,
 } from 'ai';
 import { db, chatMessages, messages } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 /** Narrow a UIMessage part to TextUIPart */
 function isTextPart(part: { type: string }): part is TextUIPart {

--- a/apps/web/src/lib/ai/core/model-capabilities.ts
+++ b/apps/web/src/lib/ai/core/model-capabilities.ts
@@ -1,4 +1,4 @@
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { hasVisionCapability } from './vision-models';
 
 const capabilityLogger = loggers.ai.child({ module: 'model-capabilities' });

--- a/apps/web/src/lib/ai/core/page-tree-context.ts
+++ b/apps/web/src/lib/ai/core/page-tree-context.ts
@@ -6,7 +6,7 @@
  */
 
 import { db, pages, drives, eq, and, asc } from '@pagespace/db';
-import { getUserDriveAccess } from '@pagespace/lib/permissions/permissions'
+import { getUserDriveAccess } from '@pagespace/lib/permissions/permissions';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { buildTree, formatTreeAsMarkdown, filterToSubtree } from '@pagespace/lib/content/tree-utils';
 

--- a/apps/web/src/lib/ai/core/page-tree-context.ts
+++ b/apps/web/src/lib/ai/core/page-tree-context.ts
@@ -6,8 +6,9 @@
  */
 
 import { db, pages, drives, eq, and, asc } from '@pagespace/db';
-import { getUserDriveAccess, loggers } from '@pagespace/lib/server';
-import { buildTree, formatTreeAsMarkdown, filterToSubtree } from '@pagespace/lib';
+import { getUserDriveAccess } from '@pagespace/lib/permissions/permissions'
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { buildTree, formatTreeAsMarkdown, filterToSubtree } from '@pagespace/lib/content/tree-utils';
 
 interface TreeNode {
   id: string;

--- a/apps/web/src/lib/ai/tools/__tests__/activity-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/activity-tools.test.ts
@@ -2,22 +2,22 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { z } from 'zod';
 
 // Mock boundaries
-vi.mock('@pagespace/lib', () => ({
-  isUserDriveMember: vi.fn(),
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    isUserDriveMember: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/content', () => ({
-  groupActivitiesForDiff: vi.fn(),
-  generateStackedDiff: vi.fn(),
-  truncateDiffsToTokenBudget: vi.fn(),
+    groupActivitiesForDiff: vi.fn(),
+    generateStackedDiff: vi.fn(),
+    truncateDiffsToTokenBudget: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  readPageContent: vi.fn(),
+vi.mock('@pagespace/lib/services/page-content-store', () => ({
+    readPageContent: vi.fn(),
 }));
 
 import { activityTools } from '../activity-tools';
-import { isUserDriveMember } from '@pagespace/lib';
+import { isUserDriveMember } from '@pagespace/lib/permissions/permissions';
 import type { ToolExecutionContext } from '../../core';
 
 const mockIsUserDriveMember = vi.mocked(isUserDriveMember);

--- a/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
@@ -19,9 +19,11 @@ vi.mock('@pagespace/db', () => ({
   sql: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  canUserViewPage: vi.fn(),
-  loggers: {
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    canUserViewPage: vi.fn(),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     ai: {
       info: vi.fn(),
       warn: vi.fn(),
@@ -29,6 +31,8 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 vi.mock('ai', () => ({
@@ -79,7 +83,7 @@ vi.mock('../../core', () => ({
 
 import { agentCommunicationTools } from '../agent-communication-tools';
 import { db } from '@pagespace/db';
-import { canUserViewPage } from '@pagespace/lib/server';
+import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
 import { createAIProvider, saveMessageToDatabase } from '../../core';
 import type { ToolExecutionContext } from '../../core';
 import { generateText } from 'ai';

--- a/apps/web/src/lib/ai/tools/__tests__/agent-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/agent-tools.test.ts
@@ -2,13 +2,17 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ToolExecutionContext } from '../../core';
 
 // Mock repository seams - the proper boundary for tests
-vi.mock('@pagespace/lib/server', () => ({
-  canUserEditPage: vi.fn(),
-  getActorInfo: vi.fn().mockResolvedValue({
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    canUserEditPage: vi.fn(),
+}));
+vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
+    getActorInfo: vi.fn().mockResolvedValue({
     actorEmail: 'test@example.com',
     actorDisplayName: 'Test User',
   }),
-  loggers: {
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     ai: {
       child: vi.fn(() => ({
         info: vi.fn(),
@@ -18,7 +22,10 @@ vi.mock('@pagespace/lib/server', () => ({
       })),
     },
   },
-  agentRepository: {
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/repositories', () => ({
+    agentRepository: {
     findById: vi.fn(),
   },
 }));
@@ -45,7 +52,8 @@ vi.mock('../../core', () => ({
 }));
 
 import { agentTools } from '../agent-tools';
-import { canUserEditPage, agentRepository } from '@pagespace/lib/server';
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions'
+import { agentRepository } from '@pagespace/lib/repositories';
 import { broadcastPageEvent } from '@/lib/websocket';
 import { applyPageMutation } from '@/services/api/page-mutation-service';
 

--- a/apps/web/src/lib/ai/tools/__tests__/agent-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/agent-tools.test.ts
@@ -52,7 +52,7 @@ vi.mock('../../core', () => ({
 }));
 
 import { agentTools } from '../agent-tools';
-import { canUserEditPage } from '@pagespace/lib/permissions/permissions'
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { agentRepository } from '@pagespace/lib/repositories';
 import { broadcastPageEvent } from '@/lib/websocket';
 import { applyPageMutation } from '@/services/api/page-mutation-service';

--- a/apps/web/src/lib/ai/tools/__tests__/calendar-read-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/calendar-read-tools.test.ts
@@ -40,12 +40,12 @@ vi.mock('@pagespace/db', () => ({
   not: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib', () => ({
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
   isUserDriveMember: vi.fn(),
   getDriveIdsForUser: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
   loggers: {
     ai: {
       child: vi.fn(() => ({
@@ -56,6 +56,7 @@ vi.mock('@pagespace/lib/server', () => ({
       })),
     },
   },
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 vi.mock('@/lib/logging/mask', () => ({
@@ -64,7 +65,7 @@ vi.mock('@/lib/logging/mask', () => ({
 
 import { calendarReadTools } from '../calendar-read-tools';
 import { db } from '@pagespace/db';
-import { isUserDriveMember, getDriveIdsForUser } from '@pagespace/lib';
+import { isUserDriveMember, getDriveIdsForUser } from '@pagespace/lib/permissions/permissions';
 import type { ToolExecutionContext } from '../../core';
 
 const mockDb = vi.mocked(db);

--- a/apps/web/src/lib/ai/tools/__tests__/calendar-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/calendar-write-tools.test.ts
@@ -140,7 +140,7 @@ vi.mock('chrono-node', () => ({
 
 import { calendarWriteTools } from '../calendar-write-tools';
 import { db, inArray } from '@pagespace/db';
-import { isUserDriveMember } from '@pagespace/lib';
+import { isUserDriveMember } from '@pagespace/lib/permissions/permissions';
 import { getDriveMemberUserIds } from '@pagespace/lib/services/drive-member-service';
 import { broadcastCalendarEvent } from '@/lib/websocket/calendar-events';
 import type { ToolExecutionContext } from '../../core';

--- a/apps/web/src/lib/ai/tools/__tests__/calendar-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/calendar-write-tools.test.ts
@@ -54,13 +54,15 @@ vi.mock('@pagespace/db', () => ({
   inArray: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib', () => ({
-  isUserDriveMember: vi.fn(),
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    isUserDriveMember: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  getDriveMemberUserIds: vi.fn(),
-  loggers: {
+vi.mock('@pagespace/lib/services/drive-member-service', () => ({
+    getDriveMemberUserIds: vi.fn(),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     ai: {
       child: vi.fn(() => ({
         info: vi.fn(),
@@ -70,6 +72,7 @@ vi.mock('@pagespace/lib/server', () => ({
       })),
     },
   },
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 vi.mock('@/lib/websocket/calendar-events', () => ({
@@ -138,7 +141,7 @@ vi.mock('chrono-node', () => ({
 import { calendarWriteTools } from '../calendar-write-tools';
 import { db, inArray } from '@pagespace/db';
 import { isUserDriveMember } from '@pagespace/lib';
-import { getDriveMemberUserIds } from '@pagespace/lib/server';
+import { getDriveMemberUserIds } from '@pagespace/lib/services/drive-member-service';
 import { broadcastCalendarEvent } from '@/lib/websocket/calendar-events';
 import type { ToolExecutionContext } from '../../core';
 

--- a/apps/web/src/lib/ai/tools/__tests__/channel-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/channel-tools.test.ts
@@ -31,17 +31,19 @@ vi.mock('@pagespace/db', () => ({
   and: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/permissions', () => ({
-  canUserEditPage: vi.fn(),
-  canUserViewPage: vi.fn(),
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    canUserEditPage: vi.fn(),
+    canUserViewPage: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  getActorInfo: vi.fn().mockResolvedValue({
+vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
+    getActorInfo: vi.fn().mockResolvedValue({
     actorEmail: 'test@example.com',
     actorDisplayName: 'Test User',
   }),
-  loggers: {
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     ai: {
       child: vi.fn(() => ({
         info: vi.fn(),
@@ -51,6 +53,7 @@ vi.mock('@pagespace/lib/server', () => ({
       })),
     },
   },
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 vi.mock('@pagespace/lib/auth/broadcast-auth', () => ({
@@ -73,8 +76,8 @@ vi.mock('@/lib/logging/mask', () => ({
 }));
 
 import { channelTools } from '../channel-tools';
-import { canUserEditPage, canUserViewPage } from '@pagespace/lib/permissions';
-import { getActorInfo } from '@pagespace/lib/server';
+import { canUserEditPage, canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import { db } from '@pagespace/db';
 import { broadcastInboxEvent } from '@/lib/websocket/socket-utils';
 import type { ToolExecutionContext } from '../../core';

--- a/apps/web/src/lib/ai/tools/__tests__/drive-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/drive-tools.test.ts
@@ -12,8 +12,8 @@ vi.mock('@pagespace/db', () => ({
   and: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     ai: {
       child: vi.fn(() => ({
         info: vi.fn(),
@@ -23,6 +23,7 @@ vi.mock('@pagespace/lib/server', () => ({
       })),
     },
   },
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 vi.mock('@/lib/websocket', () => ({

--- a/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
@@ -56,9 +56,8 @@ vi.mock('@pagespace/lib/permissions/permissions', () => ({
     canUserViewPage: vi.fn(),
 }));
 vi.mock('@pagespace/lib/content/page-types.config', () => ({
-    isDocumentPage: vi.fn((type) => type === 'DOCUMENT'),
-    isAIChatPage: vi.fn((type) => type === 'AI_CHAT'),
-    getCreatablePageTypes: vi.fn(() => ['FOLDER', 'DOCUMENT', 'CHANNEL', 'AI_CHAT', 'CANVAS', 'SHEET', 'TASK_LIST', 'CODE']),
+    getPageTypeEmoji: vi.fn((type: string) => '📄'),
+    isFolderPage: vi.fn((type: string) => type === 'FOLDER'),
 }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
     loggers: {

--- a/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
@@ -81,14 +81,6 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   },
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
-vi.mock('@pagespace/lib/server', () => ({
-    isChannelPage: vi.fn((type) => type === 'CHANNEL'),
-    formatContentForAI: vi.fn((content) => content),
-    formatSheetForAI: vi.fn(),
-    formatTaskListForAI: vi.fn(),
-    getPagePath: vi.fn().mockResolvedValue('/drive/page'),
-}));
-
 vi.mock('@/lib/logging/mask', () => ({
   maskIdentifier: vi.fn((id) => `***${id?.slice(-4) || ''}`),
 }));

--- a/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
@@ -49,20 +49,19 @@ vi.mock('@pagespace/db', () => ({
   min: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  getUserDriveAccess: vi.fn(),
-  getUserAccessLevel: vi.fn(),
-  getUserAccessiblePagesInDriveWithDetails: vi.fn(),
-  canUserViewPage: vi.fn(),
-  isDocumentPage: vi.fn((type) => type === 'DOCUMENT'),
-  isAIChatPage: vi.fn((type) => type === 'AI_CHAT'),
-  isChannelPage: vi.fn((type) => type === 'CHANNEL'),
-  getCreatablePageTypes: vi.fn(() => ['FOLDER', 'DOCUMENT', 'CHANNEL', 'AI_CHAT', 'CANVAS', 'SHEET', 'TASK_LIST', 'CODE']),
-  formatContentForAI: vi.fn((content) => content),
-  formatSheetForAI: vi.fn(),
-  formatTaskListForAI: vi.fn(),
-  getPagePath: vi.fn().mockResolvedValue('/drive/page'),
-  loggers: {
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    getUserDriveAccess: vi.fn(),
+    getUserAccessLevel: vi.fn(),
+    getUserAccessiblePagesInDriveWithDetails: vi.fn(),
+    canUserViewPage: vi.fn(),
+}));
+vi.mock('@pagespace/lib/content/page-types.config', () => ({
+    isDocumentPage: vi.fn((type) => type === 'DOCUMENT'),
+    isAIChatPage: vi.fn((type) => type === 'AI_CHAT'),
+    getCreatablePageTypes: vi.fn(() => ['FOLDER', 'DOCUMENT', 'CHANNEL', 'AI_CHAT', 'CANVAS', 'SHEET', 'TASK_LIST', 'CODE']),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     ai: {
       child: vi.fn(() => ({
         info: vi.fn(),
@@ -80,6 +79,14 @@ vi.mock('@pagespace/lib/server', () => ({
       })),
     },
   },
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/server', () => ({
+    isChannelPage: vi.fn((type) => type === 'CHANNEL'),
+    formatContentForAI: vi.fn((content) => content),
+    formatSheetForAI: vi.fn(),
+    formatTaskListForAI: vi.fn(),
+    getPagePath: vi.fn().mockResolvedValue('/drive/page'),
 }));
 
 vi.mock('@/lib/logging/mask', () => ({
@@ -88,7 +95,7 @@ vi.mock('@/lib/logging/mask', () => ({
 
 import { pageReadTools } from '../page-read-tools';
 import { db } from '@pagespace/db';
-import { getUserDriveAccess, getUserAccessLevel } from '@pagespace/lib/server';
+import { getUserDriveAccess, getUserAccessLevel } from '@pagespace/lib/permissions/permissions';
 import type { ToolExecutionContext } from '../../core';
 
 const mockDb = vi.mocked(db);

--- a/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
@@ -11,17 +11,27 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  */
 
 // Mock repository seams - the proper architectural boundaries
-vi.mock('@pagespace/lib/server', () => ({
-  canUserEditPage: vi.fn(),
-  canUserDeletePage: vi.fn(),
-  logPageActivity: vi.fn(),
-  logDriveActivity: vi.fn(),
-  getActorInfo: vi.fn().mockResolvedValue({ actorEmail: 'test@example.com', actorDisplayName: 'Test User' }),
-  detectPageContentFormat: vi.fn(() => 'text'),
-  hashWithPrefix: vi.fn(() => 'content-ref'),
-  computePageStateHash: vi.fn(() => 'state-hash'),
-  createPageVersion: vi.fn().mockResolvedValue({ id: 'version-1', contentRef: 'content-ref', contentSize: 0 }),
-  PageType: {
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    canUserEditPage: vi.fn(),
+    canUserDeletePage: vi.fn(),
+}));
+vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
+    logPageActivity: vi.fn(),
+    logDriveActivity: vi.fn(),
+    getActorInfo: vi.fn().mockResolvedValue({ actorEmail: 'test@example.com', actorDisplayName: 'Test User' }),
+}));
+vi.mock('@pagespace/lib/content/page-content-format', () => ({
+    detectPageContentFormat: vi.fn(() => 'text'),
+}));
+vi.mock('@pagespace/lib/utils/hash-utils', () => ({
+    hashWithPrefix: vi.fn(() => 'content-ref'),
+}));
+vi.mock('@pagespace/lib/services/page-version-service', () => ({
+    computePageStateHash: vi.fn(() => 'state-hash'),
+    createPageVersion: vi.fn().mockResolvedValue({ id: 'version-1', contentRef: 'content-ref', contentSize: 0 }),
+}));
+vi.mock('@pagespace/lib/utils/enums', () => ({
+    PageType: {
     FOLDER: 'FOLDER',
     DOCUMENT: 'DOCUMENT',
     AI_CHAT: 'AI_CHAT',
@@ -33,16 +43,22 @@ vi.mock('@pagespace/lib/server', () => ({
     CODE: 'CODE',
     TERMINAL: 'TERMINAL',
   },
-  getDefaultContent: vi.fn(() => ''),
-  getCreatablePageTypes: vi.fn(() => ['FOLDER', 'DOCUMENT', 'CHANNEL', 'AI_CHAT', 'CANVAS', 'SHEET', 'TASK_LIST', 'CODE']),
-  isAIChatPage: vi.fn((type) => type === 'AI_CHAT'),
-  isDocumentPage: vi.fn((type) => type === 'DOCUMENT'),
-  parseSheetContent: vi.fn(() => ({ rowCount: 10, columnCount: 5 })),
-  serializeSheetContent: vi.fn(() => ''),
-  updateSheetCells: vi.fn((data) => data),
-  isValidCellAddress: vi.fn((addr) => /^[A-Z]+\d+$/.test(addr.toUpperCase())),
-  isSheetType: vi.fn((type) => type === 'SHEET'),
-  loggers: {
+}));
+vi.mock('@pagespace/lib/content/page-types.config', () => ({
+    getDefaultContent: vi.fn(() => ''),
+    getCreatablePageTypes: vi.fn(() => ['FOLDER', 'DOCUMENT', 'CHANNEL', 'AI_CHAT', 'CANVAS', 'SHEET', 'TASK_LIST', 'CODE']),
+    isAIChatPage: vi.fn((type) => type === 'AI_CHAT'),
+    isDocumentPage: vi.fn((type) => type === 'DOCUMENT'),
+}));
+vi.mock('@pagespace/lib/sheets', () => ({
+    parseSheetContent: vi.fn(() => ({ rowCount: 10, columnCount: 5 })),
+    serializeSheetContent: vi.fn(() => ''),
+    updateSheetCells: vi.fn((data) => data),
+    isValidCellAddress: vi.fn((addr) => /^[A-Z]+\d+$/.test(addr.toUpperCase())),
+    isSheetType: vi.fn((type) => type === 'SHEET'),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     ai: {
       child: vi.fn(() => ({
         info: vi.fn(),
@@ -52,8 +68,10 @@ vi.mock('@pagespace/lib/server', () => ({
       })),
     },
   },
-  // Repository seams
-  pageRepository: {
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/repositories', () => ({
+    pageRepository: {
     findById: vi.fn(),
     findTrashedById: vi.fn(),
     existsInDrive: vi.fn(),
@@ -65,7 +83,7 @@ vi.mock('@pagespace/lib/server', () => ({
     restore: vi.fn(),
     getChildIds: vi.fn(),
   },
-  driveRepository: {
+    driveRepository: {
     findById: vi.fn(),
     findByIdBasic: vi.fn(),
     findByIdAndOwner: vi.fn(),
@@ -90,7 +108,8 @@ vi.mock('@/lib/logging/mask', () => ({
 }));
 
 import { pageWriteTools } from '../page-write-tools';
-import { canUserEditPage, pageRepository, driveRepository } from '@pagespace/lib/server';
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions'
+import { pageRepository, driveRepository } from '@pagespace/lib/repositories';
 import { applyPageMutation } from '@/services/api/page-mutation-service';
 import type { ToolExecutionContext } from '../../core';
 

--- a/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
@@ -108,7 +108,7 @@ vi.mock('@/lib/logging/mask', () => ({
 }));
 
 import { pageWriteTools } from '../page-write-tools';
-import { canUserEditPage } from '@pagespace/lib/permissions/permissions'
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { pageRepository, driveRepository } from '@pagespace/lib/repositories';
 import { applyPageMutation } from '@/services/api/page-mutation-service';
 import type { ToolExecutionContext } from '../../core';

--- a/apps/web/src/lib/ai/tools/__tests__/search-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/search-tools.test.ts
@@ -2,12 +2,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { assert } from './riteway';
 
 // Mock only the boundary we actually test
-vi.mock('@pagespace/lib/server', () => ({
-  getUserDriveAccess: vi.fn(),
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    getUserDriveAccess: vi.fn(),
 }));
 
 import { searchTools } from '../search-tools';
-import { getUserDriveAccess } from '@pagespace/lib/server';
+import { getUserDriveAccess } from '@pagespace/lib/permissions/permissions';
 import type { ToolExecutionContext } from '../../core';
 
 const mockGetUserDriveAccess = vi.mocked(getUserDriveAccess);

--- a/apps/web/src/lib/ai/tools/__tests__/task-management-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/task-management-tools.test.ts
@@ -29,21 +29,22 @@ vi.mock('@pagespace/db', () => ({
   asc: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@pagespace/lib/server')>();
-  return {
-    ...actual,
-    canUserEditPage: vi.fn(),
-    canUserViewPage: vi.fn(),
-    getUserDriveAccess: vi.fn(),
-    logPageActivity: vi.fn(),
-    getActorInfo: vi.fn().mockResolvedValue({ actorEmail: 'test@test.com' }),
-  };
-});
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  canUserEditPage: vi.fn(),
+  canUserViewPage: vi.fn(),
+  getUserDriveAccess: vi.fn(),
+}));
+vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
+  logPageActivity: vi.fn(),
+  getActorInfo: vi.fn().mockResolvedValue({ actorEmail: 'test@test.com' }),
+}));
 
-vi.mock('@pagespace/lib', () => ({
+vi.mock('@pagespace/lib/content/page-types.config', () => ({
   getDefaultContent: vi.fn(() => ''),
-  PageType: { DOCUMENT: 'DOCUMENT' },
+  getCreatablePageTypes: vi.fn(() => ['DOCUMENT', 'FOLDER', 'TASK_LIST']),
+}));
+vi.mock('@pagespace/lib/utils/enums', () => ({
+    PageType: { DOCUMENT: 'DOCUMENT' },
 }));
 
 vi.mock('@/lib/websocket', () => ({
@@ -54,7 +55,7 @@ vi.mock('@/lib/websocket', () => ({
 
 import { taskManagementTools } from '../task-management-tools';
 import { db } from '@pagespace/db';
-import { canUserEditPage } from '@pagespace/lib/server';
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import type { ToolExecutionContext } from '../../core';
 
 const mockDb = vi.mocked(db);

--- a/apps/web/src/lib/ai/tools/__tests__/web-search-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/web-search-tools.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Mock dependencies
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     ai: {
       child: vi.fn(() => ({
         info: vi.fn(),
@@ -12,6 +12,7 @@ vi.mock('@pagespace/lib/server', () => ({
       })),
     },
   },
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 vi.mock('@/lib/logging/mask', () => ({

--- a/apps/web/src/lib/ai/tools/activity-tools.ts
+++ b/apps/web/src/lib/ai/tools/activity-tools.ts
@@ -15,16 +15,18 @@ import {
   isNull,
   inArray,
 } from '@pagespace/db';
-import { isUserDriveMember, getBatchPagePermissions, isDriveOwnerOrAdmin } from '@pagespace/lib';
+import { isUserDriveMember, getBatchPagePermissions, isDriveOwnerOrAdmin } from '@pagespace/lib/permissions/permissions';
 import {
   groupActivitiesForDiff,
-  resolveStackedVersionContent,
+  type ActivityForDiff,
+} from '@pagespace/lib/content/activity-diff-utils';
+import { resolveStackedVersionContent } from '@pagespace/lib/content/version-resolver';
+import {
   generateDiffsWithinBudget,
   calculateDiffBudget,
-  type ActivityForDiff,
   type DiffRequest,
-} from '@pagespace/lib/content';
-import { readPageContent } from '@pagespace/lib/server';
+} from '@pagespace/lib/content/diff-generator';
+import { readPageContent } from '@pagespace/lib/services/page-content-store';
 import { type ToolExecutionContext } from '../core';
 
 /**

--- a/apps/web/src/lib/ai/tools/agent-communication-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-communication-tools.ts
@@ -3,7 +3,7 @@ import { finishTool, FINISH_TOOL_NAME } from './finish-tool';
 import { z } from 'zod';
 import { generateText, convertToModelMessages, UIMessage } from 'ai';
 import { db, pages, chatMessages, drives, eq, and, sql } from '@pagespace/db';
-import { canUserViewPage } from '@pagespace/lib/server';
+import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
 import {
   sanitizeMessagesForModel,
   saveMessageToDatabase,
@@ -23,7 +23,7 @@ import { pageWriteTools } from './page-write-tools';
 import { searchTools } from './search-tools';
 import { taskManagementTools } from './task-management-tools';
 import { agentTools } from './agent-tools';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 // Nesting cap. Intent is 3+ for richer agent-to-agent composition, but held at 2
 // until inner stepCountIs budget is reworked — see PR #713. Raising this without

--- a/apps/web/src/lib/ai/tools/agent-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-tools.ts
@@ -1,8 +1,8 @@
 import { tool } from 'ai';
 import { z } from 'zod';
-import { canUserEditPage } from '@pagespace/lib/permissions/permissions'
-import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger'
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
+import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { agentRepository } from '@pagespace/lib/repositories';
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { maskIdentifier } from '@/lib/logging/mask';

--- a/apps/web/src/lib/ai/tools/agent-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-tools.ts
@@ -1,11 +1,9 @@
 import { tool } from 'ai';
 import { z } from 'zod';
-import {
-  canUserEditPage,
-  getActorInfo,
-  loggers,
-  agentRepository,
-} from '@pagespace/lib/server';
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions'
+import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger'
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { agentRepository } from '@pagespace/lib/repositories';
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { maskIdentifier } from '@/lib/logging/mask';
 import { type ToolExecutionContext, pageSpaceTools } from '../core';

--- a/apps/web/src/lib/ai/tools/calendar-read-tools.ts
+++ b/apps/web/src/lib/ai/tools/calendar-read-tools.ts
@@ -15,7 +15,7 @@ import {
   desc,
 } from '@pagespace/db';
 import type { CalendarTriggerMetadata } from '@pagespace/db';
-import { isUserDriveMember, getDriveIdsForUser } from '@pagespace/lib';
+import { isUserDriveMember, getDriveIdsForUser } from '@pagespace/lib/permissions/permissions';
 import { type ToolExecutionContext } from '../core';
 import { normalizeTimezone, getTimezoneOffsetMinutes, formatDateInTimezone, isNaiveISODatetime, parseNaiveDatetimeInTimezone } from '../core/timestamp-utils';
 

--- a/apps/web/src/lib/ai/tools/calendar-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/calendar-write-tools.ts
@@ -12,8 +12,9 @@ import {
   inArray,
 } from '@pagespace/db';
 import type { CalendarTriggerMetadata } from '@pagespace/db';
-import { isUserDriveMember } from '@pagespace/lib';
-import { getDriveMemberUserIds, loggers } from '@pagespace/lib/server';
+import { isUserDriveMember } from '@pagespace/lib/permissions/permissions';
+import { getDriveMemberUserIds } from '@pagespace/lib/services/drive-member-service'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { broadcastCalendarEvent } from '@/lib/websocket/calendar-events';
 import { type ToolExecutionContext } from '../core';
 import { normalizeTimezone, formatDateInTimezone, parseDateTime } from '../core/timestamp-utils';

--- a/apps/web/src/lib/ai/tools/calendar-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/calendar-write-tools.ts
@@ -13,7 +13,7 @@ import {
 } from '@pagespace/db';
 import type { CalendarTriggerMetadata } from '@pagespace/db';
 import { isUserDriveMember } from '@pagespace/lib/permissions/permissions';
-import { getDriveMemberUserIds } from '@pagespace/lib/services/drive-member-service'
+import { getDriveMemberUserIds } from '@pagespace/lib/services/drive-member-service';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { broadcastCalendarEvent } from '@/lib/websocket/calendar-events';
 import { type ToolExecutionContext } from '../core';

--- a/apps/web/src/lib/ai/tools/channel-tools.ts
+++ b/apps/web/src/lib/ai/tools/channel-tools.ts
@@ -1,11 +1,8 @@
 import { tool } from 'ai';
 import { z } from 'zod';
-import { canUserEditPage, canUserViewPage } from '@pagespace/lib/permissions';
-import {
-  loggers,
-  getActorInfo,
-  logMessageActivity,
-} from '@pagespace/lib/server';
+import { canUserEditPage, canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { getActorInfo, logMessageActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { db, channelMessages, channelReadStatus, pages, driveMembers, eq, and } from '@pagespace/db';
 import { createSignedBroadcastHeaders } from '@pagespace/lib/auth/broadcast-auth';
 import { broadcastInboxEvent } from '@/lib/websocket/socket-utils';

--- a/apps/web/src/lib/ai/tools/channel-tools.ts
+++ b/apps/web/src/lib/ai/tools/channel-tools.ts
@@ -1,7 +1,7 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 import { canUserEditPage, canUserViewPage } from '@pagespace/lib/permissions/permissions';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getActorInfo, logMessageActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { db, channelMessages, channelReadStatus, pages, driveMembers, eq, and } from '@pagespace/db';
 import { createSignedBroadcastHeaders } from '@pagespace/lib/auth/broadcast-auth';

--- a/apps/web/src/lib/ai/tools/drive-tools.ts
+++ b/apps/web/src/lib/ai/tools/drive-tools.ts
@@ -1,8 +1,8 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 import { db, pages, drives, eq, and, driveMembers, pagePermissions, ne } from '@pagespace/db';
-import { slugify } from '@pagespace/lib/utils/utils'
-import { logDriveActivity, getActorInfo } from '@pagespace/lib/monitoring/activity-logger'
+import { slugify } from '@pagespace/lib/utils/utils';
+import { logDriveActivity, getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import { getDriveAccessWithDrive } from '@pagespace/lib/services/drive-service';
 import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket';
 import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';

--- a/apps/web/src/lib/ai/tools/drive-tools.ts
+++ b/apps/web/src/lib/ai/tools/drive-tools.ts
@@ -1,7 +1,9 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 import { db, pages, drives, eq, and, driveMembers, pagePermissions, ne } from '@pagespace/db';
-import { slugify, logDriveActivity, getActorInfo, getDriveAccessWithDrive } from '@pagespace/lib/server';
+import { slugify } from '@pagespace/lib/utils/utils'
+import { logDriveActivity, getActorInfo } from '@pagespace/lib/monitoring/activity-logger'
+import { getDriveAccessWithDrive } from '@pagespace/lib/services/drive-service';
 import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket';
 import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
 import { type ToolExecutionContext } from '../core';

--- a/apps/web/src/lib/ai/tools/page-read-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-read-tools.ts
@@ -1,7 +1,10 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 import { db, pages, taskItems, taskLists, chatMessages, channelMessages, eq, and, asc, isNotNull, count, max, min, inArray } from '@pagespace/db';
-import { buildTree, getUserAccessLevel, getUserDriveAccess, getUserAccessiblePagesInDriveWithDetails, getPageTypeEmoji, isFolderPage, PageType } from '@pagespace/lib/server';
+import { buildTree } from '@pagespace/lib/content/tree-utils'
+import { getUserAccessLevel, getUserDriveAccess, getUserAccessiblePagesInDriveWithDetails } from '@pagespace/lib/permissions/permissions'
+import { getPageTypeEmoji, isFolderPage } from '@pagespace/lib/content/page-types.config'
+import { PageType } from '@pagespace/lib/utils/enums';
 import { type ToolExecutionContext, getSuggestedVisionModels } from '../core';
 import { addLineBreaksForAI } from '@/lib/editor/line-breaks';
 

--- a/apps/web/src/lib/ai/tools/page-read-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-read-tools.ts
@@ -1,9 +1,9 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 import { db, pages, taskItems, taskLists, chatMessages, channelMessages, eq, and, asc, isNotNull, count, max, min, inArray } from '@pagespace/db';
-import { buildTree } from '@pagespace/lib/content/tree-utils'
-import { getUserAccessLevel, getUserDriveAccess, getUserAccessiblePagesInDriveWithDetails } from '@pagespace/lib/permissions/permissions'
-import { getPageTypeEmoji, isFolderPage } from '@pagespace/lib/content/page-types.config'
+import { buildTree } from '@pagespace/lib/content/tree-utils';
+import { getUserAccessLevel, getUserDriveAccess, getUserAccessiblePagesInDriveWithDetails } from '@pagespace/lib/permissions/permissions';
+import { getPageTypeEmoji, isFolderPage } from '@pagespace/lib/content/page-types.config';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { type ToolExecutionContext, getSuggestedVisionModels } from '../core';
 import { addLineBreaksForAI } from '@/lib/editor/line-breaks';

--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -1,31 +1,16 @@
 import { tool } from 'ai';
 import { z } from 'zod';
-import {
-  canUserEditPage,
-  canUserDeletePage,
-  PageType,
-  isAIChatPage,
-  isDocumentPage,
-  getDefaultContent,
-  getCreatablePageTypes,
-  parseSheetContent,
-  serializeSheetContent,
-  updateSheetCells,
-  isValidCellAddress,
-  isSheetType,
-  loggers,
-  logPageActivity,
-  logDriveActivity,
-  getActorInfo,
-  detectPageContentFormat,
-  hashWithPrefix,
-  computePageStateHash,
-  createPageVersion,
-  pageRepository,
-  driveRepository,
-  type ActivityOperation,
-} from '@pagespace/lib/server';
-import { createChangeGroupId } from '@pagespace/lib/monitoring';
+import { canUserEditPage, canUserDeletePage } from '@pagespace/lib/permissions/permissions'
+import { PageType } from '@pagespace/lib/utils/enums'
+import { isAIChatPage, isDocumentPage, getDefaultContent, getCreatablePageTypes } from '@pagespace/lib/content/page-types.config'
+import { parseSheetContent, serializeSheetContent, updateSheetCells, isValidCellAddress, isSheetType } from '@pagespace/lib/sheets'
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { logPageActivity, logDriveActivity, getActorInfo, type ActivityOperation } from '@pagespace/lib/monitoring/activity-logger'
+import { detectPageContentFormat } from '@pagespace/lib/content/page-content-format'
+import { hashWithPrefix } from '@pagespace/lib/utils/hash-utils'
+import { computePageStateHash, createPageVersion } from '@pagespace/lib/services/page-version-service'
+import { pageRepository, driveRepository } from '@pagespace/lib/repositories';
+import { createChangeGroupId } from '@pagespace/lib/monitoring/change-group';
 import { applyPageMutation, type PageMutationContext } from '@/services/api/page-mutation-service';
 import { broadcastPageEvent, createPageEventPayload, broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket';
 import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';

--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -1,14 +1,14 @@
 import { tool } from 'ai';
 import { z } from 'zod';
-import { canUserEditPage, canUserDeletePage } from '@pagespace/lib/permissions/permissions'
-import { PageType } from '@pagespace/lib/utils/enums'
-import { isAIChatPage, isDocumentPage, getDefaultContent, getCreatablePageTypes } from '@pagespace/lib/content/page-types.config'
-import { parseSheetContent, serializeSheetContent, updateSheetCells, isValidCellAddress, isSheetType } from '@pagespace/lib/sheets'
-import { loggers } from '@pagespace/lib/logging/logger-config'
-import { logPageActivity, logDriveActivity, getActorInfo, type ActivityOperation } from '@pagespace/lib/monitoring/activity-logger'
-import { detectPageContentFormat } from '@pagespace/lib/content/page-content-format'
-import { hashWithPrefix } from '@pagespace/lib/utils/hash-utils'
-import { computePageStateHash, createPageVersion } from '@pagespace/lib/services/page-version-service'
+import { canUserEditPage, canUserDeletePage } from '@pagespace/lib/permissions/permissions';
+import { PageType } from '@pagespace/lib/utils/enums';
+import { isAIChatPage, isDocumentPage, getDefaultContent, getCreatablePageTypes } from '@pagespace/lib/content/page-types.config';
+import { parseSheetContent, serializeSheetContent, updateSheetCells, isValidCellAddress, isSheetType } from '@pagespace/lib/sheets';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { logPageActivity, logDriveActivity, getActorInfo, type ActivityOperation } from '@pagespace/lib/monitoring/activity-logger';
+import { detectPageContentFormat } from '@pagespace/lib/content/page-content-format';
+import { hashWithPrefix } from '@pagespace/lib/utils/hash-utils';
+import { computePageStateHash, createPageVersion } from '@pagespace/lib/services/page-version-service';
 import { pageRepository, driveRepository } from '@pagespace/lib/repositories';
 import { createChangeGroupId } from '@pagespace/lib/monitoring/change-group';
 import { applyPageMutation, type PageMutationContext } from '@/services/api/page-mutation-service';

--- a/apps/web/src/lib/ai/tools/search-tools.ts
+++ b/apps/web/src/lib/ai/tools/search-tools.ts
@@ -1,7 +1,7 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 import { db, pages, drives, chatMessages, eq, and, sql, inArray, asc } from '@pagespace/db';
-import { getUserDriveAccess, getUserAccessiblePagesInDriveWithDetails } from '@pagespace/lib/server';
+import { getUserDriveAccess, getUserAccessiblePagesInDriveWithDetails } from '@pagespace/lib/permissions/permissions';
 import { type ToolExecutionContext } from '../core';
 
 export const searchTools = {

--- a/apps/web/src/lib/ai/tools/task-management-tools.ts
+++ b/apps/web/src/lib/ai/tools/task-management-tools.ts
@@ -3,8 +3,10 @@ import { z } from 'zod';
 import { db, taskLists, taskItems, taskStatusConfigs, taskAssignees, pages, eq, and, desc, asc, isNull, inArray } from '@pagespace/db';
 import { type ToolExecutionContext } from '../core';
 import { broadcastTaskEvent, broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
-import { canUserEditPage, canUserViewPage, getUserDriveAccess, logPageActivity, getActorInfo } from '@pagespace/lib/server';
-import { getDefaultContent, PageType } from '@pagespace/lib';
+import { canUserEditPage, canUserViewPage, getUserDriveAccess } from '@pagespace/lib/permissions/permissions'
+import { logPageActivity, getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
+import { getDefaultContent } from '@pagespace/lib/content/page-types.config'
+import { PageType } from '@pagespace/lib/utils/enums';
 import {
   syncTaskDueDateTrigger,
   cancelTaskDueDateTrigger,

--- a/apps/web/src/lib/ai/tools/task-management-tools.ts
+++ b/apps/web/src/lib/ai/tools/task-management-tools.ts
@@ -3,9 +3,9 @@ import { z } from 'zod';
 import { db, taskLists, taskItems, taskStatusConfigs, taskAssignees, pages, eq, and, desc, asc, isNull, inArray } from '@pagespace/db';
 import { type ToolExecutionContext } from '../core';
 import { broadcastTaskEvent, broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
-import { canUserEditPage, canUserViewPage, getUserDriveAccess } from '@pagespace/lib/permissions/permissions'
+import { canUserEditPage, canUserViewPage, getUserDriveAccess } from '@pagespace/lib/permissions/permissions';
 import { logPageActivity, getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
-import { getDefaultContent } from '@pagespace/lib/content/page-types.config'
+import { getDefaultContent } from '@pagespace/lib/content/page-types.config';
 import { PageType } from '@pagespace/lib/utils/enums';
 import {
   syncTaskDueDateTrigger,

--- a/apps/web/src/lib/ai/tools/web-search-tools.ts
+++ b/apps/web/src/lib/ai/tools/web-search-tools.ts
@@ -1,7 +1,7 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 import { type ToolExecutionContext } from '../core';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { maskIdentifier } from '@/lib/logging/mask';
 
 const webSearchLogger = loggers.ai.child({ module: 'web-search-tools' });

--- a/apps/web/src/lib/integrations/google-calendar/__tests__/map-attendees.test.ts
+++ b/apps/web/src/lib/integrations/google-calendar/__tests__/map-attendees.test.ts
@@ -24,10 +24,12 @@ vi.mock('@pagespace/db', () => ({
   sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => `lower(${String(values[0])})`),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 vi.mock('@paralleldrive/cuid2', () => ({

--- a/apps/web/src/lib/integrations/google-calendar/__tests__/sync-service.test.ts
+++ b/apps/web/src/lib/integrations/google-calendar/__tests__/sync-service.test.ts
@@ -69,14 +69,16 @@ vi.mock('@pagespace/db', () => ({
   desc: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: {
       info: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 const mockGetValidAccessToken = vi.fn();

--- a/apps/web/src/lib/integrations/google-calendar/api-client.ts
+++ b/apps/web/src/lib/integrations/google-calendar/api-client.ts
@@ -7,7 +7,7 @@
  * API Reference: https://developers.google.com/calendar/api/v3/reference
  */
 
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 const GOOGLE_CALENDAR_API_BASE = 'https://www.googleapis.com/calendar/v3';
 

--- a/apps/web/src/lib/integrations/google-calendar/push-service.ts
+++ b/apps/web/src/lib/integrations/google-calendar/push-service.ts
@@ -7,7 +7,7 @@
 
 import { db, googleCalendarConnections, calendarEvents, eq, and } from '@pagespace/db';
 import type { CalendarEvent } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getValidAccessToken } from './token-refresh';
 import {
   createGoogleEvent,

--- a/apps/web/src/lib/integrations/google-calendar/sync-service.ts
+++ b/apps/web/src/lib/integrations/google-calendar/sync-service.ts
@@ -6,7 +6,7 @@
  */
 
 import { db, googleCalendarConnections, calendarEvents, eventAttendees, users, eq, and, isNull, inArray, sql, desc } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { maskIdentifier } from '@/lib/logging/mask';
 import { getValidAccessToken, updateConnectionStatus } from './token-refresh';
 import { listEvents, watchCalendar, stopChannel, type GoogleCalendarEvent, type GoogleEventAttendee } from './api-client';

--- a/apps/web/src/lib/integrations/google-calendar/token-refresh.ts
+++ b/apps/web/src/lib/integrations/google-calendar/token-refresh.ts
@@ -11,8 +11,8 @@
  */
 
 import { db, googleCalendarConnections, eq, type GoogleCalendarConnection } from '@pagespace/db';
-import { encrypt, decrypt } from '@pagespace/lib';
-import { loggers } from '@pagespace/lib/server';
+import { encrypt, decrypt } from '@pagespace/lib/encryption';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { OAuth2Client } from 'google-auth-library';
 
 // Buffer time before expiration to refresh (5 minutes)

--- a/apps/web/src/lib/integrations/google-calendar/webhook-token.ts
+++ b/apps/web/src/lib/integrations/google-calendar/webhook-token.ts
@@ -8,7 +8,7 @@
  */
 
 import crypto from 'crypto';
-import { secureCompare } from '@pagespace/lib';
+import { secureCompare } from '@pagespace/lib/auth/secure-compare';
 
 /**
  * Generate an HMAC token for webhook authentication.

--- a/apps/web/src/lib/mcp/__tests__/mcp-bridge.test.ts
+++ b/apps/web/src/lib/mcp/__tests__/mcp-bridge.test.ts
@@ -8,8 +8,8 @@ vi.mock('@/lib/websocket', () => ({
 }));
 
 // Mock the logger
-vi.mock('@pagespace/lib', () => ({
-  logger: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    logger: {
     child: vi.fn(() => ({
       info: vi.fn(),
       warn: vi.fn(),

--- a/apps/web/src/lib/mcp/__tests__/mcp-bridge.test.ts
+++ b/apps/web/src/lib/mcp/__tests__/mcp-bridge.test.ts
@@ -8,7 +8,7 @@ vi.mock('@/lib/websocket', () => ({
 }));
 
 // Mock the logger
-vi.mock('@pagespace/lib/logging/logger-config', () => ({
+vi.mock('@pagespace/lib/logging/logger', () => ({
     logger: {
     child: vi.fn(() => ({
       info: vi.fn(),

--- a/apps/web/src/lib/mcp/mcp-bridge.ts
+++ b/apps/web/src/lib/mcp/mcp-bridge.ts
@@ -1,5 +1,5 @@
 import { getConnection, checkConnectionHealth } from '@/lib/websocket';
-import { logger } from '@pagespace/lib';
+import { logger } from '@pagespace/lib/logging/logger-config';
 
 /**
  * MCP Bridge - Server-side WebSocket manager for tool execution

--- a/apps/web/src/lib/mcp/mcp-bridge.ts
+++ b/apps/web/src/lib/mcp/mcp-bridge.ts
@@ -1,5 +1,5 @@
 import { getConnection, checkConnectionHealth } from '@/lib/websocket';
-import { logger } from '@pagespace/lib/logging/logger-config';
+import { logger } from '@pagespace/lib/logging/logger';
 
 /**
  * MCP Bridge - Server-side WebSocket manager for tool execution

--- a/apps/web/src/lib/memory/__tests__/compaction-service.test.ts
+++ b/apps/web/src/lib/memory/__tests__/compaction-service.test.ts
@@ -40,8 +40,8 @@ vi.mock('@/lib/ai/core', () => ({
 }));
 
 // Mock loggers
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: {
       info: vi.fn(),
       warn: vi.fn(),
@@ -49,6 +49,8 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 // Mock generateText

--- a/apps/web/src/lib/memory/__tests__/discovery-service.test.ts
+++ b/apps/web/src/lib/memory/__tests__/discovery-service.test.ts
@@ -42,8 +42,8 @@ vi.mock('@/lib/ai/core', () => ({
 }));
 
 // Mock loggers
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: {
       info: vi.fn(),
       warn: vi.fn(),
@@ -51,6 +51,8 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 // Mock generateText from AI SDK

--- a/apps/web/src/lib/memory/__tests__/integration-service.test.ts
+++ b/apps/web/src/lib/memory/__tests__/integration-service.test.ts
@@ -40,8 +40,8 @@ vi.mock('@/lib/ai/core', () => ({
 }));
 
 // Mock loggers
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: {
       info: vi.fn(),
       warn: vi.fn(),
@@ -49,6 +49,8 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 // Mock generateText

--- a/apps/web/src/lib/memory/compaction-service.ts
+++ b/apps/web/src/lib/memory/compaction-service.ts
@@ -8,7 +8,7 @@
 
 import { generateText } from 'ai';
 import { createAIProvider, isProviderError } from '@/lib/ai/core';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import {
   updatePersonalization,
   getCurrentPersonalization,

--- a/apps/web/src/lib/memory/discovery-service.ts
+++ b/apps/web/src/lib/memory/discovery-service.ts
@@ -22,7 +22,7 @@ import {
   inArray,
 } from '@pagespace/db';
 import { createAIProvider, isProviderError } from '@/lib/ai/core';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 export interface DiscoveryResult {
   worldview: string[];

--- a/apps/web/src/lib/memory/integration-service.ts
+++ b/apps/web/src/lib/memory/integration-service.ts
@@ -9,7 +9,7 @@
 import { generateText } from 'ai';
 import { db, userPersonalization, eq } from '@pagespace/db';
 import { createAIProvider, isProviderError } from '@/lib/ai/core';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import type { DiscoveryResult } from './discovery-service';
 
 export interface UserPersonalizationData {

--- a/apps/web/src/lib/workflows/__tests__/calendar-trigger-executor.test.ts
+++ b/apps/web/src/lib/workflows/__tests__/calendar-trigger-executor.test.ts
@@ -81,12 +81,11 @@ vi.mock('@/lib/logging/mask', () => ({
   maskIdentifier: vi.fn((id: string) => `***${id?.slice(-4) || ''}`),
 }));
 
-vi.mock('@pagespace/lib', () => ({
-  isUserDriveMember: mockIsUserDriveMember,
-  logger: { child: vi.fn(() => makeChildLogger()) },
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    isUserDriveMember: mockIsUserDriveMember,
 }));
-
-vi.mock('@pagespace/lib/server', () => ({
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  logger: { child: vi.fn(() => makeChildLogger()) },
   loggers: {
     api: { child: vi.fn(() => makeChildLogger()), info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     ai: { child: vi.fn(() => makeChildLogger()), info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },

--- a/apps/web/src/lib/workflows/__tests__/task-trigger-helpers.test.ts
+++ b/apps/web/src/lib/workflows/__tests__/task-trigger-helpers.test.ts
@@ -43,8 +43,8 @@ vi.mock('../workflow-executor', () => ({
   executeWorkflow: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: {
       child: vi.fn(() => ({
         info: vi.fn(),
@@ -54,6 +54,7 @@ vi.mock('@pagespace/lib/server', () => ({
       })),
     },
   },
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 import {

--- a/apps/web/src/lib/workflows/__tests__/workflow-executor.test.ts
+++ b/apps/web/src/lib/workflows/__tests__/workflow-executor.test.ts
@@ -57,10 +57,12 @@ vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
   AIMonitoring: { trackUsage: vi.fn() },
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 import { executeWorkflow } from '../workflow-executor';

--- a/apps/web/src/lib/workflows/calendar-trigger-executor.ts
+++ b/apps/web/src/lib/workflows/calendar-trigger-executor.ts
@@ -2,8 +2,8 @@ import { db, calendarTriggers, pages, eventAttendees, users, eq, and } from '@pa
 import type { CalendarTrigger, CalendarEvent } from '@pagespace/db';
 import { executeWorkflow, type WorkflowExecutionResult } from './workflow-executor';
 import { incrementUsage } from '@/lib/subscription/usage-service';
-import { isUserDriveMember } from '@pagespace/lib';
-import { loggers } from '@pagespace/lib/server';
+import { isUserDriveMember } from '@pagespace/lib/permissions/permissions';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 const logger = loggers.api.child({ module: 'calendar-trigger-executor' });
 

--- a/apps/web/src/lib/workflows/task-trigger-helpers.ts
+++ b/apps/web/src/lib/workflows/task-trigger-helpers.ts
@@ -1,6 +1,6 @@
 import { db, workflows, taskItems, pages, eq, and, inArray } from '@pagespace/db';
 import { executeWorkflow } from './workflow-executor';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 export interface AgentTriggerInput {
   agentPageId: string;

--- a/apps/web/src/lib/workflows/workflow-executor.ts
+++ b/apps/web/src/lib/workflows/workflow-executor.ts
@@ -12,7 +12,7 @@ import {
 import { saveMessageToDatabase } from '@/lib/ai/core/message-utils';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 import { db, pages, drives, eq, and, inArray, workflows as workflowsTable, taskItems, taskAssignees, taskStatusConfigs, users } from '@pagespace/db';
-import { isUserDriveMember } from '@pagespace/lib/permissions/permissions'
+import { isUserDriveMember } from '@pagespace/lib/permissions/permissions';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 
 export interface WorkflowExecutionResult {

--- a/apps/web/src/lib/workflows/workflow-executor.ts
+++ b/apps/web/src/lib/workflows/workflow-executor.ts
@@ -12,7 +12,8 @@ import {
 import { saveMessageToDatabase } from '@/lib/ai/core/message-utils';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 import { db, pages, drives, eq, and, inArray, workflows as workflowsTable, taskItems, taskAssignees, taskStatusConfigs, users } from '@pagespace/db';
-import { isUserDriveMember, loggers } from '@pagespace/lib/server';
+import { isUserDriveMember } from '@pagespace/lib/permissions/permissions'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 export interface WorkflowExecutionResult {
   success: boolean;


### PR DESCRIPTION
## Summary

Replaces barrel imports with direct subpath imports across the AI and integrations subsystem of apps/web:

- \`apps/web/src/app/api/ai/**\` — AI API routes and tests (chat, completions, tools)
- \`apps/web/src/lib/ai/**\` — AI provider setup, tool definitions, stream handlers
- \`apps/web/src/app/api/agents/**\` — agent API routes
- \`apps/web/src/app/api/integrations/**\` — integration API routes
- \`apps/web/src/lib/integrations/**\` — GitHub, Calendar, OAuth integration libraries
- \`apps/web/src/lib/mcp/**\` — Model Context Protocol handlers
- \`apps/web/src/lib/memory/**\` — agent memory management
- \`apps/web/src/lib/workflows/**\` — workflow execution and task triggers

**115 files total — all mechanical import-path swaps. No logic changes.**

## Context

**PR D of 6** in the barrel-import removal series.

**⚠️ Depends on PR A (#1088) \`barrel/foundation\` being merged first.**
Base branch is \`barrel/foundation\` so CI resolves the new subpath exports.
After A merges, this PR's base will be updated to \`master\`.

PRs B, C, D, E1, E2 are independent of each other and can be reviewed/merged in any order after A lands.

## Why AI is grouped together

AI tools, integrations, MCP, and workflows form a coherent subsystem. Grouping them lets reviewers verify the tool-call chain, integration OAuth flows, and workflow triggers as a unit.

## Review fixes applied (post-review commits)

Two review passes found a total of **9 mock/source mismatches** — all fixed:

**Pass 1 fixes (`34f82b9`):**
1. `mcp-scope.test.ts` — malformed logger mock: `logger` was embedded inside `child()` return value instead of exported at the module top level
2. `agents/integrations/__tests__/route.test.ts` — `createGrant`/`findGrant` still mocked at the barrel; moved to `grant-repository` subpath mock to match source imports
3. `ollama/models/__tests__/route.test.ts` — `validateLocalProviderURL` mock path not updated from `@pagespace/lib/security` to `/security/url-validator`
4. `calendar-write-tools.test.ts` — mock path updated but import statement left pointing at barrel `@pagespace/lib`
5. `page-read-tools.test.ts` — dead `@pagespace/lib/server` stubs removed (source no longer imports from that path)

Also added 74 missing trailing semicolons to subpath import statements across 45 source files.

**Pass 2 fixes (`1799bcd`):**
6. `mcp-bridge.test.ts` — mock path was `/logging/logger-config` but source imports from `/logging/logger`; these are different modules (`logger` = root Winston instance, `loggers` = named namespaces)
7. `page-read-tools.test.ts` — `/content/page-types.config` mock had wrong function names (`isDocumentPage`, `isAIChatPage`, `getCreatablePageTypes`) carried over from old barrel mock; source uses `getPageTypeEmoji` and `isFolderPage`
8. `agent-tools.test.ts` — missing semicolon on import statement
9. `page-write-tools.test.ts` — missing semicolon on import statement