### PR TITLE
refactor(billing): responsive grid for plan cards

### DIFF
--- a/apps/web/src/app/settings/plan/page.tsx
+++ b/apps/web/src/app/settings/plan/page.tsx
@@ -367,22 +367,24 @@ export default function PlanPage() {
 
       {/* Plan Cards - Only show when not in checkout */}
       {!checkoutPlan && (
-        <div className="flex overflow-x-auto gap-4 pt-6 pb-4 snap-x snap-mandatory -mx-6 px-6 justify-center">
-          {plans.map((plan) => (
-            <PlanCard
-              key={plan.id}
-              plan={plan}
-              currentTier={subscriptionData?.subscriptionTier || 'free'}
-              isCurrentPlan={plan.id === subscriptionData?.subscriptionTier}
-              isScheduledPlan={plan.id === scheduledTier}
-              hasPendingSchedule={!!scheduledTier}
-              onUpgrade={handlePlanSelect}
-              onManageBilling={() => router.push('/settings/billing')}
-              onCancelSchedule={handleCancelSchedule}
-              cancellingSchedule={cancellingSchedule}
-              className={plan.highlighted ? 'relative z-10' : ''}
-            />
-          ))}
+        <div className="overflow-x-auto snap-x snap-mandatory -mx-6 pt-6 pb-4">
+          <div className="flex gap-4 px-6 w-max mx-auto">
+            {plans.map((plan) => (
+              <PlanCard
+                key={plan.id}
+                plan={plan}
+                currentTier={subscriptionData?.subscriptionTier || 'free'}
+                isCurrentPlan={plan.id === subscriptionData?.subscriptionTier}
+                isScheduledPlan={plan.id === scheduledTier}
+                hasPendingSchedule={!!scheduledTier}
+                onUpgrade={handlePlanSelect}
+                onManageBilling={() => router.push('/settings/billing')}
+                onCancelSchedule={handleCancelSchedule}
+                cancellingSchedule={cancellingSchedule}
+                className={plan.highlighted ? 'relative z-10' : ''}
+              />
+            ))}
+          </div>
         </div>
       )}
 

--- a/apps/web/src/app/settings/plan/page.tsx
+++ b/apps/web/src/app/settings/plan/page.tsx
@@ -367,24 +367,22 @@ export default function PlanPage() {
 
       {/* Plan Cards - Only show when not in checkout */}
       {!checkoutPlan && (
-        <div className="overflow-x-auto snap-x snap-mandatory -mx-6 pt-6 pb-4">
-          <div className="flex gap-4 px-6 w-max mx-auto">
-            {plans.map((plan) => (
-              <PlanCard
-                key={plan.id}
-                plan={plan}
-                currentTier={subscriptionData?.subscriptionTier || 'free'}
-                isCurrentPlan={plan.id === subscriptionData?.subscriptionTier}
-                isScheduledPlan={plan.id === scheduledTier}
-                hasPendingSchedule={!!scheduledTier}
-                onUpgrade={handlePlanSelect}
-                onManageBilling={() => router.push('/settings/billing')}
-                onCancelSchedule={handleCancelSchedule}
-                cancellingSchedule={cancellingSchedule}
-                className={plan.highlighted ? 'relative z-10' : ''}
-              />
-            ))}
-          </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 pt-6 pb-4">
+          {plans.map((plan) => (
+            <PlanCard
+              key={plan.id}
+              plan={plan}
+              currentTier={subscriptionData?.subscriptionTier || 'free'}
+              isCurrentPlan={plan.id === subscriptionData?.subscriptionTier}
+              isScheduledPlan={plan.id === scheduledTier}
+              hasPendingSchedule={!!scheduledTier}
+              onUpgrade={handlePlanSelect}
+              onManageBilling={() => router.push('/settings/billing')}
+              onCancelSchedule={handleCancelSchedule}
+              cancellingSchedule={cancellingSchedule}
+              className={plan.highlighted ? 'relative z-10' : ''}
+            />
+          ))}
         </div>
       )}
 

--- a/apps/web/src/components/billing/PlanCard.tsx
+++ b/apps/web/src/components/billing/PlanCard.tsx
@@ -154,7 +154,7 @@ export function PlanCard({
   return (
     <Card
       className={cn(
-        'relative transition-all duration-300 hover:shadow-lg flex flex-col min-w-[280px] shrink-0 snap-center',
+        'relative transition-all duration-300 hover:shadow-lg flex flex-col w-full',
         plan.highlighted && 'ring-2 ring-zinc-400 dark:ring-zinc-500 shadow-lg',
         isCurrentPlan && 'ring-2 ring-zinc-900 dark:ring-zinc-100',
         isScheduledPlan && !isCurrentPlan && 'ring-2 ring-blue-400 dark:ring-blue-500',


### PR DESCRIPTION
## Summary

- Replaces the horizontal scroll container with a responsive CSS grid (`grid-cols-1 sm:grid-cols-2 xl:grid-cols-4`)
- Removes scroll-specific classes from `PlanCard` (`min-w-[280px]`, `shrink-0`, `snap-center`) and adds `w-full` to fill grid cells
- Cards reflow naturally: single column on mobile → 2×2 on tablet → 4-across on wide screens
- No horizontal scrolling — matches standard SaaS pricing page conventions

## Test plan

- [ ] Full desktop width: all 4 cards in one row
- [ ] ~900px width: cards wrap to 2×2 grid
- [ ] Mobile: cards stack single column
- [ ] Badge, ring styles, and CTA buttons render correctly at each breakpoint
- [ ] Feature comparison table below is unaffected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)