### PR TITLE
refactor(imports): direct subpath imports — PR E2: Web Admin + Billing + Infra

### DIFF
--- a/apps/web/src/app/api/account/__tests__/delete-route.test.ts
+++ b/apps/web/src/app/api/account/__tests__/delete-route.test.ts
@@ -2,9 +2,8 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { NextResponse } from 'next/server';
 import type { SessionAuthResult, AuthError } from '@/lib/auth';
 
-// Mock repository seams - the proper architectural boundary
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       info: vi.fn(),
       error: vi.fn(),
@@ -12,24 +11,52 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
       debug: vi.fn(),
     },
   },
-
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
+
 vi.mock('@pagespace/lib/repositories', () => ({
-    accountRepository: {
+  accountRepository: {
     findById: vi.fn(),
     getOwnedDrives: vi.fn(),
     getDriveMemberCount: vi.fn(),
     deleteDrive: vi.fn(),
     deleteUser: vi.fn(),
   },
-    activityLogRepository: {
+  activityLogRepository: {
     anonymizeForUser: vi.fn(),
   },
 }));
+
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/services/validated-service-token', () => ({
+  createUserServiceToken: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/logging/ai-usage-purge', () => ({
+  deleteAiUsageLogsForUser: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/logging/monitoring-purge', () => ({
+  deleteMonitoringDataForUser: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/compliance/erasure/revoke-integration-tokens', () => ({
+  revokeUserIntegrationTokens: vi.fn().mockResolvedValue({ revoked: 0, failed: 0 }),
+}));
+
+vi.mock('@pagespace/lib/deployment-mode', () => ({
+  isCloud: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('@/lib/stripe/client', () => ({
+  stripe: {
+    customers: {
+      del: vi.fn(),
+    },
+  },
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -37,22 +64,20 @@ vi.mock('@/lib/auth', () => ({
   isAuthError: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/services/validated-service-token', () => ({
-    createUserServiceToken: vi.fn(),
-}));
-vi.mock('@pagespace/lib/logging/ai-usage-purge', () => ({
-    deleteAiUsageLogsForUser: vi.fn(),
-}));
-vi.mock('@pagespace/lib/logging/monitoring-purge', () => ({
-    deleteMonitoringDataForUser: vi.fn(),
+vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
+  getActorInfo: vi.fn().mockResolvedValue({ email: 'user@example.com', displayName: 'Test User' }),
+  logUserActivity: vi.fn(),
 }));
 
 import { DELETE } from '../route';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { accountRepository, activityLogRepository } from '@pagespace/lib/repositories';
+import { revokeUserIntegrationTokens } from '@pagespace/lib/compliance/erasure/revoke-integration-tokens';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { createUserServiceToken } from '@pagespace/lib/services/validated-service-token'
-import { deleteMonitoringDataForUser } from '@pagespace/lib/logging/monitoring-purge';
+import { deleteMonitoringDataForUser } from '@pagespace/lib/logging/monitoring-purge'
+import { isCloud } from '@pagespace/lib/deployment-mode';
+import { stripe } from '@/lib/stripe/client';
 
 // Type the mocked repositories
 const mockAccountRepo = vi.mocked(accountRepository);
@@ -86,11 +111,12 @@ describe('DELETE /api/account', () => {
     );
     vi.mocked(isAuthError).mockReturnValue(false);
 
-    // Arrange: default user exists
+    // Arrange: default user exists (includes stripeCustomerId for #910)
     mockAccountRepo.findById.mockResolvedValue({
       id: mockUserId,
       email: mockUserEmail,
       image: null,
+      stripeCustomerId: null,
     });
 
     // Arrange: default no owned drives
@@ -100,6 +126,12 @@ describe('DELETE /api/account', () => {
     mockAccountRepo.deleteDrive.mockResolvedValue(undefined);
     mockAccountRepo.deleteUser.mockResolvedValue(undefined);
     mockActivityLogRepo.anonymizeForUser.mockResolvedValue({ success: true });
+
+    // Arrange: default non-cloud (no Stripe calls)
+    vi.mocked(isCloud).mockReturnValue(false);
+
+    // Arrange: default successful OAuth revocation (#911)
+    vi.mocked(revokeUserIntegrationTokens).mockResolvedValue({ revoked: 0, failed: 0 });
   });
 
   describe('email confirmation validation', () => {
@@ -292,6 +324,7 @@ describe('DELETE /api/account', () => {
         id: mockUserId,
         email: mockUserEmail,
         image: '/avatars/user_123.jpg',
+        stripeCustomerId: null,
       });
 
       global.fetch = vi.fn().mockResolvedValue({
@@ -325,6 +358,7 @@ describe('DELETE /api/account', () => {
         id: mockUserId,
         email: mockUserEmail,
         image: 'https://example.com/avatar.jpg',
+        stripeCustomerId: null,
       });
 
       global.fetch = vi.fn();
@@ -347,6 +381,7 @@ describe('DELETE /api/account', () => {
         id: mockUserId,
         email: mockUserEmail,
         image: '/avatars/user_123.jpg',
+        stripeCustomerId: null,
       });
 
       vi.mocked(createUserServiceToken).mockRejectedValueOnce(new Error('Token creation failed'));
@@ -500,6 +535,200 @@ describe('DELETE /api/account', () => {
       expect(loggers.auth.error).toHaveBeenCalledWith(
         'Account deletion error:',
         expect.objectContaining({ message: 'Database connection lost' })
+      );
+    });
+  });
+
+  describe('stripe customer deletion (#910)', () => {
+    it('given stripeCustomerId and cloud mode, should delete Stripe customer after account deletion', async () => {
+      // Arrange
+      mockAccountRepo.findById.mockResolvedValue({
+        id: mockUserId,
+        email: mockUserEmail,
+        image: null,
+        stripeCustomerId: 'cus_test123',
+      });
+      vi.mocked(isCloud).mockReturnValue(true);
+      vi.mocked(stripe.customers.del).mockResolvedValue({} as never);
+
+      const request = new Request('https://example.com/api/account', {
+        method: 'DELETE',
+        body: JSON.stringify({ emailConfirmation: mockUserEmail }),
+      });
+
+      // Act
+      const response = await DELETE(request);
+
+      // Assert
+      expect(response.status).toBe(200);
+      expect(stripe.customers.del).toHaveBeenCalledWith('cus_test123');
+    });
+
+    it('given null stripeCustomerId, should not call Stripe delete', async () => {
+      // Arrange — default beforeEach already has stripeCustomerId: null
+      vi.mocked(isCloud).mockReturnValue(true);
+
+      const request = new Request('https://example.com/api/account', {
+        method: 'DELETE',
+        body: JSON.stringify({ emailConfirmation: mockUserEmail }),
+      });
+
+      // Act
+      const response = await DELETE(request);
+
+      // Assert
+      expect(response.status).toBe(200);
+      expect(stripe.customers.del).not.toHaveBeenCalled();
+    });
+
+    it('given non-cloud deployment, should not call Stripe delete even with stripeCustomerId', async () => {
+      // Arrange
+      mockAccountRepo.findById.mockResolvedValue({
+        id: mockUserId,
+        email: mockUserEmail,
+        image: null,
+        stripeCustomerId: 'cus_onprem123',
+      });
+      vi.mocked(isCloud).mockReturnValue(false);
+
+      const request = new Request('https://example.com/api/account', {
+        method: 'DELETE',
+        body: JSON.stringify({ emailConfirmation: mockUserEmail }),
+      });
+
+      // Act
+      const response = await DELETE(request);
+
+      // Assert
+      expect(response.status).toBe(200);
+      expect(stripe.customers.del).not.toHaveBeenCalled();
+    });
+
+    it('given Stripe API failure, should log error but not block deletion', async () => {
+      // Arrange
+      mockAccountRepo.findById.mockResolvedValue({
+        id: mockUserId,
+        email: mockUserEmail,
+        image: null,
+        stripeCustomerId: 'cus_test123',
+      });
+      vi.mocked(isCloud).mockReturnValue(true);
+      vi.mocked(stripe.customers.del).mockRejectedValue(new Error('Stripe API unavailable'));
+
+      const request = new Request('https://example.com/api/account', {
+        method: 'DELETE',
+        body: JSON.stringify({ emailConfirmation: mockUserEmail }),
+      });
+
+      // Act
+      const response = await DELETE(request);
+
+      // Assert — user deleted, Stripe failure only logged
+      expect(response.status).toBe(200);
+      expect(mockAccountRepo.deleteUser).toHaveBeenCalledWith(mockUserId);
+      expect(loggers.auth.error).toHaveBeenCalledWith(
+        'Could not delete Stripe customer during account deletion:',
+        expect.objectContaining({ message: 'Stripe API unavailable' })
+      );
+    });
+
+    it('given Stripe deletion, should call deleteUser BEFORE stripe.customers.del', async () => {
+      // Arrange — right to erasure cannot be gated on Stripe API availability
+      mockAccountRepo.findById.mockResolvedValue({
+        id: mockUserId,
+        email: mockUserEmail,
+        image: null,
+        stripeCustomerId: 'cus_test123',
+      });
+      vi.mocked(isCloud).mockReturnValue(true);
+
+      const callOrder: string[] = [];
+      mockAccountRepo.deleteUser.mockImplementation(async () => {
+        callOrder.push('deleteUser');
+      });
+      vi.mocked(stripe.customers.del).mockImplementation(async () => {
+        callOrder.push('stripeDel');
+        return {} as never;
+      });
+
+      const request = new Request('https://example.com/api/account', {
+        method: 'DELETE',
+        body: JSON.stringify({ emailConfirmation: mockUserEmail }),
+      });
+
+      // Act
+      await DELETE(request);
+
+      // Assert — DB deletion before Stripe
+      expect(callOrder.indexOf('deleteUser')).toBeLessThan(callOrder.indexOf('stripeDel'));
+    });
+  });
+
+  describe('oauth token revocation (#911)', () => {
+    it('given active oauth connections, should revoke tokens before user deletion', async () => {
+      // Arrange
+      const callOrder: string[] = [];
+      vi.mocked(revokeUserIntegrationTokens).mockImplementation(async () => {
+        callOrder.push('revokeTokens');
+        return { revoked: 2, failed: 0 };
+      });
+      mockAccountRepo.deleteUser.mockImplementation(async () => {
+        callOrder.push('deleteUser');
+      });
+
+      const request = new Request('https://example.com/api/account', {
+        method: 'DELETE',
+        body: JSON.stringify({ emailConfirmation: mockUserEmail }),
+      });
+
+      // Act
+      const response = await DELETE(request);
+
+      // Assert — revoke before delete
+      expect(response.status).toBe(200);
+      expect(revokeUserIntegrationTokens).toHaveBeenCalledWith(mockUserId);
+      expect(callOrder.indexOf('revokeTokens')).toBeLessThan(callOrder.indexOf('deleteUser'));
+    });
+
+    it('given oauth revocation failure, should log error but not block deletion', async () => {
+      // Arrange
+      vi.mocked(revokeUserIntegrationTokens).mockRejectedValue(
+        new Error('Revocation service down')
+      );
+
+      const request = new Request('https://example.com/api/account', {
+        method: 'DELETE',
+        body: JSON.stringify({ emailConfirmation: mockUserEmail }),
+      });
+
+      // Act
+      const response = await DELETE(request);
+
+      // Assert
+      expect(response.status).toBe(200);
+      expect(mockAccountRepo.deleteUser).toHaveBeenCalledWith(mockUserId);
+      expect(loggers.auth.error).toHaveBeenCalledWith(
+        'Could not revoke OAuth tokens during account deletion:',
+        expect.objectContaining({ message: 'Revocation service down' })
+      );
+    });
+
+    it('given partial revocation failures, should log the counts and continue', async () => {
+      // Arrange
+      vi.mocked(revokeUserIntegrationTokens).mockResolvedValue({ revoked: 1, failed: 2 });
+
+      const request = new Request('https://example.com/api/account', {
+        method: 'DELETE',
+        body: JSON.stringify({ emailConfirmation: mockUserEmail }),
+      });
+
+      // Act
+      const response = await DELETE(request);
+
+      // Assert
+      expect(response.status).toBe(200);
+      expect(loggers.auth.info).toHaveBeenCalledWith(
+        expect.stringMatching(/revoked=1.*failed=2|OAuth.*1.*2/i)
       );
     });
   });

--- a/apps/web/src/app/api/account/__tests__/delete-route.test.ts
+++ b/apps/web/src/app/api/account/__tests__/delete-route.test.ts
@@ -3,8 +3,8 @@ import { NextResponse } from 'next/server';
 import type { SessionAuthResult, AuthError } from '@/lib/auth';
 
 // Mock repository seams - the proper architectural boundary
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       info: vi.fn(),
       error: vi.fn(),
@@ -12,19 +12,24 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
-  accountRepository: {
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/repositories', () => ({
+    accountRepository: {
     findById: vi.fn(),
     getOwnedDrives: vi.fn(),
     getDriveMemberCount: vi.fn(),
     deleteDrive: vi.fn(),
     deleteUser: vi.fn(),
   },
-  activityLogRepository: {
+    activityLogRepository: {
     anonymizeForUser: vi.fn(),
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
-  revokeUserIntegrationTokens: vi.fn(),
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -32,31 +37,22 @@ vi.mock('@/lib/auth', () => ({
   isAuthError: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib', () => ({
-  createUserServiceToken: vi.fn(),
-  deleteAiUsageLogsForUser: vi.fn(),
-  deleteMonitoringDataForUser: vi.fn(),
-  isCloud: vi.fn(),
+vi.mock('@pagespace/lib/services/validated-service-token', () => ({
+    createUserServiceToken: vi.fn(),
 }));
-
-vi.mock('@/lib/stripe/client', () => ({
-  stripe: {
-    customers: {
-      del: vi.fn(),
-    },
-  },
+vi.mock('@pagespace/lib/logging/ai-usage-purge', () => ({
+    deleteAiUsageLogsForUser: vi.fn(),
+}));
+vi.mock('@pagespace/lib/logging/monitoring-purge', () => ({
+    deleteMonitoringDataForUser: vi.fn(),
 }));
 
 import { DELETE } from '../route';
-import {
-  loggers,
-  accountRepository,
-  activityLogRepository,
-  revokeUserIntegrationTokens,
-} from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { accountRepository, activityLogRepository } from '@pagespace/lib/repositories';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { createUserServiceToken, deleteMonitoringDataForUser, isCloud } from '@pagespace/lib';
-import { stripe } from '@/lib/stripe/client';
+import { createUserServiceToken } from '@pagespace/lib/services/validated-service-token'
+import { deleteMonitoringDataForUser } from '@pagespace/lib/logging/monitoring-purge';
 
 // Type the mocked repositories
 const mockAccountRepo = vi.mocked(accountRepository);
@@ -90,12 +86,11 @@ describe('DELETE /api/account', () => {
     );
     vi.mocked(isAuthError).mockReturnValue(false);
 
-    // Arrange: default user exists (includes stripeCustomerId for #910)
+    // Arrange: default user exists
     mockAccountRepo.findById.mockResolvedValue({
       id: mockUserId,
       email: mockUserEmail,
       image: null,
-      stripeCustomerId: null,
     });
 
     // Arrange: default no owned drives
@@ -105,12 +100,6 @@ describe('DELETE /api/account', () => {
     mockAccountRepo.deleteDrive.mockResolvedValue(undefined);
     mockAccountRepo.deleteUser.mockResolvedValue(undefined);
     mockActivityLogRepo.anonymizeForUser.mockResolvedValue({ success: true });
-
-    // Arrange: default non-cloud (no Stripe calls)
-    vi.mocked(isCloud).mockReturnValue(false);
-
-    // Arrange: default successful OAuth revocation (#911)
-    vi.mocked(revokeUserIntegrationTokens).mockResolvedValue({ revoked: 0, failed: 0 });
   });
 
   describe('email confirmation validation', () => {
@@ -303,7 +292,6 @@ describe('DELETE /api/account', () => {
         id: mockUserId,
         email: mockUserEmail,
         image: '/avatars/user_123.jpg',
-        stripeCustomerId: null,
       });
 
       global.fetch = vi.fn().mockResolvedValue({
@@ -337,7 +325,6 @@ describe('DELETE /api/account', () => {
         id: mockUserId,
         email: mockUserEmail,
         image: 'https://example.com/avatar.jpg',
-        stripeCustomerId: null,
       });
 
       global.fetch = vi.fn();
@@ -360,7 +347,6 @@ describe('DELETE /api/account', () => {
         id: mockUserId,
         email: mockUserEmail,
         image: '/avatars/user_123.jpg',
-        stripeCustomerId: null,
       });
 
       vi.mocked(createUserServiceToken).mockRejectedValueOnce(new Error('Token creation failed'));
@@ -514,200 +500,6 @@ describe('DELETE /api/account', () => {
       expect(loggers.auth.error).toHaveBeenCalledWith(
         'Account deletion error:',
         expect.objectContaining({ message: 'Database connection lost' })
-      );
-    });
-  });
-
-  describe('stripe customer deletion (#910)', () => {
-    it('given stripeCustomerId and cloud mode, should delete Stripe customer after account deletion', async () => {
-      // Arrange
-      mockAccountRepo.findById.mockResolvedValue({
-        id: mockUserId,
-        email: mockUserEmail,
-        image: null,
-        stripeCustomerId: 'cus_test123',
-      });
-      vi.mocked(isCloud).mockReturnValue(true);
-      vi.mocked(stripe.customers.del).mockResolvedValue({} as never);
-
-      const request = new Request('https://example.com/api/account', {
-        method: 'DELETE',
-        body: JSON.stringify({ emailConfirmation: mockUserEmail }),
-      });
-
-      // Act
-      const response = await DELETE(request);
-
-      // Assert
-      expect(response.status).toBe(200);
-      expect(stripe.customers.del).toHaveBeenCalledWith('cus_test123');
-    });
-
-    it('given null stripeCustomerId, should not call Stripe delete', async () => {
-      // Arrange — default beforeEach already has stripeCustomerId: null
-      vi.mocked(isCloud).mockReturnValue(true);
-
-      const request = new Request('https://example.com/api/account', {
-        method: 'DELETE',
-        body: JSON.stringify({ emailConfirmation: mockUserEmail }),
-      });
-
-      // Act
-      const response = await DELETE(request);
-
-      // Assert
-      expect(response.status).toBe(200);
-      expect(stripe.customers.del).not.toHaveBeenCalled();
-    });
-
-    it('given non-cloud deployment, should not call Stripe delete even with stripeCustomerId', async () => {
-      // Arrange
-      mockAccountRepo.findById.mockResolvedValue({
-        id: mockUserId,
-        email: mockUserEmail,
-        image: null,
-        stripeCustomerId: 'cus_onprem123',
-      });
-      vi.mocked(isCloud).mockReturnValue(false);
-
-      const request = new Request('https://example.com/api/account', {
-        method: 'DELETE',
-        body: JSON.stringify({ emailConfirmation: mockUserEmail }),
-      });
-
-      // Act
-      const response = await DELETE(request);
-
-      // Assert
-      expect(response.status).toBe(200);
-      expect(stripe.customers.del).not.toHaveBeenCalled();
-    });
-
-    it('given Stripe API failure, should log error but not block deletion', async () => {
-      // Arrange
-      mockAccountRepo.findById.mockResolvedValue({
-        id: mockUserId,
-        email: mockUserEmail,
-        image: null,
-        stripeCustomerId: 'cus_test123',
-      });
-      vi.mocked(isCloud).mockReturnValue(true);
-      vi.mocked(stripe.customers.del).mockRejectedValue(new Error('Stripe API unavailable'));
-
-      const request = new Request('https://example.com/api/account', {
-        method: 'DELETE',
-        body: JSON.stringify({ emailConfirmation: mockUserEmail }),
-      });
-
-      // Act
-      const response = await DELETE(request);
-
-      // Assert — user deleted, Stripe failure only logged
-      expect(response.status).toBe(200);
-      expect(mockAccountRepo.deleteUser).toHaveBeenCalledWith(mockUserId);
-      expect(loggers.auth.error).toHaveBeenCalledWith(
-        'Could not delete Stripe customer during account deletion:',
-        expect.objectContaining({ message: 'Stripe API unavailable' })
-      );
-    });
-
-    it('given Stripe deletion, should call deleteUser BEFORE stripe.customers.del', async () => {
-      // Arrange — right to erasure cannot be gated on Stripe API availability
-      mockAccountRepo.findById.mockResolvedValue({
-        id: mockUserId,
-        email: mockUserEmail,
-        image: null,
-        stripeCustomerId: 'cus_test123',
-      });
-      vi.mocked(isCloud).mockReturnValue(true);
-
-      const callOrder: string[] = [];
-      mockAccountRepo.deleteUser.mockImplementation(async () => {
-        callOrder.push('deleteUser');
-      });
-      vi.mocked(stripe.customers.del).mockImplementation(async () => {
-        callOrder.push('stripeDel');
-        return {} as never;
-      });
-
-      const request = new Request('https://example.com/api/account', {
-        method: 'DELETE',
-        body: JSON.stringify({ emailConfirmation: mockUserEmail }),
-      });
-
-      // Act
-      await DELETE(request);
-
-      // Assert — DB deletion before Stripe
-      expect(callOrder.indexOf('deleteUser')).toBeLessThan(callOrder.indexOf('stripeDel'));
-    });
-  });
-
-  describe('oauth token revocation (#911)', () => {
-    it('given active oauth connections, should revoke tokens before user deletion', async () => {
-      // Arrange
-      const callOrder: string[] = [];
-      vi.mocked(revokeUserIntegrationTokens).mockImplementation(async () => {
-        callOrder.push('revokeTokens');
-        return { revoked: 2, failed: 0 };
-      });
-      mockAccountRepo.deleteUser.mockImplementation(async () => {
-        callOrder.push('deleteUser');
-      });
-
-      const request = new Request('https://example.com/api/account', {
-        method: 'DELETE',
-        body: JSON.stringify({ emailConfirmation: mockUserEmail }),
-      });
-
-      // Act
-      const response = await DELETE(request);
-
-      // Assert — revoke before delete
-      expect(response.status).toBe(200);
-      expect(revokeUserIntegrationTokens).toHaveBeenCalledWith(mockUserId);
-      expect(callOrder.indexOf('revokeTokens')).toBeLessThan(callOrder.indexOf('deleteUser'));
-    });
-
-    it('given oauth revocation failure, should log error but not block deletion', async () => {
-      // Arrange
-      vi.mocked(revokeUserIntegrationTokens).mockRejectedValue(
-        new Error('Revocation service down')
-      );
-
-      const request = new Request('https://example.com/api/account', {
-        method: 'DELETE',
-        body: JSON.stringify({ emailConfirmation: mockUserEmail }),
-      });
-
-      // Act
-      const response = await DELETE(request);
-
-      // Assert
-      expect(response.status).toBe(200);
-      expect(mockAccountRepo.deleteUser).toHaveBeenCalledWith(mockUserId);
-      expect(loggers.auth.error).toHaveBeenCalledWith(
-        'Could not revoke OAuth tokens during account deletion:',
-        expect.objectContaining({ message: 'Revocation service down' })
-      );
-    });
-
-    it('given partial revocation failures, should log the counts and continue', async () => {
-      // Arrange
-      vi.mocked(revokeUserIntegrationTokens).mockResolvedValue({ revoked: 1, failed: 2 });
-
-      const request = new Request('https://example.com/api/account', {
-        method: 'DELETE',
-        body: JSON.stringify({ emailConfirmation: mockUserEmail }),
-      });
-
-      // Act
-      const response = await DELETE(request);
-
-      // Assert
-      expect(response.status).toBe(200);
-      expect(loggers.auth.info).toHaveBeenCalledWith(
-        expect.stringMatching(/revoked=1.*failed=2|OAuth.*1.*2/i)
       );
     });
   });

--- a/apps/web/src/app/api/account/__tests__/get-patch-route.test.ts
+++ b/apps/web/src/app/api/account/__tests__/get-patch-route.test.ts
@@ -16,7 +16,7 @@ vi.mock('@pagespace/db', () => ({
   eq: vi.fn((field: unknown, value: unknown) => ({ field, value })),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
   loggers: {
     auth: {
       info: vi.fn(),
@@ -25,6 +25,10 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/repositories', () => ({
   accountRepository: {
     findById: vi.fn(),
     getOwnedDrives: vi.fn(),
@@ -35,6 +39,8 @@ vi.mock('@pagespace/lib/server', () => ({
   activityLogRepository: {
     anonymizeForUser: vi.fn(),
   },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
   audit: vi.fn(),
   auditRequest: vi.fn(),
 }));
@@ -44,7 +50,7 @@ vi.mock('@/lib/auth', () => ({
   isAuthError: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib', () => {
+vi.mock('@pagespace/lib/validators/email', () => {
   const EMAIL_PATTERN = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
   return {
     isValidEmail: (email: string) => {
@@ -52,11 +58,17 @@ vi.mock('@pagespace/lib', () => {
       if (!EMAIL_PATTERN.test(email)) return false;
       return email.slice(email.lastIndexOf('@') + 1).includes('.');
     },
-    createUserServiceToken: vi.fn(),
-    deleteAiUsageLogsForUser: vi.fn(),
-    deleteMonitoringDataForUser: vi.fn(),
   };
 });
+vi.mock('@pagespace/lib/services/validated-service-token', () => ({
+  createUserServiceToken: vi.fn(),
+}));
+vi.mock('@pagespace/lib/logging/ai-usage-purge', () => ({
+  deleteAiUsageLogsForUser: vi.fn(),
+}));
+vi.mock('@pagespace/lib/logging/monitoring-purge', () => ({
+  deleteMonitoringDataForUser: vi.fn(),
+}));
 
 vi.mock('@pagespace/lib/compliance/anonymize', () => ({
   createAnonymizedActorEmail: vi.fn(() => 'deleted_user_abc123'),
@@ -72,7 +84,7 @@ vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
 
 import { GET, PATCH } from '../route';
 import { db } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 
 // Helper to create mock SessionAuthResult

--- a/apps/web/src/app/api/account/avatar/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/avatar/__tests__/route.test.ts
@@ -17,13 +17,13 @@ vi.mock('@pagespace/db', () => ({
   eq: vi.fn((a, b) => ({ field: a, value: b })),
 }));
 
-vi.mock('@pagespace/lib', () => ({
-  createUserServiceToken: vi.fn().mockResolvedValue({ token: 'mock-service-token' }),
+vi.mock('@pagespace/lib/services/validated-service-token', () => ({
+    createUserServiceToken: vi.fn().mockResolvedValue({ token: 'mock-service-token' }),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 // Mock global fetch
@@ -33,7 +33,7 @@ vi.stubGlobal('fetch', mockFetch);
 import { POST, DELETE } from '../route';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db } from '@pagespace/db';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 // Test helpers
 const mockSessionAuth = (userId: string): SessionAuthResult => ({

--- a/apps/web/src/app/api/account/avatar/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/avatar/__tests__/route.test.ts
@@ -18,12 +18,12 @@ vi.mock('@pagespace/db', () => ({
 }));
 
 vi.mock('@pagespace/lib/services/validated-service-token', () => ({
-    createUserServiceToken: vi.fn().mockResolvedValue({ token: 'mock-service-token' }),
+  createUserServiceToken: vi.fn().mockResolvedValue({ token: 'mock-service-token' }),
 }));
 
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 // Mock global fetch

--- a/apps/web/src/app/api/account/avatar/route.ts
+++ b/apps/web/src/app/api/account/avatar/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db, users, eq } from '@pagespace/db';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
-import { createUserServiceToken, type ServiceScope } from '@pagespace/lib';
+import { createUserServiceToken, type ServiceScope } from '@pagespace/lib/services/validated-service-token';
 
 // Maximum file size: 5MB
 const MAX_FILE_SIZE = 5 * 1024 * 1024;

--- a/apps/web/src/app/api/account/devices/[deviceId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/devices/[deviceId]/__tests__/route.test.ts
@@ -21,24 +21,28 @@ vi.mock('@pagespace/db', () => ({
   eq: vi.fn((a, b) => ({ eq: [a, b] })),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       info: vi.fn(),
       error: vi.fn(),
       warn: vi.fn(),
     },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/auth/secure-compare', () => ({
   secureCompare: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/auth', () => ({
-  hashToken: vi.fn((token: string) => `hashed_${token}`),
+vi.mock('@pagespace/lib/auth/token-utils', () => ({
+    hashToken: vi.fn((token: string) => `hashed_${token}`),
 }));
 
 vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
@@ -54,7 +58,7 @@ import { DELETE } from '../route';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db } from '@pagespace/db';
 import { secureCompare } from '@pagespace/lib/auth/secure-compare';
-import { hashToken } from '@pagespace/lib/auth';
+import { hashToken } from '@pagespace/lib/auth/token-utils';
 import { revokeDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
 import { getActorInfo, logTokenActivity } from '@pagespace/lib/monitoring/activity-logger';
 

--- a/apps/web/src/app/api/account/devices/[deviceId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/devices/[deviceId]/__tests__/route.test.ts
@@ -22,7 +22,7 @@ vi.mock('@pagespace/db', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       info: vi.fn(),
       error: vi.fn(),
@@ -33,8 +33,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/auth/secure-compare', () => ({
@@ -42,7 +42,7 @@ vi.mock('@pagespace/lib/auth/secure-compare', () => ({
 }));
 
 vi.mock('@pagespace/lib/auth/token-utils', () => ({
-    hashToken: vi.fn((token: string) => `hashed_${token}`),
+  hashToken: vi.fn((token: string) => `hashed_${token}`),
 }));
 
 vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({

--- a/apps/web/src/app/api/account/devices/[deviceId]/route.ts
+++ b/apps/web/src/app/api/account/devices/[deviceId]/route.ts
@@ -1,5 +1,5 @@
 import { db, eq, deviceTokens } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { secureCompare } from '@pagespace/lib/auth/secure-compare';
 import { hashToken } from '@pagespace/lib/auth/token-utils';

--- a/apps/web/src/app/api/account/devices/[deviceId]/route.ts
+++ b/apps/web/src/app/api/account/devices/[deviceId]/route.ts
@@ -1,7 +1,8 @@
 import { db, eq, deviceTokens } from '@pagespace/db';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { secureCompare } from '@pagespace/lib/auth/secure-compare';
-import { hashToken } from '@pagespace/lib/auth';
+import { hashToken } from '@pagespace/lib/auth/token-utils';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { revokeDeviceToken } from '@pagespace/lib/auth/device-auth-utils';
 import { getActorInfo, logTokenActivity } from '@pagespace/lib/monitoring/activity-logger';

--- a/apps/web/src/app/api/account/devices/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/devices/__tests__/route.test.ts
@@ -31,7 +31,7 @@ vi.mock('@pagespace/db', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       info: vi.fn(),
       error: vi.fn(),
@@ -42,16 +42,16 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/auth/token-utils', () => ({
-    hashToken: vi.fn((token: string) => `hashed_${token}`),
+  hashToken: vi.fn((token: string) => `hashed_${token}`),
 }));
 vi.mock('@pagespace/lib/auth/opaque-tokens', () => ({
-    isValidTokenFormat: vi.fn(),
-    getTokenType: vi.fn(),
+  isValidTokenFormat: vi.fn(),
+  getTokenType: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/auth/secure-compare', () => ({

--- a/apps/web/src/app/api/account/devices/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/devices/__tests__/route.test.ts
@@ -30,22 +30,28 @@ vi.mock('@pagespace/db', () => ({
   sql: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       info: vi.fn(),
       error: vi.fn(),
       warn: vi.fn(),
     },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/auth', () => ({
-  hashToken: vi.fn((token: string) => `hashed_${token}`),
-  isValidTokenFormat: vi.fn(),
-  getTokenType: vi.fn(),
+vi.mock('@pagespace/lib/auth/token-utils', () => ({
+    hashToken: vi.fn((token: string) => `hashed_${token}`),
+}));
+vi.mock('@pagespace/lib/auth/opaque-tokens', () => ({
+    isValidTokenFormat: vi.fn(),
+    getTokenType: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/auth/secure-compare', () => ({
@@ -62,7 +68,8 @@ vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
 import { GET, DELETE } from '../route';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db } from '@pagespace/db';
-import { hashToken, isValidTokenFormat, getTokenType } from '@pagespace/lib/auth';
+import { hashToken } from '@pagespace/lib/auth/token-utils';
+import { isValidTokenFormat, getTokenType } from '@pagespace/lib/auth/opaque-tokens';
 import { secureCompare } from '@pagespace/lib/auth/secure-compare';
 import {
   getUserDeviceTokens,

--- a/apps/web/src/app/api/account/devices/route.ts
+++ b/apps/web/src/app/api/account/devices/route.ts
@@ -1,10 +1,11 @@
 import { users, db, eq, deviceTokens, sql, and, isNull, gt } from '@pagespace/db';
-import { loggers, auditRequest } from '@pagespace/lib/server';
-import { hashToken } from '@pagespace/lib/auth';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { hashToken } from '@pagespace/lib/auth/token-utils';
 import { secureCompare } from '@pagespace/lib/auth/secure-compare';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { getUserDeviceTokens, revokeAllUserDeviceTokens, createDeviceTokenRecord, revokeExpiredDeviceTokens } from '@pagespace/lib/auth/device-auth-utils';
-import { isValidTokenFormat, getTokenType } from '@pagespace/lib/auth';
+import { isValidTokenFormat, getTokenType } from '@pagespace/lib/auth/opaque-tokens';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/account/devices/route.ts
+++ b/apps/web/src/app/api/account/devices/route.ts
@@ -1,5 +1,5 @@
 import { users, db, eq, deviceTokens, sql, and, isNull, gt } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { hashToken } from '@pagespace/lib/auth/token-utils';
 import { secureCompare } from '@pagespace/lib/auth/secure-compare';

--- a/apps/web/src/app/api/account/drives-status/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/drives-status/__tests__/route.test.ts
@@ -27,7 +27,7 @@ vi.mock('@pagespace/db', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       info: vi.fn(),
       error: vi.fn(),

--- a/apps/web/src/app/api/account/drives-status/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/drives-status/__tests__/route.test.ts
@@ -26,8 +26,8 @@ vi.mock('@pagespace/db', () => ({
   sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values, type: 'sql' })),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       info: vi.fn(),
       error: vi.fn(),
@@ -35,6 +35,8 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -43,7 +45,7 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 import { db } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 
 // Helper to create mock SessionAuthResult

--- a/apps/web/src/app/api/account/drives-status/route.ts
+++ b/apps/web/src/app/api/account/drives-status/route.ts
@@ -1,5 +1,5 @@
 import { db, eq, and, sql, drives, driveMembers, users } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };

--- a/apps/web/src/app/api/account/export/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/export/__tests__/route.test.ts
@@ -12,26 +12,30 @@ vi.mock('@pagespace/db', () => ({
   db: {},
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       info: vi.fn(),
       error: vi.fn(),
       warn: vi.fn(),
     },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/compliance/export/gdpr-export', () => ({
   collectAllUserData: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn(),
-  resetDistributedRateLimit: vi.fn(),
-  DISTRIBUTED_RATE_LIMITS: {
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn(),
+    resetDistributedRateLimit: vi.fn(),
+    DISTRIBUTED_RATE_LIMITS: {
     EXPORT_DATA: {
       maxAttempts: 1,
       windowMs: 24 * 60 * 60 * 1000,
@@ -54,7 +58,7 @@ vi.mock('archiver', () => ({
 
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { collectAllUserData } from '@pagespace/lib/compliance/export/gdpr-export';
-import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security';
+import { checkDistributedRateLimit, resetDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { GET } from '../route';
 
 // Test helpers
@@ -83,10 +87,6 @@ const mockUserData = {
   activity: [],
   aiUsage: [],
   tasks: [],
-  sessions: [],
-  notifications: [],
-  displayPreferences: [],
-  personalization: null,
 };
 
 describe('GET /api/account/export', () => {
@@ -186,8 +186,8 @@ describe('GET /api/account/export', () => {
 
       await GET(createRequest());
 
-      // Should append 11 JSON files (sessions, notifications, displayPreferences added; personalization omitted when null)
-      expect(mockArchive.append).toHaveBeenCalledTimes(11);
+      // Should append 8 JSON files
+      expect(mockArchive.append).toHaveBeenCalledTimes(8);
       // Verify each data category name pattern
       const appendCalls = mockArchive.append.mock.calls.map(
         (call: unknown[]) => (call[1] as { name: string }).name
@@ -200,24 +200,6 @@ describe('GET /api/account/export', () => {
       expect(appendCalls.some((n: string) => n.includes('activity.json'))).toBe(true);
       expect(appendCalls.some((n: string) => n.includes('ai-usage.json'))).toBe(true);
       expect(appendCalls.some((n: string) => n.includes('tasks.json'))).toBe(true);
-      expect(appendCalls.some((n: string) => n.includes('sessions.json'))).toBe(true);
-      expect(appendCalls.some((n: string) => n.includes('notifications.json'))).toBe(true);
-      expect(appendCalls.some((n: string) => n.includes('display-preferences.json'))).toBe(true);
-    });
-
-    it('appends personalization.json when personalization data exists', async () => {
-      vi.mocked(collectAllUserData).mockResolvedValue({
-        ...mockUserData,
-        personalization: { bio: 'test', writingStyle: null, rules: null, enabled: true, createdAt: new Date(), updatedAt: new Date() },
-      } as never);
-
-      await GET(createRequest());
-
-      expect(mockArchive.append).toHaveBeenCalledTimes(12);
-      const appendCalls = mockArchive.append.mock.calls.map(
-        (call: unknown[]) => (call[1] as { name: string }).name
-      );
-      expect(appendCalls.some((n: string) => n.includes('personalization.json'))).toBe(true);
     });
 
     it('calls archive.finalize()', async () => {

--- a/apps/web/src/app/api/account/export/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/export/__tests__/route.test.ts
@@ -13,7 +13,7 @@ vi.mock('@pagespace/db', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       info: vi.fn(),
       error: vi.fn(),
@@ -24,8 +24,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/compliance/export/gdpr-export', () => ({
@@ -33,9 +33,9 @@ vi.mock('@pagespace/lib/compliance/export/gdpr-export', () => ({
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn(),
-    resetDistributedRateLimit: vi.fn(),
-    DISTRIBUTED_RATE_LIMITS: {
+  checkDistributedRateLimit: vi.fn(),
+  resetDistributedRateLimit: vi.fn(),
+  DISTRIBUTED_RATE_LIMITS: {
     EXPORT_DATA: {
       maxAttempts: 1,
       windowMs: 24 * 60 * 60 * 1000,
@@ -87,6 +87,10 @@ const mockUserData = {
   activity: [],
   aiUsage: [],
   tasks: [],
+  sessions: [],
+  notifications: [],
+  displayPreferences: [],
+  personalization: null,
 };
 
 describe('GET /api/account/export', () => {
@@ -186,8 +190,8 @@ describe('GET /api/account/export', () => {
 
       await GET(createRequest());
 
-      // Should append 8 JSON files
-      expect(mockArchive.append).toHaveBeenCalledTimes(8);
+      // Should append 11 JSON files (sessions, notifications, displayPreferences added; personalization omitted when null)
+      expect(mockArchive.append).toHaveBeenCalledTimes(11);
       // Verify each data category name pattern
       const appendCalls = mockArchive.append.mock.calls.map(
         (call: unknown[]) => (call[1] as { name: string }).name
@@ -200,6 +204,24 @@ describe('GET /api/account/export', () => {
       expect(appendCalls.some((n: string) => n.includes('activity.json'))).toBe(true);
       expect(appendCalls.some((n: string) => n.includes('ai-usage.json'))).toBe(true);
       expect(appendCalls.some((n: string) => n.includes('tasks.json'))).toBe(true);
+      expect(appendCalls.some((n: string) => n.includes('sessions.json'))).toBe(true);
+      expect(appendCalls.some((n: string) => n.includes('notifications.json'))).toBe(true);
+      expect(appendCalls.some((n: string) => n.includes('display-preferences.json'))).toBe(true);
+    });
+
+    it('appends personalization.json when personalization data exists', async () => {
+      vi.mocked(collectAllUserData).mockResolvedValue({
+        ...mockUserData,
+        personalization: { bio: 'test', writingStyle: null, rules: null, enabled: true, createdAt: new Date(), updatedAt: new Date() },
+      } as never);
+
+      await GET(createRequest());
+
+      expect(mockArchive.append).toHaveBeenCalledTimes(12);
+      const appendCalls = mockArchive.append.mock.calls.map(
+        (call: unknown[]) => (call[1] as { name: string }).name
+      );
+      expect(appendCalls.some((n: string) => n.includes('personalization.json'))).toBe(true);
     });
 
     it('calls archive.finalize()', async () => {

--- a/apps/web/src/app/api/account/export/route.ts
+++ b/apps/web/src/app/api/account/export/route.ts
@@ -81,6 +81,12 @@ export async function GET(request: Request) {
     archive.append(JSON.stringify(data.activity, null, 2), { name: `pagespace-export-${dateStr}/activity.json` });
     archive.append(JSON.stringify(data.aiUsage, null, 2), { name: `pagespace-export-${dateStr}/ai-usage.json` });
     archive.append(JSON.stringify(data.tasks, null, 2), { name: `pagespace-export-${dateStr}/tasks.json` });
+    archive.append(JSON.stringify(data.sessions, null, 2), { name: `pagespace-export-${dateStr}/sessions.json` });
+    archive.append(JSON.stringify(data.notifications, null, 2), { name: `pagespace-export-${dateStr}/notifications.json` });
+    archive.append(JSON.stringify(data.displayPreferences, null, 2), { name: `pagespace-export-${dateStr}/display-preferences.json` });
+    if (data.personalization) {
+      archive.append(JSON.stringify(data.personalization, null, 2), { name: `pagespace-export-${dateStr}/personalization.json` });
+    }
 
     // Finalize the archive (must be called after all data is appended)
     archive.finalize();

--- a/apps/web/src/app/api/account/export/route.ts
+++ b/apps/web/src/app/api/account/export/route.ts
@@ -1,8 +1,8 @@
 import { collectAllUserData } from '@pagespace/lib/compliance/export/gdpr-export';
 import { db } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { checkDistributedRateLimit, resetDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security';
-import { auditRequest } from '@pagespace/lib/server';
+import { checkDistributedRateLimit, resetDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security/distributed-rate-limit';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import archiver from 'archiver';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
@@ -81,12 +81,6 @@ export async function GET(request: Request) {
     archive.append(JSON.stringify(data.activity, null, 2), { name: `pagespace-export-${dateStr}/activity.json` });
     archive.append(JSON.stringify(data.aiUsage, null, 2), { name: `pagespace-export-${dateStr}/ai-usage.json` });
     archive.append(JSON.stringify(data.tasks, null, 2), { name: `pagespace-export-${dateStr}/tasks.json` });
-    archive.append(JSON.stringify(data.sessions, null, 2), { name: `pagespace-export-${dateStr}/sessions.json` });
-    archive.append(JSON.stringify(data.notifications, null, 2), { name: `pagespace-export-${dateStr}/notifications.json` });
-    archive.append(JSON.stringify(data.displayPreferences, null, 2), { name: `pagespace-export-${dateStr}/display-preferences.json` });
-    if (data.personalization) {
-      archive.append(JSON.stringify(data.personalization, null, 2), { name: `pagespace-export-${dateStr}/personalization.json` });
-    }
 
     // Finalize the archive (must be called after all data is appended)
     archive.finalize();

--- a/apps/web/src/app/api/account/handle-drive/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/handle-drive/__tests__/route.test.ts
@@ -23,8 +23,8 @@ vi.mock('@pagespace/db', () => ({
   and: vi.fn((...args: unknown[]) => ({ args, type: 'and' })),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     auth: {
       info: vi.fn(),
       error: vi.fn(),
@@ -32,8 +32,12 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -48,7 +52,7 @@ vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
 }));
 
 import { db } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { getActorInfo, logDriveActivity } from '@pagespace/lib/monitoring/activity-logger';
 

--- a/apps/web/src/app/api/account/handle-drive/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/handle-drive/__tests__/route.test.ts
@@ -24,7 +24,7 @@ vi.mock('@pagespace/db', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     auth: {
       info: vi.fn(),
       error: vi.fn(),
@@ -36,8 +36,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({

--- a/apps/web/src/app/api/account/handle-drive/route.ts
+++ b/apps/web/src/app/api/account/handle-drive/route.ts
@@ -1,5 +1,5 @@
 import { db, eq, and, drives, driveMembers } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { getActorInfo, logDriveActivity } from '@pagespace/lib/monitoring/activity-logger';

--- a/apps/web/src/app/api/account/handle-drive/route.ts
+++ b/apps/web/src/app/api/account/handle-drive/route.ts
@@ -1,5 +1,6 @@
 import { db, eq, and, drives, driveMembers } from '@pagespace/db';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { getActorInfo, logDriveActivity } from '@pagespace/lib/monitoring/activity-logger';
 

--- a/apps/web/src/app/api/account/route.ts
+++ b/apps/web/src/app/api/account/route.ts
@@ -1,14 +1,14 @@
 import { users, db, eq } from '@pagespace/db';
 import { z } from 'zod';
-import { loggers } from '@pagespace/lib/logging/logger-config'
-import { accountRepository, activityLogRepository } from '@pagespace/lib/repositories'
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { accountRepository, activityLogRepository } from '@pagespace/lib/repositories';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { revokeUserIntegrationTokens } from '@pagespace/lib/compliance/erasure/revoke-integration-tokens';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { createUserServiceToken, type ServiceScope } from '@pagespace/lib/services/validated-service-token'
-import { deleteAiUsageLogsForUser } from '@pagespace/lib/logging/ai-usage-purge'
-import { deleteMonitoringDataForUser } from '@pagespace/lib/logging/monitoring-purge'
-import { isValidEmail } from '@pagespace/lib/validators/email'
+import { createUserServiceToken, type ServiceScope } from '@pagespace/lib/services/validated-service-token';
+import { deleteAiUsageLogsForUser } from '@pagespace/lib/logging/ai-usage-purge';
+import { deleteMonitoringDataForUser } from '@pagespace/lib/logging/monitoring-purge';
+import { isValidEmail } from '@pagespace/lib/validators/email';
 import { isCloud } from '@pagespace/lib/deployment-mode';
 import { createAnonymizedActorEmail } from '@pagespace/lib/compliance/anonymize';
 import { getActorInfo, logUserActivity } from '@pagespace/lib/monitoring/activity-logger';

--- a/apps/web/src/app/api/account/route.ts
+++ b/apps/web/src/app/api/account/route.ts
@@ -1,11 +1,15 @@
 import { users, db, eq } from '@pagespace/db';
 import { z } from 'zod';
-import { loggers, accountRepository, activityLogRepository, auditRequest, revokeUserIntegrationTokens } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { accountRepository, activityLogRepository } from '@pagespace/lib/repositories'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { createUserServiceToken, deleteAiUsageLogsForUser, deleteMonitoringDataForUser, isValidEmail, isCloud, type ServiceScope } from '@pagespace/lib';
+import { createUserServiceToken, type ServiceScope } from '@pagespace/lib/services/validated-service-token'
+import { deleteAiUsageLogsForUser } from '@pagespace/lib/logging/ai-usage-purge'
+import { deleteMonitoringDataForUser } from '@pagespace/lib/logging/monitoring-purge'
+import { isValidEmail } from '@pagespace/lib/validators/email';
 import { createAnonymizedActorEmail } from '@pagespace/lib/compliance/anonymize';
 import { getActorInfo, logUserActivity } from '@pagespace/lib/monitoring/activity-logger';
-import { stripe } from '@/lib/stripe/client';
 
 const patchBodySchema = z
   .object({
@@ -269,33 +273,12 @@ export async function DELETE(req: Request) {
       loggers.auth.error('Could not delete monitoring data during account deletion:', error as Error);
     }
 
-    // Revoke all OAuth integration tokens BEFORE user deletion (Art. 17 GDPR — #911)
-    // Best-effort: log failures but never block the right to erasure
-    try {
-      const { revoked, failed } = await revokeUserIntegrationTokens(userId);
-      loggers.auth.info(`OAuth token revocation complete for user ${userId}: revoked=${revoked}, failed=${failed}`);
-    } catch (error) {
-      loggers.auth.error('Could not revoke OAuth tokens during account deletion:', error as Error);
-    }
-
     // Log security audit BEFORE user deletion so the userId FK is still valid.
     // Timeout prevents stalling account deletion if the advisory lock hangs.
     auditRequest(req, { eventType: 'admin.user.deleted', userId, resourceType: 'account', resourceId: userId });
 
     // Delete the user via repository seam (FK set null will preserve activity logs with userId = null)
     await accountRepository.deleteUser(userId);
-
-    // Delete Stripe customer AFTER user deletion (Art. 17 GDPR — #910)
-    // Cloud-only: on-prem and tenant deployments don't use Stripe
-    // Right to erasure cannot be gated on Stripe API availability — log failures only
-    if (user.stripeCustomerId && isCloud()) {
-      try {
-        await stripe.customers.del(user.stripeCustomerId);
-        loggers.auth.info(`Stripe customer deleted: ${user.stripeCustomerId}`);
-      } catch (error) {
-        loggers.auth.error('Could not delete Stripe customer during account deletion:', error as Error);
-      }
-    }
 
     loggers.auth.info(`User account deleted: ${userId}`);
 

--- a/apps/web/src/app/api/account/route.ts
+++ b/apps/web/src/app/api/account/route.ts
@@ -3,13 +3,16 @@ import { z } from 'zod';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { accountRepository, activityLogRepository } from '@pagespace/lib/repositories'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { revokeUserIntegrationTokens } from '@pagespace/lib/compliance/erasure/revoke-integration-tokens';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { createUserServiceToken, type ServiceScope } from '@pagespace/lib/services/validated-service-token'
 import { deleteAiUsageLogsForUser } from '@pagespace/lib/logging/ai-usage-purge'
 import { deleteMonitoringDataForUser } from '@pagespace/lib/logging/monitoring-purge'
-import { isValidEmail } from '@pagespace/lib/validators/email';
+import { isValidEmail } from '@pagespace/lib/validators/email'
+import { isCloud } from '@pagespace/lib/deployment-mode';
 import { createAnonymizedActorEmail } from '@pagespace/lib/compliance/anonymize';
 import { getActorInfo, logUserActivity } from '@pagespace/lib/monitoring/activity-logger';
+import { stripe } from '@/lib/stripe/client';
 
 const patchBodySchema = z
   .object({
@@ -273,12 +276,33 @@ export async function DELETE(req: Request) {
       loggers.auth.error('Could not delete monitoring data during account deletion:', error as Error);
     }
 
+    // Revoke all OAuth integration tokens BEFORE user deletion (Art. 17 GDPR — #911)
+    // Best-effort: log failures but never block the right to erasure
+    try {
+      const { revoked, failed } = await revokeUserIntegrationTokens(userId);
+      loggers.auth.info(`OAuth token revocation complete for user ${userId}: revoked=${revoked}, failed=${failed}`);
+    } catch (error) {
+      loggers.auth.error('Could not revoke OAuth tokens during account deletion:', error as Error);
+    }
+
     // Log security audit BEFORE user deletion so the userId FK is still valid.
     // Timeout prevents stalling account deletion if the advisory lock hangs.
     auditRequest(req, { eventType: 'admin.user.deleted', userId, resourceType: 'account', resourceId: userId });
 
     // Delete the user via repository seam (FK set null will preserve activity logs with userId = null)
     await accountRepository.deleteUser(userId);
+
+    // Delete Stripe customer AFTER user deletion (Art. 17 GDPR — #910)
+    // Cloud-only: on-prem and tenant deployments don't use Stripe
+    // Right to erasure cannot be gated on Stripe API availability — log failures only
+    if (user.stripeCustomerId && isCloud()) {
+      try {
+        await stripe.customers.del(user.stripeCustomerId);
+        loggers.auth.info(`Stripe customer deleted: ${user.stripeCustomerId}`);
+      } catch (error) {
+        loggers.auth.error('Could not delete Stripe customer during account deletion:', error as Error);
+      }
+    }
 
     loggers.auth.info(`User account deleted: ${userId}`);
 

--- a/apps/web/src/app/api/activity/summary/__tests__/route.test.ts
+++ b/apps/web/src/app/api/activity/summary/__tests__/route.test.ts
@@ -10,14 +10,14 @@ const { mockAuditRequest } = vi.hoisted(() => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
 
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: mockAuditRequest,
+  auditRequest: mockAuditRequest,
 }));
 
 vi.mock('@/lib/auth', () => ({

--- a/apps/web/src/app/api/activity/summary/__tests__/route.test.ts
+++ b/apps/web/src/app/api/activity/summary/__tests__/route.test.ts
@@ -9,11 +9,15 @@ const { mockAuditRequest } = vi.hoisted(() => ({
   mockAuditRequest: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
-  auditRequest: mockAuditRequest,
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: mockAuditRequest,
 }));
 
 vi.mock('@/lib/auth', () => ({

--- a/apps/web/src/app/api/activity/summary/route.ts
+++ b/apps/web/src/app/api/activity/summary/route.ts
@@ -17,7 +17,8 @@ import {
   sql,
   count,
 } from '@pagespace/db';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const };
 

--- a/apps/web/src/app/api/activity/summary/route.ts
+++ b/apps/web/src/app/api/activity/summary/route.ts
@@ -17,7 +17,7 @@ import {
   sql,
   count,
 } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const };

--- a/apps/web/src/app/api/admin/audit-logs/__tests__/search-security.test.ts
+++ b/apps/web/src/app/api/admin/audit-logs/__tests__/search-security.test.ts
@@ -44,8 +44,8 @@ vi.mock('@/lib/auth', () => ({
   },
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: {
       error: vi.fn(),
       info: vi.fn(),
@@ -54,7 +54,11 @@ vi.mock('@pagespace/lib/server', () => ({
     },
     security: { warn: vi.fn() },
   },
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
 // Mock the database module

--- a/apps/web/src/app/api/admin/audit-logs/__tests__/search-security.test.ts
+++ b/apps/web/src/app/api/admin/audit-logs/__tests__/search-security.test.ts
@@ -45,7 +45,7 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: {
       error: vi.fn(),
       info: vi.fn(),
@@ -58,7 +58,7 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 // Mock the database module

--- a/apps/web/src/app/api/admin/audit-logs/export/route.ts
+++ b/apps/web/src/app/api/admin/audit-logs/export/route.ts
@@ -9,7 +9,7 @@ import {
   lte,
   sql,
 } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { withAdminAuth } from '@/lib/auth';
 import { format } from 'date-fns';
 

--- a/apps/web/src/app/api/admin/audit-logs/integrity/route.ts
+++ b/apps/web/src/app/api/admin/audit-logs/integrity/route.ts
@@ -1,11 +1,11 @@
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import {
   verifyHashChain,
   quickIntegrityCheck,
   getHashChainStats,
   verifyEntry,
 } from '@pagespace/lib/monitoring/hash-chain-verifier';
-import { isValidId } from '@pagespace/lib/validators';
+import { isValidId } from '@pagespace/lib/validators/id-validators';
 import { withAdminAuth } from '@/lib/auth';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
 

--- a/apps/web/src/app/api/admin/audit-logs/route.ts
+++ b/apps/web/src/app/api/admin/audit-logs/route.ts
@@ -11,7 +11,7 @@ import {
   lte,
   ilike,
 } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { withAdminAuth } from '@/lib/auth';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';

--- a/apps/web/src/app/api/admin/audit-logs/route.ts
+++ b/apps/web/src/app/api/admin/audit-logs/route.ts
@@ -11,7 +11,8 @@ import {
   lte,
   ilike,
 } from '@pagespace/db';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { withAdminAuth } from '@/lib/auth';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
 

--- a/apps/web/src/app/api/admin/contact/route.ts
+++ b/apps/web/src/app/api/admin/contact/route.ts
@@ -7,7 +7,7 @@ import {
   or,
   count
 } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { withAdminAuth } from '@/lib/auth';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
 

--- a/apps/web/src/app/api/admin/schema/route.ts
+++ b/apps/web/src/app/api/admin/schema/route.ts
@@ -1,5 +1,5 @@
 import { db, sql } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { withAdminAuth } from '@/lib/auth';
 
 export const GET = withAdminAuth(async (_adminUser) => {

--- a/apps/web/src/app/api/admin/users/[userId]/data/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/data/__tests__/route.test.ts
@@ -18,20 +18,23 @@ vi.mock('@/lib/auth/csrf-validation', () => ({
   validateCSRF: vi.fn().mockResolvedValue(null),
 }));
 
+vi.mock('@/lib/stripe/client', () => ({
+  stripe: {
+    customers: {
+      del: vi.fn(),
+    },
+  },
+}));
+
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
     auth: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
   },
-    logSecurityEvent: vi.fn(),
+}));
 
-  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
-}));
-vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
-}));
 vi.mock('@pagespace/lib/repositories', () => ({
-    accountRepository: {
+  accountRepository: {
     findById: vi.fn(),
     getOwnedDrives: vi.fn().mockResolvedValue([]),
     getDriveMemberCount: vi.fn().mockResolvedValue(0),
@@ -39,21 +42,34 @@ vi.mock('@pagespace/lib/repositories', () => ({
     deleteUser: vi.fn(),
     checkAndDeleteSoloDrives: vi.fn().mockResolvedValue({ multiMemberDriveNames: [] }),
   },
-    activityLogRepository: {
+  activityLogRepository: {
     anonymizeForUser: vi.fn().mockResolvedValue({ success: true, count: 0 }),
   },
 }));
 
-vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
-  getActorInfo: vi.fn().mockResolvedValue({ email: 'admin@example.com', displayName: 'Admin' }),
-  logUserActivity: vi.fn(),
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/compliance/erasure/revoke-integration-tokens', () => ({
+  revokeUserIntegrationTokens: vi.fn().mockResolvedValue({ revoked: 0, failed: 0 }),
 }));
 
 vi.mock('@pagespace/lib/logging/ai-usage-purge', () => ({
   deleteAiUsageLogsForUser: vi.fn().mockResolvedValue(undefined),
 }));
+
 vi.mock('@pagespace/lib/logging/monitoring-purge', () => ({
   deleteMonitoringDataForUser: vi.fn().mockResolvedValue({ systemLogs: 0, apiMetrics: 0, errorLogs: 0, userActivities: 0 }),
+}));
+
+vi.mock('@pagespace/lib/deployment-mode', () => ({
+  isCloud: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
+  getActorInfo: vi.fn().mockResolvedValue({ email: 'admin@example.com', displayName: 'Admin' }),
+  logUserActivity: vi.fn(),
 }));
 
 import { DELETE } from '../route';
@@ -62,9 +78,12 @@ import { validateAdminAccess } from '@/lib/auth/admin-role';
 import { validateCSRF } from '@/lib/auth/csrf-validation';
 import { accountRepository, activityLogRepository } from '@pagespace/lib/repositories'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { revokeUserIntegrationTokens } from '@pagespace/lib/compliance/erasure/revoke-integration-tokens';
 import { logUserActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { deleteAiUsageLogsForUser } from '@pagespace/lib/logging/ai-usage-purge'
-import { deleteMonitoringDataForUser } from '@pagespace/lib/logging/monitoring-purge';
+import { deleteMonitoringDataForUser } from '@pagespace/lib/logging/monitoring-purge'
+import { isCloud } from '@pagespace/lib/deployment-mode';
+import { stripe } from '@/lib/stripe/client';
 
 const mockAuth = vi.mocked(authenticateSessionRequest);
 const mockAdminValidation = vi.mocked(validateAdminAccess);
@@ -93,6 +112,11 @@ function mockAuthDenied() {
 describe('/api/admin/users/[userId]/data', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(isCloud).mockReturnValue(false);
+    vi.mocked(revokeUserIntegrationTokens).mockResolvedValue({ revoked: 0, failed: 0 });
+    vi.mocked(stripe.customers.del).mockResolvedValue({} as never);
+    // Reset mocks that individual tests override (clearAllMocks preserves implementations)
+    vi.mocked(accountRepository.checkAndDeleteSoloDrives).mockResolvedValue({ multiMemberDriveNames: [] });
   });
 
   it('DELETE_withValidAdmin_anonymizesAndDeletesUserData', async () => {
@@ -101,6 +125,7 @@ describe('/api/admin/users/[userId]/data', () => {
       id: 'user-1',
       email: 'target@example.com',
       image: null,
+      stripeCustomerId: null,
     });
 
     const request = new Request('http://localhost/api/admin/users/user-1/data', {
@@ -133,6 +158,7 @@ describe('/api/admin/users/[userId]/data', () => {
       id: 'admin-123',
       email: 'admin@example.com',
       image: null,
+      stripeCustomerId: null,
     });
 
     const request = new Request('http://localhost/api/admin/users/admin-123/data', {
@@ -186,6 +212,7 @@ describe('/api/admin/users/[userId]/data', () => {
       id: 'user-1',
       email: 'target@example.com',
       image: null,
+      stripeCustomerId: null,
     });
 
     const request = new Request('http://localhost/api/admin/users/user-1/data', {
@@ -218,6 +245,7 @@ describe('/api/admin/users/[userId]/data', () => {
       id: 'user-1',
       email: 'target@example.com',
       image: null,
+      stripeCustomerId: null,
     });
     vi.mocked(accountRepository.checkAndDeleteSoloDrives).mockResolvedValue({
       multiMemberDriveNames: ['Shared Drive'],
@@ -236,5 +264,135 @@ describe('/api/admin/users/[userId]/data', () => {
     expect(response.status).toBe(400);
     expect(body.error).toContain('Transfer ownership first');
     expect(body.multiMemberDrives).toContain('Shared Drive');
+  });
+
+  describe('oauth token revocation (#911)', () => {
+    it('given_activeOAuthConnections_shouldRevokeTokensBeforeUserDeletion', async () => {
+      mockAdminAuth();
+      mockFindById.mockResolvedValue({
+        id: 'user-1',
+        email: 'target@example.com',
+        image: null,
+        stripeCustomerId: null,
+      });
+
+      const callOrder: string[] = [];
+      vi.mocked(revokeUserIntegrationTokens).mockImplementation(async () => {
+        callOrder.push('revoke');
+        return { revoked: 2, failed: 0 };
+      });
+      vi.mocked(accountRepository.deleteUser).mockImplementation(async () => {
+        callOrder.push('deleteUser');
+      });
+
+      const request = new Request('http://localhost/api/admin/users/user-1/data', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason: 'DSAR' }),
+      });
+
+      await DELETE(request, { params: Promise.resolve({ userId: 'user-1' }) });
+
+      expect(callOrder.indexOf('revoke')).toBeLessThan(callOrder.indexOf('deleteUser'));
+    });
+
+    it('given_oauthRevocationFailure_shouldLogErrorButNotBlockDeletion', async () => {
+      mockAdminAuth();
+      mockFindById.mockResolvedValue({
+        id: 'user-1',
+        email: 'target@example.com',
+        image: null,
+        stripeCustomerId: null,
+      });
+      vi.mocked(revokeUserIntegrationTokens).mockRejectedValue(new Error('DB connection lost'));
+
+      const request = new Request('http://localhost/api/admin/users/user-1/data', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason: 'DSAR' }),
+      });
+
+      const response = await DELETE(request, { params: Promise.resolve({ userId: 'user-1' }) });
+
+      expect(response.status).toBe(200);
+      expect(accountRepository.deleteUser).toHaveBeenCalledWith('user-1');
+    });
+  });
+
+  describe('stripe customer deletion (#910)', () => {
+    it('given_cloudDeploymentWithStripeCustomer_shouldDeleteStripeCustomerAfterUserDeletion', async () => {
+      mockAdminAuth();
+      mockFindById.mockResolvedValue({
+        id: 'user-1',
+        email: 'target@example.com',
+        image: null,
+        stripeCustomerId: 'cus_abc123',
+      });
+      vi.mocked(isCloud).mockReturnValue(true);
+
+      const callOrder: string[] = [];
+      vi.mocked(accountRepository.deleteUser).mockImplementation(async () => {
+        callOrder.push('deleteUser');
+      });
+      vi.mocked(stripe.customers.del).mockImplementation(async () => {
+        callOrder.push('stripeDelete');
+        return {} as never;
+      });
+
+      const request = new Request('http://localhost/api/admin/users/user-1/data', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason: 'DSAR' }),
+      });
+
+      await DELETE(request, { params: Promise.resolve({ userId: 'user-1' }) });
+
+      expect(stripe.customers.del).toHaveBeenCalledWith('cus_abc123');
+      expect(callOrder.indexOf('deleteUser')).toBeLessThan(callOrder.indexOf('stripeDelete'));
+    });
+
+    it('given_nonCloudDeployment_shouldNotCallStripeEvenWithStripeCustomerId', async () => {
+      mockAdminAuth();
+      mockFindById.mockResolvedValue({
+        id: 'user-1',
+        email: 'target@example.com',
+        image: null,
+        stripeCustomerId: 'cus_abc123',
+      });
+      vi.mocked(isCloud).mockReturnValue(false);
+
+      const request = new Request('http://localhost/api/admin/users/user-1/data', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason: 'DSAR' }),
+      });
+
+      await DELETE(request, { params: Promise.resolve({ userId: 'user-1' }) });
+
+      expect(stripe.customers.del).not.toHaveBeenCalled();
+    });
+
+    it('given_stripeApiFailure_shouldLogErrorButNotBlockDeletion', async () => {
+      mockAdminAuth();
+      mockFindById.mockResolvedValue({
+        id: 'user-1',
+        email: 'target@example.com',
+        image: null,
+        stripeCustomerId: 'cus_abc123',
+      });
+      vi.mocked(isCloud).mockReturnValue(true);
+      vi.mocked(stripe.customers.del).mockRejectedValue(new Error('Stripe API unavailable'));
+
+      const request = new Request('http://localhost/api/admin/users/user-1/data', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reason: 'DSAR' }),
+      });
+
+      const response = await DELETE(request, { params: Promise.resolve({ userId: 'user-1' }) });
+
+      expect(response.status).toBe(200);
+      expect(accountRepository.deleteUser).toHaveBeenCalledWith('user-1');
+    });
   });
 });

--- a/apps/web/src/app/api/admin/users/[userId]/data/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/data/__tests__/route.test.ts
@@ -18,23 +18,20 @@ vi.mock('@/lib/auth/csrf-validation', () => ({
   validateCSRF: vi.fn().mockResolvedValue(null),
 }));
 
-vi.mock('@/lib/stripe/client', () => ({
-  stripe: {
-    customers: {
-      del: vi.fn(),
-    },
-  },
-}));
-
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
     auth: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
   },
-  logSecurityEvent: vi.fn(),
-  auditRequest: vi.fn(),
-  revokeUserIntegrationTokens: vi.fn().mockResolvedValue({ revoked: 0, failed: 0 }),
-  accountRepository: {
+    logSecurityEvent: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
+}));
+vi.mock('@pagespace/lib/repositories', () => ({
+    accountRepository: {
     findById: vi.fn(),
     getOwnedDrives: vi.fn().mockResolvedValue([]),
     getDriveMemberCount: vi.fn().mockResolvedValue(0),
@@ -42,7 +39,7 @@ vi.mock('@pagespace/lib/server', () => ({
     deleteUser: vi.fn(),
     checkAndDeleteSoloDrives: vi.fn().mockResolvedValue({ multiMemberDriveNames: [] }),
   },
-  activityLogRepository: {
+    activityLogRepository: {
     anonymizeForUser: vi.fn().mockResolvedValue({ success: true, count: 0 }),
   },
 }));
@@ -52,24 +49,22 @@ vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
   logUserActivity: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib', async (importOriginal) => {
-  const actual = await importOriginal();
-  return {
-    ...(actual as object),
-    deleteAiUsageLogsForUser: vi.fn().mockResolvedValue(undefined),
-    deleteMonitoringDataForUser: vi.fn().mockResolvedValue({ systemLogs: 0, apiMetrics: 0, errorLogs: 0, userActivities: 0 }),
-    isCloud: vi.fn().mockReturnValue(false),
-  };
-});
+vi.mock('@pagespace/lib/logging/ai-usage-purge', () => ({
+  deleteAiUsageLogsForUser: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@pagespace/lib/logging/monitoring-purge', () => ({
+  deleteMonitoringDataForUser: vi.fn().mockResolvedValue({ systemLogs: 0, apiMetrics: 0, errorLogs: 0, userActivities: 0 }),
+}));
 
 import { DELETE } from '../route';
 import { authenticateSessionRequest } from '@/lib/auth/index';
 import { validateAdminAccess } from '@/lib/auth/admin-role';
 import { validateCSRF } from '@/lib/auth/csrf-validation';
-import { accountRepository, activityLogRepository, auditRequest, revokeUserIntegrationTokens } from '@pagespace/lib/server';
+import { accountRepository, activityLogRepository } from '@pagespace/lib/repositories'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { logUserActivity } from '@pagespace/lib/monitoring/activity-logger';
-import { deleteAiUsageLogsForUser, deleteMonitoringDataForUser, isCloud } from '@pagespace/lib';
-import { stripe } from '@/lib/stripe/client';
+import { deleteAiUsageLogsForUser } from '@pagespace/lib/logging/ai-usage-purge'
+import { deleteMonitoringDataForUser } from '@pagespace/lib/logging/monitoring-purge';
 
 const mockAuth = vi.mocked(authenticateSessionRequest);
 const mockAdminValidation = vi.mocked(validateAdminAccess);
@@ -98,11 +93,6 @@ function mockAuthDenied() {
 describe('/api/admin/users/[userId]/data', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(isCloud).mockReturnValue(false);
-    vi.mocked(revokeUserIntegrationTokens).mockResolvedValue({ revoked: 0, failed: 0 });
-    vi.mocked(stripe.customers.del).mockResolvedValue({} as never);
-    // Reset mocks that individual tests override (clearAllMocks preserves implementations)
-    vi.mocked(accountRepository.checkAndDeleteSoloDrives).mockResolvedValue({ multiMemberDriveNames: [] });
   });
 
   it('DELETE_withValidAdmin_anonymizesAndDeletesUserData', async () => {
@@ -111,7 +101,6 @@ describe('/api/admin/users/[userId]/data', () => {
       id: 'user-1',
       email: 'target@example.com',
       image: null,
-      stripeCustomerId: null,
     });
 
     const request = new Request('http://localhost/api/admin/users/user-1/data', {
@@ -144,7 +133,6 @@ describe('/api/admin/users/[userId]/data', () => {
       id: 'admin-123',
       email: 'admin@example.com',
       image: null,
-      stripeCustomerId: null,
     });
 
     const request = new Request('http://localhost/api/admin/users/admin-123/data', {
@@ -198,7 +186,6 @@ describe('/api/admin/users/[userId]/data', () => {
       id: 'user-1',
       email: 'target@example.com',
       image: null,
-      stripeCustomerId: null,
     });
 
     const request = new Request('http://localhost/api/admin/users/user-1/data', {
@@ -231,7 +218,6 @@ describe('/api/admin/users/[userId]/data', () => {
       id: 'user-1',
       email: 'target@example.com',
       image: null,
-      stripeCustomerId: null,
     });
     vi.mocked(accountRepository.checkAndDeleteSoloDrives).mockResolvedValue({
       multiMemberDriveNames: ['Shared Drive'],
@@ -250,135 +236,5 @@ describe('/api/admin/users/[userId]/data', () => {
     expect(response.status).toBe(400);
     expect(body.error).toContain('Transfer ownership first');
     expect(body.multiMemberDrives).toContain('Shared Drive');
-  });
-
-  describe('oauth token revocation (#911)', () => {
-    it('given_activeOAuthConnections_shouldRevokeTokensBeforeUserDeletion', async () => {
-      mockAdminAuth();
-      mockFindById.mockResolvedValue({
-        id: 'user-1',
-        email: 'target@example.com',
-        image: null,
-        stripeCustomerId: null,
-      });
-
-      const callOrder: string[] = [];
-      vi.mocked(revokeUserIntegrationTokens).mockImplementation(async () => {
-        callOrder.push('revoke');
-        return { revoked: 2, failed: 0 };
-      });
-      vi.mocked(accountRepository.deleteUser).mockImplementation(async () => {
-        callOrder.push('deleteUser');
-      });
-
-      const request = new Request('http://localhost/api/admin/users/user-1/data', {
-        method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ reason: 'DSAR' }),
-      });
-
-      await DELETE(request, { params: Promise.resolve({ userId: 'user-1' }) });
-
-      expect(callOrder.indexOf('revoke')).toBeLessThan(callOrder.indexOf('deleteUser'));
-    });
-
-    it('given_oauthRevocationFailure_shouldLogErrorButNotBlockDeletion', async () => {
-      mockAdminAuth();
-      mockFindById.mockResolvedValue({
-        id: 'user-1',
-        email: 'target@example.com',
-        image: null,
-        stripeCustomerId: null,
-      });
-      vi.mocked(revokeUserIntegrationTokens).mockRejectedValue(new Error('DB connection lost'));
-
-      const request = new Request('http://localhost/api/admin/users/user-1/data', {
-        method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ reason: 'DSAR' }),
-      });
-
-      const response = await DELETE(request, { params: Promise.resolve({ userId: 'user-1' }) });
-
-      expect(response.status).toBe(200);
-      expect(accountRepository.deleteUser).toHaveBeenCalledWith('user-1');
-    });
-  });
-
-  describe('stripe customer deletion (#910)', () => {
-    it('given_cloudDeploymentWithStripeCustomer_shouldDeleteStripeCustomerAfterUserDeletion', async () => {
-      mockAdminAuth();
-      mockFindById.mockResolvedValue({
-        id: 'user-1',
-        email: 'target@example.com',
-        image: null,
-        stripeCustomerId: 'cus_abc123',
-      });
-      vi.mocked(isCloud).mockReturnValue(true);
-
-      const callOrder: string[] = [];
-      vi.mocked(accountRepository.deleteUser).mockImplementation(async () => {
-        callOrder.push('deleteUser');
-      });
-      vi.mocked(stripe.customers.del).mockImplementation(async () => {
-        callOrder.push('stripeDelete');
-        return {} as never;
-      });
-
-      const request = new Request('http://localhost/api/admin/users/user-1/data', {
-        method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ reason: 'DSAR' }),
-      });
-
-      await DELETE(request, { params: Promise.resolve({ userId: 'user-1' }) });
-
-      expect(stripe.customers.del).toHaveBeenCalledWith('cus_abc123');
-      expect(callOrder.indexOf('deleteUser')).toBeLessThan(callOrder.indexOf('stripeDelete'));
-    });
-
-    it('given_nonCloudDeployment_shouldNotCallStripeEvenWithStripeCustomerId', async () => {
-      mockAdminAuth();
-      mockFindById.mockResolvedValue({
-        id: 'user-1',
-        email: 'target@example.com',
-        image: null,
-        stripeCustomerId: 'cus_abc123',
-      });
-      vi.mocked(isCloud).mockReturnValue(false);
-
-      const request = new Request('http://localhost/api/admin/users/user-1/data', {
-        method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ reason: 'DSAR' }),
-      });
-
-      await DELETE(request, { params: Promise.resolve({ userId: 'user-1' }) });
-
-      expect(stripe.customers.del).not.toHaveBeenCalled();
-    });
-
-    it('given_stripeApiFailure_shouldLogErrorButNotBlockDeletion', async () => {
-      mockAdminAuth();
-      mockFindById.mockResolvedValue({
-        id: 'user-1',
-        email: 'target@example.com',
-        image: null,
-        stripeCustomerId: 'cus_abc123',
-      });
-      vi.mocked(isCloud).mockReturnValue(true);
-      vi.mocked(stripe.customers.del).mockRejectedValue(new Error('Stripe API unavailable'));
-
-      const request = new Request('http://localhost/api/admin/users/user-1/data', {
-        method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ reason: 'DSAR' }),
-      });
-
-      const response = await DELETE(request, { params: Promise.resolve({ userId: 'user-1' }) });
-
-      expect(response.status).toBe(200);
-      expect(accountRepository.deleteUser).toHaveBeenCalledWith('user-1');
-    });
   });
 });

--- a/apps/web/src/app/api/admin/users/[userId]/data/route.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/data/route.ts
@@ -2,10 +2,13 @@ import { withAdminAuth } from '@/lib/auth/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log'
 import { accountRepository, activityLogRepository } from '@pagespace/lib/repositories';
+import { revokeUserIntegrationTokens } from '@pagespace/lib/compliance/erasure/revoke-integration-tokens';
 import { deleteAiUsageLogsForUser } from '@pagespace/lib/logging/ai-usage-purge'
-import { deleteMonitoringDataForUser } from '@pagespace/lib/logging/monitoring-purge';
+import { deleteMonitoringDataForUser } from '@pagespace/lib/logging/monitoring-purge'
+import { isCloud } from '@pagespace/lib/deployment-mode';
 import { createAnonymizedActorEmail } from '@pagespace/lib/compliance/anonymize';
 import { getActorInfo, logUserActivity } from '@pagespace/lib/monitoring/activity-logger';
+import { stripe } from '@/lib/stripe/client';
 
 type DataRouteContext = { params: Promise<{ userId: string }> };
 
@@ -74,8 +77,26 @@ export const DELETE = withAdminAuth<DataRouteContext>(
       // Note: security_audit_log is intentionally NOT deleted — legal retention requirement
       await deleteMonitoringDataForUser(userId);
 
+      // Revoke OAuth integration tokens BEFORE user deletion (Art. 17 GDPR — #911)
+      try {
+        const { revoked, failed } = await revokeUserIntegrationTokens(userId);
+        loggers.api.info(`Admin DSAR: OAuth token revocation for ${userId}: revoked=${revoked}, failed=${failed}`);
+      } catch (error) {
+        loggers.api.error('Admin DSAR: Could not revoke OAuth tokens:', error as Error);
+      }
+
       // Delete user record
       await accountRepository.deleteUser(userId);
+
+      // Delete Stripe customer AFTER user deletion (Art. 17 GDPR — #910)
+      if (user.stripeCustomerId && isCloud()) {
+        try {
+          await stripe.customers.del(user.stripeCustomerId);
+          loggers.api.info(`Admin DSAR: Stripe customer deleted: ${user.stripeCustomerId}`);
+        } catch (error) {
+          loggers.api.error('Admin DSAR: Could not delete Stripe customer:', error as Error);
+        }
+      }
 
       loggers.api.info(`Admin DSAR deletion: admin=${adminUser.id} target=${userId} reason="${reason}"`);
 

--- a/apps/web/src/app/api/admin/users/[userId]/data/route.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/data/route.ts
@@ -1,10 +1,10 @@
 import { withAdminAuth } from '@/lib/auth/auth';
-import { loggers } from '@pagespace/lib/logging/logger-config'
-import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { accountRepository, activityLogRepository } from '@pagespace/lib/repositories';
 import { revokeUserIntegrationTokens } from '@pagespace/lib/compliance/erasure/revoke-integration-tokens';
-import { deleteAiUsageLogsForUser } from '@pagespace/lib/logging/ai-usage-purge'
-import { deleteMonitoringDataForUser } from '@pagespace/lib/logging/monitoring-purge'
+import { deleteAiUsageLogsForUser } from '@pagespace/lib/logging/ai-usage-purge';
+import { deleteMonitoringDataForUser } from '@pagespace/lib/logging/monitoring-purge';
 import { isCloud } from '@pagespace/lib/deployment-mode';
 import { createAnonymizedActorEmail } from '@pagespace/lib/compliance/anonymize';
 import { getActorInfo, logUserActivity } from '@pagespace/lib/monitoring/activity-logger';

--- a/apps/web/src/app/api/admin/users/[userId]/data/route.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/data/route.ts
@@ -1,9 +1,11 @@
 import { withAdminAuth } from '@/lib/auth/auth';
-import { loggers, auditRequest, accountRepository, activityLogRepository, revokeUserIntegrationTokens } from '@pagespace/lib/server';
-import { deleteAiUsageLogsForUser, deleteMonitoringDataForUser, isCloud } from '@pagespace/lib';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log'
+import { accountRepository, activityLogRepository } from '@pagespace/lib/repositories';
+import { deleteAiUsageLogsForUser } from '@pagespace/lib/logging/ai-usage-purge'
+import { deleteMonitoringDataForUser } from '@pagespace/lib/logging/monitoring-purge';
 import { createAnonymizedActorEmail } from '@pagespace/lib/compliance/anonymize';
 import { getActorInfo, logUserActivity } from '@pagespace/lib/monitoring/activity-logger';
-import { stripe } from '@/lib/stripe/client';
 
 type DataRouteContext = { params: Promise<{ userId: string }> };
 
@@ -72,26 +74,8 @@ export const DELETE = withAdminAuth<DataRouteContext>(
       // Note: security_audit_log is intentionally NOT deleted — legal retention requirement
       await deleteMonitoringDataForUser(userId);
 
-      // Revoke OAuth integration tokens BEFORE user deletion (Art. 17 GDPR — #911)
-      try {
-        const { revoked, failed } = await revokeUserIntegrationTokens(userId);
-        loggers.api.info(`Admin DSAR: OAuth token revocation for ${userId}: revoked=${revoked}, failed=${failed}`);
-      } catch (error) {
-        loggers.api.error('Admin DSAR: Could not revoke OAuth tokens:', error as Error);
-      }
-
       // Delete user record
       await accountRepository.deleteUser(userId);
-
-      // Delete Stripe customer AFTER user deletion (Art. 17 GDPR — #910)
-      if (user.stripeCustomerId && isCloud()) {
-        try {
-          await stripe.customers.del(user.stripeCustomerId);
-          loggers.api.info(`Admin DSAR: Stripe customer deleted: ${user.stripeCustomerId}`);
-        } catch (error) {
-          loggers.api.error('Admin DSAR: Could not delete Stripe customer:', error as Error);
-        }
-      }
 
       loggers.api.info(`Admin DSAR deletion: admin=${adminUser.id} target=${userId} reason="${reason}"`);
 

--- a/apps/web/src/app/api/admin/users/[userId]/export/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/export/__tests__/route.test.ts
@@ -15,14 +15,18 @@ vi.mock('@/lib/auth/csrf-validation', () => ({
   validateCSRF: vi.fn().mockResolvedValue(null),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
     auth: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
     security: { warn: vi.fn() },
   },
-  logSecurityEvent: vi.fn(),
-  auditRequest: vi.fn(),
+    logSecurityEvent: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
 const mockCollectAllUserData = vi.fn();

--- a/apps/web/src/app/api/admin/users/[userId]/export/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/export/__tests__/route.test.ts
@@ -16,17 +16,17 @@ vi.mock('@/lib/auth/csrf-validation', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
     auth: { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() },
     security: { warn: vi.fn() },
   },
-    logSecurityEvent: vi.fn(),
+  logSecurityEvent: vi.fn(),
 
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 const mockCollectAllUserData = vi.fn();

--- a/apps/web/src/app/api/admin/users/[userId]/export/route.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/export/route.ts
@@ -1,7 +1,7 @@
 import { withAdminAuth } from '@/lib/auth/auth';
 import { collectAllUserData } from '@pagespace/lib/compliance/export/gdpr-export';
 import { db } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 type ExportRouteContext = { params: Promise<{ userId: string }> };

--- a/apps/web/src/app/api/admin/users/[userId]/export/route.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/export/route.ts
@@ -1,7 +1,8 @@
 import { withAdminAuth } from '@/lib/auth/auth';
 import { collectAllUserData } from '@pagespace/lib/compliance/export/gdpr-export';
 import { db } from '@pagespace/db';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 type ExportRouteContext = { params: Promise<{ userId: string }> };
 

--- a/apps/web/src/app/api/admin/users/[userId]/gift-subscription/__tests__/route.pii.test.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/gift-subscription/__tests__/route.pii.test.ts
@@ -92,11 +92,7 @@ vi.mock('@/lib/stripe-config', () => ({
   },
 }));
 
-vi.mock('@pagespace/lib/server', async () => {
-  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
-    '@pagespace/lib/audit/mask-email'
-  );
-  return {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
     loggers: {
       api: {
         info: vi.fn(),
@@ -104,12 +100,12 @@ vi.mock('@pagespace/lib/server', async () => {
         error: vi.fn(),
       },
     },
-    maskEmail,
-  };
-});
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
 
 import { POST, DELETE } from '../route';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 describe('Gift subscription PII scrub', () => {
   beforeEach(() => {

--- a/apps/web/src/app/api/admin/users/[userId]/gift-subscription/__tests__/route.pii.test.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/gift-subscription/__tests__/route.pii.test.ts
@@ -93,7 +93,7 @@ vi.mock('@/lib/stripe-config', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
       api: {
         info: vi.fn(),
         warn: vi.fn(),

--- a/apps/web/src/app/api/admin/users/[userId]/gift-subscription/__tests__/route.security.test.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/gift-subscription/__tests__/route.security.test.ts
@@ -4,7 +4,8 @@ import { NextRequest } from 'next/server';
 import { db, users, subscriptions, sessions, eq } from '@pagespace/db';
 import { createId } from '@paralleldrive/cuid2';
 import { updateUserRole } from '@/lib/auth/admin-role';
-import { sessionService, generateCSRFToken } from '@pagespace/lib/auth';
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
 
 /**
  * Security Tests for Gift Subscription Admin Routes
@@ -70,10 +71,7 @@ vi.mock('@/lib/stripe-config', () => ({
 }));
 
 // Mock loggers
-vi.mock('@pagespace/lib/server', async () => {
-  const actual = await vi.importActual('@pagespace/lib/server');
-  return {
-    ...actual,
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
     loggers: {
       api: {
         info: vi.fn(),
@@ -91,10 +89,11 @@ vi.mock('@pagespace/lib/server', async () => {
       },
     },
     logSecurityEvent: vi.fn(),
-  };
-});
 
-import { logSecurityEvent } from '@pagespace/lib/server';
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+
+import { logSecurityEvent } from '@pagespace/lib/logging/logger-config';
 
 describe('/api/admin/users/[userId]/gift-subscription - Security Tests', () => {
   let adminUserId: string;

--- a/apps/web/src/app/api/admin/users/[userId]/gift-subscription/__tests__/route.security.test.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/gift-subscription/__tests__/route.security.test.ts
@@ -72,7 +72,7 @@ vi.mock('@/lib/stripe-config', () => ({
 
 // Mock loggers
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
       api: {
         info: vi.fn(),
         error: vi.fn(),
@@ -88,7 +88,7 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
         warn: vi.fn(),
       },
     },
-    logSecurityEvent: vi.fn(),
+  logSecurityEvent: vi.fn(),
 
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));

--- a/apps/web/src/app/api/admin/users/[userId]/gift-subscription/route.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/gift-subscription/route.ts
@@ -5,7 +5,7 @@ import { stripe, Stripe } from '@/lib/stripe';
 import { getOrCreateStripeCustomer } from '@/lib/stripe-customer';
 import { getUserFriendlyStripeError } from '@/lib/stripe-errors';
 import { stripeConfig } from '@/lib/stripe-config';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { maskEmail } from '@pagespace/lib/audit/mask-email';
 
 type GiftTier = 'pro' | 'founder' | 'business';

--- a/apps/web/src/app/api/admin/users/[userId]/gift-subscription/route.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/gift-subscription/route.ts
@@ -5,7 +5,8 @@ import { stripe, Stripe } from '@/lib/stripe';
 import { getOrCreateStripeCustomer } from '@/lib/stripe-customer';
 import { getUserFriendlyStripeError } from '@/lib/stripe-errors';
 import { stripeConfig } from '@/lib/stripe-config';
-import { loggers, maskEmail } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { maskEmail } from '@pagespace/lib/audit/mask-email';
 
 type GiftTier = 'pro' | 'founder' | 'business';
 

--- a/apps/web/src/app/api/admin/users/create/route.ts
+++ b/apps/web/src/app/api/admin/users/create/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod/v4';
 import { db, users, userAiSettings, eq } from '@pagespace/db';
 import { createId } from '@paralleldrive/cuid2';
-import { isOnPrem } from '@pagespace/lib/deployment-mode'
+import { isOnPrem } from '@pagespace/lib/deployment-mode';
 import { getOnPremUserDefaults, getOnPremOllamaSettings } from '@pagespace/lib/onprem-defaults';
 import { withAdminAuth } from '@/lib/auth/auth';
 import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-started-drive';

--- a/apps/web/src/app/api/admin/users/create/route.ts
+++ b/apps/web/src/app/api/admin/users/create/route.ts
@@ -2,10 +2,11 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod/v4';
 import { db, users, userAiSettings, eq } from '@pagespace/db';
 import { createId } from '@paralleldrive/cuid2';
-import { isOnPrem, getOnPremUserDefaults, getOnPremOllamaSettings } from '@pagespace/lib';
+import { isOnPrem } from '@pagespace/lib/deployment-mode'
+import { getOnPremUserDefaults, getOnPremOllamaSettings } from '@pagespace/lib/onprem-defaults';
 import { withAdminAuth } from '@/lib/auth/auth';
 import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-started-drive';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 const createUserSchema = z.object({
   name: z.string().min(1, 'Name is required'),

--- a/apps/web/src/app/api/admin/users/route.ts
+++ b/apps/web/src/app/api/admin/users/route.ts
@@ -14,7 +14,7 @@ import {
   count,
 } from '@pagespace/db';
 import { stripe } from '@/lib/stripe';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { isOnPrem } from '@pagespace/lib/deployment-mode';
 import { withAdminAuth } from '@/lib/auth';

--- a/apps/web/src/app/api/admin/users/route.ts
+++ b/apps/web/src/app/api/admin/users/route.ts
@@ -14,8 +14,9 @@ import {
   count,
 } from '@pagespace/db';
 import { stripe } from '@/lib/stripe';
-import { loggers, auditRequest } from '@pagespace/lib/server';
-import { isOnPrem } from '@pagespace/lib';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { isOnPrem } from '@pagespace/lib/deployment-mode';
 import { withAdminAuth } from '@/lib/auth';
 
 export const GET = withAdminAuth(async (_adminUser, _request) => {

--- a/apps/web/src/app/api/calendar/events/[eventId]/__tests__/can-edit-event.test.ts
+++ b/apps/web/src/app/api/calendar/events/[eventId]/__tests__/can-edit-event.test.ts
@@ -52,12 +52,12 @@ vi.mock('@pagespace/db', () => ({
 }));
 
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
-    isUserDriveMember: vi.fn(),
-    isDriveOwnerOrAdmin: vi.fn(),
+  isUserDriveMember: vi.fn(),
+  isDriveOwnerOrAdmin: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: {
       info: vi.fn(),
       error: vi.fn(),
@@ -69,8 +69,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('../../../../../../lib/auth', () => ({

--- a/apps/web/src/app/api/calendar/events/[eventId]/__tests__/can-edit-event.test.ts
+++ b/apps/web/src/app/api/calendar/events/[eventId]/__tests__/can-edit-event.test.ts
@@ -51,13 +51,13 @@ vi.mock('@pagespace/db', () => ({
   and: vi.fn((...args: unknown[]) => args),
 }));
 
-vi.mock('@pagespace/lib', () => ({
-  isUserDriveMember: vi.fn(),
-  isDriveOwnerOrAdmin: vi.fn(),
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    isUserDriveMember: vi.fn(),
+    isDriveOwnerOrAdmin: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: {
       info: vi.fn(),
       error: vi.fn(),
@@ -65,8 +65,12 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 vi.mock('../../../../../../lib/auth', () => ({
@@ -88,7 +92,7 @@ vi.mock('../../../../../../lib/integrations/google-calendar/push-service', () =>
 
 import { PATCH } from '../route';
 import { db } from '@pagespace/db';
-import { isDriveOwnerOrAdmin } from '@pagespace/lib';
+import { isDriveOwnerOrAdmin } from '@pagespace/lib/permissions/permissions';
 import { authenticateRequestWithOptions } from '../../../../../../lib/auth';
 
 // ============================================================================

--- a/apps/web/src/app/api/calendar/events/[eventId]/attendees/route.ts
+++ b/apps/web/src/app/api/calendar/events/[eventId]/attendees/route.ts
@@ -7,8 +7,8 @@ import {
   eq,
   and,
 } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/logging/logger-config'
-import { getDriveMemberUserIds } from '@pagespace/lib/services/drive-member-service'
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { getDriveMemberUserIds } from '@pagespace/lib/services/drive-member-service';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { isUserDriveMember } from '@pagespace/lib/permissions/permissions';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope } from '@/lib/auth';

--- a/apps/web/src/app/api/calendar/events/[eventId]/attendees/route.ts
+++ b/apps/web/src/app/api/calendar/events/[eventId]/attendees/route.ts
@@ -7,8 +7,10 @@ import {
   eq,
   and,
 } from '@pagespace/db';
-import { loggers, getDriveMemberUserIds, auditRequest } from '@pagespace/lib/server';
-import { isUserDriveMember } from '@pagespace/lib';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { getDriveMemberUserIds } from '@pagespace/lib/services/drive-member-service'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { isUserDriveMember } from '@pagespace/lib/permissions/permissions';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope } from '@/lib/auth';
 import { broadcastCalendarEvent } from '@/lib/websocket/calendar-events';
 

--- a/apps/web/src/app/api/calendar/events/[eventId]/route.ts
+++ b/apps/web/src/app/api/calendar/events/[eventId]/route.ts
@@ -7,9 +7,10 @@ import {
   eq,
   and,
 } from '@pagespace/db';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope } from '@/lib/auth';
-import { isUserDriveMember, isDriveOwnerOrAdmin } from '@pagespace/lib';
+import { isUserDriveMember, isDriveOwnerOrAdmin } from '@pagespace/lib/permissions/permissions';
 import { broadcastCalendarEvent } from '@/lib/websocket/calendar-events';
 import { pushEventUpdateToGoogle, pushEventDeleteToGoogle } from '@/lib/integrations/google-calendar/push-service';
 import { isNaiveISODatetime, parseNaiveDatetimeInTimezone } from '@/lib/ai/core/timestamp-utils';

--- a/apps/web/src/app/api/calendar/events/[eventId]/route.ts
+++ b/apps/web/src/app/api/calendar/events/[eventId]/route.ts
@@ -7,7 +7,7 @@ import {
   eq,
   and,
 } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope } from '@/lib/auth';
 import { isUserDriveMember, isDriveOwnerOrAdmin } from '@pagespace/lib/permissions/permissions';

--- a/apps/web/src/app/api/calendar/events/route.ts
+++ b/apps/web/src/app/api/calendar/events/route.ts
@@ -14,8 +14,8 @@ import {
   isNull,
   asc,
 } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/logging/logger-config'
-import { getDriveMemberUserIds } from '@pagespace/lib/services/drive-member-service'
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { getDriveMemberUserIds } from '@pagespace/lib/services/drive-member-service';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope, checkMCPCreateScope, filterDrivesByMCPScope } from '@/lib/auth';
 import { isUserDriveMember, getDriveIdsForUser } from '@pagespace/lib/permissions/permissions';

--- a/apps/web/src/app/api/calendar/events/route.ts
+++ b/apps/web/src/app/api/calendar/events/route.ts
@@ -14,9 +14,11 @@ import {
   isNull,
   asc,
 } from '@pagespace/db';
-import { loggers, getDriveMemberUserIds, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { getDriveMemberUserIds } from '@pagespace/lib/services/drive-member-service'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope, checkMCPCreateScope, filterDrivesByMCPScope } from '@/lib/auth';
-import { isUserDriveMember, getDriveIdsForUser } from '@pagespace/lib';
+import { isUserDriveMember, getDriveIdsForUser } from '@pagespace/lib/permissions/permissions';
 import { broadcastCalendarEvent } from '@/lib/websocket/calendar-events';
 import { pushEventToGoogle } from '@/lib/integrations/google-calendar/push-service';
 import { isNaiveISODatetime, parseNaiveDatetimeInTimezone } from '@/lib/ai/core/timestamp-utils';

--- a/apps/web/src/app/api/compiled-css/route.ts
+++ b/apps/web/src/app/api/compiled-css/route.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 import { NextResponse } from 'next/server';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 export async function GET() {
   try {

--- a/apps/web/src/app/api/connections/[connectionId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/connections/[connectionId]/__tests__/route.test.ts
@@ -40,22 +40,26 @@ vi.mock('@pagespace/db', () => ({
   and: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib', () => ({
-  createNotification: vi.fn(),
+vi.mock('@pagespace/lib/notifications/notifications', () => ({
+    createNotification: vi.fn(),
 }));
 
 import { PATCH, DELETE } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const mockUserId = 'user_123';
 const mockConnectionId = 'conn-1';

--- a/apps/web/src/app/api/connections/[connectionId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/connections/[connectionId]/__tests__/route.test.ts
@@ -41,7 +41,7 @@ vi.mock('@pagespace/db', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
@@ -49,12 +49,12 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/notifications/notifications', () => ({
-    createNotification: vi.fn(),
+  createNotification: vi.fn(),
 }));
 
 import { PATCH, DELETE } from '../route';

--- a/apps/web/src/app/api/connections/[connectionId]/route.ts
+++ b/apps/web/src/app/api/connections/[connectionId]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db, connections, users, userProfiles, eq } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { createNotification } from '@pagespace/lib/notifications/notifications';
 

--- a/apps/web/src/app/api/connections/[connectionId]/route.ts
+++ b/apps/web/src/app/api/connections/[connectionId]/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from 'next/server';
 import { db, connections, users, userProfiles, eq } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
-import { createNotification } from '@pagespace/lib';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { createNotification } from '@pagespace/lib/notifications/notifications';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 

--- a/apps/web/src/app/api/connections/__tests__/route.test.ts
+++ b/apps/web/src/app/api/connections/__tests__/route.test.ts
@@ -30,7 +30,7 @@ vi.mock('@pagespace/db', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
@@ -38,15 +38,15 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/notifications/notifications', () => ({
-    createNotification: vi.fn(),
+  createNotification: vi.fn(),
 }));
 vi.mock('@pagespace/lib/auth/verification-utils', () => ({
-    isEmailVerified: vi.fn().mockResolvedValue(true),
+  isEmailVerified: vi.fn().mockResolvedValue(true),
 }));
 
 import { GET, POST } from '../route';

--- a/apps/web/src/app/api/connections/__tests__/route.test.ts
+++ b/apps/web/src/app/api/connections/__tests__/route.test.ts
@@ -29,23 +29,29 @@ vi.mock('@pagespace/db', () => ({
   inArray: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib', () => ({
-  createNotification: vi.fn(),
-  isEmailVerified: vi.fn().mockResolvedValue(true),
+vi.mock('@pagespace/lib/notifications/notifications', () => ({
+    createNotification: vi.fn(),
+}));
+vi.mock('@pagespace/lib/auth/verification-utils', () => ({
+    isEmailVerified: vi.fn().mockResolvedValue(true),
 }));
 
 import { GET, POST } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const mockUserId = 'user_123';
 

--- a/apps/web/src/app/api/connections/route.ts
+++ b/apps/web/src/app/api/connections/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from 'next/server';
 import { db, connections, users, userProfiles, eq, and, or, desc, inArray } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
-import { createNotification, isEmailVerified } from '@pagespace/lib';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { createNotification } from '@pagespace/lib/notifications/notifications'
+import { isEmailVerified } from '@pagespace/lib/auth/verification-utils';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/connections/route.ts
+++ b/apps/web/src/app/api/connections/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from 'next/server';
 import { db, connections, users, userProfiles, eq, and, or, desc, inArray } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
-import { createNotification } from '@pagespace/lib/notifications/notifications'
+import { createNotification } from '@pagespace/lib/notifications/notifications';
 import { isEmailVerified } from '@pagespace/lib/auth/verification-utils';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };

--- a/apps/web/src/app/api/connections/search/__tests__/route.test.ts
+++ b/apps/web/src/app/api/connections/search/__tests__/route.test.ts
@@ -31,18 +31,22 @@ vi.mock('@pagespace/db', () => ({
   or: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 import { GET } from '../route';
 import { verifyAuth } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const mockUserId = 'user_123';
 

--- a/apps/web/src/app/api/connections/search/__tests__/route.test.ts
+++ b/apps/web/src/app/api/connections/search/__tests__/route.test.ts
@@ -32,7 +32,7 @@ vi.mock('@pagespace/db', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
@@ -40,8 +40,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 import { GET } from '../route';

--- a/apps/web/src/app/api/connections/search/route.ts
+++ b/apps/web/src/app/api/connections/search/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { db, users, userProfiles, connections, eq, and, or } from '@pagespace/db';
 import { verifyAuth } from '@/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 // GET /api/connections/search - Search for users by email to connect with
 export async function GET(request: Request) {

--- a/apps/web/src/app/api/connections/search/route.ts
+++ b/apps/web/src/app/api/connections/search/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db, users, userProfiles, connections, eq, and, or } from '@pagespace/db';
 import { verifyAuth } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 // GET /api/connections/search - Search for users by email to connect with

--- a/apps/web/src/app/api/contact/__tests__/route.test.ts
+++ b/apps/web/src/app/api/contact/__tests__/route.test.ts
@@ -31,8 +31,8 @@ vi.mock('@pagespace/db', () => ({
   contactSubmissions: {},
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: {
       info: vi.fn(),
       warn: vi.fn(),
@@ -40,11 +40,13 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn(),
-  DISTRIBUTED_RATE_LIMITS: {
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn(),
+    DISTRIBUTED_RATE_LIMITS: {
     CONTACT_FORM: { maxAttempts: 10, windowMs: 60000 },
   },
 }));
@@ -54,8 +56,8 @@ vi.mock('@/lib/auth/auth-helpers', () => ({
 }));
 
 import { db } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/server';
-import { checkDistributedRateLimit } from '@pagespace/lib/security';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 
 const validPayload = {
   name: 'John Doe',

--- a/apps/web/src/app/api/contact/__tests__/route.test.ts
+++ b/apps/web/src/app/api/contact/__tests__/route.test.ts
@@ -32,7 +32,7 @@ vi.mock('@pagespace/db', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: {
       info: vi.fn(),
       warn: vi.fn(),
@@ -45,8 +45,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn(),
-    DISTRIBUTED_RATE_LIMITS: {
+  checkDistributedRateLimit: vi.fn(),
+  DISTRIBUTED_RATE_LIMITS: {
     CONTACT_FORM: { maxAttempts: 10, windowMs: 60000 },
   },
 }));

--- a/apps/web/src/app/api/contact/route.ts
+++ b/apps/web/src/app/api/contact/route.ts
@@ -8,8 +8,8 @@
 
 import { z } from 'zod/v4';
 import { db, contactSubmissions } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/server';
-import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security/distributed-rate-limit';
 import { getClientIP } from '@/lib/auth/auth-helpers';
 
 const MAX_PAYLOAD_BYTES = 5 * 1024; // 5KB

--- a/apps/web/src/app/api/cron/calendar-sync/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/calendar-sync/__tests__/route.test.ts
@@ -38,9 +38,13 @@ vi.mock('@/lib/integrations/google-calendar/sync-service', () => ({
   syncGoogleCalendar: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: mockLoggers,
-  audit: mockAudit,
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: mockLoggers,
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: mockAudit,
 }));
 
 vi.mock('next/server', () => ({

--- a/apps/web/src/app/api/cron/calendar-sync/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/calendar-sync/__tests__/route.test.ts
@@ -39,12 +39,12 @@ vi.mock('@/lib/integrations/google-calendar/sync-service', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: mockLoggers,
+  loggers: mockLoggers,
 
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: mockAudit,
+  audit: mockAudit,
 }));
 
 vi.mock('next/server', () => ({

--- a/apps/web/src/app/api/cron/calendar-sync/route.ts
+++ b/apps/web/src/app/api/cron/calendar-sync/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { db, googleCalendarConnections, eq, and, or, lt, isNull, sql } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { audit } from '@pagespace/lib/audit/audit-log';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
 import { syncGoogleCalendar } from '@/lib/integrations/google-calendar/sync-service';

--- a/apps/web/src/app/api/cron/calendar-sync/route.ts
+++ b/apps/web/src/app/api/cron/calendar-sync/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db, googleCalendarConnections, eq, and, or, lt, isNull, sql } from '@pagespace/db';
-import { loggers, audit } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { audit } from '@pagespace/lib/audit/audit-log';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
 import { syncGoogleCalendar } from '@/lib/integrations/google-calendar/sync-service';
 

--- a/apps/web/src/app/api/cron/calendar-triggers/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/calendar-triggers/__tests__/route.test.ts
@@ -39,15 +39,18 @@ vi.mock('@/lib/workflows/calendar-trigger-executor', () => ({
 
 const mockAudit = vi.hoisted(() => vi.fn());
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: {
       child: vi.fn(() => ({
         info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(),
       })),
     },
   },
-  audit: mockAudit,
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: mockAudit,
 }));
 
 vi.mock('@pagespace/db', () => ({

--- a/apps/web/src/app/api/cron/calendar-triggers/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/calendar-triggers/__tests__/route.test.ts
@@ -40,7 +40,7 @@ vi.mock('@/lib/workflows/calendar-trigger-executor', () => ({
 const mockAudit = vi.hoisted(() => vi.fn());
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: {
       child: vi.fn(() => ({
         info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(),
@@ -50,7 +50,7 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: mockAudit,
+  audit: mockAudit,
 }));
 
 vi.mock('@pagespace/db', () => ({

--- a/apps/web/src/app/api/cron/calendar-triggers/route.ts
+++ b/apps/web/src/app/api/cron/calendar-triggers/route.ts
@@ -2,7 +2,8 @@ import { NextResponse } from 'next/server';
 import { db, calendarTriggers, calendarEvents, eq, and, lte, inArray, asc } from '@pagespace/db';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
 import { executeCalendarTrigger } from '@/lib/workflows/calendar-trigger-executor';
-import { loggers, audit } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { audit } from '@pagespace/lib/audit/audit-log';
 
 const STUCK_TRIGGER_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 const MAX_CONCURRENT_TRIGGERS = 5;

--- a/apps/web/src/app/api/cron/calendar-triggers/route.ts
+++ b/apps/web/src/app/api/cron/calendar-triggers/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { db, calendarTriggers, calendarEvents, eq, and, lte, inArray, asc } from '@pagespace/db';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
 import { executeCalendarTrigger } from '@/lib/workflows/calendar-trigger-executor';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { audit } from '@pagespace/lib/audit/audit-log';
 
 const STUCK_TRIGGER_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes

--- a/apps/web/src/app/api/cron/cleanup-orphaned-files/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/cleanup-orphaned-files/__tests__/route.test.ts
@@ -25,11 +25,11 @@ vi.mock('@pagespace/db', () => ({
 }));
 
 vi.mock('@pagespace/lib/services/validated-service-token', () => ({
-    createDriveServiceToken: mockCreateServiceToken,
+  createDriveServiceToken: mockCreateServiceToken,
 }));
 
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: mockAudit,
+  audit: mockAudit,
 }));
 
 vi.mock('next/server', () => ({

--- a/apps/web/src/app/api/cron/cleanup-orphaned-files/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/cleanup-orphaned-files/__tests__/route.test.ts
@@ -24,12 +24,12 @@ vi.mock('@pagespace/db', () => ({
   db: {},
 }));
 
-vi.mock('@pagespace/lib', () => ({
-  createDriveServiceToken: mockCreateServiceToken,
+vi.mock('@pagespace/lib/services/validated-service-token', () => ({
+    createDriveServiceToken: mockCreateServiceToken,
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  audit: mockAudit,
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: mockAudit,
 }));
 
 vi.mock('next/server', () => ({

--- a/apps/web/src/app/api/cron/cleanup-orphaned-files/route.ts
+++ b/apps/web/src/app/api/cron/cleanup-orphaned-files/route.ts
@@ -1,10 +1,10 @@
 import { findOrphanedFileRecords, deleteFileRecords } from '@pagespace/lib/compliance/file-cleanup/orphan-detector';
 import { db } from '@pagespace/db';
-import { createDriveServiceToken } from '@pagespace/lib';
-import { audit } from '@pagespace/lib/server';
+import { createDriveServiceToken } from '@pagespace/lib/services/validated-service-token';
+import { audit } from '@pagespace/lib/audit/audit-log';
 import { NextResponse } from 'next/server';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
-import type { ServiceScope } from '@pagespace/lib';
+import type { ServiceScope } from '@pagespace/lib/services/validated-service-token';
 
 const PROCESSOR_URL = process.env.PROCESSOR_URL || 'http://processor:3003';
 const FILE_DELETE_SCOPES: ServiceScope[] = ['files:delete'];

--- a/apps/web/src/app/api/cron/cleanup-tokens/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/cleanup-tokens/__tests__/route.test.ts
@@ -13,12 +13,12 @@ vi.mock('@/lib/auth/cron-auth', () => ({
   validateSignedCronRequest: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib', () => ({
-  cleanupExpiredDeviceTokens: mockCleanup,
+vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
+    cleanupExpiredDeviceTokens: mockCleanup,
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  audit: mockAudit,
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: mockAudit,
 }));
 
 vi.mock('next/server', () => ({

--- a/apps/web/src/app/api/cron/cleanup-tokens/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/cleanup-tokens/__tests__/route.test.ts
@@ -14,11 +14,11 @@ vi.mock('@/lib/auth/cron-auth', () => ({
 }));
 
 vi.mock('@pagespace/lib/auth/device-auth-utils', () => ({
-    cleanupExpiredDeviceTokens: mockCleanup,
+  cleanupExpiredDeviceTokens: mockCleanup,
 }));
 
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: mockAudit,
+  audit: mockAudit,
 }));
 
 vi.mock('next/server', () => ({

--- a/apps/web/src/app/api/cron/cleanup-tokens/route.ts
+++ b/apps/web/src/app/api/cron/cleanup-tokens/route.ts
@@ -1,5 +1,5 @@
-import { cleanupExpiredDeviceTokens } from '@pagespace/lib';
-import { audit } from '@pagespace/lib/server';
+import { cleanupExpiredDeviceTokens } from '@pagespace/lib/auth/device-auth-utils';
+import { audit } from '@pagespace/lib/audit/audit-log';
 import { NextResponse } from 'next/server';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
 

--- a/apps/web/src/app/api/cron/purge-ai-usage-logs/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/purge-ai-usage-logs/__tests__/route.test.ts
@@ -20,7 +20,7 @@ vi.mock('@pagespace/lib/logging/ai-usage-purge', () => ({
 }));
 
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: mockAudit,
+  audit: mockAudit,
 }));
 
 vi.mock('next/server', () => ({

--- a/apps/web/src/app/api/cron/purge-ai-usage-logs/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/purge-ai-usage-logs/__tests__/route.test.ts
@@ -4,21 +4,23 @@
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-const { mockPurge, mockAudit } = vi.hoisted(() => ({
+const { mockPurge, mockAudit, mockAnonymize } = vi.hoisted(() => ({
   mockPurge: vi.fn(),
   mockAudit: vi.fn(),
+  mockAnonymize: vi.fn(),
 }));
 
 vi.mock('@/lib/auth/cron-auth', () => ({
   validateSignedCronRequest: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib', () => ({
+vi.mock('@pagespace/lib/logging/ai-usage-purge', () => ({
+  anonymizeAiUsageContent: mockAnonymize,
   purgeAiUsageLogs: mockPurge,
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  audit: mockAudit,
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: mockAudit,
 }));
 
 vi.mock('next/server', () => ({

--- a/apps/web/src/app/api/cron/purge-ai-usage-logs/route.ts
+++ b/apps/web/src/app/api/cron/purge-ai-usage-logs/route.ts
@@ -1,5 +1,5 @@
-import { purgeAiUsageLogs } from '@pagespace/lib';
-import { audit } from '@pagespace/lib/server';
+import { anonymizeAiUsageContent, purgeAiUsageLogs } from '@pagespace/lib/logging/ai-usage-purge';
+import { audit } from '@pagespace/lib/audit/audit-log';
 import { NextResponse } from 'next/server';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
 

--- a/apps/web/src/app/api/cron/purge-deleted-messages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/purge-deleted-messages/__tests__/route.test.ts
@@ -22,8 +22,8 @@ vi.mock('@/lib/repositories/global-conversation-repository', () => ({
   globalConversationRepository: mockGlobalRepo,
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  audit: mockAudit,
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: mockAudit,
 }));
 
 vi.mock('next/server', () => ({

--- a/apps/web/src/app/api/cron/purge-deleted-messages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/purge-deleted-messages/__tests__/route.test.ts
@@ -23,7 +23,7 @@ vi.mock('@/lib/repositories/global-conversation-repository', () => ({
 }));
 
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: mockAudit,
+  audit: mockAudit,
 }));
 
 vi.mock('next/server', () => ({

--- a/apps/web/src/app/api/cron/purge-deleted-messages/route.ts
+++ b/apps/web/src/app/api/cron/purge-deleted-messages/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { audit } from '@pagespace/lib/server';
+import { audit } from '@pagespace/lib/audit/audit-log';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
 import { chatMessageRepository } from '@/lib/repositories/chat-message-repository';
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';

--- a/apps/web/src/app/api/cron/retention-cleanup/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/retention-cleanup/__tests__/route.test.ts
@@ -22,7 +22,7 @@ vi.mock('@pagespace/db', () => ({
 }));
 
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: mockAudit,
+  audit: mockAudit,
 }));
 
 vi.mock('next/server', () => ({

--- a/apps/web/src/app/api/cron/retention-cleanup/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/retention-cleanup/__tests__/route.test.ts
@@ -21,8 +21,8 @@ vi.mock('@pagespace/db', () => ({
   db: {},
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  audit: mockAudit,
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: mockAudit,
 }));
 
 vi.mock('next/server', () => ({

--- a/apps/web/src/app/api/cron/retention-cleanup/route.ts
+++ b/apps/web/src/app/api/cron/retention-cleanup/route.ts
@@ -1,6 +1,6 @@
 import { runRetentionCleanup } from '@pagespace/lib/compliance/retention/retention-engine';
 import { db } from '@pagespace/db';
-import { audit } from '@pagespace/lib/server';
+import { audit } from '@pagespace/lib/audit/audit-log';
 import { NextResponse } from 'next/server';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
 

--- a/apps/web/src/app/api/cron/sweep-expired/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/sweep-expired/__tests__/route.test.ts
@@ -23,17 +23,17 @@ vi.mock('@/lib/auth/cron-auth', () => ({
 }));
 
 vi.mock('@pagespace/lib/security/jti-revocation', () => ({
-    sweepExpiredRevokedJTIs: mockSweepJTI,
+  sweepExpiredRevokedJTIs: mockSweepJTI,
 }));
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    sweepExpiredRateLimitBuckets: mockSweepRateLimit,
+  sweepExpiredRateLimitBuckets: mockSweepRateLimit,
 }));
 vi.mock('@pagespace/lib/security/auth-handoff-sweep', () => ({
-    sweepExpiredAuthHandoffTokens: mockSweepAuthHandoff,
+  sweepExpiredAuthHandoffTokens: mockSweepAuthHandoff,
 }));
 
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: mockAudit,
+  audit: mockAudit,
 }));
 
 vi.mock('next/server', () => ({

--- a/apps/web/src/app/api/cron/sweep-expired/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/sweep-expired/__tests__/route.test.ts
@@ -22,14 +22,18 @@ vi.mock('@/lib/auth/cron-auth', () => ({
   validateSignedCronRequest: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/security', () => ({
-  sweepExpiredRevokedJTIs: mockSweepJTI,
-  sweepExpiredRateLimitBuckets: mockSweepRateLimit,
-  sweepExpiredAuthHandoffTokens: mockSweepAuthHandoff,
+vi.mock('@pagespace/lib/security/jti-revocation', () => ({
+    sweepExpiredRevokedJTIs: mockSweepJTI,
+}));
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    sweepExpiredRateLimitBuckets: mockSweepRateLimit,
+}));
+vi.mock('@pagespace/lib/security/auth-handoff-sweep', () => ({
+    sweepExpiredAuthHandoffTokens: mockSweepAuthHandoff,
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  audit: mockAudit,
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: mockAudit,
 }));
 
 vi.mock('next/server', () => ({

--- a/apps/web/src/app/api/cron/sweep-expired/route.ts
+++ b/apps/web/src/app/api/cron/sweep-expired/route.ts
@@ -1,9 +1,7 @@
-import {
-  sweepExpiredRevokedJTIs,
-  sweepExpiredRateLimitBuckets,
-  sweepExpiredAuthHandoffTokens,
-} from '@pagespace/lib/security';
-import { audit } from '@pagespace/lib/server';
+import { sweepExpiredRevokedJTIs } from '@pagespace/lib/security/jti-revocation';
+import { sweepExpiredRateLimitBuckets } from '@pagespace/lib/security/distributed-rate-limit';
+import { sweepExpiredAuthHandoffTokens } from '@pagespace/lib/security/auth-handoff-sweep';
+import { audit } from '@pagespace/lib/audit/audit-log';
 import { NextResponse } from 'next/server';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
 

--- a/apps/web/src/app/api/cron/verify-audit-chain/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/verify-audit-chain/__tests__/route.test.ts
@@ -20,18 +20,18 @@ vi.mock('@/lib/auth/cron-auth', () => ({
 }));
 
 vi.mock('@pagespace/lib/audit/security-audit-alerting', () => ({
-    verifyAndAlert: mockVerifyAndAlert,
+  verifyAndAlert: mockVerifyAndAlert,
 }));
 
 const mockAudit = vi.hoisted(() => vi.fn());
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: mockLoggers,
+  loggers: mockLoggers,
 
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: mockAudit,
+  audit: mockAudit,
 }));
 
 vi.mock('next/server', () => ({

--- a/apps/web/src/app/api/cron/verify-audit-chain/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/verify-audit-chain/__tests__/route.test.ts
@@ -19,15 +19,19 @@ vi.mock('@/lib/auth/cron-auth', () => ({
   validateSignedCronRequest: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib', () => ({
-  verifyAndAlert: mockVerifyAndAlert,
+vi.mock('@pagespace/lib/audit/security-audit-alerting', () => ({
+    verifyAndAlert: mockVerifyAndAlert,
 }));
 
 const mockAudit = vi.hoisted(() => vi.fn());
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: mockLoggers,
-  audit: mockAudit,
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: mockLoggers,
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: mockAudit,
 }));
 
 vi.mock('next/server', () => ({

--- a/apps/web/src/app/api/cron/verify-audit-chain/route.ts
+++ b/apps/web/src/app/api/cron/verify-audit-chain/route.ts
@@ -1,5 +1,5 @@
 import { verifyAndAlert } from '@pagespace/lib/audit/security-audit-alerting';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { audit } from '@pagespace/lib/audit/audit-log';
 import { NextResponse } from 'next/server';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';

--- a/apps/web/src/app/api/cron/verify-audit-chain/route.ts
+++ b/apps/web/src/app/api/cron/verify-audit-chain/route.ts
@@ -1,5 +1,6 @@
-import { verifyAndAlert } from '@pagespace/lib';
-import { loggers, audit } from '@pagespace/lib/server';
+import { verifyAndAlert } from '@pagespace/lib/audit/security-audit-alerting';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { audit } from '@pagespace/lib/audit/audit-log';
 import { NextResponse } from 'next/server';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
 

--- a/apps/web/src/app/api/cron/workflows/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/workflows/__tests__/route.test.ts
@@ -37,11 +37,15 @@ vi.mock('@/lib/workflows/cron-utils', () => ({
 
 const mockAudit = vi.hoisted(() => vi.fn());
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
-  audit: mockAudit,
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: mockAudit,
 }));
 
 vi.mock('@pagespace/db', () => ({

--- a/apps/web/src/app/api/cron/workflows/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/workflows/__tests__/route.test.ts
@@ -38,14 +38,14 @@ vi.mock('@/lib/workflows/cron-utils', () => ({
 const mockAudit = vi.hoisted(() => vi.fn());
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
 
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: mockAudit,
+  audit: mockAudit,
 }));
 
 vi.mock('@pagespace/db', () => ({

--- a/apps/web/src/app/api/cron/workflows/route.ts
+++ b/apps/web/src/app/api/cron/workflows/route.ts
@@ -3,7 +3,8 @@ import { db, workflows, taskItems, eq, and, lte, ne, inArray } from '@pagespace/
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
 import { executeWorkflow } from '@/lib/workflows/workflow-executor';
 import { getNextRunDate } from '@/lib/workflows/cron-utils';
-import { loggers, audit } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { audit } from '@pagespace/lib/audit/audit-log';
 
 const STUCK_WORKFLOW_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 const MAX_CONCURRENT_WORKFLOWS = 5;

--- a/apps/web/src/app/api/cron/workflows/route.ts
+++ b/apps/web/src/app/api/cron/workflows/route.ts
@@ -3,7 +3,7 @@ import { db, workflows, taskItems, eq, and, lte, ne, inArray } from '@pagespace/
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
 import { executeWorkflow } from '@/lib/workflows/workflow-executor';
 import { getNextRunDate } from '@/lib/workflows/cron-utils';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { audit } from '@pagespace/lib/audit/audit-log';
 
 const STUCK_WORKFLOW_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes

--- a/apps/web/src/app/api/debug/chat-messages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/debug/chat-messages/__tests__/route.test.ts
@@ -32,8 +32,8 @@ vi.mock('@/lib/auth', () => ({
 
 // Mock permissions (boundary)
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
-    canUserViewPage: vi.fn(),
-    canUserEditPage: vi.fn(),
+  canUserViewPage: vi.fn(),
+  canUserEditPage: vi.fn(),
 }));
 
 // Mock database (boundary)
@@ -64,7 +64,7 @@ vi.mock('@pagespace/db', () => {
 
 // Mock loggers (boundary)
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: {
       debug: vi.fn(),
       error: vi.fn(),

--- a/apps/web/src/app/api/debug/chat-messages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/debug/chat-messages/__tests__/route.test.ts
@@ -31,9 +31,9 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock permissions (boundary)
-vi.mock('@pagespace/lib/permissions', () => ({
-  canUserViewPage: vi.fn(),
-  canUserEditPage: vi.fn(),
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    canUserViewPage: vi.fn(),
+    canUserEditPage: vi.fn(),
 }));
 
 // Mock database (boundary)
@@ -63,19 +63,21 @@ vi.mock('@pagespace/db', () => {
 });
 
 // Mock loggers (boundary)
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: {
       debug: vi.fn(),
       error: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 import { NextResponse } from 'next/server';
 import { GET, POST } from '../route';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { canUserViewPage, canUserEditPage } from '@pagespace/lib/permissions';
+import { canUserViewPage, canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { db } from '@pagespace/db';
 
 // Test fixtures

--- a/apps/web/src/app/api/debug/chat-messages/route.ts
+++ b/apps/web/src/app/api/debug/chat-messages/route.ts
@@ -2,8 +2,8 @@ import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db, chatMessages, eq, and, desc } from '@pagespace/db';
 import { createId } from '@paralleldrive/cuid2';
-import { loggers } from '@pagespace/lib/server';
-import { canUserViewPage, canUserEditPage } from '@pagespace/lib/permissions';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { canUserViewPage, canUserEditPage } from '@pagespace/lib/permissions/permissions';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/feedback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/feedback/__tests__/route.test.ts
@@ -35,7 +35,7 @@ vi.mock('@pagespace/db', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: {
       info: vi.fn(),
       warn: vi.fn(),
@@ -47,8 +47,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -57,8 +57,8 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn(),
-    DISTRIBUTED_RATE_LIMITS: {
+  checkDistributedRateLimit: vi.fn(),
+  DISTRIBUTED_RATE_LIMITS: {
     CONTACT_FORM: { maxRequests: 5, windowMs: 3600000 },
   },
 }));

--- a/apps/web/src/app/api/feedback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/feedback/__tests__/route.test.ts
@@ -34,8 +34,8 @@ vi.mock('@pagespace/db', () => ({
   feedbackSubmissions: {},
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: {
       info: vi.fn(),
       warn: vi.fn(),
@@ -43,8 +43,12 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -52,9 +56,9 @@ vi.mock('@/lib/auth', () => ({
   isAuthError: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn(),
-  DISTRIBUTED_RATE_LIMITS: {
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn(),
+    DISTRIBUTED_RATE_LIMITS: {
     CONTACT_FORM: { maxRequests: 5, windowMs: 3600000 },
   },
 }));
@@ -65,9 +69,10 @@ vi.mock('@paralleldrive/cuid2', () => ({
 }));
 
 import { db } from '@pagespace/db';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { checkDistributedRateLimit } from '@pagespace/lib/security';
+import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 
 // Test fixtures
 const mockWebAuth = (userId: string): SessionAuthResult => ({

--- a/apps/web/src/app/api/feedback/route.ts
+++ b/apps/web/src/app/api/feedback/route.ts
@@ -1,11 +1,12 @@
 import { db, feedbackSubmissions } from '@pagespace/db';
 import { z } from 'zod/v4';
 import { createId } from '@paralleldrive/cuid2';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { sendEmail } from '@pagespace/lib/services/email-service';
 import { FeedbackNotificationEmail } from '@pagespace/lib/email-templates/FeedbackNotificationEmail';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security';
+import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security/distributed-rate-limit';
 import { ALLOWED_IMAGE_TYPES, validateImageAttachment } from '@/lib/validation/image-validation';
 
 const FEEDBACK_EMAIL = process.env.CONTACT_EMAIL || 'hello@pagespace.ai';

--- a/apps/web/src/app/api/feedback/route.ts
+++ b/apps/web/src/app/api/feedback/route.ts
@@ -1,7 +1,7 @@
 import { db, feedbackSubmissions } from '@pagespace/db';
 import { z } from 'zod/v4';
 import { createId } from '@paralleldrive/cuid2';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { sendEmail } from '@pagespace/lib/services/email-service';
 import { FeedbackNotificationEmail } from '@pagespace/lib/email-templates/FeedbackNotificationEmail';

--- a/apps/web/src/app/api/health/__tests__/route.test.ts
+++ b/apps/web/src/app/api/health/__tests__/route.test.ts
@@ -10,14 +10,16 @@ vi.mock('@pagespace/db', () => ({
   sql: (strings: TemplateStringsArray) => strings.join(''),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: {
       info: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 vi.mock('@/middleware/monitoring', () => ({

--- a/apps/web/src/app/api/health/__tests__/route.test.ts
+++ b/apps/web/src/app/api/health/__tests__/route.test.ts
@@ -11,7 +11,7 @@ vi.mock('@pagespace/db', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: {
       info: vi.fn(),
       warn: vi.fn(),

--- a/apps/web/src/app/api/health/route.ts
+++ b/apps/web/src/app/api/health/route.ts
@@ -1,5 +1,5 @@
 import { db, sql } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getMonitoringIngestStatus } from '@/middleware/monitoring';
 
 interface HealthResponse {

--- a/apps/web/src/app/api/inbox/route.ts
+++ b/apps/web/src/app/api/inbox/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from 'next/server';
 import { db, sql } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers, getBatchPagePermissions, auditRequest } from '@pagespace/lib/server';
-import type { InboxItem, InboxResponse } from '@pagespace/lib';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { getBatchPagePermissions } from '@pagespace/lib/permissions/permissions'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import type { InboxItem, InboxResponse } from '@pagespace/lib/types';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
 import { toISOTimestamp } from '@/lib/utils/timestamp';
 import type { ChannelRow, DMRow } from '@/types/messaging';

--- a/apps/web/src/app/api/inbox/route.ts
+++ b/apps/web/src/app/api/inbox/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 import { db, sql } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/logging/logger-config'
-import { getBatchPagePermissions } from '@pagespace/lib/permissions/permissions'
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { getBatchPagePermissions } from '@pagespace/lib/permissions/permissions';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import type { InboxItem, InboxResponse } from '@pagespace/lib/types';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';

--- a/apps/web/src/app/api/internal/contact/route.ts
+++ b/apps/web/src/app/api/internal/contact/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { db, contactSubmissions } from '@pagespace/db';
-import { isValidEmail } from '@pagespace/lib/validators/email'
+import { isValidEmail } from '@pagespace/lib/validators/email';
 import { secureCompare } from '@pagespace/lib/auth/secure-compare';
 
 export async function POST(request: Request) {

--- a/apps/web/src/app/api/internal/contact/route.ts
+++ b/apps/web/src/app/api/internal/contact/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db, contactSubmissions } from '@pagespace/db';
-import { isValidEmail, secureCompare } from '@pagespace/lib';
+import { isValidEmail } from '@pagespace/lib/validators/email'
+import { secureCompare } from '@pagespace/lib/auth/secure-compare';
 
 export async function POST(request: Request) {
   const secret = process.env.INTERNAL_API_SECRET;

--- a/apps/web/src/app/api/internal/monitoring/ingest/route.ts
+++ b/apps/web/src/app/api/internal/monitoring/ingest/route.ts
@@ -2,8 +2,8 @@ import { NextResponse } from 'next/server';
 import { createId } from '@paralleldrive/cuid2';
 import { db, systemLogs } from '@pagespace/db';
 import { writeApiMetrics, writeError } from '@pagespace/lib/logging/logger-database';
-import { loggers } from '@pagespace/lib/server';
-import { secureCompare } from '@pagespace/lib';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { secureCompare } from '@pagespace/lib/auth/secure-compare';
 import { sanitizeIngestPayload, type IngestPayload } from '@/lib/monitoring/ingest-sanitizer';
 
 function unauthorized(message: string, status: number = 401) {

--- a/apps/web/src/app/api/mcp-ws/__tests__/route.security.test.ts
+++ b/apps/web/src/app/api/mcp-ws/__tests__/route.security.test.ts
@@ -54,11 +54,13 @@ vi.mock('@/lib/websocket/ws-security', () => ({
   isSecureConnection: vi.fn(() => true),
 }));
 
-vi.mock('@pagespace/lib', () => ({
-  sessionService: {
+vi.mock('@pagespace/lib/auth/session-service', () => ({
+    sessionService: {
     validateSession: vi.fn(),
     createSession: vi.fn(),
   },
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: {
     child: vi.fn(() => ({
       info: vi.fn(),
@@ -68,14 +70,13 @@ vi.mock('@pagespace/lib', () => ({
       fatal: vi.fn(),
     })),
   },
-}));
-
-vi.mock('@pagespace/lib/server', () => ({
   loggers: {
     security: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
     api: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
   },
-  auditRequest: vi.fn(),
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    auditRequest: vi.fn(),
 }));
 
 import {
@@ -87,8 +88,8 @@ import {
   getConnectionFingerprint,
   validateMessageSize,
 } from '@/lib/websocket';
-import { sessionService } from '@pagespace/lib';
-import { auditRequest } from '@pagespace/lib/server';
+import { sessionService } from '@pagespace/lib/auth/session-service';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 // Mock session expiry (1 hour from now)
 const mockSessionExpiry = new Date(Date.now() + 60 * 60 * 1000);

--- a/apps/web/src/app/api/mcp-ws/__tests__/route.security.test.ts
+++ b/apps/web/src/app/api/mcp-ws/__tests__/route.security.test.ts
@@ -55,7 +55,7 @@ vi.mock('@/lib/websocket/ws-security', () => ({
 }));
 
 vi.mock('@pagespace/lib/auth/session-service', () => ({
-    sessionService: {
+  sessionService: {
     validateSession: vi.fn(),
     createSession: vi.fn(),
   },
@@ -76,7 +76,7 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    auditRequest: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 import {

--- a/apps/web/src/app/api/mcp-ws/route.ts
+++ b/apps/web/src/app/api/mcp-ws/route.ts
@@ -24,8 +24,8 @@ import {
   isFetchResponseEndMessage,
   isFetchResponseErrorMessage,
 } from '@/lib/websocket';
-import { sessionService, type SessionClaims } from '@pagespace/lib';
-import { auditRequest } from '@pagespace/lib/server';
+import { sessionService, type SessionClaims } from '@pagespace/lib/auth/session-service';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 // Initialize cleanup interval on module load
 // This prevents memory leaks from stale connections

--- a/apps/web/src/app/api/mcp/documents/__tests__/route.security.test.ts
+++ b/apps/web/src/app/api/mcp/documents/__tests__/route.security.test.ts
@@ -29,20 +29,20 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
-    getUserAccessLevel: (...args: unknown[]) => mockGetUserAccessLevel(...args),
+  getUserAccessLevel: (...args: unknown[]) => mockGetUserAccessLevel(...args),
 }));
 vi.mock('@pagespace/lib/utils/enums', () => ({
-    PageType: {},
+  PageType: {},
 }));
 vi.mock('@pagespace/lib/sheets', () => ({
-    isSheetType: vi.fn(() => false),
-    parseSheetContent: vi.fn(),
-    serializeSheetContent: vi.fn(),
-    updateSheetCells: vi.fn(),
-    isValidCellAddress: vi.fn(() => true),
+  isSheetType: vi.fn(() => false),
+  parseSheetContent: vi.fn(),
+  serializeSheetContent: vi.fn(),
+  updateSheetCells: vi.fn(),
+  isValidCellAddress: vi.fn(() => true),
 }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
@@ -50,8 +50,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/db', () => ({

--- a/apps/web/src/app/api/mcp/documents/__tests__/route.security.test.ts
+++ b/apps/web/src/app/api/mcp/documents/__tests__/route.security.test.ts
@@ -28,20 +28,30 @@ vi.mock('@/lib/auth', () => ({
   isMCPAuthResult: (result: unknown) => !('error' in (result as object)) && (result as { tokenType?: string }).tokenType === 'mcp',
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  getUserAccessLevel: (...args: unknown[]) => mockGetUserAccessLevel(...args),
-  PageType: {},
-  isSheetType: vi.fn(() => false),
-  parseSheetContent: vi.fn(),
-  serializeSheetContent: vi.fn(),
-  updateSheetCells: vi.fn(),
-  isValidCellAddress: vi.fn(() => true),
-  loggers: {
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    getUserAccessLevel: (...args: unknown[]) => mockGetUserAccessLevel(...args),
+}));
+vi.mock('@pagespace/lib/utils/enums', () => ({
+    PageType: {},
+}));
+vi.mock('@pagespace/lib/sheets', () => ({
+    isSheetType: vi.fn(() => false),
+    parseSheetContent: vi.fn(),
+    serializeSheetContent: vi.fn(),
+    updateSheetCells: vi.fn(),
+    isValidCellAddress: vi.fn(() => true),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/db', () => ({

--- a/apps/web/src/app/api/mcp/documents/route.ts
+++ b/apps/web/src/app/api/mcp/documents/route.ts
@@ -1,10 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db, pages, eq } from '@pagespace/db';
-import { getUserAccessLevel, PageType, isSheetType, parseSheetContent, serializeSheetContent, updateSheetCells, isValidCellAddress } from '@pagespace/lib/server';
+import { getUserAccessLevel } from '@pagespace/lib/permissions/permissions'
+import { PageType } from '@pagespace/lib/utils/enums'
+import { isSheetType, parseSheetContent, serializeSheetContent, updateSheetCells, isValidCellAddress } from '@pagespace/lib/sheets';
 import { z } from 'zod/v4';
 import { addLineBreaksForAI } from '@/lib/editor/line-breaks';
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateMCPRequest, isAuthError, isMCPAuthResult } from '@/lib/auth';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import { applyPageMutation, PageRevisionMismatchError } from '@/services/api/page-mutation-service';

--- a/apps/web/src/app/api/mcp/documents/route.ts
+++ b/apps/web/src/app/api/mcp/documents/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db, pages, eq } from '@pagespace/db';
-import { getUserAccessLevel } from '@pagespace/lib/permissions/permissions'
-import { PageType } from '@pagespace/lib/utils/enums'
+import { getUserAccessLevel } from '@pagespace/lib/permissions/permissions';
+import { PageType } from '@pagespace/lib/utils/enums';
 import { isSheetType, parseSheetContent, serializeSheetContent, updateSheetCells, isValidCellAddress } from '@pagespace/lib/sheets';
 import { z } from 'zod/v4';
 import { addLineBreaksForAI } from '@/lib/editor/line-breaks';
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateMCPRequest, isAuthError, isMCPAuthResult } from '@/lib/auth';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';

--- a/apps/web/src/app/api/mcp/drives/route.ts
+++ b/apps/web/src/app/api/mcp/drives/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db, drives } from '@pagespace/db';
 import { z } from 'zod/v4';
-import { slugify } from '@pagespace/lib/server';
+import { slugify } from '@pagespace/lib/utils/utils';
 import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateMCPRequest, isAuthError, isMCPAuthResult } from '@/lib/auth';
 import { getActorInfo, logDriveActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { listAccessibleDrives } from '@pagespace/lib/services/drive-service';

--- a/apps/web/src/app/api/mcp/drives/route.ts
+++ b/apps/web/src/app/api/mcp/drives/route.ts
@@ -3,7 +3,7 @@ import { db, drives } from '@pagespace/db';
 import { z } from 'zod/v4';
 import { slugify } from '@pagespace/lib/utils/utils';
 import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateMCPRequest, isAuthError, isMCPAuthResult } from '@/lib/auth';
 import { getActorInfo, logDriveActivity } from '@pagespace/lib/monitoring/activity-logger';

--- a/apps/web/src/app/api/memory/cron/__tests__/route.test.ts
+++ b/apps/web/src/app/api/memory/cron/__tests__/route.test.ts
@@ -63,8 +63,8 @@ vi.mock('@/lib/memory/compaction-service', () => ({
 }));
 
 // Mock loggers
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: {
       info: vi.fn(),
       warn: vi.fn(),
@@ -72,6 +72,8 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 // Helper that creates a properly HMAC-signed cron request.

--- a/apps/web/src/app/api/memory/cron/__tests__/route.test.ts
+++ b/apps/web/src/app/api/memory/cron/__tests__/route.test.ts
@@ -64,7 +64,7 @@ vi.mock('@/lib/memory/compaction-service', () => ({
 
 // Mock loggers
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: {
       info: vi.fn(),
       warn: vi.fn(),

--- a/apps/web/src/app/api/memory/cron/route.ts
+++ b/apps/web/src/app/api/memory/cron/route.ts
@@ -30,7 +30,7 @@ import {
   inArray,
   isNull,
 } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
 import { runDiscoveryPasses } from '@/lib/memory/discovery-service';
 import {

--- a/apps/web/src/app/api/mentions/search/__tests__/route.test.ts
+++ b/apps/web/src/app/api/mentions/search/__tests__/route.test.ts
@@ -26,11 +26,13 @@ vi.mock('next/server', () => {
 // 3. Unauthorized access returns 403, not data
 // ============================================================================
 
-vi.mock('@pagespace/lib/server', () => ({
-  getUserAccessLevel: vi.fn(),
-  getUserDriveAccess: vi.fn(),
-  getDriveIdsForUser: vi.fn(),
-  loggers: {
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    getUserAccessLevel: vi.fn(),
+    getUserDriveAccess: vi.fn(),
+    getDriveIdsForUser: vi.fn(),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: {
       info: vi.fn(),
       error: vi.fn(),
@@ -38,6 +40,8 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -61,7 +65,7 @@ vi.mock('@pagespace/db', async () => {
 // Import after all mocks are set up
 import { NextResponse } from 'next/server';
 import { GET } from '../route';
-import { getUserAccessLevel, getUserDriveAccess, getDriveIdsForUser } from '@pagespace/lib/server';
+import { getUserAccessLevel, getUserDriveAccess, getDriveIdsForUser } from '@pagespace/lib/permissions/permissions';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db } from '@pagespace/db';
 

--- a/apps/web/src/app/api/mentions/search/__tests__/route.test.ts
+++ b/apps/web/src/app/api/mentions/search/__tests__/route.test.ts
@@ -27,12 +27,12 @@ vi.mock('next/server', () => {
 // ============================================================================
 
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
-    getUserAccessLevel: vi.fn(),
-    getUserDriveAccess: vi.fn(),
-    getDriveIdsForUser: vi.fn(),
+  getUserAccessLevel: vi.fn(),
+  getUserDriveAccess: vi.fn(),
+  getDriveIdsForUser: vi.fn(),
 }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: {
       info: vi.fn(),
       error: vi.fn(),

--- a/apps/web/src/app/api/mentions/search/route.ts
+++ b/apps/web/src/app/api/mentions/search/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server';
-import { getUserAccessLevel, getUserDriveAccess, getDriveIdsForUser, loggers, auditRequest } from '@pagespace/lib/server';
+import { getUserAccessLevel, getUserDriveAccess, getDriveIdsForUser } from '@pagespace/lib/permissions/permissions'
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { pages, users, db, and, eq, ilike, drives, inArray, desc, SQL } from '@pagespace/db';
 import { MentionSuggestion, MentionType } from '@/types/mentions';

--- a/apps/web/src/app/api/mentions/search/route.ts
+++ b/apps/web/src/app/api/mentions/search/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
-import { getUserAccessLevel, getUserDriveAccess, getDriveIdsForUser } from '@pagespace/lib/permissions/permissions'
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { getUserAccessLevel, getUserDriveAccess, getDriveIdsForUser } from '@pagespace/lib/permissions/permissions';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { pages, users, db, and, eq, ilike, drives, inArray, desc, SQL } from '@pagespace/db';

--- a/apps/web/src/app/api/monitoring/[metric]/route.ts
+++ b/apps/web/src/app/api/monitoring/[metric]/route.ts
@@ -9,7 +9,7 @@ import {
   getPerformanceMetrics,
   getDateRange
 } from '@/lib/monitoring';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 type RouteContext = { params: Promise<{ metric: string }> };
 

--- a/apps/web/src/app/api/notifications/[id]/read/route.ts
+++ b/apps/web/src/app/api/notifications/[id]/read/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { markNotificationAsRead } from '@pagespace/lib';
-import { loggers } from '@pagespace/lib/server';
+import { markNotificationAsRead } from '@pagespace/lib/notifications/notifications';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 

--- a/apps/web/src/app/api/notifications/[id]/route.ts
+++ b/apps/web/src/app/api/notifications/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { deleteNotification } from '@pagespace/lib/notifications/notifications';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/notifications/[id]/route.ts
+++ b/apps/web/src/app/api/notifications/[id]/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { deleteNotification } from '@pagespace/lib';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { deleteNotification } from '@pagespace/lib/notifications/notifications';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 

--- a/apps/web/src/app/api/notifications/push-tokens/route.ts
+++ b/apps/web/src/app/api/notifications/push-tokens/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { registerPushToken, unregisterPushToken, getUserPushTokens } from '@pagespace/lib/notifications/push-notifications';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 

--- a/apps/web/src/app/api/notifications/push-tokens/route.ts
+++ b/apps/web/src/app/api/notifications/push-tokens/route.ts
@@ -1,10 +1,7 @@
 import { NextResponse } from 'next/server';
-import {
-  registerPushToken,
-  unregisterPushToken,
-  getUserPushTokens,
-} from '@pagespace/lib/notifications';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { registerPushToken, unregisterPushToken, getUserPushTokens } from '@pagespace/lib/notifications/push-notifications';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/notifications/read-all/route.ts
+++ b/apps/web/src/app/api/notifications/read-all/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { markAllNotificationsAsRead } from '@pagespace/lib';
-import { loggers } from '@pagespace/lib/server';
+import { markAllNotificationsAsRead } from '@pagespace/lib/notifications/notifications';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 

--- a/apps/web/src/app/api/notifications/route.ts
+++ b/apps/web/src/app/api/notifications/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getUserNotifications, getUnreadNotificationCount } from '@pagespace/lib/notifications/notifications';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';

--- a/apps/web/src/app/api/notifications/route.ts
+++ b/apps/web/src/app/api/notifications/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
-import { getUserNotifications, getUnreadNotificationCount } from '@pagespace/lib';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { getUserNotifications, getUnreadNotificationCount } from '@pagespace/lib/notifications/notifications';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
 

--- a/apps/web/src/app/api/notifications/unsubscribe/[token]/route.ts
+++ b/apps/web/src/app/api/notifications/unsubscribe/[token]/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { db, emailNotificationPreferences, emailUnsubscribeTokens, eq, and, gt, isNull } from '@pagespace/db';
-import { hashToken } from '@pagespace/lib/auth';
-import { loggers, audit } from '@pagespace/lib/server';
+import { hashToken } from '@pagespace/lib/auth/token-utils';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { audit } from '@pagespace/lib/audit/audit-log';
 
 type NotificationType =
   | 'PERMISSION_GRANTED'

--- a/apps/web/src/app/api/notifications/unsubscribe/[token]/route.ts
+++ b/apps/web/src/app/api/notifications/unsubscribe/[token]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db, emailNotificationPreferences, emailUnsubscribeTokens, eq, and, gt, isNull } from '@pagespace/db';
 import { hashToken } from '@pagespace/lib/auth/token-utils';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { audit } from '@pagespace/lib/audit/audit-log';
 
 type NotificationType =

--- a/apps/web/src/app/api/permissions/batch/__tests__/route.test.ts
+++ b/apps/web/src/app/api/permissions/batch/__tests__/route.test.ts
@@ -11,10 +11,10 @@ import type { SessionAuthResult, AuthError } from '@/lib/auth';
 const mockGetBatchPagePermissions = vi.fn();
 
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
-    getBatchPagePermissions: (...args: unknown[]) => mockGetBatchPagePermissions(...args),
+  getBatchPagePermissions: (...args: unknown[]) => mockGetBatchPagePermissions(...args),
 }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
@@ -22,8 +22,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({

--- a/apps/web/src/app/api/permissions/batch/__tests__/route.test.ts
+++ b/apps/web/src/app/api/permissions/batch/__tests__/route.test.ts
@@ -10,14 +10,20 @@ import type { SessionAuthResult, AuthError } from '@/lib/auth';
 
 const mockGetBatchPagePermissions = vi.fn();
 
-vi.mock('@pagespace/lib/server', () => ({
-  getBatchPagePermissions: (...args: unknown[]) => mockGetBatchPagePermissions(...args),
-  loggers: {
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+    getBatchPagePermissions: (...args: unknown[]) => mockGetBatchPagePermissions(...args),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -26,7 +32,7 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 import { POST } from '../route';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 
 // ============================================================================

--- a/apps/web/src/app/api/permissions/batch/route.ts
+++ b/apps/web/src/app/api/permissions/batch/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { getBatchPagePermissions } from '@pagespace/lib/server';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { getBatchPagePermissions } from '@pagespace/lib/permissions/permissions';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
 

--- a/apps/web/src/app/api/permissions/batch/route.ts
+++ b/apps/web/src/app/api/permissions/batch/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { getBatchPagePermissions } from '@pagespace/lib/permissions/permissions';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/provisioning-status/[slug]/route.ts
+++ b/apps/web/src/app/api/provisioning-status/[slug]/route.ts
@@ -1,4 +1,4 @@
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 // Mirrors control-plane's tenant-validation.ts SLUG_PATTERN
 const SLUG_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;

--- a/apps/web/src/app/api/pulse/cron/route.ts
+++ b/apps/web/src/app/api/pulse/cron/route.ts
@@ -47,7 +47,7 @@ import {
   calculateDiffBudget,
   type DiffRequest,
 } from '@pagespace/lib/content/diff-generator';
-import { readPageContent } from '@pagespace/lib/services/page-content-store'
+import { readPageContent } from '@pagespace/lib/services/page-content-store';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';

--- a/apps/web/src/app/api/pulse/cron/route.ts
+++ b/apps/web/src/app/api/pulse/cron/route.ts
@@ -37,15 +37,18 @@ import {
 import { fetchCalendarContext } from '../calendar-context';
 import {
   groupActivitiesForDiff,
-  resolveStackedVersionContent,
-  generateDiffsWithinBudget,
-  calculateDiffBudget,
   type ActivityForDiff,
   type ActivityDiffGroup,
-  type DiffRequest,
   type StackedDiff,
-} from '@pagespace/lib/content';
-import { readPageContent, loggers } from '@pagespace/lib/server';
+} from '@pagespace/lib/content/activity-diff-utils';
+import { resolveStackedVersionContent } from '@pagespace/lib/content/version-resolver';
+import {
+  generateDiffsWithinBudget,
+  calculateDiffBudget,
+  type DiffRequest,
+} from '@pagespace/lib/content/diff-generator';
+import { readPageContent } from '@pagespace/lib/services/page-content-store'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
 import { PULSE_SYSTEM_PROMPT } from '../pulse-prompt';

--- a/apps/web/src/app/api/pulse/generate/route.ts
+++ b/apps/web/src/app/api/pulse/generate/route.ts
@@ -37,15 +37,18 @@ import {
 import { fetchCalendarContext } from '../calendar-context';
 import {
   groupActivitiesForDiff,
-  resolveStackedVersionContent,
-  generateDiffsWithinBudget,
-  calculateDiffBudget,
   type ActivityForDiff,
   type ActivityDiffGroup,
-  type DiffRequest,
   type StackedDiff,
-} from '@pagespace/lib/content';
-import { readPageContent, loggers } from '@pagespace/lib/server';
+} from '@pagespace/lib/content/activity-diff-utils';
+import { resolveStackedVersionContent } from '@pagespace/lib/content/version-resolver';
+import {
+  generateDiffsWithinBudget,
+  calculateDiffBudget,
+  type DiffRequest,
+} from '@pagespace/lib/content/diff-generator';
+import { readPageContent } from '@pagespace/lib/services/page-content-store'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 
 import { PULSE_SYSTEM_PROMPT } from '../pulse-prompt';

--- a/apps/web/src/app/api/pulse/generate/route.ts
+++ b/apps/web/src/app/api/pulse/generate/route.ts
@@ -47,7 +47,7 @@ import {
   calculateDiffBudget,
   type DiffRequest,
 } from '@pagespace/lib/content/diff-generator';
-import { readPageContent } from '@pagespace/lib/services/page-content-store'
+import { readPageContent } from '@pagespace/lib/services/page-content-store';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 

--- a/apps/web/src/app/api/pulse/route.ts
+++ b/apps/web/src/app/api/pulse/route.ts
@@ -22,7 +22,7 @@ import {
   inArray,
   isNull,
 } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getStartOfTodayInTimezone, normalizeTimezone } from '@/lib/ai/core';
 
 const AUTH_OPTIONS = { allow: ['session'] as const };

--- a/apps/web/src/app/api/settings/display-preferences/route.ts
+++ b/apps/web/src/app/api/settings/display-preferences/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db, displayPreferences, eq, and } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { audit } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };

--- a/apps/web/src/app/api/settings/display-preferences/route.ts
+++ b/apps/web/src/app/api/settings/display-preferences/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { db, displayPreferences, eq, and } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers, audit } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { audit } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/settings/hotkey-preferences/__tests__/route.test.ts
+++ b/apps/web/src/app/api/settings/hotkey-preferences/__tests__/route.test.ts
@@ -34,12 +34,16 @@ vi.mock('@/lib/auth', () => ({
   isAuthError: vi.fn((result) => 'error' in result),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 vi.mock('@/lib/hotkeys/registry', () => ({

--- a/apps/web/src/app/api/settings/hotkey-preferences/__tests__/route.test.ts
+++ b/apps/web/src/app/api/settings/hotkey-preferences/__tests__/route.test.ts
@@ -35,15 +35,15 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
   },
 
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@/lib/hotkeys/registry', () => ({

--- a/apps/web/src/app/api/settings/hotkey-preferences/route.ts
+++ b/apps/web/src/app/api/settings/hotkey-preferences/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db, userHotkeyPreferences, eq, and } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { audit } from '@pagespace/lib/audit/audit-log';
 import { getHotkeyDefinition } from '@/lib/hotkeys/registry';
 

--- a/apps/web/src/app/api/settings/hotkey-preferences/route.ts
+++ b/apps/web/src/app/api/settings/hotkey-preferences/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { db, userHotkeyPreferences, eq, and } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers, audit } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { audit } from '@pagespace/lib/audit/audit-log';
 import { getHotkeyDefinition } from '@/lib/hotkeys/registry';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };

--- a/apps/web/src/app/api/settings/notification-preferences/route.ts
+++ b/apps/web/src/app/api/settings/notification-preferences/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { db, emailNotificationPreferences, eq, and } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers, audit } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { audit } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/settings/notification-preferences/route.ts
+++ b/apps/web/src/app/api/settings/notification-preferences/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db, emailNotificationPreferences, eq, and } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { audit } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };

--- a/apps/web/src/app/api/settings/personalization/route.ts
+++ b/apps/web/src/app/api/settings/personalization/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { db, userPersonalization, eq } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers, audit } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { audit } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/settings/personalization/route.ts
+++ b/apps/web/src/app/api/settings/personalization/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db, userPersonalization, eq } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { audit } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };

--- a/apps/web/src/app/api/stripe/apply-promo/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/apply-promo/__tests__/route.test.ts
@@ -67,19 +67,23 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock @pagespace/lib/server
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 // Import after mocks
 import { POST } from '../route';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 // Helper to create mock SessionAuthResult
 const mockWebAuth = (userId: string): SessionAuthResult => ({

--- a/apps/web/src/app/api/stripe/apply-promo/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/apply-promo/__tests__/route.test.ts
@@ -68,7 +68,7 @@ vi.mock('@/lib/auth', () => ({
 
 // Mock @pagespace/lib/server
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
@@ -76,8 +76,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 // Import after mocks

--- a/apps/web/src/app/api/stripe/apply-promo/route.ts
+++ b/apps/web/src/app/api/stripe/apply-promo/route.ts
@@ -3,7 +3,8 @@ import { db, eq, users } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe, Stripe } from '@/lib/stripe';
 import { getUserFriendlyStripeError } from '@/lib/stripe-errors';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 

--- a/apps/web/src/app/api/stripe/apply-promo/route.ts
+++ b/apps/web/src/app/api/stripe/apply-promo/route.ts
@@ -3,7 +3,7 @@ import { db, eq, users } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe, Stripe } from '@/lib/stripe';
 import { getUserFriendlyStripeError } from '@/lib/stripe-errors';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/stripe/billing-address/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/billing-address/__tests__/route.test.ts
@@ -70,19 +70,23 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock @pagespace/lib/server
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 // Import after mocks
 import { GET, PUT } from '../route';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 // Helper to create mock SessionAuthResult
 const mockWebAuth = (userId: string): SessionAuthResult => ({

--- a/apps/web/src/app/api/stripe/billing-address/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/billing-address/__tests__/route.test.ts
@@ -71,7 +71,7 @@ vi.mock('@/lib/auth', () => ({
 
 // Mock @pagespace/lib/server
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
@@ -79,8 +79,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 // Import after mocks

--- a/apps/web/src/app/api/stripe/billing-address/route.ts
+++ b/apps/web/src/app/api/stripe/billing-address/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db, eq, users } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe, Stripe } from '@/lib/stripe';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/stripe/billing-address/route.ts
+++ b/apps/web/src/app/api/stripe/billing-address/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db, eq, users } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe, Stripe } from '@/lib/stripe';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };

--- a/apps/web/src/app/api/stripe/cancel-checkout/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/cancel-checkout/__tests__/route.test.ts
@@ -67,7 +67,7 @@ vi.mock('@/lib/auth', () => ({
 
 // Mock @pagespace/lib/server
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
@@ -75,8 +75,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 // Import after mocks

--- a/apps/web/src/app/api/stripe/cancel-checkout/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/cancel-checkout/__tests__/route.test.ts
@@ -66,19 +66,23 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock @pagespace/lib/server
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 // Import after mocks
 import { POST } from '../route';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 // Helper to create mock SessionAuthResult
 const mockWebAuth = (userId: string): SessionAuthResult => ({

--- a/apps/web/src/app/api/stripe/cancel-checkout/route.ts
+++ b/apps/web/src/app/api/stripe/cancel-checkout/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db, eq, users } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe, Stripe } from '@/lib/stripe';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/stripe/cancel-checkout/route.ts
+++ b/apps/web/src/app/api/stripe/cancel-checkout/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db, eq, users } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe, Stripe } from '@/lib/stripe';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 

--- a/apps/web/src/app/api/stripe/cancel-schedule/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/cancel-schedule/__tests__/route.test.ts
@@ -92,7 +92,7 @@ vi.mock('@/lib/auth', () => ({
 
 // Mock @pagespace/lib/server
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
@@ -100,8 +100,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 // Import after mocks

--- a/apps/web/src/app/api/stripe/cancel-schedule/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/cancel-schedule/__tests__/route.test.ts
@@ -91,19 +91,23 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock @pagespace/lib/server
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 // Import after mocks
 import { POST } from '../route';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 // Helper to create mock SessionAuthResult
 const mockWebAuth = (userId: string): SessionAuthResult => ({

--- a/apps/web/src/app/api/stripe/cancel-schedule/route.ts
+++ b/apps/web/src/app/api/stripe/cancel-schedule/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db, eq, and, inArray, desc, users, subscriptions } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe, Stripe } from '@/lib/stripe';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 

--- a/apps/web/src/app/api/stripe/cancel-schedule/route.ts
+++ b/apps/web/src/app/api/stripe/cancel-schedule/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db, eq, and, inArray, desc, users, subscriptions } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe, Stripe } from '@/lib/stripe';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/stripe/cancel-subscription/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/cancel-subscription/__tests__/route.test.ts
@@ -100,7 +100,7 @@ vi.mock('@/lib/auth', () => ({
 
 // Mock @pagespace/lib/server
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
@@ -108,8 +108,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 // Import after mocks

--- a/apps/web/src/app/api/stripe/cancel-subscription/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/cancel-subscription/__tests__/route.test.ts
@@ -99,19 +99,23 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock @pagespace/lib/server
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 // Import after mocks
 import { POST } from '../route';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 // Helper to create mock SessionAuthResult
 const mockWebAuth = (userId: string): SessionAuthResult => ({

--- a/apps/web/src/app/api/stripe/cancel-subscription/route.ts
+++ b/apps/web/src/app/api/stripe/cancel-subscription/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db, eq, and, inArray, desc, users, subscriptions } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe, Stripe } from '@/lib/stripe';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 

--- a/apps/web/src/app/api/stripe/cancel-subscription/route.ts
+++ b/apps/web/src/app/api/stripe/cancel-subscription/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db, eq, and, inArray, desc, users, subscriptions } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe, Stripe } from '@/lib/stripe';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/stripe/create-subscription/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/create-subscription/__tests__/route.test.ts
@@ -63,7 +63,7 @@ vi.mock('@/lib/auth', () => ({
 
 // Mock @pagespace/lib/server
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
@@ -71,8 +71,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 // Import after mocks

--- a/apps/web/src/app/api/stripe/create-subscription/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/create-subscription/__tests__/route.test.ts
@@ -62,19 +62,23 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock @pagespace/lib/server
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 // Import after mocks
 import { POST } from '../route';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 // Helper to create mock SessionAuthResult
 const mockWebAuth = (userId: string): SessionAuthResult => ({

--- a/apps/web/src/app/api/stripe/create-subscription/route.ts
+++ b/apps/web/src/app/api/stripe/create-subscription/route.ts
@@ -4,7 +4,7 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe, Stripe } from '@/lib/stripe';
 import { getOrCreateStripeCustomer } from '@/lib/stripe-customer';
 import { getUserFriendlyStripeError } from '@/lib/stripe-errors';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/stripe/create-subscription/route.ts
+++ b/apps/web/src/app/api/stripe/create-subscription/route.ts
@@ -4,7 +4,8 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe, Stripe } from '@/lib/stripe';
 import { getOrCreateStripeCustomer } from '@/lib/stripe-customer';
 import { getUserFriendlyStripeError } from '@/lib/stripe-errors';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 

--- a/apps/web/src/app/api/stripe/customer/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/customer/__tests__/route.test.ts
@@ -56,19 +56,23 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock @pagespace/lib/server
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 // Import after mocks
 import { GET, POST } from '../route';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 // Helper to create mock SessionAuthResult
 const mockWebAuth = (userId: string): SessionAuthResult => ({

--- a/apps/web/src/app/api/stripe/customer/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/customer/__tests__/route.test.ts
@@ -57,7 +57,7 @@ vi.mock('@/lib/auth', () => ({
 
 // Mock @pagespace/lib/server
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
@@ -65,8 +65,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 // Import after mocks

--- a/apps/web/src/app/api/stripe/customer/route.ts
+++ b/apps/web/src/app/api/stripe/customer/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db, eq, users } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe } from '@/lib/stripe';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };

--- a/apps/web/src/app/api/stripe/customer/route.ts
+++ b/apps/web/src/app/api/stripe/customer/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db, eq, users } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe } from '@/lib/stripe';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/stripe/invoices/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/invoices/__tests__/route.test.ts
@@ -54,19 +54,23 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock @pagespace/lib/server
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 // Import after mocks
 import { GET } from '../route';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 // Helper to create mock SessionAuthResult
 const mockWebAuth = (userId: string): SessionAuthResult => ({

--- a/apps/web/src/app/api/stripe/invoices/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/invoices/__tests__/route.test.ts
@@ -55,7 +55,7 @@ vi.mock('@/lib/auth', () => ({
 
 // Mock @pagespace/lib/server
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
@@ -63,8 +63,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 // Import after mocks

--- a/apps/web/src/app/api/stripe/invoices/route.ts
+++ b/apps/web/src/app/api/stripe/invoices/route.ts
@@ -4,7 +4,7 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe, Stripe } from '@/lib/stripe';
 import { getTierFromPrice } from '@/lib/stripe/price-config';
 import { PLANS } from '@/lib/subscription/plans';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
 

--- a/apps/web/src/app/api/stripe/invoices/route.ts
+++ b/apps/web/src/app/api/stripe/invoices/route.ts
@@ -4,7 +4,8 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe, Stripe } from '@/lib/stripe';
 import { getTierFromPrice } from '@/lib/stripe/price-config';
 import { PLANS } from '@/lib/subscription/plans';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };

--- a/apps/web/src/app/api/stripe/payment-methods/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/payment-methods/__tests__/route.test.ts
@@ -68,19 +68,23 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock @pagespace/lib/server
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 // Import after mocks
 import { GET, DELETE, PATCH } from '../route';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 // Helper to create mock SessionAuthResult
 const mockWebAuth = (userId: string): SessionAuthResult => ({

--- a/apps/web/src/app/api/stripe/payment-methods/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/payment-methods/__tests__/route.test.ts
@@ -69,7 +69,7 @@ vi.mock('@/lib/auth', () => ({
 
 // Mock @pagespace/lib/server
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
@@ -77,8 +77,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 // Import after mocks

--- a/apps/web/src/app/api/stripe/payment-methods/route.ts
+++ b/apps/web/src/app/api/stripe/payment-methods/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db, eq, users } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe, Stripe } from '@/lib/stripe';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/stripe/payment-methods/route.ts
+++ b/apps/web/src/app/api/stripe/payment-methods/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db, eq, users } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe, Stripe } from '@/lib/stripe';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };

--- a/apps/web/src/app/api/stripe/portal/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/portal/__tests__/route.test.ts
@@ -46,7 +46,7 @@ vi.mock('@/lib/auth', () => ({
 
 // Mock @pagespace/lib/server
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
@@ -54,8 +54,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 // Import after mocks

--- a/apps/web/src/app/api/stripe/portal/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/portal/__tests__/route.test.ts
@@ -45,19 +45,23 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock @pagespace/lib/server
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 // Import after mocks
 import { POST } from '../route';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 // Helper to create mock SessionAuthResult
 const mockWebAuth = (userId: string): SessionAuthResult => ({

--- a/apps/web/src/app/api/stripe/portal/route.ts
+++ b/apps/web/src/app/api/stripe/portal/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db, eq, users } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe } from '@/lib/stripe';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 

--- a/apps/web/src/app/api/stripe/portal/route.ts
+++ b/apps/web/src/app/api/stripe/portal/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db, eq, users } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe } from '@/lib/stripe';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/stripe/reactivate-subscription/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/reactivate-subscription/__tests__/route.test.ts
@@ -90,19 +90,23 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock @pagespace/lib/server
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 // Import after mocks
 import { POST } from '../route';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 // Helper to create mock SessionAuthResult
 const mockWebAuth = (userId: string): SessionAuthResult => ({

--- a/apps/web/src/app/api/stripe/reactivate-subscription/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/reactivate-subscription/__tests__/route.test.ts
@@ -91,7 +91,7 @@ vi.mock('@/lib/auth', () => ({
 
 // Mock @pagespace/lib/server
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
@@ -99,8 +99,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 // Import after mocks

--- a/apps/web/src/app/api/stripe/reactivate-subscription/route.ts
+++ b/apps/web/src/app/api/stripe/reactivate-subscription/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db, eq, and, inArray, desc, users, subscriptions } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe, Stripe } from '@/lib/stripe';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 

--- a/apps/web/src/app/api/stripe/reactivate-subscription/route.ts
+++ b/apps/web/src/app/api/stripe/reactivate-subscription/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db, eq, and, inArray, desc, users, subscriptions } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe, Stripe } from '@/lib/stripe';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/stripe/setup-intent/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/setup-intent/__tests__/route.test.ts
@@ -70,7 +70,7 @@ vi.mock('@/lib/auth', () => ({
 
 // Mock @pagespace/lib/server
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
@@ -78,8 +78,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 // Import after mocks

--- a/apps/web/src/app/api/stripe/setup-intent/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/setup-intent/__tests__/route.test.ts
@@ -69,19 +69,23 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock @pagespace/lib/server
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 // Import after mocks
 import { POST } from '../route';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 // Helper to create mock SessionAuthResult
 const mockWebAuth = (userId: string): SessionAuthResult => ({

--- a/apps/web/src/app/api/stripe/setup-intent/route.ts
+++ b/apps/web/src/app/api/stripe/setup-intent/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db, eq, users } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe, Stripe } from '@/lib/stripe';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/stripe/setup-intent/route.ts
+++ b/apps/web/src/app/api/stripe/setup-intent/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db, eq, users } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe, Stripe } from '@/lib/stripe';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 

--- a/apps/web/src/app/api/stripe/upcoming-invoice/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/upcoming-invoice/__tests__/route.test.ts
@@ -84,19 +84,23 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock @pagespace/lib/server
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 // Import after mocks
 import { GET } from '../route';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 // Helper to create mock SessionAuthResult
 const mockWebAuth = (userId: string): SessionAuthResult => ({

--- a/apps/web/src/app/api/stripe/upcoming-invoice/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/upcoming-invoice/__tests__/route.test.ts
@@ -85,7 +85,7 @@ vi.mock('@/lib/auth', () => ({
 
 // Mock @pagespace/lib/server
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
@@ -93,8 +93,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 // Import after mocks

--- a/apps/web/src/app/api/stripe/upcoming-invoice/route.ts
+++ b/apps/web/src/app/api/stripe/upcoming-invoice/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db, eq, and, inArray, desc, users, subscriptions } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe, Stripe } from '@/lib/stripe';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
 

--- a/apps/web/src/app/api/stripe/upcoming-invoice/route.ts
+++ b/apps/web/src/app/api/stripe/upcoming-invoice/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db, eq, and, inArray, desc, users, subscriptions } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe, Stripe } from '@/lib/stripe';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };

--- a/apps/web/src/app/api/stripe/update-subscription/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/update-subscription/__tests__/route.test.ts
@@ -108,19 +108,23 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock @pagespace/lib/server
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 // Import after mocks
 import { POST } from '../route';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 // Helper to create mock SessionAuthResult
 const mockWebAuth = (userId: string): SessionAuthResult => ({

--- a/apps/web/src/app/api/stripe/update-subscription/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/update-subscription/__tests__/route.test.ts
@@ -109,7 +109,7 @@ vi.mock('@/lib/auth', () => ({
 
 // Mock @pagespace/lib/server
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
@@ -117,8 +117,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 // Import after mocks

--- a/apps/web/src/app/api/stripe/update-subscription/route.ts
+++ b/apps/web/src/app/api/stripe/update-subscription/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db, eq, and, inArray, desc, users, subscriptions } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe, Stripe } from '@/lib/stripe';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 

--- a/apps/web/src/app/api/stripe/update-subscription/route.ts
+++ b/apps/web/src/app/api/stripe/update-subscription/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db, eq, and, inArray, desc, users, subscriptions } from '@pagespace/db';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe, Stripe } from '@/lib/stripe';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/stripe/validate-promo-code/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/validate-promo-code/__tests__/route.test.ts
@@ -47,19 +47,23 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 // Mock @pagespace/lib/server
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 // Import after mocks
 import { POST } from '../route';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 // Helper to create mock SessionAuthResult
 const mockWebAuth = (userId: string): SessionAuthResult => ({

--- a/apps/web/src/app/api/stripe/validate-promo-code/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/validate-promo-code/__tests__/route.test.ts
@@ -48,7 +48,7 @@ vi.mock('@/lib/auth', () => ({
 
 // Mock @pagespace/lib/server
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
@@ -56,8 +56,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 // Import after mocks

--- a/apps/web/src/app/api/stripe/validate-promo-code/route.ts
+++ b/apps/web/src/app/api/stripe/validate-promo-code/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe, Stripe } from '@/lib/stripe';
 import { getUserFriendlyStripeError } from '@/lib/stripe-errors';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };

--- a/apps/web/src/app/api/stripe/validate-promo-code/route.ts
+++ b/apps/web/src/app/api/stripe/validate-promo-code/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { stripe, Stripe } from '@/lib/stripe';
 import { getUserFriendlyStripeError } from '@/lib/stripe-errors';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
 

--- a/apps/web/src/app/api/stripe/webhook/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/webhook/__tests__/route.test.ts
@@ -88,7 +88,7 @@ vi.mock('@pagespace/db', () => {
 });
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
       api: {
         error: vi.fn(),
         info: vi.fn(),

--- a/apps/web/src/app/api/stripe/webhook/__tests__/route.test.ts
+++ b/apps/web/src/app/api/stripe/webhook/__tests__/route.test.ts
@@ -87,11 +87,7 @@ vi.mock('@pagespace/db', () => {
   };
 });
 
-vi.mock('@pagespace/lib/server', async () => {
-  const { maskEmail } = await vi.importActual<typeof import('@pagespace/lib/audit/mask-email')>(
-    '@pagespace/lib/audit/mask-email'
-  );
-  return {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
     loggers: {
       api: {
         error: vi.fn(),
@@ -105,13 +101,13 @@ vi.mock('@pagespace/lib/server', async () => {
         warn: vi.fn(),
       },
     },
-    maskEmail,
-  };
-});
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
 
 // Import after mocks
 import { POST } from '../route';
-import { loggers } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 // Helper to create mock Stripe event
 const mockStripeEvent = (type: string, data: unknown) => ({

--- a/apps/web/src/app/api/stripe/webhook/route.ts
+++ b/apps/web/src/app/api/stripe/webhook/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db, eq, subscriptions, stripeEvents, users } from '@pagespace/db';
 import { stripe, Stripe, getTierFromPrice } from '@/lib/stripe';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { maskEmail } from '@pagespace/lib/audit/mask-email';
 
 export async function POST(request: NextRequest) {

--- a/apps/web/src/app/api/stripe/webhook/route.ts
+++ b/apps/web/src/app/api/stripe/webhook/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { db, eq, subscriptions, stripeEvents, users } from '@pagespace/db';
 import { stripe, Stripe, getTierFromPrice } from '@/lib/stripe';
-import { loggers, maskEmail } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { maskEmail } from '@pagespace/lib/audit/mask-email';
 
 export async function POST(request: NextRequest) {
   try {

--- a/apps/web/src/app/api/subscriptions/status/__tests__/route.test.ts
+++ b/apps/web/src/app/api/subscriptions/status/__tests__/route.test.ts
@@ -32,19 +32,23 @@ vi.mock('@/lib/auth/auth-helpers', () => ({
 }));
 
 // Mock @pagespace/lib/server
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 // Import after mocks
 import { GET } from '../route';
 import { requireAuth, isAuthError } from '@/lib/auth/auth-helpers';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 // Helper to create mock SessionAuthResult
 const mockWebAuth = (userId: string): SessionAuthResult => ({

--- a/apps/web/src/app/api/subscriptions/status/__tests__/route.test.ts
+++ b/apps/web/src/app/api/subscriptions/status/__tests__/route.test.ts
@@ -33,7 +33,7 @@ vi.mock('@/lib/auth/auth-helpers', () => ({
 
 // Mock @pagespace/lib/server
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
@@ -41,8 +41,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 // Import after mocks

--- a/apps/web/src/app/api/subscriptions/status/route.ts
+++ b/apps/web/src/app/api/subscriptions/status/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireAuth, isAuthError } from '@/lib/auth/auth-helpers';
 import { db, eq, and, inArray, desc, subscriptions, users } from '@pagespace/db';
 import { getStorageConfigFromSubscription, type SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 export async function GET(request: NextRequest) {
   try {

--- a/apps/web/src/app/api/subscriptions/usage/__tests__/route.test.ts
+++ b/apps/web/src/app/api/subscriptions/usage/__tests__/route.test.ts
@@ -17,19 +17,23 @@ vi.mock('@/lib/auth/auth-helpers', () => ({
 }));
 
 // Mock @pagespace/lib/server
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 // Import after mocks
 import { GET } from '../route';
 import { requireAuth, isAuthError } from '@/lib/auth/auth-helpers';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 // Helper to create mock SessionAuthResult
 const mockWebAuth = (userId: string): SessionAuthResult => ({

--- a/apps/web/src/app/api/subscriptions/usage/__tests__/route.test.ts
+++ b/apps/web/src/app/api/subscriptions/usage/__tests__/route.test.ts
@@ -18,7 +18,7 @@ vi.mock('@/lib/auth/auth-helpers', () => ({
 
 // Mock @pagespace/lib/server
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
@@ -26,8 +26,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 // Import after mocks

--- a/apps/web/src/app/api/subscriptions/usage/route.ts
+++ b/apps/web/src/app/api/subscriptions/usage/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAuth, isAuthError } from '@/lib/auth/auth-helpers';
 import { getUserUsageSummary } from '@/lib/subscription/usage-service';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 export async function GET(request: NextRequest) {
   try {

--- a/apps/web/src/app/api/track/__tests__/route.test.ts
+++ b/apps/web/src/app/api/track/__tests__/route.test.ts
@@ -28,8 +28,8 @@ vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
 }));
 
 vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
-    checkDistributedRateLimit: vi.fn(),
-    DISTRIBUTED_RATE_LIMITS: {
+  checkDistributedRateLimit: vi.fn(),
+  DISTRIBUTED_RATE_LIMITS: {
     TRACKING: { maxAttempts: 100, windowMs: 60000 },
   },
 }));

--- a/apps/web/src/app/api/track/__tests__/route.test.ts
+++ b/apps/web/src/app/api/track/__tests__/route.test.ts
@@ -27,9 +27,9 @@ vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
   trackError: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/security', () => ({
-  checkDistributedRateLimit: vi.fn(),
-  DISTRIBUTED_RATE_LIMITS: {
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+    checkDistributedRateLimit: vi.fn(),
+    DISTRIBUTED_RATE_LIMITS: {
     TRACKING: { maxAttempts: 100, windowMs: 60000 },
   },
 }));
@@ -43,7 +43,7 @@ vi.mock('@/lib/auth/auth-helpers', () => ({
   getClientIP: vi.fn().mockReturnValue('127.0.0.1'),
 }));
 
-import { checkDistributedRateLimit } from '@pagespace/lib/security';
+import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { trackActivity, trackFeature, trackError } from '@pagespace/lib/monitoring/activity-tracker';
 
 const createRequest = (body: object, headers?: Record<string, string>) => {

--- a/apps/web/src/app/api/track/route.ts
+++ b/apps/web/src/app/api/track/route.ts
@@ -10,7 +10,7 @@
 
 import { z } from 'zod/v4';
 import { trackActivity, trackFeature, trackError } from '@pagespace/lib/monitoring/activity-tracker';
-import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security';
+import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security/distributed-rate-limit';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { getClientIP } from '@/lib/auth/auth-helpers';
 

--- a/apps/web/src/app/api/upload/route.ts
+++ b/apps/web/src/app/api/upload/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError, checkMCPCreateScope } from '@/lib/auth';
 import { db, pages, drives, filePages, files, eq, isNull } from '@pagespace/db';
 import { createId } from '@paralleldrive/cuid2';
-import { PageType } from '@pagespace/lib/server';
+import { PageType } from '@pagespace/lib/utils/enums';
 import {
   checkStorageQuota,
   updateStorageUsage,
@@ -18,7 +18,7 @@ import {
 } from '@pagespace/lib/services/validated-service-token';
 import { sanitizeFilenameForHeader } from '@pagespace/lib/utils/file-security';
 import { getActorInfo, logFileActivity } from '@pagespace/lib/monitoring/activity-logger';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 // Define allowed file types and size limits
 

--- a/apps/web/src/app/api/user/assistant-config/__tests__/route.test.ts
+++ b/apps/web/src/app/api/user/assistant-config/__tests__/route.test.ts
@@ -14,23 +14,27 @@ vi.mock('@/lib/auth', () => ({
 
 vi.mock('@pagespace/db', () => ({ db: {} }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/integrations', () => ({
-  getOrCreateConfig: mockGetOrCreateConfig,
-  updateConfig: mockUpdateConfig,
+    getOrCreateConfig: mockGetOrCreateConfig,
+    updateConfig: mockUpdateConfig,
 }));
 
 import { GET, PUT } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const mockUserId = 'user_123';
 

--- a/apps/web/src/app/api/user/assistant-config/__tests__/route.test.ts
+++ b/apps/web/src/app/api/user/assistant-config/__tests__/route.test.ts
@@ -15,7 +15,7 @@ vi.mock('@/lib/auth', () => ({
 vi.mock('@pagespace/db', () => ({ db: {} }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
@@ -23,13 +23,13 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/integrations', () => ({
-    getOrCreateConfig: mockGetOrCreateConfig,
-    updateConfig: mockUpdateConfig,
+  getOrCreateConfig: mockGetOrCreateConfig,
+  updateConfig: mockUpdateConfig,
 }));
 
 import { GET, PUT } from '../route';

--- a/apps/web/src/app/api/user/assistant-config/route.ts
+++ b/apps/web/src/app/api/user/assistant-config/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { getOrCreateConfig, updateConfig } from '@pagespace/lib/integrations/repositories/config-repository';
 

--- a/apps/web/src/app/api/user/assistant-config/route.ts
+++ b/apps/web/src/app/api/user/assistant-config/route.ts
@@ -2,8 +2,9 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db } from '@pagespace/db';
-import { loggers, auditRequest } from '@pagespace/lib/server';
-import { getOrCreateConfig, updateConfig } from '@pagespace/lib/integrations';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { getOrCreateConfig, updateConfig } from '@pagespace/lib/integrations/repositories/config-repository';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/user/favorites/[id]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/user/favorites/[id]/__tests__/route.test.ts
@@ -26,7 +26,7 @@ vi.mock('@pagespace/db', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
@@ -34,8 +34,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 import { DELETE } from '../route';

--- a/apps/web/src/app/api/user/favorites/[id]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/user/favorites/[id]/__tests__/route.test.ts
@@ -25,18 +25,22 @@ vi.mock('@pagespace/db', () => ({
   and: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 import { DELETE } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const mockUserId = 'user_123';
 const mockFavoriteId = 'fav-1';

--- a/apps/web/src/app/api/user/favorites/[id]/route.ts
+++ b/apps/web/src/app/api/user/favorites/[id]/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db, favorites, eq, and } from '@pagespace/db';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 

--- a/apps/web/src/app/api/user/favorites/[id]/route.ts
+++ b/apps/web/src/app/api/user/favorites/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db, favorites, eq, and } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/user/favorites/__tests__/route.test.ts
+++ b/apps/web/src/app/api/user/favorites/__tests__/route.test.ts
@@ -31,18 +31,22 @@ vi.mock('@pagespace/db', () => ({
   asc: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 import { GET, POST } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { db } from '@pagespace/db';
 
 const mockUserId = 'user_123';

--- a/apps/web/src/app/api/user/favorites/__tests__/route.test.ts
+++ b/apps/web/src/app/api/user/favorites/__tests__/route.test.ts
@@ -32,7 +32,7 @@ vi.mock('@pagespace/db', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
@@ -40,8 +40,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 import { GET, POST } from '../route';

--- a/apps/web/src/app/api/user/favorites/reorder/__tests__/route.test.ts
+++ b/apps/web/src/app/api/user/favorites/reorder/__tests__/route.test.ts
@@ -32,18 +32,22 @@ vi.mock('@pagespace/db', () => ({
   inArray: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 import { PATCH } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const mockUserId = 'user_123';
 

--- a/apps/web/src/app/api/user/favorites/reorder/__tests__/route.test.ts
+++ b/apps/web/src/app/api/user/favorites/reorder/__tests__/route.test.ts
@@ -33,7 +33,7 @@ vi.mock('@pagespace/db', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
@@ -41,8 +41,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 import { PATCH } from '../route';

--- a/apps/web/src/app/api/user/favorites/reorder/route.ts
+++ b/apps/web/src/app/api/user/favorites/reorder/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db, favorites, eq, and, inArray } from '@pagespace/db';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 

--- a/apps/web/src/app/api/user/favorites/reorder/route.ts
+++ b/apps/web/src/app/api/user/favorites/reorder/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db, favorites, eq, and, inArray } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/user/favorites/route.ts
+++ b/apps/web/src/app/api/user/favorites/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db, favorites, pages, drives, eq, and, desc, asc } from '@pagespace/db';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 const AUTH_OPTIONS_READ = { allow: ['session'] as const };

--- a/apps/web/src/app/api/user/favorites/route.ts
+++ b/apps/web/src/app/api/user/favorites/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db, favorites, pages, drives, eq, and, desc, asc } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/user/integrations/[connectionId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/user/integrations/[connectionId]/__tests__/route.test.ts
@@ -27,7 +27,7 @@ vi.mock('@pagespace/db', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
@@ -35,13 +35,13 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/integrations/repositories/connection-repository', () => ({
-    getConnectionById: mockGetConnectionById,
-    deleteConnection: mockDeleteConnection,
+  getConnectionById: mockGetConnectionById,
+  deleteConnection: mockDeleteConnection,
 }));
 
 import { DELETE } from '../route';

--- a/apps/web/src/app/api/user/integrations/[connectionId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/user/integrations/[connectionId]/__tests__/route.test.ts
@@ -26,23 +26,27 @@ vi.mock('@pagespace/db', () => ({
   eq: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/integrations', () => ({
-  getConnectionById: mockGetConnectionById,
-  deleteConnection: mockDeleteConnection,
+vi.mock('@pagespace/lib/integrations/repositories/connection-repository', () => ({
+    getConnectionById: mockGetConnectionById,
+    deleteConnection: mockDeleteConnection,
 }));
 
 import { DELETE } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const mockUserId = 'user_123';
 const mockConnectionId = 'conn-1';

--- a/apps/web/src/app/api/user/integrations/[connectionId]/route.ts
+++ b/apps/web/src/app/api/user/integrations/[connectionId]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db, integrationConnections, eq } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { getConnectionById, deleteConnection } from '@pagespace/lib/integrations/repositories/connection-repository';
 

--- a/apps/web/src/app/api/user/integrations/[connectionId]/route.ts
+++ b/apps/web/src/app/api/user/integrations/[connectionId]/route.ts
@@ -2,11 +2,9 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db, integrationConnections, eq } from '@pagespace/db';
-import { loggers, auditRequest } from '@pagespace/lib/server';
-import {
-  getConnectionById,
-  deleteConnection,
-} from '@pagespace/lib/integrations';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { getConnectionById, deleteConnection } from '@pagespace/lib/integrations/repositories/connection-repository';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/user/integrations/__tests__/route.test.ts
+++ b/apps/web/src/app/api/user/integrations/__tests__/route.test.ts
@@ -14,7 +14,7 @@ vi.mock('@/lib/auth', () => ({
 vi.mock('@pagespace/db', () => ({ db: {} }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
@@ -22,26 +22,26 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/integrations/repositories/connection-repository', () => ({
-    listUserConnections: mockListUserConnections,
-    createConnection: vi.fn(),
-    findUserConnection: vi.fn(),
+  listUserConnections: mockListUserConnections,
+  createConnection: vi.fn(),
+  findUserConnection: vi.fn(),
 }));
 vi.mock('@pagespace/lib/integrations/repositories/provider-repository', () => ({
-    getProviderById: vi.fn(),
+  getProviderById: vi.fn(),
 }));
 vi.mock('@pagespace/lib/integrations/credentials/encrypt-credentials', () => ({
-    encryptCredentials: vi.fn(),
+  encryptCredentials: vi.fn(),
 }));
 vi.mock('@pagespace/lib/integrations/oauth/oauth-handler', () => ({
-    buildOAuthAuthorizationUrl: vi.fn(),
+  buildOAuthAuthorizationUrl: vi.fn(),
 }));
 vi.mock('@pagespace/lib/integrations/oauth/oauth-state', () => ({
-    createSignedState: vi.fn(),
+  createSignedState: vi.fn(),
 }));
 
 import { GET } from '../route';

--- a/apps/web/src/app/api/user/integrations/__tests__/route.test.ts
+++ b/apps/web/src/app/api/user/integrations/__tests__/route.test.ts
@@ -13,28 +13,40 @@ vi.mock('@/lib/auth', () => ({
 
 vi.mock('@pagespace/db', () => ({ db: {} }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/integrations', () => ({
-  listUserConnections: mockListUserConnections,
-  createConnection: vi.fn(),
-  getProviderById: vi.fn(),
-  findUserConnection: vi.fn(),
-  encryptCredentials: vi.fn(),
-  buildOAuthAuthorizationUrl: vi.fn(),
-  createSignedState: vi.fn(),
+vi.mock('@pagespace/lib/integrations/repositories/connection-repository', () => ({
+    listUserConnections: mockListUserConnections,
+    createConnection: vi.fn(),
+    findUserConnection: vi.fn(),
+}));
+vi.mock('@pagespace/lib/integrations/repositories/provider-repository', () => ({
+    getProviderById: vi.fn(),
+}));
+vi.mock('@pagespace/lib/integrations/credentials/encrypt-credentials', () => ({
+    encryptCredentials: vi.fn(),
+}));
+vi.mock('@pagespace/lib/integrations/oauth/oauth-handler', () => ({
+    buildOAuthAuthorizationUrl: vi.fn(),
+}));
+vi.mock('@pagespace/lib/integrations/oauth/oauth-state', () => ({
+    createSignedState: vi.fn(),
 }));
 
 import { GET } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const mockUserId = 'user_123';
 

--- a/apps/web/src/app/api/user/integrations/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/user/integrations/callback/__tests__/route.test.ts
@@ -66,26 +66,26 @@ vi.mock('@pagespace/db', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: mockLoggers,
+  loggers: mockLoggers,
 
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: mockAuditRequest,
+  audit: vi.fn(),
+  auditRequest: mockAuditRequest,
 }));
 
 vi.mock('@pagespace/lib/integrations/oauth/oauth-state', () => ({
-    verifySignedState: mockVerifySignedState,
+  verifySignedState: mockVerifySignedState,
 }));
 vi.mock('@pagespace/lib/integrations/oauth/oauth-handler', () => ({
-    exchangeOAuthCode: mockExchangeOAuthCode,
+  exchangeOAuthCode: mockExchangeOAuthCode,
 }));
 vi.mock('@pagespace/lib/integrations/credentials/encrypt-credentials', () => ({
-    encryptCredentials: mockEncryptCredentials,
+  encryptCredentials: mockEncryptCredentials,
 }));
 vi.mock('@pagespace/lib/integrations/repositories/provider-repository', () => ({
-    getProviderById: mockGetProviderById,
+  getProviderById: mockGetProviderById,
 }));
 vi.mock('@pagespace/lib/integrations/repositories/connection-repository', () => ({
   createConnection: mockCreateConnection,

--- a/apps/web/src/app/api/user/integrations/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/user/integrations/callback/__tests__/route.test.ts
@@ -65,17 +65,29 @@ vi.mock('@pagespace/db', () => ({
   db: {},
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: mockLoggers,
-  audit: vi.fn(),
-  auditRequest: mockAuditRequest,
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: mockLoggers,
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: mockAuditRequest,
 }));
 
-vi.mock('@pagespace/lib/integrations', () => ({
-  verifySignedState: mockVerifySignedState,
-  exchangeOAuthCode: mockExchangeOAuthCode,
-  encryptCredentials: mockEncryptCredentials,
-  getProviderById: mockGetProviderById,
+vi.mock('@pagespace/lib/integrations/oauth/oauth-state', () => ({
+    verifySignedState: mockVerifySignedState,
+}));
+vi.mock('@pagespace/lib/integrations/oauth/oauth-handler', () => ({
+    exchangeOAuthCode: mockExchangeOAuthCode,
+}));
+vi.mock('@pagespace/lib/integrations/credentials/encrypt-credentials', () => ({
+    encryptCredentials: mockEncryptCredentials,
+}));
+vi.mock('@pagespace/lib/integrations/repositories/provider-repository', () => ({
+    getProviderById: mockGetProviderById,
+}));
+vi.mock('@pagespace/lib/integrations/repositories/connection-repository', () => ({
   createConnection: mockCreateConnection,
   findUserConnection: mockFindUserConnection,
   findDriveConnection: mockFindDriveConnection,

--- a/apps/web/src/app/api/user/integrations/callback/route.ts
+++ b/apps/web/src/app/api/user/integrations/callback/route.ts
@@ -1,19 +1,14 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { db } from '@pagespace/db';
-import { loggers, auditRequest } from '@pagespace/lib/server';
-import {
-  verifySignedState,
-  exchangeOAuthCode,
-  encryptCredentials,
-  getProviderById,
-  createConnection,
-  findUserConnection,
-  findDriveConnection,
-  updateConnectionCredentials,
-  updateConnectionStatus,
-} from '@pagespace/lib/integrations';
-import type { IntegrationProviderConfig, OAuth2Config } from '@pagespace/lib/integrations';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { verifySignedState } from '@pagespace/lib/integrations/oauth/oauth-state'
+import { exchangeOAuthCode } from '@pagespace/lib/integrations/oauth/oauth-handler'
+import { encryptCredentials } from '@pagespace/lib/integrations/credentials/encrypt-credentials'
+import { getProviderById } from '@pagespace/lib/integrations/repositories/provider-repository'
+import { createConnection, findUserConnection, findDriveConnection, updateConnectionCredentials, updateConnectionStatus } from '@pagespace/lib/integrations/repositories/connection-repository';
+import type { IntegrationProviderConfig, OAuth2Config } from '@pagespace/lib/integrations/types';
 import { getDriveAccess } from '@pagespace/lib/services/drive-service';
 import { isSafeReturnUrl } from '@/lib/auth';
 

--- a/apps/web/src/app/api/user/integrations/callback/route.ts
+++ b/apps/web/src/app/api/user/integrations/callback/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { db } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
-import { verifySignedState } from '@pagespace/lib/integrations/oauth/oauth-state'
-import { exchangeOAuthCode } from '@pagespace/lib/integrations/oauth/oauth-handler'
-import { encryptCredentials } from '@pagespace/lib/integrations/credentials/encrypt-credentials'
-import { getProviderById } from '@pagespace/lib/integrations/repositories/provider-repository'
+import { verifySignedState } from '@pagespace/lib/integrations/oauth/oauth-state';
+import { exchangeOAuthCode } from '@pagespace/lib/integrations/oauth/oauth-handler';
+import { encryptCredentials } from '@pagespace/lib/integrations/credentials/encrypt-credentials';
+import { getProviderById } from '@pagespace/lib/integrations/repositories/provider-repository';
 import { createConnection, findUserConnection, findDriveConnection, updateConnectionCredentials, updateConnectionStatus } from '@pagespace/lib/integrations/repositories/connection-repository';
 import type { IntegrationProviderConfig, OAuth2Config } from '@pagespace/lib/integrations/types';
 import { getDriveAccess } from '@pagespace/lib/services/drive-service';

--- a/apps/web/src/app/api/user/integrations/route.ts
+++ b/apps/web/src/app/api/user/integrations/route.ts
@@ -2,12 +2,12 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db } from '@pagespace/db';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
-import { listUserConnections, createConnection, findUserConnection } from '@pagespace/lib/integrations/repositories/connection-repository'
-import { getProviderById } from '@pagespace/lib/integrations/repositories/provider-repository'
-import { encryptCredentials } from '@pagespace/lib/integrations/credentials/encrypt-credentials'
-import { buildOAuthAuthorizationUrl } from '@pagespace/lib/integrations/oauth/oauth-handler'
+import { listUserConnections, createConnection, findUserConnection } from '@pagespace/lib/integrations/repositories/connection-repository';
+import { getProviderById } from '@pagespace/lib/integrations/repositories/provider-repository';
+import { encryptCredentials } from '@pagespace/lib/integrations/credentials/encrypt-credentials';
+import { buildOAuthAuthorizationUrl } from '@pagespace/lib/integrations/oauth/oauth-handler';
 import { createSignedState } from '@pagespace/lib/integrations/oauth/oauth-state';
 import type { IntegrationProviderConfig } from '@pagespace/lib/integrations/types';
 

--- a/apps/web/src/app/api/user/integrations/route.ts
+++ b/apps/web/src/app/api/user/integrations/route.ts
@@ -2,17 +2,14 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db } from '@pagespace/db';
-import { loggers, auditRequest } from '@pagespace/lib/server';
-import {
-  listUserConnections,
-  createConnection,
-  getProviderById,
-  findUserConnection,
-  encryptCredentials,
-  buildOAuthAuthorizationUrl,
-  createSignedState,
-} from '@pagespace/lib/integrations';
-import type { IntegrationProviderConfig } from '@pagespace/lib/integrations';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { listUserConnections, createConnection, findUserConnection } from '@pagespace/lib/integrations/repositories/connection-repository'
+import { getProviderById } from '@pagespace/lib/integrations/repositories/provider-repository'
+import { encryptCredentials } from '@pagespace/lib/integrations/credentials/encrypt-credentials'
+import { buildOAuthAuthorizationUrl } from '@pagespace/lib/integrations/oauth/oauth-handler'
+import { createSignedState } from '@pagespace/lib/integrations/oauth/oauth-state';
+import type { IntegrationProviderConfig } from '@pagespace/lib/integrations/types';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/user/recents/__tests__/route.test.ts
+++ b/apps/web/src/app/api/user/recents/__tests__/route.test.ts
@@ -37,7 +37,7 @@ vi.mock('@pagespace/lib/client-safe', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
@@ -45,8 +45,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 import { GET } from '../route';

--- a/apps/web/src/app/api/user/recents/__tests__/route.test.ts
+++ b/apps/web/src/app/api/user/recents/__tests__/route.test.ts
@@ -36,18 +36,22 @@ vi.mock('@pagespace/lib/client-safe', () => ({
   },
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 import { GET } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
-import { auditRequest } from '@pagespace/lib/server';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const mockUserId = 'user_123';
 

--- a/apps/web/src/app/api/user/recents/route.ts
+++ b/apps/web/src/app/api/user/recents/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db, userPageViews, eq, desc } from '@pagespace/db';
 import { PageType } from '@pagespace/lib/utils/enums';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const };

--- a/apps/web/src/app/api/user/recents/route.ts
+++ b/apps/web/src/app/api/user/recents/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db, userPageViews, eq, desc } from '@pagespace/db';
-import { PageType } from '@pagespace/lib/client-safe';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { PageType } from '@pagespace/lib/utils/enums';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const };
 

--- a/apps/web/src/app/api/users/find/__tests__/route.test.ts
+++ b/apps/web/src/app/api/users/find/__tests__/route.test.ts
@@ -9,7 +9,7 @@ import type { SessionAuthResult, AuthError } from '@/lib/auth';
 // ============================================================================
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: {
       info: vi.fn(),
       error: vi.fn(),
@@ -21,8 +21,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({

--- a/apps/web/src/app/api/users/find/__tests__/route.test.ts
+++ b/apps/web/src/app/api/users/find/__tests__/route.test.ts
@@ -8,8 +8,8 @@ import type { SessionAuthResult, AuthError } from '@/lib/auth';
 // Mock at the SERVICE SEAM level: auth and db.query.users.findFirst
 // ============================================================================
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: {
       info: vi.fn(),
       error: vi.fn(),
@@ -17,8 +17,12 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -41,7 +45,8 @@ vi.mock('@pagespace/db', () => ({
 }));
 
 import { GET } from '../route';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 
 // ============================================================================

--- a/apps/web/src/app/api/users/find/route.ts
+++ b/apps/web/src/app/api/users/find/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { users, db, eq } from '@pagespace/db';
 

--- a/apps/web/src/app/api/users/find/route.ts
+++ b/apps/web/src/app/api/users/find/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { users, db, eq } from '@pagespace/db';

--- a/apps/web/src/app/api/users/search/__tests__/route.test.ts
+++ b/apps/web/src/app/api/users/search/__tests__/route.test.ts
@@ -7,7 +7,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 // ============================================================================
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: {
       info: vi.fn(),
       error: vi.fn(),
@@ -19,8 +19,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({

--- a/apps/web/src/app/api/users/search/__tests__/route.test.ts
+++ b/apps/web/src/app/api/users/search/__tests__/route.test.ts
@@ -6,8 +6,8 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 // Mock at the SERVICE SEAM level: auth, db queries, and query-params utility
 // ============================================================================
 
-vi.mock('@pagespace/lib/server', () => ({
-  loggers: {
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: {
       info: vi.fn(),
       error: vi.fn(),
@@ -15,8 +15,12 @@ vi.mock('@pagespace/lib/server', () => ({
       debug: vi.fn(),
     },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -87,7 +91,8 @@ vi.mock('@/lib/utils/query-params', () => ({
 }));
 
 import { GET } from '../route';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { verifyAuth } from '@/lib/auth';
 import { db } from '@pagespace/db';
 

--- a/apps/web/src/app/api/users/search/route.ts
+++ b/apps/web/src/app/api/users/search/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db, eq, and, or, ilike, userProfiles, users } from '@pagespace/db';
 import { verifyAuth } from '@/lib/auth';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
 

--- a/apps/web/src/app/api/users/search/route.ts
+++ b/apps/web/src/app/api/users/search/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { db, eq, and, or, ilike, userProfiles, users } from '@pagespace/db';
 import { verifyAuth } from '@/lib/auth';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
 
 export async function GET(request: Request) {

--- a/apps/web/src/app/api/voice/synthesize/route.ts
+++ b/apps/web/src/app/api/voice/synthesize/route.ts
@@ -12,7 +12,8 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { getUserOpenAISettings } from '@/lib/ai/core/ai-utils';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 

--- a/apps/web/src/app/api/voice/synthesize/route.ts
+++ b/apps/web/src/app/api/voice/synthesize/route.ts
@@ -12,7 +12,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { getUserOpenAISettings } from '@/lib/ai/core/ai-utils';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/voice/transcribe/route.ts
+++ b/apps/web/src/app/api/voice/transcribe/route.ts
@@ -10,7 +10,8 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { getUserOpenAISettings } from '@/lib/ai/core/ai-utils';
-import { loggers, auditRequest } from '@pagespace/lib/server';
+import { loggers } from '@pagespace/lib/logging/logger-config'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 

--- a/apps/web/src/app/api/voice/transcribe/route.ts
+++ b/apps/web/src/app/api/voice/transcribe/route.ts
@@ -10,7 +10,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { getUserOpenAISettings } from '@/lib/ai/core/ai-utils';
-import { loggers } from '@pagespace/lib/logging/logger-config'
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/workflows/[workflowId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/__tests__/route.test.ts
@@ -30,10 +30,10 @@ const {
 }));
 
 vi.mock('@pagespace/lib/services/drive-member-service', () => ({
-    checkDriveAccess: vi.fn(),
+  checkDriveAccess: vi.fn(),
 }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
@@ -41,8 +41,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({

--- a/apps/web/src/app/api/workflows/[workflowId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/__tests__/route.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { NextResponse } from 'next/server';
 import type { SessionAuthResult, AuthError } from '@/lib/auth';
-import type { DriveAccessResult } from '@pagespace/lib/server';
+import type { DriveAccessResult } from '@pagespace/lib/services/drive-member-service';
 
 // ============================================================================
 // Contract Tests for /api/workflows/[workflowId]
@@ -29,14 +29,20 @@ const {
   mockSelect: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  checkDriveAccess: vi.fn(),
-  loggers: {
+vi.mock('@pagespace/lib/services/drive-member-service', () => ({
+    checkDriveAccess: vi.fn(),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -63,7 +69,7 @@ vi.mock('@pagespace/db', () => ({
 }));
 
 import { GET, PATCH, DELETE } from '../route';
-import { checkDriveAccess } from '@pagespace/lib/server';
+import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { validateCronExpression, validateTimezone, getNextRunDate } from '@/lib/workflows/cron-utils';
 

--- a/apps/web/src/app/api/workflows/[workflowId]/route.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { checkDriveAccess, auditRequest } from '@pagespace/lib/server';
+import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { db, workflows, pages, eq, and } from '@pagespace/db';
 import { validateCronExpression, validateTimezone, getNextRunDate } from '@/lib/workflows/cron-utils';
 

--- a/apps/web/src/app/api/workflows/[workflowId]/route.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service'
+import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { db, workflows, pages, eq, and } from '@pagespace/db';
 import { validateCronExpression, validateTimezone, getNextRunDate } from '@/lib/workflows/cron-utils';

--- a/apps/web/src/app/api/workflows/[workflowId]/run/__tests__/route.test.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/run/__tests__/route.test.ts
@@ -42,10 +42,10 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 vi.mock('@pagespace/lib/services/drive-member-service', () => ({
-    checkDriveAccess: vi.fn(),
+  checkDriveAccess: vi.fn(),
 }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
@@ -53,8 +53,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@/lib/workflows/workflow-executor', () => ({

--- a/apps/web/src/app/api/workflows/[workflowId]/run/__tests__/route.test.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/run/__tests__/route.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, beforeEach, vi } from 'vitest';
 import { NextResponse } from 'next/server';
 import type { SessionAuthResult, AuthError } from '@/lib/auth';
-import type { DriveAccessResult } from '@pagespace/lib/server';
+import type { DriveAccessResult } from '@pagespace/lib/services/drive-member-service';
 
 // ============================================================================
 // Contract Tests for POST /api/workflows/[workflowId]/run
@@ -41,14 +41,20 @@ vi.mock('@/lib/auth', () => ({
   isAuthError: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  checkDriveAccess: vi.fn(),
-  loggers: {
+vi.mock('@pagespace/lib/services/drive-member-service', () => ({
+    checkDriveAccess: vi.fn(),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 vi.mock('@/lib/workflows/workflow-executor', () => ({
@@ -61,7 +67,7 @@ vi.mock('@/lib/workflows/cron-utils', () => ({
 
 import { POST } from '../../run/route';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { checkDriveAccess } from '@pagespace/lib/server';
+import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service';
 import { executeWorkflow } from '@/lib/workflows/workflow-executor';
 import { getNextRunDate } from '@/lib/workflows/cron-utils';
 

--- a/apps/web/src/app/api/workflows/[workflowId]/run/route.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/run/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service'
+import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { db, workflows, eq, and, ne } from '@pagespace/db';
 import { executeWorkflow } from '@/lib/workflows/workflow-executor';

--- a/apps/web/src/app/api/workflows/[workflowId]/run/route.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/run/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { checkDriveAccess, auditRequest } from '@pagespace/lib/server';
+import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { db, workflows, eq, and, ne } from '@pagespace/db';
 import { executeWorkflow } from '@/lib/workflows/workflow-executor';
 import { getNextRunDate } from '@/lib/workflows/cron-utils';

--- a/apps/web/src/app/api/workflows/__tests__/route.test.ts
+++ b/apps/web/src/app/api/workflows/__tests__/route.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { NextResponse } from 'next/server';
 import type { SessionAuthResult, AuthError } from '@/lib/auth';
-import type { DriveAccessResult } from '@pagespace/lib/server';
+import type { DriveAccessResult } from '@pagespace/lib/services/drive-member-service';
 
 // ============================================================================
 // Contract Tests for /api/workflows
@@ -26,14 +26,20 @@ const {
   mockSelect: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
-  checkDriveAccess: vi.fn(),
-  loggers: {
+vi.mock('@pagespace/lib/services/drive-member-service', () => ({
+    checkDriveAccess: vi.fn(),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+    loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
-  audit: vi.fn(),
-  auditRequest: vi.fn(),
+
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+    audit: vi.fn(),
+    auditRequest: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -59,7 +65,7 @@ vi.mock('@pagespace/db', () => ({
 }));
 
 import { GET, POST } from '../route';
-import { checkDriveAccess } from '@pagespace/lib/server';
+import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { validateCronExpression, validateTimezone, getNextRunDate } from '@/lib/workflows/cron-utils';
 

--- a/apps/web/src/app/api/workflows/__tests__/route.test.ts
+++ b/apps/web/src/app/api/workflows/__tests__/route.test.ts
@@ -27,10 +27,10 @@ const {
 }));
 
 vi.mock('@pagespace/lib/services/drive-member-service', () => ({
-    checkDriveAccess: vi.fn(),
+  checkDriveAccess: vi.fn(),
 }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
-    loggers: {
+  loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
     security: { warn: vi.fn() },
   },
@@ -38,8 +38,8 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
-    audit: vi.fn(),
-    auditRequest: vi.fn(),
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
 }));
 
 vi.mock('@/lib/auth', () => ({

--- a/apps/web/src/app/api/workflows/agents/route.ts
+++ b/apps/web/src/app/api/workflows/agents/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { isUserDriveMember } from '@pagespace/lib';
-import { auditRequest } from '@pagespace/lib/server';
+import { isUserDriveMember } from '@pagespace/lib/permissions/permissions';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { db, pages, eq, and } from '@pagespace/db';
 
 // GET /api/workflows/agents?driveId=xxx - List AI_CHAT pages in a drive

--- a/apps/web/src/app/api/workflows/route.ts
+++ b/apps/web/src/app/api/workflows/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { checkDriveAccess, auditRequest } from '@pagespace/lib/server';
+import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service'
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { db, workflows, pages, eq, and } from '@pagespace/db';
 import { validateCronExpression, validateTimezone, getNextRunDate } from '@/lib/workflows/cron-utils';
 

--- a/apps/web/src/app/api/workflows/route.ts
+++ b/apps/web/src/app/api/workflows/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service'
+import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { db, workflows, pages, eq, and } from '@pagespace/db';
 import { validateCronExpression, validateTimezone, getNextRunDate } from '@/lib/workflows/cron-utils';


### PR DESCRIPTION
## Summary

Replaces barrel imports with direct subpath imports in the admin, billing, and infrastructure API routes of apps/web:

**Billing (32 files):** \`app/api/stripe/**\` — subscriptions, webhooks, checkout, portal

**Scheduled jobs (20 files):** \`app/api/cron/**\` — cron routes for cleanup, sync, billing checks

**User management (35 files):** \`app/api/user/**\`, \`app/api/admin/**\`, \`app/api/account/**\`

**Collaboration infrastructure (30+ files):** \`app/api/workflows/**\`, \`app/api/notifications/**\`, \`app/api/connections/**\`, \`app/api/settings/**\`, \`app/api/calendar/**\`, \`app/api/pulse/**\`

**Other (50+ files):** \`app/api/mcp/**\`, \`app/api/voice/**\`, \`app/api/track/**\`, \`app/api/permissions/**\`, \`app/api/mentions/**\`, \`app/api/memory/**\`, \`app/api/health/**\`, \`app/api/feedback/**\`, \`app/api/debug/**\`, \`app/api/contact/**\`, \`app/api/inbox/**\`, and more

**169 files total — mechanical import-path swaps.**

## Fixes applied during review

- **GDPR Art. 15 export regression** (`425164a59`): The initial barrel-import commit accidentally dropped 4 `archive.append` calls from `account/export/route.ts` (sessions, notifications, display-preferences, personalization). These are valid fields of `AllUserData` and present on master. Restored to maintain parity with master.
- **Semicolons**: ~70 production import statements missing trailing semicolons — fixed.
- **Test mock indentation**: 67 test files had 4-space indentation on top-level `vi.mock` factory properties instead of the standard 2-space — fixed.

## Context

**PR E2 of 6** in the barrel-import removal series.

**⚠️ Depends on PR A (#1088) \`barrel/foundation\` being merged first.**
Base branch is \`barrel/foundation\` so CI resolves the new subpath exports.
After A merges, this PR's base will be updated to \`master\`.

PRs B, C, D, E1, E2 are independent of each other and can be reviewed/merged in any order after A lands.

## Validation

- All Stripe webhook imports verified: `loggers` → `@pagespace/lib/logging/logger-config`, `auditRequest` → `@pagespace/lib/audit/audit-log`, `maskEmail` → `@pagespace/lib/audit/mask-email`
- Admin routes: `withAdminAuth` from `@/lib/auth` untouched throughout
- Cron routes: `validateSignedCronRequest` from `@/lib/auth/cron-auth` untouched throughout
- Health endpoint: single import change, no new imports added
- GDPR erasure routes: `revokeUserIntegrationTokens`, `deleteAiUsageLogsForUser`, `deleteMonitoringDataForUser` all map to correct subpaths

🤖 Generated with [Claude Code](https://claude.ai/claude-code)