### PR TITLE
fix(mentions): include all members in @ suggestions

### DIFF
--- a/apps/web/src/app/api/mentions/search/route.ts
+++ b/apps/web/src/app/api/mentions/search/route.ts
@@ -286,15 +286,17 @@ export async function GET(request: Request) {
       const authorizedUserIds = new Set<string>();
       
       if (crossDrive) {
-        // Cross-drive search: collect owner + members from all accessible drives
+        // Cross-drive: only enumerate members of drives where requester is a member/owner
         for (const targetDriveId of targetDriveIds) {
           const memberIds = await getDriveRecipientUserIds(targetDriveId);
-          for (const id of memberIds) {
-            authorizedUserIds.add(id);
+          if (memberIds.includes(userId)) {
+            for (const id of memberIds) {
+              authorizedUserIds.add(id);
+            }
           }
         }
       } else {
-        // Within-drive search: owner + all drive members
+        // Within-drive: surface members only to other drive members/owners
         const memberIds = await getDriveRecipientUserIds(driveId!);
         if (memberIds.length === 0) {
           return NextResponse.json(
@@ -302,8 +304,10 @@ export async function GET(request: Request) {
             { status: 404 }
           );
         }
-        for (const id of memberIds) {
-          authorizedUserIds.add(id);
+        if (memberIds.includes(userId)) {
+          for (const id of memberIds) {
+            authorizedUserIds.add(id);
+          }
         }
       }
 

--- a/apps/web/src/app/api/mentions/search/route.ts
+++ b/apps/web/src/app/api/mentions/search/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { getUserAccessLevel, getUserDriveAccess, getDriveIdsForUser } from '@pagespace/lib/permissions/permissions';
+import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
@@ -285,30 +286,25 @@ export async function GET(request: Request) {
       const authorizedUserIds = new Set<string>();
       
       if (crossDrive) {
-        // Cross-drive search: collect users from all accessible drives
+        // Cross-drive search: collect owner + members from all accessible drives
         for (const targetDriveId of targetDriveIds) {
-          // Get the drive owner
-          const driveResults = await db.select({ ownerId: drives.ownerId }).from(drives).where(eq(drives.id, targetDriveId)).limit(1);
-          const drive = driveResults[0];
-          
-          if (drive) {
-            authorizedUserIds.add(drive.ownerId);
+          const memberIds = await getDriveRecipientUserIds(targetDriveId);
+          for (const id of memberIds) {
+            authorizedUserIds.add(id);
           }
         }
       } else {
-        // Within-drive search: only users from the specified drive
-        const driveResults = await db.select({ ownerId: drives.ownerId }).from(drives).where(eq(drives.id, driveId!)).limit(1);
-        const drive = driveResults[0];
-        
-        if (!drive) {
+        // Within-drive search: owner + all drive members
+        const memberIds = await getDriveRecipientUserIds(driveId!);
+        if (memberIds.length === 0) {
           return NextResponse.json(
             { error: 'Drive not found' },
             { status: 404 }
           );
         }
-
-        // Add the drive owner
-        authorizedUserIds.add(drive.ownerId);
+        for (const id of memberIds) {
+          authorizedUserIds.add(id);
+        }
       }
 
       // Search for users only within the authorized set


### PR DESCRIPTION
## Summary

- `@` mention suggestions in channels only returned the drive owner — all other members were invisible
- Root cause: `authorizedUserIds` was populated from `drives.ownerId` only, never querying `drive_members`
- Fix: use `getDriveRecipientUserIds()` to get owner + all members, but gate behind a membership check — only users who are themselves a drive member/owner get the expanded list. Page-level-only users (shared single page) cannot enumerate drive members.

## Security note

`getUserDriveAccess` (the existing route gate) allows page-level access, which is broader than drive membership. The previous fix over-expanded: anyone with any access could enumerate all members. This revision adds `memberIds.includes(userId)` as a second check so user discovery is scoped to people who share actual drive membership — matching the behaviour of the dedicated members API.

## Test plan

- [ ] As a drive owner, type `@` in a channel — all admins/members should appear
- [ ] As a drive member, type `@` — other members and owner appear
- [ ] As a page-level-only guest, type `@` — no drive member suggestions returned
- [ ] Cross-drive mention search only surfaces members from drives where requester is a member/owner

🤖 Generated with [Claude Code](https://claude.com/claude-code)