### PR TITLE
feat(realtime): auto-join users to user:{userId}:global socket room

### DIFF
--- a/apps/realtime/src/__tests__/rooms.test.ts
+++ b/apps/realtime/src/__tests__/rooms.test.ts
@@ -86,10 +86,12 @@ const createRoomHandlers = (socket: ReturnType<typeof createMockSocket>) => {
         const taskRoom = `user:${user.id}:tasks`;
         const calendarRoom = `user:${user.id}:calendar`;
         const userDrivesRoom = `user:${user.id}:drives`;
+        const globalRoom = `user:${user.id}:global`;
         socket.join(notificationRoom);
         socket.join(taskRoom);
         socket.join(calendarRoom);
         socket.join(userDrivesRoom);
+        socket.join(globalRoom);
       }
     },
 
@@ -433,6 +435,44 @@ describe('Room Management', () => {
 
       expect(socket.leave).toHaveBeenCalledWith(`user:${userId}:drives`);
       expect(socket.hasJoinedRoom(`user:${userId}:drives`)).toBe(false);
+    });
+  });
+
+  describe('user-scoped global room', () => {
+    it('given authenticated user on connect, should auto-join user:{userId}:global room', () => {
+      const userId = 'test-user-123';
+      const socket = createMockSocket(userId);
+      const handlers = createRoomHandlers(socket);
+
+      handlers.onConnect();
+
+      expect(socket.hasJoinedRoom(`user:${userId}:global`)).toBe(true);
+    });
+
+    it('given unauthenticated socket, should not join global room', () => {
+      const socket = createMockSocket(undefined);
+      const handlers = createRoomHandlers(socket);
+
+      handlers.onConnect();
+
+      expect(socket.join).not.toHaveBeenCalled();
+    });
+
+    it('given two users, user A should NOT be in user B global room', () => {
+      const userA = 'user-a-111';
+      const userB = 'user-b-222';
+      const socketA = createMockSocket(userA);
+      const socketB = createMockSocket(userB);
+      const handlersA = createRoomHandlers(socketA);
+      const handlersB = createRoomHandlers(socketB);
+
+      handlersA.onConnect();
+      handlersB.onConnect();
+
+      expect(socketA.hasJoinedRoom(`user:${userA}:global`)).toBe(true);
+      expect(socketB.hasJoinedRoom(`user:${userB}:global`)).toBe(true);
+      expect(socketA.hasJoinedRoom(`user:${userB}:global`)).toBe(false);
+      expect(socketB.hasJoinedRoom(`user:${userA}:global`)).toBe(false);
     });
   });
 

--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -484,24 +484,27 @@ io.on('connection', (socket: AuthSocket) => {
     socketRegistry.registerSocket(user.id, socket.id);
   }
 
-  // Auto-join user's notification, task, and personal calendar rooms
+  // Auto-join user's personal rooms on connection
   if (user?.id) {
     const notificationRoom = `notifications:${user.id}`;
     const taskRoom = `user:${user.id}:tasks`;
     const calendarRoom = `user:${user.id}:calendar`;
     const userDrivesRoom = `user:${user.id}:drives`;
+    const globalRoom = `user:${user.id}:global`;
     socket.join(notificationRoom);
     socket.join(taskRoom);
     socket.join(calendarRoom);
     socket.join(userDrivesRoom);
+    socket.join(globalRoom);
     // Track in registry (these are always-on rooms, not permission-gated)
     socketRegistry.trackRoomJoin(socket.id, notificationRoom);
     socketRegistry.trackRoomJoin(socket.id, taskRoom);
     socketRegistry.trackRoomJoin(socket.id, calendarRoom);
     socketRegistry.trackRoomJoin(socket.id, userDrivesRoom);
-    loggers.realtime.debug('User joined notification, task, calendar, and drives rooms', {
+    socketRegistry.trackRoomJoin(socket.id, globalRoom);
+    loggers.realtime.debug('User joined notification, task, calendar, drives, and global rooms', {
       userId: user.id,
-      rooms: [notificationRoom, taskRoom, calendarRoom, userDrivesRoom]
+      rooms: [notificationRoom, taskRoom, calendarRoom, userDrivesRoom, globalRoom]
     });
   }
 

--- a/tasks/ai-chat-streaming-persistence.md
+++ b/tasks/ai-chat-streaming-persistence.md
@@ -118,7 +118,7 @@ Extend the pending streams store with an `isOwn` flag to distinguish the current
 Fix own-stream detection to use tabId, support global channel IDs, and bootstrap from DB on mount.
 
 **Requirements**:
-- Given two tabs open by the same user, should mark only the originating tab's stream as own
+- Given a stream from any source, `isOwn` must be `triggeredBy.tabId === getTabId()` — tabId persists through refresh via sessionStorage so the originating tab correctly reclaims its stream; a different window of the same user gets `isOwn: false` (sees indicator, cannot stop)
 - Given `channelId` is a `user:${userId}:global` string, should pass it through to the active-streams endpoint correctly
 - Given active streams exist in DB at mount time, should bootstrap the store before any socket events arrive
 - Given a bootstrapped stream completes via SSE, should call the same completion handler as live socket events
@@ -156,6 +156,8 @@ Wire global chat context to handle multiplayer stream events: DB bootstrap on mo
 
 **Requirements**:
 - Given mount with active streams in DB, should bootstrap `usePendingStreamsStore` before any socket event arrives
+- Given a bootstrapped stream where `triggeredBy.tabId === getTabId()` (own stream), should call `setIsStreaming(true)` and `setStopStreaming(() => abortActiveStreamByMessageId(messageId))` so the existing stop button in the global chat UI works without any UI changes
+- Given the bootstrapped own stream completes via SSE, should call `setIsStreaming(false)`, `setStopStreaming(null)`, and `refreshConversation`
 - Given `chat:stream_start` from the current tab, should skip it (tabId filter prevents duplicate handling)
 - Given `chat:stream_start` for a different user's global channel, should skip it (pageId guard)
 - Given `chat:stream_start` for the correct channel from another tab, should addStream and open SSE join

--- a/tasks/ai-chat-streaming-persistence.md
+++ b/tasks/ai-chat-streaming-persistence.md
@@ -15,7 +15,7 @@ Add `packages/db/src/schema/ai-streams.ts` with a new `aiStreamSessions` pgTable
 
 **Requirements**:
 - Given a new schema file is added, should export `aiStreamSessions` from `packages/db/src/schema.ts`
-- Given `channelId` field, should accept pageId for page chats and `global:${userId}` for global chat
+- Given `channelId` field, should accept pageId for page chats and `user:${userId}:global` for global chat
 - Given `status` field, should only allow values: 'streaming', 'complete', or 'aborted'
 - Given (channelId, status) index, should enable fast queries for active streams per channel
 - Given schema change, should run `pnpm db:generate` to produce migration files (never hand-edit SQL)
@@ -66,10 +66,10 @@ Upgrade the page AI chat route to persist stream sessions to DB, thread tabId th
 Bring the global chat route to feature parity with the page chat route: multicast registry, DB persistence, socket events, and abort key registration.
 
 **Requirements**:
-- Given global chat stream starts, should register with multicast registry using `global:${userId}` as channelId
-- Given global chat stream starts, should INSERT into `aiStreamSessions` with `channelId = \`global:${userId}\``
+- Given global chat stream starts, should register with multicast registry using `user:${userId}:global` as channelId
+- Given global chat stream starts, should INSERT into `aiStreamSessions` with `channelId = \`user:${userId}:global\``
 - Given `text-delta` events, should push chunks to multicast registry
-- Given stream completes, should emit `broadcastAiStreamComplete` to the `global:${userId}` socket room
+- Given stream completes, should emit `broadcastAiStreamComplete` to the `user:${userId}:global` socket room
 - Given stream is aborted, should UPDATE `aiStreamSessions` status to 'aborted'
 - Given `finishMulticast` guard, should prevent double-broadcast if called more than once
 
@@ -119,7 +119,7 @@ Fix own-stream detection to use tabId, support global channel IDs, and bootstrap
 
 **Requirements**:
 - Given two tabs open by the same user, should mark only the originating tab's stream as own
-- Given `channelId` is a `global:${userId}` string, should pass it through to the active-streams endpoint correctly
+- Given `channelId` is a `user:${userId}:global` string, should pass it through to the active-streams endpoint correctly
 - Given active streams exist in DB at mount time, should bootstrap the store before any socket events arrive
 - Given a bootstrapped stream completes via SSE, should call the same completion handler as live socket events
 - Given the component unmounts, should abort all bootstrapped SSE connections
@@ -141,10 +141,10 @@ Show a stop button and wire abort-by-messageId for streams the current tab initi
 
 ## Global chat socket room — realtime server
 
-Auto-join each authenticated user to their `global:${userId}` socket room for global chat stream routing.
+Auto-join each authenticated user to their `user:${userId}:global` socket room for global chat stream routing.
 
 **Requirements**:
-- Given a user authenticates with the realtime server, should automatically join the `global:${user.id}` socket room
+- Given a user authenticates with the realtime server, should automatically join the `user:${user.id}:global` socket room
 - Given the user is already authenticated (prior checks pass), should not require an additional permission check
 - Given the join follows the existing auto-join pattern for other rooms, should be placed in the same block for consistency
 

--- a/tasks/ai-chat-streaming-persistence.md
+++ b/tasks/ai-chat-streaming-persistence.md
@@ -1,0 +1,165 @@
+# AI Chat Streaming Persistence & Multiplayer Epic
+
+**Status**: 📋 PLANNED  
+**Goal**: Persist AI stream sessions to the DB and extend full multiplayer streaming support to global chat
+
+## Overview
+
+Users who refresh mid-stream, open a second tab, or switch to global chat lose all visibility into in-progress AI responses — there is no recovery path and no stop button after reconnect. The core gap is that stream state lives only in process memory and in-flight socket events, so any late join misses everything. This epic adds a `aiStreamSessions` DB table as the source of truth, introduces a stable per-tab identity (`tabId`) to correctly attribute streams, wires full multicast/socket infrastructure into global chat, and adds a bootstrap endpoint so any component can reconstruct active stream state on mount.
+
+---
+
+## DB schema — aiStreamSessions table
+
+Add `packages/db/src/schema/ai-streams.ts` with a new `aiStreamSessions` pgTable to persist streaming session state across server restarts and enable multiplayer bootstrap.
+
+**Requirements**:
+- Given a new schema file is added, should export `aiStreamSessions` from `packages/db/src/schema.ts`
+- Given `channelId` field, should accept pageId for page chats and `global:${userId}` for global chat
+- Given `status` field, should only allow values: 'streaming', 'complete', or 'aborted'
+- Given (channelId, status) index, should enable fast queries for active streams per channel
+- Given schema change, should run `pnpm db:generate` to produce migration files (never hand-edit SQL)
+
+---
+
+## messageId as canonical abort key
+
+Wire `messageId` as the primary abort key so clients can cancel a specific stream by message ID rather than opaque stream ID.
+
+**Requirements**:
+- Given `createStreamAbortController` is called with a `messageId`, should populate the messageId→streamId index
+- Given `removeStream` is called, should clean up the messageId index entry
+- Given `abortStreamByMessageId` is called, should look up streamId from index and abort it
+- Given abort route receives `{ messageId }` instead of `{ streamId }`, should resolve and abort the correct stream
+- Given client calls `abortActiveStreamByMessageId`, should POST `{ messageId }` to `/api/ai/abort`
+
+---
+
+## tabId — per-tab identity
+
+Introduce a stable per-browser-tab identity so multiplayer stream events can be filtered by the originating tab rather than just user ID.
+
+**Requirements**:
+- Given `getTabId()` is called on the same tab after a page refresh, should return the same UUID
+- Given `getTabId()` is called in two different browser tabs, should return different UUIDs
+- Given `createStreamTrackingFetch` makes any AI request, should include `X-Tab-Id` header
+- Given `AiStreamStartPayload.triggeredBy`, should include `tabId` field alongside `userId` and `displayName`
+
+---
+
+## Page AI chat route — DB writes + tabId + messageId abort key
+
+Upgrade the page AI chat route to persist stream sessions to DB, thread tabId through the multicast registry, and register messageId as the abort key.
+
+**Requirements**:
+- Given a stream starts, should INSERT a row into `aiStreamSessions` with status 'streaming'
+- Given stream completes normally, should UPDATE status to 'complete' and set `completedAt`
+- Given stream is aborted, should UPDATE status to 'aborted' and set `completedAt`
+- Given `X-Tab-Id` header is present, should pass `tabId` to multicast registry and socket broadcast
+- Given `serverAssistantMessageId` exists, should pass it as `messageId` to `createStreamAbortController`
+- Given `broadcastAiStreamStart` payload, should include `tabId` in `triggeredBy`
+
+---
+
+## Global chat route — add full streaming infrastructure
+
+Bring the global chat route to feature parity with the page chat route: multicast registry, DB persistence, socket events, and abort key registration.
+
+**Requirements**:
+- Given global chat stream starts, should register with multicast registry using `global:${userId}` as channelId
+- Given global chat stream starts, should INSERT into `aiStreamSessions` with `channelId = \`global:${userId}\``
+- Given `text-delta` events, should push chunks to multicast registry
+- Given stream completes, should emit `broadcastAiStreamComplete` to the `global:${userId}` socket room
+- Given stream is aborted, should UPDATE `aiStreamSessions` status to 'aborted'
+- Given `finishMulticast` guard, should prevent double-broadcast if called more than once
+
+---
+
+## streamMulticastRegistry — richer metadata
+
+Expand the `register()` metadata type to carry the full context needed by downstream consumers.
+
+**Requirements**:
+- Given `register()` is called, should accept `displayName`, `conversationId`, and `tabId` in addition to existing fields
+- Given `getMeta()` is called on a registered stream, should return the full metadata including new fields
+- Given both page and global route call sites, should be updated to pass the extended metadata
+- Given the `StreamMeta` interface, should be exported so downstream consumers can type-check against it
+
+---
+
+## Active streams endpoint
+
+Create `GET /api/ai/chat/active-streams?channelId=X` so clients can bootstrap multiplayer state on mount.
+
+**Requirements**:
+- Given an unauthenticated request, should return 401
+- Given a page channel and a user without view permission, should return 403
+- Given a global channel where the userId does not match the session user, should return 403
+- Given active streams exist within the 10-minute window, should return them with full triggeredBy metadata
+- Given no active streams, should return `{ streams: [] }`
+- Given streams older than 10 minutes with status 'streaming', should exclude them from results
+
+---
+
+## usePendingStreamsStore — add isOwn
+
+Extend the pending streams store with an `isOwn` flag to distinguish the current tab's streams from remote ones.
+
+**Requirements**:
+- Given `addStream` is called with `isOwn: true`, should store the flag on the PendingStream entry
+- Given `addStream` is called with `isOwn: false`, should store the flag as false
+- Given `getOwnStreams(channelId)`, should return only streams where `isOwn === true` for that channel
+- Given existing callers of `addStream`, should be updated to pass `isOwn` without breaking
+
+---
+
+## useChatStreamSocket — tabId filter + DB bootstrap
+
+Fix own-stream detection to use tabId, support global channel IDs, and bootstrap from DB on mount.
+
+**Requirements**:
+- Given two tabs open by the same user, should mark only the originating tab's stream as own
+- Given `channelId` is a `global:${userId}` string, should pass it through to the active-streams endpoint correctly
+- Given active streams exist in DB at mount time, should bootstrap the store before any socket events arrive
+- Given a bootstrapped stream completes via SSE, should call the same completion handler as live socket events
+- Given the component unmounts, should abort all bootstrapped SSE connections
+
+---
+
+## Stop button for reconnected own streams in AiChatView
+
+Show a stop button and wire abort-by-messageId for streams the current tab initiated, even after reconnect.
+
+**Requirements**:
+- Given `isStreaming` is true from local useChat, should show the stop button (existing behavior preserved)
+- Given an own stream exists in `usePendingStreamsStore` with `isOwn: true`, should show the stop button
+- Given the stop button is clicked for a pending own stream, should call `abortActiveStreamByMessageId` with the stream's messageId
+- Given no local or pending own streams are active, should not show the stop button
+- Given both a local stream and a pending own stream exist simultaneously, should show only one stop button
+
+---
+
+## Global chat socket room — realtime server
+
+Auto-join each authenticated user to their `global:${userId}` socket room for global chat stream routing.
+
+**Requirements**:
+- Given a user authenticates with the realtime server, should automatically join the `global:${user.id}` socket room
+- Given the user is already authenticated (prior checks pass), should not require an additional permission check
+- Given the join follows the existing auto-join pattern for other rooms, should be placed in the same block for consistency
+
+---
+
+## GlobalChatContext — stream socket listener + bootstrap
+
+Wire global chat context to handle multiplayer stream events: DB bootstrap on mount, live socket listeners, and SSE cleanup on unmount.
+
+**Requirements**:
+- Given mount with active streams in DB, should bootstrap `usePendingStreamsStore` before any socket event arrives
+- Given `chat:stream_start` from the current tab, should skip it (tabId filter prevents duplicate handling)
+- Given `chat:stream_start` for a different user's global channel, should skip it (pageId guard)
+- Given `chat:stream_start` for the correct channel from another tab, should addStream and open SSE join
+- Given `chat:stream_complete`, should abort the SSE connection, removeStream, and call refreshConversation
+- Given component unmounts, should abort all active SSE connections and remove all socket listeners
+
+---


### PR DESCRIPTION
## Summary
- Auto-joins every authenticated user to their `user:{userId}:global` Socket.IO room on connect
- Enables AI chat stream broadcasts (`io.to('user:{userId}:global').emit(...)`) to reach the client without requiring a DB-validated `join_channel` call
- Uses the `user:{userId}:*` naming convention for consistency with existing user-scoped rooms (`user:{userId}:tasks`, `user:{userId}:calendar`, `user:{userId}:drives`)
- Tracks the room in the socket registry alongside the other always-on rooms
- Adds tests for the auto-join room logic

## Why
Global chat broadcasts AI stream events to the channel `user:{userId}:global`. Previously no client was ever subscribed to that room — the `join_channel` event validates pageIds against the DB, so a userId-prefixed room name would fail the lookup. The user is already authenticated at connection time, so no extra DB check is needed.

## Test plan
- [ ] Connect as an authenticated user and verify the socket is placed in `user:<userId>:global` (check registry/logs)
- [ ] Trigger a global AI chat stream and confirm events arrive on the client
- [ ] Confirm existing notification, task, calendar, and drives rooms are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)