### PR TITLE
fix(cron): drop userId 'system' from audit calls

### DIFF
--- a/apps/web/src/app/api/cron/calendar-sync/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/calendar-sync/__tests__/route.test.ts
@@ -72,7 +72,7 @@ describe('/api/cron/calendar-sync', () => {
     await GET(makeRequest());
 
     expect(mockAudit).toHaveBeenCalledWith(
-      expect.objectContaining({ eventType: 'data.write', userId: 'system', resourceType: 'cron_job', resourceId: 'calendar_sync', details: { synced: 0, failed: 0 } })
+      expect.objectContaining({ eventType: 'data.write', resourceType: 'cron_job', resourceId: 'calendar_sync', details: { synced: 0, failed: 0 } })
     );
   });
 
@@ -88,7 +88,7 @@ describe('/api/cron/calendar-sync', () => {
     await GET(makeRequest());
 
     expect(mockAudit).toHaveBeenCalledWith(
-      expect.objectContaining({ eventType: 'data.write', userId: 'system', resourceType: 'cron_job', resourceId: 'calendar_sync', details: { synced: 1, failed: 1 } })
+      expect.objectContaining({ eventType: 'data.write', resourceType: 'cron_job', resourceId: 'calendar_sync', details: { synced: 1, failed: 1 } })
     );
   });
 

--- a/apps/web/src/app/api/cron/calendar-sync/route.ts
+++ b/apps/web/src/app/api/cron/calendar-sync/route.ts
@@ -79,7 +79,7 @@ export async function GET(request: Request) {
 
     loggers.api.info('Calendar sync cron completed', { synced, failed });
 
-    audit({ eventType: 'data.write', userId: 'system', resourceType: 'cron_job', resourceId: 'calendar_sync', details: { synced, failed } });
+    audit({ eventType: 'data.write', resourceType: 'cron_job', resourceId: 'calendar_sync', details: { synced, failed } });
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/cron/calendar-triggers/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/calendar-triggers/__tests__/route.test.ts
@@ -301,7 +301,7 @@ describe('POST /api/cron/calendar-triggers', () => {
     await POST(request);
 
     expect(mockAudit).toHaveBeenCalledWith(
-      expect.objectContaining({ eventType: 'data.write', userId: 'system', resourceType: 'cron_job', resourceId: 'calendar_triggers', details: { executed: 1, failed: 0 } })
+      expect.objectContaining({ eventType: 'data.write', resourceType: 'cron_job', resourceId: 'calendar_triggers', details: { executed: 1, failed: 0 } })
     );
   });
 
@@ -310,7 +310,7 @@ describe('POST /api/cron/calendar-triggers', () => {
     await POST(request);
 
     expect(mockAudit).toHaveBeenCalledWith(
-      expect.objectContaining({ eventType: 'data.write', userId: 'system', resourceType: 'cron_job', resourceId: 'calendar_triggers', details: { executed: 0, failed: 0 } })
+      expect.objectContaining({ eventType: 'data.write', resourceType: 'cron_job', resourceId: 'calendar_triggers', details: { executed: 0, failed: 0 } })
     );
   });
 

--- a/apps/web/src/app/api/cron/calendar-triggers/route.ts
+++ b/apps/web/src/app/api/cron/calendar-triggers/route.ts
@@ -47,7 +47,7 @@ export async function POST(req: Request) {
       .limit(MAX_DUE_TRIGGERS);
 
     if (dueTriggers.length === 0) {
-      audit({ eventType: 'data.write', userId: 'system', resourceType: 'cron_job', resourceId: 'calendar_triggers', details: { executed: 0, failed: 0 } });
+      audit({ eventType: 'data.write', resourceType: 'cron_job', resourceId: 'calendar_triggers', details: { executed: 0, failed: 0 } });
       return NextResponse.json({ message: 'No calendar triggers due', executed: 0 });
     }
 
@@ -131,7 +131,7 @@ export async function POST(req: Request) {
 
     logger.info(`Calendar trigger cron: Complete. Executed ${executed}/${totalClaimed}`);
 
-    audit({ eventType: 'data.write', userId: 'system', resourceType: 'cron_job', resourceId: 'calendar_triggers', details: { executed, failed: errors.length } });
+    audit({ eventType: 'data.write', resourceType: 'cron_job', resourceId: 'calendar_triggers', details: { executed, failed: errors.length } });
 
     return NextResponse.json({
       message: 'Calendar trigger cron complete',

--- a/apps/web/src/app/api/cron/cleanup-orphaned-files/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/cleanup-orphaned-files/__tests__/route.test.ts
@@ -61,7 +61,7 @@ describe('/api/cron/cleanup-orphaned-files', () => {
     await GET(makeRequest());
 
     expect(mockAudit).toHaveBeenCalledWith(
-      expect.objectContaining({ eventType: 'data.delete', userId: 'system', resourceType: 'cron_job', resourceId: 'cleanup_orphaned_files', details: { orphansFound: 0, filesDeleted: 0, physicalFilesDeleted: 0 } })
+      expect.objectContaining({ eventType: 'data.delete', resourceType: 'cron_job', resourceId: 'cleanup_orphaned_files', details: { orphansFound: 0, filesDeleted: 0, physicalFilesDeleted: 0 } })
     );
   });
 
@@ -76,7 +76,7 @@ describe('/api/cron/cleanup-orphaned-files', () => {
     await GET(makeRequest());
 
     expect(mockAudit).toHaveBeenCalledWith(
-      expect.objectContaining({ eventType: 'data.delete', userId: 'system', resourceType: 'cron_job', resourceId: 'cleanup_orphaned_files', details: { orphansFound: 2, filesDeleted: 2, physicalFilesDeleted: 0 } })
+      expect.objectContaining({ eventType: 'data.delete', resourceType: 'cron_job', resourceId: 'cleanup_orphaned_files', details: { orphansFound: 2, filesDeleted: 2, physicalFilesDeleted: 0 } })
     );
   });
 

--- a/apps/web/src/app/api/cron/cleanup-orphaned-files/route.ts
+++ b/apps/web/src/app/api/cron/cleanup-orphaned-files/route.ts
@@ -29,7 +29,7 @@ export async function GET(request: Request) {
     const orphans = await findOrphanedFileRecords(db as Parameters<typeof findOrphanedFileRecords>[0]);
 
     if (orphans.length === 0) {
-      audit({ eventType: 'data.delete', userId: 'system', resourceType: 'cron_job', resourceId: 'cleanup_orphaned_files', details: { orphansFound: 0, filesDeleted: 0, physicalFilesDeleted: 0 } });
+      audit({ eventType: 'data.delete', resourceType: 'cron_job', resourceId: 'cleanup_orphaned_files', details: { orphansFound: 0, filesDeleted: 0, physicalFilesDeleted: 0 } });
       return NextResponse.json({
         success: true,
         orphansFound: 0,
@@ -104,7 +104,7 @@ export async function GET(request: Request) {
       `${physicalFilesDeleted} physical files deleted, ${dbDeleted} DB records deleted`
     );
 
-    audit({ eventType: 'data.delete', userId: 'system', resourceType: 'cron_job', resourceId: 'cleanup_orphaned_files', details: { orphansFound: orphans.length, filesDeleted: dbDeleted, physicalFilesDeleted } });
+    audit({ eventType: 'data.delete', resourceType: 'cron_job', resourceId: 'cleanup_orphaned_files', details: { orphansFound: orphans.length, filesDeleted: dbDeleted, physicalFilesDeleted } });
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/cron/cleanup-tokens/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/cleanup-tokens/__tests__/route.test.ts
@@ -49,7 +49,7 @@ describe('/api/cron/cleanup-tokens', () => {
     await GET(makeRequest());
 
     expect(mockAudit).toHaveBeenCalledWith(
-      expect.objectContaining({ eventType: 'data.delete', userId: 'system', resourceType: 'cron_job', resourceId: 'cleanup_tokens', details: { cleaned: 5 } })
+      expect.objectContaining({ eventType: 'data.delete', resourceType: 'cron_job', resourceId: 'cleanup_tokens', details: { cleaned: 5 } })
     );
   });
 

--- a/apps/web/src/app/api/cron/cleanup-tokens/route.ts
+++ b/apps/web/src/app/api/cron/cleanup-tokens/route.ts
@@ -30,7 +30,7 @@ export async function GET(request: Request) {
 
     console.log(`[Cron] Cleaned up ${count} expired device tokens`);
 
-    audit({ eventType: 'data.delete', userId: 'system', resourceType: 'cron_job', resourceId: 'cleanup_tokens', details: { cleaned: count } });
+    audit({ eventType: 'data.delete', resourceType: 'cron_job', resourceId: 'cleanup_tokens', details: { cleaned: count } });
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/cron/purge-ai-usage-logs/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/purge-ai-usage-logs/__tests__/route.test.ts
@@ -52,7 +52,7 @@ describe('/api/cron/purge-ai-usage-logs', () => {
     await GET(makeRequest());
 
     expect(mockAudit).toHaveBeenCalledWith(
-      expect.objectContaining({ eventType: 'data.delete', userId: 'system', resourceType: 'cron_job', resourceId: 'purge_ai_usage', details: { anonymized: 10, purged: 3 } })
+      expect.objectContaining({ eventType: 'data.delete', resourceType: 'cron_job', resourceId: 'purge_ai_usage', details: { anonymized: 10, purged: 3 } })
     );
   });
 

--- a/apps/web/src/app/api/cron/purge-ai-usage-logs/route.ts
+++ b/apps/web/src/app/api/cron/purge-ai-usage-logs/route.ts
@@ -30,7 +30,7 @@ export async function GET(request: Request) {
 
     console.log(`[Cron] AI usage logs: anonymized ${anonymized}, purged ${purged}`);
 
-    audit({ eventType: 'data.delete', userId: 'system', resourceType: 'cron_job', resourceId: 'purge_ai_usage', details: { anonymized, purged } });
+    audit({ eventType: 'data.delete', resourceType: 'cron_job', resourceId: 'purge_ai_usage', details: { anonymized, purged } });
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/cron/purge-deleted-messages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/purge-deleted-messages/__tests__/route.test.ts
@@ -56,7 +56,7 @@ describe('/api/cron/purge-deleted-messages', () => {
     await GET(makeRequest());
 
     expect(mockAudit).toHaveBeenCalledWith(
-      expect.objectContaining({ eventType: 'data.delete', userId: 'system', resourceType: 'cron_job', resourceId: 'purge_deleted_messages', details: { chatMessagesPurged: 5, globalMessagesPurged: 3, conversationsPurged: 2 } })
+      expect.objectContaining({ eventType: 'data.delete', resourceType: 'cron_job', resourceId: 'purge_deleted_messages', details: { chatMessagesPurged: 5, globalMessagesPurged: 3, conversationsPurged: 2 } })
     );
   });
 

--- a/apps/web/src/app/api/cron/purge-deleted-messages/route.ts
+++ b/apps/web/src/app/api/cron/purge-deleted-messages/route.ts
@@ -30,7 +30,7 @@ export async function GET(request: Request) {
       `[Cron] Purged deleted messages: chat=${chatMessagesPurged}, global=${globalMessagesPurged}, conversations=${conversationsPurged}`
     );
 
-    audit({ eventType: 'data.delete', userId: 'system', resourceType: 'cron_job', resourceId: 'purge_deleted_messages', details: { chatMessagesPurged, globalMessagesPurged, conversationsPurged } });
+    audit({ eventType: 'data.delete', resourceType: 'cron_job', resourceId: 'purge_deleted_messages', details: { chatMessagesPurged, globalMessagesPurged, conversationsPurged } });
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/cron/retention-cleanup/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/retention-cleanup/__tests__/route.test.ts
@@ -58,7 +58,7 @@ describe('/api/cron/retention-cleanup', () => {
     await GET(makeRequest());
 
     expect(mockAudit).toHaveBeenCalledWith(
-      expect.objectContaining({ eventType: 'data.delete', userId: 'system', resourceType: 'cron_job', resourceId: 'retention_cleanup', details: { totalDeleted: 15, tables: MOCK_RESULTS } })
+      expect.objectContaining({ eventType: 'data.delete', resourceType: 'cron_job', resourceId: 'retention_cleanup', details: { totalDeleted: 15, tables: MOCK_RESULTS } })
     );
   });
 

--- a/apps/web/src/app/api/cron/retention-cleanup/route.ts
+++ b/apps/web/src/app/api/cron/retention-cleanup/route.ts
@@ -31,7 +31,7 @@ export async function GET(request: Request) {
       }
     }
 
-    audit({ eventType: 'data.delete', userId: 'system', resourceType: 'cron_job', resourceId: 'retention_cleanup', details: { totalDeleted, tables: results } });
+    audit({ eventType: 'data.delete', resourceType: 'cron_job', resourceId: 'retention_cleanup', details: { totalDeleted, tables: results } });
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/cron/sweep-expired/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/sweep-expired/__tests__/route.test.ts
@@ -107,7 +107,6 @@ describe('/api/cron/sweep-expired', () => {
       expect(mockAudit).toHaveBeenCalledWith(
         expect.objectContaining({
           eventType: 'data.delete',
-          userId: 'system',
           resourceType: 'cron_job',
           resourceId: 'sweep_expired',
           details: {

--- a/apps/web/src/app/api/cron/sweep-expired/route.ts
+++ b/apps/web/src/app/api/cron/sweep-expired/route.ts
@@ -63,7 +63,6 @@ export async function GET(request: Request) {
 
   audit({
     eventType: 'data.delete',
-    userId: 'system',
     resourceType: 'cron_job',
     resourceId: 'sweep_expired',
     details: results,

--- a/apps/web/src/app/api/cron/verify-audit-chain/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/verify-audit-chain/__tests__/route.test.ts
@@ -173,7 +173,7 @@ describe('/api/cron/verify-audit-chain', () => {
     await GET(makeRequest());
 
     expect(mockAudit).toHaveBeenCalledWith(
-      expect.objectContaining({ eventType: 'data.read', userId: 'system', resourceType: 'cron_job', resourceId: 'verify_audit_chain', details: { isValid: true, entriesVerified: 100 } })
+      expect.objectContaining({ eventType: 'data.read', resourceType: 'cron_job', resourceId: 'verify_audit_chain', details: { isValid: true, entriesVerified: 100 } })
     );
   });
 
@@ -183,7 +183,7 @@ describe('/api/cron/verify-audit-chain', () => {
     await GET(makeRequest());
 
     expect(mockAudit).toHaveBeenCalledWith(
-      expect.objectContaining({ eventType: 'data.read', userId: 'system', resourceType: 'cron_job', resourceId: 'verify_audit_chain', details: { isValid: false, entriesVerified: 100 } })
+      expect.objectContaining({ eventType: 'data.read', resourceType: 'cron_job', resourceId: 'verify_audit_chain', details: { isValid: false, entriesVerified: 100 } })
     );
   });
 

--- a/apps/web/src/app/api/cron/verify-audit-chain/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/verify-audit-chain/__tests__/route.test.ts
@@ -175,6 +175,7 @@ describe('/api/cron/verify-audit-chain', () => {
     expect(mockAudit).toHaveBeenCalledWith(
       expect.objectContaining({ eventType: 'data.read', resourceType: 'cron_job', resourceId: 'verify_audit_chain', details: { isValid: true, entriesVerified: 100 } })
     );
+    expect(mockAudit.mock.calls[0]?.[0]).not.toHaveProperty('userId');
   });
 
   it('logs audit event on failed chain verification', async () => {
@@ -185,6 +186,7 @@ describe('/api/cron/verify-audit-chain', () => {
     expect(mockAudit).toHaveBeenCalledWith(
       expect.objectContaining({ eventType: 'data.read', resourceType: 'cron_job', resourceId: 'verify_audit_chain', details: { isValid: false, entriesVerified: 100 } })
     );
+    expect(mockAudit.mock.calls[0]?.[0]).not.toHaveProperty('userId');
   });
 
   it('does not log audit event when verification throws', async () => {

--- a/apps/web/src/app/api/cron/verify-audit-chain/route.ts
+++ b/apps/web/src/app/api/cron/verify-audit-chain/route.ts
@@ -35,7 +35,7 @@ export async function GET(request: Request) {
       );
     }
 
-    audit({ eventType: 'data.read', userId: 'system', resourceType: 'cron_job', resourceId: 'verify_audit_chain', details: { isValid: result.isValid, entriesVerified: result.entriesVerified } });
+    audit({ eventType: 'data.read', resourceType: 'cron_job', resourceId: 'verify_audit_chain', details: { isValid: result.isValid, entriesVerified: result.entriesVerified } });
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/cron/workflows/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/workflows/__tests__/route.test.ts
@@ -200,7 +200,7 @@ describe('POST /api/cron/workflows', () => {
     await POST(request);
 
     expect(mockAudit).toHaveBeenCalledWith(
-      expect.objectContaining({ eventType: 'data.write', userId: 'system', resourceType: 'cron_job', resourceId: 'workflows', details: { executed: 1, failed: 0 } })
+      expect.objectContaining({ eventType: 'data.write', resourceType: 'cron_job', resourceId: 'workflows', details: { executed: 1, failed: 0 } })
     );
   });
 
@@ -209,7 +209,7 @@ describe('POST /api/cron/workflows', () => {
     await POST(request);
 
     expect(mockAudit).toHaveBeenCalledWith(
-      expect.objectContaining({ eventType: 'data.write', userId: 'system', resourceType: 'cron_job', resourceId: 'workflows', details: { executed: 0, failed: 0 } })
+      expect.objectContaining({ eventType: 'data.write', resourceType: 'cron_job', resourceId: 'workflows', details: { executed: 0, failed: 0 } })
     );
   });
 

--- a/apps/web/src/app/api/cron/workflows/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/workflows/__tests__/route.test.ts
@@ -202,6 +202,7 @@ describe('POST /api/cron/workflows', () => {
     expect(mockAudit).toHaveBeenCalledWith(
       expect.objectContaining({ eventType: 'data.write', resourceType: 'cron_job', resourceId: 'workflows', details: { executed: 1, failed: 0 } })
     );
+    expect(mockAudit).not.toHaveBeenCalledWith(expect.objectContaining({ userId: expect.anything() }));
   });
 
   it('should log audit event with zero executed when no workflows are due', async () => {
@@ -211,6 +212,7 @@ describe('POST /api/cron/workflows', () => {
     expect(mockAudit).toHaveBeenCalledWith(
       expect.objectContaining({ eventType: 'data.write', resourceType: 'cron_job', resourceId: 'workflows', details: { executed: 0, failed: 0 } })
     );
+    expect(mockAudit).not.toHaveBeenCalledWith(expect.objectContaining({ userId: expect.anything() }));
   });
 
   it('should handle thrown exceptions during execution', async () => {

--- a/apps/web/src/app/api/cron/workflows/route.ts
+++ b/apps/web/src/app/api/cron/workflows/route.ts
@@ -59,7 +59,7 @@ export async function POST(req: Request) {
       );
 
     if (dueWorkflows.length === 0) {
-      audit({ eventType: 'data.write', userId: 'system', resourceType: 'cron_job', resourceId: 'workflows', details: { executed: 0, failed: 0 } });
+      audit({ eventType: 'data.write', resourceType: 'cron_job', resourceId: 'workflows', details: { executed: 0, failed: 0 } });
       return NextResponse.json({ message: 'No workflows due', executed: 0 });
     }
 
@@ -192,7 +192,7 @@ export async function POST(req: Request) {
 
     loggers.api.info(`Workflow cron: Complete. Executed ${executed}/${totalClaimed}`);
 
-    audit({ eventType: 'data.write', userId: 'system', resourceType: 'cron_job', resourceId: 'workflows', details: { executed, failed: errors.length } });
+    audit({ eventType: 'data.write', resourceType: 'cron_job', resourceId: 'workflows', details: { executed, failed: errors.length } });
 
     return NextResponse.json({
       message: 'Workflow cron complete',

--- a/apps/web/src/app/api/memory/cron/route.ts
+++ b/apps/web/src/app/api/memory/cron/route.ts
@@ -14,7 +14,7 @@
  *
  * Paying users only: 'pro', 'founder', 'business' subscription tiers
  *
- * Security: HMAC-signed cron requests (via cron-curl) + internal network origin check
+ * Security: HMAC-signed cron requests via cron-curl (X-Cron-Timestamp/Nonce/Signature)
  * Trigger via: cron-curl POST http://web:3000/api/memory/cron
  */
 
@@ -45,7 +45,6 @@ const PAYING_TIERS = ['pro', 'founder', 'business'];
 const DELAY_BETWEEN_USERS_MS = 1000;
 
 export async function POST(request: Request) {
-  // Validate cron secret + internal network origin
   const authError = validateSignedCronRequest(request);
   if (authError) {
     return authError;

--- a/apps/web/src/app/api/pulse/cron/route.ts
+++ b/apps/web/src/app/api/pulse/cron/route.ts
@@ -51,7 +51,6 @@ import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
 import { PULSE_SYSTEM_PROMPT } from '../pulse-prompt';
 
 export async function POST(req: Request) {
-  // Validate cron secret + internal network origin
   const authError = validateSignedCronRequest(req);
   if (authError) {
     return authError;

--- a/docker/cron/entrypoint.sh
+++ b/docker/cron/entrypoint.sh
@@ -28,7 +28,7 @@ if [ -z "$METHOD" ] || [ -z "$URL" ]; then
 fi
 
 # Extract path from URL — pathname only, no query string, matching how Next.js parses url.pathname
-PATH_PART=$(echo "$URL" | sed 's|^https\?://[^/]*||' | sed 's|?.*||')
+PATH_PART=$(echo "$URL" | sed -e 's|^https\?://[^/]*||' -e 's|?.*||')
 
 TIMESTAMP=$(date +%s)
 NONCE=$(cat /proc/sys/kernel/random/uuid 2>/dev/null || head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')

--- a/docker/cron/entrypoint.sh
+++ b/docker/cron/entrypoint.sh
@@ -6,7 +6,7 @@
 # so we bake the CRON_SECRET into a signing helper at startup.
 
 if [ -z "$CRON_SECRET" ]; then
-  echo "[cron] WARNING: CRON_SECRET is not set. Cron requests will rely on network-only auth."
+  echo "[cron] WARNING: CRON_SECRET is not set. Cron requests will be sent without HMAC signatures and will be rejected by the server in all non-dev environments."
 fi
 
 # Create the HMAC-signed curl helper used by crontab entries
@@ -27,8 +27,8 @@ if [ -z "$METHOD" ] || [ -z "$URL" ]; then
   exit 1
 fi
 
-# Extract path from URL (everything after host:port)
-PATH_PART=$(echo "$URL" | sed 's|^https\?://[^/]*||')
+# Extract path from URL — pathname only, no query string, matching how Next.js parses url.pathname
+PATH_PART=$(echo "$URL" | sed 's|^https\?://[^/]*||' | sed 's|?.*||')
 
 TIMESTAMP=$(date +%s)
 NONCE=$(cat /proc/sys/kernel/random/uuid 2>/dev/null || head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')

--- a/packages/lib/src/audit/__tests__/security-audit.test.ts
+++ b/packages/lib/src/audit/__tests__/security-audit.test.ts
@@ -214,35 +214,20 @@ describe('Security Audit Service', () => {
   });
 
   describe('initialize', () => {
-    it('initializes with genesis hash when no previous events exist', async () => {
-      vi.mocked(db.query.securityAuditLog.findFirst).mockResolvedValue(undefined);
-
+    it('marks service as initialized without a DB query', async () => {
       await service.initialize();
 
-      expect(db.query.securityAuditLog.findFirst).toHaveBeenCalled();
+      expect(service.isInitialized()).toBe(true);
+      expect(db.query.securityAuditLog.findFirst).not.toHaveBeenCalled();
     });
 
-    it('initializes with last event hash when events exist', async () => {
-      const lastEvent = {
-        id: 'evt123',
-        eventHash: 'abc123def456',
-        timestamp: new Date(),
-      };
-      vi.mocked(db.query.securityAuditLog.findFirst).mockResolvedValue(lastEvent as never);
-
-      await service.initialize();
-
-      expect(db.query.securityAuditLog.findFirst).toHaveBeenCalled();
-    });
-
-    it('only initializes once (idempotent)', async () => {
-      vi.mocked(db.query.securityAuditLog.findFirst).mockResolvedValue(undefined);
-
+    it('is idempotent when called multiple times', async () => {
       await service.initialize();
       await service.initialize();
       await service.initialize();
 
-      expect(db.query.securityAuditLog.findFirst).toHaveBeenCalledTimes(1);
+      expect(service.isInitialized()).toBe(true);
+      expect(db.query.securityAuditLog.findFirst).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/lib/src/audit/__tests__/security-audit.test.ts
+++ b/packages/lib/src/audit/__tests__/security-audit.test.ts
@@ -34,9 +34,7 @@ vi.mock('@pagespace/db', () => {
   return {
     db: {
       query: {
-        securityAuditLog: {
-          findFirst: vi.fn(),
-        },
+        securityAuditLog: {},
       },
       insert: vi.fn().mockReturnValue({
         values: vi.fn().mockReturnValue({
@@ -214,11 +212,10 @@ describe('Security Audit Service', () => {
   });
 
   describe('initialize', () => {
-    it('marks service as initialized without a DB query', async () => {
+    it('marks service as initialized', async () => {
       await service.initialize();
 
       expect(service.isInitialized()).toBe(true);
-      expect(db.query.securityAuditLog.findFirst).not.toHaveBeenCalled();
     });
 
     it('is idempotent when called multiple times', async () => {
@@ -227,13 +224,11 @@ describe('Security Audit Service', () => {
       await service.initialize();
 
       expect(service.isInitialized()).toBe(true);
-      expect(db.query.securityAuditLog.findFirst).not.toHaveBeenCalled();
     });
   });
 
   describe('logEvent', () => {
     beforeEach(async () => {
-      vi.mocked(db.query.securityAuditLog.findFirst).mockResolvedValue(undefined);
       await service.initialize();
     });
 
@@ -316,7 +311,6 @@ describe('Security Audit Service', () => {
 
   describe('convenience methods', () => {
     beforeEach(async () => {
-      vi.mocked(db.query.securityAuditLog.findFirst).mockResolvedValue(undefined);
       await service.initialize();
     });
 

--- a/packages/lib/src/audit/security-audit.ts
+++ b/packages/lib/src/audit/security-audit.ts
@@ -16,7 +16,7 @@
  */
 
 import { createHash } from 'crypto';
-import { db, securityAuditLog, desc, sql } from '@pagespace/db';
+import { db, securityAuditLog, sql } from '@pagespace/db';
 import type { SecurityEventType, SelectSecurityAuditLog } from '@pagespace/db';
 import { queryAuditEvents } from './audit-query';
 import { stableStringify } from '../utils/stable-stringify';
@@ -105,10 +105,8 @@ export class SecurityAuditService {
   private initializePromise: Promise<void> | null = null;
 
   /**
-   * Initialize the service by loading the last hash from the database.
-   * Call this during service startup, not lazily.
-   *
-   * This method is idempotent - calling it multiple times is safe.
+   * Mark the service as initialized. Call during app startup before logEvent().
+   * Idempotent — safe to call multiple times.
    */
   async initialize(): Promise<void> {
     if (this.initialized) return;
@@ -123,18 +121,7 @@ export class SecurityAuditService {
   }
 
   private async _doInitialize(): Promise<void> {
-    try {
-      const lastEvent = await db.query.securityAuditLog.findFirst({
-        orderBy: [desc(securityAuditLog.chainSeq)],
-        columns: { eventHash: true },
-      });
-
-      this.initialized = true;
-    } catch (error) {
-      // Reset promise so initialization can be retried
-      this.initializePromise = null;
-      throw error;
-    }
+    this.initialized = true;
   }
 
   /**

--- a/packages/lib/src/audit/security-audit.ts
+++ b/packages/lib/src/audit/security-audit.ts
@@ -96,11 +96,11 @@ export function computeSecurityEventHash(
 /**
  * Security Audit Service with hash chain integrity.
  *
- * Maintains an in-memory reference to the last hash for building the chain.
- * Must be initialized before use by calling initialize().
+ * Must be initialized before first use by calling initialize().
+ * Each logEvent() reads the previous hash from the DB inside an advisory lock,
+ * so multi-instance deployments are safe without any in-memory state.
  */
 export class SecurityAuditService {
-  private lastHash: string = 'genesis';
   private initialized = false;
   private initializePromise: Promise<void> | null = null;
 
@@ -129,7 +129,6 @@ export class SecurityAuditService {
         columns: { eventHash: true },
       });
 
-      this.lastHash = lastEvent?.eventHash ?? 'genesis';
       this.initialized = true;
     } catch (error) {
       // Reset promise so initialization can be retried

--- a/packages/lib/src/audit/security-audit.ts
+++ b/packages/lib/src/audit/security-audit.ts
@@ -102,25 +102,13 @@ export function computeSecurityEventHash(
  */
 export class SecurityAuditService {
   private initialized = false;
-  private initializePromise: Promise<void> | null = null;
 
   /**
-   * Mark the service as initialized. Call during app startup before logEvent().
-   * Idempotent — safe to call multiple times.
+   * Mark the service as initialized. Retained for callers that invoke it at
+   * app startup; logEvent() also self-initializes. Idempotent.
    */
+  // eslint-disable-next-line @typescript-eslint/require-await
   async initialize(): Promise<void> {
-    if (this.initialized) return;
-
-    // Prevent concurrent initialization
-    if (this.initializePromise) {
-      return this.initializePromise;
-    }
-
-    this.initializePromise = this._doInitialize();
-    await this.initializePromise;
-  }
-
-  private async _doInitialize(): Promise<void> {
     this.initialized = true;
   }
 


### PR DESCRIPTION
## Summary

- All 10 cron jobs were passing \`userId: 'system'\` to \`audit()\`, causing PostgreSQL FK violation 23503 on every cron execution
- \`security_audit_log.user_id\` is a nullable FK to \`users.id\` — any non-NULL value must exist in the \`users\` table, but no \`'system'\` user exists
- Fix: remove \`userId: 'system'\` from all 12 audit call sites so system-actor events write \`NULL\`, which the schema already supports via \`onDelete: 'set null'\`
- Updated all matching test assertions to reflect the corrected behavior

Additional fixes discovered and addressed on this branch:

- **HMAC signature mismatch**: \`cron-curl\` was including the query string in the signed path, but \`validateSignedCronRequest\` validates against \`url.pathname\` (query-stripped). Fixed: strip query string before computing path for HMAC signature
- **Dead in-memory state**: \`SecurityAuditService.lastHash\` was an in-memory field from before \`pg_advisory_xact_lock\` was added. It was a latent multi-instance bug (each pod restart would fork the chain from \`'genesis'\`). Removed — the advisory lock already reads the previous hash from DB inside the transaction
- **Dead DB query**: After removing \`lastHash\`, the \`findFirst\` call in \`_doInitialize()\` had no consumer. Removed the round-trip; \`logEvent()\` surfaces DB errors on first write
- **Test alignment**: Updated 3 \`initialize()\` tests that were asserting on the now-removed \`findFirst\` implementation detail

## Test plan

- [ ] Deploy and watch logs — \`[Audit] audit write failed\` errors should stop within 2 minutes (calendar-triggers runs every 2 min)
- [ ] Verify in DB: \`SELECT user_id, COUNT(*) FROM security_audit_log WHERE resource_type = 'cron_job' GROUP BY user_id\` should show \`null\` rows, not \`'system'\`
- [ ] All cron route unit tests pass
- [ ] \`security-audit.test.ts\` passes (initialize tests updated to reflect no-DB-on-init behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)