### PR TITLE
feat(ai): tool-call multicast — widen SSE wire to UIMessagePart

### DIFF
--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -11,11 +11,11 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 const {
   mockCreateStreamLifecycle,
-  mockLifecyclePushChunk,
+  mockLifecyclePushPart,
   mockLifecycleFinish,
 } = vi.hoisted(() => ({
   mockCreateStreamLifecycle: vi.fn(),
-  mockLifecyclePushChunk: vi.fn(),
+  mockLifecyclePushPart: vi.fn(),
   mockLifecycleFinish: vi.fn(),
 }));
 
@@ -295,7 +295,7 @@ describe('POST /api/ai/chat — lifecycle handoff', () => {
     captured.streamTextOptions = {};
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuth());
     mockCreateStreamLifecycle.mockResolvedValue({
-      pushChunk: mockLifecyclePushChunk,
+      pushPart: mockLifecyclePushPart,
       finish: mockLifecycleFinish,
     });
   });
@@ -343,22 +343,63 @@ describe('POST /api/ai/chat — lifecycle handoff', () => {
   });
 
   describe('chunk forwarding', () => {
-    it('given a text-delta chunk, should forward the text to lifecycle.pushChunk', async () => {
+    it('given a text-delta chunk, should forward a text part to lifecycle.pushPart', async () => {
       await POST(makeRequest());
       await captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() });
 
       captured.streamTextOptions.onChunk?.({ chunk: { type: 'text-delta', text: 'hello', id: 'c1' } });
 
-      expect(mockLifecyclePushChunk).toHaveBeenCalledWith('hello');
+      expect(mockLifecyclePushPart).toHaveBeenCalledWith({ type: 'text', text: 'hello' });
     });
 
-    it('given a non-text-delta chunk, should not forward anything', async () => {
+    it('given a tool-call chunk, should forward an input-available tool part to lifecycle.pushPart', async () => {
       await POST(makeRequest());
       await captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() });
 
-      captured.streamTextOptions.onChunk?.({ chunk: { type: 'tool-call', toolCallId: 'tc', toolName: 'x', args: {} } });
+      captured.streamTextOptions.onChunk?.({
+        chunk: { type: 'tool-call', toolCallId: 'tc1', toolName: 'list_pages', input: { driveId: 'd1' } },
+      });
 
-      expect(mockLifecyclePushChunk).not.toHaveBeenCalled();
+      expect(mockLifecyclePushPart).toHaveBeenCalledWith({
+        type: 'tool-list_pages',
+        toolCallId: 'tc1',
+        toolName: 'list_pages',
+        state: 'input-available',
+        input: { driveId: 'd1' },
+      });
+    });
+
+    it('given a tool-result chunk, should forward an output-available tool part to lifecycle.pushPart', async () => {
+      await POST(makeRequest());
+      await captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() });
+
+      captured.streamTextOptions.onChunk?.({
+        chunk: {
+          type: 'tool-result',
+          toolCallId: 'tc1',
+          toolName: 'list_pages',
+          input: { driveId: 'd1' },
+          output: { pages: [{ id: 'p1' }] },
+        },
+      });
+
+      expect(mockLifecyclePushPart).toHaveBeenCalledWith({
+        type: 'tool-list_pages',
+        toolCallId: 'tc1',
+        toolName: 'list_pages',
+        state: 'output-available',
+        input: { driveId: 'd1' },
+        output: { pages: [{ id: 'p1' }] },
+      });
+    });
+
+    it('given a chunk type out of v1 multicast scope, should not forward anything', async () => {
+      await POST(makeRequest());
+      await captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() });
+
+      captured.streamTextOptions.onChunk?.({ chunk: { type: 'finish-step' } });
+
+      expect(mockLifecyclePushPart).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -18,6 +18,7 @@ import { incrementUsage, getCurrentUsage, getUserUsageSummary } from '@/lib/subs
 import { requiresProSubscription, createRateLimitResponse } from '@/lib/subscription/rate-limit-middleware';
 import { broadcastUsageEvent } from '@/lib/websocket';
 import { createStreamLifecycle, type StreamLifecycleHandle } from '@/lib/ai/core/stream-lifecycle';
+import { chunkToPart } from '@/lib/ai/streams/chunkToPart';
 import { validateBrowserSessionIdHeader } from '@/lib/ai/core/browser-session-id-validation';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
 
@@ -875,9 +876,8 @@ export async function POST(request: Request) {
             }, // Pass userId, timezone, AI context, location context, model capabilities, and chat source to tools
             maxRetries: 20, // Increase from default 2 to 20 for better handling of rate limits
             onChunk: ({ chunk }) => {
-              if (chunk.type === 'text-delta') {
-                lifecycle!.pushChunk(chunk.text);
-              }
+              const part = chunkToPart(chunk as never);
+              if (part) lifecycle!.pushPart(part);
             },
             onAbort: () => {
               loggers.ai.info('AI Chat API: Stream aborted by user', {

--- a/apps/web/src/app/api/ai/chat/stream-join/[messageId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/chat/stream-join/[messageId]/__tests__/route.test.ts
@@ -195,18 +195,38 @@ describe('GET /api/ai/chat/stream-join/[messageId]', () => {
       );
     });
 
-    it('given buffered chunks, should stream them as SSE data events', async () => {
+    it('given buffered parts, should stream them as SSE part frames', async () => {
       testRegistry.register(mockMessageId, mockMeta);
-      testRegistry.push(mockMessageId, 'hello');
-      testRegistry.push(mockMessageId, ' world');
+      testRegistry.push(mockMessageId, { type: 'text', text: 'hello' });
+      testRegistry.push(mockMessageId, { type: 'text', text: ' world' });
 
       const response = await GET(makeRequest(), makeContext(mockMessageId));
       testRegistry.finish(mockMessageId);
 
       const body = await readSSEBody(response);
 
-      expect(body).toContain('data: {"text":"hello"}\n\n');
-      expect(body).toContain('data: {"text":" world"}\n\n');
+      expect(body).toContain('data: {"part":{"type":"text","text":"hello"}}\n\n');
+      expect(body).toContain('data: {"part":{"type":"text","text":" world"}}\n\n');
+    });
+
+    it('given a tool part, should stream it as an SSE part frame preserving the full tool shape', async () => {
+      testRegistry.register(mockMessageId, mockMeta);
+      const toolPart = {
+        type: 'tool-list_pages',
+        toolCallId: 'tc1',
+        toolName: 'list_pages',
+        state: 'output-available',
+        input: { driveId: 'd1' },
+        output: { pages: [] },
+      } as const;
+      testRegistry.push(mockMessageId, toolPart as never);
+
+      const response = await GET(makeRequest(), makeContext(mockMessageId));
+      testRegistry.finish(mockMessageId);
+
+      const body = await readSSEBody(response);
+
+      expect(body).toContain(`data: ${JSON.stringify({ part: toolPart })}\n\n`);
     });
 
     it('given stream completion, should send [DONE] sentinel and close', async () => {
@@ -231,19 +251,19 @@ describe('GET /api/ai/chat/stream-join/[messageId]', () => {
       expect(body).toContain('data: {"done":true,"aborted":true}\n\n');
     });
 
-    it('given live chunks pushed after subscribe, should stream them in order', async () => {
+    it('given live parts pushed after subscribe, should stream them in order', async () => {
       testRegistry.register(mockMessageId, mockMeta);
-      testRegistry.push(mockMessageId, 'buffered');
+      testRegistry.push(mockMessageId, { type: 'text', text: 'buffered' });
 
       const response = await GET(makeRequest(), makeContext(mockMessageId));
 
-      testRegistry.push(mockMessageId, 'live');
+      testRegistry.push(mockMessageId, { type: 'text', text: 'live' });
       testRegistry.finish(mockMessageId);
 
       const body = await readSSEBody(response);
 
-      expect(body).toContain('data: {"text":"buffered"}\n\n');
-      expect(body).toContain('data: {"text":"live"}\n\n');
+      expect(body).toContain('data: {"part":{"type":"text","text":"buffered"}}\n\n');
+      expect(body).toContain('data: {"part":{"type":"text","text":"live"}}\n\n');
       expect(body).toContain('data: {"done":true,"aborted":false}\n\n');
     });
 

--- a/apps/web/src/app/api/ai/chat/stream-join/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/chat/stream-join/[messageId]/route.ts
@@ -54,8 +54,8 @@ export async function GET(
 
   const unsubscribe = streamMulticastRegistry.subscribe(
     messageId,
-    (text) => {
-      const chunk = encoder.encode(`data: ${JSON.stringify({ text })}\n\n`);
+    (part) => {
+      const chunk = encoder.encode(`data: ${JSON.stringify({ part })}\n\n`);
       if (streamController) {
         streamController.enqueue(chunk);
       } else {

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
@@ -10,11 +10,11 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 const {
   mockCreateStreamLifecycle,
-  mockLifecyclePushChunk,
+  mockLifecyclePushPart,
   mockLifecycleFinish,
 } = vi.hoisted(() => ({
   mockCreateStreamLifecycle: vi.fn(),
-  mockLifecyclePushChunk: vi.fn(),
+  mockLifecyclePushPart: vi.fn(),
   mockLifecycleFinish: vi.fn(),
 }));
 
@@ -307,7 +307,7 @@ describe('POST /api/ai/global/[id]/messages — lifecycle handoff', () => {
     captured.streamTextOptions = {};
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuth());
     mockCreateStreamLifecycle.mockResolvedValue({
-      pushChunk: mockLifecyclePushChunk,
+      pushPart: mockLifecyclePushPart,
       finish: mockLifecycleFinish,
     });
   });
@@ -397,22 +397,63 @@ describe('POST /api/ai/global/[id]/messages — lifecycle handoff', () => {
   });
 
   describe('chunk forwarding', () => {
-    it('given a text-delta chunk, should forward the text to lifecycle.pushChunk', async () => {
+    it('given a text-delta chunk, should forward a text part to lifecycle.pushPart', async () => {
       await POST(makeRequest(), makeContext());
       await captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() });
 
       captured.streamTextOptions.onChunk?.({ chunk: { type: 'text-delta', text: 'hello', id: 'c1' } });
 
-      expect(mockLifecyclePushChunk).toHaveBeenCalledWith('hello');
+      expect(mockLifecyclePushPart).toHaveBeenCalledWith({ type: 'text', text: 'hello' });
     });
 
-    it('given a non-text-delta chunk, should not forward anything', async () => {
+    it('given a tool-call chunk, should forward an input-available tool part', async () => {
       await POST(makeRequest(), makeContext());
       await captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() });
 
-      captured.streamTextOptions.onChunk?.({ chunk: { type: 'tool-call', toolCallId: 't', toolName: 'x', args: {} } });
+      captured.streamTextOptions.onChunk?.({
+        chunk: { type: 'tool-call', toolCallId: 'tc1', toolName: 'list_pages', input: { driveId: 'd1' } },
+      });
 
-      expect(mockLifecyclePushChunk).not.toHaveBeenCalled();
+      expect(mockLifecyclePushPart).toHaveBeenCalledWith({
+        type: 'tool-list_pages',
+        toolCallId: 'tc1',
+        toolName: 'list_pages',
+        state: 'input-available',
+        input: { driveId: 'd1' },
+      });
+    });
+
+    it('given a tool-result chunk, should forward an output-available tool part', async () => {
+      await POST(makeRequest(), makeContext());
+      await captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() });
+
+      captured.streamTextOptions.onChunk?.({
+        chunk: {
+          type: 'tool-result',
+          toolCallId: 'tc1',
+          toolName: 'list_pages',
+          input: { driveId: 'd1' },
+          output: { pages: [{ id: 'p1' }] },
+        },
+      });
+
+      expect(mockLifecyclePushPart).toHaveBeenCalledWith({
+        type: 'tool-list_pages',
+        toolCallId: 'tc1',
+        toolName: 'list_pages',
+        state: 'output-available',
+        input: { driveId: 'd1' },
+        output: { pages: [{ id: 'p1' }] },
+      });
+    });
+
+    it('given a chunk type out of v1 multicast scope, should not forward anything', async () => {
+      await POST(makeRequest(), makeContext());
+      await captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() });
+
+      captured.streamTextOptions.onChunk?.({ chunk: { type: 'finish-step' } });
+
+      expect(mockLifecyclePushPart).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -7,6 +7,7 @@ import { incrementUsage, getCurrentUsage, getUserUsageSummary } from '@/lib/subs
 import { createRateLimitResponse } from '@/lib/subscription/rate-limit-middleware';
 import { broadcastUsageEvent } from '@/lib/websocket';
 import { createStreamLifecycle, type StreamLifecycleHandle } from '@/lib/ai/core/stream-lifecycle';
+import { chunkToPart } from '@/lib/ai/streams/chunkToPart';
 import { validateBrowserSessionIdHeader } from '@/lib/ai/core/browser-session-id-validation';
 import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
@@ -886,9 +887,8 @@ MENTION PROCESSING:
           },
           maxRetries: 20,
           onChunk: ({ chunk }) => {
-            if (chunk.type === 'text-delta') {
-              lifecycle!.pushChunk(chunk.text);
-            }
+            const part = chunkToPart(chunk as never);
+            if (part) lifecycle!.pushPart(part);
           },
           onAbort: () => {
             loggers.api.info('Global Assistant Chat API: Stream aborted by user', {

--- a/apps/web/src/components/ai/chat/layouts/__tests__/ChatLayout.remoteStreams.test.tsx
+++ b/apps/web/src/components/ai/chat/layouts/__tests__/ChatLayout.remoteStreams.test.tsx
@@ -56,7 +56,7 @@ const makeStream = (overrides: Partial<PendingStream>): PendingStream => ({
   pageId: 'page-1',
   conversationId: 'conv-1',
   triggeredBy: { userId: 'u-1', displayName: 'Alice' },
-  text: '',
+  parts: [],
   isOwn: false,
   ...overrides,
 });

--- a/apps/web/src/components/ai/shared/chat/ChatMessagesArea.tsx
+++ b/apps/web/src/components/ai/shared/chat/ChatMessagesArea.tsx
@@ -243,7 +243,7 @@ const ChatMessagesAreaInner = forwardRef<ChatMessagesAreaRef, ChatMessagesAreaPr
               message={{
                 id: stream.messageId,
                 role: 'assistant',
-                parts: [{ type: 'text', text: stream.text }],
+                parts: stream.parts,
                 messageType: 'standard',
               }}
               isStreaming

--- a/apps/web/src/components/ai/shared/chat/__tests__/ChatMessagesArea.remoteStreams.test.tsx
+++ b/apps/web/src/components/ai/shared/chat/__tests__/ChatMessagesArea.remoteStreams.test.tsx
@@ -62,10 +62,12 @@ const makeStream = (overrides: Partial<PendingStream>): PendingStream => ({
   pageId: 'page-1',
   conversationId: 'conv-1',
   triggeredBy: { userId: 'u-1', displayName: 'Alice' },
-  text: '',
+  parts: [],
   isOwn: false,
   ...overrides,
 });
+
+const textPart = (text: string) => ({ type: 'text' as const, text });
 
 const makeMessage = (id: string, role: UIMessage['role'] = 'user', text = ''): UIMessage => ({
   id,
@@ -91,8 +93,8 @@ describe('ChatMessagesArea — remoteStreams rendering', () => {
 
   it('given a non-empty remoteStreams, renders one MessageRenderer per stream with synthesized assistant message and isStreaming=true', () => {
     const remoteStreams = [
-      makeStream({ messageId: 'remote-a', text: 'partial response' }),
-      makeStream({ messageId: 'remote-b', text: '' }),
+      makeStream({ messageId: 'remote-a', parts: [textPart('partial response')] }),
+      makeStream({ messageId: 'remote-b', parts: [] }),
     ];
 
     render(
@@ -119,13 +121,42 @@ describe('ChatMessagesArea — remoteStreams rendering', () => {
     expect(synthesizedCalls[0].onRetry).toBeUndefined();
 
     expect(synthesizedCalls[1].message.id).toBe('remote-b');
-    expect(synthesizedCalls[1].message.parts).toEqual([{ type: 'text', text: '' }]);
+    expect(synthesizedCalls[1].message.parts).toEqual([]);
+  });
+
+  it('given a remote stream whose parts include a tool part, forwards the full tool shape to MessageRenderer (no flattening to text)', () => {
+    const toolPart = {
+      type: 'tool-list_pages',
+      toolCallId: 'tc1',
+      toolName: 'list_pages',
+      state: 'output-available',
+      input: { driveId: 'd1' },
+      output: { pages: [{ id: 'p1' }] },
+    };
+    const remoteStreams = [
+      makeStream({
+        messageId: 'remote-tool',
+        parts: [textPart('let me check'), toolPart as never],
+      }),
+    ];
+
+    render(
+      <ChatMessagesArea
+        messages={[]}
+        isLoading={false}
+        isStreaming={false}
+        remoteStreams={remoteStreams}
+      />
+    );
+
+    const [call] = remoteRendererCalls();
+    expect(call.message.parts).toEqual([{ type: 'text', text: 'let me check' }, toolPart]);
   });
 
   it('given a remote stream whose messageId is already present in messages, does NOT render the duplicate', () => {
     const remoteStreams = [
-      makeStream({ messageId: 'msg-already-landed', text: 'finalised text' }),
-      makeStream({ messageId: 'msg-still-streaming', text: 'in progress' }),
+      makeStream({ messageId: 'msg-already-landed', parts: [textPart('finalised text')] }),
+      makeStream({ messageId: 'msg-still-streaming', parts: [textPart('in progress')] }),
     ];
 
     render(
@@ -173,7 +204,7 @@ describe('ChatMessagesArea — remoteStreams rendering', () => {
         messages={[]}
         isLoading={true}
         isStreaming={false}
-        remoteStreams={[makeStream({ messageId: 'remote-x', text: 'partial' })]}
+        remoteStreams={[makeStream({ messageId: 'remote-x', parts: [textPart('partial')] })]}
       />
     );
 

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -33,6 +33,7 @@ import { isEditingActive } from '@/stores/useEditingStore';
 import { usePageSocketRoom } from '@/hooks/usePageSocketRoom';
 import { useChannelStreamSocket } from '@/hooks/useChannelStreamSocket';
 import { usePendingStreamsStore } from '@/stores/usePendingStreamsStore';
+import { synthesizeAssistantMessage } from '@/lib/ai/streams/synthesizeAssistantMessage';
 import { useShallow } from 'zustand/react/shallow';
 
 // Shared hooks and components
@@ -345,18 +346,15 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
   useChannelStreamSocket(page.id, {
     onStreamComplete: (messageId) => {
       const stream = usePendingStreamsStore.getState().streams.get(messageId);
-      if (stream?.text && stream.conversationId === currentConversationId) {
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: messageId,
-            role: 'assistant' as const,
-            content: stream.text,
-            parts: [{ type: 'text' as const, text: stream.text }],
-          },
-        ]);
-      } else if (stream?.text && currentConversationId === `${page.id}-default`) {
-        const { text, conversationId: streamConvId } = stream;
+      if (!stream || stream.parts.length === 0) return;
+
+      if (stream.conversationId === currentConversationId) {
+        setMessages((prev) => [...prev, synthesizeAssistantMessage(messageId, stream.parts)]);
+        return;
+      }
+
+      if (currentConversationId === `${page.id}-default`) {
+        const { parts, conversationId: streamConvId } = stream;
         fetchWithAuth(`/api/ai/page-agents/${page.id}/conversations?pageSize=1`)
           .then(async (res) => {
             if (pageIdRef.current !== page.id) return;
@@ -365,15 +363,7 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
             const persisted = data.conversations?.[0];
             if (!persisted || persisted.id !== streamConvId) return;
             setCurrentConversationId(persisted.id);
-            setMessages((prev) => [
-              ...prev,
-              {
-                id: messageId,
-                role: 'assistant' as const,
-                content: text,
-                parts: [{ type: 'text' as const, text }],
-              },
-            ]);
+            setMessages((prev) => [...prev, synthesizeAssistantMessage(messageId, parts)]);
           })
           .catch((err) => console.warn('[AiChatView] late-joiner sync failed', err));
       }

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
@@ -488,7 +488,7 @@ describe('AiChatView late-joiner conversation sync', () => {
     });
 
     (usePendingStreamsStore as unknown as { getState: Mock }).getState.mockReturnValue({
-      streams: new Map([[MESSAGE_ID, { text: 'AI response', conversationId: REAL_CONV_ID }]]),
+      streams: new Map([[MESSAGE_ID, { parts: [{ type: 'text', text: 'AI response' }], conversationId: REAL_CONV_ID }]]),
     });
 
     mockFetchWithAuth.mockImplementation(async (url: string) => {
@@ -529,7 +529,7 @@ describe('AiChatView late-joiner conversation sync', () => {
     });
 
     (usePendingStreamsStore as unknown as { getState: Mock }).getState.mockReturnValue({
-      streams: new Map([[MESSAGE_ID, { text: 'AI response', conversationId: REAL_CONV_ID }]]),
+      streams: new Map([[MESSAGE_ID, { parts: [{ type: 'text', text: 'AI response' }], conversationId: REAL_CONV_ID }]]),
     });
 
     mockFetchWithAuth.mockImplementation(async (url: string) => {
@@ -571,7 +571,7 @@ describe('AiChatView late-joiner conversation sync', () => {
     });
 
     (usePendingStreamsStore as unknown as { getState: Mock }).getState.mockReturnValue({
-      streams: new Map([[MESSAGE_ID, { text: 'AI response', conversationId: REAL_CONV_ID }]]),
+      streams: new Map([[MESSAGE_ID, { parts: [{ type: 'text', text: 'AI response' }], conversationId: REAL_CONV_ID }]]),
     });
 
     mockFetchWithAuth.mockImplementation(async (url: string) => {
@@ -611,7 +611,7 @@ describe('AiChatView late-joiner conversation sync', () => {
     });
 
     (usePendingStreamsStore as unknown as { getState: Mock }).getState.mockReturnValue({
-      streams: new Map([[MESSAGE_ID, { text: 'AI response', conversationId: REAL_CONV_ID }]]),
+      streams: new Map([[MESSAGE_ID, { parts: [{ type: 'text', text: 'AI response' }], conversationId: REAL_CONV_ID }]]),
     });
 
     mockFetchWithAuth.mockImplementation(async (url: string) => {
@@ -652,7 +652,7 @@ describe('AiChatView late-joiner conversation sync', () => {
     });
 
     (usePendingStreamsStore as unknown as { getState: Mock }).getState.mockReturnValue({
-      streams: new Map([[MESSAGE_ID, { text: 'AI response', conversationId: REAL_CONV_ID }]]),
+      streams: new Map([[MESSAGE_ID, { parts: [{ type: 'text', text: 'AI response' }], conversationId: REAL_CONV_ID }]]),
     });
 
     mockFetchWithAuth.mockImplementation(async (url: string) => {
@@ -723,7 +723,7 @@ describe('AiChatView late-joiner conversation sync', () => {
     });
 
     (usePendingStreamsStore as unknown as { getState: Mock }).getState.mockReturnValue({
-      streams: new Map([[MESSAGE_ID, { text: 'AI from page A', conversationId: REAL_CONV_ID }]]),
+      streams: new Map([[MESSAGE_ID, { parts: [{ type: 'text', text: 'AI from page A' }], conversationId: REAL_CONV_ID }]]),
     });
 
     // Trigger the late-joiner sync (starts the deferred fetch)

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -141,7 +141,7 @@ export const SidebarMessagesContent: React.FC<SidebarMessagesContentProps> = ({
       {inflightRemoteStreams.map((stream) => (
         <CompactMessageRenderer
           key={stream.messageId}
-          message={synthesizeAssistantMessage(stream.messageId, stream.text)}
+          message={synthesizeAssistantMessage(stream.messageId, stream.parts)}
           isStreaming
         />
       ))}

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarMessagesContent.test.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/__tests__/SidebarMessagesContent.test.tsx
@@ -72,7 +72,7 @@ const stream = (overrides: Partial<PendingStream>): PendingStream => ({
   pageId: 'user:u1:global',
   conversationId: 'conv-1',
   triggeredBy: { userId: 'user-2', displayName: 'Alice' },
-  text: '',
+  parts: [],
   isOwn: false,
   ...overrides,
 });
@@ -99,7 +99,7 @@ describe('SidebarMessagesContent — multiplayer remote stream rendering (Task 3
       <SidebarMessagesContent
         {...baseProps}
         messages={[]}
-        remoteStreams={[stream({ messageId: 'msg-remote', text: 'partial response' })]}
+        remoteStreams={[stream({ messageId: 'msg-remote', parts: [{ type: 'text', text: 'partial response' }] })]}
       />,
     );
 
@@ -115,7 +115,7 @@ describe('SidebarMessagesContent — multiplayer remote stream rendering (Task 3
         {...baseProps}
         messages={[assistantMessage('msg-shared', 'final landed')]}
         remoteStreams={[
-          stream({ messageId: 'msg-shared', text: 'should not show as duplicate' }),
+          stream({ messageId: 'msg-shared', parts: [{ type: 'text', text: 'should not show as duplicate' }] }),
         ]}
       />,
     );
@@ -130,7 +130,7 @@ describe('SidebarMessagesContent — multiplayer remote stream rendering (Task 3
       <SidebarMessagesContent
         {...baseProps}
         messages={[userMessage('msg-u', 'user question')]}
-        remoteStreams={[stream({ messageId: 'msg-r', text: 'remote answer' })]}
+        remoteStreams={[stream({ messageId: 'msg-r', parts: [{ type: 'text', text: 'remote answer' }] })]}
       />,
     );
 
@@ -159,7 +159,7 @@ describe('SidebarMessagesContent — multiplayer remote stream rendering (Task 3
       <SidebarMessagesContent
         {...baseProps}
         messages={[]}
-        remoteStreams={[stream({ messageId: 'msg-only', text: 'mid-stream content' })]}
+        remoteStreams={[stream({ messageId: 'msg-only', parts: [{ type: 'text', text: 'mid-stream content' }] })]}
       />,
     );
 
@@ -173,9 +173,9 @@ describe('SidebarMessagesContent — multiplayer remote stream rendering (Task 3
         {...baseProps}
         messages={[]}
         remoteStreams={[
-          stream({ messageId: 'msg-a', text: 'first' }),
-          stream({ messageId: 'msg-b', text: 'second' }),
-          stream({ messageId: 'msg-c', text: 'third' }),
+          stream({ messageId: 'msg-a', parts: [{ type: 'text', text: 'first' }] }),
+          stream({ messageId: 'msg-b', parts: [{ type: 'text', text: 'second' }] }),
+          stream({ messageId: 'msg-c', parts: [{ type: 'text', text: 'third' }] }),
         ]}
       />,
     );

--- a/apps/web/src/contexts/__tests__/GlobalChatContext.test.tsx
+++ b/apps/web/src/contexts/__tests__/GlobalChatContext.test.tsx
@@ -13,7 +13,7 @@ const {
   mockSocket,
   mockUseAuth,
   mockAddStream,
-  mockAppendText,
+  mockAppendPart,
   mockRemoveStream,
   mockClearPageStreams,
   mockConsumeStreamJoin,
@@ -46,7 +46,7 @@ const {
     mockSocket: socket,
     mockUseAuth: vi.fn(),
     mockAddStream: vi.fn(),
-    mockAppendText: vi.fn(),
+    mockAppendPart: vi.fn(),
     mockRemoveStream: vi.fn(),
     mockClearPageStreams: vi.fn(),
     mockConsumeStreamJoin: vi.fn().mockResolvedValue(undefined),
@@ -71,7 +71,7 @@ vi.mock('@/stores/usePendingStreamsStore', () => ({
   usePendingStreamsStore: {
     getState: () => ({
       addStream: mockAddStream,
-      appendText: mockAppendText,
+      appendPart: mockAppendPart,
       removeStream: mockRemoveStream,
       clearPageStreams: mockClearPageStreams,
     }),

--- a/apps/web/src/hooks/__tests__/useAgentChannelMultiplayer.test.ts
+++ b/apps/web/src/hooks/__tests__/useAgentChannelMultiplayer.test.ts
@@ -26,7 +26,7 @@ const {
     mockUseStreamingRegistration: vi.fn(),
     mockAbortByMessageId: vi.fn(),
     mockSocketStatus: { current: 'disconnected' as 'disconnected' | 'connecting' | 'connected' | 'error' },
-    pendingStreams: { current: new Map<string, { messageId: string; pageId: string; conversationId: string; triggeredBy: { userId: string; displayName: string }; text: string; isOwn: boolean }>() },
+    pendingStreams: { current: new Map<string, { messageId: string; pageId: string; conversationId: string; triggeredBy: { userId: string; displayName: string }; parts: UIMessage['parts']; isOwn: boolean }>() },
   };
 });
 

--- a/apps/web/src/hooks/__tests__/useAgentChannelMultiplayer.test.ts
+++ b/apps/web/src/hooks/__tests__/useAgentChannelMultiplayer.test.ts
@@ -219,7 +219,7 @@ describe('useAgentChannelMultiplayer', () => {
             pageId: AGENT.id,
             conversationId: 'conv-active',
             triggeredBy: { userId: 'someone-else', displayName: 'X' },
-            text: 'final response text',
+            parts: [{ type: 'text', text: 'final response text' }],
             isOwn: false,
           },
         ],
@@ -256,7 +256,7 @@ describe('useAgentChannelMultiplayer', () => {
             pageId: AGENT.id,
             conversationId: 'conv-different',
             triggeredBy: { userId: 'x', displayName: 'X' },
-            text: 'belongs to different conversation',
+            parts: [{ type: 'text', text: 'belongs to different conversation' }],
             isOwn: false,
           },
         ],
@@ -276,7 +276,7 @@ describe('useAgentChannelMultiplayer', () => {
       expect(setLocalMessages).not.toHaveBeenCalled();
     });
 
-    it('given a stream finalizes with empty text, setLocalMessages should not be called', () => {
+    it('given a stream finalizes with empty parts, setLocalMessages should not be called', () => {
       pendingStreams.current = new Map([
         [
           'msg-empty',
@@ -285,7 +285,7 @@ describe('useAgentChannelMultiplayer', () => {
             pageId: AGENT.id,
             conversationId: 'conv-active',
             triggeredBy: { userId: 'x', displayName: 'X' },
-            text: '',
+            parts: [],
             isOwn: false,
           },
         ],

--- a/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
+++ b/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
@@ -10,7 +10,7 @@ const SESSION_ID_REMOTE = 'session-other';
 const {
   mockSocket,
   mockAddStream,
-  mockAppendText,
+  mockAppendPart,
   mockRemoveStream,
   mockClearPageStreams,
   mockConsumeStreamJoin,
@@ -39,7 +39,7 @@ const {
   };
 
   const mockAddStream = vi.fn();
-  const mockAppendText = vi.fn();
+  const mockAppendPart = vi.fn();
   const mockRemoveStream = vi.fn();
   const mockClearPageStreams = vi.fn();
   const mockConsumeStreamJoin = vi.fn().mockResolvedValue({ aborted: false });
@@ -52,7 +52,7 @@ const {
   return {
     mockSocket,
     mockAddStream,
-    mockAppendText,
+    mockAppendPart,
     mockRemoveStream,
     mockClearPageStreams,
     mockConsumeStreamJoin,
@@ -69,7 +69,7 @@ vi.mock('@/stores/usePendingStreamsStore', () => ({
   usePendingStreamsStore: {
     getState: () => ({
       addStream: mockAddStream,
-      appendText: mockAppendText,
+      appendPart: mockAppendPart,
       removeStream: mockRemoveStream,
       clearPageStreams: mockClearPageStreams,
     }),
@@ -139,10 +139,10 @@ describe('useChannelStreamSocket', () => {
       );
     });
 
-    it('should wire onChunk to appendText in the store', async () => {
-      let capturedOnChunk!: (text: string) => void;
+    it('should wire onChunk to appendPart in the store', async () => {
+      let capturedOnChunk!: (part: unknown) => void;
       mockConsumeStreamJoin.mockImplementation(
-        (_id: string, _signal: AbortSignal, onChunk: (text: string) => void) => {
+        (_id: string, _signal: AbortSignal, onChunk: (part: unknown) => void) => {
           capturedOnChunk = onChunk;
           return new Promise(() => {}); // never resolves
         },
@@ -151,8 +151,9 @@ describe('useChannelStreamSocket', () => {
       renderHook(() => useChannelStreamSocket('page-a'));
       act(() => { mockSocket._trigger('chat:stream_start', START_PAYLOAD); });
 
-      capturedOnChunk('hello');
-      expect(mockAppendText).toHaveBeenCalledWith('msg-1', 'hello');
+      const textPart = { type: 'text', text: 'hello' };
+      capturedOnChunk(textPart);
+      expect(mockAppendPart).toHaveBeenCalledWith('msg-1', textPart);
     });
 
     it('should call removeStream and onStreamComplete after consumeStreamJoin resolves', async () => {

--- a/apps/web/src/hooks/useAgentChannelMultiplayer.ts
+++ b/apps/web/src/hooks/useAgentChannelMultiplayer.ts
@@ -92,11 +92,11 @@ export function useAgentChannelMultiplayer({
   useChannelStreamSocket(channelId, {
     onStreamComplete: (messageId) => {
       const stream = usePendingStreamsStore.getState().streams.get(messageId);
-      if (!stream?.text) return;
+      if (!stream || stream.parts.length === 0) return;
       if (stream.conversationId !== agentConversationIdRef.current) return;
       setLocalMessagesRef.current((prev) => [
         ...prev,
-        synthesizeAssistantMessage(messageId, stream.text),
+        synthesizeAssistantMessage(messageId, stream.parts),
       ]);
     },
     onOwnStreamBootstrap: ({ messageId }) => {

--- a/apps/web/src/hooks/useChannelStreamSocket.ts
+++ b/apps/web/src/hooks/useChannelStreamSocket.ts
@@ -51,7 +51,7 @@ export function useChannelStreamSocket(
     // lookup and a one-shot guard for onOwnStreamFinalize.
     const ownStreamIds = new Set<string>();
 
-    const { addStream, appendText, removeStream, clearPageStreams } =
+    const { addStream, appendPart, removeStream, clearPageStreams } =
       usePendingStreamsStore.getState();
 
     const fireComplete = (messageId: string) => {
@@ -70,8 +70,8 @@ export function useChannelStreamSocket(
       const controller = new AbortController();
       controllers.set(messageId, controller);
 
-      consumeStreamJoin(messageId, controller.signal, (chunk) => {
-        appendText(messageId, chunk);
+      consumeStreamJoin(messageId, controller.signal, (part) => {
+        appendPart(messageId, part);
       })
         .then(() => {
           // Cleanup runs synchronously on unmount but the SSE promise resolves

--- a/apps/web/src/lib/ai/core/__tests__/stream-join-client.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stream-join-client.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 
+const text = (text: string) => ({ type: 'text' as const, text });
+
 describe('consumeStreamJoin', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -28,10 +30,10 @@ describe('consumeStreamJoin', () => {
     );
   }
 
-  it('given valid SSE chunks and done sentinel, should call onChunk for each text and return { aborted: false }', async () => {
+  it('given valid part frames and done sentinel, should call onChunk for each part and return { aborted: false }', async () => {
     stubFetch(encodeLines([
-      'data: {"text":"hello"}\n\n',
-      'data: {"text":" world"}\n\n',
+      'data: {"part":{"type":"text","text":"hello"}}\n\n',
+      'data: {"part":{"type":"text","text":" world"}}\n\n',
       'data: {"done":true,"aborted":false}\n\n',
     ]));
 
@@ -40,14 +42,35 @@ describe('consumeStreamJoin', () => {
     const result = await consumeStreamJoin('msg-1', AbortSignal.timeout(5000), onChunk);
 
     expect(onChunk).toHaveBeenCalledTimes(2);
-    expect(onChunk).toHaveBeenNthCalledWith(1, 'hello');
-    expect(onChunk).toHaveBeenNthCalledWith(2, ' world');
+    expect(onChunk).toHaveBeenNthCalledWith(1, text('hello'));
+    expect(onChunk).toHaveBeenNthCalledWith(2, text(' world'));
     expect(result).toEqual({ aborted: false });
+  });
+
+  it('given a tool part frame, should pass the full tool object through to onChunk', async () => {
+    const tool = {
+      type: 'tool-list_pages',
+      toolCallId: 'tc1',
+      toolName: 'list_pages',
+      state: 'output-available',
+      input: { driveId: 'd1' },
+      output: { pages: [] },
+    };
+    stubFetch(encodeLines([
+      `data: ${JSON.stringify({ part: tool })}\n\n`,
+      'data: {"done":true,"aborted":false}\n\n',
+    ]));
+
+    const { consumeStreamJoin } = await import('../stream-join-client');
+    const onChunk = vi.fn();
+    await consumeStreamJoin('msg-tool', AbortSignal.timeout(5000), onChunk);
+
+    expect(onChunk).toHaveBeenCalledWith(tool);
   });
 
   it('given done sentinel with aborted: true, should return { aborted: true } without throwing', async () => {
     stubFetch(encodeLines([
-      'data: {"text":"partial"}\n\n',
+      'data: {"part":{"type":"text","text":"partial"}}\n\n',
       'data: {"done":true,"aborted":true}\n\n',
     ]));
 
@@ -55,7 +78,7 @@ describe('consumeStreamJoin', () => {
     const onChunk = vi.fn();
     const result = await consumeStreamJoin('msg-2', AbortSignal.timeout(5000), onChunk);
 
-    expect(onChunk).toHaveBeenCalledWith('partial');
+    expect(onChunk).toHaveBeenCalledWith(text('partial'));
     expect(result).toEqual({ aborted: true });
   });
 
@@ -93,7 +116,7 @@ describe('consumeStreamJoin', () => {
     stubFetch(encodeLines([
       'data: not-json\n\n',
       'comment: ignored\n\n',
-      'data: {"text":"ok"}\n\n',
+      'data: {"part":{"type":"text","text":"ok"}}\n\n',
       'data: {"done":true,"aborted":false}\n\n',
     ]));
 
@@ -102,8 +125,23 @@ describe('consumeStreamJoin', () => {
     const result = await consumeStreamJoin('msg-5', AbortSignal.timeout(5000), onChunk);
 
     expect(onChunk).toHaveBeenCalledTimes(1);
-    expect(onChunk).toHaveBeenCalledWith('ok');
+    expect(onChunk).toHaveBeenCalledWith(text('ok'));
     expect(result).toEqual({ aborted: false });
+  });
+
+  it('given a legacy {text:...} frame from an old server, should skip it (no part field present)', async () => {
+    stubFetch(encodeLines([
+      'data: {"text":"legacy"}\n\n',
+      'data: {"part":{"type":"text","text":"current"}}\n\n',
+      'data: {"done":true,"aborted":false}\n\n',
+    ]));
+
+    const { consumeStreamJoin } = await import('../stream-join-client');
+    const onChunk = vi.fn();
+    await consumeStreamJoin('msg-mixed', AbortSignal.timeout(5000), onChunk);
+
+    expect(onChunk).toHaveBeenCalledTimes(1);
+    expect(onChunk).toHaveBeenCalledWith(text('current'));
   });
 
   it('given fetch call, should include credentials and the correct URL', async () => {
@@ -123,7 +161,6 @@ describe('consumeStreamJoin', () => {
     );
   });
 
-  // C1 — encodeURIComponent
   it('given messageId with special characters, should URL-encode it in the request', async () => {
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
@@ -141,7 +178,6 @@ describe('consumeStreamJoin', () => {
     );
   });
 
-  // C2 — null body guard
   it('given a 2xx response with a null body, should throw', async () => {
     vi.stubGlobal(
       'fetch',
@@ -155,12 +191,10 @@ describe('consumeStreamJoin', () => {
     ).rejects.toThrow();
   });
 
-  // C5 — partial-chunk buffer
-  it('given SSE line split across two read chunks, should buffer and parse correctly', async () => {
+  it('given an SSE line split across two read chunks, should buffer and parse correctly', async () => {
     const encoder = new TextEncoder();
-    // 'data: {"text":"hello"}\n\n' split mid-JSON across two enqueues
-    const halfA = 'data: {"text"';
-    const halfB = ':"hello"}\n\ndata: {"done":true,"aborted":false}\n\n';
+    const halfA = 'data: {"part":{"type":"text"';
+    const halfB = ',"text":"hello"}}\n\ndata: {"done":true,"aborted":false}\n\n';
 
     stubFetch(new ReadableStream({
       start(controller) {
@@ -174,7 +208,7 @@ describe('consumeStreamJoin', () => {
     const onChunk = vi.fn();
     const result = await consumeStreamJoin('msg-split', AbortSignal.timeout(5000), onChunk);
 
-    expect(onChunk).toHaveBeenCalledWith('hello');
+    expect(onChunk).toHaveBeenCalledWith(text('hello'));
     expect(result).toEqual({ aborted: false });
   });
 });

--- a/apps/web/src/lib/ai/core/__tests__/stream-join-client.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stream-join-client.test.ts
@@ -144,6 +144,36 @@ describe('consumeStreamJoin', () => {
     expect(onChunk).toHaveBeenCalledWith(text('current'));
   });
 
+  it('given a frame with an empty part object, should skip it without forwarding (no type discriminator means no renderer route)', async () => {
+    stubFetch(encodeLines([
+      'data: {"part":{}}\n\n',
+      'data: {"part":{"type":"text","text":"after"}}\n\n',
+      'data: {"done":true,"aborted":false}\n\n',
+    ]));
+
+    const { consumeStreamJoin } = await import('../stream-join-client');
+    const onChunk = vi.fn();
+    await consumeStreamJoin('msg-empty-part', AbortSignal.timeout(5000), onChunk);
+
+    expect(onChunk).toHaveBeenCalledTimes(1);
+    expect(onChunk).toHaveBeenCalledWith(text('after'));
+  });
+
+  it('given a tool part frame missing toolCallId, should skip it (the idempotency key would be lost)', async () => {
+    stubFetch(encodeLines([
+      'data: {"part":{"type":"tool-list_pages","state":"output-available"}}\n\n',
+      'data: {"part":{"type":"text","text":"recovered"}}\n\n',
+      'data: {"done":true,"aborted":false}\n\n',
+    ]));
+
+    const { consumeStreamJoin } = await import('../stream-join-client');
+    const onChunk = vi.fn();
+    await consumeStreamJoin('msg-bad-tool', AbortSignal.timeout(5000), onChunk);
+
+    expect(onChunk).toHaveBeenCalledTimes(1);
+    expect(onChunk).toHaveBeenCalledWith(text('recovered'));
+  });
+
   it('given fetch call, should include credentials and the correct URL', async () => {
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,

--- a/apps/web/src/lib/ai/core/__tests__/stream-lifecycle.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stream-lifecycle.test.ts
@@ -193,20 +193,22 @@ describe('createStreamLifecycle', () => {
     });
   });
 
-  describe('pushChunk', () => {
-    it('given a chunk, should push it through the multicast registry under the messageId', async () => {
+  describe('pushPart', () => {
+    const textPart = { type: 'text' as const, text: 'hello' };
+
+    it('given a part, should forward it to the multicast registry under the messageId', async () => {
       const lifecycle = await createStreamLifecycle(params());
 
-      lifecycle.pushChunk('hello');
+      lifecycle.pushPart(textPart);
 
-      expect(mockRegistryPush).toHaveBeenCalledWith('msg-1', 'hello');
+      expect(mockRegistryPush).toHaveBeenCalledWith('msg-1', textPart);
     });
 
-    it('given the registry throws on push, should not throw out of pushChunk', async () => {
+    it('given the registry throws on push, should not throw out of pushPart', async () => {
       mockRegistryPush.mockImplementationOnce(() => { throw new Error('push'); });
       const lifecycle = await createStreamLifecycle(params());
 
-      expect(() => lifecycle.pushChunk('hi')).not.toThrow();
+      expect(() => lifecycle.pushPart(textPart)).not.toThrow();
     });
 
     it('given the registry throws on push, should warn-log so the swallow is observable', async () => {
@@ -214,7 +216,7 @@ describe('createStreamLifecycle', () => {
       const lifecycle = await createStreamLifecycle(params());
 
       mockLoggerWarn.mockClear();
-      lifecycle.pushChunk('hi');
+      lifecycle.pushPart(textPart);
 
       expect(mockLoggerWarn).toHaveBeenCalled();
     });

--- a/apps/web/src/lib/ai/core/__tests__/stream-multicast-registry.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stream-multicast-registry.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { StreamMulticastRegistry, type StreamMeta } from '../stream-multicast-registry';
+import {
+  StreamMulticastRegistry,
+  type StreamMeta,
+  type UIMessagePart,
+} from '../stream-multicast-registry';
 
 const meta = (overrides: Partial<StreamMeta> = {}): StreamMeta => ({
   pageId: 'page-1',
@@ -9,6 +13,8 @@ const meta = (overrides: Partial<StreamMeta> = {}): StreamMeta => ({
   browserSessionId: 'session-1',
   ...overrides,
 });
+
+const text = (text: string): UIMessagePart => ({ type: 'text', text });
 
 describe('StreamMulticastRegistry', () => {
   afterEach(() => {
@@ -30,55 +36,77 @@ describe('StreamMulticastRegistry', () => {
   });
 
   describe('push', () => {
-    it('given a registered stream with subscribers, should push text chunks to all active subscribers', () => {
+    it('given a registered stream with subscribers, should fan out each part to every active subscriber', () => {
       const registry = new StreamMulticastRegistry();
       registry.register('msg-1', meta());
 
-      const received1: string[] = [];
-      const received2: string[] = [];
-      registry.subscribe('msg-1', (text) => received1.push(text), () => {});
-      registry.subscribe('msg-1', (text) => received2.push(text), () => {});
+      const received1: UIMessagePart[] = [];
+      const received2: UIMessagePart[] = [];
+      registry.subscribe('msg-1', (p) => received1.push(p), () => {});
+      registry.subscribe('msg-1', (p) => received2.push(p), () => {});
 
-      registry.push('msg-1', 'hello');
-      registry.push('msg-1', ' world');
+      registry.push('msg-1', text('hello'));
+      registry.push('msg-1', text(' world'));
 
-      expect(received1).toEqual(['hello', ' world']);
-      expect(received2).toEqual(['hello', ' world']);
+      expect(received1).toEqual([text('hello'), text(' world')]);
+      expect(received2).toEqual([text('hello'), text(' world')]);
     });
 
     it('silently ignores push for unknown messageId', () => {
       const registry = new StreamMulticastRegistry();
-      expect(() => registry.push('unknown', 'chunk')).not.toThrow();
+      expect(() => registry.push('unknown', text('chunk'))).not.toThrow();
+    });
+
+    it('given an interleaved sequence of text and tool parts, should preserve order at every subscriber', () => {
+      const registry = new StreamMulticastRegistry();
+      registry.register('msg-1', meta());
+
+      const received: UIMessagePart[] = [];
+      registry.subscribe('msg-1', (p) => received.push(p), () => {});
+
+      const tool: UIMessagePart = {
+        type: 'tool-list_pages',
+        toolCallId: 'tc1',
+        state: 'output-available',
+        input: { driveId: 'd1' },
+        output: { pages: [] },
+      } as unknown as UIMessagePart;
+
+      registry.push('msg-1', text('thinking'));
+      registry.push('msg-1', tool);
+      registry.push('msg-1', text('done'));
+
+      expect(received).toEqual([text('thinking'), tool, text('done')]);
     });
   });
 
   describe('subscribe', () => {
-    it('given a late-joining subscriber, should replay all buffered chunks before delivering live ones', () => {
+    it('given a late-joining subscriber, should replay all buffered parts before delivering live ones', () => {
       const registry = new StreamMulticastRegistry();
       registry.register('msg-1', meta());
 
-      registry.push('msg-1', 'chunk1');
-      registry.push('msg-1', 'chunk2');
+      registry.push('msg-1', text('chunk1'));
+      registry.push('msg-1', text('chunk2'));
 
-      const received: string[] = [];
-      registry.subscribe('msg-1', (text) => received.push(text), () => {});
+      const received: UIMessagePart[] = [];
+      registry.subscribe('msg-1', (p) => received.push(p), () => {});
 
-      expect(received).toEqual(['chunk1', 'chunk2']);
+      expect(received).toEqual([text('chunk1'), text('chunk2')]);
     });
 
-    it('given buffered and live chunks, should deliver them in order to a late subscriber', () => {
+    it('given buffered then live parts, should deliver them in order to a late subscriber', () => {
       const registry = new StreamMulticastRegistry();
       registry.register('msg-1', meta());
 
-      registry.push('msg-1', 'chunk1');
-      registry.push('msg-1', 'chunk2');
+      registry.push('msg-1', text('chunk1'));
+      registry.push('msg-1', text('chunk2'));
 
-      const received: string[] = [];
-      registry.subscribe('msg-1', (text) => received.push(text), () => {});
+      const received: UIMessagePart[] = [];
+      registry.subscribe('msg-1', (p) => received.push(p), () => {});
 
-      registry.push('msg-1', 'chunk3');
+      registry.push('msg-1', text('chunk3'));
 
-      expect(received).toEqual(['chunk1', 'chunk2', 'chunk3']);
+      expect(received).toEqual([text('chunk1'), text('chunk2'), text('chunk3')]);
     });
 
     it('given a finished stream, should return null', () => {
@@ -106,23 +134,23 @@ describe('StreamMulticastRegistry', () => {
   });
 
   describe('unsubscribe', () => {
-    it('given a subscriber that unsubscribes, should stop receiving chunks without affecting other subscribers', () => {
+    it('given a subscriber that unsubscribes, should stop receiving parts without affecting others', () => {
       const registry = new StreamMulticastRegistry();
       registry.register('msg-1', meta());
 
-      const received1: string[] = [];
-      const received2: string[] = [];
+      const received1: UIMessagePart[] = [];
+      const received2: UIMessagePart[] = [];
 
-      const unsubscribe1 = registry.subscribe('msg-1', (text) => received1.push(text), () => {});
-      registry.subscribe('msg-1', (text) => received2.push(text), () => {});
+      const unsubscribe1 = registry.subscribe('msg-1', (p) => received1.push(p), () => {});
+      registry.subscribe('msg-1', (p) => received2.push(p), () => {});
 
-      registry.push('msg-1', 'chunk1');
+      registry.push('msg-1', text('chunk1'));
       expect(unsubscribe1).not.toBeNull();
       (unsubscribe1 as () => void)();
-      registry.push('msg-1', 'chunk2');
+      registry.push('msg-1', text('chunk2'));
 
-      expect(received1).toEqual(['chunk1']);
-      expect(received2).toEqual(['chunk1', 'chunk2']);
+      expect(received1).toEqual([text('chunk1')]);
+      expect(received2).toEqual([text('chunk1'), text('chunk2')]);
     });
 
     it('given an unsubscribed listener, should not call its onComplete when stream finishes', () => {
@@ -259,12 +287,12 @@ describe('StreamMulticastRegistry', () => {
       const registry = new StreamMulticastRegistry();
       registry.register('msg-1', meta());
 
-      const received: string[] = [];
+      const received: UIMessagePart[] = [];
       registry.subscribe('msg-1', () => { throw new Error('bad subscriber'); }, () => {});
-      registry.subscribe('msg-1', (text) => received.push(text), () => {});
+      registry.subscribe('msg-1', (p) => received.push(p), () => {});
 
-      expect(() => registry.push('msg-1', 'chunk1')).not.toThrow();
-      expect(received).toEqual(['chunk1']);
+      expect(() => registry.push('msg-1', text('chunk1'))).not.toThrow();
+      expect(received).toEqual([text('chunk1')]);
     });
 
     it('given a subscriber whose onComplete throws, should still remove the entry and notify remaining subscribers', () => {

--- a/apps/web/src/lib/ai/core/stream-join-client.ts
+++ b/apps/web/src/lib/ai/core/stream-join-client.ts
@@ -3,6 +3,13 @@ import { isValidPartFrame } from '@/lib/ai/streams/isValidPartFrame';
 
 type UIMessagePart = UIMessage['parts'][number];
 
+/**
+ * SSE wire protocol (paired with `apps/web/src/app/api/ai/chat/stream-join/[messageId]/route.ts`):
+ *   data: {"part": <UIMessagePart>}\n\n      — one accumulated part per frame
+ *   data: {"done": true, "aborted": <bool>}\n\n  — end sentinel
+ * Anything else (legacy `{text:...}` frames, malformed JSON, frames missing
+ * required fields) is silently skipped — `isValidPartFrame` is the gate.
+ */
 export async function consumeStreamJoin(
   messageId: string,
   signal: AbortSignal,

--- a/apps/web/src/lib/ai/core/stream-join-client.ts
+++ b/apps/web/src/lib/ai/core/stream-join-client.ts
@@ -1,4 +1,5 @@
 import type { UIMessage } from 'ai';
+import { isValidPartFrame } from '@/lib/ai/streams/isValidPartFrame';
 
 type UIMessagePart = UIMessage['parts'][number];
 
@@ -60,8 +61,8 @@ export async function consumeStreamJoin(
           if (parsed.done) {
             return { aborted: (parsed.aborted as boolean | undefined) ?? false };
           }
-          if (parsed.part && typeof parsed.part === 'object') {
-            onChunk(parsed.part as UIMessagePart);
+          if (isValidPartFrame(parsed.part)) {
+            onChunk(parsed.part);
           }
         } catch {
           // skip malformed SSE lines

--- a/apps/web/src/lib/ai/core/stream-join-client.ts
+++ b/apps/web/src/lib/ai/core/stream-join-client.ts
@@ -1,7 +1,11 @@
+import type { UIMessage } from 'ai';
+
+type UIMessagePart = UIMessage['parts'][number];
+
 export async function consumeStreamJoin(
   messageId: string,
   signal: AbortSignal,
-  onChunk: (text: string) => void,
+  onChunk: (part: UIMessagePart) => void,
 ): Promise<{ aborted: boolean }> {
   let response: Response;
   try {
@@ -56,8 +60,8 @@ export async function consumeStreamJoin(
           if (parsed.done) {
             return { aborted: (parsed.aborted as boolean | undefined) ?? false };
           }
-          if (typeof parsed.text === 'string') {
-            onChunk(parsed.text);
+          if (parsed.part && typeof parsed.part === 'object') {
+            onChunk(parsed.part as UIMessagePart);
           }
         } catch {
           // skip malformed SSE lines

--- a/apps/web/src/lib/ai/core/stream-lifecycle.ts
+++ b/apps/web/src/lib/ai/core/stream-lifecycle.ts
@@ -3,7 +3,10 @@ import { eq } from '@pagespace/db/operators';
 import { aiStreamSessions } from '@pagespace/db/schema/ai-streams';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { broadcastAiStreamStart, broadcastAiStreamComplete } from '@/lib/websocket';
-import { streamMulticastRegistry } from '@/lib/ai/core/stream-multicast-registry';
+import {
+  streamMulticastRegistry,
+  type UIMessagePart,
+} from '@/lib/ai/core/stream-multicast-registry';
 
 export interface StreamLifecycleParams {
   messageId: string;
@@ -16,7 +19,7 @@ export interface StreamLifecycleParams {
 
 export interface StreamLifecycleHandle {
   finish: (aborted: boolean) => void;
-  pushChunk: (text: string) => void;
+  pushPart: (part: UIMessagePart) => void;
 }
 
 export const createStreamLifecycle = async (
@@ -118,9 +121,9 @@ export const createStreamLifecycle = async (
     }).catch(() => {});
   };
 
-  const pushChunk = (text: string): void => {
+  const pushPart = (part: UIMessagePart): void => {
     try {
-      streamMulticastRegistry.push(messageId, text);
+      streamMulticastRegistry.push(messageId, part);
     } catch (error) {
       // one bad chunk must not interrupt the stream — log so the swallow stays observable
       loggers.ai.warn('stream-lifecycle: registry.push threw', {
@@ -130,5 +133,5 @@ export const createStreamLifecycle = async (
     }
   };
 
-  return { finish, pushChunk };
+  return { finish, pushPart };
 };

--- a/apps/web/src/lib/ai/core/stream-multicast-registry.ts
+++ b/apps/web/src/lib/ai/core/stream-multicast-registry.ts
@@ -1,4 +1,8 @@
+import type { UIMessage } from 'ai';
+
 const MAX_STREAM_AGE_MS = 10 * 60 * 1000;
+
+export type UIMessagePart = UIMessage['parts'][number];
 
 export interface StreamMeta {
   pageId: string;
@@ -9,13 +13,13 @@ export interface StreamMeta {
 }
 
 interface Subscriber {
-  onChunk: (text: string) => void;
+  onChunk: (part: UIMessagePart) => void;
   onComplete: (aborted: boolean) => void;
 }
 
 interface StreamEntry {
   meta: StreamMeta;
-  buffer: string[];
+  buffer: UIMessagePart[];
   subscribers: Map<symbol, Subscriber>;
   finished: boolean;
   cleanupTimeoutId: ReturnType<typeof setTimeout> | null;
@@ -41,14 +45,14 @@ export class StreamMulticastRegistry {
     });
   }
 
-  push(messageId: string, text: string): void {
+  push(messageId: string, part: UIMessagePart): void {
     const entry = this.entries.get(messageId);
     if (!entry || entry.finished) return;
 
-    entry.buffer.push(text);
+    entry.buffer.push(part);
     for (const subscriber of entry.subscribers.values()) {
       try {
-        subscriber.onChunk(text);
+        subscriber.onChunk(part);
       } catch {
         // one bad subscriber must not break fanout to others
       }
@@ -57,14 +61,14 @@ export class StreamMulticastRegistry {
 
   subscribe(
     messageId: string,
-    onChunk: (text: string) => void,
+    onChunk: (part: UIMessagePart) => void,
     onComplete: (aborted: boolean) => void,
   ): (() => void) | null {
     const entry = this.entries.get(messageId);
     if (!entry || entry.finished) return null;
 
-    for (const chunk of entry.buffer) {
-      onChunk(chunk);
+    for (const part of entry.buffer) {
+      onChunk(part);
     }
 
     const key = Symbol();

--- a/apps/web/src/lib/ai/streams/__tests__/appendPart.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/appendPart.test.ts
@@ -18,4 +18,29 @@ describe('appendPart', () => {
     };
     expect(appendPart(initial, tool)).toEqual([...initial, tool]);
   });
+
+  it('given a tool part whose toolCallId is already present, should replace the existing entry in place', () => {
+    const initial = [
+      { type: 'text' as const, text: 'before' },
+      {
+        type: 'tool-list_pages' as const,
+        toolCallId: 'tc1',
+        state: 'input-available' as const,
+        input: { driveId: 'd1' },
+      },
+      { type: 'text' as const, text: 'after' },
+    ];
+    const completed = {
+      type: 'tool-list_pages' as const,
+      toolCallId: 'tc1',
+      state: 'output-available' as const,
+      input: { driveId: 'd1' },
+      output: { pages: [{ id: 'p1' }] },
+    };
+    expect(appendPart(initial, completed)).toEqual([
+      { type: 'text', text: 'before' },
+      completed,
+      { type: 'text', text: 'after' },
+    ]);
+  });
 });

--- a/apps/web/src/lib/ai/streams/__tests__/appendPart.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/appendPart.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { appendPart } from '../appendPart';
+
+describe('appendPart', () => {
+  it('given a text part and parts ending in text, should concat into the last text part', () => {
+    const initial = [{ type: 'text' as const, text: 'hel' }];
+    const next = { type: 'text' as const, text: 'lo' };
+    expect(appendPart(initial, next)).toEqual([{ type: 'text', text: 'hello' }]);
+  });
+});

--- a/apps/web/src/lib/ai/streams/__tests__/appendPart.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/appendPart.test.ts
@@ -7,4 +7,15 @@ describe('appendPart', () => {
     const next = { type: 'text' as const, text: 'lo' };
     expect(appendPart(initial, next)).toEqual([{ type: 'text', text: 'hello' }]);
   });
+
+  it('given a tool part with a toolCallId not yet in parts, should append it', () => {
+    const initial = [{ type: 'text' as const, text: 'thinking' }];
+    const tool = {
+      type: 'tool-list_pages' as const,
+      toolCallId: 'tc1',
+      state: 'input-available' as const,
+      input: { driveId: 'd1' },
+    };
+    expect(appendPart(initial, tool)).toEqual([...initial, tool]);
+  });
 });

--- a/apps/web/src/lib/ai/streams/__tests__/appendPart.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/appendPart.test.ts
@@ -43,4 +43,17 @@ describe('appendPart', () => {
       { type: 'text', text: 'after' },
     ]);
   });
+
+  it('given the same final tool part applied twice, should converge to a single entry (idempotent)', () => {
+    const completed = {
+      type: 'tool-list_pages' as const,
+      toolCallId: 'tc1',
+      state: 'output-available' as const,
+      input: { driveId: 'd1' },
+      output: { pages: [] },
+    };
+    const once = appendPart([], completed);
+    const twice = appendPart(once, completed);
+    expect(twice).toEqual([completed]);
+  });
 });

--- a/apps/web/src/lib/ai/streams/__tests__/chunkToPart.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/chunkToPart.test.ts
@@ -7,4 +7,21 @@ describe('chunkToPart', () => {
       chunkToPart({ type: 'text-delta', id: 't1', text: 'hello' }),
     ).toEqual({ type: 'text', text: 'hello' });
   });
+
+  it('given a tool-call chunk, should return a tool part keyed by toolName with state input-available', () => {
+    expect(
+      chunkToPart({
+        type: 'tool-call',
+        toolCallId: 'tc1',
+        toolName: 'list_pages',
+        input: { driveId: 'd1' },
+      }),
+    ).toEqual({
+      type: 'tool-list_pages',
+      toolCallId: 'tc1',
+      toolName: 'list_pages',
+      state: 'input-available',
+      input: { driveId: 'd1' },
+    });
+  });
 });

--- a/apps/web/src/lib/ai/streams/__tests__/chunkToPart.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/chunkToPart.test.ts
@@ -44,6 +44,48 @@ describe('chunkToPart', () => {
     });
   });
 
+  it('given a tool-call chunk missing toolName, should return null (cannot derive type prefix)', () => {
+    expect(
+      chunkToPart({
+        type: 'tool-call',
+        toolCallId: 'tc1',
+        input: { driveId: 'd1' },
+      } as never),
+    ).toBeNull();
+  });
+
+  it('given a tool-call chunk missing toolCallId, should return null (idempotency key required)', () => {
+    expect(
+      chunkToPart({
+        type: 'tool-call',
+        toolName: 'list_pages',
+        input: { driveId: 'd1' },
+      } as never),
+    ).toBeNull();
+  });
+
+  it('given a tool-result chunk missing toolName, should return null', () => {
+    expect(
+      chunkToPart({
+        type: 'tool-result',
+        toolCallId: 'tc1',
+        input: { driveId: 'd1' },
+        output: { pages: [] },
+      } as never),
+    ).toBeNull();
+  });
+
+  it('given a tool-result chunk missing toolCallId, should return null', () => {
+    expect(
+      chunkToPart({
+        type: 'tool-result',
+        toolName: 'list_pages',
+        input: { driveId: 'd1' },
+        output: { pages: [] },
+      } as never),
+    ).toBeNull();
+  });
+
   it.each([
     ['start'],
     ['start-step'],

--- a/apps/web/src/lib/ai/streams/__tests__/chunkToPart.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/chunkToPart.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { chunkToPart } from '../chunkToPart';
+
+describe('chunkToPart', () => {
+  it('given a text-delta chunk, should return a text part with the same text', () => {
+    expect(
+      chunkToPart({ type: 'text-delta', id: 't1', text: 'hello' }),
+    ).toEqual({ type: 'text', text: 'hello' });
+  });
+});

--- a/apps/web/src/lib/ai/streams/__tests__/chunkToPart.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/chunkToPart.test.ts
@@ -24,4 +24,23 @@ describe('chunkToPart', () => {
       input: { driveId: 'd1' },
     });
   });
+
+  it('given a tool-result chunk, should return a tool part with state output-available carrying input and output', () => {
+    expect(
+      chunkToPart({
+        type: 'tool-result',
+        toolCallId: 'tc1',
+        toolName: 'list_pages',
+        input: { driveId: 'd1' },
+        output: { pages: [{ id: 'p1' }] },
+      }),
+    ).toEqual({
+      type: 'tool-list_pages',
+      toolCallId: 'tc1',
+      toolName: 'list_pages',
+      state: 'output-available',
+      input: { driveId: 'd1' },
+      output: { pages: [{ id: 'p1' }] },
+    });
+  });
 });

--- a/apps/web/src/lib/ai/streams/__tests__/chunkToPart.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/chunkToPart.test.ts
@@ -43,4 +43,22 @@ describe('chunkToPart', () => {
       output: { pages: [{ id: 'p1' }] },
     });
   });
+
+  it.each([
+    ['start'],
+    ['start-step'],
+    ['finish-step'],
+    ['finish'],
+    ['abort'],
+    ['error'],
+    ['raw'],
+    ['reasoning-delta'],
+    ['tool-input-start'],
+    ['tool-input-delta'],
+    ['tool-input-end'],
+    ['source'],
+    ['file'],
+  ])('given a %s chunk, should return null (out of v1 multicast scope)', (type) => {
+    expect(chunkToPart({ type } as never)).toBeNull();
+  });
 });

--- a/apps/web/src/lib/ai/streams/__tests__/dedupRemoteStreams.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/dedupRemoteStreams.test.ts
@@ -7,7 +7,7 @@ const stream = (messageId: string): PendingStream => ({
   pageId: 'p',
   conversationId: 'c',
   triggeredBy: { userId: 'u', displayName: 'U' },
-  text: '',
+  parts: [],
   isOwn: false,
 });
 

--- a/apps/web/src/lib/ai/streams/__tests__/isValidPartFrame.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/isValidPartFrame.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { isValidPartFrame } from '../isValidPartFrame';
+
+describe('isValidPartFrame', () => {
+  it('given a text part with a non-empty type, should return true', () => {
+    expect(isValidPartFrame({ type: 'text', text: 'hi' })).toBe(true);
+  });
+
+  it('given a tool part with type and toolCallId, should return true', () => {
+    expect(
+      isValidPartFrame({
+        type: 'tool-list_pages',
+        toolCallId: 'tc1',
+        state: 'output-available',
+        input: {},
+        output: {},
+      }),
+    ).toBe(true);
+  });
+
+  it('given null, should return false', () => {
+    expect(isValidPartFrame(null)).toBe(false);
+  });
+
+  it('given undefined, should return false', () => {
+    expect(isValidPartFrame(undefined)).toBe(false);
+  });
+
+  it('given a non-object primitive, should return false', () => {
+    expect(isValidPartFrame('text')).toBe(false);
+    expect(isValidPartFrame(42)).toBe(false);
+    expect(isValidPartFrame(true)).toBe(false);
+  });
+
+  it('given an object with no type field, should return false', () => {
+    expect(isValidPartFrame({})).toBe(false);
+  });
+
+  it('given an object whose type is not a string, should return false', () => {
+    expect(isValidPartFrame({ type: 5 })).toBe(false);
+  });
+
+  it('given an object whose type is an empty string, should return false', () => {
+    expect(isValidPartFrame({ type: '' })).toBe(false);
+  });
+
+  it('given a tool-prefixed part missing toolCallId, should return false (toolCallId is the idempotency key for appendPart)', () => {
+    expect(isValidPartFrame({ type: 'tool-list_pages', state: 'input-available' })).toBe(false);
+  });
+
+  it('given a tool-prefixed part with a non-string toolCallId, should return false', () => {
+    expect(isValidPartFrame({ type: 'tool-list_pages', toolCallId: 42 })).toBe(false);
+  });
+});

--- a/apps/web/src/lib/ai/streams/__tests__/mergeTextDeltas.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/mergeTextDeltas.test.ts
@@ -6,4 +6,10 @@ describe('mergeTextDeltas', () => {
     const textPart = { type: 'text' as const, text: 'hello' };
     expect(mergeTextDeltas([], textPart)).toEqual([textPart]);
   });
+
+  it('given parts ending in a text part, should concat the new text into that last part', () => {
+    const initial = [{ type: 'text' as const, text: 'hel' }];
+    const next = { type: 'text' as const, text: 'lo' };
+    expect(mergeTextDeltas(initial, next)).toEqual([{ type: 'text', text: 'hello' }]);
+  });
 });

--- a/apps/web/src/lib/ai/streams/__tests__/mergeTextDeltas.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/mergeTextDeltas.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { mergeTextDeltas } from '../mergeTextDeltas';
+
+describe('mergeTextDeltas', () => {
+  it('given empty parts and a text part, should return a new array containing only the text part', () => {
+    const textPart = { type: 'text' as const, text: 'hello' };
+    expect(mergeTextDeltas([], textPart)).toEqual([textPart]);
+  });
+});

--- a/apps/web/src/lib/ai/streams/__tests__/mergeTextDeltas.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/mergeTextDeltas.test.ts
@@ -12,4 +12,29 @@ describe('mergeTextDeltas', () => {
     const next = { type: 'text' as const, text: 'lo' };
     expect(mergeTextDeltas(initial, next)).toEqual([{ type: 'text', text: 'hello' }]);
   });
+
+  it('given parts ending in a tool part, should append the text part as a new entry rather than concat', () => {
+    const initial = [
+      { type: 'text' as const, text: 'before' },
+      {
+        type: 'tool-list_pages' as const,
+        toolCallId: 'tc1',
+        state: 'output-available' as const,
+        input: { driveId: 'd1' },
+        output: { pages: [] },
+      },
+    ];
+    const next = { type: 'text' as const, text: 'after' };
+    expect(mergeTextDeltas(initial, next)).toEqual([
+      ...initial,
+      { type: 'text', text: 'after' },
+    ]);
+  });
+
+  it('given a non-empty initial, should not mutate the input array', () => {
+    const initial = [{ type: 'text' as const, text: 'hel' }];
+    const snapshot = JSON.parse(JSON.stringify(initial));
+    mergeTextDeltas(initial, { type: 'text', text: 'lo' });
+    expect(initial).toEqual(snapshot);
+  });
 });

--- a/apps/web/src/lib/ai/streams/__tests__/multicast-outcome.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/multicast-outcome.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Outcome integration: drives the producer-side conversion + client-side
+ * accumulation + synthesis end-to-end without any test doubles. Proves that
+ * a remote stream of (text-delta → tool-call → tool-result → text-delta)
+ * produces the *same* UIMessage parts array a co-mounted originator sees,
+ * with the tool part landing in 'output-available' state — the binding
+ * acceptance criterion for Task 1.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { chunkToPart } from '../chunkToPart';
+import { synthesizeAssistantMessage } from '../synthesizeAssistantMessage';
+import { usePendingStreamsStore } from '@/stores/usePendingStreamsStore';
+
+describe('multicast outcome — text + tool-call + tool-result render parity', () => {
+  beforeEach(() => {
+    usePendingStreamsStore.setState({ streams: new Map() });
+  });
+
+  it('given a remote stream of interleaved text and tool chunks, should accumulate into the same parts array a co-mounted originator would see', () => {
+    const messageId = 'msg-multicast';
+    const { addStream, appendPart } = usePendingStreamsStore.getState();
+    const currentParts = (id: string) => usePendingStreamsStore.getState().streams.get(id)?.parts;
+
+    addStream({
+      messageId,
+      pageId: 'page-1',
+      conversationId: 'conv-1',
+      triggeredBy: { userId: 'user-author', displayName: 'Author' },
+      isOwn: false,
+    });
+
+    // Producer-side: AI SDK fullStream chunks, each translated by chunkToPart.
+    const producerChunks = [
+      { type: 'text-delta', id: 't1', text: 'Let me check ' },
+      { type: 'text-delta', id: 't1', text: 'your pages.' },
+      { type: 'tool-call', toolCallId: 'tc-list', toolName: 'list_pages', input: { driveId: 'd1' } },
+      {
+        type: 'tool-result',
+        toolCallId: 'tc-list',
+        toolName: 'list_pages',
+        input: { driveId: 'd1' },
+        output: { pages: [{ id: 'p1', title: 'Roadmap' }] },
+      },
+      { type: 'text-delta', id: 't2', text: 'You have 1 page: Roadmap.' },
+      { type: 'finish-step' }, // dropped by chunkToPart
+    ];
+
+    for (const chunk of producerChunks) {
+      const part = chunkToPart(chunk as never);
+      if (part) appendPart(messageId, part);
+    }
+
+    const parts = currentParts(messageId)!;
+    const synthesized = synthesizeAssistantMessage(messageId, parts);
+
+    expect(synthesized).toEqual({
+      id: messageId,
+      role: 'assistant',
+      parts: [
+        { type: 'text', text: 'Let me check your pages.' },
+        {
+          type: 'tool-list_pages',
+          toolCallId: 'tc-list',
+          toolName: 'list_pages',
+          state: 'output-available',
+          input: { driveId: 'd1' },
+          output: { pages: [{ id: 'p1', title: 'Roadmap' }] },
+        },
+        { type: 'text', text: 'You have 1 page: Roadmap.' },
+      ],
+    });
+  });
+
+  it('given the tool-call frame is delivered before the tool-result, should expose the input-available state mid-flight (so the renderer can show the call before the result lands)', () => {
+    const messageId = 'msg-midflight';
+    const { addStream, appendPart } = usePendingStreamsStore.getState();
+    const currentParts = (id: string) => usePendingStreamsStore.getState().streams.get(id)?.parts;
+
+    addStream({
+      messageId,
+      pageId: 'page-1',
+      conversationId: 'conv-1',
+      triggeredBy: { userId: 'user-author', displayName: 'Author' },
+      isOwn: false,
+    });
+
+    const callPart = chunkToPart({
+      type: 'tool-call',
+      toolCallId: 'tc1',
+      toolName: 'list_pages',
+      input: { driveId: 'd1' },
+    } as never);
+    appendPart(messageId, callPart!);
+
+    const midflight = currentParts(messageId)!;
+    expect(midflight).toEqual([
+      {
+        type: 'tool-list_pages',
+        toolCallId: 'tc1',
+        toolName: 'list_pages',
+        state: 'input-available',
+        input: { driveId: 'd1' },
+      },
+    ]);
+
+    const resultPart = chunkToPart({
+      type: 'tool-result',
+      toolCallId: 'tc1',
+      toolName: 'list_pages',
+      input: { driveId: 'd1' },
+      output: { pages: [] },
+    } as never);
+    appendPart(messageId, resultPart!);
+
+    const final = currentParts(messageId)!;
+    expect(final).toHaveLength(1);
+    expect(final[0]).toMatchObject({ state: 'output-available', toolCallId: 'tc1' });
+  });
+
+  it('given a buffer-replay sequence (late join applies stored parts) followed by the same final part again, should converge to the same final array (idempotent under double-apply)', () => {
+    const messageId = 'msg-replay';
+    const { addStream, appendPart } = usePendingStreamsStore.getState();
+    const currentParts = (id: string) => usePendingStreamsStore.getState().streams.get(id)?.parts;
+
+    addStream({
+      messageId,
+      pageId: 'page-1',
+      conversationId: 'conv-1',
+      triggeredBy: { userId: 'user-author', displayName: 'Author' },
+      isOwn: false,
+    });
+
+    const finalToolPart = {
+      type: 'tool-list_pages',
+      toolCallId: 'tc1',
+      toolName: 'list_pages',
+      state: 'output-available',
+      input: { driveId: 'd1' },
+      output: { pages: [] },
+    } as const;
+
+    // Late join: replay buffer includes the same final part twice (defensive
+    // against duplicate delivery from buffer + a live frame that lands at the
+    // same instant).
+    appendPart(messageId, finalToolPart as never);
+    appendPart(messageId, finalToolPart as never);
+
+    expect(currentParts(messageId)!).toEqual([finalToolPart]);
+  });
+});

--- a/apps/web/src/lib/ai/streams/__tests__/selectChannelRemoteStreams.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/selectChannelRemoteStreams.test.ts
@@ -7,7 +7,7 @@ const stream = (overrides: Partial<PendingStream>): PendingStream => ({
   pageId: 'channel-1',
   conversationId: 'conv-1',
   triggeredBy: { userId: 'user-1', displayName: 'U' },
-  text: '',
+  parts: [],
   isOwn: false,
   ...overrides,
 });

--- a/apps/web/src/lib/ai/streams/__tests__/synthesizeAssistantMessage.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/synthesizeAssistantMessage.test.ts
@@ -2,30 +2,50 @@ import { describe, it, expect } from 'vitest';
 import { synthesizeAssistantMessage } from '../synthesizeAssistantMessage';
 
 describe('synthesizeAssistantMessage', () => {
-  it('given a messageId and text, should produce an assistant UIMessage with one text part holding that text', () => {
-    const msg = synthesizeAssistantMessage('msg-1', 'Hello world');
+  it('given a messageId and a parts array, should produce an assistant UIMessage carrying those parts', () => {
+    const parts = [{ type: 'text' as const, text: 'Hello world' }];
+    const msg = synthesizeAssistantMessage('msg-1', parts);
 
     expect(msg).toEqual({
       id: 'msg-1',
       role: 'assistant',
-      parts: [{ type: 'text', text: 'Hello world' }],
+      parts,
     });
   });
 
-  it('given empty text, should still produce a valid message (the renderer suppresses empty parts)', () => {
-    const msg = synthesizeAssistantMessage('msg-1', '');
+  it('given an empty parts array, should still produce a valid message with id, role, and empty parts', () => {
+    const msg = synthesizeAssistantMessage('msg-1', []);
 
     expect(msg.id).toBe('msg-1');
     expect(msg.role).toBe('assistant');
-    expect(msg.parts).toEqual([{ type: 'text', text: '' }]);
+    expect(msg.parts).toEqual([]);
   });
 
-  it('given the same input twice, should produce structurally equal messages (referentially independent)', () => {
-    const a = synthesizeAssistantMessage('msg-1', 'hi');
-    const b = synthesizeAssistantMessage('msg-1', 'hi');
+  it('given parts with a text part and a tool part, should preserve their order in the synthesized message', () => {
+    const parts = [
+      { type: 'text' as const, text: 'thinking' },
+      {
+        type: 'tool-list_pages' as const,
+        toolCallId: 'tc1',
+        toolName: 'list_pages',
+        state: 'output-available' as const,
+        input: { driveId: 'd1' },
+        output: { pages: [] },
+      },
+    ];
+    const msg = synthesizeAssistantMessage('msg-1', parts);
+
+    expect(msg.parts.map((p) => p.type)).toEqual(['text', 'tool-list_pages']);
+  });
+
+  it('given the same input twice, should produce structurally equal messages but referentially independent parts arrays', () => {
+    const parts = [{ type: 'text' as const, text: 'hi' }];
+    const a = synthesizeAssistantMessage('msg-1', parts);
+    const b = synthesizeAssistantMessage('msg-1', parts);
 
     expect(a).toEqual(b);
     expect(a).not.toBe(b);
     expect(a.parts).not.toBe(b.parts);
+    expect(a.parts).not.toBe(parts);
   });
 });

--- a/apps/web/src/lib/ai/streams/appendPart.ts
+++ b/apps/web/src/lib/ai/streams/appendPart.ts
@@ -10,6 +10,10 @@ type AnyPart = UIMessage['parts'][number];
  * transitions input-available → output-available are convergent). Other part
  * types append as-is. Pure — never mutates input.
  */
+// Stricter than message-utils.ts's `isToolInvocationPart` (which only checks
+// the `tool-` prefix): we additionally require a string `toolCallId` because
+// it is the merge key for the replace-by-toolCallId branch below — a tool
+// part missing the id can't converge state transitions.
 const isToolPart = (
   part: AnyPart,
 ): part is AnyPart & { type: `tool-${string}`; toolCallId: string } =>

--- a/apps/web/src/lib/ai/streams/appendPart.ts
+++ b/apps/web/src/lib/ai/streams/appendPart.ts
@@ -1,0 +1,21 @@
+import type { UIMessage } from 'ai';
+import { mergeTextDeltas } from './mergeTextDeltas';
+
+type AnyPart = UIMessage['parts'][number];
+
+/**
+ * Append a UIMessagePart to a parts array with shape-aware merge semantics.
+ * Text parts delegate to `mergeTextDeltas` (positional concat). Tool parts
+ * are keyed by `toolCallId` — re-applying the same id replaces (state
+ * transitions input-available → output-available are convergent). Other part
+ * types append as-is. Pure — never mutates input.
+ */
+export const appendPart = (
+  parts: readonly AnyPart[],
+  part: AnyPart,
+): AnyPart[] => {
+  if (part.type === 'text') {
+    return mergeTextDeltas(parts, part);
+  }
+  return [...parts, part];
+};

--- a/apps/web/src/lib/ai/streams/appendPart.ts
+++ b/apps/web/src/lib/ai/streams/appendPart.ts
@@ -10,12 +10,30 @@ type AnyPart = UIMessage['parts'][number];
  * transitions input-available → output-available are convergent). Other part
  * types append as-is. Pure — never mutates input.
  */
+const isToolPart = (
+  part: AnyPart,
+): part is AnyPart & { type: `tool-${string}`; toolCallId: string } =>
+  typeof part.type === 'string' &&
+  part.type.startsWith('tool-') &&
+  'toolCallId' in part &&
+  typeof (part as { toolCallId?: unknown }).toolCallId === 'string';
+
 export const appendPart = (
   parts: readonly AnyPart[],
   part: AnyPart,
 ): AnyPart[] => {
   if (part.type === 'text') {
     return mergeTextDeltas(parts, part);
+  }
+  if (isToolPart(part)) {
+    const idx = parts.findIndex(
+      (p) => isToolPart(p) && p.toolCallId === part.toolCallId,
+    );
+    if (idx >= 0) {
+      const next = parts.slice();
+      next[idx] = part;
+      return next;
+    }
   }
   return [...parts, part];
 };

--- a/apps/web/src/lib/ai/streams/chunkToPart.ts
+++ b/apps/web/src/lib/ai/streams/chunkToPart.ts
@@ -2,36 +2,56 @@ import type { UIMessage } from 'ai';
 
 type AnyPart = UIMessage['parts'][number];
 
+interface ToolPart {
+  type: `tool-${string}`;
+  toolCallId: string;
+  toolName: string;
+  state: 'input-available' | 'output-available';
+  input: unknown;
+  output?: unknown;
+}
+
+interface AISDKChunk {
+  type: string;
+  text?: string;
+  toolName?: string;
+  toolCallId?: string;
+  input?: unknown;
+  output?: unknown;
+  [key: string]: unknown;
+}
+
+const toolPart = (
+  state: ToolPart['state'],
+  chunk: AISDKChunk & { toolName: string; toolCallId: string },
+): ToolPart => ({
+  type: `tool-${chunk.toolName}`,
+  toolCallId: chunk.toolCallId,
+  toolName: chunk.toolName,
+  state,
+  input: chunk.input,
+  ...(state === 'output-available' ? { output: chunk.output } : {}),
+});
+
 /**
  * Convert an AI SDK v5 streamText `onChunk` chunk into a `UIMessagePart`
  * suitable for multicast. Returns `null` for chunk types we don't forward
- * (step-start/finish, raw, reasoning-delta, tool-input-delta — minimal v1
- * scope; later waves can extend).
+ * (step boundaries, raw, reasoning, tool-input-streaming, source/file —
+ * minimal v1 scope; later waves can extend without a wire change).
  *
  * Pure — never reads or writes external state.
  */
-export const chunkToPart = (chunk: { type: string } & Record<string, unknown>): AnyPart | null => {
+export const chunkToPart = (chunk: AISDKChunk): AnyPart | null => {
   if (chunk.type === 'text-delta' && typeof chunk.text === 'string') {
     return { type: 'text', text: chunk.text };
   }
-  if (chunk.type === 'tool-call' && typeof chunk.toolName === 'string') {
-    return {
-      type: `tool-${chunk.toolName}`,
-      toolCallId: chunk.toolCallId as string,
-      toolName: chunk.toolName,
-      state: 'input-available',
-      input: chunk.input,
-    } as unknown as AnyPart;
-  }
-  if (chunk.type === 'tool-result' && typeof chunk.toolName === 'string') {
-    return {
-      type: `tool-${chunk.toolName}`,
-      toolCallId: chunk.toolCallId as string,
-      toolName: chunk.toolName,
-      state: 'output-available',
-      input: chunk.input,
-      output: chunk.output,
-    } as unknown as AnyPart;
+  if (
+    (chunk.type === 'tool-call' || chunk.type === 'tool-result') &&
+    typeof chunk.toolName === 'string' &&
+    typeof chunk.toolCallId === 'string'
+  ) {
+    const state = chunk.type === 'tool-call' ? 'input-available' : 'output-available';
+    return toolPart(state, { ...chunk, toolName: chunk.toolName, toolCallId: chunk.toolCallId }) as unknown as AnyPart;
   }
   return null;
 };

--- a/apps/web/src/lib/ai/streams/chunkToPart.ts
+++ b/apps/web/src/lib/ai/streams/chunkToPart.ts
@@ -23,5 +23,15 @@ export const chunkToPart = (chunk: { type: string } & Record<string, unknown>): 
       input: chunk.input,
     } as unknown as AnyPart;
   }
+  if (chunk.type === 'tool-result' && typeof chunk.toolName === 'string') {
+    return {
+      type: `tool-${chunk.toolName}`,
+      toolCallId: chunk.toolCallId as string,
+      toolName: chunk.toolName,
+      state: 'output-available',
+      input: chunk.input,
+      output: chunk.output,
+    } as unknown as AnyPart;
+  }
   return null;
 };

--- a/apps/web/src/lib/ai/streams/chunkToPart.ts
+++ b/apps/web/src/lib/ai/streams/chunkToPart.ts
@@ -1,0 +1,18 @@
+import type { UIMessage } from 'ai';
+
+type AnyPart = UIMessage['parts'][number];
+
+/**
+ * Convert an AI SDK v5 streamText `onChunk` chunk into a `UIMessagePart`
+ * suitable for multicast. Returns `null` for chunk types we don't forward
+ * (step-start/finish, raw, reasoning-delta, tool-input-delta — minimal v1
+ * scope; later waves can extend).
+ *
+ * Pure — never reads or writes external state.
+ */
+export const chunkToPart = (chunk: { type: string } & Record<string, unknown>): AnyPart | null => {
+  if (chunk.type === 'text-delta' && typeof chunk.text === 'string') {
+    return { type: 'text', text: chunk.text };
+  }
+  return null;
+};

--- a/apps/web/src/lib/ai/streams/chunkToPart.ts
+++ b/apps/web/src/lib/ai/streams/chunkToPart.ts
@@ -14,5 +14,14 @@ export const chunkToPart = (chunk: { type: string } & Record<string, unknown>): 
   if (chunk.type === 'text-delta' && typeof chunk.text === 'string') {
     return { type: 'text', text: chunk.text };
   }
+  if (chunk.type === 'tool-call' && typeof chunk.toolName === 'string') {
+    return {
+      type: `tool-${chunk.toolName}`,
+      toolCallId: chunk.toolCallId as string,
+      toolName: chunk.toolName,
+      state: 'input-available',
+      input: chunk.input,
+    } as unknown as AnyPart;
+  }
   return null;
 };

--- a/apps/web/src/lib/ai/streams/isValidPartFrame.ts
+++ b/apps/web/src/lib/ai/streams/isValidPartFrame.ts
@@ -1,0 +1,24 @@
+import type { UIMessage } from 'ai';
+
+type UIMessagePart = UIMessage['parts'][number];
+
+/**
+ * Runtime guard for incoming SSE part frames. The wire is trusted only
+ * structurally: every UIMessagePart has a string `type` discriminator the
+ * renderer branches on. A frame missing `type` (or with a non-string `type`)
+ * cannot route to any renderer and would silently corrupt the parts array,
+ * so it is dropped.
+ *
+ * Tool parts additionally require a `toolCallId` because that field is the
+ * idempotency key inside `appendPart`'s replace-by-toolCallId branch — a
+ * tool frame missing it would append duplicates instead of converging.
+ *
+ * Pure — no I/O, no side effects.
+ */
+export const isValidPartFrame = (raw: unknown): raw is UIMessagePart => {
+  if (!raw || typeof raw !== 'object') return false;
+  const part = raw as { type?: unknown; toolCallId?: unknown };
+  if (typeof part.type !== 'string' || part.type.length === 0) return false;
+  if (part.type.startsWith('tool-') && typeof part.toolCallId !== 'string') return false;
+  return true;
+};

--- a/apps/web/src/lib/ai/streams/mergeTextDeltas.ts
+++ b/apps/web/src/lib/ai/streams/mergeTextDeltas.ts
@@ -1,0 +1,15 @@
+import type { UIMessage } from 'ai';
+
+type AnyPart = UIMessage['parts'][number];
+type TextPart = Extract<AnyPart, { type: 'text' }>;
+
+/**
+ * Append a text-delta part to a parts array. If the last part is also text,
+ * concatenate; otherwise push as a new part. Pure — never mutates input.
+ */
+export const mergeTextDeltas = (
+  parts: readonly AnyPart[],
+  textPart: TextPart,
+): AnyPart[] => {
+  return [...parts, textPart];
+};

--- a/apps/web/src/lib/ai/streams/mergeTextDeltas.ts
+++ b/apps/web/src/lib/ai/streams/mergeTextDeltas.ts
@@ -11,5 +11,12 @@ export const mergeTextDeltas = (
   parts: readonly AnyPart[],
   textPart: TextPart,
 ): AnyPart[] => {
+  const last = parts[parts.length - 1];
+  if (last && last.type === 'text') {
+    return [
+      ...parts.slice(0, -1),
+      { ...last, text: last.text + textPart.text },
+    ];
+  }
   return [...parts, textPart];
 };

--- a/apps/web/src/lib/ai/streams/synthesizeAssistantMessage.ts
+++ b/apps/web/src/lib/ai/streams/synthesizeAssistantMessage.ts
@@ -1,15 +1,20 @@
 import type { UIMessage } from 'ai';
 
+type UIMessagePart = UIMessage['parts'][number];
+
 /**
- * Builds a minimal assistant `UIMessage` from a stream's accumulated text.
- * Used by surfaces that synthesize the completed assistant message locally on
- * `onStreamComplete` instead of waiting for a server-side conversation refresh.
+ * Builds a minimal assistant `UIMessage` from a stream's accumulated parts
+ * array. Used by surfaces that synthesize the in-flight remote stream as a
+ * real assistant message bubble (so MessageRenderer + ToolCallRenderer
+ * render identically to the originator's view).
+ *
+ * Pure — never mutates the input parts array.
  */
 export const synthesizeAssistantMessage = (
   messageId: string,
-  text: string,
+  parts: readonly UIMessagePart[],
 ): UIMessage => ({
   id: messageId,
   role: 'assistant',
-  parts: [{ type: 'text', text }],
+  parts: [...parts],
 });

--- a/apps/web/src/stores/__tests__/usePendingStreamsStore.test.ts
+++ b/apps/web/src/stores/__tests__/usePendingStreamsStore.test.ts
@@ -9,6 +9,8 @@ const BASE_STREAM = {
   isOwn: false,
 };
 
+const text = (text: string) => ({ type: 'text' as const, text });
+
 describe('usePendingStreamsStore', () => {
   beforeEach(() => {
     usePendingStreamsStore.setState({ streams: new Map() });
@@ -22,13 +24,13 @@ describe('usePendingStreamsStore', () => {
   });
 
   describe('addStream', () => {
-    it('given a new stream, should add it with empty text', () => {
+    it('given a new stream, should add it with empty parts', () => {
       const { addStream } = usePendingStreamsStore.getState();
       addStream(BASE_STREAM);
 
       const { getRemotePageStreams } = usePendingStreamsStore.getState();
       const [stream] = getRemotePageStreams('page-a');
-      expect(stream).toEqual({ ...BASE_STREAM, text: '' });
+      expect(stream).toEqual({ ...BASE_STREAM, parts: [] });
     });
 
     it('given two streams for the same page, should store both', () => {
@@ -40,46 +42,68 @@ describe('usePendingStreamsStore', () => {
       expect(getRemotePageStreams('page-a')).toHaveLength(2);
     });
 
-    it('given a stream with messageId X already present, should preserve existing text on duplicate addStream', () => {
-      const { addStream, appendText } = usePendingStreamsStore.getState();
+    it('given a stream with messageId X already present, should preserve existing parts on duplicate addStream', () => {
+      const { addStream, appendPart } = usePendingStreamsStore.getState();
       addStream(BASE_STREAM);
-      appendText('msg-1', 'partial-text');
+      appendPart('msg-1', text('partial-text'));
       addStream(BASE_STREAM);
 
       const { getRemotePageStreams } = usePendingStreamsStore.getState();
       const [stream] = getRemotePageStreams('page-a');
-      expect(stream.text).toBe('partial-text');
+      expect(stream.parts).toEqual([text('partial-text')]);
     });
 
     it('given a duplicate addStream with different metadata, should keep the existing entry unchanged', () => {
-      const { addStream, appendText } = usePendingStreamsStore.getState();
+      const { addStream, appendPart } = usePendingStreamsStore.getState();
       addStream({ ...BASE_STREAM, isOwn: false });
-      appendText('msg-1', 'hello');
+      appendPart('msg-1', text('hello'));
       addStream({ ...BASE_STREAM, isOwn: true, conversationId: 'conv-other' });
 
       const { getRemotePageStreams } = usePendingStreamsStore.getState();
       const [stream] = getRemotePageStreams('page-a');
-      expect(stream.text).toBe('hello');
+      expect(stream.parts).toEqual([text('hello')]);
       expect(stream.isOwn).toBe(false);
       expect(stream.conversationId).toBe('conv-1');
     });
   });
 
-  describe('appendText', () => {
-    it('given an existing stream, should accumulate text chunks', () => {
-      const { addStream, appendText } = usePendingStreamsStore.getState();
+  describe('appendPart', () => {
+    it('given two consecutive text-deltas, should merge them positionally into one text part', () => {
+      const { addStream, appendPart } = usePendingStreamsStore.getState();
       addStream(BASE_STREAM);
-      appendText('msg-1', 'hello');
-      appendText('msg-1', ' world');
+      appendPart('msg-1', text('hello'));
+      appendPart('msg-1', text(' world'));
 
       const { getRemotePageStreams } = usePendingStreamsStore.getState();
       const [stream] = getRemotePageStreams('page-a');
-      expect(stream.text).toBe('hello world');
+      expect(stream.parts).toEqual([text('hello world')]);
     });
 
-    it('given unknown messageId, should not throw', () => {
-      const { appendText } = usePendingStreamsStore.getState();
-      expect(() => appendText('unknown', 'text')).not.toThrow();
+    it('given a tool part with new toolCallId then output for the same id, should replace the in-place entry rather than duplicate', () => {
+      const { addStream, appendPart } = usePendingStreamsStore.getState();
+      addStream(BASE_STREAM);
+      const inputPart = {
+        type: 'tool-list_pages' as const,
+        toolCallId: 'tc1',
+        toolName: 'list_pages',
+        state: 'input-available' as const,
+        input: { driveId: 'd1' },
+      };
+      const outputPart = { ...inputPart, state: 'output-available' as const, output: { pages: [] } };
+      appendPart('msg-1', inputPart);
+      appendPart('msg-1', outputPart);
+
+      const { getRemotePageStreams } = usePendingStreamsStore.getState();
+      const [stream] = getRemotePageStreams('page-a');
+      expect(stream.parts).toEqual([outputPart]);
+    });
+
+    it('given unknown messageId, should not throw and should leave state untouched', () => {
+      const { addStream, appendPart, getRemotePageStreams } = usePendingStreamsStore.getState();
+      addStream(BASE_STREAM);
+      const before = getRemotePageStreams('page-a');
+      expect(() => appendPart('unknown', text('lost'))).not.toThrow();
+      expect(usePendingStreamsStore.getState().getRemotePageStreams('page-a')).toEqual(before);
     });
   });
 
@@ -136,14 +160,14 @@ describe('usePendingStreamsStore', () => {
       expect(getRemotePageStreams('page-empty')).toEqual([]);
     });
 
-    it('given appended text, should reflect accumulated text in returned stream', () => {
-      const { addStream, appendText, getRemotePageStreams } = usePendingStreamsStore.getState();
+    it('given appended parts, should reflect accumulated parts in returned stream', () => {
+      const { addStream, appendPart, getRemotePageStreams } = usePendingStreamsStore.getState();
       addStream(BASE_STREAM);
-      appendText('msg-1', 'chunk-a');
-      appendText('msg-1', 'chunk-b');
+      appendPart('msg-1', text('chunk-a'));
+      appendPart('msg-1', text('chunk-b'));
 
       const [stream] = getRemotePageStreams('page-a');
-      expect(stream.text).toBe('chunk-achunk-b');
+      expect(stream.parts).toEqual([text('chunk-achunk-b')]);
     });
   });
 
@@ -157,7 +181,7 @@ describe('usePendingStreamsStore', () => {
 
     it('given a stream with isOwn false, should exclude it', () => {
       const { addStream, getOwnStreams } = usePendingStreamsStore.getState();
-      addStream(BASE_STREAM); // isOwn: false
+      addStream(BASE_STREAM);
 
       expect(getOwnStreams('page-a')).toHaveLength(0);
     });

--- a/apps/web/src/stores/usePendingStreamsStore.ts
+++ b/apps/web/src/stores/usePendingStreamsStore.ts
@@ -1,18 +1,22 @@
 import { create } from 'zustand';
+import type { UIMessage } from 'ai';
+import { appendPart as appendPartPure } from '@/lib/ai/streams/appendPart';
+
+type UIMessagePart = UIMessage['parts'][number];
 
 export interface PendingStream {
   messageId: string;
   pageId: string;
   conversationId: string;
   triggeredBy: { userId: string; displayName: string };
-  text: string;
+  parts: UIMessagePart[];
   isOwn: boolean;
 }
 
 interface PendingStreamsState {
   streams: Map<string, PendingStream>;
-  addStream: (stream: Omit<PendingStream, 'text'>) => void;
-  appendText: (messageId: string, chunk: string) => void;
+  addStream: (stream: Omit<PendingStream, 'parts'>) => void;
+  appendPart: (messageId: string, part: UIMessagePart) => void;
   removeStream: (messageId: string) => void;
   clearPageStreams: (pageId: string) => void;
   getRemotePageStreams: (pageId: string) => PendingStream[];
@@ -26,17 +30,17 @@ export const usePendingStreamsStore = create<PendingStreamsState>((set, get) => 
     set((state) => {
       if (state.streams.has(stream.messageId)) return state;
       const next = new Map(state.streams);
-      next.set(stream.messageId, { ...stream, text: '' });
+      next.set(stream.messageId, { ...stream, parts: [] });
       return { streams: next };
     });
   },
 
-  appendText: (messageId, chunk) => {
+  appendPart: (messageId, part) => {
     set((state) => {
       const existing = state.streams.get(messageId);
       if (!existing) return state;
       const next = new Map(state.streams);
-      next.set(messageId, { ...existing, text: existing.text + chunk });
+      next.set(messageId, { ...existing, parts: appendPartPure(existing.parts, part) });
       return { streams: next };
     });
   },


### PR DESCRIPTION
## Summary

Wave 1 of the multiplayer AI streaming epic (closest spec: `tasks/multiplayer-ai-chat-streaming.md`). Widens the SSE multicast wire from text deltas to full `UIMessagePart` objects so a co-mounted remote viewer's bubble renders the **same** `ToolCallRenderer` UI the originator sees, **while the stream is in flight**.

- **Wire:** SSE frames carry `data: {"part":<UIMessagePart>}\n\n` instead of `{"text":"..."}`. Done sentinel unchanged. Legacy `{text:...}` frames from an unmigrated server are silently ignored (no `part` field — same path as malformed JSON). Incoming part frames pass through `isValidPartFrame` before reaching `appendPart`/render.
- **Pipeline:** Multicast registry, lifecycle (`pushChunk` → `pushPart`), `consumeStreamJoin`, and `usePendingStreamsStore` (`text` → `parts: UIMessagePart[]`, `appendText` → `appendPart`) all carry parts.
- **Producers:** Both AI chat routes (page, global) translate every `streamText` chunk via `chunkToPart` and forward the result. Text-delta → text part. Tool-call → input-available. Tool-result → output-available with the same `toolCallId` (client merges by id, replacing the prior input-available render in place).

## New pure helpers (`apps/web/src/lib/ai/streams/`)

All pure, no I/O, no-mock unit tests:

- **`mergeTextDeltas(parts, textPart)`** — positional concat into the trailing text part. AI SDK v5's `TextUIPart` has no `id` field, so merge is positional rather than id-keyed.
- **`appendPart(parts, part)`** — orchestrator. Text → `mergeTextDeltas`. Tool parts replace by `toolCallId` (idempotent state transitions). Other shapes append as-is.
- **`chunkToPart(chunk)`** — server-side AI SDK v5 chunk → `UIMessagePart`. Forwards text-delta / tool-call / tool-result; returns `null` for the 13 out-of-scope chunk types and for malformed tool chunks missing `toolName`/`toolCallId`.
- **`isValidPartFrame(raw)`** — runtime guard for incoming SSE frames. Rejects non-objects, frames without a non-empty string `type`, and tool-prefixed frames missing `toolCallId` (the idempotency key inside `appendPart`).

## Anti-DRY

No speculative abstractions extracted for Tasks 2–5. They will write their own helpers and decide later.

## Test plan

- [x] 30 RED→GREEN→REFACTOR cycles, one commit each
- [x] `pnpm typecheck` — green
- [x] `pnpm --filter web test` — **6,517 / 6,517** passing (the 3 unrelated DB-connection security tests fail on master too)
- [x] `pnpm --filter web lint` — only a pre-existing warning in `QuickCreatePalette.tsx`, unrelated
- [x] **Outcome integration test** locks in: interleaved text + tool-call + tool-result → identical UIMessage parts array a co-mounted originator sees, with tool part in `output-available` state
- [x] **CodeRabbit review** addressed: runtime guard for incoming part frames + negative tests for malformed tool chunks
- [ ] Manual two-tab smoke: open chat in two browser windows, run a prompt that triggers `list_pages` from window A, expect window B to render the tool call in real time

## Out of scope (Wave 2)

Reasoning multicast, source-part / file-part, tool-input streaming-state, indicator UI changes, persistence schema, new socket events.

## Do not auto-merge — awaiting review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)