### PR TITLE
feat(db): expose Postgres pool stats via /api/health

### DIFF
--- a/apps/web/src/app/api/health/__tests__/route.test.ts
+++ b/apps/web/src/app/api/health/__tests__/route.test.ts
@@ -1,12 +1,14 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { GET } from '../route';
 const mockExecute = vi.hoisted(() => vi.fn());
+const mockGetPoolStats = vi.hoisted(() => vi.fn());
 const mockGetMonitoringIngestStatus = vi.hoisted(() => vi.fn());
 
 vi.mock('@pagespace/db/db', () => ({
   db: {
     execute: mockExecute,
   },
+  getPoolStats: mockGetPoolStats,
 }));
 vi.mock('@pagespace/db/operators', () => ({
   sql: (strings: TemplateStringsArray) => strings.join(''),
@@ -32,6 +34,7 @@ describe('GET /api/health', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetMonitoringIngestStatus.mockReturnValue('active');
+    mockGetPoolStats.mockReturnValue({ total: 0, idle: 0, waiting: 0 });
   });
 
   describe('healthy system', () => {
@@ -91,6 +94,20 @@ describe('GET /api/health', () => {
       expect(body.memory).toBeDefined();
       expect(typeof body.memory.heapUsed).toBe('number');
       expect(typeof body.memory.heapTotal).toBe('number');
+    });
+
+    it('given healthy state, should include pool stats', async () => {
+      mockExecute.mockResolvedValue([{ '1': 1 }]);
+      mockGetPoolStats.mockReturnValue({ total: 5, idle: 3, waiting: 1 });
+
+      const request = new Request('https://example.com/api/health', { method: 'GET' });
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(body.pool).toBeDefined();
+      expect(body.pool.total).toBe(5);
+      expect(body.pool.idle).toBe(3);
+      expect(body.pool.waiting).toBe(1);
     });
   });
 

--- a/apps/web/src/app/api/health/route.ts
+++ b/apps/web/src/app/api/health/route.ts
@@ -1,4 +1,4 @@
-import { db } from '@pagespace/db/db'
+import { db, getPoolStats } from '@pagespace/db/db'
 import { sql } from '@pagespace/db/operators';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getMonitoringIngestStatus } from '@/middleware/monitoring';
@@ -16,6 +16,11 @@ interface HealthResponse {
     heapUsed: number;
     heapTotal: number;
     rss: number;
+  };
+  pool: {
+    total: number;
+    idle: number;
+    waiting: number;
   };
   warnings?: string[];
   error?: string;
@@ -62,6 +67,7 @@ export async function GET(_request: Request): Promise<Response> {
         heapTotal: Math.round(memoryUsage.heapTotal / 1024 / 1024),
         rss: Math.round(memoryUsage.rss / 1024 / 1024),
       },
+      pool: getPoolStats(),
     };
 
     if (warnings.length > 0) {
@@ -106,6 +112,7 @@ export async function GET(_request: Request): Promise<Response> {
         heapTotal: 0,
         rss: 0,
       },
+      pool: getPoolStats(),
       error: 'Health check failed unexpectedly',
     };
 

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -1,7 +1,7 @@
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
 import { schema } from './schema';
-import { registerPoolEvents, getPoolStats } from './pool-stats';
+import { registerPool, getPoolStats } from './pool-stats';
 import 'dotenv/config';
 
 const pool = new Pool({
@@ -9,7 +9,7 @@ const pool = new Pool({
   ssl: process.env.DATABASE_SSL === 'true' ? { rejectUnauthorized: false } : false,
 });
 
-registerPoolEvents(pool);
+registerPool(pool);
 
 export { getPoolStats };
 export const db = drizzle(pool, { schema });

--- a/packages/db/src/db.ts
+++ b/packages/db/src/db.ts
@@ -1,6 +1,7 @@
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
 import { schema } from './schema';
+import { registerPoolEvents, getPoolStats } from './pool-stats';
 import 'dotenv/config';
 
 const pool = new Pool({
@@ -8,4 +9,7 @@ const pool = new Pool({
   ssl: process.env.DATABASE_SSL === 'true' ? { rejectUnauthorized: false } : false,
 });
 
+registerPoolEvents(pool);
+
+export { getPoolStats };
 export const db = drizzle(pool, { schema });

--- a/packages/db/src/pool-stats.test.ts
+++ b/packages/db/src/pool-stats.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import EventEmitter from 'events';
+import { registerPoolEvents, getPoolStats } from './pool-stats';
+
+describe('pool-stats', () => {
+  describe('getPoolStats', () => {
+    it('returns zeros when no events have fired', () => {
+      const mockPool = new EventEmitter();
+      registerPoolEvents(mockPool);
+      expect(getPoolStats()).toEqual({ total: 0, idle: 0, waiting: 0 });
+    });
+  });
+
+  describe('registerPoolEvents', () => {
+    let mockPool: EventEmitter;
+
+    beforeEach(() => {
+      mockPool = new EventEmitter();
+      registerPoolEvents(mockPool);
+    });
+
+    it('increments total by 1 per connect event', () => {
+      mockPool.emit('connect');
+      mockPool.emit('connect');
+      mockPool.emit('connect');
+      expect(getPoolStats().total).toBe(3);
+    });
+
+    it('decrements total when remove fires after connects', () => {
+      mockPool.emit('connect');
+      mockPool.emit('connect');
+      mockPool.emit('connect');
+      mockPool.emit('remove');
+      expect(getPoolStats().total).toBe(2);
+    });
+
+    it('decrements idle when acquire fires', () => {
+      mockPool.emit('connect');
+      const before = getPoolStats().idle;
+      mockPool.emit('acquire');
+      expect(getPoolStats().idle).toBe(before - 1);
+    });
+
+    it('restores idle to initial value after acquire and release', () => {
+      mockPool.emit('connect');
+      const initial = getPoolStats().idle;
+      mockPool.emit('acquire');
+      mockPool.emit('release', undefined);
+      expect(getPoolStats().idle).toBe(initial);
+    });
+  });
+});

--- a/packages/db/src/pool-stats.test.ts
+++ b/packages/db/src/pool-stats.test.ts
@@ -1,52 +1,40 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import EventEmitter from 'events';
-import { registerPoolEvents, getPoolStats } from './pool-stats';
+import { describe, it, expect } from 'vitest';
+import type { Pool } from 'pg';
+import { registerPool, getPoolStats } from './pool-stats';
+
+const makePool = (totalCount: number, idleCount: number, waitingCount: number) =>
+  ({ totalCount, idleCount, waitingCount } as unknown as Pool);
 
 describe('pool-stats', () => {
   describe('getPoolStats', () => {
-    it('returns zeros when no events have fired', () => {
-      const mockPool = new EventEmitter();
-      registerPoolEvents(mockPool);
-      expect(getPoolStats()).toEqual({ total: 0, idle: 0, waiting: 0 });
+    it('returns pool counts from the registered pool', () => {
+      registerPool(makePool(5, 3, 1));
+      expect(getPoolStats()).toEqual({ total: 5, idle: 3, waiting: 1 });
+    });
+
+    it('reflects current pool state on each call', () => {
+      registerPool(makePool(2, 1, 0));
+      expect(getPoolStats()).toEqual({ total: 2, idle: 1, waiting: 0 });
+
+      registerPool(makePool(3, 0, 2));
+      expect(getPoolStats()).toEqual({ total: 3, idle: 0, waiting: 2 });
     });
   });
 
-  describe('registerPoolEvents', () => {
-    let mockPool: EventEmitter;
-
-    beforeEach(() => {
-      mockPool = new EventEmitter();
-      registerPoolEvents(mockPool);
+  describe('registerPool', () => {
+    it('returns total from pool.totalCount', () => {
+      registerPool(makePool(7, 3, 2));
+      expect(getPoolStats().total).toBe(7);
     });
 
-    it('increments total by 1 per connect event', () => {
-      mockPool.emit('connect');
-      mockPool.emit('connect');
-      mockPool.emit('connect');
-      expect(getPoolStats().total).toBe(3);
+    it('returns idle from pool.idleCount', () => {
+      registerPool(makePool(4, 2, 0));
+      expect(getPoolStats().idle).toBe(2);
     });
 
-    it('decrements total when remove fires after connects', () => {
-      mockPool.emit('connect');
-      mockPool.emit('connect');
-      mockPool.emit('connect');
-      mockPool.emit('remove');
-      expect(getPoolStats().total).toBe(2);
-    });
-
-    it('decrements idle when acquire fires', () => {
-      mockPool.emit('connect');
-      const before = getPoolStats().idle;
-      mockPool.emit('acquire');
-      expect(getPoolStats().idle).toBe(before - 1);
-    });
-
-    it('restores idle to initial value after acquire and release', () => {
-      mockPool.emit('connect');
-      const initial = getPoolStats().idle;
-      mockPool.emit('acquire');
-      mockPool.emit('release', undefined);
-      expect(getPoolStats().idle).toBe(initial);
+    it('returns waiting from pool.waitingCount', () => {
+      registerPool(makePool(4, 0, 3));
+      expect(getPoolStats().waiting).toBe(3);
     });
   });
 });

--- a/packages/db/src/pool-stats.ts
+++ b/packages/db/src/pool-stats.ts
@@ -1,0 +1,34 @@
+import { EventEmitter } from 'events';
+
+let total = 0;
+let idle = 0;
+const waiting = 0;
+
+export function registerPoolEvents(pool: EventEmitter): void {
+  total = 0;
+  idle = 0;
+
+  pool.on('connect', () => {
+    total++;
+    idle++;
+  });
+
+  pool.on('acquire', () => {
+    idle--;
+  });
+
+  pool.on('release', (err?: Error) => {
+    if (!err) {
+      idle++;
+    }
+  });
+
+  pool.on('remove', () => {
+    total--;
+    if (idle > 0) idle--;
+  });
+}
+
+export function getPoolStats(): { total: number; idle: number; waiting: number } {
+  return { total, idle, waiting };
+}

--- a/packages/db/src/pool-stats.ts
+++ b/packages/db/src/pool-stats.ts
@@ -1,34 +1,16 @@
-import { EventEmitter } from 'events';
+import type { Pool } from 'pg';
 
-let total = 0;
-let idle = 0;
-const waiting = 0;
+let _pool: Pool | null = null;
 
-export function registerPoolEvents(pool: EventEmitter): void {
-  total = 0;
-  idle = 0;
-
-  pool.on('connect', () => {
-    total++;
-    idle++;
-  });
-
-  pool.on('acquire', () => {
-    idle--;
-  });
-
-  pool.on('release', (err?: Error) => {
-    if (!err) {
-      idle++;
-    }
-  });
-
-  pool.on('remove', () => {
-    total--;
-    if (idle > 0) idle--;
-  });
+export function registerPool(pool: Pool): void {
+  _pool = pool;
 }
 
 export function getPoolStats(): { total: number; idle: number; waiting: number } {
-  return { total, idle, waiting };
+  if (!_pool) return { total: 0, idle: 0, waiting: 0 };
+  return {
+    total: _pool.totalCount,
+    idle: _pool.idleCount,
+    waiting: _pool.waitingCount,
+  };
 }


### PR DESCRIPTION
## Summary

- Adds \`packages/db/src/pool-stats.ts\` with \`registerPool(pool)\` and \`getPoolStats()\` — reads live pool counters directly from pg-pool properties, no DB query on call
- Wires \`registerPool(pool)\` into \`packages/db/src/db.ts\` at startup and re-exports \`getPoolStats\`
- Extends \`/api/health\` (\`apps/web/src/app/api/health/route.ts\`) with \`pool: { total, idle, waiting }\` in both the success and error response paths

## How it works

\`getPoolStats()\` reads directly from the pg-pool instance properties at call time:

- \`pool.totalCount\` → total physical connections (connected + pending)
- \`pool.idleCount\` → clients not currently checked out
- \`pool.waitingCount\` → requests queued waiting for a client

No events, no global counters — just a direct snapshot of the pool's live state on every health check call.

## What changed vs initial commit

After review feedback, replaced the event-listener approach (which couldn't track \`waiting\` and accumulated mutable global state) with direct property reads from \`pg-pool\`'s public API (\`totalCount\`, \`idleCount\`, \`waitingCount\`). This is simpler, more accurate, and eliminates the listener-duplication risk.

## Test plan

- [x] 5 unit tests in \`packages/db/src/pool-stats.test.ts\` — all pass
- [x] 11 health route tests in \`apps/web/src/app/api/health/__tests__/route.test.ts\` — all pass (mock updated to include \`getPoolStats\`, new pool field assertion added)
- [x] \`pnpm typecheck\` on \`@pagespace/db\` and \`web\` → both clean
- [x] Codex P2 review comment (waiting: 0) addressed and replied to

🤖 Generated with [Claude Code](https://claude.com/claude-code)