### PR TITLE
feat(ai): GlobalChatContext stream listener + DB bootstrap — completes streaming epic

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -80,6 +80,7 @@ import {
 import { ChatInput, type ChatInputRef } from '@/components/ai/chat/input';
 import { useImageAttachments } from '@/lib/ai/shared/hooks/useImageAttachments';
 import { hasVisionCapability } from '@/lib/ai/core/vision-models';
+import { useGlobalEffectiveStream } from './useGlobalEffectiveStream';
 
 const VOICE_OWNER: VoiceModeOwner = 'global-assistant';
 
@@ -96,6 +97,8 @@ const GlobalAssistantView: React.FC = () => {
     setMessages: setGlobalMessages,
     setIsStreaming: setGlobalIsStreaming,
     setStopStreaming: setGlobalStopStreaming,
+    isStreaming: contextIsStreaming,
+    stopStreaming: contextStopStreaming,
     currentConversationId: globalConversationId,
     isInitialized: globalIsInitialized,
     createNewConversation,
@@ -329,6 +332,18 @@ const GlobalAssistantView: React.FC = () => {
     latestGlobalMessagesRef.current = globalLocalMessages;
   }, [globalLocalMessages]);
   const stop = useChatStop(currentConversationId, rawStop);
+
+  // After a refresh mid-stream, useChat starts at idle — but the
+  // GlobalChatContext bootstrap may have detected an own in-flight stream
+  // and registered a stop function. Surface either source so the UI shows
+  // a stop button + streaming indicator from both bootstrap and live paths.
+  const { effectiveIsStreaming, effectiveStop } = useGlobalEffectiveStream({
+    localIsStreaming: isStreaming,
+    rawStop: stop,
+    selectedAgent,
+    contextIsStreaming,
+    contextStopStreaming,
+  });
   // Agent mode: initialized when we have a conversationId and not loading
   // Global mode: use globalIsInitialized from context
   const agentIsInitialized = selectedAgent ? (!!agentConversationId && !agentIsLoading) : false;
@@ -824,8 +839,8 @@ const GlobalAssistantView: React.FC = () => {
         input={input}
         onInputChange={setInput}
         onSend={handleSendMessage}
-        onStop={stop}
-        isStreaming={isStreaming}
+        onStop={effectiveStop}
+        isStreaming={effectiveIsStreaming}
         isLoading={isLoading}
         disabled={!isAnyProviderConfigured}
         placeholder={selectedAgent ? `Ask ${selectedAgent.title}...` : 'Ask about your workspace...'}
@@ -866,9 +881,9 @@ const GlobalAssistantView: React.FC = () => {
                 owner={VOICE_OWNER}
                 onSend={handleVoiceSend}
                 latestAssistantMessage={lastAIResponse}
-                isAIStreaming={isStreaming}
+                isAIStreaming={effectiveIsStreaming}
                 streamingText={streamingAssistantText}
-                onStopStream={stop}
+                onStopStream={effectiveStop}
                 onClose={disableVoiceMode}
               />
             )}

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/useGlobalEffectiveStream.test.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/__tests__/useGlobalEffectiveStream.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+import { useGlobalEffectiveStream } from '../useGlobalEffectiveStream';
+
+describe('useGlobalEffectiveStream', () => {
+  // AC9
+  it('given global mode with local idle and context isStreaming=true, should report effectiveIsStreaming=true', () => {
+    const { result } = renderHook(() =>
+      useGlobalEffectiveStream({
+        localIsStreaming: false,
+        rawStop: vi.fn(),
+        selectedAgent: null,
+        contextIsStreaming: true,
+        contextStopStreaming: vi.fn(),
+      }),
+    );
+
+    expect(result.current.effectiveIsStreaming).toBe(true);
+  });
+
+  // AC10
+  it('given global mode with local idle and context stopStreaming set, should dispatch effectiveStop to context', () => {
+    const rawStop = vi.fn();
+    const contextStopStreaming = vi.fn();
+
+    const { result } = renderHook(() =>
+      useGlobalEffectiveStream({
+        localIsStreaming: false,
+        rawStop,
+        selectedAgent: null,
+        contextIsStreaming: true,
+        contextStopStreaming,
+      }),
+    );
+
+    result.current.effectiveStop();
+
+    expect(contextStopStreaming).toHaveBeenCalledTimes(1);
+    expect(rawStop).not.toHaveBeenCalled();
+  });
+
+  // AC11
+  it('given local stream is active, should call rawStop and not the context stop', () => {
+    const rawStop = vi.fn();
+    const contextStopStreaming = vi.fn();
+
+    const { result } = renderHook(() =>
+      useGlobalEffectiveStream({
+        localIsStreaming: true,
+        rawStop,
+        selectedAgent: null,
+        contextIsStreaming: true,
+        contextStopStreaming,
+      }),
+    );
+
+    result.current.effectiveStop();
+
+    expect(rawStop).toHaveBeenCalledTimes(1);
+    expect(contextStopStreaming).not.toHaveBeenCalled();
+  });
+
+  // AC12
+  it('given an agent is selected, should ignore the context streaming flags', () => {
+    const { result } = renderHook(() =>
+      useGlobalEffectiveStream({
+        localIsStreaming: false,
+        rawStop: vi.fn(),
+        selectedAgent: { id: 'agent-1' },
+        contextIsStreaming: true,
+        contextStopStreaming: vi.fn(),
+      }),
+    );
+
+    expect(result.current.effectiveIsStreaming).toBe(false);
+  });
+
+  it('given an agent is selected with local streaming, should still call rawStop on stop', () => {
+    const rawStop = vi.fn();
+    const contextStopStreaming = vi.fn();
+
+    const { result } = renderHook(() =>
+      useGlobalEffectiveStream({
+        localIsStreaming: true,
+        rawStop,
+        selectedAgent: { id: 'agent-1' },
+        contextIsStreaming: true,
+        contextStopStreaming,
+      }),
+    );
+
+    result.current.effectiveStop();
+
+    expect(rawStop).toHaveBeenCalledTimes(1);
+    expect(contextStopStreaming).not.toHaveBeenCalled();
+  });
+
+  it('given idle in agent mode with no rawStop, calling effectiveStop should be a no-op', () => {
+    const rawStop = vi.fn();
+    const contextStopStreaming = vi.fn();
+
+    const { result } = renderHook(() =>
+      useGlobalEffectiveStream({
+        localIsStreaming: false,
+        rawStop,
+        selectedAgent: { id: 'agent-1' },
+        contextIsStreaming: false,
+        contextStopStreaming,
+      }),
+    );
+
+    result.current.effectiveStop();
+
+    expect(rawStop).not.toHaveBeenCalled();
+    expect(contextStopStreaming).not.toHaveBeenCalled();
+  });
+
+  it('given idle global mode with no context stop, calling effectiveStop should be a no-op', () => {
+    const rawStop = vi.fn();
+
+    const { result } = renderHook(() =>
+      useGlobalEffectiveStream({
+        localIsStreaming: false,
+        rawStop,
+        selectedAgent: null,
+        contextIsStreaming: false,
+        contextStopStreaming: null,
+      }),
+    );
+
+    result.current.effectiveStop();
+
+    expect(rawStop).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/useGlobalEffectiveStream.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/useGlobalEffectiveStream.ts
@@ -1,0 +1,48 @@
+import { useCallback } from 'react';
+
+interface UseGlobalEffectiveStreamArgs {
+  localIsStreaming: boolean;
+  rawStop: () => void;
+  selectedAgent: { id: string } | null;
+  contextIsStreaming: boolean;
+  contextStopStreaming: (() => void) | null;
+}
+
+interface GlobalEffectiveStream {
+  effectiveIsStreaming: boolean;
+  effectiveStop: () => void;
+}
+
+/**
+ * Bridges the local useChat stream with the GlobalChatContext stream so the
+ * dashboard surfaces a stop button + streaming indicator after a refresh
+ * mid-stream — the local hook starts at idle, but the context's bootstrap
+ * may have detected an own in-flight stream and registered a stop function.
+ *
+ * Agent mode is intentionally pass-through: the context tracks Global Assistant
+ * state only, and is irrelevant when an agent is selected.
+ */
+export function useGlobalEffectiveStream({
+  localIsStreaming,
+  rawStop,
+  selectedAgent,
+  contextIsStreaming,
+  contextStopStreaming,
+}: UseGlobalEffectiveStreamArgs): GlobalEffectiveStream {
+  const inGlobalMode = !selectedAgent;
+  const effectiveIsStreaming = inGlobalMode
+    ? localIsStreaming || contextIsStreaming
+    : localIsStreaming;
+
+  const effectiveStop = useCallback(() => {
+    if (localIsStreaming) {
+      rawStop();
+      return;
+    }
+    if (inGlobalMode && contextStopStreaming) {
+      contextStopStreaming();
+    }
+  }, [localIsStreaming, rawStop, inGlobalMode, contextStopStreaming]);
+
+  return { effectiveIsStreaming, effectiveStop };
+}

--- a/apps/web/src/contexts/GlobalChatContext.tsx
+++ b/apps/web/src/contexts/GlobalChatContext.tsx
@@ -7,6 +7,19 @@ import { conversationState } from '@/lib/ai/core/conversation-state';
 import { getAgentId, getConversationId, setConversationId } from '@/lib/url-state';
 import { useChatTransport } from '@/lib/ai/shared';
 import { useSocketStore } from '@/stores/useSocketStore';
+import { useSocket } from '@/hooks/useSocket';
+import { useAuth } from '@/hooks/useAuth';
+import { usePendingStreamsStore } from '@/stores/usePendingStreamsStore';
+import { consumeStreamJoin } from '@/lib/ai/core/stream-join-client';
+import { abortActiveStreamByMessageId } from '@/lib/ai/core/stream-abort-client';
+import { getBrowserSessionId } from '@/lib/ai/core/browser-session-id';
+import type { AiStreamStartPayload, AiStreamCompletePayload } from '@/lib/websocket/socket-utils';
+
+interface ActiveStreamRow {
+  messageId: string;
+  conversationId: string;
+  triggeredBy: { userId: string; displayName: string; browserSessionId: string };
+}
 
 /**
  * Global Chat Context - Split into three tiers to minimize re-render noise:
@@ -232,6 +245,157 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
       hasInitialConnectRef.current = true;
     }
   }, [connectionStatus, currentConversationId, refreshConversation]);
+
+  // ============================================
+  // GLOBAL CHANNEL STREAM SOCKET — bootstrap + live events
+  // ============================================
+  // Mirrors useChatStreamSocket for the synthetic global channel
+  // (`user:${userId}:global`). On mount we replay any in-flight stream rows from
+  // the DB so a refresh mid-stream restores the stop button + remote-stream
+  // append. Live chat:stream_start/_complete events keep the store in sync for
+  // streams started in another tab. Streams initiated by the local browser
+  // session are intentionally ignored — useChat in the active tab is the
+  // source of truth there.
+  const socket = useSocket();
+  const { user } = useAuth();
+  const userId = user?.id ?? null;
+
+  // Always-current refs so the live SSE complete handler can call into the
+  // latest setters/refresh without re-binding socket listeners every render.
+  const setIsStreamingRef = useRef(setIsStreaming);
+  setIsStreamingRef.current = setIsStreaming;
+  const setStopStreamingRef = useRef(setStopStreaming);
+  setStopStreamingRef.current = setStopStreaming;
+  const refreshConversationRef = useRef(refreshConversation);
+  refreshConversationRef.current = refreshConversation;
+
+  useEffect(() => {
+    if (!socket || !userId) return;
+
+    const channelId = `user:${userId}:global`;
+    const localBrowserSessionId = getBrowserSessionId();
+    const controllers = new Map<string, AbortController>();
+    // Tracks bootstrapped own streams so the corresponding SSE-resolve / live
+    // complete event can clear the local stop button surface — non-own and
+    // live cross-tab streams must NOT mutate the local streaming flags.
+    const ownStreamIds = new Set<string>();
+    // Guards against firing finalize twice for the same messageId when both the
+    // socket complete event and the SSE done sentinel arrive (the abort triggered
+    // by the former resolves consumeStreamJoin, which would otherwise re-enter).
+    const finalized = new Set<string>();
+    let cancelled = false;
+
+    const { addStream, appendText, removeStream, clearPageStreams } =
+      usePendingStreamsStore.getState();
+
+    const finalizeStream = (messageId: string) => {
+      if (finalized.has(messageId)) return;
+      finalized.add(messageId);
+      controllers.delete(messageId);
+      if (ownStreamIds.delete(messageId)) {
+        setIsStreamingRef.current(false);
+        setStopStreamingRef.current(null);
+      }
+      removeStream(messageId);
+      refreshConversationRef.current();
+    };
+
+    const startConsume = (messageId: string) => {
+      const controller = new AbortController();
+      controllers.set(messageId, controller);
+
+      consumeStreamJoin(messageId, controller.signal, (chunk) => {
+        appendText(messageId, chunk);
+      })
+        .then(() => {
+          finalizeStream(messageId);
+        })
+        .catch((err) => {
+          controllers.delete(messageId);
+          ownStreamIds.delete(messageId);
+          removeStream(messageId);
+          if (!controller.signal.aborted) {
+            console.error('[GlobalChatContext] SSE join error:', err);
+          }
+        });
+    };
+
+    (async () => {
+      try {
+        const res = await fetchWithAuth(
+          `/api/ai/chat/active-streams?channelId=${encodeURIComponent(channelId)}`,
+          { credentials: 'include' },
+        );
+        if (cancelled) return;
+        if (!res.ok) return;
+        const data = (await res.json()) as { streams?: ActiveStreamRow[] };
+        if (cancelled) return;
+        for (const stream of data.streams ?? []) {
+          if (controllers.has(stream.messageId)) continue;
+          const isOwn = stream.triggeredBy.browserSessionId === localBrowserSessionId;
+          addStream({
+            messageId: stream.messageId,
+            pageId: channelId,
+            conversationId: stream.conversationId,
+            triggeredBy: stream.triggeredBy,
+            isOwn,
+          });
+          if (isOwn) {
+            ownStreamIds.add(stream.messageId);
+            const messageIdForAbort = stream.messageId;
+            setIsStreamingRef.current(true);
+            setStopStreamingRef.current(() => () => {
+              abortActiveStreamByMessageId({ messageId: messageIdForAbort });
+            });
+          }
+          startConsume(stream.messageId);
+        }
+      } catch (err) {
+        if (cancelled) return;
+        console.warn('[GlobalChatContext] bootstrap failed', err);
+      }
+    })();
+
+    const handleStreamStart = (payload: AiStreamStartPayload) => {
+      if (payload.pageId !== channelId) return;
+      if (payload.triggeredBy.browserSessionId === localBrowserSessionId) return;
+      if (controllers.has(payload.messageId)) return;
+
+      addStream({
+        messageId: payload.messageId,
+        pageId: payload.pageId,
+        conversationId: payload.conversationId,
+        triggeredBy: payload.triggeredBy,
+        isOwn: false,
+      });
+
+      startConsume(payload.messageId);
+    };
+
+    const handleStreamComplete = (payload: AiStreamCompletePayload) => {
+      if (payload.pageId !== channelId) return;
+      const controller = controllers.get(payload.messageId);
+      if (controller) {
+        controller.abort();
+      }
+      finalizeStream(payload.messageId);
+    };
+
+    socket.on('chat:stream_start', handleStreamStart);
+    socket.on('chat:stream_complete', handleStreamComplete);
+
+    return () => {
+      cancelled = true;
+      socket.off('chat:stream_start', handleStreamStart);
+      socket.off('chat:stream_complete', handleStreamComplete);
+      for (const controller of controllers.values()) {
+        controller.abort();
+      }
+      controllers.clear();
+      ownStreamIds.clear();
+      clearPageStreams(channelId);
+    };
+  }, [socket, userId]);
 
   // Track the previous conversation ID to detect conversation switches
   const prevConversationIdRef = useRef<string | null>(null);

--- a/apps/web/src/contexts/GlobalChatContext.tsx
+++ b/apps/web/src/contexts/GlobalChatContext.tsx
@@ -288,14 +288,21 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
     const { addStream, appendText, removeStream, clearPageStreams } =
       usePendingStreamsStore.getState();
 
+    const clearOwnStreamFlags = (messageId: string): boolean => {
+      if (!ownStreamIds.delete(messageId)) return false;
+      setIsStreamingRef.current(false);
+      setStopStreamingRef.current(null);
+      return true;
+    };
+
     const finalizeStream = (messageId: string) => {
+      // After unmount, controllers are aborted which resolves consumeStreamJoin
+      // and re-enters this callback — guard against post-teardown fetch/state.
+      if (cancelled) return;
       if (finalized.has(messageId)) return;
       finalized.add(messageId);
       controllers.delete(messageId);
-      if (ownStreamIds.delete(messageId)) {
-        setIsStreamingRef.current(false);
-        setStopStreamingRef.current(null);
-      }
+      clearOwnStreamFlags(messageId);
       removeStream(messageId);
       refreshConversationRef.current();
     };
@@ -311,8 +318,15 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
           finalizeStream(messageId);
         })
         .catch((err) => {
+          if (cancelled) return;
+          if (finalized.has(messageId)) return;
+          finalized.add(messageId);
           controllers.delete(messageId);
-          ownStreamIds.delete(messageId);
+          // Treat a join error as terminal locally so the stop button is not
+          // left dangling — the stream may still finish server-side, but the
+          // socket complete handler will be a no-op (already finalized) and
+          // we have no live SSE to drive the UI forward.
+          clearOwnStreamFlags(messageId);
           removeStream(messageId);
           if (!controller.signal.aborted) {
             console.error('[GlobalChatContext] SSE join error:', err);

--- a/apps/web/src/contexts/__tests__/GlobalChatContext.test.tsx
+++ b/apps/web/src/contexts/__tests__/GlobalChatContext.test.tsx
@@ -5,12 +5,89 @@ import React from 'react';
 
 // --- Mocks (hoisted so vi.mock factories can reference them) ---
 
-const { mockUseSocketStore } = vi.hoisted(() => ({
-  mockUseSocketStore: vi.fn(),
-}));
+const SESSION_ID_LOCAL = 'session-current';
+const SESSION_ID_REMOTE = 'session-other';
+
+const {
+  mockUseSocketStore,
+  mockSocket,
+  mockUseAuth,
+  mockAddStream,
+  mockAppendText,
+  mockRemoveStream,
+  mockClearPageStreams,
+  mockConsumeStreamJoin,
+  mockAbortActiveStreamByMessageId,
+  mockGetBrowserSessionId,
+} = vi.hoisted(() => {
+  const handlers: Record<string, ((...args: unknown[]) => void)[]> = {};
+  const socket = {
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (!handlers[event]) handlers[event] = [];
+      handlers[event].push(handler);
+    }),
+    off: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (handlers[event]) {
+        handlers[event] = handlers[event].filter((h) => h !== handler);
+      }
+    }),
+    emit: vi.fn(),
+    _trigger: (event: string, payload: unknown) => {
+      handlers[event]?.slice().forEach((h) => h(payload));
+    },
+    _reset: () => {
+      Object.keys(handlers).forEach((k) => { handlers[k] = []; });
+    },
+    _handlerCount: (event: string) => handlers[event]?.length ?? 0,
+  };
+
+  return {
+    mockUseSocketStore: vi.fn(),
+    mockSocket: socket,
+    mockUseAuth: vi.fn(),
+    mockAddStream: vi.fn(),
+    mockAppendText: vi.fn(),
+    mockRemoveStream: vi.fn(),
+    mockClearPageStreams: vi.fn(),
+    mockConsumeStreamJoin: vi.fn().mockResolvedValue(undefined),
+    mockAbortActiveStreamByMessageId: vi.fn().mockResolvedValue({ aborted: true, reason: '' }),
+    mockGetBrowserSessionId: vi.fn(() => SESSION_ID_LOCAL),
+  };
+});
 
 vi.mock('@/stores/useSocketStore', () => ({
   useSocketStore: mockUseSocketStore,
+}));
+
+vi.mock('@/hooks/useSocket', () => ({
+  useSocket: () => mockSocket,
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+vi.mock('@/stores/usePendingStreamsStore', () => ({
+  usePendingStreamsStore: {
+    getState: () => ({
+      addStream: mockAddStream,
+      appendText: mockAppendText,
+      removeStream: mockRemoveStream,
+      clearPageStreams: mockClearPageStreams,
+    }),
+  },
+}));
+
+vi.mock('@/lib/ai/core/stream-join-client', () => ({
+  consumeStreamJoin: mockConsumeStreamJoin,
+}));
+
+vi.mock('@/lib/ai/core/stream-abort-client', () => ({
+  abortActiveStreamByMessageId: mockAbortActiveStreamByMessageId,
+}));
+
+vi.mock('@/lib/ai/core/browser-session-id', () => ({
+  getBrowserSessionId: mockGetBrowserSessionId,
 }));
 
 const mockFetchWithAuth = vi.fn();
@@ -37,17 +114,20 @@ vi.mock('@/lib/ai/shared', () => ({
   useChatTransport: vi.fn().mockReturnValue(null),
 }));
 
-import { GlobalChatProvider, useGlobalChatConversation } from '../GlobalChatContext';
+import { GlobalChatProvider, useGlobalChat, useGlobalChatConversation } from '../GlobalChatContext';
 
 // --- Helpers ---
 
 const CONV_ID = 'conv-1';
+const USER_ID = 'u1';
+const GLOBAL_CHANNEL_ID = `user:${USER_ID}:global`;
 
 const okResponse = (data: unknown) =>
   Promise.resolve({ ok: true, json: () => Promise.resolve(data) });
 
 const defaultFetch = (url: string) => {
   if (url === '/api/ai/global/active') return okResponse({ id: CONV_ID });
+  if (url.includes('/api/ai/chat/active-streams')) return okResponse({ streams: [] });
   if (url.includes('/messages')) return okResponse([]);
   return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
 };
@@ -64,10 +144,14 @@ describe('GlobalChatProvider — socket reconnect refresh', () => {
   beforeEach(() => {
     mockConnectionStatus = 'disconnected';
     vi.clearAllMocks();
+    mockSocket._reset();
     mockUseSocketStore.mockImplementation((selector: (s: { connectionStatus: string }) => unknown) =>
       selector({ connectionStatus: mockConnectionStatus })
     );
     mockFetchWithAuth.mockImplementation(defaultFetch);
+    mockUseAuth.mockReturnValue({ user: { id: USER_ID }, isAuthenticated: true });
+    mockGetBrowserSessionId.mockReturnValue(SESSION_ID_LOCAL);
+    mockConsumeStreamJoin.mockResolvedValue(undefined);
   });
 
   const renderProvider = () =>
@@ -217,6 +301,312 @@ describe('GlobalChatProvider — socket reconnect refresh', () => {
     // Second connect — isInitialized still false, should not refresh
     setStatus('connected', rerender);
 
-    await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalledTimes(1));
+    // The bootstrap effect always fetches active-streams once on mount; that call
+    // is unrelated to refreshConversation and must be excluded from the assertion.
+    await waitFor(() => {
+      const conversationCalls = mockFetchWithAuth.mock.calls.filter(
+        ([url]) => typeof url === 'string' && !(url as string).includes('/api/ai/chat/active-streams'),
+      );
+      expect(conversationCalls).toHaveLength(1);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bootstrap + live socket events for the global channel — completes the
+// streaming-persistence epic by giving the global chat refresh-mid-stream
+// visibility (stop button + live append) on par with page chats.
+// ---------------------------------------------------------------------------
+
+describe('GlobalChatProvider — global channel stream socket', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSocket._reset();
+    mockUseSocketStore.mockImplementation((selector: (s: { connectionStatus: string }) => unknown) =>
+      selector({ connectionStatus: 'connected' })
+    );
+    mockFetchWithAuth.mockImplementation(defaultFetch);
+    mockUseAuth.mockReturnValue({ user: { id: USER_ID }, isAuthenticated: true });
+    mockGetBrowserSessionId.mockReturnValue(SESSION_ID_LOCAL);
+    mockConsumeStreamJoin.mockResolvedValue(undefined);
+  });
+
+  const renderProvider = () =>
+    renderHook(() => useGlobalChat(), { wrapper: Wrapper });
+
+  // AC1
+  it('given the provider mounts with userId, should fetch active streams for the global channel', async () => {
+    renderProvider();
+
+    await waitFor(() => {
+      const matched = mockFetchWithAuth.mock.calls.find(
+        ([url]) => typeof url === 'string' && url.includes('/api/ai/chat/active-streams'),
+      );
+      expect(matched).toBeDefined();
+      expect(matched?.[0]).toBe(
+        `/api/ai/chat/active-streams?channelId=${encodeURIComponent(GLOBAL_CHANNEL_ID)}`,
+      );
+    });
+  });
+
+  // AC2 — own bootstrap stream
+  it('given a bootstrapped own stream, should addStream isOwn=true and surface stop via context', async () => {
+    mockFetchWithAuth.mockImplementation((url: string) => {
+      if (url.includes('/api/ai/chat/active-streams')) {
+        return okResponse({
+          streams: [{
+            messageId: 'msg-own',
+            conversationId: 'conv-own',
+            triggeredBy: { userId: USER_ID, displayName: 'Me', browserSessionId: SESSION_ID_LOCAL },
+          }],
+        });
+      }
+      return defaultFetch(url);
+    });
+
+    let pendingResolve!: () => void;
+    mockConsumeStreamJoin.mockReturnValueOnce(new Promise((res) => { pendingResolve = () => res(undefined); }));
+
+    const { result } = renderProvider();
+
+    await waitFor(() => {
+      expect(mockAddStream).toHaveBeenCalledWith(expect.objectContaining({
+        messageId: 'msg-own',
+        pageId: GLOBAL_CHANNEL_ID,
+        isOwn: true,
+      }));
+    });
+
+    await waitFor(() => expect(result.current.isStreaming).toBe(true));
+    expect(typeof result.current.stopStreaming).toBe('function');
+
+    // Invoking the registered stop should hit abortActiveStreamByMessageId
+    act(() => { result.current.stopStreaming?.(); });
+    expect(mockAbortActiveStreamByMessageId).toHaveBeenCalledWith({ messageId: 'msg-own' });
+
+    // keep promise alive past test until cleanup
+    pendingResolve();
+  });
+
+  // AC3 — own bootstrap stream complete via SSE
+  it('given an own bootstrap stream resolves via SSE, should clear context streaming + refresh conversation', async () => {
+    mockFetchWithAuth.mockImplementation((url: string) => {
+      if (url.includes('/api/ai/chat/active-streams')) {
+        return okResponse({
+          streams: [{
+            messageId: 'msg-own',
+            conversationId: 'conv-own',
+            triggeredBy: { userId: USER_ID, displayName: 'Me', browserSessionId: SESSION_ID_LOCAL },
+          }],
+        });
+      }
+      return defaultFetch(url);
+    });
+
+    let resolveJoin!: () => void;
+    mockConsumeStreamJoin.mockReturnValueOnce(new Promise((res) => { resolveJoin = () => res(undefined); }));
+
+    const { result } = renderProvider();
+
+    await waitFor(() => expect(result.current.isStreaming).toBe(true));
+
+    const messagesCallsBefore = mockFetchWithAuth.mock.calls.filter(
+      ([url]) => typeof url === 'string' && (url as string).includes('/messages'),
+    ).length;
+
+    await act(async () => { resolveJoin(); });
+
+    await waitFor(() => expect(result.current.isStreaming).toBe(false));
+    expect(result.current.stopStreaming).toBeNull();
+    expect(mockRemoveStream).toHaveBeenCalledWith('msg-own');
+
+    await waitFor(() => {
+      const messagesCallsAfter = mockFetchWithAuth.mock.calls.filter(
+        ([url]) => typeof url === 'string' && (url as string).includes('/messages'),
+      ).length;
+      expect(messagesCallsAfter).toBeGreaterThan(messagesCallsBefore);
+    });
+  });
+
+  // AC4 — live cross-tab stream_start
+  it('given chat:stream_start from another tab same user, should addStream isOwn=false and start consumeStreamJoin without touching context streaming flags', async () => {
+    const { result } = renderProvider();
+
+    // wait for socket listener registration
+    await waitFor(() => expect(mockSocket._handlerCount('chat:stream_start')).toBeGreaterThan(0));
+
+    act(() => {
+      mockSocket._trigger('chat:stream_start', {
+        messageId: 'msg-remote',
+        pageId: GLOBAL_CHANNEL_ID,
+        conversationId: 'conv-1',
+        triggeredBy: { userId: USER_ID, displayName: 'Me-otherTab', browserSessionId: SESSION_ID_REMOTE },
+      });
+    });
+
+    expect(mockAddStream).toHaveBeenCalledWith({
+      messageId: 'msg-remote',
+      pageId: GLOBAL_CHANNEL_ID,
+      conversationId: 'conv-1',
+      triggeredBy: { userId: USER_ID, displayName: 'Me-otherTab', browserSessionId: SESSION_ID_REMOTE },
+      isOwn: false,
+    });
+    expect(mockConsumeStreamJoin).toHaveBeenCalledWith(
+      'msg-remote',
+      expect.any(AbortSignal),
+      expect.any(Function),
+    );
+    // Cross-tab streams must NOT mutate the local streaming flags — only the
+    // owning tab's useChat hook should drive the local stop button surface.
+    expect(result.current.isStreaming).toBe(false);
+    expect(result.current.stopStreaming).toBeNull();
+  });
+
+  // AC5 — own-tab live event filtered
+  it('given chat:stream_start from the own browser session, should ignore the event', async () => {
+    renderProvider();
+
+    await waitFor(() => expect(mockSocket._handlerCount('chat:stream_start')).toBeGreaterThan(0));
+
+    act(() => {
+      mockSocket._trigger('chat:stream_start', {
+        messageId: 'msg-self',
+        pageId: GLOBAL_CHANNEL_ID,
+        conversationId: 'conv-1',
+        triggeredBy: { userId: USER_ID, displayName: 'Me', browserSessionId: SESSION_ID_LOCAL },
+      });
+    });
+
+    expect(mockAddStream).not.toHaveBeenCalledWith(expect.objectContaining({ messageId: 'msg-self' }));
+    expect(mockConsumeStreamJoin).not.toHaveBeenCalledWith('msg-self', expect.anything(), expect.anything());
+  });
+
+  // AC6 — channel filter
+  it('given chat:stream_start with a different channel id, should ignore the event', async () => {
+    renderProvider();
+
+    await waitFor(() => expect(mockSocket._handlerCount('chat:stream_start')).toBeGreaterThan(0));
+
+    act(() => {
+      mockSocket._trigger('chat:stream_start', {
+        messageId: 'msg-elsewhere',
+        pageId: 'page-xyz',
+        conversationId: 'conv-1',
+        triggeredBy: { userId: 'u2', displayName: 'Other', browserSessionId: SESSION_ID_REMOTE },
+      });
+    });
+
+    expect(mockAddStream).not.toHaveBeenCalled();
+    expect(mockConsumeStreamJoin).not.toHaveBeenCalled();
+  });
+
+  // AC7 — live stream_complete cleanup
+  it('given chat:stream_complete for a tracked messageId, should abort SSE, removeStream and refresh conversation', async () => {
+    let capturedSignal!: AbortSignal;
+    mockConsumeStreamJoin.mockImplementationOnce(
+      (_id: string, signal: AbortSignal) => {
+        capturedSignal = signal;
+        return new Promise(() => {}); // never resolves
+      },
+    );
+
+    const { result } = renderProvider();
+
+    await waitFor(() => expect(mockSocket._handlerCount('chat:stream_start')).toBeGreaterThan(0));
+
+    // Wait for initial conversation load to finish so refreshConversation has a target
+    await waitFor(() => expect(result.current.currentConversationId).toBe(CONV_ID));
+
+    act(() => {
+      mockSocket._trigger('chat:stream_start', {
+        messageId: 'msg-live',
+        pageId: GLOBAL_CHANNEL_ID,
+        conversationId: 'conv-1',
+        triggeredBy: { userId: USER_ID, displayName: 'Me-otherTab', browserSessionId: SESSION_ID_REMOTE },
+      });
+    });
+
+    const messagesCallsBefore = mockFetchWithAuth.mock.calls.filter(
+      ([url]) => typeof url === 'string' && (url as string).includes('/messages'),
+    ).length;
+
+    act(() => {
+      mockSocket._trigger('chat:stream_complete', {
+        messageId: 'msg-live',
+        pageId: GLOBAL_CHANNEL_ID,
+      });
+    });
+
+    expect(capturedSignal.aborted).toBe(true);
+    expect(mockRemoveStream).toHaveBeenCalledWith('msg-live');
+
+    await waitFor(() => {
+      const messagesCallsAfter = mockFetchWithAuth.mock.calls.filter(
+        ([url]) => typeof url === 'string' && (url as string).includes('/messages'),
+      ).length;
+      expect(messagesCallsAfter).toBeGreaterThan(messagesCallsBefore);
+    });
+  });
+
+  // AC8 — unmount safety
+  it('given the provider unmounts, should abort in-flight SSE controllers and remove socket listeners', async () => {
+    let capturedSignal!: AbortSignal;
+    mockConsumeStreamJoin.mockImplementationOnce(
+      (_id: string, signal: AbortSignal) => {
+        capturedSignal = signal;
+        return new Promise(() => {});
+      },
+    );
+
+    const { unmount } = renderProvider();
+
+    await waitFor(() => expect(mockSocket._handlerCount('chat:stream_start')).toBeGreaterThan(0));
+
+    act(() => {
+      mockSocket._trigger('chat:stream_start', {
+        messageId: 'msg-live',
+        pageId: GLOBAL_CHANNEL_ID,
+        conversationId: 'conv-1',
+        triggeredBy: { userId: USER_ID, displayName: 'Me-otherTab', browserSessionId: SESSION_ID_REMOTE },
+      });
+    });
+
+    unmount();
+
+    expect(capturedSignal.aborted).toBe(true);
+    expect(mockSocket.off).toHaveBeenCalledWith('chat:stream_start', expect.any(Function));
+    expect(mockSocket.off).toHaveBeenCalledWith('chat:stream_complete', expect.any(Function));
+  });
+
+  // AC8 — bootstrap unmount cancellation
+  it('given fetch resolves after unmount, should not call addStream', async () => {
+    let resolveFetch!: (value: unknown) => void;
+    mockFetchWithAuth.mockImplementation((url: string) => {
+      if (url.includes('/api/ai/chat/active-streams')) {
+        return new Promise((res) => { resolveFetch = res; });
+      }
+      return defaultFetch(url);
+    });
+
+    const { unmount } = renderProvider();
+
+    unmount();
+
+    await act(async () => {
+      resolveFetch({
+        ok: true,
+        json: async () => ({
+          streams: [{
+            messageId: 'msg-late',
+            conversationId: 'conv-1',
+            triggeredBy: { userId: USER_ID, displayName: 'Me', browserSessionId: SESSION_ID_LOCAL },
+          }],
+        }),
+      });
+      await Promise.resolve();
+    });
+
+    expect(mockAddStream).not.toHaveBeenCalled();
+    expect(mockConsumeStreamJoin).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/contexts/__tests__/GlobalChatContext.test.tsx
+++ b/apps/web/src/contexts/__tests__/GlobalChatContext.test.tsx
@@ -578,6 +578,130 @@ describe('GlobalChatProvider — global channel stream socket', () => {
     expect(mockSocket.off).toHaveBeenCalledWith('chat:stream_complete', expect.any(Function));
   });
 
+  // Codex P1 — SSE join failure on own bootstrap stream must not strand UI
+  it('given an own bootstrap stream and consumeStreamJoin rejects, should clear context streaming flags', async () => {
+    mockFetchWithAuth.mockImplementation((url: string) => {
+      if (url.includes('/api/ai/chat/active-streams')) {
+        return okResponse({
+          streams: [{
+            messageId: 'msg-own',
+            conversationId: 'conv-own',
+            triggeredBy: { userId: USER_ID, displayName: 'Me', browserSessionId: SESSION_ID_LOCAL },
+          }],
+        });
+      }
+      return defaultFetch(url);
+    });
+
+    let rejectJoin!: (err: Error) => void;
+    mockConsumeStreamJoin.mockReturnValueOnce(
+      new Promise((_res, rej) => { rejectJoin = rej; }),
+    );
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { result } = renderProvider();
+
+    await waitFor(() => expect(result.current.isStreaming).toBe(true));
+
+    await act(async () => {
+      rejectJoin(new Error('network down'));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(result.current.isStreaming).toBe(false));
+    expect(result.current.stopStreaming).toBeNull();
+    expect(mockRemoveStream).toHaveBeenCalledWith('msg-own');
+
+    errorSpy.mockRestore();
+  });
+
+  // Codex P1 follow-up — after a failed SSE join, a later complete event must
+  // not double-clear flags; the catch path already finalized the stream.
+  it('given own SSE rejected then chat:stream_complete fires, should not refresh twice', async () => {
+    mockFetchWithAuth.mockImplementation((url: string) => {
+      if (url.includes('/api/ai/chat/active-streams')) {
+        return okResponse({
+          streams: [{
+            messageId: 'msg-own',
+            conversationId: 'conv-own',
+            triggeredBy: { userId: USER_ID, displayName: 'Me', browserSessionId: SESSION_ID_LOCAL },
+          }],
+        });
+      }
+      return defaultFetch(url);
+    });
+
+    let rejectJoin!: (err: Error) => void;
+    mockConsumeStreamJoin.mockReturnValueOnce(
+      new Promise((_res, rej) => { rejectJoin = rej; }),
+    );
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { result } = renderProvider();
+
+    await waitFor(() => expect(result.current.isStreaming).toBe(true));
+
+    await act(async () => {
+      rejectJoin(new Error('network down'));
+      await Promise.resolve();
+    });
+
+    const messagesCallsAfterCatch = mockFetchWithAuth.mock.calls.filter(
+      ([url]) => typeof url === 'string' && (url as string).includes('/messages'),
+    ).length;
+
+    act(() => {
+      mockSocket._trigger('chat:stream_complete', {
+        messageId: 'msg-own',
+        pageId: GLOBAL_CHANNEL_ID,
+      });
+    });
+
+    // No additional /messages refresh — finalize is a no-op on already-finalized id
+    const messagesCallsAfterComplete = mockFetchWithAuth.mock.calls.filter(
+      ([url]) => typeof url === 'string' && (url as string).includes('/messages'),
+    ).length;
+    expect(messagesCallsAfterComplete).toBe(messagesCallsAfterCatch);
+
+    errorSpy.mockRestore();
+  });
+
+  // Codex P2 — finalize must not run after teardown
+  it('given a stream resolves after unmount via aborted SSE, should not call refreshConversation post-unmount', async () => {
+    let resolveJoin!: () => void;
+    mockConsumeStreamJoin.mockImplementationOnce(
+      (_id: string, _signal: AbortSignal) =>
+        new Promise<undefined>((res) => { resolveJoin = () => res(undefined); }),
+    );
+
+    const { unmount } = renderProvider();
+
+    await waitFor(() => expect(mockSocket._handlerCount('chat:stream_start')).toBeGreaterThan(0));
+
+    act(() => {
+      mockSocket._trigger('chat:stream_start', {
+        messageId: 'msg-live',
+        pageId: GLOBAL_CHANNEL_ID,
+        conversationId: 'conv-1',
+        triggeredBy: { userId: USER_ID, displayName: 'Other', browserSessionId: SESSION_ID_REMOTE },
+      });
+    });
+
+    const messagesCallsBeforeUnmount = mockFetchWithAuth.mock.calls.filter(
+      ([url]) => typeof url === 'string' && (url as string).includes('/messages'),
+    ).length;
+
+    unmount();
+
+    // Now resolve the SSE — simulates abort-triggered resolution post-unmount
+    await act(async () => { resolveJoin(); await Promise.resolve(); });
+
+    const messagesCallsAfterUnmount = mockFetchWithAuth.mock.calls.filter(
+      ([url]) => typeof url === 'string' && (url as string).includes('/messages'),
+    ).length;
+    expect(messagesCallsAfterUnmount).toBe(messagesCallsBeforeUnmount);
+  });
+
   // AC8 — bootstrap unmount cancellation
   it('given fetch resolves after unmount, should not call addStream', async () => {
     let resolveFetch!: (value: unknown) => void;


### PR DESCRIPTION
## Summary

Final task in the AI chat streaming-persistence epic (`tasks/ai-chat-streaming-persistence.md`). After this lands, refresh-mid-stream works end-to-end in global chat from both surfaces (sidebar + dashboard).

- `GlobalChatContext` now bootstraps active streams from the DB on mount and listens to `chat:stream_start` / `chat:stream_complete` on the synthetic `user:${userId}:global` channel, mirroring `useChatStreamSocket`. Bootstrapped own streams register a stop function via the existing `setStopStreaming` setter so the stop button survives a refresh.
- `GlobalAssistantView` derives `effectiveIsStreaming` / `effectiveStop` from a small new `useGlobalEffectiveStream` hook so the context-tracked stream reaches `ChatLayout`, `VoiceCallPanel`, and `ChatInput` even when local `useChat` is idle. Agent mode passes through unchanged.

## Acceptance criteria

13 ACs from the spec, each with a dedicated test:

- AC1–AC8: bootstrap + live socket events on `GlobalChatContext` (own/cross-tab/own-tab-filter/channel-filter/cleanup/unmount).
- AC9–AC12: `useGlobalEffectiveStream` derivation (context isStreaming surfaced, context stop dispatched, local stop preserved, agent mode untouched).
- AC13: `pnpm --filter web typecheck` and `pnpm --filter web lint` show no regressions in touched files; relevant test suites all green.

## Test plan

- [x] `pnpm exec vitest run src/contexts src/components/layout/middle-content/page-views/dashboard` — 21/21 passing
- [x] `pnpm exec vitest run src/hooks/__tests__/useChatStreamSocket.test.ts` — 25/25 passing (no regression)
- [x] Typecheck delta on touched files: 0 new errors (3055 total = pre-existing baseline)
- [x] Lint on touched files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced stream state management to better reconcile streaming status across different operational modes.
  * Improved stop handling to intelligently route stream termination commands to the correct source.
  * Added cross-tab awareness for streaming operations to maintain consistent state across browser sessions.

* **Tests**
  * Added comprehensive test coverage for new streaming behavior and cross-tab synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->