### PR TITLE
feat(ai): client state for multiplayer AI chat streaming

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -29,6 +29,8 @@ import { useSWRConfig } from 'swr';
 import { clearActiveStreamId } from '@/lib/ai/core/client';
 import { useAppStateRecovery } from '@/hooks/useAppStateRecovery';
 import { isEditingActive } from '@/stores/useEditingStore';
+import { usePageSocketRoom } from '@/hooks/usePageSocketRoom';
+import { useChatStreamSocket } from '@/hooks/useChatStreamSocket';
 
 // Shared hooks and components
 import {
@@ -281,6 +283,9 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
     isStreaming,
     { pageId: page.id, componentName: 'AiChatView' }
   );
+
+  usePageSocketRoom(page.id);
+  useChatStreamSocket(page.id, user?.id);
 
   // Reset error visibility when new error occurs
   useEffect(() => {

--- a/apps/web/src/hooks/__tests__/useChatStreamSocket.test.ts
+++ b/apps/web/src/hooks/__tests__/useChatStreamSocket.test.ts
@@ -26,7 +26,10 @@ const {
     }),
     emit: vi.fn(),
     _trigger: (event: string, payload: unknown) => {
-      handlers[event]?.forEach((h) => h(payload));
+      handlers[event]?.slice().forEach((h) => h(payload));
+    },
+    _reset: () => {
+      Object.keys(handlers).forEach((k) => { handlers[k] = []; });
     },
   };
 
@@ -83,6 +86,7 @@ const COMPLETE_PAYLOAD: AiStreamCompletePayload = {
 describe('useChatStreamSocket', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSocket._reset();
     mockConsumeStreamJoin.mockResolvedValue({ aborted: false });
   });
 
@@ -157,6 +161,32 @@ describe('useChatStreamSocket', () => {
     });
   });
 
+  // A1 — pageId guard
+  describe('pageId guard', () => {
+    it('given chat:stream_start with a different pageId, should ignore the event', () => {
+      renderHook(() => useChatStreamSocket('page-a', 'user-1'));
+
+      act(() => {
+        mockSocket._trigger('chat:stream_start', { ...START_PAYLOAD, pageId: 'page-b' });
+      });
+
+      expect(mockAddStream).not.toHaveBeenCalled();
+      expect(mockConsumeStreamJoin).not.toHaveBeenCalled();
+    });
+
+    it('given chat:stream_complete with a different pageId, should ignore the event', () => {
+      const onStreamComplete = vi.fn();
+      renderHook(() => useChatStreamSocket('page-a', 'user-1', onStreamComplete));
+
+      act(() => {
+        mockSocket._trigger('chat:stream_complete', { ...COMPLETE_PAYLOAD, pageId: 'page-b' });
+      });
+
+      expect(mockRemoveStream).not.toHaveBeenCalled();
+      expect(onStreamComplete).not.toHaveBeenCalled();
+    });
+  });
+
   describe('chat:stream_complete', () => {
     it('should call removeStream and onStreamComplete', () => {
       const onStreamComplete = vi.fn();
@@ -185,6 +215,82 @@ describe('useChatStreamSocket', () => {
     });
   });
 
+  // A2 — double onStreamComplete prevention
+  describe('onStreamComplete deduplication', () => {
+    it('given SSE done sentinel resolves and chat:stream_complete also fires, should call onStreamComplete exactly once', async () => {
+      let resolveJoin!: () => void;
+      mockConsumeStreamJoin.mockReturnValue(
+        new Promise<{ aborted: boolean }>((res) => { resolveJoin = () => res({ aborted: false }); }),
+      );
+      const onStreamComplete = vi.fn();
+
+      renderHook(() => useChatStreamSocket('page-a', 'user-1', onStreamComplete));
+      act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
+
+      // SSE done resolves first
+      await act(async () => { resolveJoin(); });
+
+      // Then socket stream_complete also fires
+      act(() => { mockSocket._trigger('chat:stream_complete', COMPLETE_PAYLOAD); });
+
+      expect(onStreamComplete).toHaveBeenCalledTimes(1);
+    });
+
+    it('given chat:stream_complete fires before SSE resolves, should call onStreamComplete exactly once', async () => {
+      mockConsumeStreamJoin.mockReturnValue(new Promise(() => {})); // never resolves naturally
+      const onStreamComplete = vi.fn();
+
+      renderHook(() => useChatStreamSocket('page-a', 'user-1', onStreamComplete));
+      act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
+
+      // stream_complete fires (aborts the SSE join)
+      act(() => { mockSocket._trigger('chat:stream_complete', COMPLETE_PAYLOAD); });
+
+      // Give any pending promise chains a tick to settle
+      await act(async () => { await Promise.resolve(); });
+
+      expect(onStreamComplete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // A3 — callback ref: onStreamComplete change should not re-register handlers
+  describe('onStreamComplete stability', () => {
+    it('given onStreamComplete reference changes between renders, should not re-register socket handlers', () => {
+      let callback = vi.fn();
+      const { rerender } = renderHook(() => useChatStreamSocket('page-a', 'user-1', callback));
+
+      const onCallCount = mockSocket.on.mock.calls.length;
+
+      callback = vi.fn(); // new reference
+      rerender();
+
+      expect(mockSocket.on.mock.calls.length).toBe(onCallCount);
+    });
+
+    it('given onStreamComplete reference changes between renders, should invoke the latest callback', async () => {
+      let resolveJoin!: () => void;
+      mockConsumeStreamJoin.mockReturnValue(
+        new Promise<{ aborted: boolean }>((res) => { resolveJoin = () => res({ aborted: false }); }),
+      );
+
+      const firstCallback = vi.fn();
+      let callback = firstCallback;
+      const { rerender } = renderHook(() => useChatStreamSocket('page-a', 'user-1', callback));
+
+      act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
+
+      // Swap callback before stream resolves
+      const secondCallback = vi.fn();
+      callback = secondCallback;
+      rerender();
+
+      await act(async () => { resolveJoin(); });
+
+      expect(firstCallback).not.toHaveBeenCalled();
+      expect(secondCallback).toHaveBeenCalledWith('msg-1');
+    });
+  });
+
   describe('cleanup on unmount', () => {
     it('should remove socket listeners, abort controllers, and clearPageStreams', () => {
       const { unmount } = renderHook(() => useChatStreamSocket('page-a', 'user-1'));
@@ -192,7 +298,6 @@ describe('useChatStreamSocket', () => {
       act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
 
       let capturedSignal!: AbortSignal;
-      // Re-check: consumeStreamJoin was called, signal captured from last call
       const lastCall = mockConsumeStreamJoin.mock.calls.at(-1);
       if (lastCall) capturedSignal = lastCall[1] as AbortSignal;
 

--- a/apps/web/src/hooks/__tests__/useChatStreamSocket.test.ts
+++ b/apps/web/src/hooks/__tests__/useChatStreamSocket.test.ts
@@ -146,6 +146,19 @@ describe('useChatStreamSocket', () => {
     });
   });
 
+  describe('SSE join error', () => {
+    it('given consumeStreamJoin rejects, should call removeStream to prevent stale store entry', async () => {
+      mockConsumeStreamJoin.mockRejectedValue(new Error('network error'));
+
+      renderHook(() => useChatStreamSocket('page-a', 'user-1'));
+      act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
+
+      await act(async () => { await Promise.resolve(); });
+
+      expect(mockRemoveStream).toHaveBeenCalledWith('msg-1');
+    });
+  });
+
   describe('chat:stream_start from local user', () => {
     it('should skip addStream and consumeStreamJoin when triggeredBy.userId matches currentUserId', () => {
       const localPayload: AiStreamStartPayload = {

--- a/apps/web/src/hooks/__tests__/useChatStreamSocket.test.ts
+++ b/apps/web/src/hooks/__tests__/useChatStreamSocket.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Hoisted mock factories
+// ---------------------------------------------------------------------------
+const {
+  mockSocket,
+  mockAddStream,
+  mockAppendText,
+  mockRemoveStream,
+  mockClearPageStreams,
+  mockConsumeStreamJoin,
+} = vi.hoisted(() => {
+  const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+
+  const mockSocket = {
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (!handlers[event]) handlers[event] = [];
+      handlers[event].push(handler);
+    }),
+    off: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (handlers[event]) {
+        handlers[event] = handlers[event].filter((h) => h !== handler);
+      }
+    }),
+    emit: vi.fn(),
+    _trigger: (event: string, payload: unknown) => {
+      handlers[event]?.forEach((h) => h(payload));
+    },
+  };
+
+  const mockAddStream = vi.fn();
+  const mockAppendText = vi.fn();
+  const mockRemoveStream = vi.fn();
+  const mockClearPageStreams = vi.fn();
+  const mockConsumeStreamJoin = vi.fn().mockResolvedValue({ aborted: false });
+
+  return {
+    mockSocket,
+    mockAddStream,
+    mockAppendText,
+    mockRemoveStream,
+    mockClearPageStreams,
+    mockConsumeStreamJoin,
+  };
+});
+
+vi.mock('@/hooks/useSocket', () => ({
+  useSocket: () => mockSocket,
+}));
+
+vi.mock('@/stores/usePendingStreamsStore', () => ({
+  usePendingStreamsStore: {
+    getState: () => ({
+      addStream: mockAddStream,
+      appendText: mockAppendText,
+      removeStream: mockRemoveStream,
+      clearPageStreams: mockClearPageStreams,
+    }),
+  },
+}));
+
+vi.mock('@/lib/ai/core/stream-join-client', () => ({
+  consumeStreamJoin: mockConsumeStreamJoin,
+}));
+
+import { useChatStreamSocket } from '../useChatStreamSocket';
+import type { AiStreamStartPayload, AiStreamCompletePayload } from '@/lib/websocket/socket-utils';
+
+const START_PAYLOAD: AiStreamStartPayload = {
+  messageId: 'msg-1',
+  pageId: 'page-a',
+  conversationId: 'conv-1',
+  triggeredBy: { userId: 'user-2', displayName: 'Alice' },
+};
+
+const COMPLETE_PAYLOAD: AiStreamCompletePayload = {
+  messageId: 'msg-1',
+  pageId: 'page-a',
+};
+
+describe('useChatStreamSocket', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConsumeStreamJoin.mockResolvedValue({ aborted: false });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('chat:stream_start from another user', () => {
+    it('should call addStream and start consumeStreamJoin', () => {
+      renderHook(() => useChatStreamSocket('page-a', 'user-1'));
+
+      act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
+
+      expect(mockAddStream).toHaveBeenCalledWith({
+        messageId: 'msg-1',
+        pageId: 'page-a',
+        conversationId: 'conv-1',
+        triggeredBy: { userId: 'user-2', displayName: 'Alice' },
+      });
+      expect(mockConsumeStreamJoin).toHaveBeenCalledWith(
+        'msg-1',
+        expect.any(AbortSignal),
+        expect.any(Function),
+      );
+    });
+
+    it('should wire onChunk to appendText in the store', async () => {
+      let capturedOnChunk!: (text: string) => void;
+      mockConsumeStreamJoin.mockImplementation(
+        (_id: string, _signal: AbortSignal, onChunk: (text: string) => void) => {
+          capturedOnChunk = onChunk;
+          return new Promise(() => {}); // never resolves
+        },
+      );
+
+      renderHook(() => useChatStreamSocket('page-a', 'user-1'));
+      act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
+
+      capturedOnChunk('hello');
+      expect(mockAppendText).toHaveBeenCalledWith('msg-1', 'hello');
+    });
+
+    it('should call removeStream and onStreamComplete after consumeStreamJoin resolves', async () => {
+      let resolveJoin!: () => void;
+      mockConsumeStreamJoin.mockReturnValue(
+        new Promise<{ aborted: boolean }>((res) => { resolveJoin = () => res({ aborted: false }); }),
+      );
+      const onStreamComplete = vi.fn();
+
+      renderHook(() => useChatStreamSocket('page-a', 'user-1', onStreamComplete));
+      act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
+
+      await act(async () => { resolveJoin(); });
+
+      expect(mockRemoveStream).toHaveBeenCalledWith('msg-1');
+      expect(onStreamComplete).toHaveBeenCalledWith('msg-1');
+    });
+  });
+
+  describe('chat:stream_start from local user', () => {
+    it('should skip addStream and consumeStreamJoin when triggeredBy.userId matches currentUserId', () => {
+      const localPayload: AiStreamStartPayload = {
+        ...START_PAYLOAD,
+        triggeredBy: { userId: 'user-1', displayName: 'Me' },
+      };
+
+      renderHook(() => useChatStreamSocket('page-a', 'user-1'));
+      act(() => { mockSocket._trigger('chat:stream_start', localPayload); });
+
+      expect(mockAddStream).not.toHaveBeenCalled();
+      expect(mockConsumeStreamJoin).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('chat:stream_complete', () => {
+    it('should call removeStream and onStreamComplete', () => {
+      const onStreamComplete = vi.fn();
+      renderHook(() => useChatStreamSocket('page-a', 'user-1', onStreamComplete));
+
+      act(() => { mockSocket._trigger('chat:stream_complete', COMPLETE_PAYLOAD); });
+
+      expect(mockRemoveStream).toHaveBeenCalledWith('msg-1');
+      expect(onStreamComplete).toHaveBeenCalledWith('msg-1');
+    });
+
+    it('should abort the in-flight controller if one exists', async () => {
+      let capturedSignal!: AbortSignal;
+      mockConsumeStreamJoin.mockImplementation(
+        (_id: string, signal: AbortSignal) => {
+          capturedSignal = signal;
+          return new Promise(() => {}); // never resolves
+        },
+      );
+
+      renderHook(() => useChatStreamSocket('page-a', 'user-1'));
+      act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
+      act(() => { mockSocket._trigger('chat:stream_complete', COMPLETE_PAYLOAD); });
+
+      expect(capturedSignal.aborted).toBe(true);
+    });
+  });
+
+  describe('cleanup on unmount', () => {
+    it('should remove socket listeners, abort controllers, and clearPageStreams', () => {
+      const { unmount } = renderHook(() => useChatStreamSocket('page-a', 'user-1'));
+
+      act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
+
+      let capturedSignal!: AbortSignal;
+      // Re-check: consumeStreamJoin was called, signal captured from last call
+      const lastCall = mockConsumeStreamJoin.mock.calls.at(-1);
+      if (lastCall) capturedSignal = lastCall[1] as AbortSignal;
+
+      unmount();
+
+      if (capturedSignal) expect(capturedSignal.aborted).toBe(true);
+      expect(mockClearPageStreams).toHaveBeenCalledWith('page-a');
+      expect(mockSocket.off).toHaveBeenCalledWith('chat:stream_start', expect.any(Function));
+      expect(mockSocket.off).toHaveBeenCalledWith('chat:stream_complete', expect.any(Function));
+    });
+  });
+});

--- a/apps/web/src/hooks/__tests__/usePageSocketRoom.test.ts
+++ b/apps/web/src/hooks/__tests__/usePageSocketRoom.test.ts
@@ -5,6 +5,7 @@ const { mockSocket } = vi.hoisted(() => {
   const handlers: Record<string, (() => void)[]> = {};
 
   const mockSocket = {
+    connected: true,
     on: vi.fn((event: string, handler: () => void) => {
       if (!handlers[event]) handlers[event] = [];
       handlers[event].push(handler);
@@ -20,6 +21,7 @@ const { mockSocket } = vi.hoisted(() => {
     },
     _reset: () => {
       Object.keys(handlers).forEach((k) => { handlers[k] = []; });
+      mockSocket.connected = true;
     },
   };
 
@@ -49,6 +51,12 @@ describe('usePageSocketRoom', () => {
 
   it('given pageId is undefined, should not emit join_channel', () => {
     renderHook(() => usePageSocketRoom(undefined));
+    expect(mockSocket.emit).not.toHaveBeenCalled();
+  });
+
+  it('given socket is not yet connected at mount, should not emit join_channel', () => {
+    mockSocket.connected = false;
+    renderHook(() => usePageSocketRoom('page-a'));
     expect(mockSocket.emit).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/hooks/__tests__/usePageSocketRoom.test.ts
+++ b/apps/web/src/hooks/__tests__/usePageSocketRoom.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+const { mockSocket } = vi.hoisted(() => {
+  const handlers: Record<string, (() => void)[]> = {};
+
+  const mockSocket = {
+    on: vi.fn((event: string, handler: () => void) => {
+      if (!handlers[event]) handlers[event] = [];
+      handlers[event].push(handler);
+    }),
+    off: vi.fn((event: string, handler: () => void) => {
+      if (handlers[event]) {
+        handlers[event] = handlers[event].filter((h) => h !== handler);
+      }
+    }),
+    emit: vi.fn(),
+    _trigger: (event: string) => {
+      handlers[event]?.slice().forEach((h) => h());
+    },
+    _reset: () => {
+      Object.keys(handlers).forEach((k) => { handlers[k] = []; });
+    },
+  };
+
+  return { mockSocket };
+});
+
+vi.mock('@/hooks/useSocket', () => ({
+  useSocket: () => mockSocket,
+}));
+
+import { usePageSocketRoom } from '../usePageSocketRoom';
+
+describe('usePageSocketRoom', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSocket._reset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('given socket and pageId are available, should emit join_channel on mount', () => {
+    renderHook(() => usePageSocketRoom('page-a'));
+    expect(mockSocket.emit).toHaveBeenCalledWith('join_channel', 'page-a');
+  });
+
+  it('given pageId is undefined, should not emit join_channel', () => {
+    renderHook(() => usePageSocketRoom(undefined));
+    expect(mockSocket.emit).not.toHaveBeenCalled();
+  });
+
+  it('given pageId changes, should emit join_channel for the new pageId', () => {
+    let pageId = 'page-a';
+    const { rerender } = renderHook(() => usePageSocketRoom(pageId));
+
+    pageId = 'page-b';
+    rerender();
+
+    expect(mockSocket.emit).toHaveBeenCalledWith('join_channel', 'page-a');
+    expect(mockSocket.emit).toHaveBeenCalledWith('join_channel', 'page-b');
+  });
+
+  // B1 — reconnect re-join
+  it('given socket reconnects while hook is mounted, should re-emit join_channel', () => {
+    renderHook(() => usePageSocketRoom('page-a'));
+
+    const countAfterMount = mockSocket.emit.mock.calls.length;
+
+    act(() => { mockSocket._trigger('connect'); });
+
+    expect(mockSocket.emit.mock.calls.length).toBe(countAfterMount + 1);
+    expect(mockSocket.emit).toHaveBeenLastCalledWith('join_channel', 'page-a');
+  });
+
+  it('given unmount, should remove the connect listener so reconnects no longer emit', () => {
+    const { unmount } = renderHook(() => usePageSocketRoom('page-a'));
+
+    unmount();
+
+    expect(mockSocket.off).toHaveBeenCalledWith('connect', expect.any(Function));
+  });
+});

--- a/apps/web/src/hooks/useChatStreamSocket.ts
+++ b/apps/web/src/hooks/useChatStreamSocket.ts
@@ -11,6 +11,12 @@ export function useChatStreamSocket(
 ): void {
   const socket = useSocket();
   const controllersRef = useRef<Map<string, AbortController>>(new Map());
+  // Tracks which messageIds have had onStreamComplete called to prevent double-firing
+  // when both the SSE done sentinel and the chat:stream_complete socket event arrive.
+  const processedRef = useRef<Set<string>>(new Set());
+  // Stable ref so onStreamComplete changes never cause handler re-registration.
+  const onStreamCompleteRef = useRef(onStreamComplete);
+  onStreamCompleteRef.current = onStreamComplete;
 
   useEffect(() => {
     if (!socket || !pageId) return;
@@ -18,7 +24,15 @@ export function useChatStreamSocket(
     const { addStream, appendText, removeStream, clearPageStreams } =
       usePendingStreamsStore.getState();
 
+    const fireComplete = (messageId: string) => {
+      if (processedRef.current.has(messageId)) return;
+      processedRef.current.add(messageId);
+      onStreamCompleteRef.current?.(messageId);
+    };
+
     const handleStreamStart = (payload: AiStreamStartPayload) => {
+      // A1: ignore events for other pages (stale-room guard)
+      if (payload.pageId !== pageId) return;
       if (payload.triggeredBy.userId === currentUserId) return;
 
       addStream({
@@ -37,21 +51,26 @@ export function useChatStreamSocket(
         .then(() => {
           controllersRef.current.delete(payload.messageId);
           removeStream(payload.messageId);
-          onStreamComplete?.(payload.messageId);
+          fireComplete(payload.messageId);
         })
-        .catch(() => {
+        .catch((err) => {
           controllersRef.current.delete(payload.messageId);
+          if (!controller.signal.aborted) {
+            console.error('[useChatStreamSocket] SSE join error:', err);
+          }
         });
     };
 
     const handleStreamComplete = (payload: AiStreamCompletePayload) => {
+      // A1: ignore events for other pages (stale-room guard)
+      if (payload.pageId !== pageId) return;
       const controller = controllersRef.current.get(payload.messageId);
       if (controller) {
         controller.abort();
         controllersRef.current.delete(payload.messageId);
       }
       removeStream(payload.messageId);
-      onStreamComplete?.(payload.messageId);
+      fireComplete(payload.messageId);
     };
 
     socket.on('chat:stream_start', handleStreamStart);
@@ -64,7 +83,8 @@ export function useChatStreamSocket(
         controller.abort();
       }
       controllersRef.current.clear();
+      processedRef.current.clear();
       clearPageStreams(pageId);
     };
-  }, [socket, pageId, currentUserId, onStreamComplete]);
+  }, [socket, pageId, currentUserId]); // A3: onStreamComplete intentionally excluded — use ref
 }

--- a/apps/web/src/hooks/useChatStreamSocket.ts
+++ b/apps/web/src/hooks/useChatStreamSocket.ts
@@ -1,0 +1,70 @@
+import { useEffect, useRef } from 'react';
+import { useSocket } from './useSocket';
+import { usePendingStreamsStore } from '@/stores/usePendingStreamsStore';
+import { consumeStreamJoin } from '@/lib/ai/core/stream-join-client';
+import type { AiStreamStartPayload, AiStreamCompletePayload } from '@/lib/websocket/socket-utils';
+
+export function useChatStreamSocket(
+  pageId: string | undefined,
+  currentUserId: string | undefined,
+  onStreamComplete?: (messageId: string) => void,
+): void {
+  const socket = useSocket();
+  const controllersRef = useRef<Map<string, AbortController>>(new Map());
+
+  useEffect(() => {
+    if (!socket || !pageId) return;
+
+    const { addStream, appendText, removeStream, clearPageStreams } =
+      usePendingStreamsStore.getState();
+
+    const handleStreamStart = (payload: AiStreamStartPayload) => {
+      if (payload.triggeredBy.userId === currentUserId) return;
+
+      addStream({
+        messageId: payload.messageId,
+        pageId: payload.pageId,
+        conversationId: payload.conversationId,
+        triggeredBy: payload.triggeredBy,
+      });
+
+      const controller = new AbortController();
+      controllersRef.current.set(payload.messageId, controller);
+
+      consumeStreamJoin(payload.messageId, controller.signal, (chunk) => {
+        appendText(payload.messageId, chunk);
+      })
+        .then(() => {
+          controllersRef.current.delete(payload.messageId);
+          removeStream(payload.messageId);
+          onStreamComplete?.(payload.messageId);
+        })
+        .catch(() => {
+          controllersRef.current.delete(payload.messageId);
+        });
+    };
+
+    const handleStreamComplete = (payload: AiStreamCompletePayload) => {
+      const controller = controllersRef.current.get(payload.messageId);
+      if (controller) {
+        controller.abort();
+        controllersRef.current.delete(payload.messageId);
+      }
+      removeStream(payload.messageId);
+      onStreamComplete?.(payload.messageId);
+    };
+
+    socket.on('chat:stream_start', handleStreamStart);
+    socket.on('chat:stream_complete', handleStreamComplete);
+
+    return () => {
+      socket.off('chat:stream_start', handleStreamStart);
+      socket.off('chat:stream_complete', handleStreamComplete);
+      for (const controller of controllersRef.current.values()) {
+        controller.abort();
+      }
+      controllersRef.current.clear();
+      clearPageStreams(pageId);
+    };
+  }, [socket, pageId, currentUserId, onStreamComplete]);
+}

--- a/apps/web/src/hooks/useChatStreamSocket.ts
+++ b/apps/web/src/hooks/useChatStreamSocket.ts
@@ -55,6 +55,7 @@ export function useChatStreamSocket(
         })
         .catch((err) => {
           controllersRef.current.delete(payload.messageId);
+          removeStream(payload.messageId);
           if (!controller.signal.aborted) {
             console.error('[useChatStreamSocket] SSE join error:', err);
           }

--- a/apps/web/src/hooks/usePageSocketRoom.ts
+++ b/apps/web/src/hooks/usePageSocketRoom.ts
@@ -1,0 +1,11 @@
+import { useEffect } from 'react';
+import { useSocket } from './useSocket';
+
+export function usePageSocketRoom(pageId: string | undefined): void {
+  const socket = useSocket();
+
+  useEffect(() => {
+    if (!socket || !pageId) return;
+    socket.emit('join_channel', pageId);
+  }, [socket, pageId]);
+}

--- a/apps/web/src/hooks/usePageSocketRoom.ts
+++ b/apps/web/src/hooks/usePageSocketRoom.ts
@@ -6,6 +6,9 @@ export function usePageSocketRoom(pageId: string | undefined): void {
 
   useEffect(() => {
     if (!socket || !pageId) return;
-    socket.emit('join_channel', pageId);
+    const join = () => socket.emit('join_channel', pageId);
+    join();
+    socket.on('connect', join);
+    return () => { socket.off('connect', join); };
   }, [socket, pageId]);
 }

--- a/apps/web/src/hooks/usePageSocketRoom.ts
+++ b/apps/web/src/hooks/usePageSocketRoom.ts
@@ -6,7 +6,10 @@ export function usePageSocketRoom(pageId: string | undefined): void {
 
   useEffect(() => {
     if (!socket || !pageId) return;
-    const join = () => socket.emit('join_channel', pageId);
+    const join = () => {
+      if (!socket.connected) return;
+      socket.emit('join_channel', pageId);
+    };
     join();
     socket.on('connect', join);
     return () => { socket.off('connect', join); };

--- a/apps/web/src/lib/ai/core/__tests__/stream-join-client.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stream-join-client.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+describe('consumeStreamJoin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function encodeLines(lines: string[]): ReadableStream<Uint8Array> {
+    const encoder = new TextEncoder();
+    return new ReadableStream({
+      start(controller) {
+        for (const line of lines) {
+          controller.enqueue(encoder.encode(line));
+        }
+        controller.close();
+      },
+    });
+  }
+
+  function stubFetch(body: ReadableStream<Uint8Array>, ok = true, status = 200) {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok, status, body }),
+    );
+  }
+
+  it('given valid SSE chunks and done sentinel, should call onChunk for each text and return { aborted: false }', async () => {
+    stubFetch(encodeLines([
+      'data: {"text":"hello"}\n\n',
+      'data: {"text":" world"}\n\n',
+      'data: {"done":true,"aborted":false}\n\n',
+    ]));
+
+    const { consumeStreamJoin } = await import('../stream-join-client');
+    const onChunk = vi.fn();
+    const result = await consumeStreamJoin('msg-1', AbortSignal.timeout(5000), onChunk);
+
+    expect(onChunk).toHaveBeenCalledTimes(2);
+    expect(onChunk).toHaveBeenNthCalledWith(1, 'hello');
+    expect(onChunk).toHaveBeenNthCalledWith(2, ' world');
+    expect(result).toEqual({ aborted: false });
+  });
+
+  it('given done sentinel with aborted: true, should return { aborted: true } without throwing', async () => {
+    stubFetch(encodeLines([
+      'data: {"text":"partial"}\n\n',
+      'data: {"done":true,"aborted":true}\n\n',
+    ]));
+
+    const { consumeStreamJoin } = await import('../stream-join-client');
+    const onChunk = vi.fn();
+    const result = await consumeStreamJoin('msg-2', AbortSignal.timeout(5000), onChunk);
+
+    expect(onChunk).toHaveBeenCalledWith('partial');
+    expect(result).toEqual({ aborted: true });
+  });
+
+  it('given signal is already aborted, should return { aborted: true } without calling onChunk', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(Object.assign(new Error('The operation was aborted.'), { name: 'AbortError' })),
+    );
+
+    const { consumeStreamJoin } = await import('../stream-join-client');
+    const onChunk = vi.fn();
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await consumeStreamJoin('msg-3', controller.signal, onChunk);
+
+    expect(result).toEqual({ aborted: true });
+    expect(onChunk).not.toHaveBeenCalled();
+  });
+
+  it('given non-2xx response, should throw an error with the status', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 403, body: encodeLines([]) }),
+    );
+
+    const { consumeStreamJoin } = await import('../stream-join-client');
+
+    await expect(
+      consumeStreamJoin('msg-4', AbortSignal.timeout(5000), vi.fn()),
+    ).rejects.toThrow('403');
+  });
+
+  it('given malformed SSE lines, should skip them and continue processing', async () => {
+    stubFetch(encodeLines([
+      'data: not-json\n\n',
+      'comment: ignored\n\n',
+      'data: {"text":"ok"}\n\n',
+      'data: {"done":true,"aborted":false}\n\n',
+    ]));
+
+    const { consumeStreamJoin } = await import('../stream-join-client');
+    const onChunk = vi.fn();
+    const result = await consumeStreamJoin('msg-5', AbortSignal.timeout(5000), onChunk);
+
+    expect(onChunk).toHaveBeenCalledTimes(1);
+    expect(onChunk).toHaveBeenCalledWith('ok');
+    expect(result).toEqual({ aborted: false });
+  });
+
+  it('given fetch call, should include credentials and the correct URL', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: encodeLines(['data: {"done":true,"aborted":false}\n\n']),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { consumeStreamJoin } = await import('../stream-join-client');
+    await consumeStreamJoin('msg-xyz', AbortSignal.timeout(5000), vi.fn());
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/ai/chat/stream-join/msg-xyz',
+      expect.objectContaining({ credentials: 'include' }),
+    );
+  });
+});

--- a/apps/web/src/lib/ai/core/__tests__/stream-join-client.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stream-join-client.test.ts
@@ -122,4 +122,59 @@ describe('consumeStreamJoin', () => {
       expect.objectContaining({ credentials: 'include' }),
     );
   });
+
+  // C1 — encodeURIComponent
+  it('given messageId with special characters, should URL-encode it in the request', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      body: encodeLines(['data: {"done":true,"aborted":false}\n\n']),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { consumeStreamJoin } = await import('../stream-join-client');
+    await consumeStreamJoin('msg/with spaces', AbortSignal.timeout(5000), vi.fn());
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/ai/chat/stream-join/msg%2Fwith%20spaces',
+      expect.any(Object),
+    );
+  });
+
+  // C2 — null body guard
+  it('given a 2xx response with a null body, should throw', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, status: 200, body: null }),
+    );
+
+    const { consumeStreamJoin } = await import('../stream-join-client');
+
+    await expect(
+      consumeStreamJoin('msg-null', AbortSignal.timeout(5000), vi.fn()),
+    ).rejects.toThrow();
+  });
+
+  // C5 — partial-chunk buffer
+  it('given SSE line split across two read chunks, should buffer and parse correctly', async () => {
+    const encoder = new TextEncoder();
+    // 'data: {"text":"hello"}\n\n' split mid-JSON across two enqueues
+    const halfA = 'data: {"text"';
+    const halfB = ':"hello"}\n\ndata: {"done":true,"aborted":false}\n\n';
+
+    stubFetch(new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(halfA));
+        controller.enqueue(encoder.encode(halfB));
+        controller.close();
+      },
+    }));
+
+    const { consumeStreamJoin } = await import('../stream-join-client');
+    const onChunk = vi.fn();
+    const result = await consumeStreamJoin('msg-split', AbortSignal.timeout(5000), onChunk);
+
+    expect(onChunk).toHaveBeenCalledWith('hello');
+    expect(result).toEqual({ aborted: false });
+  });
 });

--- a/apps/web/src/lib/ai/core/stream-join-client.ts
+++ b/apps/web/src/lib/ai/core/stream-join-client.ts
@@ -1,0 +1,69 @@
+export async function consumeStreamJoin(
+  messageId: string,
+  signal: AbortSignal,
+  onChunk: (text: string) => void,
+): Promise<{ aborted: boolean }> {
+  let response: Response;
+  try {
+    response = await fetch(`/api/ai/chat/stream-join/${messageId}`, {
+      credentials: 'include',
+      signal,
+    });
+  } catch (err) {
+    if (signal.aborted || (err instanceof Error && err.name === 'AbortError')) {
+      return { aborted: true };
+    }
+    throw err;
+  }
+
+  if (!response.ok) {
+    throw new Error(`Stream join failed with status ${response.status}`);
+  }
+
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  try {
+    while (true) {
+      if (signal.aborted) {
+        return { aborted: true };
+      }
+
+      let done: boolean;
+      let value: Uint8Array | undefined;
+      try {
+        ({ done, value } = await reader.read());
+      } catch (readErr) {
+        if (signal.aborted) return { aborted: true };
+        throw readErr;
+      }
+
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+
+      for (const line of lines) {
+        if (!line.startsWith('data: ')) continue;
+        const jsonStr = line.slice('data: '.length);
+        try {
+          const parsed = JSON.parse(jsonStr) as Record<string, unknown>;
+          if (parsed.done) {
+            return { aborted: (parsed.aborted as boolean | undefined) ?? false };
+          }
+          if (typeof parsed.text === 'string') {
+            onChunk(parsed.text);
+          }
+        } catch {
+          // skip malformed SSE lines
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return { aborted: false };
+}

--- a/apps/web/src/lib/ai/core/stream-join-client.ts
+++ b/apps/web/src/lib/ai/core/stream-join-client.ts
@@ -5,7 +5,7 @@ export async function consumeStreamJoin(
 ): Promise<{ aborted: boolean }> {
   let response: Response;
   try {
-    response = await fetch(`/api/ai/chat/stream-join/${messageId}`, {
+    response = await fetch(`/api/ai/chat/stream-join/${encodeURIComponent(messageId)}`, {
       credentials: 'include',
       signal,
     });
@@ -20,7 +20,10 @@ export async function consumeStreamJoin(
     throw new Error(`Stream join failed with status ${response.status}`);
   }
 
-  const reader = response.body!.getReader();
+  if (!response.body) {
+    throw new Error(`Stream join response has no body (status ${response.status})`);
+  }
+  const reader = response.body.getReader();
   const decoder = new TextDecoder();
   let buffer = '';
 

--- a/apps/web/src/stores/__tests__/usePendingStreamsStore.test.ts
+++ b/apps/web/src/stores/__tests__/usePendingStreamsStore.test.ts
@@ -14,27 +14,29 @@ describe('usePendingStreamsStore', () => {
   });
 
   describe('initial state', () => {
-    it('given store is created, should have no streams', () => {
-      const { streams } = usePendingStreamsStore.getState();
-      expect(streams.size).toBe(0);
+    it('given store is created, should have no streams for any page', () => {
+      const { getRemotePageStreams } = usePendingStreamsStore.getState();
+      expect(getRemotePageStreams('page-a')).toEqual([]);
     });
   });
 
   describe('addStream', () => {
     it('given a new stream, should add it with empty text', () => {
-      const { addStream, streams } = usePendingStreamsStore.getState();
+      const { addStream } = usePendingStreamsStore.getState();
       addStream(BASE_STREAM);
 
-      const stream = usePendingStreamsStore.getState().streams.get('msg-1');
+      const { getRemotePageStreams } = usePendingStreamsStore.getState();
+      const [stream] = getRemotePageStreams('page-a');
       expect(stream).toEqual({ ...BASE_STREAM, text: '' });
     });
 
-    it('given two streams for different messages, should store both', () => {
+    it('given two streams for the same page, should store both', () => {
       const { addStream } = usePendingStreamsStore.getState();
       addStream(BASE_STREAM);
       addStream({ ...BASE_STREAM, messageId: 'msg-2' });
 
-      expect(usePendingStreamsStore.getState().streams.size).toBe(2);
+      const { getRemotePageStreams } = usePendingStreamsStore.getState();
+      expect(getRemotePageStreams('page-a')).toHaveLength(2);
     });
   });
 
@@ -45,8 +47,9 @@ describe('usePendingStreamsStore', () => {
       appendText('msg-1', 'hello');
       appendText('msg-1', ' world');
 
-      const stream = usePendingStreamsStore.getState().streams.get('msg-1');
-      expect(stream?.text).toBe('hello world');
+      const { getRemotePageStreams } = usePendingStreamsStore.getState();
+      const [stream] = getRemotePageStreams('page-a');
+      expect(stream.text).toBe('hello world');
     });
 
     it('given unknown messageId, should not throw', () => {
@@ -61,7 +64,8 @@ describe('usePendingStreamsStore', () => {
       addStream(BASE_STREAM);
       removeStream('msg-1');
 
-      expect(usePendingStreamsStore.getState().streams.size).toBe(0);
+      const { getRemotePageStreams } = usePendingStreamsStore.getState();
+      expect(getRemotePageStreams('page-a')).toHaveLength(0);
     });
 
     it('given unknown messageId, should not throw', () => {
@@ -71,7 +75,7 @@ describe('usePendingStreamsStore', () => {
   });
 
   describe('clearPageStreams', () => {
-    it('given streams for a page, should remove only that page\'s streams', () => {
+    it("given streams for a page, should remove only that page's streams", () => {
       const { addStream, clearPageStreams } = usePendingStreamsStore.getState();
       addStream(BASE_STREAM);
       addStream({ ...BASE_STREAM, messageId: 'msg-2' });
@@ -79,9 +83,9 @@ describe('usePendingStreamsStore', () => {
 
       clearPageStreams('page-a');
 
-      const remaining = usePendingStreamsStore.getState().streams;
-      expect(remaining.size).toBe(1);
-      expect(remaining.has('msg-3')).toBe(true);
+      const { getRemotePageStreams } = usePendingStreamsStore.getState();
+      expect(getRemotePageStreams('page-a')).toHaveLength(0);
+      expect(getRemotePageStreams('page-b')).toHaveLength(1);
     });
 
     it('given no streams for the page, should not throw', () => {
@@ -91,7 +95,7 @@ describe('usePendingStreamsStore', () => {
   });
 
   describe('getRemotePageStreams', () => {
-    it('given streams for multiple pages, should return only the requested page\'s streams', () => {
+    it("given streams for multiple pages, should return only the requested page's streams", () => {
       const { addStream, getRemotePageStreams } = usePendingStreamsStore.getState();
       addStream(BASE_STREAM);
       addStream({ ...BASE_STREAM, messageId: 'msg-2' });
@@ -99,7 +103,7 @@ describe('usePendingStreamsStore', () => {
 
       const streams = getRemotePageStreams('page-a');
       expect(streams).toHaveLength(2);
-      expect(streams.every(s => s.pageId === 'page-a')).toBe(true);
+      expect(streams.every((s) => s.pageId === 'page-a')).toBe(true);
     });
 
     it('given no streams for the page, should return empty array', () => {

--- a/apps/web/src/stores/__tests__/usePendingStreamsStore.test.ts
+++ b/apps/web/src/stores/__tests__/usePendingStreamsStore.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { usePendingStreamsStore } from '../usePendingStreamsStore';
+
+const BASE_STREAM = {
+  messageId: 'msg-1',
+  pageId: 'page-a',
+  conversationId: 'conv-1',
+  triggeredBy: { userId: 'user-2', displayName: 'Alice' },
+};
+
+describe('usePendingStreamsStore', () => {
+  beforeEach(() => {
+    usePendingStreamsStore.setState({ streams: new Map() });
+  });
+
+  describe('initial state', () => {
+    it('given store is created, should have no streams', () => {
+      const { streams } = usePendingStreamsStore.getState();
+      expect(streams.size).toBe(0);
+    });
+  });
+
+  describe('addStream', () => {
+    it('given a new stream, should add it with empty text', () => {
+      const { addStream, streams } = usePendingStreamsStore.getState();
+      addStream(BASE_STREAM);
+
+      const stream = usePendingStreamsStore.getState().streams.get('msg-1');
+      expect(stream).toEqual({ ...BASE_STREAM, text: '' });
+    });
+
+    it('given two streams for different messages, should store both', () => {
+      const { addStream } = usePendingStreamsStore.getState();
+      addStream(BASE_STREAM);
+      addStream({ ...BASE_STREAM, messageId: 'msg-2' });
+
+      expect(usePendingStreamsStore.getState().streams.size).toBe(2);
+    });
+  });
+
+  describe('appendText', () => {
+    it('given an existing stream, should accumulate text chunks', () => {
+      const { addStream, appendText } = usePendingStreamsStore.getState();
+      addStream(BASE_STREAM);
+      appendText('msg-1', 'hello');
+      appendText('msg-1', ' world');
+
+      const stream = usePendingStreamsStore.getState().streams.get('msg-1');
+      expect(stream?.text).toBe('hello world');
+    });
+
+    it('given unknown messageId, should not throw', () => {
+      const { appendText } = usePendingStreamsStore.getState();
+      expect(() => appendText('unknown', 'text')).not.toThrow();
+    });
+  });
+
+  describe('removeStream', () => {
+    it('given an existing stream, should remove it', () => {
+      const { addStream, removeStream } = usePendingStreamsStore.getState();
+      addStream(BASE_STREAM);
+      removeStream('msg-1');
+
+      expect(usePendingStreamsStore.getState().streams.size).toBe(0);
+    });
+
+    it('given unknown messageId, should not throw', () => {
+      const { removeStream } = usePendingStreamsStore.getState();
+      expect(() => removeStream('unknown')).not.toThrow();
+    });
+  });
+
+  describe('clearPageStreams', () => {
+    it('given streams for a page, should remove only that page\'s streams', () => {
+      const { addStream, clearPageStreams } = usePendingStreamsStore.getState();
+      addStream(BASE_STREAM);
+      addStream({ ...BASE_STREAM, messageId: 'msg-2' });
+      addStream({ ...BASE_STREAM, messageId: 'msg-3', pageId: 'page-b' });
+
+      clearPageStreams('page-a');
+
+      const remaining = usePendingStreamsStore.getState().streams;
+      expect(remaining.size).toBe(1);
+      expect(remaining.has('msg-3')).toBe(true);
+    });
+
+    it('given no streams for the page, should not throw', () => {
+      const { clearPageStreams } = usePendingStreamsStore.getState();
+      expect(() => clearPageStreams('page-missing')).not.toThrow();
+    });
+  });
+
+  describe('getRemotePageStreams', () => {
+    it('given streams for multiple pages, should return only the requested page\'s streams', () => {
+      const { addStream, getRemotePageStreams } = usePendingStreamsStore.getState();
+      addStream(BASE_STREAM);
+      addStream({ ...BASE_STREAM, messageId: 'msg-2' });
+      addStream({ ...BASE_STREAM, messageId: 'msg-3', pageId: 'page-b' });
+
+      const streams = getRemotePageStreams('page-a');
+      expect(streams).toHaveLength(2);
+      expect(streams.every(s => s.pageId === 'page-a')).toBe(true);
+    });
+
+    it('given no streams for the page, should return empty array', () => {
+      const { getRemotePageStreams } = usePendingStreamsStore.getState();
+      expect(getRemotePageStreams('page-empty')).toEqual([]);
+    });
+
+    it('given appended text, should reflect accumulated text in returned stream', () => {
+      const { addStream, appendText, getRemotePageStreams } = usePendingStreamsStore.getState();
+      addStream(BASE_STREAM);
+      appendText('msg-1', 'chunk-a');
+      appendText('msg-1', 'chunk-b');
+
+      const [stream] = getRemotePageStreams('page-a');
+      expect(stream.text).toBe('chunk-achunk-b');
+    });
+  });
+});

--- a/apps/web/src/stores/usePendingStreamsStore.ts
+++ b/apps/web/src/stores/usePendingStreamsStore.ts
@@ -1,0 +1,62 @@
+import { create } from 'zustand';
+
+export interface PendingStream {
+  messageId: string;
+  pageId: string;
+  conversationId: string;
+  triggeredBy: { userId: string; displayName: string };
+  text: string;
+}
+
+interface PendingStreamsState {
+  streams: Map<string, PendingStream>;
+  addStream: (stream: Omit<PendingStream, 'text'>) => void;
+  appendText: (messageId: string, chunk: string) => void;
+  removeStream: (messageId: string) => void;
+  clearPageStreams: (pageId: string) => void;
+  getRemotePageStreams: (pageId: string) => PendingStream[];
+}
+
+export const usePendingStreamsStore = create<PendingStreamsState>((set, get) => ({
+  streams: new Map(),
+
+  addStream: (stream) => {
+    set((state) => {
+      const next = new Map(state.streams);
+      next.set(stream.messageId, { ...stream, text: '' });
+      return { streams: next };
+    });
+  },
+
+  appendText: (messageId, chunk) => {
+    set((state) => {
+      const existing = state.streams.get(messageId);
+      if (!existing) return state;
+      const next = new Map(state.streams);
+      next.set(messageId, { ...existing, text: existing.text + chunk });
+      return { streams: next };
+    });
+  },
+
+  removeStream: (messageId) => {
+    set((state) => {
+      const next = new Map(state.streams);
+      next.delete(messageId);
+      return { streams: next };
+    });
+  },
+
+  clearPageStreams: (pageId) => {
+    set((state) => {
+      const next = new Map(state.streams);
+      for (const [id, stream] of next) {
+        if (stream.pageId === pageId) next.delete(id);
+      }
+      return { streams: next };
+    });
+  },
+
+  getRemotePageStreams: (pageId) => {
+    return Array.from(get().streams.values()).filter((s) => s.pageId === pageId);
+  },
+}));

--- a/apps/web/src/stores/usePendingStreamsStore.ts
+++ b/apps/web/src/stores/usePendingStreamsStore.ts
@@ -47,13 +47,9 @@ export const usePendingStreamsStore = create<PendingStreamsState>((set, get) => 
   },
 
   clearPageStreams: (pageId) => {
-    set((state) => {
-      const next = new Map(state.streams);
-      for (const [id, stream] of next) {
-        if (stream.pageId === pageId) next.delete(id);
-      }
-      return { streams: next };
-    });
+    set((state) => ({
+      streams: new Map([...state.streams].filter(([, s]) => s.pageId !== pageId)),
+    }));
   },
 
   getRemotePageStreams: (pageId) => {

--- a/tasks/multiplayer-ai-chat-streaming.md
+++ b/tasks/multiplayer-ai-chat-streaming.md
@@ -64,6 +64,10 @@ Implement a Zustand store and socket hook that tracks in-progress remote streams
 - Given incoming SSE chunks for a non-local stream, should accumulate text in the store keyed by messageId
 - Given `chat:stream_complete`, should remove the stream and call the completion callback
 - Given page unmount, should abort all in-flight join connections and clear all page streams from the store
+- Given `chat:stream_start` with a different pageId than the active page, should ignore the event (stale-room guard)
+- Given `chat:stream_complete` with a different pageId than the active page, should ignore the event
+- Given SSE done sentinel resolves and `chat:stream_complete` also fires, should call `onStreamComplete` exactly once
+- Given the socket reconnects while the hook is mounted, should re-emit `join_channel` to rejoin the page room
 
 ### Task 5: Multiplayer Chat UI
 **Status:** Pending

--- a/tasks/multiplayer-ai-chat-streaming.md
+++ b/tasks/multiplayer-ai-chat-streaming.md
@@ -55,7 +55,8 @@ Wire `chat:stream_start` and `chat:stream_complete` socket broadcasts into the A
 - Given a route error that skips `onFinish`, should still emit `chat:stream_complete` via a finally path
 
 ### Task 4: AI Stream Client State
-**Status:** Pending
+**Status:** ✅ COMPLETED
+**PR:** https://github.com/2witstudios/PageSpace/pull/1149
 
 Implement a Zustand store and socket hook that tracks in-progress remote streams and accumulates ghost text.
 


### PR DESCRIPTION
## Summary

Task 4 of the [Multiplayer AI Chat Streaming epic](../tasks/multiplayer-ai-chat-streaming.md). Tasks 1–3 (server multicast registry, SSE join endpoint, socket broadcasts) are already merged. This PR wires the client side so all page viewers receive the AI stream in real-time.

### New files
- **`consumeStreamJoin`** (`lib/ai/core/stream-join-client.ts`) — pure async SSE reader: fetches `/api/ai/chat/stream-join/[messageId]`, streams `data: {"text":"..."}` chunks via `onChunk`, returns `{ aborted }` from the done sentinel. URL-encodes the messageId; guards null body with a thrown error (no `!` assertion).
- **`usePendingStreamsStore`** (`stores/usePendingStreamsStore.ts`) — Zustand store for **remote-only** streams keyed by `messageId`. Actions: `addStream`, `appendText`, `removeStream`, `clearPageStreams`. Selector: `getRemotePageStreams(pageId)`. Local streams stay in `useEditingStore` — no dual tracking.
- **`usePageSocketRoom`** (`hooks/usePageSocketRoom.ts`) — emits `join_channel pageId` on mount (only when `socket.connected`) and on every socket `connect` event (handles reconnects). Cleans up `connect` listener on unmount. Aligns with `usePageTreeSocket` / `useCalendarSocket` pattern.
- **`useChatStreamSocket`** (`hooks/useChatStreamSocket.ts`) — lifecycle hook with four key properties:
  - **pageId guard**: drops `stream_start` / `stream_complete` events from stale rooms (other pages)
  - **callback ref**: `onStreamComplete` stored in a ref so handler re-registration never fires on callback identity change
  - **deduplication mutex**: `processedRef` Set ensures `onStreamComplete` fires exactly once even when both the SSE done sentinel and `chat:stream_complete` socket event arrive
  - **AbortControllers in `useRef`**: not in Zustand; all aborted + cleared on unmount
  - **Error cleanup**: `.catch()` calls both `controllersRef.current.delete` and `removeStream` so failed SSE joins never leave stale pending-stream entries
- **`AiChatView`** — wired with `usePageSocketRoom(page.id)` and `useChatStreamSocket(page.id, user?.id)` after `useStreamingRegistration`. `onStreamComplete` intentionally left undefined — Task 5 wires the SWR revalidation.

## Test plan

- [x] `consumeStreamJoin` — 9 tests: SSE chunks, aborted sentinel, pre-aborted signal, non-2xx, malformed lines, credentials/URL, encodeURIComponent, null body guard, partial-chunk buffer
- [x] `usePendingStreamsStore` — 12 tests (all read via `getRemotePageStreams` selector): add, appendText accumulation, remove, clearPageStreams scoping, selector
- [x] `usePageSocketRoom` — 6 tests: mount join, undefined pageId, socket-not-connected-at-mount, pageId change, reconnect re-join, unmount cleanup
- [x] `useChatStreamSocket` — 14 tests: remote start, onChunk wiring, resolve completion, SSE error cleanup (removeStream called on reject), local start skip, pageId guard (start + complete), stream_complete abort, double-callback deduplication (both orderings), callback ref stability (no re-register, latest ref invoked), unmount cleanup
- [x] 41 tests total, all passing; 3631 pre-existing tests unaffected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)