### PR TITLE
feat(channels): consistent always-visible action buttons

### DIFF
--- a/apps/web/src/app/dashboard/inbox/channel/[pageId]/page.tsx
+++ b/apps/web/src/app/dashboard/inbox/channel/[pageId]/page.tsx
@@ -5,7 +5,7 @@ import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import useSWR from 'swr';
 import { toast } from 'sonner';
-import { Hash, ExternalLink, Lock, FileIcon, FileText, Download, Pencil, Trash2, Check, X } from 'lucide-react';
+import { Hash, ExternalLink, Lock, FileIcon, FileText, Download, Pencil, Trash2, Check, X, MoreHorizontal } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
 import { usePermissions, getPermissionErrorMessage } from '@/hooks/usePermissions';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -17,7 +17,13 @@ import { ChannelInput, type ChannelInputRef, type FileAttachment } from '@/compo
 import { MessageReactions, type Reaction } from '@/components/layout/middle-content/page-views/channel/MessageReactions';
 import { PullToRefresh } from '@/components/ui/pull-to-refresh';
 import { post, del, patch, fetchWithAuth } from '@/lib/auth/auth-fetch';
-import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { useSocketStore } from '@/stores/useSocketStore';
 import {
   type AttachmentMeta,
@@ -510,7 +516,7 @@ export default function InboxChannelPage() {
 
                 const isOwnMessage = !isAi && m.userId === user?.id;
                 return (
-                <div key={m.id} className="group flex items-start gap-4">
+                <div key={m.id} className="flex items-start gap-4">
                   <Avatar className="shrink-0">
                     {!isAi && <AvatarImage src={m.user?.image || ''} />}
                     <AvatarFallback>{avatarFallback}</AvatarFallback>
@@ -530,32 +536,31 @@ export default function InboxChannelPage() {
                         <span className="text-xs text-muted-foreground italic">(Edited)</span>
                       )}
                       {isOwnMessage && !m.id.startsWith('temp-') && editingMessageId !== m.id && (
-                        <div className="flex items-center gap-1 ml-1">
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <button
-                                onClick={() => { setEditingMessageId(m.id); setEditContent(m.content); }}
-                                className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
-                                type="button"
-                              >
-                                <Pencil size={12} />
-                              </button>
-                            </TooltipTrigger>
-                            <TooltipContent side="top">Edit</TooltipContent>
-                          </Tooltip>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <button
-                                onClick={() => handleDeleteMessage(m.id)}
-                                className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-destructive transition-colors"
-                                type="button"
-                              >
-                                <Trash2 size={12} />
-                              </button>
-                            </TooltipTrigger>
-                            <TooltipContent side="top">Delete</TooltipContent>
-                          </Tooltip>
-                        </div>
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <button
+                              aria-label="Message actions"
+                              className="ml-auto p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                              type="button"
+                            >
+                              <MoreHorizontal size={14} aria-hidden />
+                            </button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuItem
+                              onClick={() => { setEditingMessageId(m.id); setEditContent(m.content); }}
+                            >
+                              <Pencil className="mr-2 h-4 w-4" /> Edit
+                            </DropdownMenuItem>
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem
+                              onClick={() => handleDeleteMessage(m.id)}
+                              className="text-destructive focus:text-destructive"
+                            >
+                              <Trash2 className="mr-2 h-4 w-4" /> Delete
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
                       )}
                     </div>
                     {editingMessageId === m.id ? (

--- a/apps/web/src/app/dashboard/inbox/channel/[pageId]/page.tsx
+++ b/apps/web/src/app/dashboard/inbox/channel/[pageId]/page.tsx
@@ -539,7 +539,7 @@ export default function InboxChannelPage() {
                         <DropdownMenu>
                           <DropdownMenuTrigger asChild>
                             <button
-                              aria-label="Message actions"
+                              aria-label="Message options"
                               className="ml-auto p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
                               type="button"
                             >

--- a/apps/web/src/app/dashboard/inbox/dm/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/inbox/dm/[conversationId]/page.tsx
@@ -11,8 +11,14 @@ import useSWR from 'swr';
 import { toast } from 'sonner';
 import { useSocket } from '@/hooks/useSocket';
 import { post, patch, del, fetchWithAuth } from '@/lib/auth/auth-fetch';
-import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
-import { Pencil, Trash2, Check, X } from 'lucide-react';
+import { Pencil, Trash2, Check, X, MoreHorizontal } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 
 const fetcher = async (url: string) => {
   const response = await fetchWithAuth(url);
@@ -227,32 +233,31 @@ export default function InboxDMPage() {
                         <span className="text-xs text-muted-foreground">Read</span>
                       )}
                       {isOwnMessage && editingMessageId !== message.id && (
-                        <div className="flex items-center gap-1 ml-1">
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <button
-                                onClick={() => { setEditingMessageId(message.id); setEditContent(message.content); }}
-                                className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
-                                type="button"
-                              >
-                                <Pencil size={12} />
-                              </button>
-                            </TooltipTrigger>
-                            <TooltipContent side="top">Edit</TooltipContent>
-                          </Tooltip>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <button
-                                onClick={() => handleDeleteMessage(message.id)}
-                                className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-destructive transition-colors"
-                                type="button"
-                              >
-                                <Trash2 size={12} />
-                              </button>
-                            </TooltipTrigger>
-                            <TooltipContent side="top">Delete</TooltipContent>
-                          </Tooltip>
-                        </div>
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <button
+                              aria-label="Message actions"
+                              className="ml-auto p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                              type="button"
+                            >
+                              <MoreHorizontal size={14} aria-hidden />
+                            </button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuItem
+                              onClick={() => { setEditingMessageId(message.id); setEditContent(message.content); }}
+                            >
+                              <Pencil className="mr-2 h-4 w-4" /> Edit
+                            </DropdownMenuItem>
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem
+                              onClick={() => handleDeleteMessage(message.id)}
+                              className="text-destructive focus:text-destructive"
+                            >
+                              <Trash2 className="mr-2 h-4 w-4" /> Delete
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
                       )}
                     </div>
 

--- a/apps/web/src/app/dashboard/inbox/dm/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/inbox/dm/[conversationId]/page.tsx
@@ -236,7 +236,7 @@ export default function InboxDMPage() {
                         <DropdownMenu>
                           <DropdownMenuTrigger asChild>
                             <button
-                              aria-label="Message actions"
+                              aria-label="Message options"
                               className="ml-auto p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
                               type="button"
                             >

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -13,8 +13,14 @@ import { MessageReactions, type Reaction } from './MessageReactions';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Lock, FileIcon, FileText, Download } from 'lucide-react';
 import { post, del, patch, fetchWithAuth } from '@/lib/auth/auth-fetch';
-import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
-import { Pencil, Trash2, Check, X } from 'lucide-react';
+import { Pencil, Trash2, Check, X, MoreHorizontal } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { useSocketStore } from '@/stores/useSocketStore';
 import { PullToRefresh } from '@/components/ui/pull-to-refresh';
 import {
@@ -460,32 +466,30 @@ function ChannelView({ page }: ChannelViewProps) {
                                       <span className="text-xs text-muted-foreground italic">(Edited)</span>
                                     )}
                                     {isOwnMessage && !m.id.startsWith('temp-') && editingMessageId !== m.id && (
-                                      <div className="flex items-center gap-1 ml-1">
-                                        <Tooltip>
-                                          <TooltipTrigger asChild>
-                                            <button
-                                              onClick={() => { setEditingMessageId(m.id); setEditContent(m.content); }}
-                                              className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
-                                              type="button"
-                                            >
-                                              <Pencil size={12} />
-                                            </button>
-                                          </TooltipTrigger>
-                                          <TooltipContent side="top">Edit</TooltipContent>
-                                        </Tooltip>
-                                        <Tooltip>
-                                          <TooltipTrigger asChild>
-                                            <button
-                                              onClick={() => handleDeleteMessage(m.id)}
-                                              className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-destructive transition-colors"
-                                              type="button"
-                                            >
-                                              <Trash2 size={12} />
-                                            </button>
-                                          </TooltipTrigger>
-                                          <TooltipContent side="top">Delete</TooltipContent>
-                                        </Tooltip>
-                                      </div>
+                                      <DropdownMenu>
+                                        <DropdownMenuTrigger asChild>
+                                          <button
+                                            className="ml-auto p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                                            type="button"
+                                          >
+                                            <MoreHorizontal size={14} />
+                                          </button>
+                                        </DropdownMenuTrigger>
+                                        <DropdownMenuContent align="end">
+                                          <DropdownMenuItem
+                                            onClick={() => { setEditingMessageId(m.id); setEditContent(m.content); }}
+                                          >
+                                            <Pencil className="mr-2 h-4 w-4" /> Edit
+                                          </DropdownMenuItem>
+                                          <DropdownMenuSeparator />
+                                          <DropdownMenuItem
+                                            onClick={() => handleDeleteMessage(m.id)}
+                                            className="text-destructive focus:text-destructive"
+                                          >
+                                            <Trash2 className="mr-2 h-4 w-4" /> Delete
+                                          </DropdownMenuItem>
+                                        </DropdownMenuContent>
+                                      </DropdownMenu>
                                     )}
                                 </div>
                                 {editingMessageId === m.id ? (

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -445,7 +445,7 @@ function ChannelView({ page }: ChannelViewProps) {
                           : m.user?.name?.[0];
                         const isOwnMessage = !isAi && m.userId === user?.id;
                         return (
-                        <div key={m.id} className="group flex items-start gap-4">
+                        <div key={m.id} className="flex items-start gap-4">
                             <Avatar className="shrink-0">
                                 {!isAi && <AvatarImage src={m.user?.image || ''} />}
                                 <AvatarFallback>{avatarFallback}</AvatarFallback>

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -468,7 +468,7 @@ function ChannelView({ page }: ChannelViewProps) {
                                       <DropdownMenu>
                                         <DropdownMenuTrigger asChild>
                                           <button
-                                            aria-label="Message actions"
+                                            aria-label="Message options"
                                             className="ml-auto p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
                                             type="button"
                                           >

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -11,9 +11,8 @@ import { StreamingMarkdown } from '@/components/ai/shared/chat/StreamingMarkdown
 import { ChannelInput, type ChannelInputRef, type FileAttachment } from './ChannelInput';
 import { MessageReactions, type Reaction } from './MessageReactions';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Lock, FileIcon, FileText, Download } from 'lucide-react';
+import { Lock, FileIcon, FileText, Download, Pencil, Trash2, Check, X, MoreHorizontal } from 'lucide-react';
 import { post, del, patch, fetchWithAuth } from '@/lib/auth/auth-fetch';
-import { Pencil, Trash2, Check, X, MoreHorizontal } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -469,10 +468,11 @@ function ChannelView({ page }: ChannelViewProps) {
                                       <DropdownMenu>
                                         <DropdownMenuTrigger asChild>
                                           <button
+                                            aria-label="Message actions"
                                             className="ml-auto p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
                                             type="button"
                                           >
-                                            <MoreHorizontal size={14} />
+                                            <MoreHorizontal size={14} aria-hidden />
                                           </button>
                                         </DropdownMenuTrigger>
                                         <DropdownMenuContent align="end">

--- a/apps/web/src/components/layout/middle-content/page-views/channel/MessageReactions.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/MessageReactions.tsx
@@ -178,9 +178,6 @@ export function MessageReactions({
               'h-6 w-6 p-0 rounded-full',
               'text-muted-foreground hover:text-foreground',
               'hover:bg-muted/50',
-              'opacity-0 group-hover:opacity-100 transition-opacity',
-              // Always show if there are reactions
-              groupedReactions.length > 0 && 'opacity-100'
             )}
           >
             <Plus className="h-3.5 w-3.5" />

--- a/apps/web/src/components/layout/middle-content/page-views/channel/MessageReactions.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/MessageReactions.tsx
@@ -134,7 +134,7 @@ export function MessageReactions({
   }
 
   return (
-    <div className={cn('group flex flex-wrap items-center gap-1 mt-1', className)}>
+    <div className={cn('flex flex-wrap items-center gap-1 mt-1', className)}>
       {/* Reaction chips */}
       {groupedReactions.map((group) => (
         <Tooltip key={group.emoji}>


### PR DESCRIPTION
## Summary

- Replace the two inline Edit/Delete icon buttons in the message header with a single `⋯` `DropdownMenu`; Delete now requires one extra click, which is appropriate friction for an irreversible action
- Use `ml-auto` on the `⋯` trigger to push it to the far right of the header row, creating a clean metadata-left / action-right visual split
- Remove `opacity-0 group-hover:opacity-100` hiding from the reaction `+` button so it is always visible and reachable on touch devices
- Add `aria-label="Message actions"` and `aria-hidden` to the `⋯` trigger for screen reader accessibility
- Apply the same DropdownMenu pattern consistently to **inbox channel view** and **DM view** (previously still using the old Tooltip button pair)
- Clean up dead `group` Tailwind class from message row divs and merged duplicate `lucide-react` imports

## Files changed

- `ChannelView.tsx` — primary channel view (main layout)
- `apps/web/src/app/dashboard/inbox/channel/[pageId]/page.tsx` — inbox channel view
- `apps/web/src/app/dashboard/inbox/dm/[conversationId]/page.tsx` — inbox DM view
- `MessageReactions.tsx` — reaction `+` button always visible

## Test plan

- [ ] Send a message in a channel — own message shows `⋯` at the right of the header row
- [ ] Click `⋯` — dropdown shows Edit (with pencil icon) and Delete (red, with trash icon)
- [ ] Click Edit — inline textarea opens and saves correctly
- [ ] Click Delete — message is removed
- [ ] Messages from other users show no `⋯`
- [ ] Reaction `+` button is visible without hovering, on messages with and without existing reactions
- [ ] Verify on mobile viewport (DevTools touch emulation) — all actions accessible
- [ ] Verify with screen reader — `⋯` button reads as "Message actions"
- [ ] Repeat above in **inbox channel view** (`/dashboard/inbox/channel/[id]`)
- [ ] Repeat Edit/Delete in **inbox DM view** (`/dashboard/inbox/dm/[id]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)