### PR TITLE
feat(realtime): page-scoped task broadcasts (T2/5)

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -424,7 +424,7 @@ function TaskListView({ page }: TaskListViewProps) {
   useEffect(() => {
     if (!socket || connectionStatus !== 'connected') return;
 
-    socket.emit('join_page', page.id);
+    socket.emit('join_channel', page.id);
 
     // Handle task events (event names match backend broadcast format: task:${operation})
     const handleTaskAdded = () => {

--- a/apps/web/src/lib/websocket/__tests__/socket-utils.test.ts
+++ b/apps/web/src/lib/websocket/__tests__/socket-utils.test.ts
@@ -220,11 +220,52 @@ describe('socket-utils', () => {
 
       await broadcastTaskEvent(payload);
 
-      const fetchCall = mockFetch.mock.calls[0];
-      const requestBody = JSON.parse(fetchCall[1].body);
+      const channelIds = mockFetch.mock.calls.map((call) => JSON.parse(call[1].body).channelId);
+      expect(channelIds).toContain('user:user-789:tasks');
+      const userCallBody = JSON.parse(
+        mockFetch.mock.calls.find((call) => JSON.parse(call[1].body).channelId === 'user:user-789:tasks')![1].body
+      );
+      expect(userCallBody.event).toBe('task:task_added');
+    });
 
-      expect(requestBody.channelId).toBe('user:user-789:tasks');
-      expect(requestBody.event).toBe('task:task_added');
+    it('given payload with pageId, should fan out to BOTH user:{userId}:tasks and pageId channels', async () => {
+      const payload: TaskEventPayload = {
+        type: 'task_updated',
+        userId: 'user-789',
+        taskId: 'task-123',
+        pageId: 'page-456',
+        data: { title: 'Updated Task' },
+      };
+
+      await broadcastTaskEvent(payload);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      const bodies = mockFetch.mock.calls.map((call) => JSON.parse(call[1].body));
+      const channelIds = bodies.map((b) => b.channelId);
+      expect(channelIds).toContain('user:user-789:tasks');
+      expect(channelIds).toContain('page-456');
+
+      // Both fetches should carry the same event name and payload
+      for (const body of bodies) {
+        expect(body.event).toBe('task:task_updated');
+        expect(body.payload).toEqual(payload);
+      }
+    });
+
+    it('given payload without pageId, should fan out only to user:{userId}:tasks channel', async () => {
+      const payload: TaskEventPayload = {
+        type: 'task_added',
+        userId: 'user-789',
+        data: { title: 'Pageless Task' },
+      };
+
+      await broadcastTaskEvent(payload);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.channelId).toBe('user:user-789:tasks');
+      expect(body.event).toBe('task:task_added');
     });
   });
 

--- a/apps/web/src/lib/websocket/socket-utils.ts
+++ b/apps/web/src/lib/websocket/socket-utils.ts
@@ -354,7 +354,14 @@ export function createDriveMemberEventPayload(
 }
 
 /**
- * Broadcasts a task event to the realtime server
+ * Broadcasts a task event to the realtime server.
+ *
+ * Always fans out to the originating user's task channel
+ * (`user:${userId}:tasks`) so their other tabs stay in sync. When
+ * `payload.pageId` is set, ALSO fans out to the `pageId` room so any
+ * collaborator currently viewing that task list (joined via
+ * `join_channel`) sees badge / list updates without a manual refresh.
+ *
  * @param payload - The task event payload to broadcast
  */
 export async function broadcastTaskEvent(payload: TaskEventPayload): Promise<void> {
@@ -367,30 +374,37 @@ export async function broadcastTaskEvent(payload: TaskEventPayload): Promise<voi
     return;
   }
 
-  try {
-    const requestBody = JSON.stringify({
-      channelId: `user:${payload.userId}:tasks`,
-      event: `task:${payload.type}`,
-      payload,
-    });
-
-    await fetch(`${realtimeUrl}/api/broadcast`, {
-      method: 'POST',
-      headers: createSignedBroadcastHeaders(requestBody),
-      body: requestBody,
-      signal: AbortSignal.timeout(5000),
-    });
-  } catch (error) {
-    // Log error but don't throw - broadcasting failures shouldn't break operations
-    realtimeLogger.error(
-      'Failed to broadcast task event',
-      error instanceof Error ? error : undefined,
-      {
-        event: 'task',
-        channel: `user:${maskIdentifier(payload.userId)}:tasks`
-      }
-    );
+  const event = `task:${payload.type}`;
+  const channelIds = [`user:${payload.userId}:tasks`];
+  if (payload.pageId) {
+    channelIds.push(payload.pageId);
   }
+
+  await Promise.all(
+    channelIds.map(async (channelId) => {
+      try {
+        const requestBody = JSON.stringify({ channelId, event, payload });
+        await fetch(`${realtimeUrl}/api/broadcast`, {
+          method: 'POST',
+          headers: createSignedBroadcastHeaders(requestBody),
+          body: requestBody,
+          signal: AbortSignal.timeout(5000),
+        });
+      } catch (error) {
+        // Log error but don't throw - broadcasting failures shouldn't break operations
+        realtimeLogger.error(
+          'Failed to broadcast task event',
+          error instanceof Error ? error : undefined,
+          {
+            event: 'task',
+            channel: channelId.startsWith('user:')
+              ? `user:${maskIdentifier(payload.userId)}:tasks`
+              : maskIdentifier(channelId),
+          }
+        );
+      }
+    })
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

- `broadcastTaskEvent` now fans out to BOTH the originating user's task channel AND the page's room when `payload.pageId` is set, so collaborators viewing the same Task List see badge / list updates in real time.
- Fixes `TaskListView`'s socket-join: `join_page` (which the realtime server doesn't handle) → `join_channel` (the existing access-checked handler).
- Adds test coverage for both the dual-fan-out (with `pageId`) and single-fan-out (without `pageId`) cases.

## Why

PR #1177 shipped per-task agent triggers, but a post-merge audit found that User A's trigger configuration was only broadcast to User A's own tabs (`user:${userId}:tasks`). User B looking at the same Task List in another tab saw nothing happen — the bell badge would not appear without a manual refresh. The cause was twofold:

1. **`broadcastTaskEvent` only fanned out to one channel.** It was hardcoded to `user:${payload.userId}:tasks`, so by design only the originating user's sockets received the event.
2. **`TaskListView` joined the wrong room.** It emitted `socket.emit('join_page', page.id)` but the realtime server has no `join_page` handler — only `join_channel` (`apps/realtime/src/index.ts:511`), which does an access check and joins the socket to a room named after the `pageId`. So even if `broadcastTaskEvent` had emitted to the page room, no socket was actually in it.

This is T2 of the [Task List Agent Triggers Follow-up epic](../blob/master/tasks/task-list-agent-triggers-followup.md) (T1 / polish + correctness shipped as #1184).

## What changed

### C1 — `apps/web/src/lib/websocket/socket-utils.ts`
- `broadcastTaskEvent` now builds a list of `channelIds` and fires one `/api/broadcast` request per channel via `Promise.all`. The user's task channel is always included; when `payload.pageId` is set, the `pageId` room is also included.
- Each fetch is wrapped in its own `try/catch` so one channel failing doesn't prevent the other from being delivered.
- Updated the function's JSDoc to explain the dual-channel behavior.

### C2 — `apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx`
- One-line change: `socket.emit('join_page', page.id)` → `socket.emit('join_channel', page.id)`. This mirrors the pattern used by `EventModal` and the calendar surface, and lines up with the realtime server's existing access-checked handler.

### C4 — `apps/web/src/lib/websocket/__tests__/socket-utils.test.ts`
- Updated the existing `'given task event, should route to user:{userId}:tasks channel'` test to look up the user-channel call via `.find()` (robust to `Promise.all` ordering rather than depending on call index 0).
- Added a new test asserting `broadcastTaskEvent` fires exactly two fetches when `pageId` is set, with one going to `user:${userId}:tasks` and one going to `${pageId}` — both carrying the same event name and payload.
- Added a new test asserting that when `pageId` is absent, only the user channel is hit (single fetch).

## Test plan

- [x] `pnpm --filter @pagespace/db build && pnpm --filter @pagespace/lib build` — clean
- [x] `pnpm --filter web typecheck` — clean
- [x] `pnpm --filter web lint` — only pre-existing `QuickCreatePalette` warning, no new warnings
- [x] `pnpm --filter web test src/lib/websocket src/app/api/tasks` — 186/186 pass, including the two new tests
- [x] `pnpm --filter web test src/app/api/pages` — 630/630 pass (existing task route tests mock `broadcastTaskEvent`, so the dual-channel change doesn't affect them)

## Manual verification (planned, not yet performed)

- Two browsers signed in as different users, both viewing the same Task List page → User A configures a trigger → User B's bell badge appears without refresh.
- Verify a viewer-only socket that has not been granted access to the page does NOT receive the page-channel event (the `join_channel` handler refuses on access check, so the socket is never in the room).

## Scope

This PR delivers C1, C2, and C4 from the epic. The remaining phases (C3 agent parity in dialog, C5 workflows anchored-to clarity, C6 TaskDetailSheet integration) are tracked in [`tasks/task-list-agent-triggers-followup.md`](../blob/master/tasks/task-list-agent-triggers-followup.md).