### PR TITLE
feat(load): Grafana + InfluxDB monitoring stack for k6

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -1,0 +1,56 @@
+services:
+  influxdb:
+    image: influxdb:2
+    ports:
+      - "8086:8086"
+    environment:
+      DOCKER_INFLUXDB_INIT_MODE: setup
+      DOCKER_INFLUXDB_INIT_USERNAME: admin
+      DOCKER_INFLUXDB_INIT_PASSWORD: adminpassword
+      DOCKER_INFLUXDB_INIT_ORG: pagespace
+      DOCKER_INFLUXDB_INIT_BUCKET: k6
+      DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: pagespace-local-token
+    volumes:
+      - influxdb_data:/var/lib/influxdb2
+    healthcheck:
+      test: ["CMD", "influx", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3001:3000"
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - ./tests/load/grafana/provisioning:/etc/grafana/provisioning
+      - ./tests/load/grafana/dashboards:/var/lib/grafana/dashboards
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      influxdb:
+        condition: service_healthy
+
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./tests/load/grafana/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  postgres_exporter:
+    image: prometheuscommunity/postgres-exporter:latest
+    ports:
+      - "9187:9187"
+    environment:
+      DATA_SOURCE_NAME: "${POSTGRES_EXPORTER_DSN:-postgresql://postgres:postgres@host.docker.internal:5432/pagespace?sslmode=disable}"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+volumes:
+  influxdb_data:
+  grafana_data:

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -1,15 +1,15 @@
 services:
   influxdb:
-    image: influxdb:2
+    image: influxdb:2.7
     ports:
       - "8086:8086"
     environment:
       DOCKER_INFLUXDB_INIT_MODE: setup
       DOCKER_INFLUXDB_INIT_USERNAME: admin
-      DOCKER_INFLUXDB_INIT_PASSWORD: adminpassword
+      DOCKER_INFLUXDB_INIT_PASSWORD: "${INFLUXDB_ADMIN_PASSWORD:-adminpassword}"
       DOCKER_INFLUXDB_INIT_ORG: pagespace
       DOCKER_INFLUXDB_INIT_BUCKET: k6
-      DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: pagespace-local-token
+      DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: "${INFLUXDB_TOKEN:-pagespace-local-token}"
     volumes:
       - influxdb_data:/var/lib/influxdb2
     healthcheck:
@@ -19,12 +19,13 @@ services:
       retries: 5
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:11.4.0
     ports:
       - "3001:3000"
     environment:
-      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_SECURITY_ADMIN_PASSWORD: "${GRAFANA_ADMIN_PASSWORD:-admin}"
       GF_USERS_ALLOW_SIGN_UP: "false"
+      INFLUXDB_TOKEN: "${INFLUXDB_TOKEN:-pagespace-local-token}"
     volumes:
       - ./tests/load/grafana/provisioning:/etc/grafana/provisioning
       - ./tests/load/grafana/dashboards:/var/lib/grafana/dashboards
@@ -34,7 +35,7 @@ services:
         condition: service_healthy
 
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v2.55.1
     ports:
       - "9090:9090"
     volumes:
@@ -43,7 +44,7 @@ services:
       - "host.docker.internal:host-gateway"
 
   postgres_exporter:
-    image: prometheuscommunity/postgres-exporter:latest
+    image: prometheuscommunity/postgres-exporter:v0.15.0
     ports:
       - "9187:9187"
     environment:

--- a/scripts/run-load-test.sh
+++ b/scripts/run-load-test.sh
@@ -5,9 +5,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 BASE_URL="${BASE_URL:-http://localhost:3000}"
-INFLUXDB_URL="http://localhost:8086/k6"
-GRAFANA_URL="http://localhost:3001"
-K6_OUT="--out influxdb=${INFLUXDB_URL}"
+INFLUXDB_HOST="${INFLUXDB_HOST:-localhost}"
+INFLUXDB_URL="http://${INFLUXDB_HOST}:8086/k6"
+GRAFANA_URL="${GRAFANA_URL:-http://localhost:3001}"
+K6_OUT_ARGS=(--out "influxdb=${INFLUXDB_URL}")
 
 echo "==> Starting monitoring stack..."
 docker compose -f "$REPO_ROOT/docker-compose.monitoring.yml" up -d
@@ -15,7 +16,7 @@ docker compose -f "$REPO_ROOT/docker-compose.monitoring.yml" up -d
 echo "==> Waiting for InfluxDB to be ready..."
 MAX_WAIT=60
 WAITED=0
-until curl -sf http://localhost:8086/health > /dev/null 2>&1; do
+until curl -sf "http://${INFLUXDB_HOST}:8086/health" > /dev/null 2>&1; do
   if [ "$WAITED" -ge "$MAX_WAIT" ]; then
     echo "ERROR: InfluxDB did not become healthy within ${MAX_WAIT}s" >&2
     exit 1
@@ -26,8 +27,13 @@ until curl -sf http://localhost:8086/health > /dev/null 2>&1; do
 done
 echo "  InfluxDB is ready."
 
-echo "==> Seeding load test user..."
-npx tsx "$REPO_ROOT/tests/load/scripts/seed-load-user.ts"
+SEED_SCRIPT="$REPO_ROOT/tests/load/scripts/seed-load-user.ts"
+if [ -f "$SEED_SCRIPT" ]; then
+  echo "==> Seeding load test user..."
+  pnpm exec tsx "$SEED_SCRIPT"
+else
+  echo "WARNING: Seed script not found at $SEED_SCRIPT — skipping user seed."
+fi
 
 echo "==> Running k6 scenarios..."
 SCENARIOS_DIR="$REPO_ROOT/tests/load/scenarios"
@@ -43,19 +49,22 @@ else
       --network host \
       -v "$REPO_ROOT/tests/load:/tests/load" \
       -v "$AUTH_FILE:/k6-auth.json:ro" \
-      grafana/k6:latest run \
-        $K6_OUT \
+      grafana/k6:0.55.0 run \
+        "${K6_OUT_ARGS[@]}" \
         -e BASE_URL="$BASE_URL" \
         -e AUTH_FILE="/k6-auth.json" \
         "/tests/load/scenarios/$(basename "$scenario")"
   done
 fi
 
-echo "==> Cleaning up load test user..."
-npx tsx "$REPO_ROOT/tests/load/scripts/cleanup-load-user.ts" || true
+CLEANUP_SCRIPT="$REPO_ROOT/tests/load/scripts/cleanup-load-user.ts"
+if [ -f "$CLEANUP_SCRIPT" ]; then
+  echo "==> Cleaning up load test user..."
+  pnpm exec tsx "$CLEANUP_SCRIPT" || true
+fi
 
 echo ""
 echo "==> Load test complete."
-echo "    Grafana dashboard: ${GRAFANA_URL} (admin / admin)"
-echo "    InfluxDB UI:       http://localhost:8086 (token: pagespace-local-token)"
+echo "    Grafana dashboard: ${GRAFANA_URL}"
+echo "    InfluxDB UI:       http://${INFLUXDB_HOST}:8086"
 echo "    Prometheus:        http://localhost:9090"

--- a/scripts/run-load-test.sh
+++ b/scripts/run-load-test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+BASE_URL="${BASE_URL:-http://localhost:3000}"
+INFLUXDB_URL="http://localhost:8086/k6"
+GRAFANA_URL="http://localhost:3001"
+K6_OUT="--out influxdb=${INFLUXDB_URL}"
+
+echo "==> Starting monitoring stack..."
+docker compose -f "$REPO_ROOT/docker-compose.monitoring.yml" up -d
+
+echo "==> Waiting for InfluxDB to be ready..."
+MAX_WAIT=60
+WAITED=0
+until curl -sf http://localhost:8086/health > /dev/null 2>&1; do
+  if [ "$WAITED" -ge "$MAX_WAIT" ]; then
+    echo "ERROR: InfluxDB did not become healthy within ${MAX_WAIT}s" >&2
+    exit 1
+  fi
+  sleep 2
+  WAITED=$((WAITED + 2))
+  echo "  ...waiting (${WAITED}s)"
+done
+echo "  InfluxDB is ready."
+
+echo "==> Seeding load test user..."
+npx tsx "$REPO_ROOT/tests/load/scripts/seed-load-user.ts"
+
+echo "==> Running k6 scenarios..."
+SCENARIOS_DIR="$REPO_ROOT/tests/load/scenarios"
+AUTH_FILE="$REPO_ROOT/.k6-auth.json"
+
+if [ ! -d "$SCENARIOS_DIR" ]; then
+  echo "WARNING: No scenarios directory found at $SCENARIOS_DIR — skipping k6 runs."
+else
+  for scenario in "$SCENARIOS_DIR"/*.js; do
+    [ -f "$scenario" ] || continue
+    echo "  Running: $(basename "$scenario")"
+    docker run --rm \
+      --network host \
+      -v "$REPO_ROOT/tests/load:/tests/load" \
+      -v "$AUTH_FILE:/k6-auth.json:ro" \
+      grafana/k6:latest run \
+        $K6_OUT \
+        -e BASE_URL="$BASE_URL" \
+        -e AUTH_FILE="/k6-auth.json" \
+        "/tests/load/scenarios/$(basename "$scenario")"
+  done
+fi
+
+echo "==> Cleaning up load test user..."
+npx tsx "$REPO_ROOT/tests/load/scripts/cleanup-load-user.ts" || true
+
+echo ""
+echo "==> Load test complete."
+echo "    Grafana dashboard: ${GRAFANA_URL} (admin / admin)"
+echo "    InfluxDB UI:       http://localhost:8086 (token: pagespace-local-token)"
+echo "    Prometheus:        http://localhost:9090"

--- a/tests/load/grafana/dashboards/k6-load-test.json
+++ b/tests/load/grafana/dashboards/k6-load-test.json
@@ -1,0 +1,158 @@
+{
+  "id": null,
+  "uid": "k6-load-test",
+  "title": "k6 Load Test Results",
+  "schemaVersion": 36,
+  "version": 1,
+  "refresh": "10s",
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "tags": ["k6", "load-test"],
+  "panels": [
+    {
+      "id": 1,
+      "title": "Active VUs",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "influxdb", "uid": "InfluxDB_k6" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "single" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "influxdb", "uid": "InfluxDB_k6" },
+          "query": "from(bucket: \"k6\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"k6_vus\")\n  |> filter(fn: (r) => r[\"_field\"] == \"value\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Request Rate (RPS)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "influxdb", "uid": "InfluxDB_k6" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "single" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "influxdb", "uid": "InfluxDB_k6" },
+          "query": "from(bucket: \"k6\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"k6_http_reqs\")\n  |> filter(fn: (r) => r[\"_field\"] == \"value\")\n  |> derivative(unit: 1s, nonNegative: true)\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"rps\")"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "HTTP Request Duration",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
+      "datasource": { "type": "influxdb", "uid": "InfluxDB_k6" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "refId": "p50",
+          "datasource": { "type": "influxdb", "uid": "InfluxDB_k6" },
+          "query": "from(bucket: \"k6\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"k6_http_req_duration\")\n  |> filter(fn: (r) => r[\"_field\"] == \"value\")\n  |> aggregateWindow(every: v.windowPeriod, fn: (tables=<-, column) => tables |> quantile(q: 0.5, column: column), createEmpty: false)\n  |> set(key: \"_field\", value: \"p50\")\n  |> yield(name: \"p50\")"
+        },
+        {
+          "refId": "p95",
+          "datasource": { "type": "influxdb", "uid": "InfluxDB_k6" },
+          "query": "from(bucket: \"k6\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"k6_http_req_duration\")\n  |> filter(fn: (r) => r[\"_field\"] == \"value\")\n  |> aggregateWindow(every: v.windowPeriod, fn: (tables=<-, column) => tables |> quantile(q: 0.95, column: column), createEmpty: false)\n  |> set(key: \"_field\", value: \"p95\")\n  |> yield(name: \"p95\")"
+        },
+        {
+          "refId": "p99",
+          "datasource": { "type": "influxdb", "uid": "InfluxDB_k6" },
+          "query": "from(bucket: \"k6\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"k6_http_req_duration\")\n  |> filter(fn: (r) => r[\"_field\"] == \"value\")\n  |> aggregateWindow(every: v.windowPeriod, fn: (tables=<-, column) => tables |> quantile(q: 0.99, column: column), createEmpty: false)\n  |> set(key: \"_field\", value: \"p99\")\n  |> yield(name: \"p99\")"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "HTTP Failure Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "datasource": { "type": "influxdb", "uid": "InfluxDB_k6" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed", "fixedColor": "red" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "single" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "influxdb", "uid": "InfluxDB_k6" },
+          "query": "errors = from(bucket: \"k6\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"k6_http_reqs\")\n  |> filter(fn: (r) => r[\"_field\"] == \"value\")\n  |> filter(fn: (r) => r[\"status\"] >= \"400\" or r[\"error\"] != \"\")\n  |> aggregateWindow(every: v.windowPeriod, fn: sum, createEmpty: false)\n\ntotal = from(bucket: \"k6\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"k6_http_reqs\")\n  |> filter(fn: (r) => r[\"_field\"] == \"value\")\n  |> aggregateWindow(every: v.windowPeriod, fn: sum, createEmpty: false)\n\njoin(tables: {errors: errors, total: total}, on: [\"_time\"])\n  |> map(fn: (r) => ({r with _value: if r._value_total > 0.0 then r._value_errors / r._value_total else 0.0}))\n  |> yield(name: \"failure_rate\")"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Checks Pass Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "datasource": { "type": "influxdb", "uid": "InfluxDB_k6" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed", "fixedColor": "green" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "single" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "influxdb", "uid": "InfluxDB_k6" },
+          "query": "passes = from(bucket: \"k6\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"k6_checks\")\n  |> filter(fn: (r) => r[\"_field\"] == \"value\")\n  |> filter(fn: (r) => r[\"check\"] != \"\")\n  |> aggregateWindow(every: v.windowPeriod, fn: sum, createEmpty: false)\n\nfrom(bucket: \"k6\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"k6_checks\")\n  |> filter(fn: (r) => r[\"_field\"] == \"value\")\n  |> aggregateWindow(every: v.windowPeriod, fn: sum, createEmpty: false)\n  |> yield(name: \"checks\")"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/load/grafana/dashboards/k6-load-test.json
+++ b/tests/load/grafana/dashboards/k6-load-test.json
@@ -150,7 +150,7 @@
         {
           "refId": "A",
           "datasource": { "type": "influxdb", "uid": "InfluxDB_k6" },
-          "query": "passes = from(bucket: \"k6\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"k6_checks\")\n  |> filter(fn: (r) => r[\"_field\"] == \"value\")\n  |> filter(fn: (r) => r[\"check\"] != \"\")\n  |> aggregateWindow(every: v.windowPeriod, fn: sum, createEmpty: false)\n\nfrom(bucket: \"k6\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"k6_checks\")\n  |> filter(fn: (r) => r[\"_field\"] == \"value\")\n  |> aggregateWindow(every: v.windowPeriod, fn: sum, createEmpty: false)\n  |> yield(name: \"checks\")"
+          "query": "total = from(bucket: \"k6\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"k6_checks\")\n  |> filter(fn: (r) => r[\"_field\"] == \"value\")\n  |> aggregateWindow(every: v.windowPeriod, fn: count, createEmpty: false)\n\npasses = from(bucket: \"k6\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"k6_checks\")\n  |> filter(fn: (r) => r[\"_field\"] == \"value\")\n  |> filter(fn: (r) => r[\"_value\"] == 1.0)\n  |> aggregateWindow(every: v.windowPeriod, fn: count, createEmpty: false)\n\njoin(tables: {passes: passes, total: total}, on: [\"_time\"])\n  |> map(fn: (r) => ({r with _value: if r._value_total > 0 then float(v: r._value_passes) / float(v: r._value_total) else 0.0}))\n  |> yield(name: \"pass_rate\")"
         }
       ]
     }

--- a/tests/load/grafana/dashboards/postgres-overview.json
+++ b/tests/load/grafana/dashboards/postgres-overview.json
@@ -1,0 +1,198 @@
+{
+  "id": null,
+  "uid": "postgres-overview",
+  "title": "PostgreSQL Overview",
+  "schemaVersion": 36,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "tags": ["postgres", "database"],
+  "panels": [
+    {
+      "id": 1,
+      "title": "Active DB Connections",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "single" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "expr": "pg_stat_activity_count{state=\"active\"}",
+          "legendFormat": "Active connections"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Idle DB Connections",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "single" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "expr": "pg_stat_activity_count{state=\"idle\"}",
+          "legendFormat": "Idle connections"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Connections Waiting (idle in transaction)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed", "fixedColor": "orange" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "single" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "expr": "pg_stat_activity_count{state=\"idle in transaction\"}",
+          "legendFormat": "Waiting (idle in txn)"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Checkpoint Activity (bgwriter)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "tooltip": { "mode": "multi" },
+        "legend": { "displayMode": "list", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "expr": "rate(pg_stat_bgwriter_checkpoints_timed_total[5m])",
+          "legendFormat": "Timed checkpoints/s"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "expr": "rate(pg_stat_bgwriter_checkpoints_req_total[5m])",
+          "legendFormat": "Requested checkpoints/s"
+        },
+        {
+          "refId": "C",
+          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "expr": "rate(pg_stat_bgwriter_buffers_clean_total[5m])",
+          "legendFormat": "Buffers cleaned/s"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Total Connections",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 50 },
+              { "color": "red", "value": 90 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "expr": "sum(pg_stat_activity_count)",
+          "legendFormat": "Total"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Max Connections",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 16 },
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed", "fixedColor": "blue" },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "expr": "pg_settings_max_connections",
+          "legendFormat": "Max"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/load/grafana/prometheus.yml
+++ b/tests/load/grafana/prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: postgres
+    static_configs:
+      - targets: ['postgres_exporter:9187']
+
+  - job_name: pagespace_health
+    metrics_path: /api/health
+    static_configs:
+      - targets: ['host.docker.internal:3000']

--- a/tests/load/grafana/prometheus.yml
+++ b/tests/load/grafana/prometheus.yml
@@ -5,8 +5,3 @@ scrape_configs:
   - job_name: postgres
     static_configs:
       - targets: ['postgres_exporter:9187']
-
-  - job_name: pagespace_health
-    metrics_path: /api/health
-    static_configs:
-      - targets: ['host.docker.internal:3000']

--- a/tests/load/grafana/provisioning/alerting/alerting.yml
+++ b/tests/load/grafana/provisioning/alerting/alerting.yml
@@ -1,0 +1,1 @@
+apiVersion: 1

--- a/tests/load/grafana/provisioning/dashboards/dashboard-provider.yml
+++ b/tests/load/grafana/provisioning/dashboards/dashboard-provider.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+providers:
+  - name: default
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    options:
+      path: /var/lib/grafana/dashboards

--- a/tests/load/grafana/provisioning/datasources/influxdb.yml
+++ b/tests/load/grafana/provisioning/datasources/influxdb.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+datasources:
+  - name: InfluxDB_k6
+    type: influxdb
+    access: proxy
+    url: http://influxdb:8086
+    jsonData:
+      version: Flux
+      organization: pagespace
+      defaultBucket: k6
+    secureJsonData:
+      token: pagespace-local-token

--- a/tests/load/grafana/provisioning/datasources/influxdb.yml
+++ b/tests/load/grafana/provisioning/datasources/influxdb.yml
@@ -9,4 +9,4 @@ datasources:
       organization: pagespace
       defaultBucket: k6
     secureJsonData:
-      token: pagespace-local-token
+      token: "${INFLUXDB_TOKEN}"

--- a/tests/load/grafana/provisioning/datasources/prometheus.yml
+++ b/tests/load/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,6 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090


### PR DESCRIPTION
## Summary

- Adds \`docker-compose.monitoring.yml\` — standalone sidecar that starts InfluxDB v2, Grafana (port 3001), Prometheus, and postgres_exporter; does not depend on any PageSpace services
- Adds \`tests/load/grafana/\` — pre-provisioned datasources (InfluxDB Flux + Prometheus), dashboard provider, alerting stub, and two dashboards (k6 load test results + PostgreSQL overview)
- Adds \`scripts/run-load-test.sh\` — orchestrates the full load test: starts monitoring stack, waits for InfluxDB health, seeds auth (if script present), runs k6 scenarios, cleans up, prints URLs
- k6 dashboard panels: Active VUs, RPS, HTTP duration p50/p95/p99, failure rate, checks pass rate (all Flux queries against InfluxDB v2)
- Postgres dashboard panels: active/idle/waiting connections, bgwriter checkpoint activity, total vs max connections stat panels

## Configuration

All credentials have defaults for local dev and can be overridden via environment variables:

| Variable | Default | Usage |
|---|---|---|
| `INFLUXDB_TOKEN` | `pagespace-local-token` | InfluxDB admin token + Grafana datasource auth |
| `INFLUXDB_ADMIN_PASSWORD` | `adminpassword` | InfluxDB admin user password |
| `GRAFANA_ADMIN_PASSWORD` | `admin` | Grafana admin password |
| `POSTGRES_EXPORTER_DSN` | `postgresql://postgres:postgres@host.docker.internal:5432/pagespace?sslmode=disable` | postgres_exporter connection string |
| `BASE_URL` | `http://localhost:3000` | k6 target base URL |
| `INFLUXDB_HOST` | `localhost` | InfluxDB host for k6 output URL |

## Test plan

- [ ] `docker compose -f docker-compose.monitoring.yml up -d` starts all four services without errors
- [ ] Grafana at http://localhost:3001 shows both dashboards pre-loaded
- [ ] InfluxDB datasource resolves and Flux queries execute without error
- [ ] Prometheus datasource connects and postgres_exporter targets are up
- [ ] `scripts/run-load-test.sh` runs end-to-end (with web app running); warns gracefully if seed scripts are absent
- [ ] JSON files pass `python3 -m json.tool` validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)