### PR TITLE
feat(tasks): Agent triggers from TaskDetailSheet (T6/5)

### DIFF
--- a/apps/web/src/components/tasks/TaskDetailSheet.tsx
+++ b/apps/web/src/components/tasks/TaskDetailSheet.tsx
@@ -3,9 +3,11 @@
 import { useState, useRef, useEffect, useMemo } from 'react';
 import Link from 'next/link';
 import {
+  Bell,
   ExternalLink,
   Trash2,
   FileText,
+  Zap,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -28,6 +30,7 @@ import {
 import { cn } from '@/lib/utils';
 import { MultiAssigneeSelect } from '@/components/layout/middle-content/page-views/task-list/MultiAssigneeSelect';
 import { DueDatePicker } from '@/components/layout/middle-content/page-views/task-list/DueDatePicker';
+import { TaskAgentTriggersDialog } from '@/components/layout/middle-content/page-views/task-list/TaskAgentTriggersDialog';
 import {
   PRIORITY_CONFIG,
   buildStatusConfig,
@@ -35,6 +38,7 @@ import {
   type TaskPriority,
   type TaskStatusConfig,
 } from '@/components/layout/middle-content/page-views/task-list/task-list-types';
+import { useCanEdit } from '@/hooks/usePermissions';
 import type { Task } from './types';
 import { getStatusDisplay } from './task-helpers';
 
@@ -51,6 +55,7 @@ export interface TaskDetailSheetProps {
   onSaveTitle: (task: Task, title: string) => void;
   onDelete: (task: Task) => void;
   onNavigate: (task: Task) => void;
+  onTriggersSaved?: () => void;
 }
 
 export function TaskDetailSheet({
@@ -66,15 +71,22 @@ export function TaskDetailSheet({
   onSaveTitle,
   onDelete,
   onNavigate,
+  onTriggersSaved,
 }: TaskDetailSheetProps) {
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [editingTitle, setEditingTitle] = useState('');
+  const [triggersDialogOpen, setTriggersDialogOpen] = useState(false);
   const cancelTriggeredRef = useRef(false);
+
+  // Permission gate mirrors the row-level Task List badge: edit on the parent
+  // task list page is what authorizes configuring triggers on its tasks.
+  const canEdit = useCanEdit(task?.taskListPageId ?? null);
 
   // Reset editing state when task changes
   useEffect(() => {
     setIsEditingTitle(false);
     setEditingTitle('');
+    setTriggersDialogOpen(false);
   }, [task?.id]);
 
   const statusConfigMap = useMemo(() => buildStatusConfig(statusConfigs), [statusConfigs]);
@@ -86,6 +98,9 @@ export function TaskDetailSheet({
   const isCompleted = statusDisplay.group === 'done';
   const hasLinkedPage = Boolean(task.pageId && task.driveId);
   const { label: statusLabel, color: statusColor } = statusDisplay;
+  const triggerCount = task.activeTriggerCount ?? 0;
+  const canConfigureTriggers = canEdit && Boolean(task.taskListPageId && task.driveId);
+  const showTriggerBadge = canConfigureTriggers && triggerCount > 0;
 
   const startEditTitle = () => {
     setEditingTitle(task.title);
@@ -174,6 +189,22 @@ export function TaskDetailSheet({
               )}
             </div>
           </div>
+
+          {/* Trigger badge — opens dialog, mirrors row-level UX on the Task List page */}
+          {showTriggerBadge && (
+            <div className="flex">
+              <button
+                type="button"
+                onClick={() => setTriggersDialogOpen(true)}
+                title="Agent trigger configured — click to edit"
+                aria-label="Agent trigger configured — click to edit"
+                className="inline-flex h-7 items-center gap-1 rounded-md border border-amber-300/60 bg-amber-50 px-2 text-xs text-amber-700 hover:bg-amber-100 dark:border-amber-700/50 dark:bg-amber-950/40 dark:text-amber-300"
+              >
+                <Bell className="h-3 w-3" />
+                <span>Trigger</span>
+              </button>
+            </div>
+          )}
 
           {/* Status & Priority row */}
           <div className="grid grid-cols-2 gap-3">
@@ -283,6 +314,18 @@ export function TaskDetailSheet({
                 Open Page
               </Button>
             )}
+            {canConfigureTriggers && (
+              <Button
+                variant="outline"
+                className="h-11"
+                onClick={() => setTriggersDialogOpen(true)}
+                title="Agent triggers"
+                aria-label="Agent triggers"
+              >
+                <Zap className="h-4 w-4 mr-2" />
+                Triggers
+              </Button>
+            )}
             <Button
               variant="outline"
               className="h-11 text-destructive hover:text-destructive hover:bg-destructive/10"
@@ -293,6 +336,19 @@ export function TaskDetailSheet({
           </div>
         </div>
       </SheetContent>
+
+      {canConfigureTriggers && task.taskListPageId && task.driveId && (
+        <TaskAgentTriggersDialog
+          open={triggersDialogOpen}
+          onOpenChange={setTriggersDialogOpen}
+          taskId={task.id}
+          taskTitle={task.title}
+          pageId={task.taskListPageId}
+          driveId={task.driveId}
+          hasDueDate={!!task.dueDate}
+          onSaved={onTriggersSaved}
+        />
+      )}
     </Sheet>
   );
 }

--- a/apps/web/src/components/tasks/TasksDashboard.tsx
+++ b/apps/web/src/components/tasks/TasksDashboard.tsx
@@ -524,6 +524,14 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
     return grouped;
   }, [tasks]);
 
+  // Resolve the sheet's task against the live tasks array so edits and refetches
+  // (status, priority, trigger badge after onTriggersSaved, etc.) are reflected
+  // without closing and reopening the sheet.
+  const liveDetailSheetTask = useMemo(
+    () => (detailSheetTask ? tasks.find(t => t.id === detailSheetTask.id) ?? detailSheetTask : null),
+    [detailSheetTask, tasks],
+  );
+
   // Loading skeleton
   if (loading && tasks.length === 0) {
     return (
@@ -700,8 +708,8 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
 
                 {/* Mobile Sheets */}
                 <TaskDetailSheet
-                  task={detailSheetTask}
-                  statusConfigs={detailSheetTask ? getConfigsForTask(detailSheetTask) : []}
+                  task={liveDetailSheetTask}
+                  statusConfigs={liveDetailSheetTask ? getConfigsForTask(liveDetailSheetTask) : []}
                   open={detailSheetOpen}
                   onOpenChange={setDetailSheetOpen}
                   onStatusChange={handleStatusChange}

--- a/apps/web/src/components/tasks/TasksDashboard.tsx
+++ b/apps/web/src/components/tasks/TasksDashboard.tsx
@@ -712,6 +712,7 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
                   onSaveTitle={handleSaveTitle}
                   onDelete={handleDeleteTask}
                   onNavigate={handleNavigate}
+                  onTriggersSaved={() => fetchTasks()}
                 />
                 <TaskFilterSheet
                   open={filterSheetOpen}

--- a/apps/web/src/components/tasks/types.ts
+++ b/apps/web/src/components/tasks/types.ts
@@ -64,6 +64,10 @@ export interface Task {
   driveId?: string;
   taskListPageId?: string;
   taskListPageTitle?: string;
+  // Live join from /api/pages/[pageId]/tasks. Optional here because /api/tasks
+  // (the dashboard endpoint) does not currently surface this field — the bell
+  // badge stays hidden until a follow-up enriches that response.
+  activeTriggerCount?: number;
   // Status metadata (computed from custom status configs)
   statusGroup?: TaskStatusGroup;
   statusLabel?: string;


### PR DESCRIPTION
## Summary

Wire agent-trigger configuration into `TaskDetailSheet` (right-sidebar / dashboard / "my tasks" surface) so users can configure triggers without first navigating back to the source Task List page.

- Reuses `TaskAgentTriggersDialog` directly (no duplicate, no prop changes).
- Bell badge in the sheet header area, gated on `canEdit` AND `(task.activeTriggerCount ?? 0) > 0`.
- "Triggers" action button alongside Open Page / Delete, gated on `canEdit` only — gives a way in even when no triggers exist yet.
- New optional `onTriggersSaved` callback wired from `TasksDashboard` to `fetchTasks()`.
- `TasksDashboard` now resolves the sheet's task against the live `tasks` array each render so edits and refetches reflect immediately without closing/reopening the sheet (fixes a class of stale-display bugs that pre-dated this PR but matters most for the new badge).

## Why

Cross-surface discoverability gap. `TaskDetailSheet` is the right-sidebar / dashboard / "my tasks" surface for tasks. Before this PR, opening a task from any of those surfaces meant the user had to navigate back to the source Task List page just to configure agent triggers — which made the per-task trigger feature feel like a Task-List-page-only thing.

## What changed

- `apps/web/src/components/tasks/TaskDetailSheet.tsx` — added `useCanEdit`, Bell badge, Triggers button, `TaskAgentTriggersDialog` mount, and `onTriggersSaved` prop.
- `apps/web/src/components/tasks/TasksDashboard.tsx` — passes `onTriggersSaved={() => fetchTasks()}` to the sheet so saves refresh dashboard state (the dashboard uses fetch-based local state, not SWR; the dialog's internal `globalMutate` of `/api/pages/[pageId]/tasks` does not cover it). Adds a `liveDetailSheetTask` useMemo that resolves `detailSheetTask.id` against the live `tasks` array so the sheet always renders fresh data.
- `apps/web/src/components/tasks/types.ts` — added optional `activeTriggerCount?: number` on `Task` for the badge gate.

Caller plumbing: `TasksDashboard` is the only caller of `TaskDetailSheet`. `task.taskListPageId` and `task.driveId` are already enriched on the `/api/tasks` response shape, so the dialog's `pageId` / `driveId` come straight from the task — no caller refactor needed beyond the dashboard.

## API note (follow-up)

`/api/tasks` does **not** currently surface `activeTriggerCount` — only `/api/pages/[pageId]/tasks` does (live join on `workflows`). This PR keeps the bell badge gated on `(task.activeTriggerCount ?? 0) > 0`, so the badge stays hidden until a follow-up enriches the dashboard endpoint with the same join. The dedicated **Triggers** button still lets users open the dialog and read live trigger state. Surfacing the count on `/api/tasks` was deliberately kept out of this PR's allow-list per the orchestrator's hard rule.

## Test plan

- [x] `pnpm --filter @pagespace/db build && pnpm --filter @pagespace/lib build` (clean)
- [x] `pnpm --filter web typecheck` (clean)
- [x] `pnpm --filter web lint` (only pre-existing `QuickCreatePalette` warning)
- [x] `pnpm --filter web test src/components/tasks src/app/api/tasks` (38 tests passing)
- [ ] Manual: open a task from `/dashboard/tasks`, click **Triggers**, save a due-date trigger, confirm the dialog reads/writes against the same `/api/tasks/[taskId]/triggers` endpoint as the row-level button.
- [ ] Manual: viewer-only user sees neither the **Triggers** button nor the bell badge.
- [ ] Manual: navigate to the source task list page after saving — the row-level bell badge appears (this verifies the dashboard and row-level surfaces share the same trigger state).
- [ ] Manual: edit task status/priority/due-date from the sheet and confirm the displayed value updates immediately (live-task-sync regression check).

## Related

- `tasks/task-list-agent-triggers-followup.md` — section B (Trigger discoverability in TaskDetailSheet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)