### PR TITLE
feat(auth): promote passkey above OAuth in auth flows

### DIFF
--- a/apps/web/src/app/auth/signin/page.tsx
+++ b/apps/web/src/app/auth/signin/page.tsx
@@ -147,32 +147,38 @@ function SignInForm() {
         </p>
       </motion.div>
 
-      {/* OAuth buttons */}
-      {isWaitingForExternalAuth ? (
-        <ExternalAuthWaiting provider={waitingProvider} onCancel={cancelExternalAuth} />
-      ) : (
-        <OAuthButtons
-          onGoogleClick={handleGoogleSignIn}
-          onAppleClick={handleAppleSignIn}
-          disabled={isGoogleLoading || isAppleLoading}
-          isGoogleLoading={isGoogleLoading}
-          isAppleLoading={isAppleLoading}
-        />
-      )}
-
-      <AuthDivider delay={0.3} />
-
       {/* Passkey login */}
       {csrfToken && (
         <motion.div
           initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.35, duration: 0.3 }}
+          transition={{ delay: 0.2, duration: 0.3 }}
         >
           <PasskeyLoginButton
             csrfToken={csrfToken}
             refreshToken={refreshToken}
             variant="outline"
+          />
+        </motion.div>
+      )}
+
+      <AuthDivider delay={0.3} />
+
+      {/* OAuth buttons */}
+      {isWaitingForExternalAuth ? (
+        <ExternalAuthWaiting provider={waitingProvider} onCancel={cancelExternalAuth} />
+      ) : (
+        <motion.div
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.35, duration: 0.3 }}
+        >
+          <OAuthButtons
+            onGoogleClick={handleGoogleSignIn}
+            onAppleClick={handleAppleSignIn}
+            disabled={isGoogleLoading || isAppleLoading}
+            isGoogleLoading={isGoogleLoading}
+            isAppleLoading={isAppleLoading}
           />
         </motion.div>
       )}

--- a/apps/web/src/app/auth/signup/page.tsx
+++ b/apps/web/src/app/auth/signup/page.tsx
@@ -83,27 +83,12 @@ function CloudSignUp() {
         </motion.p>
       )}
 
-      {/* OAuth buttons */}
-      {isWaitingForExternalAuth ? (
-        <ExternalAuthWaiting provider={waitingProvider} onCancel={cancelExternalAuth} />
-      ) : (
-        <OAuthButtons
-          onGoogleClick={handleGoogleSignIn}
-          onAppleClick={handleAppleSignIn}
-          disabled={isAnyLoading}
-          isGoogleLoading={isGoogleLoading}
-          isAppleLoading={isAppleLoading}
-        />
-      )}
-
-      <AuthDivider delay={0.3} />
-
       {/* Passkey signup */}
       {csrfToken && (
         <motion.div
           initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.35, duration: 0.3 }}
+          transition={{ delay: 0.2, duration: 0.3 }}
         >
           <PasskeySignupButton
             csrfToken={csrfToken}
@@ -113,6 +98,27 @@ function CloudSignUp() {
             }}
             onLoadingChange={setPasskeyLoading}
             disabled={isAnyLoading}
+          />
+        </motion.div>
+      )}
+
+      <AuthDivider delay={0.3} />
+
+      {/* OAuth buttons */}
+      {isWaitingForExternalAuth ? (
+        <ExternalAuthWaiting provider={waitingProvider} onCancel={cancelExternalAuth} />
+      ) : (
+        <motion.div
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.35, duration: 0.3 }}
+        >
+          <OAuthButtons
+            onGoogleClick={handleGoogleSignIn}
+            onAppleClick={handleAppleSignIn}
+            disabled={isAnyLoading}
+            isGoogleLoading={isGoogleLoading}
+            isAppleLoading={isAppleLoading}
           />
         </motion.div>
       )}


### PR DESCRIPTION
## Summary

- Moves passkey button to the top (primary position) in both cloud signup and signin flows
- OAuth (Google/Apple) is now secondary, rendered below the "or" divider
- Animation stagger delays re-sequenced to match new top-to-bottom order
- On-prem signin is unchanged — passkey was already first there

## Test plan

- [ ] Open `/auth/signup` — passkey button appears first, then "or" divider, then Google/Apple
- [ ] Open `/auth/signin` — same order
- [ ] Initiate a Google/Apple sign-in — `ExternalAuthWaiting` state still renders correctly
- [ ] Confirm on-prem signin flow is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)