### PR TITLE
feat(tasks): agent trigger UI for task lists

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/tasks/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/__tests__/route.test.ts
@@ -60,6 +60,14 @@ vi.mock('@pagespace/db/db', () => {
       returning: vi.fn(),
     })),
   }));
+  // Active-trigger-count lookup: db.select(...).from(workflows).where(...).groupBy(...)
+  const mockSelect = vi.fn(() => ({
+    from: vi.fn(() => ({
+      where: vi.fn(() => ({
+        groupBy: vi.fn().mockResolvedValue([]),
+      })),
+    })),
+  }));
   return {
     db: {
       query: {
@@ -78,6 +86,7 @@ vi.mock('@pagespace/db/db', () => {
         },
       },
       insert: mockInsert,
+      select: mockSelect,
       transaction: vi.fn(async (callback) => {
         let insertCallCount = 0;
         // Create a tx object that mimics the transaction context
@@ -102,9 +111,14 @@ vi.mock('@pagespace/db/operators', () => ({
   and: vi.fn((...conditions) => conditions),
   asc: vi.fn((col) => ({ type: 'asc', col })),
   desc: vi.fn((col) => ({ type: 'desc', col })),
+  inArray: vi.fn((col, values) => ({ type: 'inArray', col, values })),
+  count: vi.fn(() => ({ type: 'count' })),
 }));
 vi.mock('@pagespace/db/schema/core', () => ({
   pages: {},
+}));
+vi.mock('@pagespace/db/schema/workflows', () => ({
+  workflows: { taskItemId: 'taskItemId-col', isEnabled: 'isEnabled-col', triggerType: 'triggerType-col' },
 }));
 vi.mock('@pagespace/db/schema/tasks', () => ({
   taskLists: {},
@@ -147,6 +161,14 @@ describe('Task API Routes', () => {
     vi.mocked(db.insert).mockReturnValue({
       values: vi.fn(() => ({
         returning: vi.fn(),
+      })),
+    } as never);
+    // Re-set up db.select default for active-trigger-count lookup
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          groupBy: vi.fn().mockResolvedValue([]),
+        })),
       })),
     } as never);
     // Re-set up db.transaction

--- a/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from 'next/server';
 import { db } from '@pagespace/db/db'
-import { eq, and, desc, asc } from '@pagespace/db/operators'
+import { eq, and, desc, asc, inArray, count } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core'
 import { taskLists, taskItems, taskStatusConfigs, taskAssignees } from '@pagespace/db/schema/tasks';
+import { workflows } from '@pagespace/db/schema/workflows';
 import { createTaskTriggerWorkflow } from '@/lib/workflows/task-trigger-helpers';
 import { DEFAULT_TASK_STATUSES } from '@pagespace/db/schema/tasks';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
@@ -207,6 +208,30 @@ export async function GET(req: Request, { params }: { params: Promise<{ pageId: 
     );
   }
 
+  // Ground-truth active trigger count from the workflows table so badges don't
+  // go stale when an agent page is trashed and the workflow row cascade-deletes.
+  const triggerCountByTaskId = new Map<string, number>();
+  if (tasks.length > 0) {
+    const taskIdList = tasks.map((t) => t.id);
+    const triggerRows = await db
+      .select({ taskItemId: workflows.taskItemId, total: count() })
+      .from(workflows)
+      .where(and(
+        inArray(workflows.taskItemId, taskIdList),
+        eq(workflows.isEnabled, true),
+        inArray(workflows.triggerType, ['task_due_date', 'task_completion']),
+      ))
+      .groupBy(workflows.taskItemId);
+    for (const row of triggerRows) {
+      if (row.taskItemId) triggerCountByTaskId.set(row.taskItemId, Number(row.total));
+    }
+  }
+
+  const enrichedTasks = tasks.map((t) => ({
+    ...t,
+    activeTriggerCount: triggerCountByTaskId.get(t.id) ?? 0,
+  }));
+
   return NextResponse.json({
     taskList: {
       id: taskList.id,
@@ -215,7 +240,7 @@ export async function GET(req: Request, { params }: { params: Promise<{ pageId: 
       status: taskList.status,
       updatedAt: taskList.updatedAt,
     },
-    tasks,
+    tasks: enrichedTasks,
     statusConfigs,
   });
 }

--- a/apps/web/src/app/api/tasks/[taskId]/triggers/[triggerType]/route.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/triggers/[triggerType]/route.ts
@@ -4,7 +4,7 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { db } from '@pagespace/db/db';
-import { eq, and } from '@pagespace/db/operators';
+import { eq, and, inArray } from '@pagespace/db/operators';
 import { pages } from '@pagespace/db/schema/core';
 import { taskItems, taskLists } from '@pagespace/db/schema/tasks';
 import { workflows } from '@pagespace/db/schema/workflows';
@@ -59,9 +59,19 @@ export async function DELETE(
     .set({ isEnabled: false, lastRunError: 'Disabled by user', nextRunAt: null })
     .where(and(eq(workflows.taskItemId, taskId), eq(workflows.triggerType, triggerTypeDb)));
 
-  // Refresh metadata.triggerTypes — drop the disabled type
-  const existingTypes = ((task.metadata as Record<string, unknown> | null)?.triggerTypes as string[] | undefined) ?? [];
-  const remaining = existingTypes.filter((t) => t !== triggerTypeDb);
+  // Recompute metadata.triggerTypes from the workflows table — task.metadata can
+  // drift (e.g., when a trigger's agent page is trashed and the workflow row
+  // cascade-deletes without touching task metadata).
+  const remainingRows = await db
+    .select({ triggerType: workflows.triggerType })
+    .from(workflows)
+    .where(and(
+      eq(workflows.taskItemId, taskId),
+      eq(workflows.isEnabled, true),
+      inArray(workflows.triggerType, ['task_due_date', 'task_completion']),
+    ));
+  const remaining = Array.from(new Set(remainingRows.map((r) => r.triggerType)));
+
   await db.update(taskItems).set({
     metadata: {
       ...((task.metadata as Record<string, unknown> | null) ?? {}),

--- a/apps/web/src/app/api/tasks/[taskId]/triggers/[triggerType]/route.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/triggers/[triggerType]/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
+import { db } from '@pagespace/db/db';
+import { eq, and } from '@pagespace/db/operators';
+import { pages } from '@pagespace/db/schema/core';
+import { taskItems, taskLists } from '@pagespace/db/schema/tasks';
+import { workflows } from '@pagespace/db/schema/workflows';
+import { broadcastTaskEvent } from '@/lib/websocket';
+
+const SESSION_WRITE = { allow: ['session'] as const, requireCSRF: true };
+
+const triggerTypeParam = z.enum(['due_date', 'completion']);
+
+// DELETE /api/tasks/[taskId]/triggers/[triggerType] — disable one specific trigger
+export async function DELETE(
+  request: Request,
+  context: { params: Promise<{ taskId: string; triggerType: string }> },
+) {
+  const auth = await authenticateRequestWithOptions(request, SESSION_WRITE);
+  if (isAuthError(auth)) return auth.error;
+  const userId = auth.userId;
+
+  const { taskId, triggerType } = await context.params;
+
+  const parsedType = triggerTypeParam.safeParse(triggerType);
+  if (!parsedType.success) {
+    return NextResponse.json({ error: 'Invalid trigger type' }, { status: 400 });
+  }
+  const triggerTypeDb = parsedType.data === 'completion' ? 'task_completion' as const : 'task_due_date' as const;
+
+  const task = await db.query.taskItems.findFirst({ where: eq(taskItems.id, taskId) });
+  if (!task) {
+    return NextResponse.json({ error: 'Task not found' }, { status: 404 });
+  }
+
+  const taskList = await db.query.taskLists.findFirst({ where: eq(taskLists.id, task.taskListId) });
+  if (!taskList?.pageId) {
+    return NextResponse.json({ error: 'Task list not found' }, { status: 404 });
+  }
+
+  const page = await db.query.pages.findFirst({
+    where: eq(pages.id, taskList.pageId),
+    columns: { id: true, isTrashed: true },
+  });
+  if (!page || page.isTrashed) {
+    return NextResponse.json({ error: 'Task list page not found' }, { status: 404 });
+  }
+
+  const canEdit = await canUserEditPage(userId, taskList.pageId);
+  if (!canEdit) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  await db
+    .update(workflows)
+    .set({ isEnabled: false, lastRunError: 'Disabled by user', nextRunAt: null })
+    .where(and(eq(workflows.taskItemId, taskId), eq(workflows.triggerType, triggerTypeDb)));
+
+  // Refresh metadata.triggerTypes — drop the disabled type
+  const existingTypes = ((task.metadata as Record<string, unknown> | null)?.triggerTypes as string[] | undefined) ?? [];
+  const remaining = existingTypes.filter((t) => t !== triggerTypeDb);
+  await db.update(taskItems).set({
+    metadata: {
+      ...((task.metadata as Record<string, unknown> | null) ?? {}),
+      triggerTypes: remaining,
+      hasTrigger: remaining.length > 0,
+    },
+  }).where(eq(taskItems.id, taskId));
+
+  auditRequest(request, {
+    eventType: 'data.delete',
+    userId,
+    resourceType: 'task_triggers',
+    resourceId: taskId,
+    details: { triggerType: triggerTypeDb },
+  });
+
+  void broadcastTaskEvent({
+    type: 'task_updated',
+    taskId,
+    taskListId: task.taskListId,
+    userId,
+    pageId: taskList.pageId,
+    data: { id: taskId, removedTriggerType: triggerTypeDb },
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/apps/web/src/app/api/tasks/[taskId]/triggers/[triggerType]/route.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/triggers/[triggerType]/route.ts
@@ -4,10 +4,11 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { db } from '@pagespace/db/db';
-import { eq, and, inArray } from '@pagespace/db/operators';
+import { eq, and } from '@pagespace/db/operators';
 import { pages } from '@pagespace/db/schema/core';
 import { taskItems, taskLists } from '@pagespace/db/schema/tasks';
 import { workflows } from '@pagespace/db/schema/workflows';
+import { recomputeTaskTriggerMetadata } from '@/lib/workflows/task-trigger-helpers';
 import { broadcastTaskEvent } from '@/lib/websocket';
 
 const SESSION_WRITE = { allow: ['session'] as const, requireCSRF: true };
@@ -59,26 +60,7 @@ export async function DELETE(
     .set({ isEnabled: false, lastRunError: 'Disabled by user', nextRunAt: null })
     .where(and(eq(workflows.taskItemId, taskId), eq(workflows.triggerType, triggerTypeDb)));
 
-  // Recompute metadata.triggerTypes from the workflows table — task.metadata can
-  // drift (e.g., when a trigger's agent page is trashed and the workflow row
-  // cascade-deletes without touching task metadata).
-  const remainingRows = await db
-    .select({ triggerType: workflows.triggerType })
-    .from(workflows)
-    .where(and(
-      eq(workflows.taskItemId, taskId),
-      eq(workflows.isEnabled, true),
-      inArray(workflows.triggerType, ['task_due_date', 'task_completion']),
-    ));
-  const remaining = Array.from(new Set(remainingRows.map((r) => r.triggerType)));
-
-  await db.update(taskItems).set({
-    metadata: {
-      ...((task.metadata as Record<string, unknown> | null) ?? {}),
-      triggerTypes: remaining,
-      hasTrigger: remaining.length > 0,
-    },
-  }).where(eq(taskItems.id, taskId));
+  await recomputeTaskTriggerMetadata(db, taskId, task.metadata as Record<string, unknown> | null);
 
   auditRequest(request, {
     eventType: 'data.delete',

--- a/apps/web/src/app/api/tasks/[taskId]/triggers/__tests__/route.test.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/triggers/__tests__/route.test.ts
@@ -51,6 +51,7 @@ vi.mock('@pagespace/db/db', () => ({
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((field, value) => ({ field, value })),
   and: vi.fn((...conditions) => conditions),
+  inArray: vi.fn((col, values) => ({ type: 'inArray', col, values })),
 }));
 
 vi.mock('@pagespace/db/schema/core', () => ({ pages: {} }));
@@ -199,6 +200,24 @@ describe('Task triggers API', () => {
       expect(res.status).toBe(200);
       expect(createTaskTriggerWorkflow).toHaveBeenCalledOnce();
     });
+
+    it('returns 500 if the trigger row is missing after upsert', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId } as never);
+      vi.mocked(db.query.taskItems.findFirst).mockResolvedValue({ id: taskId, taskListId, dueDate: null, metadata: null } as never);
+      vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: taskListId, pageId } as never);
+      vi.mocked(db.query.pages.findFirst).mockResolvedValue({ id: pageId, driveId, isTrashed: false } as never);
+      vi.mocked(canUserEditPage).mockResolvedValue(true);
+      // Simulate the post-upsert re-query coming back empty (race / constraint loss)
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn(() => ({ where: vi.fn().mockResolvedValue([]) })),
+      } as never);
+
+      const res = await PUT(
+        mkRequest('PUT', { triggerType: 'completion', agentPageId, prompt: 'go' }),
+        { params: mkParams() },
+      );
+      expect(res.status).toBe(500);
+    });
   });
 
   describe('DELETE /api/tasks/[taskId]/triggers/[triggerType]', () => {
@@ -212,22 +231,73 @@ describe('Task triggers API', () => {
       expect(res.status).toBe(400);
     });
 
-    it('disables trigger and clears metadata triggerTypes', async () => {
+    it('disables trigger and recomputes metadata from the workflows table', async () => {
       vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId } as never);
       vi.mocked(db.query.taskItems.findFirst).mockResolvedValue({
         id: taskId,
         taskListId,
+        // Stale metadata: claims both triggers active even though completion is being removed
         metadata: { hasTrigger: true, triggerTypes: ['task_completion', 'task_due_date'] },
       } as never);
       vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: taskListId, pageId } as never);
       vi.mocked(db.query.pages.findFirst).mockResolvedValue({ id: pageId, isTrashed: false } as never);
       vi.mocked(canUserEditPage).mockResolvedValue(true);
 
+      // Live workflows query returns only the due_date trigger (the completion one was just disabled)
+      const setCalls: Record<string, unknown>[] = [];
+      const setSpy = vi.fn((args) => {
+        setCalls.push(args);
+        return { where: vi.fn().mockResolvedValue(undefined) };
+      });
+      vi.mocked(db.update).mockReturnValue({ set: setSpy } as never);
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn(() => ({
+          where: vi.fn().mockResolvedValue([{ triggerType: 'task_due_date' }]),
+        })),
+      } as never);
+
       const res = await DELETE(mkRequest('DELETE'), { params: mkDeleteParams('completion') });
       expect(res.status).toBe(200);
 
       // db.update was called twice: once for workflows, once for taskItems metadata
       expect(db.update).toHaveBeenCalledTimes(2);
+
+      // Metadata write should reflect the live workflows table, not the stale task.metadata
+      const metadataWrite = setCalls.find((c) => c.metadata !== undefined);
+      const meta = metadataWrite?.metadata as { triggerTypes?: string[]; hasTrigger?: boolean };
+      expect(meta?.triggerTypes).toEqual(['task_due_date']);
+      expect(meta?.hasTrigger).toBe(true);
+    });
+
+    it('marks hasTrigger=false when removing the last trigger', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId } as never);
+      vi.mocked(db.query.taskItems.findFirst).mockResolvedValue({
+        id: taskId,
+        taskListId,
+        metadata: { hasTrigger: true, triggerTypes: ['task_completion'] },
+      } as never);
+      vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: taskListId, pageId } as never);
+      vi.mocked(db.query.pages.findFirst).mockResolvedValue({ id: pageId, isTrashed: false } as never);
+      vi.mocked(canUserEditPage).mockResolvedValue(true);
+
+      const setCalls: Record<string, unknown>[] = [];
+      const setSpy = vi.fn((args) => {
+        setCalls.push(args);
+        return { where: vi.fn().mockResolvedValue(undefined) };
+      });
+      vi.mocked(db.update).mockReturnValue({ set: setSpy } as never);
+      // No remaining triggers
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn(() => ({ where: vi.fn().mockResolvedValue([]) })),
+      } as never);
+
+      const res = await DELETE(mkRequest('DELETE'), { params: mkDeleteParams('completion') });
+      expect(res.status).toBe(200);
+
+      const metadataWrite = setCalls.find((c) => c.metadata !== undefined);
+      const meta = metadataWrite?.metadata as { triggerTypes?: string[]; hasTrigger?: boolean };
+      expect(meta?.triggerTypes).toEqual([]);
+      expect(meta?.hasTrigger).toBe(false);
     });
   });
 });

--- a/apps/web/src/app/api/tasks/[taskId]/triggers/__tests__/route.test.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/triggers/__tests__/route.test.ts
@@ -22,6 +22,7 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
 
 vi.mock('@/lib/workflows/task-trigger-helpers', () => ({
   createTaskTriggerWorkflow: vi.fn().mockResolvedValue(undefined),
+  recomputeTaskTriggerMetadata: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('@/lib/websocket', () => ({
@@ -61,7 +62,7 @@ vi.mock('@pagespace/db/schema/workflows', () => ({ workflows: { taskItemId: 't',
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { db } from '@pagespace/db/db';
-import { createTaskTriggerWorkflow } from '@/lib/workflows/task-trigger-helpers';
+import { createTaskTriggerWorkflow, recomputeTaskTriggerMetadata } from '@/lib/workflows/task-trigger-helpers';
 import { GET, PUT } from '../route';
 import { DELETE } from '../[triggerType]/route';
 
@@ -231,73 +232,25 @@ describe('Task triggers API', () => {
       expect(res.status).toBe(400);
     });
 
-    it('disables trigger and recomputes metadata from the workflows table', async () => {
+    it('disables trigger and delegates metadata recompute to the helper', async () => {
       vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId } as never);
+      const taskMetadata = { hasTrigger: true, triggerTypes: ['task_completion', 'task_due_date'] };
       vi.mocked(db.query.taskItems.findFirst).mockResolvedValue({
         id: taskId,
         taskListId,
-        // Stale metadata: claims both triggers active even though completion is being removed
-        metadata: { hasTrigger: true, triggerTypes: ['task_completion', 'task_due_date'] },
+        metadata: taskMetadata,
       } as never);
       vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: taskListId, pageId } as never);
       vi.mocked(db.query.pages.findFirst).mockResolvedValue({ id: pageId, isTrashed: false } as never);
       vi.mocked(canUserEditPage).mockResolvedValue(true);
 
-      // Live workflows query returns only the due_date trigger (the completion one was just disabled)
-      const setCalls: Record<string, unknown>[] = [];
-      const setSpy = vi.fn((args) => {
-        setCalls.push(args);
-        return { where: vi.fn().mockResolvedValue(undefined) };
-      });
-      vi.mocked(db.update).mockReturnValue({ set: setSpy } as never);
-      vi.mocked(db.select).mockReturnValueOnce({
-        from: vi.fn(() => ({
-          where: vi.fn().mockResolvedValue([{ triggerType: 'task_due_date' }]),
-        })),
-      } as never);
-
       const res = await DELETE(mkRequest('DELETE'), { params: mkDeleteParams('completion') });
       expect(res.status).toBe(200);
 
-      // db.update was called twice: once for workflows, once for taskItems metadata
-      expect(db.update).toHaveBeenCalledTimes(2);
-
-      // Metadata write should reflect the live workflows table, not the stale task.metadata
-      const metadataWrite = setCalls.find((c) => c.metadata !== undefined);
-      const meta = metadataWrite?.metadata as { triggerTypes?: string[]; hasTrigger?: boolean };
-      expect(meta?.triggerTypes).toEqual(['task_due_date']);
-      expect(meta?.hasTrigger).toBe(true);
-    });
-
-    it('marks hasTrigger=false when removing the last trigger', async () => {
-      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId } as never);
-      vi.mocked(db.query.taskItems.findFirst).mockResolvedValue({
-        id: taskId,
-        taskListId,
-        metadata: { hasTrigger: true, triggerTypes: ['task_completion'] },
-      } as never);
-      vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: taskListId, pageId } as never);
-      vi.mocked(db.query.pages.findFirst).mockResolvedValue({ id: pageId, isTrashed: false } as never);
-      vi.mocked(canUserEditPage).mockResolvedValue(true);
-
-      const setCalls: Record<string, unknown>[] = [];
-      const setSpy = vi.fn((args) => {
-        setCalls.push(args);
-        return { where: vi.fn().mockResolvedValue(undefined) };
-      });
-      vi.mocked(db.update).mockReturnValue({ set: setSpy } as never);
-      // No remaining triggers
-      vi.mocked(db.select).mockReturnValueOnce({
-        from: vi.fn(() => ({ where: vi.fn().mockResolvedValue([]) })),
-      } as never);
-
-      const res = await DELETE(mkRequest('DELETE'), { params: mkDeleteParams('completion') });
-      expect(res.status).toBe(200);
-
-      const metadataWrite = setCalls.find((c) => c.metadata !== undefined);
-      const meta = metadataWrite?.metadata as { triggerTypes?: string[]; hasTrigger?: boolean };
-      expect(meta?.triggerTypes).toEqual([]);
-      expect(meta?.hasTrigger).toBe(false);
+      // Workflow row was disabled
+      expect(db.update).toHaveBeenCalledTimes(1);
+      // Metadata recompute is delegated to the shared helper (DB-truth source)
+      expect(recomputeTaskTriggerMetadata).toHaveBeenCalledWith(db, taskId, taskMetadata);
     });
   });
 });

--- a/apps/web/src/app/api/tasks/[taskId]/triggers/__tests__/route.test.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/triggers/__tests__/route.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn((result) => 'error' in result),
+}));
+
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  canUserEditPage: vi.fn(),
+  canUserViewPage: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+  },
+}));
+
+vi.mock('@/lib/workflows/task-trigger-helpers', () => ({
+  createTaskTriggerWorkflow: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/websocket', () => ({
+  broadcastTaskEvent: vi.fn(),
+}));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: {
+      taskItems: { findFirst: vi.fn() },
+      taskLists: { findFirst: vi.fn() },
+      pages: { findFirst: vi.fn() },
+    },
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn().mockResolvedValue([]),
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn().mockResolvedValue(undefined),
+      })),
+    })),
+  },
+}));
+
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((field, value) => ({ field, value })),
+  and: vi.fn((...conditions) => conditions),
+}));
+
+vi.mock('@pagespace/db/schema/core', () => ({ pages: {} }));
+vi.mock('@pagespace/db/schema/tasks', () => ({ taskItems: {}, taskLists: {} }));
+vi.mock('@pagespace/db/schema/workflows', () => ({ workflows: { taskItemId: 't', triggerType: 'tt' } }));
+
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { canUserEditPage, canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { db } from '@pagespace/db/db';
+import { createTaskTriggerWorkflow } from '@/lib/workflows/task-trigger-helpers';
+import { GET, PUT } from '../route';
+import { DELETE } from '../[triggerType]/route';
+
+const userId = 'user-1';
+const taskId = 'task-1';
+const taskListId = 'tasklist-1';
+const pageId = 'page-1';
+const driveId = 'drive-1';
+const agentPageId = 'agent-1';
+
+const mkRequest = (method: string, body?: unknown) =>
+  new Request(`https://example.com/api/tasks/${taskId}/triggers`, {
+    method,
+    body: body ? JSON.stringify(body) : undefined,
+    headers: body ? { 'content-type': 'application/json' } : undefined,
+  });
+
+const mkParams = (extra: Record<string, string> = {}) => Promise.resolve({ taskId, ...extra });
+
+describe('Task triggers API', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(isAuthError).mockImplementation(
+      (r: unknown) => r != null && typeof r === 'object' && 'error' in r,
+    );
+    vi.mocked(db.update).mockReturnValue({
+      set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+    } as never);
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn(() => ({ where: vi.fn().mockResolvedValue([]) })),
+    } as never);
+  });
+
+  describe('GET /api/tasks/[taskId]/triggers', () => {
+    it('returns 401 when unauthenticated', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({
+        error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+      } as never);
+
+      const res = await GET(mkRequest('GET'), { params: mkParams() });
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 404 when task does not exist', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId } as never);
+      vi.mocked(db.query.taskItems.findFirst).mockResolvedValue(undefined as never);
+
+      const res = await GET(mkRequest('GET'), { params: mkParams() });
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 403 when user lacks view permission', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId } as never);
+      vi.mocked(db.query.taskItems.findFirst).mockResolvedValue({ id: taskId, taskListId, dueDate: null, metadata: null } as never);
+      vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: taskListId, pageId } as never);
+      vi.mocked(db.query.pages.findFirst).mockResolvedValue({ id: pageId, driveId, isTrashed: false } as never);
+      vi.mocked(canUserViewPage).mockResolvedValue(false);
+
+      const res = await GET(mkRequest('GET'), { params: mkParams() });
+      expect(res.status).toBe(403);
+    });
+
+    it('returns triggers list on success', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId } as never);
+      vi.mocked(db.query.taskItems.findFirst).mockResolvedValue({ id: taskId, taskListId, dueDate: null, metadata: null } as never);
+      vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: taskListId, pageId } as never);
+      vi.mocked(db.query.pages.findFirst).mockResolvedValue({ id: pageId, driveId, isTrashed: false } as never);
+      vi.mocked(canUserViewPage).mockResolvedValue(true);
+      const triggerRow = { id: 'wf-1', triggerType: 'task_completion', agentPageId, prompt: 'do it', isEnabled: true };
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn(() => ({ where: vi.fn().mockResolvedValue([triggerRow]) })),
+      } as never);
+
+      const res = await GET(mkRequest('GET'), { params: mkParams() });
+      const body = await res.json();
+      expect(res.status).toBe(200);
+      expect(body.triggers).toHaveLength(1);
+      expect(body.triggers[0].id).toBe('wf-1');
+    });
+  });
+
+  describe('PUT /api/tasks/[taskId]/triggers', () => {
+    it('returns 400 for invalid input', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId } as never);
+
+      const res = await PUT(mkRequest('PUT', { triggerType: 'bogus' }), { params: mkParams() });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 403 when user lacks edit permission', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId } as never);
+      vi.mocked(db.query.taskItems.findFirst).mockResolvedValue({ id: taskId, taskListId, dueDate: null, metadata: null } as never);
+      vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: taskListId, pageId } as never);
+      vi.mocked(db.query.pages.findFirst).mockResolvedValue({ id: pageId, driveId, isTrashed: false } as never);
+      vi.mocked(canUserEditPage).mockResolvedValue(false);
+
+      const res = await PUT(
+        mkRequest('PUT', { triggerType: 'completion', agentPageId, prompt: 'go' }),
+        { params: mkParams() },
+      );
+      expect(res.status).toBe(403);
+    });
+
+    it('rejects due_date trigger when task has no due date', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId } as never);
+      vi.mocked(db.query.taskItems.findFirst).mockResolvedValue({ id: taskId, taskListId, dueDate: null, metadata: null } as never);
+      vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: taskListId, pageId } as never);
+      vi.mocked(db.query.pages.findFirst).mockResolvedValue({ id: pageId, driveId, isTrashed: false } as never);
+      vi.mocked(canUserEditPage).mockResolvedValue(true);
+
+      const res = await PUT(
+        mkRequest('PUT', { triggerType: 'due_date', agentPageId, prompt: 'go' }),
+        { params: mkParams() },
+      );
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(/due date/i);
+    });
+
+    it('upserts trigger and returns 200 on success', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId } as never);
+      vi.mocked(db.query.taskItems.findFirst).mockResolvedValue({ id: taskId, taskListId, dueDate: null, metadata: null } as never);
+      vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: taskListId, pageId } as never);
+      vi.mocked(db.query.pages.findFirst).mockResolvedValue({ id: pageId, driveId, isTrashed: false } as never);
+      vi.mocked(canUserEditPage).mockResolvedValue(true);
+      vi.mocked(db.select).mockReturnValueOnce({
+        from: vi.fn(() => ({
+          where: vi.fn().mockResolvedValue([{ id: 'wf-2', triggerType: 'task_completion' }]),
+        })),
+      } as never);
+
+      const res = await PUT(
+        mkRequest('PUT', { triggerType: 'completion', agentPageId, prompt: 'go' }),
+        { params: mkParams() },
+      );
+      expect(res.status).toBe(200);
+      expect(createTaskTriggerWorkflow).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('DELETE /api/tasks/[taskId]/triggers/[triggerType]', () => {
+    const mkDeleteParams = (triggerType: string) =>
+      Promise.resolve({ taskId, triggerType });
+
+    it('returns 400 for invalid trigger type', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId } as never);
+
+      const res = await DELETE(mkRequest('DELETE'), { params: mkDeleteParams('bogus') });
+      expect(res.status).toBe(400);
+    });
+
+    it('disables trigger and clears metadata triggerTypes', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId } as never);
+      vi.mocked(db.query.taskItems.findFirst).mockResolvedValue({
+        id: taskId,
+        taskListId,
+        metadata: { hasTrigger: true, triggerTypes: ['task_completion', 'task_due_date'] },
+      } as never);
+      vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: taskListId, pageId } as never);
+      vi.mocked(db.query.pages.findFirst).mockResolvedValue({ id: pageId, isTrashed: false } as never);
+      vi.mocked(canUserEditPage).mockResolvedValue(true);
+
+      const res = await DELETE(mkRequest('DELETE'), { params: mkDeleteParams('completion') });
+      expect(res.status).toBe(200);
+
+      // db.update was called twice: once for workflows, once for taskItems metadata
+      expect(db.update).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/apps/web/src/app/api/tasks/[taskId]/triggers/__tests__/route.test.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/triggers/__tests__/route.test.ts
@@ -8,7 +8,6 @@ vi.mock('@/lib/auth', () => ({
 
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
   canUserEditPage: vi.fn(),
-  canUserViewPage: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
@@ -59,7 +58,7 @@ vi.mock('@pagespace/db/schema/tasks', () => ({ taskItems: {}, taskLists: {} }));
 vi.mock('@pagespace/db/schema/workflows', () => ({ workflows: { taskItemId: 't', triggerType: 'tt' } }));
 
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { canUserEditPage, canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { db } from '@pagespace/db/db';
 import { createTaskTriggerWorkflow } from '@/lib/workflows/task-trigger-helpers';
 import { GET, PUT } from '../route';
@@ -113,12 +112,12 @@ describe('Task triggers API', () => {
       expect(res.status).toBe(404);
     });
 
-    it('returns 403 when user lacks view permission', async () => {
+    it('returns 403 when user lacks edit permission (trigger configs are editor-only)', async () => {
       vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId } as never);
       vi.mocked(db.query.taskItems.findFirst).mockResolvedValue({ id: taskId, taskListId, dueDate: null, metadata: null } as never);
       vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: taskListId, pageId } as never);
       vi.mocked(db.query.pages.findFirst).mockResolvedValue({ id: pageId, driveId, isTrashed: false } as never);
-      vi.mocked(canUserViewPage).mockResolvedValue(false);
+      vi.mocked(canUserEditPage).mockResolvedValue(false);
 
       const res = await GET(mkRequest('GET'), { params: mkParams() });
       expect(res.status).toBe(403);
@@ -129,7 +128,7 @@ describe('Task triggers API', () => {
       vi.mocked(db.query.taskItems.findFirst).mockResolvedValue({ id: taskId, taskListId, dueDate: null, metadata: null } as never);
       vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: taskListId, pageId } as never);
       vi.mocked(db.query.pages.findFirst).mockResolvedValue({ id: pageId, driveId, isTrashed: false } as never);
-      vi.mocked(canUserViewPage).mockResolvedValue(true);
+      vi.mocked(canUserEditPage).mockResolvedValue(true);
       const triggerRow = { id: 'wf-1', triggerType: 'task_completion', agentPageId, prompt: 'do it', isEnabled: true };
       vi.mocked(db.select).mockReturnValueOnce({
         from: vi.fn(() => ({ where: vi.fn().mockResolvedValue([triggerRow]) })),

--- a/apps/web/src/app/api/tasks/[taskId]/triggers/route.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/triggers/route.ts
@@ -165,6 +165,11 @@ export async function PUT(request: Request, context: { params: Promise<{ taskId:
     .from(workflows)
     .where(and(eq(workflows.taskItemId, taskId), eq(workflows.triggerType, triggerTypeDb)));
 
+  if (!saved) {
+    logger.error('Trigger row missing after upsert', { taskId, triggerType: triggerTypeDb });
+    return NextResponse.json({ error: 'Failed to retrieve saved trigger' }, { status: 500 });
+  }
+
   auditRequest(request, {
     eventType: 'data.write',
     userId,

--- a/apps/web/src/app/api/tasks/[taskId]/triggers/route.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/triggers/route.ts
@@ -1,0 +1,184 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { canUserEditPage, canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { db } from '@pagespace/db/db';
+import { eq, and } from '@pagespace/db/operators';
+import { pages } from '@pagespace/db/schema/core';
+import { taskItems, taskLists } from '@pagespace/db/schema/tasks';
+import { workflows } from '@pagespace/db/schema/workflows';
+import { createTaskTriggerWorkflow } from '@/lib/workflows/task-trigger-helpers';
+import { broadcastTaskEvent } from '@/lib/websocket';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+
+const logger = loggers.api.child({ module: 'task-triggers-api' });
+
+const SESSION_READ = { allow: ['session'] as const, requireCSRF: false };
+const SESSION_WRITE = { allow: ['session'] as const, requireCSRF: true };
+
+const upsertTriggerSchema = z.object({
+  triggerType: z.enum(['due_date', 'completion']),
+  agentPageId: z.string().min(1),
+  prompt: z.string().max(10000).optional(),
+  instructionPageId: z.string().nullable().optional(),
+  contextPageIds: z.array(z.string()).max(10).optional(),
+}).strict().refine(
+  (data) => Boolean(data.prompt?.trim()) || Boolean(data.instructionPageId),
+  { message: 'Either prompt or instructionPageId is required' }
+);
+
+type ResolvedTaskContext = {
+  task: typeof taskItems.$inferSelect;
+  taskListPageId: string;
+  driveId: string;
+  timezone: string;
+};
+
+async function resolveTaskContext(taskId: string): Promise<ResolvedTaskContext | null> {
+  const task = await db.query.taskItems.findFirst({
+    where: eq(taskItems.id, taskId),
+  });
+  if (!task) return null;
+
+  const taskList = await db.query.taskLists.findFirst({
+    where: eq(taskLists.id, task.taskListId),
+  });
+  if (!taskList?.pageId) return null;
+
+  const page = await db.query.pages.findFirst({
+    where: eq(pages.id, taskList.pageId),
+    columns: { id: true, driveId: true, isTrashed: true },
+  });
+  if (!page || page.isTrashed) return null;
+
+  return {
+    task,
+    taskListPageId: taskList.pageId,
+    driveId: page.driveId,
+    timezone: 'UTC',
+  };
+}
+
+// GET /api/tasks/[taskId]/triggers — list both task triggers (due_date + completion) for this task
+export async function GET(request: Request, context: { params: Promise<{ taskId: string }> }) {
+  const auth = await authenticateRequestWithOptions(request, SESSION_READ);
+  if (isAuthError(auth)) return auth.error;
+  const userId = auth.userId;
+
+  const { taskId } = await context.params;
+
+  const ctx = await resolveTaskContext(taskId);
+  if (!ctx) {
+    return NextResponse.json({ error: 'Task not found' }, { status: 404 });
+  }
+
+  const canView = await canUserViewPage(userId, ctx.taskListPageId);
+  if (!canView) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const rows = await db
+    .select()
+    .from(workflows)
+    .where(and(eq(workflows.taskItemId, taskId)));
+
+  auditRequest(request, {
+    eventType: 'data.read',
+    userId,
+    resourceType: 'task_triggers',
+    resourceId: taskId,
+    details: { count: rows.length },
+  });
+
+  return NextResponse.json({ triggers: rows });
+}
+
+// PUT /api/tasks/[taskId]/triggers — upsert a single trigger for this task
+export async function PUT(request: Request, context: { params: Promise<{ taskId: string }> }) {
+  const auth = await authenticateRequestWithOptions(request, SESSION_WRITE);
+  if (isAuthError(auth)) return auth.error;
+  const userId = auth.userId;
+
+  const { taskId } = await context.params;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const parsed = upsertTriggerSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid input', details: parsed.error.flatten() },
+      { status: 400 }
+    );
+  }
+
+  const ctx = await resolveTaskContext(taskId);
+  if (!ctx) {
+    return NextResponse.json({ error: 'Task not found' }, { status: 404 });
+  }
+
+  const canEdit = await canUserEditPage(userId, ctx.taskListPageId);
+  if (!canEdit) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  if (parsed.data.triggerType === 'due_date' && !ctx.task.dueDate) {
+    return NextResponse.json(
+      { error: 'A due date is required before adding a due-date trigger' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    await createTaskTriggerWorkflow({
+      database: db,
+      driveId: ctx.driveId,
+      userId,
+      taskId,
+      taskMetadata: ctx.task.metadata as Record<string, unknown> | null,
+      agentTrigger: {
+        agentPageId: parsed.data.agentPageId,
+        prompt: parsed.data.prompt,
+        instructionPageId: parsed.data.instructionPageId ?? undefined,
+        contextPageIds: parsed.data.contextPageIds ?? [],
+        triggerType: parsed.data.triggerType,
+      },
+      dueDate: ctx.task.dueDate,
+      timezone: ctx.timezone,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to save trigger';
+    logger.warn('Failed to upsert task trigger', { taskId, error: message });
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  const triggerTypeDb = parsed.data.triggerType === 'completion' ? 'task_completion' : 'task_due_date';
+  const [saved] = await db
+    .select()
+    .from(workflows)
+    .where(and(eq(workflows.taskItemId, taskId), eq(workflows.triggerType, triggerTypeDb)));
+
+  auditRequest(request, {
+    eventType: 'data.write',
+    userId,
+    resourceType: 'task_triggers',
+    resourceId: taskId,
+    details: { triggerType: triggerTypeDb },
+  });
+
+  void broadcastTaskEvent({
+    type: 'task_updated',
+    taskId,
+    taskListId: ctx.task.taskListId,
+    userId,
+    pageId: ctx.taskListPageId,
+    data: { id: taskId, triggerType: triggerTypeDb },
+  });
+
+  return NextResponse.json({ trigger: saved }, { status: 200 });
+}

--- a/apps/web/src/app/api/tasks/[taskId]/triggers/route.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/triggers/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
-import { canUserEditPage, canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { db } from '@pagespace/db/db';
 import { eq, and } from '@pagespace/db/operators';
 import { pages } from '@pagespace/db/schema/core';
@@ -73,8 +73,10 @@ export async function GET(request: Request, context: { params: Promise<{ taskId:
     return NextResponse.json({ error: 'Task not found' }, { status: 404 });
   }
 
-  const canView = await canUserViewPage(userId, ctx.taskListPageId);
-  if (!canView) {
+  // Trigger configs include agent IDs and prompt text, so restrict reads to editors
+  // — same gate as PUT/DELETE. View-only users cannot inspect trigger configuration.
+  const canEdit = await canUserEditPage(userId, ctx.taskListPageId);
+  if (!canEdit) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskAgentTriggersDialog.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskAgentTriggersDialog.tsx
@@ -1,0 +1,330 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Bot, Zap } from 'lucide-react';
+import { toast } from 'sonner';
+import useSWR, { mutate as globalMutate } from 'swr';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Switch } from '@/components/ui/switch';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { fetchWithAuth, put, del } from '@/lib/auth/auth-fetch';
+
+type ApiTriggerType = 'task_due_date' | 'task_completion';
+type UiTriggerType = 'due_date' | 'completion';
+
+interface DriveAgent {
+  id: string;
+  title: string | null;
+}
+
+interface TriggerRow {
+  id: string;
+  triggerType: ApiTriggerType;
+  agentPageId: string;
+  prompt: string;
+  isEnabled: boolean;
+  lastRunStatus: 'never_run' | 'success' | 'error' | 'running';
+  lastRunAt: string | null;
+}
+
+interface TaskAgentTriggersDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  taskId: string;
+  taskTitle: string;
+  pageId: string;
+  driveId: string;
+  hasDueDate: boolean;
+  onSaved?: () => void;
+}
+
+const TRIGGER_TYPES: { ui: UiTriggerType; api: ApiTriggerType; label: string; help: string }[] = [
+  {
+    ui: 'due_date',
+    api: 'task_due_date',
+    label: 'Run when due date arrives',
+    help: 'Requires a due date on this task. The agent runs once at the scheduled time.',
+  },
+  {
+    ui: 'completion',
+    api: 'task_completion',
+    label: 'Run when task is completed',
+    help: 'Fires the moment the task is moved to a status in the Done group.',
+  },
+];
+
+const triggersFetcher = async (url: string): Promise<{ triggers: TriggerRow[] }> => {
+  const res = await fetchWithAuth(url);
+  if (!res.ok) throw new Error('Failed to load triggers');
+  return res.json();
+};
+
+const agentsFetcher = async (url: string): Promise<{ agents: DriveAgent[] }> => {
+  const res = await fetchWithAuth(url);
+  if (!res.ok) throw new Error('Failed to load agents');
+  return res.json();
+};
+
+interface SectionState {
+  enabled: boolean;
+  agentPageId: string;
+  prompt: string;
+}
+
+const EMPTY_SECTION: SectionState = { enabled: false, agentPageId: '', prompt: '' };
+
+export function TaskAgentTriggersDialog({
+  open,
+  onOpenChange,
+  taskId,
+  taskTitle,
+  pageId,
+  driveId,
+  hasDueDate,
+  onSaved,
+}: TaskAgentTriggersDialogProps) {
+  const triggersKey = open ? `/api/tasks/${taskId}/triggers` : null;
+  const agentsKey = open && driveId ? `/api/drives/${driveId}/agents` : null;
+
+  const { data: triggersData, isLoading: triggersLoading, mutate: refetchTriggers } = useSWR(
+    triggersKey,
+    triggersFetcher,
+    { revalidateOnFocus: false },
+  );
+  const { data: agentsData, isLoading: agentsLoading } = useSWR(
+    agentsKey,
+    agentsFetcher,
+    { revalidateOnFocus: false },
+  );
+
+  const agents = agentsData?.agents ?? [];
+
+  const [sections, setSections] = useState<Record<UiTriggerType, SectionState>>({
+    due_date: { ...EMPTY_SECTION },
+    completion: { ...EMPTY_SECTION },
+  });
+  const [savingType, setSavingType] = useState<UiTriggerType | null>(null);
+  const [removingType, setRemovingType] = useState<UiTriggerType | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const next: Record<UiTriggerType, SectionState> = {
+      due_date: { ...EMPTY_SECTION },
+      completion: { ...EMPTY_SECTION },
+    };
+    for (const row of triggersData?.triggers ?? []) {
+      const ui: UiTriggerType = row.triggerType === 'task_completion' ? 'completion' : 'due_date';
+      next[ui] = {
+        enabled: row.isEnabled,
+        agentPageId: row.agentPageId,
+        prompt: row.prompt ?? '',
+      };
+    }
+    setSections(next);
+  }, [open, triggersData]);
+
+  const updateSection = (type: UiTriggerType, patch: Partial<SectionState>) => {
+    setSections((prev) => ({ ...prev, [type]: { ...prev[type], ...patch } }));
+  };
+
+  const handleSave = async (type: UiTriggerType) => {
+    const section = sections[type];
+    if (!section.agentPageId) {
+      toast.error('Pick an agent first');
+      return;
+    }
+    if (!section.prompt.trim()) {
+      toast.error('Enter a prompt for the agent');
+      return;
+    }
+    if (type === 'due_date' && !hasDueDate) {
+      toast.error('Set a due date on the task before adding a due-date trigger');
+      return;
+    }
+
+    setSavingType(type);
+    try {
+      await put(`/api/tasks/${taskId}/triggers`, {
+        triggerType: type,
+        agentPageId: section.agentPageId,
+        prompt: section.prompt.trim(),
+      });
+      await refetchTriggers();
+      await globalMutate(`/api/pages/${pageId}/tasks`);
+      toast.success(type === 'due_date' ? 'Due-date trigger saved' : 'Completion trigger saved');
+      onSaved?.();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to save trigger';
+      toast.error(msg);
+    } finally {
+      setSavingType(null);
+    }
+  };
+
+  const handleRemove = async (type: UiTriggerType) => {
+    setRemovingType(type);
+    try {
+      await del(`/api/tasks/${taskId}/triggers/${type}`);
+      await refetchTriggers();
+      await globalMutate(`/api/pages/${pageId}/tasks`);
+      updateSection(type, { ...EMPTY_SECTION });
+      toast.success('Trigger removed');
+      onSaved?.();
+    } catch {
+      toast.error('Failed to remove trigger');
+    } finally {
+      setRemovingType(null);
+    }
+  };
+
+  const noAgents = !agentsLoading && agents.length === 0;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Zap className="h-4 w-4 text-amber-500" />
+            Agent triggers
+          </DialogTitle>
+          <DialogDescription className="truncate">
+            <span className="font-medium">{taskTitle}</span>
+          </DialogDescription>
+        </DialogHeader>
+
+        {triggersLoading ? (
+          <div className="py-8 text-center text-sm text-muted-foreground">Loading…</div>
+        ) : (
+          <div className="space-y-4">
+            {noAgents && (
+              <p className="text-xs text-muted-foreground">
+                No agents in this drive. Create an AI Chat page first.
+              </p>
+            )}
+
+            {TRIGGER_TYPES.map(({ ui, label, help }) => {
+              const section = sections[ui];
+              const existing = (triggersData?.triggers ?? []).find(
+                (t) => t.triggerType === (ui === 'completion' ? 'task_completion' : 'task_due_date'),
+              );
+              const disabled = noAgents || (ui === 'due_date' && !hasDueDate);
+              return (
+                <div key={ui} className="space-y-3 rounded-md border p-3">
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-2 min-w-0">
+                      <Bot className="h-4 w-4 text-muted-foreground shrink-0" />
+                      <Label className="font-medium cursor-pointer truncate">{label}</Label>
+                    </div>
+                    <Switch
+                      checked={section.enabled}
+                      disabled={disabled}
+                      onCheckedChange={(checked) => updateSection(ui, { enabled: checked })}
+                    />
+                  </div>
+
+                  <p className="text-xs text-muted-foreground">{help}</p>
+                  {ui === 'due_date' && !hasDueDate && (
+                    <p className="text-xs text-amber-600 dark:text-amber-400">
+                      Add a due date to this task to enable this trigger.
+                    </p>
+                  )}
+
+                  {section.enabled && !disabled && (
+                    <div className="space-y-3 pt-1">
+                      <div className="space-y-2">
+                        <Label>Agent</Label>
+                        <Select
+                          value={section.agentPageId}
+                          onValueChange={(v) => updateSection(ui, { agentPageId: v })}
+                          disabled={agentsLoading}
+                        >
+                          <SelectTrigger>
+                            <SelectValue placeholder={agentsLoading ? 'Loading agents…' : 'Select an agent'} />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {agents.map((agent) => (
+                              <SelectItem key={agent.id} value={agent.id}>
+                                {agent.title ?? 'Untitled agent'}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
+
+                      <div className="space-y-2">
+                        <Label>Prompt</Label>
+                        <Textarea
+                          placeholder={
+                            ui === 'due_date'
+                              ? 'What should the agent do when the due date arrives?'
+                              : 'What should the agent do when the task is completed?'
+                          }
+                          value={section.prompt}
+                          onChange={(e) => updateSection(ui, { prompt: e.target.value })}
+                          rows={3}
+                        />
+                      </div>
+
+                      {existing?.lastRunStatus && existing.lastRunStatus !== 'never_run' && (
+                        <p className="text-xs text-muted-foreground">
+                          Last run: <span className="font-medium">{existing.lastRunStatus}</span>
+                          {existing.lastRunAt
+                            ? ` • ${new Date(existing.lastRunAt).toLocaleString()}`
+                            : ''}
+                        </p>
+                      )}
+
+                      <div className="flex items-center justify-end gap-2">
+                        {existing?.isEnabled && (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => handleRemove(ui)}
+                            disabled={removingType === ui}
+                          >
+                            {removingType === ui ? 'Removing…' : 'Remove'}
+                          </Button>
+                        )}
+                        <Button
+                          type="button"
+                          size="sm"
+                          onClick={() => handleSave(ui)}
+                          disabled={savingType === ui}
+                        >
+                          {savingType === ui ? 'Saving…' : existing ? 'Update' : 'Save'}
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Done
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskKanbanView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskKanbanView.tsx
@@ -40,6 +40,8 @@ import {
   FileText,
   GripVertical,
   Plus,
+  Zap,
+  Bell,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import {
@@ -236,6 +238,15 @@ function TaskCard({
                 <Pencil className="h-4 w-4 mr-2" />
                 Rename
               </DropdownMenuItem>
+              {handlers.onConfigureTriggers && (
+                <DropdownMenuItem
+                  onClick={() => handlers.onConfigureTriggers?.(task)}
+                  disabled={!canEdit}
+                >
+                  <Zap className="h-4 w-4 mr-2" />
+                  Agent triggers…
+                </DropdownMenuItem>
+              )}
               <DropdownMenuItem
                 onClick={() => handlers.onDelete(task.id)}
                 className="text-destructive"
@@ -267,6 +278,19 @@ function TaskCard({
             <span className="text-xs text-muted-foreground">
               {new Date(task.dueDate).toLocaleDateString()}
             </span>
+          )}
+
+          {canEdit && handlers.onConfigureTriggers && (task.activeTriggerCount ?? 0) > 0 && (
+            <button
+              type="button"
+              onClick={() => handlers.onConfigureTriggers?.(task)}
+              title="Agent trigger configured — click to edit"
+              aria-label="Agent trigger configured — click to edit"
+              className="inline-flex h-5 items-center gap-0.5 rounded-md border border-amber-300/60 bg-amber-50 px-1.5 text-[10px] text-amber-700 hover:bg-amber-100 dark:border-amber-700/50 dark:bg-amber-950/40 dark:text-amber-300"
+            >
+              <Bell className="h-2.5 w-2.5" />
+              <span>Trigger</span>
+            </button>
           )}
         </div>
       </CardContent>

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -704,6 +704,7 @@ function TaskListView({ page }: TaskListViewProps) {
     onDelete: handleDeleteTask,
     onNavigate: handleNavigate,
     onStartEdit: handleStartEdit,
+    onConfigureTriggers: setTriggerDialogTask,
   };
 
   if (isLoading) {

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -281,7 +281,7 @@ function MobileTaskCard({
           disabled={!canEdit}
         />
 
-        {(task.activeTriggerCount ?? 0) > 0 && (
+        {canEdit && (task.activeTriggerCount ?? 0) > 0 && (
           <button
             type="button"
             onClick={() => onConfigureTriggers(task)}
@@ -1032,7 +1032,7 @@ function TaskListView({ page }: TaskListViewProps) {
                               onUpdate={(assigneeIds) => handleMultiAssigneeChange(task.id, assigneeIds)}
                               disabled={!canEdit}
                             />
-                            {(task.activeTriggerCount ?? 0) > 0 && (
+                            {canEdit && (task.activeTriggerCount ?? 0) > 0 && (
                               <button
                                 type="button"
                                 onClick={() => setTriggerDialogTask(task)}

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -6,7 +6,8 @@ import { toast } from 'sonner';
 import useSWR, { mutate } from 'swr';
 import { formatDistanceToNow } from 'date-fns';
 import { useAuth } from '@/hooks/useAuth';
-import { usePermissions } from '@/hooks/usePermissions';
+import { usePermissions, canManageDrive } from '@/hooks/usePermissions';
+import { useDriveStore } from '@/hooks/useDrive';
 import { useEditingStore } from '@/stores/useEditingStore';
 import { useLayoutStore } from '@/stores/useLayoutStore';
 import { TreePage } from '@/hooks/usePageTree';
@@ -48,6 +49,7 @@ import {
   LayoutList,
   Kanban,
   Zap,
+  Bell,
 } from 'lucide-react';
 import {
   DndContext,
@@ -279,14 +281,15 @@ function MobileTaskCard({
           disabled={!canEdit}
         />
 
-        {task.metadata?.hasTrigger && (
+        {(task.activeTriggerCount ?? 0) > 0 && (
           <button
             type="button"
             onClick={() => onConfigureTriggers(task)}
             title="Agent trigger configured — click to edit"
+            aria-label="Agent trigger configured — click to edit"
             className="inline-flex h-7 items-center gap-1 rounded-md border border-amber-300/60 bg-amber-50 px-2 text-xs text-amber-700 hover:bg-amber-100 dark:border-amber-700/50 dark:bg-amber-950/40 dark:text-amber-300"
           >
-            <Zap className="h-3 w-3" />
+            <Bell className="h-3 w-3" />
             <span>Trigger</span>
           </button>
         )}
@@ -357,6 +360,8 @@ function TaskListView({ page }: TaskListViewProps) {
   const { user } = useAuth();
   const { permissions } = usePermissions(page.id);
   const canEdit = permissions?.canEdit || false;
+  const drive = useDriveStore((s) => s.drives.find((d) => d.id === page.driveId));
+  const canManageWorkflows = canManageDrive(drive);
   const isAnyActive = useEditingStore(state => state.isAnyActive());
 
   const [filter, setFilter] = useState<'all' | 'active' | 'completed'>('all');
@@ -791,7 +796,7 @@ function TaskListView({ page }: TaskListViewProps) {
             />
           )}
 
-          {canEdit && (
+          {canManageWorkflows && (
             <Button
               variant="ghost"
               size="sm"
@@ -1027,14 +1032,15 @@ function TaskListView({ page }: TaskListViewProps) {
                               onUpdate={(assigneeIds) => handleMultiAssigneeChange(task.id, assigneeIds)}
                               disabled={!canEdit}
                             />
-                            {task.metadata?.hasTrigger && (
+                            {(task.activeTriggerCount ?? 0) > 0 && (
                               <button
                                 type="button"
                                 onClick={() => setTriggerDialogTask(task)}
                                 title="Agent trigger configured — click to edit"
+                                aria-label="Agent trigger configured — click to edit"
                                 className="inline-flex h-6 w-6 items-center justify-center rounded-md border border-amber-300/60 bg-amber-50 text-amber-700 hover:bg-amber-100 dark:border-amber-700/50 dark:bg-amber-950/40 dark:text-amber-300"
                               >
-                                <Zap className="h-3 w-3" />
+                                <Bell className="h-3 w-3" />
                                 <span className="sr-only">Agent trigger configured</span>
                               </button>
                             )}

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -47,6 +47,7 @@ import {
   GripVertical,
   LayoutList,
   Kanban,
+  Zap,
 } from 'lucide-react';
 import {
   DndContext,
@@ -68,6 +69,8 @@ import { MultiAssigneeSelect } from './MultiAssigneeSelect';
 import { DueDatePicker } from './DueDatePicker';
 import { TaskKanbanView } from './TaskKanbanView';
 import { StatusConfigManager } from './StatusConfigManager';
+import { TaskAgentTriggersDialog } from './TaskAgentTriggersDialog';
+import { TaskListWorkflowsDialog } from './TaskListWorkflowsDialog';
 import {
   TaskItem,
   TaskListData,
@@ -101,6 +104,7 @@ interface MobileTaskCardProps {
   onSaveTitle: (taskId: string, title: string) => void;
   onDelete: (taskId: string) => void;
   onNavigate: (task: TaskItem) => void;
+  onConfigureTriggers: (task: TaskItem) => void;
   driveId: string;
   isEditing: boolean;
   editingTitle: string;
@@ -123,6 +127,7 @@ function MobileTaskCard({
   onSaveTitle,
   onDelete,
   onNavigate,
+  onConfigureTriggers,
   driveId,
   isEditing,
   editingTitle,
@@ -200,6 +205,10 @@ function MobileTaskCard({
               <Pencil className="h-4 w-4 mr-2" />
               Rename
             </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => onConfigureTriggers(task)} disabled={!canEdit}>
+              <Zap className="h-4 w-4 mr-2" />
+              Agent triggers…
+            </DropdownMenuItem>
             <DropdownMenuItem
               onClick={() => onDelete(task.id)}
               className="text-destructive"
@@ -269,6 +278,18 @@ function MobileTaskCard({
           onUpdate={(assigneeIds) => onMultiAssigneeChange(task.id, assigneeIds)}
           disabled={!canEdit}
         />
+
+        {task.metadata?.hasTrigger && (
+          <button
+            type="button"
+            onClick={() => onConfigureTriggers(task)}
+            title="Agent trigger configured — click to edit"
+            className="inline-flex h-7 items-center gap-1 rounded-md border border-amber-300/60 bg-amber-50 px-2 text-xs text-amber-700 hover:bg-amber-100 dark:border-amber-700/50 dark:bg-amber-950/40 dark:text-amber-300"
+          >
+            <Zap className="h-3 w-3" />
+            <span>Trigger</span>
+          </button>
+        )}
 
         {/* Due Date */}
         <DueDatePicker
@@ -343,6 +364,8 @@ function TaskListView({ page }: TaskListViewProps) {
   const [newTaskTitle, setNewTaskTitle] = useState('');
   const [editingTaskId, setEditingTaskId] = useState<string | null>(null);
   const [editingTitle, setEditingTitle] = useState('');
+  const [triggerDialogTask, setTriggerDialogTask] = useState<TaskItem | null>(null);
+  const [workflowsDialogOpen, setWorkflowsDialogOpen] = useState(false);
   const viewMode = useLayoutStore((state) => state.taskListViewMode);
   const setViewMode = useLayoutStore((state) => state.setTaskListViewMode);
   const hasLoadedRef = useRef(false);
@@ -768,6 +791,18 @@ function TaskListView({ page }: TaskListViewProps) {
             />
           )}
 
+          {canEdit && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 gap-1"
+              onClick={() => setWorkflowsDialogOpen(true)}
+            >
+              <Zap className="h-3.5 w-3.5" />
+              <span className="hidden sm:inline">Workflows</span>
+            </Button>
+          )}
+
           {canEdit && viewMode === 'table' && (
             <Button
               size="sm"
@@ -805,6 +840,7 @@ function TaskListView({ page }: TaskListViewProps) {
                 router.push(`/dashboard/${page.driveId}/${t.pageId}`);
               }
             }}
+            onConfigureTriggers={(t) => setTriggerDialogTask(t)}
             driveId={page.driveId}
             isEditing={editingTaskId === task.id}
             editingTitle={editingTitle}
@@ -984,12 +1020,25 @@ function TaskListView({ page }: TaskListViewProps) {
 
                         {/* Multiple Assignees */}
                         <TableCell>
-                          <MultiAssigneeSelect
-                            driveId={page.driveId}
-                            assignees={task.assignees || []}
-                            onUpdate={(assigneeIds) => handleMultiAssigneeChange(task.id, assigneeIds)}
-                            disabled={!canEdit}
-                          />
+                          <div className="flex items-center gap-1.5">
+                            <MultiAssigneeSelect
+                              driveId={page.driveId}
+                              assignees={task.assignees || []}
+                              onUpdate={(assigneeIds) => handleMultiAssigneeChange(task.id, assigneeIds)}
+                              disabled={!canEdit}
+                            />
+                            {task.metadata?.hasTrigger && (
+                              <button
+                                type="button"
+                                onClick={() => setTriggerDialogTask(task)}
+                                title="Agent trigger configured — click to edit"
+                                className="inline-flex h-6 w-6 items-center justify-center rounded-md border border-amber-300/60 bg-amber-50 text-amber-700 hover:bg-amber-100 dark:border-amber-700/50 dark:bg-amber-950/40 dark:text-amber-300"
+                              >
+                                <Zap className="h-3 w-3" />
+                                <span className="sr-only">Agent trigger configured</span>
+                              </button>
+                            )}
+                          </div>
                         </TableCell>
 
                         {/* Due Date */}
@@ -1020,6 +1069,10 @@ function TaskListView({ page }: TaskListViewProps) {
                                 <DropdownMenuItem onClick={() => handleStartEdit(task)} disabled={!canEdit}>
                                   <Pencil className="h-4 w-4 mr-2" />
                                   Rename
+                                </DropdownMenuItem>
+                                <DropdownMenuItem onClick={() => setTriggerDialogTask(task)} disabled={!canEdit}>
+                                  <Zap className="h-4 w-4 mr-2" />
+                                  Agent triggers…
                                 </DropdownMenuItem>
                                 <DropdownMenuItem
                                   onClick={() => handleDeleteTask(task.id)}
@@ -1083,6 +1136,27 @@ function TaskListView({ page }: TaskListViewProps) {
             : 'never'}
         </span>
       </div>
+
+      {triggerDialogTask && (
+        <TaskAgentTriggersDialog
+          open={!!triggerDialogTask}
+          onOpenChange={(open) => { if (!open) setTriggerDialogTask(null); }}
+          taskId={triggerDialogTask.id}
+          taskTitle={triggerDialogTask.title}
+          pageId={page.id}
+          driveId={page.driveId}
+          hasDueDate={!!triggerDialogTask.dueDate}
+          onSaved={() => mutate(`/api/pages/${page.id}/tasks`)}
+        />
+      )}
+
+      <TaskListWorkflowsDialog
+        open={workflowsDialogOpen}
+        onOpenChange={setWorkflowsDialogOpen}
+        driveId={page.driveId}
+        pageId={page.id}
+        taskListTitle={data?.taskList.title ?? page.title ?? 'Task list'}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListWorkflowsDialog.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListWorkflowsDialog.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Plus, Workflow as WorkflowIcon } from 'lucide-react';
+import { toast } from 'sonner';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { post, patch } from '@/lib/auth/auth-fetch';
+import { useWorkflows } from '@/hooks/useWorkflows';
+import { WorkflowList } from '@/components/workflows/WorkflowList';
+import { WorkflowForm } from '@/components/workflows/WorkflowForm';
+import { DeleteWorkflowDialog } from '@/components/workflows/DeleteWorkflowDialog';
+import type { Workflow } from '@/components/workflows/types';
+
+interface WorkflowFormData {
+  name: string;
+  agentPageId: string;
+  prompt: string;
+  contextPageIds: string[];
+  cronExpression: string;
+  timezone: string;
+  isEnabled: boolean;
+}
+
+interface TaskListWorkflowsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  driveId: string;
+  pageId: string;
+  taskListTitle: string;
+}
+
+export function TaskListWorkflowsDialog({
+  open,
+  onOpenChange,
+  driveId,
+  pageId,
+  taskListTitle,
+}: TaskListWorkflowsDialogProps) {
+  const { workflows, isLoading, mutate, runWorkflow, toggleWorkflow, deleteWorkflow } = useWorkflows(open ? driveId : '');
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<Workflow | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Workflow | null>(null);
+
+  const scoped = useMemo(
+    () => workflows.filter((wf) => Array.isArray(wf.contextPageIds) && wf.contextPageIds.includes(pageId)),
+    [workflows, pageId],
+  );
+
+  const ensurePageAnchor = (ids: string[] | undefined): string[] => {
+    const base = ids ?? [];
+    return base.includes(pageId) ? base : [...base, pageId];
+  };
+
+  const handleCreate = async (data: WorkflowFormData) => {
+    await post('/api/workflows', {
+      ...data,
+      contextPageIds: ensurePageAnchor(data.contextPageIds),
+      driveId,
+    });
+    mutate();
+    toast.success('Workflow created');
+  };
+
+  const handleUpdate = async (data: WorkflowFormData) => {
+    if (!editing) return;
+    await patch(`/api/workflows/${editing.id}`, {
+      ...data,
+      contextPageIds: ensurePageAnchor(data.contextPageIds),
+    });
+    mutate();
+    toast.success('Workflow updated');
+  };
+
+  const handleRun = async (id: string) => {
+    try {
+      const result = await runWorkflow(id);
+      if (result.success) toast.success('Workflow executed');
+      else toast.error(result.error || 'Workflow execution failed');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to run workflow');
+    }
+  };
+
+  const handleToggle = async (id: string, enabled: boolean) => {
+    try {
+      await toggleWorkflow(id, enabled);
+      toast.success(enabled ? 'Workflow enabled' : 'Workflow disabled');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to update workflow');
+    }
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!deleteTarget) return;
+    try {
+      await deleteWorkflow(deleteTarget.id);
+      toast.success('Workflow deleted');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to delete workflow');
+    }
+  };
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <WorkflowIcon className="h-4 w-4 text-muted-foreground" />
+              Scheduled workflows
+            </DialogTitle>
+            <DialogDescription className="truncate">
+              Recurring agents anchored to <span className="font-medium">{taskListTitle}</span>
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <p className="text-sm text-muted-foreground">
+                {scoped.length} workflow{scoped.length === 1 ? '' : 's'} on this task list
+              </p>
+              <Button size="sm" onClick={() => { setEditing(null); setFormOpen(true); }}>
+                <Plus className="h-4 w-4 mr-1.5" />
+                New workflow
+              </Button>
+            </div>
+
+            {isLoading ? (
+              <div className="py-8 text-center text-sm text-muted-foreground">Loading…</div>
+            ) : scoped.length === 0 ? (
+              <div className="py-8 text-center text-sm text-muted-foreground">
+                No scheduled workflows yet. Create one to run an agent on a recurring schedule with this task list as context.
+              </div>
+            ) : (
+              <WorkflowList
+                workflows={scoped}
+                onRun={handleRun}
+                onToggle={handleToggle}
+                onEdit={(wf) => { setEditing(wf); setFormOpen(true); }}
+                onDelete={(id) => {
+                  const wf = scoped.find((w) => w.id === id);
+                  if (wf) setDeleteTarget(wf);
+                }}
+              />
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <WorkflowForm
+        open={formOpen}
+        onOpenChange={setFormOpen}
+        driveId={driveId}
+        initialData={editing
+          ? {
+              id: editing.id,
+              name: editing.name,
+              agentPageId: editing.agentPageId,
+              prompt: editing.prompt,
+              contextPageIds: ensurePageAnchor(editing.contextPageIds),
+              cronExpression: editing.cronExpression ?? '0 9 * * 1-5',
+              timezone: editing.timezone,
+              isEnabled: editing.isEnabled,
+            }
+          : { contextPageIds: [pageId] }}
+        onSubmit={editing ? handleUpdate : handleCreate}
+      />
+
+      <DeleteWorkflowDialog
+        workflowName={deleteTarget?.name ?? ''}
+        open={!!deleteTarget}
+        onOpenChange={(o) => { if (!o) setDeleteTarget(null); }}
+        onConfirm={handleDeleteConfirm}
+      />
+    </>
+  );
+}

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/task-list-types.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/task-list-types.ts
@@ -140,4 +140,5 @@ export interface TaskHandlers {
   onDelete: (taskId: string) => void;
   onNavigate: (task: TaskItem) => void;
   onStartEdit: (task: TaskItem) => void;
+  onConfigureTriggers?: (task: TaskItem) => void;
 }

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/task-list-types.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/task-list-types.ts
@@ -44,6 +44,11 @@ export interface TaskItem {
   priority: 'low' | 'medium' | 'high';
   position: number;
   dueDate: string | null;
+  metadata?: {
+    hasTrigger?: boolean;
+    triggerTypes?: string[];
+    [key: string]: unknown;
+  } | null;
   completedAt: string | null;
   createdAt: string;
   updatedAt: string;

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/task-list-types.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/task-list-types.ts
@@ -49,6 +49,7 @@ export interface TaskItem {
     triggerTypes?: string[];
     [key: string]: unknown;
   } | null;
+  activeTriggerCount?: number;
   completedAt: string | null;
   createdAt: string;
   updatedAt: string;

--- a/apps/web/src/components/workflows/WorkflowForm.tsx
+++ b/apps/web/src/components/workflows/WorkflowForm.tsx
@@ -65,6 +65,7 @@ export function WorkflowForm({ open, onOpenChange, driveId, initialData, onSubmi
   const [cronExpression, setCronExpression] = useState(initialData?.cronExpression ?? '0 9 * * 1-5');
   const [timezone, setTimezone] = useState(initialData?.timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone);
   const [isEnabled, setIsEnabled] = useState(initialData?.isEnabled ?? true);
+  const [contextPageIds, setContextPageIds] = useState<string[]>(initialData?.contextPageIds ?? []);
   const [cronPreview, setCronPreview] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState('');
@@ -95,6 +96,7 @@ export function WorkflowForm({ open, onOpenChange, driveId, initialData, onSubmi
       setCronExpression(initialData?.cronExpression ?? '0 9 * * 1-5');
       setTimezone(initialData?.timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone);
       setIsEnabled(initialData?.isEnabled ?? true);
+      setContextPageIds(initialData?.contextPageIds ?? []);
       setError('');
     }
   }, [open, initialData]);
@@ -109,7 +111,7 @@ export function WorkflowForm({ open, onOpenChange, driveId, initialData, onSubmi
         name,
         agentPageId,
         prompt,
-        contextPageIds: [],
+        contextPageIds,
         cronExpression,
         timezone,
         isEnabled,

--- a/apps/web/src/lib/workflows/__tests__/task-trigger-helpers.test.ts
+++ b/apps/web/src/lib/workflows/__tests__/task-trigger-helpers.test.ts
@@ -1,17 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockUpdate, mockSet, mockWhere, mockReturning, mockFrom, mockSelect, mockInsert, mockValues, mockOnConflict, mockQueryPages } = vi.hoisted(() => {
+const { mockUpdate, mockSet, mockWhere, mockReturning, mockFrom, mockSelect, mockSelectWhere, mockInsert, mockValues, mockOnConflict, mockQueryPages } = vi.hoisted(() => {
   const mockReturning = vi.fn().mockResolvedValue([]);
   const mockWhere = vi.fn(() => ({ returning: mockReturning }));
   const mockSet = vi.fn(() => ({ where: mockWhere }));
-  const mockFrom = vi.fn().mockReturnThis();
+  // db.select(...).from(...).where(...) resolves directly to a row array (no .returning())
+  const mockSelectWhere = vi.fn().mockResolvedValue([]);
+  const mockFrom = vi.fn(() => ({ where: mockSelectWhere }));
   const mockUpdate = vi.fn(() => ({ set: mockSet }));
   const mockSelect = vi.fn(() => ({ from: mockFrom }));
   const mockOnConflict = vi.fn().mockResolvedValue(undefined);
   const mockValues = vi.fn(() => ({ onConflictDoUpdate: mockOnConflict }));
   const mockInsert = vi.fn(() => ({ values: mockValues }));
   const mockQueryPages = { findFirst: vi.fn(), findMany: vi.fn() };
-  return { mockUpdate, mockSet, mockWhere, mockReturning, mockFrom, mockSelect, mockInsert, mockValues, mockOnConflict, mockQueryPages };
+  return { mockUpdate, mockSet, mockWhere, mockReturning, mockFrom, mockSelect, mockSelectWhere, mockInsert, mockValues, mockOnConflict, mockQueryPages };
 });
 
 vi.mock('@pagespace/db/db', () => ({
@@ -71,6 +73,7 @@ import {
   fireCompletionTrigger,
   disableTaskTriggers,
   createTaskTriggerWorkflow,
+  recomputeTaskTriggerMetadata,
 } from '../task-trigger-helpers';
 import { executeWorkflow } from '../workflow-executor';
 import { db } from '@pagespace/db/db';
@@ -84,7 +87,8 @@ describe('task-trigger-helpers', () => {
     mockWhere.mockImplementation(() => ({ returning: mockReturning }));
     mockReturning.mockResolvedValue([]);
     mockSelect.mockImplementation(() => ({ from: mockFrom }));
-    mockFrom.mockImplementation(() => ({ where: mockWhere }));
+    mockFrom.mockImplementation(() => ({ where: mockSelectWhere }));
+    mockSelectWhere.mockResolvedValue([]);
   });
 
   describe('syncTaskDueDateTrigger', () => {
@@ -313,6 +317,51 @@ describe('task-trigger-helpers', () => {
       await createTaskTriggerWorkflow(validParams);
 
       expect(mockOnConflict).toHaveBeenCalled();
+    });
+  });
+
+  describe('recomputeTaskTriggerMetadata', () => {
+    it('writes triggerTypes and hasTrigger from the live workflows table, ignoring stale baseMetadata', async () => {
+      // Live DB state: only due_date is enabled (completion was just disabled)
+      mockSelectWhere.mockResolvedValueOnce([{ triggerType: 'task_due_date' }]);
+      // Caller passes stale baseMetadata claiming both types are active
+      const stale = { hasTrigger: true, triggerTypes: ['task_completion', 'task_due_date'], otherKey: 'preserved' };
+
+      await recomputeTaskTriggerMetadata(db, 'task-1', stale);
+
+      expect(mockSet).toHaveBeenCalledWith({
+        metadata: {
+          otherKey: 'preserved',
+          triggerTypes: ['task_due_date'],
+          hasTrigger: true,
+        },
+      });
+    });
+
+    it('clears hasTrigger when no enabled triggers remain', async () => {
+      mockSelectWhere.mockResolvedValueOnce([]);
+
+      await recomputeTaskTriggerMetadata(db, 'task-1', { hasTrigger: true, triggerTypes: ['task_completion'] });
+
+      expect(mockSet).toHaveBeenCalledWith({
+        metadata: {
+          triggerTypes: [],
+          hasTrigger: false,
+        },
+      });
+    });
+
+    it('handles null baseMetadata', async () => {
+      mockSelectWhere.mockResolvedValueOnce([{ triggerType: 'task_completion' }]);
+
+      await recomputeTaskTriggerMetadata(db, 'task-1', null);
+
+      expect(mockSet).toHaveBeenCalledWith({
+        metadata: {
+          triggerTypes: ['task_completion'],
+          hasTrigger: true,
+        },
+      });
     });
   });
 });

--- a/apps/web/src/lib/workflows/task-trigger-helpers.ts
+++ b/apps/web/src/lib/workflows/task-trigger-helpers.ts
@@ -27,6 +27,37 @@ export interface CreateTaskTriggerWorkflowParams {
 
 const logger = loggers.api.child({ module: 'task-trigger-helpers' });
 
+const TASK_TRIGGER_TYPES: ('task_due_date' | 'task_completion')[] = ['task_due_date', 'task_completion'];
+
+/**
+ * Recompute taskItems.metadata.triggerTypes / hasTrigger from the live workflows table.
+ * Use this after any insert/upsert/disable so metadata never drifts from DB truth — in
+ * particular it stays correct when an agent page cascade-deletes a workflow row without
+ * touching the task.
+ */
+export async function recomputeTaskTriggerMetadata(
+  database: typeof db,
+  taskId: string,
+  baseMetadata: Record<string, unknown> | null,
+): Promise<void> {
+  const rows = await database
+    .select({ triggerType: workflows.triggerType })
+    .from(workflows)
+    .where(and(
+      eq(workflows.taskItemId, taskId),
+      eq(workflows.isEnabled, true),
+      inArray(workflows.triggerType, TASK_TRIGGER_TYPES),
+    ));
+  const triggerTypes = Array.from(new Set(rows.map((r) => r.triggerType)));
+  await database.update(taskItems).set({
+    metadata: {
+      ...(baseMetadata ?? {}),
+      triggerTypes,
+      hasTrigger: triggerTypes.length > 0,
+    },
+  }).where(eq(taskItems.id, taskId));
+}
+
 /**
  * Create (or upsert) a task trigger workflow.
  * Validates agent page, instruction page, and context pages before inserting.
@@ -107,16 +138,8 @@ export async function createTaskTriggerWorkflow(params: CreateTaskTriggerWorkflo
     },
   });
 
-  // Mark task metadata — store trigger types as array to support both types on one task
-  const existingTypes = ((taskMetadata as Record<string, unknown> | null)?.triggerTypes as string[]) ?? [];
-  const triggerTypes = existingTypes.includes(triggerType) ? existingTypes : [...existingTypes, triggerType];
-  await database.update(taskItems).set({
-    metadata: {
-      ...(taskMetadata || {}),
-      hasTrigger: true,
-      triggerTypes,
-    },
-  }).where(eq(taskItems.id, taskId));
+  // Recompute metadata from the live workflows table so it never drifts from DB truth.
+  await recomputeTaskTriggerMetadata(database, taskId, taskMetadata);
 }
 
 /**


### PR DESCRIPTION
## Summary
Adds human-facing UI for agent triggers on Task List pages, mirroring the calendar pattern.

- **Per-task** Agent triggers… dialog from the row kebab menu (table view + kanban view + mobile), with on-due-date and on-completion sections — mirrors the calendar `EventModal` "Run agent" pattern.
- **Page-level** Workflows button on the task list toolbar opens a dialog of recurring cron workflows scoped to this task list (reuses existing `WorkflowList` / `WorkflowForm` / `DeleteWorkflowDialog`).
- Small `Bell` badge appears next to the assignee chip when a task has active triggers; clicking it opens the same dialog.

## Why
Task triggers (`task_due_date`, `task_completion`) and the supporting `workflows` schema/helpers were already shipped — agents could set them via the `update_task` tool's `agentTrigger` parameter, but humans had no UI. This closes the gap without disrupting the existing inline edit flow that humans + agents use to collaborate on tasks.

## What changed
- **API routes**
  - `GET /api/tasks/[taskId]/triggers` — list workflows for a task; gated on `canUserEditPage` (trigger configs include agent IDs and prompt text, so editor-only).
  - `PUT /api/tasks/[taskId]/triggers` — upsert one trigger via `createTaskTriggerWorkflow`. Returns 500 with logged error if the post-upsert re-query is unexpectedly empty.
  - `DELETE /api/tasks/[taskId]/triggers/[triggerType]` — disable one specific trigger.
- **`recomputeTaskTriggerMetadata`** (shared helper) — single source of truth for `taskItems.metadata.triggerTypes` / `hasTrigger`. Queries the `workflows` table for live state (`isEnabled = true` AND `triggerType IN ('task_due_date','task_completion')`). Used by both `createTaskTriggerWorkflow` (the AI `update_task` path) and the human DELETE route, so the metadata never drifts — including the cascade-delete drift case (agent page trashed → workflow row vanishes without touching task metadata).
- **`activeTriggerCount`** — joined into the `GET /api/pages/[pageId]/tasks` response so the row badge ground-truths against the live workflows table rather than the metadata flag.
- **TaskListView**: kebab entry, row badge (Bell), Workflows toolbar button. Per-task dialog gated on `canEdit`; Workflows toolbar gated on `canManageDrive` (matches the `/api/workflows` API which requires drive owner/admin).
- **TaskKanbanView**: parity — Agent triggers… kebab entry + Bell badge.
- **WorkflowForm**: thread `initialData.contextPageIds` through (was hardcoded `[]`) so the page anchor survives edits.

Page-level workflows are anchored to the task list page via `contextPageIds` — no schema change needed.

## Test plan
- [ ] Configure an on-completion trigger via the dialog → mark the task complete inline → agent runs (`workflows.lastRunStatus = success`).
- [ ] Configure an on-due-date trigger → change the due date inline → `workflows.nextRunAt` updates.
- [ ] Have an agent set a trigger via the `update_task` `agentTrigger` parameter → human opens the dialog → trigger is present and editable; metadata.triggerTypes matches DB truth.
- [ ] Trash the agent page used by a trigger → workflow cascade-deletes → next page-tasks fetch shows `activeTriggerCount = 0` (no stale Bell badge).
- [ ] Toolbar → Workflows → create `*/2 * * * *` cron pointing at an agent. Wait 2 min; confirm the cron poller fires with the task list page in context.
- [ ] Drive viewer (no `canEdit`) cannot see the Bell badge or `Agent triggers…` menu, and `GET /api/tasks/[taskId]/triggers` returns 403.
- [ ] Page editor who is not drive owner/admin does not see the Workflows toolbar button.
- [ ] Trash the task → `disableTaskTriggers` runs (existing path) → badges disappear.

## Validation
- `pnpm --filter web typecheck` clean
- `pnpm --filter web lint` clean (only a pre-existing unrelated warning)
- 464+ tests pass across affected suites (page-tasks API, trigger API, workflow lib, task-management AI tool)
- 13 new tests added (trigger routes + recompute helper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)