### PR TITLE
fix(ai): stabilise chatConfig deps and extend invalidateTree guard to cover all active states

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -60,6 +60,7 @@ interface AiChatViewProps {
 }
 
 const VOICE_OWNER: VoiceModeOwner = 'ai-page';
+const EMPTY_MESSAGES: UIMessage[] = [];
 
 const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
   const params = useParams();
@@ -72,7 +73,6 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
   // LOCAL STATE
   // ============================================
   const [isInitialized, setIsInitialized] = useState<boolean>(false);
-  const [initialMessages, setInitialMessages] = useState<UIMessage[]>([]);
   const [input, setInput] = useState<string>('');
   const [activeTab, setActiveTab] = useState<string>('chat');
   const [agentConfig, setAgentConfig] = useState<AgentConfig | null>(null);
@@ -167,17 +167,19 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
 
   const transport = useChatTransport(streamTrackingId, '/api/ai/chat');
 
+  const handleChatError = useCallback((error: Error) => {
+    console.error('AiChatView: Chat error:', error);
+  }, []);
+
   const chatConfig = useMemo(
     () => !transport ? null : ({
       id: page.id,
-      messages: initialMessages,
+      messages: EMPTY_MESSAGES,
       transport,
       experimental_throttle: 100,
-      onError: (error: Error) => {
-        console.error('AiChatView: Chat error:', error);
-      },
+      onError: handleChatError,
     }),
-    [page.id, transport, initialMessages]
+    [page.id, transport, handleChatError]
   );
 
   const { messages, sendMessage, status, error, regenerate, setMessages, stop: chatStop } =
@@ -254,24 +256,20 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
         if (newConvResponse.ok) {
           const newConvData = await newConvResponse.json();
           setCurrentConversationId(newConvData.conversationId);
-          setInitialMessages([]);
           setMessages([]);
         } else {
-          setInitialMessages([]);
           setMessages([]);
         }
 
         setIsInitialized(true);
       } catch (error) {
         console.error('Failed to initialize chat:', error);
-        setInitialMessages([]);
         setMessages([]);
         setIsInitialized(true);
       }
     };
 
     setIsInitialized(false);
-    setInitialMessages([]);
     setCurrentConversationId(null);
     initializeChat();
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/web/src/hooks/__tests__/usePageTree.test.ts
+++ b/apps/web/src/hooks/__tests__/usePageTree.test.ts
@@ -14,6 +14,7 @@ const {
   mockSWRState,
   mockIsAnyEditing,
   mockIsAnyActive,
+  mockSubscribe,
 } = vi.hoisted(() => ({
   mockFetchWithAuth: vi.fn(),
   mockMutate: vi.fn(),
@@ -24,6 +25,7 @@ const {
   },
   mockIsAnyEditing: vi.fn(() => false),
   mockIsAnyActive: vi.fn(() => false),
+  mockSubscribe: vi.fn((_cb: (state: { isAnyActive: () => boolean }) => void): (() => void) => vi.fn()),
 }));
 
 // Mock dependencies with hoisted mocks
@@ -37,6 +39,7 @@ vi.mock('@/stores/useEditingStore', () => ({
       isAnyEditing: mockIsAnyEditing,
       isAnyActive: mockIsAnyActive,
     }),
+    subscribe: (cb: (state: { isAnyActive: () => boolean }) => void) => mockSubscribe(cb),
   },
   isEditingActive: () => mockIsAnyActive(),
 }));
@@ -96,6 +99,7 @@ describe('usePageTree', () => {
     mockSWRState.error = undefined;
     mockIsAnyEditing.mockReturnValue(false);
     mockIsAnyActive.mockReturnValue(false);
+    mockSubscribe.mockImplementation(() => vi.fn()); // noop unsubscribe
   });
 
   afterEach(() => {
@@ -334,6 +338,90 @@ describe('usePageTree', () => {
       expect(mockMutate).not.toHaveBeenCalled();
       expect(mockCacheDelete).not.toHaveBeenCalled();
       consoleLog.mockRestore();
+    });
+
+    it('given skipped invalidation, should flush mutate once active state clears', () => {
+      mockSWRState.data = [createMockTreePage()];
+      mockIsAnyActive.mockReturnValue(true);
+      const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => { });
+
+      // Capture the subscriber registered by the hook
+      let capturedSubscriber: ((state: { isAnyActive: () => boolean }) => void) | null = null;
+      mockSubscribe.mockImplementation((cb: (state: { isAnyActive: () => boolean }) => void) => {
+        capturedSubscriber = cb;
+        return vi.fn(); // unsubscribe noop
+      });
+
+      const { result } = renderHook(() => usePageTree('drive-123'));
+
+      // Invalidate during active state — deferred, not fired immediately
+      act(() => {
+        result.current.invalidateTree();
+      });
+      expect(mockMutate).not.toHaveBeenCalled();
+      expect(capturedSubscriber).not.toBeNull();
+
+      // Simulate store transitioning to inactive
+      mockIsAnyActive.mockReturnValue(false);
+      act(() => {
+        capturedSubscriber!({ isAnyActive: () => false });
+      });
+
+      // Pending invalidation should now be flushed
+      expect(mockMutate).toHaveBeenCalledTimes(1);
+      consoleLog.mockRestore();
+    });
+
+    it('given multiple skipped invalidations, should flush mutate only once', () => {
+      mockSWRState.data = [createMockTreePage()];
+      mockIsAnyActive.mockReturnValue(true);
+      const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => { });
+
+      let capturedSubscriber: ((state: { isAnyActive: () => boolean }) => void) | null = null;
+      mockSubscribe.mockImplementation((cb: (state: { isAnyActive: () => boolean }) => void) => {
+        capturedSubscriber = cb;
+        return vi.fn();
+      });
+
+      const { result } = renderHook(() => usePageTree('drive-123'));
+
+      // Multiple invalidations during active state — all coalesced
+      act(() => {
+        result.current.invalidateTree();
+        result.current.invalidateTree();
+        result.current.invalidateTree();
+      });
+      expect(mockMutate).not.toHaveBeenCalled();
+
+      // Store goes inactive
+      mockIsAnyActive.mockReturnValue(false);
+      act(() => {
+        capturedSubscriber!({ isAnyActive: () => false });
+      });
+
+      // Only one mutate despite three invalidateTree calls
+      expect(mockMutate).toHaveBeenCalledTimes(1);
+      consoleLog.mockRestore();
+    });
+
+    it('given no skipped invalidation, should not flush when state clears', () => {
+      mockSWRState.data = [createMockTreePage()];
+      mockIsAnyActive.mockReturnValue(false);
+
+      let capturedSubscriber: ((state: { isAnyActive: () => boolean }) => void) | null = null;
+      mockSubscribe.mockImplementation((cb: (state: { isAnyActive: () => boolean }) => void) => {
+        capturedSubscriber = cb;
+        return vi.fn();
+      });
+
+      renderHook(() => usePageTree('drive-123'));
+
+      // No invalidateTree called — subscriber fires but nothing pending
+      act(() => {
+        capturedSubscriber!({ isAnyActive: () => false });
+      });
+
+      expect(mockMutate).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/hooks/__tests__/usePageTree.test.ts
+++ b/apps/web/src/hooks/__tests__/usePageTree.test.ts
@@ -320,27 +320,9 @@ describe('usePageTree', () => {
       consoleLog.mockRestore();
     });
 
-    it('given active AI streaming session, should skip invalidation', () => {
+    it('given any active state (AI streaming or pending send), should skip invalidation', () => {
       mockSWRState.data = [createMockTreePage()];
       mockIsAnyActive.mockReturnValue(true);
-      mockIsAnyEditing.mockReturnValue(false);
-      const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => { });
-
-      const { result } = renderHook(() => usePageTree('drive-123'));
-
-      act(() => {
-        result.current.invalidateTree();
-      });
-
-      expect(mockMutate).not.toHaveBeenCalled();
-      expect(mockCacheDelete).not.toHaveBeenCalled();
-      consoleLog.mockRestore();
-    });
-
-    it('given pending send in progress, should skip invalidation', () => {
-      mockSWRState.data = [createMockTreePage()];
-      mockIsAnyActive.mockReturnValue(true);
-      mockIsAnyEditing.mockReturnValue(false);
       const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => { });
 
       const { result } = renderHook(() => usePageTree('drive-123'));

--- a/apps/web/src/hooks/__tests__/usePageTree.test.ts
+++ b/apps/web/src/hooks/__tests__/usePageTree.test.ts
@@ -13,6 +13,7 @@ const {
   mockCacheDelete,
   mockSWRState,
   mockIsAnyEditing,
+  mockIsAnyActive,
 } = vi.hoisted(() => ({
   mockFetchWithAuth: vi.fn(),
   mockMutate: vi.fn(),
@@ -22,6 +23,7 @@ const {
     error: undefined as unknown,
   },
   mockIsAnyEditing: vi.fn(() => false),
+  mockIsAnyActive: vi.fn(() => false),
 }));
 
 // Mock dependencies with hoisted mocks
@@ -33,9 +35,10 @@ vi.mock('@/stores/useEditingStore', () => ({
   useEditingStore: {
     getState: () => ({
       isAnyEditing: mockIsAnyEditing,
+      isAnyActive: mockIsAnyActive,
     }),
   },
-  isEditingActive: () => mockIsAnyEditing(),
+  isEditingActive: () => mockIsAnyActive(),
 }));
 
 vi.mock('@/lib/tree/tree-utils', () => ({
@@ -92,6 +95,7 @@ describe('usePageTree', () => {
     mockSWRState.data = undefined;
     mockSWRState.error = undefined;
     mockIsAnyEditing.mockReturnValue(false);
+    mockIsAnyActive.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -283,9 +287,9 @@ describe('usePageTree', () => {
   });
 
   describe('invalidateTree', () => {
-    it('given no active editing, should mutate without deleting cache', () => {
+    it('given no active state, should mutate without deleting cache', () => {
       mockSWRState.data = [createMockTreePage()];
-      mockIsAnyEditing.mockReturnValue(false);
+      mockIsAnyActive.mockReturnValue(false);
 
       const { result } = renderHook(() => usePageTree('drive-123'));
 
@@ -297,9 +301,9 @@ describe('usePageTree', () => {
       expect(mockMutate).toHaveBeenCalled();
     });
 
-    it('given active editing, should skip invalidation', () => {
+    it('given active document editing, should skip invalidation', () => {
       mockSWRState.data = [createMockTreePage()];
-      mockIsAnyEditing.mockReturnValue(true);
+      mockIsAnyActive.mockReturnValue(true);
       const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => { });
 
       const { result } = renderHook(() => usePageTree('drive-123'));
@@ -308,10 +312,45 @@ describe('usePageTree', () => {
         result.current.invalidateTree();
       });
 
+      expect(mockMutate).not.toHaveBeenCalled();
       expect(mockCacheDelete).not.toHaveBeenCalled();
       expect(consoleLog).toHaveBeenCalledWith(
-        '⏸️ Skipping tree revalidation - document editing in progress'
+        '⏸️ Skipping tree revalidation - document editing, AI streaming, or pending send in progress'
       );
+      consoleLog.mockRestore();
+    });
+
+    it('given active AI streaming session, should skip invalidation', () => {
+      mockSWRState.data = [createMockTreePage()];
+      mockIsAnyActive.mockReturnValue(true);
+      mockIsAnyEditing.mockReturnValue(false);
+      const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => { });
+
+      const { result } = renderHook(() => usePageTree('drive-123'));
+
+      act(() => {
+        result.current.invalidateTree();
+      });
+
+      expect(mockMutate).not.toHaveBeenCalled();
+      expect(mockCacheDelete).not.toHaveBeenCalled();
+      consoleLog.mockRestore();
+    });
+
+    it('given pending send in progress, should skip invalidation', () => {
+      mockSWRState.data = [createMockTreePage()];
+      mockIsAnyActive.mockReturnValue(true);
+      mockIsAnyEditing.mockReturnValue(false);
+      const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => { });
+
+      const { result } = renderHook(() => usePageTree('drive-123'));
+
+      act(() => {
+        result.current.invalidateTree();
+      });
+
+      expect(mockMutate).not.toHaveBeenCalled();
+      expect(mockCacheDelete).not.toHaveBeenCalled();
       consoleLog.mockRestore();
     });
   });

--- a/apps/web/src/hooks/usePageTree.ts
+++ b/apps/web/src/hooks/usePageTree.ts
@@ -80,6 +80,7 @@ export function usePageTree(driveId?: string, trashView?: boolean) {
   const { cache } = useSWRConfig();
   const hasTreeSnapshotRef = useRef(!!data);
   hasTreeSnapshotRef.current = !!data;
+  const pendingInvalidateRef = useRef(false);
 
   // Self-healing: detect when SWR gets stuck (valid key, no data, no error, not fetching).
   // On desktop/Capacitor, async token retrieval in fetchWithAuth can cause SWR to lose track
@@ -125,17 +126,30 @@ export function usePageTree(driveId?: string, trashView?: boolean) {
 
   const invalidateTree = useCallback(() => {
     if (swrKey) {
-      // Guard: skip revalidation during any active state (document editing, AI streaming,
-      // or pending send) to prevent editor remounting and stream abort. Tradeoff: tree
-      // may show stale data until all sessions end, but correctness beats interruption.
+      // Guard: defer revalidation during any active state (document editing, AI streaming,
+      // or pending send) to prevent editor remounting and stream abort. The deferred flag
+      // is flushed by the store subscriber below once all sessions end.
       const isActive = useEditingStore.getState().isAnyActive();
       if (isActive) {
+        pendingInvalidateRef.current = true;
         console.log('⏸️ Skipping tree revalidation - document editing, AI streaming, or pending send in progress');
         return;
       }
 
+      pendingInvalidateRef.current = false;
       mutate();
     }
+  }, [swrKey, mutate]);
+
+  // Flush any deferred invalidation once all active sessions end.
+  useEffect(() => {
+    const unsubscribe = useEditingStore.subscribe((state) => {
+      if (!swrKey || !pendingInvalidateRef.current) return;
+      if (state.isAnyActive()) return;
+      pendingInvalidateRef.current = false;
+      mutate();
+    });
+    return unsubscribe;
   }, [swrKey, mutate]);
 
   const updateNode = useCallback((nodeId: string, updates: Partial<TreePage>) => {

--- a/apps/web/src/hooks/usePageTree.ts
+++ b/apps/web/src/hooks/usePageTree.ts
@@ -125,12 +125,11 @@ export function usePageTree(driveId?: string, trashView?: boolean) {
 
   const invalidateTree = useCallback(() => {
     if (swrKey) {
-      // Guard: skip revalidation during document/form editing to prevent editor remounting.
-      // AI streaming is intentionally NOT blocked — without cache.delete, revalidation
-      // fetches fresh data in the background (stale-while-revalidate) without causing unmounts.
-      const isEditing = useEditingStore.getState().isAnyEditing();
-      if (isEditing) {
-        console.log('⏸️ Skipping tree revalidation - document editing in progress');
+      // Guard: skip revalidation during any active state (document editing, AI streaming,
+      // or pending send) to prevent editor remounting and stream abort.
+      const isActive = useEditingStore.getState().isAnyActive();
+      if (isActive) {
+        console.log('⏸️ Skipping tree revalidation - document editing, AI streaming, or pending send in progress');
         return;
       }
 

--- a/apps/web/src/hooks/usePageTree.ts
+++ b/apps/web/src/hooks/usePageTree.ts
@@ -126,7 +126,8 @@ export function usePageTree(driveId?: string, trashView?: boolean) {
   const invalidateTree = useCallback(() => {
     if (swrKey) {
       // Guard: skip revalidation during any active state (document editing, AI streaming,
-      // or pending send) to prevent editor remounting and stream abort.
+      // or pending send) to prevent editor remounting and stream abort. Tradeoff: tree
+      // may show stale data until all sessions end, but correctness beats interruption.
       const isActive = useEditingStore.getState().isAnyActive();
       if (isActive) {
         console.log('⏸️ Skipping tree revalidation - document editing, AI streaming, or pending send in progress');


### PR DESCRIPTION
## Summary

- **AiChatView**: Removes the \`initialMessages\` useState (always \`[]\`) that caused \`chatConfig\` to get a new object reference on every \`initializeChat()\` call. Replaces it with a module-level \`EMPTY_MESSAGES\` constant and extracts \`onError\` into a stable \`handleChatError\` useCallback. \`chatConfig\` deps are now \`[page.id, transport, handleChatError]\` only — no more spurious config churn that causes \`useChat\` to abort in-flight streams.

- **usePageTree — guard + deferred flush**: Changes the \`invalidateTree\` guard from \`isAnyEditing()\` to \`isAnyActive()\` so revalidation is suppressed during AI streaming sessions and pending sends. Critically, instead of silently discarding the skipped invalidation, sets a \`pendingInvalidateRef\` flag and subscribes to \`useEditingStore\` to flush the deferred \`mutate()\` once all sessions end — preventing the permanent tree staleness that would otherwise occur since \`revalidateOnFocus: false\` means no automatic recovery.

## Test plan

- [x] Failing tests written first for \`invalidateTree\` guard (TDD): verified tests red before implementation
- [x] 3 new tests for deferred-flush: flush after active-state clears, coalescion of multiple skipped calls, no-op when nothing pending
- [x] All 19 \`usePageTree\` tests passing
- [x] No TypeScript errors in changed files
- [x] Lint clean
- [x] 386/388 web test files passing (2 DB-integration test files fail pre-existing — unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)