### PR TITLE
feat(db): add subpath exports for db, operators, and all schema files

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -9,6 +9,142 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./db": {
+      "types": "./dist/db.d.ts",
+      "default": "./dist/db.js"
+    },
+    "./operators": {
+      "types": "./dist/operators.d.ts",
+      "default": "./dist/operators.js"
+    },
+    "./schema/ai": {
+      "types": "./dist/schema/ai.d.ts",
+      "default": "./dist/schema/ai.js"
+    },
+    "./schema/auth": {
+      "types": "./dist/schema/auth.d.ts",
+      "default": "./dist/schema/auth.js"
+    },
+    "./schema/auth-handoff-tokens": {
+      "types": "./dist/schema/auth-handoff-tokens.d.ts",
+      "default": "./dist/schema/auth-handoff-tokens.js"
+    },
+    "./schema/calendar": {
+      "types": "./dist/schema/calendar.d.ts",
+      "default": "./dist/schema/calendar.js"
+    },
+    "./schema/calendar-triggers": {
+      "types": "./dist/schema/calendar-triggers.d.ts",
+      "default": "./dist/schema/calendar-triggers.js"
+    },
+    "./schema/chat": {
+      "types": "./dist/schema/chat.d.ts",
+      "default": "./dist/schema/chat.js"
+    },
+    "./schema/contact": {
+      "types": "./dist/schema/contact.d.ts",
+      "default": "./dist/schema/contact.js"
+    },
+    "./schema/conversations": {
+      "types": "./dist/schema/conversations.d.ts",
+      "default": "./dist/schema/conversations.js"
+    },
+    "./schema/core": {
+      "types": "./dist/schema/core.d.ts",
+      "default": "./dist/schema/core.js"
+    },
+    "./schema/dashboard": {
+      "types": "./dist/schema/dashboard.d.ts",
+      "default": "./dist/schema/dashboard.js"
+    },
+    "./schema/display-preferences": {
+      "types": "./dist/schema/display-preferences.d.ts",
+      "default": "./dist/schema/display-preferences.js"
+    },
+    "./schema/email-notifications": {
+      "types": "./dist/schema/email-notifications.d.ts",
+      "default": "./dist/schema/email-notifications.js"
+    },
+    "./schema/feedback": {
+      "types": "./dist/schema/feedback.d.ts",
+      "default": "./dist/schema/feedback.js"
+    },
+    "./schema/hotkeys": {
+      "types": "./dist/schema/hotkeys.d.ts",
+      "default": "./dist/schema/hotkeys.js"
+    },
+    "./schema/integrations": {
+      "types": "./dist/schema/integrations.d.ts",
+      "default": "./dist/schema/integrations.js"
+    },
+    "./schema/members": {
+      "types": "./dist/schema/members.d.ts",
+      "default": "./dist/schema/members.js"
+    },
+    "./schema/monitoring": {
+      "types": "./dist/schema/monitoring.d.ts",
+      "default": "./dist/schema/monitoring.js"
+    },
+    "./schema/notifications": {
+      "types": "./dist/schema/notifications.d.ts",
+      "default": "./dist/schema/notifications.js"
+    },
+    "./schema/page-views": {
+      "types": "./dist/schema/page-views.d.ts",
+      "default": "./dist/schema/page-views.js"
+    },
+    "./schema/permissions": {
+      "types": "./dist/schema/permissions.d.ts",
+      "default": "./dist/schema/permissions.js"
+    },
+    "./schema/personalization": {
+      "types": "./dist/schema/personalization.d.ts",
+      "default": "./dist/schema/personalization.js"
+    },
+    "./schema/push-notifications": {
+      "types": "./dist/schema/push-notifications.d.ts",
+      "default": "./dist/schema/push-notifications.js"
+    },
+    "./schema/rate-limit-buckets": {
+      "types": "./dist/schema/rate-limit-buckets.d.ts",
+      "default": "./dist/schema/rate-limit-buckets.js"
+    },
+    "./schema/revoked-service-tokens": {
+      "types": "./dist/schema/revoked-service-tokens.d.ts",
+      "default": "./dist/schema/revoked-service-tokens.js"
+    },
+    "./schema/security-audit": {
+      "types": "./dist/schema/security-audit.d.ts",
+      "default": "./dist/schema/security-audit.js"
+    },
+    "./schema/sessions": {
+      "types": "./dist/schema/sessions.d.ts",
+      "default": "./dist/schema/sessions.js"
+    },
+    "./schema/social": {
+      "types": "./dist/schema/social.d.ts",
+      "default": "./dist/schema/social.js"
+    },
+    "./schema/storage": {
+      "types": "./dist/schema/storage.d.ts",
+      "default": "./dist/schema/storage.js"
+    },
+    "./schema/subscriptions": {
+      "types": "./dist/schema/subscriptions.d.ts",
+      "default": "./dist/schema/subscriptions.js"
+    },
+    "./schema/tasks": {
+      "types": "./dist/schema/tasks.d.ts",
+      "default": "./dist/schema/tasks.js"
+    },
+    "./schema/versioning": {
+      "types": "./dist/schema/versioning.d.ts",
+      "default": "./dist/schema/versioning.js"
+    },
+    "./schema/workflows": {
+      "types": "./dist/schema/workflows.d.ts",
+      "default": "./dist/schema/workflows.js"
+    },
     "./test/factories": {
       "types": "./dist/test/factories.d.ts",
       "default": "./dist/test/factories.js"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -17,6 +17,10 @@
       "types": "./dist/operators.d.ts",
       "default": "./dist/operators.js"
     },
+    "./schema": {
+      "types": "./dist/schema.d.ts",
+      "default": "./dist/schema.js"
+    },
     "./schema/ai": {
       "types": "./dist/schema/ai.d.ts",
       "default": "./dist/schema/ai.js"

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -5,7 +5,7 @@ import 'dotenv/config';
 
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
-  ssl: false,
+  ssl: process.env.DATABASE_SSL === 'true' ? { rejectUnauthorized: false } : false,
 });
 
 export const db = drizzle(pool, { schema });

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -1,0 +1,11 @@
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { Pool } from 'pg';
+import { schema } from './schema';
+import 'dotenv/config';
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: false,
+});
+
+export const db = drizzle(pool, { schema });

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,11 +1,9 @@
-// Re-export commonly used drizzle-orm functions
 export {
-  eq, and, or, not, inArray, sql, asc, desc, count, sum, avg, max, min,
-  like, ilike, exists, between, gt, gte, lt, lte, ne, isNull, isNotNull
-} from 'drizzle-orm';
-
-// Re-export types
-export type { SQL, InferSelectModel, InferInsertModel } from 'drizzle-orm';
+  eq, ne, gt, gte, lt, lte, and, or, not, like, ilike, between,
+  exists, isNull, isNotNull, inArray, count, sum, avg, max, min, asc,
+  desc, sql,
+} from './operators';
+export type { SQL, InferSelectModel, InferInsertModel } from './operators';
 
 export { db } from './db';
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,8 +1,3 @@
-import { drizzle } from 'drizzle-orm/node-postgres';
-import { Pool } from 'pg';
-import { schema } from './schema';
-import 'dotenv/config';
-
 // Re-export commonly used drizzle-orm functions
 export {
   eq, and, or, not, inArray, sql, asc, desc, count, sum, avg, max, min,
@@ -12,12 +7,7 @@ export {
 // Re-export types
 export type { SQL, InferSelectModel, InferInsertModel } from 'drizzle-orm';
 
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: false,
-});
-
-export const db = drizzle(pool, { schema });
+export { db } from './db';
 
 // Export schema for external use
 export * from './schema';

--- a/packages/db/src/operators.ts
+++ b/packages/db/src/operators.ts
@@ -1,0 +1,6 @@
+export {
+  eq, ne, gt, gte, lt, lte, and, or, not, like, ilike, between,
+  exists, isNull, isNotNull, inArray, count, sum, avg, max, min, asc,
+  desc, sql,
+} from 'drizzle-orm';
+export type { SQL, InferSelectModel, InferInsertModel } from 'drizzle-orm';


### PR DESCRIPTION
## Summary

- Extracts the drizzle db instance from \`src/index.ts\` into its own \`src/db.ts\` file
- Creates \`src/operators.ts\` that re-exports all drizzle-orm operators and types (canonical source — \`index.ts\` re-exports from it, eliminating ordering drift)
- Adds \`./db\`, \`./operators\`, \`./schema\` (combined barrel), and \`./schema/<name>\` subpath exports to \`package.json\` for all 32 schema files
- Root \`"."\` export is preserved for backward compatibility
- \`DATABASE_SSL=true\` env var opts into SSL for the connection pool (was hardcoded \`false\`)

## Context

This is **Agent 1 of 4** — the foundation PR in a series eliminating all ~290 remaining \`@pagespace/db\` barrel imports across the monorepo. The three follow-on PRs (packages/lib, apps/web, and small apps + ESLint config) depend on these subpath exports existing before they can land.

**Merge order**: this PR → packages/lib PR → apps/web PR → small apps PR

## Subpath exports added

| Export | Source |
|--------|--------|
| \`@pagespace/db/db\` | \`src/db.ts\` — drizzle client instance |
| \`@pagespace/db/operators\` | \`src/operators.ts\` — eq, and, or, sql, etc. |
| \`@pagespace/db/schema\` | \`src/schema.ts\` — combined Drizzle schema barrel |
| \`@pagespace/db/schema/ai\` … \`@pagespace/db/schema/workflows\` | 32 individual schema files |

## Test plan

- [x] \`pnpm --filter @pagespace/db build\` exits 0
- [x] \`dist/db.js\`, \`dist/operators.js\`, \`dist/schema.js\` and all \`dist/schema/*.js\` files present after build
- [x] \`pnpm --filter @pagespace/db typecheck\` exits 0
- [x] Root \`"."\` export unchanged — no breaking changes to existing consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)