### PR TITLE
fix(vitest): remove @pagespace/lib aliases from apps/marketing

### DIFF
--- a/apps/marketing/vitest.config.ts
+++ b/apps/marketing/vitest.config.ts
@@ -1,18 +1,9 @@
 import { defineConfig } from 'vitest/config'
-import path from 'path'
-
-const packagesDir = path.resolve(__dirname, '../../packages')
 
 export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
     include: ['src/**/*.{test,spec}.{js,ts,tsx}'],
-  },
-  resolve: {
-    alias: {
-      '@pagespace/lib/security': path.resolve(packagesDir, 'lib/src/security'),
-      '@pagespace/lib': path.resolve(packagesDir, 'lib/src'),
-    },
   },
 })


### PR DESCRIPTION
## Summary

- Removes the `resolve.alias` block from `apps/marketing/vitest.config.ts` that mapped `@pagespace/lib` and `@pagespace/lib/security` to raw source paths
- Drops the now-unused `path` import and `packagesDir` variable
- Native pnpm workspace resolution handles `@pagespace/lib` imports correctly without aliases (same fix pattern as #1112 for `@pagespace/db`)

## Motivation

Post-merge audit of #1112 found these aliases still present. They cause vite version type conflicts (same root cause as the vite@5/vite@6 crash fixed previously). This is a 1-file cleanup with no behaviour change.

## Test plan

- [x] `pnpm --filter marketing test` exits 0
- [x] No resolve.alias block remains in `apps/marketing/vitest.config.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test configuration by removing unused module path mappings. No impact on application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->