### PR TITLE
fix(ai): clean titles for integration tool calls

### DIFF
--- a/apps/web/src/components/ai/shared/chat/tool-calls/ToolCallRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/ToolCallRenderer.tsx
@@ -16,6 +16,8 @@ import { SearchResultsRenderer, type SearchResult } from './SearchResultsRendere
 import { AgentListRenderer, type AgentInfo } from './AgentListRenderer';
 import { ActivityRenderer, type ActivityItem } from './ActivityRenderer';
 import { WebSearchRenderer, type WebSearchResult } from './WebSearchRenderer';
+import { parseIntegrationToolName, isIntegrationTool } from '@pagespace/lib/integrations/converter/ai-sdk';
+import { getBuiltinProvider } from '@pagespace/lib/integrations/providers/builtin-providers';
 
 interface ToolPart {
   type: string;
@@ -242,6 +244,15 @@ const ToolCallRendererInternal: React.FC<{ part: ToolPart; toolName: string }> =
 
   // Memoize formatted tool name
   const formattedToolName = useMemo(() => {
+    if (isIntegrationTool(toolName)) {
+      const parsed = parseIntegrationToolName(toolName);
+      if (parsed) {
+        const provider = getBuiltinProvider(parsed.providerSlug);
+        const tool = provider?.tools.find(t => t.id === parsed.toolId);
+        if (tool) return tool.name;
+        return parsed.toolId.split('_').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+      }
+    }
     return TOOL_NAME_MAP[toolName] || toolName.split('_').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
   }, [toolName]);
 
@@ -266,6 +277,16 @@ const ToolCallRendererInternal: React.FC<{ part: ToolPart; toolName: string }> =
     }
     if (params.driveSlug && typeof params.driveSlug === 'string') {
       return `${formattedToolName}: ${params.driveSlug}`;
+    }
+    if (params.owner && params.repo && typeof params.owner === 'string' && typeof params.repo === 'string') {
+      const suffix = params.path && typeof params.path === 'string' ? `/${params.path}` : '';
+      return `${formattedToolName}: ${params.owner}/${params.repo}${suffix}`;
+    }
+    if (params.channel && typeof params.channel === 'string') {
+      return `${formattedToolName}: ${params.channel}`;
+    }
+    if (params.repo && typeof params.repo === 'string') {
+      return `${formattedToolName}: ${params.repo}`;
     }
 
     return formattedToolName;


### PR DESCRIPTION
## Summary

- Integration tool calls (GitHub, Slack, Notion) were showing raw internal names like **"Int Github Xenm2qsp Get Repo Content"** because the renderer fell back to splitting `int__provider__shortid__tool_id` on underscores
- Now parses the `int__` prefix, looks up the provider config, and returns the tool's human-friendly `name` (e.g. **"Get Repository Content"**)
- Extended `descriptiveTitle` with `owner`/`repo`/`path` and `channel` context checks to match the `read_page` style (**"Get Repository Content: owner/repo/path"**)

## Test plan

- [ ] Connect a GitHub integration to an AI agent, trigger a `get_repo_content` call — card title should read **"Get Repository Content: owner/repo/path"**
- [ ] Trigger `list_repos` — should show **"List Repositories"** (no suffix)
- [ ] Trigger a code search — should show **"Search Code: query..."**
- [ ] Slack `send_message` should show **"Send Message: #channel"**
- [ ] Unknown/custom provider: shortId is stripped, toolId is title-cased (graceful fallback)
- [ ] Native PageSpace tools (read_page, list_drives etc.) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)