### PR TITLE
refactor(ai): extract pipeUIMessageStreamStrippingStart helper

### DIFF
--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -77,6 +77,7 @@ import {
   removeStream,
   STREAM_ID_HEADER,
 } from '@/lib/ai/core/stream-abort-registry';
+import { pipeUIMessageStreamStrippingStart } from '@/lib/ai/core/stream-pipe-utils';
 import { validateUserMessageFileParts, hasFileParts } from '@/lib/ai/core/validate-image-parts';
 import { hasVisionCapability } from '@/lib/ai/core/model-capabilities';
 
@@ -870,22 +871,7 @@ export async function POST(request: Request) {
               return undefined;
             });
 
-          // Stream the AI response directly to the client
-          // Wrap in try-catch to handle client disconnection gracefully - the AI stream
-          // will continue processing server-side even if writes fail
-          for await (const chunk of aiResult.toUIMessageStream()) {
-            try {
-              if (chunk.type === 'start') {
-                // Strip inner messageId so the outer idInjectedStream uses serverAssistantMessageId
-                writer.write({ type: 'start' });
-                continue;
-              }
-              writer.write(chunk);
-            } catch {
-              // Client disconnected - continue processing to ensure onFinish fires
-              // and the message is saved to the database
-            }
-          }
+          await pipeUIMessageStreamStrippingStart(aiResult, writer);
         },
         onFinish: async ({ responseMessage }) => {
           // Clean up abort controller from registry

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -55,6 +55,7 @@ import {
   removeStream,
   STREAM_ID_HEADER,
 } from '@/lib/ai/core/stream-abort-registry';
+import { pipeUIMessageStreamStrippingStart } from '@/lib/ai/core/stream-pipe-utils';
 import { validateUserMessageFileParts, hasFileParts } from '@/lib/ai/core/validate-image-parts';
 import { hasVisionCapability } from '@/lib/ai/core/model-capabilities';
 
@@ -871,19 +872,7 @@ MENTION PROCESSING:
             return undefined;
           });
 
-        // Stream all chunks to client, continuing server-side even if client disconnects
-        for await (const chunk of aiResult.toUIMessageStream()) {
-          try {
-            if (chunk.type === 'start') {
-              // Strip inner messageId so the outer idInjectedStream uses serverAssistantMessageId
-              writer.write({ type: 'start' });
-              continue;
-            }
-            writer.write(chunk);
-          } catch {
-            // Client disconnected - continue processing to ensure onFinish fires
-          }
-        }
+        await pipeUIMessageStreamStrippingStart(aiResult, writer);
       },
       onFinish: async ({ responseMessage }) => {
         // Clean up abort controller from registry

--- a/apps/web/src/lib/ai/core/index.ts
+++ b/apps/web/src/lib/ai/core/index.ts
@@ -41,6 +41,9 @@ export * from './complete-request-builder';
 // Stream Abort (server-side registry)
 export * from './stream-abort-registry';
 
+// Stream Pipe Utilities
+export * from './stream-pipe-utils';
+
 // NOTE: Client-side stream-abort functions are NOT exported here to prevent
 // accidental import in server contexts. Import from '@/lib/ai/core/client' instead.
 

--- a/apps/web/src/lib/ai/core/stream-pipe-utils.ts
+++ b/apps/web/src/lib/ai/core/stream-pipe-utils.ts
@@ -1,0 +1,26 @@
+import type { UIMessageChunk, UIMessageStreamWriter } from 'ai';
+
+/**
+ * Pipes an AI result's UI message stream to a writer, stripping the inner
+ * messageId from 'start' chunks so the outer createUIMessageStream's
+ * generateId/idInjectedStream remains the authoritative source for message ID.
+ *
+ * Write errors are swallowed so server-side processing (onFinish, DB save)
+ * continues even when the client disconnects mid-stream.
+ */
+export async function pipeUIMessageStreamStrippingStart(
+  aiResult: { toUIMessageStream(): AsyncIterable<UIMessageChunk> },
+  writer: UIMessageStreamWriter,
+): Promise<void> {
+  for await (const chunk of aiResult.toUIMessageStream()) {
+    try {
+      if (chunk.type === 'start') {
+        writer.write({ type: 'start' });
+        continue;
+      }
+      writer.write(chunk);
+    } catch {
+      // Client disconnected - continue processing to ensure onFinish fires
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Extracts the duplicated for-await streaming loop from `chat/route.ts` and `global/[id]/messages/route.ts` into a shared `pipeUIMessageStreamStrippingStart` helper in `apps/web/src/lib/ai/core/stream-pipe-utils.ts`
- The helper owns the start-chunk `messageId` stripping logic (so the outer `generateId`/`idInjectedStream` remains authoritative for server CUID2 ID injection) in one place
- Both routes replace their inline loops with `await pipeUIMessageStreamStrippingStart(aiResult, writer)`

## Test plan

- [ ] Send a message in AI Chat page type — undo should work (no "Message not found")
- [ ] Send a message in Global Assistant sidebar — undo should work
- [ ] Stop streaming mid-response — stream should continue server-side and save to DB
- [ ] Confirm no regressions in tool calls or multi-step responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)