### PR TITLE
[codex] Include integration tools in workflows

### DIFF
--- a/apps/web/src/lib/workflows/__tests__/workflow-executor.test.ts
+++ b/apps/web/src/lib/workflows/__tests__/workflow-executor.test.ts
@@ -9,10 +9,12 @@ const {
   mockSelectWhere,
   mockSelectFrom,
   mockSelect,
+  mockResolvePageAgentIntegrationTools,
 } = vi.hoisted(() => ({
   mockSelectWhere: vi.fn(),
   mockSelectFrom: vi.fn(),
   mockSelect: vi.fn(),
+  mockResolvePageAgentIntegrationTools: vi.fn(),
 }));
 
 vi.mock('@pagespace/db/db', () => ({
@@ -57,6 +59,10 @@ vi.mock('@/lib/ai/core', () => ({
 
 vi.mock('@/lib/ai/core/message-utils', () => ({
   saveMessageToDatabase: vi.fn(),
+}));
+
+vi.mock('@/lib/ai/core/integration-tool-resolver', () => ({
+  resolvePageAgentIntegrationTools: mockResolvePageAgentIntegrationTools,
 }));
 
 vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
@@ -158,6 +164,7 @@ describe('executeWorkflow', () => {
     vi.resetAllMocks();
     vi.mocked(isProviderError).mockReturnValue(false);
     vi.mocked(createAIProvider).mockResolvedValue(mockProviderResult as never);
+    mockResolvePageAgentIntegrationTools.mockResolvedValue({});
     vi.mocked(generateText).mockResolvedValue({
       text: 'Report complete',
       steps: [{ text: 'Report complete', toolCalls: [{}] }],
@@ -249,6 +256,30 @@ describe('executeWorkflow', () => {
     expect(toolKeys).toContain('list_pages');
     expect(toolKeys).toContain('create_page');
     expect(toolKeys).not.toContain('search_pages');
+  });
+
+  test('merges granted integration tools for workflow agents', async () => {
+    setupSelectChain(
+      [{ ...mockAgent, enabledTools: [] }],
+      [mockDrive],
+    );
+    mockResolvePageAgentIntegrationTools.mockResolvedValue({
+      github_create_issue: { name: 'github_create_issue' },
+    });
+
+    const result = await executeWorkflow(createWorkflowFixture());
+
+    expect(result.success).toBe(true);
+    expect(mockResolvePageAgentIntegrationTools).toHaveBeenCalledWith({
+      agentId: 'agent_1',
+      userId: 'user_123',
+      driveId: 'drive_abc',
+    });
+
+    const genCall = vi.mocked(generateText).mock.calls[0][0] as Record<string, unknown>;
+    expect(genCall.tools).toBeDefined();
+    const toolKeys = Object.keys(genCall.tools as object);
+    expect(toolKeys).toContain('github_create_issue');
   });
 
   test('execution without tools when enabledTools is empty', async () => {

--- a/apps/web/src/lib/workflows/workflow-executor.ts
+++ b/apps/web/src/lib/workflows/workflow-executor.ts
@@ -1,5 +1,6 @@
-import { convertToModelMessages, generateText, stepCountIs, hasToolCall } from 'ai';
+import { convertToModelMessages, generateText, stepCountIs, hasToolCall, type ToolSet } from 'ai';
 import { finishTool, FINISH_TOOL_NAME } from '@/lib/ai/tools/finish-tool';
+import { mergeToolSets } from '@/lib/ai/core/tool-utils';
 import { createId } from '@paralleldrive/cuid2';
 import {
   createAIProvider,
@@ -135,13 +136,39 @@ export async function executeWorkflow(workflow: WorkflowRow): Promise<WorkflowEx
 
     // 6. Filter tools based on agent's enabled tools
     const enabledTools = (agent.enabledTools as string[] | null) ?? [];
-    const availableTools = enabledTools.length > 0
+    let availableTools: ToolSet = enabledTools.length > 0
       ? Object.fromEntries(
           Object.entries(pageSpaceTools).filter(([toolName]) =>
             enabledTools.includes(toolName)
           )
-        )
+        ) as ToolSet
       : {};
+
+    // Workflows execute the same page agent used in chat, so they should also
+    // inherit integration grants such as GitHub/Notion tools.
+    try {
+      const { resolvePageAgentIntegrationTools } = await import('@/lib/ai/core/integration-tool-resolver');
+      const integrationTools = await resolvePageAgentIntegrationTools({
+        agentId: agent.id,
+        userId: workflow.createdBy,
+        driveId: workflow.driveId,
+      });
+
+      if (Object.keys(integrationTools).length > 0) {
+        availableTools = mergeToolSets(availableTools, integrationTools);
+        loggers.api.info('Workflow executor: merged integration tools', {
+          workflowId: workflow.id,
+          agentId: agent.id,
+          integrationToolCount: Object.keys(integrationTools).length,
+          totalTools: Object.keys(availableTools).length,
+        });
+      }
+    } catch (error) {
+      loggers.api.error('Workflow executor: failed to resolve integration tools', error as Error, {
+        workflowId: workflow.id,
+        agentId: agent.id,
+      });
+    }
 
     // 7. Build execution context
     const conversationId = `workflow-${workflow.id}-${Date.now()}`;


### PR DESCRIPTION
## Summary

- Resolve page-agent integration grants inside workflow execution.
- Merge granted external adapter tools, such as GitHub tools, into the AI SDK tool set for scheduled workflows, calendar triggers, and task-list triggers.
- Add a regression test covering integration tools when no built-in tools are enabled.

## Root Cause

Workflow execution filtered only built-in PageSpace tools from `agent.enabledTools`. The chat routes already merged page-agent integration grants, but automated workflow runs skipped that resolver, so external adapter tools were unavailable.

## Validation

- `pnpm --filter web test src/lib/workflows/__tests__/workflow-executor.test.ts src/lib/workflows/__tests__/calendar-trigger-executor.test.ts src/lib/workflows/__tests__/task-trigger-helpers.test.ts`
- `pnpm --filter web typecheck`