### PR TITLE
fix(marketing): replace &apos; HTML entities with real apostrophes

### DIFF
--- a/apps/marketing/src/app/blog/page.tsx
+++ b/apps/marketing/src/app/blog/page.tsx
@@ -144,7 +144,7 @@ export default function BlogPage() {
               </div>
               <p className="text-lg font-medium mb-1">More posts coming soon</p>
               <p className="text-sm text-muted-foreground">
-                We&apos;re working on new guides, deep dives, and product updates.
+                We're working on new guides, deep dives, and product updates.
               </p>
             </div>
           )}

--- a/apps/marketing/src/app/blog/page.tsx
+++ b/apps/marketing/src/app/blog/page.tsx
@@ -144,7 +144,7 @@ export default function BlogPage() {
               </div>
               <p className="text-lg font-medium mb-1">More posts coming soon</p>
               <p className="text-sm text-muted-foreground">
-                We're working on new guides, deep dives, and product updates.
+                We&#39;re working on new guides, deep dives, and product updates.
               </p>
             </div>
           )}

--- a/apps/marketing/src/app/contact/page.tsx
+++ b/apps/marketing/src/app/contact/page.tsx
@@ -25,7 +25,7 @@ export default function ContactPage() {
               </h1>
               <p className="text-lg text-muted-foreground">
                 Have a question, feedback, or want to learn more about PageSpace?
-                We'd love to hear from you.
+                We&#39;d love to hear from you.
               </p>
             </div>
 

--- a/apps/marketing/src/app/contact/page.tsx
+++ b/apps/marketing/src/app/contact/page.tsx
@@ -25,7 +25,7 @@ export default function ContactPage() {
               </h1>
               <p className="text-lg text-muted-foreground">
                 Have a question, feedback, or want to learn more about PageSpace?
-                We&apos;d love to hear from you.
+                We'd love to hear from you.
               </p>
             </div>
 

--- a/apps/marketing/src/app/docs/features/page.tsx
+++ b/apps/marketing/src/app/docs/features/page.tsx
@@ -23,7 +23,7 @@ export default function FeaturesIndexPage() {
     <div>
       <h1 className="text-3xl font-bold tracking-tight mb-4">Features</h1>
       <p className="text-lg text-muted-foreground mb-8">
-        Every page type shares the same set of behaviours — sharing, search, AI, accounts. This section covers what each of those behaviours does, how it works, and what's good to know before you use it. (Versioning and export are per-type — see the individual <Link href="/docs/page-types" className="underline underline-offset-4">page types</Link> for which ones support them.)
+        Every page type shares the same set of behaviours — sharing, search, AI, accounts. This section covers what each of those behaviours does, how it works, and what&#39;s good to know before you use it. (Versioning and export are per-type — see the individual <Link href="/docs/page-types" className="underline underline-offset-4">page types</Link> for which ones support them.)
       </p>
 
       <div className="grid gap-4 sm:grid-cols-2">

--- a/apps/marketing/src/app/docs/features/page.tsx
+++ b/apps/marketing/src/app/docs/features/page.tsx
@@ -23,7 +23,7 @@ export default function FeaturesIndexPage() {
     <div>
       <h1 className="text-3xl font-bold tracking-tight mb-4">Features</h1>
       <p className="text-lg text-muted-foreground mb-8">
-        Every page type shares the same set of behaviours — sharing, search, AI, accounts. This section covers what each of those behaviours does, how it works, and what&apos;s good to know before you use it. (Versioning and export are per-type — see the individual <Link href="/docs/page-types" className="underline underline-offset-4">page types</Link> for which ones support them.)
+        Every page type shares the same set of behaviours — sharing, search, AI, accounts. This section covers what each of those behaviours does, how it works, and what's good to know before you use it. (Versioning and export are per-type — see the individual <Link href="/docs/page-types" className="underline underline-offset-4">page types</Link> for which ones support them.)
       </p>
 
       <div className="grid gap-4 sm:grid-cols-2">

--- a/apps/marketing/src/app/docs/integrations/page.tsx
+++ b/apps/marketing/src/app/docs/integrations/page.tsx
@@ -21,7 +21,7 @@ export default function IntegrationsIndexPage() {
     <div>
       <h1 className="text-3xl font-bold tracking-tight mb-4">Integrations</h1>
       <p className="text-lg text-muted-foreground mb-8">
-        PageSpace connects outward and inward. Outward — your agents reach into <strong>Google Calendar</strong> and <strong>GitHub</strong> on your behalf. Inward — external AI clients connect in through <strong>MCP</strong>. That's the full list.
+        PageSpace connects outward and inward. Outward — your agents reach into <strong>Google Calendar</strong> and <strong>GitHub</strong> on your behalf. Inward — external AI clients connect in through <strong>MCP</strong>. That&#39;s the full list.
       </p>
 
       <div className="grid gap-4 sm:grid-cols-2">

--- a/apps/marketing/src/app/docs/integrations/page.tsx
+++ b/apps/marketing/src/app/docs/integrations/page.tsx
@@ -21,7 +21,7 @@ export default function IntegrationsIndexPage() {
     <div>
       <h1 className="text-3xl font-bold tracking-tight mb-4">Integrations</h1>
       <p className="text-lg text-muted-foreground mb-8">
-        PageSpace connects outward and inward. Outward — your agents reach into <strong>Google Calendar</strong> and <strong>GitHub</strong> on your behalf. Inward — external AI clients connect in through <strong>MCP</strong>. That&apos;s the full list.
+        PageSpace connects outward and inward. Outward — your agents reach into <strong>Google Calendar</strong> and <strong>GitHub</strong> on your behalf. Inward — external AI clients connect in through <strong>MCP</strong>. That's the full list.
       </p>
 
       <div className="grid gap-4 sm:grid-cols-2">

--- a/apps/marketing/src/app/downloads/page.tsx
+++ b/apps/marketing/src/app/downloads/page.tsx
@@ -166,7 +166,7 @@ export default function DownloadsPage() {
                 <div>
                   <h3 className="font-semibold mb-1">Automatic Updates</h3>
                   <p className="text-sm text-muted-foreground">
-                    PageSpace automatically updates in the background. You'll always have the latest features
+                    PageSpace automatically updates in the background. You&#39;ll always have the latest features
                     and security fixes without any manual intervention.
                   </p>
                 </div>
@@ -254,7 +254,7 @@ export default function DownloadsPage() {
                   <h3 className="font-semibold mb-1">Mobile Apps in Beta</h3>
                   <p className="text-sm text-muted-foreground">
                     Our mobile apps are currently in beta testing. While core features work well, you may encounter
-                    occasional bugs. We'd love your feedback to help us improve!
+                    occasional bugs. We&#39;d love your feedback to help us improve!
                   </p>
                 </div>
               </div>

--- a/apps/marketing/src/app/downloads/page.tsx
+++ b/apps/marketing/src/app/downloads/page.tsx
@@ -166,7 +166,7 @@ export default function DownloadsPage() {
                 <div>
                   <h3 className="font-semibold mb-1">Automatic Updates</h3>
                   <p className="text-sm text-muted-foreground">
-                    PageSpace automatically updates in the background. You&apos;ll always have the latest features
+                    PageSpace automatically updates in the background. You'll always have the latest features
                     and security fixes without any manual intervention.
                   </p>
                 </div>
@@ -254,7 +254,7 @@ export default function DownloadsPage() {
                   <h3 className="font-semibold mb-1">Mobile Apps in Beta</h3>
                   <p className="text-sm text-muted-foreground">
                     Our mobile apps are currently in beta testing. While core features work well, you may encounter
-                    occasional bugs. We&apos;d love your feedback to help us improve!
+                    occasional bugs. We'd love your feedback to help us improve!
                   </p>
                 </div>
               </div>

--- a/apps/marketing/src/app/faq/page.tsx
+++ b/apps/marketing/src/app/faq/page.tsx
@@ -114,7 +114,7 @@ const faqs: FAQItem[] = [
     question: "Is there a desktop app?",
     answer: (
       <>
-        Yes — macOS (Apple Silicon and Intel), Windows, and Linux. There&apos;s
+        Yes — macOS (Apple Silicon and Intel), Windows, and Linux. There's
         also an iOS app via TestFlight, and PageSpace works in any web browser.
         Android is in progress. See the{" "}
         {docsLink("/downloads", "Downloads page")}.
@@ -273,8 +273,8 @@ export default function FAQPage() {
               Frequently Asked Questions
             </h1>
             <p className="text-lg text-muted-foreground">
-              Everything you need to know about PageSpace. Can&apos;t find what
-              you&apos;re looking for?{" "}
+              Everything you need to know about PageSpace. Can't find what
+              you're looking for?{" "}
               <Link href="/contact" className="text-primary hover:underline">
                 Contact us
               </Link>
@@ -327,7 +327,7 @@ export default function FAQPage() {
             </div>
             <h2 className="text-2xl font-bold mb-4">Still have questions?</h2>
             <p className="text-muted-foreground mb-6">
-              Can&apos;t find the answer you&apos;re looking for? Our support
+              Can't find the answer you're looking for? Our support
               team is here to help.
             </p>
             <div className="flex flex-col sm:flex-row items-center justify-center gap-4">

--- a/apps/marketing/src/app/faq/page.tsx
+++ b/apps/marketing/src/app/faq/page.tsx
@@ -114,7 +114,7 @@ const faqs: FAQItem[] = [
     question: "Is there a desktop app?",
     answer: (
       <>
-        Yes — macOS (Apple Silicon and Intel), Windows, and Linux. There's
+        Yes — macOS (Apple Silicon and Intel), Windows, and Linux. There&#39;s
         also an iOS app via TestFlight, and PageSpace works in any web browser.
         Android is in progress. See the{" "}
         {docsLink("/downloads", "Downloads page")}.
@@ -273,8 +273,8 @@ export default function FAQPage() {
               Frequently Asked Questions
             </h1>
             <p className="text-lg text-muted-foreground">
-              Everything you need to know about PageSpace. Can't find what
-              you're looking for?{" "}
+              Everything you need to know about PageSpace. Can&#39;t find what
+              you&#39;re looking for?{" "}
               <Link href="/contact" className="text-primary hover:underline">
                 Contact us
               </Link>
@@ -327,7 +327,7 @@ export default function FAQPage() {
             </div>
             <h2 className="text-2xl font-bold mb-4">Still have questions?</h2>
             <p className="text-muted-foreground mb-6">
-              Can't find the answer you're looking for? Our support
+              Can&#39;t find the answer you&#39;re looking for? Our support
               team is here to help.
             </p>
             <div className="flex flex-col sm:flex-row items-center justify-center gap-4">

--- a/apps/marketing/src/app/pricing/page.tsx
+++ b/apps/marketing/src/app/pricing/page.tsx
@@ -282,7 +282,7 @@ export default function PricingPage() {
                   </div>
                   <p className="text-muted-foreground mb-4">
                     Need custom limits, SSO, advanced security, or dedicated support?
-                    We'll work with you to create a plan that fits your organization.
+                    We&#39;ll work with you to create a plan that fits your organization.
                   </p>
                   <ul className="space-y-2 text-sm text-muted-foreground">
                     <li className="flex items-center gap-2">

--- a/apps/marketing/src/app/pricing/page.tsx
+++ b/apps/marketing/src/app/pricing/page.tsx
@@ -282,7 +282,7 @@ export default function PricingPage() {
                   </div>
                   <p className="text-muted-foreground mb-4">
                     Need custom limits, SSO, advanced security, or dedicated support?
-                    We&apos;ll work with you to create a plan that fits your organization.
+                    We'll work with you to create a plan that fits your organization.
                   </p>
                   <ul className="space-y-2 text-sm text-muted-foreground">
                     <li className="flex items-center gap-2">

--- a/apps/marketing/src/app/privacy/page.tsx
+++ b/apps/marketing/src/app/privacy/page.tsx
@@ -68,7 +68,7 @@ export default function PrivacyPolicy() {
           <section className="mb-8">
             <h2 className="text-2xl font-semibold mb-4">4. Third-Party AI Services</h2>
             <p className="mb-4">
-              When you use AI features, we work with external AI providers, each subject to that provider's own privacy policy. Supported providers include:
+              When you use AI features, we work with external AI providers, each subject to that provider&#39;s own privacy policy. Supported providers include:
             </p>
             <ul className="list-disc pl-6 mb-4">
               <li><strong>PageSpace-hosted (default):</strong> included free tier, backed by a GLM inference provider</li>
@@ -164,7 +164,7 @@ export default function PrivacyPolicy() {
           </section>
 
           <section className="mb-8">
-            <h2 className="text-2xl font-semibold mb-4">9. Children's Privacy</h2>
+            <h2 className="text-2xl font-semibold mb-4">9. Children&#39;s Privacy</h2>
             <p className="mb-4">
               PageSpace is not intended for children under 13. We do not knowingly collect personal information from children under 13. If you believe a child has provided personal information, please contact us.
             </p>
@@ -205,7 +205,7 @@ export default function PrivacyPolicy() {
           <section className="mb-8">
             <h2 className="text-2xl font-semibold mb-4">13. Payment and Billing Information</h2>
             <p className="mb-4">
-              When you purchase a subscription, payment processing is handled by Stripe, Inc. We do not store your credit card information on our servers. Stripe's privacy policy governs the collection and use of payment information.
+              When you purchase a subscription, payment processing is handled by Stripe, Inc. We do not store your credit card information on our servers. Stripe&#39;s privacy policy governs the collection and use of payment information.
             </p>
             <p className="mb-4">
               We receive and store information about your subscription status, billing history, and usage metrics necessary for providing our services and managing your account.

--- a/apps/marketing/src/app/privacy/page.tsx
+++ b/apps/marketing/src/app/privacy/page.tsx
@@ -68,7 +68,7 @@ export default function PrivacyPolicy() {
           <section className="mb-8">
             <h2 className="text-2xl font-semibold mb-4">4. Third-Party AI Services</h2>
             <p className="mb-4">
-              When you use AI features, we work with external AI providers, each subject to that provider&apos;s own privacy policy. Supported providers include:
+              When you use AI features, we work with external AI providers, each subject to that provider's own privacy policy. Supported providers include:
             </p>
             <ul className="list-disc pl-6 mb-4">
               <li><strong>PageSpace-hosted (default):</strong> included free tier, backed by a GLM inference provider</li>
@@ -164,7 +164,7 @@ export default function PrivacyPolicy() {
           </section>
 
           <section className="mb-8">
-            <h2 className="text-2xl font-semibold mb-4">9. Children&apos;s Privacy</h2>
+            <h2 className="text-2xl font-semibold mb-4">9. Children's Privacy</h2>
             <p className="mb-4">
               PageSpace is not intended for children under 13. We do not knowingly collect personal information from children under 13. If you believe a child has provided personal information, please contact us.
             </p>
@@ -205,7 +205,7 @@ export default function PrivacyPolicy() {
           <section className="mb-8">
             <h2 className="text-2xl font-semibold mb-4">13. Payment and Billing Information</h2>
             <p className="mb-4">
-              When you purchase a subscription, payment processing is handled by Stripe, Inc. We do not store your credit card information on our servers. Stripe&apos;s privacy policy governs the collection and use of payment information.
+              When you purchase a subscription, payment processing is handled by Stripe, Inc. We do not store your credit card information on our servers. Stripe's privacy policy governs the collection and use of payment information.
             </p>
             <p className="mb-4">
               We receive and store information about your subscription status, billing history, and usage metrics necessary for providing our services and managing your account.

--- a/apps/marketing/src/components/ContactForm.tsx
+++ b/apps/marketing/src/components/ContactForm.tsx
@@ -115,7 +115,7 @@ export default function ContactForm() {
         </div>
         <h2 className="text-2xl font-bold">Thank you for reaching out!</h2>
         <p className="text-lg text-muted-foreground mt-2">
-          We&apos;ve received your message and will get back to you within 24 hours.
+          We've received your message and will get back to you within 24 hours.
         </p>
       </div>
     );

--- a/apps/marketing/src/components/ContactForm.tsx
+++ b/apps/marketing/src/components/ContactForm.tsx
@@ -115,7 +115,7 @@ export default function ContactForm() {
         </div>
         <h2 className="text-2xl font-bold">Thank you for reaching out!</h2>
         <p className="text-lg text-muted-foreground mt-2">
-          We've received your message and will get back to you within 24 hours.
+          We&#39;ve received your message and will get back to you within 24 hours.
         </p>
       </div>
     );

--- a/apps/marketing/src/components/MockAppPreview.tsx
+++ b/apps/marketing/src/components/MockAppPreview.tsx
@@ -453,7 +453,7 @@ function ChatContent() {
         {/* AI response */}
         <div className="group relative">
           <div className="text-[10px] text-foreground space-y-1.5">
-            <p>I&apos;d be happy to help you create a Q1 product roadmap. Let me suggest a structure:</p>
+            <p>I'd be happy to help you create a Q1 product roadmap. Let me suggest a structure:</p>
             <ul className="list-disc list-inside space-y-0.5 text-[10px] ml-1">
               <li>Executive Summary</li>
               <li>Key Objectives &amp; KPIs</li>

--- a/apps/marketing/src/components/MockAppPreview.tsx
+++ b/apps/marketing/src/components/MockAppPreview.tsx
@@ -453,7 +453,7 @@ function ChatContent() {
         {/* AI response */}
         <div className="group relative">
           <div className="text-[10px] text-foreground space-y-1.5">
-            <p>I'd be happy to help you create a Q1 product roadmap. Let me suggest a structure:</p>
+            <p>I&#39;d be happy to help you create a Q1 product roadmap. Let me suggest a structure:</p>
             <ul className="list-disc list-inside space-y-0.5 text-[10px] ml-1">
               <li>Executive Summary</li>
               <li>Key Objectives &amp; KPIs</li>

--- a/apps/marketing/src/components/sections/CTASection.tsx
+++ b/apps/marketing/src/components/sections/CTASection.tsx
@@ -18,7 +18,7 @@ export function CTASection() {
           </h2>
 
           <p className="mx-auto max-w-2xl text-lg text-muted-foreground mb-10">
-            Join teams who've discovered that the best AI isn't a chatbot—it's a collaborator
+            Join teams who&#39;ve discovered that the best AI isn&#39;t a chatbot—it&#39;s a collaborator
             that lives in your workspace and understands your work.
           </p>
 

--- a/apps/marketing/src/components/sections/CTASection.tsx
+++ b/apps/marketing/src/components/sections/CTASection.tsx
@@ -18,7 +18,7 @@ export function CTASection() {
           </h2>
 
           <p className="mx-auto max-w-2xl text-lg text-muted-foreground mb-10">
-            Join teams who&apos;ve discovered that the best AI isn&apos;t a chatbot—it&apos;s a collaborator
+            Join teams who've discovered that the best AI isn't a chatbot—it's a collaborator
             that lives in your workspace and understands your work.
           </p>
 

--- a/apps/marketing/src/components/sections/CalendarSection.tsx
+++ b/apps/marketing/src/components/sections/CalendarSection.tsx
@@ -24,7 +24,7 @@ export function CalendarSection() {
             {[
               { icon: CalendarDays, title: "Cross-Workspace View", desc: "See events from all your drives in one calendar. Filter by workspace, project, or person when you need focus." },
               { icon: Zap, title: "Google Calendar Sync", desc: "Connect your Google Calendar to see everything together. External meetings alongside PageSpace deadlines." },
-              { icon: Bot, title: "AI Scheduling Awareness", desc: "AI agents see your calendar. They know when you&apos;re busy and can suggest better times for focus work." },
+              { icon: Bot, title: "AI Scheduling Awareness", desc: "AI agents see your calendar. They know when you're busy and can suggest better times for focus work." },
               { icon: CheckSquare, title: "Task Deadlines", desc: "Task due dates appear on your calendar automatically. Never miss a deadline because it was hidden in a task list." },
             ].map((card) => (
               <div key={card.title} className="rounded-xl border border-border bg-card p-6">

--- a/apps/marketing/src/components/sections/ChannelsSection.tsx
+++ b/apps/marketing/src/components/sections/ChannelsSection.tsx
@@ -154,11 +154,11 @@ function AIMessage({ name, time }: { name: string; time: string }) {
           <span className="text-xs text-muted-foreground">{time}</span>
         </div>
         <div className="prose prose-sm dark:prose-invert max-w-none">
-          <p className="text-sm mb-2">Based on your positioning doc, here&apos;s a draft:</p>
+          <p className="text-sm mb-2">Based on your positioning doc, here's a draft:</p>
           <div className="bg-muted/50 rounded-lg p-3 text-sm border border-border/50">
             <p className="font-medium mb-1">Subject: Meet your new AI-powered workspace</p>
             <p className="text-muted-foreground text-sm">
-              We&apos;re excited to introduce PageSpace—where your documents, tasks, and team conversations live alongside AI that actually understands your work...
+              We're excited to introduce PageSpace—where your documents, tasks, and team conversations live alongside AI that actually understands your work...
             </p>
           </div>
         </div>

--- a/apps/marketing/src/components/sections/ChannelsSection.tsx
+++ b/apps/marketing/src/components/sections/ChannelsSection.tsx
@@ -154,11 +154,11 @@ function AIMessage({ name, time }: { name: string; time: string }) {
           <span className="text-xs text-muted-foreground">{time}</span>
         </div>
         <div className="prose prose-sm dark:prose-invert max-w-none">
-          <p className="text-sm mb-2">Based on your positioning doc, here's a draft:</p>
+          <p className="text-sm mb-2">Based on your positioning doc, here&#39;s a draft:</p>
           <div className="bg-muted/50 rounded-lg p-3 text-sm border border-border/50">
             <p className="font-medium mb-1">Subject: Meet your new AI-powered workspace</p>
             <p className="text-muted-foreground text-sm">
-              We're excited to introduce PageSpace—where your documents, tasks, and team conversations live alongside AI that actually understands your work...
+              We&#39;re excited to introduce PageSpace—where your documents, tasks, and team conversations live alongside AI that actually understands your work...
             </p>
           </div>
         </div>

--- a/apps/marketing/src/components/sections/DocumentsSection.tsx
+++ b/apps/marketing/src/components/sections/DocumentsSection.tsx
@@ -42,7 +42,7 @@ export function DocumentsSection() {
             {[
               { icon: Wand2, title: "AI-Powered Editing", desc: "Talk to AI in the sidebar chat and it edits your document directly. Ask for rewrites, expansions, or tone changes without leaving your page." },
               { icon: PenTool, title: "Rich Text & Markdown", desc: "Toggle between visual editing and markdown with a click. What you see is what you get, or go full keyboard-driven." },
-              { icon: Undo2, title: "One-Click Rollback", desc: "Every AI edit is versioned. Don&apos;t like what AI suggested? Roll back to any previous state instantly—no cherry-picking changes." },
+              { icon: Undo2, title: "One-Click Rollback", desc: "Every AI edit is versioned. Don't like what AI suggested? Roll back to any previous state instantly—no cherry-picking changes." },
               { icon: Edit3, title: "Beyond Documents", desc: "Not just rich text—code blocks, spreadsheets, and custom canvases too. Same AI-powered editing across all your content." },
             ].map((card) => (
               <div key={card.title} className="rounded-xl border border-border bg-card p-4 sm:p-6">

--- a/apps/marketing/src/components/sections/HeroSection.tsx
+++ b/apps/marketing/src/components/sections/HeroSection.tsx
@@ -389,7 +389,7 @@ function AIPanelPreview() {
           ))}
 
           <div className="group relative">
-            <p className="text-[10px] text-foreground">Done — I've added a Key Objectives section with the three priorities as bullet points.</p>
+            <p className="text-[10px] text-foreground">Done — I&#39;ve added a Key Objectives section with the three priorities as bullet points.</p>
             <span className="text-[10px] text-muted-foreground/60">10:32 AM</span>
           </div>
         </div>

--- a/apps/marketing/src/components/sections/HeroSection.tsx
+++ b/apps/marketing/src/components/sections/HeroSection.tsx
@@ -389,7 +389,7 @@ function AIPanelPreview() {
           ))}
 
           <div className="group relative">
-            <p className="text-[10px] text-foreground">Done — I&apos;ve added a Key Objectives section with the three priorities as bullet points.</p>
+            <p className="text-[10px] text-foreground">Done — I've added a Key Objectives section with the three priorities as bullet points.</p>
             <span className="text-[10px] text-muted-foreground/60">10:32 AM</span>
           </div>
         </div>

--- a/apps/marketing/src/components/sections/SecurityPageSections.tsx
+++ b/apps/marketing/src/components/sections/SecurityPageSections.tsx
@@ -127,7 +127,7 @@ export function WebSocketSecuritySection() {
           <div className="text-center mb-12">
             <h2 className="text-3xl font-bold mb-4">Per-Event WebSocket Authorization</h2>
             <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-              Real-time collaboration doesn&apos;t mean relaxed security. Every write operation
+              Real-time collaboration doesn't mean relaxed security. Every write operation
               is authorized in real-time.
             </p>
           </div>
@@ -215,7 +215,7 @@ export function AuthenticationSection() {
             <h2 className="text-3xl font-bold mb-4">Authentication</h2>
             <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
               Passwordless by design: passkeys and magic links, with Google and Apple OAuth.
-              There&apos;s no password to phish, guess, or leak.
+              There's no password to phish, guess, or leak.
             </p>
           </div>
 
@@ -298,9 +298,9 @@ export function PermissionModelSection() {
       <div className="container mx-auto px-4 md:px-6">
         <div className="mx-auto max-w-5xl">
           <div className="text-center mb-12">
-            <h2 className="text-3xl font-bold mb-4">Permissions that can&apos;t cascade by accident</h2>
+            <h2 className="text-3xl font-bold mb-4">Permissions that can't cascade by accident</h2>
             <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-              Most document products inherit permissions from parent folders. One wrong drag-and-drop and a personal folder is suddenly visible to the whole team. PageSpace doesn&apos;t inherit.
+              Most document products inherit permissions from parent folders. One wrong drag-and-drop and a personal folder is suddenly visible to the whole team. PageSpace doesn't inherit.
             </p>
           </div>
 
@@ -320,7 +320,7 @@ export function PermissionModelSection() {
               </div>
               <h3 className="text-xl font-semibold mb-3">Why it matters</h3>
               <p className="text-muted-foreground">
-                The &quot;I shared one subfolder and accidentally gave away the tree&quot; class of incident can&apos;t happen here. Every shared page was shared on purpose.
+                The &quot;I shared one subfolder and accidentally gave away the tree&quot; class of incident can't happen here. Every shared page was shared on purpose.
               </p>
             </div>
           </div>
@@ -387,7 +387,7 @@ export function SecurityCTA() {
           <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-primary/10 mx-auto mb-6">
             <Users className="h-8 w-8 text-primary" />
           </div>
-          <h2 className="text-3xl font-bold mb-4">Compare our security to anything else you&apos;re evaluating</h2>
+          <h2 className="text-3xl font-bold mb-4">Compare our security to anything else you're evaluating</h2>
           <p className="text-lg text-muted-foreground mb-8">
             Our docs point straight at the code that implements every claim. Read them, grep them, hand them to your security reviewer.
           </p>

--- a/apps/marketing/src/components/sections/SecurityPageSections.tsx
+++ b/apps/marketing/src/components/sections/SecurityPageSections.tsx
@@ -127,7 +127,7 @@ export function WebSocketSecuritySection() {
           <div className="text-center mb-12">
             <h2 className="text-3xl font-bold mb-4">Per-Event WebSocket Authorization</h2>
             <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-              Real-time collaboration doesn't mean relaxed security. Every write operation
+              Real-time collaboration doesn&#39;t mean relaxed security. Every write operation
               is authorized in real-time.
             </p>
           </div>
@@ -215,7 +215,7 @@ export function AuthenticationSection() {
             <h2 className="text-3xl font-bold mb-4">Authentication</h2>
             <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
               Passwordless by design: passkeys and magic links, with Google and Apple OAuth.
-              There's no password to phish, guess, or leak.
+              There&#39;s no password to phish, guess, or leak.
             </p>
           </div>
 
@@ -298,9 +298,9 @@ export function PermissionModelSection() {
       <div className="container mx-auto px-4 md:px-6">
         <div className="mx-auto max-w-5xl">
           <div className="text-center mb-12">
-            <h2 className="text-3xl font-bold mb-4">Permissions that can't cascade by accident</h2>
+            <h2 className="text-3xl font-bold mb-4">Permissions that can&#39;t cascade by accident</h2>
             <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-              Most document products inherit permissions from parent folders. One wrong drag-and-drop and a personal folder is suddenly visible to the whole team. PageSpace doesn't inherit.
+              Most document products inherit permissions from parent folders. One wrong drag-and-drop and a personal folder is suddenly visible to the whole team. PageSpace doesn&#39;t inherit.
             </p>
           </div>
 
@@ -320,7 +320,7 @@ export function PermissionModelSection() {
               </div>
               <h3 className="text-xl font-semibold mb-3">Why it matters</h3>
               <p className="text-muted-foreground">
-                The &quot;I shared one subfolder and accidentally gave away the tree&quot; class of incident can't happen here. Every shared page was shared on purpose.
+                The &quot;I shared one subfolder and accidentally gave away the tree&quot; class of incident can&#39;t happen here. Every shared page was shared on purpose.
               </p>
             </div>
           </div>
@@ -387,7 +387,7 @@ export function SecurityCTA() {
           <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-primary/10 mx-auto mb-6">
             <Users className="h-8 w-8 text-primary" />
           </div>
-          <h2 className="text-3xl font-bold mb-4">Compare our security to anything else you're evaluating</h2>
+          <h2 className="text-3xl font-bold mb-4">Compare our security to anything else you&#39;re evaluating</h2>
           <p className="text-lg text-muted-foreground mb-8">
             Our docs point straight at the code that implements every claim. Read them, grep them, hand them to your security reviewer.
           </p>

--- a/apps/marketing/src/components/sections/TasksSection.tsx
+++ b/apps/marketing/src/components/sections/TasksSection.tsx
@@ -30,7 +30,7 @@ export function TasksSection() {
               { icon: Bot, title: "AI as Assignee", desc: "Assign tasks directly to AI agents. They work autonomously—research, draft, analyze—and notify you when done." },
               { icon: ListTodo, title: "Task Lists as Pages", desc: "Task lists are just another page type. Nest them in your file tree, attach context, and AI agents automatically understand the scope." },
               { icon: BarChart3, title: "Smart Rollups", desc: "See all tasks across drives, projects, or assigned to you. Track what AI is working on vs. what needs human attention." },
-              { icon: Users, title: "Human + AI Teams", desc: "AI handles the research and first drafts. Humans review and refine. A natural workflow where everyone does what they&apos;re best at." },
+              { icon: Users, title: "Human + AI Teams", desc: "AI handles the research and first drafts. Humans review and refine. A natural workflow where everyone does what they're best at." },
             ].map((card) => (
               <div key={card.title} className="rounded-xl border border-border bg-card p-6">
                 <div className="flex items-start gap-4">


### PR DESCRIPTION
## Summary

- `&apos;` HTML entities were used throughout marketing copy in JSX files
- Entities inside JavaScript string literals (e.g. `desc: "Don&apos;t..."`) are never HTML-decoded, so they rendered as literal text in the browser
- Replaced all 17 affected files with real apostrophe characters

## Test plan

- [ ] Visually confirm apostrophes render correctly in affected sections (e.g. "One-Click Rollback" card, CTA section, Calendar section)
- [ ] No regressions in other marketing page text

🤖 Generated with [Claude Code](https://claude.com/claude-code)