### PR TITLE
fix(sidebar): activity tab subscribes to page events

### DIFF
--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarActivityTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarActivityTab.tsx
@@ -254,6 +254,8 @@ export default function SidebarActivityTab() {
     context: activityContext || 'drive', // Fallback for type, but won't be used when contextId is null
     contextId: activityContextId,
     onActivityLogged: loadActivities,
+    driveId: driveId ?? null,
+    pageId: pageId ?? null,
   });
 
   // Handle undo click - fetch preview and show confirm dialog

--- a/apps/web/src/hooks/useActivitySocket.ts
+++ b/apps/web/src/hooks/useActivitySocket.ts
@@ -7,6 +7,8 @@ interface UseActivitySocketOptions {
   context: ActivityContext;
   contextId: string | null;
   onActivityLogged: () => void;
+  driveId?: string | null;
+  pageId?: string | null;
 }
 
 /**
@@ -17,6 +19,8 @@ export function useActivitySocket({
   context,
   contextId,
   onActivityLogged,
+  driveId,
+  pageId,
 }: UseActivitySocketOptions) {
   const socket = useSocket();
   const hasJoinedRef = useRef(false);
@@ -71,6 +75,29 @@ export function useActivitySocket({
       socket.off('activity:logged', handleActivityLogged);
     };
   }, [socket, context, contextId, debouncedRefetch]);
+
+  // Subscribe to page-level events via the drive room as a reliable secondary trigger.
+  // page:content-updated fires synchronously after applyPageMutation commits, so by the
+  // time the client receives it the activity record is already queryable.
+  useEffect(() => {
+    if (!socket || !driveId) return;
+
+    socket.emit('join_drive', driveId);
+
+    const handlePageEvent = (event: { pageId?: string }) => {
+      // In page context, only react to events for this specific page
+      if (pageId && event.pageId && event.pageId !== pageId) return;
+      debouncedRefetch();
+    };
+
+    socket.on('page:content-updated', handlePageEvent);
+    socket.on('page:updated', handlePageEvent);
+
+    return () => {
+      socket.off('page:content-updated', handlePageEvent);
+      socket.off('page:updated', handlePageEvent);
+    };
+  }, [socket, driveId, pageId, debouncedRefetch]);
 
   // Cleanup on unmount
   useEffect(() => {


### PR DESCRIPTION
## Summary

- `useActivitySocket` now also joins the drive room and listens to `page:content-updated` / `page:updated` events
- When those fire for the current page, the Activity tab calls `loadActivities()` immediately
- `SidebarActivityTab` passes `driveId` and `pageId` through to the hook

## Problem

After an AI edits a document from the chat window, the Activity tab in the right sidebar wouldn't update until the user refreshed. The document editor itself updated in real-time (via `page:content-updated`), but the Activity tab only subscribed to `activity:logged` — which requires a successful `join_activity_page` room join that can fail silently (async server-side access check, no ack, lost on reconnect).

## Fix

`page:content-updated` is broadcast synchronously **after** `applyPageMutation` commits its transaction (which already writes the activity row). So by the time the client receives it, the new activity is already in the DB. Subscribing to `page:content-updated` via the proven drive room gives the Activity tab a reliable second trigger.

The existing `activity:logged` subscription is unchanged — it still handles non-content events (permission changes, renames, etc.).

## Test plan

- [ ] Open a document, switch to Activity tab in right sidebar
- [ ] Ask AI (sidebar chat) to edit the document — Activity tab should update within ~500ms without refreshing
- [ ] Navigate to drive root — Activity tab should update when any page in the drive is edited
- [ ] Non-content events (permission grant, rename) still appear via `activity:logged`

🤖 Generated with [Claude Code](https://claude.com/claude-code)