### PR TITLE
feat(streams): bring GlobalAssistantView agent mode + SidebarChatTab to multiplayer parity

### DIFF
--- a/apps/realtime/src/index.ts
+++ b/apps/realtime/src/index.ts
@@ -19,6 +19,7 @@ import {
   emitValidationError,
 } from './validation';
 import { loggers } from '@pagespace/lib/logging/logger-config';
+import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
 import { socketRegistry } from './socket-registry';
 import { handleKickRequest } from './kick-handler';
 import { presenceTracker, type PresenceViewer } from './presence-tracker';
@@ -490,7 +491,7 @@ io.on('connection', (socket: AuthSocket) => {
     const taskRoom = `user:${user.id}:tasks`;
     const calendarRoom = `user:${user.id}:calendar`;
     const userDrivesRoom = `user:${user.id}:drives`;
-    const globalRoom = `user:${user.id}:global`;
+    const globalRoom = globalChannelId(user.id);
     socket.join(notificationRoom);
     socket.join(taskRoom);
     socket.join(calendarRoom);

--- a/apps/web/src/app/api/ai/chat/active-streams/route.ts
+++ b/apps/web/src/app/api/ai/chat/active-streams/route.ts
@@ -6,6 +6,7 @@ import { and, asc, eq, gte } from '@pagespace/db/operators';
 import { aiStreamSessions } from '@pagespace/db/schema/ai-streams';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { parseGlobalChannelId } from '@pagespace/lib/ai/global-channel-id';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
 
@@ -31,9 +32,9 @@ export async function GET(request: Request) {
       return NextResponse.json({ error: 'channelId is required' }, { status: 400 });
     }
 
-    const globalMatch = channelId.match(/^user:(.+):global$/);
-    if (globalMatch) {
-      if (globalMatch[1] !== userId) {
+    const channelOwnerUserId = parseGlobalChannelId(channelId);
+    if (channelOwnerUserId !== null) {
+      if (channelOwnerUserId !== userId) {
         auditRequest(request, {
           eventType: 'authz.access.denied',
           userId,

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -8,6 +8,7 @@ import { createRateLimitResponse } from '@/lib/subscription/rate-limit-middlewar
 import { broadcastUsageEvent } from '@/lib/websocket';
 import { createStreamLifecycle, type StreamLifecycleHandle } from '@/lib/ai/core/stream-lifecycle';
 import { validateBrowserSessionIdHeader } from '@/lib/ai/core/browser-session-id-validation';
+import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import {
   createAIProvider,
@@ -832,7 +833,7 @@ MENTION PROCESSING:
     const { streamId, signal: abortSignal } = createStreamAbortController({ userId, messageId: serverAssistantMessageId });
     activeStreamId = streamId;
 
-    const channelId = `user:${userId}:global`;
+    const channelId = globalChannelId(userId);
 
     const [authUserResult, profileResult] = await Promise.allSettled([
       db

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -71,6 +71,7 @@ import { abortActiveStream, clearActiveStreamId } from '@/lib/ai/core/client';
 import { useAppStateRecovery } from '@/hooks/useAppStateRecovery';
 import { isEditingActive } from '@/stores/useEditingStore';
 import { useAgentChannelMultiplayer } from '@/hooks/useAgentChannelMultiplayer';
+import { selectChannelRemoteStreams } from '@/lib/ai/streams/selectChannelRemoteStreams';
 import {
   ProviderSetupCard,
 } from '@/components/ai/shared/chat';
@@ -125,26 +126,19 @@ const GlobalAssistantView: React.FC = () => {
   const setAgentStopStreaming = usePageAgentDashboardStore((state) => state.setAgentStopStreaming);
   const setActiveTab = usePageAgentDashboardStore((state) => state.setActiveTab);
 
-  // Remote in-progress streams for the active chat. The selector picks the
-  // right channel — agent mode reads `selectedAgent.id`; global mode reads
-  // `user:USERID:global` — and filters by the active conversation so that
-  // concurrent streams in other conversations on the same channel are hidden.
-  // PendingStream.pageId holds the channel id (the `pageId` name is legacy;
-  // it's the bus key, not necessarily a page).
+  // Remote in-progress streams for the active chat — channel + filter logic
+  // lives in the pure helper so both this view and the sidebar share one
+  // tested implementation.
   const globalChannelId = user?.id ? `user:${user.id}:global` : null;
   const remoteStreams = usePendingStreamsStore(
-    useShallow((state) => {
-      if (selectedAgent) {
-        if (!agentConversationId) return [];
-        return state
-          .getRemotePageStreams(selectedAgent.id)
-          .filter((s) => s.conversationId === agentConversationId);
-      }
-      if (!globalChannelId || !globalConversationId) return [];
-      return state
-        .getRemotePageStreams(globalChannelId)
-        .filter((s) => s.conversationId === globalConversationId);
-    })
+    useShallow((state) =>
+      selectChannelRemoteStreams(state, {
+        selectedAgent,
+        agentConversationId,
+        globalChannelId,
+        globalConversationId,
+      }),
+    ),
   );
 
   // ============================================

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -126,6 +126,7 @@ const GlobalAssistantView: React.FC = () => {
   const setAgentStreaming = usePageAgentDashboardStore((state) => state.setAgentStreaming);
   const setAgentStopStreaming = usePageAgentDashboardStore((state) => state.setAgentStopStreaming);
   const setActiveTab = usePageAgentDashboardStore((state) => state.setActiveTab);
+  const loadAgentConversation = usePageAgentDashboardStore((state) => state.loadConversation);
 
   // Remote in-progress streams for the active chat — channel + filter logic
   // lives in the pure helper so both this view and the sidebar share one
@@ -619,6 +620,7 @@ const GlobalAssistantView: React.FC = () => {
     setLocalMessages: setAgentMessages,
     isLocallyStreaming: isStreaming,
     surfaceComponentName: 'GlobalAssistantView',
+    loadConversation: loadAgentConversation,
   });
 
   // Register streaming state with editing store

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -72,6 +72,7 @@ import { useAppStateRecovery } from '@/hooks/useAppStateRecovery';
 import { isEditingActive } from '@/stores/useEditingStore';
 import { useAgentChannelMultiplayer } from '@/hooks/useAgentChannelMultiplayer';
 import { selectChannelRemoteStreams } from '@/lib/ai/streams/selectChannelRemoteStreams';
+import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
 import {
   ProviderSetupCard,
 } from '@/components/ai/shared/chat';
@@ -129,13 +130,13 @@ const GlobalAssistantView: React.FC = () => {
   // Remote in-progress streams for the active chat — channel + filter logic
   // lives in the pure helper so both this view and the sidebar share one
   // tested implementation.
-  const globalChannelId = user?.id ? `user:${user.id}:global` : null;
+  const channelIdForGlobal = user?.id ? globalChannelId(user.id) : null;
   const remoteStreams = usePendingStreamsStore(
     useShallow((state) =>
       selectChannelRemoteStreams(state, {
         selectedAgent,
         agentConversationId,
-        globalChannelId,
+        globalChannelId: channelIdForGlobal,
         globalConversationId,
       }),
     ),

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -68,18 +68,9 @@ import {
   LocationContext,
 } from '@/lib/ai/shared';
 import { abortActiveStream, clearActiveStreamId } from '@/lib/ai/core/client';
-import { abortActiveStreamByMessageId } from '@/lib/ai/core/stream-abort-client';
 import { useAppStateRecovery } from '@/hooks/useAppStateRecovery';
 import { isEditingActive } from '@/stores/useEditingStore';
-import { usePageSocketRoom } from '@/hooks/usePageSocketRoom';
-import { useChannelStreamSocket } from '@/hooks/useChannelStreamSocket';
-import { useSocketStore } from '@/stores/useSocketStore';
-import { synthesizeAssistantMessage } from '@/lib/ai/streams/synthesizeAssistantMessage';
-import { shouldClaimAgentStopSlot } from '@/lib/ai/streams/shouldClaimAgentStopSlot';
-import {
-  shouldRefreshOnReconnect,
-  type ConnectionStatus,
-} from '@/lib/ai/streams/shouldRefreshOnReconnect';
+import { useAgentChannelMultiplayer } from '@/hooks/useAgentChannelMultiplayer';
 import {
   ProviderSetupCard,
 } from '@/components/ai/shared/chat';
@@ -623,91 +614,17 @@ const GlobalAssistantView: React.FC = () => {
     };
   }, [selectedAgent, agentStatus, agentStop, agentConversationId, setAgentStopStreaming]);
 
-  // ============================================
-  // AGENT MODE — multiplayer stream socket (Tasks 2 + 5 + 6)
-  // ============================================
-
-  // Channel-room subscription so chat:stream_start/_complete events land here.
-  usePageSocketRoom(selectedAgent?.id);
-
-  // Stable ref so the hook's onStreamComplete sees the latest setMessages
-  // without re-binding the socket subscription on every render.
-  const setAgentMessagesRef = useRef(setAgentMessages);
-  setAgentMessagesRef.current = setAgentMessages;
-
-  // Single-writer guard for the dashboard store's stop-streaming slot. This
-  // view's onOwnStreamFinalize only clears the slot if THIS view claimed it
-  // — preserving whichever surface (dashboard or sidebar agent mode) wrote
-  // first when both are co-mounted on the same agent.
-  const agentOwnedStopSlotRef = useRef(false);
-
-  useChannelStreamSocket(selectedAgent?.id, {
-    // Local synthesis on stream completion. No `${id}-default` placeholder
-    // branch: the dashboard store is loaded with a real conversationId by
-    // loadMostRecentConversation before bootstrap returns.
-    onStreamComplete: (messageId) => {
-      if (!selectedAgent) return;
-      const stream = usePendingStreamsStore.getState().streams.get(messageId);
-      if (!stream?.text) return;
-      if (stream.conversationId !== agentConversationId) return;
-      setAgentMessagesRef.current((prev) => [
-        ...prev,
-        synthesizeAssistantMessage(messageId, stream.text),
-      ]);
-    },
-    onOwnStreamBootstrap: ({ messageId }) => {
-      const current = usePageAgentDashboardStore.getState();
-      if (!shouldClaimAgentStopSlot(current.agentStopStreaming)) return;
-      agentOwnedStopSlotRef.current = true;
-      setAgentStreaming(true);
-      setAgentStopStreaming(() => () => {
-        abortActiveStreamByMessageId({ messageId });
-      });
-    },
-    onOwnStreamFinalize: () => {
-      if (!agentOwnedStopSlotRef.current) return;
-      agentOwnedStopSlotRef.current = false;
-      setAgentStreaming(false);
-      setAgentStopStreaming(null);
-    },
+  // Agent-mode multiplayer wiring (Tasks 2 + 5 + 6). No-op when selectedAgent
+  // is null. Encapsulates page-room subscription, stream bootstrap/socket
+  // events, dashboard-store stop-slot single-writer claim, channel-id-keyed
+  // editing-store registration, and reconnect-refresh.
+  useAgentChannelMultiplayer({
+    selectedAgent,
+    agentConversationId,
+    setLocalMessages: setAgentMessages,
+    isLocallyStreaming: isStreaming,
+    surfaceComponentName: 'GlobalAssistantView',
   });
-
-  // Channel-id-keyed editing-store registration for agent mode. Sidebar agent
-  // mode (Task 4) will register the same `ai-channel-${id}` key when
-  // co-mounted on the same agent — the editing store dedups same-key writes
-  // naturally. The bool merges useChat-driven streaming with the
-  // bootstrap-replay flag in the dashboard store so a mid-stream refresh
-  // stays protected before useChat re-engages.
-  const dashboardAgentStreaming = usePageAgentDashboardStore((s) => s.isAgentStreaming);
-  useStreamingRegistration(
-    selectedAgent ? `ai-channel-${selectedAgent.id}` : 'ai-channel-no-agent',
-    Boolean(selectedAgent) && (isStreaming || dashboardAgentStreaming),
-    selectedAgent
-      ? { conversationId: agentConversationId || undefined, componentName: 'GlobalAssistantView' }
-      : undefined,
-  );
-
-  // Reconnect-refresh: re-fetch the active agent conversation when the socket
-  // transitions back to connected. Skipped on the very first connect (already
-  // covered by mount-time load).
-  const socketConnectionStatus = useSocketStore((s) => s.connectionStatus);
-  const prevAgentConnectionStatusRef = useRef<ConnectionStatus | null>(null);
-  const agentHasInitialConnectRef = useRef(false);
-  const loadAgentConversation = usePageAgentDashboardStore((state) => state.loadConversation);
-  useEffect(() => {
-    if (!selectedAgent) return;
-    const prev = prevAgentConnectionStatusRef.current;
-    prevAgentConnectionStatusRef.current = socketConnectionStatus;
-    if (
-      shouldRefreshOnReconnect(prev, socketConnectionStatus, agentHasInitialConnectRef.current)
-      && agentConversationId
-    ) {
-      loadAgentConversation(agentConversationId);
-    }
-    if (prev !== 'connected' && socketConnectionStatus === 'connected') {
-      agentHasInitialConnectRef.current = true;
-    }
-  }, [selectedAgent, socketConnectionStatus, agentConversationId, loadAgentConversation]);
 
   // Register streaming state with editing store
   useStreamingRegistration(

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -68,8 +68,18 @@ import {
   LocationContext,
 } from '@/lib/ai/shared';
 import { abortActiveStream, clearActiveStreamId } from '@/lib/ai/core/client';
+import { abortActiveStreamByMessageId } from '@/lib/ai/core/stream-abort-client';
 import { useAppStateRecovery } from '@/hooks/useAppStateRecovery';
 import { isEditingActive } from '@/stores/useEditingStore';
+import { usePageSocketRoom } from '@/hooks/usePageSocketRoom';
+import { useChannelStreamSocket } from '@/hooks/useChannelStreamSocket';
+import { useSocketStore } from '@/stores/useSocketStore';
+import { synthesizeAssistantMessage } from '@/lib/ai/streams/synthesizeAssistantMessage';
+import { shouldClaimAgentStopSlot } from '@/lib/ai/streams/shouldClaimAgentStopSlot';
+import {
+  shouldRefreshOnReconnect,
+  type ConnectionStatus,
+} from '@/lib/ai/streams/shouldRefreshOnReconnect';
 import {
   ProviderSetupCard,
 } from '@/components/ai/shared/chat';
@@ -124,18 +134,22 @@ const GlobalAssistantView: React.FC = () => {
   const setAgentStopStreaming = usePageAgentDashboardStore((state) => state.setAgentStopStreaming);
   const setActiveTab = usePageAgentDashboardStore((state) => state.setActiveTab);
 
-  // Remote in-progress streams for the active chat. Filtered by:
-  //   1. Mode — agent mode subscribes to a per-agent channel elsewhere; here we
-  //      only render global-channel streams, so return [] when an agent is selected.
-  //   2. Conversation — the global channel may carry concurrent streams from
-  //      other global conversations; only show streams matching the current one.
-  // Note: PendingStream.pageId holds the channel id (e.g. `user:USERID:global`)
-  // for non-page channels. Renaming the field is tracked as separate tech debt;
-  // until then, the channel string is what gets passed to getRemotePageStreams.
+  // Remote in-progress streams for the active chat. The selector picks the
+  // right channel — agent mode reads `selectedAgent.id`; global mode reads
+  // `user:USERID:global` — and filters by the active conversation so that
+  // concurrent streams in other conversations on the same channel are hidden.
+  // PendingStream.pageId holds the channel id (the `pageId` name is legacy;
+  // it's the bus key, not necessarily a page).
   const globalChannelId = user?.id ? `user:${user.id}:global` : null;
   const remoteStreams = usePendingStreamsStore(
     useShallow((state) => {
-      if (selectedAgent || !globalChannelId || !globalConversationId) return [];
+      if (selectedAgent) {
+        if (!agentConversationId) return [];
+        return state
+          .getRemotePageStreams(selectedAgent.id)
+          .filter((s) => s.conversationId === agentConversationId);
+      }
+      if (!globalChannelId || !globalConversationId) return [];
       return state
         .getRemotePageStreams(globalChannelId)
         .filter((s) => s.conversationId === globalConversationId);
@@ -608,6 +622,92 @@ const GlobalAssistantView: React.FC = () => {
       setAgentStopStreaming(null);
     };
   }, [selectedAgent, agentStatus, agentStop, agentConversationId, setAgentStopStreaming]);
+
+  // ============================================
+  // AGENT MODE — multiplayer stream socket (Tasks 2 + 5 + 6)
+  // ============================================
+
+  // Channel-room subscription so chat:stream_start/_complete events land here.
+  usePageSocketRoom(selectedAgent?.id);
+
+  // Stable ref so the hook's onStreamComplete sees the latest setMessages
+  // without re-binding the socket subscription on every render.
+  const setAgentMessagesRef = useRef(setAgentMessages);
+  setAgentMessagesRef.current = setAgentMessages;
+
+  // Single-writer guard for the dashboard store's stop-streaming slot. This
+  // view's onOwnStreamFinalize only clears the slot if THIS view claimed it
+  // — preserving whichever surface (dashboard or sidebar agent mode) wrote
+  // first when both are co-mounted on the same agent.
+  const agentOwnedStopSlotRef = useRef(false);
+
+  useChannelStreamSocket(selectedAgent?.id, {
+    // Local synthesis on stream completion. No `${id}-default` placeholder
+    // branch: the dashboard store is loaded with a real conversationId by
+    // loadMostRecentConversation before bootstrap returns.
+    onStreamComplete: (messageId) => {
+      if (!selectedAgent) return;
+      const stream = usePendingStreamsStore.getState().streams.get(messageId);
+      if (!stream?.text) return;
+      if (stream.conversationId !== agentConversationId) return;
+      setAgentMessagesRef.current((prev) => [
+        ...prev,
+        synthesizeAssistantMessage(messageId, stream.text),
+      ]);
+    },
+    onOwnStreamBootstrap: ({ messageId }) => {
+      const current = usePageAgentDashboardStore.getState();
+      if (!shouldClaimAgentStopSlot(current.agentStopStreaming)) return;
+      agentOwnedStopSlotRef.current = true;
+      setAgentStreaming(true);
+      setAgentStopStreaming(() => () => {
+        abortActiveStreamByMessageId({ messageId });
+      });
+    },
+    onOwnStreamFinalize: () => {
+      if (!agentOwnedStopSlotRef.current) return;
+      agentOwnedStopSlotRef.current = false;
+      setAgentStreaming(false);
+      setAgentStopStreaming(null);
+    },
+  });
+
+  // Channel-id-keyed editing-store registration for agent mode. Sidebar agent
+  // mode (Task 4) will register the same `ai-channel-${id}` key when
+  // co-mounted on the same agent — the editing store dedups same-key writes
+  // naturally. The bool merges useChat-driven streaming with the
+  // bootstrap-replay flag in the dashboard store so a mid-stream refresh
+  // stays protected before useChat re-engages.
+  const dashboardAgentStreaming = usePageAgentDashboardStore((s) => s.isAgentStreaming);
+  useStreamingRegistration(
+    selectedAgent ? `ai-channel-${selectedAgent.id}` : 'ai-channel-no-agent',
+    Boolean(selectedAgent) && (isStreaming || dashboardAgentStreaming),
+    selectedAgent
+      ? { conversationId: agentConversationId || undefined, componentName: 'GlobalAssistantView' }
+      : undefined,
+  );
+
+  // Reconnect-refresh: re-fetch the active agent conversation when the socket
+  // transitions back to connected. Skipped on the very first connect (already
+  // covered by mount-time load).
+  const socketConnectionStatus = useSocketStore((s) => s.connectionStatus);
+  const prevAgentConnectionStatusRef = useRef<ConnectionStatus | null>(null);
+  const agentHasInitialConnectRef = useRef(false);
+  const loadAgentConversation = usePageAgentDashboardStore((state) => state.loadConversation);
+  useEffect(() => {
+    if (!selectedAgent) return;
+    const prev = prevAgentConnectionStatusRef.current;
+    prevAgentConnectionStatusRef.current = socketConnectionStatus;
+    if (
+      shouldRefreshOnReconnect(prev, socketConnectionStatus, agentHasInitialConnectRef.current)
+      && agentConversationId
+    ) {
+      loadAgentConversation(agentConversationId);
+    }
+    if (prev !== 'connected' && socketConnectionStatus === 'connected') {
+      agentHasInitialConnectRef.current = true;
+    }
+  }, [selectedAgent, socketConnectionStatus, agentConversationId, loadAgentConversation]);
 
   // Register streaming state with editing store
   useStreamingRegistration(

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -29,6 +29,7 @@ import { dedupRemoteStreams } from '@/lib/ai/streams/dedupRemoteStreams';
 import { synthesizeAssistantMessage } from '@/lib/ai/streams/synthesizeAssistantMessage';
 import { selectChannelRemoteStreams } from '@/lib/ai/streams/selectChannelRemoteStreams';
 import { useAgentChannelMultiplayer } from '@/hooks/useAgentChannelMultiplayer';
+import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
 import { toast } from 'sonner';
 import { LocationContext } from '@/lib/ai/shared';
 import { abortActiveStream, clearActiveStreamId } from '@/lib/ai/core/client';
@@ -269,13 +270,13 @@ const SidebarChatTab: React.FC = () => {
   // way this selector just reads the store and the pure helper picks the
   // right channel + applies the conversation filter.
   const { user } = useAuth();
-  const globalChannelId = user?.id ? `user:${user.id}:global` : null;
+  const channelIdForGlobal = user?.id ? globalChannelId(user.id) : null;
   const remoteStreams = usePendingStreamsStore(
     useShallow((state) =>
       selectChannelRemoteStreams(state, {
         selectedAgent,
         agentConversationId,
-        globalChannelId,
+        globalChannelId: channelIdForGlobal,
         globalConversationId,
       }),
     ),

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -27,6 +27,8 @@ import { useShallow } from 'zustand/react/shallow';
 import { useAuth } from '@/hooks/useAuth';
 import { dedupRemoteStreams } from '@/lib/ai/streams/dedupRemoteStreams';
 import { synthesizeAssistantMessage } from '@/lib/ai/streams/synthesizeAssistantMessage';
+import { selectChannelRemoteStreams } from '@/lib/ai/streams/selectChannelRemoteStreams';
+import { useAgentChannelMultiplayer } from '@/hooks/useAgentChannelMultiplayer';
 import { toast } from 'sonner';
 import { LocationContext } from '@/lib/ai/shared';
 import { abortActiveStream, clearActiveStreamId } from '@/lib/ai/core/client';
@@ -262,21 +264,36 @@ const SidebarChatTab: React.FC = () => {
   // ============================================
   // Remote Streams (multiplayer rendering)
   // ============================================
-  // GlobalChatProvider runs the bootstrap+socket subscription for the global
-  // channel above this component, so global mode here only needs to read the
-  // store and render. Agent-mode wiring + render lands in Task 4 — for now
-  // the agent branch returns [].
+  // Global mode bootstrap+socket runs in GlobalChatProvider above this
+  // component; agent mode runs via useAgentChannelMultiplayer below. Either
+  // way this selector just reads the store and the pure helper picks the
+  // right channel + applies the conversation filter.
   const { user } = useAuth();
   const globalChannelId = user?.id ? `user:${user.id}:global` : null;
   const remoteStreams = usePendingStreamsStore(
-    useShallow((state) => {
-      if (selectedAgent) return [];
-      if (!globalChannelId || !globalConversationId) return [];
-      return state
-        .getRemotePageStreams(globalChannelId)
-        .filter((s) => s.conversationId === globalConversationId);
-    }),
+    useShallow((state) =>
+      selectChannelRemoteStreams(state, {
+        selectedAgent,
+        agentConversationId,
+        globalChannelId,
+        globalConversationId,
+      }),
+    ),
   );
+
+  // Agent-mode wiring (Tasks 4 + 5 + 6 for the sidebar). No-op when
+  // selectedAgent is null. Joins the agent socket room, bootstrap-replays
+  // in-flight streams, claims the dashboard stop slot under co-mount safety,
+  // registers `ai-channel-${agent.id}` with the editing store (same key as
+  // GlobalAssistantView agent mode → natural same-channel de-dup), and
+  // re-fetches the active conversation on socket reconnect.
+  useAgentChannelMultiplayer({
+    selectedAgent,
+    agentConversationId,
+    setLocalMessages: setMessages,
+    isLocallyStreaming: isStreaming,
+    surfaceComponentName: 'SidebarChatTab',
+  });
 
   const streamingAssistantText = useMemo(() => {
     if (!displayIsStreaming) return null;

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -45,7 +45,7 @@ const SIDEBAR_VIRTUALIZATION_THRESHOLD = 30;
 /**
  * Inner component for rendering messages with access to stick-to-bottom context
  */
-interface SidebarMessagesContentProps {
+export interface SidebarMessagesContentProps {
   messages: UIMessage[];
   assistantName: string;
   locationContext: LocationContext | null;
@@ -60,7 +60,7 @@ interface SidebarMessagesContentProps {
   remoteStreams: PendingStream[];
 }
 
-const SidebarMessagesContent: React.FC<SidebarMessagesContentProps> = ({
+export const SidebarMessagesContent: React.FC<SidebarMessagesContentProps> = ({
   messages,
   assistantName,
   locationContext,

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -22,6 +22,11 @@ import { useVoiceModeStore, type VoiceModeOwner } from '@/stores/useVoiceModeSto
 import { useGlobalChatConversation, useGlobalChatConfig, useGlobalChatStream } from '@/contexts/GlobalChatContext';
 import { usePageAgentSidebarState, usePageAgentSidebarChat, type SidebarAgentInfo } from '@/hooks/page-agents';
 import { usePageAgentDashboardStore } from '@/stores/page-agents';
+import { usePendingStreamsStore, type PendingStream } from '@/stores/usePendingStreamsStore';
+import { useShallow } from 'zustand/react/shallow';
+import { useAuth } from '@/hooks/useAuth';
+import { dedupRemoteStreams } from '@/lib/ai/streams/dedupRemoteStreams';
+import { synthesizeAssistantMessage } from '@/lib/ai/streams/synthesizeAssistantMessage';
 import { toast } from 'sonner';
 import { LocationContext } from '@/lib/ai/shared';
 import { abortActiveStream, clearActiveStreamId } from '@/lib/ai/core/client';
@@ -51,6 +56,8 @@ interface SidebarMessagesContentProps {
   lastAssistantMessageId: string | undefined;
   lastUserMessageId: string | undefined;
   displayIsStreaming: boolean;
+  /** Remote in-progress streams to render inline below the messages. */
+  remoteStreams: PendingStream[];
 }
 
 const SidebarMessagesContent: React.FC<SidebarMessagesContentProps> = ({
@@ -64,9 +71,18 @@ const SidebarMessagesContent: React.FC<SidebarMessagesContentProps> = ({
   lastAssistantMessageId,
   lastUserMessageId,
   displayIsStreaming,
+  remoteStreams,
 }) => {
   const scrollRef = useConversationScrollRef();
   const shouldVirtualize = messages.length >= SIDEBAR_VIRTUALIZATION_THRESHOLD;
+  // Streams whose messageId already landed in `messages` are filtered out so
+  // we don't render the same message twice during the brief window between
+  // server-confirm and store-removal.
+  const inflightRemoteStreams = useMemo(
+    () => dedupRemoteStreams(remoteStreams, messages),
+    [remoteStreams, messages],
+  );
+  const isEmpty = messages.length === 0 && inflightRemoteStreams.length === 0;
 
   // Memoized render function for virtualized list
   const renderMessage = useCallback((message: UIMessage) => (
@@ -93,7 +109,7 @@ const SidebarMessagesContent: React.FC<SidebarMessagesContentProps> = ({
 
   return (
     <ConversationContent className="p-3 min-w-0 gap-1.5">
-      {messages.length === 0 ? (
+      {isEmpty ? (
         <div className="flex items-center justify-center h-20 text-muted-foreground text-xs text-center overflow-hidden">
           <div className="max-w-full px-2">
             <p className="font-medium truncate">{assistantName}</p>
@@ -118,6 +134,14 @@ const SidebarMessagesContent: React.FC<SidebarMessagesContentProps> = ({
         // Regular rendering for smaller conversations
         messages.map(message => renderMessage(message))
       )}
+
+      {inflightRemoteStreams.map((stream) => (
+        <CompactMessageRenderer
+          key={stream.messageId}
+          message={synthesizeAssistantMessage(stream.messageId, stream.text)}
+          isStreaming
+        />
+      ))}
 
       {displayIsStreaming && (
         <div className="mb-1">
@@ -234,6 +258,25 @@ const SidebarChatTab: React.FC = () => {
   const displayIsStreaming = selectedAgent
     ? (isStreaming || dashboardIsStreaming)
     : (isStreaming || contextIsStreaming);
+
+  // ============================================
+  // Remote Streams (multiplayer rendering)
+  // ============================================
+  // GlobalChatProvider runs the bootstrap+socket subscription for the global
+  // channel above this component, so global mode here only needs to read the
+  // store and render. Agent-mode wiring + render lands in Task 4 — for now
+  // the agent branch returns [].
+  const { user } = useAuth();
+  const globalChannelId = user?.id ? `user:${user.id}:global` : null;
+  const remoteStreams = usePendingStreamsStore(
+    useShallow((state) => {
+      if (selectedAgent) return [];
+      if (!globalChannelId || !globalConversationId) return [];
+      return state
+        .getRemotePageStreams(globalChannelId)
+        .filter((s) => s.conversationId === globalConversationId);
+    }),
+  );
 
   const streamingAssistantText = useMemo(() => {
     if (!displayIsStreaming) return null;
@@ -783,6 +826,7 @@ const SidebarChatTab: React.FC = () => {
             lastAssistantMessageId={lastAssistantMessageId}
             lastUserMessageId={lastUserMessageId}
             displayIsStreaming={displayIsStreaming}
+            remoteStreams={remoteStreams}
           />
           {/* Scroll-to-bottom button - visible when user scrolls up */}
           <ConversationScrollButton className="z-10 bottom-8" />

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -204,6 +204,7 @@ const SidebarChatTab: React.FC = () => {
     selectAgent,
     createNewConversation: createAgentConversation,
     refreshConversation: refreshAgentConversation,
+    loadConversation: loadSidebarAgentConversation,
   } = usePageAgentSidebarState();
 
   // ============================================
@@ -294,6 +295,7 @@ const SidebarChatTab: React.FC = () => {
     setLocalMessages: setMessages,
     isLocallyStreaming: isStreaming,
     surfaceComponentName: 'SidebarChatTab',
+    loadConversation: loadSidebarAgentConversation,
   });
 
   const streamingAssistantText = useMemo(() => {

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarMessagesContent.test.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarMessagesContent.test.tsx
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { UIMessage } from 'ai';
+import type { PendingStream } from '@/stores/usePendingStreamsStore';
+
+// ---------------------------------------------------------------------------
+// Mocks: keep CompactMessageRenderer transparent so the test can read the
+// rendered text directly. ConversationContent / VirtualizedMessageList /
+// useConversationScrollRef are stubs that just render their children — we
+// don't care about virtualization or scroll behavior at this layer.
+// ---------------------------------------------------------------------------
+vi.mock('@/components/ai/ui/conversation', () => ({
+  ConversationContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  useConversationScrollRef: () => ({ current: null }),
+}));
+
+vi.mock('@/components/ai/shared', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    CompactMessageRenderer: ({
+      message,
+      isStreaming,
+    }: {
+      message: { id: string; role: string; parts: { type: string; text?: string }[] };
+      isStreaming?: boolean;
+    }) => {
+      const text = message.parts
+        .filter((p) => p.type === 'text')
+        .map((p) => (p as { text: string }).text)
+        .join('');
+      return (
+        <div
+          data-testid={`message-${message.id}`}
+          data-role={message.role}
+          data-streaming={isStreaming ? 'true' : 'false'}
+        >
+          {text}
+        </div>
+      );
+    },
+  };
+});
+
+vi.mock('@/components/ai/shared/chat', () => ({
+  VirtualizedMessageList: ({
+    messages,
+    renderMessage,
+  }: {
+    messages: UIMessage[];
+    renderMessage: (m: UIMessage) => React.ReactNode;
+  }) => <div>{messages.map(renderMessage)}</div>,
+  UndoAiChangesDialog: () => null,
+}));
+
+import { SidebarMessagesContent } from '../SidebarChatTab';
+
+const userMessage = (id: string, text: string): UIMessage => ({
+  id,
+  role: 'user',
+  parts: [{ type: 'text', text }],
+});
+
+const assistantMessage = (id: string, text: string): UIMessage => ({
+  id,
+  role: 'assistant',
+  parts: [{ type: 'text', text }],
+});
+
+const stream = (overrides: Partial<PendingStream>): PendingStream => ({
+  messageId: 'msg-stream',
+  pageId: 'user:u1:global',
+  conversationId: 'conv-1',
+  triggeredBy: { userId: 'user-2', displayName: 'Alice' },
+  text: '',
+  isOwn: false,
+  ...overrides,
+});
+
+const noopHandlers = {
+  handleEdit: vi.fn(),
+  handleDelete: vi.fn(),
+  handleRetry: vi.fn(),
+  handleUndoFromHere: vi.fn(),
+};
+
+const baseProps = {
+  ...noopHandlers,
+  assistantName: 'Global Assistant',
+  locationContext: null,
+  lastAssistantMessageId: undefined,
+  lastUserMessageId: undefined,
+  displayIsStreaming: false,
+};
+
+describe('SidebarMessagesContent — multiplayer remote stream rendering (Task 3)', () => {
+  it('given a remote stream for the active conversation, the sidebar should render it as a streaming assistant bubble holding the stream text', () => {
+    render(
+      <SidebarMessagesContent
+        {...baseProps}
+        messages={[]}
+        remoteStreams={[stream({ messageId: 'msg-remote', text: 'partial response' })]}
+      />,
+    );
+
+    const node = screen.getByTestId('message-msg-remote');
+    expect(node.textContent).toBe('partial response');
+    expect(node.getAttribute('data-role')).toBe('assistant');
+    expect(node.getAttribute('data-streaming')).toBe('true');
+  });
+
+  it('given a remote stream whose messageId is already in messages, the duplicate render should be suppressed', () => {
+    render(
+      <SidebarMessagesContent
+        {...baseProps}
+        messages={[assistantMessage('msg-shared', 'final landed')]}
+        remoteStreams={[
+          stream({ messageId: 'msg-shared', text: 'should not show as duplicate' }),
+        ]}
+      />,
+    );
+
+    // The persisted message renders; the duplicate stream entry does not.
+    expect(screen.queryAllByTestId('message-msg-shared')).toHaveLength(1);
+    expect(screen.getByTestId('message-msg-shared').textContent).toBe('final landed');
+  });
+
+  it('given streams and messages with no overlap, the streams render BELOW the messages', () => {
+    const { container } = render(
+      <SidebarMessagesContent
+        {...baseProps}
+        messages={[userMessage('msg-u', 'user question')]}
+        remoteStreams={[stream({ messageId: 'msg-r', text: 'remote answer' })]}
+      />,
+    );
+
+    const items = Array.from(container.querySelectorAll('[data-testid^="message-"]'));
+    expect(items.map((el) => el.getAttribute('data-testid'))).toEqual([
+      'message-msg-u',
+      'message-msg-r',
+    ]);
+  });
+
+  it('given empty messages and an empty stream list, the empty-state placeholder should render', () => {
+    render(
+      <SidebarMessagesContent
+        {...baseProps}
+        messages={[]}
+        remoteStreams={[]}
+      />,
+    );
+
+    expect(screen.getByText('Global Assistant')).toBeDefined();
+    expect(screen.queryByTestId(/^message-/)).toBeNull();
+  });
+
+  it('given empty messages but a non-empty remote stream, the empty-state placeholder should NOT render (the stream is the visible content)', () => {
+    render(
+      <SidebarMessagesContent
+        {...baseProps}
+        messages={[]}
+        remoteStreams={[stream({ messageId: 'msg-only', text: 'mid-stream content' })]}
+      />,
+    );
+
+    expect(screen.queryByText('Global Assistant')).toBeNull();
+    expect(screen.getByTestId('message-msg-only')).toBeDefined();
+  });
+
+  it('given multiple remote streams, all non-deduped streams should render in the order they arrived', () => {
+    render(
+      <SidebarMessagesContent
+        {...baseProps}
+        messages={[]}
+        remoteStreams={[
+          stream({ messageId: 'msg-a', text: 'first' }),
+          stream({ messageId: 'msg-b', text: 'second' }),
+          stream({ messageId: 'msg-c', text: 'third' }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId('message-msg-a').textContent).toBe('first');
+    expect(screen.getByTestId('message-msg-b').textContent).toBe('second');
+    expect(screen.getByTestId('message-msg-c').textContent).toBe('third');
+  });
+});

--- a/apps/web/src/contexts/GlobalChatContext.tsx
+++ b/apps/web/src/contexts/GlobalChatContext.tsx
@@ -11,6 +11,7 @@ import { useSocketStore } from '@/stores/useSocketStore';
 import { useAuth } from '@/hooks/useAuth';
 import { useChannelStreamSocket } from '@/hooks/useChannelStreamSocket';
 import { abortActiveStreamByMessageId } from '@/lib/ai/core/stream-abort-client';
+import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
 
 /**
  * Global Chat Context - Split into three tiers to minimize re-render noise:
@@ -261,7 +262,7 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
   // own-stream callbacks below.
   const { user } = useAuth();
   const userId = user?.id ?? null;
-  const channelId = userId ? `user:${userId}:global` : undefined;
+  const channelId = userId ? globalChannelId(userId) : undefined;
 
   // Always-current refs so the hook's stable callbacks can call into the
   // latest setters/refresh without forcing the hook to resubscribe.

--- a/apps/web/src/contexts/GlobalChatContext.tsx
+++ b/apps/web/src/contexts/GlobalChatContext.tsx
@@ -6,6 +6,7 @@ import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { conversationState } from '@/lib/ai/core/conversation-state';
 import { getAgentId, getConversationId, setConversationId } from '@/lib/url-state';
 import { useChatTransport, useStreamingRegistration } from '@/lib/ai/shared';
+import { shouldRefreshOnReconnect } from '@/lib/ai/streams/shouldRefreshOnReconnect';
 import { useSocketStore } from '@/stores/useSocketStore';
 import { useAuth } from '@/hooks/useAuth';
 import { useChannelStreamSocket } from '@/hooks/useChannelStreamSocket';
@@ -233,14 +234,20 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
   isInitializedRef.current = isInitialized;
 
   useEffect(() => {
-    const didTransitionToConnected =
-      prevConnectionStatusRef.current !== 'connected' && connectionStatus === 'connected';
+    const prevStatus = prevConnectionStatusRef.current;
     prevConnectionStatusRef.current = connectionStatus;
 
-    if (didTransitionToConnected) {
-      if (hasInitialConnectRef.current && isInitializedRef.current && currentConversationId) {
-        refreshConversation();
-      }
+    const refreshNow = shouldRefreshOnReconnect(
+      prevStatus,
+      connectionStatus,
+      hasInitialConnectRef.current,
+    );
+    if (refreshNow && isInitializedRef.current && currentConversationId) {
+      refreshConversation();
+    }
+
+    const isFreshConnect = prevStatus !== 'connected' && connectionStatus === 'connected';
+    if (isFreshConnect) {
       hasInitialConnectRef.current = true;
     }
   }, [connectionStatus, currentConversationId, refreshConversation]);

--- a/apps/web/src/hooks/__tests__/useAgentChannelMultiplayer.test.ts
+++ b/apps/web/src/hooks/__tests__/useAgentChannelMultiplayer.test.ts
@@ -338,7 +338,11 @@ describe('useAgentChannelMultiplayer', () => {
             surfaceComponentName: 'TestSurface',
           });
         },
-        { initialProps: { status: 'disconnected' as const } },
+        {
+          initialProps: {
+            status: 'disconnected' as 'disconnected' | 'connecting' | 'connected' | 'error',
+          },
+        },
       );
 
       const loadConversation = vi.fn();
@@ -366,7 +370,11 @@ describe('useAgentChannelMultiplayer', () => {
             surfaceComponentName: 'TestSurface',
           });
         },
-        { initialProps: { status: 'disconnected' as const } },
+        {
+          initialProps: {
+            status: 'disconnected' as 'disconnected' | 'connecting' | 'connected' | 'error',
+          },
+        },
       );
 
       // First connect.
@@ -397,7 +405,11 @@ describe('useAgentChannelMultiplayer', () => {
             surfaceComponentName: 'TestSurface',
           });
         },
-        { initialProps: { status: 'disconnected' as const } },
+        {
+          initialProps: {
+            status: 'disconnected' as 'disconnected' | 'connecting' | 'connected' | 'error',
+          },
+        },
       );
 
       result.rerender({ status: 'connected' });

--- a/apps/web/src/hooks/__tests__/useAgentChannelMultiplayer.test.ts
+++ b/apps/web/src/hooks/__tests__/useAgentChannelMultiplayer.test.ts
@@ -1,0 +1,453 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { UIMessage } from 'ai';
+import type { UseChannelStreamSocketOptions } from '@/hooks/useChannelStreamSocket';
+
+// ---------------------------------------------------------------------------
+// Hoisted state captured from the dependency hooks under test
+// ---------------------------------------------------------------------------
+const {
+  capturedChannel,
+  mockUseChannelStreamSocket,
+  mockUsePageSocketRoom,
+  mockUseStreamingRegistration,
+  mockAbortByMessageId,
+  mockSocketStatus,
+  pendingStreams,
+} = vi.hoisted(() => {
+  const ref: { channelId: string | undefined; options: UseChannelStreamSocketOptions | undefined } = {
+    channelId: undefined,
+    options: undefined,
+  };
+  return {
+    capturedChannel: ref,
+    mockUseChannelStreamSocket: vi.fn(),
+    mockUsePageSocketRoom: vi.fn(),
+    mockUseStreamingRegistration: vi.fn(),
+    mockAbortByMessageId: vi.fn(),
+    mockSocketStatus: { current: 'disconnected' as 'disconnected' | 'connecting' | 'connected' | 'error' },
+    pendingStreams: { current: new Map<string, { messageId: string; pageId: string; conversationId: string; triggeredBy: { userId: string; displayName: string }; text: string; isOwn: boolean }>() },
+  };
+});
+
+vi.mock('@/hooks/useChannelStreamSocket', () => ({
+  useChannelStreamSocket: (channelId: string | undefined, options?: UseChannelStreamSocketOptions) => {
+    capturedChannel.channelId = channelId;
+    capturedChannel.options = options;
+    mockUseChannelStreamSocket(channelId, options);
+  },
+}));
+
+vi.mock('@/hooks/usePageSocketRoom', () => ({
+  usePageSocketRoom: mockUsePageSocketRoom,
+}));
+
+vi.mock('@/stores/useSocketStore', () => ({
+  useSocketStore: vi.fn((selector: (s: { connectionStatus: string }) => unknown) =>
+    selector({ connectionStatus: mockSocketStatus.current }),
+  ),
+}));
+
+vi.mock('@/stores/usePendingStreamsStore', () => ({
+  usePendingStreamsStore: Object.assign(vi.fn(() => []), {
+    getState: vi.fn(() => ({ streams: pendingStreams.current })),
+  }),
+}));
+
+vi.mock('@/lib/ai/shared', () => ({
+  useStreamingRegistration: mockUseStreamingRegistration,
+}));
+
+vi.mock('@/lib/ai/core/stream-abort-client', () => ({
+  abortActiveStreamByMessageId: mockAbortByMessageId,
+}));
+
+// Real Zustand store imported AFTER mocks
+import { usePageAgentDashboardStore } from '@/stores/page-agents';
+import { useAgentChannelMultiplayer } from '../useAgentChannelMultiplayer';
+
+const AGENT = { id: 'agent-1' };
+
+const seedDashboard = (overrides: Partial<{ agentStopStreaming: (() => void) | null; isAgentStreaming: boolean }> = {}) => {
+  usePageAgentDashboardStore.setState({
+    isAgentStreaming: overrides.isAgentStreaming ?? false,
+    agentStopStreaming: overrides.agentStopStreaming !== undefined ? overrides.agentStopStreaming : null,
+  });
+};
+
+const renderWiring = (
+  options: Parameters<typeof useAgentChannelMultiplayer>[0],
+) => renderHook(({ opts }) => useAgentChannelMultiplayer(opts), {
+  initialProps: { opts: options },
+});
+
+describe('useAgentChannelMultiplayer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedChannel.channelId = undefined;
+    capturedChannel.options = undefined;
+    mockSocketStatus.current = 'disconnected';
+    pendingStreams.current = new Map();
+    seedDashboard({ agentStopStreaming: null, isAgentStreaming: false });
+  });
+
+  describe('subscription', () => {
+    it('given a selected agent, the channel-stream socket should be subscribed to the agent id', () => {
+      renderWiring({
+        selectedAgent: AGENT,
+        agentConversationId: 'conv-1',
+        setLocalMessages: vi.fn(),
+        isLocallyStreaming: false,
+        surfaceComponentName: 'TestSurface',
+      });
+
+      expect(capturedChannel.channelId).toBe(AGENT.id);
+    });
+
+    it('given selectedAgent is null, the channel-stream socket should be subscribed to undefined (no-op)', () => {
+      renderWiring({
+        selectedAgent: null,
+        agentConversationId: null,
+        setLocalMessages: vi.fn(),
+        isLocallyStreaming: false,
+        surfaceComponentName: 'TestSurface',
+      });
+
+      expect(capturedChannel.channelId).toBeUndefined();
+    });
+  });
+
+  describe('own-stream slot ownership', () => {
+    it('given onOwnStreamBootstrap fires while the dashboard stop slot is empty, the slot should be claimed', () => {
+      seedDashboard({ agentStopStreaming: null });
+      renderWiring({
+        selectedAgent: AGENT,
+        agentConversationId: 'conv-1',
+        setLocalMessages: vi.fn(),
+        isLocallyStreaming: false,
+        surfaceComponentName: 'TestSurface',
+      });
+
+      act(() => {
+        capturedChannel.options?.onOwnStreamBootstrap?.({ messageId: 'msg-own' });
+      });
+
+      const state = usePageAgentDashboardStore.getState();
+      expect(typeof state.agentStopStreaming).toBe('function');
+      expect(state.isAgentStreaming).toBe(true);
+    });
+
+    it('given onOwnStreamBootstrap fires while the slot is already populated, the existing slot should be preserved', () => {
+      const existingStop = vi.fn();
+      seedDashboard({ agentStopStreaming: existingStop });
+      renderWiring({
+        selectedAgent: AGENT,
+        agentConversationId: 'conv-1',
+        setLocalMessages: vi.fn(),
+        isLocallyStreaming: false,
+        surfaceComponentName: 'TestSurface',
+      });
+
+      act(() => {
+        capturedChannel.options?.onOwnStreamBootstrap?.({ messageId: 'msg-own' });
+      });
+
+      expect(usePageAgentDashboardStore.getState().agentStopStreaming).toBe(existingStop);
+    });
+
+    it('given onOwnStreamFinalize fires after this surface claimed the slot, the slot should be cleared', () => {
+      seedDashboard({ agentStopStreaming: null });
+      renderWiring({
+        selectedAgent: AGENT,
+        agentConversationId: 'conv-1',
+        setLocalMessages: vi.fn(),
+        isLocallyStreaming: false,
+        surfaceComponentName: 'TestSurface',
+      });
+
+      act(() => {
+        capturedChannel.options?.onOwnStreamBootstrap?.({ messageId: 'msg-own' });
+      });
+      act(() => {
+        capturedChannel.options?.onOwnStreamFinalize?.({ messageId: 'msg-own' });
+      });
+
+      const state = usePageAgentDashboardStore.getState();
+      expect(state.agentStopStreaming).toBeNull();
+      expect(state.isAgentStreaming).toBe(false);
+    });
+
+    it('given onOwnStreamFinalize fires when this surface never claimed the slot, the existing stop should remain', () => {
+      const otherSurfaceStop = vi.fn();
+      seedDashboard({ agentStopStreaming: otherSurfaceStop });
+      renderWiring({
+        selectedAgent: AGENT,
+        agentConversationId: 'conv-1',
+        setLocalMessages: vi.fn(),
+        isLocallyStreaming: false,
+        surfaceComponentName: 'TestSurface',
+      });
+
+      // Bootstrap fires but slot is occupied; this surface declines to claim.
+      act(() => {
+        capturedChannel.options?.onOwnStreamBootstrap?.({ messageId: 'msg-own' });
+      });
+      // Finalize arrives — must NOT clear the other surface's slot.
+      act(() => {
+        capturedChannel.options?.onOwnStreamFinalize?.({ messageId: 'msg-own' });
+      });
+
+      expect(usePageAgentDashboardStore.getState().agentStopStreaming).toBe(otherSurfaceStop);
+    });
+
+    it("given the slot is claimed, calling the stop function in the slot should invoke the abort endpoint", () => {
+      seedDashboard({ agentStopStreaming: null });
+      renderWiring({
+        selectedAgent: AGENT,
+        agentConversationId: 'conv-1',
+        setLocalMessages: vi.fn(),
+        isLocallyStreaming: false,
+        surfaceComponentName: 'TestSurface',
+      });
+
+      act(() => {
+        capturedChannel.options?.onOwnStreamBootstrap?.({ messageId: 'msg-own' });
+      });
+
+      const stop = usePageAgentDashboardStore.getState().agentStopStreaming;
+      stop?.();
+
+      expect(mockAbortByMessageId).toHaveBeenCalledWith({ messageId: 'msg-own' });
+    });
+  });
+
+  describe('local message synthesis on stream complete', () => {
+    it("given a stream finalizes whose conversationId matches the active agent conversation, the synthesized assistant message should be appended via setLocalMessages", () => {
+      pendingStreams.current = new Map([
+        [
+          'msg-done',
+          {
+            messageId: 'msg-done',
+            pageId: AGENT.id,
+            conversationId: 'conv-active',
+            triggeredBy: { userId: 'someone-else', displayName: 'X' },
+            text: 'final response text',
+            isOwn: false,
+          },
+        ],
+      ]);
+
+      const setLocalMessages = vi.fn();
+      renderWiring({
+        selectedAgent: AGENT,
+        agentConversationId: 'conv-active',
+        setLocalMessages,
+        isLocallyStreaming: false,
+        surfaceComponentName: 'TestSurface',
+      });
+
+      act(() => {
+        capturedChannel.options?.onStreamComplete?.('msg-done');
+      });
+
+      expect(setLocalMessages).toHaveBeenCalledTimes(1);
+      const updater = setLocalMessages.mock.calls[0][0] as (prev: UIMessage[]) => UIMessage[];
+      expect(updater([])).toEqual([
+        {
+          id: 'msg-done',
+          role: 'assistant',
+          parts: [{ type: 'text', text: 'final response text' }],
+        },
+      ]);
+    });
+
+    it("given a stream finalizes whose conversationId does not match the active agent conversation, setLocalMessages should not be called", () => {
+      pendingStreams.current = new Map([
+        [
+          'msg-stale',
+          {
+            messageId: 'msg-stale',
+            pageId: AGENT.id,
+            conversationId: 'conv-different',
+            triggeredBy: { userId: 'x', displayName: 'X' },
+            text: 'belongs to different conversation',
+            isOwn: false,
+          },
+        ],
+      ]);
+
+      const setLocalMessages = vi.fn();
+      renderWiring({
+        selectedAgent: AGENT,
+        agentConversationId: 'conv-active',
+        setLocalMessages,
+        isLocallyStreaming: false,
+        surfaceComponentName: 'TestSurface',
+      });
+
+      act(() => {
+        capturedChannel.options?.onStreamComplete?.('msg-stale');
+      });
+
+      expect(setLocalMessages).not.toHaveBeenCalled();
+    });
+
+    it('given a stream finalizes with empty text, setLocalMessages should not be called', () => {
+      pendingStreams.current = new Map([
+        [
+          'msg-empty',
+          {
+            messageId: 'msg-empty',
+            pageId: AGENT.id,
+            conversationId: 'conv-active',
+            triggeredBy: { userId: 'x', displayName: 'X' },
+            text: '',
+            isOwn: false,
+          },
+        ],
+      ]);
+
+      const setLocalMessages = vi.fn();
+      renderWiring({
+        selectedAgent: AGENT,
+        agentConversationId: 'conv-active',
+        setLocalMessages,
+        isLocallyStreaming: false,
+        surfaceComponentName: 'TestSurface',
+      });
+
+      act(() => {
+        capturedChannel.options?.onStreamComplete?.('msg-empty');
+      });
+
+      expect(setLocalMessages).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reconnect refresh', () => {
+    it('given the very first connect, the agent conversation should NOT be reloaded (mount-time load already covers it)', () => {
+      seedDashboard();
+      const result = renderHook(
+        ({ status }: { status: 'disconnected' | 'connecting' | 'connected' | 'error' }) => {
+          mockSocketStatus.current = status;
+          return useAgentChannelMultiplayer({
+            selectedAgent: AGENT,
+            agentConversationId: 'conv-1',
+            setLocalMessages: vi.fn(),
+            isLocallyStreaming: false,
+            surfaceComponentName: 'TestSurface',
+          });
+        },
+        { initialProps: { status: 'disconnected' as const } },
+      );
+
+      const loadConversation = vi.fn();
+      usePageAgentDashboardStore.setState({ loadConversation });
+
+      // First connect.
+      result.rerender({ status: 'connected' });
+      expect(loadConversation).not.toHaveBeenCalled();
+    });
+
+    it('given a reconnect AFTER the initial connect, the active conversation should be reloaded', async () => {
+      seedDashboard();
+      const loadConversation = vi.fn();
+      usePageAgentDashboardStore.setState({ loadConversation });
+
+      mockSocketStatus.current = 'disconnected';
+      const result = renderHook(
+        ({ status }: { status: 'disconnected' | 'connecting' | 'connected' | 'error' }) => {
+          mockSocketStatus.current = status;
+          return useAgentChannelMultiplayer({
+            selectedAgent: AGENT,
+            agentConversationId: 'conv-1',
+            setLocalMessages: vi.fn(),
+            isLocallyStreaming: false,
+            surfaceComponentName: 'TestSurface',
+          });
+        },
+        { initialProps: { status: 'disconnected' as const } },
+      );
+
+      // First connect.
+      result.rerender({ status: 'connected' });
+      expect(loadConversation).not.toHaveBeenCalled();
+
+      // Goes offline, then reconnects.
+      result.rerender({ status: 'disconnected' });
+      result.rerender({ status: 'connected' });
+
+      expect(loadConversation).toHaveBeenCalledTimes(1);
+      expect(loadConversation).toHaveBeenCalledWith('conv-1');
+    });
+
+    it('given selectedAgent is null, reconnect should never trigger a refresh', () => {
+      seedDashboard();
+      const loadConversation = vi.fn();
+      usePageAgentDashboardStore.setState({ loadConversation });
+
+      const result = renderHook(
+        ({ status }: { status: 'disconnected' | 'connecting' | 'connected' | 'error' }) => {
+          mockSocketStatus.current = status;
+          return useAgentChannelMultiplayer({
+            selectedAgent: null,
+            agentConversationId: null,
+            setLocalMessages: vi.fn(),
+            isLocallyStreaming: false,
+            surfaceComponentName: 'TestSurface',
+          });
+        },
+        { initialProps: { status: 'disconnected' as const } },
+      );
+
+      result.rerender({ status: 'connected' });
+      result.rerender({ status: 'disconnected' });
+      result.rerender({ status: 'connected' });
+
+      expect(loadConversation).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('editing-store registration', () => {
+    it('given a selected agent, the registration key should be `ai-channel-${agent.id}`', () => {
+      renderWiring({
+        selectedAgent: AGENT,
+        agentConversationId: 'conv-1',
+        setLocalMessages: vi.fn(),
+        isLocallyStreaming: true,
+        surfaceComponentName: 'TestSurface',
+      });
+
+      const lastCall = mockUseStreamingRegistration.mock.calls.at(-1);
+      expect(lastCall?.[0]).toBe(`ai-channel-${AGENT.id}`);
+      expect(lastCall?.[1]).toBe(true); // isLocallyStreaming → registration true
+    });
+
+    it('given selectedAgent is null, the registration should be inactive (isStreaming=false)', () => {
+      renderWiring({
+        selectedAgent: null,
+        agentConversationId: null,
+        setLocalMessages: vi.fn(),
+        isLocallyStreaming: true,
+        surfaceComponentName: 'TestSurface',
+      });
+
+      const lastCall = mockUseStreamingRegistration.mock.calls.at(-1);
+      expect(lastCall?.[1]).toBe(false);
+    });
+
+    it('given an agent and the dashboard store reports streaming (e.g. bootstrap-replay), the registration should be active even if the surface itself is not streaming', () => {
+      seedDashboard({ isAgentStreaming: true });
+      renderWiring({
+        selectedAgent: AGENT,
+        agentConversationId: 'conv-1',
+        setLocalMessages: vi.fn(),
+        isLocallyStreaming: false,
+        surfaceComponentName: 'TestSurface',
+      });
+
+      const lastCall = mockUseStreamingRegistration.mock.calls.at(-1);
+      expect(lastCall?.[1]).toBe(true);
+    });
+  });
+});

--- a/apps/web/src/hooks/__tests__/useAgentChannelMultiplayer.test.ts
+++ b/apps/web/src/hooks/__tests__/useAgentChannelMultiplayer.test.ts
@@ -75,6 +75,18 @@ const seedDashboard = (overrides: Partial<{ agentStopStreaming: (() => void) | n
   });
 };
 
+const baseOptions = (
+  overrides: Partial<Parameters<typeof useAgentChannelMultiplayer>[0]>,
+): Parameters<typeof useAgentChannelMultiplayer>[0] => ({
+  selectedAgent: null,
+  agentConversationId: null,
+  setLocalMessages: vi.fn(),
+  isLocallyStreaming: false,
+  surfaceComponentName: 'TestSurface',
+  loadConversation: vi.fn(),
+  ...overrides,
+});
+
 const renderWiring = (
   options: Parameters<typeof useAgentChannelMultiplayer>[0],
 ) => renderHook(({ opts }) => useAgentChannelMultiplayer(opts), {
@@ -93,25 +105,16 @@ describe('useAgentChannelMultiplayer', () => {
 
   describe('subscription', () => {
     it('given a selected agent, the channel-stream socket should be subscribed to the agent id', () => {
-      renderWiring({
+      renderWiring(baseOptions({
         selectedAgent: AGENT,
         agentConversationId: 'conv-1',
-        setLocalMessages: vi.fn(),
-        isLocallyStreaming: false,
-        surfaceComponentName: 'TestSurface',
-      });
+      }));
 
       expect(capturedChannel.channelId).toBe(AGENT.id);
     });
 
     it('given selectedAgent is null, the channel-stream socket should be subscribed to undefined (no-op)', () => {
-      renderWiring({
-        selectedAgent: null,
-        agentConversationId: null,
-        setLocalMessages: vi.fn(),
-        isLocallyStreaming: false,
-        surfaceComponentName: 'TestSurface',
-      });
+      renderWiring(baseOptions({}));
 
       expect(capturedChannel.channelId).toBeUndefined();
     });
@@ -120,13 +123,10 @@ describe('useAgentChannelMultiplayer', () => {
   describe('own-stream slot ownership', () => {
     it('given onOwnStreamBootstrap fires while the dashboard stop slot is empty, the slot should be claimed', () => {
       seedDashboard({ agentStopStreaming: null });
-      renderWiring({
+      renderWiring(baseOptions({
         selectedAgent: AGENT,
         agentConversationId: 'conv-1',
-        setLocalMessages: vi.fn(),
-        isLocallyStreaming: false,
-        surfaceComponentName: 'TestSurface',
-      });
+      }));
 
       act(() => {
         capturedChannel.options?.onOwnStreamBootstrap?.({ messageId: 'msg-own' });
@@ -140,13 +140,10 @@ describe('useAgentChannelMultiplayer', () => {
     it('given onOwnStreamBootstrap fires while the slot is already populated, the existing slot should be preserved', () => {
       const existingStop = vi.fn();
       seedDashboard({ agentStopStreaming: existingStop });
-      renderWiring({
+      renderWiring(baseOptions({
         selectedAgent: AGENT,
         agentConversationId: 'conv-1',
-        setLocalMessages: vi.fn(),
-        isLocallyStreaming: false,
-        surfaceComponentName: 'TestSurface',
-      });
+      }));
 
       act(() => {
         capturedChannel.options?.onOwnStreamBootstrap?.({ messageId: 'msg-own' });
@@ -157,13 +154,10 @@ describe('useAgentChannelMultiplayer', () => {
 
     it('given onOwnStreamFinalize fires after this surface claimed the slot, the slot should be cleared', () => {
       seedDashboard({ agentStopStreaming: null });
-      renderWiring({
+      renderWiring(baseOptions({
         selectedAgent: AGENT,
         agentConversationId: 'conv-1',
-        setLocalMessages: vi.fn(),
-        isLocallyStreaming: false,
-        surfaceComponentName: 'TestSurface',
-      });
+      }));
 
       act(() => {
         capturedChannel.options?.onOwnStreamBootstrap?.({ messageId: 'msg-own' });
@@ -180,13 +174,10 @@ describe('useAgentChannelMultiplayer', () => {
     it('given onOwnStreamFinalize fires when this surface never claimed the slot, the existing stop should remain', () => {
       const otherSurfaceStop = vi.fn();
       seedDashboard({ agentStopStreaming: otherSurfaceStop });
-      renderWiring({
+      renderWiring(baseOptions({
         selectedAgent: AGENT,
         agentConversationId: 'conv-1',
-        setLocalMessages: vi.fn(),
-        isLocallyStreaming: false,
-        surfaceComponentName: 'TestSurface',
-      });
+      }));
 
       // Bootstrap fires but slot is occupied; this surface declines to claim.
       act(() => {
@@ -202,13 +193,10 @@ describe('useAgentChannelMultiplayer', () => {
 
     it("given the slot is claimed, calling the stop function in the slot should invoke the abort endpoint", () => {
       seedDashboard({ agentStopStreaming: null });
-      renderWiring({
+      renderWiring(baseOptions({
         selectedAgent: AGENT,
         agentConversationId: 'conv-1',
-        setLocalMessages: vi.fn(),
-        isLocallyStreaming: false,
-        surfaceComponentName: 'TestSurface',
-      });
+      }));
 
       act(() => {
         capturedChannel.options?.onOwnStreamBootstrap?.({ messageId: 'msg-own' });
@@ -238,13 +226,11 @@ describe('useAgentChannelMultiplayer', () => {
       ]);
 
       const setLocalMessages = vi.fn();
-      renderWiring({
+      renderWiring(baseOptions({
         selectedAgent: AGENT,
         agentConversationId: 'conv-active',
         setLocalMessages,
-        isLocallyStreaming: false,
-        surfaceComponentName: 'TestSurface',
-      });
+      }));
 
       act(() => {
         capturedChannel.options?.onStreamComplete?.('msg-done');
@@ -277,13 +263,11 @@ describe('useAgentChannelMultiplayer', () => {
       ]);
 
       const setLocalMessages = vi.fn();
-      renderWiring({
+      renderWiring(baseOptions({
         selectedAgent: AGENT,
         agentConversationId: 'conv-active',
         setLocalMessages,
-        isLocallyStreaming: false,
-        surfaceComponentName: 'TestSurface',
-      });
+      }));
 
       act(() => {
         capturedChannel.options?.onStreamComplete?.('msg-stale');
@@ -308,13 +292,11 @@ describe('useAgentChannelMultiplayer', () => {
       ]);
 
       const setLocalMessages = vi.fn();
-      renderWiring({
+      renderWiring(baseOptions({
         selectedAgent: AGENT,
         agentConversationId: 'conv-active',
         setLocalMessages,
-        isLocallyStreaming: false,
-        surfaceComponentName: 'TestSurface',
-      });
+      }));
 
       act(() => {
         capturedChannel.options?.onStreamComplete?.('msg-empty');
@@ -325,50 +307,18 @@ describe('useAgentChannelMultiplayer', () => {
   });
 
   describe('reconnect refresh', () => {
-    it('given the very first connect, the agent conversation should NOT be reloaded (mount-time load already covers it)', () => {
+    it('given the very first connect, the surface-provided loadConversation should NOT be called (mount-time load already covers it)', () => {
       seedDashboard();
-      const result = renderHook(
-        ({ status }: { status: 'disconnected' | 'connecting' | 'connected' | 'error' }) => {
-          mockSocketStatus.current = status;
-          return useAgentChannelMultiplayer({
-            selectedAgent: AGENT,
-            agentConversationId: 'conv-1',
-            setLocalMessages: vi.fn(),
-            isLocallyStreaming: false,
-            surfaceComponentName: 'TestSurface',
-          });
-        },
-        {
-          initialProps: {
-            status: 'disconnected' as 'disconnected' | 'connecting' | 'connected' | 'error',
-          },
-        },
-      );
-
-      const loadConversation = vi.fn();
-      usePageAgentDashboardStore.setState({ loadConversation });
-
-      // First connect.
-      result.rerender({ status: 'connected' });
-      expect(loadConversation).not.toHaveBeenCalled();
-    });
-
-    it('given a reconnect AFTER the initial connect, the active conversation should be reloaded', async () => {
-      seedDashboard();
-      const loadConversation = vi.fn();
-      usePageAgentDashboardStore.setState({ loadConversation });
-
+      const surfaceLoadConversation = vi.fn();
       mockSocketStatus.current = 'disconnected';
       const result = renderHook(
         ({ status }: { status: 'disconnected' | 'connecting' | 'connected' | 'error' }) => {
           mockSocketStatus.current = status;
-          return useAgentChannelMultiplayer({
+          return useAgentChannelMultiplayer(baseOptions({
             selectedAgent: AGENT,
             agentConversationId: 'conv-1',
-            setLocalMessages: vi.fn(),
-            isLocallyStreaming: false,
-            surfaceComponentName: 'TestSurface',
-          });
+            loadConversation: surfaceLoadConversation,
+          }));
         },
         {
           initialProps: {
@@ -379,31 +329,82 @@ describe('useAgentChannelMultiplayer', () => {
 
       // First connect.
       result.rerender({ status: 'connected' });
-      expect(loadConversation).not.toHaveBeenCalled();
+      expect(surfaceLoadConversation).not.toHaveBeenCalled();
+    });
+
+    it('given a reconnect AFTER the initial connect, the surface-provided loadConversation should be called with the active conversation id', () => {
+      seedDashboard();
+      const surfaceLoadConversation = vi.fn();
+      mockSocketStatus.current = 'disconnected';
+      const result = renderHook(
+        ({ status }: { status: 'disconnected' | 'connecting' | 'connected' | 'error' }) => {
+          mockSocketStatus.current = status;
+          return useAgentChannelMultiplayer(baseOptions({
+            selectedAgent: AGENT,
+            agentConversationId: 'conv-1',
+            loadConversation: surfaceLoadConversation,
+          }));
+        },
+        {
+          initialProps: {
+            status: 'disconnected' as 'disconnected' | 'connecting' | 'connected' | 'error',
+          },
+        },
+      );
+
+      // First connect — primes hasInitialConnect, no refresh.
+      result.rerender({ status: 'connected' });
+      expect(surfaceLoadConversation).not.toHaveBeenCalled();
 
       // Goes offline, then reconnects.
       result.rerender({ status: 'disconnected' });
       result.rerender({ status: 'connected' });
 
-      expect(loadConversation).toHaveBeenCalledTimes(1);
-      expect(loadConversation).toHaveBeenCalledWith('conv-1');
+      expect(surfaceLoadConversation).toHaveBeenCalledTimes(1);
+      expect(surfaceLoadConversation).toHaveBeenCalledWith('conv-1');
+    });
+
+    it('given a custom loadConversation is provided, the dashboard store loadConversation should NOT be called (the surface owns the refresh path — sidebar agent state vs dashboard state)', () => {
+      seedDashboard();
+      const dashboardLoad = vi.fn();
+      usePageAgentDashboardStore.setState({ loadConversation: dashboardLoad });
+      const surfaceLoadConversation = vi.fn();
+
+      mockSocketStatus.current = 'disconnected';
+      const result = renderHook(
+        ({ status }: { status: 'disconnected' | 'connecting' | 'connected' | 'error' }) => {
+          mockSocketStatus.current = status;
+          return useAgentChannelMultiplayer(baseOptions({
+            selectedAgent: AGENT,
+            agentConversationId: 'conv-1',
+            loadConversation: surfaceLoadConversation,
+          }));
+        },
+        {
+          initialProps: {
+            status: 'disconnected' as 'disconnected' | 'connecting' | 'connected' | 'error',
+          },
+        },
+      );
+
+      // Initial connect, then reconnect.
+      result.rerender({ status: 'connected' });
+      result.rerender({ status: 'disconnected' });
+      result.rerender({ status: 'connected' });
+
+      expect(surfaceLoadConversation).toHaveBeenCalledWith('conv-1');
+      expect(dashboardLoad).not.toHaveBeenCalled();
     });
 
     it('given selectedAgent is null, reconnect should never trigger a refresh', () => {
       seedDashboard();
-      const loadConversation = vi.fn();
-      usePageAgentDashboardStore.setState({ loadConversation });
-
+      const surfaceLoadConversation = vi.fn();
       const result = renderHook(
         ({ status }: { status: 'disconnected' | 'connecting' | 'connected' | 'error' }) => {
           mockSocketStatus.current = status;
-          return useAgentChannelMultiplayer({
-            selectedAgent: null,
-            agentConversationId: null,
-            setLocalMessages: vi.fn(),
-            isLocallyStreaming: false,
-            surfaceComponentName: 'TestSurface',
-          });
+          return useAgentChannelMultiplayer(baseOptions({
+            loadConversation: surfaceLoadConversation,
+          }));
         },
         {
           initialProps: {
@@ -416,19 +417,61 @@ describe('useAgentChannelMultiplayer', () => {
       result.rerender({ status: 'disconnected' });
       result.rerender({ status: 'connected' });
 
-      expect(loadConversation).not.toHaveBeenCalled();
+      expect(surfaceLoadConversation).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cleanup on unmount', () => {
+    it('given this surface claimed the dashboard stop slot then unmounts mid-stream, the slot should be cleared on cleanup', () => {
+      seedDashboard({ agentStopStreaming: null });
+      const { unmount } = renderWiring(baseOptions({
+        selectedAgent: AGENT,
+        agentConversationId: 'conv-1',
+      }));
+
+      // Bootstrap claims the slot.
+      act(() => {
+        capturedChannel.options?.onOwnStreamBootstrap?.({ messageId: 'msg-own' });
+      });
+      expect(typeof usePageAgentDashboardStore.getState().agentStopStreaming).toBe('function');
+
+      // Surface unmounts before stream finalizes (e.g. user navigates away).
+      // useChannelStreamSocket aborts the controller but does NOT fire
+      // onOwnStreamFinalize, so the hook's own cleanup must clear the slot.
+      unmount();
+
+      const state = usePageAgentDashboardStore.getState();
+      expect(state.agentStopStreaming).toBeNull();
+      expect(state.isAgentStreaming).toBe(false);
+    });
+
+    it('given this surface never claimed the slot, unmount should NOT clear another writer\'s slot', () => {
+      const otherSurfaceStop = vi.fn();
+      seedDashboard({ agentStopStreaming: otherSurfaceStop, isAgentStreaming: true });
+      const { unmount } = renderWiring(baseOptions({
+        selectedAgent: AGENT,
+        agentConversationId: 'conv-1',
+      }));
+
+      // Bootstrap fires but slot is occupied — this surface declines.
+      act(() => {
+        capturedChannel.options?.onOwnStreamBootstrap?.({ messageId: 'msg-own' });
+      });
+      // Surface unmounts. The other writer's slot must survive.
+      unmount();
+
+      expect(usePageAgentDashboardStore.getState().agentStopStreaming).toBe(otherSurfaceStop);
+      expect(usePageAgentDashboardStore.getState().isAgentStreaming).toBe(true);
     });
   });
 
   describe('editing-store registration', () => {
     it('given a selected agent, the registration key should be `ai-channel-${agent.id}`', () => {
-      renderWiring({
+      renderWiring(baseOptions({
         selectedAgent: AGENT,
         agentConversationId: 'conv-1',
-        setLocalMessages: vi.fn(),
         isLocallyStreaming: true,
-        surfaceComponentName: 'TestSurface',
-      });
+      }));
 
       const lastCall = mockUseStreamingRegistration.mock.calls.at(-1);
       expect(lastCall?.[0]).toBe(`ai-channel-${AGENT.id}`);
@@ -436,13 +479,9 @@ describe('useAgentChannelMultiplayer', () => {
     });
 
     it('given selectedAgent is null, the registration should be inactive (isStreaming=false)', () => {
-      renderWiring({
-        selectedAgent: null,
-        agentConversationId: null,
-        setLocalMessages: vi.fn(),
+      renderWiring(baseOptions({
         isLocallyStreaming: true,
-        surfaceComponentName: 'TestSurface',
-      });
+      }));
 
       const lastCall = mockUseStreamingRegistration.mock.calls.at(-1);
       expect(lastCall?.[1]).toBe(false);
@@ -450,13 +489,10 @@ describe('useAgentChannelMultiplayer', () => {
 
     it('given an agent and the dashboard store reports streaming (e.g. bootstrap-replay), the registration should be active even if the surface itself is not streaming', () => {
       seedDashboard({ isAgentStreaming: true });
-      renderWiring({
+      renderWiring(baseOptions({
         selectedAgent: AGENT,
         agentConversationId: 'conv-1',
-        setLocalMessages: vi.fn(),
-        isLocallyStreaming: false,
-        surfaceComponentName: 'TestSurface',
-      });
+      }));
 
       const lastCall = mockUseStreamingRegistration.mock.calls.at(-1);
       expect(lastCall?.[1]).toBe(true);

--- a/apps/web/src/hooks/useAgentChannelMultiplayer.ts
+++ b/apps/web/src/hooks/useAgentChannelMultiplayer.ts
@@ -1,0 +1,138 @@
+import { useEffect, useRef } from 'react';
+import type { UIMessage } from 'ai';
+import { useChannelStreamSocket } from './useChannelStreamSocket';
+import { usePageSocketRoom } from './usePageSocketRoom';
+import { useSocketStore } from '@/stores/useSocketStore';
+import { usePendingStreamsStore } from '@/stores/usePendingStreamsStore';
+import { usePageAgentDashboardStore } from '@/stores/page-agents';
+import { useStreamingRegistration } from '@/lib/ai/shared';
+import { abortActiveStreamByMessageId } from '@/lib/ai/core/stream-abort-client';
+import { synthesizeAssistantMessage } from '@/lib/ai/streams/synthesizeAssistantMessage';
+import { shouldClaimAgentStopSlot } from '@/lib/ai/streams/shouldClaimAgentStopSlot';
+import {
+  shouldRefreshOnReconnect,
+  type ConnectionStatus,
+} from '@/lib/ai/streams/shouldRefreshOnReconnect';
+
+export interface UseAgentChannelMultiplayerOptions {
+  selectedAgent: { id: string } | null;
+  agentConversationId: string | null;
+  /** useChat-style messages setter for local synthesis on stream completion. */
+  setLocalMessages: (updater: (prev: UIMessage[]) => UIMessage[]) => void;
+  /** True when the surface is locally driving a stream (e.g. via useChat). */
+  isLocallyStreaming: boolean;
+  /** componentName for the editing-store metadata. */
+  surfaceComponentName: string;
+}
+
+/**
+ * Wires a surface (GlobalAssistantView agent mode, SidebarChatTab agent mode)
+ * to the multiplayer streaming pipeline for an agent's page channel:
+ *
+ * - Joins the agent's socket room.
+ * - Bootstrap-replays in-flight streams from the DB and subscribes to live
+ *   chat:stream_start / chat:stream_complete events via useChannelStreamSocket.
+ * - On stream completion, synthesizes the assistant message locally and
+ *   appends to the surface's useChat messages state.
+ * - Single-writer-claims the dashboard store's agent stop-streaming slot when
+ *   bootstrap discovers an own stream; releases only if THIS surface claimed.
+ *   Co-mounted surfaces (dashboard + sidebar agent mode) preserve each
+ *   other's claim — first writer wins.
+ * - Registers the channel with the editing store under `ai-channel-${id}` so
+ *   SWR is blocked while a stream is in flight, including the bootstrap-replay
+ *   window before useChat has re-engaged.
+ * - Refreshes the active conversation when the socket transitions back to
+ *   connected after an offline blip (skipped on the very first connect).
+ *
+ * Pass `selectedAgent: null` to no-op (e.g. the surface is in global mode).
+ */
+export function useAgentChannelMultiplayer({
+  selectedAgent,
+  agentConversationId,
+  setLocalMessages,
+  isLocallyStreaming,
+  surfaceComponentName,
+}: UseAgentChannelMultiplayerOptions): void {
+  const channelId = selectedAgent?.id;
+
+  usePageSocketRoom(channelId);
+
+  // Stable refs so the hook's callbacks see the latest setter / conversation
+  // id without re-binding the socket subscription on every render.
+  const setLocalMessagesRef = useRef(setLocalMessages);
+  setLocalMessagesRef.current = setLocalMessages;
+  const agentConversationIdRef = useRef(agentConversationId);
+  agentConversationIdRef.current = agentConversationId;
+
+  // Single-writer ownership of the dashboard store's stop slot. Only this
+  // surface's onOwnStreamFinalize clears the slot, and only when this surface
+  // claimed it on bootstrap.
+  const ownedStopSlotRef = useRef(false);
+
+  useChannelStreamSocket(channelId, {
+    onStreamComplete: (messageId) => {
+      const stream = usePendingStreamsStore.getState().streams.get(messageId);
+      if (!stream?.text) return;
+      if (stream.conversationId !== agentConversationIdRef.current) return;
+      setLocalMessagesRef.current((prev) => [
+        ...prev,
+        synthesizeAssistantMessage(messageId, stream.text),
+      ]);
+    },
+    onOwnStreamBootstrap: ({ messageId }) => {
+      const dashboard = usePageAgentDashboardStore.getState();
+      if (!shouldClaimAgentStopSlot(dashboard.agentStopStreaming)) return;
+      ownedStopSlotRef.current = true;
+      dashboard.setAgentStreaming(true);
+      dashboard.setAgentStopStreaming(() => {
+        abortActiveStreamByMessageId({ messageId });
+      });
+    },
+    onOwnStreamFinalize: () => {
+      if (!ownedStopSlotRef.current) return;
+      ownedStopSlotRef.current = false;
+      const dashboard = usePageAgentDashboardStore.getState();
+      dashboard.setAgentStreaming(false);
+      dashboard.setAgentStopStreaming(null);
+    },
+  });
+
+  // Channel-id-keyed registration so co-mounted surfaces (dashboard + sidebar
+  // in agent mode on the same agent) write the same key and the editing store
+  // dedups same-key writes naturally. The flag ORs the surface's local
+  // streaming flag with the dashboard store's bootstrap-driven flag so a
+  // mid-stream refresh stays SWR-protected before useChat re-engages.
+  const dashboardAgentStreaming = usePageAgentDashboardStore((s) => s.isAgentStreaming);
+  useStreamingRegistration(
+    selectedAgent ? `ai-channel-${selectedAgent.id}` : 'ai-channel-no-agent',
+    Boolean(selectedAgent) && (isLocallyStreaming || dashboardAgentStreaming),
+    selectedAgent
+      ? {
+          conversationId: agentConversationId || undefined,
+          componentName: surfaceComponentName,
+        }
+      : undefined,
+  );
+
+  // Reconnect-refresh: re-fetch the active agent conversation when the socket
+  // transitions back to connected. Skipped on the very first connect (already
+  // covered by mount-time load).
+  const socketConnectionStatus = useSocketStore((s) => s.connectionStatus);
+  const prevConnectionStatusRef = useRef<ConnectionStatus | null>(null);
+  const hasInitialConnectRef = useRef(false);
+  const loadConversation = usePageAgentDashboardStore((s) => s.loadConversation);
+  useEffect(() => {
+    if (!selectedAgent) return;
+    const prev = prevConnectionStatusRef.current;
+    prevConnectionStatusRef.current = socketConnectionStatus;
+    if (
+      shouldRefreshOnReconnect(prev, socketConnectionStatus, hasInitialConnectRef.current)
+      && agentConversationId
+    ) {
+      loadConversation(agentConversationId);
+    }
+    if (prev !== 'connected' && socketConnectionStatus === 'connected') {
+      hasInitialConnectRef.current = true;
+    }
+  }, [selectedAgent, socketConnectionStatus, agentConversationId, loadConversation]);
+}

--- a/apps/web/src/hooks/useAgentChannelMultiplayer.ts
+++ b/apps/web/src/hooks/useAgentChannelMultiplayer.ts
@@ -23,6 +23,13 @@ export interface UseAgentChannelMultiplayerOptions {
   isLocallyStreaming: boolean;
   /** componentName for the editing-store metadata. */
   surfaceComponentName: string;
+  /**
+   * Re-fetch handler invoked on socket reconnect (after the initial connect).
+   * Surface owns this — dashboard agent mode passes the dashboard store
+   * loader, sidebar agent mode passes its own sidebar-state loader, since
+   * those two surfaces resolve to different agents/conversations.
+   */
+  loadConversation: (conversationId: string) => void | Promise<void>;
 }
 
 /**
@@ -52,6 +59,7 @@ export function useAgentChannelMultiplayer({
   setLocalMessages,
   isLocallyStreaming,
   surfaceComponentName,
+  loadConversation,
 }: UseAgentChannelMultiplayerOptions): void {
   const channelId = selectedAgent?.id;
 
@@ -66,8 +74,20 @@ export function useAgentChannelMultiplayer({
 
   // Single-writer ownership of the dashboard store's stop slot. Only this
   // surface's onOwnStreamFinalize clears the slot, and only when this surface
-  // claimed it on bootstrap.
+  // claimed it on bootstrap. The unmount cleanup below also clears it if
+  // this surface unmounts mid-stream — useChannelStreamSocket intentionally
+  // does not fire onOwnStreamFinalize on teardown, so without the cleanup
+  // a navigate-away mid-stream would leave the slot stuck.
   const ownedStopSlotRef = useRef(false);
+  useEffect(() => {
+    return () => {
+      if (!ownedStopSlotRef.current) return;
+      ownedStopSlotRef.current = false;
+      const dashboard = usePageAgentDashboardStore.getState();
+      dashboard.setAgentStreaming(false);
+      dashboard.setAgentStopStreaming(null);
+    };
+  }, []);
 
   useChannelStreamSocket(channelId, {
     onStreamComplete: (messageId) => {
@@ -116,11 +136,15 @@ export function useAgentChannelMultiplayer({
 
   // Reconnect-refresh: re-fetch the active agent conversation when the socket
   // transitions back to connected. Skipped on the very first connect (already
-  // covered by mount-time load).
+  // covered by mount-time load). Uses the surface-provided loadConversation
+  // because the two consuming surfaces (dashboard agent mode + sidebar agent
+  // mode) resolve their agent state from different stores; one shared loader
+  // would refresh the wrong conversation in the other surface.
   const socketConnectionStatus = useSocketStore((s) => s.connectionStatus);
   const prevConnectionStatusRef = useRef<ConnectionStatus | null>(null);
   const hasInitialConnectRef = useRef(false);
-  const loadConversation = usePageAgentDashboardStore((s) => s.loadConversation);
+  const loadConversationRef = useRef(loadConversation);
+  loadConversationRef.current = loadConversation;
   useEffect(() => {
     if (!selectedAgent) return;
     const prev = prevConnectionStatusRef.current;
@@ -129,10 +153,10 @@ export function useAgentChannelMultiplayer({
       shouldRefreshOnReconnect(prev, socketConnectionStatus, hasInitialConnectRef.current)
       && agentConversationId
     ) {
-      loadConversation(agentConversationId);
+      loadConversationRef.current(agentConversationId);
     }
     if (prev !== 'connected' && socketConnectionStatus === 'connected') {
       hasInitialConnectRef.current = true;
     }
-  }, [selectedAgent, socketConnectionStatus, agentConversationId, loadConversation]);
+  }, [selectedAgent, socketConnectionStatus, agentConversationId]);
 }

--- a/apps/web/src/hooks/useChannelStreamSocket.ts
+++ b/apps/web/src/hooks/useChannelStreamSocket.ts
@@ -4,6 +4,8 @@ import { usePendingStreamsStore } from '@/stores/usePendingStreamsStore';
 import { consumeStreamJoin } from '@/lib/ai/core/stream-join-client';
 import { getBrowserSessionId } from '@/lib/ai/core/browser-session-id';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { isOwnStream } from '@/lib/ai/streams/isOwnStream';
+import { shouldSkipBootstrappedStream } from '@/lib/ai/streams/shouldSkipBootstrappedStream';
 import type { AiStreamStartPayload, AiStreamCompletePayload } from '@/lib/websocket/socket-utils';
 
 interface ActiveStreamRow {
@@ -111,9 +113,8 @@ export function useChannelStreamSocket(
         const data = (await res.json()) as { streams?: ActiveStreamRow[] };
         if (cancelled) return;
         for (const stream of data.streams ?? []) {
-          if (processed.has(stream.messageId)) continue;
-          if (controllers.has(stream.messageId)) continue;
-          const isOwn = stream.triggeredBy.browserSessionId === localBrowserSessionId;
+          if (shouldSkipBootstrappedStream(stream.messageId, processed, controllers)) continue;
+          const isOwn = isOwnStream(stream.triggeredBy, localBrowserSessionId);
           addStream({
             messageId: stream.messageId,
             pageId: channelId,
@@ -135,7 +136,7 @@ export function useChannelStreamSocket(
 
     const handleStreamStart = (payload: AiStreamStartPayload) => {
       if (payload.pageId !== channelId) return;
-      if (payload.triggeredBy.browserSessionId === localBrowserSessionId) return;
+      if (isOwnStream(payload.triggeredBy, localBrowserSessionId)) return;
       if (controllers.has(payload.messageId)) return;
 
       addStream({

--- a/apps/web/src/lib/ai/streams/__tests__/dedupRemoteStreams.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/dedupRemoteStreams.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { dedupRemoteStreams } from '../dedupRemoteStreams';
+import type { PendingStream } from '@/stores/usePendingStreamsStore';
+
+const stream = (messageId: string): PendingStream => ({
+  messageId,
+  pageId: 'p',
+  conversationId: 'c',
+  triggeredBy: { userId: 'u', displayName: 'U' },
+  text: '',
+  isOwn: false,
+});
+
+describe('dedupRemoteStreams', () => {
+  it('given a stream whose messageId is already in messages, should drop it', () => {
+    const streams = [stream('msg-1'), stream('msg-2')];
+    const messages = [{ id: 'msg-1' }];
+
+    expect(dedupRemoteStreams(streams, messages)).toEqual([stream('msg-2')]);
+  });
+
+  it('given streams with no overlap with messages, should return all streams unchanged', () => {
+    const streams = [stream('msg-1'), stream('msg-2')];
+    const messages = [{ id: 'msg-3' }];
+
+    expect(dedupRemoteStreams(streams, messages)).toEqual(streams);
+  });
+
+  it('given an empty stream list, should return an empty array', () => {
+    expect(dedupRemoteStreams([], [{ id: 'msg-1' }])).toEqual([]);
+  });
+
+  it('given empty messages, should return all streams unchanged', () => {
+    const streams = [stream('msg-1')];
+    expect(dedupRemoteStreams(streams, [])).toEqual(streams);
+  });
+
+  it('given a stream that overlaps and others that do not, should preserve order of the survivors', () => {
+    const streams = [stream('msg-a'), stream('msg-b'), stream('msg-c')];
+    const messages = [{ id: 'msg-b' }];
+
+    const result = dedupRemoteStreams(streams, messages);
+    expect(result.map((s) => s.messageId)).toEqual(['msg-a', 'msg-c']);
+  });
+});

--- a/apps/web/src/lib/ai/streams/__tests__/isOwnStream.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/isOwnStream.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { isOwnStream } from '../isOwnStream';
+
+describe('isOwnStream', () => {
+  it('given the triggering session matches the local session, should be true', () => {
+    expect(isOwnStream({ browserSessionId: 'session-A' }, 'session-A')).toBe(true);
+  });
+
+  it('given the triggering session differs from the local session, should be false', () => {
+    expect(isOwnStream({ browserSessionId: 'session-A' }, 'session-B')).toBe(false);
+  });
+
+  it('given an empty local session id and a non-empty triggering session, should be false', () => {
+    expect(isOwnStream({ browserSessionId: 'session-A' }, '')).toBe(false);
+  });
+
+  it('given two empty session ids, should be true (matches identity even on the SSR placeholder)', () => {
+    expect(isOwnStream({ browserSessionId: '' }, '')).toBe(true);
+  });
+});

--- a/apps/web/src/lib/ai/streams/__tests__/isPlaceholderConversationId.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/isPlaceholderConversationId.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { isPlaceholderConversationId } from '../isPlaceholderConversationId';
+
+describe('isPlaceholderConversationId', () => {
+  it('given the channel-scoped default, should be true', () => {
+    expect(isPlaceholderConversationId('page-123-default', 'page-123')).toBe(true);
+  });
+
+  it('given a real conversation id (not the placeholder), should be false', () => {
+    expect(isPlaceholderConversationId('conv-abc', 'page-123')).toBe(false);
+  });
+
+  it('given null, should be false', () => {
+    expect(isPlaceholderConversationId(null, 'page-123')).toBe(false);
+  });
+
+  it('given undefined, should be false', () => {
+    expect(isPlaceholderConversationId(undefined, 'page-123')).toBe(false);
+  });
+
+  it('given a placeholder for a different channel, should be false', () => {
+    expect(isPlaceholderConversationId('page-other-default', 'page-123')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/ai/streams/__tests__/selectChannelRemoteStreams.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/selectChannelRemoteStreams.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { selectChannelRemoteStreams } from '../selectChannelRemoteStreams';
+import type { PendingStream } from '@/stores/usePendingStreamsStore';
+
+const stream = (overrides: Partial<PendingStream>): PendingStream => ({
+  messageId: 'msg-1',
+  pageId: 'channel-1',
+  conversationId: 'conv-1',
+  triggeredBy: { userId: 'user-1', displayName: 'U' },
+  text: '',
+  isOwn: false,
+  ...overrides,
+});
+
+const stateFrom = (streamsByChannel: Record<string, PendingStream[]>) => ({
+  getRemotePageStreams: (channelId: string): PendingStream[] => streamsByChannel[channelId] ?? [],
+});
+
+describe('selectChannelRemoteStreams', () => {
+  describe('agent mode', () => {
+    it('given a selected agent and a matching agent conversation, should return streams from the agent channel filtered by the agent conversation id', () => {
+      const state = stateFrom({
+        'agent-1': [
+          stream({ messageId: 'm1', pageId: 'agent-1', conversationId: 'conv-active' }),
+          stream({ messageId: 'm2', pageId: 'agent-1', conversationId: 'conv-other' }),
+        ],
+      });
+
+      const result = selectChannelRemoteStreams(state, {
+        selectedAgent: { id: 'agent-1' },
+        agentConversationId: 'conv-active',
+        globalChannelId: 'user:u:global',
+        globalConversationId: 'g-1',
+      });
+
+      expect(result.map((s) => s.messageId)).toEqual(['m1']);
+    });
+
+    it('given a selected agent but no agent conversation id yet, should return []', () => {
+      const state = stateFrom({
+        'agent-1': [stream({ messageId: 'm1', pageId: 'agent-1', conversationId: 'whatever' })],
+      });
+
+      const result = selectChannelRemoteStreams(state, {
+        selectedAgent: { id: 'agent-1' },
+        agentConversationId: null,
+        globalChannelId: 'user:u:global',
+        globalConversationId: 'g-1',
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    it('given a selected agent, should NOT return streams from the global channel even if globalChannelId is populated', () => {
+      const state = stateFrom({
+        'agent-1': [],
+        'user:u:global': [stream({ messageId: 'm-global', pageId: 'user:u:global', conversationId: 'g-1' })],
+      });
+
+      const result = selectChannelRemoteStreams(state, {
+        selectedAgent: { id: 'agent-1' },
+        agentConversationId: 'conv-active',
+        globalChannelId: 'user:u:global',
+        globalConversationId: 'g-1',
+      });
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('global mode', () => {
+    it('given selectedAgent is null and a matching global conversation, should return streams from the global channel filtered by the global conversation id', () => {
+      const state = stateFrom({
+        'user:u:global': [
+          stream({ messageId: 'm1', pageId: 'user:u:global', conversationId: 'g-active' }),
+          stream({ messageId: 'm2', pageId: 'user:u:global', conversationId: 'g-other' }),
+        ],
+      });
+
+      const result = selectChannelRemoteStreams(state, {
+        selectedAgent: null,
+        agentConversationId: null,
+        globalChannelId: 'user:u:global',
+        globalConversationId: 'g-active',
+      });
+
+      expect(result.map((s) => s.messageId)).toEqual(['m1']);
+    });
+
+    it('given selectedAgent is null but no global channel id (e.g. unauthenticated), should return []', () => {
+      const state = stateFrom({
+        'user:u:global': [stream({ messageId: 'm1', pageId: 'user:u:global', conversationId: 'g-1' })],
+      });
+
+      const result = selectChannelRemoteStreams(state, {
+        selectedAgent: null,
+        agentConversationId: null,
+        globalChannelId: null,
+        globalConversationId: 'g-1',
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    it('given selectedAgent is null but no global conversation id loaded yet, should return []', () => {
+      const state = stateFrom({
+        'user:u:global': [stream({ messageId: 'm1', pageId: 'user:u:global', conversationId: 'g-1' })],
+      });
+
+      const result = selectChannelRemoteStreams(state, {
+        selectedAgent: null,
+        agentConversationId: null,
+        globalChannelId: 'user:u:global',
+        globalConversationId: null,
+      });
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/apps/web/src/lib/ai/streams/__tests__/shouldClaimAgentStopSlot.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/shouldClaimAgentStopSlot.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { shouldClaimAgentStopSlot } from '../shouldClaimAgentStopSlot';
+
+describe('shouldClaimAgentStopSlot', () => {
+  it('given an empty slot, should claim', () => {
+    expect(shouldClaimAgentStopSlot(null)).toBe(true);
+  });
+
+  it('given a populated slot, should not claim (so the first writer is preserved)', () => {
+    const existingStop = () => {};
+    expect(shouldClaimAgentStopSlot(existingStop)).toBe(false);
+  });
+
+  it('given a populated slot whose function is a no-op, should still not claim', () => {
+    expect(shouldClaimAgentStopSlot(() => undefined)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/ai/streams/__tests__/shouldRefreshOnReconnect.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/shouldRefreshOnReconnect.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { shouldRefreshOnReconnect } from '../shouldRefreshOnReconnect';
+
+describe('shouldRefreshOnReconnect', () => {
+  it('given a transition from disconnected to connected after the initial connect, should refresh', () => {
+    expect(shouldRefreshOnReconnect('disconnected', 'connected', true)).toBe(true);
+  });
+
+  it('given a transition from error to connected after the initial connect, should refresh', () => {
+    expect(shouldRefreshOnReconnect('error', 'connected', true)).toBe(true);
+  });
+
+  it('given the very first connect (hadInitialConnect=false), should NOT refresh — the mount-time load already covers it', () => {
+    expect(shouldRefreshOnReconnect(null, 'connected', false)).toBe(false);
+  });
+
+  it('given a status change while still connected (e.g. dep change firing the effect), should NOT refresh', () => {
+    expect(shouldRefreshOnReconnect('connected', 'connected', true)).toBe(false);
+  });
+
+  it('given a transition INTO a non-connected state, should NOT refresh', () => {
+    expect(shouldRefreshOnReconnect('connected', 'disconnected', true)).toBe(false);
+  });
+
+  it('given prevStatus null and connected after initial connect already happened, should refresh (covers the unusual ref-reset case)', () => {
+    expect(shouldRefreshOnReconnect(null, 'connected', true)).toBe(true);
+  });
+});

--- a/apps/web/src/lib/ai/streams/__tests__/shouldSkipBootstrappedStream.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/shouldSkipBootstrappedStream.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { shouldSkipBootstrappedStream } from '../shouldSkipBootstrappedStream';
+
+describe('shouldSkipBootstrappedStream', () => {
+  it('given a messageId not seen anywhere, should not skip', () => {
+    expect(shouldSkipBootstrappedStream('msg-1', new Set(), new Map())).toBe(false);
+  });
+
+  it('given a messageId already in the processed set (already finalized via socket race), should skip', () => {
+    expect(shouldSkipBootstrappedStream('msg-1', new Set(['msg-1']), new Map())).toBe(true);
+  });
+
+  it('given a messageId already with an active controller (live consume in flight), should skip', () => {
+    const controllers = new Map<string, unknown>([['msg-1', {}]]);
+    expect(shouldSkipBootstrappedStream('msg-1', new Set(), controllers)).toBe(true);
+  });
+
+  it('given a messageId in both sets, should skip (no double-skip surprises)', () => {
+    const controllers = new Map<string, unknown>([['msg-1', {}]]);
+    expect(shouldSkipBootstrappedStream('msg-1', new Set(['msg-1']), controllers)).toBe(true);
+  });
+
+  it('given a different messageId from what is tracked, should not skip', () => {
+    const controllers = new Map<string, unknown>([['msg-1', {}]]);
+    expect(shouldSkipBootstrappedStream('msg-2', new Set(['msg-3']), controllers)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/ai/streams/__tests__/synthesizeAssistantMessage.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/synthesizeAssistantMessage.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { synthesizeAssistantMessage } from '../synthesizeAssistantMessage';
+
+describe('synthesizeAssistantMessage', () => {
+  it('given a messageId and text, should produce an assistant UIMessage with one text part holding that text', () => {
+    const msg = synthesizeAssistantMessage('msg-1', 'Hello world');
+
+    expect(msg).toEqual({
+      id: 'msg-1',
+      role: 'assistant',
+      parts: [{ type: 'text', text: 'Hello world' }],
+    });
+  });
+
+  it('given empty text, should still produce a valid message (the renderer suppresses empty parts)', () => {
+    const msg = synthesizeAssistantMessage('msg-1', '');
+
+    expect(msg.id).toBe('msg-1');
+    expect(msg.role).toBe('assistant');
+    expect(msg.parts).toEqual([{ type: 'text', text: '' }]);
+  });
+
+  it('given the same input twice, should produce structurally equal messages (referentially independent)', () => {
+    const a = synthesizeAssistantMessage('msg-1', 'hi');
+    const b = synthesizeAssistantMessage('msg-1', 'hi');
+
+    expect(a).toEqual(b);
+    expect(a).not.toBe(b);
+    expect(a.parts).not.toBe(b.parts);
+  });
+});

--- a/apps/web/src/lib/ai/streams/dedupRemoteStreams.ts
+++ b/apps/web/src/lib/ai/streams/dedupRemoteStreams.ts
@@ -1,0 +1,17 @@
+import type { PendingStream } from '@/stores/usePendingStreamsStore';
+
+/**
+ * Drops any pending stream whose `messageId` already appears in the local
+ * messages array. Surfaces that render remote streams alongside local
+ * messages need this so they don't show the same message twice during the
+ * brief window when the message has landed in `messages` but the stream
+ * entry hasn't yet been removed from the store.
+ */
+export const dedupRemoteStreams = (
+  streams: readonly PendingStream[],
+  messages: readonly { id: string }[],
+): PendingStream[] => {
+  if (streams.length === 0) return [];
+  const seen = new Set(messages.map((m) => m.id));
+  return streams.filter((s) => !seen.has(s.messageId));
+};

--- a/apps/web/src/lib/ai/streams/isOwnStream.ts
+++ b/apps/web/src/lib/ai/streams/isOwnStream.ts
@@ -1,0 +1,10 @@
+/**
+ * True when a stream's `triggeredBy.browserSessionId` matches the local browser
+ * session — i.e. the stream originated in this tab. Streams that don't match
+ * are either from another user, another tab of the same user, or from a server
+ * action with no associated session.
+ */
+export const isOwnStream = (
+  triggeredBy: { browserSessionId: string },
+  localBrowserSessionId: string,
+): boolean => triggeredBy.browserSessionId === localBrowserSessionId;

--- a/apps/web/src/lib/ai/streams/isPlaceholderConversationId.ts
+++ b/apps/web/src/lib/ai/streams/isPlaceholderConversationId.ts
@@ -1,0 +1,11 @@
+/**
+ * True when `conversationId` is the channel-scoped placeholder a surface uses
+ * before a real persisted conversation id arrives — e.g. `${pageId}-default`
+ * for AiChatView. Used by the late-joiner reconciliation path to detect when
+ * the synthesized assistant message needs to wait for the real id before
+ * being appended.
+ */
+export const isPlaceholderConversationId = (
+  conversationId: string | null | undefined,
+  channelId: string,
+): boolean => conversationId === `${channelId}-default`;

--- a/apps/web/src/lib/ai/streams/selectChannelRemoteStreams.ts
+++ b/apps/web/src/lib/ai/streams/selectChannelRemoteStreams.ts
@@ -1,0 +1,39 @@
+import type { PendingStream } from '@/stores/usePendingStreamsStore';
+
+interface ChannelStreamsState {
+  getRemotePageStreams: (channelId: string) => PendingStream[];
+}
+
+interface SelectArgs {
+  selectedAgent: { id: string } | null;
+  agentConversationId: string | null;
+  globalChannelId: string | null;
+  globalConversationId: string | null;
+}
+
+/**
+ * Picks the right channel and applies the conversation filter for the surface
+ * that's calling. Agent mode reads `selectedAgent.id`; global mode reads
+ * `globalChannelId`. In either mode, streams whose `conversationId` doesn't
+ * match the active conversation are dropped — concurrent streams in other
+ * conversations on the same channel must not render here.
+ *
+ * Used by GlobalAssistantView and SidebarChatTab. The two surfaces had the
+ * same dispatch + filter inline before; consolidating here keeps the
+ * mode/conversation rules in one tested unit.
+ */
+export const selectChannelRemoteStreams = (
+  state: ChannelStreamsState,
+  { selectedAgent, agentConversationId, globalChannelId, globalConversationId }: SelectArgs,
+): PendingStream[] => {
+  if (selectedAgent) {
+    if (!agentConversationId) return [];
+    return state
+      .getRemotePageStreams(selectedAgent.id)
+      .filter((s) => s.conversationId === agentConversationId);
+  }
+  if (!globalChannelId || !globalConversationId) return [];
+  return state
+    .getRemotePageStreams(globalChannelId)
+    .filter((s) => s.conversationId === globalConversationId);
+};

--- a/apps/web/src/lib/ai/streams/shouldClaimAgentStopSlot.ts
+++ b/apps/web/src/lib/ai/streams/shouldClaimAgentStopSlot.ts
@@ -1,0 +1,9 @@
+/**
+ * Single-writer guard for the dashboard store's agent stop-streaming slot:
+ * only claim if the slot is currently empty. Lets the dashboard view and the
+ * sidebar agent-mode tab co-mount on the same agent without overwriting each
+ * other's stop function — first writer wins, second is a no-op.
+ */
+export const shouldClaimAgentStopSlot = (
+  currentStop: (() => void) | null,
+): boolean => currentStop === null;

--- a/apps/web/src/lib/ai/streams/shouldRefreshOnReconnect.ts
+++ b/apps/web/src/lib/ai/streams/shouldRefreshOnReconnect.ts
@@ -1,0 +1,15 @@
+export type ConnectionStatus = 'disconnected' | 'connecting' | 'connected' | 'error';
+
+/**
+ * True when the socket has just transitioned from a non-connected state to
+ * `connected` AND the surface has already seen its initial connect. Surfaces
+ * call this on every connection-status change to decide whether to refresh
+ * their conversation; the `hadInitialConnect` flag suppresses the refresh on
+ * the very first connect (already covered by the surface's mount-time load).
+ */
+export const shouldRefreshOnReconnect = (
+  prevStatus: ConnectionStatus | null,
+  currStatus: ConnectionStatus,
+  hadInitialConnect: boolean,
+): boolean =>
+  prevStatus !== 'connected' && currStatus === 'connected' && hadInitialConnect;

--- a/apps/web/src/lib/ai/streams/shouldSkipBootstrappedStream.ts
+++ b/apps/web/src/lib/ai/streams/shouldSkipBootstrappedStream.ts
@@ -1,0 +1,10 @@
+/**
+ * Bootstrap may surface a messageId that's already finalized via the live
+ * socket path (race) or already being consumed (effect re-run before cleanup
+ * settled). True means the bootstrap loop should skip this stream.
+ */
+export const shouldSkipBootstrappedStream = (
+  messageId: string,
+  processed: ReadonlySet<string>,
+  controllers: ReadonlyMap<string, unknown>,
+): boolean => processed.has(messageId) || controllers.has(messageId);

--- a/apps/web/src/lib/ai/streams/synthesizeAssistantMessage.ts
+++ b/apps/web/src/lib/ai/streams/synthesizeAssistantMessage.ts
@@ -1,0 +1,15 @@
+import type { UIMessage } from 'ai';
+
+/**
+ * Builds a minimal assistant `UIMessage` from a stream's accumulated text.
+ * Used by surfaces that synthesize the completed assistant message locally on
+ * `onStreamComplete` instead of waiting for a server-side conversation refresh.
+ */
+export const synthesizeAssistantMessage = (
+  messageId: string,
+  text: string,
+): UIMessage => ({
+  id: messageId,
+  role: 'assistant',
+  parts: [{ type: 'text', text }],
+});

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -16,6 +16,11 @@
       "import": "./dist/client-safe.js",
       "default": "./dist/client-safe.js"
     },
+    "./ai/global-channel-id": {
+      "types": "./dist/ai/global-channel-id.d.ts",
+      "import": "./dist/ai/global-channel-id.js",
+      "require": "./dist/ai/global-channel-id.js"
+    },
     "./logging/logger": {
       "types": "./dist/logging/logger.d.ts",
       "import": "./dist/logging/logger.js",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -647,6 +647,9 @@
       "client-safe": [
         "./dist/client-safe.d.ts"
       ],
+      "ai/global-channel-id": [
+        "./dist/ai/global-channel-id.d.ts"
+      ],
       "logging/logger": [
         "./dist/logging/logger.d.ts"
       ],

--- a/packages/lib/src/ai/__tests__/global-channel-id.test.ts
+++ b/packages/lib/src/ai/__tests__/global-channel-id.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { globalChannelId, parseGlobalChannelId } from '../global-channel-id';
+
+describe('globalChannelId', () => {
+  it('given a userId, should return the `user:${userId}:global` literal', () => {
+    expect(globalChannelId('user-1')).toBe('user:user-1:global');
+  });
+
+  it('given a userId containing colons, should embed it verbatim (the format is positional, not delimited)', () => {
+    expect(globalChannelId('a:b:c')).toBe('user:a:b:c:global');
+  });
+});
+
+describe('parseGlobalChannelId', () => {
+  it('given a well-formed global channel id, should return the embedded userId', () => {
+    expect(parseGlobalChannelId('user:user-1:global')).toBe('user-1');
+  });
+
+  it('given a userId that itself contains colons, should round-trip with globalChannelId', () => {
+    const userId = 'a:b:c';
+    expect(parseGlobalChannelId(globalChannelId(userId))).toBe(userId);
+  });
+
+  it('given a non-global channel id, should return null', () => {
+    expect(parseGlobalChannelId('user:user-1:tasks')).toBeNull();
+  });
+
+  it('given a string that does not start with `user:`, should return null', () => {
+    expect(parseGlobalChannelId('page-123')).toBeNull();
+  });
+
+  it('given an empty string, should return null', () => {
+    expect(parseGlobalChannelId('')).toBeNull();
+  });
+
+  it('given a string missing the user-id segment (`user::global`), should return an empty userId — caller must reject empty ids if needed', () => {
+    expect(parseGlobalChannelId('user::global')).toBe('');
+  });
+});

--- a/packages/lib/src/ai/global-channel-id.ts
+++ b/packages/lib/src/ai/global-channel-id.ts
@@ -1,0 +1,18 @@
+/**
+ * The synthetic socket-room/channel id used by the global assistant pipeline.
+ * Construct via `globalChannelId(userId)`; parse via `parseGlobalChannelId`.
+ *
+ * Format: `user:${userId}:global`. The format is positional, not delimited,
+ * so userIds containing `:` round-trip correctly through both functions.
+ */
+const GLOBAL_PREFIX = 'user:';
+const GLOBAL_SUFFIX = ':global';
+
+export const globalChannelId = (userId: string): string =>
+  `${GLOBAL_PREFIX}${userId}${GLOBAL_SUFFIX}`;
+
+export const parseGlobalChannelId = (channelId: string): string | null => {
+  if (!channelId.startsWith(GLOBAL_PREFIX)) return null;
+  if (!channelId.endsWith(GLOBAL_SUFFIX)) return null;
+  return channelId.slice(GLOBAL_PREFIX.length, channelId.length - GLOBAL_SUFFIX.length);
+};


### PR DESCRIPTION
## Summary

PR2 of the [Multiplayer Streaming — Surface Parity](https://github.com/2witstudios/PageSpace/pull/1174) epic. Wires `GlobalAssistantView` agent mode and `SidebarChatTab` (both modes) to the multiplayer streaming pipeline so every AI chat surface renders remote streams identically — same bubble, same markdown, same stop button after refresh — regardless of which surface the originating user used.

PR1 (#1174) shipped the shared `useChannelStreamSocket` hook. This PR consumes it across two more surfaces and extracts the rest of the supporting helpers under a functional-core / imperative-shell discipline: each predicate, transform, or decision is its own pure function with input/output tests, and the surface code is a thin shell that composes them.

## What's delivered

**Surface wiring (per the original epic):**
- **Task 2** — `GlobalAssistantView` agent mode: joins the agent's page room, bootstrap-replays in-flight streams, claims the dashboard-store stop slot under co-mount safety, registers `ai-channel-${agent.id}` with the editing store, refreshes the active conversation on socket reconnect.
- **Task 3** — `SidebarChatTab` global mode render path: reads global remote streams from `usePendingStreamsStore` (provider already runs the bootstrap+socket above the layout) and renders them inline below the messages. Empty-state placeholder respects active streams.
- **Task 4** — `SidebarChatTab` agent mode: same wiring as Task 2 via the shared hook (`useAgentChannelMultiplayer`); same `ai-channel-${agent.id}` editing-store key so co-mounted dashboard + sidebar de-dup naturally; same single-writer claim guard for the stop slot.
- **Tasks 5 + 6** — local synthesis on stream completion + reconnect refresh: cross-cutting concerns implemented per-surface via the pure helpers `synthesizeAssistantMessage` and `shouldRefreshOnReconnect`. The latter is also retrofit into `GlobalChatContext`.
- **Task 7** — `globalChannelId(userId)` / `parseGlobalChannelId(channelId)` helpers in `@pagespace/lib`. Sweeps 6 production call sites (5 in apps/web, 1 in apps/realtime) onto them.

**Pure helpers (input/output tested, no mocks):**
1. `isOwnStream(triggeredBy, localBrowserSessionId)`
2. `shouldSkipBootstrappedStream(messageId, processed, controllers)`
3. `synthesizeAssistantMessage(messageId, text)` — UIMessage builder
4. `dedupRemoteStreams(streams, messages)` — drops streams whose messageId already landed
5. `isPlaceholderConversationId(conversationId, channelId)` — `${channelId}-default` detector
6. `shouldClaimAgentStopSlot(currentStop)` — single-writer guard for co-mount safety
7. `shouldRefreshOnReconnect(prev, curr, hadInitialConnect)` — socket transition decision
8. `selectChannelRemoteStreams(state, args)` — mode + conversation dispatch
9. `globalChannelId` / `parseGlobalChannelId` — synthetic global channel id

**Shell hook:**
- `useAgentChannelMultiplayer({ selectedAgent, agentConversationId, setLocalMessages, isLocallyStreaming, surfaceComponentName, loadConversation })` — encapsulates the agent-mode pipeline shared by `GlobalAssistantView` and `SidebarChatTab`. 19 behavioral tests.

**Pre-existing bugs fixed in passing:**
- `agentStopStreaming` was being stored as a HOF (`setAgentStopStreaming(() => () => abort())`), so consumers calling `dashboardStopStreaming()` got the inner function back without invoking it — agent stop was a no-op. New wiring stores the stop as a real `() => void` and pins it via a hook test.

**Codex review feedback resolved (fixed in `8901c6218`):**
- **P1: surface-owned `loadConversation`** — hook used to hardcode `usePageAgentDashboardStore.loadConversation`, but `SidebarChatTab` resolves agent state from `usePageAgentSidebarState`. Now `loadConversation` is a required option each surface provides, so reconnect refresh hits the right store.
- **P1: stop slot leak on unmount** — `useChannelStreamSocket` does not fire `onOwnStreamFinalize` on unmount, so a navigate-away mid-stream left the dashboard stop slot stuck. Hook now has a cleanup effect that releases the slot iff this surface claimed it. Co-mount safety preserved.

## Commits

- `b32a1d9a6` — extract `isOwnStream` + `shouldSkipBootstrappedStream` helpers
- `6266d9d6f` — 5 more pure helpers + opportunistic swap of GCC reconnect onto `shouldRefreshOnReconnect`
- `96801a3e0` — wire `GlobalAssistantView` agent mode (inline)
- `e3cca98ce` — extract `useAgentChannelMultiplayer` hook
- `fd04372ea` — 16 behavioral tests for `useAgentChannelMultiplayer`
- `d5eca5c7b` — widen renderHook initialProps so test typechecks under workspace `tsc`
- `84f319dec` — `SidebarChatTab` global-mode render path (Task 3)
- `73acc22a2` — 6 behavioral tests for `SidebarMessagesContent`
- `002b5c095` — extract `selectChannelRemoteStreams` pure helper; refactor `GlobalAssistantView` onto it
- `eeb512adc` — wire `SidebarChatTab` agent mode (Task 4)
- `34d12cc3f` — `globalChannelId` / `parseGlobalChannelId` helpers in `@pagespace/lib`
- `a7aa0a2eb` — sweep 6 production call sites onto the helpers; add `typesVersions` for classic Node10 moduleResolution support
- `8901c6218` — Codex P1 fixes: surface-owned `loadConversation` + cleanup-on-unmount for the dashboard stop slot (3 new tests)

## Test plan

- [x] `pnpm --filter web typecheck` clean
- [x] `pnpm --filter realtime typecheck` clean
- [x] `pnpm --filter web lint` — only pre-existing `QuickCreatePalette` warning (untouched)
- [x] `pnpm --filter web test src/hooks src/lib/ai/streams src/contexts src/stores src/components/layout` — 439/439 across 38 files
- [x] `pnpm --filter realtime test` — 337/337 across 10 files
- [x] `pnpm --filter @pagespace/lib test src/ai/__tests__/global-channel-id.test.ts` — 8/8

## Behavior preserved

- All four surfaces (`AiChatView`, `GlobalChatContext`-backed global mode, `GlobalAssistantView` agent mode, `SidebarChatTab` both modes) consume the same `useChannelStreamSocket` and the same set of pure helpers.
- Live `chat:stream_start` events from the local browser session are still skipped — `useChat` in the active tab remains source of truth for own post-mount streams.
- Per-conversation editing-store registrations on `GlobalAssistantView` and `SidebarChatTab` are unchanged; the new `ai-channel-${agent.id}` key is additive coverage for the bootstrap-replay window before useChat re-engages.

## Co-mount semantics

- Both `GlobalAssistantView` and `SidebarChatTab` agent mode write to the same dashboard store stop slot via `shouldClaimAgentStopSlot`. First writer claims; second is a no-op. Pinned by hook test.
- Both register under the same `ai-channel-${agent.id}` editing-store key. Same-key writes dedup naturally; SWR is blocked while either surface considers the channel active.
- The sidebar uses `usePageAgentSidebarState` (its own agent selection, separate from `usePageAgentDashboardStore`), so the sidebar can be on a different agent than the dashboard. When agents differ, they're on different channels and don't collide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)