### PR TITLE
fix(calendar): remove stale selectedCalendars entry on Google 404

### DIFF
--- a/apps/web/src/lib/integrations/google-calendar/__tests__/sync-service.test.ts
+++ b/apps/web/src/lib/integrations/google-calendar/__tests__/sync-service.test.ts
@@ -373,6 +373,65 @@ describe('parseSyncCursors (tested via syncGoogleCalendar)', () => {
 });
 
 describe('syncGoogleCalendar error handling', () => {
+  it('should remove stale calendar from selectedCalendars when Google returns 404', async () => {
+    mockGetValidAccessToken.mockResolvedValue({
+      success: true,
+      accessToken: 'valid-token',
+    });
+    mockFindFirst.mockResolvedValue({
+      status: 'active',
+      selectedCalendars: ['stale@group.calendar.google.com', 'user@gmail.com'],
+      syncCursor: null,
+      targetDriveId: null,
+      markAsReadOnly: false,
+      webhookChannels: null,
+      googleEmail: 'user@gmail.com',
+    });
+
+    // First calendar returns 404, second succeeds
+    mockListEvents
+      .mockResolvedValueOnce({
+        success: false,
+        error: 'Not Found',
+        statusCode: 404,
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        data: { events: [], nextSyncToken: 'token-1' },
+      });
+    mockWatchCalendar.mockResolvedValue({ success: false, error: 'skip' });
+
+    const { syncGoogleCalendar } = await import('../sync-service');
+    const result = await syncGoogleCalendar('user-1');
+
+    assert({
+      given: 'one calendar returns 404',
+      should: 'succeed overall',
+      actual: result.success,
+      expected: true,
+    });
+
+    // 404 warning log must be retained
+    const { loggers } = await import('@pagespace/lib/server');
+    assert({
+      given: 'a 404 from Google Calendar API',
+      should: 'log a warning for the not-found calendar',
+      actual: (loggers.api.warn as ReturnType<typeof vi.fn>).mock.calls.some(
+        (call: unknown[]) => typeof call[0] === 'string' && (call[0] as string).includes('not found')
+      ),
+      expected: true,
+    });
+
+    // The stale calendar should be removed from selectedCalendars in the DB update
+    const setArgs = mockUpdate.mock.results[0]?.value?.set?.mock?.calls?.[0]?.[0] as Record<string, unknown> | undefined;
+    assert({
+      given: 'a 404 for one calendar with another valid calendar remaining',
+      should: 'persist selectedCalendars without the stale entry',
+      actual: setArgs?.selectedCalendars,
+      expected: ['user@gmail.com'],
+    });
+  });
+
   it('should handle token expiration (410) with sync token fallback', async () => {
     mockGetValidAccessToken.mockResolvedValue({
       success: true,

--- a/apps/web/src/lib/integrations/google-calendar/sync-service.ts
+++ b/apps/web/src/lib/integrations/google-calendar/sync-service.ts
@@ -139,6 +139,7 @@ export const syncGoogleCalendar = async (
     const syncCursors = parseSyncCursors(connection.syncCursor);
 
     // Sync each selected calendar
+    const staleCalendarIds = new Set<string>();
     for (const calendarId of calendarsToSync) {
       // Use per-calendar sync token for incremental sync if available and not forcing full sync
       const calendarSyncToken = !options.fullSync ? syncCursors[calendarId] : undefined;
@@ -158,6 +159,10 @@ export const syncGoogleCalendar = async (
         timeMax
       );
 
+      if (calendarResult.calendarNotFound) {
+        staleCalendarIds.add(calendarId);
+      }
+
       result.eventsCreated += calendarResult.eventsCreated;
       result.eventsUpdated += calendarResult.eventsUpdated;
       result.eventsDeleted += calendarResult.eventsDeleted;
@@ -168,6 +173,14 @@ export const syncGoogleCalendar = async (
       }
     }
 
+    // Remove stale (404) calendars from selectedCalendars so they are not re-synced
+    const updatedSelectedCalendars = staleCalendarIds.size > 0
+      ? rawCalendars.filter(rawId => {
+          const resolvedId = rawId === 'primary' ? (connection.googleEmail || 'primary') : rawId;
+          return !staleCalendarIds.has(resolvedId);
+        })
+      : rawCalendars;
+
     // Persist all updated sync cursors and update last sync time
     await db
       .update(googleCalendarConnections)
@@ -176,6 +189,7 @@ export const syncGoogleCalendar = async (
         lastSyncAt: new Date(),
         lastSyncError: null,
         updatedAt: new Date(),
+        ...(staleCalendarIds.size > 0 ? { selectedCalendars: updatedSelectedCalendars } : {}),
       })
       .where(eq(googleCalendarConnections.userId, userId));
 
@@ -334,6 +348,7 @@ const syncCalendar = async (
   eventsUpdated: number;
   eventsDeleted: number;
   syncCursor?: string;
+  calendarNotFound?: boolean;
 }> => {
   const result = {
     eventsCreated: 0,
@@ -365,13 +380,13 @@ const syncCalendar = async (
       );
     }
 
-    // Calendar not found — skip gracefully instead of failing the entire sync
+    // Calendar not found — signal the caller to remove this stale entry
     if (listResult.statusCode === 404) {
       loggers.api.warn('Calendar not found, skipping', {
         userId,
         calendarId: maskIdentifier(storageCalendarId),
       });
-      return result;
+      return { ...result, calendarNotFound: true };
     }
 
     // Propagate permission/auth errors so the caller can update connection status


### PR DESCRIPTION
## Summary

- When `syncCalendar()` receives a 404 from the Google Calendar API, `syncCalendar` now returns `calendarNotFound: true` (existing warn log retained)
- `syncGoogleCalendar` collects all 404'd calendar IDs and filters them out of `selectedCalendars` in the final DB update, so the next cron cycle skips them entirely
- The fix is in-loop: no extra DB round-trip, just a conditional spread into the existing `db.update().set()` call

## Test plan

- [x] New test: `syncGoogleCalendar error handling > should remove stale calendar from selectedCalendars when Google returns 404` — verifies success, warn log retained, and stale calendar removed from `selectedCalendars` in the DB update
- [x] All 9 existing sync-service tests still pass
- [x] Non-404 errors (410, reauth, unknown) are unchanged — verified by existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)