### PR TITLE
feat(calendar): schedule agent on events + event type filter

### DIFF
--- a/apps/web/src/app/api/calendar/events/[eventId]/__tests__/can-edit-event.test.ts
+++ b/apps/web/src/app/api/calendar/events/[eventId]/__tests__/can-edit-event.test.ts
@@ -17,8 +17,8 @@ vi.mock('next/server', async () => {
   };
 });
 
-vi.mock('@pagespace/db/db', () => ({
-  db: {
+vi.mock('@pagespace/db/db', () => {
+  const db = {
     query: {
       calendarEvents: { findFirst: vi.fn() },
       eventAttendees: { findFirst: vi.fn() },
@@ -35,8 +35,10 @@ vi.mock('@pagespace/db/db', () => ({
         where: vi.fn().mockResolvedValue([]),
       })),
     })),
-  },
-}));
+    transaction: vi.fn(async (cb: (tx: unknown) => unknown) => cb(db)),
+  };
+  return { db };
+});
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn(),
   and: vi.fn((...args: unknown[]) => args),
@@ -53,6 +55,18 @@ vi.mock('@pagespace/db/schema/calendar', () => ({
     eventId: 'eventId',
     userId: 'userId',
   },
+}));
+
+vi.mock('@pagespace/db/schema/calendar-triggers', () => ({
+  calendarTriggers: {
+    calendarEventId: 'calendarEventId',
+    status: 'status',
+  },
+}));
+
+vi.mock('../../../../../../lib/ai/core/timestamp-utils', () => ({
+  isNaiveISODatetime: vi.fn(() => false),
+  parseNaiveDatetimeInTimezone: vi.fn((dt: string) => new Date(dt)),
 }));
 
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
@@ -169,11 +183,12 @@ function createContext(): { params: Promise<{ eventId: string }> } {
 
 /**
  * Helper to set up db mocks for a PATCH request flow.
- * The PATCH handler calls:
+ * The PATCH handler:
  *   1. db.query.calendarEvents.findFirst (get existing event)
- *   2. db.update().set().where().returning() (update the event)
+ *   2. db.transaction(cb) — wraps update + optional trigger sync
  *   3. db.query.calendarEvents.findFirst (fetch complete event with relations)
  *   4. db.select().from().where() (get attendee IDs)
+ * The transaction mock passes `db` itself as `tx` so update/set/where chains work.
  */
 function setupDbMocksForPatch(event: ReturnType<typeof createMockEvent>) {
   const findFirstMock = vi.fn()
@@ -186,6 +201,9 @@ function setupDbMocksForPatch(event: ReturnType<typeof createMockEvent>) {
   const whereMock = vi.fn(() => ({ returning: returningMock }));
   const setMock = vi.fn(() => ({ where: whereMock }));
   (db.update as Mock).mockReturnValue({ set: setMock });
+
+  // transaction passes db itself as the tx object
+  (db.transaction as Mock).mockImplementation(async (cb: (tx: typeof db) => unknown) => cb(db));
 
   const selectWhereMock = vi.fn().mockResolvedValue([]);
   const selectFromMock = vi.fn(() => ({ where: selectWhereMock }));

--- a/apps/web/src/app/api/calendar/events/[eventId]/route.ts
+++ b/apps/web/src/app/api/calendar/events/[eventId]/route.ts
@@ -221,38 +221,41 @@ export async function PATCH(
       );
     }
 
-    // Update the event
-    const [updatedEvent] = await db
-      .update(calendarEvents)
-      .set({
-        title: data.title,
-        description: data.description,
-        location: data.location,
-        startAt: adjustedStartAt,
-        endAt: adjustedEndAt,
-        allDay: data.allDay,
-        timezone: data.timezone,
-        recurrenceRule: data.recurrenceRule,
-        visibility: data.visibility,
-        color: data.color,
-        pageId: data.pageId,
-        updatedAt: new Date(),
-      })
-      .where(eq(calendarEvents.id, eventId))
-      .returning();
+    // Update the event and sync pending trigger time atomically
+    const [updatedEvent] = await db.transaction(async (tx) => {
+      const result = await tx
+        .update(calendarEvents)
+        .set({
+          title: data.title,
+          description: data.description,
+          location: data.location,
+          startAt: adjustedStartAt,
+          endAt: adjustedEndAt,
+          allDay: data.allDay,
+          timezone: data.timezone,
+          recurrenceRule: data.recurrenceRule,
+          visibility: data.visibility,
+          color: data.color,
+          pageId: data.pageId,
+          updatedAt: new Date(),
+        })
+        .where(eq(calendarEvents.id, eventId))
+        .returning();
 
-    // Sync pending trigger's fire time if the event start changed
-    if (adjustedStartAt) {
-      await db
-        .update(calendarTriggers)
-        .set({ triggerAt: adjustedStartAt })
-        .where(
-          and(
-            eq(calendarTriggers.calendarEventId, eventId),
-            eq(calendarTriggers.status, 'pending'),
-          )
-        );
-    }
+      if (adjustedStartAt) {
+        await tx
+          .update(calendarTriggers)
+          .set({ triggerAt: adjustedStartAt })
+          .where(
+            and(
+              eq(calendarTriggers.calendarEventId, eventId),
+              eq(calendarTriggers.status, 'pending'),
+            )
+          );
+      }
+
+      return result;
+    });
 
     // Fetch complete event with relations
     const completeEvent = await db.query.calendarEvents.findFirst({

--- a/apps/web/src/app/api/calendar/events/[eventId]/route.ts
+++ b/apps/web/src/app/api/calendar/events/[eventId]/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { db } from '@pagespace/db/db'
 import { eq, and } from '@pagespace/db/operators'
 import { calendarEvents, eventAttendees } from '@pagespace/db/schema/calendar';
+import { calendarTriggers } from '@pagespace/db/schema/calendar-triggers';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope } from '@/lib/auth';
@@ -239,6 +240,19 @@ export async function PATCH(
       })
       .where(eq(calendarEvents.id, eventId))
       .returning();
+
+    // Sync pending trigger's fire time if the event start changed
+    if (adjustedStartAt) {
+      await db
+        .update(calendarTriggers)
+        .set({ triggerAt: adjustedStartAt })
+        .where(
+          and(
+            eq(calendarTriggers.calendarEventId, eventId),
+            eq(calendarTriggers.status, 'pending'),
+          )
+        );
+    }
 
     // Fetch complete event with relations
     const completeEvent = await db.query.calendarEvents.findFirst({

--- a/apps/web/src/app/api/calendar/events/route.ts
+++ b/apps/web/src/app/api/calendar/events/route.ts
@@ -53,7 +53,7 @@ const createEventSchema = z.object({
   attendeeIds: z.array(z.string()).optional(),
   agentTrigger: z.object({
     agentPageId: z.string(),
-    prompt: z.string().min(1).max(10000),
+    prompt: z.string().trim().min(1).max(10000),
   }).optional(),
 });
 
@@ -513,52 +513,66 @@ export async function POST(request: Request) {
       }
     }
 
-    // Create the event
-    const [event] = await db
-      .insert(calendarEvents)
-      .values({
-        driveId: data.driveId ?? null,
-        createdById: userId,
-        pageId: data.pageId ?? null,
-        title: data.title,
-        description: data.description ?? null,
-        location: data.location ?? null,
-        startAt,
-        endAt,
-        allDay: data.allDay,
-        timezone: data.timezone,
-        recurrenceRule: data.recurrenceRule ?? null,
-        visibility: data.visibility,
-        color: data.color,
-        updatedAt: new Date(),
-      })
-      .returning();
+    // Create event, attendees, and optional agent trigger atomically
+    const event = await db.transaction(async (tx) => {
+      const [created] = await tx
+        .insert(calendarEvents)
+        .values({
+          driveId: data.driveId ?? null,
+          createdById: userId,
+          pageId: data.pageId ?? null,
+          title: data.title,
+          description: data.description ?? null,
+          location: data.location ?? null,
+          startAt,
+          endAt,
+          allDay: data.allDay,
+          timezone: data.timezone,
+          recurrenceRule: data.recurrenceRule ?? null,
+          visibility: data.visibility,
+          color: data.color,
+          updatedAt: new Date(),
+        })
+        .returning();
 
-    // Add creator as organizer attendee
-    await db.insert(eventAttendees).values({
-      eventId: event.id,
-      userId: userId,
-      status: 'ACCEPTED',
-      isOrganizer: true,
-      respondedAt: new Date(),
+      await tx.insert(eventAttendees).values({
+        eventId: created.id,
+        userId: userId,
+        status: 'ACCEPTED',
+        isOrganizer: true,
+        respondedAt: new Date(),
+      });
+
+      if (data.attendeeIds && data.attendeeIds.length > 0) {
+        const others = data.attendeeIds.filter(id => id !== userId);
+        if (others.length > 0) {
+          await tx.insert(eventAttendees).values(
+            others.map(attendeeId => ({
+              eventId: created.id,
+              userId: attendeeId,
+              status: 'PENDING' as const,
+              isOrganizer: false,
+            }))
+          );
+        }
+      }
+
+      if (data.agentTrigger && agentPageId && data.driveId) {
+        await tx.insert(calendarTriggers).values({
+          calendarEventId: created.id,
+          agentPageId,
+          driveId: data.driveId,
+          scheduledById: userId,
+          prompt: data.agentTrigger.prompt,
+          triggerAt: startAt,
+          contextPageIds: [],
+        });
+      }
+
+      return created;
     });
 
-    // Add other attendees if provided
-    if (data.attendeeIds && data.attendeeIds.length > 0) {
-      const otherAttendees = data.attendeeIds.filter(id => id !== userId);
-      if (otherAttendees.length > 0) {
-        await db.insert(eventAttendees).values(
-          otherAttendees.map(attendeeId => ({
-            eventId: event.id,
-            userId: attendeeId,
-            status: 'PENDING' as const,
-            isOrganizer: false,
-          }))
-        );
-      }
-    }
-
-    // Fetch the complete event with relations
+    // Fetch the complete event with relations (read after committed transaction)
     const completeEvent = await db.query.calendarEvents.findFirst({
       where: eq(calendarEvents.id, event.id),
       with: {
@@ -577,19 +591,6 @@ export async function POST(request: Request) {
         },
       },
     });
-
-    // Create agent trigger if requested (validation already done above)
-    if (data.agentTrigger && agentPageId && data.driveId) {
-      await db.insert(calendarTriggers).values({
-        calendarEventId: event.id,
-        agentPageId,
-        driveId: data.driveId,
-        scheduledById: userId,
-        prompt: data.agentTrigger.prompt,
-        triggerAt: startAt,
-        contextPageIds: [],
-      });
-    }
 
     // Broadcast event creation
     await broadcastCalendarEvent({

--- a/apps/web/src/app/api/calendar/events/route.ts
+++ b/apps/web/src/app/api/calendar/events/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, after } from 'next/server';
 import { z } from 'zod';
 import { db } from '@pagespace/db/db'
-import { eq, and, or, gte, lte, inArray, isNull, asc } from '@pagespace/db/operators'
+import { eq, and, or, gte, lte, inArray, not, isNull, asc } from '@pagespace/db/operators'
 import { calendarEvents, eventAttendees } from '@pagespace/db/schema/calendar'
 import { calendarTriggers } from '@pagespace/db/schema/calendar-triggers'
 import { pages } from '@pagespace/db/schema/core'
@@ -10,7 +10,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getDriveMemberUserIds } from '@pagespace/lib/services/drive-member-service';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope, checkMCPCreateScope, filterDrivesByMCPScope } from '@/lib/auth';
-import { isUserDriveMember, getDriveIdsForUser } from '@pagespace/lib/permissions/permissions';
+import { isUserDriveMember, getDriveIdsForUser, canUserViewPage } from '@pagespace/lib/permissions/permissions';
 import { broadcastCalendarEvent } from '@/lib/websocket/calendar-events';
 import { pushEventToGoogle } from '@/lib/integrations/google-calendar/push-service';
 import { isNaiveISODatetime, parseNaiveDatetimeInTimezone } from '@/lib/ai/core/timestamp-utils';
@@ -58,7 +58,7 @@ const createEventSchema = z.object({
 });
 
 /**
- * Returns the set of calendarEventIds that have a non-cancelled agent trigger.
+ * Returns the set of calendarEventIds that have an active (non-cancelled, non-failed) agent trigger.
  */
 async function getTriggeredEventIds(eventIds: string[]): Promise<Set<string>> {
   if (eventIds.length === 0) return new Set();
@@ -68,6 +68,7 @@ async function getTriggeredEventIds(eventIds: string[]): Promise<Set<string>> {
     .where(
       and(
         inArray(calendarTriggers.calendarEventId, eventIds),
+        not(inArray(calendarTriggers.status, ['cancelled', 'failed'])),
       )
     );
   return new Set(rows.map(r => r.calendarEventId).filter((id): id is string => id !== null));
@@ -471,6 +472,13 @@ export async function POST(request: Request) {
           )
         );
       if (!agentPage) {
+        return NextResponse.json(
+          { error: 'Agent not found in this drive' },
+          { status: 400 }
+        );
+      }
+      const canViewAgent = await canUserViewPage(userId, agentPage.id);
+      if (!canViewAgent) {
         return NextResponse.json(
           { error: 'Agent not found in this drive' },
           { status: 400 }

--- a/apps/web/src/app/api/calendar/events/route.ts
+++ b/apps/web/src/app/api/calendar/events/route.ts
@@ -3,6 +3,8 @@ import { z } from 'zod';
 import { db } from '@pagespace/db/db'
 import { eq, and, or, gte, lte, inArray, isNull, asc } from '@pagespace/db/operators'
 import { calendarEvents, eventAttendees } from '@pagespace/db/schema/calendar'
+import { calendarTriggers } from '@pagespace/db/schema/calendar-triggers'
+import { pages } from '@pagespace/db/schema/core'
 import { workflows } from '@pagespace/db/schema/workflows';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getDriveMemberUserIds } from '@pagespace/lib/services/drive-member-service';
@@ -49,7 +51,27 @@ const createEventSchema = z.object({
   visibility: z.enum(['DRIVE', 'ATTENDEES_ONLY', 'PRIVATE']).default('DRIVE'),
   color: z.string().default('default'),
   attendeeIds: z.array(z.string()).optional(),
+  agentTrigger: z.object({
+    agentPageId: z.string(),
+    prompt: z.string().min(1).max(10000),
+  }).optional(),
 });
+
+/**
+ * Returns the set of calendarEventIds that have a non-cancelled agent trigger.
+ */
+async function getTriggeredEventIds(eventIds: string[]): Promise<Set<string>> {
+  if (eventIds.length === 0) return new Set();
+  const rows = await db
+    .select({ calendarEventId: calendarTriggers.calendarEventId })
+    .from(calendarTriggers)
+    .where(
+      and(
+        inArray(calendarTriggers.calendarEventId, eventIds),
+      )
+    );
+  return new Set(rows.map(r => r.calendarEventId).filter((id): id is string => id !== null));
+}
 
 /**
  * Expand workflow schedules into virtual calendar events within a date range.
@@ -262,10 +284,14 @@ export async function GET(request: Request) {
         orderBy: [asc(calendarEvents.startAt)],
       });
 
+      // Annotate events with agent trigger presence
+      const triggeredIds = await getTriggeredEventIds(events.map(e => e.id));
+      const annotatedEvents = events.map(e => ({ ...e, hasAgentTrigger: triggeredIds.has(e.id) }));
+
       // Append workflow virtual events
       const workflowEvents = await getWorkflowVirtualEvents([params.driveId], params.startDate, params.endDate);
 
-      return NextResponse.json({ events, workflowEvents });
+      return NextResponse.json({ events: annotatedEvents, workflowEvents });
     }
 
     // User context: aggregate events from all sources
@@ -342,10 +368,14 @@ export async function GET(request: Request) {
       orderBy: [asc(calendarEvents.startAt)],
     });
 
+    // Annotate events with agent trigger presence
+    const triggeredIds = await getTriggeredEventIds(events.map(e => e.id));
+    const annotatedEvents = events.map(e => ({ ...e, hasAgentTrigger: triggeredIds.has(e.id) }));
+
     // Append workflow virtual events
     const workflowEvents = await getWorkflowVirtualEvents(driveIds, params.startDate, params.endDate);
 
-    return NextResponse.json({ events, workflowEvents });
+    return NextResponse.json({ events: annotatedEvents, workflowEvents });
   } catch (error) {
     loggers.api.error('Error fetching calendar events:', error as Error);
     return NextResponse.json(
@@ -412,6 +442,41 @@ export async function POST(request: Request) {
         { error: 'End date must be after start date' },
         { status: 400 }
       );
+    }
+
+    // Validate agent trigger before any DB writes
+    let agentPageId: string | undefined;
+    if (data.agentTrigger) {
+      if (!data.driveId) {
+        return NextResponse.json(
+          { error: 'Agent triggers require a drive event' },
+          { status: 400 }
+        );
+      }
+      if (data.recurrenceRule) {
+        return NextResponse.json(
+          { error: 'Agent triggers are not supported for recurring events' },
+          { status: 400 }
+        );
+      }
+      const [agentPage] = await db
+        .select({ id: pages.id })
+        .from(pages)
+        .where(
+          and(
+            eq(pages.id, data.agentTrigger.agentPageId),
+            eq(pages.type, 'AI_CHAT'),
+            eq(pages.isTrashed, false),
+            eq(pages.driveId, data.driveId)
+          )
+        );
+      if (!agentPage) {
+        return NextResponse.json(
+          { error: 'Agent not found in this drive' },
+          { status: 400 }
+        );
+      }
+      agentPageId = agentPage.id;
     }
 
     // Validate attendees constraints
@@ -504,6 +569,19 @@ export async function POST(request: Request) {
         },
       },
     });
+
+    // Create agent trigger if requested (validation already done above)
+    if (data.agentTrigger && agentPageId && data.driveId) {
+      await db.insert(calendarTriggers).values({
+        calendarEventId: event.id,
+        agentPageId,
+        driveId: data.driveId,
+        scheduledById: userId,
+        prompt: data.agentTrigger.prompt,
+        triggerAt: startAt,
+        contextPageIds: [],
+      });
+    }
 
     // Broadcast event creation
     await broadcastCalendarEvent({

--- a/apps/web/src/components/calendar/CalendarSidebar.tsx
+++ b/apps/web/src/components/calendar/CalendarSidebar.tsx
@@ -108,7 +108,9 @@ export function CalendarSidebar({
         </div>
 
         <div
-          role="button"
+          role="checkbox"
+          aria-checked={userEventsVisible}
+          aria-label="Toggle user events"
           tabIndex={0}
           onClick={onToggleUserEvents}
           onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggleUserEvents(); } }}
@@ -119,9 +121,7 @@ export function CalendarSidebar({
           )}
         >
           <span
-            role="checkbox"
-            aria-checked={userEventsVisible}
-            aria-label="Toggle user events"
+            aria-hidden="true"
             className={cn(
               'size-3.5 shrink-0 rounded-sm border transition-colors flex items-center justify-center',
               userEventsVisible
@@ -147,7 +147,9 @@ export function CalendarSidebar({
         </div>
 
         <div
-          role="button"
+          role="checkbox"
+          aria-checked={agentEventsVisible}
+          aria-label="Toggle agent events"
           tabIndex={0}
           onClick={onToggleAgentEvents}
           onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggleAgentEvents(); } }}
@@ -158,9 +160,7 @@ export function CalendarSidebar({
           )}
         >
           <span
-            role="checkbox"
-            aria-checked={agentEventsVisible}
-            aria-label="Toggle agent events"
+            aria-hidden="true"
             className={cn(
               'size-3.5 shrink-0 rounded-sm border transition-colors flex items-center justify-center',
               agentEventsVisible

--- a/apps/web/src/components/calendar/CalendarSidebar.tsx
+++ b/apps/web/src/components/calendar/CalendarSidebar.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Bot, User } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { EventColorConfig } from './calendar-types';
 
@@ -15,6 +16,10 @@ interface CalendarSidebarProps {
   onToggle: (key: string) => void;
   onShowAll: () => void;
   onHideAll: () => void;
+  agentEventsVisible: boolean;
+  userEventsVisible: boolean;
+  onToggleAgentEvents: () => void;
+  onToggleUserEvents: () => void;
   className?: string;
 }
 
@@ -23,6 +28,10 @@ export function CalendarSidebar({
   onToggle,
   onShowAll,
   onHideAll,
+  agentEventsVisible,
+  userEventsVisible,
+  onToggleAgentEvents,
+  onToggleUserEvents,
   className,
 }: CalendarSidebarProps) {
   const hasCalendars = calendars.length > 0;
@@ -89,6 +98,93 @@ export function CalendarSidebar({
           All calendars hidden
         </p>
       )}
+
+      {/* Event type filters */}
+      <div className="mt-4">
+        <div className="flex items-center justify-between px-1 mb-1">
+          <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+            Event types
+          </span>
+        </div>
+
+        <div
+          role="button"
+          tabIndex={0}
+          onClick={onToggleUserEvents}
+          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggleUserEvents(); } }}
+          className={cn(
+            'flex items-center gap-2 px-1.5 py-1 rounded cursor-pointer transition-colors',
+            'hover:bg-muted/50',
+            !userEventsVisible && 'opacity-50'
+          )}
+        >
+          <span
+            role="checkbox"
+            aria-checked={userEventsVisible}
+            aria-label="Toggle user events"
+            className={cn(
+              'size-3.5 shrink-0 rounded-sm border transition-colors flex items-center justify-center',
+              userEventsVisible
+                ? 'bg-primary border-transparent'
+                : 'border-muted-foreground/40 bg-transparent'
+            )}
+          >
+            {userEventsVisible && (
+              <svg viewBox="0 0 14 14" className="size-3.5 text-white">
+                <path
+                  d="M11.5 3.5L5.5 9.5L2.5 6.5"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  fill="none"
+                />
+              </svg>
+            )}
+          </span>
+          <User className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+          <span className="text-sm truncate">User events</span>
+        </div>
+
+        <div
+          role="button"
+          tabIndex={0}
+          onClick={onToggleAgentEvents}
+          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggleAgentEvents(); } }}
+          className={cn(
+            'flex items-center gap-2 px-1.5 py-1 rounded cursor-pointer transition-colors',
+            'hover:bg-muted/50',
+            !agentEventsVisible && 'opacity-50'
+          )}
+        >
+          <span
+            role="checkbox"
+            aria-checked={agentEventsVisible}
+            aria-label="Toggle agent events"
+            className={cn(
+              'size-3.5 shrink-0 rounded-sm border transition-colors flex items-center justify-center',
+              agentEventsVisible
+                ? 'bg-primary border-transparent'
+                : 'border-muted-foreground/40 bg-transparent'
+            )}
+          >
+            {agentEventsVisible && (
+              <svg viewBox="0 0 14 14" className="size-3.5 text-white">
+                <path
+                  d="M11.5 3.5L5.5 9.5L2.5 6.5"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  fill="none"
+                />
+              </svg>
+            )}
+          </span>
+          <Bot className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+          <span className="text-sm truncate">Agent events</span>
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/calendar/CalendarView.tsx
+++ b/apps/web/src/components/calendar/CalendarView.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useMemo, useEffect } from 'react';
 import { format, addMonths, subMonths, addWeeks, subWeeks, addDays, subDays } from 'date-fns';
-import { ChevronLeft, ChevronRight, Plus, Calendar as CalendarIcon, List, LayoutGrid, Clock, PanelLeft } from 'lucide-react';
+import { Bot, ChevronLeft, ChevronRight, Plus, Calendar as CalendarIcon, List, LayoutGrid, Clock, PanelLeft, User } from 'lucide-react';
 import useSWR from 'swr';
 import { Button } from '@/components/ui/button';
 import { Toggle } from '@/components/ui/toggle';
@@ -90,7 +90,7 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
   // Drive filtering (root calendar only)
   const drives = useDriveStore((s) => s.drives);
   const fetchDrives = useDriveStore((s) => s.fetchDrives);
-  const { hiddenCalendars, toggleCalendar, showAll, hideAll } =
+  const { hiddenCalendars, toggleCalendar, showAll, hideAll, hiddenEventTypes, toggleEventType, isEventTypeVisible } =
     useCalendarFilterStore();
   const [sidebarOpen, setSidebarOpen] = useState(true);
 
@@ -136,9 +136,17 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
 
   // Filter events and tasks by visibility
   const filteredEvents = useMemo(() => {
-    if (!isUserContext) return events;
-    return events.filter((e) => !hiddenCalendars.includes(e.driveId ?? 'personal'));
-  }, [isUserContext, events, hiddenCalendars]);
+    let result = isUserContext
+      ? events.filter((e) => !hiddenCalendars.includes(e.driveId ?? 'personal'))
+      : events;
+    if (hiddenEventTypes.length > 0) {
+      result = result.filter((e) => {
+        const type = e.hasAgentTrigger ? 'agent' : 'user';
+        return isEventTypeVisible(type);
+      });
+    }
+    return result;
+  }, [isUserContext, events, hiddenCalendars, hiddenEventTypes, isEventTypeVisible]);
 
   const filteredTasks = useMemo(() => {
     if (!isUserContext) return tasks;
@@ -237,6 +245,7 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
     allDay: boolean;
     color?: string;
     attendeeIds?: string[];
+    agentTrigger?: { agentPageId: string; prompt: string };
   }) => {
     if (selectedEvent) {
       await updateEvent(selectedEvent.id, eventData);
@@ -410,6 +419,34 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
             </SelectContent>
           </Select>
 
+          {/* Event type filters (drive context — in user context these live in the sidebar) */}
+          {!isUserContext && (
+            <div className="flex items-center gap-1">
+              <Toggle
+                pressed={isEventTypeVisible('user')}
+                onPressedChange={() => toggleEventType('user')}
+                size="sm"
+                aria-label="Show user events"
+                title="User events"
+                className="data-[state=on]:bg-primary/10 gap-1"
+              >
+                <User className="h-3.5 w-3.5" />
+                <span className="hidden sm:inline">Events</span>
+              </Toggle>
+              <Toggle
+                pressed={isEventTypeVisible('agent')}
+                onPressedChange={() => toggleEventType('agent')}
+                size="sm"
+                aria-label="Show agent events"
+                title="Agent events"
+                className="data-[state=on]:bg-primary/10 gap-1"
+              >
+                <Bot className="h-3.5 w-3.5" />
+                <span className="hidden sm:inline">Agents</span>
+              </Toggle>
+            </div>
+          )}
+
           {/* Tasks toggle */}
           <Toggle
             pressed={showTasks}
@@ -458,6 +495,10 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
               onToggle={toggleCalendar}
               onShowAll={showAll}
               onHideAll={() => hideAll(allCalendarKeys)}
+              agentEventsVisible={isEventTypeVisible('agent')}
+              userEventsVisible={isEventTypeVisible('user')}
+              onToggleAgentEvents={() => toggleEventType('agent')}
+              onToggleUserEvents={() => toggleEventType('user')}
             />
           </aside>
         )}

--- a/apps/web/src/components/calendar/EventModal.tsx
+++ b/apps/web/src/components/calendar/EventModal.tsx
@@ -410,7 +410,10 @@ export function EventModal({
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
                   <Bot className="h-4 w-4 text-muted-foreground" />
-                  <Label htmlFor="schedule-agent" className="cursor-pointer font-medium">
+                  <Label
+                    htmlFor="schedule-agent"
+                    className={agentsLoading || agents.length > 0 ? 'cursor-pointer font-medium' : 'font-medium text-muted-foreground'}
+                  >
                     Run agent
                   </Label>
                 </div>
@@ -418,8 +421,14 @@ export function EventModal({
                   id="schedule-agent"
                   checked={scheduleAgent}
                   onCheckedChange={setScheduleAgent}
+                  disabled={!agentsLoading && agents.length === 0}
                 />
               </div>
+              {!agentsLoading && agents.length === 0 && (
+                <p className="text-xs text-muted-foreground">
+                  No agents in this drive. Create an AI agent page first.
+                </p>
+              )}
 
               {scheduleAgent && (
                 <div className="space-y-3 pt-1">

--- a/apps/web/src/components/calendar/EventModal.tsx
+++ b/apps/web/src/components/calendar/EventModal.tsx
@@ -185,7 +185,7 @@ export function EventModal({
       return;
     }
 
-    if (scheduleAgent && (!selectedAgentId || !agentPrompt.trim())) {
+    if (scheduleAgent && (!selectedAgentId || selectedAgentId === '__none' || !agentPrompt.trim())) {
       toast.error('Please select an agent and enter a prompt');
       return;
     }

--- a/apps/web/src/components/calendar/EventModal.tsx
+++ b/apps/web/src/components/calendar/EventModal.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { format } from 'date-fns';
-import { CalendarIcon, Clock, MapPin, Trash2 } from 'lucide-react';
+import { Bot, CalendarIcon, Clock, MapPin, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 import {
   Dialog,
@@ -30,7 +30,13 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { cn } from '@/lib/utils';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { CalendarEvent, EVENT_COLORS } from './calendar-types';
+
+interface DriveAgent {
+  id: string;
+  title: string | null;
+}
 
 interface EventModalProps {
   isOpen: boolean;
@@ -50,6 +56,7 @@ interface EventModalProps {
     allDay: boolean;
     color?: string;
     attendeeIds?: string[];
+    agentTrigger?: { agentPageId: string; prompt: string };
   }) => Promise<void>;
   onDelete?: () => Promise<void>;
   driveId?: string;
@@ -76,10 +83,11 @@ export function EventModal({
   defaultValues,
   onSave,
   onDelete,
-  driveId: _driveId,
-  context: _context,
+  driveId,
+  context,
 }: EventModalProps) {
   const isEditing = !!event;
+  const canScheduleAgent = context === 'drive' && !!driveId && !isEditing;
 
   // Form state
   const [title, setTitle] = useState('');
@@ -93,11 +101,17 @@ export function EventModal({
   const [color, setColor] = useState<keyof typeof EVENT_COLORS>('default');
   const [isSaving, setIsSaving] = useState(false);
 
+  // Agent scheduling state
+  const [scheduleAgent, setScheduleAgent] = useState(false);
+  const [selectedAgentId, setSelectedAgentId] = useState('');
+  const [agentPrompt, setAgentPrompt] = useState('');
+  const [agents, setAgents] = useState<DriveAgent[]>([]);
+  const [agentsLoading, setAgentsLoading] = useState(false);
+
   // Initialize form when modal opens
   useEffect(() => {
     if (isOpen) {
       if (event) {
-        // Editing existing event
         setTitle(event.title);
         setDescription(event.description ?? '');
         setLocation(event.location ?? '');
@@ -111,7 +125,6 @@ export function EventModal({
         setStartTime(format(start, 'HH:mm'));
         setEndTime(format(end, 'HH:mm'));
       } else if (defaultValues) {
-        // Creating new event with defaults
         setTitle('');
         setDescription('');
         setLocation('');
@@ -122,7 +135,6 @@ export function EventModal({
         setStartTime(format(defaultValues.startAt, 'HH:mm'));
         setEndTime(format(defaultValues.endAt, 'HH:mm'));
       } else {
-        // Creating new event without defaults
         const now = new Date();
         const start = new Date(now);
         start.setMinutes(0, 0, 0);
@@ -140,10 +152,26 @@ export function EventModal({
         setStartTime(format(start, 'HH:mm'));
         setEndTime(format(end, 'HH:mm'));
       }
+
+      // Reset agent scheduling state
+      setScheduleAgent(false);
+      setSelectedAgentId('');
+      setAgentPrompt('');
     }
   }, [isOpen, event, defaultValues]);
 
-  // Build datetime from date and time
+  // Fetch drive agents when modal opens in drive context
+  useEffect(() => {
+    if (!isOpen || !canScheduleAgent || !driveId) return;
+
+    setAgentsLoading(true);
+    fetchWithAuth(`/api/drives/${driveId}/agents`)
+      .then(res => res.ok ? res.json() : Promise.reject())
+      .then(data => setAgents(data.agents ?? []))
+      .catch(() => setAgents([]))
+      .finally(() => setAgentsLoading(false));
+  }, [isOpen, canScheduleAgent, driveId]);
+
   const buildDateTime = (date: Date, time: string): Date => {
     const [hours, minutes] = time.split(':').map(Number);
     const result = new Date(date);
@@ -151,10 +179,14 @@ export function EventModal({
     return result;
   };
 
-  // Handle save
   const handleSave = async () => {
     if (!title.trim()) {
       toast.error('Please enter a title');
+      return;
+    }
+
+    if (scheduleAgent && (!selectedAgentId || !agentPrompt.trim())) {
+      toast.error('Please select an agent and enter a prompt');
       return;
     }
 
@@ -180,6 +212,9 @@ export function EventModal({
         endAt,
         allDay,
         color,
+        agentTrigger: scheduleAgent && selectedAgentId && agentPrompt.trim()
+          ? { agentPageId: selectedAgentId, prompt: agentPrompt.trim() }
+          : undefined,
       });
       toast.success(isEditing ? 'Event updated' : 'Event created');
       onClose();
@@ -192,7 +227,6 @@ export function EventModal({
     }
   };
 
-  // Handle delete
   const handleDelete = async () => {
     if (!onDelete) return;
 
@@ -369,6 +403,69 @@ export function EventModal({
               })}
             </div>
           </div>
+
+          {/* Agent scheduling (drive context, new events only) */}
+          {canScheduleAgent && (
+            <div className="space-y-3 rounded-md border p-3">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <Bot className="h-4 w-4 text-muted-foreground" />
+                  <Label htmlFor="schedule-agent" className="cursor-pointer font-medium">
+                    Run agent
+                  </Label>
+                </div>
+                <Switch
+                  id="schedule-agent"
+                  checked={scheduleAgent}
+                  onCheckedChange={setScheduleAgent}
+                />
+              </div>
+
+              {scheduleAgent && (
+                <div className="space-y-3 pt-1">
+                  <div className="space-y-2">
+                    <Label>Agent</Label>
+                    <Select
+                      value={selectedAgentId}
+                      onValueChange={setSelectedAgentId}
+                      disabled={agentsLoading}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder={agentsLoading ? 'Loading agents…' : 'Select an agent'} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {agents.length === 0 && !agentsLoading && (
+                          <SelectItem value="__none" disabled>
+                            No agents in this drive
+                          </SelectItem>
+                        )}
+                        {agents.map((agent) => (
+                          <SelectItem key={agent.id} value={agent.id}>
+                            {agent.title ?? 'Untitled agent'}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="agent-prompt">Prompt</Label>
+                    <Textarea
+                      id="agent-prompt"
+                      placeholder="What should the agent do when this event starts?"
+                      value={agentPrompt}
+                      onChange={(e) => setAgentPrompt(e.target.value)}
+                      rows={3}
+                    />
+                  </div>
+
+                  <p className="text-xs text-muted-foreground">
+                    The agent will run at the event&apos;s start time.
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
 
           {/* Description */}
           <div className="space-y-2">

--- a/apps/web/src/components/calendar/MobileCalendarView.tsx
+++ b/apps/web/src/components/calendar/MobileCalendarView.tsx
@@ -35,6 +35,7 @@ import { MobileWeekStrip } from './MobileWeekStrip';
 import { MobileDayAgenda } from './MobileDayAgenda';
 import { MobileMonthPicker } from './MobileMonthPicker';
 import { CalendarSidebar } from './CalendarSidebar';
+import { useCalendarFilterStore } from '@/stores/useCalendarFilterStore';
 import {
   CalendarEvent,
   CalendarHandlers,
@@ -89,6 +90,7 @@ export function MobileCalendarView({
   onShowAllCalendars,
   onHideAllCalendars,
 }: MobileCalendarViewProps) {
+  const { isEventTypeVisible, toggleEventType } = useCalendarFilterStore();
   const [selectedDate, setSelectedDate] = useState(() => parentDate ?? new Date());
   const [currentWeekStart, setCurrentWeekStart] = useState(() =>
     startOfWeek(parentDate ?? new Date())
@@ -251,6 +253,10 @@ export function MobileCalendarView({
                     onToggle={onToggleCalendar}
                     onShowAll={onShowAllCalendars}
                     onHideAll={onHideAllCalendars}
+                    agentEventsVisible={isEventTypeVisible('agent')}
+                    userEventsVisible={isEventTypeVisible('user')}
+                    onToggleAgentEvents={() => toggleEventType('agent')}
+                    onToggleUserEvents={() => toggleEventType('user')}
                   />
                 </div>
               </SheetContent>

--- a/apps/web/src/components/calendar/__tests__/CalendarSidebar.test.tsx
+++ b/apps/web/src/components/calendar/__tests__/CalendarSidebar.test.tsx
@@ -34,6 +34,10 @@ describe('CalendarSidebar', () => {
         onToggle={() => {}}
         onShowAll={() => {}}
         onHideAll={() => {}}
+        agentEventsVisible={true}
+        userEventsVisible={true}
+        onToggleAgentEvents={() => {}}
+        onToggleUserEvents={() => {}}
       />
     );
 
@@ -67,6 +71,10 @@ describe('CalendarSidebar', () => {
         onToggle={onToggle}
         onShowAll={() => {}}
         onHideAll={() => {}}
+        agentEventsVisible={true}
+        userEventsVisible={true}
+        onToggleAgentEvents={() => {}}
+        onToggleUserEvents={() => {}}
       />
     );
 
@@ -89,6 +97,10 @@ describe('CalendarSidebar', () => {
         onToggle={() => {}}
         onShowAll={() => {}}
         onHideAll={onHideAll}
+        agentEventsVisible={true}
+        userEventsVisible={true}
+        onToggleAgentEvents={() => {}}
+        onToggleUserEvents={() => {}}
       />
     );
 
@@ -110,6 +122,10 @@ describe('CalendarSidebar', () => {
         onToggle={() => {}}
         onShowAll={onShowAll}
         onHideAll={() => {}}
+        agentEventsVisible={true}
+        userEventsVisible={true}
+        onToggleAgentEvents={() => {}}
+        onToggleUserEvents={() => {}}
       />
     );
 
@@ -130,6 +146,10 @@ describe('CalendarSidebar', () => {
         onToggle={() => {}}
         onShowAll={() => {}}
         onHideAll={() => {}}
+        agentEventsVisible={true}
+        userEventsVisible={true}
+        onToggleAgentEvents={() => {}}
+        onToggleUserEvents={() => {}}
       />
     );
 

--- a/apps/web/src/components/calendar/calendar-types.ts
+++ b/apps/web/src/components/calendar/calendar-types.ts
@@ -59,6 +59,7 @@ export interface CalendarEvent {
     name: string;
     slug: string;
   } | null;
+  hasAgentTrigger?: boolean;
 }
 
 export interface RecurrenceRule {

--- a/apps/web/src/components/calendar/useCalendarData.ts
+++ b/apps/web/src/components/calendar/useCalendarData.ts
@@ -124,6 +124,7 @@ export function useCalendarData({
       color?: string;
       attendeeIds?: string[];
       pageId?: string;
+      agentTrigger?: { agentPageId: string; prompt: string };
     }) => {
       const result = await post<CalendarEvent>('/api/calendar/events', {
         driveId: context === 'drive' ? driveId : null,

--- a/apps/web/src/stores/useCalendarFilterStore.ts
+++ b/apps/web/src/stores/useCalendarFilterStore.ts
@@ -7,6 +7,10 @@ interface CalendarFilterState {
   showAll: () => void;
   hideAll: (keys: string[]) => void;
   isVisible: (key: string) => boolean;
+
+  hiddenEventTypes: string[];
+  toggleEventType: (type: string) => void;
+  isEventTypeVisible: (type: string) => boolean;
 }
 
 export const useCalendarFilterStore = create<CalendarFilterState>()(
@@ -28,11 +32,25 @@ export const useCalendarFilterStore = create<CalendarFilterState>()(
       hideAll: (keys: string[]) => set({ hiddenCalendars: [...keys] }),
 
       isVisible: (key: string) => !get().hiddenCalendars.includes(key),
+
+      hiddenEventTypes: [],
+
+      toggleEventType: (type: string) => {
+        const { hiddenEventTypes } = get();
+        if (hiddenEventTypes.includes(type)) {
+          set({ hiddenEventTypes: hiddenEventTypes.filter((t) => t !== type) });
+        } else {
+          set({ hiddenEventTypes: [...hiddenEventTypes, type] });
+        }
+      },
+
+      isEventTypeVisible: (type: string) => !get().hiddenEventTypes.includes(type),
     }),
     {
       name: 'calendar-filter-storage',
       partialize: (state) => ({
         hiddenCalendars: state.hiddenCalendars,
+        hiddenEventTypes: state.hiddenEventTypes,
       }),
     }
   )

--- a/apps/web/src/stores/useCalendarFilterStore.ts
+++ b/apps/web/src/stores/useCalendarFilterStore.ts
@@ -8,9 +8,9 @@ interface CalendarFilterState {
   hideAll: (keys: string[]) => void;
   isVisible: (key: string) => boolean;
 
-  hiddenEventTypes: string[];
-  toggleEventType: (type: string) => void;
-  isEventTypeVisible: (type: string) => boolean;
+  hiddenEventTypes: Array<'agent' | 'user'>;
+  toggleEventType: (type: 'agent' | 'user') => void;
+  isEventTypeVisible: (type: 'agent' | 'user') => boolean;
 }
 
 export const useCalendarFilterStore = create<CalendarFilterState>()(
@@ -35,7 +35,7 @@ export const useCalendarFilterStore = create<CalendarFilterState>()(
 
       hiddenEventTypes: [],
 
-      toggleEventType: (type: string) => {
+      toggleEventType: (type: 'agent' | 'user') => {
         const { hiddenEventTypes } = get();
         if (hiddenEventTypes.includes(type)) {
           set({ hiddenEventTypes: hiddenEventTypes.filter((t) => t !== type) });
@@ -44,7 +44,7 @@ export const useCalendarFilterStore = create<CalendarFilterState>()(
         }
       },
 
-      isEventTypeVisible: (type: string) => !get().hiddenEventTypes.includes(type),
+      isEventTypeVisible: (type: 'agent' | 'user') => !get().hiddenEventTypes.includes(type),
     }),
     {
       name: 'calendar-filter-storage',


### PR DESCRIPTION
## Summary

- **Schedule agent UI**: New \"Run agent\" section in the event creation modal (drive context, new events only). A toggle reveals an agent picker (populated from the drive's AI agents) and a prompt field. On save, creates a \`calendarTriggers\` row so the cron poller fires the agent at event start time. The switch is disabled (with an explanatory note) when the drive has no AI agents.
- **API: accept agent trigger on POST**: \`POST /api/calendar/events\` now accepts an optional \`agentTrigger: { agentPageId, prompt }\`. Agent is validated (must be \`AI_CHAT\`, not trashed, in same drive, user must have view permission via \`canUserViewPage\`) before any DB writes. The event, attendees, and trigger rows are created in a single \`db.transaction()\` so a partial failure leaves no orphaned data.
- **API: sync trigger on PATCH**: \`PATCH /api/calendar/events/[eventId]\` now updates \`calendar_triggers.triggerAt\` atomically (same \`db.transaction()\`) when \`startAt\` changes. Only \`pending\` triggers are synced; completed/failed/cancelled rows are left untouched.
- **API: annotate events on GET**: Both GET branches annotate each event with \`hasAgentTrigger: boolean\` via a secondary batch query on \`calendarTriggers\`. Only active (non-cancelled, non-failed) triggers count.
- **Event type filter**: New \`hiddenEventTypes\` state in \`useCalendarFilterStore\` (persisted, typed as \`'agent' | 'user'\` literal union). Drive calendar header gets \"Events\" / \"Agents\" Toggle chips; user calendar sidebar gets an \"Event types\" section with User events / Agent events checkboxes. Wired into both desktop (\`CalendarView\`) and mobile (\`MobileCalendarView\`) paths.
- **Prompt validation**: \`agentTrigger.prompt\` is validated with \`.trim().min(1)\` so whitespace-only strings are rejected server-side.

## Test plan

- [ ] Open a drive calendar → \"New Event\" → confirm \"Run agent\" section appears with toggle
- [ ] Open personal calendar → \"New Event\" → confirm section is absent
- [ ] Toggle \"Run agent\" on → agent dropdown populates with drive's AI agents
- [ ] Select agent + enter prompt → save → event appears on calendar
- [ ] Confirm \`calendar_triggers\` row exists with \`status='pending'\` and correct \`triggerAt\`
- [ ] Reschedule event via PATCH → confirm \`calendar_triggers.triggerAt\` updates to match new \`startAt\`
- [ ] Cancel/fail a trigger, then GET events → \`hasAgentTrigger\` is \`false\` for that event
- [ ] Toggle \"Agents\" filter off in drive header → agent-triggered events disappear
- [ ] Toggle \"Events\" filter off → regular events disappear, agent events remain
- [ ] User calendar sidebar: both filter checkboxes work correctly
- [ ] Mobile sidebar sheet: same filter toggles appear and work
- [ ] Drive with no agents: \"Run agent\" switch is disabled with explanatory message
- [ ] Filter state persists across page reload (localStorage)
- [ ] POST with whitespace-only prompt → 400 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)