### PR TITLE
fix(ai): resolve integration tools for agents @mentioned in channels

### DIFF
--- a/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
@@ -172,6 +172,25 @@ describe('agent-communication-tools', () => {
   });
 
   describe('ask_agent', () => {
+    beforeEach(() => {
+      mockCanUserViewPage.mockResolvedValue(true);
+      vi.mocked(mockDb.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            orderBy: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      } as never);
+      vi.mocked(createAIProvider).mockResolvedValue({
+        model: { modelId: 'test-model' } as unknown as ReturnType<typeof createAIProvider> extends Promise<infer T> ? T extends { model: infer M } ? M : never : never,
+      } as Awaited<ReturnType<typeof createAIProvider>>);
+      vi.mocked(generateText).mockResolvedValue({
+        text: 'Agent response',
+        steps: [],
+      } as unknown as ReturnType<typeof generateText> extends Promise<infer T> ? T : never);
+      vi.mocked(saveMessageToDatabase).mockResolvedValue(undefined);
+    });
+
     it('has correct tool definition', () => {
       expect(agentCommunicationTools.ask_agent).toBeDefined();
       expect(agentCommunicationTools.ask_agent.description).toContain('Consult');
@@ -290,22 +309,6 @@ describe('agent-communication-tools', () => {
 
       beforeEach(() => {
         mockDb.query.pages.findFirst = vi.fn().mockResolvedValue(mockAgent);
-        mockCanUserViewPage.mockResolvedValue(true);
-        vi.mocked(mockDb.select).mockReturnValue({
-          from: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({
-              orderBy: vi.fn().mockResolvedValue([]),
-            }),
-          }),
-        } as never);
-        vi.mocked(createAIProvider).mockResolvedValue({
-          model: { modelId: 'test-model' } as unknown as ReturnType<typeof createAIProvider> extends Promise<infer T> ? T extends { model: infer M } ? M : never : never,
-        } as Awaited<ReturnType<typeof createAIProvider>>);
-        vi.mocked(generateText).mockResolvedValue({
-          text: 'Agent response',
-          steps: [],
-        } as unknown as ReturnType<typeof generateText> extends Promise<infer T> ? T : never);
-        vi.mocked(saveMessageToDatabase).mockResolvedValue(undefined);
       });
 
       it('should set parentAgentId from calling agent location context', async () => {
@@ -529,22 +532,6 @@ describe('agent-communication-tools', () => {
 
       beforeEach(() => {
         mockDb.query.pages.findFirst = vi.fn().mockResolvedValue(mockAgent);
-        mockCanUserViewPage.mockResolvedValue(true);
-        vi.mocked(mockDb.select).mockReturnValue({
-          from: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({
-              orderBy: vi.fn().mockResolvedValue([]),
-            }),
-          }),
-        } as never);
-        vi.mocked(createAIProvider).mockResolvedValue({
-          model: { modelId: 'test-model' } as unknown as ReturnType<typeof createAIProvider> extends Promise<infer T> ? T extends { model: infer M } ? M : never : never,
-        } as Awaited<ReturnType<typeof createAIProvider>>);
-        vi.mocked(generateText).mockResolvedValue({
-          text: 'Agent response',
-          steps: [],
-        } as unknown as ReturnType<typeof generateText> extends Promise<infer T> ? T : never);
-        vi.mocked(saveMessageToDatabase).mockResolvedValue(undefined);
       });
 
       it('should pass sourceAgentId when called from an AI_CHAT page', async () => {
@@ -660,22 +647,6 @@ describe('agent-communication-tools', () => {
 
       beforeEach(() => {
         mockDb.query.pages.findFirst = vi.fn().mockResolvedValue(mockAgent);
-        mockCanUserViewPage.mockResolvedValue(true);
-        vi.mocked(mockDb.select).mockReturnValue({
-          from: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({
-              orderBy: vi.fn().mockResolvedValue([]),
-            }),
-          }),
-        } as never);
-        vi.mocked(createAIProvider).mockResolvedValue({
-          model: { modelId: 'test-model' } as unknown as ReturnType<typeof createAIProvider> extends Promise<infer T> ? T extends { model: infer M } ? M : never : never,
-        } as Awaited<ReturnType<typeof createAIProvider>>);
-        vi.mocked(generateText).mockResolvedValue({
-          text: 'Agent response',
-          steps: [],
-        } as unknown as ReturnType<typeof generateText> extends Promise<infer T> ? T : never);
-        vi.mocked(saveMessageToDatabase).mockResolvedValue(undefined);
       });
 
       it('merges integration tools into the generateText tools call', async () => {

--- a/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
@@ -73,6 +73,10 @@ vi.mock('../agent-tools', () => ({
   agentTools: { update_agent_config: { name: 'update_agent_config' } },
 }));
 
+vi.mock('../../core/integration-tool-resolver', () => ({
+  resolvePageAgentIntegrationTools: vi.fn().mockResolvedValue({}),
+}));
+
 // Mock core AI modules
 vi.mock('../../core', () => ({
   sanitizeMessagesForModel: vi.fn((msgs) => msgs),
@@ -91,6 +95,7 @@ import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
 import { createAIProvider, saveMessageToDatabase } from '../../core';
 import type { ToolExecutionContext } from '../../core';
 import { generateText } from 'ai';
+import { resolvePageAgentIntegrationTools } from '../../core/integration-tool-resolver';
 
 const mockDb = vi.mocked(db);
 const mockCanUserViewPage = vi.mocked(canUserViewPage);
@@ -637,6 +642,89 @@ describe('agent-communication-tools', () => {
           sourceAgentId: null,
           role: 'user',
         });
+      });
+    });
+
+    describe('integration tool resolution', () => {
+      const mockAgent = {
+        id: 'agent-1',
+        title: 'Test Agent',
+        type: 'AI_CHAT',
+        driveId: 'drive-1',
+        systemPrompt: 'I am a helpful agent',
+        enabledTools: null,
+        aiProvider: null,
+        aiModel: null,
+        isTrashed: false,
+      };
+
+      beforeEach(() => {
+        mockDb.query.pages.findFirst = vi.fn().mockResolvedValue(mockAgent);
+        mockCanUserViewPage.mockResolvedValue(true);
+        vi.mocked(mockDb.select).mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockResolvedValue([]),
+            }),
+          }),
+        } as never);
+        vi.mocked(createAIProvider).mockResolvedValue({
+          model: { modelId: 'test-model' } as unknown as ReturnType<typeof createAIProvider> extends Promise<infer T> ? T extends { model: infer M } ? M : never : never,
+        } as Awaited<ReturnType<typeof createAIProvider>>);
+        vi.mocked(generateText).mockResolvedValue({
+          text: 'Agent response',
+          steps: [],
+        } as unknown as ReturnType<typeof generateText> extends Promise<infer T> ? T : never);
+        vi.mocked(saveMessageToDatabase).mockResolvedValue(undefined);
+      });
+
+      it('merges integration tools into the generateText tools call', async () => {
+        const githubTool = { description: 'List GitHub repos', parameters: {}, execute: vi.fn() };
+        vi.mocked(resolvePageAgentIntegrationTools).mockResolvedValue({
+          github_list_repos: githubTool,
+        } as never);
+
+        const context = {
+          toolCallId: '1',
+          messages: [],
+          experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+        };
+
+        await agentCommunicationTools.ask_agent!.execute!(
+          { agentPath: '/drive/agent', agentId: 'agent-1', question: 'List my repos' },
+          context
+        );
+
+        expect(generateText).toHaveBeenCalledWith(
+          expect.objectContaining({
+            tools: expect.objectContaining({ github_list_repos: githubTool }),
+          })
+        );
+      });
+
+      it('falls back to built-in tools only when integration resolver throws', async () => {
+        vi.mocked(resolvePageAgentIntegrationTools).mockRejectedValue(
+          new Error('DB connection failed')
+        );
+
+        const context = {
+          toolCallId: '1',
+          messages: [],
+          experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+        };
+
+        // Should not throw — error is caught and logged
+        await expect(
+          agentCommunicationTools.ask_agent!.execute!(
+            { agentPath: '/drive/agent', agentId: 'agent-1', question: 'Test' },
+            context
+          )
+        ).resolves.not.toThrow();
+
+        // generateText still called (with built-in tools only, no integration tools)
+        expect(generateText).toHaveBeenCalled();
+        const toolsArg = vi.mocked(generateText).mock.calls[0][0].tools as Record<string, unknown>;
+        expect(toolsArg).not.toHaveProperty('github_list_repos');
       });
     });
   });

--- a/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
@@ -721,10 +721,11 @@ describe('agent-communication-tools', () => {
           )
         ).resolves.not.toThrow();
 
-        // generateText still called (with built-in tools only, no integration tools)
+        // generateText still called; no integration tools in any tools argument
         expect(generateText).toHaveBeenCalled();
-        const toolsArg = vi.mocked(generateText).mock.calls[0][0].tools as Record<string, unknown>;
-        expect(toolsArg).not.toHaveProperty('github_list_repos');
+        const toolsArg = vi.mocked(generateText).mock.calls[0][0].tools as Record<string, unknown> | undefined;
+        // When built-in tool set is empty, generateText is called with no tools at all
+        expect(toolsArg?.github_list_repos).toBeUndefined();
       });
     });
   });

--- a/apps/web/src/lib/ai/tools/agent-communication-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-communication-tools.ts
@@ -529,14 +529,21 @@ export const agentCommunicationTools = {
         // 9. Filter tools for agent
         const agentTools = filterToolsForAgent(targetAgent.enabledTools as string[] | null);
 
-        // Resolve integration/adapter tools (GitHub, Calendar, etc.) via grants
-        const { resolvePageAgentIntegrationTools } = await import('@/lib/ai/core/integration-tool-resolver');
-        const integrationTools = await resolvePageAgentIntegrationTools({
-          agentId,
-          userId,
-          driveId: targetAgent.driveId,
-        });
-        const allAgentTools = { ...agentTools, ...integrationTools };
+        // Resolve integration/adapter tools (GitHub, Calendar, etc.) via grants.
+        // Wrapped in try/catch so transient DB or provider errors degrade gracefully
+        // rather than turning the entire ask_agent call into a hard failure.
+        let allAgentTools = { ...agentTools };
+        try {
+          const { resolvePageAgentIntegrationTools } = await import('@/lib/ai/core/integration-tool-resolver');
+          const integrationTools = await resolvePageAgentIntegrationTools({
+            agentId,
+            userId,
+            driveId: targetAgent.driveId,
+          });
+          allAgentTools = { ...agentTools, ...integrationTools };
+        } catch (error) {
+          loggers.ai.error('ask_agent: failed to resolve integration tools, falling back to built-in tools only', error as Error);
+        }
 
         // 10. Create enhanced execution context for nested calls
         // Preserve locationContext so nested agents know which drive/page they're operating in

--- a/apps/web/src/lib/ai/tools/agent-communication-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-communication-tools.ts
@@ -529,9 +529,7 @@ export const agentCommunicationTools = {
         // 9. Filter tools for agent
         const agentTools = filterToolsForAgent(targetAgent.enabledTools as string[] | null);
 
-        // Resolve integration/adapter tools (GitHub, Calendar, etc.) via grants.
-        // Wrapped in try/catch so transient DB or provider errors degrade gracefully
-        // rather than turning the entire ask_agent call into a hard failure.
+        // try/catch: resolver failures degrade to built-in tools only rather than hard-failing the call
         let allAgentTools = { ...agentTools };
         try {
           const { resolvePageAgentIntegrationTools } = await import('@/lib/ai/core/integration-tool-resolver');

--- a/apps/web/src/lib/ai/tools/agent-communication-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-communication-tools.ts
@@ -530,18 +530,18 @@ export const agentCommunicationTools = {
         const agentTools = filterToolsForAgent(targetAgent.enabledTools as string[] | null);
 
         // try/catch: resolver failures degrade to built-in tools only rather than hard-failing the call
-        let allAgentTools = { ...agentTools };
+        let integrationTools: Record<string, unknown> = {};
         try {
           const { resolvePageAgentIntegrationTools } = await import('@/lib/ai/core/integration-tool-resolver');
-          const integrationTools = await resolvePageAgentIntegrationTools({
+          integrationTools = await resolvePageAgentIntegrationTools({
             agentId,
             userId,
             driveId: targetAgent.driveId,
           });
-          allAgentTools = { ...agentTools, ...integrationTools };
         } catch (error) {
           loggers.ai.error('ask_agent: failed to resolve integration tools, falling back to built-in tools only', error as Error);
         }
+        const allAgentTools = { ...agentTools, ...integrationTools };
 
         // 10. Create enhanced execution context for nested calls
         // Preserve locationContext so nested agents know which drive/page they're operating in

--- a/apps/web/src/lib/ai/tools/agent-communication-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-communication-tools.ts
@@ -528,7 +528,16 @@ export const agentCommunicationTools = {
         
         // 9. Filter tools for agent
         const agentTools = filterToolsForAgent(targetAgent.enabledTools as string[] | null);
-        
+
+        // Resolve integration/adapter tools (GitHub, Calendar, etc.) via grants
+        const { resolvePageAgentIntegrationTools } = await import('@/lib/ai/core/integration-tool-resolver');
+        const integrationTools = await resolvePageAgentIntegrationTools({
+          agentId,
+          userId,
+          driveId: targetAgent.driveId,
+        });
+        const allAgentTools = { ...agentTools, ...integrationTools };
+
         // 10. Create enhanced execution context for nested calls
         // Preserve locationContext so nested agents know which drive/page they're operating in
         // Include chain tracking for activity logging (Tier 1)
@@ -548,12 +557,12 @@ export const agentCommunicationTools = {
         } as ToolExecutionContext & { agentCallDepth: number; currentAgentId: string };
         
         // 11. Process with target agent's configuration (ephemeral - no persistence)
-        const response = Object.keys(agentTools).length > 0
+        const response = Object.keys(allAgentTools).length > 0
           ? await generateText({
               model,
               system: systemPrompt,
               messages: convertToModelMessages(sanitizedMessages),
-              tools: { ...agentTools, ...finishTool } as Parameters<typeof generateText>[0]['tools'],
+              tools: { ...allAgentTools, ...finishTool } as Parameters<typeof generateText>[0]['tools'],
               experimental_context: nestedContext,
               stopWhen: [hasToolCall(FINISH_TOOL_NAME), stepCountIs(20)],
               maxRetries: 3,


### PR DESCRIPTION
## Bug

Agents @mentioned in Channel pages were silently missing their grant-backed adapter tools (GitHub, Calendar, etc.). The \`ask_agent\` execute handler in \`agent-communication-tools.ts\` only called \`filterToolsForAgent()\` at step 9, which returns built-in PageSpace tools only. \`resolvePageAgentIntegrationTools()\` was never called on this code path.

The chat route (\`apps/web/src/app/api/ai/chat/route.ts\` lines 570–587) already handles this correctly by calling \`resolvePageAgentIntegrationTools()\` and merging the result. The channel @mention path had no equivalent.

## Fix

In \`agent-communication-tools.ts\` after step 9:

1. Added a call to \`resolvePageAgentIntegrationTools()\` using \`agentId\`, \`userId\`, and \`targetAgent.driveId\` (all already in scope).
2. Wrapped in \`try/catch\` so transient DB or provider errors degrade gracefully to built-in tools only — matching the same defensive pattern in the chat route.
3. Both the tool-count guard and the \`generateText\` tools spread now use \`allAgentTools\` (built-in + integration).

**One source file changed.** Tests added to cover both the happy path (tools merged) and the error path (graceful fallback).

## Test plan

- [ ] Create an agent with a GitHub integration grant
- [ ] @mention the agent in a Channel page
- [ ] Confirm the agent can execute GitHub tools in its response
- [ ] Confirm agents without integration grants continue to work (empty merge is a no-op)
- [ ] Confirm a resolver error does not hard-fail the entire agent consultation

🤖 Generated with [Claude Code](https://claude.com/claude-code)