### PR TITLE
fix(imports): eliminate all remaining barrel imports and fix CI lint

### DIFF
--- a/apps/control-plane/vitest.config.ts
+++ b/apps/control-plane/vitest.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
-      '@pagespace/lib/validators': path.resolve(__dirname, '../../packages/lib/src/validators/index.ts'),
+      '@pagespace/lib/validators': path.resolve(__dirname, '../../packages/lib/src/validators'),
       '@pagespace/lib': path.resolve(__dirname, '../../packages/lib/src'),
     },
   },

--- a/apps/control-plane/vitest.config.ts
+++ b/apps/control-plane/vitest.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './src'),
       '@pagespace/lib/validators': path.resolve(__dirname, '../../packages/lib/src/validators/index.ts'),
-      '@pagespace/lib': path.resolve(__dirname, '../../packages/lib/src/index.ts'),
+      '@pagespace/lib': path.resolve(__dirname, '../../packages/lib/src'),
     },
   },
 })

--- a/apps/realtime/vitest.config.ts
+++ b/apps/realtime/vitest.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
       // Map monorepo packages to their source files for testing without building
       '@pagespace/db': path.resolve(__dirname, '../../packages/db/src/index.ts'),
-      '@pagespace/lib': path.resolve(__dirname, '../../packages/lib/src/index.ts'),
+      '@pagespace/lib': path.resolve(__dirname, '../../packages/lib/src'),
     },
   },
 })

--- a/apps/web/src/app/api/account/__tests__/delete-route.test.ts
+++ b/apps/web/src/app/api/account/__tests__/delete-route.test.ts
@@ -13,7 +13,7 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   },
 }));
 
-vi.mock('@pagespace/lib/repositories', () => ({
+vi.mock('@pagespace/lib/repositories/account-repository', () => ({
   accountRepository: {
     findById: vi.fn(),
     getOwnedDrives: vi.fn(),
@@ -21,6 +21,8 @@ vi.mock('@pagespace/lib/repositories', () => ({
     deleteDrive: vi.fn(),
     deleteUser: vi.fn(),
   },
+}));
+vi.mock('@pagespace/lib/repositories/activity-log-repository', () => ({
   activityLogRepository: {
     anonymizeForUser: vi.fn(),
   },

--- a/apps/web/src/app/api/account/__tests__/delete-route.test.ts
+++ b/apps/web/src/app/api/account/__tests__/delete-route.test.ts
@@ -71,7 +71,8 @@ vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
 
 import { DELETE } from '../route';
 import { loggers } from '@pagespace/lib/logging/logger-config'
-import { accountRepository, activityLogRepository } from '@pagespace/lib/repositories';
+import { accountRepository } from '@pagespace/lib/repositories/account-repository';
+import { activityLogRepository } from '@pagespace/lib/repositories/activity-log-repository';
 import { revokeUserIntegrationTokens } from '@pagespace/lib/compliance/erasure/revoke-integration-tokens';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { createUserServiceToken } from '@pagespace/lib/services/validated-service-token'

--- a/apps/web/src/app/api/account/__tests__/get-patch-route.test.ts
+++ b/apps/web/src/app/api/account/__tests__/get-patch-route.test.ts
@@ -28,7 +28,7 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
 
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
-vi.mock('@pagespace/lib/repositories', () => ({
+vi.mock('@pagespace/lib/repositories/account-repository', () => ({
   accountRepository: {
     findById: vi.fn(),
     getOwnedDrives: vi.fn(),
@@ -36,6 +36,8 @@ vi.mock('@pagespace/lib/repositories', () => ({
     deleteDrive: vi.fn(),
     deleteUser: vi.fn(),
   },
+}));
+vi.mock('@pagespace/lib/repositories/activity-log-repository', () => ({
   activityLogRepository: {
     anonymizeForUser: vi.fn(),
   },

--- a/apps/web/src/app/api/account/route.ts
+++ b/apps/web/src/app/api/account/route.ts
@@ -1,7 +1,8 @@
 import { users, db, eq } from '@pagespace/db';
 import { z } from 'zod';
 import { loggers } from '@pagespace/lib/logging/logger-config';
-import { accountRepository, activityLogRepository } from '@pagespace/lib/repositories';
+import { accountRepository } from '@pagespace/lib/repositories/account-repository';
+import { activityLogRepository } from '@pagespace/lib/repositories/activity-log-repository';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { revokeUserIntegrationTokens } from '@pagespace/lib/compliance/erasure/revoke-integration-tokens';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';

--- a/apps/web/src/app/api/admin/users/[userId]/data/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/data/__tests__/route.test.ts
@@ -67,6 +67,7 @@ vi.mock('@pagespace/lib/logging/monitoring-purge', () => ({
 
 vi.mock('@pagespace/lib/deployment-mode', () => ({
   isCloud: vi.fn().mockReturnValue(false),
+  isOnPrem: vi.fn().mockReturnValue(false),
 }));
 
 vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({

--- a/apps/web/src/app/api/admin/users/[userId]/data/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/data/__tests__/route.test.ts
@@ -76,7 +76,8 @@ import { DELETE } from '../route';
 import { authenticateSessionRequest } from '@/lib/auth/index';
 import { validateAdminAccess } from '@/lib/auth/admin-role';
 import { validateCSRF } from '@/lib/auth/csrf-validation';
-import { accountRepository, activityLogRepository } from '@pagespace/lib/repositories'
+import { accountRepository } from '@pagespace/lib/repositories/account-repository';
+import { activityLogRepository } from '@pagespace/lib/repositories/activity-log-repository'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { revokeUserIntegrationTokens } from '@pagespace/lib/compliance/erasure/revoke-integration-tokens';
 import { logUserActivity } from '@pagespace/lib/monitoring/activity-logger';

--- a/apps/web/src/app/api/admin/users/[userId]/data/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/data/__tests__/route.test.ts
@@ -33,7 +33,7 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   },
 }));
 
-vi.mock('@pagespace/lib/repositories', () => ({
+vi.mock('@pagespace/lib/repositories/account-repository', () => ({
   accountRepository: {
     findById: vi.fn(),
     getOwnedDrives: vi.fn().mockResolvedValue([]),
@@ -42,6 +42,8 @@ vi.mock('@pagespace/lib/repositories', () => ({
     deleteUser: vi.fn(),
     checkAndDeleteSoloDrives: vi.fn().mockResolvedValue({ multiMemberDriveNames: [] }),
   },
+}));
+vi.mock('@pagespace/lib/repositories/activity-log-repository', () => ({
   activityLogRepository: {
     anonymizeForUser: vi.fn().mockResolvedValue({ success: true, count: 0 }),
   },

--- a/apps/web/src/app/api/admin/users/[userId]/data/route.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/data/route.ts
@@ -1,7 +1,8 @@
 import { withAdminAuth } from '@/lib/auth/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
-import { accountRepository, activityLogRepository } from '@pagespace/lib/repositories';
+import { accountRepository } from '@pagespace/lib/repositories/account-repository';
+import { activityLogRepository } from '@pagespace/lib/repositories/activity-log-repository';
 import { revokeUserIntegrationTokens } from '@pagespace/lib/compliance/erasure/revoke-integration-tokens';
 import { deleteAiUsageLogsForUser } from '@pagespace/lib/logging/ai-usage-purge';
 import { deleteMonitoringDataForUser } from '@pagespace/lib/logging/monitoring-purge';

--- a/apps/web/src/app/api/admin/users/[userId]/gift-subscription/__tests__/route.security.test.ts
+++ b/apps/web/src/app/api/admin/users/[userId]/gift-subscription/__tests__/route.security.test.ts
@@ -85,7 +85,9 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
         error: vi.fn(),
       },
       security: {
+        info: vi.fn(),
         warn: vi.fn(),
+        error: vi.fn(),
       },
     },
   logSecurityEvent: vi.fn(),

--- a/apps/web/src/app/api/auth/socket-token/route.ts
+++ b/apps/web/src/app/api/auth/socket-token/route.ts
@@ -1,7 +1,7 @@
 import { requireAuth, isAuthError } from '@/lib/auth/auth-helpers';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { sessionRepository } from '@/lib/repositories/session-repository';
-import { hashToken } from '@pagespace/lib/auth';
+import { hashToken } from '@pagespace/lib/auth/token-utils';
 import { randomBytes } from 'crypto';
 
 /**

--- a/apps/web/src/app/api/cron/purge-ai-usage-logs/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/purge-ai-usage-logs/__tests__/route.test.ts
@@ -4,10 +4,9 @@
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-const { mockPurge, mockAudit, mockAnonymize } = vi.hoisted(() => ({
+const { mockPurge, mockAudit } = vi.hoisted(() => ({
   mockPurge: vi.fn(),
   mockAudit: vi.fn(),
-  mockAnonymize: vi.fn(),
 }));
 
 vi.mock('@/lib/auth/cron-auth', () => ({
@@ -15,7 +14,6 @@ vi.mock('@/lib/auth/cron-auth', () => ({
 }));
 
 vi.mock('@pagespace/lib/logging/ai-usage-purge', () => ({
-  anonymizeAiUsageContent: mockAnonymize,
   purgeAiUsageLogs: mockPurge,
 }));
 

--- a/apps/web/src/app/api/cron/purge-ai-usage-logs/route.ts
+++ b/apps/web/src/app/api/cron/purge-ai-usage-logs/route.ts
@@ -1,4 +1,4 @@
-import { anonymizeAiUsageContent, purgeAiUsageLogs } from '@pagespace/lib/logging/ai-usage-purge';
+import { purgeAiUsageLogs } from '@pagespace/lib/logging/ai-usage-purge';
 import { audit } from '@pagespace/lib/audit/audit-log';
 import { NextResponse } from 'next/server';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';

--- a/apps/web/src/app/api/cron/purge-trashed-pages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/purge-trashed-pages/__tests__/route.test.ts
@@ -9,8 +9,11 @@ vi.mock('@/lib/auth/cron-auth', () => ({
   validateSignedCronRequest: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
   audit: mockAudit,
+}));
+
+vi.mock('@pagespace/lib/repositories/page-repository', () => ({
   pageRepository: mockPageRepo,
 }));
 

--- a/apps/web/src/app/api/cron/purge-trashed-pages/route.ts
+++ b/apps/web/src/app/api/cron/purge-trashed-pages/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
-import { audit, pageRepository } from '@pagespace/lib/server';
+import { audit } from '@pagespace/lib/audit/audit-log';
+import { pageRepository } from '@pagespace/lib/repositories/page-repository';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
 
 /**

--- a/apps/web/src/app/api/integrations/google-calendar/__tests__/deployment-mode-gate.test.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/__tests__/deployment-mode-gate.test.ts
@@ -2,19 +2,31 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 const mockIsOnPrem = vi.hoisted(() => vi.fn(() => false));
 
-vi.mock('@pagespace/lib', () => ({
+vi.mock('@pagespace/lib/deployment-mode', () => ({
   isOnPrem: mockIsOnPrem,
+}));
+
+vi.mock('@pagespace/lib/encryption', () => ({
   encrypt: vi.fn(),
-  secureCompare: vi.fn(),
   decrypt: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/server', () => ({
+vi.mock('@pagespace/lib/auth/secure-compare', () => ({
+  secureCompare: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
   loggers: {
     auth: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
     api: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
   },
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
   auditRequest: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/audit/mask-email', () => ({
   maskEmail: (e: string) => e,
 }));
 

--- a/apps/web/src/app/api/integrations/google-calendar/calendars/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/calendars/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { isOnPrem } from '@pagespace/lib';
+import { isOnPrem } from '@pagespace/lib/deployment-mode';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';

--- a/apps/web/src/app/api/integrations/google-calendar/settings/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/settings/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod/v4';
 import { db, googleCalendarConnections, calendarEvents, eq, and, count } from '@pagespace/db';
-import { isOnPrem } from '@pagespace/lib';
+import { isOnPrem } from '@pagespace/lib/deployment-mode';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';

--- a/apps/web/src/app/api/integrations/google-calendar/status/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/status/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { db, googleCalendarConnections, calendarEvents, eq, and, count } from '@pagespace/db';
-import { isOnPrem } from '@pagespace/lib';
+import { isOnPrem } from '@pagespace/lib/deployment-mode';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';

--- a/apps/web/src/app/api/integrations/google-calendar/sync/route.ts
+++ b/apps/web/src/app/api/integrations/google-calendar/sync/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { isOnPrem } from '@pagespace/lib';
+import { isOnPrem } from '@pagespace/lib/deployment-mode';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';

--- a/apps/web/src/lib/ai/tools/__tests__/agent-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/agent-tools.test.ts
@@ -53,7 +53,7 @@ vi.mock('../../core', () => ({
 
 import { agentTools } from '../agent-tools';
 import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
-import { agentRepository } from '@pagespace/lib/repositories';
+import { agentRepository } from '@pagespace/lib/repositories/agent-repository';
 import { broadcastPageEvent } from '@/lib/websocket';
 import { applyPageMutation } from '@/services/api/page-mutation-service';
 

--- a/apps/web/src/lib/ai/tools/__tests__/agent-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/agent-tools.test.ts
@@ -24,7 +24,7 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   },
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
-vi.mock('@pagespace/lib/repositories', () => ({
+vi.mock('@pagespace/lib/repositories/agent-repository', () => ({
     agentRepository: {
     findById: vi.fn(),
   },

--- a/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
@@ -56,7 +56,7 @@ vi.mock('@pagespace/lib/permissions/permissions', () => ({
     canUserViewPage: vi.fn(),
 }));
 vi.mock('@pagespace/lib/content/page-types.config', () => ({
-    getPageTypeEmoji: vi.fn((type: string) => '📄'),
+    getPageTypeEmoji: vi.fn((_type: string) => '📄'),
     isFolderPage: vi.fn((type: string) => type === 'FOLDER'),
 }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({

--- a/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
@@ -58,6 +58,7 @@ vi.mock('@pagespace/lib/permissions/permissions', () => ({
 vi.mock('@pagespace/lib/content/page-types.config', () => ({
     getPageTypeEmoji: vi.fn((_type: string) => '📄'),
     isFolderPage: vi.fn((type: string) => type === 'FOLDER'),
+    getCreatablePageTypes: vi.fn(() => []),
 }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
     loggers: {

--- a/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
@@ -109,7 +109,8 @@ vi.mock('@/lib/logging/mask', () => ({
 
 import { pageWriteTools } from '../page-write-tools';
 import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
-import { pageRepository, driveRepository } from '@pagespace/lib/repositories';
+import { pageRepository } from '@pagespace/lib/repositories/page-repository';
+import { driveRepository } from '@pagespace/lib/repositories/drive-repository';
 import { applyPageMutation } from '@/services/api/page-mutation-service';
 import type { ToolExecutionContext } from '../../core';
 

--- a/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
@@ -70,7 +70,7 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
   },
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
-vi.mock('@pagespace/lib/repositories', () => ({
+vi.mock('@pagespace/lib/repositories/page-repository', () => ({
     pageRepository: {
     findById: vi.fn(),
     findTrashedById: vi.fn(),
@@ -83,6 +83,8 @@ vi.mock('@pagespace/lib/repositories', () => ({
     restore: vi.fn(),
     getChildIds: vi.fn(),
   },
+}));
+vi.mock('@pagespace/lib/repositories/drive-repository', () => ({
     driveRepository: {
     findById: vi.fn(),
     findByIdBasic: vi.fn(),

--- a/apps/web/src/lib/ai/tools/agent-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-tools.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import { loggers } from '@pagespace/lib/logging/logger-config';
-import { agentRepository } from '@pagespace/lib/repositories';
+import { agentRepository } from '@pagespace/lib/repositories/agent-repository';
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { maskIdentifier } from '@/lib/logging/mask';
 import { type ToolExecutionContext, pageSpaceTools } from '../core';

--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -9,7 +9,8 @@ import { logPageActivity, logDriveActivity, getActorInfo, type ActivityOperation
 import { detectPageContentFormat } from '@pagespace/lib/content/page-content-format';
 import { hashWithPrefix } from '@pagespace/lib/utils/hash-utils';
 import { computePageStateHash, createPageVersion } from '@pagespace/lib/services/page-version-service';
-import { pageRepository, driveRepository } from '@pagespace/lib/repositories';
+import { pageRepository } from '@pagespace/lib/repositories/page-repository';
+import { driveRepository } from '@pagespace/lib/repositories/drive-repository';
 import { createChangeGroupId } from '@pagespace/lib/monitoring/change-group';
 import { applyPageMutation, type PageMutationContext } from '@/services/api/page-mutation-service';
 import { broadcastPageEvent, createPageEventPayload, broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket';

--- a/apps/web/src/lib/fetch-bridge/__tests__/fetch-bridge.test.ts
+++ b/apps/web/src/lib/fetch-bridge/__tests__/fetch-bridge.test.ts
@@ -20,7 +20,7 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
 const { mockValidateURL } = vi.hoisted(() => ({
   mockValidateURL: vi.fn(),
 }));
-vi.mock('@pagespace/lib/security', () => ({
+vi.mock('@pagespace/lib/security/url-validator', () => ({
     validateLocalProviderURL: mockValidateURL,
 }));
 

--- a/apps/web/src/lib/integrations/google-calendar/__tests__/sync-service.test.ts
+++ b/apps/web/src/lib/integrations/google-calendar/__tests__/sync-service.test.ts
@@ -112,6 +112,7 @@ vi.mock('../event-transform', () => ({
 vi.mock('@paralleldrive/cuid2', () => ({
   createId: vi.fn().mockReturnValue('mock-cuid'),
   init: vi.fn(() => vi.fn(() => 'test-cuid')),
+  isCuid: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock('../webhook-token', () => ({

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -124,6 +124,31 @@
       "import": "./dist/auth/broadcast-auth.js",
       "require": "./dist/auth/broadcast-auth.js"
     },
+    "./repositories/account-repository": {
+      "types": "./dist/repositories/account-repository.d.ts",
+      "import": "./dist/repositories/account-repository.js",
+      "require": "./dist/repositories/account-repository.js"
+    },
+    "./repositories/activity-log-repository": {
+      "types": "./dist/repositories/activity-log-repository.d.ts",
+      "import": "./dist/repositories/activity-log-repository.js",
+      "require": "./dist/repositories/activity-log-repository.js"
+    },
+    "./repositories/agent-repository": {
+      "types": "./dist/repositories/agent-repository.d.ts",
+      "import": "./dist/repositories/agent-repository.js",
+      "require": "./dist/repositories/agent-repository.js"
+    },
+    "./repositories/page-repository": {
+      "types": "./dist/repositories/page-repository.d.ts",
+      "import": "./dist/repositories/page-repository.js",
+      "require": "./dist/repositories/page-repository.js"
+    },
+    "./repositories/drive-repository": {
+      "types": "./dist/repositories/drive-repository.d.ts",
+      "import": "./dist/repositories/drive-repository.js",
+      "require": "./dist/repositories/drive-repository.js"
+    },
     "./services/storage-limits": {
       "types": "./dist/services/storage-limits.d.ts",
       "import": "./dist/services/storage-limits.js",


### PR DESCRIPTION
## Summary

- **CI lint fix**: Renamed `type` → `_type` in `page-read-tools.test.ts` line 59 to satisfy `@typescript-eslint/no-unused-vars`
- **5 new subpath exports** added to `packages/lib/package.json` for `account-repository`, `activity-log-repository`, `agent-repository`, `page-repository`, and `drive-repository`
- **14 source files migrated** off barrel imports (`@pagespace/lib`, `@pagespace/lib/server`, `@pagespace/lib/auth`, `@pagespace/lib/repositories`) to direct subpath imports
- **7 test files updated**: `vi.mock()` paths aligned to match new subpath imports (Vitest matches mocks by module ID — barrel mocks don't intercept subpath imports)
- **2 vitest configs fixed**: `apps/realtime` and `apps/control-plane` had `@pagespace/lib` aliased to `src/index.ts` (a file) instead of `src/` (directory), preventing subpath resolution in tests. Changed to directory alias matching the pattern already used by `web`, `marketing`, and `processor`

## Test plan

- [ ] `pnpm --filter web typecheck` passes (verified clean)
- [ ] `pnpm --filter @pagespace/lib typecheck` passes (verified clean)
- [ ] No bare `@pagespace/lib`, `/server`, bare `/auth`, or bare `/repositories` barrel imports remain in `apps/`
- [ ] All CI unit tests pass (realtime module resolution fixed, mock paths corrected)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)