### PR TITLE
fix(ui): correct task list page type icons

### DIFF
--- a/apps/web/src/components/common/PageTypeIcon.tsx
+++ b/apps/web/src/components/common/PageTypeIcon.tsx
@@ -32,13 +32,14 @@ const iconMap = {
   MessagesSquare,
   BotMessageSquare,
   SquareTerminal,
+  SquareCheckBig,
 } as const;
 
 export function PageTypeIcon({ type, className, isTaskLinked }: PageTypeIconProps) {
   const iconName = getPageTypeIconName(type);
 
   if (type === 'DOCUMENT' && isTaskLinked) {
-    return <SquareCheckBig className={className} />;
+    return <FileCheck2 className={className} />;
   }
 
   const Icon = iconMap[iconName as keyof typeof iconMap] || FileText;


### PR DESCRIPTION
## Summary

- `SquareCheckBig` was missing from `iconMap` in `PageTypeIcon.tsx`, causing Task List pages to fall back to the `FileText` icon instead of the intended square checkbox
- The `isTaskLinked` branch was using `SquareCheckBig`, so sub-tasks were incorrectly showing the square checkbox icon (which belongs to the container)

**After this fix:**
- Task List page → `SquareCheckBig` (square checkbox)
- Individual sub-tasks (task-linked documents) → `FileCheck2` (document with checkmark)

## Test plan

- [ ] Open a workspace with a Task List page in the sidebar — verify it shows the square checkbox icon
- [ ] Open a task list — verify individual task sub-pages show the file-with-check icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)