### PR TITLE
refactor(streams): extract useChannelStreamSocket and adopt in AiChatView/GlobalChatContext

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -31,7 +31,7 @@ import { abortActiveStreamByMessageId } from '@/lib/ai/core/stream-abort-client'
 import { useAppStateRecovery } from '@/hooks/useAppStateRecovery';
 import { isEditingActive } from '@/stores/useEditingStore';
 import { usePageSocketRoom } from '@/hooks/usePageSocketRoom';
-import { useChatStreamSocket } from '@/hooks/useChatStreamSocket';
+import { useChannelStreamSocket } from '@/hooks/useChannelStreamSocket';
 import { usePendingStreamsStore } from '@/stores/usePendingStreamsStore';
 import { useShallow } from 'zustand/react/shallow';
 
@@ -342,40 +342,42 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
   }, [isStreaming, stop, ownStreamMessageId]);
 
   usePageSocketRoom(page.id);
-  useChatStreamSocket(page.id, (messageId) => {
-    const stream = usePendingStreamsStore.getState().streams.get(messageId);
-    if (stream?.text && stream.conversationId === currentConversationId) {
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: messageId,
-          role: 'assistant' as const,
-          content: stream.text,
-          parts: [{ type: 'text' as const, text: stream.text }],
-        },
-      ]);
-    } else if (stream?.text && currentConversationId === `${page.id}-default`) {
-      const { text, conversationId: streamConvId } = stream;
-      fetchWithAuth(`/api/ai/page-agents/${page.id}/conversations?pageSize=1`)
-        .then(async (res) => {
-          if (pageIdRef.current !== page.id) return;
-          if (!res.ok) return;
-          const data = (await res.json()) as ConversationListResponse;
-          const persisted = data.conversations?.[0];
-          if (!persisted || persisted.id !== streamConvId) return;
-          setCurrentConversationId(persisted.id);
-          setMessages((prev) => [
-            ...prev,
-            {
-              id: messageId,
-              role: 'assistant' as const,
-              content: text,
-              parts: [{ type: 'text' as const, text }],
-            },
-          ]);
-        })
-        .catch((err) => console.warn('[AiChatView] late-joiner sync failed', err));
-    }
+  useChannelStreamSocket(page.id, {
+    onStreamComplete: (messageId) => {
+      const stream = usePendingStreamsStore.getState().streams.get(messageId);
+      if (stream?.text && stream.conversationId === currentConversationId) {
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: messageId,
+            role: 'assistant' as const,
+            content: stream.text,
+            parts: [{ type: 'text' as const, text: stream.text }],
+          },
+        ]);
+      } else if (stream?.text && currentConversationId === `${page.id}-default`) {
+        const { text, conversationId: streamConvId } = stream;
+        fetchWithAuth(`/api/ai/page-agents/${page.id}/conversations?pageSize=1`)
+          .then(async (res) => {
+            if (pageIdRef.current !== page.id) return;
+            if (!res.ok) return;
+            const data = (await res.json()) as ConversationListResponse;
+            const persisted = data.conversations?.[0];
+            if (!persisted || persisted.id !== streamConvId) return;
+            setCurrentConversationId(persisted.id);
+            setMessages((prev) => [
+              ...prev,
+              {
+                id: messageId,
+                role: 'assistant' as const,
+                content: text,
+                parts: [{ type: 'text' as const, text }],
+              },
+            ]);
+          })
+          .catch((err) => console.warn('[AiChatView] late-joiner sync failed', err));
+      }
+    },
   });
 
   // Reset error visibility when new error occurs

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
@@ -73,7 +73,7 @@ vi.mock('@/stores/usePendingStreamsStore', () => ({
 }));
 
 vi.mock('@/hooks/usePageSocketRoom', () => ({ usePageSocketRoom: vi.fn() }));
-vi.mock('@/hooks/useChatStreamSocket', () => ({ useChatStreamSocket: vi.fn() }));
+vi.mock('@/hooks/useChannelStreamSocket', () => ({ useChannelStreamSocket: vi.fn() }));
 vi.mock('@/hooks/useAppStateRecovery', () => ({ useAppStateRecovery: vi.fn() }));
 
 vi.mock('@/hooks/useDisplayPreferences', () => ({
@@ -192,7 +192,7 @@ vi.mock('zustand/react/shallow', () => ({ useShallow: vi.fn((fn: unknown) => fn)
 import AiChatView from '../AiChatView';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
-import { useChatStreamSocket } from '@/hooks/useChatStreamSocket';
+import { useChannelStreamSocket } from '@/hooks/useChannelStreamSocket';
 import { usePendingStreamsStore } from '@/stores/usePendingStreamsStore';
 import { ChatLayout } from '@/components/ai/chat/layouts';
 import { VoiceCallPanel } from '@/components/ai/voice/VoiceCallPanel';
@@ -471,8 +471,8 @@ describe('AiChatView late-joiner conversation sync', () => {
 
   test('given fireComplete fires with stream.conversationId matching the persisted conversation while currentConversationId is the page-scoped default, should sync ID and append the message', async () => {
     let capturedCallback: ((messageId: string) => void) | undefined;
-    vi.mocked(useChatStreamSocket).mockImplementation((_pageId, cb) => {
-      capturedCallback = cb;
+    vi.mocked(useChannelStreamSocket).mockImplementation((_pageId, opts) => {
+      capturedCallback = opts?.onStreamComplete;
     });
 
     setupNoConversationsInit();
@@ -512,8 +512,8 @@ describe('AiChatView late-joiner conversation sync', () => {
 
   test('given fireComplete fires with stream.conversationId that does NOT match the persisted conversation, should NOT append the message', async () => {
     let capturedCallback: ((messageId: string) => void) | undefined;
-    vi.mocked(useChatStreamSocket).mockImplementation((_pageId, cb) => {
-      capturedCallback = cb;
+    vi.mocked(useChannelStreamSocket).mockImplementation((_pageId, opts) => {
+      capturedCallback = opts?.onStreamComplete;
     });
 
     setupNoConversationsInit();
@@ -554,8 +554,8 @@ describe('AiChatView late-joiner conversation sync', () => {
 
   test('given the sync fetch returns !res.ok, should NOT append any message', async () => {
     let capturedCallback: ((messageId: string) => void) | undefined;
-    vi.mocked(useChatStreamSocket).mockImplementation((_pageId, cb) => {
-      capturedCallback = cb;
+    vi.mocked(useChannelStreamSocket).mockImplementation((_pageId, opts) => {
+      capturedCallback = opts?.onStreamComplete;
     });
 
     setupNoConversationsInit();
@@ -594,8 +594,8 @@ describe('AiChatView late-joiner conversation sync', () => {
 
   test('given the sync fetch returns an empty conversations array, should NOT append any message', async () => {
     let capturedCallback: ((messageId: string) => void) | undefined;
-    vi.mocked(useChatStreamSocket).mockImplementation((_pageId, cb) => {
-      capturedCallback = cb;
+    vi.mocked(useChannelStreamSocket).mockImplementation((_pageId, opts) => {
+      capturedCallback = opts?.onStreamComplete;
     });
 
     setupNoConversationsInit();
@@ -635,8 +635,8 @@ describe('AiChatView late-joiner conversation sync', () => {
   test('given the sync fetch throws a network error, should warn and NOT append any message', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     let capturedCallback: ((messageId: string) => void) | undefined;
-    vi.mocked(useChatStreamSocket).mockImplementation((_pageId, cb) => {
-      capturedCallback = cb;
+    vi.mocked(useChannelStreamSocket).mockImplementation((_pageId, opts) => {
+      capturedCallback = opts?.onStreamComplete;
     });
 
     setupNoConversationsInit();
@@ -685,8 +685,8 @@ describe('AiChatView late-joiner conversation sync', () => {
   test('given the component navigates to a different page while the sync fetch is in-flight, should NOT apply stale page-A state to page B', async () => {
     const PAGE_B_ID = 'page-b-456';
     let capturedPageACallback: ((messageId: string) => void) | undefined;
-    vi.mocked(useChatStreamSocket).mockImplementation((pageId, cb) => {
-      if (pageId === PAGE_ID) capturedPageACallback = cb;
+    vi.mocked(useChannelStreamSocket).mockImplementation((pageId, opts) => {
+      if (pageId === PAGE_ID) capturedPageACallback = opts?.onStreamComplete;
     });
 
     let resolveSyncFetch!: () => void;

--- a/apps/web/src/contexts/GlobalChatContext.tsx
+++ b/apps/web/src/contexts/GlobalChatContext.tsx
@@ -7,19 +7,9 @@ import { conversationState } from '@/lib/ai/core/conversation-state';
 import { getAgentId, getConversationId, setConversationId } from '@/lib/url-state';
 import { useChatTransport } from '@/lib/ai/shared';
 import { useSocketStore } from '@/stores/useSocketStore';
-import { useSocket } from '@/hooks/useSocket';
 import { useAuth } from '@/hooks/useAuth';
-import { usePendingStreamsStore } from '@/stores/usePendingStreamsStore';
-import { consumeStreamJoin } from '@/lib/ai/core/stream-join-client';
+import { useChannelStreamSocket } from '@/hooks/useChannelStreamSocket';
 import { abortActiveStreamByMessageId } from '@/lib/ai/core/stream-abort-client';
-import { getBrowserSessionId } from '@/lib/ai/core/browser-session-id';
-import type { AiStreamStartPayload, AiStreamCompletePayload } from '@/lib/websocket/socket-utils';
-
-interface ActiveStreamRow {
-  messageId: string;
-  conversationId: string;
-  triggeredBy: { userId: string; displayName: string; browserSessionId: string };
-}
 
 /**
  * Global Chat Context - Split into three tiers to minimize re-render noise:
@@ -249,19 +239,16 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
   // ============================================
   // GLOBAL CHANNEL STREAM SOCKET — bootstrap + live events
   // ============================================
-  // Mirrors useChatStreamSocket for the synthetic global channel
-  // (`user:${userId}:global`). On mount we replay any in-flight stream rows from
-  // the DB so a refresh mid-stream restores the stop button + remote-stream
-  // append. Live chat:stream_start/_complete events keep the store in sync for
-  // streams started in another tab. Streams initiated by the local browser
-  // session are intentionally ignored — useChat in the active tab is the
-  // source of truth there.
-  const socket = useSocket();
+  // Hook handles DB replay, live chat:stream_start/_complete, SSE join, and
+  // teardown. Local own-stream side effects (the in-flight streaming flag and
+  // stop-button slot driven by useChat in this tab) are wired through the
+  // own-stream callbacks below.
   const { user } = useAuth();
   const userId = user?.id ?? null;
+  const channelId = userId ? `user:${userId}:global` : undefined;
 
-  // Always-current refs so the live SSE complete handler can call into the
-  // latest setters/refresh without re-binding socket listeners every render.
+  // Always-current refs so the hook's stable callbacks can call into the
+  // latest setters/refresh without forcing the hook to resubscribe.
   const setIsStreamingRef = useRef(setIsStreaming);
   setIsStreamingRef.current = setIsStreaming;
   const setStopStreamingRef = useRef(setStopStreaming);
@@ -269,147 +256,21 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
   const refreshConversationRef = useRef(refreshConversation);
   refreshConversationRef.current = refreshConversation;
 
-  useEffect(() => {
-    if (!socket || !userId) return;
-
-    const channelId = `user:${userId}:global`;
-    const localBrowserSessionId = getBrowserSessionId();
-    const controllers = new Map<string, AbortController>();
-    // Tracks bootstrapped own streams so the corresponding SSE-resolve / live
-    // complete event can clear the local stop button surface — non-own and
-    // live cross-tab streams must NOT mutate the local streaming flags.
-    const ownStreamIds = new Set<string>();
-    // Guards against firing finalize twice for the same messageId when both the
-    // socket complete event and the SSE done sentinel arrive (the abort triggered
-    // by the former resolves consumeStreamJoin, which would otherwise re-enter).
-    const finalized = new Set<string>();
-    let cancelled = false;
-
-    const { addStream, appendText, removeStream, clearPageStreams } =
-      usePendingStreamsStore.getState();
-
-    const clearOwnStreamFlags = (messageId: string): boolean => {
-      if (!ownStreamIds.delete(messageId)) return false;
+  useChannelStreamSocket(channelId, {
+    onStreamComplete: () => {
+      refreshConversationRef.current();
+    },
+    onOwnStreamBootstrap: ({ messageId }) => {
+      setIsStreamingRef.current(true);
+      setStopStreamingRef.current(() => () => {
+        abortActiveStreamByMessageId({ messageId });
+      });
+    },
+    onOwnStreamFinalize: () => {
       setIsStreamingRef.current(false);
       setStopStreamingRef.current(null);
-      return true;
-    };
-
-    const finalizeStream = (messageId: string) => {
-      // After unmount, controllers are aborted which resolves consumeStreamJoin
-      // and re-enters this callback — guard against post-teardown fetch/state.
-      if (cancelled) return;
-      if (finalized.has(messageId)) return;
-      finalized.add(messageId);
-      controllers.delete(messageId);
-      clearOwnStreamFlags(messageId);
-      removeStream(messageId);
-      refreshConversationRef.current();
-    };
-
-    const startConsume = (messageId: string) => {
-      const controller = new AbortController();
-      controllers.set(messageId, controller);
-
-      consumeStreamJoin(messageId, controller.signal, (chunk) => {
-        appendText(messageId, chunk);
-      })
-        .then(() => {
-          finalizeStream(messageId);
-        })
-        .catch((err) => {
-          if (cancelled) return;
-          if (finalized.has(messageId)) return;
-          finalized.add(messageId);
-          controllers.delete(messageId);
-          // Treat a join error as terminal locally so the stop button is not
-          // left dangling — the stream may still finish server-side, but the
-          // socket complete handler will be a no-op (already finalized) and
-          // we have no live SSE to drive the UI forward.
-          clearOwnStreamFlags(messageId);
-          removeStream(messageId);
-          if (!controller.signal.aborted) {
-            console.error('[GlobalChatContext] SSE join error:', err);
-          }
-        });
-    };
-
-    (async () => {
-      try {
-        const res = await fetchWithAuth(
-          `/api/ai/chat/active-streams?channelId=${encodeURIComponent(channelId)}`,
-          { credentials: 'include' },
-        );
-        if (cancelled) return;
-        if (!res.ok) return;
-        const data = (await res.json()) as { streams?: ActiveStreamRow[] };
-        if (cancelled) return;
-        for (const stream of data.streams ?? []) {
-          if (controllers.has(stream.messageId)) continue;
-          const isOwn = stream.triggeredBy.browserSessionId === localBrowserSessionId;
-          addStream({
-            messageId: stream.messageId,
-            pageId: channelId,
-            conversationId: stream.conversationId,
-            triggeredBy: stream.triggeredBy,
-            isOwn,
-          });
-          if (isOwn) {
-            ownStreamIds.add(stream.messageId);
-            const messageIdForAbort = stream.messageId;
-            setIsStreamingRef.current(true);
-            setStopStreamingRef.current(() => () => {
-              abortActiveStreamByMessageId({ messageId: messageIdForAbort });
-            });
-          }
-          startConsume(stream.messageId);
-        }
-      } catch (err) {
-        if (cancelled) return;
-        console.warn('[GlobalChatContext] bootstrap failed', err);
-      }
-    })();
-
-    const handleStreamStart = (payload: AiStreamStartPayload) => {
-      if (payload.pageId !== channelId) return;
-      if (payload.triggeredBy.browserSessionId === localBrowserSessionId) return;
-      if (controllers.has(payload.messageId)) return;
-
-      addStream({
-        messageId: payload.messageId,
-        pageId: payload.pageId,
-        conversationId: payload.conversationId,
-        triggeredBy: payload.triggeredBy,
-        isOwn: false,
-      });
-
-      startConsume(payload.messageId);
-    };
-
-    const handleStreamComplete = (payload: AiStreamCompletePayload) => {
-      if (payload.pageId !== channelId) return;
-      const controller = controllers.get(payload.messageId);
-      if (controller) {
-        controller.abort();
-      }
-      finalizeStream(payload.messageId);
-    };
-
-    socket.on('chat:stream_start', handleStreamStart);
-    socket.on('chat:stream_complete', handleStreamComplete);
-
-    return () => {
-      cancelled = true;
-      socket.off('chat:stream_start', handleStreamStart);
-      socket.off('chat:stream_complete', handleStreamComplete);
-      for (const controller of controllers.values()) {
-        controller.abort();
-      }
-      controllers.clear();
-      ownStreamIds.clear();
-      clearPageStreams(channelId);
-    };
-  }, [socket, userId]);
+    },
+  });
 
   // Track the previous conversation ID to detect conversation switches
   const prevConversationIdRef = useRef<string | null>(null);

--- a/apps/web/src/contexts/GlobalChatContext.tsx
+++ b/apps/web/src/contexts/GlobalChatContext.tsx
@@ -5,7 +5,7 @@ import { DefaultChatTransport, UIMessage } from 'ai';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { conversationState } from '@/lib/ai/core/conversation-state';
 import { getAgentId, getConversationId, setConversationId } from '@/lib/url-state';
-import { useChatTransport } from '@/lib/ai/shared';
+import { useChatTransport, useStreamingRegistration } from '@/lib/ai/shared';
 import { useSocketStore } from '@/stores/useSocketStore';
 import { useAuth } from '@/hooks/useAuth';
 import { useChannelStreamSocket } from '@/hooks/useChannelStreamSocket';
@@ -88,6 +88,15 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
 
   // Global stop function
   const [stopStreaming, setStopStreaming] = useState<(() => void) | null>(null);
+
+  // Protects bootstrap-replayed own streams from SWR clobbers. Surfaces
+  // (GlobalAssistantView, SidebarChatTab) register based on local useChat
+  // status, which is `idle` immediately after a refresh — so they miss the
+  // case where the hook re-detects an in-flight own stream and flips this
+  // provider's isStreaming. This registration covers that gap.
+  useStreamingRegistration('global-chat', isStreaming, {
+    componentName: 'GlobalChatProvider',
+  });
 
   /**
    * Load a conversation by ID

--- a/apps/web/src/contexts/__tests__/GlobalChatContext.test.tsx
+++ b/apps/web/src/contexts/__tests__/GlobalChatContext.test.tsx
@@ -112,9 +112,11 @@ vi.mock('@/lib/url-state', () => ({
 
 vi.mock('@/lib/ai/shared', () => ({
   useChatTransport: vi.fn().mockReturnValue(null),
+  useStreamingRegistration: vi.fn(),
 }));
 
 import { GlobalChatProvider, useGlobalChat, useGlobalChatConversation } from '../GlobalChatContext';
+import { useStreamingRegistration } from '@/lib/ai/shared';
 
 // --- Helpers ---
 
@@ -732,5 +734,33 @@ describe('GlobalChatProvider — global channel stream socket', () => {
 
     expect(mockAddStream).not.toHaveBeenCalled();
     expect(mockConsumeStreamJoin).not.toHaveBeenCalled();
+  });
+});
+
+describe('GlobalChatProvider — editing-store registration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSocket._reset();
+    mockUseSocketStore.mockImplementation((selector: (s: { connectionStatus: string }) => unknown) =>
+      selector({ connectionStatus: 'connected' })
+    );
+    mockFetchWithAuth.mockImplementation(defaultFetch);
+    mockUseAuth.mockReturnValue({ user: { id: USER_ID }, isAuthenticated: true });
+    mockGetBrowserSessionId.mockReturnValue(SESSION_ID_LOCAL);
+    mockConsumeStreamJoin.mockResolvedValue(undefined);
+  });
+
+  // Surfaces (GlobalAssistantView, SidebarChatTab) key their useStreamingRegistration
+  // on local useChat status, which is `idle` immediately after a refresh — so they
+  // miss bootstrap-replayed own streams. The provider must register too so SWR
+  // doesn't clobber in-flight chat work during that window.
+  it('given the provider mounts, should register a streaming session keyed `global-chat` with the editing store', () => {
+    renderHook(() => useGlobalChat(), { wrapper: Wrapper });
+
+    expect(useStreamingRegistration).toHaveBeenCalledWith(
+      'global-chat',
+      expect.any(Boolean),
+      expect.objectContaining({ componentName: 'GlobalChatProvider' }),
+    );
   });
 });

--- a/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
+++ b/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
@@ -88,7 +88,7 @@ vi.mock('@/lib/ai/core/browser-session-id', () => ({
   getBrowserSessionId: mockGetBrowserSessionId,
 }));
 
-import { useChatStreamSocket } from '../useChatStreamSocket';
+import { useChannelStreamSocket } from '../useChannelStreamSocket';
 import type { AiStreamStartPayload, AiStreamCompletePayload } from '@/lib/websocket/socket-utils';
 
 const START_PAYLOAD: AiStreamStartPayload = {
@@ -103,7 +103,7 @@ const COMPLETE_PAYLOAD: AiStreamCompletePayload = {
   pageId: 'page-a',
 };
 
-describe('useChatStreamSocket', () => {
+describe('useChannelStreamSocket', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSocket._reset();
@@ -121,7 +121,7 @@ describe('useChatStreamSocket', () => {
 
   describe('chat:stream_start from another user', () => {
     it('should call addStream and start consumeStreamJoin', () => {
-      renderHook(() => useChatStreamSocket('page-a'));
+      renderHook(() => useChannelStreamSocket('page-a'));
 
       act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
 
@@ -148,7 +148,7 @@ describe('useChatStreamSocket', () => {
         },
       );
 
-      renderHook(() => useChatStreamSocket('page-a'));
+      renderHook(() => useChannelStreamSocket('page-a'));
       act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
 
       capturedOnChunk('hello');
@@ -162,7 +162,7 @@ describe('useChatStreamSocket', () => {
       );
       const onStreamComplete = vi.fn();
 
-      renderHook(() => useChatStreamSocket('page-a', onStreamComplete));
+      renderHook(() => useChannelStreamSocket('page-a', { onStreamComplete }));
       act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
 
       await act(async () => { resolveJoin(); });
@@ -180,7 +180,7 @@ describe('useChatStreamSocket', () => {
       mockRemoveStream.mockImplementation(() => { callOrder.push('removeStream'); });
       const onStreamComplete = vi.fn(() => { callOrder.push('onStreamComplete'); });
 
-      renderHook(() => useChatStreamSocket('page-a', onStreamComplete));
+      renderHook(() => useChannelStreamSocket('page-a', { onStreamComplete }));
       act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
 
       await act(async () => { resolveJoin(); });
@@ -193,7 +193,7 @@ describe('useChatStreamSocket', () => {
     it('given consumeStreamJoin rejects, should call removeStream to prevent stale store entry', async () => {
       mockConsumeStreamJoin.mockRejectedValue(new Error('network error'));
 
-      renderHook(() => useChatStreamSocket('page-a'));
+      renderHook(() => useChannelStreamSocket('page-a'));
       act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
 
       await act(async () => { await Promise.resolve(); });
@@ -209,7 +209,7 @@ describe('useChatStreamSocket', () => {
         triggeredBy: { userId: 'user-1', displayName: 'Me', browserSessionId: SESSION_ID_LOCAL },
       };
 
-      renderHook(() => useChatStreamSocket('page-a'));
+      renderHook(() => useChannelStreamSocket('page-a'));
       act(() => { mockSocket._trigger('chat:stream_start', localPayload); });
 
       expect(mockAddStream).not.toHaveBeenCalled();
@@ -222,7 +222,7 @@ describe('useChatStreamSocket', () => {
         triggeredBy: { userId: 'user-1', displayName: 'Me', browserSessionId: SESSION_ID_REMOTE },
       };
 
-      renderHook(() => useChatStreamSocket('page-a'));
+      renderHook(() => useChannelStreamSocket('page-a'));
       act(() => { mockSocket._trigger('chat:stream_start', otherSessionSameUser); });
 
       expect(mockAddStream).toHaveBeenCalledWith(expect.objectContaining({
@@ -235,7 +235,7 @@ describe('useChatStreamSocket', () => {
   // A1 — pageId guard
   describe('pageId guard', () => {
     it('given chat:stream_start with a different pageId, should ignore the event', () => {
-      renderHook(() => useChatStreamSocket('page-a'));
+      renderHook(() => useChannelStreamSocket('page-a'));
 
       act(() => {
         mockSocket._trigger('chat:stream_start', { ...START_PAYLOAD, pageId: 'page-b' });
@@ -247,7 +247,7 @@ describe('useChatStreamSocket', () => {
 
     it('given chat:stream_complete with a different pageId, should ignore the event', () => {
       const onStreamComplete = vi.fn();
-      renderHook(() => useChatStreamSocket('page-a', onStreamComplete));
+      renderHook(() => useChannelStreamSocket('page-a', { onStreamComplete }));
 
       act(() => {
         mockSocket._trigger('chat:stream_complete', { ...COMPLETE_PAYLOAD, pageId: 'page-b' });
@@ -261,7 +261,7 @@ describe('useChatStreamSocket', () => {
   describe('chat:stream_complete', () => {
     it('should call removeStream and onStreamComplete', () => {
       const onStreamComplete = vi.fn();
-      renderHook(() => useChatStreamSocket('page-a', onStreamComplete));
+      renderHook(() => useChannelStreamSocket('page-a', { onStreamComplete }));
 
       act(() => { mockSocket._trigger('chat:stream_complete', COMPLETE_PAYLOAD); });
 
@@ -274,7 +274,7 @@ describe('useChatStreamSocket', () => {
       mockRemoveStream.mockImplementation(() => { callOrder.push('removeStream'); });
       const onStreamComplete = vi.fn(() => { callOrder.push('onStreamComplete'); });
 
-      renderHook(() => useChatStreamSocket('page-a', onStreamComplete));
+      renderHook(() => useChannelStreamSocket('page-a', { onStreamComplete }));
 
       act(() => { mockSocket._trigger('chat:stream_complete', COMPLETE_PAYLOAD); });
 
@@ -290,7 +290,7 @@ describe('useChatStreamSocket', () => {
         },
       );
 
-      renderHook(() => useChatStreamSocket('page-a'));
+      renderHook(() => useChannelStreamSocket('page-a'));
       act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
       act(() => { mockSocket._trigger('chat:stream_complete', COMPLETE_PAYLOAD); });
 
@@ -307,7 +307,7 @@ describe('useChatStreamSocket', () => {
       );
       const onStreamComplete = vi.fn();
 
-      renderHook(() => useChatStreamSocket('page-a', onStreamComplete));
+      renderHook(() => useChannelStreamSocket('page-a', { onStreamComplete }));
       act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
 
       // SSE done resolves first
@@ -323,7 +323,7 @@ describe('useChatStreamSocket', () => {
       mockConsumeStreamJoin.mockReturnValue(new Promise(() => {})); // never resolves naturally
       const onStreamComplete = vi.fn();
 
-      renderHook(() => useChatStreamSocket('page-a', onStreamComplete));
+      renderHook(() => useChannelStreamSocket('page-a', { onStreamComplete }));
       act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
 
       // stream_complete fires (aborts the SSE join)
@@ -340,7 +340,7 @@ describe('useChatStreamSocket', () => {
   describe('onStreamComplete stability', () => {
     it('given onStreamComplete reference changes between renders, should not re-register socket handlers', () => {
       let callback = vi.fn();
-      const { rerender } = renderHook(() => useChatStreamSocket('page-a', callback));
+      const { rerender } = renderHook(() => useChannelStreamSocket('page-a', { onStreamComplete: callback }));
 
       const onCallCount = mockSocket.on.mock.calls.length;
 
@@ -358,7 +358,7 @@ describe('useChatStreamSocket', () => {
 
       const firstCallback = vi.fn();
       let callback = firstCallback;
-      const { rerender } = renderHook(() => useChatStreamSocket('page-a', callback));
+      const { rerender } = renderHook(() => useChannelStreamSocket('page-a', { onStreamComplete: callback }));
 
       act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
 
@@ -376,7 +376,7 @@ describe('useChatStreamSocket', () => {
 
   describe('cleanup on unmount', () => {
     it('should remove socket listeners, abort controllers, and clearPageStreams', () => {
-      const { unmount } = renderHook(() => useChatStreamSocket('page-a'));
+      const { unmount } = renderHook(() => useChannelStreamSocket('page-a'));
 
       act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
 
@@ -396,7 +396,7 @@ describe('useChatStreamSocket', () => {
   // AC5 — DB bootstrap on mount
   describe('DB bootstrap on mount', () => {
     it('given the hook mounts, should fetch active streams for the channelId', async () => {
-      renderHook(() => useChatStreamSocket('page-a'));
+      renderHook(() => useChannelStreamSocket('page-a'));
 
       await act(async () => { await Promise.resolve(); });
 
@@ -407,7 +407,7 @@ describe('useChatStreamSocket', () => {
     });
 
     it('given the channelId contains characters needing encoding, should encode it in the URL', async () => {
-      renderHook(() => useChatStreamSocket('user:abc:global'));
+      renderHook(() => useChannelStreamSocket('user:abc:global'));
 
       await act(async () => { await Promise.resolve(); });
 
@@ -429,7 +429,7 @@ describe('useChatStreamSocket', () => {
         }),
       });
 
-      renderHook(() => useChatStreamSocket('page-a'));
+      renderHook(() => useChannelStreamSocket('page-a'));
 
       await act(async () => { await Promise.resolve(); });
 
@@ -459,7 +459,7 @@ describe('useChatStreamSocket', () => {
         }),
       });
 
-      renderHook(() => useChatStreamSocket('page-a'));
+      renderHook(() => useChannelStreamSocket('page-a'));
 
       await act(async () => { await Promise.resolve(); });
 
@@ -485,7 +485,7 @@ describe('useChatStreamSocket', () => {
       });
 
       const onStreamComplete = vi.fn();
-      renderHook(() => useChatStreamSocket('page-a', onStreamComplete));
+      renderHook(() => useChannelStreamSocket('page-a', { onStreamComplete }));
 
       // Fire stream_complete BEFORE the bootstrap fetch resolves —
       // this populates processedRef, so the bootstrap should skip msg-1.
@@ -500,12 +500,12 @@ describe('useChatStreamSocket', () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
       mockFetchWithAuth.mockRejectedValueOnce(new Error('network down'));
 
-      renderHook(() => useChatStreamSocket('page-a'));
+      renderHook(() => useChannelStreamSocket('page-a'));
 
       await act(async () => { await Promise.resolve(); await Promise.resolve(); });
 
       expect(warn).toHaveBeenCalledWith(
-        '[useChatStreamSocket] bootstrap failed',
+        '[useChannelStreamSocket] bootstrap failed',
         expect.any(Error),
       );
       warn.mockRestore();
@@ -520,7 +520,7 @@ describe('useChatStreamSocket', () => {
         () => new Promise((res) => { resolveFetch = res; }),
       );
 
-      const { unmount } = renderHook(() => useChatStreamSocket('page-a'));
+      const { unmount } = renderHook(() => useChannelStreamSocket('page-a'));
       unmount();
 
       await act(async () => {
@@ -554,7 +554,7 @@ describe('useChatStreamSocket', () => {
       });
       mockConsumeStreamJoin.mockReturnValue(new Promise(() => {})); // never resolves
 
-      const { unmount } = renderHook(() => useChatStreamSocket('page-a'));
+      const { unmount } = renderHook(() => useChannelStreamSocket('page-a'));
 
       await act(async () => { await Promise.resolve(); await Promise.resolve(); });
 
@@ -565,6 +565,147 @@ describe('useChatStreamSocket', () => {
       unmount();
 
       expect(capturedSignal.aborted).toBe(true);
+    });
+  });
+
+  describe('onOwnStreamBootstrap', () => {
+    it('given a bootstrapped stream from the local browser session, should fire onOwnStreamBootstrap exactly once with the messageId', async () => {
+      mockFetchWithAuth.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          streams: [{
+            messageId: 'msg-own-bootstrap',
+            conversationId: 'conv-1',
+            triggeredBy: { userId: 'user-1', displayName: 'Me', browserSessionId: SESSION_ID_LOCAL },
+          }],
+        }),
+      });
+      const onOwnStreamBootstrap = vi.fn();
+
+      renderHook(() => useChannelStreamSocket('page-a', { onOwnStreamBootstrap }));
+      await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+      expect(onOwnStreamBootstrap).toHaveBeenCalledTimes(1);
+      expect(onOwnStreamBootstrap).toHaveBeenCalledWith({ messageId: 'msg-own-bootstrap' });
+    });
+
+    it('given a bootstrapped stream from a remote tab, should not fire onOwnStreamBootstrap', async () => {
+      mockFetchWithAuth.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          streams: [{
+            messageId: 'msg-remote-bootstrap',
+            conversationId: 'conv-1',
+            triggeredBy: { userId: 'user-2', displayName: 'Alice', browserSessionId: SESSION_ID_REMOTE },
+          }],
+        }),
+      });
+      const onOwnStreamBootstrap = vi.fn();
+
+      renderHook(() => useChannelStreamSocket('page-a', { onOwnStreamBootstrap }));
+      await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+      expect(onOwnStreamBootstrap).not.toHaveBeenCalled();
+    });
+
+    it('given a chat:stream_start fires after mount, should not fire onOwnStreamBootstrap', () => {
+      const onOwnStreamBootstrap = vi.fn();
+      renderHook(() => useChannelStreamSocket('page-a', { onOwnStreamBootstrap }));
+      act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
+
+      expect(onOwnStreamBootstrap).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onOwnStreamFinalize', () => {
+    const bootstrapOwnStream = (messageId = 'msg-own') => {
+      mockFetchWithAuth.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          streams: [{
+            messageId,
+            conversationId: 'conv-1',
+            triggeredBy: { userId: 'user-1', displayName: 'Me', browserSessionId: SESSION_ID_LOCAL },
+          }],
+        }),
+      });
+    };
+
+    it('given a bootstrapped own stream completes via SSE resolve, should fire onOwnStreamFinalize exactly once', async () => {
+      bootstrapOwnStream();
+      let resolveJoin!: () => void;
+      mockConsumeStreamJoin.mockReturnValue(
+        new Promise<{ aborted: boolean }>((res) => { resolveJoin = () => res({ aborted: false }); }),
+      );
+      const onOwnStreamFinalize = vi.fn();
+
+      renderHook(() => useChannelStreamSocket('page-a', { onOwnStreamFinalize }));
+      await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+      await act(async () => { resolveJoin(); });
+
+      expect(onOwnStreamFinalize).toHaveBeenCalledTimes(1);
+      expect(onOwnStreamFinalize).toHaveBeenCalledWith({ messageId: 'msg-own' });
+    });
+
+    it('given a bootstrapped own stream is finalized via chat:stream_complete socket, should fire onOwnStreamFinalize exactly once', async () => {
+      bootstrapOwnStream();
+      mockConsumeStreamJoin.mockReturnValue(new Promise(() => {})); // never resolves
+      const onOwnStreamFinalize = vi.fn();
+
+      renderHook(() => useChannelStreamSocket('page-a', { onOwnStreamFinalize }));
+      await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+      act(() => {
+        mockSocket._trigger('chat:stream_complete', { messageId: 'msg-own', pageId: 'page-a' });
+      });
+      await act(async () => { await Promise.resolve(); });
+
+      expect(onOwnStreamFinalize).toHaveBeenCalledTimes(1);
+      expect(onOwnStreamFinalize).toHaveBeenCalledWith({ messageId: 'msg-own' });
+    });
+
+    it('given both SSE resolve and chat:stream_complete fire for the same own stream, should fire onOwnStreamFinalize exactly once', async () => {
+      bootstrapOwnStream();
+      let resolveJoin!: () => void;
+      mockConsumeStreamJoin.mockReturnValue(
+        new Promise<{ aborted: boolean }>((res) => { resolveJoin = () => res({ aborted: false }); }),
+      );
+      const onOwnStreamFinalize = vi.fn();
+
+      renderHook(() => useChannelStreamSocket('page-a', { onOwnStreamFinalize }));
+      await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+      await act(async () => { resolveJoin(); });
+      act(() => {
+        mockSocket._trigger('chat:stream_complete', { messageId: 'msg-own', pageId: 'page-a' });
+      });
+
+      expect(onOwnStreamFinalize).toHaveBeenCalledTimes(1);
+    });
+
+    it('given a remote stream completes, should not fire onOwnStreamFinalize', async () => {
+      const onOwnStreamFinalize = vi.fn();
+      renderHook(() => useChannelStreamSocket('page-a', { onOwnStreamFinalize }));
+
+      act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
+      act(() => { mockSocket._trigger('chat:stream_complete', COMPLETE_PAYLOAD); });
+
+      expect(onOwnStreamFinalize).not.toHaveBeenCalled();
+    });
+
+    it('given the hook unmounts while an own stream is in flight, should not fire onOwnStreamFinalize', async () => {
+      bootstrapOwnStream();
+      mockConsumeStreamJoin.mockReturnValue(new Promise(() => {}));
+      const onOwnStreamFinalize = vi.fn();
+
+      const { unmount } = renderHook(() => useChannelStreamSocket('page-a', { onOwnStreamFinalize }));
+      await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+      unmount();
+      await act(async () => { await Promise.resolve(); });
+
+      expect(onOwnStreamFinalize).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
+++ b/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
@@ -334,6 +334,44 @@ describe('useChannelStreamSocket', () => {
 
       expect(onStreamComplete).toHaveBeenCalledTimes(1);
     });
+
+    it('given SSE rejects then chat:stream_complete fires, should NOT call onStreamComplete', async () => {
+      let rejectJoin!: (err: Error) => void;
+      mockConsumeStreamJoin.mockReturnValueOnce(
+        new Promise((_res, rej) => { rejectJoin = rej; }),
+      );
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const onStreamComplete = vi.fn();
+
+      renderHook(() => useChannelStreamSocket('page-a', { onStreamComplete }));
+      act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
+
+      await act(async () => { rejectJoin(new Error('network down')); await Promise.resolve(); });
+
+      act(() => { mockSocket._trigger('chat:stream_complete', COMPLETE_PAYLOAD); });
+
+      expect(onStreamComplete).not.toHaveBeenCalled();
+      errorSpy.mockRestore();
+    });
+
+    it('given SSE resolves after unmount via aborted controller, should NOT call onStreamComplete', async () => {
+      let resolveJoin!: () => void;
+      mockConsumeStreamJoin.mockReturnValue(
+        new Promise<{ aborted: boolean }>((res) => { resolveJoin = () => res({ aborted: false }); }),
+      );
+      const onStreamComplete = vi.fn();
+
+      const { unmount } = renderHook(() =>
+        useChannelStreamSocket('page-a', { onStreamComplete }),
+      );
+      act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
+
+      unmount();
+
+      await act(async () => { resolveJoin(); await Promise.resolve(); });
+
+      expect(onStreamComplete).not.toHaveBeenCalled();
+    });
   });
 
   // A3 — callback ref: onStreamComplete change should not re-register handlers

--- a/apps/web/src/hooks/useChannelStreamSocket.ts
+++ b/apps/web/src/hooks/useChannelStreamSocket.ts
@@ -12,18 +12,31 @@ interface ActiveStreamRow {
   triggeredBy: { userId: string; displayName: string; browserSessionId: string };
 }
 
-export function useChatStreamSocket(
+export interface UseChannelStreamSocketOptions {
+  onStreamComplete?: (messageId: string) => void;
+  onOwnStreamBootstrap?: (event: { messageId: string }) => void;
+  onOwnStreamFinalize?: (event: { messageId: string }) => void;
+}
+
+export function useChannelStreamSocket(
   channelId: string | undefined,
-  onStreamComplete?: (messageId: string) => void,
+  options?: UseChannelStreamSocketOptions,
 ): void {
   const socket = useSocket();
   const controllersRef = useRef<Map<string, AbortController>>(new Map());
   // Tracks which messageIds have had onStreamComplete called to prevent double-firing
   // when both the SSE done sentinel and the chat:stream_complete socket event arrive.
   const processedRef = useRef<Set<string>>(new Set());
-  // Stable ref so onStreamComplete changes never cause handler re-registration.
-  const onStreamCompleteRef = useRef(onStreamComplete);
-  onStreamCompleteRef.current = onStreamComplete;
+  // Bootstrap-discovered own-stream messageIds. Acts as both an "is-own" lookup
+  // and a one-shot guard for onOwnStreamFinalize.
+  const ownStreamIdsRef = useRef<Set<string>>(new Set());
+  // Stable refs so callback identity changes never trigger handler re-registration.
+  const onStreamCompleteRef = useRef(options?.onStreamComplete);
+  const onOwnStreamBootstrapRef = useRef(options?.onOwnStreamBootstrap);
+  const onOwnStreamFinalizeRef = useRef(options?.onOwnStreamFinalize);
+  onStreamCompleteRef.current = options?.onStreamComplete;
+  onOwnStreamBootstrapRef.current = options?.onOwnStreamBootstrap;
+  onOwnStreamFinalizeRef.current = options?.onOwnStreamFinalize;
 
   useEffect(() => {
     if (!socket || !channelId) return;
@@ -40,6 +53,12 @@ export function useChatStreamSocket(
       onStreamCompleteRef.current?.(messageId);
     };
 
+    const fireOwnFinalize = (messageId: string) => {
+      if (!ownStreamIdsRef.current.has(messageId)) return;
+      ownStreamIdsRef.current.delete(messageId);
+      onOwnStreamFinalizeRef.current?.({ messageId });
+    };
+
     const startConsume = (messageId: string) => {
       const controller = new AbortController();
       controllersRef.current.set(messageId, controller);
@@ -53,13 +72,15 @@ export function useChatStreamSocket(
             fireComplete(messageId);
           } finally {
             removeStream(messageId);
+            fireOwnFinalize(messageId);
           }
         })
         .catch((err) => {
           controllersRef.current.delete(messageId);
           removeStream(messageId);
+          fireOwnFinalize(messageId);
           if (!controller.signal.aborted) {
-            console.error('[useChatStreamSocket] SSE join error:', err);
+            console.error('[useChannelStreamSocket] SSE join error:', err);
           }
         });
     };
@@ -79,18 +100,23 @@ export function useChatStreamSocket(
         for (const stream of data.streams ?? []) {
           if (processedRef.current.has(stream.messageId)) continue;
           if (controllersRef.current.has(stream.messageId)) continue;
+          const isOwn = stream.triggeredBy.browserSessionId === localBrowserSessionId;
           addStream({
             messageId: stream.messageId,
             pageId: channelId,
             conversationId: stream.conversationId,
             triggeredBy: stream.triggeredBy,
-            isOwn: stream.triggeredBy.browserSessionId === localBrowserSessionId,
+            isOwn,
           });
+          if (isOwn) {
+            ownStreamIdsRef.current.add(stream.messageId);
+            onOwnStreamBootstrapRef.current?.({ messageId: stream.messageId });
+          }
           startConsume(stream.messageId);
         }
       } catch (err) {
         if (cancelled) return;
-        console.warn('[useChatStreamSocket] bootstrap failed', err);
+        console.warn('[useChannelStreamSocket] bootstrap failed', err);
       }
     })();
 
@@ -121,6 +147,7 @@ export function useChatStreamSocket(
         fireComplete(payload.messageId);
       } finally {
         removeStream(payload.messageId);
+        fireOwnFinalize(payload.messageId);
       }
     };
 
@@ -136,6 +163,7 @@ export function useChatStreamSocket(
       }
       controllersRef.current.clear();
       processedRef.current.clear();
+      ownStreamIdsRef.current.clear();
       clearPageStreams(channelId);
     };
   }, [socket, channelId]);

--- a/apps/web/src/hooks/useChannelStreamSocket.ts
+++ b/apps/web/src/hooks/useChannelStreamSocket.ts
@@ -13,11 +13,15 @@ interface ActiveStreamRow {
 }
 
 export interface UseChannelStreamSocketOptions {
+  /** Fires once per messageId on clean finalize (SSE resolve or socket complete); NOT on SSE error. */
   onStreamComplete?: (messageId: string) => void;
+  /** Fires once per messageId when DB bootstrap finds an in-flight stream from this browser session. */
   onOwnStreamBootstrap?: (event: { messageId: string }) => void;
+  /** Fires once per own-bootstrapped messageId on any finalize path (resolve, complete, or error). */
   onOwnStreamFinalize?: (event: { messageId: string }) => void;
 }
 
+/** Subscribes a component to a channel's AI streaming lifecycle: DB-replay on mount, live socket events, SSE join, store cleanup on unmount. Pass `undefined` channelId to no-op. */
 export function useChannelStreamSocket(
   channelId: string | undefined,
   options?: UseChannelStreamSocketOptions,

--- a/apps/web/src/hooks/useChannelStreamSocket.ts
+++ b/apps/web/src/hooks/useChannelStreamSocket.ts
@@ -23,13 +23,6 @@ export function useChannelStreamSocket(
   options?: UseChannelStreamSocketOptions,
 ): void {
   const socket = useSocket();
-  const controllersRef = useRef<Map<string, AbortController>>(new Map());
-  // Tracks which messageIds have had onStreamComplete called to prevent double-firing
-  // when both the SSE done sentinel and the chat:stream_complete socket event arrive.
-  const processedRef = useRef<Set<string>>(new Set());
-  // Bootstrap-discovered own-stream messageIds. Acts as both an "is-own" lookup
-  // and a one-shot guard for onOwnStreamFinalize.
-  const ownStreamIdsRef = useRef<Set<string>>(new Set());
   // Stable refs so callback identity changes never trigger handler re-registration.
   const onStreamCompleteRef = useRef(options?.onStreamComplete);
   const onOwnStreamBootstrapRef = useRef(options?.onOwnStreamBootstrap);
@@ -43,25 +36,33 @@ export function useChannelStreamSocket(
 
     let cancelled = false;
     const localBrowserSessionId = getBrowserSessionId();
+    const controllers = new Map<string, AbortController>();
+    // Tracks which messageIds have had onStreamComplete called to prevent
+    // double-firing when both the SSE done sentinel and chat:stream_complete
+    // arrive, and to gate post-error stream_complete events.
+    const processed = new Set<string>();
+    // Bootstrap-discovered own-stream messageIds. Acts as both an "is-own"
+    // lookup and a one-shot guard for onOwnStreamFinalize.
+    const ownStreamIds = new Set<string>();
 
     const { addStream, appendText, removeStream, clearPageStreams } =
       usePendingStreamsStore.getState();
 
     const fireComplete = (messageId: string) => {
-      if (processedRef.current.has(messageId)) return;
-      processedRef.current.add(messageId);
+      if (processed.has(messageId)) return;
+      processed.add(messageId);
       onStreamCompleteRef.current?.(messageId);
     };
 
     const fireOwnFinalize = (messageId: string) => {
-      if (!ownStreamIdsRef.current.has(messageId)) return;
-      ownStreamIdsRef.current.delete(messageId);
+      if (!ownStreamIds.has(messageId)) return;
+      ownStreamIds.delete(messageId);
       onOwnStreamFinalizeRef.current?.({ messageId });
     };
 
     const startConsume = (messageId: string) => {
       const controller = new AbortController();
-      controllersRef.current.set(messageId, controller);
+      controllers.set(messageId, controller);
 
       consumeStreamJoin(messageId, controller.signal, (chunk) => {
         appendText(messageId, chunk);
@@ -70,7 +71,7 @@ export function useChannelStreamSocket(
           // Cleanup runs synchronously on unmount but the SSE promise resolves
           // asynchronously after controller.abort(); skip post-teardown effects.
           if (cancelled) return;
-          controllersRef.current.delete(messageId);
+          controllers.delete(messageId);
           try {
             fireComplete(messageId);
           } finally {
@@ -79,12 +80,12 @@ export function useChannelStreamSocket(
           }
         })
         .catch((err) => {
-          controllersRef.current.delete(messageId);
           if (cancelled) return;
+          controllers.delete(messageId);
           // Mark as processed so a subsequent chat:stream_complete event for
           // the same messageId is a no-op for onStreamComplete: the catch
           // path already finalized this stream locally.
-          processedRef.current.add(messageId);
+          processed.add(messageId);
           removeStream(messageId);
           fireOwnFinalize(messageId);
           if (!controller.signal.aborted) {
@@ -106,8 +107,8 @@ export function useChannelStreamSocket(
         const data = (await res.json()) as { streams?: ActiveStreamRow[] };
         if (cancelled) return;
         for (const stream of data.streams ?? []) {
-          if (processedRef.current.has(stream.messageId)) continue;
-          if (controllersRef.current.has(stream.messageId)) continue;
+          if (processed.has(stream.messageId)) continue;
+          if (controllers.has(stream.messageId)) continue;
           const isOwn = stream.triggeredBy.browserSessionId === localBrowserSessionId;
           addStream({
             messageId: stream.messageId,
@@ -117,7 +118,7 @@ export function useChannelStreamSocket(
             isOwn,
           });
           if (isOwn) {
-            ownStreamIdsRef.current.add(stream.messageId);
+            ownStreamIds.add(stream.messageId);
             onOwnStreamBootstrapRef.current?.({ messageId: stream.messageId });
           }
           startConsume(stream.messageId);
@@ -131,7 +132,7 @@ export function useChannelStreamSocket(
     const handleStreamStart = (payload: AiStreamStartPayload) => {
       if (payload.pageId !== channelId) return;
       if (payload.triggeredBy.browserSessionId === localBrowserSessionId) return;
-      if (controllersRef.current.has(payload.messageId)) return;
+      if (controllers.has(payload.messageId)) return;
 
       addStream({
         messageId: payload.messageId,
@@ -146,10 +147,10 @@ export function useChannelStreamSocket(
 
     const handleStreamComplete = (payload: AiStreamCompletePayload) => {
       if (payload.pageId !== channelId) return;
-      const controller = controllersRef.current.get(payload.messageId);
+      const controller = controllers.get(payload.messageId);
       if (controller) {
         controller.abort();
-        controllersRef.current.delete(payload.messageId);
+        controllers.delete(payload.messageId);
       }
       try {
         fireComplete(payload.messageId);
@@ -166,12 +167,9 @@ export function useChannelStreamSocket(
       cancelled = true;
       socket.off('chat:stream_start', handleStreamStart);
       socket.off('chat:stream_complete', handleStreamComplete);
-      for (const controller of controllersRef.current.values()) {
+      for (const controller of controllers.values()) {
         controller.abort();
       }
-      controllersRef.current.clear();
-      processedRef.current.clear();
-      ownStreamIdsRef.current.clear();
       clearPageStreams(channelId);
     };
   }, [socket, channelId]);

--- a/apps/web/src/hooks/useChannelStreamSocket.ts
+++ b/apps/web/src/hooks/useChannelStreamSocket.ts
@@ -67,6 +67,9 @@ export function useChannelStreamSocket(
         appendText(messageId, chunk);
       })
         .then(() => {
+          // Cleanup runs synchronously on unmount but the SSE promise resolves
+          // asynchronously after controller.abort(); skip post-teardown effects.
+          if (cancelled) return;
           controllersRef.current.delete(messageId);
           try {
             fireComplete(messageId);
@@ -77,6 +80,11 @@ export function useChannelStreamSocket(
         })
         .catch((err) => {
           controllersRef.current.delete(messageId);
+          if (cancelled) return;
+          // Mark as processed so a subsequent chat:stream_complete event for
+          // the same messageId is a no-op for onStreamComplete: the catch
+          // path already finalized this stream locally.
+          processedRef.current.add(messageId);
           removeStream(messageId);
           fireOwnFinalize(messageId);
           if (!controller.signal.aborted) {

--- a/apps/web/src/stores/__tests__/usePendingStreamsStore.test.ts
+++ b/apps/web/src/stores/__tests__/usePendingStreamsStore.test.ts
@@ -39,6 +39,30 @@ describe('usePendingStreamsStore', () => {
       const { getRemotePageStreams } = usePendingStreamsStore.getState();
       expect(getRemotePageStreams('page-a')).toHaveLength(2);
     });
+
+    it('given a stream with messageId X already present, should preserve existing text on duplicate addStream', () => {
+      const { addStream, appendText } = usePendingStreamsStore.getState();
+      addStream(BASE_STREAM);
+      appendText('msg-1', 'partial-text');
+      addStream(BASE_STREAM);
+
+      const { getRemotePageStreams } = usePendingStreamsStore.getState();
+      const [stream] = getRemotePageStreams('page-a');
+      expect(stream.text).toBe('partial-text');
+    });
+
+    it('given a duplicate addStream with different metadata, should keep the existing entry unchanged', () => {
+      const { addStream, appendText } = usePendingStreamsStore.getState();
+      addStream({ ...BASE_STREAM, isOwn: false });
+      appendText('msg-1', 'hello');
+      addStream({ ...BASE_STREAM, isOwn: true, conversationId: 'conv-other' });
+
+      const { getRemotePageStreams } = usePendingStreamsStore.getState();
+      const [stream] = getRemotePageStreams('page-a');
+      expect(stream.text).toBe('hello');
+      expect(stream.isOwn).toBe(false);
+      expect(stream.conversationId).toBe('conv-1');
+    });
   });
 
   describe('appendText', () => {

--- a/apps/web/src/stores/usePendingStreamsStore.ts
+++ b/apps/web/src/stores/usePendingStreamsStore.ts
@@ -24,6 +24,7 @@ export const usePendingStreamsStore = create<PendingStreamsState>((set, get) => 
 
   addStream: (stream) => {
     set((state) => {
+      if (state.streams.has(stream.messageId)) return state;
       const next = new Map(state.streams);
       next.set(stream.messageId, { ...stream, text: '' });
       return { streams: next };


### PR DESCRIPTION
## Summary

PR1 of the Multiplayer Streaming — Surface Parity follow-up epic. Pure refactor + invariant tightening + one targeted fix surfaced by review; no user-visible regression.

- Renames `useChatStreamSocket` → `useChannelStreamSocket` and converts the second positional argument into an options object so additional callbacks compose cleanly.
- Adds two own-stream callbacks (`onOwnStreamBootstrap`, `onOwnStreamFinalize`) for surfaces that drive a local `isStreaming` flag — what `GlobalChatContext` was inlining at the call site.
- Tightens the hook's finalize semantics: skip `onStreamComplete` after unmount; mark a SSE-rejected messageId as processed so a subsequent `chat:stream_complete` is a no-op for `onStreamComplete`.
- Refactors `GlobalChatContext` (−140 lines) and `AiChatView` (signature only) onto the shared hook.
- Makes `usePendingStreamsStore.addStream` idempotent. Co-mounted hook instances bootstrapping the same channel in parallel would otherwise clobber each other's accumulated text.
- Demotes the per-effect collections inside the hook (`controllers`, `processed`, `ownStreamIds`) from `useRef` to plain locals — they never needed ref identity, and dropping them clears the `react-hooks/exhaustive-deps` warnings on the cleanup function.
- Registers `GlobalChatProvider` streaming state with `useEditingStore` under id `global-chat`. Surfaces (`GlobalAssistantView`, `SidebarChatTab`) key their `useStreamingRegistration` on local `useChat.status`, which is `idle` immediately after a refresh — so the bootstrap-replayed own stream this provider drives wasn't covered by SWR-clobber protection. Registering at the provider level closes that window.

This unblocks PR2–PR4 (wiring the same hook into `GlobalAssistantView` agent mode and `SidebarChatTab` both modes).

## Commits

- `fix(streams): make pending-streams addStream idempotent` (+ 2 tests)
- `refactor(streams): rename useChatStreamSocket → useChannelStreamSocket and add own-stream callbacks` (+ 9 tests)
- `refactor(ai-chat): adopt useChannelStreamSocket options-object signature in AiChatView` (mock impls updated)
- `fix(streams): tighten useChannelStreamSocket finalize semantics` (+ 2 tests)
- `refactor(streams): switch GlobalChatContext to useChannelStreamSocket` (−140 lines)
- `refactor(streams): drop unnecessary useRef wrappers around per-effect collections in useChannelStreamSocket`
- `docs(streams): add one-line JSDoc to useChannelStreamSocket and its options`
- `fix(streams): register GlobalChatProvider's bootstrap-replayed isStreaming with the editing store` (+ 1 test)

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm --filter web test src/hooks/__tests__/useChannelStreamSocket.test.ts` — 35/35
- [x] `pnpm --filter web test src/contexts/__tests__/GlobalChatContext.test.tsx` — 18/18 (incl. new editing-store registration assertion, SSE-error-then-complete and post-unmount finalize)
- [x] `pnpm --filter web test src/stores/__tests__/usePendingStreamsStore.test.ts` — 18/18 (incl. new idempotency cases)
- [x] `pnpm --filter web test src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx` — 17/17
- [x] `pnpm --filter web lint` — only the pre-existing `QuickCreatePalette` warning remains (untouched by this PR)
- [x] Full `pnpm --filter web test` — 6414/6440 (the 26 failures are 2 pre-existing integration test files for `gift-subscription` requiring a real Postgres; verified to fail on `master`)

## Behavior preserved

- `AiChatView` keeps its synthesize-on-complete + page-scoped late-joiner sync intact, just routed through `options.onStreamComplete`.
- `GlobalChatContext` keeps its bootstrap-replay, own-stream stop-button restoration, refresh-on-complete, and reconnect-refresh effect; only the inline plumbing moves to the hook.
- Live `chat:stream_start` events from the local browser session are still skipped — `useChat` in the active tab remains source of truth for own post-mount streams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)