### PR TITLE
feat(ai): wire stream socket events into AI chat route

### DIFF
--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -443,6 +443,34 @@ describe('POST /api/ai/chat — stream socket events', () => {
 
       expect(mockRegistryFinish).toHaveBeenCalledWith('test-message-id', true);
     });
+
+    it('given stream abort, should broadcast chat:stream_complete with aborted=true', async () => {
+      await POST(makeRequest());
+      await captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() });
+
+      captured.streamTextOptions.onAbort?.();
+
+      expect(mockBroadcastAiStreamComplete).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messageId: 'test-message-id',
+          pageId: 'page-1',
+          aborted: true,
+        })
+      );
+    });
+
+    it('given stream abort followed by onFinish, should broadcast complete only once with aborted=true', async () => {
+      await POST(makeRequest());
+      await captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() });
+
+      captured.streamTextOptions.onAbort?.();
+      await captured.createUIMessageStreamOptions.onFinish?.({ responseMessage: mockResponseMessage });
+
+      expect(mockBroadcastAiStreamComplete).toHaveBeenCalledTimes(1);
+      expect(mockBroadcastAiStreamComplete).toHaveBeenCalledWith(
+        expect.objectContaining({ aborted: true })
+      );
+    });
   });
 
   describe('error finally path', () => {

--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * Tests for Task 3: stream socket events wired into the AI chat route.
  *
@@ -28,9 +27,19 @@ const {
 }));
 
 // Captured AI SDK callbacks
+interface MockUIStreamOptions {
+  execute?: (ctx: Record<string, unknown>) => Promise<void> | void;
+  onFinish?: (result: { responseMessage: unknown }) => Promise<void> | void;
+  originalMessages?: unknown[];
+  generateId?: () => string;
+}
+interface MockStreamTextOptions {
+  onChunk?: (ctx: { chunk: Record<string, unknown> }) => void;
+  onAbort?: () => void;
+}
 const captured = vi.hoisted(() => ({
-  createUIMessageStreamOptions: null as any,
-  streamTextOptions: null as any,
+  createUIMessageStreamOptions: {} as MockUIStreamOptions,
+  streamTextOptions: {} as MockStreamTextOptions,
 }));
 
 // ============================================================================
@@ -56,7 +65,7 @@ vi.mock('@/lib/websocket', () => ({
 
 vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
-  isAuthError: vi.fn((result: any) => 'error' in result),
+  isAuthError: vi.fn((result: unknown) => typeof result === 'object' && result !== null && 'error' in result),
   checkMCPPageScope: vi.fn().mockResolvedValue(null),
 }));
 
@@ -87,7 +96,10 @@ vi.mock('@pagespace/db/db', () => ({
       from: vi.fn(() => ({
         where: vi.fn(() => ({
           // supports direct await (pages, users), .orderBy() (chatMessages), and .limit() (userProfiles, drives)
-          then: (resolve: any, reject: any) => Promise.resolve([mockDbRow]).then(resolve, reject),
+          then: <T>(
+            resolve?: ((value: (typeof mockDbRow)[]) => T | PromiseLike<T>) | null,
+            reject?: ((reason: unknown) => T | PromiseLike<T>) | null,
+          ) => Promise.resolve([mockDbRow]).then(resolve, reject),
           orderBy: vi.fn().mockResolvedValue([]),
           limit: vi.fn().mockResolvedValue([{ displayName: 'Test User', drivePrompt: null }]),
         })),
@@ -155,12 +167,12 @@ vi.mock('@/lib/ai/core', () => ({
   getModelCapabilities: vi.fn().mockResolvedValue({}),
   convertMCPToolsToAISDKSchemas: vi.fn(),
   parseMCPToolName: vi.fn(),
-  sanitizeToolNamesForProvider: vi.fn((t: any) => t),
+  sanitizeToolNamesForProvider: vi.fn((t: unknown) => t),
   getUserPersonalization: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock('ai', () => ({
-  streamText: vi.fn().mockImplementation((options: any) => {
+  streamText: vi.fn().mockImplementation((options: MockStreamTextOptions) => {
     captured.streamTextOptions = options;
     return {
       toUIMessageStream: () => (async function* () {})(),
@@ -171,7 +183,7 @@ vi.mock('ai', () => ({
   stepCountIs: vi.fn(),
   hasToolCall: vi.fn(() => () => false),
   tool: vi.fn((config: any) => config),
-  createUIMessageStream: vi.fn().mockImplementation((options: any) => {
+  createUIMessageStream: vi.fn().mockImplementation((options: MockUIStreamOptions) => {
     captured.createUIMessageStreamOptions = options;
     return {};
   }),
@@ -220,7 +232,7 @@ vi.mock('@/lib/ai/core/ai-providers-config', () => ({
 }));
 
 vi.mock('@/lib/ai/core/tool-utils', () => ({
-  mergeToolSets: vi.fn((a: any, b: any) => ({ ...a, ...b })),
+  mergeToolSets: vi.fn((a: Record<string, unknown>, b: Record<string, unknown>) => ({ ...a, ...b })),
 }));
 
 vi.mock('@/lib/ai/tools/finish-tool', () => ({
@@ -304,8 +316,8 @@ const mockResponseMessage = {
 describe('POST /api/ai/chat — stream socket events', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    captured.createUIMessageStreamOptions = null;
-    captured.streamTextOptions = null;
+    captured.createUIMessageStreamOptions = {};
+    captured.streamTextOptions = {};
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuth());
   });
 

--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -182,7 +182,7 @@ vi.mock('ai', () => ({
   convertToModelMessages: vi.fn().mockReturnValue([]),
   stepCountIs: vi.fn(),
   hasToolCall: vi.fn(() => () => false),
-  tool: vi.fn((config: any) => config),
+  tool: vi.fn((config: unknown) => config),
   createUIMessageStream: vi.fn().mockImplementation((options: MockUIStreamOptions) => {
     captured.createUIMessageStreamOptions = options;
     return {};

--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -1,0 +1,473 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * Tests for Task 3: stream socket events wired into the AI chat route.
+ *
+ * Verifies that route.ts calls register → broadcastAiStreamStart before streaming,
+ * pushes text-delta chunks to the registry, and calls finish + broadcastAiStreamComplete
+ * on completion or abort. Also verifies the finally path on route error.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ============================================================================
+// Hoisted mocks (referenced inside vi.mock factories)
+// ============================================================================
+
+const {
+  mockRegistryRegister,
+  mockRegistryPush,
+  mockRegistryFinish,
+  mockBroadcastAiStreamStart,
+  mockBroadcastAiStreamComplete,
+} = vi.hoisted(() => ({
+  mockRegistryRegister: vi.fn(),
+  mockRegistryPush: vi.fn(),
+  mockRegistryFinish: vi.fn(),
+  mockBroadcastAiStreamStart: vi.fn().mockResolvedValue(undefined),
+  mockBroadcastAiStreamComplete: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Captured AI SDK callbacks
+const captured = vi.hoisted(() => ({
+  createUIMessageStreamOptions: null as any,
+  streamTextOptions: null as any,
+}));
+
+// ============================================================================
+// Module mocks
+// ============================================================================
+
+vi.mock('@/lib/ai/core/stream-multicast-registry', () => ({
+  streamMulticastRegistry: {
+    register: mockRegistryRegister,
+    push: mockRegistryPush,
+    finish: mockRegistryFinish,
+    getMeta: vi.fn(),
+    subscribe: vi.fn(),
+  },
+  StreamMulticastRegistry: vi.fn(),
+}));
+
+vi.mock('@/lib/websocket', () => ({
+  broadcastUsageEvent: vi.fn(),
+  broadcastAiStreamStart: mockBroadcastAiStreamStart,
+  broadcastAiStreamComplete: mockBroadcastAiStreamComplete,
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn((result: any) => 'error' in result),
+  checkMCPPageScope: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  canUserViewPage: vi.fn().mockResolvedValue(true),
+  canUserEditPage: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
+  getActorInfo: vi.fn().mockResolvedValue({ actorEmail: 'test@test.com', actorDisplayName: 'Test' }),
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    ai: {
+      info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), trace: vi.fn(),
+      child: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), trace: vi.fn() })),
+    },
+  },
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          // supports direct await (pages, users), .orderBy() (chatMessages), and .limit() (userProfiles, drives)
+          then: (resolve: any, reject: any) => Promise.resolve([mockDbRow]).then(resolve, reject),
+          orderBy: vi.fn().mockResolvedValue([]),
+          limit: vi.fn().mockResolvedValue([{ displayName: 'Test User', drivePrompt: null }]),
+        })),
+      })),
+    })),
+  },
+}));
+
+vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn(), and: vi.fn() }));
+vi.mock('@pagespace/db/schema/auth', () => ({ users: { id: 'id' } }));
+vi.mock('@pagespace/db/schema/core', () => ({
+  chatMessages: { pageId: 'pageId', conversationId: 'conversationId', isActive: 'isActive', createdAt: 'createdAt' },
+  pages: { id: 'id' },
+  drives: { id: 'id', drivePrompt: 'drivePrompt' },
+}));
+vi.mock('@pagespace/db/schema/members', () => ({
+  userProfiles: { userId: 'userId', displayName: 'displayName' },
+}));
+
+vi.mock('@/lib/subscription/usage-service', () => ({
+  incrementUsage: vi.fn().mockResolvedValue({ currentCount: 1, limit: 100, remainingCalls: 99, success: true }),
+  getCurrentUsage: vi.fn().mockResolvedValue({ success: true, remainingCalls: 100, currentCount: 0, limit: 100 }),
+  getUserUsageSummary: vi.fn().mockResolvedValue({
+    subscriptionTier: 'free',
+    standard: { current: 0, limit: 100, remaining: 100 },
+    pro: { current: 0, limit: 0, remaining: 0 },
+  }),
+}));
+
+vi.mock('@/lib/subscription/rate-limit-middleware', () => ({
+  requiresProSubscription: vi.fn().mockReturnValue(false),
+  createRateLimitResponse: vi.fn(),
+  createSubscriptionRequiredResponse: vi.fn(),
+}));
+
+vi.mock('@/lib/ai/core', () => ({
+  createAIProvider: vi.fn().mockResolvedValue({ model: {} }),
+  updateUserProviderSettings: vi.fn(),
+  createProviderErrorResponse: vi.fn(),
+  isProviderError: vi.fn().mockReturnValue(false),
+  getUserOpenRouterSettings: vi.fn(),
+  getUserGoogleSettings: vi.fn(),
+  getDefaultPageSpaceSettings: vi.fn(),
+  getUserOpenAISettings: vi.fn(),
+  getUserAnthropicSettings: vi.fn(),
+  getUserXAISettings: vi.fn(),
+  getUserOllamaSettings: vi.fn(),
+  getUserLMStudioSettings: vi.fn(),
+  getUserGLMSettings: vi.fn(),
+  pageSpaceTools: {},
+  extractMessageContent: vi.fn().mockReturnValue('test content'),
+  extractToolCalls: vi.fn().mockReturnValue([]),
+  extractToolResults: vi.fn().mockReturnValue([]),
+  saveMessageToDatabase: vi.fn(),
+  sanitizeMessagesForModel: vi.fn().mockReturnValue([]),
+  convertDbMessageToUIMessage: vi.fn(),
+  processMentionsInMessage: vi.fn().mockReturnValue({ mentions: [], pageIds: [] }),
+  buildMentionSystemPrompt: vi.fn().mockReturnValue(''),
+  buildTimestampSystemPrompt: vi.fn().mockReturnValue(''),
+  buildSystemPrompt: vi.fn().mockReturnValue(''),
+  buildPersonalizationPrompt: vi.fn().mockReturnValue(''),
+  filterToolsForReadOnly: vi.fn().mockReturnValue({}),
+  filterToolsForWebSearch: vi.fn().mockReturnValue({}),
+  getPageTreeContext: vi.fn(),
+  getModelCapabilities: vi.fn().mockResolvedValue({}),
+  convertMCPToolsToAISDKSchemas: vi.fn(),
+  parseMCPToolName: vi.fn(),
+  sanitizeToolNamesForProvider: vi.fn((t: any) => t),
+  getUserPersonalization: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('ai', () => ({
+  streamText: vi.fn().mockImplementation((options: any) => {
+    captured.streamTextOptions = options;
+    return {
+      toUIMessageStream: () => (async function* () {})(),
+      totalUsage: Promise.resolve({ inputTokens: 0, outputTokens: 0, totalTokens: 0 }),
+    };
+  }),
+  convertToModelMessages: vi.fn().mockReturnValue([]),
+  stepCountIs: vi.fn(),
+  hasToolCall: vi.fn(() => () => false),
+  tool: vi.fn((config: any) => config),
+  createUIMessageStream: vi.fn().mockImplementation((options: any) => {
+    captured.createUIMessageStreamOptions = options;
+    return {};
+  }),
+  createUIMessageStreamResponse: vi.fn().mockReturnValue(new Response('', { status: 200 })),
+}));
+
+vi.mock('@paralleldrive/cuid2', () => ({
+  createId: vi.fn().mockReturnValue('test-message-id'),
+  init: vi.fn(() => vi.fn(() => 'test-cuid')),
+}));
+
+vi.mock('@/lib/logging/mask', () => ({
+  maskIdentifier: vi.fn((id: string) => `***${id.slice(-3)}`),
+}));
+
+vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({ trackFeature: vi.fn() }));
+
+vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
+  AIMonitoring: { trackUsage: vi.fn(), trackToolUsage: vi.fn() },
+}));
+
+vi.mock('@/lib/mcp', () => ({ getMCPBridge: vi.fn() }));
+
+vi.mock('@/services/api/page-mutation-service', () => ({
+  applyPageMutation: vi.fn(),
+  PageRevisionMismatchError: class extends Error {},
+}));
+
+vi.mock('@/lib/ai/core/stream-abort-registry', () => ({
+  createStreamAbortController: vi.fn().mockReturnValue({ streamId: 'stream_123', signal: new AbortController().signal }),
+  removeStream: vi.fn(),
+  STREAM_ID_HEADER: 'x-stream-id',
+}));
+
+vi.mock('@/lib/ai/core/validate-image-parts', () => ({
+  validateUserMessageFileParts: vi.fn().mockReturnValue({ valid: true }),
+  hasFileParts: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('@/lib/ai/core/model-capabilities', () => ({
+  hasVisionCapability: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('@/lib/ai/core/ai-providers-config', () => ({
+  getPageSpaceModelTier: vi.fn().mockReturnValue('standard'),
+}));
+
+vi.mock('@/lib/ai/core/tool-utils', () => ({
+  mergeToolSets: vi.fn((a: any, b: any) => ({ ...a, ...b })),
+}));
+
+vi.mock('@/lib/ai/tools/finish-tool', () => ({
+  finishTool: {},
+  FINISH_TOOL_NAME: 'finish',
+}));
+
+vi.mock('@/lib/ai/core/stream-pipe-utils', () => ({
+  pipeUIMessageStreamStrippingStart: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/ai/core/integration-tool-resolver', () => ({
+  resolvePageAgentIntegrationTools: vi.fn().mockResolvedValue({}),
+}));
+
+// ============================================================================
+// Imports (after mocks)
+// ============================================================================
+
+import { POST } from '../route';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+import type { SessionAuthResult } from '@/lib/auth';
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+const mockDbRow = {
+  id: 'page-1',
+  title: 'Test Page',
+  systemPrompt: null,
+  enabledTools: null,
+  aiProvider: 'pagespace',
+  aiModel: 'glm-4.5-air',
+  driveId: 'drive-1',
+  includeDrivePrompt: false,
+  includePageTree: false,
+  pageTreeScope: null,
+  revision: 0,
+  name: 'Test User',
+  currentAiProvider: 'pagespace',
+  currentAiModel: 'glm-4.5-air',
+  subscriptionTier: 'free',
+  timezone: 'UTC',
+  displayName: 'Test User',
+  drivePrompt: null,
+};
+
+const mockAuth = (): SessionAuthResult => ({
+  userId: 'user-1',
+  tokenVersion: 0,
+  tokenType: 'session',
+  sessionId: 'sess-1',
+  role: 'user',
+  adminRoleVersion: 0,
+});
+
+const makeRequest = () =>
+  new Request('https://example.com/api/ai/chat', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'content-length': '200' },
+    body: JSON.stringify({
+      messages: [{ id: 'msg_1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] }],
+      chatId: 'page-1',
+      conversationId: 'conv-1',
+      selectedProvider: 'pagespace',
+      selectedModel: 'glm-4.5-air',
+    }),
+  });
+
+const mockResponseMessage = {
+  id: 'test-message-id',
+  role: 'assistant' as const,
+  parts: [{ type: 'text', text: 'Hello' }],
+};
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('POST /api/ai/chat — stream socket events', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    captured.createUIMessageStreamOptions = null;
+    captured.streamTextOptions = null;
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuth());
+  });
+
+  describe('registry registration', () => {
+    it('given a new AI stream, should register the messageId in the multicast registry before streaming', async () => {
+      await POST(makeRequest());
+
+      expect(mockRegistryRegister).toHaveBeenCalledWith(
+        'test-message-id',
+        { pageId: 'page-1', userId: 'user-1' }
+      );
+    });
+
+    it('given registry.register throws, should not interrupt the stream', async () => {
+      mockRegistryRegister.mockImplementationOnce(() => { throw new Error('registry error'); });
+
+      const response = await POST(makeRequest());
+
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe('chat:stream_start broadcast', () => {
+    it('given a new AI stream, should broadcast chat:stream_start after registering', async () => {
+      await POST(makeRequest());
+
+      expect(mockBroadcastAiStreamStart).toHaveBeenCalled();
+
+      const callOrder = [
+        mockRegistryRegister.mock.invocationCallOrder[0],
+        mockBroadcastAiStreamStart.mock.invocationCallOrder[0],
+      ];
+      expect(callOrder[0]).toBeLessThan(callOrder[1]);
+    });
+
+    it('given chat:stream_start, should include messageId, pageId, conversationId, and triggeredBy', async () => {
+      await POST(makeRequest());
+
+      expect(mockBroadcastAiStreamStart).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messageId: 'test-message-id',
+          pageId: 'page-1',
+          conversationId: 'conv-1',
+          triggeredBy: expect.objectContaining({
+            userId: 'user-1',
+            displayName: expect.any(String),
+          }),
+        })
+      );
+    });
+
+    it('given a user profile, should use displayName from userProfiles in triggeredBy', async () => {
+      await POST(makeRequest());
+
+      const payload = mockBroadcastAiStreamStart.mock.calls[0][0];
+      expect(payload.triggeredBy.displayName).toBe('Test User');
+    });
+
+    it('given broadcastAiStreamStart throws, should not interrupt the stream', async () => {
+      mockBroadcastAiStreamStart.mockRejectedValueOnce(new Error('broadcast error'));
+
+      const response = await POST(makeRequest());
+
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe('text-delta chunk → registry push', () => {
+    it('given a text-delta chunk, should push the text to the registry', async () => {
+      await POST(makeRequest());
+      await captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() });
+
+      captured.streamTextOptions.onChunk?.({ chunk: { type: 'text-delta', text: 'hello', id: 'chunk-1' } });
+
+      expect(mockRegistryPush).toHaveBeenCalledWith('test-message-id', 'hello');
+    });
+
+    it('given a non-text-delta chunk type, should not push to the registry', async () => {
+      await POST(makeRequest());
+      await captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() });
+
+      captured.streamTextOptions.onChunk?.({ chunk: { type: 'tool-call', toolCallId: 'tc1', toolName: 'search', args: {} } });
+
+      expect(mockRegistryPush).not.toHaveBeenCalled();
+    });
+
+    it('given registry.push throws on a chunk, should not interrupt the stream', async () => {
+      mockRegistryPush.mockImplementationOnce(() => { throw new Error('push error'); });
+
+      await POST(makeRequest());
+      await captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() });
+
+      expect(() => {
+        captured.streamTextOptions.onChunk?.({ chunk: { type: 'text-delta', text: 'hello', id: 'chunk-1' } });
+      }).not.toThrow();
+    });
+  });
+
+  describe('onFinish → finish + chat:stream_complete', () => {
+    it('given stream completion, should call finish with aborted=false', async () => {
+      await POST(makeRequest());
+      await captured.createUIMessageStreamOptions.onFinish?.({ responseMessage: mockResponseMessage });
+
+      expect(mockRegistryFinish).toHaveBeenCalledWith('test-message-id', false);
+    });
+
+    it('given stream completion, should broadcast chat:stream_complete with aborted=false', async () => {
+      await POST(makeRequest());
+      await captured.createUIMessageStreamOptions.onFinish?.({ responseMessage: mockResponseMessage });
+
+      expect(mockBroadcastAiStreamComplete).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messageId: 'test-message-id',
+          pageId: 'page-1',
+          aborted: false,
+        })
+      );
+    });
+
+    it('given onFinish called twice, should broadcast chat:stream_complete only once', async () => {
+      await POST(makeRequest());
+      await captured.createUIMessageStreamOptions.onFinish?.({ responseMessage: mockResponseMessage });
+      await captured.createUIMessageStreamOptions.onFinish?.({ responseMessage: mockResponseMessage });
+
+      expect(mockBroadcastAiStreamComplete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('onAbort → early finish', () => {
+    it('given stream abort, should call registry finish with aborted=true', async () => {
+      await POST(makeRequest());
+      await captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() });
+
+      captured.streamTextOptions.onAbort?.();
+
+      expect(mockRegistryFinish).toHaveBeenCalledWith('test-message-id', true);
+    });
+  });
+
+  describe('error finally path', () => {
+    it('given createUIMessageStream throws, should call finish with aborted=true', async () => {
+      const { createUIMessageStream } = await import('ai');
+      vi.mocked(createUIMessageStream).mockImplementationOnce(() => {
+        throw new Error('stream creation failed');
+      });
+
+      await POST(makeRequest());
+
+      expect(mockRegistryFinish).toHaveBeenCalledWith('test-message-id', true);
+    });
+
+    it('given createUIMessageStream throws, should broadcast chat:stream_complete with aborted=true', async () => {
+      const { createUIMessageStream } = await import('ai');
+      vi.mocked(createUIMessageStream).mockImplementationOnce(() => {
+        throw new Error('stream creation failed');
+      });
+
+      await POST(makeRequest());
+
+      expect(mockBroadcastAiStreamComplete).toHaveBeenCalledWith(
+        expect.objectContaining({ aborted: true })
+      );
+    });
+  });
+});

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -16,7 +16,8 @@ import { mergeToolSets } from '@/lib/ai/core/tool-utils';
 import { finishTool, FINISH_TOOL_NAME } from '@/lib/ai/tools/finish-tool';
 import { incrementUsage, getCurrentUsage, getUserUsageSummary } from '@/lib/subscription/usage-service';
 import { requiresProSubscription, createRateLimitResponse } from '@/lib/subscription/rate-limit-middleware';
-import { broadcastUsageEvent } from '@/lib/websocket';
+import { broadcastUsageEvent, broadcastAiStreamStart, broadcastAiStreamComplete } from '@/lib/websocket';
+import { streamMulticastRegistry } from '@/lib/ai/core/stream-multicast-registry';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
@@ -63,6 +64,7 @@ import { db } from '@pagespace/db/db'
 import { eq, and } from '@pagespace/db/operators'
 import { users } from '@pagespace/db/schema/auth'
 import { chatMessages, pages, drives } from '@pagespace/db/schema/core';
+import { userProfiles } from '@pagespace/db/schema/members';
 import { createId } from '@paralleldrive/cuid2';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
@@ -99,8 +101,21 @@ export async function POST(request: Request) {
   let selectedProvider: string | undefined;
   let selectedModel: string | undefined;
   let usagePromise: Promise<LanguageModelUsage | undefined> | undefined;
+  let serverAssistantMessageId: string | undefined;
+  let multicastFinished = false;
   const usageLogger = loggers.ai.child({ module: 'page-ai-usage' });
   const permissionLogger = loggers.ai.child({ module: 'page-ai-permissions' });
+
+  const finishMulticast = (aborted: boolean): void => {
+    if (multicastFinished || !serverAssistantMessageId) return;
+    multicastFinished = true;
+    try { streamMulticastRegistry.finish(serverAssistantMessageId, aborted); } catch {}
+    broadcastAiStreamComplete({
+      messageId: serverAssistantMessageId,
+      pageId: chatId!,
+      aborted,
+    }).catch(() => {});
+  };
 
   try {
     loggers.ai.info('AI Chat API: Starting request processing');
@@ -804,16 +819,35 @@ export async function POST(request: Request) {
     // Generate server-side message ID for the AI response
     // This ensures client and server use the same ID, fixing the undo-after-streaming issue
     // See: https://ai-sdk.dev/docs/ai-sdk-ui/chatbot-message-persistence
-    const serverAssistantMessageId = createId();
+    serverAssistantMessageId = createId();
 
     // Create abort controller for explicit user-initiated stop (via /api/ai/abort endpoint)
     // This is separate from request.signal which fires on any client disconnect
     const { streamId, signal: abortSignal } = createStreamAbortController({ userId });
 
+    // Register in multicast registry so other viewers can join via stream-join endpoint
+    try { streamMulticastRegistry.register(serverAssistantMessageId, { pageId: chatId, userId: userId! }); } catch {}
+
+    // Resolve display name for stream_start payload (fall back through user.name → 'Someone')
+    const [userProfile] = await db
+      .select({ displayName: userProfiles.displayName })
+      .from(userProfiles)
+      .where(eq(userProfiles.userId, userId!))
+      .limit(1);
+    const displayName = userProfile?.displayName ?? user?.name ?? 'Someone';
+
+    // Notify all page viewers that an AI stream is starting
+    broadcastAiStreamStart({
+      messageId: serverAssistantMessageId,
+      pageId: chatId,
+      conversationId: conversationId!,
+      triggeredBy: { userId: userId!, displayName },
+    }).catch(() => {});
+
     try {
       const stream = createUIMessageStream({
         originalMessages: sanitizedMessages,
-        generateId: () => serverAssistantMessageId,
+        generateId: () => serverAssistantMessageId!,
         execute: async ({ writer }) => {
           // Start the AI response
           const aiResult = streamText({
@@ -851,6 +885,11 @@ export async function POST(request: Request) {
               },
             }, // Pass userId, timezone, AI context, location context, model capabilities, and chat source to tools
             maxRetries: 20, // Increase from default 2 to 20 for better handling of rate limits
+            onChunk: ({ chunk }) => {
+              if (chunk.type === 'text-delta') {
+                try { streamMulticastRegistry.push(serverAssistantMessageId!, chunk.text); } catch {}
+              }
+            },
             onAbort: () => {
               loggers.ai.info('AI Chat API: Stream aborted by user', {
                 userId: maskIdentifier(userId!),
@@ -859,6 +898,8 @@ export async function POST(request: Request) {
                 model: currentModel,
                 provider: currentProvider,
               });
+              // Flush the registry early so stream-join subscribers get the done sentinel promptly
+              try { streamMulticastRegistry.finish(serverAssistantMessageId!, true); } catch {}
             },
           });
 
@@ -905,7 +946,7 @@ export async function POST(request: Request) {
             try {
               // Use the server-generated ID that was sent to the client at stream start
               // This ensures the saved message ID matches what the client has
-              const messageId = serverAssistantMessageId;
+              const messageId = serverAssistantMessageId!;
               const messageContent = extractMessageContent(responseMessage);
               
               // Extract tool calls and results from the response
@@ -1074,6 +1115,8 @@ export async function POST(request: Request) {
           } else {
             loggers.ai.warn('AI Chat API: No chatId or response message provided, skipping persistence');
           }
+
+          finishMulticast(false);
         },
       });
 
@@ -1086,6 +1129,7 @@ export async function POST(request: Request) {
     } catch (streamError) {
       // Clean up the registry entry since onFinish won't be called
       removeStream({ streamId });
+      finishMulticast(true);
       loggers.ai.error('AI Chat API: Failed to create stream', streamError as Error, {
         message: streamError instanceof Error ? streamError.message : 'Unknown error',
         stack: streamError instanceof Error ? streamError.stack : undefined
@@ -1099,6 +1143,7 @@ export async function POST(request: Request) {
     return result.toUIMessageStreamResponse();
 
   } catch (error) {
+    finishMulticast(true);
     loggers.ai.error('AI Chat API Error', error as Error, {
       userId,
       chatId,

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -898,8 +898,9 @@ export async function POST(request: Request) {
                 model: currentModel,
                 provider: currentProvider,
               });
-              // Flush the registry early so stream-join subscribers get the done sentinel promptly
-              try { streamMulticastRegistry.finish(serverAssistantMessageId!, true); } catch {}
+              // Route through finishMulticast so multicastFinished is set and chat:stream_complete
+              // is broadcast with aborted=true — prevents onFinish from double-broadcasting with aborted=false
+              finishMulticast(true);
             },
           });
 

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -829,12 +829,18 @@ export async function POST(request: Request) {
     try { streamMulticastRegistry.register(serverAssistantMessageId, { pageId: chatId, userId: userId! }); } catch {}
 
     // Resolve display name for stream_start payload (fall back through user.name → 'Someone')
-    const [userProfile] = await db
-      .select({ displayName: userProfiles.displayName })
-      .from(userProfiles)
-      .where(eq(userProfiles.userId, userId!))
-      .limit(1);
-    const displayName = userProfile?.displayName ?? user?.name ?? 'Someone';
+    // Wrapped in try/catch so a DB hiccup here never aborts the stream
+    let displayName = user?.name ?? 'Someone';
+    try {
+      const [userProfile] = await db
+        .select({ displayName: userProfiles.displayName })
+        .from(userProfiles)
+        .where(eq(userProfiles.userId, userId!))
+        .limit(1);
+      displayName = userProfile?.displayName ?? displayName;
+    } catch {
+      // non-critical — fall back to user.name already set above
+    }
 
     // Notify all page viewers that an AI stream is starting
     broadcastAiStreamStart({

--- a/apps/web/src/lib/websocket/__tests__/socket-utils.test.ts
+++ b/apps/web/src/lib/websocket/__tests__/socket-utils.test.ts
@@ -40,6 +40,8 @@ import {
   broadcastDriveMemberEvent,
   broadcastTaskEvent,
   broadcastUsageEvent,
+  broadcastAiStreamStart,
+  broadcastAiStreamComplete,
   createPageEventPayload,
   createDriveEventPayload,
   createDriveMemberEventPayload,
@@ -48,6 +50,8 @@ import {
   type DriveMemberEventPayload,
   type TaskEventPayload,
   type UsageEventPayload,
+  type AiStreamStartPayload,
+  type AiStreamCompletePayload,
 } from '../socket-utils';
 import { createSignedBroadcastHeaders } from '@pagespace/lib/auth/broadcast-auth';
 
@@ -340,6 +344,98 @@ describe('socket-utils', () => {
         role: 'ADMIN',
         driveName: 'My Drive',
       });
+    });
+  });
+
+  describe('broadcastAiStreamStart', () => {
+    it('given valid payload, should route to page:{pageId} channel with chat:stream_start event', async () => {
+      const payload: AiStreamStartPayload = {
+        messageId: 'msg-1',
+        pageId: 'page-1',
+        conversationId: 'conv-1',
+        triggeredBy: { userId: 'user-1', displayName: 'Alice' },
+      };
+
+      await broadcastAiStreamStart(payload);
+
+      const fetchCall = mockFetch.mock.calls[0];
+      const requestBody = JSON.parse(fetchCall[1].body);
+
+      expect(requestBody.channelId).toBe('page:page-1');
+      expect(requestBody.event).toBe('chat:stream_start');
+      expect(requestBody.payload).toEqual(payload);
+    });
+
+    it('given no INTERNAL_REALTIME_URL, should not call fetch', async () => {
+      process.env.INTERNAL_REALTIME_URL = '';
+
+      await broadcastAiStreamStart({
+        messageId: 'msg-1',
+        pageId: 'page-1',
+        conversationId: 'conv-1',
+        triggeredBy: { userId: 'user-1', displayName: 'Alice' },
+      });
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('given fetch throws, should not throw', async () => {
+      mockFetch.mockRejectedValue(new Error('Network error'));
+
+      await expect(broadcastAiStreamStart({
+        messageId: 'msg-1',
+        pageId: 'page-1',
+        conversationId: 'conv-1',
+        triggeredBy: { userId: 'user-1', displayName: 'Alice' },
+      })).resolves.not.toThrow();
+    });
+  });
+
+  describe('broadcastAiStreamComplete', () => {
+    it('given completed stream, should route to page:{pageId} with chat:stream_complete and aborted=false', async () => {
+      const payload: AiStreamCompletePayload = {
+        messageId: 'msg-1',
+        pageId: 'page-1',
+        aborted: false,
+      };
+
+      await broadcastAiStreamComplete(payload);
+
+      const fetchCall = mockFetch.mock.calls[0];
+      const requestBody = JSON.parse(fetchCall[1].body);
+
+      expect(requestBody.channelId).toBe('page:page-1');
+      expect(requestBody.event).toBe('chat:stream_complete');
+      expect(requestBody.payload).toEqual(payload);
+    });
+
+    it('given aborted stream, should include aborted=true in payload', async () => {
+      const payload: AiStreamCompletePayload = {
+        messageId: 'msg-1',
+        pageId: 'page-1',
+        aborted: true,
+      };
+
+      await broadcastAiStreamComplete(payload);
+
+      const requestBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(requestBody.payload.aborted).toBe(true);
+    });
+
+    it('given no INTERNAL_REALTIME_URL, should not call fetch', async () => {
+      process.env.INTERNAL_REALTIME_URL = '';
+
+      await broadcastAiStreamComplete({ messageId: 'msg-1', pageId: 'page-1' });
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('given fetch throws, should not throw', async () => {
+      mockFetch.mockRejectedValue(new Error('Network error'));
+
+      await expect(
+        broadcastAiStreamComplete({ messageId: 'msg-1', pageId: 'page-1' })
+      ).resolves.not.toThrow();
     });
   });
 

--- a/apps/web/src/lib/websocket/socket-utils.ts
+++ b/apps/web/src/lib/websocket/socket-utils.ts
@@ -493,6 +493,91 @@ export async function broadcastInboxEvent(userId: string, payload: InboxEventPay
 }
 
 // ============================================================================
+// AI Stream Events
+// ============================================================================
+
+export interface AiStreamStartPayload {
+  messageId: string;
+  pageId: string;
+  conversationId: string;
+  triggeredBy: { userId: string; displayName: string };
+}
+
+export interface AiStreamCompletePayload {
+  messageId: string;
+  pageId: string;
+  aborted?: boolean;
+}
+
+export async function broadcastAiStreamStart(payload: AiStreamStartPayload): Promise<void> {
+  const realtimeUrl = getEnvVar('INTERNAL_REALTIME_URL');
+  if (!realtimeUrl) {
+    realtimeLogger.warn('Realtime URL not configured, skipping AI stream start broadcast', {
+      event: 'ai_stream_start',
+    });
+    return;
+  }
+
+  try {
+    const requestBody = JSON.stringify({
+      channelId: `page:${payload.pageId}`,
+      event: 'chat:stream_start',
+      payload,
+    });
+
+    await fetch(`${realtimeUrl}/api/broadcast`, {
+      method: 'POST',
+      headers: createSignedBroadcastHeaders(requestBody),
+      body: requestBody,
+      signal: AbortSignal.timeout(5000),
+    });
+  } catch (error) {
+    realtimeLogger.error(
+      'Failed to broadcast AI stream start',
+      error instanceof Error ? error : undefined,
+      {
+        event: 'ai_stream_start',
+        channel: `page:${maskIdentifier(payload.pageId)}`,
+      }
+    );
+  }
+}
+
+export async function broadcastAiStreamComplete(payload: AiStreamCompletePayload): Promise<void> {
+  const realtimeUrl = getEnvVar('INTERNAL_REALTIME_URL');
+  if (!realtimeUrl) {
+    realtimeLogger.warn('Realtime URL not configured, skipping AI stream complete broadcast', {
+      event: 'ai_stream_complete',
+    });
+    return;
+  }
+
+  try {
+    const requestBody = JSON.stringify({
+      channelId: `page:${payload.pageId}`,
+      event: 'chat:stream_complete',
+      payload,
+    });
+
+    await fetch(`${realtimeUrl}/api/broadcast`, {
+      method: 'POST',
+      headers: createSignedBroadcastHeaders(requestBody),
+      body: requestBody,
+      signal: AbortSignal.timeout(5000),
+    });
+  } catch (error) {
+    realtimeLogger.error(
+      'Failed to broadcast AI stream complete',
+      error instanceof Error ? error : undefined,
+      {
+        event: 'ai_stream_complete',
+        channel: `page:${maskIdentifier(payload.pageId)}`,
+      }
+    );
+  }
+}
+
+// ============================================================================
 // Activity Events (with debouncing)
 // ============================================================================
 

--- a/tasks/multiplayer-ai-chat-streaming.md
+++ b/tasks/multiplayer-ai-chat-streaming.md
@@ -43,8 +43,8 @@ SSE endpoint at `apps/web/src/app/api/ai/chat/stream-join/[messageId]/route.ts`.
 - Given unauthenticated request, should emit `authz.access.denied` audit event
 - Given request from user without view permission, should emit `authz.access.denied` audit event
 
-### Task 3: Stream Socket Events
-**Status:** Pending
+### Task 3: Stream Socket Events ✅ COMPLETED
+**PR:** https://github.com/2witstudios/PageSpace/pull/1144
 
 Wire `chat:stream_start` and `chat:stream_complete` socket broadcasts into the AI chat route alongside the multicast registry.
 


### PR DESCRIPTION
## Summary

- Adds \`broadcastAiStreamStart\` and \`broadcastAiStreamComplete\` to \`socket-utils.ts\` — broadcasts on \`page:{pageId}\` with events \`chat:stream_start\` / \`chat:stream_complete\`
- Wires \`StreamMulticastRegistry\` into \`route.ts\`: \`register\` before stream creation, \`push\` on each text-delta chunk, \`finish\` + broadcast on completion or abort
- \`finishMulticast\` closure (idempotent, guards with \`multicastFinished\` flag) prevents double-broadcasting when both \`onAbort\` and \`onFinish\` fire, and ensures \`chat:stream_complete\` emits even if \`onFinish\` is skipped by a route error
- Fix: \`onAbort\` now routes through \`finishMulticast(true)\` so \`multicastFinished\` is set immediately on abort, preventing a subsequent \`onFinish\` from broadcasting \`aborted: false\` for a user-aborted stream

## Test plan

- [ ] \`pnpm --filter web typecheck\` — 0 errors
- [ ] 88 tests passing across 5 test files:
  - \`socket-utils.test.ts\` — 29 tests (7 new)
  - \`stream-socket-events.test.ts\` — 17 new tests
  - \`mcp-scope.test.ts\` — 3 tests (no regression)
  - \`stream-join/route.test.ts\` — 17 tests (no regression)
  - \`stream-multicast-registry.test.ts\` — 22 tests (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI chat responses now stream and broadcast to multiple viewers in real-time, allowing all participants to see live message generation as it happens.

* **Tests**
  * Added comprehensive test coverage for multi-user AI stream event handling and real-time broadcast functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->