### PR TITLE
fix(ai): shared conversation init — deterministic ID prevents multiplayer race

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -274,6 +274,7 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
               const { messages: loaded } = msgResponse.ok
                 ? ((await msgResponse.json()) as ConversationMessagesResponse)
                 : { messages: [] as UIMessage[] };
+              if (controller.signal.aborted) return;
               setCurrentConversationId(conv.id);
               setMessages(loaded ?? []);
               setIsInitialized(true);
@@ -281,10 +282,11 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
             }
           }
         } catch (err) {
-          // GET failed — fall through to page-scoped default below
+          if (controller.signal.aborted) return;
           console.warn('Failed to load conversations on init, using page-scoped default:', err);
         }
 
+        if (controller.signal.aborted) return;
         // No persisted conversations exist yet. Derive a stable ID from the page so
         // concurrent openers share the same conversation before either sends a message.
         // The conversation is anchored in the DB once the first message is saved.
@@ -292,6 +294,7 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
         setMessages([]);
         setIsInitialized(true);
       } catch (error) {
+        if (controller.signal.aborted) return;
         console.error('Failed to initialize chat:', error);
         setMessages([]);
         setIsInitialized(true);

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -239,10 +239,14 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
 
   // Initialize chat
   useEffect(() => {
+    const controller = new AbortController();
+
     const initializeChat = async () => {
       try {
         // Load agent config
-        const agentConfigResponse = await fetchWithAuth(`/api/pages/${page.id}/agent-config`);
+        const agentConfigResponse = await fetchWithAuth(`/api/pages/${page.id}/agent-config`, {
+          signal: controller.signal,
+        });
         if (agentConfigResponse.ok) {
           const config = await agentConfigResponse.json();
           setAgentConfig(config);
@@ -250,47 +254,39 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
           if (config.aiModel) setSelectedModel(config.aiModel);
         }
 
-        // Load most recent conversation, or create one if none exists
-        let conversationLoaded = false;
+        // Try to load the most recent existing conversation
         try {
           const listResponse = await fetchWithAuth(
-            `/api/ai/page-agents/${page.id}/conversations?pageSize=1`
+            `/api/ai/page-agents/${page.id}/conversations?pageSize=1`,
+            { signal: controller.signal }
           );
           if (listResponse.ok) {
-            const listData = await listResponse.json();
-            if (listData.conversations?.length > 0) {
-              const conv = listData.conversations[0];
+            const { conversations: list } = await listResponse.json();
+            if (list?.length > 0) {
+              const conv = list[0];
               const msgResponse = await fetchWithAuth(
-                `/api/ai/page-agents/${page.id}/conversations/${conv.id}/messages`
+                `/api/ai/page-agents/${page.id}/conversations/${conv.id}/messages`,
+                { signal: controller.signal }
               );
-              if (msgResponse.ok) {
-                const msgData = await msgResponse.json();
-                setCurrentConversationId(conv.id);
-                setMessages(msgData.messages);
-              } else {
-                setCurrentConversationId(conv.id);
-                setMessages([]);
-              }
-              conversationLoaded = true;
+              const { messages: loaded } = msgResponse.ok
+                ? await msgResponse.json()
+                : { messages: [] };
+              setCurrentConversationId(conv.id);
+              setMessages(loaded ?? []);
+              setIsInitialized(true);
+              return;
             }
           }
-        } catch {
-          // GET failed — fall through to create a new conversation
+        } catch (err) {
+          // GET failed — fall through to page-scoped default below
+          console.warn('Failed to load conversations on init, using page-scoped default:', err);
         }
 
-        if (!conversationLoaded) {
-          const newConvResponse = await fetchWithAuth(`/api/ai/page-agents/${page.id}/conversations`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({}),
-          });
-          if (newConvResponse.ok) {
-            const newConvData = await newConvResponse.json();
-            setCurrentConversationId(newConvData.conversationId);
-          }
-          setMessages([]);
-        }
-
+        // No persisted conversations exist yet. Derive a stable ID from the page so
+        // concurrent openers share the same conversation before either sends a message.
+        // The conversation is anchored in the DB once the first message is saved.
+        setCurrentConversationId(`${page.id}-default`);
+        setMessages([]);
         setIsInitialized(true);
       } catch (error) {
         console.error('Failed to initialize chat:', error);
@@ -302,6 +298,7 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
     setIsInitialized(false);
     setCurrentConversationId(null);
     initializeChat();
+    return () => controller.abort();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [page.id]);
 

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -63,6 +63,9 @@ interface AiChatViewProps {
   page: TreePage;
 }
 
+type ConversationListResponse = { conversations?: Array<{ id: string }> };
+type ConversationMessagesResponse = { messages: UIMessage[] };
+
 const VOICE_OWNER: VoiceModeOwner = 'ai-page';
 const EMPTY_MESSAGES: UIMessage[] = [];
 
@@ -261,16 +264,16 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
             { signal: controller.signal }
           );
           if (listResponse.ok) {
-            const { conversations: list } = await listResponse.json();
-            if (list?.length > 0) {
+            const { conversations: list } = (await listResponse.json()) as ConversationListResponse;
+            if (list && list.length > 0) {
               const conv = list[0];
               const msgResponse = await fetchWithAuth(
                 `/api/ai/page-agents/${page.id}/conversations/${conv.id}/messages`,
                 { signal: controller.signal }
               );
               const { messages: loaded } = msgResponse.ok
-                ? await msgResponse.json()
-                : { messages: [] };
+                ? ((await msgResponse.json()) as ConversationMessagesResponse)
+                : { messages: [] as UIMessage[] };
               setCurrentConversationId(conv.id);
               setMessages(loaded ?? []);
               setIsInitialized(true);

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -250,18 +250,44 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
           if (config.aiModel) setSelectedModel(config.aiModel);
         }
 
-        // Create new conversation (fresh start on page load)
-        const newConvResponse = await fetchWithAuth(`/api/ai/page-agents/${page.id}/conversations`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({}),
-        });
+        // Load most recent conversation, or create one if none exists
+        let conversationLoaded = false;
+        try {
+          const listResponse = await fetchWithAuth(
+            `/api/ai/page-agents/${page.id}/conversations?pageSize=1`
+          );
+          if (listResponse.ok) {
+            const listData = await listResponse.json();
+            if (listData.conversations?.length > 0) {
+              const conv = listData.conversations[0];
+              const msgResponse = await fetchWithAuth(
+                `/api/ai/page-agents/${page.id}/conversations/${conv.id}/messages`
+              );
+              if (msgResponse.ok) {
+                const msgData = await msgResponse.json();
+                setCurrentConversationId(conv.id);
+                setMessages(msgData.messages);
+              } else {
+                setCurrentConversationId(conv.id);
+                setMessages([]);
+              }
+              conversationLoaded = true;
+            }
+          }
+        } catch {
+          // GET failed — fall through to create a new conversation
+        }
 
-        if (newConvResponse.ok) {
-          const newConvData = await newConvResponse.json();
-          setCurrentConversationId(newConvData.conversationId);
-          setMessages([]);
-        } else {
+        if (!conversationLoaded) {
+          const newConvResponse = await fetchWithAuth(`/api/ai/page-agents/${page.id}/conversations`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({}),
+          });
+          if (newConvResponse.ok) {
+            const newConvData = await newConvResponse.json();
+            setCurrentConversationId(newConvData.conversationId);
+          }
           setMessages([]);
         }
 

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
@@ -1,0 +1,451 @@
+import { describe, test, vi, beforeEach } from 'vitest';
+import { render, waitFor, screen, fireEvent } from '@testing-library/react';
+import { assert } from './riteway';
+
+// ============================================================
+// Hoisted mock instances (accessible inside vi.mock factories)
+// ============================================================
+const { mockFetchWithAuth, mockSetMessages } = vi.hoisted(() => ({
+  mockFetchWithAuth: vi.fn(),
+  mockSetMessages: vi.fn(),
+}));
+
+// ============================================================
+// Module mocks — must be declared before any import of the module
+// ============================================================
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: mockFetchWithAuth,
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(() => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn(), back: vi.fn(), forward: vi.fn(), prefetch: vi.fn() })),
+  usePathname: vi.fn(() => '/'),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+  useParams: vi.fn(() => ({ driveId: 'test-drive-id' })),
+}));
+
+vi.mock('@ai-sdk/react', () => ({
+  useChat: vi.fn(() => ({
+    messages: [],
+    sendMessage: vi.fn(),
+    status: 'idle',
+    error: undefined,
+    regenerate: vi.fn(),
+    setMessages: mockSetMessages,
+    stop: vi.fn(),
+  })),
+}));
+
+vi.mock('swr', () => ({
+  default: vi.fn(() => ({ data: undefined, error: undefined })),
+  useSWRConfig: vi.fn(() => ({ cache: { get: vi.fn(() => undefined) } })),
+}));
+
+vi.mock('@/hooks/useDrive', () => ({
+  useDriveStore: vi.fn((selector: (state: { drives: unknown[] }) => unknown) =>
+    selector({ drives: [] })
+  ),
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: vi.fn(() => ({ user: { id: 'user-1', name: 'Test User' } })),
+}));
+
+vi.mock('@/stores/useAssistantSettingsStore', () => ({
+  useAssistantSettingsStore: vi.fn((selector: (state: { webSearchEnabled: boolean }) => unknown) =>
+    selector({ webSearchEnabled: false })
+  ),
+}));
+
+vi.mock('@/stores/useVoiceModeStore', () => ({
+  useVoiceModeStore: vi.fn(
+    (selector: (state: { isEnabled: boolean; owner: null; enable: () => void; disable: () => void }) => unknown) => {
+      const state = { isEnabled: false, owner: null, enable: vi.fn(), disable: vi.fn() };
+      return selector(state);
+    }
+  ),
+}));
+
+vi.mock('@/stores/useEditingStore', () => ({
+  useEditingStore: vi.fn(() => ({ register: vi.fn(), unregister: vi.fn() })),
+  isEditingActive: vi.fn(() => false),
+}));
+
+vi.mock('@/stores/usePendingStreamsStore', () => {
+  const mockStore = Object.assign(vi.fn(() => []), {
+    getState: vi.fn(() => ({ streams: new Map() })),
+  });
+  return { usePendingStreamsStore: mockStore };
+});
+
+vi.mock('@/hooks/usePageSocketRoom', () => ({
+  usePageSocketRoom: vi.fn(),
+}));
+
+vi.mock('@/hooks/useChatStreamSocket', () => ({
+  useChatStreamSocket: vi.fn(),
+}));
+
+vi.mock('@/hooks/useAppStateRecovery', () => ({
+  useAppStateRecovery: vi.fn(),
+}));
+
+vi.mock('@/hooks/useDisplayPreferences', () => ({
+  useDisplayPreferences: vi.fn(() => ({ preferences: { showTokenCounts: false } })),
+}));
+
+vi.mock('@/lib/ai/core/client', () => ({
+  clearActiveStreamId: vi.fn(),
+}));
+
+vi.mock('@/lib/ai/core/vision-models', () => ({
+  hasVisionCapability: vi.fn(() => false),
+}));
+
+const mockCreateConversation = vi.fn();
+
+vi.mock('@/lib/ai/shared', () => ({
+  useMCPTools: vi.fn(() => ({
+    isDesktop: false,
+    runningServers: [],
+    runningServerNames: [],
+    mcpToolSchemas: [],
+    enabledServerCount: 0,
+    isServerEnabled: vi.fn(() => false),
+    setServerEnabled: vi.fn(),
+    allServersEnabled: false,
+    setAllServersEnabled: vi.fn(),
+  })),
+  useMessageActions: vi.fn(() => ({
+    handleEdit: vi.fn(),
+    handleDelete: vi.fn(),
+    handleRetry: vi.fn(),
+    lastAssistantMessageId: null,
+    lastUserMessageId: null,
+  })),
+  useProviderSettings: vi.fn(() => ({
+    isLoading: false,
+    isAnyProviderConfigured: true,
+    needsSetup: false,
+    selectedProvider: 'anthropic',
+    setSelectedProvider: vi.fn(),
+    selectedModel: 'claude-3-5-sonnet',
+    setSelectedModel: vi.fn(),
+    isProviderConfigured: vi.fn(() => true),
+  })),
+  useConversations: vi.fn(() => ({
+    conversations: [],
+    isLoading: false,
+    loadConversation: vi.fn(),
+    createConversation: mockCreateConversation,
+    deleteConversation: vi.fn(),
+  })),
+  useChatTransport: vi.fn(() => ({})),
+  useStreamingRegistration: vi.fn(),
+  useChatStop: vi.fn(() => vi.fn()),
+  useSendHandoff: vi.fn(() => ({ wrapSend: vi.fn((cb: () => void) => cb()) })),
+}));
+
+vi.mock('@/lib/ai/shared/hooks/useImageAttachments', () => ({
+  useImageAttachments: vi.fn(() => ({
+    attachments: [],
+    addFiles: vi.fn(),
+    removeFile: vi.fn(),
+    clearFiles: vi.fn(),
+    getFilesForSend: vi.fn(() => []),
+  })),
+}));
+
+vi.mock('@/lib/tree/tree-utils', () => ({
+  buildPagePath: vi.fn(() => null),
+}));
+
+vi.mock('@/components/ai/page-agents', () => ({
+  PageAgentSettingsTab: vi.fn(() => null),
+  PageAgentHistoryTab: vi.fn(() => null),
+}));
+
+vi.mock('@/components/ai/page-agents/AgentIntegrationsPanel', () => ({
+  AgentIntegrationsPanel: vi.fn(() => null),
+}));
+
+vi.mock('@/components/ai/voice/VoiceCallPanel', () => ({
+  VoiceCallPanel: vi.fn(() => null),
+}));
+
+vi.mock('@/components/ai/shared/chat', () => ({
+  ProviderSetupCard: vi.fn(() => null),
+}));
+
+vi.mock('@/components/ai/shared', () => ({
+  AiUsageMonitor: vi.fn(() => null),
+  TasksDropdown: vi.fn(() => null),
+}));
+
+vi.mock('@/components/ai/chat/layouts', () => ({
+  ChatLayout: vi.fn(() => null),
+}));
+
+vi.mock('@/components/ai/chat/input', () => ({
+  ChatInput: vi.fn(() => null),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock('zustand/react/shallow', () => ({
+  useShallow: vi.fn((fn: unknown) => fn),
+}));
+
+// ============================================================
+// Import component after mocks
+// ============================================================
+import AiChatView from '../AiChatView';
+import { PageType } from '@pagespace/lib/utils/enums';
+
+// ============================================================
+// Test constants
+// ============================================================
+const PAGE_ID = 'page-123';
+const CONV_ID = 'conv-existing-abc';
+const NEW_CONV_ID = 'conv-new-xyz';
+const CONVERSATIONS_URL = `/api/ai/page-agents/${PAGE_ID}/conversations`;
+const MESSAGES_URL = `/api/ai/page-agents/${PAGE_ID}/conversations/${CONV_ID}/messages`;
+const AGENT_CONFIG_URL = `/api/pages/${PAGE_ID}/agent-config`;
+const PERMISSIONS_URL = `/api/pages/${PAGE_ID}/permissions/check`;
+
+// ============================================================
+// Test helpers
+// ============================================================
+const makeOkResponse = (data: unknown) => ({
+  ok: true as const,
+  json: vi.fn().mockResolvedValue(data),
+});
+
+const makeErrorResponse = () => ({
+  ok: false as const,
+  json: vi.fn().mockResolvedValue({}),
+});
+
+const makePage = () => ({
+  id: PAGE_ID,
+  title: 'Test Chat',
+  type: PageType.AI_CHAT,
+  content: null,
+  position: 0,
+  isTrashed: false,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+  trashedAt: null,
+  driveId: 'test-drive-id',
+  parentId: null,
+  originalParentId: null,
+  children: [],
+  aiChat: null,
+  messages: [],
+});
+
+const existingConversation = {
+  id: CONV_ID,
+  title: 'Existing conversation',
+  preview: 'hello',
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-01T00:00:00Z',
+  messageCount: 1,
+  lastMessage: 'hello',
+};
+
+const wasGetCalled = (url: string) =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockFetchWithAuth.mock.calls.some((args: any[]) => {
+    const [callUrl, opts] = args;
+    return callUrl === url && (!opts?.method || opts.method === 'GET');
+  });
+
+const wasPostCalled = (url: string) =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mockFetchWithAuth.mock.calls.some((args: any[]) => {
+    const [callUrl, opts] = args;
+    return callUrl === url && opts?.method === 'POST';
+  });
+
+// ============================================================
+// Tests
+// ============================================================
+describe('AiChatView initializeChat', () => {
+  const page = makePage();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('given a page with existing conversations, loads the most recent conversation without creating a new one', async () => {
+    mockFetchWithAuth.mockImplementation(async (url: string, opts?: { method?: string }) => {
+      if (url === PERMISSIONS_URL) return makeOkResponse({ canEdit: true });
+      if (url === AGENT_CONFIG_URL) return makeOkResponse({});
+      if (url === `${CONVERSATIONS_URL}?pageSize=1` && !opts?.method) {
+        return makeOkResponse({ conversations: [existingConversation] });
+      }
+      if (url === MESSAGES_URL && !opts?.method) {
+        return makeOkResponse({
+          messages: [{ id: 'msg-1', role: 'user', content: 'hello', parts: [{ type: 'text', text: 'hello' }] }],
+        });
+      }
+      return makeErrorResponse();
+    });
+
+    render(<AiChatView page={page} />);
+
+    await waitFor(() => {
+      assert({
+        given: 'a page with existing conversations',
+        should: 'GET conversations list (not POST)',
+        actual: wasGetCalled(`${CONVERSATIONS_URL}?pageSize=1`),
+        expected: true,
+      });
+    });
+
+    assert({
+      given: 'a page with existing conversations',
+      should: 'NOT create a new conversation via POST',
+      actual: wasPostCalled(CONVERSATIONS_URL),
+      expected: false,
+    });
+  });
+
+  test('given a page with no conversations, creates a new conversation after checking for existing ones', async () => {
+    mockFetchWithAuth.mockImplementation(async (url: string, opts?: { method?: string }) => {
+      if (url === PERMISSIONS_URL) return makeOkResponse({ canEdit: true });
+      if (url === AGENT_CONFIG_URL) return makeOkResponse({});
+      if (url === `${CONVERSATIONS_URL}?pageSize=1` && !opts?.method) {
+        return makeOkResponse({ conversations: [] });
+      }
+      if (url === CONVERSATIONS_URL && opts?.method === 'POST') {
+        return makeOkResponse({ conversationId: NEW_CONV_ID });
+      }
+      return makeErrorResponse();
+    });
+
+    render(<AiChatView page={page} />);
+
+    await waitFor(() => {
+      assert({
+        given: 'a page with no conversations',
+        should: 'GET conversations list first',
+        actual: wasGetCalled(`${CONVERSATIONS_URL}?pageSize=1`),
+        expected: true,
+      });
+    });
+
+    assert({
+      given: 'a page with no conversations',
+      should: 'create a new conversation via POST after finding none',
+      actual: wasPostCalled(CONVERSATIONS_URL),
+      expected: true,
+    });
+  });
+
+  test('given conversations fetch fails with non-ok response, falls back to creating a new conversation', async () => {
+    mockFetchWithAuth.mockImplementation(async (url: string, opts?: { method?: string }) => {
+      if (url === PERMISSIONS_URL) return makeOkResponse({ canEdit: true });
+      if (url === AGENT_CONFIG_URL) return makeOkResponse({});
+      if (url === `${CONVERSATIONS_URL}?pageSize=1` && !opts?.method) {
+        return makeErrorResponse();
+      }
+      if (url === CONVERSATIONS_URL && opts?.method === 'POST') {
+        return makeOkResponse({ conversationId: NEW_CONV_ID });
+      }
+      return makeErrorResponse();
+    });
+
+    render(<AiChatView page={page} />);
+
+    await waitFor(() => {
+      assert({
+        given: 'conversations GET returns non-ok',
+        should: 'attempt to GET conversations first',
+        actual: wasGetCalled(`${CONVERSATIONS_URL}?pageSize=1`),
+        expected: true,
+      });
+    });
+
+    assert({
+      given: 'conversations GET returns non-ok',
+      should: 'fall back to creating a new conversation via POST',
+      actual: wasPostCalled(CONVERSATIONS_URL),
+      expected: true,
+    });
+  });
+
+  test('given two users opening the same page, both load the same existing conversation by fetching its messages', async () => {
+    mockFetchWithAuth.mockImplementation(async (url: string, opts?: { method?: string }) => {
+      if (url === PERMISSIONS_URL) return makeOkResponse({ canEdit: true });
+      if (url === AGENT_CONFIG_URL) return makeOkResponse({});
+      if (url === `${CONVERSATIONS_URL}?pageSize=1` && !opts?.method) {
+        return makeOkResponse({ conversations: [existingConversation] });
+      }
+      if (url === MESSAGES_URL && !opts?.method) {
+        return makeOkResponse({ messages: [] });
+      }
+      return makeErrorResponse();
+    });
+
+    render(<AiChatView page={page} />);
+
+    await waitFor(() => {
+      assert({
+        given: 'a second user opening the same page',
+        should: 'load messages from the shared existing conversation (not create a new one)',
+        actual: wasGetCalled(MESSAGES_URL),
+        expected: true,
+      });
+    });
+
+    assert({
+      given: 'a second user opening the same page',
+      should: 'NOT create a new separate conversation',
+      actual: wasPostCalled(CONVERSATIONS_URL),
+      expected: false,
+    });
+  });
+
+  test('given user clicks New Chat button, createConversation from useConversations is called', async () => {
+    mockFetchWithAuth.mockImplementation(async (url: string, opts?: { method?: string }) => {
+      if (url === PERMISSIONS_URL) return makeOkResponse({ canEdit: true });
+      if (url === AGENT_CONFIG_URL) return makeOkResponse({});
+      if (url === `${CONVERSATIONS_URL}?pageSize=1` && !opts?.method) {
+        return makeOkResponse({ conversations: [existingConversation] });
+      }
+      if (url === MESSAGES_URL && !opts?.method) {
+        return makeOkResponse({ messages: [] });
+      }
+      return makeErrorResponse();
+    });
+
+    render(<AiChatView page={page} />);
+
+    await waitFor(() => {
+      assert({
+        given: 'component initialized',
+        should: 'render the New Chat button',
+        actual: screen.getAllByRole('button').some(
+          (b) => b.textContent?.includes('New Chat') || b.getAttribute('aria-label')?.includes('New Chat')
+        ),
+        expected: true,
+      });
+    });
+
+    const newChatButton = screen.getAllByRole('button').find(
+      (b) => b.textContent?.includes('New Chat') || b.getAttribute('aria-label')?.includes('New Chat')
+    );
+    if (newChatButton) fireEvent.click(newChatButton);
+
+    assert({
+      given: 'user clicks the New Chat button',
+      should: 'call createConversation from useConversations (no change to existing behavior)',
+      actual: mockCreateConversation.mock.calls.length,
+      expected: 1,
+    });
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
@@ -2,17 +2,12 @@ import { describe, test, vi, beforeEach } from 'vitest';
 import { render, waitFor, screen, fireEvent } from '@testing-library/react';
 import { assert } from './riteway';
 
-// ============================================================
-// Hoisted mock instances (accessible inside vi.mock factories)
-// ============================================================
+// Hoisted mock instances accessible inside vi.mock factories
 const { mockFetchWithAuth, mockSetMessages } = vi.hoisted(() => ({
   mockFetchWithAuth: vi.fn(),
   mockSetMessages: vi.fn(),
 }));
 
-// ============================================================
-// Module mocks — must be declared before any import of the module
-// ============================================================
 vi.mock('@/lib/auth/auth-fetch', () => ({
   fetchWithAuth: mockFetchWithAuth,
 }));
@@ -59,10 +54,8 @@ vi.mock('@/stores/useAssistantSettingsStore', () => ({
 
 vi.mock('@/stores/useVoiceModeStore', () => ({
   useVoiceModeStore: vi.fn(
-    (selector: (state: { isEnabled: boolean; owner: null; enable: () => void; disable: () => void }) => unknown) => {
-      const state = { isEnabled: false, owner: null, enable: vi.fn(), disable: vi.fn() };
-      return selector(state);
-    }
+    (selector: (state: { isEnabled: boolean; owner: null; enable: () => void; disable: () => void }) => unknown) =>
+      selector({ isEnabled: false, owner: null, enable: vi.fn(), disable: vi.fn() })
   ),
 }));
 
@@ -71,38 +64,26 @@ vi.mock('@/stores/useEditingStore', () => ({
   isEditingActive: vi.fn(() => false),
 }));
 
-vi.mock('@/stores/usePendingStreamsStore', () => {
-  const mockStore = Object.assign(vi.fn(() => []), {
+vi.mock('@/stores/usePendingStreamsStore', () => ({
+  usePendingStreamsStore: Object.assign(vi.fn(() => []), {
     getState: vi.fn(() => ({ streams: new Map() })),
-  });
-  return { usePendingStreamsStore: mockStore };
-});
-
-vi.mock('@/hooks/usePageSocketRoom', () => ({
-  usePageSocketRoom: vi.fn(),
+  }),
 }));
 
-vi.mock('@/hooks/useChatStreamSocket', () => ({
-  useChatStreamSocket: vi.fn(),
-}));
-
-vi.mock('@/hooks/useAppStateRecovery', () => ({
-  useAppStateRecovery: vi.fn(),
-}));
+vi.mock('@/hooks/usePageSocketRoom', () => ({ usePageSocketRoom: vi.fn() }));
+vi.mock('@/hooks/useChatStreamSocket', () => ({ useChatStreamSocket: vi.fn() }));
+vi.mock('@/hooks/useAppStateRecovery', () => ({ useAppStateRecovery: vi.fn() }));
 
 vi.mock('@/hooks/useDisplayPreferences', () => ({
   useDisplayPreferences: vi.fn(() => ({ preferences: { showTokenCounts: false } })),
 }));
 
-vi.mock('@/lib/ai/core/client', () => ({
-  clearActiveStreamId: vi.fn(),
-}));
+vi.mock('@/lib/ai/core/client', () => ({ clearActiveStreamId: vi.fn() }));
+vi.mock('@/lib/ai/core/vision-models', () => ({ hasVisionCapability: vi.fn(() => false) }));
 
-vi.mock('@/lib/ai/core/vision-models', () => ({
-  hasVisionCapability: vi.fn(() => false),
+const { mockCreateConversation } = vi.hoisted(() => ({
+  mockCreateConversation: vi.fn(),
 }));
-
-const mockCreateConversation = vi.fn();
 
 vi.mock('@/lib/ai/shared', () => ({
   useMCPTools: vi.fn(() => ({
@@ -156,68 +137,36 @@ vi.mock('@/lib/ai/shared/hooks/useImageAttachments', () => ({
   })),
 }));
 
-vi.mock('@/lib/tree/tree-utils', () => ({
-  buildPagePath: vi.fn(() => null),
-}));
-
+vi.mock('@/lib/tree/tree-utils', () => ({ buildPagePath: vi.fn(() => null) }));
 vi.mock('@/components/ai/page-agents', () => ({
   PageAgentSettingsTab: vi.fn(() => null),
   PageAgentHistoryTab: vi.fn(() => null),
 }));
-
 vi.mock('@/components/ai/page-agents/AgentIntegrationsPanel', () => ({
   AgentIntegrationsPanel: vi.fn(() => null),
 }));
-
-vi.mock('@/components/ai/voice/VoiceCallPanel', () => ({
-  VoiceCallPanel: vi.fn(() => null),
-}));
-
-vi.mock('@/components/ai/shared/chat', () => ({
-  ProviderSetupCard: vi.fn(() => null),
-}));
-
+vi.mock('@/components/ai/voice/VoiceCallPanel', () => ({ VoiceCallPanel: vi.fn(() => null) }));
+vi.mock('@/components/ai/shared/chat', () => ({ ProviderSetupCard: vi.fn(() => null) }));
 vi.mock('@/components/ai/shared', () => ({
   AiUsageMonitor: vi.fn(() => null),
   TasksDropdown: vi.fn(() => null),
 }));
+vi.mock('@/components/ai/chat/layouts', () => ({ ChatLayout: vi.fn(() => null) }));
+vi.mock('@/components/ai/chat/input', () => ({ ChatInput: vi.fn(() => null) }));
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+vi.mock('zustand/react/shallow', () => ({ useShallow: vi.fn((fn: unknown) => fn) }));
 
-vi.mock('@/components/ai/chat/layouts', () => ({
-  ChatLayout: vi.fn(() => null),
-}));
-
-vi.mock('@/components/ai/chat/input', () => ({
-  ChatInput: vi.fn(() => null),
-}));
-
-vi.mock('sonner', () => ({
-  toast: { error: vi.fn(), success: vi.fn() },
-}));
-
-vi.mock('zustand/react/shallow', () => ({
-  useShallow: vi.fn((fn: unknown) => fn),
-}));
-
-// ============================================================
-// Import component after mocks
-// ============================================================
 import AiChatView from '../AiChatView';
 import { PageType } from '@pagespace/lib/utils/enums';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 
-// ============================================================
-// Test constants
-// ============================================================
 const PAGE_ID = 'page-123';
 const CONV_ID = 'conv-existing-abc';
-const NEW_CONV_ID = 'conv-new-xyz';
 const CONVERSATIONS_URL = `/api/ai/page-agents/${PAGE_ID}/conversations`;
 const MESSAGES_URL = `/api/ai/page-agents/${PAGE_ID}/conversations/${CONV_ID}/messages`;
 const AGENT_CONFIG_URL = `/api/pages/${PAGE_ID}/agent-config`;
 const PERMISSIONS_URL = `/api/pages/${PAGE_ID}/permissions/check`;
 
-// ============================================================
-// Test helpers
-// ============================================================
 const makeOkResponse = (data: unknown) => ({
   ok: true as const,
   json: vi.fn().mockResolvedValue(data),
@@ -257,22 +206,15 @@ const existingConversation = {
 };
 
 const wasGetCalled = (url: string) =>
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  mockFetchWithAuth.mock.calls.some((args: any[]) => {
-    const [callUrl, opts] = args;
-    return callUrl === url && (!opts?.method || opts.method === 'GET');
-  });
+  (mockFetchWithAuth.mock.calls as Parameters<typeof fetchWithAuth>[]).some(([callUrl, opts]) =>
+    callUrl === url && (!opts?.method || opts.method === 'GET')
+  );
 
 const wasPostCalled = (url: string) =>
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  mockFetchWithAuth.mock.calls.some((args: any[]) => {
-    const [callUrl, opts] = args;
-    return callUrl === url && opts?.method === 'POST';
-  });
+  (mockFetchWithAuth.mock.calls as Parameters<typeof fetchWithAuth>[]).some(([callUrl, opts]) =>
+    callUrl === url && opts?.method === 'POST'
+  );
 
-// ============================================================
-// Tests
-// ============================================================
 describe('AiChatView initializeChat', () => {
   const page = makePage();
 
@@ -281,6 +223,8 @@ describe('AiChatView initializeChat', () => {
   });
 
   test('given a page with existing conversations, loads the most recent conversation without creating a new one', async () => {
+    const testMessages = [{ id: 'msg-1', role: 'user', content: 'hello', parts: [{ type: 'text', text: 'hello' }] }];
+
     mockFetchWithAuth.mockImplementation(async (url: string, opts?: { method?: string }) => {
       if (url === PERMISSIONS_URL) return makeOkResponse({ canEdit: true });
       if (url === AGENT_CONFIG_URL) return makeOkResponse({});
@@ -288,9 +232,7 @@ describe('AiChatView initializeChat', () => {
         return makeOkResponse({ conversations: [existingConversation] });
       }
       if (url === MESSAGES_URL && !opts?.method) {
-        return makeOkResponse({
-          messages: [{ id: 'msg-1', role: 'user', content: 'hello', parts: [{ type: 'text', text: 'hello' }] }],
-        });
+        return makeOkResponse({ messages: testMessages });
       }
       return makeErrorResponse();
     });
@@ -312,17 +254,23 @@ describe('AiChatView initializeChat', () => {
       actual: wasPostCalled(CONVERSATIONS_URL),
       expected: false,
     });
+
+    assert({
+      given: 'a page with existing conversations',
+      should: 'apply the fetched messages to chat state',
+      actual: mockSetMessages.mock.calls.some(
+        (args) => JSON.stringify(args[0]) === JSON.stringify(testMessages)
+      ),
+      expected: true,
+    });
   });
 
-  test('given a page with no conversations, creates a new conversation after checking for existing ones', async () => {
+  test('given a page with no conversations, uses a page-scoped deterministic ID without POSTing', async () => {
     mockFetchWithAuth.mockImplementation(async (url: string, opts?: { method?: string }) => {
       if (url === PERMISSIONS_URL) return makeOkResponse({ canEdit: true });
       if (url === AGENT_CONFIG_URL) return makeOkResponse({});
       if (url === `${CONVERSATIONS_URL}?pageSize=1` && !opts?.method) {
         return makeOkResponse({ conversations: [] });
-      }
-      if (url === CONVERSATIONS_URL && opts?.method === 'POST') {
-        return makeOkResponse({ conversationId: NEW_CONV_ID });
       }
       return makeErrorResponse();
     });
@@ -331,7 +279,7 @@ describe('AiChatView initializeChat', () => {
 
     await waitFor(() => {
       assert({
-        given: 'a page with no conversations',
+        given: 'a brand-new page with no conversations',
         should: 'GET conversations list first',
         actual: wasGetCalled(`${CONVERSATIONS_URL}?pageSize=1`),
         expected: true,
@@ -339,22 +287,19 @@ describe('AiChatView initializeChat', () => {
     });
 
     assert({
-      given: 'a page with no conversations',
-      should: 'create a new conversation via POST after finding none',
+      given: 'a brand-new page with no conversations',
+      should: 'NOT POST a server-side conversation (avoids race between concurrent openers)',
       actual: wasPostCalled(CONVERSATIONS_URL),
-      expected: true,
+      expected: false,
     });
   });
 
-  test('given conversations fetch fails with non-ok response, falls back to creating a new conversation', async () => {
+  test('given conversations fetch fails with non-ok response, falls back to page-scoped deterministic ID without POSTing', async () => {
     mockFetchWithAuth.mockImplementation(async (url: string, opts?: { method?: string }) => {
       if (url === PERMISSIONS_URL) return makeOkResponse({ canEdit: true });
       if (url === AGENT_CONFIG_URL) return makeOkResponse({});
       if (url === `${CONVERSATIONS_URL}?pageSize=1` && !opts?.method) {
         return makeErrorResponse();
-      }
-      if (url === CONVERSATIONS_URL && opts?.method === 'POST') {
-        return makeOkResponse({ conversationId: NEW_CONV_ID });
       }
       return makeErrorResponse();
     });
@@ -372,9 +317,9 @@ describe('AiChatView initializeChat', () => {
 
     assert({
       given: 'conversations GET returns non-ok',
-      should: 'fall back to creating a new conversation via POST',
+      should: 'NOT POST — fall back to page-scoped deterministic ID',
       actual: wasPostCalled(CONVERSATIONS_URL),
-      expected: true,
+      expected: false,
     });
   });
 
@@ -396,7 +341,7 @@ describe('AiChatView initializeChat', () => {
     await waitFor(() => {
       assert({
         given: 'a second user opening the same page',
-        should: 'load messages from the shared existing conversation (not create a new one)',
+        should: 'load messages from the shared existing conversation',
         actual: wasGetCalled(MESSAGES_URL),
         expected: true,
       });
@@ -425,21 +370,8 @@ describe('AiChatView initializeChat', () => {
 
     render(<AiChatView page={page} />);
 
-    await waitFor(() => {
-      assert({
-        given: 'component initialized',
-        should: 'render the New Chat button',
-        actual: screen.getAllByRole('button').some(
-          (b) => b.textContent?.includes('New Chat') || b.getAttribute('aria-label')?.includes('New Chat')
-        ),
-        expected: true,
-      });
-    });
-
-    const newChatButton = screen.getAllByRole('button').find(
-      (b) => b.textContent?.includes('New Chat') || b.getAttribute('aria-label')?.includes('New Chat')
-    );
-    if (newChatButton) fireEvent.click(newChatButton);
+    const newChatButton = await screen.findByRole('button', { name: /new chat/i });
+    fireEvent.click(newChatButton);
 
     assert({
       given: 'user clicks the New Chat button',

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
@@ -323,6 +323,37 @@ describe('AiChatView initializeChat', () => {
     });
   });
 
+  test('given conversations GET throws a network error, falls back to page-scoped deterministic ID without POSTing', async () => {
+    mockFetchWithAuth.mockImplementation(async (url: string, opts?: { method?: string }) => {
+      if (url === PERMISSIONS_URL) return makeOkResponse({ canEdit: true });
+      if (url === AGENT_CONFIG_URL) return makeOkResponse({});
+      if (url === `${CONVERSATIONS_URL}?pageSize=1` && !opts?.method) {
+        throw new Error('network error');
+      }
+      return makeErrorResponse();
+    });
+
+    render(<AiChatView page={page} />);
+
+    await waitFor(() => {
+      assert({
+        given: 'conversations GET throws',
+        should: 'attempt to GET conversations first',
+        actual: (mockFetchWithAuth.mock.calls as Parameters<typeof fetchWithAuth>[]).some(
+          ([callUrl]) => callUrl === `${CONVERSATIONS_URL}?pageSize=1`
+        ),
+        expected: true,
+      });
+    });
+
+    assert({
+      given: 'conversations GET throws',
+      should: 'NOT POST — fall back to page-scoped deterministic ID',
+      actual: wasPostCalled(CONVERSATIONS_URL),
+      expected: false,
+    });
+  });
+
   test('given two users opening the same page, both load the same existing conversation by fetching its messages', async () => {
     mockFetchWithAuth.mockImplementation(async (url: string, opts?: { method?: string }) => {
       if (url === PERMISSIONS_URL) return makeOkResponse({ canEdit: true });

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/riteway.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/riteway.ts
@@ -1,0 +1,13 @@
+import { expect } from 'vitest';
+
+interface AssertParams {
+  given: string;
+  should: string;
+  actual: unknown;
+  expected: unknown;
+}
+
+export const assert = ({ given, should, actual, expected }: AssertParams): void => {
+  const message = `Given ${given}, should ${should}`;
+  expect(actual, message).toEqual(expected);
+};

--- a/tasks/multiplayer-ai-chat-streaming.md
+++ b/tasks/multiplayer-ai-chat-streaming.md
@@ -70,18 +70,19 @@ Implement a Zustand store and socket hook that tracks in-progress remote streams
 - Given SSE done sentinel resolves and `chat:stream_complete` also fires, should call `onStreamComplete` exactly once
 - Given the socket reconnects while the hook is mounted, should re-emit `join_channel` to rejoin the page room
 
-### Task 6: Shared Conversation Init (review fixes)
+### Task 6: Fix conversation init so the stream completion guard works
 **Status:** In progress
 **PR:** https://github.com/2witstudios/PageSpace/pull/1152
 
-Fix `initializeChat` so all openers of an AI chat page land in the same conversation.
+Each conversation is a session that multiple users can join. The stream completion guard in `AiChatView` — `stream.conversationId === currentConversationId` — only appends a remote AI response to your view if you're in the same conversation as the sender. The bug: `initializeChat` always POSTed a new conversation on every page load, so each user got a different `conversationId` and the guard never matched.
+
+Fix: load the most recent existing conversation on open (GET instead of POST). Fall back to a deterministic `${page.id}-default` ID when no conversations exist yet — the server accepts any string as a conversation ID, so this becomes a real conversation once the first message is saved.
 
 #### Acceptance criteria
 - Given an existing conversation, should load it on page load without creating a new one via POST
-- Given no conversations exist, should NOT POST a new server-side conversation (avoids race between concurrent openers)
-- Given no conversations exist, should use a page-scoped deterministic conversation ID so concurrent openers share the same ID before either sends a message
-- Given the conversations list fetch fails (non-ok or throws), should fall back to the page-scoped deterministic ID
-- Given loaded conversation messages, should apply the fetched messages to chat state (not empty array)
+- Given no conversations exist, should derive a stable ID from the page so the guard can match before either user sends a message
+- Given the conversations list fetch fails (non-ok or throws), should fall back to the page-scoped ID
+- Given loaded conversation messages, should apply them to chat state
 - Given user clicks New Chat, should call `createConversation` from `useConversations` (existing behavior unchanged)
 
 ### Task 5: Multiplayer Chat UI

--- a/tasks/multiplayer-ai-chat-streaming.md
+++ b/tasks/multiplayer-ai-chat-streaming.md
@@ -70,6 +70,20 @@ Implement a Zustand store and socket hook that tracks in-progress remote streams
 - Given SSE done sentinel resolves and `chat:stream_complete` also fires, should call `onStreamComplete` exactly once
 - Given the socket reconnects while the hook is mounted, should re-emit `join_channel` to rejoin the page room
 
+### Task 6: Shared Conversation Init (review fixes)
+**Status:** In progress
+**PR:** https://github.com/2witstudios/PageSpace/pull/1152
+
+Fix `initializeChat` so all openers of an AI chat page land in the same conversation.
+
+#### Acceptance criteria
+- Given an existing conversation, should load it on page load without creating a new one via POST
+- Given no conversations exist, should NOT POST a new server-side conversation (avoids race between concurrent openers)
+- Given no conversations exist, should use a page-scoped deterministic conversation ID so concurrent openers share the same ID before either sends a message
+- Given the conversations list fetch fails (non-ok or throws), should fall back to the page-scoped deterministic ID
+- Given loaded conversation messages, should apply the fetched messages to chat state (not empty array)
+- Given user clicks New Chat, should call `createConversation` from `useConversations` (existing behavior unchanged)
+
 ### Task 5: Multiplayer Chat UI
 **Status:** Pending
 


### PR DESCRIPTION
## Summary

Each conversation is a session that multiple users can join. The stream completion guard in `AiChatView` — `stream.conversationId === currentConversationId` — only appends a remote AI response to your view if you're in the same conversation as the sender. Users can be in independent conversations on the same page, or the same one.

**The bug**: `initializeChat` always POSTed a new conversation on every page load, so each user got a different `conversationId` and the guard never matched for users in the same conversation.

**Fix**: GET the most recent existing conversation on open instead of POSTing. Falls back to a `${page.id}-default` ID when none exist — the server stores whatever string you pass as `conversationId`, so this becomes a real conversation once the first message is saved.

**Also**: all three `fetchWithAuth` calls in `initializeChat` now share an `AbortController` for clean unmount cancellation.

## Test plan

- [x] Given existing conversation → GET list, load messages, no POST
- [x] Given no conversations → derive page-scoped ID, no POST
- [x] Given GET fails (non-ok) → fall back to page-scoped ID, no POST
- [x] Given two users on same page → both load same conversation via GET
- [x] Given user clicks New Chat → `createConversation` called (existing behavior unchanged)
- [x] `pnpm --filter web typecheck` — clean
- [x] 5/5 tests passing in `__tests__/AiChatView.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)