### PR TITLE
feat(e2e): direct DB seed infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,13 @@ test-results/
 tests/load/results/*.json
 tests/load/results/*.html
 
+## k6 auth seed file (contains live session token)
+.k6-auth.json
+
+## Playwright e2e seed state and storage state (contains live session token)
+apps/e2e/.seed-state.json
+apps/e2e/storageState.json
+
 ## Code coverage
 coverage/
 *.gcda

--- a/apps/e2e/global-setup.ts
+++ b/apps/e2e/global-setup.ts
@@ -1,0 +1,60 @@
+import fs from 'fs/promises';
+import path from 'path';
+import 'dotenv/config';
+import { factories } from '@pagespace/db/test/factories';
+import { sessionService } from '../../packages/lib/src/auth/session-service';
+
+const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const E2E_DIR = path.join(process.cwd(), 'apps/e2e');
+
+function assertNotProduction(url: string): void {
+  const { hostname } = new URL(url);
+  const safeHosts = ['localhost', '127.0.0.1', 'postgres', 'db', '::1'];
+  if (!safeHosts.includes(hostname)) {
+    throw new Error(
+      `ABORT: seed scripts must not run against a non-local database (host: ${hostname})`
+    );
+  }
+}
+
+export default async function globalSetup() {
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl) throw new Error('DATABASE_URL is required');
+  assertNotProduction(dbUrl);
+
+  const user = await factories.createUser();
+  const drive = await factories.createDrive(user.id);
+  const token = await sessionService.createSession({
+    userId: user.id,
+    type: 'user',
+    scopes: [],
+    expiresInMs: SESSION_TTL_MS,
+  });
+
+  await fs.writeFile(
+    path.join(E2E_DIR, '.seed-state.json'),
+    JSON.stringify({ userId: user.id, driveId: drive.id })
+  );
+
+  const storageState = {
+    cookies: [
+      {
+        name: 'session',
+        value: token,
+        domain: 'localhost',
+        path: '/',
+        httpOnly: true,
+        secure: false,
+        sameSite: 'Strict' as const,
+        expires: Math.floor((Date.now() + SESSION_TTL_MS) / 1000),
+      },
+    ],
+    origins: [],
+  };
+  await fs.writeFile(
+    path.join(E2E_DIR, 'storageState.json'),
+    JSON.stringify(storageState, null, 2)
+  );
+
+  console.log(`[e2e setup] Seeded user=${user.id} drive=${drive.id}`);
+}

--- a/apps/e2e/global-teardown.ts
+++ b/apps/e2e/global-teardown.ts
@@ -1,0 +1,45 @@
+import fs from 'fs/promises';
+import path from 'path';
+import 'dotenv/config';
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { users } from '@pagespace/db/schema/auth';
+import { drives } from '@pagespace/db/schema/core';
+import { sessions } from '@pagespace/db/schema/sessions';
+
+const E2E_DIR = path.join(process.cwd(), 'apps/e2e');
+const STATE_FILE = path.join(E2E_DIR, '.seed-state.json');
+const STORAGE_STATE_FILE = path.join(E2E_DIR, 'storageState.json');
+
+export default async function globalTeardown() {
+  let userId: string;
+  try {
+    const raw = await fs.readFile(STATE_FILE, 'utf-8');
+    ({ userId } = JSON.parse(raw));
+  } catch {
+    console.warn('[e2e teardown] No .seed-state.json — nothing to clean up');
+    return;
+  }
+
+  // Cascade: sessions, driveMembers, pages all cascade from users
+  await db.delete(users).where(eq(users.id, userId));
+
+  const [orphanedDrives, orphanedSessions] = await Promise.all([
+    db.select({ id: drives.id }).from(drives).where(eq(drives.ownerId, userId)),
+    db.select({ id: sessions.id }).from(sessions).where(eq(sessions.userId, userId)),
+  ]);
+
+  if (orphanedDrives.length > 0 || orphanedSessions.length > 0) {
+    throw new Error(
+      `[e2e teardown] Orphaned rows after deleting user ${userId}: ` +
+        `${orphanedDrives.length} drives, ${orphanedSessions.length} sessions`
+    );
+  }
+
+  await Promise.all([
+    fs.rm(STATE_FILE, { force: true }),
+    fs.rm(STORAGE_STATE_FILE, { force: true }),
+  ]);
+
+  console.log(`[e2e teardown] Cleaned up user=${userId}`);
+}

--- a/tests/load/scripts/cleanup-load-user.ts
+++ b/tests/load/scripts/cleanup-load-user.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env tsx
+import fs from 'fs/promises';
+import path from 'path';
+import 'dotenv/config';
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { users } from '@pagespace/db/schema/auth';
+
+const AUTH_FILE = path.join(process.cwd(), '.k6-auth.json');
+
+async function main() {
+  let userId: string;
+  try {
+    const raw = await fs.readFile(AUTH_FILE, 'utf-8');
+    ({ userId } = JSON.parse(raw));
+  } catch {
+    console.warn('[k6 cleanup] No .k6-auth.json — nothing to clean up');
+    return;
+  }
+
+  // Cascade: sessions, drives, pages all cascade from users
+  await db.delete(users).where(eq(users.id, userId));
+  await fs.rm(AUTH_FILE, { force: true });
+  console.log(`[k6 cleanup] Deleted user=${userId}`);
+}
+
+main().catch(err => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/tests/load/scripts/seed-load-user.ts
+++ b/tests/load/scripts/seed-load-user.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env tsx
+import fs from 'fs/promises';
+import path from 'path';
+import 'dotenv/config';
+import { factories } from '@pagespace/db/test/factories';
+import { sessionService } from '../../../packages/lib/src/auth/session-service';
+
+const AUTH_FILE = path.join(process.cwd(), '.k6-auth.json');
+const SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+function assertNotProduction(url: string): void {
+  const { hostname } = new URL(url);
+  const safeHosts = ['localhost', '127.0.0.1', 'postgres', 'db', '::1'];
+  if (!safeHosts.includes(hostname)) {
+    throw new Error(
+      `ABORT: seed scripts must not run against a non-local database (host: ${hostname})`
+    );
+  }
+}
+
+async function main() {
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl) throw new Error('DATABASE_URL is required');
+  assertNotProduction(dbUrl);
+
+  const user = await factories.createUser();
+  const drive = await factories.createDrive(user.id);
+  const sessionToken = await sessionService.createSession({
+    userId: user.id,
+    type: 'user',
+    scopes: [],
+    expiresInMs: SESSION_TTL_MS,
+  });
+
+  await fs.writeFile(AUTH_FILE, JSON.stringify({ sessionToken, userId: user.id, driveId: drive.id }, null, 2));
+  console.log(`[k6 seed] user=${user.id} drive=${drive.id} → .k6-auth.json`);
+}
+
+main().catch(err => {
+  console.error(err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- `apps/e2e/global-setup.ts` — seeds one user + drive via `factories`, creates a 7-day session via `sessionService`, writes `storageState.json` (Playwright cookie jar) and `.seed-state.json` for teardown
- `apps/e2e/global-teardown.ts` — deletes seeded user by ID; `onDelete: cascade` on sessions/drives/pages handles cleanup; asserts zero orphaned rows remain
- `tests/load/scripts/seed-load-user.ts` — same seed pattern, writes `{ sessionToken, userId, driveId }` to `.k6-auth.json`
- `tests/load/scripts/cleanup-load-user.ts` — reads `.k6-auth.json`, deletes user by ID (cascade)
- `.gitignore` — adds `.k6-auth.json`, `apps/e2e/.seed-state.json`, `apps/e2e/storageState.json` (all contain live session tokens)

No HTTP endpoints added to the application. No env flags in application source. Production guard throws before touching the DB if hostname is not `localhost`, `127.0.0.1`, `postgres`, or `db`.

## Test plan

- [ ] `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/pagespace npx tsx tests/load/scripts/seed-load-user.ts` — writes `.k6-auth.json`
- [ ] `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/pagespace npx tsx tests/load/scripts/cleanup-load-user.ts` — deletes user, removes file
- [ ] Pass a prod-like URL (e.g. `@db.pagespace.ai:5432/`) — exits non-zero before any DB operation
- [ ] TypeScript: `tsc --noEmit` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end testing infrastructure with automated setup and teardown processes.
  * Added load testing utilities for automated user seeding and cleanup operations.

* **Chores**
  * Updated configuration to exclude sensitive test authentication state files and artifacts from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->