### PR TITLE
refactor(channel): share attachment infra (DM-files PR 1/2)

### DIFF
--- a/apps/web/src/app/api/channels/[pageId]/messages/route.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/route.ts
@@ -11,14 +11,7 @@ import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { createSignedBroadcastHeaders } from '@pagespace/lib/auth/broadcast-auth';
 import { broadcastInboxEvent } from '@/lib/websocket/socket-utils';
-
-// Type for attachment metadata stored in the database
-interface AttachmentMeta {
-  originalName: string;
-  size: number;
-  mimeType: string;
-  contentHash: string;
-}
+import type { AttachmentMeta } from '@pagespace/lib/types';
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };

--- a/apps/web/src/app/dashboard/inbox/channel/[pageId]/page.tsx
+++ b/apps/web/src/app/dashboard/inbox/channel/[pageId]/page.tsx
@@ -5,7 +5,8 @@ import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import useSWR from 'swr';
 import { toast } from 'sonner';
-import { Hash, ExternalLink, Lock, FileIcon, FileText, Download, Pencil, Trash2, Check, X, MoreHorizontal } from 'lucide-react';
+import { Hash, ExternalLink, Lock, Pencil, Trash2, Check, X, MoreHorizontal } from 'lucide-react';
+import { MessageAttachment } from '@/components/shared/MessageAttachment';
 import { useAuth } from '@/hooks/useAuth';
 import { usePermissions, getPermissionErrorMessage } from '@/hooks/usePermissions';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -28,13 +29,6 @@ import { useSocketStore } from '@/stores/useSocketStore';
 import {
   type AttachmentMeta,
   type FileRelation,
-  isImageAttachment,
-  getFileId,
-  getAttachmentName,
-  getAttachmentMimeType,
-  getAttachmentSize,
-  formatFileSize,
-  hasAttachment,
 } from '@/lib/attachment-utils';
 
 const fetcher = async (url: string) => {
@@ -605,50 +599,7 @@ export default function InboxChannelPage() {
                         />
                       </div>
                     ) : null}
-                    {/* File attachment */}
-                    {hasAttachment(m) && (
-                      <div className="mt-2">
-                        {isImageAttachment(m) ? (
-                          <a
-                            href={`/api/files/${getFileId(m)}/view?filename=${encodeURIComponent(getAttachmentName(m))}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="block max-w-sm"
-                          >
-                            {/* eslint-disable-next-line @next/next/no-img-element -- auth-gated API route; processor already optimizes on upload */}
-                            <img
-                              src={`/api/files/${getFileId(m)}/view`}
-                              alt={getAttachmentName(m)}
-                              className="rounded-lg max-h-64 object-contain border border-border/50"
-                            />
-                          </a>
-                        ) : (
-                          <a
-                            href={`/api/files/${getFileId(m)}/download?filename=${encodeURIComponent(getAttachmentName(m))}`}
-                            className="flex items-center gap-3 p-3 bg-muted/50 hover:bg-muted rounded-lg border border-border/50 max-w-sm transition-colors"
-                          >
-                            <div className="w-10 h-10 rounded bg-muted flex items-center justify-center shrink-0">
-                              {getAttachmentMimeType(m).includes('pdf') ? (
-                                <FileText className="h-5 w-5 text-red-500" />
-                              ) : getAttachmentMimeType(m).includes('document') || getAttachmentMimeType(m).includes('word') ? (
-                                <FileText className="h-5 w-5 text-blue-500" />
-                              ) : (
-                                <FileIcon className="h-5 w-5 text-muted-foreground" />
-                              )}
-                            </div>
-                            <div className="flex-1 min-w-0">
-                              <p className="text-sm font-medium truncate">{getAttachmentName(m)}</p>
-                              {getAttachmentSize(m) != null && (
-                                <p className="text-xs text-muted-foreground">
-                                  {formatFileSize(getAttachmentSize(m)!)}
-                                </p>
-                              )}
-                            </div>
-                            <Download className="h-4 w-4 text-muted-foreground shrink-0" />
-                          </a>
-                        )}
-                      </div>
-                    )}
+                    <MessageAttachment message={m} />
                     {/* Reactions */}
                     {user && !m.id.startsWith('temp-') && (
                       <MessageReactions

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInput.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInput.tsx
@@ -8,6 +8,7 @@ import { InputCard } from '@/components/ui/floating-input';
 import { ChatTextarea, type ChatTextareaRef } from '@/components/ai/chat/input/ChatTextarea';
 import { ChannelInputFooter } from './ChannelInputFooter';
 import { useAttachmentUpload, type FileAttachment } from '@/hooks/useAttachmentUpload';
+import { formatFileSize } from '@/lib/attachment-utils';
 
 export type { FileAttachment };
 
@@ -114,18 +115,10 @@ export const ChannelInput = forwardRef<ChannelInputRef, ChannelInputProps>(
       fileInputRef.current?.click();
     };
 
-    // Get icon for file type
     const getFileIcon = (mimeType: string) => {
       if (mimeType.startsWith('image/')) return ImageIcon;
       if (mimeType.includes('pdf') || mimeType.includes('document')) return FileText;
       return FileIcon;
-    };
-
-    // Format file size
-    const formatFileSize = (bytes: number) => {
-      if (bytes < 1024) return `${bytes} B`;
-      if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-      return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
     };
 
     // Handle formatting shortcuts

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInput.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInput.tsx
@@ -3,21 +3,13 @@
 import { forwardRef, useImperativeHandle, useRef, useState } from 'react';
 import { motion, useReducedMotion } from 'motion/react';
 import { ArrowUp, X, FileIcon, ImageIcon, FileText } from 'lucide-react';
-import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import { InputCard } from '@/components/ui/floating-input';
 import { ChatTextarea, type ChatTextareaRef } from '@/components/ai/chat/input/ChatTextarea';
 import { ChannelInputFooter } from './ChannelInputFooter';
-import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { useAttachmentUpload, type FileAttachment } from '@/hooks/useAttachmentUpload';
 
-// File attachment info returned from upload
-export interface FileAttachment {
-  id: string;
-  originalName: string;
-  size: number;
-  mimeType: string;
-  contentHash: string;
-}
+export type { FileAttachment };
 
 export interface ChannelInputProps {
   /** Current input value */
@@ -85,8 +77,11 @@ export const ChannelInput = forwardRef<ChannelInputRef, ChannelInputProps>(
     const fileInputRef = useRef<HTMLInputElement>(null);
     const shouldReduceMotion = useReducedMotion();
     const [isFocused, setIsFocused] = useState(false);
-    const [attachment, setAttachment] = useState<FileAttachment | null>(null);
-    const [isUploading, setIsUploading] = useState(false);
+
+    const { attachment, isUploading, uploadFile, clearAttachment } = useAttachmentUpload({
+      uploadUrl: channelId ? `/api/channels/${channelId}/upload` : null,
+      onUploaded: () => textareaRef.current?.focus(),
+    });
 
     useImperativeHandle(ref, () => ({
       focus: () => textareaRef.current?.focus(),
@@ -101,70 +96,22 @@ export const ChannelInput = forwardRef<ChannelInputRef, ChannelInputProps>(
     const handleSend = () => {
       if ((value.trim() || attachment) && !disabled && !isUploading) {
         onSend(attachment || undefined);
-        setAttachment(null);
+        clearAttachment();
       }
     };
 
-    // Handle file selection
     const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
       const file = e.target.files?.[0];
-      if (!file || !channelId) return;
-
-      setIsUploading(true);
+      if (!file) return;
       try {
-        const formData = new FormData();
-        formData.append('file', file);
-
-        const response = await fetchWithAuth(`/api/channels/${channelId}/upload`, {
-          method: 'POST',
-          body: formData,
-        });
-
-        if (!response.ok) {
-          const errorData = await response.json().catch(() => ({ error: 'Upload failed' }));
-          if (response.status === 413) {
-            toast.error(errorData.error || 'File too large');
-          } else if (response.status === 429) {
-            toast.error('Too many uploads in progress. Please wait.');
-          } else if (response.status === 503) {
-            toast.error('Server is busy. Please try again later.');
-          } else if (response.status === 403) {
-            toast.error(errorData.error || 'You do not have permission to upload files here.');
-          } else {
-            toast.error(errorData.error || 'Upload failed');
-          }
-          return;
-        }
-
-        const result = await response.json();
-        setAttachment({
-          id: result.file.id,
-          originalName: result.file.originalName,
-          size: result.file.size,
-          mimeType: result.file.mimeType,
-          contentHash: result.file.contentHash,
-        });
-        textareaRef.current?.focus();
-      } catch (error) {
-        console.error('Failed to upload file:', error);
-        toast.error('Failed to upload file. Please try again.');
+        await uploadFile(file);
       } finally {
-        setIsUploading(false);
-        // Reset file input
-        if (fileInputRef.current) {
-          fileInputRef.current.value = '';
-        }
+        if (fileInputRef.current) fileInputRef.current.value = '';
       }
     };
 
-    // Handle attachment button click
     const handleAttachmentClick = () => {
       fileInputRef.current?.click();
-    };
-
-    // Remove attachment
-    const handleRemoveAttachment = () => {
-      setAttachment(null);
     };
 
     // Get icon for file type
@@ -285,7 +232,7 @@ export const ChannelInput = forwardRef<ChannelInputRef, ChannelInputProps>(
                       <p className="text-xs text-muted-foreground">{formatFileSize(attachment.size)}</p>
                     </div>
                     <button
-                      onClick={handleRemoveAttachment}
+                      onClick={clearAttachment}
                       className="p-1 hover:bg-muted rounded"
                       title="Remove attachment"
                     >

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -11,7 +11,8 @@ import { StreamingMarkdown } from '@/components/ai/shared/chat/StreamingMarkdown
 import { ChannelInput, type ChannelInputRef, type FileAttachment } from './ChannelInput';
 import { MessageReactions, type Reaction } from './MessageReactions';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Lock, FileIcon, FileText, Download, Pencil, Trash2, Check, X, MoreHorizontal } from 'lucide-react';
+import { Lock, Pencil, Trash2, Check, X, MoreHorizontal } from 'lucide-react';
+import { MessageAttachment } from '@/components/shared/MessageAttachment';
 import { post, del, patch, fetchWithAuth } from '@/lib/auth/auth-fetch';
 import {
   DropdownMenu,
@@ -25,13 +26,6 @@ import { PullToRefresh } from '@/components/ui/pull-to-refresh';
 import {
   type AttachmentMeta,
   type FileRelation,
-  isImageAttachment,
-  getFileId,
-  getAttachmentName,
-  getAttachmentMimeType,
-  getAttachmentSize,
-  formatFileSize,
-  hasAttachment,
 } from '@/lib/attachment-utils';
 
 interface ChannelViewProps {
@@ -534,50 +528,7 @@ function ChannelView({ page }: ChannelViewProps) {
                                     />
                                   </div>
                                 ) : null}
-                                {/* File attachment */}
-                                {hasAttachment(m) && (
-                                  <div className="mt-2">
-                                    {isImageAttachment(m) ? (
-                                      <a
-                                        href={`/api/files/${getFileId(m)}/view?filename=${encodeURIComponent(getAttachmentName(m))}`}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        className="block max-w-sm"
-                                      >
-                                        {/* eslint-disable-next-line @next/next/no-img-element -- auth-gated API route; processor already optimizes on upload */}
-                                        <img
-                                          src={`/api/files/${getFileId(m)}/view`}
-                                          alt={getAttachmentName(m)}
-                                          className="rounded-lg max-h-64 object-contain border border-border/50"
-                                        />
-                                      </a>
-                                    ) : (
-                                      <a
-                                        href={`/api/files/${getFileId(m)}/download?filename=${encodeURIComponent(getAttachmentName(m))}`}
-                                        className="flex items-center gap-3 p-3 bg-muted/50 hover:bg-muted rounded-lg border border-border/50 max-w-sm transition-colors"
-                                      >
-                                        <div className="w-10 h-10 rounded bg-muted flex items-center justify-center shrink-0">
-                                          {getAttachmentMimeType(m).includes('pdf') ? (
-                                            <FileText className="h-5 w-5 text-red-500" />
-                                          ) : getAttachmentMimeType(m).includes('document') || getAttachmentMimeType(m).includes('word') ? (
-                                            <FileText className="h-5 w-5 text-blue-500" />
-                                          ) : (
-                                            <FileIcon className="h-5 w-5 text-muted-foreground" />
-                                          )}
-                                        </div>
-                                        <div className="flex-1 min-w-0">
-                                          <p className="text-sm font-medium truncate">{getAttachmentName(m)}</p>
-                                          {getAttachmentSize(m) != null && (
-                                            <p className="text-xs text-muted-foreground">
-                                              {formatFileSize(getAttachmentSize(m)!)}
-                                            </p>
-                                          )}
-                                        </div>
-                                        <Download className="h-4 w-4 text-muted-foreground shrink-0" />
-                                      </a>
-                                    )}
-                                  </div>
-                                )}
+                                <MessageAttachment message={m} />
                                 {/* Reactions */}
                                 {user && !m.id.startsWith('temp-') && (
                                   <MessageReactions

--- a/apps/web/src/components/shared/MessageAttachment.tsx
+++ b/apps/web/src/components/shared/MessageAttachment.tsx
@@ -1,0 +1,72 @@
+import { FileIcon, FileText, Download } from 'lucide-react';
+import {
+  type MessageWithAttachment,
+  isImageAttachment,
+  getFileId,
+  getAttachmentName,
+  getAttachmentMimeType,
+  getAttachmentSize,
+  formatFileSize,
+  hasAttachment,
+} from '@/lib/attachment-utils';
+
+interface MessageAttachmentProps {
+  message: MessageWithAttachment;
+}
+
+export function MessageAttachment({ message }: MessageAttachmentProps) {
+  if (!hasAttachment(message)) return null;
+
+  const fileId = getFileId(message);
+  const name = getAttachmentName(message);
+  const mimeType = getAttachmentMimeType(message);
+  const size = getAttachmentSize(message);
+
+  if (isImageAttachment(message)) {
+    return (
+      <div className="mt-2">
+        <a
+          href={`/api/files/${fileId}/view?filename=${encodeURIComponent(name)}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block max-w-sm"
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element -- auth-gated API route; processor already optimizes on upload */}
+          <img
+            src={`/api/files/${fileId}/view`}
+            alt={name}
+            className="rounded-lg max-h-64 object-contain border border-border/50"
+          />
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-2">
+      <a
+        href={`/api/files/${fileId}/download?filename=${encodeURIComponent(name)}`}
+        className="flex items-center gap-3 p-3 bg-muted/50 hover:bg-muted rounded-lg border border-border/50 max-w-sm transition-colors"
+      >
+        <div className="w-10 h-10 rounded bg-muted flex items-center justify-center shrink-0">
+          {mimeType.includes('pdf') ? (
+            <FileText className="h-5 w-5 text-red-500" />
+          ) : mimeType.includes('document') || mimeType.includes('word') ? (
+            <FileText className="h-5 w-5 text-blue-500" />
+          ) : (
+            <FileIcon className="h-5 w-5 text-muted-foreground" />
+          )}
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium truncate">{name}</p>
+          {size != null && (
+            <p className="text-xs text-muted-foreground">
+              {formatFileSize(size)}
+            </p>
+          )}
+        </div>
+        <Download className="h-4 w-4 text-muted-foreground shrink-0" />
+      </a>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/__tests__/useAttachmentUpload.test.ts
+++ b/apps/web/src/hooks/__tests__/useAttachmentUpload.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+const { mockFetchWithAuth, mockToast, startEditing, endEditing } = vi.hoisted(() => ({
+  mockFetchWithAuth: vi.fn(),
+  mockToast: { error: vi.fn(), success: vi.fn() },
+  startEditing: vi.fn(),
+  endEditing: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: (...args: unknown[]) => mockFetchWithAuth(...args),
+}));
+
+vi.mock('sonner', () => ({ toast: mockToast }));
+
+vi.mock('@/stores/useEditingStore', () => ({
+  useEditingStore: Object.assign(vi.fn(), {
+    getState: () => ({ startEditing, endEditing }),
+  }),
+}));
+
+import { useAttachmentUpload } from '../useAttachmentUpload';
+
+const fileResponse = {
+  file: {
+    id: 'file-1',
+    originalName: 'photo.png',
+    size: 1024,
+    mimeType: 'image/png',
+    contentHash: 'hash-1',
+  },
+};
+
+const okResponse = (body: unknown) => ({
+  ok: true,
+  status: 200,
+  json: async () => body,
+}) as unknown as Response;
+
+const errorResponse = (status: number, body: unknown = {}) => ({
+  ok: false,
+  status,
+  json: async () => body,
+}) as unknown as Response;
+
+const makeFile = () => new File(['data'], 'photo.png', { type: 'image/png' });
+
+describe('useAttachmentUpload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uploads a file, stores the attachment, and brackets the upload in startEditing/endEditing', async () => {
+    mockFetchWithAuth.mockResolvedValueOnce(okResponse(fileResponse));
+    const onUploaded = vi.fn();
+
+    const { result } = renderHook(() =>
+      useAttachmentUpload({ uploadUrl: '/api/x/upload', onUploaded })
+    );
+
+    await act(async () => {
+      await result.current.uploadFile(makeFile());
+    });
+
+    expect(mockFetchWithAuth).toHaveBeenCalledWith(
+      '/api/x/upload',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(result.current.attachment).toEqual({
+      id: 'file-1',
+      originalName: 'photo.png',
+      size: 1024,
+      mimeType: 'image/png',
+      contentHash: 'hash-1',
+    });
+    expect(result.current.isUploading).toBe(false);
+    expect(onUploaded).toHaveBeenCalledWith(result.current.attachment);
+    expect(startEditing).toHaveBeenCalledTimes(1);
+    expect(endEditing).toHaveBeenCalledTimes(1);
+    expect(startEditing.mock.calls[0][1]).toBe('form');
+  });
+
+  it('does nothing when uploadUrl is null', async () => {
+    const { result } = renderHook(() => useAttachmentUpload({ uploadUrl: null }));
+
+    await act(async () => {
+      await result.current.uploadFile(makeFile());
+    });
+
+    expect(mockFetchWithAuth).not.toHaveBeenCalled();
+    expect(startEditing).not.toHaveBeenCalled();
+    expect(result.current.attachment).toBeNull();
+  });
+
+  it('shows the file-too-large toast on 413 and leaves attachment null', async () => {
+    mockFetchWithAuth.mockResolvedValueOnce(
+      errorResponse(413, { error: 'File too large' })
+    );
+
+    const { result } = renderHook(() =>
+      useAttachmentUpload({ uploadUrl: '/api/x/upload' })
+    );
+
+    await act(async () => {
+      await result.current.uploadFile(makeFile());
+    });
+
+    expect(mockToast.error).toHaveBeenCalledWith('File too large');
+    expect(result.current.attachment).toBeNull();
+    expect(endEditing).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the editing session when the request throws', async () => {
+    mockFetchWithAuth.mockRejectedValueOnce(new Error('network'));
+
+    const { result } = renderHook(() =>
+      useAttachmentUpload({ uploadUrl: '/api/x/upload' })
+    );
+
+    await act(async () => {
+      await result.current.uploadFile(makeFile());
+    });
+
+    expect(mockToast.error).toHaveBeenCalledWith(
+      'Failed to upload file. Please try again.'
+    );
+    await waitFor(() => expect(result.current.isUploading).toBe(false));
+    expect(endEditing).toHaveBeenCalledTimes(1);
+  });
+
+  it('clearAttachment resets the stored attachment', async () => {
+    mockFetchWithAuth.mockResolvedValueOnce(okResponse(fileResponse));
+    const { result } = renderHook(() =>
+      useAttachmentUpload({ uploadUrl: '/api/x/upload' })
+    );
+
+    await act(async () => {
+      await result.current.uploadFile(makeFile());
+    });
+    expect(result.current.attachment).not.toBeNull();
+
+    act(() => result.current.clearAttachment());
+    expect(result.current.attachment).toBeNull();
+  });
+});

--- a/apps/web/src/hooks/__tests__/useAttachmentUpload.test.ts
+++ b/apps/web/src/hooks/__tests__/useAttachmentUpload.test.ts
@@ -143,4 +143,34 @@ describe('useAttachmentUpload', () => {
     act(() => result.current.clearAttachment());
     expect(result.current.attachment).toBeNull();
   });
+
+  it('drops a second uploadFile call while one is already in flight', async () => {
+    let resolveFirst: ((value: Response) => void) | null = null;
+    mockFetchWithAuth.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFirst = resolve;
+        })
+    );
+    mockFetchWithAuth.mockResolvedValueOnce(okResponse(fileResponse));
+
+    const { result } = renderHook(() =>
+      useAttachmentUpload({ uploadUrl: '/api/x/upload' })
+    );
+
+    let secondCall: Promise<void> | undefined;
+    await act(async () => {
+      void result.current.uploadFile(makeFile());
+      secondCall = result.current.uploadFile(makeFile());
+      await secondCall;
+    });
+
+    expect(mockFetchWithAuth).toHaveBeenCalledTimes(1);
+    expect(startEditing).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveFirst?.(okResponse(fileResponse));
+      await Promise.resolve();
+    });
+  });
 });

--- a/apps/web/src/hooks/useAttachmentUpload.ts
+++ b/apps/web/src/hooks/useAttachmentUpload.ts
@@ -26,22 +26,34 @@ interface UseAttachmentUploadReturn {
   clearAttachment: () => void;
 }
 
+interface UploadErrorBody {
+  error?: string;
+}
+
+interface UploadSuccessBody {
+  file: FileAttachment;
+}
+
 export function useAttachmentUpload({
   uploadUrl,
   onUploaded,
 }: UseAttachmentUploadOptions): UseAttachmentUploadReturn {
   const [attachment, setAttachment] = useState<FileAttachment | null>(null);
   const [isUploading, setIsUploading] = useState(false);
+  // Ref mirrors isUploading so concurrent uploadFile calls can early-return
+  // without waiting for the React state flush.
+  const isUploadingRef = useRef(false);
   const onUploadedRef = useRef(onUploaded);
   onUploadedRef.current = onUploaded;
 
   const uploadFile = useCallback(
     async (file: File) => {
-      if (!uploadUrl) return;
+      if (!uploadUrl || isUploadingRef.current) return;
 
       const sessionId = `attachment-upload-${createId()}`;
       const { startEditing, endEditing } = useEditingStore.getState();
 
+      isUploadingRef.current = true;
       setIsUploading(true);
       startEditing(sessionId, 'form', { componentName: 'useAttachmentUpload' });
 
@@ -55,9 +67,9 @@ export function useAttachmentUpload({
         });
 
         if (!response.ok) {
-          const errorData = await response
+          const errorData = (await response
             .json()
-            .catch(() => ({ error: 'Upload failed' }));
+            .catch(() => ({ error: 'Upload failed' }))) as UploadErrorBody;
           if (response.status === 413) {
             toast.error(errorData.error || 'File too large');
           } else if (response.status === 429) {
@@ -74,7 +86,7 @@ export function useAttachmentUpload({
           return;
         }
 
-        const result = await response.json();
+        const result = (await response.json()) as UploadSuccessBody;
         const next: FileAttachment = {
           id: result.file.id,
           originalName: result.file.originalName,
@@ -88,6 +100,7 @@ export function useAttachmentUpload({
         console.error('Failed to upload file:', error);
         toast.error('Failed to upload file. Please try again.');
       } finally {
+        isUploadingRef.current = false;
         setIsUploading(false);
         endEditing(sessionId);
       }

--- a/apps/web/src/hooks/useAttachmentUpload.ts
+++ b/apps/web/src/hooks/useAttachmentUpload.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useRef, useState } from 'react';
 import { toast } from 'sonner';
+import { createId } from '@paralleldrive/cuid2';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useEditingStore } from '@/stores/useEditingStore';
 
@@ -23,10 +24,7 @@ interface UseAttachmentUploadReturn {
   isUploading: boolean;
   uploadFile: (file: File) => Promise<void>;
   clearAttachment: () => void;
-  setAttachment: (attachment: FileAttachment | null) => void;
 }
-
-let sessionCounter = 0;
 
 export function useAttachmentUpload({
   uploadUrl,
@@ -41,7 +39,7 @@ export function useAttachmentUpload({
     async (file: File) => {
       if (!uploadUrl) return;
 
-      const sessionId = `attachment-upload-${++sessionCounter}-${Date.now()}`;
+      const sessionId = `attachment-upload-${createId()}`;
       const { startEditing, endEditing } = useEditingStore.getState();
 
       setIsUploading(true);
@@ -104,6 +102,5 @@ export function useAttachmentUpload({
     isUploading,
     uploadFile,
     clearAttachment,
-    setAttachment,
   };
 }

--- a/apps/web/src/hooks/useAttachmentUpload.ts
+++ b/apps/web/src/hooks/useAttachmentUpload.ts
@@ -1,0 +1,109 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { useEditingStore } from '@/stores/useEditingStore';
+
+export interface FileAttachment {
+  id: string;
+  originalName: string;
+  size: number;
+  mimeType: string;
+  contentHash: string;
+}
+
+interface UseAttachmentUploadOptions {
+  uploadUrl: string | null | undefined;
+  onUploaded?: (attachment: FileAttachment) => void;
+}
+
+interface UseAttachmentUploadReturn {
+  attachment: FileAttachment | null;
+  isUploading: boolean;
+  uploadFile: (file: File) => Promise<void>;
+  clearAttachment: () => void;
+  setAttachment: (attachment: FileAttachment | null) => void;
+}
+
+let sessionCounter = 0;
+
+export function useAttachmentUpload({
+  uploadUrl,
+  onUploaded,
+}: UseAttachmentUploadOptions): UseAttachmentUploadReturn {
+  const [attachment, setAttachment] = useState<FileAttachment | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const onUploadedRef = useRef(onUploaded);
+  onUploadedRef.current = onUploaded;
+
+  const uploadFile = useCallback(
+    async (file: File) => {
+      if (!uploadUrl) return;
+
+      const sessionId = `attachment-upload-${++sessionCounter}-${Date.now()}`;
+      const { startEditing, endEditing } = useEditingStore.getState();
+
+      setIsUploading(true);
+      startEditing(sessionId, 'form', { componentName: 'useAttachmentUpload' });
+
+      try {
+        const formData = new FormData();
+        formData.append('file', file);
+
+        const response = await fetchWithAuth(uploadUrl, {
+          method: 'POST',
+          body: formData,
+        });
+
+        if (!response.ok) {
+          const errorData = await response
+            .json()
+            .catch(() => ({ error: 'Upload failed' }));
+          if (response.status === 413) {
+            toast.error(errorData.error || 'File too large');
+          } else if (response.status === 429) {
+            toast.error('Too many uploads in progress. Please wait.');
+          } else if (response.status === 503) {
+            toast.error('Server is busy. Please try again later.');
+          } else if (response.status === 403) {
+            toast.error(
+              errorData.error || 'You do not have permission to upload files here.'
+            );
+          } else {
+            toast.error(errorData.error || 'Upload failed');
+          }
+          return;
+        }
+
+        const result = await response.json();
+        const next: FileAttachment = {
+          id: result.file.id,
+          originalName: result.file.originalName,
+          size: result.file.size,
+          mimeType: result.file.mimeType,
+          contentHash: result.file.contentHash,
+        };
+        setAttachment(next);
+        onUploadedRef.current?.(next);
+      } catch (error) {
+        console.error('Failed to upload file:', error);
+        toast.error('Failed to upload file. Please try again.');
+      } finally {
+        setIsUploading(false);
+        endEditing(sessionId);
+      }
+    },
+    [uploadUrl]
+  );
+
+  const clearAttachment = useCallback(() => setAttachment(null), []);
+
+  return {
+    attachment,
+    isUploading,
+    uploadFile,
+    clearAttachment,
+    setAttachment,
+  };
+}

--- a/apps/web/src/lib/attachment-utils.ts
+++ b/apps/web/src/lib/attachment-utils.ts
@@ -12,7 +12,7 @@ export interface FileRelation {
   sizeBytes: number;
 }
 
-interface MessageWithAttachment {
+export interface MessageWithAttachment {
   fileId?: string | null;
   attachmentMeta?: AttachmentMeta | null;
   file?: FileRelation | null;

--- a/apps/web/src/lib/attachment-utils.ts
+++ b/apps/web/src/lib/attachment-utils.ts
@@ -3,12 +3,8 @@
  * Used by both the inbox channel page and the ChannelView component.
  */
 
-export interface AttachmentMeta {
-  originalName: string;
-  size: number;
-  mimeType: string;
-  contentHash: string;
-}
+import type { AttachmentMeta } from '@pagespace/lib/types';
+export type { AttachmentMeta };
 
 export interface FileRelation {
   id: string;

--- a/packages/db/src/schema/chat.ts
+++ b/packages/db/src/schema/chat.ts
@@ -2,7 +2,7 @@ import { pgTable, text, timestamp, jsonb, boolean, index, uniqueIndex, primaryKe
 import { relations } from 'drizzle-orm';
 import { users } from './auth';
 import { pages, drives } from './core';
-import { files } from './storage';
+import { files, type AttachmentMeta } from './storage';
 import { createId } from '@paralleldrive/cuid2';
 
 export const channelMessages = pgTable('channel_messages', {
@@ -13,13 +13,7 @@ export const channelMessages = pgTable('channel_messages', {
   userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),
   // File attachment (optional)
   fileId: text('fileId').references(() => files.id, { onDelete: 'set null' }),
-  // Attachment metadata: {originalName, size, mimeType, contentHash}
-  attachmentMeta: jsonb('attachmentMeta').$type<{
-    originalName: string;
-    size: number;
-    mimeType: string;
-    contentHash: string;
-  } | null>(),
+  attachmentMeta: jsonb('attachmentMeta').$type<AttachmentMeta | null>(),
   // Soft-delete flag for rollback support (matches messages/chatMessages pattern)
   isActive: boolean('isActive').default(true).notNull(),
   editedAt: timestamp('editedAt', { mode: 'date' }),

--- a/packages/db/src/schema/storage.ts
+++ b/packages/db/src/schema/storage.ts
@@ -3,6 +3,13 @@ import { relations } from 'drizzle-orm';
 import { drives, pages } from './core';
 import { users } from './auth';
 
+export interface AttachmentMeta {
+  originalName: string;
+  size: number;
+  mimeType: string;
+  contentHash: string;
+}
+
 export const files = pgTable('files', {
   id: text('id').primaryKey(),
   driveId: text('driveId')

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -1,5 +1,7 @@
 import { PageType, PermissionAction } from './utils/enums';
 
+export type { AttachmentMeta } from '@pagespace/db/schema/storage';
+
 // JSON-compatible value types for structured data (logging, metadata, etc.)
 export type JsonPrimitive = string | number | boolean | null;
 export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };

--- a/plan.md
+++ b/plan.md
@@ -2,6 +2,7 @@
 
 ## Active Epics
 
+- [DM File Attachments](tasks/dm-file-attachments.md) — bring DM conversations to channel parity for file attachments via a `fileConversations` join table, nullable `files.driveId`, and shared upload/token/processor/composer/renderer infrastructure.
 - [Multiplayer AI Chat Streaming](tasks/multiplayer-ai-chat-streaming.md) — Socket-notified, HTTP-joined AI stream sharing: all page viewers see live ghost text and "X is waiting for AI response…" indicators in real-time.
 - [AI Chat Send Flash Fix](tasks/ai-chat-send-flash-fix.md) — eliminate stream-abort and flash on send; stabilise `chatConfig` deps and extend `invalidateTree` guard to cover all active states.
 - [E2E and Load Testing](tasks/e2e-and-load-testing.md) — Playwright e2e for core user journeys + k6 load scenarios with Grafana dashboard for API latency and Postgres pool monitoring.

--- a/tasks/dm-file-attachments.md
+++ b/tasks/dm-file-attachments.md
@@ -1,0 +1,134 @@
+# DM File Attachments Epic
+
+**Status**: 📋 PLANNED
+**Goal**: Let users send each other files in DM conversations at feature parity with channels.
+
+## Overview
+
+Channels already support file attachments end-to-end (schema, upload, renderer, realtime). DMs cannot — `directMessages` has only `content: text`, and `files.driveId` is `NOT NULL`, but `dmConversations` lives outside any drive. The processor and storage layer are already content-hash addressed and the storage quota is already user-scoped, so the obstacle is a schema-level scoping rule plus the wiring on top of it. This epic extends `files` with a `fileConversations` join table (mirroring `filePages`) and makes `driveId` nullable, then lands four DRY refactors before any DM-specific code so channels and DMs share a single upload core, service-token issuer, processor binding, composer hook, and renderer component.
+
+---
+
+## Centralize AttachmentMeta type
+
+Define `AttachmentMeta` once in `packages/lib/src/types.ts` and import on both `channelMessages.attachmentMeta` and `directMessages.attachmentMeta` JSONB columns.
+
+**Requirements**:
+- Given the existing `channelMessages` table, schema and tests should still typecheck against the imported type with zero behavior change.
+
+---
+
+## Extract MessageAttachment shared component
+
+Pull the attachment block from `ChannelView.tsx:537-580` into `apps/web/src/components/shared/MessageAttachment.tsx`, consumed by both channel and DM message renderers.
+
+**Requirements**:
+- Given a message with `fileId` + `attachmentMeta`, should render image preview or download card pixel-identically to today's ChannelView.
+- Given the existing channel attachment tests, should still pass without modification.
+
+---
+
+## Extract useAttachmentUpload hook
+
+Pull drag-drop / paste / file-picker / optimistic-state / error-handling out of `ChannelInput.tsx` into `apps/web/src/hooks/useAttachmentUpload.ts`, parameterized by upload URL.
+
+**Requirements**:
+- Given an in-flight upload, the hook should register state with `useEditingStore` so SWR cannot clobber the pending upload.
+- Given the channel composer after refactor, should behave identically to today across drag, paste, picker, error, and optimistic-state flows.
+
+---
+
+## Polymorphic attachment-upload core
+
+Introduce `AttachmentTarget = { type: 'page'; pageId; driveId } | { type: 'conversation'; conversationId }`, a single `createAttachmentUploadServiceToken({ userId, target })`, a single `processAttachmentUpload({ request, target })` in `packages/lib/src/services/attachment-upload.ts`, and a polymorphic dispatch in `apps/processor/src/api/upload.ts:124`. The channel upload route is rewritten as a thin wrapper.
+
+**Requirements**:
+- Given a page target, channel upload should behave identically to today end-to-end.
+- Given a conversation target with a non-participant user, the service-token mint should fail before reaching the processor.
+- Given the polymorphic processor handler, an unknown target type should reject with 400 rather than crashing or defaulting.
+- Given a conversation-target upload, the processor should write the file with `driveId = NULL` and a `fileConversations` linkage instead of `filePages`.
+
+---
+
+## Schema: nullable driveId, fileConversations, DM message attachment fields
+
+Modify `packages/db/src/schema/storage.ts` and `packages/db/src/schema/social.ts`; generate via `pnpm db:generate`.
+
+**Requirements**:
+- Given a file uploaded with no drive context, should persist with `driveId = NULL` and a row in `fileConversations`.
+- Given an existing channel-attached file, the migration should leave it unchanged with `driveId` populated and no `fileConversations` row.
+- Given a deleted DM conversation, `fileConversations` rows should cascade-delete while `files` rows should NOT — orphan GC handles them.
+- Given a deleted DM message, the `directMessages.fileId` reference should `SET NULL` so other messages and the conversation linkage survive.
+
+---
+
+## Permission helper: conversation-linked file access
+
+Update `canUserAccessFile()` to accept a nullable `driveId` and add a second linkage branch for `fileConversations`. NO new file-serving routes — `/api/files/[id]/{view,download}` generalize once the helper updates.
+
+**Requirements**:
+- Given Alice and Bob in a DM with an attached file, both should access it via the existing `/api/files/[id]/...` routes.
+- Given Carol who is not a participant, should be denied access.
+- Given a file linked to both a page and a conversation, should grant access if either path qualifies, without leaking page access to non-page-viewers or conversation membership to non-participants.
+- Given a file with no linkages and `driveId === null`, should be denied (no fall-through to "anyone can see it").
+
+---
+
+## DM upload route
+
+Create `apps/web/src/app/api/messages/[conversationId]/upload/route.ts` as a thin wrapper that builds a conversation `AttachmentTarget` and delegates to `processAttachmentUpload`.
+
+**Requirements**:
+- Given a non-participant uploads to a conversation, should return 403.
+- Given an unverified email, should return 403 with `requiresEmailVerification: true` matching DM POST behavior.
+- Given storage quota exceeded, should return 413 at parity with channel upload.
+- Given a successful upload, the response shape should match channel upload exactly so the shared `useAttachmentUpload` hook needs no per-target branching.
+
+---
+
+## DM POST accepts file and broadcast carries it
+
+Update `apps/web/src/app/api/messages/[conversationId]/route.ts` POST to accept optional `fileId` + `attachmentMeta`, validate ownership and conversation linkage, persist on `directMessages`, and include both fields in the existing `new_dm_message` realtime payload and inbox event.
+
+**Requirements**:
+- Given a DM with only a file (empty `content`), should be accepted and rendered without an empty-string artifact.
+- Given a `fileId` for a file the sender did not upload, should return 403.
+- Given a `fileId` for a file not linked to this conversation, should return 403 (prevents cross-DM file smuggling).
+- Given a delivered DM with a file, the receiver's client should receive the full payload over Socket.IO without an extra fetch.
+- Given a DM whose only payload is an attachment, `dmConversations.lastMessagePreview` should render a synthetic preview (`[image: name.png]` or `[file: name.pdf]`) so inbox lists are meaningful.
+
+---
+
+## DM UI composer and renderer
+
+Update `apps/web/src/components/messages/ChatInput.tsx` to consume `useAttachmentUpload` against the DM upload route, and render attachments via the shared `MessageAttachment` component.
+
+**Requirements**:
+- Given a user pastes, drops, or picks a file in the DM composer, should upload optimistically and send on submit with the same UX as channels.
+- Given a received DM with an image, should render a clickable thumbnail; with a non-image, should render the download card — pixel-identical to channels.
+
+---
+
+## Lifecycle and orphan GC
+
+Soft-delete a DM message via `directMessages.isActive = false`. Find the existing orphan-file GC and extend its predicate; do NOT introduce a new GC.
+
+**Requirements**:
+- Given a deleted conversation whose attached files are not linked elsewhere, the GC should reclaim the rows and blobs and decrement the uploader's `users.storageUsedBytes` by exactly `sizeBytes` per file.
+- Given a deleted conversation containing a file also linked to a still-live page or another conversation, neither the `files` row nor the blob should be reclaimed.
+- Given a soft-deleted DM message, the file and its `fileConversations` row should remain so other messages and inbox previews are not broken.
+
+---
+
+## Tests
+
+TDD per `references/tdd.md`; colocate with source.
+
+**Requirements**:
+- Given the new `canUserAccessFile` branch, should have tests for participant-grant, non-participant-deny, dual-linked isolation, and unlinked-null-drive deny.
+- Given the polymorphic service-token issuer, should have tests for page-branch parity, conversation-branch participant validation, and unknown-type rejection.
+- Given `processAttachmentUpload`, should have tests for happy path on both target types, quota gate, and email-verification gate.
+- Given DM POST with `fileId`, should have tests for happy path, cross-conversation rejection, and non-owner rejection.
+- Given the orphan GC, should have tests for both reclaim and no-reclaim paths.
+
+---

--- a/tasks/dm-file-attachments.md
+++ b/tasks/dm-file-attachments.md
@@ -11,7 +11,7 @@ Channels already support file attachments end-to-end (schema, upload, renderer, 
 
 ## Centralize AttachmentMeta type
 
-Define `AttachmentMeta` once in `packages/lib/src/types.ts` and import on both `channelMessages.attachmentMeta` and `directMessages.attachmentMeta` JSONB columns.
+Define `AttachmentMeta` once in `packages/db/src/schema/storage.ts` (next to `files`; canonical owner), re-export it from `packages/lib/src/types.ts` for non-db consumers, and import on both `channelMessages.attachmentMeta` and `directMessages.attachmentMeta` JSONB columns. Keeping the canonical type in db avoids the `db → lib → db` cycle.
 
 **Requirements**:
 - Given the existing `channelMessages` table, schema and tests should still typecheck against the imported type with zero behavior change.


### PR DESCRIPTION
## Summary

Pure-refactor groundwork for DM file attachments — Tasks 1–3 of the [DM File Attachments epic](tasks/dm-file-attachments.md). Channels adopt three shared modules so the second caller (DM upload route in PR 2) drops in as a thin wrapper.

- **One canonical `AttachmentMeta` type** (was 3 copies — db schema, attachment-utils, channel messages route). Lives in `packages/db/src/schema/storage.ts` next to `files`; re-exported from `@pagespace/lib/types` for non-db consumers.
- **One `MessageAttachment` component** (was 2 copies of a 50-line block — `ChannelView.tsx` + `inbox/channel/[pageId]/page.tsx`). Pixel-identical output by construction.
- **One `useAttachmentUpload` hook** with `useEditingStore` registration so SWR cannot clobber an in-flight upload — closes a latent gap that affected channels too. `ChannelInput.tsx` is ~75 lines lighter.
- **5 colocated unit tests** for the new hook covering happy path, null-URL no-op, 413 toast, thrown-error session release, and `clearAttachment`. The original inline upload logic was untested; this is the right moment to lock the contract once for both channels and DMs.

Zero behavior change: channel rendering, channel upload, and channel send all work identically.

## Out of scope (deliberate, lands in PR 2)

- `AttachmentTarget` discriminated union — the abstraction is only meaningful with a second caller, which only appears in PR 2 (DM upload route). Keeping it out of this PR avoids forcing reviewers to imagine a future branch.
- `fileConversations` schema migration, `files.driveId` nullability, DM upload endpoint, DM POST acceptance of `fileId`, DM composer wiring. All planned in `tasks/dm-file-attachments.md`.

## Test plan

- [x] `pnpm turbo typecheck lint` — 4/4 tasks pass, no new warnings
- [x] `vitest run src/hooks/__tests__/useAttachmentUpload.test.ts` — 5/5 pass (new)
- [x] `vitest run src/lib/ai/tools/__tests__/channel-tools.test.ts` — 11/11 pass
- [ ] Manual: open a channel, pick a file via the attachment button → image preview renders inline; non-image renders as download card
- [ ] Manual: open `/dashboard/inbox/channel/[id]`, scroll history with mixed image/file attachments → identical to today
- [ ] Manual: start a slow upload, confirm SWR refresh doesn't clear the pending preview mid-upload (new behavior — uses `useEditingStore`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated attachment handling infrastructure by centralizing attachment metadata type definitions across the application.
  * Extracted shared attachment upload logic into a reusable hook with improved error handling and user feedback for file upload operations.
  * Created a unified attachment rendering component to ensure consistent behavior for file preview and download functionality across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->