### PR TITLE
chore(tasks): plan agent-triggers follow-up + polish (Task 1/5)

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskAgentTriggersDialog.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskAgentTriggersDialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { Bot, Zap } from 'lucide-react';
+import { AlertCircle, Bot, Zap } from 'lucide-react';
 import { toast } from 'sonner';
 import useSWR, { mutate as globalMutate } from 'swr';
 import {
@@ -70,6 +70,9 @@ const TRIGGER_TYPES: { ui: UiTriggerType; api: ApiTriggerType; label: string; he
     help: 'Fires the moment the task is moved to a status in the Done group.',
   },
 ];
+
+export const statusToneClass = (status: TriggerRow['lastRunStatus']) =>
+  status === 'error' ? 'text-xs text-destructive' : 'text-xs text-muted-foreground';
 
 const triggersFetcher = async (url: string): Promise<{ triggers: TriggerRow[] }> => {
   const res = await fetchWithAuth(url);
@@ -309,11 +312,10 @@ export function TaskAgentTriggersDialog({
                       </div>
 
                       {existing?.lastRunStatus && existing.lastRunStatus !== 'never_run' && (
-                        <p className={
-                          existing.lastRunStatus === 'error'
-                            ? 'text-xs text-destructive'
-                            : 'text-xs text-muted-foreground'
-                        }>
+                        <p className={statusToneClass(existing.lastRunStatus)}>
+                          {existing.lastRunStatus === 'error' && (
+                            <AlertCircle className="h-3 w-3 inline mr-1" aria-hidden="true" />
+                          )}
                           Last run: <span className="font-medium">{existing.lastRunStatus}</span>
                           {existing.lastRunAt
                             ? ` • ${new Date(existing.lastRunAt).toLocaleString()}`

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskAgentTriggersDialog.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskAgentTriggersDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Bot, Zap } from 'lucide-react';
 import { toast } from 'sonner';
 import useSWR, { mutate as globalMutate } from 'swr';
@@ -24,6 +24,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { fetchWithAuth, put, del } from '@/lib/auth/auth-fetch';
+import { useEditingStore } from '@/stores/useEditingStore';
 import { useEditingSession } from '@/stores/useEditingSession';
 
 type ApiTriggerType = 'task_due_date' | 'task_completion';
@@ -103,15 +104,35 @@ export function TaskAgentTriggersDialog({
   const triggersKey = open ? `/api/tasks/${taskId}/triggers` : null;
   const agentsKey = open && driveId ? `/api/drives/${driveId}/agents` : null;
 
+  // Pause background revalidation while any editing session is active so a remote
+  // task_updated broadcast cannot refetch this dialog and clobber in-progress prompt
+  // typing. Initial load and explicit mutate() (e.g. refetchTriggers after save) are
+  // unaffected because *LoadedRef gates the pause until first success.
+  const isAnyActive = useEditingStore((s) => s.isAnyActive());
+  const triggersLoadedRef = useRef(false);
+  const agentsLoadedRef = useRef(false);
+
   const { data: triggersData, isLoading: triggersLoading, mutate: refetchTriggers } = useSWR(
     triggersKey,
     triggersFetcher,
-    { revalidateOnFocus: false },
+    {
+      revalidateOnFocus: false,
+      isPaused: () => triggersLoadedRef.current && isAnyActive,
+      onSuccess: () => {
+        triggersLoadedRef.current = true;
+      },
+    },
   );
   const { data: agentsData, isLoading: agentsLoading } = useSWR(
     agentsKey,
     agentsFetcher,
-    { revalidateOnFocus: false },
+    {
+      revalidateOnFocus: false,
+      isPaused: () => agentsLoadedRef.current && isAnyActive,
+      onSuccess: () => {
+        agentsLoadedRef.current = true;
+      },
+    },
   );
 
   const agents = agentsData?.agents ?? [];

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskAgentTriggersDialog.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskAgentTriggersDialog.tsx
@@ -24,7 +24,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { fetchWithAuth, put, del } from '@/lib/auth/auth-fetch';
-import { useEditingStore } from '@/stores/useEditingStore';
+import { useEditingSession } from '@/stores/useEditingSession';
 
 type ApiTriggerType = 'task_due_date' | 'task_completion';
 type UiTriggerType = 'due_date' | 'completion';
@@ -123,14 +123,10 @@ export function TaskAgentTriggersDialog({
   const [savingType, setSavingType] = useState<UiTriggerType | null>(null);
   const [removingType, setRemovingType] = useState<UiTriggerType | null>(null);
 
-  // Block SWR refetch from clobbering in-progress prompt typing while the dialog is open.
-  useEffect(() => {
-    const sessionId = `task-triggers:${taskId}`;
-    if (open) {
-      useEditingStore.getState().startEditing(sessionId, 'form', { pageId, componentName: 'TaskAgentTriggersDialog' });
-      return () => useEditingStore.getState().endEditing(sessionId);
-    }
-  }, [open, taskId, pageId]);
+  useEditingSession(`task-triggers:${taskId}`, open, 'form', {
+    pageId,
+    componentName: 'TaskAgentTriggersDialog',
+  });
 
   useEffect(() => {
     if (!open) return;

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskAgentTriggersDialog.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskAgentTriggersDialog.tsx
@@ -24,6 +24,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { fetchWithAuth, put, del } from '@/lib/auth/auth-fetch';
+import { useEditingStore } from '@/stores/useEditingStore';
 
 type ApiTriggerType = 'task_due_date' | 'task_completion';
 type UiTriggerType = 'due_date' | 'completion';
@@ -121,6 +122,15 @@ export function TaskAgentTriggersDialog({
   });
   const [savingType, setSavingType] = useState<UiTriggerType | null>(null);
   const [removingType, setRemovingType] = useState<UiTriggerType | null>(null);
+
+  // Block SWR refetch from clobbering in-progress prompt typing while the dialog is open.
+  useEffect(() => {
+    const sessionId = `task-triggers:${taskId}`;
+    if (open) {
+      useEditingStore.getState().startEditing(sessionId, 'form', { pageId, componentName: 'TaskAgentTriggersDialog' });
+      return () => useEditingStore.getState().endEditing(sessionId);
+    }
+  }, [open, taskId, pageId]);
 
   useEffect(() => {
     if (!open) return;
@@ -282,7 +292,11 @@ export function TaskAgentTriggersDialog({
                       </div>
 
                       {existing?.lastRunStatus && existing.lastRunStatus !== 'never_run' && (
-                        <p className="text-xs text-muted-foreground">
+                        <p className={
+                          existing.lastRunStatus === 'error'
+                            ? 'text-xs text-destructive'
+                            : 'text-xs text-muted-foreground'
+                        }>
                           Last run: <span className="font-medium">{existing.lastRunStatus}</span>
                           {existing.lastRunAt
                             ? ` • ${new Date(existing.lastRunAt).toLocaleString()}`

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -9,6 +9,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { usePermissions, canManageDrive } from '@/hooks/usePermissions';
 import { useDriveStore } from '@/hooks/useDrive';
 import { useEditingStore } from '@/stores/useEditingStore';
+import { useEditingSession } from '@/stores/useEditingSession';
 import { useLayoutStore } from '@/stores/useLayoutStore';
 import { TreePage } from '@/hooks/usePageTree';
 import { fetchWithAuth, post, patch, del } from '@/lib/auth/auth-fetch';
@@ -389,15 +390,10 @@ function TaskListView({ page }: TaskListViewProps) {
     })
   );
 
-  // Register/unregister editing state for UI refresh protection
-  useEffect(() => {
-    if (editingTaskId) {
-      useEditingStore.getState().startEditing(page.id, 'form', { pageId: page.id, componentName: 'TaskListView' });
-    } else {
-      useEditingStore.getState().endEditing(page.id);
-    }
-    return () => useEditingStore.getState().endEditing(page.id);
-  }, [editingTaskId, page.id]);
+  useEditingSession(page.id, !!editingTaskId, 'form', {
+    pageId: page.id,
+    componentName: 'TaskListView',
+  });
 
   // Fetch tasks with refresh protection
   // CRITICAL: Only pause AFTER initial load - never block the first fetch

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -106,7 +106,7 @@ interface MobileTaskCardProps {
   onSaveTitle: (taskId: string, title: string) => void;
   onDelete: (taskId: string) => void;
   onNavigate: (task: TaskItem) => void;
-  onConfigureTriggers: (task: TaskItem) => void;
+  onConfigureTriggers?: (task: TaskItem) => void;
   driveId: string;
   isEditing: boolean;
   editingTitle: string;
@@ -207,10 +207,12 @@ function MobileTaskCard({
               <Pencil className="h-4 w-4 mr-2" />
               Rename
             </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => onConfigureTriggers(task)} disabled={!canEdit}>
-              <Zap className="h-4 w-4 mr-2" />
-              Agent triggers…
-            </DropdownMenuItem>
+            {onConfigureTriggers && (
+              <DropdownMenuItem onClick={() => onConfigureTriggers?.(task)} disabled={!canEdit}>
+                <Zap className="h-4 w-4 mr-2" />
+                Agent triggers…
+              </DropdownMenuItem>
+            )}
             <DropdownMenuItem
               onClick={() => onDelete(task.id)}
               className="text-destructive"
@@ -281,10 +283,10 @@ function MobileTaskCard({
           disabled={!canEdit}
         />
 
-        {canEdit && (task.activeTriggerCount ?? 0) > 0 && (
+        {canEdit && onConfigureTriggers && (task.activeTriggerCount ?? 0) > 0 && (
           <button
             type="button"
-            onClick={() => onConfigureTriggers(task)}
+            onClick={() => onConfigureTriggers?.(task)}
             title="Agent trigger configured — click to edit"
             aria-label="Agent trigger configured — click to edit"
             className="inline-flex h-7 items-center gap-1 rounded-md border border-amber-300/60 bg-amber-50 px-2 text-xs text-amber-700 hover:bg-amber-100 dark:border-amber-700/50 dark:bg-amber-950/40 dark:text-amber-300"

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -209,7 +209,7 @@ function MobileTaskCard({
               Rename
             </DropdownMenuItem>
             {onConfigureTriggers && (
-              <DropdownMenuItem onClick={() => onConfigureTriggers?.(task)} disabled={!canEdit}>
+              <DropdownMenuItem onClick={() => onConfigureTriggers(task)} disabled={!canEdit}>
                 <Zap className="h-4 w-4 mr-2" />
                 Agent triggers…
               </DropdownMenuItem>
@@ -287,7 +287,7 @@ function MobileTaskCard({
         {canEdit && onConfigureTriggers && (task.activeTriggerCount ?? 0) > 0 && (
           <button
             type="button"
-            onClick={() => onConfigureTriggers?.(task)}
+            onClick={() => onConfigureTriggers(task)}
             title="Agent trigger configured — click to edit"
             aria-label="Agent trigger configured — click to edit"
             className="inline-flex h-7 items-center gap-1 rounded-md border border-amber-300/60 bg-amber-50 px-2 text-xs text-amber-700 hover:bg-amber-100 dark:border-amber-700/50 dark:bg-amber-950/40 dark:text-amber-300"

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/TaskAgentTriggersDialog.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/TaskAgentTriggersDialog.test.tsx
@@ -1,0 +1,107 @@
+import { describe, test, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SWRConfig, mutate as globalMutate } from 'swr';
+import { assert } from '@/stores/__tests__/riteway';
+import { useEditingStore } from '@/stores/useEditingStore';
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: vi.fn(),
+  put: vi.fn(),
+  del: vi.fn(),
+}));
+
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { TaskAgentTriggersDialog } from '../TaskAgentTriggersDialog';
+
+const TASK_ID = 'task-1';
+const PAGE_ID = 'page-1';
+const DRIVE_ID = 'drive-1';
+const TRIGGERS_URL = `/api/tasks/${TASK_ID}/triggers`;
+
+const remoteTrigger = () => ({
+  id: 'trig-1',
+  triggerType: 'task_due_date' as const,
+  agentPageId: 'agent-1',
+  prompt: 'remote-prompt',
+  isEnabled: true,
+  lastRunStatus: 'never_run' as const,
+  lastRunAt: null,
+});
+
+const remoteAgent = () => ({ id: 'agent-1', title: 'Triage Bot' });
+
+const cannedFetch = () =>
+  vi.mocked(fetchWithAuth).mockImplementation(async (...args: unknown[]) => {
+    const url = String(args[0]);
+    if (url.endsWith('/triggers')) {
+      return new Response(JSON.stringify({ triggers: [remoteTrigger()] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (url.endsWith('/agents')) {
+      return new Response(JSON.stringify({ agents: [remoteAgent()] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    return new Response('{}', { status: 200 });
+  });
+
+const renderDialog = () =>
+  render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      <TaskAgentTriggersDialog
+        open
+        onOpenChange={() => {}}
+        taskId={TASK_ID}
+        taskTitle="Some task"
+        pageId={PAGE_ID}
+        driveId={DRIVE_ID}
+        hasDueDate
+      />
+    </SWRConfig>,
+  );
+
+describe('TaskAgentTriggersDialog — editing-store contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useEditingStore.getState().clearAllSessions();
+    cannedFetch();
+  });
+
+  test('preserves in-flight prompt text across a remote refetch', async () => {
+    renderDialog();
+
+    const promptInput = (await waitFor(() =>
+      screen.getByDisplayValue('remote-prompt'),
+    )) as HTMLTextAreaElement;
+
+    await userEvent.clear(promptInput);
+    await userEvent.type(promptInput, 'in-flight typing');
+
+    assert({
+      given: 'the user has typed into the prompt textarea while the dialog is open',
+      should: 'show the typed text in the textarea (sanity check before remote refetch)',
+      actual: promptInput.value,
+      expected: 'in-flight typing',
+    });
+
+    await act(async () => {
+      await globalMutate(TRIGGERS_URL);
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    assert({
+      given: 'a remote task_updated arrives while the dialog is open with unsaved prompt text',
+      should: 'preserve the in-progress prompt text rather than refetching and clobbering it',
+      actual: promptInput.value,
+      expected: 'in-flight typing',
+    });
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/TaskAgentTriggersDialog.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/TaskAgentTriggersDialog.test.tsx
@@ -16,7 +16,7 @@ vi.mock('@/lib/auth/auth-fetch', () => ({
 }));
 
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
-import { TaskAgentTriggersDialog } from '../TaskAgentTriggersDialog';
+import { TaskAgentTriggersDialog, statusToneClass } from '../TaskAgentTriggersDialog';
 
 const TASK_ID = 'task-1';
 const PAGE_ID = 'page-1';
@@ -67,6 +67,30 @@ const renderDialog = () =>
       />
     </SWRConfig>,
   );
+
+describe('statusToneClass', () => {
+  test('error status maps to destructive tone', () => {
+    assert({
+      given: 'lastRunStatus = "error"',
+      should: 'return the destructive tone class',
+      actual: statusToneClass('error'),
+      expected: 'text-xs text-destructive',
+    });
+  });
+
+  test('non-error statuses map to muted tone', () => {
+    assert({
+      given: 'lastRunStatus values that are not "error"',
+      should: 'return the muted-foreground tone class',
+      actual: (['success', 'running', 'never_run'] as const).map(statusToneClass),
+      expected: [
+        'text-xs text-muted-foreground',
+        'text-xs text-muted-foreground',
+        'text-xs text-muted-foreground',
+      ],
+    });
+  });
+});
 
 describe('TaskAgentTriggersDialog — editing-store contract', () => {
   beforeEach(() => {

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/task-list-types.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/task-list-types.ts
@@ -44,11 +44,10 @@ export interface TaskItem {
   priority: 'low' | 'medium' | 'high';
   position: number;
   dueDate: string | null;
-  metadata?: {
-    hasTrigger?: boolean;
-    triggerTypes?: string[];
-    [key: string]: unknown;
-  } | null;
+  metadata?: Record<string, unknown> | null;
+  // activeTriggerCount is the canonical UI source for trigger presence (live join in
+  // /api/pages/[pageId]/tasks). The DB row also carries metadata.hasTrigger/triggerTypes
+  // written by recomputeTaskTriggerMetadata, but no UI path reads them.
   activeTriggerCount?: number;
   completedAt: string | null;
   createdAt: string;

--- a/apps/web/src/stores/__tests__/useEditingSession.test.ts
+++ b/apps/web/src/stores/__tests__/useEditingSession.test.ts
@@ -1,0 +1,99 @@
+import { describe, test, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { assert } from './riteway';
+import { useEditingStore } from '../useEditingStore';
+import { useEditingSession } from '../useEditingSession';
+
+beforeEach(() => {
+  useEditingStore.getState().clearAllSessions();
+});
+
+const sessionSummary = () =>
+  useEditingStore
+    .getState()
+    .getActiveSessions()
+    .map((s) => ({ id: s.id, type: s.type, metadata: s.metadata }));
+
+describe('useEditingSession', () => {
+  test('active=true on mount registers session', () => {
+    renderHook(() => useEditingSession('sess-1', true));
+    assert({
+      given: 'active=true on mount',
+      should: 'register a session with the supplied id and default type=form',
+      actual: sessionSummary(),
+      expected: [{ id: 'sess-1', type: 'form', metadata: {} }],
+    });
+  });
+
+  test('unmount with active=true clears the session', () => {
+    const { unmount } = renderHook(() => useEditingSession('sess-1', true));
+    unmount();
+    assert({
+      given: 'unmount while active=true',
+      should: 'clear the session',
+      actual: sessionSummary(),
+      expected: [],
+    });
+  });
+
+  test('active flipping true to false clears the session', () => {
+    const { rerender } = renderHook(
+      ({ active }: { active: boolean }) => useEditingSession('sess-1', active),
+      { initialProps: { active: true } },
+    );
+    assert({
+      given: 'active=true on mount',
+      should: 'register the session',
+      actual: sessionSummary().map((s) => s.id),
+      expected: ['sess-1'],
+    });
+    rerender({ active: false });
+    assert({
+      given: 'active flipped to false',
+      should: 'clear the session',
+      actual: sessionSummary(),
+      expected: [],
+    });
+  });
+
+  test('active=false on mount does not register', () => {
+    renderHook(() => useEditingSession('sess-1', false));
+    assert({
+      given: 'active=false on mount',
+      should: 'not register any session',
+      actual: sessionSummary(),
+      expected: [],
+    });
+  });
+
+  test('metadata is forwarded to the store', () => {
+    renderHook(() =>
+      useEditingSession('sess-1', true, 'form', {
+        pageId: 'page-42',
+        componentName: 'TaskAgentTriggersDialog',
+      }),
+    );
+    assert({
+      given: 'metadata with pageId and componentName',
+      should: 'forward those fields verbatim into the registered session',
+      actual: sessionSummary().map((s) => s.metadata),
+      expected: [
+        {
+          pageId: 'page-42',
+          componentName: 'TaskAgentTriggersDialog',
+          conversationId: undefined,
+        },
+      ],
+    });
+  });
+
+  test('non-default session type is honored', () => {
+    renderHook(() => useEditingSession('sess-1', true, 'document'));
+    assert({
+      given: 'an explicit session type=document',
+      should: 'register the session with that type',
+      actual: sessionSummary().map((s) => s.type),
+      expected: ['document'],
+    });
+  });
+});

--- a/apps/web/src/stores/useEditingSession.ts
+++ b/apps/web/src/stores/useEditingSession.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { useEditingStore, type EditingSession, type SessionType } from './useEditingStore';
+
+/**
+ * Register an editing-store session while `active` is true.
+ * Cleans up on unmount or when `active` flips to false.
+ */
+export function useEditingSession(
+  sessionId: string,
+  active: boolean,
+  type: SessionType = 'form',
+  metadata?: EditingSession['metadata'],
+) {
+  const componentName = metadata?.componentName;
+  const pageId = metadata?.pageId;
+  const conversationId = metadata?.conversationId;
+  useEffect(() => {
+    if (!active) return;
+    useEditingStore
+      .getState()
+      .startEditing(sessionId, type, { componentName, pageId, conversationId });
+    return () => useEditingStore.getState().endEditing(sessionId);
+  }, [active, sessionId, type, componentName, pageId, conversationId]);
+}

--- a/plan.md
+++ b/plan.md
@@ -6,6 +6,7 @@
 - [Multiplayer AI Chat Streaming](tasks/multiplayer-ai-chat-streaming.md) — Socket-notified, HTTP-joined AI stream sharing: all page viewers see live ghost text and "X is waiting for AI response…" indicators in real-time.
 - [AI Chat Send Flash Fix](tasks/ai-chat-send-flash-fix.md) — eliminate stream-abort and flash on send; stabilise `chatConfig` deps and extend `invalidateTree` guard to cover all active states.
 - [E2E and Load Testing](tasks/e2e-and-load-testing.md) — Playwright e2e for core user journeys + k6 load scenarios with Grafana dashboard for API latency and Postgres pool monitoring.
+- [Task List Agent Triggers Follow-up](tasks/task-list-agent-triggers-followup.md) — close PR #1177 post-merge gaps: cross-surface discoverability via TaskDetailSheet, page-scoped task broadcasts for collaborative real-time, agent-parity (instructionPageId + contextPageIds) in the trigger dialog, "anchored to" clarity in the page-level Workflows dialog, and small polish + correctness fixes.
 
 ## Recently Completed
 

--- a/tasks/task-list-agent-triggers-followup.md
+++ b/tasks/task-list-agent-triggers-followup.md
@@ -1,0 +1,64 @@
+# Task List Agent Triggers Follow-up Epic
+
+**Status**: 📋 PLANNED
+**Goal**: Close the post-merge gaps from PR #1177 so per-task agent triggers feel "fully working" to a typical user.
+
+## Overview
+
+PR #1177 (squash-merged as `b853f3b74`) shipped per-task and page-level agent triggers on Task List pages, but a post-merge audit found that triggers are configurable from only one surface (the Task List page itself, not from `TaskDetailSheet` used by the dashboard / right sidebar / "my tasks"); that `broadcastTaskEvent` only fans out to the originating user's room, so collaborators do not see badge changes in real time; that the per-task dialog hides `instructionPageId` and `contextPageIds`, leaving humans with strictly less power than agents who set those fields via `update_task`'s `agentTrigger` parameter; and that minor wiring inconsistencies (mobile kebab vs kanban, dialog typing clobbered by remote refetches, gray-on-gray "error" status text, dead `metadata.hasTrigger`/`metadata.triggerTypes` on the `TaskItem` TS type) accumulated through the late-stage refactor that extracted `recomputeTaskTriggerMetadata`. This epic addresses those gaps without expanding scope to cross-list moves, run-history UI, or trigger-error toasts.
+
+---
+
+## Polish and correctness pass
+
+Tighten the post-refactor edges: gate the mobile kebab "Agent triggers…" item like kanban does, register the per-task dialog with `useEditingStore` while open, color `lastRunStatus === 'error'` with `text-destructive`, and drop the now-unread `hasTrigger` / `triggerTypes` fields from `TaskItem.metadata` in `task-list-types.ts`.
+
+**Requirements**:
+- Given a remote `task_updated` broadcast arrives while the trigger dialog is open with unsaved prompt text, should preserve the in-progress text rather than refetching and clobbering it.
+- Given a workflow row with `lastRunStatus = 'error'` shown in the dialog, should signal the failure visually (not blend in with neutral muted text) so users notice broken triggers.
+- Given a `MobileTaskCard` rendered without an `onConfigureTriggers` handler, should hide the kebab item rather than throw on click.
+
+---
+
+## Page-scoped task broadcast
+
+Make `broadcastTaskEvent` fan out to a `pageId`-scoped room in addition to `user:${userId}:tasks` when `payload.pageId` is set, and fix `TaskListView`'s client emit from the unhandled `join_page` to the existing access-checked `join_channel` handler so its socket actually joins that page room.
+
+**Requirements**:
+- Given two users open the same Task List page and User A configures a trigger, should make User B's bell badge appear without a manual refresh.
+- Given the existing `update_task` AI tool path, should continue to deliver task events to the originator's other tabs without regression after the broadcast becomes dual-channel.
+- Given a client socket that has not been granted view access to a page, should not receive that page's task events even after the dual-channel broadcast lands.
+
+---
+
+## Agent parity in trigger dialog
+
+Add an "Advanced" collapsible section to each trigger pane in `TaskAgentTriggersDialog` exposing an instruction-page picker and a context-pages multi-picker (capped at 10 to match the Zod schema), plumb both through the `SectionState` shape into the existing PUT body, and relax dialog-side validation so `prompt` is optional once `instructionPageId` is set.
+
+**Requirements**:
+- Given an agent that previously created a trigger with `instructionPageId` and `contextPageIds` via `update_task`, should let a human user open the dialog, see those values, and edit or clear them without losing the rest of the trigger config.
+- Given a user who selects an instruction page and leaves the prompt empty, should accept and save the trigger (matching the helper-level "either prompt or instructionPageId" rule), rather than block on a prompt-required validation.
+- Given a user picking context pages, should not allow more than 10 entries and should not allow pages from a different drive than the task list.
+
+---
+
+## Workflows anchored-to clarity
+
+In the page-level Workflows dialog (`TaskListWorkflowsDialog` + `WorkflowForm`), surface a small "Anchored to: [taskListTitle]" badge plus read-only chips for any non-anchor `contextPageIds`, so users understand the scope of a workflow before editing it.
+
+**Requirements**:
+- Given a workflow whose `contextPageIds` includes other pages alongside the task list page, should make those additional context pages visible (without requiring edit) so the user is not surprised when the agent runs with that wider context.
+- Given the auto-anchor behavior that adds the task list page to `contextPageIds` on every save, should communicate that the relationship exists rather than appearing as an opaque magic field.
+
+---
+
+## Trigger discoverability in TaskDetailSheet
+
+Wire the same trigger UI into `apps/web/src/components/tasks/TaskDetailSheet.tsx` (the dashboard / right-sidebar / "my tasks" surface) by reusing `TaskAgentTriggersDialog` directly: a `Bell` badge when `task.activeTriggerCount > 0`, an "Agent triggers…" entry, and pass-through of `pageId` / `driveId` from the sheet's caller.
+
+**Requirements**:
+- Given a user clicks a task from the dashboard or right sidebar, should let them configure triggers from that surface end-to-end without first navigating to the source Task List page.
+- Given a viewer-only user opens the same sheet, should show neither the badge nor the trigger entry, mirroring the row-level gate on the Task List page.
+- Given a saved trigger in the sheet, should make the bell badge appear consistently on both the sheet and the corresponding row in the source Task List page.
+
+---


### PR DESCRIPTION
## Summary
First slice of the [Task List Agent Triggers Follow-up](../blob/master/tasks/task-list-agent-triggers-followup.md) epic, hardened per code-review feedback.

## What changed
- **A1** `MobileTaskCard`'s "Agent triggers…" kebab item now renders conditionally on `onConfigureTriggers`, matching `TaskKanbanView`. Prop is now optional; safer for any future caller that omits it.
- **A2** `TaskAgentTriggersDialog` registers a `form` session with `useEditingStore` while open, **and the dialog's own `triggersFetcher`/`agentsFetcher` SWRs are now `isPaused`-gated** so a remote `task_updated` broadcast cannot refetch and clobber in-progress prompt typing. (Hardens the editing-store contract per code-review feedback — the original A2 wired registration but left the dialog's SWRs ungated, so the protection only covered the parent `TaskListView`'s SWR.)
- **A3** `lastRunStatus === 'error'` renders via a pure `statusToneClass` helper plus an `AlertCircle` icon — color + icon, not color-only, so the error state is conveyed without relying on color perception alone.
- **A4** Dropped unread `metadata.hasTrigger` / `metadata.triggerTypes` from the `TaskItem` TS shape. `activeTriggerCount` (live join) is the canonical UI source. The DB row still carries them via `recomputeTaskTriggerMetadata`.

### Eric Elliott hardening pass (composability + tests + dead-code)
- Extracted `useEditingSession` (`apps/web/src/stores/useEditingSession.ts`) — a small declarative hook wrapping the imperative `start/end Editing` pattern. AHA on the third occurrence: `TaskListView` and `TaskAgentTriggersDialog` already had the inline effect, and `TaskDetailSheet` (T6) is about to need it. Both existing call sites now use the hook.
- RITE-way unit tests for `useEditingSession` covering register-on-mount, clear-on-unmount, clear-on-active-flip, no-op when inactive, metadata forwarding, and non-default session type. Exercises the real Zustand store (no mocks).
- RITE-way behavioral test for `TaskAgentTriggersDialog` that maps verbatim to the epic requirement: render the dialog open, type into the prompt textarea, fire `globalMutate(triggersUrl)` to simulate a remote refetch, assert the typed text is preserved. Mocks only `fetchWithAuth`; exercises the real editing store.
- Pulled the inline `lastRunStatus` ternary into a pure module-scope `statusToneClass` (covered by two RITE-way tests).
- Dropped redundant `onConfigureTriggers?.(task)` chains in `TaskListView`'s `MobileTaskCard` — both call sites sit inside `{onConfigureTriggers && …}` guards, so the optional-call form is dead defensive code.

Plus: epic file `tasks/task-list-agent-triggers-followup.md` and `plan.md` entry covering the four remaining phases.

## Test plan
- [x] `pnpm --filter web typecheck` clean
- [x] `pnpm --filter web lint` clean (only pre-existing unrelated `QuickCreatePalette` warning)
- [x] All affected tests pass (389/389 in `src/stores` + `src/components/layout/middle-content/page-views/task-list`)
- [x] **New**: `useEditingSession` RITE-way tests (6) prove register-on-mount / clear-on-unmount / clear-on-active-flip / no-op-when-inactive / metadata-forwarding / non-default-type
- [x] **New**: `TaskAgentTriggersDialog` RITE-way behavioral test proves in-flight prompt text survives a simulated remote refetch
- [x] **New**: `statusToneClass` RITE-way unit tests (2) prove the pure tone-class derivation
- [ ] Manual: open trigger dialog, type in prompt, fire a remote `task_updated` event for the same task — typed text preserved
- [ ] Manual: force a workflow row to `lastRunStatus = 'error'` — dialog renders in red with an `AlertCircle` icon
- [ ] Manual: render `MobileTaskCard` with `onConfigureTriggers={undefined}` — kebab item hidden, no NPE on click
