### PR TITLE
fix(socket): leave drive room on drive switch

### DIFF
--- a/apps/web/src/hooks/useActivitySocket.ts
+++ b/apps/web/src/hooks/useActivitySocket.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useCallback } from 'react';
 import { useSocket } from './useSocket';
+import type { ActivityEventPayload } from '@/lib/websocket/socket-utils';
 
 export type ActivityContext = 'drive' | 'page';
 
@@ -60,8 +61,10 @@ export function useActivitySocket({
       currentContextRef.current = contextKey;
     }
 
-    // Listen for activity events
-    const handleActivityLogged = () => {
+    // Listen for activity events — validate payload context before refetching
+    const handleActivityLogged = (payload: ActivityEventPayload) => {
+      if (context === 'drive' && payload.driveId !== contextId) return;
+      if (context === 'page' && payload.pageId !== contextId) return;
       debouncedRefetch();
     };
 

--- a/apps/web/src/hooks/usePageTreeSocket.ts
+++ b/apps/web/src/hooks/usePageTreeSocket.ts
@@ -24,6 +24,8 @@ export function usePageTreeSocket(driveId?: string, trashView?: boolean) {
 
   // Track the current drive to avoid unnecessary revalidations
   const currentDriveRef = useRef<string | undefined>(driveId);
+  // Track which drive room the socket has joined so we can leave it on drive switch
+  const joinedDriveIdRef = useRef<string | null>(null);
   // Track page IDs present in the current tree snapshot for safe granular updates.
   // If an incoming event targets a missing page, we must fall back to full revalidation.
   const treePageIdsRef = useRef<Set<string>>(new Set());
@@ -138,8 +140,20 @@ export function usePageTreeSocket(driveId?: string, trashView?: boolean) {
 
     console.log('🌳 usePageTreeSocket: Setting up listeners for drive:', driveId);
 
-    // Join the drive room to receive page events (using drive ID)
-    socket.emit('join_drive', driveId);
+    const joinDrive = () => {
+      if (!socket.connected) return;
+      if (joinedDriveIdRef.current && joinedDriveIdRef.current !== driveId) {
+        socket.emit('leave_drive', joinedDriveIdRef.current);
+        joinedDriveIdRef.current = null;
+      }
+      if (joinedDriveIdRef.current !== driveId) {
+        socket.emit('join_drive', driveId);
+        joinedDriveIdRef.current = driveId;
+      }
+    };
+
+    joinDrive();
+    socket.on('connect', joinDrive);
 
     // Listen for page events
     const events = ['page:created', 'page:updated', 'page:moved', 'page:trashed', 'page:restored', 'page:content-updated'];
@@ -159,10 +173,13 @@ export function usePageTreeSocket(driveId?: string, trashView?: boolean) {
     return () => {
       console.log('🌳 usePageTreeSocket: Cleaning up listeners for drive:', driveId);
 
+      socket.off('connect', joinDrive);
+
       // Note: We don't leave the drive on unmount because:
       // 1. Other hooks (useCalendarSocket, usePageContentSocket) may share the drive room
       // 2. Server cleans up room membership on disconnect
       // 3. Leaving prematurely could cause missed events for other components
+      // Drive switches are handled above via joinedDriveIdRef.
 
       // Remove all event listeners
       events.forEach(event => {

--- a/apps/web/src/hooks/usePageTreeSocket.ts
+++ b/apps/web/src/hooks/usePageTreeSocket.ts
@@ -166,7 +166,11 @@ export function usePageTreeSocket(driveId?: string, trashView?: boolean) {
     socket.on('presence:page_viewers', handlePresenceUpdate);
 
     // Clear stale presence data on socket disconnect (server won't deliver updates)
-    const handleDisconnect = () => { clearAllPresence(); };
+    // Also reset joinedDriveIdRef so the reconnect path re-emits join_drive.
+    const handleDisconnect = () => {
+      clearAllPresence();
+      joinedDriveIdRef.current = null;
+    };
     socket.on('disconnect', handleDisconnect);
 
     // Cleanup function


### PR DESCRIPTION
## Summary

- `usePageTreeSocket` now emits `leave_drive` for the previous drive before joining a new one, matching the pattern already used by `useCalendarSocket` and `usePageContentSocket`. Without this, the socket accumulated subscriptions to every drive visited in a session.
- Adds a `'connect'` listener in `usePageTreeSocket` so the hook rejoins the correct drive room after a socket reconnect. Resets `joinedDriveIdRef` in the `'disconnect'` handler so the reconnect path always re-emits `join_drive` — without this, the ref still held the previous driveId after reconnect, so `joinDrive()` saw it as already joined and silently skipped re-subscribing.
- `useActivitySocket` now validates the `driveId`/`pageId` in the server-supplied `ActivityEventPayload` before calling `loadActivities()`, preventing stale room subscriptions from triggering spurious refetches for the wrong drive.

## Test plan

- [ ] Navigate between two or more drives — `leave_drive` visible in devtools WS for each previous drive before `join_drive` for the next
- [ ] Simulate a transient disconnect (disable/re-enable network) — page tree events resume without a drive change or reload
- [ ] Activity in a previously-visited drive does not trigger a refetch in the current drive view
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test:unit` passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)