### PR TITLE
feat(ai): StreamMulticastRegistry for multiplayer chat streaming

### DIFF
--- a/apps/web/src/lib/ai/core/__tests__/stream-multicast-registry.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stream-multicast-registry.test.ts
@@ -108,7 +108,8 @@ describe('StreamMulticastRegistry', () => {
       registry.subscribe('msg-1', (text) => received2.push(text), () => {});
 
       registry.push('msg-1', 'chunk1');
-      unsubscribe1!();
+      expect(unsubscribe1).not.toBeNull();
+      (unsubscribe1 as () => void)();
       registry.push('msg-1', 'chunk2');
 
       expect(received1).toEqual(['chunk1']);
@@ -125,7 +126,8 @@ describe('StreamMulticastRegistry', () => {
       const unsubscribe1 = registry.subscribe('msg-1', () => {}, (aborted) => completed1.push(aborted));
       registry.subscribe('msg-1', () => {}, (aborted) => completed2.push(aborted));
 
-      unsubscribe1!();
+      expect(unsubscribe1).not.toBeNull();
+      (unsubscribe1 as () => void)();
       registry.finish('msg-1');
 
       expect(completed1).toEqual([]);
@@ -178,7 +180,7 @@ describe('StreamMulticastRegistry', () => {
       registry.subscribe('msg-1', () => {}, (aborted) => completed.push(aborted));
 
       registry.finish('msg-1');
-      registry.finish('msg-1'); // second call should be a no-op
+      registry.finish('msg-1');
 
       expect(completed).toEqual([false]);
     });
@@ -213,8 +215,48 @@ describe('StreamMulticastRegistry', () => {
 
       vi.advanceTimersByTime(10 * 60 * 1000);
 
-      // Only one completion, not two
       expect(completedValues).toEqual([false]);
+    });
+
+    it('given register is called twice for the same messageId, should call onComplete only once after 10 minutes', () => {
+      vi.useFakeTimers();
+      const registry = new StreamMulticastRegistry();
+      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+
+      const completed: boolean[] = [];
+      registry.subscribe('msg-1', () => {}, (aborted) => completed.push(aborted));
+
+      vi.advanceTimersByTime(10 * 60 * 1000);
+
+      expect(completed).toHaveLength(1);
+    });
+  });
+
+  describe('resilience', () => {
+    it('given a subscriber whose onChunk throws, should not interrupt fanout to remaining subscribers', () => {
+      const registry = new StreamMulticastRegistry();
+      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+
+      const received: string[] = [];
+      registry.subscribe('msg-1', () => { throw new Error('bad subscriber'); }, () => {});
+      registry.subscribe('msg-1', (text) => received.push(text), () => {});
+
+      expect(() => registry.push('msg-1', 'chunk1')).not.toThrow();
+      expect(received).toEqual(['chunk1']);
+    });
+
+    it('given a subscriber whose onComplete throws, should still remove the entry and notify remaining subscribers', () => {
+      const registry = new StreamMulticastRegistry();
+      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+
+      const completed: boolean[] = [];
+      registry.subscribe('msg-1', () => {}, () => { throw new Error('bad subscriber'); });
+      registry.subscribe('msg-1', () => {}, (aborted) => completed.push(aborted));
+
+      expect(() => registry.finish('msg-1')).not.toThrow();
+      expect(registry.getMeta('msg-1')).toBeUndefined();
+      expect(completed).toEqual([false]);
     });
   });
 });

--- a/apps/web/src/lib/ai/core/__tests__/stream-multicast-registry.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stream-multicast-registry.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { StreamMulticastRegistry } from '../stream-multicast-registry';
+
+describe('StreamMulticastRegistry', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('register / getMeta', () => {
+    it('stores stream metadata accessible via getMeta', () => {
+      const registry = new StreamMulticastRegistry();
+      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+
+      expect(registry.getMeta('msg-1')).toEqual({ pageId: 'page-1', userId: 'user-1' });
+    });
+
+    it('returns undefined for unknown messageId', () => {
+      const registry = new StreamMulticastRegistry();
+      expect(registry.getMeta('unknown')).toBeUndefined();
+    });
+  });
+
+  describe('push', () => {
+    it('given a registered stream with subscribers, should push text chunks to all active subscribers', () => {
+      const registry = new StreamMulticastRegistry();
+      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+
+      const received1: string[] = [];
+      const received2: string[] = [];
+      registry.subscribe('msg-1', (text) => received1.push(text), () => {});
+      registry.subscribe('msg-1', (text) => received2.push(text), () => {});
+
+      registry.push('msg-1', 'hello');
+      registry.push('msg-1', ' world');
+
+      expect(received1).toEqual(['hello', ' world']);
+      expect(received2).toEqual(['hello', ' world']);
+    });
+
+    it('silently ignores push for unknown messageId', () => {
+      const registry = new StreamMulticastRegistry();
+      expect(() => registry.push('unknown', 'chunk')).not.toThrow();
+    });
+  });
+
+  describe('subscribe', () => {
+    it('given a late-joining subscriber, should replay all buffered chunks before delivering live ones', () => {
+      const registry = new StreamMulticastRegistry();
+      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+
+      registry.push('msg-1', 'chunk1');
+      registry.push('msg-1', 'chunk2');
+
+      const received: string[] = [];
+      registry.subscribe('msg-1', (text) => received.push(text), () => {});
+
+      expect(received).toEqual(['chunk1', 'chunk2']);
+    });
+
+    it('given buffered and live chunks, should deliver them in order to a late subscriber', () => {
+      const registry = new StreamMulticastRegistry();
+      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+
+      registry.push('msg-1', 'chunk1');
+      registry.push('msg-1', 'chunk2');
+
+      const received: string[] = [];
+      registry.subscribe('msg-1', (text) => received.push(text), () => {});
+
+      registry.push('msg-1', 'chunk3');
+
+      expect(received).toEqual(['chunk1', 'chunk2', 'chunk3']);
+    });
+
+    it('given a finished stream, should return null', () => {
+      const registry = new StreamMulticastRegistry();
+      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+      registry.finish('msg-1');
+
+      const result = registry.subscribe('msg-1', () => {}, () => {});
+      expect(result).toBeNull();
+    });
+
+    it('given an unknown messageId, should return null', () => {
+      const registry = new StreamMulticastRegistry();
+      const result = registry.subscribe('unknown', () => {}, () => {});
+      expect(result).toBeNull();
+    });
+
+    it('returns an unsubscribe function for an active stream', () => {
+      const registry = new StreamMulticastRegistry();
+      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+
+      const unsubscribe = registry.subscribe('msg-1', () => {}, () => {});
+      expect(typeof unsubscribe).toBe('function');
+    });
+  });
+
+  describe('unsubscribe', () => {
+    it('given a subscriber that unsubscribes, should stop receiving chunks without affecting other subscribers', () => {
+      const registry = new StreamMulticastRegistry();
+      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+
+      const received1: string[] = [];
+      const received2: string[] = [];
+
+      const unsubscribe1 = registry.subscribe('msg-1', (text) => received1.push(text), () => {});
+      registry.subscribe('msg-1', (text) => received2.push(text), () => {});
+
+      registry.push('msg-1', 'chunk1');
+      unsubscribe1!();
+      registry.push('msg-1', 'chunk2');
+
+      expect(received1).toEqual(['chunk1']);
+      expect(received2).toEqual(['chunk1', 'chunk2']);
+    });
+
+    it('given an unsubscribed listener, should not call its onComplete when stream finishes', () => {
+      const registry = new StreamMulticastRegistry();
+      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+
+      const completed1: boolean[] = [];
+      const completed2: boolean[] = [];
+
+      const unsubscribe1 = registry.subscribe('msg-1', () => {}, (aborted) => completed1.push(aborted));
+      registry.subscribe('msg-1', () => {}, (aborted) => completed2.push(aborted));
+
+      unsubscribe1!();
+      registry.finish('msg-1');
+
+      expect(completed1).toEqual([]);
+      expect(completed2).toEqual([false]);
+    });
+  });
+
+  describe('finish', () => {
+    it('given a finished stream, should call complete callbacks with aborted=false by default', () => {
+      const registry = new StreamMulticastRegistry();
+      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+
+      const abortedValues: boolean[] = [];
+      registry.subscribe('msg-1', () => {}, (aborted) => abortedValues.push(aborted));
+
+      registry.finish('msg-1');
+      expect(abortedValues).toEqual([false]);
+    });
+
+    it('given a finished stream with aborted=true, should call complete callbacks with the correct aborted status', () => {
+      const registry = new StreamMulticastRegistry();
+      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+
+      const abortedValues: boolean[] = [];
+      registry.subscribe('msg-1', () => {}, (aborted) => abortedValues.push(aborted));
+
+      registry.finish('msg-1', true);
+      expect(abortedValues).toEqual([true]);
+    });
+
+    it('removes the stream entry after finishing so getMeta returns undefined', () => {
+      const registry = new StreamMulticastRegistry();
+      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+
+      registry.finish('msg-1');
+
+      expect(registry.getMeta('msg-1')).toBeUndefined();
+    });
+
+    it('silently ignores finish for unknown messageId', () => {
+      const registry = new StreamMulticastRegistry();
+      expect(() => registry.finish('unknown')).not.toThrow();
+    });
+
+    it('silently ignores a second finish call', () => {
+      const registry = new StreamMulticastRegistry();
+      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+
+      const completed: boolean[] = [];
+      registry.subscribe('msg-1', () => {}, (aborted) => completed.push(aborted));
+
+      registry.finish('msg-1');
+      registry.finish('msg-1'); // second call should be a no-op
+
+      expect(completed).toEqual([false]);
+    });
+  });
+
+  describe('auto-cleanup', () => {
+    it('given a stream still open after 10 minutes, should auto-cleanup to prevent memory leaks', () => {
+      vi.useFakeTimers();
+      const registry = new StreamMulticastRegistry();
+      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+
+      const completedValues: boolean[] = [];
+      registry.subscribe('msg-1', () => {}, (aborted) => completedValues.push(aborted));
+
+      expect(registry.getMeta('msg-1')).toBeDefined();
+
+      vi.advanceTimersByTime(10 * 60 * 1000);
+
+      expect(registry.getMeta('msg-1')).toBeUndefined();
+      expect(completedValues).toEqual([true]);
+    });
+
+    it('given a stream that finishes before 10 minutes, should not fire the auto-cleanup timer', () => {
+      vi.useFakeTimers();
+      const registry = new StreamMulticastRegistry();
+      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+
+      const completedValues: boolean[] = [];
+      registry.subscribe('msg-1', () => {}, (aborted) => completedValues.push(aborted));
+
+      registry.finish('msg-1', false);
+
+      vi.advanceTimersByTime(10 * 60 * 1000);
+
+      // Only one completion, not two
+      expect(completedValues).toEqual([false]);
+    });
+  });
+});

--- a/apps/web/src/lib/ai/core/stream-multicast-registry.ts
+++ b/apps/web/src/lib/ai/core/stream-multicast-registry.ts
@@ -1,0 +1,91 @@
+const MAX_STREAM_AGE_MS = 10 * 60 * 1000;
+
+interface StreamMeta {
+  pageId: string;
+  userId: string;
+}
+
+interface Subscriber {
+  onChunk: (text: string) => void;
+  onComplete: (aborted: boolean) => void;
+}
+
+interface StreamEntry {
+  meta: StreamMeta;
+  buffer: string[];
+  subscribers: Map<symbol, Subscriber>;
+  finished: boolean;
+  cleanupTimeoutId: ReturnType<typeof setTimeout> | null;
+}
+
+export class StreamMulticastRegistry {
+  private entries = new Map<string, StreamEntry>();
+
+  register(messageId: string, meta: StreamMeta): void {
+    const cleanupTimeoutId = setTimeout(() => {
+      this.finish(messageId, true);
+    }, MAX_STREAM_AGE_MS);
+
+    this.entries.set(messageId, {
+      meta,
+      buffer: [],
+      subscribers: new Map(),
+      finished: false,
+      cleanupTimeoutId,
+    });
+  }
+
+  push(messageId: string, text: string): void {
+    const entry = this.entries.get(messageId);
+    if (!entry || entry.finished) return;
+
+    entry.buffer.push(text);
+    for (const subscriber of entry.subscribers.values()) {
+      subscriber.onChunk(text);
+    }
+  }
+
+  subscribe(
+    messageId: string,
+    onChunk: (text: string) => void,
+    onComplete: (aborted: boolean) => void,
+  ): (() => void) | null {
+    const entry = this.entries.get(messageId);
+    if (!entry || entry.finished) return null;
+
+    for (const chunk of entry.buffer) {
+      onChunk(chunk);
+    }
+
+    const key = Symbol();
+    entry.subscribers.set(key, { onChunk, onComplete });
+
+    return () => {
+      entry.subscribers.delete(key);
+    };
+  }
+
+  finish(messageId: string, aborted = false): void {
+    const entry = this.entries.get(messageId);
+    if (!entry || entry.finished) return;
+
+    entry.finished = true;
+
+    if (entry.cleanupTimeoutId !== null) {
+      clearTimeout(entry.cleanupTimeoutId);
+      entry.cleanupTimeoutId = null;
+    }
+
+    for (const subscriber of entry.subscribers.values()) {
+      subscriber.onComplete(aborted);
+    }
+
+    this.entries.delete(messageId);
+  }
+
+  getMeta(messageId: string): StreamMeta | undefined {
+    return this.entries.get(messageId)?.meta;
+  }
+}
+
+export const streamMulticastRegistry = new StreamMulticastRegistry();

--- a/apps/web/src/lib/ai/core/stream-multicast-registry.ts
+++ b/apps/web/src/lib/ai/core/stream-multicast-registry.ts
@@ -1,6 +1,6 @@
 const MAX_STREAM_AGE_MS = 10 * 60 * 1000;
 
-interface StreamMeta {
+export interface StreamMeta {
   pageId: string;
   userId: string;
 }
@@ -22,6 +22,11 @@ export class StreamMulticastRegistry {
   private entries = new Map<string, StreamEntry>();
 
   register(messageId: string, meta: StreamMeta): void {
+    const existing = this.entries.get(messageId);
+    if (existing?.cleanupTimeoutId !== null && existing?.cleanupTimeoutId !== undefined) {
+      clearTimeout(existing.cleanupTimeoutId);
+    }
+
     const cleanupTimeoutId = setTimeout(() => {
       this.finish(messageId, true);
     }, MAX_STREAM_AGE_MS);
@@ -41,7 +46,11 @@ export class StreamMulticastRegistry {
 
     entry.buffer.push(text);
     for (const subscriber of entry.subscribers.values()) {
-      subscriber.onChunk(text);
+      try {
+        subscriber.onChunk(text);
+      } catch {
+        // one bad subscriber must not break fanout to others
+      }
     }
   }
 
@@ -76,11 +85,15 @@ export class StreamMulticastRegistry {
       entry.cleanupTimeoutId = null;
     }
 
-    for (const subscriber of entry.subscribers.values()) {
-      subscriber.onComplete(aborted);
-    }
-
     this.entries.delete(messageId);
+
+    for (const subscriber of entry.subscribers.values()) {
+      try {
+        subscriber.onComplete(aborted);
+      } catch {
+        // one bad subscriber must not prevent others from being notified
+      }
+    }
   }
 
   getMeta(messageId: string): StreamMeta | undefined {

--- a/apps/web/src/lib/ai/core/stream-multicast-registry.ts
+++ b/apps/web/src/lib/ai/core/stream-multicast-registry.ts
@@ -23,7 +23,7 @@ export class StreamMulticastRegistry {
 
   register(messageId: string, meta: StreamMeta): void {
     const existing = this.entries.get(messageId);
-    if (existing?.cleanupTimeoutId !== null && existing?.cleanupTimeoutId !== undefined) {
+    if (existing?.cleanupTimeoutId != null) {
       clearTimeout(existing.cleanupTimeoutId);
     }
 

--- a/tasks/multiplayer-ai-chat-streaming.md
+++ b/tasks/multiplayer-ai-chat-streaming.md
@@ -1,0 +1,37 @@
+# Multiplayer AI Chat Streaming
+
+Stream AI responses to all active viewers of a chat page, not just the requesting client.
+
+## Tasks
+
+### Task 1: StreamMulticastRegistry ✅ COMPLETED
+**PR:** https://github.com/2witstudios/PageSpace/pull/1140
+
+Pure in-process pub/sub registry at `apps/web/src/lib/ai/core/stream-multicast-registry.ts`.
+
+- Buffers chunks and multicasts to all subscribers
+- Late-join replay of full buffer
+- `finish(messageId, aborted?)` notifies all via `onComplete`
+- 10-minute auto-cleanup via `setTimeout`
+- Exported singleton `streamMulticastRegistry` + class for testing
+- 18 tests, all passing
+
+### Task 2: Wire registry into AI stream route
+**Status:** Pending
+
+In the AI chat stream API route, call `register` before streaming, `push` on each chunk, `finish` on completion/abort.
+
+### Task 3: Socket.IO multicast event
+**Status:** Pending
+
+When `push` is called on the registry, emit a Socket.IO event to all clients subscribed to the page room.
+
+### Task 4: Client-side subscription
+**Status:** Pending
+
+Hook AI chat page into the Socket.IO multicast events so non-requesting viewers see chunks arrive in real time.
+
+### Task 5: Late-join HTTP replay endpoint
+**Status:** Pending
+
+Expose a GET endpoint that streams buffered chunks to a client that loads the page mid-stream.

--- a/tasks/multiplayer-ai-chat-streaming.md
+++ b/tasks/multiplayer-ai-chat-streaming.md
@@ -16,6 +16,12 @@ Pure in-process pub/sub registry at `apps/web/src/lib/ai/core/stream-multicast-r
 - Exported singleton `streamMulticastRegistry` + class for testing
 - 18 tests, all passing
 
+#### Review fixes (post-merge):
+- Given `register` is called twice for the same `messageId`, should clear the first timer so `onComplete` fires only once
+- Given a subscriber's `onComplete` callback throws, should still delete the entry and notify remaining subscribers
+- Given a subscriber's `onChunk` callback throws during `push`, should not interrupt fanout to remaining subscribers
+- `StreamMeta` interface must be exported for downstream tasks to type `getMeta` results
+
 ### Task 2: Wire registry into AI stream route
 **Status:** Pending
 


### PR DESCRIPTION
## Summary

Implements \`StreamMulticastRegistry\` — a pure in-process pub/sub registry at \`apps/web/src/lib/ai/core/stream-multicast-registry.ts\`. This is Task 1 of 5 in the Multiplayer AI Chat Streaming epic.

**What it does:**
- Buffers all text chunks per stream and multicasts to every active subscriber
- Late-joining subscribers receive a full replay of the buffer before live chunks
- \`finish(messageId, aborted?)\` notifies all subscribers via \`onComplete\` and clears the entry
- 10-minute auto-cleanup timer fires \`finish(…, true)\` to prevent memory leaks from orphaned streams
- Exports \`StreamMeta\` interface, \`StreamMulticastRegistry\` class (for per-test isolation), and \`streamMulticastRegistry\` singleton

**Public API:**
\`\`\`ts
streamMulticastRegistry.register(messageId, { pageId, userId })
streamMulticastRegistry.push(messageId, text)
streamMulticastRegistry.subscribe(messageId, onChunk, onComplete) // → unsubscribe fn | null
streamMulticastRegistry.finish(messageId, aborted?)
streamMulticastRegistry.getMeta(messageId)  // → StreamMeta | undefined
\`\`\`

## Post-review fixes (commit e48d02245)

All review comments addressed:

| Issue | Fix |
|-------|-----|
| Duplicate `register` leaks orphaned timer | Clear existing entry's `cleanupTimeoutId` before overwriting |
| `onComplete` exception leaks entry | Delete entry from map **before** subscriber loop; wrap each callback in try/catch |
| `onChunk` exception breaks fanout | Wrap each `subscriber.onChunk()` in try/catch in `push()` |
| `StreamMeta` not exported | Added `export` to the interface |
| Redundant inline comment in test | Removed |
| Non-null `!` assertions in tests | Replaced with explicit `expect(fn).not.toBeNull()` assertions |
| No test for duplicate `register` | Added to `auto-cleanup` block |
| No resilience tests | Added `resilience` block: onChunk-throws and onComplete-throws tests |

## Test plan

- [x] 21 unit tests pass (3 new tests added post-review)
- [x] TypeScript: no errors in new files (`tsc --noEmit`)
- [x] CI: Unit Tests ✅, Lint & TypeScript Check ✅, CodeRabbit ✅
- [x] Mergeable: CLEAN, no conflicts with master
- [x] All 20 review threads replied to and resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)