### PR TITLE
feat(voice): streaming TTS and true barge-in

### DIFF
--- a/apps/web/src/components/ai/voice/VoiceCallPanel.tsx
+++ b/apps/web/src/components/ai/voice/VoiceCallPanel.tsx
@@ -18,6 +18,8 @@ export interface VoiceCallPanelProps {
   onSend: (text: string) => void;
   latestAssistantMessage?: VoiceResponse | null;
   isAIStreaming?: boolean;
+  streamingText?: string | null;
+  onStopStream?: () => void;
   onClose?: () => void;
   className?: string;
 }
@@ -27,12 +29,16 @@ export function VoiceCallPanel({
   onSend,
   latestAssistantMessage,
   isAIStreaming = false,
+  streamingText,
+  onStopStream,
   onClose,
   className,
 }: VoiceCallPanelProps) {
   const [showSettings, setShowSettings] = useState(false);
   const spokenMessageIdsRef = useRef<Set<string>>(new Set());
   const hasAutoStartedRef = useRef(false);
+  const streamingSpokenRef = useRef(0);
+  const pendingTextRef = useRef('');
 
   const activeOwner = useVoiceModeStore((state) => state.owner);
   const isEnabled = useVoiceModeStore((state) => state.isEnabled);
@@ -49,10 +55,12 @@ export function VoiceCallPanel({
     startListening,
     stopListening,
     speak,
+    queueSentence,
     bargeIn,
     interactionMode,
   } = useVoiceMode({
     onSend,
+    onStopStream,
   });
 
   const isOwnerActive = isEnabled && activeOwner === owner;
@@ -72,12 +80,41 @@ export function VoiceCallPanel({
     void startListening();
   }, [isOwnerActive, hasLoadedSettings, startListening]);
 
-  // Speak each new assistant message once
+  // Queue complete sentences as text streams in
+  useEffect(() => {
+    if (!isOwnerActive || !streamingText || !isAIStreaming) return;
+    const newChunk = streamingText.slice(streamingSpokenRef.current);
+    if (!newChunk) return;
+    pendingTextRef.current += newChunk;
+    streamingSpokenRef.current = streamingText.length;
+
+    const sentenceRe = /[^.!?\n]+[.!?\n]+(?=\s|$)/g;
+    let match: RegExpExecArray | null;
+    let lastIndex = 0;
+    while ((match = sentenceRe.exec(pendingTextRef.current)) !== null) {
+      queueSentence(match[0].trim());
+      lastIndex = sentenceRe.lastIndex;
+    }
+    pendingTextRef.current = pendingTextRef.current.slice(lastIndex);
+  }, [streamingText, isAIStreaming, isOwnerActive, queueSentence]);
+
+  // When stream ends, speak any buffered tail
+  useEffect(() => {
+    if (isAIStreaming) return;
+    if (pendingTextRef.current.trim()) {
+      queueSentence(pendingTextRef.current.trim());
+      pendingTextRef.current = '';
+    }
+    streamingSpokenRef.current = 0;
+  }, [isAIStreaming, queueSentence]);
+
+  // Fallback: speak full message when voice mode was activated after streaming ended
   useEffect(() => {
     if (!isOwnerActive || !latestAssistantMessage || isAIStreaming) return;
     if (isListening || isProcessing) return;
     if (spokenMessageIdsRef.current.has(latestAssistantMessage.id)) return;
     if (!latestAssistantMessage.text.trim()) return;
+    if (streamingSpokenRef.current > 0) return;
 
     spokenMessageIdsRef.current.add(latestAssistantMessage.id);
     void speak(latestAssistantMessage.text);

--- a/apps/web/src/components/ai/voice/VoiceCallPanel.tsx
+++ b/apps/web/src/components/ai/voice/VoiceCallPanel.tsx
@@ -98,14 +98,23 @@ export function VoiceCallPanel({
     pendingTextRef.current = pendingTextRef.current.slice(lastIndex);
   }, [streamingText, isAIStreaming, isOwnerActive, queueSentence]);
 
-  // When stream ends, speak any buffered tail
+  // Reset streamed marker and pending buffer when a new stream begins
+  useEffect(() => {
+    if (!isAIStreaming) return;
+    streamingSpokenRef.current = 0;
+    pendingTextRef.current = '';
+  }, [isAIStreaming]);
+
+  // When stream ends, flush any buffered tail — skip if barge-in already started capture
   useEffect(() => {
     if (isAIStreaming) return;
-    if (pendingTextRef.current.trim()) {
-      queueSentence(pendingTextRef.current.trim());
-      pendingTextRef.current = '';
+    const tail = pendingTextRef.current.trim();
+    pendingTextRef.current = '';
+    if (!tail) return;
+    const { voiceState: liveState } = useVoiceModeStore.getState();
+    if (liveState !== 'listening' && liveState !== 'processing') {
+      queueSentence(tail);
     }
-    streamingSpokenRef.current = 0;
   }, [isAIStreaming, queueSentence]);
 
   // Fallback: speak full message when voice mode was activated after streaming ended

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -186,6 +186,16 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
   const isStreaming = status === 'submitted' || status === 'streaming';
   const { wrapSend } = useSendHandoff(currentConversationId, status);
   const stop = useChatStop(streamTrackingId, chatStop);
+
+  const streamingAssistantText = useMemo(() => {
+    if (!isStreaming) return null;
+    const last = messages[messages.length - 1];
+    if (!last || last.role !== 'assistant') return null;
+    return (last.parts ?? [])
+      .filter((p) => p.type === 'text')
+      .map((p) => (p as { type: 'text'; text: string }).text)
+      .join('');
+  }, [messages, isStreaming]);
   const isLoading = !isInitialized;
 
   // ============================================
@@ -649,6 +659,8 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
                     onSend={handleVoiceSend}
                     latestAssistantMessage={lastAIResponse}
                     isAIStreaming={isStreaming}
+                    streamingText={streamingAssistantText}
+                    onStopStream={stop}
                     onClose={disableVoiceMode}
                   />
                 )}

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -308,6 +308,16 @@ const GlobalAssistantView: React.FC = () => {
   const rawStop = selectedAgent ? agentStop : globalStop;
   const isStreaming = status === 'submitted' || status === 'streaming';
   const { wrapSend } = useSendHandoff(currentConversationId, status);
+
+  const streamingAssistantText = useMemo(() => {
+    if (!isStreaming) return null;
+    const last = messages[messages.length - 1];
+    if (!last || last.role !== 'assistant') return null;
+    return (last.parts ?? [])
+      .filter((p) => p.type === 'text')
+      .map((p) => (p as { type: 'text'; text: string }).text)
+      .join('');
+  }, [messages, isStreaming]);
   const latestAgentMessagesRef = useRef(agentMessages);
   const latestGlobalMessagesRef = useRef(globalLocalMessages);
 
@@ -857,6 +867,8 @@ const GlobalAssistantView: React.FC = () => {
                 onSend={handleVoiceSend}
                 latestAssistantMessage={lastAIResponse}
                 isAIStreaming={isStreaming}
+                streamingText={streamingAssistantText}
+                onStopStream={stop}
                 onClose={disableVoiceMode}
               />
             )}

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -835,7 +835,7 @@ const SidebarChatTab: React.FC = () => {
             latestAssistantMessage={lastAIResponse}
             isAIStreaming={displayIsStreaming}
             streamingText={streamingAssistantText}
-            onStopStream={stop}
+            onStopStream={handleStop}
             onClose={disableVoiceMode}
           />
         )}

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -235,6 +235,16 @@ const SidebarChatTab: React.FC = () => {
     ? (isStreaming || dashboardIsStreaming)
     : (isStreaming || contextIsStreaming);
 
+  const streamingAssistantText = useMemo(() => {
+    if (!displayIsStreaming) return null;
+    const last = messages[messages.length - 1];
+    if (!last || last.role !== 'assistant') return null;
+    return (last.parts ?? [])
+      .filter((p) => p.type === 'text')
+      .map((p) => (p as { type: 'text'; text: string }).text)
+      .join('');
+  }, [messages, displayIsStreaming]);
+
   // Effect-based handoff for pending send → streaming transition
   const { wrapSend } = useSendHandoff(currentConversationId, status);
 
@@ -824,6 +834,8 @@ const SidebarChatTab: React.FC = () => {
             onSend={handleVoiceSend}
             latestAssistantMessage={lastAIResponse}
             isAIStreaming={displayIsStreaming}
+            streamingText={streamingAssistantText}
+            onStopStream={stop}
             onClose={disableVoiceMode}
           />
         )}

--- a/apps/web/src/hooks/useVoiceMode.ts
+++ b/apps/web/src/hooks/useVoiceMode.ts
@@ -53,6 +53,8 @@ export interface UseVoiceModeOptions {
   onSpeakComplete?: () => void;
   /** Callback when an error occurs */
   onError?: (error: string) => void;
+  /** Callback to abort the in-flight LLM stream on barge-in */
+  onStopStream?: () => void;
   /** Language for transcription (default: 'en') */
   language?: string;
 }
@@ -74,6 +76,8 @@ export interface UseVoiceModeReturn {
   startListening: () => Promise<void>;
   stopListening: () => void;
   speak: (text: string) => Promise<void>;
+  queueSentence: (text: string) => void;
+  clearSpeechQueue: () => void;
   stopSpeaking: () => void;
   bargeIn: () => void;
 
@@ -126,6 +130,7 @@ export function useVoiceMode({
   onSend,
   onSpeakComplete,
   onError,
+  onStopStream,
   language = 'en',
 }: UseVoiceModeOptions = {}): UseVoiceModeReturn {
   // Store state
@@ -185,8 +190,11 @@ export function useVoiceMode({
   const stopListeningRef = useRef<(() => void) | null>(null);
 
   // Callbacks ref to avoid stale closures
-  const callbacksRef = useRef({ onTranscript, onSend, onSpeakComplete, onError });
-  callbacksRef.current = { onTranscript, onSend, onSpeakComplete, onError };
+  const callbacksRef = useRef({ onTranscript, onSend, onSpeakComplete, onError, onStopStream });
+  callbacksRef.current = { onTranscript, onSend, onSpeakComplete, onError, onStopStream };
+
+  // Sentence queue for chained TTS playback
+  const speechQueueRef = useRef<string[]>([]);
 
   // Derived state
   const isListening = voiceState === 'listening';
@@ -256,7 +264,11 @@ export function useVoiceMode({
         }
 
         const result = await response.json();
-        return result.text as string;
+        const text = (result.text as string).trim();
+        const WHISPER_ARTIFACTS = new Set(['you', 'thank you', 'thanks', 'bye', 'goodbye']);
+        const normalized = text.toLowerCase().replace(/[.!?,\s]+$/, '').trim();
+        if (WHISPER_ARTIFACTS.has(normalized)) return null;
+        return text;
       } catch (err) {
         const message = getTranscriptionErrorMessage(err);
         setError(message);
@@ -408,6 +420,11 @@ export function useVoiceMode({
         setVoiceState('processing');
 
         const audioBlob = new Blob(recordingRefs.current.audioChunks, { type: mimeType });
+
+        if (audioBlob.size < 6000) {
+          setVoiceState('idle');
+          return;
+        }
         const transcript = await transcribeAudio(audioBlob);
 
         if (transcript) {
@@ -492,7 +509,7 @@ export function useVoiceMode({
 
       const dataArray = new Uint8Array(analyser.frequencyBinCount);
       const SPEECH_THRESHOLD = 22;
-      const REQUIRED_SPEECH_FRAMES = 7;
+      const REQUIRED_SPEECH_FRAMES = 15;
       let speechFrames = 0;
 
       const checkSpeech = () => {
@@ -514,6 +531,8 @@ export function useVoiceMode({
 
         if (speechFrames >= REQUIRED_SPEECH_FRAMES) {
           stopBargeInMonitoring();
+          speechQueueRef.current = [];
+          callbacksRef.current.onStopStream?.();
           bargeInStore();
           stopAudioPlayback();
           setCurrentAudioId(null);
@@ -594,6 +613,12 @@ export function useVoiceMode({
           stopBargeInMonitoring();
           if (playbackRefs.current.audioSource === source) {
             playbackRefs.current.audioSource = null;
+
+            if (speechQueueRef.current.length > 0) {
+              void speak(speechQueueRef.current.shift()!);
+              return;
+            }
+
             stopSpeakingStore();
             callbacksRef.current.onSpeakComplete?.();
 
@@ -638,9 +663,28 @@ export function useVoiceMode({
     ]
   );
 
-  // Barge-in: interrupt TTS and start listening
+  const clearSpeechQueue = useCallback(() => {
+    speechQueueRef.current = [];
+  }, []);
 
+  const queueSentence = useCallback(
+    (text: string) => {
+      if (!text.trim()) return;
+      const { voiceState: currentState } = useVoiceModeStore.getState();
+      if (currentState === 'speaking') {
+        speechQueueRef.current.push(text);
+      } else {
+        speechQueueRef.current = [];
+        void speak(text);
+      }
+    },
+    [speak]
+  );
+
+  // Barge-in: interrupt TTS and start listening
   const bargeIn = useCallback(() => {
+    speechQueueRef.current = [];
+    callbacksRef.current.onStopStream?.();
     bargeInStore();
     stopAudioPlayback();
     setCurrentAudioId(null);
@@ -721,6 +765,8 @@ export function useVoiceMode({
     startListening,
     stopListening,
     speak,
+    queueSentence,
+    clearSpeechQueue,
     stopSpeaking,
     bargeIn,
 


### PR DESCRIPTION
## Summary

- **Streaming TTS**: sentences are spoken mid-stream as tokens arrive — no more waiting for the full response to finish before hearing anything
- **True barge-in**: interrupting now stops both audio playback and the in-flight LLM stream, not just audio
- **Whisper 'You' fix**: sub-6KB recordings are dropped before transcription; known Whisper hallucinations ('you', 'thank you', etc.) are filtered from results
- **Reduced false triggers**: barge-in VAD threshold raised from 7 → 15 consecutive speech frames

## How it works

`useVoiceMode` gains a sentence queue (`speechQueueRef`) — `queueSentence()` either starts speaking immediately or chains onto the current playback. `source.onended` drains the queue before auto-listening, creating seamless sentence-to-sentence chaining.

`VoiceCallPanel` receives `streamingText` (live in-progress assistant text) and extracts complete sentences via regex as tokens arrive, queuing each one for TTS. Any buffered tail is flushed when the stream ends. The existing "speak full message" fallback is retained for when voice mode opens after a stream has already completed.

All three host views (GlobalAssistantView, SidebarChatTab, AiChatView) now compute `streamingAssistantText` from live messages and pass it alongside `onStopStream` to the panel.

## Follow-up fixes (a08542f)

Three P1 issues addressed after review:

1. **Marker reset timing**: `streamingSpokenRef` now resets when a *new* stream starts (not when it ends), so the fallback TTS guard stays active through the render where `latestAssistantMessage` updates — prevents full-message replay after streaming TTS already played it.
2. **Barge-in tail flush**: The flush effect now checks live `voiceState` before calling `queueSentence`. Partial tail text is cleared but not spoken if voice is already `listening`/`processing` — prevents resumed TTS from talking over a barge-in capture.
3. **SidebarChatTab stop handler**: `onStopStream` now wired to `handleStop` (not raw `stop`), routing barge-in through `contextStopStreaming`/`dashboardStopStreaming` to hit the server-side abort endpoint in all flow configurations.

## Test plan

- [ ] Enable voice mode, send a prompt with a multi-sentence response — confirm TTS starts on the first sentence before streaming finishes
- [ ] Speak while AI is talking — confirm audio stops, LLM stream aborts, mic opens immediately with no TTS resuming afterward
- [ ] Say something very brief after a barge-in — confirm "You" is no longer sent
- [ ] After barge-in, confirm no partial AI sentence replays during the new capture
- [ ] Verify ambient noise doesn't trigger barge-in as easily
- [ ] `pnpm typecheck` passes with no new errors in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)