### PR TITLE
refactor(ai): use generateId for server message ID

### DIFF
--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -812,23 +812,8 @@ export async function POST(request: Request) {
     try {
       const stream = createUIMessageStream({
         originalMessages: sanitizedMessages,
+        generateId: () => serverAssistantMessageId,
         execute: async ({ writer }) => {
-          let startChunkSent = false;
-
-          // Send the server-generated message ID to the client at stream start
-          // streamId is passed via X-Stream-Id header (see result.toUIMessageStreamResponse below)
-          // Wrapped in try/catch to handle early disconnect - continue processing anyway
-          try {
-            writer.write({
-              type: 'start',
-              messageId: serverAssistantMessageId,
-            });
-            startChunkSent = true;
-          } catch {
-            // Client disconnected before first write - continue processing
-            // to ensure onFinish fires and the message is saved
-          }
-
           // Start the AI response
           const aiResult = streamText({
             model,
@@ -890,21 +875,11 @@ export async function POST(request: Request) {
           // will continue processing server-side even if writes fail
           for await (const chunk of aiResult.toUIMessageStream()) {
             try {
-              // We already emitted a start chunk with a server-controlled message ID.
-              // Skip any additional start chunks so client/server message IDs stay aligned.
               if (chunk.type === 'start') {
-                if (startChunkSent) {
-                  continue;
-                }
-
-                writer.write({
-                  type: 'start',
-                  messageId: serverAssistantMessageId,
-                });
-                startChunkSent = true;
+                // Strip inner messageId so the outer idInjectedStream uses serverAssistantMessageId
+                writer.write({ type: 'start' });
                 continue;
               }
-
               writer.write(chunk);
             } catch {
               // Client disconnected - continue processing to ensure onFinish fires

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -832,17 +832,8 @@ MENTION PROCESSING:
     // This ensures server-side processing continues even if the client disconnects
     const stream = createUIMessageStream({
       originalMessages: processedMessages,
+      generateId: () => serverAssistantMessageId,
       execute: async ({ writer }) => {
-        // Send the server-generated message ID to the client at stream start
-        try {
-          writer.write({
-            type: 'start',
-            messageId: serverAssistantMessageId,
-          });
-        } catch {
-          // Client disconnected before first write - continue processing
-        }
-
         const aiResult = streamText({
           model,
           system: finalSystemPrompt,
@@ -883,6 +874,11 @@ MENTION PROCESSING:
         // Stream all chunks to client, continuing server-side even if client disconnects
         for await (const chunk of aiResult.toUIMessageStream()) {
           try {
+            if (chunk.type === 'start') {
+              // Strip inner messageId so the outer idInjectedStream uses serverAssistantMessageId
+              writer.write({ type: 'start' });
+              continue;
+            }
             writer.write(chunk);
           } catch {
             // Client disconnected - continue processing to ensure onFinish fires


### PR DESCRIPTION
## Summary

- Replace manual `start` chunk injection (with `messageId`) with `generateId: () => serverAssistantMessageId` on `createUIMessageStream`
- Strip the inner `messageId` from `start` chunks emitted by `aiResult.toUIMessageStream()` to avoid double-injection
- Applied consistently across both chat routes: `api/ai/chat` and `api/ai/global/[id]/messages`

## Test plan

- [ ] Start a chat conversation — verify assistant messages get the server-controlled ID (check network response stream)
- [ ] Start a global AI chat — same verification
- [ ] Confirm no duplicate or missing `start` chunks in the stream
- [ ] Confirm `onFinish` still fires and message is saved even on early client disconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message ID handling in AI chat streaming to prevent duplicate or conflicting server-assigned identifiers, ensuring more reliable message tracking across chat operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->