### PR TITLE
feat(tasks): instructionPageId + contextPageIds pickers in trigger dialog (T3/5)

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskAgentTriggersDialog.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskAgentTriggersDialog.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { AlertCircle, Bot, Zap } from 'lucide-react';
+import { AlertCircle, Bot, ChevronRight, Zap } from 'lucide-react';
 import { toast } from 'sonner';
 import useSWR, { mutate as globalMutate } from 'swr';
 import {
@@ -23,9 +23,17 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
 import { fetchWithAuth, put, del } from '@/lib/auth/auth-fetch';
 import { useEditingStore } from '@/stores/useEditingStore';
 import { useEditingSession } from '@/stores/useEditingSession';
+import { TriggerPagePicker } from './TriggerPagePicker';
+
+const MAX_CONTEXT_PAGES = 10;
 
 type ApiTriggerType = 'task_due_date' | 'task_completion';
 type UiTriggerType = 'due_date' | 'completion';
@@ -43,6 +51,8 @@ interface TriggerRow {
   isEnabled: boolean;
   lastRunStatus: 'never_run' | 'success' | 'error' | 'running';
   lastRunAt: string | null;
+  instructionPageId: string | null;
+  contextPageIds: string[] | null;
 }
 
 interface TaskAgentTriggersDialogProps {
@@ -90,9 +100,17 @@ interface SectionState {
   enabled: boolean;
   agentPageId: string;
   prompt: string;
+  instructionPageId: string | null;
+  contextPageIds: string[];
 }
 
-const EMPTY_SECTION: SectionState = { enabled: false, agentPageId: '', prompt: '' };
+const EMPTY_SECTION: SectionState = {
+  enabled: false,
+  agentPageId: '',
+  prompt: '',
+  instructionPageId: null,
+  contextPageIds: [],
+};
 
 export function TaskAgentTriggersDialog({
   open,
@@ -164,6 +182,8 @@ export function TaskAgentTriggersDialog({
         enabled: row.isEnabled,
         agentPageId: row.agentPageId,
         prompt: row.prompt ?? '',
+        instructionPageId: row.instructionPageId ?? null,
+        contextPageIds: row.contextPageIds ?? [],
       };
     }
     setSections(next);
@@ -194,6 +214,8 @@ export function TaskAgentTriggersDialog({
         triggerType: type,
         agentPageId: section.agentPageId,
         prompt: section.prompt.trim(),
+        instructionPageId: section.instructionPageId,
+        contextPageIds: section.contextPageIds,
       });
       await refetchTriggers();
       await globalMutate(`/api/pages/${pageId}/tasks`);
@@ -310,6 +332,55 @@ export function TaskAgentTriggersDialog({
                           rows={3}
                         />
                       </div>
+
+                      <Collapsible>
+                        <CollapsibleTrigger asChild>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="h-7 -ml-2 px-2 text-xs text-muted-foreground hover:text-foreground group"
+                          >
+                            <ChevronRight className="mr-1 h-3.5 w-3.5 transition-transform group-data-[state=open]:rotate-90" />
+                            Advanced
+                            {(section.instructionPageId || section.contextPageIds.length > 0) && (
+                              <span className="ml-1.5 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium">
+                                {(section.instructionPageId ? 1 : 0) + section.contextPageIds.length}
+                              </span>
+                            )}
+                          </Button>
+                        </CollapsibleTrigger>
+                        <CollapsibleContent className="space-y-3 pt-2">
+                          <div className="space-y-2">
+                            <Label className="text-xs">Instruction page</Label>
+                            <p className="text-xs text-muted-foreground">
+                              When set, the page&apos;s body becomes the agent&apos;s instructions when the trigger fires.
+                            </p>
+                            <TriggerPagePicker
+                              mode="single"
+                              driveId={driveId}
+                              value={section.instructionPageId}
+                              onChange={(id) => updateSection(ui, { instructionPageId: id })}
+                              placeholder="Pick an instruction page…"
+                            />
+                          </div>
+
+                          <div className="space-y-2">
+                            <Label className="text-xs">Context pages</Label>
+                            <p className="text-xs text-muted-foreground">
+                              Additional pages the agent can read for context (max {MAX_CONTEXT_PAGES}).
+                            </p>
+                            <TriggerPagePicker
+                              mode="multi"
+                              driveId={driveId}
+                              value={section.contextPageIds}
+                              onChange={(ids) => updateSection(ui, { contextPageIds: ids })}
+                              placeholder="Add context pages…"
+                              max={MAX_CONTEXT_PAGES}
+                            />
+                          </div>
+                        </CollapsibleContent>
+                      </Collapsible>
 
                       {existing?.lastRunStatus && existing.lastRunStatus !== 'never_run' && (
                         <p className={statusToneClass(existing.lastRunStatus)}>

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TriggerPagePicker.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TriggerPagePicker.tsx
@@ -18,6 +18,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { useDebounce } from '@/hooks/useDebounce';
 import { cn } from '@/lib/utils';
 
 interface PageSuggestion {
@@ -74,14 +75,16 @@ export function TriggerPagePicker(props: Props) {
   const { driveId, mode, placeholder, disabled } = props;
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
+  const debouncedQuery = useDebounce(query, 200);
 
   const searchKey = open && driveId
-    ? `/api/mentions/search?q=${encodeURIComponent(query)}&driveId=${driveId}&types=page`
+    ? `/api/mentions/search?q=${encodeURIComponent(debouncedQuery)}&driveId=${driveId}&types=page`
     : null;
-  const { data: results = [], isLoading: searching } = useSWR(searchKey, searchFetcher, {
+  const { data: results = [], isLoading } = useSWR(searchKey, searchFetcher, {
     revalidateOnFocus: false,
     keepPreviousData: true,
   });
+  const searching = isLoading || query !== debouncedQuery;
 
   const selectedIds = useMemo(
     () => new Set(mode === 'multi' ? props.value : props.value ? [props.value] : []),

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TriggerPagePicker.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TriggerPagePicker.tsx
@@ -65,7 +65,6 @@ type Props = SingleProps | MultiProps;
 function PageLabel({ pageId }: { pageId: string }) {
   const { data, error } = useSWR(`/api/pages/${pageId}`, pageFetcher, {
     revalidateOnFocus: false,
-    shouldRetryOnError: false,
   });
   if (error) return <span className="text-destructive">unavailable</span>;
   return <span className="truncate">{data?.title ?? '…'}</span>;

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TriggerPagePicker.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TriggerPagePicker.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import useSWR from 'swr';
+import { Check, ChevronDown, FileText, X } from 'lucide-react';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { cn } from '@/lib/utils';
+
+interface PageSuggestion {
+  id: string;
+  label: string;
+  type: 'page' | 'user';
+  description?: string;
+}
+
+const searchFetcher = async (url: string): Promise<PageSuggestion[]> => {
+  const res = await fetchWithAuth(url);
+  if (!res.ok) throw new Error('Failed to search pages');
+  const json: unknown = await res.json();
+  return Array.isArray(json) ? (json as PageSuggestion[]) : [];
+};
+
+const pageFetcher = async (url: string): Promise<{ id: string; title: string | null }> => {
+  const res = await fetchWithAuth(url);
+  if (!res.ok) throw new Error('Failed to fetch page');
+  return res.json();
+};
+
+interface SingleProps {
+  driveId: string;
+  mode: 'single';
+  value: string | null;
+  onChange: (id: string | null) => void;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+interface MultiProps {
+  driveId: string;
+  mode: 'multi';
+  value: string[];
+  onChange: (ids: string[]) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  max?: number;
+}
+
+type Props = SingleProps | MultiProps;
+
+function PageLabel({ pageId }: { pageId: string }) {
+  const { data, error } = useSWR(`/api/pages/${pageId}`, pageFetcher, {
+    revalidateOnFocus: false,
+    shouldRetryOnError: false,
+  });
+  if (error) return <span className="text-destructive">unavailable</span>;
+  return <span className="truncate">{data?.title ?? '…'}</span>;
+}
+
+export function TriggerPagePicker(props: Props) {
+  const { driveId, mode, placeholder, disabled } = props;
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+
+  const searchKey = open && driveId
+    ? `/api/mentions/search?q=${encodeURIComponent(query)}&driveId=${driveId}&types=page`
+    : null;
+  const { data: results = [], isLoading: searching } = useSWR(searchKey, searchFetcher, {
+    revalidateOnFocus: false,
+    keepPreviousData: true,
+  });
+
+  const selectedIds = useMemo(
+    () => new Set(mode === 'multi' ? props.value : props.value ? [props.value] : []),
+    [mode, props.value],
+  );
+
+  useEffect(() => {
+    if (!open) setQuery('');
+  }, [open]);
+
+  const handleSelect = (id: string) => {
+    if (mode === 'single') {
+      props.onChange(id === props.value ? null : id);
+      setOpen(false);
+      return;
+    }
+    const next = props.value.includes(id)
+      ? props.value.filter((x) => x !== id)
+      : [...props.value, id];
+    if (props.max && next.length > props.max) return;
+    props.onChange(next);
+  };
+
+  const handleRemove = (id: string) => {
+    if (mode === 'single') {
+      props.onChange(null);
+    } else {
+      props.onChange(props.value.filter((x) => x !== id));
+    }
+  };
+
+  const triggerLabel =
+    mode === 'single'
+      ? props.value
+        ? <PageLabel pageId={props.value} />
+        : <span className="text-muted-foreground">{placeholder ?? 'Select a page…'}</span>
+      : <span className="text-muted-foreground">{placeholder ?? 'Add pages…'}</span>;
+
+  const atMax = mode === 'multi' && props.max !== undefined && props.value.length >= props.max;
+
+  return (
+    <div className="space-y-2">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild disabled={disabled}>
+          <Button
+            type="button"
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            className={cn(
+              'w-full justify-between font-normal',
+              disabled && 'pointer-events-none opacity-60',
+            )}
+          >
+            <span className="flex min-w-0 items-center gap-2">
+              <FileText className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+              {triggerLabel}
+            </span>
+            <ChevronDown className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          className="w-[var(--radix-popover-trigger-width)] p-0"
+          align="start"
+        >
+          <Command shouldFilter={false}>
+            <CommandInput
+              placeholder="Search pages…"
+              value={query}
+              onValueChange={setQuery}
+            />
+            <CommandList>
+              <CommandEmpty>
+                {searching ? 'Searching…' : 'No pages found.'}
+              </CommandEmpty>
+              {results
+                .filter((r) => r.type === 'page')
+                .map((page) => {
+                  const isSelected = selectedIds.has(page.id);
+                  const blocked = !isSelected && atMax;
+                  return (
+                    <CommandItem
+                      key={page.id}
+                      value={page.id}
+                      disabled={blocked}
+                      onSelect={() => !blocked && handleSelect(page.id)}
+                      className={cn(blocked && 'opacity-50')}
+                    >
+                      <FileText className="mr-2 h-3.5 w-3.5 text-muted-foreground" />
+                      <div className="flex min-w-0 flex-1 flex-col">
+                        <span className="truncate text-sm">{page.label}</span>
+                        {page.description && (
+                          <span className="truncate text-xs text-muted-foreground">
+                            {page.description}
+                          </span>
+                        )}
+                      </div>
+                      {isSelected && <Check className="ml-2 h-4 w-4" />}
+                    </CommandItem>
+                  );
+                })}
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+
+      {mode === 'multi' && props.value.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {props.value.map((id) => (
+            <Badge
+              key={id}
+              variant="secondary"
+              className="max-w-[14rem] gap-1 pr-1"
+            >
+              <PageLabel pageId={id} />
+              <button
+                type="button"
+                onClick={() => handleRemove(id)}
+                disabled={disabled}
+                className="ml-1 rounded p-0.5 hover:bg-muted-foreground/10"
+                aria-label="Remove page"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          ))}
+          {props.max !== undefined && (
+            <span className="text-xs text-muted-foreground self-center">
+              {props.value.length} / {props.max}
+            </span>
+          )}
+        </div>
+      )}
+
+      {mode === 'single' && props.value && (
+        <div className="flex">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-6 px-2 text-xs text-muted-foreground"
+            onClick={() => handleRemove(props.value!)}
+            disabled={disabled}
+          >
+            Clear
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TriggerPagePicker.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TriggerPagePicker.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import useSWR from 'swr';
 import { Check, ChevronDown, FileText, X } from 'lucide-react';
 import {
@@ -19,6 +19,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useDebounce } from '@/hooks/useDebounce';
+import { useEditingStore } from '@/stores/useEditingStore';
 import { cn } from '@/lib/utils';
 
 interface PageSuggestion {
@@ -62,9 +63,28 @@ interface MultiProps {
 
 type Props = SingleProps | MultiProps;
 
+// Selection state is fully owned by the parent (TaskAgentTriggersDialog) through
+// the props.value / onChange contract — this picker has no internal selection state
+// that a remote refetch could clobber. The two SWRs below (searchFetcher, pageFetcher)
+// are read-only display: they fetch search results and chip titles, but neither writes
+// back to selection. The hasLoadedRef + isPaused gates still apply so the chip label
+// and the search list don't flicker mid-edit when an editing session is active, mirroring
+// the contract the dialog uses for its own triggers/agents SWRs (see useEditingSession).
+// No dedicated "remote refetch must not clobber selection" test is added because the
+// data flow makes that property structural rather than behavioural.
+
 function PageLabel({ pageId }: { pageId: string }) {
+  // Pause background revalidation while any editing session is active so a remote
+  // task_updated broadcast cannot refetch and clobber the chip label mid-edit.
+  // Initial load is unaffected because pageLoadedRef gates the pause until first success.
+  const isAnyActive = useEditingStore((s) => s.isAnyActive());
+  const pageLoadedRef = useRef(false);
   const { data, error } = useSWR(`/api/pages/${pageId}`, pageFetcher, {
     revalidateOnFocus: false,
+    isPaused: () => pageLoadedRef.current && isAnyActive,
+    onSuccess: () => {
+      pageLoadedRef.current = true;
+    },
   });
   if (error) return <span className="text-destructive">unavailable</span>;
   return <span className="truncate">{data?.title ?? '…'}</span>;
@@ -76,12 +96,20 @@ export function TriggerPagePicker(props: Props) {
   const [query, setQuery] = useState('');
   const debouncedQuery = useDebounce(query, 200);
 
+  // Same pause-while-editing contract as PageLabel — see comment there for rationale.
+  const isAnyActive = useEditingStore((s) => s.isAnyActive());
+  const searchLoadedRef = useRef(false);
+
   const searchKey = open && driveId
     ? `/api/mentions/search?q=${encodeURIComponent(debouncedQuery)}&driveId=${driveId}&types=page`
     : null;
   const { data: results = [], isLoading } = useSWR(searchKey, searchFetcher, {
     revalidateOnFocus: false,
     keepPreviousData: true,
+    isPaused: () => searchLoadedRef.current && isAnyActive,
+    onSuccess: () => {
+      searchLoadedRef.current = true;
+    },
   });
   const searching = isLoading || query !== debouncedQuery;
 


### PR DESCRIPTION
## Summary
Closes the agent-parity gap on the per-task agent-trigger dialog: humans clicking **Agent triggers…** on a Task List row now have access to the same `instructionPageId` and `contextPageIds` knobs that agents already get via `update_task`'s `agentTrigger` Zod schema.

## Why
Phase 3 of [`tasks/task-list-agent-triggers-followup.md`](../blob/master/tasks/task-list-agent-triggers-followup.md) ("Agent parity in trigger dialog"). The PR #1177 dialog only exposed `agentPageId` + `prompt`. The PUT `/api/tasks/[taskId]/triggers` schema, the trigger helper, and the workflows table all already accept and persist `instructionPageId` + `contextPageIds` — the values were simply hidden from the UI, leaving humans strictly less powerful than agents on the same surface. Agent-created triggers were also unreadable in the dialog: opening one wiped them on save.

This PR is pure UI plumbing — no route, helper, schema, or wire-shape changes.

## What changed

### `TaskAgentTriggersDialog.tsx`
- `SectionState` extended with `instructionPageId: string | null` and `contextPageIds: string[]`; `EMPTY_SECTION` updated to match.
- GET hydration reads both new fields off the workflow row (the GET handler already returns the full row via `db.select().from(workflows)`).
- PUT body sends both fields on every save — including when the user only edited the prompt, so agent-set values are preserved through human edits.
- New **Advanced** `Collapsible` per pane (closed by default), placed directly below the prompt textarea. The trigger button shows a small count badge when advanced fields are set, so users see configuration at a glance without expanding.
- Inside the Collapsible:
  - **Instruction page** — single-page picker. When set, the page's body becomes the agent's instructions when the trigger fires (matches the existing helper contract).
  - **Context pages** — multi-page picker, hard-capped at 10 (matches the route's `z.array(z.string()).max(10)`).

### `TriggerPagePicker.tsx` (new)
Small lightweight component, scoped colocated next to the dialog:
- Popover + cmdk `Command` + `Badge` UI; same pattern as `MultiAssigneeSelect.tsx` already in this folder.
- Discriminated props: `mode: 'single'` (returns `id | null`) or `mode: 'multi'` (returns `string[]`, optional `max`).
- Drive-scoped search via `/api/mentions/search?driveId=…&types=page` — inherits the existing route's drive-membership gate, so we cannot accidentally pick context pages from another drive.
- Search input is debounced at 200ms via the existing `useDebounce` hook; the empty-state copy treats *(isLoading || query !== debouncedQuery)* as "searching" so users get immediate feedback between keystroke and request.
- Selected page IDs render as labelled badges; titles resolve through `/api/pages/[pageId]` so previously-saved IDs display correctly without first searching for them.
- **Same isPaused / hasLoadedRef contract as the dialog's SWRs** (T1, #1184): both the chip-title fetch (`PageLabel`) and the search fetch defer background revalidation while a `useEditingStore` session is active, so chip labels and the result list don't flicker mid-edit. Selection state itself is owned by the parent through `props.value` / `onChange` — the picker has no internal selection SWR — so a "remote refetch cannot clobber selection" property is structural, documented in a header comment in lieu of a dedicated test.

## Out of scope (intentional)
- **Prompt-required validation is unchanged.** T4 ("prompt optional when `instructionPageId` is set") is the next stacked PR — keeping it separate so review can focus on UI plumbing here and validation logic there.
- No edits to `apps/web/src/app/api/tasks/[taskId]/triggers/route.ts`, `task-trigger-helpers.ts`, the workflows schema, or the GET response shape.

## Stacking
Branch is rebased onto current `master` after T1 (#1184) merged at `e8a755910`. The rebase preserved both T1's hardening and this PR's plumbing — see `2fd067ec` for the merged dialog and `da1722c7` for the picker-side extension of the `isPaused` pattern.

## Test plan
- [x] `pnpm --filter @pagespace/db build && pnpm --filter @pagespace/lib build` — clean
- [x] `pnpm --filter web typecheck` — clean
- [x] `pnpm --filter web lint` — clean except the pre-existing `QuickCreatePalette` `useCallback` warning (unchanged by this PR)
- [x] `vitest run` on `src/app/api/tasks` (route + mcp-scope + triggers) and `src/components/layout/middle-content/page-views/task-list` (T1's `TaskAgentTriggersDialog.test.tsx` editing-store contract) — **41/41 pass**
- [x] CI green on the rebased branch (run 25227900723): Unit Tests + Lint & TypeScript Check both SUCCESS
- [ ] Manual UX (reviewer): create a trigger via `update_task` with `instructionPageId` + 2 `contextPageIds`; open the per-task dialog; confirm Advanced badge reads `3`; expand and verify both fields hydrate; clear instruction page, save, reopen — confirm it reflects; remove a context page; save; reopen
- [ ] Manual UX: due-date pane and completion pane behave independently (e.g. setting an instruction page on the completion pane does not bleed onto the due-date pane)
- [ ] Manual UX: try to add an 11th context page — confirm picker blocks selection at the cap
- [ ] Manual UX: type quickly in the picker search — confirm only one fetch fires after ~200ms idle (debounce)

## Related
- Epic: [`tasks/task-list-agent-triggers-followup.md`](../blob/master/tasks/task-list-agent-triggers-followup.md)
- Builds on: #1184 (T1/5 — plan + polish, including `useEditingSession` + `isPaused` pattern this PR mirrors)
- Followup: T4 — relax dialog `prompt`-required validation to match the helper-level "either prompt or instructionPageId" rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)