### PR TITLE
style(auth): swap CTA weight to match button order

### DIFF
--- a/apps/web/src/app/auth/signin/page.tsx
+++ b/apps/web/src/app/auth/signin/page.tsx
@@ -116,7 +116,6 @@ function SignInForm() {
             <PasskeyLoginButton
               csrfToken={csrfToken}
               refreshToken={refreshToken}
-              variant="outline"
             />
           </motion.div>
         )}
@@ -157,7 +156,6 @@ function SignInForm() {
           <PasskeyLoginButton
             csrfToken={csrfToken}
             refreshToken={refreshToken}
-            variant="outline"
           />
         </motion.div>
       )}

--- a/apps/web/src/components/auth/OAuthButtons.tsx
+++ b/apps/web/src/components/auth/OAuthButtons.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'motion/react';
 import { Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 
 interface OAuthButtonsProps {
   onGoogleClick: () => void;
@@ -22,65 +23,62 @@ export function OAuthButtons({
 
   return (
     <div className="flex flex-col gap-3">
-      <motion.button
-        type="button"
-        className="flex w-full items-center justify-center gap-3 rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
-        onClick={onGoogleClick}
-        disabled={disabled || isAnyLoading}
+      <motion.div
         initial={{ opacity: 0, y: 10 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.1, duration: 0.3 }}
         whileHover={{ scale: 1.01 }}
         whileTap={{ scale: 0.99 }}
       >
-        {isGoogleLoading ? (
-          <Loader2 className="h-5 w-5 animate-spin" />
-        ) : (
-          <>
-            <motion.svg
-              className="h-5 w-5"
-              viewBox="0 0 24 24"
-              whileHover={{ scale: 1.15 }}
-              transition={{ duration: 0.2 }}
-            >
-              <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" />
-              <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
-              <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
-              <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
-            </motion.svg>
-            <span>Continue with Google</span>
-          </>
-        )}
-      </motion.button>
+        <Button
+          type="button"
+          variant="outline"
+          className="w-full gap-3"
+          onClick={onGoogleClick}
+          disabled={disabled || isAnyLoading}
+        >
+          {isGoogleLoading ? (
+            <Loader2 className="h-5 w-5 animate-spin" />
+          ) : (
+            <>
+              <svg className="h-5 w-5" viewBox="0 0 24 24">
+                <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" />
+                <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" />
+                <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" />
+                <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" />
+              </svg>
+              <span>Continue with Google</span>
+            </>
+          )}
+        </Button>
+      </motion.div>
 
-      <motion.button
-        type="button"
-        className="flex w-full items-center justify-center gap-3 rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
-        onClick={onAppleClick}
-        disabled={disabled || isAnyLoading}
+      <motion.div
         initial={{ opacity: 0, y: 10 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.2, duration: 0.3 }}
         whileHover={{ scale: 1.01 }}
         whileTap={{ scale: 0.99 }}
       >
-        {isAppleLoading ? (
-          <Loader2 className="h-5 w-5 animate-spin" />
-        ) : (
-          <>
-            <motion.svg
-              className="h-5 w-5"
-              viewBox="0 0 24 24"
-              fill="currentColor"
-              whileHover={{ scale: 1.15 }}
-              transition={{ duration: 0.2 }}
-            >
-              <path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09l.01-.01zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
-            </motion.svg>
-            <span>Continue with Apple</span>
-          </>
-        )}
-      </motion.button>
+        <Button
+          type="button"
+          variant="outline"
+          className="w-full gap-3"
+          onClick={onAppleClick}
+          disabled={disabled || isAnyLoading}
+        >
+          {isAppleLoading ? (
+            <Loader2 className="h-5 w-5 animate-spin" />
+          ) : (
+            <>
+              <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M17.05 20.28c-.98.95-2.05.8-3.08.35-1.09-.46-2.09-.48-3.24 0-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09l.01-.01zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z" />
+              </svg>
+              <span>Continue with Apple</span>
+            </>
+          )}
+        </Button>
+      </motion.div>
     </div>
   );
 }

--- a/apps/web/src/components/auth/PasskeyLoginButton.tsx
+++ b/apps/web/src/components/auth/PasskeyLoginButton.tsx
@@ -31,7 +31,7 @@ export function PasskeyLoginButton({
   email,
   onSuccess,
   className,
-  variant = 'outline',
+  variant = 'default',
 }: PasskeyLoginButtonProps) {
   const isSupported = useWebAuthnSupport();
   const [isAuthenticating, setIsAuthenticating] = useState(false);


### PR DESCRIPTION
## Summary
- `PasskeyLoginButton` default variant changed from `outline` → `default` (filled primary) to match its top/primary position
- `OAuthButtons` (Google + Apple) converted to shadcn `Button variant="outline"` to reflect their secondary position below the passkey button
- Fixes the previous commit which was a no-op (removing `variant="outline"` at the call site doesn't change anything when the component defaults to `outline`)

## Test plan
- [ ] Sign-in page: passkey button renders filled/primary, Google + Apple render outline
- [ ] Verify dark mode looks correct for both button types

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated authentication button styling across the sign-in interface for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->