### PR TITLE
feat(ai-tools): enrich update_task with delete+reorder; read_page surfaces availableStatuses (MCP parity prep)

### DIFF
--- a/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
@@ -14,6 +14,8 @@ vi.mock('@pagespace/db/db', () => ({
       pages: { findFirst: vi.fn(), findMany: vi.fn().mockResolvedValue([]) },
       drives: { findFirst: vi.fn() },
       taskItems: { findFirst: vi.fn() },
+      taskLists: { findFirst: vi.fn() },
+      taskStatusConfigs: { findMany: vi.fn().mockResolvedValue([]) },
       chatMessages: { findFirst: vi.fn() },
       channelMessages: { findMany: vi.fn() },
     },
@@ -47,7 +49,15 @@ vi.mock('@pagespace/db/schema/core', () => ({
   },
 }));
 vi.mock('@pagespace/db/schema/tasks', () => ({
-  taskItems: { pageId: 'pageId' },
+  taskItems: { pageId: 'pageId', taskListId: 'taskListId', position: 'position' },
+  taskLists: { pageId: 'pageId' },
+  taskStatusConfigs: { taskListId: 'taskListId', position: 'position' },
+  DEFAULT_TASK_STATUSES: [
+    { slug: 'pending', name: 'To Do', color: 'bg-slate-100', group: 'todo', position: 0 },
+    { slug: 'in_progress', name: 'In Progress', color: 'bg-amber-100', group: 'in_progress', position: 1 },
+    { slug: 'blocked', name: 'Blocked', color: 'bg-red-100', group: 'in_progress', position: 2 },
+    { slug: 'completed', name: 'Done', color: 'bg-green-100', group: 'done', position: 3 },
+  ],
 }));
 vi.mock('@pagespace/db/schema/chat', () => ({
   channelMessages: {
@@ -439,6 +449,148 @@ describe('page-read-tools', () => {
           should: 'include totalLines for context',
           actual: (result as { totalLines?: number }).totalLines,
           expected: 10,
+        });
+      });
+    });
+
+    describe('TASK_LIST page', () => {
+      const setupTaskListMocks = (opts: {
+        tasks: Array<{ id: string; status: string; completedAt?: Date | null; position?: number; title?: string }>;
+        statusConfigs?: Array<{ slug: string; name: string; color: string; group: 'todo' | 'in_progress' | 'done'; position: number }>;
+      }) => {
+        mockDb.query.pages.findFirst = vi.fn().mockResolvedValue(createMockPage('', 'TASK_LIST'));
+        mockDb.query.taskItems = { findFirst: vi.fn().mockResolvedValue(null) } as unknown as typeof mockDb.query.taskItems;
+        mockDb.query.taskLists = {
+          findFirst: vi.fn().mockResolvedValue({
+            id: 'list-1',
+            pageId: 'page-1',
+            title: 'My Tasks',
+          }),
+        } as unknown as typeof mockDb.query.taskLists;
+        mockDb.query.taskStatusConfigs = {
+          findMany: vi.fn().mockResolvedValue(opts.statusConfigs ?? []),
+        } as unknown as typeof mockDb.query.taskStatusConfigs;
+
+        // db.select().from().where().orderBy() for tasks
+        mockDb.select = vi.fn(() => ({
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnThis(),
+          orderBy: vi.fn().mockResolvedValue(
+            opts.tasks.map((t, i) => ({
+              id: t.id,
+              title: t.title ?? `Task ${i}`,
+              description: null,
+              status: t.status,
+              priority: 'medium',
+              position: t.position ?? i,
+              assigneeId: null,
+              dueDate: null,
+              completedAt: t.completedAt ?? null,
+              pageId: `page-task-${i}`,
+            }))
+          ),
+        })) as unknown as typeof mockDb.select;
+
+        mockGetUserAccessLevel.mockResolvedValue(createMockAccessLevel('editor'));
+      };
+
+      it('returns availableStatuses with documented defaults when no custom configs exist', async () => {
+        setupTaskListMocks({ tasks: [{ id: 't1', status: 'pending' }] });
+
+        const result = await pageReadTools.read_page.execute!(
+          { title: 'My Tasks', pageId: 'page-1' },
+          createAuthContext()
+        ) as {
+          availableStatuses: Array<{ slug: string; group: string; label: string }>;
+        };
+
+        const slugs = result.availableStatuses.map(s => s.slug).sort();
+        assert({
+          given: 'a TASK_LIST page with no custom status configs',
+          should: 'return the four documented default statuses',
+          actual: slugs,
+          expected: ['blocked', 'completed', 'in_progress', 'pending'],
+        });
+
+        const completedGroup = result.availableStatuses.find(s => s.slug === 'completed')?.group;
+        assert({
+          given: 'default availableStatuses',
+          should: 'include the done group on the completed status',
+          actual: completedGroup,
+          expected: 'done',
+        });
+      });
+
+      it('returns availableStatuses describing every configured custom status', async () => {
+        setupTaskListMocks({
+          tasks: [],
+          statusConfigs: [
+            { slug: 'backlog', name: 'Backlog', color: 'bg-slate-100', group: 'todo', position: 0 },
+            { slug: 'shipped', name: 'Shipped', color: 'bg-green-100', group: 'done', position: 1 },
+          ],
+        });
+
+        const result = await pageReadTools.read_page.execute!(
+          { title: 'My Tasks', pageId: 'page-1' },
+          createAuthContext()
+        ) as {
+          availableStatuses: Array<{ slug: string; group: string; label: string; color: string }>;
+        };
+
+        assert({
+          given: 'a TASK_LIST page with custom status configs',
+          should: 'surface custom slugs',
+          actual: result.availableStatuses.map(s => s.slug),
+          expected: ['backlog', 'shipped'],
+        });
+        assert({
+          given: 'a custom status config',
+          should: 'surface label, group, and color',
+          actual: result.availableStatuses.map(s => ({ label: s.label, group: s.group, color: s.color })),
+          expected: [
+            { label: 'Backlog', group: 'todo', color: 'bg-slate-100' },
+            { label: 'Shipped', group: 'done', color: 'bg-green-100' },
+          ],
+        });
+      });
+
+      it('returns dynamic progress counts keyed by every status group present', async () => {
+        setupTaskListMocks({
+          tasks: [
+            { id: 't1', status: 'backlog' },
+            { id: 't2', status: 'shipped', completedAt: new Date() },
+            { id: 't3', status: 'shipped', completedAt: new Date() },
+          ],
+          statusConfigs: [
+            { slug: 'backlog', name: 'Backlog', color: '', group: 'todo', position: 0 },
+            { slug: 'shipped', name: 'Shipped', color: '', group: 'done', position: 1 },
+          ],
+        });
+
+        const result = await pageReadTools.read_page.execute!(
+          { title: 'My Tasks', pageId: 'page-1' },
+          createAuthContext()
+        ) as {
+          progress: { total: number; percentage: number; byGroup: Record<string, number>; bySlug: Record<string, number> };
+        };
+
+        assert({
+          given: 'tasks with custom statuses',
+          should: 'count tasks by group',
+          actual: result.progress.byGroup,
+          expected: { todo: 1, in_progress: 0, done: 2 },
+        });
+        assert({
+          given: 'tasks with custom statuses',
+          should: 'also expose per-slug counts so custom statuses surface',
+          actual: result.progress.bySlug,
+          expected: { backlog: 1, shipped: 2 },
+        });
+        assert({
+          given: 'progress',
+          should: 'compute percentage from the done group',
+          actual: result.progress.percentage,
+          expected: 67,
         });
       });
     });

--- a/apps/web/src/lib/ai/tools/__tests__/task-management-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/task-management-tools.test.ts
@@ -12,12 +12,14 @@ vi.mock('@pagespace/db/db', () => ({
     set: vi.fn().mockReturnThis(),
     insert: vi.fn().mockReturnThis(),
     values: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
     returning: vi.fn(),
     transaction: vi.fn(),
     query: {
-      taskItems: { findFirst: vi.fn() },
+      taskItems: { findFirst: vi.fn(), findMany: vi.fn() },
       taskLists: { findFirst: vi.fn() },
       pages: { findFirst: vi.fn() },
+      taskStatusConfigs: { findMany: vi.fn().mockResolvedValue([]) },
     },
   },
 }));
@@ -26,13 +28,33 @@ vi.mock('@pagespace/db/operators', () => ({
   and: vi.fn(),
   desc: vi.fn(),
   asc: vi.fn(),
+  isNull: vi.fn(),
+  inArray: vi.fn(),
 }));
 vi.mock('@pagespace/db/schema/core', () => ({
-  pages: { id: 'id', parentId: 'parentId' },
+  pages: { id: 'id', parentId: 'parentId', revision: 'revision' },
 }));
 vi.mock('@pagespace/db/schema/tasks', () => ({
   taskLists: { id: 'id', pageId: 'pageId', userId: 'userId' },
-  taskItems: { id: 'id', taskListId: 'taskListId' },
+  taskItems: { id: 'id', taskListId: 'taskListId', position: 'position' },
+  taskStatusConfigs: { taskListId: 'taskListId', position: 'position' },
+  taskAssignees: { taskId: 'taskId' },
+}));
+
+vi.mock('@/services/api/page-mutation-service', () => ({
+  applyPageMutation: vi.fn().mockResolvedValue({ pageId: 'p', driveId: 'd', nextRevision: 1 }),
+  PageRevisionMismatchError: class PageRevisionMismatchError extends Error {
+    currentRevision = 0;
+    expectedRevision?: number;
+  },
+}));
+
+vi.mock('@/lib/workflows/task-trigger-helpers', () => ({
+  createTaskTriggerWorkflow: vi.fn(),
+  syncTaskDueDateTrigger: vi.fn(),
+  cancelTaskDueDateTrigger: vi.fn(),
+  fireCompletionTrigger: vi.fn(),
+  disableTaskTriggers: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
@@ -235,6 +257,244 @@ describe('task-management-tools', () => {
           context
         )
       ).rejects.toThrow('Page must be a TASK_LIST page to add tasks');
+    });
+
+    describe('delete branch', () => {
+      it('hard-deletes task and trashes linked DOCUMENT page when delete: true', async () => {
+        mockDb.query.taskItems.findFirst = vi.fn().mockResolvedValue({
+          id: 'task-1',
+          taskListId: 'list-1',
+          pageId: 'doc-page-1',
+          title: 'Old Task',
+        });
+        mockDb.query.taskLists.findFirst = vi.fn().mockResolvedValue({
+          id: 'list-1',
+          pageId: 'task-list-page-1',
+          userId: 'user-123',
+        });
+        mockDb.query.pages.findFirst = vi.fn().mockResolvedValue({ driveId: 'drive-1' });
+        mockCanUserEditPage.mockResolvedValue(true);
+
+        const tx = {
+          select: vi.fn().mockReturnThis(),
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockResolvedValue([{ revision: 5 }]),
+          delete: vi.fn().mockReturnThis(),
+        };
+        // Make .where on delete chain return a thenable that resolves
+        const deleteCalls: unknown[] = [];
+        tx.delete = vi.fn(() => {
+          const chain = {
+            where: vi.fn().mockImplementation((arg: unknown) => {
+              deleteCalls.push(arg);
+              return Promise.resolve();
+            }),
+          };
+          return chain as unknown as typeof tx;
+        });
+        const transactionMock = vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb(tx));
+        mockDb.transaction = transactionMock as unknown as typeof mockDb.transaction;
+
+        const context = {
+          toolCallId: '1', messages: [],
+          experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+        };
+
+        const result = await taskManagementTools.update_task.execute!(
+          { taskId: 'task-1', delete: true },
+          context
+        );
+
+        const { applyPageMutation } = await import('@/services/api/page-mutation-service');
+        const { disableTaskTriggers } = await import('@/lib/workflows/task-trigger-helpers');
+
+        expect(applyPageMutation).toHaveBeenCalledWith(
+          expect.objectContaining({
+            pageId: 'doc-page-1',
+            operation: 'trash',
+            updates: expect.objectContaining({ isTrashed: true }),
+            expectedRevision: 5,
+          }),
+        );
+        expect(deleteCalls.length).toBeGreaterThanOrEqual(1);
+        expect(disableTaskTriggers).toHaveBeenCalledWith('task-1', expect.any(String));
+        expect(result).toEqual(
+          expect.objectContaining({
+            success: true,
+            action: 'deleted',
+            task: expect.objectContaining({ id: 'task-1', pageId: 'doc-page-1' }),
+          }),
+        );
+      });
+
+      it('ignores field updates when delete: true is also passed', async () => {
+        mockDb.query.taskItems.findFirst = vi.fn().mockResolvedValue({
+          id: 'task-1',
+          taskListId: 'list-1',
+          pageId: 'doc-page-1',
+          title: 'Old Task',
+        });
+        mockDb.query.taskLists.findFirst = vi.fn().mockResolvedValue({
+          id: 'list-1',
+          pageId: 'task-list-page-1',
+          userId: 'user-123',
+        });
+        mockDb.query.pages.findFirst = vi.fn().mockResolvedValue({ driveId: 'drive-1' });
+        mockCanUserEditPage.mockResolvedValue(true);
+
+        const updateMock = vi.fn().mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{ id: 'task-1', title: 'NEW' }]),
+            }),
+          }),
+        });
+        const tx = {
+          select: vi.fn().mockReturnThis(),
+          from: vi.fn().mockReturnThis(),
+          where: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockResolvedValue([{ revision: 1 }]),
+          delete: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+          update: updateMock,
+        };
+        mockDb.transaction = vi.fn(async (cb: (tx: unknown) => Promise<unknown>) =>
+          cb(tx)
+        ) as unknown as typeof mockDb.transaction;
+
+        const context = {
+          toolCallId: '1', messages: [],
+          experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+        };
+
+        const result = await taskManagementTools.update_task.execute!(
+          { taskId: 'task-1', delete: true, title: 'Should Be Ignored', status: 'completed' },
+          context
+        );
+
+        expect(updateMock).not.toHaveBeenCalled();
+        expect((result as { action: string }).action).toBe('deleted');
+      });
+
+      it('rejects delete when no taskId is provided', async () => {
+        const context = {
+          toolCallId: '1', messages: [],
+          experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+        };
+
+        await expect(
+          taskManagementTools.update_task.execute!(
+            { delete: true, pageId: 'page-1' },
+            context
+          )
+        ).rejects.toThrow('delete requires a taskId');
+      });
+    });
+
+    describe('reorder branch (position on existing task)', () => {
+      it('densifies peer positions when position is provided alongside taskId', async () => {
+        mockDb.query.taskItems.findFirst = vi.fn().mockResolvedValue({
+          id: 'task-2',
+          taskListId: 'list-1',
+          pageId: 'doc-2',
+          title: 'Middle Task',
+        });
+        mockDb.query.taskLists.findFirst = vi.fn().mockResolvedValue({
+          id: 'list-1',
+          pageId: 'task-list-page-1',
+          userId: 'user-123',
+        });
+        mockDb.query.pages.findFirst = vi.fn().mockResolvedValue({ driveId: 'drive-1' });
+        mockCanUserEditPage.mockResolvedValue(true);
+
+        // First db.select for the field-update transaction's siblings (status not provided, so won't be hit).
+        // Second db.select for reorder peer fetch.
+        const peerRows = [
+          { id: 'task-1', position: 0 },
+          { id: 'task-2', position: 1 },
+          { id: 'task-3', position: 2 },
+          { id: 'task-4', position: 3 },
+        ];
+        const selectCalls: unknown[] = [];
+        const dbSelectMock = vi.fn(() => {
+          const chain = {
+            from: vi.fn().mockReturnThis(),
+            where: vi.fn().mockReturnThis(),
+            orderBy: vi.fn(() => {
+              selectCalls.push('orderBy');
+              return Promise.resolve(peerRows);
+            }),
+          };
+          return chain;
+        });
+        mockDb.select = dbSelectMock as unknown as typeof mockDb.select;
+
+        // Field-update transaction returns the updated task
+        const fieldUpdateMock = vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => {
+          const tx = {
+            update: vi.fn(() => ({
+              set: vi.fn(() => ({
+                where: vi.fn(() => ({
+                  returning: vi.fn().mockResolvedValue([
+                    { id: 'task-2', title: 'Middle Task', position: 1 },
+                  ]),
+                })),
+              })),
+            })),
+            delete: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+            insert: vi.fn(() => ({ values: vi.fn().mockResolvedValue(undefined) })),
+          };
+          return cb(tx);
+        });
+
+        // Reorder transaction collects position writes
+        const positionWrites: Array<{ id: string; position: number }> = [];
+        const reorderTxMock = vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => {
+          const tx = {
+            update: vi.fn(() => {
+              let pendingPosition: number | undefined;
+              const chain = {
+                set: vi.fn((vals: { position: number }) => {
+                  pendingPosition = vals.position;
+                  return chain;
+                }),
+                where: vi.fn(() => {
+                  const idArg = (chain as unknown as { _id?: string })._id;
+                  positionWrites.push({ id: idArg ?? '', position: pendingPosition ?? -1 });
+                  return Promise.resolve();
+                }),
+              };
+              return chain;
+            }),
+          };
+          return cb(tx);
+        });
+
+        let txCallCount = 0;
+        mockDb.transaction = vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => {
+          txCallCount += 1;
+          if (txCallCount === 1) return fieldUpdateMock(cb);
+          return reorderTxMock(cb);
+        }) as unknown as typeof mockDb.transaction;
+
+        // Mock db.query.taskItems.findMany used by the response builder at the end
+        mockDb.query.taskItems.findMany = vi.fn().mockResolvedValue([]);
+
+        const context = {
+          toolCallId: '1', messages: [],
+          experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+        };
+
+        const result = await taskManagementTools.update_task.execute!(
+          { taskId: 'task-2', position: 3 },
+          context
+        );
+
+        // Expect the reorder transaction to have been called
+        expect(reorderTxMock).toHaveBeenCalled();
+        // Result should reflect the clamped/densified position
+        expect((result as { task: { position: number } }).task.position).toBe(3);
+      });
     });
 
   });

--- a/apps/web/src/lib/ai/tools/__tests__/task-management-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/task-management-tools.test.ts
@@ -41,8 +41,16 @@ vi.mock('@pagespace/db/schema/tasks', () => ({
   taskAssignees: { taskId: 'taskId' },
 }));
 
+const { deferredTriggerMock } = vi.hoisted(() => ({
+  deferredTriggerMock: vi.fn(),
+}));
 vi.mock('@/services/api/page-mutation-service', () => ({
-  applyPageMutation: vi.fn().mockResolvedValue({ pageId: 'p', driveId: 'd', nextRevision: 1 }),
+  applyPageMutation: vi.fn().mockResolvedValue({
+    pageId: 'p',
+    driveId: 'd',
+    nextRevision: 1,
+    deferredTrigger: deferredTriggerMock,
+  }),
   PageRevisionMismatchError: class PageRevisionMismatchError extends Error {
     currentRevision = 0;
     expectedRevision?: number;
@@ -267,10 +275,14 @@ describe('task-management-tools', () => {
           pageId: 'doc-page-1',
           title: 'Old Task',
         });
+        mockDb.query.taskItems.findMany = vi.fn().mockResolvedValue([]);
         mockDb.query.taskLists.findFirst = vi.fn().mockResolvedValue({
           id: 'list-1',
           pageId: 'task-list-page-1',
           userId: 'user-123',
+          title: 'My Tasks',
+          description: null,
+          status: 'pending',
         });
         mockDb.query.pages.findFirst = vi.fn().mockResolvedValue({ driveId: 'drive-1' });
         mockCanUserEditPage.mockResolvedValue(true);
@@ -319,11 +331,18 @@ describe('task-management-tools', () => {
         );
         expect(deleteCalls.length).toBeGreaterThanOrEqual(1);
         expect(disableTaskTriggers).toHaveBeenCalledWith('task-1', expect.any(String));
+        // Deferred workflow trigger from applyPageMutation must run after the tx commits
+        // so downstream automation tied to page-trash activity fires.
+        expect(deferredTriggerMock).toHaveBeenCalled();
         expect(result).toEqual(
           expect.objectContaining({
             success: true,
             action: 'deleted',
             task: expect.objectContaining({ id: 'task-1', pageId: 'doc-page-1' }),
+            // Refreshed list payload so client UIs (TasksDropdown via
+            // useAggregatedTasks) drop the deleted task immediately.
+            tasks: expect.any(Array),
+            taskList: expect.objectContaining({ id: 'list-1' }),
           }),
         );
       });
@@ -335,10 +354,14 @@ describe('task-management-tools', () => {
           pageId: 'doc-page-1',
           title: 'Old Task',
         });
+        mockDb.query.taskItems.findMany = vi.fn().mockResolvedValue([]);
         mockDb.query.taskLists.findFirst = vi.fn().mockResolvedValue({
           id: 'list-1',
           pageId: 'task-list-page-1',
           userId: 'user-123',
+          title: 'My Tasks',
+          description: null,
+          status: 'pending',
         });
         mockDb.query.pages.findFirst = vi.fn().mockResolvedValue({ driveId: 'drive-1' });
         mockCanUserEditPage.mockResolvedValue(true);

--- a/apps/web/src/lib/ai/tools/page-read-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-read-tools.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { db } from '@pagespace/db/db'
 import { eq, and, asc, isNotNull, count, max, min, inArray } from '@pagespace/db/operators'
 import { pages, chatMessages } from '@pagespace/db/schema/core'
-import { taskItems, taskLists } from '@pagespace/db/schema/tasks'
+import { taskItems, taskLists, taskStatusConfigs, DEFAULT_TASK_STATUSES } from '@pagespace/db/schema/tasks'
 import { channelMessages } from '@pagespace/db/schema/chat';
 import { buildTree } from '@pagespace/lib/content/tree-utils';
 import { getUserAccessLevel, getUserDriveAccess, getUserAccessiblePagesInDriveWithDetails } from '@pagespace/lib/permissions/permissions';
@@ -241,13 +241,47 @@ export const pageReadTools = {
             .where(eq(taskItems.taskListId, taskList.id))
             .orderBy(asc(taskItems.position));
 
-          // Calculate progress
+          // Resolve available statuses for this task list. Falls back to
+          // documented defaults when no custom configs are present so the
+          // AI always sees a concrete list.
+          const statusConfigs = await db.query.taskStatusConfigs.findMany({
+            where: eq(taskStatusConfigs.taskListId, taskList.id),
+            orderBy: [asc(taskStatusConfigs.position)],
+          });
+
+          const availableStatuses = statusConfigs.length > 0
+            ? statusConfigs.map(c => ({
+                slug: c.slug,
+                label: c.name,
+                group: c.group,
+                position: c.position,
+                color: c.color,
+              }))
+            : DEFAULT_TASK_STATUSES.map(s => ({
+                slug: s.slug,
+                label: s.name,
+                group: s.group,
+                position: s.position,
+                color: s.color,
+              }));
+
+          const slugToGroup = new Map(availableStatuses.map(s => [s.slug, s.group]));
+
+          // Dynamic progress breakdown — keyed by both group and slug so
+          // custom statuses surface alongside the standard groups.
           const totalTasks = tasks.length;
-          const completedTasks = tasks.filter(t => t.status === 'completed').length;
-          const inProgressTasks = tasks.filter(t => t.status === 'in_progress').length;
-          const pendingTasks = tasks.filter(t => t.status === 'pending').length;
-          const blockedTasks = tasks.filter(t => t.status === 'blocked').length;
-          const progressPercentage = totalTasks > 0 ? Math.round((completedTasks / totalTasks) * 100) : 0;
+          const byGroup: Record<string, number> = { todo: 0, in_progress: 0, done: 0 };
+          const bySlug: Record<string, number> = {};
+          for (const t of tasks) {
+            bySlug[t.status] = (bySlug[t.status] || 0) + 1;
+            const group = slugToGroup.get(t.status)
+              || (t.completedAt ? 'done' : t.status === 'in_progress' || t.status === 'blocked' ? 'in_progress' : 'todo');
+            byGroup[group] = (byGroup[group] || 0) + 1;
+          }
+          const completedCount = byGroup.done || 0;
+          const progressPercentage = totalTasks > 0 ? Math.round((completedCount / totalTasks) * 100) : 0;
+
+          const todoCount = byGroup.todo || 0;
 
           return {
             success: true,
@@ -266,22 +300,22 @@ export const pageReadTools = {
               completedAt: t.completedAt,
               linkedPageId: t.pageId,
             })),
+            availableStatuses,
             progress: {
               total: totalTasks,
-              completed: completedTasks,
-              inProgress: inProgressTasks,
-              pending: pendingTasks,
-              blocked: blockedTasks,
               percentage: progressPercentage,
+              byGroup,
+              bySlug,
             },
             summary: totalTasks > 0
-              ? `Task list "${page.title}" is ${progressPercentage}% complete (${completedTasks}/${totalTasks} tasks done)`
+              ? `Task list "${page.title}" is ${progressPercentage}% complete (${completedCount}/${totalTasks} tasks done)`
               : `Task list "${page.title}" has no tasks yet`,
             nextSteps: totalTasks === 0 ? [
               'Use update_task with this pageId to add tasks',
-            ] : pendingTasks > 0 ? [
-              'Use update_task with taskId to update task status',
+            ] : todoCount > 0 ? [
+              'Use update_task with taskId to update task status (see availableStatuses for valid slugs)',
               'Each task has a linked document page for notes',
+              'Pass delete: true with a taskId to remove a task',
             ] : [
               'All tasks are completed or in progress',
             ],

--- a/apps/web/src/lib/ai/tools/task-management-tools.ts
+++ b/apps/web/src/lib/ai/tools/task-management-tools.ts
@@ -15,7 +15,9 @@ import {
   cancelTaskDueDateTrigger,
   fireCompletionTrigger,
   createTaskTriggerWorkflow,
+  disableTaskTriggers,
 } from '@/lib/workflows/task-trigger-helpers';
+import { applyPageMutation, PageRevisionMismatchError } from '@/services/api/page-mutation-service';
 
 function normalizeTaskAgentTriggerInput(value: unknown): unknown {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -76,21 +78,23 @@ export const taskManagementTools = {
    * - If taskId is not provided but taskListId or pageId is, creates a new task
    */
   update_task: tool({
-    description: `Update an existing task or create a new one on a TASK_LIST page.
+    description: `Update an existing task, create a new one, delete one, or reorder one on a TASK_LIST page.
 
 To UPDATE: provide taskId
 To CREATE: provide pageId (of a TASK_LIST page) and title
+To DELETE: provide taskId and delete: true (hard-removes the task and trashes its linked DOCUMENT page; any other field updates passed in the same call are ignored)
+To REORDER: provide taskId and position — moves the existing task to the given index and re-densifies peer positions in the task list. Combine with field updates freely (e.g., status + position in one call).
 
 When creating tasks:
 - A DOCUMENT page is automatically created as a child of the TASK_LIST page
 - This linked page stores task notes and progress
 - The page title stays synced with the task title
-- DO NOT delete these pages directly - use this tool to manage tasks
+- DO NOT delete these pages directly - use this tool with delete: true to remove tasks
 
 Status:
 - Task lists support custom statuses. Default statuses: pending, in_progress, blocked, completed
 - Each status belongs to a group (todo, in_progress, done) that controls completion behavior
-- Use a status slug that exists in the task list's configuration
+- Use a status slug that exists in the task list's configuration (read_page on the TASK_LIST page returns availableStatuses)
 
 Assignment:
 - Use assigneeIds array to assign multiple users and/or agents
@@ -106,6 +110,7 @@ Agent Triggers:
     inputSchema: z.object({
       taskId: z.string().optional().describe('Task ID to update (omit to create new task)'),
       pageId: z.string().optional().describe('TASK_LIST page ID (required when creating new task)'),
+      delete: z.boolean().optional().describe('When true (with taskId), hard-deletes the task and trashes its linked DOCUMENT page. Field updates passed in the same call are ignored.'),
       title: z.string().optional().describe('Task title (required when creating)'),
       description: z.string().optional().describe('Task description'),
       status: z.string().optional().describe('Task status slug (e.g. pending, in_progress, completed, blocked, or any custom status)'),
@@ -118,7 +123,7 @@ Agent Triggers:
       })).optional().describe('Multiple assignees. Each: { type: "user"|"agent", id: "..." }'),
       dueDate: z.string().nullable().optional().describe('Due date in ISO format (null to clear)'),
       note: z.string().optional().describe('Note about this update'),
-      position: z.number().optional().describe('Position in the list (for new tasks, defaults to end)'),
+      position: z.number().optional().describe('Position in the list. For new tasks, defaults to end. For existing tasks (taskId provided), moves the task to this index and re-densifies peer positions.'),
       agentTrigger: z.preprocess(
         normalizeTaskAgentTriggerInput,
         z.object({
@@ -131,18 +136,23 @@ Agent Triggers:
       ).describe('Schedule an AI agent to run at task due date or on completion. Requires a drive-based task list.'),
     }),
     execute: async (params, { experimental_context: context }) => {
-      const { taskId, pageId, title, description, status, priority, assigneeId, assigneeAgentId, assigneeIds, dueDate, note, position, agentTrigger } = params;
+      const { taskId, pageId, delete: deleteTask, title, description, status, priority, assigneeId, assigneeAgentId, assigneeIds, dueDate, note, position, agentTrigger } = params;
       const userId = (context as ToolExecutionContext)?.userId;
 
       if (!userId) {
         throw new Error('User authentication required');
       }
 
-      // Determine if this is an update or create operation
+      // Determine if this is an update, create, or delete operation
       const isUpdate = !!taskId;
+      const isDelete = isUpdate && deleteTask === true;
 
       if (!isUpdate && !pageId) {
         throw new Error('Either taskId (to update) or pageId (to create) must be provided');
+      }
+
+      if (!isUpdate && deleteTask === true) {
+        throw new Error('delete requires a taskId');
       }
 
       if (!isUpdate && !title) {
@@ -180,6 +190,105 @@ Agent Triggers:
             }
           } else if (taskList.userId !== userId) {
             throw new Error('You do not have permission to update this task');
+          }
+
+          // DELETE branch — short-circuits all field updates
+          if (isDelete) {
+            const taskListPageId = taskList.pageId;
+            const taskListId = existingTask.taskListId;
+            const linkedPageId = existingTask.pageId;
+            const actorInfo = await getActorInfo(userId);
+
+            // Trash linked DOCUMENT page (if any) and hard-delete the task row in one transaction.
+            // taskAssignees rows cascade-delete via FK on taskItems.
+            try {
+              await db.transaction(async (tx) => {
+                if (linkedPageId) {
+                  const [linkedPage] = await tx
+                    .select({ revision: pages.revision })
+                    .from(pages)
+                    .where(eq(pages.id, linkedPageId))
+                    .limit(1);
+
+                  if (linkedPage) {
+                    await applyPageMutation({
+                      pageId: linkedPageId,
+                      operation: 'trash',
+                      updates: { isTrashed: true, trashedAt: new Date() },
+                      updatedFields: ['isTrashed', 'trashedAt'],
+                      expectedRevision: linkedPage.revision,
+                      context: {
+                        userId,
+                        actorEmail: actorInfo.actorEmail,
+                        actorDisplayName: actorInfo.actorDisplayName ?? undefined,
+                        isAiGenerated: true,
+                        aiProvider: (context as ToolExecutionContext).aiProvider,
+                        aiModel: (context as ToolExecutionContext).aiModel,
+                        aiConversationId: (context as ToolExecutionContext).conversationId,
+                        metadata: {
+                          taskId,
+                          taskListId,
+                          taskListPageId,
+                        },
+                      },
+                      tx,
+                    });
+                  }
+                }
+
+                await tx.delete(taskItems).where(eq(taskItems.id, taskId));
+              });
+            } catch (error) {
+              if (error instanceof PageRevisionMismatchError) {
+                throw new Error(`Linked page was modified concurrently — retry the delete: ${error.message}`);
+              }
+              throw error;
+            }
+
+            void disableTaskTriggers(taskId, 'Task deleted via update_task');
+
+            // Look up driveId for the page-trashed broadcast (best-effort)
+            let deletedDriveId: string | undefined;
+            if (taskListPageId) {
+              const taskListPage = await db.query.pages.findFirst({
+                where: eq(pages.id, taskListPageId),
+                columns: { driveId: true },
+              });
+              deletedDriveId = taskListPage?.driveId;
+            }
+
+            const broadcasts: Promise<void>[] = [
+              broadcastTaskEvent({
+                type: 'task_deleted',
+                taskId,
+                taskListId,
+                userId,
+                pageId: taskListPageId || undefined,
+                data: { id: taskId, title: existingTask.title },
+              }),
+            ];
+            if (linkedPageId && deletedDriveId) {
+              broadcasts.push(
+                broadcastPageEvent(
+                  createPageEventPayload(deletedDriveId, linkedPageId, 'trashed', {
+                    title: existingTask.title,
+                    parentId: taskListPageId || undefined,
+                  }),
+                ),
+              );
+            }
+            await Promise.all(broadcasts);
+
+            return {
+              success: true,
+              action: 'deleted' as const,
+              task: {
+                id: existingTask.id,
+                title: existingTask.title,
+                pageId: linkedPageId,
+              },
+              message: `Deleted task "${existingTask.title}"${linkedPageId ? ' and trashed its linked page' : ''}`,
+            };
           }
 
           // Get driveId for agent validation (if task list has a page)
@@ -286,6 +395,35 @@ Agent Triggers:
 
             return updatedTask;
           });
+
+          // Reorder: when position is provided alongside taskId, move the task
+          // to the requested index and re-densify peer positions to 0..n-1.
+          if (position !== undefined) {
+            const peers = await db
+              .select({ id: taskItems.id, position: taskItems.position })
+              .from(taskItems)
+              .where(eq(taskItems.taskListId, existingTask.taskListId))
+              .orderBy(asc(taskItems.position));
+
+            const filtered = peers.filter(p => p.id !== taskId);
+            const clamped = Math.max(0, Math.min(Math.trunc(position), filtered.length));
+            const reordered = [
+              ...filtered.slice(0, clamped).map(p => p.id),
+              taskId,
+              ...filtered.slice(clamped).map(p => p.id),
+            ];
+
+            await db.transaction(async (tx) => {
+              for (let i = 0; i < reordered.length; i++) {
+                await tx.update(taskItems)
+                  .set({ position: i })
+                  .where(eq(taskItems.id, reordered[i]));
+              }
+            });
+
+            // Reflect the densified position on resultTask so the response is accurate
+            resultTask = { ...resultTask, position: clamped };
+          }
 
           // Update task list status based on task completion
           if (status !== undefined) {

--- a/apps/web/src/lib/ai/tools/task-management-tools.ts
+++ b/apps/web/src/lib/ai/tools/task-management-tools.ts
@@ -18,6 +18,7 @@ import {
   disableTaskTriggers,
 } from '@/lib/workflows/task-trigger-helpers';
 import { applyPageMutation, PageRevisionMismatchError } from '@/services/api/page-mutation-service';
+import type { DeferredWorkflowTrigger } from '@pagespace/lib/monitoring/activity-logger';
 
 function normalizeTaskAgentTriggerInput(value: unknown): unknown {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -201,6 +202,9 @@ Agent Triggers:
 
             // Trash linked DOCUMENT page (if any) and hard-delete the task row in one transaction.
             // taskAssignees rows cascade-delete via FK on taskItems.
+            // applyPageMutation returns a deferredTrigger that callers passing their own tx
+            // must invoke after commit so downstream workflows tied to page activity fire.
+            let deferredTrigger: DeferredWorkflowTrigger | undefined;
             try {
               await db.transaction(async (tx) => {
                 if (linkedPageId) {
@@ -211,7 +215,7 @@ Agent Triggers:
                     .limit(1);
 
                   if (linkedPage) {
-                    await applyPageMutation({
+                    const mutationResult = await applyPageMutation({
                       pageId: linkedPageId,
                       operation: 'trash',
                       updates: { isTrashed: true, trashedAt: new Date() },
@@ -233,11 +237,13 @@ Agent Triggers:
                       },
                       tx,
                     });
+                    deferredTrigger = mutationResult.deferredTrigger;
                   }
                 }
 
                 await tx.delete(taskItems).where(eq(taskItems.id, taskId));
               });
+              deferredTrigger?.();
             } catch (error) {
               if (error instanceof PageRevisionMismatchError) {
                 throw new Error(`Linked page was modified concurrently — retry the delete: ${error.message}`);
@@ -279,6 +285,27 @@ Agent Triggers:
             }
             await Promise.all(broadcasts);
 
+            // Return the refreshed task list + remaining tasks so client UIs
+            // (e.g. useAggregatedTasks → TasksDropdown) can drop the deleted
+            // task immediately instead of waiting for a subsequent tool call.
+            const remainingTasks = await db.query.taskItems.findMany({
+              where: eq(taskItems.taskListId, taskListId),
+              orderBy: [asc(taskItems.position)],
+              with: {
+                assignee: { columns: { id: true, name: true, image: true } },
+                assigneeAgent: { columns: { id: true, title: true, type: true } },
+                assignees: {
+                  with: {
+                    user: { columns: { id: true, name: true } },
+                    agentPage: { columns: { id: true, title: true } },
+                  },
+                },
+              },
+            });
+            const refreshedTaskList = await db.query.taskLists.findFirst({
+              where: eq(taskLists.id, taskListId),
+            });
+
             return {
               success: true,
               action: 'deleted' as const,
@@ -287,6 +314,43 @@ Agent Triggers:
                 title: existingTask.title,
                 pageId: linkedPageId,
               },
+              taskList: refreshedTaskList ? {
+                id: refreshedTaskList.id,
+                title: refreshedTaskList.title,
+                description: refreshedTaskList.description,
+                status: refreshedTaskList.status,
+                pageId: refreshedTaskList.pageId,
+                driveId: deletedDriveId,
+              } : null,
+              tasks: remainingTasks.map(t => ({
+                id: t.id,
+                title: t.title,
+                description: t.description,
+                status: t.status,
+                priority: t.priority,
+                assigneeId: t.assigneeId,
+                assigneeAgentId: t.assigneeAgentId,
+                dueDate: t.dueDate,
+                position: t.position,
+                completedAt: t.completedAt,
+                pageId: t.pageId,
+                assignee: t.assignee ? {
+                  id: t.assignee.id,
+                  name: t.assignee.name,
+                  image: t.assignee.image,
+                } : null,
+                assigneeAgent: t.assigneeAgent ? {
+                  id: t.assigneeAgent.id,
+                  title: t.assigneeAgent.title,
+                  type: t.assigneeAgent.type,
+                } : null,
+                assignees: t.assignees?.map(a => ({
+                  userId: a.userId,
+                  agentPageId: a.agentPageId,
+                  user: a.user ? { id: a.user.id, name: a.user.name } : null,
+                  agentPage: a.agentPage ? { id: a.agentPage.id, title: a.agentPage.title } : null,
+                })) || [],
+              })),
               message: `Deleted task "${existingTask.title}"${linkedPageId ? ' and trashed its linked page' : ''}`,
             };
           }


### PR DESCRIPTION
## Summary

Web-side enrichment so the pagespace-mcp server can conform to web's canonical `pageSpaceTools` registry without losing real capability. PR-1 of 2 in the MCP parity epic — full plan at `tasks/pagespace-mcp-parity-conformance.md`. PR-2 (the MCP-side conformance, separate repo) is blocked on this merging.

### `update_task` (`apps/web/src/lib/ai/tools/task-management-tools.ts`)
- New `delete: boolean` schema field. With `taskId` + `delete: true` the tool hard-deletes the task row and trashes the linked DOCUMENT page in a single transaction (mirrors the `DELETE /api/pages/[pageId]/tasks/[taskId]` route — same `applyPageMutation` trash, `disableTaskTriggers`, broadcast events). When `delete: true` is passed alongside field updates, the delete wins and the field updates are ignored (documented in the tool description).
- The update branch now honors `position`. When `taskId` + `position` are provided together, the task is moved to the requested index and peer positions are re-densified to `0..n-1` in a transaction. Combines cleanly with status/title/etc. updates in the same call.

### `read_page` TASK_LIST branch (`apps/web/src/lib/ai/tools/page-read-tools.ts`)
- New `availableStatuses` array surfaced between `tasks` and `progress`. Returns the configured `taskStatusConfigs` for the list (slug, label, group, position, color); when no custom configs exist, falls back to the documented defaults from `DEFAULT_TASK_STATUSES` so the AI always sees a concrete list.
- Replaced the four hardcoded `completed/inProgress/pending/blocked` counts with dynamic `progress.byGroup` and `progress.bySlug` breakdowns. `total` and `percentage` are kept; percentage is computed from the `done` group so custom statuses with that group still count toward completion.

### Tests
- `task-management-tools.test.ts`: delete-and-trash flow, delete-with-conflicting-updates ignores updates, delete without taskId rejects, position-on-update densifies peers.
- `page-read-tools.test.ts`: TASK_LIST page returns documented defaults when no configs exist, surfaces every custom status (slug/label/group/color), and computes dynamic per-group + per-slug counts including custom statuses with `done` group counting toward completion %.

## Test plan
- [x] `pnpm typecheck` (apps/web) — green
- [x] `pnpm exec vitest run src/lib/ai/tools` — 242 tests pass (12 files)
- [x] `pnpm exec vitest run src/app/api/pages/[pageId]/tasks` — 145 route tests still pass (no regressions in adjacent code)
- [x] `pnpm next lint` on the two modified source files — clean
- [ ] Manual smoke (optional): create + update + delete + reorder a task on a TASK_LIST page through an AI_CHAT page

Note: the rest of the MCP parity work (PR-2: conform pagespace-mcp v3.0.0 to web's registry, drop dedicated delete/reorder/discover-statuses tools) lives in the `pagespace-mcp` repo and is blocked on this PR merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)