### PR TITLE
feat(ai): streamMulticastRegistry richer metadata — displayName, conversationId, tabId

### DIFF
--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -327,7 +327,13 @@ describe('POST /api/ai/chat — stream socket events', () => {
 
       expect(mockRegistryRegister).toHaveBeenCalledWith(
         'test-message-id',
-        { pageId: 'page-1', userId: 'user-1' }
+        expect.objectContaining({
+          pageId: 'page-1',
+          userId: 'user-1',
+          conversationId: 'conv-1',
+          tabId: '',
+          displayName: expect.any(String),
+        })
       );
     });
 

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -825,11 +825,8 @@ export async function POST(request: Request) {
     // This is separate from request.signal which fires on any client disconnect
     const { streamId, signal: abortSignal } = createStreamAbortController({ userId, messageId: serverAssistantMessageId });
 
-    // Register in multicast registry so other viewers can join via stream-join endpoint
-    try { streamMulticastRegistry.register(serverAssistantMessageId, { pageId: chatId, userId: userId! }); } catch {}
+    const tabId = request.headers.get('X-Tab-Id') ?? '';
 
-    // Resolve display name for stream_start payload (fall back through user.name → 'Someone')
-    // Wrapped in try/catch so a DB hiccup here never aborts the stream
     let displayName = user?.name ?? 'Someone';
     try {
       const [userProfile] = await db
@@ -842,12 +839,21 @@ export async function POST(request: Request) {
       // non-critical — fall back to user.name already set above
     }
 
-    // Notify all page viewers that an AI stream is starting
+    try {
+      streamMulticastRegistry.register(serverAssistantMessageId, {
+        pageId: chatId,
+        userId: userId!,
+        displayName,
+        conversationId: conversationId!,
+        tabId,
+      });
+    } catch {}
+
     broadcastAiStreamStart({
       messageId: serverAssistantMessageId,
       pageId: chatId,
       conversationId: conversationId!,
-      triggeredBy: { userId: userId!, displayName },
+      triggeredBy: { userId: userId!, displayName, tabId },
     }).catch(() => {});
 
     try {

--- a/apps/web/src/app/api/ai/chat/stream-join/[messageId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/chat/stream-join/[messageId]/__tests__/route.test.ts
@@ -39,6 +39,16 @@ import { auditRequest } from '@pagespace/lib/audit/audit-log';
 const mockPageId = 'page-test-123';
 const mockUserId = 'user-test-456';
 const mockMessageId = 'msg-test-789';
+const mockConversationId = 'conv-test-321';
+const mockTabId = 'tab-test-654';
+const mockDisplayName = 'Test User';
+const mockMeta = {
+  pageId: mockPageId,
+  userId: mockUserId,
+  displayName: mockDisplayName,
+  conversationId: mockConversationId,
+  tabId: mockTabId,
+};
 
 const mockSessionAuth = (userId = mockUserId): SessionAuthResult => ({
   userId,
@@ -108,7 +118,7 @@ describe('GET /api/ai/chat/stream-join/[messageId]', () => {
     });
 
     it('given an already-finished messageId, should return 404', async () => {
-      testRegistry.register(mockMessageId, { pageId: mockPageId, userId: mockUserId });
+      testRegistry.register(mockMessageId, mockMeta);
       testRegistry.finish(mockMessageId);
       // Entry is deleted — subscribe() returns null
 
@@ -120,7 +130,7 @@ describe('GET /api/ai/chat/stream-join/[messageId]', () => {
 
   describe('authorization', () => {
     it('given a user without view access, should return 403', async () => {
-      testRegistry.register(mockMessageId, { pageId: mockPageId, userId: mockUserId });
+      testRegistry.register(mockMessageId, mockMeta);
       vi.mocked(canUserViewPage).mockResolvedValue(false);
 
       const response = await GET(makeRequest(), makeContext(mockMessageId));
@@ -129,7 +139,7 @@ describe('GET /api/ai/chat/stream-join/[messageId]', () => {
     });
 
     it('given a user without view access, should emit authz.access.denied audit event', async () => {
-      testRegistry.register(mockMessageId, { pageId: mockPageId, userId: mockUserId });
+      testRegistry.register(mockMessageId, mockMeta);
       vi.mocked(canUserViewPage).mockResolvedValue(false);
 
       await GET(makeRequest(), makeContext(mockMessageId));
@@ -146,7 +156,7 @@ describe('GET /api/ai/chat/stream-join/[messageId]', () => {
     });
 
     it('should check permission against the pageId from stream metadata', async () => {
-      testRegistry.register(mockMessageId, { pageId: mockPageId, userId: mockUserId });
+      testRegistry.register(mockMessageId, mockMeta);
 
       await GET(makeRequest(), makeContext(mockMessageId));
       testRegistry.finish(mockMessageId);
@@ -157,7 +167,7 @@ describe('GET /api/ai/chat/stream-join/[messageId]', () => {
 
   describe('SSE streaming', () => {
     it('given a valid messageId and authorized viewer, should return SSE response headers', async () => {
-      testRegistry.register(mockMessageId, { pageId: mockPageId, userId: mockUserId });
+      testRegistry.register(mockMessageId, mockMeta);
 
       const response = await GET(makeRequest(), makeContext(mockMessageId));
       testRegistry.finish(mockMessageId);
@@ -169,7 +179,7 @@ describe('GET /api/ai/chat/stream-join/[messageId]', () => {
     });
 
     it('given a successful stream join, should emit an authz.access.granted audit event', async () => {
-      testRegistry.register(mockMessageId, { pageId: mockPageId, userId: mockUserId });
+      testRegistry.register(mockMessageId, mockMeta);
 
       await GET(makeRequest(), makeContext(mockMessageId));
       testRegistry.finish(mockMessageId);
@@ -186,7 +196,7 @@ describe('GET /api/ai/chat/stream-join/[messageId]', () => {
     });
 
     it('given buffered chunks, should stream them as SSE data events', async () => {
-      testRegistry.register(mockMessageId, { pageId: mockPageId, userId: mockUserId });
+      testRegistry.register(mockMessageId, mockMeta);
       testRegistry.push(mockMessageId, 'hello');
       testRegistry.push(mockMessageId, ' world');
 
@@ -200,7 +210,7 @@ describe('GET /api/ai/chat/stream-join/[messageId]', () => {
     });
 
     it('given stream completion, should send [DONE] sentinel and close', async () => {
-      testRegistry.register(mockMessageId, { pageId: mockPageId, userId: mockUserId });
+      testRegistry.register(mockMessageId, mockMeta);
 
       const response = await GET(makeRequest(), makeContext(mockMessageId));
       testRegistry.finish(mockMessageId);
@@ -211,7 +221,7 @@ describe('GET /api/ai/chat/stream-join/[messageId]', () => {
     });
 
     it('given stream aborted, should send done sentinel with aborted=true', async () => {
-      testRegistry.register(mockMessageId, { pageId: mockPageId, userId: mockUserId });
+      testRegistry.register(mockMessageId, mockMeta);
 
       const response = await GET(makeRequest(), makeContext(mockMessageId));
       testRegistry.finish(mockMessageId, true);
@@ -222,7 +232,7 @@ describe('GET /api/ai/chat/stream-join/[messageId]', () => {
     });
 
     it('given live chunks pushed after subscribe, should stream them in order', async () => {
-      testRegistry.register(mockMessageId, { pageId: mockPageId, userId: mockUserId });
+      testRegistry.register(mockMessageId, mockMeta);
       testRegistry.push(mockMessageId, 'buffered');
 
       const response = await GET(makeRequest(), makeContext(mockMessageId));
@@ -243,13 +253,10 @@ describe('GET /api/ai/chat/stream-join/[messageId]', () => {
       // We achieve this by overriding getMeta to return meta while subscribe sees finished state.
       // Simplest: use the registry — register, finish, re-set getMeta via spy.
       const spyRegistry = new StreamMulticastRegistry();
-      spyRegistry.register(mockMessageId, { pageId: mockPageId, userId: mockUserId });
+      spyRegistry.register(mockMessageId, mockMeta);
 
       // getMeta returns meta even after finish by using a spy
-      const getMetaSpy = vi.spyOn(spyRegistry, 'getMeta').mockReturnValue({
-        pageId: mockPageId,
-        userId: mockUserId,
-      });
+      const getMetaSpy = vi.spyOn(spyRegistry, 'getMeta').mockReturnValue(mockMeta);
       spyRegistry.finish(mockMessageId); // subscribe will now return null
 
       testRegistry = spyRegistry;
@@ -264,7 +271,7 @@ describe('GET /api/ai/chat/stream-join/[messageId]', () => {
   describe('client disconnect', () => {
     it('given client disconnect, should unsubscribe without leaking resources', async () => {
       const abortController = new AbortController();
-      testRegistry.register(mockMessageId, { pageId: mockPageId, userId: mockUserId });
+      testRegistry.register(mockMessageId, mockMeta);
 
       const response = await GET(makeRequest(abortController.signal), makeContext(mockMessageId));
       expect(response.status).toBe(200);
@@ -282,7 +289,7 @@ describe('GET /api/ai/chat/stream-join/[messageId]', () => {
     it('given already-aborted signal, should close the stream eagerly without leaking the subscriber', async () => {
       const abortController = new AbortController();
       abortController.abort(); // aborted BEFORE GET is called
-      testRegistry.register(mockMessageId, { pageId: mockPageId, userId: mockUserId });
+      testRegistry.register(mockMessageId, mockMeta);
 
       const response = await GET(makeRequest(abortController.signal), makeContext(mockMessageId));
 
@@ -294,7 +301,7 @@ describe('GET /api/ai/chat/stream-join/[messageId]', () => {
 
     it('given stream completes then client disconnects, should not attempt to double-close the controller', async () => {
       const abortController = new AbortController();
-      testRegistry.register(mockMessageId, { pageId: mockPageId, userId: mockUserId });
+      testRegistry.register(mockMessageId, mockMeta);
 
       const response = await GET(makeRequest(abortController.signal), makeContext(mockMessageId));
       expect(response.status).toBe(200);

--- a/apps/web/src/lib/ai/core/__tests__/stream-multicast-registry.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stream-multicast-registry.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { StreamMulticastRegistry } from '../stream-multicast-registry';
+import { StreamMulticastRegistry, type StreamMeta } from '../stream-multicast-registry';
+
+const meta = (overrides: Partial<StreamMeta> = {}): StreamMeta => ({
+  pageId: 'page-1',
+  userId: 'user-1',
+  displayName: 'Test User',
+  conversationId: 'conv-1',
+  tabId: 'tab-1',
+  ...overrides,
+});
 
 describe('StreamMulticastRegistry', () => {
   afterEach(() => {
@@ -9,9 +18,9 @@ describe('StreamMulticastRegistry', () => {
   describe('register / getMeta', () => {
     it('stores stream metadata accessible via getMeta', () => {
       const registry = new StreamMulticastRegistry();
-      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+      registry.register('msg-1', meta());
 
-      expect(registry.getMeta('msg-1')).toEqual({ pageId: 'page-1', userId: 'user-1' });
+      expect(registry.getMeta('msg-1')).toEqual(meta());
     });
 
     it('returns undefined for unknown messageId', () => {
@@ -23,7 +32,7 @@ describe('StreamMulticastRegistry', () => {
   describe('push', () => {
     it('given a registered stream with subscribers, should push text chunks to all active subscribers', () => {
       const registry = new StreamMulticastRegistry();
-      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+      registry.register('msg-1', meta());
 
       const received1: string[] = [];
       const received2: string[] = [];
@@ -46,7 +55,7 @@ describe('StreamMulticastRegistry', () => {
   describe('subscribe', () => {
     it('given a late-joining subscriber, should replay all buffered chunks before delivering live ones', () => {
       const registry = new StreamMulticastRegistry();
-      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+      registry.register('msg-1', meta());
 
       registry.push('msg-1', 'chunk1');
       registry.push('msg-1', 'chunk2');
@@ -59,7 +68,7 @@ describe('StreamMulticastRegistry', () => {
 
     it('given buffered and live chunks, should deliver them in order to a late subscriber', () => {
       const registry = new StreamMulticastRegistry();
-      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+      registry.register('msg-1', meta());
 
       registry.push('msg-1', 'chunk1');
       registry.push('msg-1', 'chunk2');
@@ -74,7 +83,7 @@ describe('StreamMulticastRegistry', () => {
 
     it('given a finished stream, should return null', () => {
       const registry = new StreamMulticastRegistry();
-      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+      registry.register('msg-1', meta());
       registry.finish('msg-1');
 
       const result = registry.subscribe('msg-1', () => {}, () => {});
@@ -89,7 +98,7 @@ describe('StreamMulticastRegistry', () => {
 
     it('returns an unsubscribe function for an active stream', () => {
       const registry = new StreamMulticastRegistry();
-      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+      registry.register('msg-1', meta());
 
       const unsubscribe = registry.subscribe('msg-1', () => {}, () => {});
       expect(typeof unsubscribe).toBe('function');
@@ -99,7 +108,7 @@ describe('StreamMulticastRegistry', () => {
   describe('unsubscribe', () => {
     it('given a subscriber that unsubscribes, should stop receiving chunks without affecting other subscribers', () => {
       const registry = new StreamMulticastRegistry();
-      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+      registry.register('msg-1', meta());
 
       const received1: string[] = [];
       const received2: string[] = [];
@@ -118,7 +127,7 @@ describe('StreamMulticastRegistry', () => {
 
     it('given an unsubscribed listener, should not call its onComplete when stream finishes', () => {
       const registry = new StreamMulticastRegistry();
-      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+      registry.register('msg-1', meta());
 
       const completed1: boolean[] = [];
       const completed2: boolean[] = [];
@@ -138,7 +147,7 @@ describe('StreamMulticastRegistry', () => {
   describe('finish', () => {
     it('given a finished stream, should call complete callbacks with aborted=false by default', () => {
       const registry = new StreamMulticastRegistry();
-      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+      registry.register('msg-1', meta());
 
       const abortedValues: boolean[] = [];
       registry.subscribe('msg-1', () => {}, (aborted) => abortedValues.push(aborted));
@@ -149,7 +158,7 @@ describe('StreamMulticastRegistry', () => {
 
     it('given a finished stream with aborted=true, should call complete callbacks with the correct aborted status', () => {
       const registry = new StreamMulticastRegistry();
-      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+      registry.register('msg-1', meta());
 
       const abortedValues: boolean[] = [];
       registry.subscribe('msg-1', () => {}, (aborted) => abortedValues.push(aborted));
@@ -160,7 +169,7 @@ describe('StreamMulticastRegistry', () => {
 
     it('removes the stream entry after finishing so getMeta returns undefined', () => {
       const registry = new StreamMulticastRegistry();
-      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+      registry.register('msg-1', meta());
 
       registry.finish('msg-1');
 
@@ -174,7 +183,7 @@ describe('StreamMulticastRegistry', () => {
 
     it('silently ignores a second finish call', () => {
       const registry = new StreamMulticastRegistry();
-      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+      registry.register('msg-1', meta());
 
       const completed: boolean[] = [];
       registry.subscribe('msg-1', () => {}, (aborted) => completed.push(aborted));
@@ -190,7 +199,7 @@ describe('StreamMulticastRegistry', () => {
     it('given a stream still open after 10 minutes, should auto-cleanup to prevent memory leaks', () => {
       vi.useFakeTimers();
       const registry = new StreamMulticastRegistry();
-      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+      registry.register('msg-1', meta());
 
       const completedValues: boolean[] = [];
       registry.subscribe('msg-1', () => {}, (aborted) => completedValues.push(aborted));
@@ -206,7 +215,7 @@ describe('StreamMulticastRegistry', () => {
     it('given a stream that finishes before 10 minutes, should not fire the auto-cleanup timer', () => {
       vi.useFakeTimers();
       const registry = new StreamMulticastRegistry();
-      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+      registry.register('msg-1', meta());
 
       const completedValues: boolean[] = [];
       registry.subscribe('msg-1', () => {}, (aborted) => completedValues.push(aborted));
@@ -220,12 +229,12 @@ describe('StreamMulticastRegistry', () => {
 
     it('given register is called with an existing messageId that has subscribers, should notify those subscribers with aborted=true', () => {
       const registry = new StreamMulticastRegistry();
-      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+      registry.register('msg-1', meta());
 
       const completed: boolean[] = [];
       registry.subscribe('msg-1', () => {}, (aborted) => completed.push(aborted));
 
-      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+      registry.register('msg-1', meta());
 
       expect(completed).toEqual([true]);
     });
@@ -233,8 +242,8 @@ describe('StreamMulticastRegistry', () => {
     it('given register is called twice for the same messageId, should call onComplete only once after 10 minutes', () => {
       vi.useFakeTimers();
       const registry = new StreamMulticastRegistry();
-      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
-      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+      registry.register('msg-1', meta());
+      registry.register('msg-1', meta());
 
       const completed: boolean[] = [];
       registry.subscribe('msg-1', () => {}, (aborted) => completed.push(aborted));
@@ -248,7 +257,7 @@ describe('StreamMulticastRegistry', () => {
   describe('resilience', () => {
     it('given a subscriber whose onChunk throws, should not interrupt fanout to remaining subscribers', () => {
       const registry = new StreamMulticastRegistry();
-      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+      registry.register('msg-1', meta());
 
       const received: string[] = [];
       registry.subscribe('msg-1', () => { throw new Error('bad subscriber'); }, () => {});
@@ -260,7 +269,7 @@ describe('StreamMulticastRegistry', () => {
 
     it('given a subscriber whose onComplete throws, should still remove the entry and notify remaining subscribers', () => {
       const registry = new StreamMulticastRegistry();
-      registry.register('msg-1', { pageId: 'page-1', userId: 'user-1' });
+      registry.register('msg-1', meta());
 
       const completed: boolean[] = [];
       registry.subscribe('msg-1', () => {}, () => { throw new Error('bad subscriber'); });

--- a/apps/web/src/lib/ai/core/stream-multicast-registry.ts
+++ b/apps/web/src/lib/ai/core/stream-multicast-registry.ts
@@ -3,6 +3,9 @@ const MAX_STREAM_AGE_MS = 10 * 60 * 1000;
 export interface StreamMeta {
   pageId: string;
   userId: string;
+  displayName: string;
+  conversationId: string;
+  tabId: string;
 }
 
 interface Subscriber {


### PR DESCRIPTION
## Summary

- Extend `StreamMeta` with `displayName`, `conversationId`, and `tabId` so downstream consumers (active-streams endpoint, stream-join route) get full context without re-querying.
- Reorder `apps/web/src/app/api/ai/chat/route.ts`: read `X-Tab-Id` header and resolve `displayName` from `userProfiles` **before** calling `streamMulticastRegistry.register()`. Eliminates the prior window where the registry held incomplete `{ pageId, userId }` metadata.
- Pass the resolved `tabId` through to both `register()` and `broadcastAiStreamStart` (the `triggeredBy.tabId` field is already optional on `AiStreamStartPayload`).
- Update affected tests (registry unit tests, stream-join route tests, stream-socket-events tests) to construct full `StreamMeta` objects.

## Why

Wave 2 of the deterministic AI chat streaming work needs rich metadata in the multicast registry so other tabs can join and render `active streams` correctly without round-tripping the DB. Without this, every consumer would have to re-look-up the conversation, display name, and originating tab.

## Test plan

- [x] `pnpm --filter web typecheck` passes
- [x] `vitest run` for the three affected suites (registry, stream-join route, stream-socket-events) — 56/56 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)