### PR TITLE
fix(billing): disable wallet methods in PaymentElement

### DIFF
--- a/apps/web/src/components/billing/AddPaymentMethodForm.tsx
+++ b/apps/web/src/components/billing/AddPaymentMethodForm.tsx
@@ -78,6 +78,10 @@ function AddPaymentMethodFormContent({
       <PaymentElement
         options={{
           layout: 'tabs',
+          wallets: {
+            googlePay: 'never',
+            applePay: 'never',
+          },
         }}
       />
 

--- a/apps/web/src/components/billing/EmbeddedCheckoutForm.tsx
+++ b/apps/web/src/components/billing/EmbeddedCheckoutForm.tsx
@@ -199,6 +199,10 @@ export function EmbeddedCheckoutForm({
         <PaymentElement
           options={{
             layout: 'tabs',
+            wallets: {
+              googlePay: 'never',
+              applePay: 'never',
+            },
           }}
         />
       </div>


### PR DESCRIPTION
## Summary

- `PaymentElement` with `layout: 'tabs'` was dynamically showing Google Pay and Apple Pay options when the browser supported them
- Clicking "Add Card" triggered `elements.submit()` which opened the Google Pay native payment sheet instead of validating a card form
- The sheet left `elements.submit()` unresolved, keeping `processing: true` indefinitely (infinite spinner)
- Fix: set `wallets: { googlePay: 'never', applePay: 'never' }` so only card input is shown, matching the dialog's intent

## Test plan

- [ ] Open `/settings/billing` in Chrome (Google Pay supported)
- [ ] Click "Add Payment Method" — confirm no Google Pay / Apple Pay tab appears
- [ ] Enter Stripe test card `4242 4242 4242 4242`, click "Add Card"
- [ ] Spinner resolves, dialog closes, toast shows "Card added successfully"
- [ ] Confirm Google Pay iframe request absent from DevTools Network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Payment Methods**
  * Google Pay and Apple Pay have been disabled as payment options during checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->