### PR TITLE
fix(navbar): all favorites reachable in drive switcher

### DIFF
--- a/apps/web/src/components/layout/navbar/DriveSwitcher.tsx
+++ b/apps/web/src/components/layout/navbar/DriveSwitcher.tsx
@@ -163,13 +163,13 @@ export default function DriveSwitcher() {
 
           <DropdownMenuSeparator />
 
-          <CustomScrollArea className="max-h-[320px] overflow-x-hidden">
-            {/* Favorites Section */}
-            {favoriteDrives.length > 0 && (
-              <>
-                <DropdownMenuLabel className="text-[10px] uppercase tracking-widest text-muted-foreground/60 px-2 py-1.5">
-                  Favorites
-                </DropdownMenuLabel>
+          {/* Favorites Section */}
+          {favoriteDrives.length > 0 && (
+            <>
+              <DropdownMenuLabel className="text-[10px] uppercase tracking-widest text-muted-foreground/60 px-2 py-1.5">
+                Favorites · {favoriteDrives.length}
+              </DropdownMenuLabel>
+              <CustomScrollArea className="max-h-[200px] overflow-x-hidden">
                 <DropdownMenuGroup>
                   {favoriteDrives.map((drive) => (
                     <DriveMenuItem
@@ -182,36 +182,38 @@ export default function DriveSwitcher() {
                     />
                   ))}
                 </DropdownMenuGroup>
-                <DropdownMenuSeparator />
-              </>
-            )}
+              </CustomScrollArea>
+              <DropdownMenuSeparator />
+            </>
+          )}
 
-            {/* Recent Section */}
-            {recentDrives.length > 0 && !searchQuery && (
-              <>
-                <DropdownMenuLabel className="text-[10px] uppercase tracking-widest text-muted-foreground/60 px-2 py-1.5">
-                  Recent
-                </DropdownMenuLabel>
-                <DropdownMenuGroup>
-                  {recentDrives.map((drive) => (
-                    <DriveMenuItem
-                      key={drive.id}
-                      drive={drive}
-                      isActive={drive.id === currentDriveId}
-                      isFavorite={false}
-                      onSelect={() => handleSelectDrive(drive)}
-                      onToggleFavorite={(e) => handleToggleFavorite(e, drive)}
-                    />
-                  ))}
-                </DropdownMenuGroup>
-                <DropdownMenuSeparator />
-              </>
-            )}
+          {/* Recent Section */}
+          {recentDrives.length > 0 && !searchQuery && (
+            <>
+              <DropdownMenuLabel className="text-[10px] uppercase tracking-widest text-muted-foreground/60 px-2 py-1.5">
+                Recent
+              </DropdownMenuLabel>
+              <DropdownMenuGroup>
+                {recentDrives.map((drive) => (
+                  <DriveMenuItem
+                    key={drive.id}
+                    drive={drive}
+                    isActive={drive.id === currentDriveId}
+                    isFavorite={false}
+                    onSelect={() => handleSelectDrive(drive)}
+                    onToggleFavorite={(e) => handleToggleFavorite(e, drive)}
+                  />
+                ))}
+              </DropdownMenuGroup>
+              <DropdownMenuSeparator />
+            </>
+          )}
 
-            {/* All Drives Section */}
-            <DropdownMenuLabel className="text-[10px] uppercase tracking-widest text-muted-foreground/60 px-2 py-1.5">
-              {searchQuery ? "Results" : "All Drives"}
-            </DropdownMenuLabel>
+          {/* All Drives Section */}
+          <DropdownMenuLabel className="text-[10px] uppercase tracking-widest text-muted-foreground/60 px-2 py-1.5">
+            {searchQuery ? "Results" : "All Drives"}
+          </DropdownMenuLabel>
+          <CustomScrollArea className="max-h-[240px] overflow-x-hidden">
             <DropdownMenuGroup>
               {allDrives.length > 0 ? (
                 allDrives.map((drive) => (

--- a/apps/web/src/components/layout/navbar/DriveSwitcher.tsx
+++ b/apps/web/src/components/layout/navbar/DriveSwitcher.tsx
@@ -167,7 +167,7 @@ export default function DriveSwitcher() {
           {favoriteDrives.length > 0 && (
             <>
               <DropdownMenuLabel className="text-[10px] uppercase tracking-widest text-muted-foreground/60 px-2 py-1.5">
-                Favorites · {favoriteDrives.length}
+                Favorites <span aria-hidden>·</span> {favoriteDrives.length}
               </DropdownMenuLabel>
               <CustomScrollArea className="max-h-[200px] overflow-x-hidden">
                 <DropdownMenuGroup>


### PR DESCRIPTION
## Summary
- DriveSwitcher wrapped Favorites + Recent + All Drives in a single `max-h-[320px]` scroll container — users with many favorites had Recent / All Drives clipped, and could not reach all their favorites without pushing the rest off-screen.
- Per-section scroll boundaries: Favorites `max-h-[200px]`, All Drives `max-h-[240px]`; Recent stays unbounded (already capped at 5 in the memo).
- Favorites label gains a count suffix (`Favorites · N`) so users can tell when there is more below the fold.
- Kept the navbar dropdown shape on purpose — `/dashboard/drives` is already the full drive-manager surface, so a center-screen redesign would duplicate that abstraction.

## Test plan
- [ ] Star ~12 drives. Open the navbar drive switcher: Favorites scrolls within its own ~200px ceiling; Recent and All Drives below remain visible without being pushed off-screen.
- [ ] With 0 favorites: Favorites section is hidden; Recent + All Drives behave as before.
- [ ] With 1–3 favorites: no scrollbar appears in Favorites (under the max-h ceiling). Visually identical to today.
- [ ] Search: type a query. Favorites filters in place; Recent hides; All Drives renames to "Results" and scrolls within its own bound.
- [ ] Active drive highlight, star toggle, drive selection, and footer ("All Drives" link, "Create Drive") all still work.
- [ ] Keyboard arrow-key navigation still flows across sections — scroll boundaries do not trap focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)