### PR TITLE
feat(tabs): add Alt+T hotkey to open a new tab

### DIFF
--- a/apps/web/src/components/layout/tabs/TabBar.tsx
+++ b/apps/web/src/components/layout/tabs/TabBar.tsx
@@ -141,6 +141,12 @@ export const TabBar = memo(function TabBar({ className }: TabBarProps) {
         return;
       }
 
+      if (matchesKeyEvent(getEffectiveBinding('tabs.new'), e)) {
+        e.preventDefault();
+        handleNewTab();
+        return;
+      }
+
       // Tab number shortcuts (1-9)
       for (let num = 1; num <= 9; num++) {
         if (matchesKeyEvent(getEffectiveBinding(`tabs.go-to-${num}`), e)) {
@@ -169,7 +175,7 @@ export const TabBar = memo(function TabBar({ className }: TabBarProps) {
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [tabs, activeTabId, handleActivate, handleClose, cycleTab, router]);
+  }, [tabs, activeTabId, handleActivate, handleClose, handleNewTab, cycleTab, router]);
 
   // Scroll active tab into view
   useEffect(() => {

--- a/apps/web/src/components/layout/tabs/TabBar.tsx
+++ b/apps/web/src/components/layout/tabs/TabBar.tsx
@@ -116,7 +116,10 @@ export const TabBar = memo(function TabBar({ className }: TabBarProps) {
   // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      // Cycle tabs
+      const target = e.target as HTMLElement;
+      const isInEditable = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
+
+      // Cycle tabs - work in editable fields (Ctrl+Tab doesn't produce characters)
       if (matchesKeyEvent(getEffectiveBinding('tabs.cycle-next'), e)) {
         e.preventDefault();
         cycleTab('next');
@@ -141,13 +144,14 @@ export const TabBar = memo(function TabBar({ className }: TabBarProps) {
         return;
       }
 
-      if (matchesKeyEvent(getEffectiveBinding('tabs.new'), e)) {
+      // New tab - skip in editable fields (Alt+T produces "†" on macOS)
+      if (!isInEditable && matchesKeyEvent(getEffectiveBinding('tabs.new'), e)) {
         e.preventDefault();
         handleNewTab();
         return;
       }
 
-      // Tab number shortcuts (1-9)
+      // Tab number shortcuts (1-9) - Meta+1-9 don't produce characters
       for (let num = 1; num <= 9; num++) {
         if (matchesKeyEvent(getEffectiveBinding(`tabs.go-to-${num}`), e)) {
           e.preventDefault();
@@ -161,9 +165,6 @@ export const TabBar = memo(function TabBar({ className }: TabBarProps) {
       }
 
       // Close tab - skip in editable inputs
-      const target = e.target as HTMLElement;
-      const isInEditable = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable;
-
       if (!isInEditable && matchesKeyEvent(getEffectiveBinding('tabs.close'), e)) {
         if (activeTabId) {
           e.preventDefault();

--- a/apps/web/src/lib/hotkeys/registry.ts
+++ b/apps/web/src/lib/hotkeys/registry.ts
@@ -68,6 +68,14 @@ export const HOTKEY_REGISTRY: HotkeyDefinition[] = [
     defaultBinding: 'Meta+W',
   },
   {
+    id: 'tabs.new',
+    label: 'New Tab',
+    description: 'Open a new tab',
+    category: 'tabs',
+    defaultBinding: 'Alt+T',
+    allowInInputs: true,
+  },
+  {
     id: 'tabs.go-to-1',
     label: 'Go to Tab 1',
     description: 'Switch to the first tab',

--- a/apps/web/src/lib/hotkeys/registry.ts
+++ b/apps/web/src/lib/hotkeys/registry.ts
@@ -73,7 +73,6 @@ export const HOTKEY_REGISTRY: HotkeyDefinition[] = [
     description: 'Open a new tab',
     category: 'tabs',
     defaultBinding: 'Alt+T',
-    allowInInputs: true,
   },
   {
     id: 'tabs.go-to-1',


### PR DESCRIPTION
## Summary

- Adds \`tabs.new\` to the hotkey registry with \`Alt+T\` as the default binding
- \`Alt\` avoids browser-native capture (\`Cmd+T\`/\`Ctrl+T\` are intercepted by browsers before JS can block them)
- Consistent with the existing \`Alt+N\` quick-create pattern
- Wires the listener in \`TabBar.tsx\` using the existing \`handleNewTab\` callback — no new logic needed
- Automatically appears in \`/settings/hotkeys\` under Tabs, fully rebindable (desktop users can change to \`Cmd+T\`)
- Skips in editable fields (INPUT/TEXTAREA/contentEditable) — \`Alt+T\` produces "†" on macOS via Option key, consistent with \`tabs.close\` behaviour

**Known limitation**: In Firefox, \`Alt+T\` is the native shortcut for the browser Tools menu (chrome-level, cannot be blocked by JavaScript). The shortcut will silently no-op for Firefox web users. Not affected: Electron desktop, Safari, Chrome. Users on Firefox can rebind via \`/settings/hotkeys\`.

## Test plan

- [ ] Press \`Alt+T\` — new tab opens at \`/dashboard\` and becomes active
- [ ] Navigate to \`/settings/hotkeys\` — "New Tab" appears in the Tabs section showing \`Alt+T\`
- [ ] Rebind to a custom key, reload, press it — still works
- [ ] Press \`Alt+T\` while focused in an input field — no new tab opens, cursor stays in input
- [ ] \`Meta+W\`, \`Ctrl+Tab\`, \`Meta+1\`–\`9\` still work (no regressions)
- [ ] Firefox: \`Alt+T\` opens browser Tools menu (expected — rebind via settings if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)