### PR TITLE
feat(ai): messageId as canonical abort key with reverse index

### DIFF
--- a/apps/web/src/app/api/ai/abort/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/abort/__tests__/route.test.ts
@@ -19,6 +19,7 @@ vi.mock('@/lib/auth', () => ({
 // Mock stream abort registry (boundary)
 vi.mock('@/lib/ai/core/stream-abort-registry', () => ({
   abortStream: vi.fn(),
+  abortStreamByMessageId: vi.fn(),
 }));
 
 // Mock logger (boundary)
@@ -42,13 +43,14 @@ vi.mock('@pagespace/lib/auth/rate-limit-utils', () => ({
 }));
 
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { abortStream } from '@/lib/ai/core/stream-abort-registry';
+import { abortStream, abortStreamByMessageId } from '@/lib/ai/core/stream-abort-registry';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { checkRateLimit } from '@pagespace/lib/auth/rate-limit-utils';
 
 // Test fixtures
 const mockUserId = 'user-123';
 const mockStreamId = 'stream-456';
+const mockMessageId = 'msg-789';
 
 const mockWebAuth = (userId: string): SessionAuthResult => ({
   userId,
@@ -95,7 +97,7 @@ describe('POST /api/ai/abort', () => {
   });
 
   describe('Input Validation', () => {
-    it('returns 400 without streamId', async () => {
+    it('returns 400 when neither streamId nor messageId provided', async () => {
       vi.mocked(authenticateRequestWithOptions).mockResolvedValueOnce(mockWebAuth(mockUserId));
       vi.mocked(isAuthError).mockReturnValueOnce(false);
 
@@ -104,11 +106,12 @@ describe('POST /api/ai/abort', () => {
       const data = await response.json();
 
       expect(response.status).toBe(400);
-      expect(data.error).toBe('streamId is required');
+      expect(data.error).toBe('streamId or messageId is required');
       expect(abortStream).not.toHaveBeenCalled();
+      expect(abortStreamByMessageId).not.toHaveBeenCalled();
     });
 
-    it('returns 400 when streamId is not a string', async () => {
+    it('returns 400 when streamId is not a string and no messageId', async () => {
       vi.mocked(authenticateRequestWithOptions).mockResolvedValueOnce(mockWebAuth(mockUserId));
       vi.mocked(isAuthError).mockReturnValueOnce(false);
 
@@ -117,10 +120,10 @@ describe('POST /api/ai/abort', () => {
       const data = await response.json();
 
       expect(response.status).toBe(400);
-      expect(data.error).toBe('streamId is required');
+      expect(data.error).toBe('streamId or messageId is required');
     });
 
-    it('returns 400 when streamId is empty string', async () => {
+    it('returns 400 when streamId is empty string and no messageId', async () => {
       vi.mocked(authenticateRequestWithOptions).mockResolvedValueOnce(mockWebAuth(mockUserId));
       vi.mocked(isAuthError).mockReturnValueOnce(false);
 
@@ -129,10 +132,10 @@ describe('POST /api/ai/abort', () => {
       const data = await response.json();
 
       expect(response.status).toBe(400);
-      expect(data.error).toBe('streamId is required');
+      expect(data.error).toBe('streamId or messageId is required');
     });
 
-    it('returns 400 when streamId is whitespace only', async () => {
+    it('returns 400 when streamId is whitespace only and no messageId', async () => {
       vi.mocked(authenticateRequestWithOptions).mockResolvedValueOnce(mockWebAuth(mockUserId));
       vi.mocked(isAuthError).mockReturnValueOnce(false);
 
@@ -141,7 +144,7 @@ describe('POST /api/ai/abort', () => {
       const data = await response.json();
 
       expect(response.status).toBe(400);
-      expect(data.error).toBe('streamId is required');
+      expect(data.error).toBe('streamId or messageId is required');
       expect(abortStream).not.toHaveBeenCalled();
     });
   });
@@ -185,11 +188,67 @@ describe('POST /api/ai/abort', () => {
         'AI stream abort requested',
         {
           streamId: mockStreamId,
+          messageId: undefined,
           userId: mockUserId,
           aborted: true,
           reason: 'Stream aborted by user request',
         }
       );
+    });
+  });
+
+  describe('Abort by messageId', () => {
+    it('calls abortStreamByMessageId when messageId is provided', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValueOnce(mockWebAuth(mockUserId));
+      vi.mocked(isAuthError).mockReturnValueOnce(false);
+      vi.mocked(abortStreamByMessageId).mockReturnValueOnce({
+        aborted: true,
+        reason: 'Stream aborted by user request',
+      });
+
+      const request = createRequest({ messageId: mockMessageId });
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.aborted).toBe(true);
+      expect(abortStreamByMessageId).toHaveBeenCalledWith({
+        messageId: mockMessageId,
+        userId: mockUserId,
+      });
+      expect(abortStream).not.toHaveBeenCalled();
+    });
+
+    it('prefers messageId over streamId when both are provided', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValueOnce(mockWebAuth(mockUserId));
+      vi.mocked(isAuthError).mockReturnValueOnce(false);
+      vi.mocked(abortStreamByMessageId).mockReturnValueOnce({
+        aborted: true,
+        reason: 'Stream aborted by user request',
+      });
+
+      const request = createRequest({ streamId: mockStreamId, messageId: mockMessageId });
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(abortStreamByMessageId).toHaveBeenCalledWith({
+        messageId: mockMessageId,
+        userId: mockUserId,
+      });
+      expect(abortStream).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when messageId is empty string and no streamId', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValueOnce(mockWebAuth(mockUserId));
+      vi.mocked(isAuthError).mockReturnValueOnce(false);
+
+      const request = createRequest({ messageId: '' });
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.error).toBe('streamId or messageId is required');
     });
   });
 

--- a/apps/web/src/app/api/ai/abort/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/abort/__tests__/route.test.ts
@@ -232,6 +232,7 @@ describe('POST /api/ai/abort', () => {
       const data = await response.json();
 
       expect(response.status).toBe(200);
+      expect(data.aborted).toBe(true);
       expect(abortStreamByMessageId).toHaveBeenCalledWith({
         messageId: mockMessageId,
         userId: mockUserId,

--- a/apps/web/src/app/api/ai/abort/route.ts
+++ b/apps/web/src/app/api/ai/abort/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { abortStream } from '@/lib/ai/core/stream-abort-registry';
+import { abortStream, abortStreamByMessageId } from '@/lib/ai/core/stream-abort-registry';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { checkRateLimit } from '@pagespace/lib/auth/rate-limit-utils';
@@ -46,25 +46,34 @@ export async function POST(request: Request) {
       );
     }
 
-    const { streamId } = await request.json();
+    const body = await request.json();
+    const { streamId, messageId } = body as { streamId?: string; messageId?: string };
 
-    if (!streamId || typeof streamId !== 'string' || !streamId.trim()) {
+    const hasStreamId = streamId && typeof streamId === 'string' && streamId.trim();
+    const hasMessageId = messageId && typeof messageId === 'string' && messageId.trim();
+
+    if (!hasStreamId && !hasMessageId) {
       return NextResponse.json(
-        { error: 'streamId is required' },
+        { error: 'streamId or messageId is required' },
         { status: 400 }
       );
     }
 
-    const result = abortStream({ streamId, userId });
+    const result = hasMessageId
+      ? abortStreamByMessageId({ messageId: messageId as string, userId })
+      : abortStream({ streamId: streamId as string, userId });
+
+    const resourceId = hasMessageId ? (messageId as string) : (streamId as string);
 
     loggers.api.info('AI stream abort requested', {
       streamId,
+      messageId,
       userId,
       aborted: result.aborted,
       reason: result.reason,
     });
 
-    auditRequest(request, { eventType: 'data.write', userId, resourceType: 'ai_chat_stream', resourceId: streamId, details: {
+    auditRequest(request, { eventType: 'data.write', userId, resourceType: 'ai_chat_stream', resourceId, details: {
       action: 'abort',
       aborted: result.aborted,
     } });

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -823,7 +823,7 @@ export async function POST(request: Request) {
 
     // Create abort controller for explicit user-initiated stop (via /api/ai/abort endpoint)
     // This is separate from request.signal which fires on any client disconnect
-    const { streamId, signal: abortSignal } = createStreamAbortController({ userId });
+    const { streamId, signal: abortSignal } = createStreamAbortController({ userId, messageId: serverAssistantMessageId });
 
     // Register in multicast registry so other viewers can join via stream-join endpoint
     try { streamMulticastRegistry.register(serverAssistantMessageId, { pageId: chatId, userId: userId! }); } catch {}

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -818,13 +818,13 @@ MENTION PROCESSING:
       wasTruncated: contextCalculation.wasTruncated,
     });
 
-    // Create abort controller for explicit user-initiated stop (via /api/ai/abort endpoint)
-    // This is separate from request.signal which fires on any client disconnect
-    const { streamId, signal: abortSignal } = createStreamAbortController({ userId });
-
     // Generate server-side message ID for the AI response
     // This ensures client and server use the same ID, fixing the undo-after-streaming issue
     const serverAssistantMessageId = createId();
+
+    // Create abort controller for explicit user-initiated stop (via /api/ai/abort endpoint)
+    // This is separate from request.signal which fires on any client disconnect
+    const { streamId, signal: abortSignal } = createStreamAbortController({ userId, messageId: serverAssistantMessageId });
 
     // Track usage promise for token counting
     let usagePromise: Promise<LanguageModelUsage | undefined> | undefined;

--- a/apps/web/src/lib/ai/core/__tests__/stream-abort-registry.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stream-abort-registry.test.ts
@@ -206,6 +206,85 @@ describe('stream-abort-registry', () => {
     });
   });
 
+  describe('abortStreamByMessageId', () => {
+    it('aborts stream by messageId when registered', async () => {
+      const registry = await import('../stream-abort-registry');
+
+      const { controller } = registry.createStreamAbortController({
+        userId: 'user-123',
+        streamId: 'stream-abc',
+        messageId: 'msg-123',
+      });
+
+      const result = registry.abortStreamByMessageId({ messageId: 'msg-123', userId: 'user-123' });
+
+      expect(result.aborted).toBe(true);
+      expect(result.reason).toBe('Stream aborted by user request');
+      expect(controller.signal.aborted).toBe(true);
+    });
+
+    it('returns not found when no messageId was registered', async () => {
+      const registry = await import('../stream-abort-registry');
+
+      registry.createStreamAbortController({ userId: 'user-123', streamId: 'stream-abc' });
+
+      const result = registry.abortStreamByMessageId({ messageId: 'msg-unknown', userId: 'user-123' });
+
+      expect(result.aborted).toBe(false);
+      expect(result.reason).toBe('Stream not found or already completed');
+    });
+
+    it('fails for different userId (IDOR protection via messageId)', async () => {
+      const registry = await import('../stream-abort-registry');
+
+      registry.createStreamAbortController({
+        userId: 'user-123',
+        streamId: 'stream-abc',
+        messageId: 'msg-123',
+      });
+
+      const result = registry.abortStreamByMessageId({ messageId: 'msg-123', userId: 'attacker-456' });
+
+      expect(result.aborted).toBe(false);
+      expect(result.reason).toBe('Unauthorized to abort this stream');
+    });
+
+    it('cleans up messageIdIndex entry after abort', async () => {
+      const registry = await import('../stream-abort-registry');
+
+      registry.createStreamAbortController({
+        userId: 'user-123',
+        streamId: 'stream-abc',
+        messageId: 'msg-123',
+      });
+
+      registry.abortStreamByMessageId({ messageId: 'msg-123', userId: 'user-123' });
+
+      // Second call should find nothing
+      const result = registry.abortStreamByMessageId({ messageId: 'msg-123', userId: 'user-123' });
+      expect(result.aborted).toBe(false);
+      expect(result.reason).toBe('Stream not found or already completed');
+    });
+  });
+
+  describe('removeStream with messageId cleanup', () => {
+    it('cleans up messageIdIndex entry on removeStream', async () => {
+      const registry = await import('../stream-abort-registry');
+
+      registry.createStreamAbortController({
+        userId: 'user-123',
+        streamId: 'stream-abc',
+        messageId: 'msg-123',
+      });
+
+      registry.removeStream({ streamId: 'stream-abc' });
+
+      const result = registry.abortStreamByMessageId({ messageId: 'msg-123', userId: 'user-123' });
+      expect(result.aborted).toBe(false);
+      expect(result.reason).toBe('Stream not found or already completed');
+    });
+  });
+
   describe('concurrent streams isolation', () => {
     it('streams from different users do not interfere', async () => {
       const registry = await import('../stream-abort-registry');

--- a/apps/web/src/lib/ai/core/client.ts
+++ b/apps/web/src/lib/ai/core/client.ts
@@ -7,6 +7,7 @@
 
 export {
   abortActiveStream,
+  abortActiveStreamByMessageId,
   createStreamTrackingFetch,
   setActiveStreamId,
   getActiveStreamId,

--- a/apps/web/src/lib/ai/core/stream-abort-client.ts
+++ b/apps/web/src/lib/ai/core/stream-abort-client.ts
@@ -106,7 +106,8 @@ export const abortActiveStreamByMessageId = async ({
       body: JSON.stringify({ messageId }),
     });
     return await response.json();
-  } catch {
+  } catch (error) {
+    console.error('Failed to abort stream by messageId:', error);
     return { aborted: false, reason: 'Failed to call abort endpoint' };
   }
 };

--- a/apps/web/src/lib/ai/core/stream-abort-client.ts
+++ b/apps/web/src/lib/ai/core/stream-abort-client.ts
@@ -106,8 +106,7 @@ export const abortActiveStreamByMessageId = async ({
       body: JSON.stringify({ messageId }),
     });
     return await response.json();
-  } catch (error) {
-    console.error('Failed to abort stream by messageId:', error);
+  } catch {
     return { aborted: false, reason: 'Failed to call abort endpoint' };
   }
 };

--- a/apps/web/src/lib/ai/core/stream-abort-client.ts
+++ b/apps/web/src/lib/ai/core/stream-abort-client.ts
@@ -94,6 +94,23 @@ export const abortActiveStream = async ({
   }
 };
 
+export const abortActiveStreamByMessageId = async ({
+  messageId,
+}: {
+  messageId: string;
+}): Promise<{ aborted: boolean; reason: string }> => {
+  try {
+    const response = await fetchWithAuth('/api/ai/abort', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ messageId }),
+    });
+    return await response.json();
+  } catch {
+    return { aborted: false, reason: 'Failed to call abort endpoint' };
+  }
+};
+
 /**
  * Create a fetch wrapper that tracks streamId from response headers
  * Use this with DefaultChatTransport

--- a/apps/web/src/lib/ai/core/stream-abort-registry.ts
+++ b/apps/web/src/lib/ai/core/stream-abort-registry.ts
@@ -23,6 +23,15 @@ interface StreamEntry {
 const registry = new Map<string, StreamEntry>();
 const messageIdIndex = new Map<string, string>(); // messageId → streamId
 
+const removeMessageIdEntry = (streamId: string): void => {
+  for (const [msgId, sid] of messageIdIndex.entries()) {
+    if (sid === streamId) {
+      messageIdIndex.delete(msgId);
+      break;
+    }
+  }
+};
+
 // Cleanup streams older than 10 minutes (safety net for orphaned entries)
 const MAX_STREAM_AGE_MS = 10 * 60 * 1000;
 const CLEANUP_INTERVAL_MS = 60 * 1000;
@@ -37,6 +46,7 @@ const startCleanupInterval = () => {
     for (const [streamId, entry] of registry.entries()) {
       if (now - entry.createdAt > MAX_STREAM_AGE_MS) {
         registry.delete(streamId);
+        removeMessageIdEntry(streamId);
       }
     }
   }, CLEANUP_INTERVAL_MS);
@@ -119,12 +129,7 @@ export const abortStream = ({
 
   entry.controller.abort();
   registry.delete(streamId);
-  for (const [msgId, sid] of messageIdIndex.entries()) {
-    if (sid === streamId) {
-      messageIdIndex.delete(msgId);
-      break;
-    }
-  }
+  removeMessageIdEntry(streamId);
 
   return { aborted: true, reason: 'Stream aborted by user request' };
 };
@@ -134,12 +139,7 @@ export const abortStream = ({
  */
 export const removeStream = ({ streamId }: { streamId: string }): void => {
   registry.delete(streamId);
-  for (const [msgId, sid] of messageIdIndex.entries()) {
-    if (sid === streamId) {
-      messageIdIndex.delete(msgId);
-      break;
-    }
-  }
+  removeMessageIdEntry(streamId);
 };
 
 export const abortStreamByMessageId = ({

--- a/apps/web/src/lib/ai/core/stream-abort-registry.ts
+++ b/apps/web/src/lib/ai/core/stream-abort-registry.ts
@@ -21,6 +21,7 @@ interface StreamEntry {
 }
 
 const registry = new Map<string, StreamEntry>();
+const messageIdIndex = new Map<string, string>(); // messageId → streamId
 
 // Cleanup streams older than 10 minutes (safety net for orphaned entries)
 const MAX_STREAM_AGE_MS = 10 * 60 * 1000;
@@ -61,9 +62,11 @@ export const stopCleanupInterval = (): void => {
 export const createStreamAbortController = ({
   userId,
   streamId = createId(),
+  messageId,
 }: {
   userId: string;
   streamId?: string;
+  messageId?: string;
 }): {
   streamId: string;
   signal: AbortSignal;
@@ -77,6 +80,10 @@ export const createStreamAbortController = ({
     createdAt: Date.now(),
     userId,
   });
+
+  if (messageId) {
+    messageIdIndex.set(messageId, streamId);
+  }
 
   return {
     streamId,
@@ -112,6 +119,12 @@ export const abortStream = ({
 
   entry.controller.abort();
   registry.delete(streamId);
+  for (const [msgId, sid] of messageIdIndex.entries()) {
+    if (sid === streamId) {
+      messageIdIndex.delete(msgId);
+      break;
+    }
+  }
 
   return { aborted: true, reason: 'Stream aborted by user request' };
 };
@@ -121,6 +134,26 @@ export const abortStream = ({
  */
 export const removeStream = ({ streamId }: { streamId: string }): void => {
   registry.delete(streamId);
+  for (const [msgId, sid] of messageIdIndex.entries()) {
+    if (sid === streamId) {
+      messageIdIndex.delete(msgId);
+      break;
+    }
+  }
+};
+
+export const abortStreamByMessageId = ({
+  messageId,
+  userId,
+}: {
+  messageId: string;
+  userId: string;
+}): { aborted: boolean; reason: string } => {
+  const streamId = messageIdIndex.get(messageId);
+  if (!streamId) {
+    return { aborted: false, reason: 'Stream not found or already completed' };
+  }
+  return abortStream({ streamId, userId });
 };
 
 /**

--- a/tasks/ai-chat-streaming-persistence.md
+++ b/tasks/ai-chat-streaming-persistence.md
@@ -118,7 +118,7 @@ Extend the pending streams store with an `isOwn` flag to distinguish the current
 Fix own-stream detection to use tabId, support global channel IDs, and bootstrap from DB on mount.
 
 **Requirements**:
-- Given two tabs open by the same user, should mark only the originating tab's stream as own
+- Given a stream from any source, `isOwn` must be `triggeredBy.tabId === getTabId()` — tabId persists through refresh via sessionStorage so the originating tab correctly reclaims its stream; a different window of the same user gets `isOwn: false` (sees indicator, cannot stop)
 - Given `channelId` is a `user:${userId}:global` string, should pass it through to the active-streams endpoint correctly
 - Given active streams exist in DB at mount time, should bootstrap the store before any socket events arrive
 - Given a bootstrapped stream completes via SSE, should call the same completion handler as live socket events
@@ -156,6 +156,8 @@ Wire global chat context to handle multiplayer stream events: DB bootstrap on mo
 
 **Requirements**:
 - Given mount with active streams in DB, should bootstrap `usePendingStreamsStore` before any socket event arrives
+- Given a bootstrapped stream where `triggeredBy.tabId === getTabId()` (own stream), should call `setIsStreaming(true)` and `setStopStreaming(() => abortActiveStreamByMessageId(messageId))` so the existing stop button in the global chat UI works without any UI changes
+- Given the bootstrapped own stream completes via SSE, should call `setIsStreaming(false)`, `setStopStreaming(null)`, and `refreshConversation`
 - Given `chat:stream_start` from the current tab, should skip it (tabId filter prevents duplicate handling)
 - Given `chat:stream_start` for a different user's global channel, should skip it (pageId guard)
 - Given `chat:stream_start` for the correct channel from another tab, should addStream and open SSE join

--- a/tasks/ai-chat-streaming-persistence.md
+++ b/tasks/ai-chat-streaming-persistence.md
@@ -15,7 +15,7 @@ Add `packages/db/src/schema/ai-streams.ts` with a new `aiStreamSessions` pgTable
 
 **Requirements**:
 - Given a new schema file is added, should export `aiStreamSessions` from `packages/db/src/schema.ts`
-- Given `channelId` field, should accept pageId for page chats and `global:${userId}` for global chat
+- Given `channelId` field, should accept pageId for page chats and `user:${userId}:global` for global chat
 - Given `status` field, should only allow values: 'streaming', 'complete', or 'aborted'
 - Given (channelId, status) index, should enable fast queries for active streams per channel
 - Given schema change, should run `pnpm db:generate` to produce migration files (never hand-edit SQL)
@@ -66,10 +66,10 @@ Upgrade the page AI chat route to persist stream sessions to DB, thread tabId th
 Bring the global chat route to feature parity with the page chat route: multicast registry, DB persistence, socket events, and abort key registration.
 
 **Requirements**:
-- Given global chat stream starts, should register with multicast registry using `global:${userId}` as channelId
-- Given global chat stream starts, should INSERT into `aiStreamSessions` with `channelId = \`global:${userId}\``
+- Given global chat stream starts, should register with multicast registry using `user:${userId}:global` as channelId
+- Given global chat stream starts, should INSERT into `aiStreamSessions` with `channelId = \`user:${userId}:global\``
 - Given `text-delta` events, should push chunks to multicast registry
-- Given stream completes, should emit `broadcastAiStreamComplete` to the `global:${userId}` socket room
+- Given stream completes, should emit `broadcastAiStreamComplete` to the `user:${userId}:global` socket room
 - Given stream is aborted, should UPDATE `aiStreamSessions` status to 'aborted'
 - Given `finishMulticast` guard, should prevent double-broadcast if called more than once
 
@@ -119,7 +119,7 @@ Fix own-stream detection to use tabId, support global channel IDs, and bootstrap
 
 **Requirements**:
 - Given two tabs open by the same user, should mark only the originating tab's stream as own
-- Given `channelId` is a `global:${userId}` string, should pass it through to the active-streams endpoint correctly
+- Given `channelId` is a `user:${userId}:global` string, should pass it through to the active-streams endpoint correctly
 - Given active streams exist in DB at mount time, should bootstrap the store before any socket events arrive
 - Given a bootstrapped stream completes via SSE, should call the same completion handler as live socket events
 - Given the component unmounts, should abort all bootstrapped SSE connections
@@ -141,10 +141,10 @@ Show a stop button and wire abort-by-messageId for streams the current tab initi
 
 ## Global chat socket room — realtime server
 
-Auto-join each authenticated user to their `global:${userId}` socket room for global chat stream routing.
+Auto-join each authenticated user to their `user:${userId}:global` socket room for global chat stream routing.
 
 **Requirements**:
-- Given a user authenticates with the realtime server, should automatically join the `global:${user.id}` socket room
+- Given a user authenticates with the realtime server, should automatically join the `user:${user.id}:global` socket room
 - Given the user is already authenticated (prior checks pass), should not require an additional permission check
 - Given the join follows the existing auto-join pattern for other rooms, should be placed in the same block for consistency
 

--- a/tasks/ai-chat-streaming-persistence.md
+++ b/tasks/ai-chat-streaming-persistence.md
@@ -1,0 +1,165 @@
+# AI Chat Streaming Persistence & Multiplayer Epic
+
+**Status**: 📋 PLANNED  
+**Goal**: Persist AI stream sessions to the DB and extend full multiplayer streaming support to global chat
+
+## Overview
+
+Users who refresh mid-stream, open a second tab, or switch to global chat lose all visibility into in-progress AI responses — there is no recovery path and no stop button after reconnect. The core gap is that stream state lives only in process memory and in-flight socket events, so any late join misses everything. This epic adds a `aiStreamSessions` DB table as the source of truth, introduces a stable per-tab identity (`tabId`) to correctly attribute streams, wires full multicast/socket infrastructure into global chat, and adds a bootstrap endpoint so any component can reconstruct active stream state on mount.
+
+---
+
+## DB schema — aiStreamSessions table
+
+Add `packages/db/src/schema/ai-streams.ts` with a new `aiStreamSessions` pgTable to persist streaming session state across server restarts and enable multiplayer bootstrap.
+
+**Requirements**:
+- Given a new schema file is added, should export `aiStreamSessions` from `packages/db/src/schema.ts`
+- Given `channelId` field, should accept pageId for page chats and `global:${userId}` for global chat
+- Given `status` field, should only allow values: 'streaming', 'complete', or 'aborted'
+- Given (channelId, status) index, should enable fast queries for active streams per channel
+- Given schema change, should run `pnpm db:generate` to produce migration files (never hand-edit SQL)
+
+---
+
+## messageId as canonical abort key
+
+Wire `messageId` as the primary abort key so clients can cancel a specific stream by message ID rather than opaque stream ID.
+
+**Requirements**:
+- Given `createStreamAbortController` is called with a `messageId`, should populate the messageId→streamId index
+- Given `removeStream` is called, should clean up the messageId index entry
+- Given `abortStreamByMessageId` is called, should look up streamId from index and abort it
+- Given abort route receives `{ messageId }` instead of `{ streamId }`, should resolve and abort the correct stream
+- Given client calls `abortActiveStreamByMessageId`, should POST `{ messageId }` to `/api/ai/abort`
+
+---
+
+## tabId — per-tab identity
+
+Introduce a stable per-browser-tab identity so multiplayer stream events can be filtered by the originating tab rather than just user ID.
+
+**Requirements**:
+- Given `getTabId()` is called on the same tab after a page refresh, should return the same UUID
+- Given `getTabId()` is called in two different browser tabs, should return different UUIDs
+- Given `createStreamTrackingFetch` makes any AI request, should include `X-Tab-Id` header
+- Given `AiStreamStartPayload.triggeredBy`, should include `tabId` field alongside `userId` and `displayName`
+
+---
+
+## Page AI chat route — DB writes + tabId + messageId abort key
+
+Upgrade the page AI chat route to persist stream sessions to DB, thread tabId through the multicast registry, and register messageId as the abort key.
+
+**Requirements**:
+- Given a stream starts, should INSERT a row into `aiStreamSessions` with status 'streaming'
+- Given stream completes normally, should UPDATE status to 'complete' and set `completedAt`
+- Given stream is aborted, should UPDATE status to 'aborted' and set `completedAt`
+- Given `X-Tab-Id` header is present, should pass `tabId` to multicast registry and socket broadcast
+- Given `serverAssistantMessageId` exists, should pass it as `messageId` to `createStreamAbortController`
+- Given `broadcastAiStreamStart` payload, should include `tabId` in `triggeredBy`
+
+---
+
+## Global chat route — add full streaming infrastructure
+
+Bring the global chat route to feature parity with the page chat route: multicast registry, DB persistence, socket events, and abort key registration.
+
+**Requirements**:
+- Given global chat stream starts, should register with multicast registry using `global:${userId}` as channelId
+- Given global chat stream starts, should INSERT into `aiStreamSessions` with `channelId = \`global:${userId}\``
+- Given `text-delta` events, should push chunks to multicast registry
+- Given stream completes, should emit `broadcastAiStreamComplete` to the `global:${userId}` socket room
+- Given stream is aborted, should UPDATE `aiStreamSessions` status to 'aborted'
+- Given `finishMulticast` guard, should prevent double-broadcast if called more than once
+
+---
+
+## streamMulticastRegistry — richer metadata
+
+Expand the `register()` metadata type to carry the full context needed by downstream consumers.
+
+**Requirements**:
+- Given `register()` is called, should accept `displayName`, `conversationId`, and `tabId` in addition to existing fields
+- Given `getMeta()` is called on a registered stream, should return the full metadata including new fields
+- Given both page and global route call sites, should be updated to pass the extended metadata
+- Given the `StreamMeta` interface, should be exported so downstream consumers can type-check against it
+
+---
+
+## Active streams endpoint
+
+Create `GET /api/ai/chat/active-streams?channelId=X` so clients can bootstrap multiplayer state on mount.
+
+**Requirements**:
+- Given an unauthenticated request, should return 401
+- Given a page channel and a user without view permission, should return 403
+- Given a global channel where the userId does not match the session user, should return 403
+- Given active streams exist within the 10-minute window, should return them with full triggeredBy metadata
+- Given no active streams, should return `{ streams: [] }`
+- Given streams older than 10 minutes with status 'streaming', should exclude them from results
+
+---
+
+## usePendingStreamsStore — add isOwn
+
+Extend the pending streams store with an `isOwn` flag to distinguish the current tab's streams from remote ones.
+
+**Requirements**:
+- Given `addStream` is called with `isOwn: true`, should store the flag on the PendingStream entry
+- Given `addStream` is called with `isOwn: false`, should store the flag as false
+- Given `getOwnStreams(channelId)`, should return only streams where `isOwn === true` for that channel
+- Given existing callers of `addStream`, should be updated to pass `isOwn` without breaking
+
+---
+
+## useChatStreamSocket — tabId filter + DB bootstrap
+
+Fix own-stream detection to use tabId, support global channel IDs, and bootstrap from DB on mount.
+
+**Requirements**:
+- Given two tabs open by the same user, should mark only the originating tab's stream as own
+- Given `channelId` is a `global:${userId}` string, should pass it through to the active-streams endpoint correctly
+- Given active streams exist in DB at mount time, should bootstrap the store before any socket events arrive
+- Given a bootstrapped stream completes via SSE, should call the same completion handler as live socket events
+- Given the component unmounts, should abort all bootstrapped SSE connections
+
+---
+
+## Stop button for reconnected own streams in AiChatView
+
+Show a stop button and wire abort-by-messageId for streams the current tab initiated, even after reconnect.
+
+**Requirements**:
+- Given `isStreaming` is true from local useChat, should show the stop button (existing behavior preserved)
+- Given an own stream exists in `usePendingStreamsStore` with `isOwn: true`, should show the stop button
+- Given the stop button is clicked for a pending own stream, should call `abortActiveStreamByMessageId` with the stream's messageId
+- Given no local or pending own streams are active, should not show the stop button
+- Given both a local stream and a pending own stream exist simultaneously, should show only one stop button
+
+---
+
+## Global chat socket room — realtime server
+
+Auto-join each authenticated user to their `global:${userId}` socket room for global chat stream routing.
+
+**Requirements**:
+- Given a user authenticates with the realtime server, should automatically join the `global:${user.id}` socket room
+- Given the user is already authenticated (prior checks pass), should not require an additional permission check
+- Given the join follows the existing auto-join pattern for other rooms, should be placed in the same block for consistency
+
+---
+
+## GlobalChatContext — stream socket listener + bootstrap
+
+Wire global chat context to handle multiplayer stream events: DB bootstrap on mount, live socket listeners, and SSE cleanup on unmount.
+
+**Requirements**:
+- Given mount with active streams in DB, should bootstrap `usePendingStreamsStore` before any socket event arrives
+- Given `chat:stream_start` from the current tab, should skip it (tabId filter prevents duplicate handling)
+- Given `chat:stream_start` for a different user's global channel, should skip it (pageId guard)
+- Given `chat:stream_start` for the correct channel from another tab, should addStream and open SSE join
+- Given `chat:stream_complete`, should abort the SSE connection, removeStream, and call refreshConversation
+- Given component unmounts, should abort all active SSE connections and remove all socket listeners
+
+---


### PR DESCRIPTION
Makes messageId the stable, DB-persisted abort key so stop buttons survive page refresh. Previously only the ephemeral in-memory streamId could abort a stream.

## Changes

**Core infrastructure (stream-abort-registry.ts)**
- Added `messageIdIndex` (Map<messageId→streamId>) as secondary index
- `createStreamAbortController` accepts optional `messageId` and populates the index
- Extracted `removeMessageIdEntry()` helper — used in `removeStream`, `abortStream`, and the orphan cleanup interval to eliminate duplication
- Orphan cleanup interval now also purges `messageIdIndex` entries for timed-out streams (prevents unbounded index growth)
- New `abortStreamByMessageId({ messageId, userId })` — IDOR-protected via userId ownership check

**Wiring up call sites (chat/route.ts, global/[id]/messages/route.ts)**
- Both routes now pass `messageId: serverAssistantMessageId` to `createStreamAbortController`, making the index actually populated during live streams
- In the global route, `serverAssistantMessageId = createId()` was moved before the abort controller call (required ordering for the messageId param)

**Abort endpoint (abort/route.ts)**
- Accepts `{ messageId }` as alternative to `{ streamId }` — `messageId` takes precedence when both are present
- Returns 400 if neither field is provided

**Client (stream-abort-client.ts, client.ts)**
- New `abortActiveStreamByMessageId({ messageId })` — POSTs `{ messageId }` to `/api/ai/abort`
- Exported from client-safe barrel

**Tests**
- 6 new registry tests: abort by messageId, IDOR protection, index cleanup, removeStream cleanup
- 3 new route tests: abort by messageId, messageId preferred over streamId, empty messageId → 400
- Updated existing route tests: error message change, log assertion includes messageId field, registry mock includes abortStreamByMessageId

## Part of
AI streaming multiplayer epic — Task 2 of 12