### PR TITLE
feat(ai): SSE stream-join endpoint for multiplayer chat streaming

### DIFF
--- a/apps/web/src/app/api/ai/chat/stream-join/[messageId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/chat/stream-join/[messageId]/__tests__/route.test.ts
@@ -34,6 +34,7 @@ vi.mock('@pagespace/lib/audit/audit-log', () => ({
 import { GET } from '../route';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const mockPageId = 'page-test-123';
 const mockUserId = 'user-test-456';
@@ -141,6 +142,23 @@ describe('GET /api/ai/chat/stream-join/[messageId]', () => {
       expect(response.headers.get('X-Accel-Buffering')).toBe('no');
     });
 
+    it('given a successful stream join, should emit an authz.access.granted audit event', async () => {
+      testRegistry.register(mockMessageId, { pageId: mockPageId, userId: mockUserId });
+
+      await GET(makeRequest(), makeContext(mockMessageId));
+      testRegistry.finish(mockMessageId);
+
+      expect(auditRequest).toHaveBeenCalledWith(
+        expect.any(Request),
+        expect.objectContaining({
+          eventType: 'authz.access.granted',
+          resourceType: 'ai_stream',
+          resourceId: mockMessageId,
+          details: expect.objectContaining({ pageId: mockPageId }),
+        }),
+      );
+    });
+
     it('given buffered chunks, should stream them as SSE data events', async () => {
       testRegistry.register(mockMessageId, { pageId: mockPageId, userId: mockUserId });
       testRegistry.push(mockMessageId, 'hello');
@@ -163,7 +181,7 @@ describe('GET /api/ai/chat/stream-join/[messageId]', () => {
 
       const body = await readSSEBody(response);
 
-      expect(body).toContain('data: [DONE]\n\n');
+      expect(body).toContain('data: {"done":true,"aborted":false}\n\n');
     });
 
     it('given live chunks pushed after subscribe, should stream them in order', async () => {
@@ -179,7 +197,7 @@ describe('GET /api/ai/chat/stream-join/[messageId]', () => {
 
       expect(body).toContain('data: {"text":"buffered"}\n\n');
       expect(body).toContain('data: {"text":"live"}\n\n');
-      expect(body).toContain('data: [DONE]\n\n');
+      expect(body).toContain('data: {"done":true,"aborted":false}\n\n');
     });
 
     it('given a race where subscribe returns null, should return 404', async () => {
@@ -222,6 +240,22 @@ describe('GET /api/ai/chat/stream-join/[messageId]', () => {
 
       // Registry finish should not error even though route subscriber was removed
       expect(() => testRegistry.finish(mockMessageId)).not.toThrow();
+    });
+
+    it('given stream completes then client disconnects, should not attempt to double-close the controller', async () => {
+      const abortController = new AbortController();
+      testRegistry.register(mockMessageId, { pageId: mockPageId, userId: mockUserId });
+
+      const response = await GET(makeRequest(abortController.signal), makeContext(mockMessageId));
+      expect(response.status).toBe(200);
+
+      // Complete the stream first
+      testRegistry.finish(mockMessageId);
+
+      // Then abort — should be a no-op, not throw
+      expect(() => abortController.abort()).not.toThrow();
+      await Promise.resolve();
+      // No error thrown from double-close
     });
   });
 });

--- a/apps/web/src/app/api/ai/chat/stream-join/[messageId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/chat/stream-join/[messageId]/__tests__/route.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextResponse } from 'next/server';
+import { StreamMulticastRegistry } from '@/lib/ai/core/stream-multicast-registry';
+import type { SessionAuthResult, AuthError } from '@/lib/auth';
+
+// Fresh registry per test — module-level let, updated in beforeEach
+let testRegistry: StreamMulticastRegistry;
+
+vi.mock('@/lib/ai/core/stream-multicast-registry', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/ai/core/stream-multicast-registry')>(
+    '@/lib/ai/core/stream-multicast-registry',
+  );
+  return {
+    ...actual,
+    get streamMulticastRegistry() {
+      return testRegistry;
+    },
+  };
+});
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  canUserViewPage: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: vi.fn(),
+}));
+
+import { GET } from '../route';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
+
+const mockPageId = 'page-test-123';
+const mockUserId = 'user-test-456';
+const mockMessageId = 'msg-test-789';
+
+const mockSessionAuth = (userId = mockUserId): SessionAuthResult => ({
+  userId,
+  tokenType: 'session',
+  sessionId: 'sess-abc',
+  role: 'user',
+  tokenVersion: 0,
+  adminRoleVersion: 0,
+});
+
+const mockAuthFailure = (status = 401): AuthError => ({
+  error: NextResponse.json({ error: 'Unauthorized' }, { status }),
+});
+
+const makeRequest = (signal?: AbortSignal) =>
+  new Request(`http://test.local/api/ai/chat/stream-join/${mockMessageId}`, { signal });
+
+const makeContext = (messageId: string) => ({
+  params: Promise.resolve({ messageId }),
+});
+
+const readSSEBody = async (response: Response): Promise<string> => response.text();
+
+describe('GET /api/ai/chat/stream-join/[messageId]', () => {
+  beforeEach(() => {
+    testRegistry = new StreamMulticastRegistry();
+    vi.clearAllMocks();
+
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockSessionAuth());
+    vi.mocked(isAuthError).mockReturnValue(false);
+    vi.mocked(canUserViewPage).mockResolvedValue(true);
+  });
+
+  describe('authentication', () => {
+    it('given unauthenticated request, should return 401', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthFailure(401));
+      vi.mocked(isAuthError).mockReturnValue(true);
+
+      const response = await GET(makeRequest(), makeContext(mockMessageId));
+
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe('stream lookup', () => {
+    it('given an unknown messageId, should return 404', async () => {
+      // Registry has no entry for mockMessageId
+      const response = await GET(makeRequest(), makeContext(mockMessageId));
+
+      expect(response.status).toBe(404);
+    });
+
+    it('given an already-finished messageId, should return 404', async () => {
+      testRegistry.register(mockMessageId, { pageId: mockPageId, userId: mockUserId });
+      testRegistry.finish(mockMessageId);
+      // Entry is deleted — subscribe() returns null
+
+      const response = await GET(makeRequest(), makeContext(mockMessageId));
+
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe('authorization', () => {
+    it('given a user without view access, should return 403', async () => {
+      testRegistry.register(mockMessageId, { pageId: mockPageId, userId: mockUserId });
+      vi.mocked(canUserViewPage).mockResolvedValue(false);
+
+      const response = await GET(makeRequest(), makeContext(mockMessageId));
+
+      expect(response.status).toBe(403);
+    });
+
+    it('should check permission against the pageId from stream metadata', async () => {
+      testRegistry.register(mockMessageId, { pageId: mockPageId, userId: mockUserId });
+      testRegistry.finish(mockMessageId); // Make subscribe return null (404 before perm check)
+      // Actually: getMeta returns undefined after finish — so we never reach perm check
+      // Let's use a live stream
+      testRegistry = new StreamMulticastRegistry();
+      testRegistry.register(mockMessageId, { pageId: mockPageId, userId: mockUserId });
+
+      await GET(makeRequest(), makeContext(mockMessageId));
+
+      // Finish to unblock any lingering streams
+      testRegistry.finish(mockMessageId);
+
+      expect(canUserViewPage).toHaveBeenCalledWith(mockUserId, mockPageId);
+    });
+  });
+
+  describe('SSE streaming', () => {
+    it('given a valid messageId and authorized viewer, should return SSE response headers', async () => {
+      testRegistry.register(mockMessageId, { pageId: mockPageId, userId: mockUserId });
+
+      const response = await GET(makeRequest(), makeContext(mockMessageId));
+      testRegistry.finish(mockMessageId);
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Content-Type')).toBe('text/event-stream');
+      expect(response.headers.get('Cache-Control')).toBe('no-cache');
+      expect(response.headers.get('X-Accel-Buffering')).toBe('no');
+    });
+
+    it('given buffered chunks, should stream them as SSE data events', async () => {
+      testRegistry.register(mockMessageId, { pageId: mockPageId, userId: mockUserId });
+      testRegistry.push(mockMessageId, 'hello');
+      testRegistry.push(mockMessageId, ' world');
+
+      const response = await GET(makeRequest(), makeContext(mockMessageId));
+      testRegistry.finish(mockMessageId);
+
+      const body = await readSSEBody(response);
+
+      expect(body).toContain('data: {"text":"hello"}\n\n');
+      expect(body).toContain('data: {"text":" world"}\n\n');
+    });
+
+    it('given stream completion, should send [DONE] sentinel and close', async () => {
+      testRegistry.register(mockMessageId, { pageId: mockPageId, userId: mockUserId });
+
+      const response = await GET(makeRequest(), makeContext(mockMessageId));
+      testRegistry.finish(mockMessageId);
+
+      const body = await readSSEBody(response);
+
+      expect(body).toContain('data: [DONE]\n\n');
+    });
+
+    it('given live chunks pushed after subscribe, should stream them in order', async () => {
+      testRegistry.register(mockMessageId, { pageId: mockPageId, userId: mockUserId });
+      testRegistry.push(mockMessageId, 'buffered');
+
+      const response = await GET(makeRequest(), makeContext(mockMessageId));
+
+      testRegistry.push(mockMessageId, 'live');
+      testRegistry.finish(mockMessageId);
+
+      const body = await readSSEBody(response);
+
+      expect(body).toContain('data: {"text":"buffered"}\n\n');
+      expect(body).toContain('data: {"text":"live"}\n\n');
+      expect(body).toContain('data: [DONE]\n\n');
+    });
+
+    it('given a race where subscribe returns null, should return 404', async () => {
+      // getMeta succeeds (stream registered) but subscribe returns null
+      // Simulate by registering, getting meta, then finishing before route subscribes.
+      // We achieve this by overriding getMeta to return meta while subscribe sees finished state.
+      // Simplest: use the registry — register, finish, re-set getMeta via spy.
+      const spyRegistry = new StreamMulticastRegistry();
+      spyRegistry.register(mockMessageId, { pageId: mockPageId, userId: mockUserId });
+
+      // getMeta returns meta even after finish by using a spy
+      const getMetaSpy = vi.spyOn(spyRegistry, 'getMeta').mockReturnValue({
+        pageId: mockPageId,
+        userId: mockUserId,
+      });
+      spyRegistry.finish(mockMessageId); // subscribe will now return null
+
+      testRegistry = spyRegistry;
+
+      const response = await GET(makeRequest(), makeContext(mockMessageId));
+
+      expect(response.status).toBe(404);
+      getMetaSpy.mockRestore();
+    });
+  });
+
+  describe('client disconnect', () => {
+    it('given client disconnect, should unsubscribe without leaking resources', async () => {
+      const abortController = new AbortController();
+      testRegistry.register(mockMessageId, { pageId: mockPageId, userId: mockUserId });
+
+      const response = await GET(makeRequest(abortController.signal), makeContext(mockMessageId));
+      expect(response.status).toBe(200);
+
+      // Abort the connection — should call unsubscribe() on the registry subscriber
+      abortController.abort();
+
+      // Allow event loop to process the abort event
+      await Promise.resolve();
+
+      // Registry finish should not error even though route subscriber was removed
+      expect(() => testRegistry.finish(mockMessageId)).not.toThrow();
+    });
+  });
+});

--- a/apps/web/src/app/api/ai/chat/stream-join/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/chat/stream-join/[messageId]/route.ts
@@ -62,15 +62,15 @@ export async function GET(
         preBuffer.push(chunk);
       }
     },
-    (_aborted) => {
-      const done = encoder.encode('data: [DONE]\n\n');
+    (aborted) => {
+      const done = encoder.encode(`data: ${JSON.stringify({ done: true, aborted })}\n\n`);
       if (streamController) {
         streamController.enqueue(done);
         streamController.close();
       } else {
         preBuffer.push(done);
-        streamClosed = true;
       }
+      streamClosed = true;
     },
   );
 
@@ -79,6 +79,14 @@ export async function GET(
   if (unsubscribe === null) {
     return NextResponse.json({ error: 'Stream not found' }, { status: 404 });
   }
+
+  auditRequest(request, {
+    eventType: 'authz.access.granted',
+    resourceType: 'ai_stream',
+    resourceId: messageId,
+    details: { pageId: meta.pageId },
+    riskScore: 0,
+  });
 
   const stream = new ReadableStream<Uint8Array>({
     start(controller) {
@@ -91,6 +99,7 @@ export async function GET(
         return;
       }
       request.signal.addEventListener('abort', () => {
+        if (streamClosed) return;
         unsubscribe();
         controller.close();
       });

--- a/apps/web/src/app/api/ai/chat/stream-join/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/chat/stream-join/[messageId]/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from 'next/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { streamMulticastRegistry } from '@/lib/ai/core/stream-multicast-registry';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ messageId: string }> },
+) {
+  const authResult = await authenticateRequestWithOptions(request, {
+    allow: ['session'],
+    requireCSRF: false,
+  });
+  if (isAuthError(authResult)) {
+    auditRequest(request, {
+      eventType: 'authz.access.denied',
+      resourceType: 'ai_stream',
+      resourceId: 'stream-join',
+      details: { reason: 'auth_failed', method: 'GET' },
+      riskScore: 0.4,
+    });
+    return authResult.error;
+  }
+  const { userId } = authResult;
+
+  const { messageId } = await context.params;
+
+  const meta = streamMulticastRegistry.getMeta(messageId);
+  if (!meta) {
+    return NextResponse.json({ error: 'Stream not found' }, { status: 404 });
+  }
+
+  const canView = await canUserViewPage(userId, meta.pageId);
+  if (!canView) {
+    auditRequest(request, {
+      eventType: 'authz.access.denied',
+      resourceType: 'ai_stream',
+      resourceId: messageId,
+      details: { reason: 'insufficient_permissions', pageId: meta.pageId },
+      riskScore: 0.5,
+    });
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const encoder = new TextEncoder();
+  // Chunks that arrive during subscribe's synchronous buffer replay, before the
+  // ReadableStream controller exists, are collected here and flushed in start().
+  const preBuffer: Uint8Array[] = [];
+  let streamController: ReadableStreamDefaultController<Uint8Array> | null = null;
+  let streamClosed = false;
+
+  const unsubscribe = streamMulticastRegistry.subscribe(
+    messageId,
+    (text) => {
+      const chunk = encoder.encode(`data: ${JSON.stringify({ text })}\n\n`);
+      if (streamController) {
+        streamController.enqueue(chunk);
+      } else {
+        preBuffer.push(chunk);
+      }
+    },
+    (_aborted) => {
+      const done = encoder.encode('data: [DONE]\n\n');
+      if (streamController) {
+        streamController.enqueue(done);
+        streamController.close();
+      } else {
+        preBuffer.push(done);
+        streamClosed = true;
+      }
+    },
+  );
+
+  // finish() deletes entries before notifying subscribers, so subscribe() returns
+  // null for both unknown and already-finished streams.
+  if (unsubscribe === null) {
+    return NextResponse.json({ error: 'Stream not found' }, { status: 404 });
+  }
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      streamController = controller;
+      for (const chunk of preBuffer) {
+        controller.enqueue(chunk);
+      }
+      if (streamClosed) {
+        controller.close();
+        return;
+      }
+      request.signal.addEventListener('abort', () => {
+        unsubscribe();
+        controller.close();
+      });
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'X-Accel-Buffering': 'no',
+    },
+  });
+}

--- a/apps/web/src/lib/ai/core/__tests__/stream-multicast-registry.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stream-multicast-registry.test.ts
@@ -218,6 +218,18 @@ describe('StreamMulticastRegistry', () => {
       expect(completedValues).toEqual([false]);
     });
 
+    it('given register is called with an existing messageId that has subscribers, should notify those subscribers with aborted=true', () => {
+      const registry = new StreamMulticastRegistry();
+      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+
+      const completed: boolean[] = [];
+      registry.subscribe('msg-1', () => {}, (aborted) => completed.push(aborted));
+
+      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+
+      expect(completed).toEqual([true]);
+    });
+
     it('given register is called twice for the same messageId, should call onComplete only once after 10 minutes', () => {
       vi.useFakeTimers();
       const registry = new StreamMulticastRegistry();

--- a/apps/web/src/lib/ai/core/stream-multicast-registry.ts
+++ b/apps/web/src/lib/ai/core/stream-multicast-registry.ts
@@ -22,10 +22,8 @@ export class StreamMulticastRegistry {
   private entries = new Map<string, StreamEntry>();
 
   register(messageId: string, meta: StreamMeta): void {
-    const existing = this.entries.get(messageId);
-    if (existing?.cleanupTimeoutId != null) {
-      clearTimeout(existing.cleanupTimeoutId);
-    }
+    // Notify and evict any existing entry so its subscribers aren't silently dropped.
+    this.finish(messageId, true);
 
     const cleanupTimeoutId = setTimeout(() => {
       this.finish(messageId, true);
@@ -101,4 +99,5 @@ export class StreamMulticastRegistry {
   }
 }
 
+// Single-process only — streams registered on one Node.js instance are not visible to others.
 export const streamMulticastRegistry = new StreamMulticastRegistry();

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -35,6 +35,8 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      '@pagespace/lib': path.resolve(__dirname, '../../packages/lib/src'),
+      '@pagespace/db': path.resolve(__dirname, '../../packages/db/src'),
     },
   },
 })

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -35,8 +35,6 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
-      '@pagespace/lib': path.resolve(__dirname, '../../packages/lib/src'),
-      '@pagespace/db': path.resolve(__dirname, '../../packages/db/src'),
     },
   },
 })

--- a/tasks/multiplayer-ai-chat-streaming.md
+++ b/tasks/multiplayer-ai-chat-streaming.md
@@ -22,22 +22,51 @@ Pure in-process pub/sub registry at `apps/web/src/lib/ai/core/stream-multicast-r
 - Given a subscriber's `onChunk` callback throws during `push`, should not interrupt fanout to remaining subscribers
 - `StreamMeta` interface must be exported for downstream tasks to type `getMeta` results
 
-### Task 2: Wire registry into AI stream route
+### Task 2: Stream Join Endpoint ✅ COMPLETED
+**PR:** Pending merge
+
+SSE endpoint at `apps/web/src/app/api/ai/chat/stream-join/[messageId]/route.ts`.
+
+- GET endpoint that subscribes to an in-progress stream via `StreamMulticastRegistry`
+- Auth: session tokens via `authenticateRequestWithOptions`
+- Permissions: `canUserViewPage` check against `meta.pageId`
+- SSE format: `data: {"text":"..."}\n\n` per chunk, `data: [DONE]\n\n` on complete
+- Proxy-friendly headers: `X-Accel-Buffering: no`
+- Client disconnect: abort signal → `unsubscribe()` + `controller.close()`
+- Race safety: subscribe called before ReadableStream created; buffer replay flushed in `start()`
+- Returns 401/403/404 before streaming begins
+- Audit logging on auth/permission denials
+- 11 tests, all passing
+
+### Task 3: Stream Socket Events
 **Status:** Pending
 
-In the AI chat stream API route, call `register` before streaming, `push` on each chunk, `finish` on completion/abort.
+Wire `chat:stream_start` and `chat:stream_complete` socket broadcasts into the AI chat route alongside the multicast registry.
 
-### Task 3: Socket.IO multicast event
+- Given a new AI stream, should register the messageId in the multicast registry before emitting `chat:stream_start`
+- Given `chat:stream_start`, should include messageId, pageId, conversationId, and triggeredBy in the payload
+- Given stream completion or abort, should flush the registry and emit `chat:stream_complete` with an aborted flag
+- Given a broadcast or registry call that throws, should not interrupt the AI response stream
+- Given a route error that skips `onFinish`, should still emit `chat:stream_complete` via a finally path
+
+### Task 4: AI Stream Client State
 **Status:** Pending
 
-When `push` is called on the registry, emit a Socket.IO event to all clients subscribed to the page room.
+Implement a Zustand store and socket hook that tracks in-progress remote streams and accumulates ghost text.
 
-### Task 4: Client-side subscription
+- Given `chat:stream_start` from another user, should register a pending stream and open a stream-join fetch connection
+- Given `chat:stream_start` from the local user, should mark the stream as local and skip the SSE join
+- Given incoming SSE chunks for a non-local stream, should accumulate text in the store keyed by messageId
+- Given `chat:stream_complete`, should remove the stream and call the completion callback
+- Given page unmount, should abort all in-flight join connections and clear all page streams from the store
+
+### Task 5: Multiplayer Chat UI
 **Status:** Pending
 
-Hook AI chat page into the Socket.IO multicast events so non-requesting viewers see chunks arrive in real time.
+Thread `pendingStreamsContent` through `ChatLayout` → `ChatMessagesArea` and render indicators and ghost text in `AiChatView`.
 
-### Task 5: Late-join HTTP replay endpoint
-**Status:** Pending
-
-Expose a GET endpoint that streams buffered chunks to a client that loads the page mid-stream.
+- Given a remote pending stream, should render a spinner with "X is waiting for AI response…" text
+- Given accumulated ghost text from a remote stream, should render it in a muted style below the indicator
+- Given multiple concurrent remote streams, should render a separate indicator for each
+- Given `chat:stream_complete` for a remote stream, should remove its indicator and trigger SWR revalidation
+- Given only a local stream in progress, should render no remote indicators


### PR DESCRIPTION
## Summary

- Adds \`GET /api/ai/chat/stream-join/[messageId]\` — an SSE endpoint that lets authorized viewers subscribe to an in-progress AI response stream backed by \`StreamMulticastRegistry\` (Task 1, PR #1140)
- Fixes \`register()\` to call \`finish()\` before overwriting, so any existing subscribers receive \`onComplete(aborted=true)\` instead of being silently dropped
- Guards abort listener against double-close: \`streamClosed\` is now set in both branches of \`onComplete\`, so a post-completion abort is a no-op rather than a \`TypeError\`
- Forwards \`aborted\` flag in the done SSE event so clients can distinguish normal completion from timeout/abort
- Adds \`authz.access.granted\` audit event on successful stream join (alongside existing denial audits)
- Removes the unnecessary \`@pagespace/lib\`/\`@pagespace/db\` vitest aliases — both packages have proper \`exports\` entries and resolve via pnpm natively

## Architecture

The endpoint follows a **subscribe-then-stream** pattern to handle the timing between buffer replay and ReadableStream initialization:

1. \`subscribe()\` is called before \`new ReadableStream()\` — any buffer-replay chunks land in \`preBuffer[]\`
2. \`start(controller)\` flushes \`preBuffer\` to the controller, then registers future chunks to flow directly
3. \`finish()\` deletes the registry entry before notifying subscribers, so \`subscribe()\` returning \`null\` means both "unknown" and "already-finished" → **404** in both cases
4. Abort listener checks \`streamClosed\` before calling \`controller.close()\` to avoid double-close when stream finishes before client disconnects

## SSE Format

```
data: {"text":"chunk text here"}\n\n        ← each chunk
data: {"done":true,"aborted":false}\n\n     ← normal completion
data: {"done":true,"aborted":true}\n\n      ← timeout/abort
```

Headers: \`Content-Type: text/event-stream\`, \`Cache-Control: no-cache\`, \`X-Accel-Buffering: no\`

## Security

- 401 on missing/invalid session
- 403 on insufficient page view permission (with \`authz.access.denied\` audit)
- 404 if stream not found or already finished
- 200 successful join emits \`authz.access.granted\` audit
- Auth/permission denials emit \`auditRequest\` per the security audit gate

> **Note:** The registry has no production writer yet — that wiring lands in Task 3 (stream socket events), which registers \`messageId\` on stream start and calls \`finish()\` on completion. This PR is intentionally the join-only side.

## Tests

35 tests total (22 registry + 13 route), covering: auth (401), stream lookup (404 × 2), authorization (403), SSE headers, buffered chunks, live chunks, done sentinel, race condition (subscribe returns null → 404), client disconnect, double-close guard, success audit event, and register overwrite subscriber notification.

## Test plan

- [x] All 35 tests pass
- [x] TypeScript clean
- [x] No vitest workspace aliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)