### PR TITLE
fix(ai): sync conversation ID for late-joining multiplayer chat users

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -108,6 +108,9 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
   const inputRef = useRef<ChatInputRef>(null);
   const agentSettingsRef = useRef<PageAgentSettingsTabRef>(null);
   const prevConversationIdRef = useRef<string | null>(null);
+  // Always reflects the current page.id so async callbacks can detect stale pages
+  const pageIdRef = useRef(page.id);
+  useEffect(() => { pageIdRef.current = page.id; }, [page.id]);
 
   // ============================================
   // SHARED HOOKS
@@ -336,6 +339,7 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
       const { text, conversationId: streamConvId } = stream;
       fetchWithAuth(`/api/ai/page-agents/${page.id}/conversations?pageSize=1`)
         .then(async (res) => {
+          if (pageIdRef.current !== page.id) return;
           if (!res.ok) return;
           const data = (await res.json()) as ConversationListResponse;
           const persisted = data.conversations?.[0];

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -332,6 +332,26 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
           parts: [{ type: 'text' as const, text: stream.text }],
         },
       ]);
+    } else if (stream?.text && currentConversationId === `${page.id}-default`) {
+      const { text, conversationId: streamConvId } = stream;
+      fetchWithAuth(`/api/ai/page-agents/${page.id}/conversations?pageSize=1`)
+        .then(async (res) => {
+          if (!res.ok) return;
+          const data = (await res.json()) as ConversationListResponse;
+          const persisted = data.conversations?.[0];
+          if (!persisted || persisted.id !== streamConvId) return;
+          setCurrentConversationId(persisted.id);
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: messageId,
+              role: 'assistant' as const,
+              content: text,
+              parts: [{ type: 'text' as const, text }],
+            },
+          ]);
+        })
+        .catch(() => {});
     }
   });
 

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -351,7 +351,7 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
             },
           ]);
         })
-        .catch(() => {});
+        .catch((err) => console.warn('[AiChatView] late-joiner sync failed', err));
     }
   });
 

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, test, vi, beforeEach, type Mock } from 'vitest';
-import { render, waitFor, screen, fireEvent } from '@testing-library/react';
+import { render, act, waitFor, screen, fireEvent } from '@testing-library/react';
 import { assert } from './riteway';
 
 // Hoisted mock instances accessible inside vi.mock factories
@@ -644,5 +644,75 @@ describe('AiChatView late-joiner conversation sync', () => {
     });
 
     warnSpy.mockRestore();
+  });
+
+  test('given the component navigates to a different page while the sync fetch is in-flight, should NOT apply stale page-A state to page B', async () => {
+    const PAGE_B_ID = 'page-b-456';
+    let capturedPageACallback: ((messageId: string) => void) | undefined;
+    vi.mocked(useChatStreamSocket).mockImplementation((pageId, _userId, cb) => {
+      if (pageId === PAGE_ID) capturedPageACallback = cb;
+    });
+
+    let resolveSyncFetch!: () => void;
+    const syncFetchReady = new Promise<void>((resolve) => { resolveSyncFetch = resolve; });
+
+    let pageAConvCallCount = 0;
+    mockFetchWithAuth.mockImplementation(async (url: string) => {
+      if (url === PERMISSIONS_URL) return makeOkResponse({ canEdit: true });
+      if (url === `/api/pages/${PAGE_B_ID}/permissions/check`) return makeOkResponse({ canEdit: true });
+      if (url === AGENT_CONFIG_URL) return makeOkResponse({});
+      if (url === `/api/pages/${PAGE_B_ID}/agent-config`) return makeOkResponse({});
+      if (url === `${CONVERSATIONS_URL}?pageSize=1`) {
+        pageAConvCallCount++;
+        if (pageAConvCallCount === 1) return makeOkResponse({ conversations: [] }); // init
+        await syncFetchReady;
+        return makeOkResponse({ conversations: [{ id: REAL_CONV_ID }] }); // sync (deferred)
+      }
+      if (url === `/api/ai/page-agents/${PAGE_B_ID}/conversations?pageSize=1`) {
+        return makeOkResponse({ conversations: [] }); // page B init
+      }
+      return makeErrorResponse();
+    });
+
+    const pageBObj = { ...makePage(), id: PAGE_B_ID };
+    const { rerender } = render(<AiChatView page={page} />);
+
+    await waitFor(() => {
+      assert({
+        given: 'page A init',
+        should: 'have fetched conversations',
+        actual: pageAConvCallCount >= 1,
+        expected: true,
+      });
+    });
+
+    (usePendingStreamsStore as unknown as { getState: Mock }).getState.mockReturnValue({
+      streams: new Map([[MESSAGE_ID, { text: 'AI from page A', conversationId: REAL_CONV_ID }]]),
+    });
+
+    // Trigger the late-joiner sync (starts the deferred fetch)
+    capturedPageACallback?.(MESSAGE_ID);
+
+    // Navigate to page B — this should update pageIdRef.current
+    rerender(<AiChatView page={pageBObj} />);
+
+    const callsBefore = mockSetMessages.mock.calls.length;
+
+    // Resolve the deferred fetch (page A's conversation data arrives after navigation)
+    await act(async () => { resolveSyncFetch(); });
+
+    // The stale late-joiner sync would use a functional update: setMessages((prev) => [...prev, msg])
+    // Page B's legitimate init uses a direct array: setMessages([])
+    // So we check that no functional-update calls were added after callsBefore
+    const functionalCallsAfterNav = mockSetMessages.mock.calls
+      .slice(callsBefore)
+      .filter((args) => typeof args[0] === 'function');
+
+    assert({
+      given: 'page A sync fetch resolves after navigating to page B',
+      should: 'NOT make any functional setMessages calls (stale page-A append)',
+      actual: functionalCallsAfterNav.length,
+      expected: 0,
+    });
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
@@ -515,4 +515,134 @@ describe('AiChatView late-joiner conversation sync', () => {
       expected: setMessagesCallsBefore,
     });
   });
+
+  test('given the sync fetch returns !res.ok, should NOT append any message', async () => {
+    let capturedCallback: ((messageId: string) => void) | undefined;
+    vi.mocked(useChatStreamSocket).mockImplementation((_pageId, _userId, cb) => {
+      capturedCallback = cb;
+    });
+
+    setupNoConversationsInit();
+    render(<AiChatView page={page} />);
+
+    await waitFor(() => {
+      assert({
+        given: 'init with no existing conversations',
+        should: 'fetch conversations list',
+        actual: wasGetCalled(`${CONVERSATIONS_URL}?pageSize=1`),
+        expected: true,
+      });
+    });
+
+    (usePendingStreamsStore as unknown as { getState: Mock }).getState.mockReturnValue({
+      streams: new Map([[MESSAGE_ID, { text: 'AI response', conversationId: REAL_CONV_ID }]]),
+    });
+
+    mockFetchWithAuth.mockImplementation(async (url: string) => {
+      if (url === `${CONVERSATIONS_URL}?pageSize=1`) return makeErrorResponse();
+      return makeErrorResponse();
+    });
+
+    const setMessagesCallsBefore = mockSetMessages.mock.calls.length;
+    capturedCallback?.(MESSAGE_ID);
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+
+    assert({
+      given: 'sync fetch returns !res.ok',
+      should: 'NOT append any message',
+      actual: mockSetMessages.mock.calls.length,
+      expected: setMessagesCallsBefore,
+    });
+  });
+
+  test('given the sync fetch returns an empty conversations array, should NOT append any message', async () => {
+    let capturedCallback: ((messageId: string) => void) | undefined;
+    vi.mocked(useChatStreamSocket).mockImplementation((_pageId, _userId, cb) => {
+      capturedCallback = cb;
+    });
+
+    setupNoConversationsInit();
+    render(<AiChatView page={page} />);
+
+    await waitFor(() => {
+      assert({
+        given: 'init with no existing conversations',
+        should: 'fetch conversations list',
+        actual: wasGetCalled(`${CONVERSATIONS_URL}?pageSize=1`),
+        expected: true,
+      });
+    });
+
+    (usePendingStreamsStore as unknown as { getState: Mock }).getState.mockReturnValue({
+      streams: new Map([[MESSAGE_ID, { text: 'AI response', conversationId: REAL_CONV_ID }]]),
+    });
+
+    mockFetchWithAuth.mockImplementation(async (url: string) => {
+      if (url === `${CONVERSATIONS_URL}?pageSize=1`) return makeOkResponse({ conversations: [] });
+      return makeErrorResponse();
+    });
+
+    const setMessagesCallsBefore = mockSetMessages.mock.calls.length;
+    capturedCallback?.(MESSAGE_ID);
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+
+    assert({
+      given: 'sync fetch returns empty conversations array',
+      should: 'NOT append any message',
+      actual: mockSetMessages.mock.calls.length,
+      expected: setMessagesCallsBefore,
+    });
+  });
+
+  test('given the sync fetch throws a network error, should warn and NOT append any message', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    let capturedCallback: ((messageId: string) => void) | undefined;
+    vi.mocked(useChatStreamSocket).mockImplementation((_pageId, _userId, cb) => {
+      capturedCallback = cb;
+    });
+
+    setupNoConversationsInit();
+    render(<AiChatView page={page} />);
+
+    await waitFor(() => {
+      assert({
+        given: 'init with no existing conversations',
+        should: 'fetch conversations list',
+        actual: wasGetCalled(`${CONVERSATIONS_URL}?pageSize=1`),
+        expected: true,
+      });
+    });
+
+    (usePendingStreamsStore as unknown as { getState: Mock }).getState.mockReturnValue({
+      streams: new Map([[MESSAGE_ID, { text: 'AI response', conversationId: REAL_CONV_ID }]]),
+    });
+
+    mockFetchWithAuth.mockImplementation(async (url: string) => {
+      if (url === `${CONVERSATIONS_URL}?pageSize=1`) throw new Error('network error');
+      return makeErrorResponse();
+    });
+
+    const setMessagesCallsBefore = mockSetMessages.mock.calls.length;
+    capturedCallback?.(MESSAGE_ID);
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+
+    assert({
+      given: 'sync fetch throws a network error',
+      should: 'call console.warn',
+      actual: warnSpy.mock.calls.length > 0,
+      expected: true,
+    });
+
+    assert({
+      given: 'sync fetch throws a network error',
+      should: 'NOT append any message',
+      actual: mockSetMessages.mock.calls.length,
+      expected: setMessagesCallsBefore,
+    });
+
+    warnSpy.mockRestore();
+  });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
@@ -1,4 +1,4 @@
-import { describe, test, vi, beforeEach } from 'vitest';
+import { describe, test, vi, beforeEach, type Mock } from 'vitest';
 import { render, waitFor, screen, fireEvent } from '@testing-library/react';
 import { assert } from './riteway';
 
@@ -159,6 +159,8 @@ vi.mock('zustand/react/shallow', () => ({ useShallow: vi.fn((fn: unknown) => fn)
 import AiChatView from '../AiChatView';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { useChatStreamSocket } from '@/hooks/useChatStreamSocket';
+import { usePendingStreamsStore } from '@/stores/usePendingStreamsStore';
 
 const PAGE_ID = 'page-123';
 const CONV_ID = 'conv-existing-abc';
@@ -409,6 +411,108 @@ describe('AiChatView initializeChat', () => {
       should: 'call createConversation from useConversations (no change to existing behavior)',
       actual: mockCreateConversation.mock.calls.length,
       expected: 1,
+    });
+  });
+});
+
+describe('AiChatView late-joiner conversation sync', () => {
+  const page = makePage();
+  const MESSAGE_ID = 'msg-late-joiner';
+  const REAL_CONV_ID = 'real-conv-id';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const setupNoConversationsInit = () => {
+    mockFetchWithAuth.mockImplementation(async (url: string) => {
+      if (url === PERMISSIONS_URL) return makeOkResponse({ canEdit: true });
+      if (url === AGENT_CONFIG_URL) return makeOkResponse({});
+      if (url === `${CONVERSATIONS_URL}?pageSize=1`) return makeOkResponse({ conversations: [] });
+      return makeErrorResponse();
+    });
+  };
+
+  test('given fireComplete fires with stream.conversationId matching the persisted conversation while currentConversationId is the page-scoped default, should sync ID and append the message', async () => {
+    let capturedCallback: ((messageId: string) => void) | undefined;
+    vi.mocked(useChatStreamSocket).mockImplementation((_pageId, _userId, cb) => {
+      capturedCallback = cb;
+    });
+
+    setupNoConversationsInit();
+    render(<AiChatView page={page} />);
+
+    await waitFor(() => {
+      assert({
+        given: 'init with no existing conversations',
+        should: 'fetch conversations list',
+        actual: wasGetCalled(`${CONVERSATIONS_URL}?pageSize=1`),
+        expected: true,
+      });
+    });
+
+    (usePendingStreamsStore as unknown as { getState: Mock }).getState.mockReturnValue({
+      streams: new Map([[MESSAGE_ID, { text: 'AI response', conversationId: REAL_CONV_ID }]]),
+    });
+
+    mockFetchWithAuth.mockImplementation(async (url: string) => {
+      if (url === `${CONVERSATIONS_URL}?pageSize=1`) {
+        return makeOkResponse({ conversations: [{ id: REAL_CONV_ID }] });
+      }
+      return makeErrorResponse();
+    });
+
+    capturedCallback?.(MESSAGE_ID);
+
+    await waitFor(() => {
+      assert({
+        given: 'stream.conversationId matches the persisted conversation while holding page-scoped default',
+        should: 'append the completed AI message',
+        actual: mockSetMessages.mock.calls.some((args) => typeof args[0] === 'function'),
+        expected: true,
+      });
+    });
+  });
+
+  test('given fireComplete fires with stream.conversationId that does NOT match the persisted conversation, should NOT append the message', async () => {
+    let capturedCallback: ((messageId: string) => void) | undefined;
+    vi.mocked(useChatStreamSocket).mockImplementation((_pageId, _userId, cb) => {
+      capturedCallback = cb;
+    });
+
+    setupNoConversationsInit();
+    render(<AiChatView page={page} />);
+
+    await waitFor(() => {
+      assert({
+        given: 'init with no existing conversations',
+        should: 'fetch conversations list',
+        actual: wasGetCalled(`${CONVERSATIONS_URL}?pageSize=1`),
+        expected: true,
+      });
+    });
+
+    (usePendingStreamsStore as unknown as { getState: Mock }).getState.mockReturnValue({
+      streams: new Map([[MESSAGE_ID, { text: 'AI response', conversationId: REAL_CONV_ID }]]),
+    });
+
+    mockFetchWithAuth.mockImplementation(async (url: string) => {
+      if (url === `${CONVERSATIONS_URL}?pageSize=1`) {
+        return makeOkResponse({ conversations: [{ id: 'different-conv-id' }] });
+      }
+      return makeErrorResponse();
+    });
+
+    const setMessagesCallsBefore = mockSetMessages.mock.calls.length;
+    capturedCallback?.(MESSAGE_ID);
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+
+    assert({
+      given: 'GET returns a different conversation id than stream.conversationId',
+      should: 'NOT append any message',
+      actual: mockSetMessages.mock.calls.length,
+      expected: setMessagesCallsBefore,
     });
   });
 });


### PR DESCRIPTION
## Summary

- **Bug**: A user (User B) who opens a shared AI chat page before any DB conversation exists gets the \`\${page.id}-default\` placeholder ID. If another user (User A) sends the first message while User B is on the page, User A's stream anchors a real DB conversation ID. When User A's stream completes, the guard \`stream.conversationId === currentConversationId\` in \`useChatStreamSocket\`'s callback fails for User B (their placeholder doesn't match), so the completed AI response is silently dropped. User B must reload to see it.

- **Fix**: Added an \`else if\` branch in the \`fireComplete\` callback. When \`currentConversationId\` is still the page-scoped default and the stream has text, we do a quick \`GET conversations?pageSize=1\` to check whether the stream's conversation is now the persisted one. If it matches, we sync \`currentConversationId\` to the real ID and append the message. If it doesn't match (unrelated page event), we do nothing.

- **Guard against stale-page state**: Added a \`pageIdRef\` (kept current via \`useEffect\`) and capture \`capturedPageId = page.id\` before the async boundary. Inside \`.then()\`, we bail immediately if \`pageIdRef.current !== capturedPageId\`, preventing cross-page data mix-up when the user navigates away while the fetch is in-flight.

- **Error visibility**: Replaced \`.catch(() => {})\` with \`.catch((err) => console.warn(...))\` so sync failures are debuggable instead of silently dropped.

## Test plan

- [x] Case A: \`fireComplete\` fires with \`stream.conversationId\` matching the persisted conversation while \`currentConversationId\` is the page-scoped default → syncs ID and appends message ✅
- [x] Case B: same scenario but GET returns a different conversation ID → does NOT append message ✅
- [x] Case C: GET returns \`!res.ok\` → does NOT append message ✅
- [x] Case D: GET returns empty conversations array → does NOT append message ✅
- [x] Case E: GET throws network error → warns via \`console.warn\`, does NOT append message ✅
- [x] Case F: user navigates to page B while GET is in-flight → stale page A data does NOT corrupt page B state ✅
- [x] All 12 \`AiChatView\` tests pass
- [x] No TypeScript errors in modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)