### PR TITLE
fix(calendar): disable connection on all-404 sync

### DIFF
--- a/apps/web/src/app/api/cron/calendar-sync/route.ts
+++ b/apps/web/src/app/api/cron/calendar-sync/route.ts
@@ -31,6 +31,7 @@ export async function GET(request: Request) {
     const dueConnections = await db.query.googleCalendarConnections.findMany({
       where: and(
         eq(googleCalendarConnections.status, 'active'),
+        sql`jsonb_array_length(coalesce(${googleCalendarConnections.selectedCalendars}::jsonb, '[]'::jsonb)) > 0`,
         or(
           isNull(googleCalendarConnections.lastSyncAt),
           lt(

--- a/apps/web/src/app/api/cron/calendar-sync/route.ts
+++ b/apps/web/src/app/api/cron/calendar-sync/route.ts
@@ -31,7 +31,7 @@ export async function GET(request: Request) {
     const dueConnections = await db.query.googleCalendarConnections.findMany({
       where: and(
         eq(googleCalendarConnections.status, 'active'),
-        sql`jsonb_array_length(coalesce(${googleCalendarConnections.selectedCalendars}::jsonb, '[]'::jsonb)) > 0`,
+        sql`jsonb_array_length(coalesce(${googleCalendarConnections.selectedCalendars}, '[]'::jsonb)) > 0`,
         or(
           isNull(googleCalendarConnections.lastSyncAt),
           lt(

--- a/apps/web/src/lib/integrations/google-calendar/__tests__/sync-service.test.ts
+++ b/apps/web/src/lib/integrations/google-calendar/__tests__/sync-service.test.ts
@@ -467,13 +467,41 @@ describe('syncGoogleCalendar error handling', () => {
       expected: true,
     });
 
+    const setArgs = mockUpdate.mock.results[0]?.value?.set?.mock?.calls?.[0]?.[0] as Record<string, unknown> | undefined;
+
     assert({
       given: 'all calendars return 404',
-      should: 'call updateConnectionStatus with error',
-      actual: mockUpdateConnectionStatus.mock.calls.some(
-        (call: unknown[]) => call[0] === 'user-1' && call[1] === 'error'
-      ),
-      expected: true,
+      should: 'persist selectedCalendars as empty array in the DB write',
+      actual: setArgs?.selectedCalendars,
+      expected: [],
+    });
+
+    assert({
+      given: 'all calendars return 404',
+      should: 'set connection status to error in the same DB write',
+      actual: setArgs?.status,
+      expected: 'error',
+    });
+
+    assert({
+      given: 'all calendars return 404',
+      should: 'set statusMessage to the inaccessible message in the same DB write',
+      actual: setArgs?.statusMessage,
+      expected: 'All connected calendars are inaccessible. Please reconnect your Google Calendar.',
+    });
+
+    assert({
+      given: 'all calendars return 404',
+      should: 'set lastSyncError to the inaccessible message in the same DB write',
+      actual: setArgs?.lastSyncError,
+      expected: 'All connected calendars are inaccessible. Please reconnect your Google Calendar.',
+    });
+
+    assert({
+      given: 'all calendars return 404',
+      should: 'not call updateConnectionStatus separately (single atomic write)',
+      actual: mockUpdateConnectionStatus.mock.calls.length,
+      expected: 0,
     });
   });
 

--- a/apps/web/src/lib/integrations/google-calendar/__tests__/sync-service.test.ts
+++ b/apps/web/src/lib/integrations/google-calendar/__tests__/sync-service.test.ts
@@ -435,6 +435,48 @@ describe('syncGoogleCalendar error handling', () => {
     });
   });
 
+  it('should disable connection when all calendars return 404', async () => {
+    mockGetValidAccessToken.mockResolvedValue({
+      success: true,
+      accessToken: 'valid-token',
+    });
+    mockFindFirst.mockResolvedValue({
+      status: 'active',
+      selectedCalendars: ['stale-1@group.calendar.google.com', 'stale-2@group.calendar.google.com'],
+      syncCursor: null,
+      targetDriveId: null,
+      markAsReadOnly: false,
+      webhookChannels: null,
+      googleEmail: 'user@gmail.com',
+    });
+
+    mockListEvents.mockResolvedValue({
+      success: false,
+      error: 'Not Found',
+      statusCode: 404,
+    });
+    mockWatchCalendar.mockResolvedValue({ success: false, error: 'skip' });
+
+    const { syncGoogleCalendar } = await import('../sync-service');
+    const result = await syncGoogleCalendar('user-1');
+
+    assert({
+      given: 'all calendars return 404',
+      should: 'succeed overall',
+      actual: result.success,
+      expected: true,
+    });
+
+    assert({
+      given: 'all calendars return 404',
+      should: 'call updateConnectionStatus with error',
+      actual: mockUpdateConnectionStatus.mock.calls.some(
+        (call: unknown[]) => call[0] === 'user-1' && call[1] === 'error'
+      ),
+      expected: true,
+    });
+  });
+
   it('should handle token expiration (410) with sync token fallback', async () => {
     mockGetValidAccessToken.mockResolvedValue({
       success: true,

--- a/apps/web/src/lib/integrations/google-calendar/sync-service.ts
+++ b/apps/web/src/lib/integrations/google-calendar/sync-service.ts
@@ -181,25 +181,23 @@ export const syncGoogleCalendar = async (
         })
       : rawCalendars;
 
-    // Persist all updated sync cursors and update last sync time
+    const allCalendarsGone = staleCalendarIds.size > 0 && updatedSelectedCalendars.length === 0;
+    const INACCESSIBLE_MSG = 'All connected calendars are inaccessible. Please reconnect your Google Calendar.';
+
+    // Single atomic write: persist cursors, prune stale calendars, and (if all are gone) mark connection error
     await db
       .update(googleCalendarConnections)
       .set({
         syncCursor: serializeSyncCursors(syncCursors),
         lastSyncAt: new Date(),
-        lastSyncError: null,
+        lastSyncError: allCalendarsGone ? INACCESSIBLE_MSG : null,
         updatedAt: new Date(),
         ...(staleCalendarIds.size > 0 ? { selectedCalendars: updatedSelectedCalendars } : {}),
+        ...(allCalendarsGone ? { status: 'error' as const, statusMessage: INACCESSIBLE_MSG } : {}),
       })
       .where(eq(googleCalendarConnections.userId, userId));
 
-    // All calendars gone after 404 cleanup — disable the connection so the cron stops picking it up
-    if (staleCalendarIds.size > 0 && updatedSelectedCalendars.length === 0) {
-      await updateConnectionStatus(
-        userId,
-        'error',
-        'All connected calendars are inaccessible. Please reconnect your Google Calendar.',
-      );
+    if (allCalendarsGone) {
       loggers.api.info('Google Calendar connection disabled: all calendars returned 404', { userId });
     }
 

--- a/apps/web/src/lib/integrations/google-calendar/sync-service.ts
+++ b/apps/web/src/lib/integrations/google-calendar/sync-service.ts
@@ -193,6 +193,16 @@ export const syncGoogleCalendar = async (
       })
       .where(eq(googleCalendarConnections.userId, userId));
 
+    // All calendars gone after 404 cleanup — disable the connection so the cron stops picking it up
+    if (staleCalendarIds.size > 0 && updatedSelectedCalendars.length === 0) {
+      await updateConnectionStatus(
+        userId,
+        'error',
+        'All connected calendars are inaccessible. Please reconnect your Google Calendar.',
+      );
+      loggers.api.info('Google Calendar connection disabled: all calendars returned 404', { userId });
+    }
+
     result.success = true;
 
     loggers.api.info('Google Calendar sync completed', {


### PR DESCRIPTION
## Summary

- When every calendar in a `google_calendar_connections` row returns 404, the sync service now calls `updateConnectionStatus(userId, 'error', ...)`, permanently stopping the cron from picking it up again
- Added a `jsonb_array_length` guard to the cron query as defense-in-depth: connections with empty `selectedCalendars` are skipped even if their status is still `active`
- Added a test covering the all-404 escalation path

## Why

Previously, a connection with all-stale calendars would stay `active` forever. If the stale-ID filter had any mismatch (e.g. `'primary'` alias), the `Calendar not found` WARN would fire on every sync cycle. Even when cleanup worked correctly, the cron still picked up the connection each cycle for a no-op loop.

Triggered by an orphaned Google identity (old `jono@...` account still paired to the primary user ID) whose calendars all return 404.

## Test plan

- [ ] Existing sync-service tests still pass
- [ ] New test: all calendars 404 → `updateConnectionStatus` called with `'error'`
- [ ] Manual: set `selectedCalendars = ['nonexistent-id']` on a test connection, trigger sync, confirm `status` flips to `error`
- [ ] Cron guard: confirm connections with empty `selectedCalendars` no longer appear in the due-connections query

🤖 Generated with [Claude Code](https://claude.com/claude-code)