### PR TITLE
fix(connections): mark request notification as actioned after accept/reject

### DIFF
--- a/apps/web/src/app/api/connections/[connectionId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/connections/[connectionId]/__tests__/route.test.ts
@@ -63,6 +63,7 @@ vi.mock('@pagespace/lib/audit/audit-log', () => ({
 
 vi.mock('@pagespace/lib/notifications/notifications', () => ({
   createNotification: vi.fn(),
+  markConnectionRequestActioned: vi.fn(),
 }));
 
 import { PATCH, DELETE } from '../route';

--- a/apps/web/src/app/api/connections/[connectionId]/route.ts
+++ b/apps/web/src/app/api/connections/[connectionId]/route.ts
@@ -7,7 +7,7 @@ import { connections } from '@pagespace/db/schema/social';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
-import { createNotification } from '@pagespace/lib/notifications/notifications';
+import { createNotification, markConnectionRequestActioned } from '@pagespace/lib/notifications/notifications';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 
@@ -125,6 +125,8 @@ export async function PATCH(
           triggeredByUserId: userId,
         });
 
+        await markConnectionRequestActioned(connectionId, userId, 'rejected');
+
         auditRequest(request, { eventType: 'data.write', userId, resourceType: 'connection', resourceId: connectionId, details: { action: 'reject' } });
 
         return NextResponse.json({ success: true });
@@ -164,6 +166,11 @@ export async function PATCH(
       .set(updateData)
       .where(eq(connections.id, connectionId))
       .returning();
+
+    // Mark the CONNECTION_REQUEST notification as actioned for the accepting user
+    if (action === 'accept') {
+      await markConnectionRequestActioned(connectionId, userId, 'accepted');
+    }
 
     // Send notification if needed
     if (notificationType && notifyUserId) {

--- a/apps/web/src/app/dashboard/connections/page.tsx
+++ b/apps/web/src/app/dashboard/connections/page.tsx
@@ -22,6 +22,7 @@ import { formatDistanceToNow } from 'date-fns';
 import { VerificationRequiredAlert } from '@/components/VerificationRequiredAlert';
 import { post, patch, del, fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useSocket } from '@/hooks/useSocket';
+import { useNotificationStore } from '@/stores/useNotificationStore';
 
 const fetcher = async (url: string) => {
   const response = await fetchWithAuth(url);
@@ -158,6 +159,28 @@ export default function ConnectionsPage() {
       } else {
         await patch(`/api/connections/${connectionId}`, { action });
         toast.success(`Connection ${action}ed`);
+
+        // Optimistically mark the matching CONNECTION_REQUEST notification as actioned
+        const { notifications: storeNotifications, updateNotification } =
+          useNotificationStore.getState();
+        const stale = storeNotifications.find(
+          (n) =>
+            n.type === 'CONNECTION_REQUEST' &&
+            n.metadata &&
+            typeof n.metadata === 'object' &&
+            'connectionId' in n.metadata &&
+            n.metadata.connectionId === connectionId,
+        );
+        if (stale) {
+          updateNotification(stale.id, {
+            isRead: true,
+            metadata: {
+              ...(stale.metadata as Record<string, unknown>),
+              actioned: true,
+              actionedStatus: action === 'accept' ? 'accepted' : 'rejected',
+            },
+          });
+        }
       }
 
       // Refresh data

--- a/apps/web/src/app/notifications/page.tsx
+++ b/apps/web/src/app/notifications/page.tsx
@@ -39,7 +39,6 @@ export default function NotificationsPage() {
   const notifications = useNotificationStore((state) => state.notifications);
   const isLoading = useNotificationStore((state) => state.isLoading);
   const fetchNotifications = useNotificationStore((state) => state.fetchNotifications);
-  const handleNotificationRead = useNotificationStore((state) => state.handleNotificationRead);
   const handleMarkAllAsRead = useNotificationStore((state) => state.handleMarkAllAsRead);
   const handleDeleteNotification = useNotificationStore((state) => state.handleDeleteNotification);
   const initializeSocketListeners = useNotificationStore((state) => state.initializeSocketListeners);
@@ -128,8 +127,19 @@ export default function NotificationsPage() {
   ) => {
     try {
       await patch(`/api/connections/${connectionId}`, { action });
-      handleNotificationRead(notificationId);
-      window.location.reload();
+      const { notifications: storeNotifications, updateNotification } =
+        useNotificationStore.getState();
+      const stale = storeNotifications.find((n) => n.id === notificationId);
+      if (stale) {
+        updateNotification(notificationId, {
+          isRead: true,
+          metadata: {
+            ...(stale.metadata as Record<string, unknown>),
+            actioned: true,
+            actionedStatus: action === 'accept' ? 'accepted' : 'rejected',
+          },
+        });
+      }
     } catch (error) {
       console.error(`Error ${action}ing connection:`, error);
     }
@@ -270,7 +280,7 @@ export default function NotificationsPage() {
                                   onSelect={() => handleSelect(notification)}
                                   onDismiss={() => handleDeleteNotification(notification.id)}
                                   onAccept={
-                                    isConnectionRequest(notification)
+                                    isConnectionRequest(notification) && !notification.metadata.actioned
                                       ? () =>
                                           handleConnectionAction(
                                             notification.metadata.connectionId,
@@ -280,7 +290,7 @@ export default function NotificationsPage() {
                                       : undefined
                                   }
                                   onDecline={
-                                    isConnectionRequest(notification)
+                                    isConnectionRequest(notification) && !notification.metadata.actioned
                                       ? () =>
                                           handleConnectionAction(
                                             notification.metadata.connectionId,

--- a/apps/web/src/app/notifications/page.tsx
+++ b/apps/web/src/app/notifications/page.tsx
@@ -281,7 +281,7 @@ export default function NotificationsPage() {
                                   onSelect={() => handleSelect(notification)}
                                   onDismiss={() => handleDeleteNotification(notification.id)}
                                   onAccept={
-                                    isConnectionRequest(notification) && !notification.metadata.actioned
+                                    isConnectionRequest(notification) && !notification.metadata?.actioned
                                       ? () =>
                                           handleConnectionAction(
                                             notification.metadata.connectionId,
@@ -291,7 +291,7 @@ export default function NotificationsPage() {
                                       : undefined
                                   }
                                   onDecline={
-                                    isConnectionRequest(notification) && !notification.metadata.actioned
+                                    isConnectionRequest(notification) && !notification.metadata?.actioned
                                       ? () =>
                                           handleConnectionAction(
                                             notification.metadata.connectionId,

--- a/apps/web/src/app/notifications/page.tsx
+++ b/apps/web/src/app/notifications/page.tsx
@@ -39,6 +39,7 @@ export default function NotificationsPage() {
   const notifications = useNotificationStore((state) => state.notifications);
   const isLoading = useNotificationStore((state) => state.isLoading);
   const fetchNotifications = useNotificationStore((state) => state.fetchNotifications);
+  const handleNotificationRead = useNotificationStore((state) => state.handleNotificationRead);
   const handleMarkAllAsRead = useNotificationStore((state) => state.handleMarkAllAsRead);
   const handleDeleteNotification = useNotificationStore((state) => state.handleDeleteNotification);
   const initializeSocketListeners = useNotificationStore((state) => state.initializeSocketListeners);

--- a/apps/web/src/components/notifications/NotificationDropdown.tsx
+++ b/apps/web/src/components/notifications/NotificationDropdown.tsx
@@ -177,7 +177,7 @@ export default function NotificationDropdown() {
                       onSelect={() => handleSelect(notification)}
                       onDismiss={() => handleDeleteNotification(notification.id)}
                       onAccept={
-                        isConnectionRequest(notification) && !notification.metadata.actioned
+                        isConnectionRequest(notification) && !notification.metadata?.actioned
                           ? () =>
                               handleConnectionAction(
                                 notification.metadata.connectionId,
@@ -187,7 +187,7 @@ export default function NotificationDropdown() {
                           : undefined
                       }
                       onDecline={
-                        isConnectionRequest(notification) && !notification.metadata.actioned
+                        isConnectionRequest(notification) && !notification.metadata?.actioned
                           ? () =>
                               handleConnectionAction(
                                 notification.metadata.connectionId,

--- a/apps/web/src/components/notifications/NotificationDropdown.tsx
+++ b/apps/web/src/components/notifications/NotificationDropdown.tsx
@@ -177,7 +177,7 @@ export default function NotificationDropdown() {
                       onSelect={() => handleSelect(notification)}
                       onDismiss={() => handleDeleteNotification(notification.id)}
                       onAccept={
-                        isConnectionRequest(notification)
+                        isConnectionRequest(notification) && !notification.metadata.actioned
                           ? () =>
                               handleConnectionAction(
                                 notification.metadata.connectionId,
@@ -187,7 +187,7 @@ export default function NotificationDropdown() {
                           : undefined
                       }
                       onDecline={
-                        isConnectionRequest(notification)
+                        isConnectionRequest(notification) && !notification.metadata.actioned
                           ? () =>
                               handleConnectionAction(
                                 notification.metadata.connectionId,

--- a/apps/web/src/components/notifications/NotificationItem.tsx
+++ b/apps/web/src/components/notifications/NotificationItem.tsx
@@ -150,7 +150,7 @@ export function NotificationItem({
         ) : null}
         {showActionedStatus ? (
           <p className="mt-2 text-xs text-muted-foreground">
-            {notification.metadata.actionedStatus === 'accepted'
+            {notification.metadata?.actionedStatus === 'accepted'
               ? 'You accepted this request'
               : 'You declined this request'}
           </p>

--- a/apps/web/src/components/notifications/NotificationItem.tsx
+++ b/apps/web/src/components/notifications/NotificationItem.tsx
@@ -44,7 +44,10 @@ export function NotificationItem({
   const triggeredByName = notification.triggeredByUser?.name ?? null;
   const driveName = variant === 'page' ? notification.drive?.name ?? null : null;
   const isInteractive = Boolean(onSelect);
-  const showConnectionActions = isConnectionRequest(notification) && onAccept && onDecline;
+  const showConnectionActions =
+    isConnectionRequest(notification) && !notification.metadata?.actioned && onAccept && onDecline;
+  const showActionedStatus =
+    isConnectionRequest(notification) && Boolean(notification.metadata?.actioned);
 
   const handleActionClick = (event: MouseEvent<HTMLButtonElement>, handler?: () => void) => {
     event.stopPropagation();
@@ -144,6 +147,13 @@ export function NotificationItem({
               Decline
             </Button>
           </div>
+        ) : null}
+        {showActionedStatus ? (
+          <p className="mt-2 text-xs text-muted-foreground">
+            {notification.metadata.actionedStatus === 'accepted'
+              ? 'You accepted this request'
+              : 'You declined this request'}
+          </p>
         ) : null}
       </div>
 

--- a/apps/web/src/components/notifications/__tests__/NotificationItem.test.tsx
+++ b/apps/web/src/components/notifications/__tests__/NotificationItem.test.tsx
@@ -250,6 +250,34 @@ describe('NotificationItem', () => {
       expect(screen.queryByRole('button', { name: 'Accept' })).not.toBeInTheDocument();
       expect(screen.queryByRole('button', { name: 'Decline' })).not.toBeInTheDocument();
     });
+
+    it('hides Accept/Decline buttons when notification is actioned', () => {
+      const actioned = build({
+        type: 'CONNECTION_REQUEST',
+        metadata: { connectionId: 'conn-42', senderId: 'jane-1', actioned: true, actionedStatus: 'accepted' },
+      });
+      render(<NotificationItem notification={actioned} onAccept={vi.fn()} onDecline={vi.fn()} />);
+      expect(screen.queryByRole('button', { name: 'Accept' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Decline' })).not.toBeInTheDocument();
+    });
+
+    it('shows accepted status text when actionedStatus is accepted', () => {
+      const accepted = build({
+        type: 'CONNECTION_REQUEST',
+        metadata: { connectionId: 'conn-42', senderId: 'jane-1', actioned: true, actionedStatus: 'accepted' },
+      });
+      render(<NotificationItem notification={accepted} />);
+      expect(screen.getByText('You accepted this request')).toBeInTheDocument();
+    });
+
+    it('shows declined status text when actionedStatus is rejected', () => {
+      const rejected = build({
+        type: 'CONNECTION_REQUEST',
+        metadata: { connectionId: 'conn-42', senderId: 'jane-1', actioned: true, actionedStatus: 'rejected' },
+      });
+      render(<NotificationItem notification={rejected} />);
+      expect(screen.getByText('You declined this request')).toBeInTheDocument();
+    });
   });
 
   describe('Theme tokens only', () => {

--- a/apps/web/src/stores/__tests__/useNotificationStore.test.ts
+++ b/apps/web/src/stores/__tests__/useNotificationStore.test.ts
@@ -370,6 +370,49 @@ describe('useNotificationStore', () => {
     });
   });
 
+  describe('updateNotification', () => {
+    it('given an id and updates, should merge updates into the matching notification', () => {
+      const notif = createMockNotification({ id: 'upd-1', isRead: false });
+      useNotificationStore.setState({ notifications: [notif], unreadCount: 1 });
+
+      const { updateNotification } = useNotificationStore.getState();
+      updateNotification('upd-1', { isRead: true });
+
+      const updated = useNotificationStore.getState().notifications.find(n => n.id === 'upd-1');
+      expect(updated?.isRead).toBe(true);
+    });
+
+    it('given isRead:true transition on unread notification, should decrement unreadCount', () => {
+      const notif = createMockNotification({ id: 'upd-2', isRead: false });
+      useNotificationStore.setState({ notifications: [notif], unreadCount: 1 });
+
+      const { updateNotification } = useNotificationStore.getState();
+      updateNotification('upd-2', { isRead: true });
+
+      expect(useNotificationStore.getState().unreadCount).toBe(0);
+    });
+
+    it('given isRead:true on already-read notification, should not change unreadCount', () => {
+      const notif = createMockNotification({ id: 'upd-3', isRead: true });
+      useNotificationStore.setState({ notifications: [notif], unreadCount: 0 });
+
+      const { updateNotification } = useNotificationStore.getState();
+      updateNotification('upd-3', { isRead: true });
+
+      expect(useNotificationStore.getState().unreadCount).toBe(0);
+    });
+
+    it('given metadata update without isRead change, should not affect unreadCount', () => {
+      const notif = createMockNotification({ id: 'upd-4', isRead: false });
+      useNotificationStore.setState({ notifications: [notif], unreadCount: 2 });
+
+      const { updateNotification } = useNotificationStore.getState();
+      updateNotification('upd-4', { metadata: { actioned: true, actionedStatus: 'accepted' } });
+
+      expect(useNotificationStore.getState().unreadCount).toBe(2);
+    });
+  });
+
   describe('handleDeleteNotification', () => {
     it('given successful API call, should remove notification locally', async () => {
       const notif = createMockNotification({ id: 'notif-to-delete' });

--- a/apps/web/src/stores/useNotificationStore.ts
+++ b/apps/web/src/stores/useNotificationStore.ts
@@ -24,6 +24,7 @@ interface NotificationStore {
   markAsRead: (notificationId: string) => void;
   markAllAsRead: () => void;
   removeNotification: (notificationId: string) => void;
+  updateNotification: (id: string, updates: Partial<Notification>) => void;
   
   fetchNotifications: () => Promise<void>;
   handleNotificationRead: (notificationId: string) => Promise<void>;
@@ -102,6 +103,10 @@ export const useNotificationStore = create<NotificationStore>((set, get) => ({
     unreadCount: 0,
   })),
   
+  updateNotification: (id, updates) => set((state) => ({
+    notifications: state.notifications.map((n) => (n.id === id ? { ...n, ...updates } : n)),
+  })),
+
   removeNotification: (notificationId) => set((state) => {
     const notification = state.notifications.find(n => n.id === notificationId);
     return {

--- a/apps/web/src/stores/useNotificationStore.ts
+++ b/apps/web/src/stores/useNotificationStore.ts
@@ -103,9 +103,14 @@ export const useNotificationStore = create<NotificationStore>((set, get) => ({
     unreadCount: 0,
   })),
   
-  updateNotification: (id, updates) => set((state) => ({
-    notifications: state.notifications.map((n) => (n.id === id ? { ...n, ...updates } : n)),
-  })),
+  updateNotification: (id, updates) => set((state) => {
+    const existing = state.notifications.find((n) => n.id === id);
+    const becomesRead = existing && !existing.isRead && updates.isRead === true;
+    return {
+      notifications: state.notifications.map((n) => (n.id === id ? { ...n, ...updates } : n)),
+      unreadCount: becomesRead ? Math.max(0, state.unreadCount - 1) : state.unreadCount,
+    };
+  }),
 
   removeNotification: (notificationId) => set((state) => {
     const notification = state.notifications.find(n => n.id === notificationId);

--- a/packages/lib/src/notifications/__tests__/notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/notifications.test.ts
@@ -674,4 +674,3 @@ describe('markConnectionRequestActioned', () => {
     expect(db.update).not.toHaveBeenCalled();
   });
 });
-});

--- a/packages/lib/src/notifications/__tests__/notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/notifications.test.ts
@@ -73,6 +73,7 @@ import {
   createMentionNotification,
   createTaskAssignedNotification,
   broadcastTosPrivacyUpdate,
+  markConnectionRequestActioned,
 } from '../notifications';
 import { db } from '@pagespace/db/db';
 import { sendPushNotification } from '../push-notifications';
@@ -620,4 +621,57 @@ describe('broadcastTosPrivacyUpdate', () => {
 
     await expect(broadcastTosPrivacyUpdate('tos')).rejects.toThrow('DB error');
   });
+});
+
+// ---------------------------------------------------------------------------
+// markConnectionRequestActioned
+// ---------------------------------------------------------------------------
+describe('markConnectionRequestActioned', () => {
+  const existingNotification = {
+    id: 'notif-1',
+    userId: 'user-1',
+    type: 'CONNECTION_REQUEST',
+    isRead: false,
+    readAt: null,
+    metadata: { connectionId: 'conn-1', senderId: 'user-2' },
+  };
+
+  beforeEach(() => {
+    vi.mocked(db.query.notifications.findFirst).mockResolvedValue(existingNotification as never);
+    setupUpdateChain([{ ...existingNotification, isRead: true, metadata: { connectionId: 'conn-1', senderId: 'user-2', actioned: true, actionedStatus: 'accepted' } }]);
+  });
+
+  it('updates the notification with actioned=true and actionedStatus when found', async () => {
+    await markConnectionRequestActioned('conn-1', 'user-1', 'accepted');
+    expect(db.query.notifications.findFirst).toHaveBeenCalled();
+    expect(db.update).toHaveBeenCalled();
+  });
+
+  it('sets isRead:true and the actioned metadata fields', async () => {
+    const { setFn } = setupUpdateChain([existingNotification]);
+    await markConnectionRequestActioned('conn-1', 'user-1', 'rejected');
+    expect(setFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isRead: true,
+        metadata: expect.objectContaining({ actioned: true, actionedStatus: 'rejected' }),
+      }),
+    );
+  });
+
+  it('preserves existing metadata fields when updating', async () => {
+    const { setFn } = setupUpdateChain([existingNotification]);
+    await markConnectionRequestActioned('conn-1', 'user-1', 'accepted');
+    expect(setFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({ connectionId: 'conn-1', senderId: 'user-2' }),
+      }),
+    );
+  });
+
+  it('returns early without updating when no notification is found', async () => {
+    vi.mocked(db.query.notifications.findFirst).mockResolvedValue(undefined as never);
+    await markConnectionRequestActioned('conn-1', 'user-1', 'accepted');
+    expect(db.update).not.toHaveBeenCalled();
+  });
+});
 });

--- a/packages/lib/src/notifications/notifications.ts
+++ b/packages/lib/src/notifications/notifications.ts
@@ -162,6 +162,33 @@ export async function markAllNotificationsAsRead(userId: string) {
     );
 }
 
+export async function markConnectionRequestActioned(
+  connectionId: string,
+  userId: string,
+  actionedStatus: 'accepted' | 'rejected'
+) {
+  const notification = await db.query.notifications.findFirst({
+    where: and(
+      eq(notifications.userId, userId),
+      eq(notifications.type, 'CONNECTION_REQUEST'),
+      sql`${notifications.metadata}->>'connectionId' = ${connectionId}`
+    ),
+  });
+  if (!notification) return;
+  await db
+    .update(notifications)
+    .set({
+      isRead: true,
+      readAt: new Date(),
+      metadata: {
+        ...(notification.metadata as Record<string, unknown>),
+        actioned: true,
+        actionedStatus,
+      },
+    })
+    .where(eq(notifications.id, notification.id));
+}
+
 export async function deleteNotification(notificationId: string, userId: string) {
   await db
     .delete(notifications)

--- a/packages/lib/src/notifications/types.ts
+++ b/packages/lib/src/notifications/types.ts
@@ -37,6 +37,8 @@ export type ConnectionRequestNotification = NotificationBase & {
     connectionId: string;
     senderId: string;
     requestMessage?: string;
+    actioned?: boolean;
+    actionedStatus?: 'accepted' | 'rejected';
   };
 };
 


### PR DESCRIPTION
## Summary

- When a user accepted a connection request via email (navigating to the connections page), the \`CONNECTION_REQUEST\` notification remained in the bell with live Accept/Decline buttons — clicking them gave a 400 \"Connection is not pending\" error
- Fix marks the notification as **actioned** (read + metadata flag) instead of deleting it, so the invitation history is preserved
- Buttons are hidden for actioned notifications; a status line (\"You accepted this request\" / \"You declined this request\") is shown instead

## Changes

- **`types.ts`** — Add `actioned?` and `actionedStatus?` to `ConnectionRequestNotification` metadata
- **`notifications.ts`** — Add `markConnectionRequestActioned()`: finds the notification via JSONB metadata query and marks it read + actioned; preserves existing metadata fields
- **`connections/[connectionId]/route.ts`** — Call `markConnectionRequestActioned` after accept and reject so the DB is updated from any surface
- **`useNotificationStore.ts`** — Add `updateNotification(id, updates)` for in-place store mutations; decrements `unreadCount` when `isRead` transitions from false to true so the bell badge stays accurate
- **`connections/page.tsx`** — Optimistically update the store after action so the bell reflects state immediately
- **`notifications/page.tsx`** — Same optimistic update; removes the `window.location.reload()` hack; re-adds `handleNotificationRead` selector used by `handleSelect`
- **`NotificationDropdown.tsx`** — Guard `onAccept`/`onDecline` with `!metadata?.actioned` to protect against cross-session stale state
- **`NotificationItem.tsx`** — Render status text instead of action buttons when `actioned` is set; uses optional chaining on all metadata access

## Tests added

- `packages/lib/src/notifications/__tests__/notifications.test.ts` — 4 tests for `markConnectionRequestActioned` (found+updated, fields set, metadata preserved, not-found early return)
- `apps/web/src/app/api/connections/[connectionId]/__tests__/route.test.ts` — Updated mock to include `markConnectionRequestActioned`
- `apps/web/src/stores/__tests__/useNotificationStore.test.ts` — 4 tests for `updateNotification` (merges updates, decrements unread on read transition, no-op when already read, metadata-only update)
- `apps/web/src/components/notifications/__tests__/NotificationItem.test.tsx` — 3 tests for actioned state (hides buttons, shows accepted/declined status text)

## Test plan

- [ ] Send connection request as User A to User B
- [ ] As User B, navigate to `/dashboard/connections` (simulating email link) and click Accept
- [ ] Bell count decreases immediately; notification shows \"You accepted this request\" with no buttons
- [ ] Repeat for Decline — shows \"You declined this request\"
- [ ] Fresh page load still shows the notification as actioned (DB persisted)
- [ ] Accepting from the bell dropdown still removes the notification entirely (existing behaviour unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)