### PR TITLE
fix(connections): revalidate on accept/reject events

### DIFF
--- a/apps/web/src/app/dashboard/connections/page.tsx
+++ b/apps/web/src/app/dashboard/connections/page.tsx
@@ -89,9 +89,11 @@ export default function ConnectionsPage() {
     if (!socket) return;
 
     const handleNotification = (notification: { type: string }) => {
-      if (notification.type === 'CONNECTION_ACCEPTED' || notification.type === 'CONNECTION_REJECTED') {
+      if (notification.type === 'CONNECTION_ACCEPTED') {
         mutate('/api/connections?status=PENDING');
         mutate('/api/connections?status=ACCEPTED');
+      } else if (notification.type === 'CONNECTION_REJECTED' || notification.type === 'CONNECTION_REQUEST') {
+        mutate('/api/connections?status=PENDING');
       }
     };
 

--- a/apps/web/src/app/dashboard/connections/page.tsx
+++ b/apps/web/src/app/dashboard/connections/page.tsx
@@ -21,6 +21,7 @@ import { toast } from 'sonner';
 import { formatDistanceToNow } from 'date-fns';
 import { VerificationRequiredAlert } from '@/components/VerificationRequiredAlert';
 import { post, patch, del, fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { useSocket } from '@/hooks/useSocket';
 
 const fetcher = async (url: string) => {
   const response = await fetchWithAuth(url);
@@ -62,6 +63,7 @@ interface SearchResult {
 export default function ConnectionsPage() {
   const { } = useAuth();
   const router = useRouter();
+  const socket = useSocket();
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
   const [isSearching, setIsSearching] = useState(false);
@@ -82,6 +84,20 @@ export default function ConnectionsPage() {
 
   const acceptedConnections = acceptedData?.connections || [];
   const pendingConnections = pendingData?.connections || [];
+
+  useEffect(() => {
+    if (!socket) return;
+
+    const handleNotification = (notification: { type: string }) => {
+      if (notification.type === 'CONNECTION_ACCEPTED' || notification.type === 'CONNECTION_REJECTED') {
+        mutate('/api/connections?status=PENDING');
+        mutate('/api/connections?status=ACCEPTED');
+      }
+    };
+
+    socket.on('notification:new', handleNotification);
+    return () => { socket.off('notification:new', handleNotification); };
+  }, [socket]);
 
   const handleSearch = async () => {
     if (!searchQuery.trim()) return;

--- a/apps/web/src/app/dashboard/connections/page.tsx
+++ b/apps/web/src/app/dashboard/connections/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { useRouter } from 'next/navigation';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';


### PR DESCRIPTION
## Summary

- Subscribes to `notification:new` socket events on the Connections page
- On `CONNECTION_ACCEPTED`: mutates both pending and accepted SWR caches (request moves from Pending tab to Connections tab for the requester)
- On `CONNECTION_REJECTED`: mutates only the pending cache (request disappears from Pending tab for the requester)
- On `CONNECTION_REQUEST`: mutates only the pending cache (new incoming request appears in Pending tab for the recipient, in real-time)
- No server changes required — reuses the notification events already proven to reach the client

## Root cause

The Connections page used SWR with no real-time subscriptions. When another user accepted/rejected/sent a connection request, the server broadcast a `notification:new` event (which correctly triggered the notification bell), but nothing in the page reacted to invalidate the stale SWR cache.

## Test plan

- [ ] User A sends a connection request to User B
- [ ] **User B** (on Connections page) sees the request appear in their Pending tab without refreshing
- [ ] User B accepts the request in a separate session
- [ ] **User A** (on Connections page): Pending tab removes the entry and the Connections tab gains the new connection — without refreshing
- [ ] User B rejects instead: **User A** sees request disappear from Pending tab without refreshing
- [ ] Notification bell still fires as before (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)