### PR TITLE
fix(cron): remove non-existent anonymizeAiUsageContent import

### DIFF
--- a/apps/web/src/app/api/cron/purge-ai-usage-logs/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/purge-ai-usage-logs/__tests__/route.test.ts
@@ -4,10 +4,9 @@
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-const { mockPurge, mockAudit, mockAnonymize } = vi.hoisted(() => ({
+const { mockPurge, mockAudit } = vi.hoisted(() => ({
   mockPurge: vi.fn(),
   mockAudit: vi.fn(),
-  mockAnonymize: vi.fn(),
 }));
 
 vi.mock('@/lib/auth/cron-auth', () => ({
@@ -15,7 +14,6 @@ vi.mock('@/lib/auth/cron-auth', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/ai-usage-purge', () => ({
-  anonymizeAiUsageContent: mockAnonymize,
   purgeAiUsageLogs: mockPurge,
 }));
 

--- a/apps/web/src/app/api/cron/purge-ai-usage-logs/route.ts
+++ b/apps/web/src/app/api/cron/purge-ai-usage-logs/route.ts
@@ -1,4 +1,4 @@
-import { anonymizeAiUsageContent, purgeAiUsageLogs } from '@pagespace/lib/logging/ai-usage-purge';
+import { purgeAiUsageLogs } from '@pagespace/lib/logging/ai-usage-purge';
 import { audit } from '@pagespace/lib/audit/audit-log';
 import { NextResponse } from 'next/server';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';


### PR DESCRIPTION
## Summary

- Removes `anonymizeAiUsageContent` import from `purge-ai-usage-logs/route.ts` — this function does not exist in `@pagespace/lib/logging/ai-usage-purge` (which only exports `purgeAiUsageLogs` and `deleteAiUsageLogsForUser`)
- Removes the dead `mockAnonymize` from the corresponding test's `vi.hoisted` block and mock
- The import was introduced during rebase conflict resolution in the barrel-import refactor series (#1088–#1093)

## Root cause

During the rebase of `barrel/web-admin` onto master, a conflict in `purge-ai-usage-logs/route.ts` was resolved by taking the incoming (PR E2) version which included `anonymizeAiUsageContent` — a function that was apparently referenced in the PR branch but never actually existed in the lib source. The route itself never calls the function.

## Impact

Without this fix: TypeScript compilation fails on `purge-ai-usage-logs/route.ts`.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)