### PR TITLE
fix(ai-chat): render remote streams as real assistant messages

### DIFF
--- a/apps/web/src/components/ai/chat/layouts/ChatLayout.tsx
+++ b/apps/web/src/components/ai/chat/layouts/ChatLayout.tsx
@@ -6,9 +6,9 @@ import { UIMessage } from 'ai';
 import { InputPositioner, type InputPosition } from '@/components/ui/floating-input/InputPositioner';
 import { InputCard } from '@/components/ui/floating-input/InputCard';
 import { ChatMessagesArea, ChatMessagesAreaRef } from '@/components/ai/shared/chat/ChatMessagesArea';
-import { StreamingIndicator } from '@/components/ai/shared/chat/StreamingIndicator';
 import { WelcomeContent } from './WelcomeContent';
 import { useEnterToSend } from '@/hooks/useEnterToSend';
+import type { PendingStream } from '@/stores/usePendingStreamsStore';
 
 export interface ChatLayoutProps {
   /** Messages in the conversation */
@@ -101,8 +101,8 @@ export interface ChatLayoutProps {
   onMcpServerToggle?: (serverName: string, enabled: boolean) => void;
   /** Whether to show MCP toggle (desktop only) */
   showMcp?: boolean;
-  /** Remote in-progress streams from other users */
-  remoteStreams?: Array<{ messageId: string; triggeredBy: { displayName: string }; text: string }>;
+  /** Remote in-progress streams from other users (or other tabs) — rendered inline as assistant messages */
+  remoteStreams?: PendingStream[];
 }
 
 export interface ChatLayoutRef {
@@ -258,17 +258,8 @@ export const ChatLayout = React.forwardRef<ChatLayoutRef, ChatLayoutProps>(
                 isReadOnly={isReadOnly}
                 onUndoSuccess={onUndoSuccess}
                 onPullUpRefresh={onPullUpRefresh}
+                remoteStreams={remoteStreams}
               />
-              {remoteStreams.map((stream) => (
-                <div key={stream.messageId} className="px-4 pb-2">
-                  <StreamingIndicator message={`${stream.triggeredBy.displayName} is waiting for AI response…`} />
-                  {stream.text && (
-                    <p className="mt-1 ml-6 text-sm text-muted-foreground whitespace-pre-wrap">
-                      {stream.text}
-                    </p>
-                  )}
-                </div>
-              ))}
             </motion.div>
           )}
         </AnimatePresence>

--- a/apps/web/src/components/ai/chat/layouts/__tests__/ChatLayout.remoteStreams.test.tsx
+++ b/apps/web/src/components/ai/chat/layouts/__tests__/ChatLayout.remoteStreams.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
 
 // ---------------------------------------------------------------------------
 // Hoisted mocks — must be before any imports that trigger the modules
@@ -13,12 +13,12 @@ vi.mock('motion/react', () => ({
   useReducedMotion: () => false,
 }));
 
+const chatMessagesAreaSpy = vi.fn();
 vi.mock('@/components/ai/shared/chat/ChatMessagesArea', () => ({
-  ChatMessagesArea: () => <div data-testid="chat-messages-area" />,
-}));
-
-vi.mock('@/components/ai/shared/chat/StreamingIndicator', () => ({
-  StreamingIndicator: ({ message }: { message?: string }) => <>{message}</>,
+  ChatMessagesArea: (props: unknown) => {
+    chatMessagesAreaSpy(props);
+    return <div data-testid="chat-messages-area" />;
+  },
 }));
 
 vi.mock('@/components/ui/floating-input/InputPositioner', () => ({
@@ -39,8 +39,8 @@ vi.mock('../WelcomeContent', () => ({
 
 import React from 'react';
 import { ChatLayout } from '../ChatLayout';
+import type { PendingStream } from '@/stores/usePendingStreamsStore';
 
-// Minimal required props to get the component to render messages area
 const BASE_PROPS = {
   messages: [{ id: '1', role: 'user' as const, content: 'hello', parts: [{ type: 'text' as const, text: 'hello' }] }],
   input: '',
@@ -51,55 +51,52 @@ const BASE_PROPS = {
   isLoading: false,
 };
 
-describe('ChatLayout — remoteStreams', () => {
-  it('given no remoteStreams, should render no stream indicators', () => {
+const makeStream = (overrides: Partial<PendingStream>): PendingStream => ({
+  messageId: 'msg-1',
+  pageId: 'page-1',
+  conversationId: 'conv-1',
+  triggeredBy: { userId: 'u-1', displayName: 'Alice' },
+  text: '',
+  isOwn: false,
+  ...overrides,
+});
+
+const lastMessagesAreaProps = () => {
+  const calls = chatMessagesAreaSpy.mock.calls;
+  return calls[calls.length - 1]?.[0] as { remoteStreams?: PendingStream[] } | undefined;
+};
+
+describe('ChatLayout — remoteStreams plumbing', () => {
+  beforeEach(() => {
+    chatMessagesAreaSpy.mockClear();
+  });
+
+  it('given no remoteStreams, passes undefined or empty array down to ChatMessagesArea', () => {
     render(<ChatLayout {...BASE_PROPS} />);
-    expect(screen.queryByText(/is waiting for AI response/)).toBeNull();
+    const props = lastMessagesAreaProps();
+    expect(props?.remoteStreams ?? []).toEqual([]);
   });
 
-  it('given a remote pending stream, should render StreamingIndicator with display name', () => {
+  it('given a remote pending stream, forwards it to ChatMessagesArea', () => {
+    const remoteStreams = [makeStream({ messageId: 'msg-1' })];
+    render(<ChatLayout {...BASE_PROPS} remoteStreams={remoteStreams} />);
+    expect(lastMessagesAreaProps()?.remoteStreams).toEqual(remoteStreams);
+  });
+
+  it('given multiple concurrent remote streams, forwards all of them in order', () => {
     const remoteStreams = [
-      { messageId: 'msg-1', triggeredBy: { displayName: 'Alice' }, text: '' },
+      makeStream({ messageId: 'msg-1', triggeredBy: { userId: 'u-1', displayName: 'Alice' } }),
+      makeStream({ messageId: 'msg-2', triggeredBy: { userId: 'u-2', displayName: 'Bob' } }),
     ];
     render(<ChatLayout {...BASE_PROPS} remoteStreams={remoteStreams} />);
-    expect(screen.getByText('Alice is waiting for AI response…')).toBeTruthy();
+    expect(lastMessagesAreaProps()?.remoteStreams).toEqual(remoteStreams);
   });
 
-  it('given accumulated ghost text, should render it below the indicator', () => {
-    const remoteStreams = [
-      { messageId: 'msg-1', triggeredBy: { displayName: 'Alice' }, text: 'Here is my partial response' },
-    ];
-    render(<ChatLayout {...BASE_PROPS} remoteStreams={remoteStreams} />);
-    expect(screen.getByText('Here is my partial response')).toBeTruthy();
-  });
-
-  it('given empty ghost text, should not render the ghost text paragraph', () => {
-    const remoteStreams = [
-      { messageId: 'msg-1', triggeredBy: { displayName: 'Alice' }, text: '' },
-    ];
-    const { container } = render(<ChatLayout {...BASE_PROPS} remoteStreams={remoteStreams} />);
-    // The muted text paragraph should not be present when text is empty
-    const paras = container.querySelectorAll('p.text-muted-foreground');
-    expect(paras).toHaveLength(0);
-  });
-
-  it('given multiple concurrent remote streams, should render one indicator per stream', () => {
-    const remoteStreams = [
-      { messageId: 'msg-1', triggeredBy: { displayName: 'Alice' }, text: '' },
-      { messageId: 'msg-2', triggeredBy: { displayName: 'Bob' }, text: '' },
-    ];
-    render(<ChatLayout {...BASE_PROPS} remoteStreams={remoteStreams} />);
-    expect(screen.getByText('Alice is waiting for AI response…')).toBeTruthy();
-    expect(screen.getByText('Bob is waiting for AI response…')).toBeTruthy();
-  });
-
-  it('given remoteStreams with no local messages, should still show the messages area', () => {
+  it('given remoteStreams with no local messages, still mounts the messages area', () => {
     const noMessages = { ...BASE_PROPS, messages: [] };
-    const remoteStreams = [
-      { messageId: 'msg-1', triggeredBy: { displayName: 'Alice' }, text: '' },
-    ];
-    render(<ChatLayout {...noMessages} remoteStreams={remoteStreams} />);
-    expect(screen.getByTestId('chat-messages-area')).toBeTruthy();
-    expect(screen.getByText('Alice is waiting for AI response…')).toBeTruthy();
+    const remoteStreams = [makeStream({ messageId: 'msg-1' })];
+    const { getByTestId } = render(<ChatLayout {...noMessages} remoteStreams={remoteStreams} />);
+    expect(getByTestId('chat-messages-area')).toBeTruthy();
+    expect(lastMessagesAreaProps()?.remoteStreams).toEqual(remoteStreams);
   });
 });

--- a/apps/web/src/components/ai/shared/chat/ChatMessagesArea.tsx
+++ b/apps/web/src/components/ai/shared/chat/ChatMessagesArea.tsx
@@ -30,6 +30,7 @@ import {
 import { useStickToBottomContext } from 'use-stick-to-bottom';
 import { useChatPullToRefresh } from '@/hooks/useChatPullToRefresh';
 import { cn } from '@/lib/utils';
+import type { PendingStream } from '@/stores/usePendingStreamsStore';
 
 // Threshold for enabling virtualization - below this count, regular rendering is fine
 const VIRTUALIZATION_THRESHOLD = 50;
@@ -63,6 +64,8 @@ interface ChatMessagesAreaProps {
   isLoadingOlder?: boolean;
   /** Callback for pull-up refresh (to check for missed messages) */
   onPullUpRefresh?: () => Promise<void>;
+  /** Remote in-progress streams from other users (or other tabs) — rendered as synthesized assistant messages */
+  remoteStreams?: PendingStream[];
 }
 
 export interface ChatMessagesAreaRef {
@@ -88,6 +91,7 @@ const ChatMessagesAreaInner = forwardRef<ChatMessagesAreaRef, ChatMessagesAreaPr
       onScrollNearTop,
       isLoadingOlder = false,
       onPullUpRefresh,
+      remoteStreams,
     },
     ref
   ) => {
@@ -133,6 +137,18 @@ const ChatMessagesAreaInner = forwardRef<ChatMessagesAreaRef, ChatMessagesAreaPr
     useImperativeHandle(ref, () => ({
       scrollToBottom: () => scrollToBottom(),
     }), [scrollToBottom]);
+
+    // Dedup remote streams whose messageId has already landed in `messages`
+    // (handles the brief frame at completion when the real message has been
+    // pushed but `removeStream` has not yet fired).
+    const messageIds = useMemo(
+      () => new Set(messages.map((m) => m.id)),
+      [messages]
+    );
+    const visibleRemoteStreams = useMemo(
+      () => (remoteStreams ?? []).filter((s) => !messageIds.has(s.messageId)),
+      [remoteStreams, messageIds]
+    );
 
     // Memoized render function for virtualized list
     const renderMessage = useCallback((message: UIMessage, _idx: number) => (
@@ -202,7 +218,7 @@ const ChatMessagesAreaInner = forwardRef<ChatMessagesAreaRef, ChatMessagesAreaPr
 
           {isLoading ? (
             LoadingSkeleton
-          ) : messages.length === 0 ? (
+          ) : messages.length === 0 && visibleRemoteStreams.length === 0 ? (
             EmptyState
           ) : shouldVirtualize ? (
             // Virtualized rendering for large conversations
@@ -220,6 +236,19 @@ const ChatMessagesAreaInner = forwardRef<ChatMessagesAreaRef, ChatMessagesAreaPr
             // Regular rendering for smaller conversations
             messages.map((message, idx) => renderMessage(message, idx))
           )}
+
+          {!isLoading && visibleRemoteStreams.map((stream) => (
+            <MessageRenderer
+              key={stream.messageId}
+              message={{
+                id: stream.messageId,
+                role: 'assistant',
+                parts: [{ type: 'text', text: stream.text }],
+                messageType: 'standard',
+              }}
+              isStreaming
+            />
+          ))}
 
           {isStreaming && !isLoading && (
             <StreamingIndicator />

--- a/apps/web/src/components/ai/shared/chat/__tests__/ChatMessagesArea.remoteStreams.test.tsx
+++ b/apps/web/src/components/ai/shared/chat/__tests__/ChatMessagesArea.remoteStreams.test.tsx
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import type { UIMessage } from 'ai';
+import type { PendingStream } from '@/stores/usePendingStreamsStore';
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — must precede the import of the component under test
+// ---------------------------------------------------------------------------
+const messageRendererSpy = vi.fn();
+vi.mock('../MessageRenderer', () => ({
+  MessageRenderer: (props: unknown) => {
+    messageRendererSpy(props);
+    return <div data-testid="message-renderer" />;
+  },
+}));
+
+vi.mock('../StreamingIndicator', () => ({
+  StreamingIndicator: () => <div data-testid="streaming-indicator" />,
+}));
+
+vi.mock('../UndoAiChangesDialog', () => ({
+  UndoAiChangesDialog: () => null,
+}));
+
+vi.mock('../VirtualizedMessageList', () => ({
+  VirtualizedMessageList: ({ messages, renderMessage }: {
+    messages: UIMessage[];
+    renderMessage: (m: UIMessage, idx: number) => React.ReactNode;
+  }) => <div>{messages.map((m, i) => renderMessage(m, i))}</div>,
+}));
+
+vi.mock('@/components/ai/ui/conversation', () => ({
+  Conversation: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ConversationContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ConversationScrollButton: () => null,
+  useConversationScrollRef: () => ({ current: null }),
+}));
+
+vi.mock('use-stick-to-bottom', () => ({
+  useStickToBottomContext: () => ({ scrollToBottom: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useChatPullToRefresh', () => ({
+  useChatPullToRefresh: () => ({
+    pullDistance: 0,
+    isRefreshing: false,
+    hasReachedThreshold: false,
+    touchHandlers: {
+      onTouchStart: vi.fn(),
+      onTouchMove: vi.fn(),
+      onTouchEnd: vi.fn(),
+      onTouchCancel: vi.fn(),
+    },
+  }),
+}));
+
+import React from 'react';
+import { ChatMessagesArea } from '../ChatMessagesArea';
+
+const makeStream = (overrides: Partial<PendingStream>): PendingStream => ({
+  messageId: 'remote-1',
+  pageId: 'page-1',
+  conversationId: 'conv-1',
+  triggeredBy: { userId: 'u-1', displayName: 'Alice' },
+  text: '',
+  isOwn: false,
+  ...overrides,
+});
+
+const makeMessage = (id: string, role: UIMessage['role'] = 'user', text = ''): UIMessage => ({
+  id,
+  role,
+  parts: [{ type: 'text', text }],
+});
+
+const remoteRendererCalls = () =>
+  messageRendererSpy.mock.calls
+    .map((args) => args[0] as {
+      message: { id: string; role: string; parts: Array<{ type: string; text: string }>; messageType?: string };
+      isStreaming?: boolean;
+      onEdit?: unknown;
+      onDelete?: unknown;
+      onRetry?: unknown;
+    })
+    .filter((p) => p.isStreaming === true);
+
+describe('ChatMessagesArea — remoteStreams rendering', () => {
+  beforeEach(() => {
+    messageRendererSpy.mockClear();
+  });
+
+  it('given a non-empty remoteStreams, renders one MessageRenderer per stream with synthesized assistant message and isStreaming=true', () => {
+    const remoteStreams = [
+      makeStream({ messageId: 'remote-a', text: 'partial response' }),
+      makeStream({ messageId: 'remote-b', text: '' }),
+    ];
+
+    render(
+      <ChatMessagesArea
+        messages={[]}
+        isLoading={false}
+        isStreaming={false}
+        remoteStreams={remoteStreams}
+      />
+    );
+
+    const synthesizedCalls = remoteRendererCalls();
+    expect(synthesizedCalls).toHaveLength(2);
+
+    expect(synthesizedCalls[0].message).toEqual({
+      id: 'remote-a',
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'partial response' }],
+      messageType: 'standard',
+    });
+    expect(synthesizedCalls[0].isStreaming).toBe(true);
+    expect(synthesizedCalls[0].onEdit).toBeUndefined();
+    expect(synthesizedCalls[0].onDelete).toBeUndefined();
+    expect(synthesizedCalls[0].onRetry).toBeUndefined();
+
+    expect(synthesizedCalls[1].message.id).toBe('remote-b');
+    expect(synthesizedCalls[1].message.parts).toEqual([{ type: 'text', text: '' }]);
+  });
+
+  it('given a remote stream whose messageId is already present in messages, does NOT render the duplicate', () => {
+    const remoteStreams = [
+      makeStream({ messageId: 'msg-already-landed', text: 'finalised text' }),
+      makeStream({ messageId: 'msg-still-streaming', text: 'in progress' }),
+    ];
+
+    render(
+      <ChatMessagesArea
+        messages={[makeMessage('msg-already-landed', 'assistant', 'finalised text')]}
+        isLoading={false}
+        isStreaming={false}
+        remoteStreams={remoteStreams}
+      />
+    );
+
+    const synthesizedIds = remoteRendererCalls().map((c) => c.message.id);
+    expect(synthesizedIds).toEqual(['msg-still-streaming']);
+  });
+
+  it('given an empty remoteStreams, renders no synthesized streaming MessageRenderer beyond the messages', () => {
+    render(
+      <ChatMessagesArea
+        messages={[makeMessage('m-1', 'user', 'hi')]}
+        isLoading={false}
+        isStreaming={false}
+        remoteStreams={[]}
+      />
+    );
+
+    expect(remoteRendererCalls()).toHaveLength(0);
+  });
+
+  it('given remoteStreams but isLoading=true, suppresses synthesized renders (loading skeleton owns the area)', () => {
+    render(
+      <ChatMessagesArea
+        messages={[]}
+        isLoading={true}
+        isStreaming={false}
+        remoteStreams={[makeStream({ messageId: 'remote-x', text: 'partial' })]}
+      />
+    );
+
+    expect(remoteRendererCalls()).toHaveLength(0);
+  });
+});

--- a/apps/web/src/components/ai/shared/chat/__tests__/ChatMessagesArea.remoteStreams.test.tsx
+++ b/apps/web/src/components/ai/shared/chat/__tests__/ChatMessagesArea.remoteStreams.test.tsx
@@ -154,6 +154,19 @@ describe('ChatMessagesArea — remoteStreams rendering', () => {
     expect(remoteRendererCalls()).toHaveLength(0);
   });
 
+  it('given remoteStreams is omitted entirely, renders without crashing and produces no synthesized streams', () => {
+    expect(() =>
+      render(
+        <ChatMessagesArea
+          messages={[makeMessage('m-1', 'user', 'hi')]}
+          isLoading={false}
+          isStreaming={false}
+        />
+      )
+    ).not.toThrow();
+    expect(remoteRendererCalls()).toHaveLength(0);
+  });
+
   it('given remoteStreams but isLoading=true, suppresses synthesized renders (loading skeleton owns the area)', () => {
     render(
       <ChatMessagesArea

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -92,12 +92,6 @@ const GlobalAssistantView: React.FC = () => {
   const setRightSidebarOpen = useLayoutStore((state) => state.setRightSidebarOpen);
   const setRightSheetOpen = useLayoutStore((state) => state.setRightSheetOpen);
   const { user } = useAuth();
-  const globalChannelId = user?.id ? `user:${user.id}:global` : null;
-  const remoteStreams = usePendingStreamsStore(
-    useShallow((state) =>
-      globalChannelId ? state.getRemotePageStreams(globalChannelId) : []
-    )
-  );
 
   // ============================================
   // GLOBAL CHAT CONTEXT - for Global Assistant mode
@@ -129,6 +123,21 @@ const GlobalAssistantView: React.FC = () => {
   const setAgentStreaming = usePageAgentDashboardStore((state) => state.setAgentStreaming);
   const setAgentStopStreaming = usePageAgentDashboardStore((state) => state.setAgentStopStreaming);
   const setActiveTab = usePageAgentDashboardStore((state) => state.setActiveTab);
+
+  // Remote in-progress streams for the active chat. Filtered by:
+  //   1. Mode — agent mode subscribes to a per-agent channel elsewhere; here we
+  //      only render global-channel streams, so return [] when an agent is selected.
+  //   2. Conversation — the global channel may carry concurrent streams from
+  //      other global conversations; only show streams matching the current one.
+  const globalChannelId = user?.id ? `user:${user.id}:global` : null;
+  const remoteStreams = usePendingStreamsStore(
+    useShallow((state) => {
+      if (selectedAgent || !globalChannelId || !globalConversationId) return [];
+      return state
+        .getRemotePageStreams(globalChannelId)
+        .filter((s) => s.conversationId === globalConversationId);
+    })
+  );
 
   // ============================================
   // CENTRALIZED ASSISTANT SETTINGS (from store)

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -129,6 +129,9 @@ const GlobalAssistantView: React.FC = () => {
   //      only render global-channel streams, so return [] when an agent is selected.
   //   2. Conversation — the global channel may carry concurrent streams from
   //      other global conversations; only show streams matching the current one.
+  // Note: PendingStream.pageId holds the channel id (e.g. `user:USERID:global`)
+  // for non-page channels. Renaming the field is tracked as separate tech debt;
+  // until then, the channel string is what gets passed to getRemotePageStreams.
   const globalChannelId = user?.id ? `user:${user.id}:global` : null;
   const remoteStreams = usePendingStreamsStore(
     useShallow((state) => {

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -81,6 +81,9 @@ import { ChatInput, type ChatInputRef } from '@/components/ai/chat/input';
 import { useImageAttachments } from '@/lib/ai/shared/hooks/useImageAttachments';
 import { hasVisionCapability } from '@/lib/ai/core/vision-models';
 import { useGlobalEffectiveStream } from './useGlobalEffectiveStream';
+import { useAuth } from '@/hooks/useAuth';
+import { usePendingStreamsStore } from '@/stores/usePendingStreamsStore';
+import { useShallow } from 'zustand/react/shallow';
 
 const VOICE_OWNER: VoiceModeOwner = 'global-assistant';
 
@@ -88,6 +91,13 @@ const GlobalAssistantView: React.FC = () => {
   const pathname = usePathname();
   const setRightSidebarOpen = useLayoutStore((state) => state.setRightSidebarOpen);
   const setRightSheetOpen = useLayoutStore((state) => state.setRightSheetOpen);
+  const { user } = useAuth();
+  const globalChannelId = user?.id ? `user:${user.id}:global` : null;
+  const remoteStreams = usePendingStreamsStore(
+    useShallow((state) =>
+      globalChannelId ? state.getRemotePageStreams(globalChannelId) : []
+    )
+  );
 
   // ============================================
   // GLOBAL CHAT CONTEXT - for Global Assistant mode
@@ -874,6 +884,7 @@ const GlobalAssistantView: React.FC = () => {
         isMcpServerEnabled={isServerEnabled}
         onMcpServerToggle={setServerEnabled}
         showMcp={isDesktop}
+        remoteStreams={remoteStreams}
         renderInput={(props) => (
           <>
             {isVoiceModeActive && (


### PR DESCRIPTION
## Summary

Render remote in-progress AI streams using the existing `MessageRenderer → TextBlock → StreamingMarkdown` pipeline so they look identical to local-user-triggered assistant messages — same `mr-2 sm:mr-8` alignment, same `prose` styling, same progressive markdown via Streamdown's streaming mode. Completes the multiplayer streaming epic (#1149–#1171) on the render side. No backend, socket, or store changes.

### Before

Remote stream rendered as `<p whitespace-pre-wrap>` indented `ml-6` under a "{name} is waiting for AI response…" `StreamingIndicator`, sitting outside the scroll container. No markdown. At completion, the message "spawned" into the real list, producing a jarring visual jump.

### After

Remote stream renders inline next to real messages inside `<ConversationContent>`. Markdown features (bold, code blocks, lists, links) render progressively as chunks arrive. At completion the synthesized bubble is replaced in-place by the persisted message — no flicker, no duplicate.

## Changes

- **`ChatMessagesArea.tsx`** — accepts `remoteStreams?: PendingStream[]`, dedups by `messageId` against the messages list, and renders each via `MessageRenderer` with a synthesized `{ id, role: 'assistant', parts: [{type:'text', text}], messageType: 'standard' }` and `isStreaming`. Empty-state suppressed when only remote streams are present. Loading-skeleton suppression preserved.
- **`ChatLayout.tsx`** — drops the old `<StreamingIndicator>` + plain-`<p>` block. Widens `remoteStreams` prop type from the inline shape to `PendingStream[]` and passes it through.
- **`GlobalAssistantView.tsx`** — subscribes via `usePendingStreamsStore` + `useShallow` with the global channel id literal (`user:${userId}:global`, mirroring `GlobalChatContext.tsx:275`) and passes `remoteStreams` to `<ChatLayout>`. Previously missing. The selector is gated to the active chat context — see below.

### Active-context gating in `GlobalAssistantView` (per CodeRabbit + Codex review)

The selector returns `[]` when:
1. An agent is selected (agent-mode streams live on per-agent page channels and are rendered by `AiChatView`; this view does not dual-subscribe).
2. `globalChannelId` is null (no signed-in user).
3. `globalConversationId` is null (during init / between conversations).

Otherwise it returns `getRemotePageStreams(globalChannelId).filter((s) => s.conversationId === globalConversationId)` — only streams for the active global conversation render in this view. This prevents two cross-context bleeds:
- A global-channel stream from another tab leaking into an agent conversation (mode bleed).
- A different global conversation's stream surfacing as a synthetic bubble in the active conversation (conversation bleed).

The subscription is placed below `useGlobalChat()` and the `selectedAgent` selector so both values are in the closure scope.

## What this **doesn't** do (by design)

- No new components, helpers, or types — synthesis is ~6 inline lines.
- No attribution / "is responding" / display name above the bubble — it is indistinguishable from a normal assistant message.
- No `onEdit`/`onDelete`/`onRetry` for synthesized messages (in-progress, not actionable).
- `MessageRenderer`, `TextBlock`, `StreamingMarkdown`, `usePendingStreamsStore` untouched.
- Sidebar AI chat (`SidebarChatTab` / `CompactMessageRenderer`) is out of scope.
- `AiChatView` (per-page agent view) keeps its existing `getRemotePageStreams(page.id)` subscription unchanged. Extending the same `conversationId` filter there is a defensible follow-up, but `AiChatView` is not in this PR's diff and reviewers did not flag it.

## Test plan

- [x] Unit — new `ChatMessagesArea.remoteStreams.test.tsx`: synthesized render with `isStreaming`, dedup against existing messages, empty case, isLoading suppression.
- [x] Unit — rewrote `ChatLayout.remoteStreams.test.tsx` to assert `remoteStreams` plumbing through to `<ChatMessagesArea>`.
- [x] Existing `AiChatView.test.tsx` (17 tests) still passes unchanged.
- [x] `pnpm exec next lint` — clean on changed files.
- [x] `grep -rn "whitespace-pre-wrap" apps/web/src/components/ai/chat/layouts/` — empty.
- [ ] Manual: two browsers / two users on a shared page AI chat; send from A, observe B renders bubble in-flow with progressive markdown; refresh B mid-stream (bootstrap path) → same render; completion → no flicker, no duplicate.
- [ ] Manual: same-user two-tab global chat — bubble appears in inactive tab.
- [ ] Manual: while in agent mode in `GlobalAssistantView`, no global-channel bubbles render (mode-gate verification).
- [ ] Manual: with two concurrent global conversations, bubbles only render in the conversation matching `globalConversationId` (conversation-gate verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)