### PR TITLE
feat(ai): GET /api/ai/chat/active-streams — DB-backed bootstrap endpoint

### DIFF
--- a/apps/web/src/app/api/ai/chat/active-streams/route.ts
+++ b/apps/web/src/app/api/ai/chat/active-streams/route.ts
@@ -5,6 +5,7 @@ import { db } from '@pagespace/db/db';
 import { and, asc, eq, gte } from '@pagespace/db/operators';
 import { aiStreamSessions } from '@pagespace/db/schema/ai-streams';
 import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
 
@@ -12,6 +13,13 @@ export async function GET(request: Request) {
   try {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
     if (isAuthError(auth)) {
+      auditRequest(request, {
+        eventType: 'authz.access.denied',
+        resourceType: 'ai_chat_stream',
+        resourceId: 'active-streams',
+        details: { reason: 'auth_failed', method: 'GET' },
+        riskScore: 0.5,
+      });
       return auth.error;
     }
     const userId = auth.userId;
@@ -26,11 +34,27 @@ export async function GET(request: Request) {
     const globalMatch = channelId.match(/^user:(.+):global$/);
     if (globalMatch) {
       if (globalMatch[1] !== userId) {
+        auditRequest(request, {
+          eventType: 'authz.access.denied',
+          userId,
+          resourceType: 'ai_chat_stream',
+          resourceId: channelId,
+          details: { reason: 'global_channel_user_mismatch', method: 'GET' },
+          riskScore: 0.6,
+        });
         return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
       }
     } else {
       const allowed = await canUserViewPage(userId, channelId);
       if (!allowed) {
+        auditRequest(request, {
+          eventType: 'authz.access.denied',
+          userId,
+          resourceType: 'ai_chat_stream',
+          resourceId: channelId,
+          details: { reason: 'page_view_denied', method: 'GET' },
+          riskScore: 0.5,
+        });
         return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
       }
     }

--- a/apps/web/src/app/api/ai/chat/active-streams/route.ts
+++ b/apps/web/src/app/api/ai/chat/active-streams/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
 import { db } from '@pagespace/db/db';
-import { and, eq, gte } from '@pagespace/db/operators';
+import { and, asc, eq, gte } from '@pagespace/db/operators';
 import { aiStreamSessions } from '@pagespace/db/schema/ai-streams';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 
@@ -51,7 +51,8 @@ export async function GET(request: Request) {
           eq(aiStreamSessions.status, 'streaming'),
           gte(aiStreamSessions.startedAt, tenMinutesAgo),
         )
-      );
+      )
+      .orderBy(asc(aiStreamSessions.startedAt), asc(aiStreamSessions.messageId));
 
     return NextResponse.json({
       streams: streams.map((s) => ({

--- a/apps/web/src/app/api/ai/chat/active-streams/route.ts
+++ b/apps/web/src/app/api/ai/chat/active-streams/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from 'next/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { db } from '@pagespace/db/db';
+import { and, eq, gte } from '@pagespace/db/operators';
+import { aiStreamSessions } from '@pagespace/db/schema/ai-streams';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+
+const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
+
+export async function GET(request: Request) {
+  try {
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
+    if (isAuthError(auth)) {
+      return auth.error;
+    }
+    const userId = auth.userId;
+
+    const { searchParams } = new URL(request.url);
+    const channelId = searchParams.get('channelId');
+
+    if (!channelId) {
+      return NextResponse.json({ error: 'channelId is required' }, { status: 400 });
+    }
+
+    const globalMatch = channelId.match(/^user:(.+):global$/);
+    if (globalMatch) {
+      if (globalMatch[1] !== userId) {
+        return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+      }
+    } else {
+      const allowed = await canUserViewPage(userId, channelId);
+      if (!allowed) {
+        return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+      }
+    }
+
+    const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000);
+    const streams = await db
+      .select({
+        messageId: aiStreamSessions.messageId,
+        conversationId: aiStreamSessions.conversationId,
+        userId: aiStreamSessions.userId,
+        displayName: aiStreamSessions.displayName,
+        tabId: aiStreamSessions.tabId,
+      })
+      .from(aiStreamSessions)
+      .where(
+        and(
+          eq(aiStreamSessions.channelId, channelId),
+          eq(aiStreamSessions.status, 'streaming'),
+          gte(aiStreamSessions.startedAt, tenMinutesAgo),
+        )
+      );
+
+    return NextResponse.json({
+      streams: streams.map((s) => ({
+        messageId: s.messageId,
+        conversationId: s.conversationId,
+        triggeredBy: {
+          userId: s.userId,
+          displayName: s.displayName,
+          tabId: s.tabId,
+        },
+      })),
+    });
+  } catch (error) {
+    loggers.api.error('Error fetching active streams', { error });
+    return NextResponse.json(
+      { error: 'Failed to fetch active streams' },
+      { status: 500 }
+    );
+  }
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -19,6 +19,10 @@
       "types": "./dist/schema/ai.d.ts",
       "default": "./dist/schema/ai.js"
     },
+    "./schema/ai-streams": {
+      "types": "./dist/schema/ai-streams.d.ts",
+      "default": "./dist/schema/ai-streams.js"
+    },
     "./schema/auth": {
       "types": "./dist/schema/auth.d.ts",
       "default": "./dist/schema/auth.js"


### PR DESCRIPTION
## Summary
- Adds `GET /api/ai/chat/active-streams?channelId=<value>` so any client can deterministically bootstrap multiplayer stream state on mount.
- Queries `aiStreamSessions` for rows with `status='streaming'` started in the last 10 minutes; returns `{ streams: [{ messageId, conversationId, triggeredBy: { userId, displayName, tabId } }] }`.
- Auth: session-only, `requireCSRF: false` (read-only). Permissions: `user:X:global` channels require `X === userId`; otherwise `canUserViewPage(userId, channelId)`.
- Registers the missing `@pagespace/db/schema/ai-streams` subpath export so the route resolves.

## Test plan
- [x] `pnpm --filter web typecheck` passes
- [ ] 401 when unauthenticated
- [ ] 400 when `channelId` is missing
- [ ] 403 when `user:X:global` and `X !== userId`
- [ ] 403 when pageId channel and user has no view permission
- [ ] `{ streams: [] }` when no rows in the 10-minute window
- [ ] Returns full payload shape with active rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New endpoint available to retrieve active AI chat stream sessions with real-time information about ongoing conversations, participants, and stream status for monitoring purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->