### PR TITLE
fix(ai): pretty integration titles in sidebar

### DIFF
--- a/apps/web/src/components/ai/shared/chat/tool-calls/CompactToolCallRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/CompactToolCallRenderer.tsx
@@ -30,6 +30,8 @@ import { SearchResultsRenderer, type SearchResult } from './SearchResultsRendere
 import { AgentListRenderer, type AgentInfo } from './AgentListRenderer';
 import { ActivityRenderer, type ActivityItem } from './ActivityRenderer';
 import { WebSearchRenderer, type WebSearchResult } from './WebSearchRenderer';
+import { parseIntegrationToolName, isIntegrationTool } from '@pagespace/lib/integrations/converter/ai-sdk';
+import { getBuiltinProvider } from '@pagespace/lib/integrations/providers/builtin-providers';
 
 interface ToolPart {
   type: string;
@@ -197,6 +199,15 @@ const CompactToolCallRendererInternal: React.FC<{ part: ToolPart; toolName: stri
 
   // Memoize formatted tool name
   const formattedToolName = useMemo(() => {
+    if (isIntegrationTool(toolName)) {
+      const parsed = parseIntegrationToolName(toolName);
+      if (parsed) {
+        const provider = getBuiltinProvider(parsed.providerSlug);
+        const tool = provider?.tools.find(t => t.id === parsed.toolId);
+        if (tool) return tool.name;
+        return parsed.toolId.split('_').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+      }
+    }
     return TOOL_NAME_MAP[toolName] || toolName
       .split('_')
       .map(word => word.charAt(0).toUpperCase() + word.slice(1))
@@ -244,6 +255,17 @@ const CompactToolCallRendererInternal: React.FC<{ part: ToolPart; toolName: stri
     // Drive rename - show current name
     if (toolName === 'rename_drive') {
       if (params.currentName) return `${formattedToolName}: "${params.currentName}"`;
+    }
+
+    if (params.owner && params.repo && typeof params.owner === 'string' && typeof params.repo === 'string') {
+      const suffix = params.path && typeof params.path === 'string' ? `/${params.path}` : '';
+      return `${formattedToolName}: ${params.owner}/${params.repo}${suffix}`;
+    }
+    if (params.channel && typeof params.channel === 'string') {
+      return `${formattedToolName}: ${params.channel}`;
+    }
+    if (params.repo && typeof params.repo === 'string') {
+      return `${formattedToolName}: ${params.repo}`;
     }
 
     return formattedToolName;


### PR DESCRIPTION
## Summary
- Mirrors PR #1148 (`fix(ai): clean titles for integration tool calls`) into the right sidebar's compact renderer
- Resolves integration tool names via `getBuiltinProvider` and appends `owner/repo[/path]`, `channel`, `repo` context suffixes
- Right sidebar (`SidebarChatTab` → `CompactMessageRenderer` → `CompactToolCallRenderer`) now matches the main `AiChatView` styling for GitHub-style integration tools

## Why
PR #1148 only patched `ToolCallRenderer.tsx`. The parallel `CompactToolCallRenderer.tsx` used by the right sidebar never received the fix, so integration tools there still showed raw names like `Int  Github  Search Repos` with no repo context.

## Test plan
- [ ] `pnpm --filter web typecheck` passes
- [ ] `pnpm --filter web test:unit` passes
- [ ] Open right sidebar AI assistant, trigger a GitHub tool call (e.g. "list issues in 2witstudios/PageSpace") — header reads `Search Repos: 2witstudios/PageSpace`
- [ ] Header text matches what the same conversation shows in the main chat view
- [ ] Native tools (`read_page`, `list_pages`, etc.) still render their existing tool-name-gated titles — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AI tool call rendering now properly detects integration sources and resolves tool names for more accurate display
  * Tool call descriptions now clearly display repository paths, channels, and ownership information in a more structured format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->