### PR TITLE
fix(cron): drop userId 'system' from audit calls

### DIFF
--- a/apps/web/src/app/api/cron/purge-ai-usage-logs/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/purge-ai-usage-logs/__tests__/route.test.ts
@@ -49,7 +49,7 @@ describe('/api/cron/purge-ai-usage-logs', () => {
     await GET(makeRequest());
 
     expect(mockAudit).toHaveBeenCalledWith(
-      expect.objectContaining({ eventType: 'data.delete', userId: 'system', resourceType: 'cron_job', resourceId: 'purge_ai_usage', details: { purged: 3 } })
+      expect.objectContaining({ eventType: 'data.delete', resourceType: 'cron_job', resourceId: 'purge_ai_usage', details: { purged: 3 } })
     );
   });
 

--- a/apps/web/src/app/api/cron/purge-ai-usage-logs/route.ts
+++ b/apps/web/src/app/api/cron/purge-ai-usage-logs/route.ts
@@ -24,7 +24,7 @@ export async function GET(request: Request) {
 
     console.log(`[Cron] AI usage logs: purged ${purged}`);
 
-    audit({ eventType: 'data.delete', userId: 'system', resourceType: 'cron_job', resourceId: 'purge_ai_usage', details: { purged } });
+    audit({ eventType: 'data.delete', resourceType: 'cron_job', resourceId: 'purge_ai_usage', details: { purged } });
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/cron/purge-trashed-pages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/purge-trashed-pages/__tests__/route.test.ts
@@ -106,7 +106,6 @@ describe('/api/cron/purge-trashed-pages', () => {
     expect(mockAudit).toHaveBeenCalledWith(
       expect.objectContaining({
         eventType: 'data.delete',
-        userId: 'system',
         resourceType: 'cron_job',
         resourceId: 'purge_trashed_pages',
         details: { pagesPurged: 3 },

--- a/apps/web/src/app/api/cron/purge-trashed-pages/route.ts
+++ b/apps/web/src/app/api/cron/purge-trashed-pages/route.ts
@@ -26,7 +26,6 @@ export async function GET(request: Request) {
 
     audit({
       eventType: 'data.delete',
-      userId: 'system',
       resourceType: 'cron_job',
       resourceId: 'purge_trashed_pages',
       details: { pagesPurged },


### PR DESCRIPTION
## Summary

- `purge-ai-usage-logs`: regressed in df3bdfae (GDPR Art. 5 rewrite started from an older copy of the file, re-introducing `userId: 'system'` that #1097 had already removed)
- `purge-trashed-pages`: was missed by #1097 entirely — never patched

Both caused FK violations on `security_audit_log` on every cron execution since `'system'` is not a valid row in the `users` table.

Fix: drop `userId` from both `audit()` calls. The field is optional in `AuditEvent` — omitting it is the established pattern across all other cron routes (see `cleanup-tokens`, `sweep-expired`, etc.).

Tests updated to match.

## Test plan

- [x] `grep -rn "userId.*system" apps/web/src/app/api/cron/` returns 0 results
- [x] Unit tests for both routes updated and passing
- [ ] Deploy and confirm FK warnings stop in runtime logs for both cron jobs

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined audit logging for automated data purge operations. System maintenance tasks now generate more accurate audit event records by eliminating unnecessary hardcoded identifiers, providing cleaner and more reliable audit trails. This improvement benefits troubleshooting and compliance review of both AI usage log purge and trashed pages cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->