### PR TITLE
feat(ai): broadcast user messages so remote viewers see prompts in real time

### DIFF
--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -13,10 +13,14 @@ const {
   mockCreateStreamLifecycle,
   mockLifecyclePushPart,
   mockLifecycleFinish,
+  mockBroadcastChatUserMessage,
+  mockSaveMessageToDatabase,
 } = vi.hoisted(() => ({
   mockCreateStreamLifecycle: vi.fn(),
   mockLifecyclePushPart: vi.fn(),
   mockLifecycleFinish: vi.fn(),
+  mockBroadcastChatUserMessage: vi.fn().mockResolvedValue(undefined),
+  mockSaveMessageToDatabase: vi.fn().mockResolvedValue(undefined),
 }));
 
 interface MockUIStreamOptions {
@@ -40,6 +44,7 @@ vi.mock('@/lib/ai/core/stream-lifecycle', () => ({
 
 vi.mock('@/lib/websocket', () => ({
   broadcastUsageEvent: vi.fn(),
+  broadcastChatUserMessage: mockBroadcastChatUserMessage,
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -131,7 +136,7 @@ vi.mock('@/lib/ai/core', () => ({
   extractMessageContent: vi.fn().mockReturnValue('test content'),
   extractToolCalls: vi.fn().mockReturnValue([]),
   extractToolResults: vi.fn().mockReturnValue([]),
-  saveMessageToDatabase: vi.fn(),
+  saveMessageToDatabase: mockSaveMessageToDatabase,
   sanitizeMessagesForModel: vi.fn().mockReturnValue([]),
   convertDbMessageToUIMessage: vi.fn(),
   processMentionsInMessage: vi.fn().mockReturnValue({ mentions: [], pageIds: [] }),
@@ -339,6 +344,34 @@ describe('POST /api/ai/chat — lifecycle handoff', () => {
         displayName: 'Profile User',
         browserSessionId: 'session-7',
       });
+    });
+  });
+
+  describe('user-message broadcast', () => {
+    it('given a POST with a user message, should broadcast chat:user_message after the DB save resolves with the saved message and full envelope', async () => {
+      await POST(makeRequest({ browserSessionId: 'session-7' }));
+
+      expect(mockBroadcastChatUserMessage).toHaveBeenCalledTimes(1);
+      expect(mockBroadcastChatUserMessage).toHaveBeenCalledWith({
+        message: { id: 'msg_1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] },
+        pageId: 'page-1',
+        conversationId: 'conv-1',
+        triggeredBy: { userId: 'user-1', displayName: 'Profile User', browserSessionId: 'session-7' },
+      });
+    });
+
+    it('given the user-message DB save rejects, should NOT broadcast chat:user_message', async () => {
+      mockSaveMessageToDatabase.mockRejectedValueOnce(new Error('db down'));
+
+      await POST(makeRequest());
+
+      expect(mockBroadcastChatUserMessage).not.toHaveBeenCalled();
+    });
+
+    it('given broadcastChatUserMessage rejects, should not block the request', async () => {
+      mockBroadcastChatUserMessage.mockRejectedValueOnce(new Error('socket dead'));
+
+      await expect(POST(makeRequest())).resolves.toBeDefined();
     });
   });
 

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -16,7 +16,7 @@ import { mergeToolSets } from '@/lib/ai/core/tool-utils';
 import { finishTool, FINISH_TOOL_NAME } from '@/lib/ai/tools/finish-tool';
 import { incrementUsage, getCurrentUsage, getUserUsageSummary } from '@/lib/subscription/usage-service';
 import { requiresProSubscription, createRateLimitResponse } from '@/lib/subscription/rate-limit-middleware';
-import { broadcastUsageEvent } from '@/lib/websocket';
+import { broadcastUsageEvent, broadcastChatUserMessage } from '@/lib/websocket';
 import { createStreamLifecycle, type StreamLifecycleHandle } from '@/lib/ai/core/stream-lifecycle';
 import { chunkToPart } from '@/lib/ai/streams/chunkToPart';
 import { validateBrowserSessionIdHeader } from '@/lib/ai/core/browser-session-id-validation';
@@ -824,6 +824,15 @@ export async function POST(request: Request) {
 
     const [userProfile] = await userProfilePromise;
     const displayName = userProfile?.displayName ?? user?.name ?? 'Someone';
+
+    if (userMessage && userMessage.role === 'user') {
+      broadcastChatUserMessage({
+        message: userMessage,
+        pageId: chatId,
+        conversationId: conversationId!,
+        triggeredBy: { userId: userId!, displayName, browserSessionId },
+      }).catch(() => {});
+    }
 
     lifecycle = await createStreamLifecycle({
       messageId: serverAssistantMessageId,

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
@@ -12,10 +12,14 @@ const {
   mockCreateStreamLifecycle,
   mockLifecyclePushPart,
   mockLifecycleFinish,
+  mockBroadcastChatUserMessage,
+  mockSaveGlobalAssistantMessageToDatabase,
 } = vi.hoisted(() => ({
   mockCreateStreamLifecycle: vi.fn(),
   mockLifecyclePushPart: vi.fn(),
   mockLifecycleFinish: vi.fn(),
+  mockBroadcastChatUserMessage: vi.fn().mockResolvedValue(undefined),
+  mockSaveGlobalAssistantMessageToDatabase: vi.fn().mockResolvedValue(undefined),
 }));
 
 interface MockUIStreamOptions {
@@ -39,6 +43,7 @@ vi.mock('@/lib/ai/core/stream-lifecycle', () => ({
 
 vi.mock('@/lib/websocket', () => ({
   broadcastUsageEvent: vi.fn().mockResolvedValue(undefined),
+  broadcastChatUserMessage: mockBroadcastChatUserMessage,
 }));
 
 vi.mock('@/lib/auth', () => ({
@@ -155,7 +160,7 @@ vi.mock('@/lib/ai/core', () => ({
   extractToolResults: vi.fn().mockReturnValue([]),
   sanitizeMessagesForModel: vi.fn().mockReturnValue([]),
   convertGlobalAssistantMessageToUIMessage: vi.fn(),
-  saveGlobalAssistantMessageToDatabase: vi.fn().mockResolvedValue(undefined),
+  saveGlobalAssistantMessageToDatabase: mockSaveGlobalAssistantMessageToDatabase,
   processMentionsInMessage: vi.fn().mockReturnValue({ mentions: [], pageIds: [] }),
   buildMentionSystemPrompt: vi.fn().mockReturnValue(''),
   buildTimestampSystemPrompt: vi.fn().mockReturnValue(''),
@@ -393,6 +398,41 @@ describe('POST /api/ai/global/[id]/messages — lifecycle handoff', () => {
       expect(mockCreateStreamLifecycle).toHaveBeenCalledWith(
         expect.objectContaining({ displayName: 'Auth User' }),
       );
+    });
+  });
+
+  describe('user-message broadcast', () => {
+    it('given a POST with a user message, should broadcast chat:user_message routed to the per-user global channel', async () => {
+      await POST(makeRequest({ browserSessionId: 'session-y' }), makeContext());
+
+      expect(mockBroadcastChatUserMessage).toHaveBeenCalledTimes(1);
+      // displayName resolution is covered by its own test; here we lock the
+      // routing fields and the saved-message passthrough.
+      expect(mockBroadcastChatUserMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: { id: 'msg_1', role: 'user', parts: [{ type: 'text', text: 'Hello' }] },
+          pageId: 'user:user-1:global',
+          conversationId: 'conv-1',
+          triggeredBy: expect.objectContaining({
+            userId: 'user-1',
+            browserSessionId: 'session-y',
+          }),
+        }),
+      );
+    });
+
+    it('given the user-message DB save rejects, should NOT broadcast chat:user_message', async () => {
+      mockSaveGlobalAssistantMessageToDatabase.mockRejectedValueOnce(new Error('db down'));
+
+      await POST(makeRequest(), makeContext());
+
+      expect(mockBroadcastChatUserMessage).not.toHaveBeenCalled();
+    });
+
+    it('given broadcastChatUserMessage rejects, should not block the request', async () => {
+      mockBroadcastChatUserMessage.mockRejectedValueOnce(new Error('socket dead'));
+
+      await expect(POST(makeRequest(), makeContext())).resolves.toBeDefined();
     });
   });
 

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -5,7 +5,7 @@ import { getPageSpaceModelTier } from '@/lib/ai/core/ai-providers-config';
 import { mergeToolSets } from '@/lib/ai/core/tool-utils';
 import { incrementUsage, getCurrentUsage, getUserUsageSummary } from '@/lib/subscription/usage-service';
 import { createRateLimitResponse } from '@/lib/subscription/rate-limit-middleware';
-import { broadcastUsageEvent } from '@/lib/websocket';
+import { broadcastUsageEvent, broadcastChatUserMessage } from '@/lib/websocket';
 import { createStreamLifecycle, type StreamLifecycleHandle } from '@/lib/ai/core/stream-lifecycle';
 import { chunkToPart } from '@/lib/ai/streams/chunkToPart';
 import { validateBrowserSessionIdHeader } from '@/lib/ai/core/browser-session-id-validation';
@@ -851,6 +851,15 @@ MENTION PROCESSING:
     const authUserName = authUserResult.status === 'fulfilled' ? authUserResult.value[0]?.name ?? null : null;
     const profileDisplayName = profileResult.status === 'fulfilled' ? profileResult.value[0]?.displayName ?? null : null;
     const displayName = profileDisplayName ?? authUserName ?? 'Someone';
+
+    if (userMessage && userMessage.role === 'user') {
+      broadcastChatUserMessage({
+        message: userMessage,
+        pageId: channelId,
+        conversationId,
+        triggeredBy: { userId, displayName, browserSessionId },
+      }).catch(() => {});
+    }
 
     lifecycle = await createStreamLifecycle({
       messageId: serverAssistantMessageId,

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -344,6 +344,10 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
 
   usePageSocketRoom(page.id);
   useChannelStreamSocket(page.id, {
+    onUserMessage: (message, payload) => {
+      if (payload.conversationId !== currentConversationId) return;
+      setMessages((prev) => (prev.some((m) => m.id === message.id) ? prev : [...prev, message]));
+    },
     onStreamComplete: (messageId) => {
       const stream = usePendingStreamsStore.getState().streams.get(messageId);
       if (!stream || stream.parts.length === 0) return;

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
@@ -753,6 +753,135 @@ describe('AiChatView late-joiner conversation sync', () => {
   });
 });
 
+describe('AiChatView remote user-message broadcast', () => {
+  const page = makePage();
+
+  type UserMsgCallback = (
+    msg: { id: string; role: string; parts: unknown[] },
+    payload: { conversationId: string },
+  ) => void;
+
+  const captureCallback = () => {
+    let captured: UserMsgCallback | undefined;
+    vi.mocked(useChannelStreamSocket).mockImplementation((_pageId, opts) => {
+      captured = opts?.onUserMessage as UserMsgCallback | undefined;
+    });
+    return () => captured;
+  };
+
+  const setupExistingConversation = (testMessages: { id: string; role: string }[] = []) => {
+    mockFetchWithAuth.mockImplementation(async (url: string, opts?: { method?: string }) => {
+      if (url === PERMISSIONS_URL) return makeOkResponse({ canEdit: true });
+      if (url === AGENT_CONFIG_URL) return makeOkResponse({});
+      if (url === `${CONVERSATIONS_URL}?pageSize=1` && !opts?.method) {
+        return makeOkResponse({ conversations: [existingConversation] });
+      }
+      if (url === MESSAGES_URL && !opts?.method) {
+        return makeOkResponse({ messages: testMessages });
+      }
+      return makeErrorResponse();
+    });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('given onUserMessage fires with conversationId matching the active conversation, should append the message', async () => {
+    const getCb = captureCallback();
+    setupExistingConversation([]);
+    render(<AiChatView page={page} />);
+
+    await waitFor(() => {
+      assert({
+        given: 'init with existing conversation',
+        should: 'load conversation messages',
+        actual: wasGetCalled(MESSAGES_URL),
+        expected: true,
+      });
+    });
+
+    const userMsg = { id: 'msg-from-alice', role: 'user' as const, parts: [{ type: 'text', text: 'hi from Alice' }] };
+    act(() => {
+      getCb()?.(userMsg, { conversationId: CONV_ID });
+    });
+
+    assert({
+      given: 'a remote user-message event for the active conversation',
+      should: 'append it to messages via setMessages',
+      actual: mockSetMessages.mock.calls.some((args) => typeof args[0] === 'function'),
+      expected: true,
+    });
+  });
+
+  test('given onUserMessage fires for a conversationId different from the current one, should NOT append', async () => {
+    const getCb = captureCallback();
+    setupExistingConversation([]);
+    render(<AiChatView page={page} />);
+
+    await waitFor(() => {
+      assert({
+        given: 'init with existing conversation',
+        should: 'load conversation messages',
+        actual: wasGetCalled(MESSAGES_URL),
+        expected: true,
+      });
+    });
+
+    const callsBefore = mockSetMessages.mock.calls.filter((a) => typeof a[0] === 'function').length;
+    const userMsg = { id: 'msg-from-other-conv', role: 'user' as const, parts: [{ type: 'text', text: 'wrong conv' }] };
+    act(() => {
+      getCb()?.(userMsg, { conversationId: 'different-conv-id' });
+    });
+
+    const callsAfter = mockSetMessages.mock.calls.filter((a) => typeof a[0] === 'function').length;
+    assert({
+      given: 'a remote user-message event for a different conversation',
+      should: 'NOT append (no functional setMessages call added)',
+      actual: callsAfter,
+      expected: callsBefore,
+    });
+  });
+
+  test('given onUserMessage fires with a messageId already present in messages, should NOT append a duplicate', async () => {
+    const getCb = captureCallback();
+    const existingMsg = { id: 'msg-already-there', role: 'user' as const, parts: [{ type: 'text', text: 'duplicate' }] };
+    setupExistingConversation([existingMsg]);
+    render(<AiChatView page={page} />);
+
+    await waitFor(() => {
+      assert({
+        given: 'init with existing conversation that includes the message',
+        should: 'load conversation messages',
+        actual: wasGetCalled(MESSAGES_URL),
+        expected: true,
+      });
+    });
+
+    const callsBefore = mockSetMessages.mock.calls.filter((a) => typeof a[0] === 'function').length;
+    act(() => {
+      getCb()?.(existingMsg, { conversationId: CONV_ID });
+    });
+    // The handler may invoke setMessages with an updater that returns prev unchanged;
+    // verify the resulting messages array has no duplicate.
+    const allFunctional = mockSetMessages.mock.calls
+      .slice(callsBefore)
+      .filter((a) => typeof a[0] === 'function')
+      .map((a) => (a[0] as (prev: unknown[]) => unknown[])([existingMsg]));
+
+    const noDup = allFunctional.every(
+      (next) => (next as Array<{ id: string }>).filter((m) => m.id === existingMsg.id).length === 1,
+    );
+
+    assert({
+      given: 'a remote user-message event whose messageId is already in messages',
+      should: 'leave the array with a single copy of that messageId',
+      actual: noDup,
+      expected: true,
+    });
+  });
+});
+
 describe('AiChatView stop button for reconnected own streams', () => {
   const page = makePage();
 

--- a/apps/web/src/contexts/GlobalChatContext.tsx
+++ b/apps/web/src/contexts/GlobalChatContext.tsx
@@ -274,6 +274,10 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
   refreshConversationRef.current = refreshConversation;
 
   useChannelStreamSocket(channelId, {
+    onUserMessage: (message, payload) => {
+      if (payload.conversationId !== currentConversationId) return;
+      setMessages((prev) => (prev.some((m) => m.id === message.id) ? prev : [...prev, message]));
+    },
     onStreamComplete: () => {
       refreshConversationRef.current();
     },

--- a/apps/web/src/contexts/__tests__/GlobalChatContext.test.tsx
+++ b/apps/web/src/contexts/__tests__/GlobalChatContext.test.tsx
@@ -550,6 +550,49 @@ describe('GlobalChatProvider — global channel stream socket', () => {
     });
   });
 
+  // remote user-message broadcast
+  it('given chat:user_message from another browser session for the active conversation, should append the message to context messages', async () => {
+    const { result } = renderHook(() => useGlobalChat(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.currentConversationId).toBe(CONV_ID));
+    await waitFor(() => expect(mockSocket._handlerCount('chat:user_message')).toBeGreaterThan(0));
+
+    const remoteUser = {
+      id: 'msg-remote-user',
+      role: 'user' as const,
+      parts: [{ type: 'text' as const, text: 'remote prompt' }],
+    };
+    act(() => {
+      mockSocket._trigger('chat:user_message', {
+        message: remoteUser,
+        pageId: GLOBAL_CHANNEL_ID,
+        conversationId: CONV_ID,
+        triggeredBy: { userId: USER_ID, displayName: 'Me-otherTab', browserSessionId: SESSION_ID_REMOTE },
+      });
+    });
+
+    expect(result.current.messages.find((m) => m.id === 'msg-remote-user')).toEqual(remoteUser);
+  });
+
+  it('given chat:user_message for a different conversation, should NOT append', async () => {
+    const { result } = renderHook(() => useGlobalChat(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.currentConversationId).toBe(CONV_ID));
+    await waitFor(() => expect(mockSocket._handlerCount('chat:user_message')).toBeGreaterThan(0));
+
+    const before = result.current.messages.length;
+    act(() => {
+      mockSocket._trigger('chat:user_message', {
+        message: { id: 'msg-stale', role: 'user', parts: [{ type: 'text', text: 'wrong conv' }] },
+        pageId: GLOBAL_CHANNEL_ID,
+        conversationId: 'conv-different',
+        triggeredBy: { userId: USER_ID, displayName: 'Me-otherTab', browserSessionId: SESSION_ID_REMOTE },
+      });
+    });
+
+    expect(result.current.messages.length).toBe(before);
+  });
+
   // AC8 — unmount safety
   it('given the provider unmounts, should abort in-flight SSE controllers and remove socket listeners', async () => {
     let capturedSignal!: AbortSignal;

--- a/apps/web/src/hooks/__tests__/useAgentChannelMultiplayer.test.ts
+++ b/apps/web/src/hooks/__tests__/useAgentChannelMultiplayer.test.ts
@@ -306,6 +306,75 @@ describe('useAgentChannelMultiplayer', () => {
     });
   });
 
+  describe('remote user-message broadcast', () => {
+    it('given onUserMessage fires with conversationId matching the active agent conversation, should append via setLocalMessages', () => {
+      const setLocalMessages = vi.fn();
+      renderWiring(baseOptions({
+        selectedAgent: AGENT,
+        agentConversationId: 'conv-active',
+        setLocalMessages,
+      }));
+
+      const remoteUser = { id: 'u-1', role: 'user' as const, parts: [{ type: 'text' as const, text: 'remote prompt' }] };
+      act(() => {
+        capturedChannel.options?.onUserMessage?.(remoteUser, {
+          message: remoteUser,
+          pageId: AGENT.id,
+          conversationId: 'conv-active',
+          triggeredBy: { userId: 'other', displayName: 'Other', browserSessionId: 'sess-x' },
+        });
+      });
+
+      expect(setLocalMessages).toHaveBeenCalledTimes(1);
+      const updater = setLocalMessages.mock.calls[0][0] as (prev: UIMessage[]) => UIMessage[];
+      expect(updater([])).toEqual([remoteUser]);
+    });
+
+    it('given onUserMessage fires for a different conversationId, should NOT call setLocalMessages', () => {
+      const setLocalMessages = vi.fn();
+      renderWiring(baseOptions({
+        selectedAgent: AGENT,
+        agentConversationId: 'conv-active',
+        setLocalMessages,
+      }));
+
+      const remoteUser = { id: 'u-1', role: 'user' as const, parts: [{ type: 'text' as const, text: 'wrong conv' }] };
+      act(() => {
+        capturedChannel.options?.onUserMessage?.(remoteUser, {
+          message: remoteUser,
+          pageId: AGENT.id,
+          conversationId: 'conv-different',
+          triggeredBy: { userId: 'other', displayName: 'Other', browserSessionId: 'sess-x' },
+        });
+      });
+
+      expect(setLocalMessages).not.toHaveBeenCalled();
+    });
+
+    it('given onUserMessage fires for a messageId already in messages, the updater should leave the array unchanged', () => {
+      const setLocalMessages = vi.fn();
+      renderWiring(baseOptions({
+        selectedAgent: AGENT,
+        agentConversationId: 'conv-active',
+        setLocalMessages,
+      }));
+
+      const remoteUser = { id: 'u-already', role: 'user' as const, parts: [{ type: 'text' as const, text: 'dup' }] };
+      act(() => {
+        capturedChannel.options?.onUserMessage?.(remoteUser, {
+          message: remoteUser,
+          pageId: AGENT.id,
+          conversationId: 'conv-active',
+          triggeredBy: { userId: 'other', displayName: 'Other', browserSessionId: 'sess-x' },
+        });
+      });
+
+      const updater = setLocalMessages.mock.calls[0][0] as (prev: UIMessage[]) => UIMessage[];
+      const prev = [remoteUser];
+      expect(updater(prev)).toBe(prev); // same reference — no append happened
+    });
+  });
+
   describe('reconnect refresh', () => {
     it('given the very first connect, the surface-provided loadConversation should NOT be called (mount-time load already covers it)', () => {
       seedDashboard();

--- a/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
+++ b/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
@@ -89,7 +89,11 @@ vi.mock('@/lib/ai/core/browser-session-id', () => ({
 }));
 
 import { useChannelStreamSocket } from '../useChannelStreamSocket';
-import type { AiStreamStartPayload, AiStreamCompletePayload } from '@/lib/websocket/socket-utils';
+import type {
+  AiStreamStartPayload,
+  AiStreamCompletePayload,
+  ChatUserMessagePayload,
+} from '@/lib/websocket/socket-utils';
 
 const START_PAYLOAD: AiStreamStartPayload = {
   messageId: 'msg-1',
@@ -101,6 +105,13 @@ const START_PAYLOAD: AiStreamStartPayload = {
 const COMPLETE_PAYLOAD: AiStreamCompletePayload = {
   messageId: 'msg-1',
   pageId: 'page-a',
+};
+
+const USER_MESSAGE_PAYLOAD: ChatUserMessagePayload = {
+  message: { id: 'msg-1', role: 'user', parts: [{ type: 'text', text: 'hi' }] },
+  pageId: 'page-a',
+  conversationId: 'conv-1',
+  triggeredBy: { userId: 'user-2', displayName: 'Alice', browserSessionId: SESSION_ID_REMOTE },
 };
 
 describe('useChannelStreamSocket', () => {
@@ -234,6 +245,58 @@ describe('useChannelStreamSocket', () => {
   });
 
   // A1 — pageId guard
+  describe('chat:user_message', () => {
+    it('given a chat:user_message from another user for the current channel, should call onUserMessage with the message payload', () => {
+      const onUserMessage = vi.fn();
+      renderHook(() => useChannelStreamSocket('page-a', { onUserMessage }));
+
+      act(() => { mockSocket._trigger('chat:user_message', USER_MESSAGE_PAYLOAD); });
+
+      expect(onUserMessage).toHaveBeenCalledTimes(1);
+      expect(onUserMessage).toHaveBeenCalledWith(USER_MESSAGE_PAYLOAD.message, USER_MESSAGE_PAYLOAD);
+    });
+
+    it('given chat:user_message with a different pageId, should NOT call onUserMessage (stale-room guard)', () => {
+      const onUserMessage = vi.fn();
+      renderHook(() => useChannelStreamSocket('page-a', { onUserMessage }));
+
+      act(() => {
+        mockSocket._trigger('chat:user_message', { ...USER_MESSAGE_PAYLOAD, pageId: 'page-b' });
+      });
+
+      expect(onUserMessage).not.toHaveBeenCalled();
+    });
+
+    it('given chat:user_message whose triggeredBy.browserSessionId matches the local session, should NOT call onUserMessage (own-tab dedup)', () => {
+      const onUserMessage = vi.fn();
+      renderHook(() => useChannelStreamSocket('page-a', { onUserMessage }));
+
+      act(() => {
+        mockSocket._trigger('chat:user_message', {
+          ...USER_MESSAGE_PAYLOAD,
+          triggeredBy: { ...USER_MESSAGE_PAYLOAD.triggeredBy, browserSessionId: SESSION_ID_LOCAL },
+        });
+      });
+
+      expect(onUserMessage).not.toHaveBeenCalled();
+    });
+
+    it('given the socket reconnects, should keep the chat:user_message handler registered', () => {
+      const onUserMessage = vi.fn();
+      const { rerender } = renderHook(({ id }) => useChannelStreamSocket(id, { onUserMessage }), {
+        initialProps: { id: 'page-a' as string | undefined },
+      });
+
+      // Re-render to a different channel and back — exercises the listener re-registration path.
+      rerender({ id: 'page-b' });
+      rerender({ id: 'page-a' });
+
+      act(() => { mockSocket._trigger('chat:user_message', USER_MESSAGE_PAYLOAD); });
+
+      expect(onUserMessage).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('pageId guard', () => {
     it('given chat:stream_start with a different pageId, should ignore the event', () => {
       renderHook(() => useChannelStreamSocket('page-a'));

--- a/apps/web/src/hooks/useAgentChannelMultiplayer.ts
+++ b/apps/web/src/hooks/useAgentChannelMultiplayer.ts
@@ -90,6 +90,12 @@ export function useAgentChannelMultiplayer({
   }, []);
 
   useChannelStreamSocket(channelId, {
+    onUserMessage: (message, payload) => {
+      if (payload.conversationId !== agentConversationIdRef.current) return;
+      setLocalMessagesRef.current((prev) =>
+        prev.some((m) => m.id === message.id) ? prev : [...prev, message],
+      );
+    },
     onStreamComplete: (messageId) => {
       const stream = usePendingStreamsStore.getState().streams.get(messageId);
       if (!stream || stream.parts.length === 0) return;

--- a/apps/web/src/hooks/useChannelStreamSocket.ts
+++ b/apps/web/src/hooks/useChannelStreamSocket.ts
@@ -6,7 +6,12 @@ import { getBrowserSessionId } from '@/lib/ai/core/browser-session-id';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { isOwnStream } from '@/lib/ai/streams/isOwnStream';
 import { shouldSkipBootstrappedStream } from '@/lib/ai/streams/shouldSkipBootstrappedStream';
-import type { AiStreamStartPayload, AiStreamCompletePayload } from '@/lib/websocket/socket-utils';
+import type {
+  AiStreamStartPayload,
+  AiStreamCompletePayload,
+  ChatUserMessagePayload,
+} from '@/lib/websocket/socket-utils';
+import type { UIMessage } from 'ai';
 
 interface ActiveStreamRow {
   messageId: string;
@@ -21,6 +26,12 @@ export interface UseChannelStreamSocketOptions {
   onOwnStreamBootstrap?: (event: { messageId: string }) => void;
   /** Fires once per own-bootstrapped messageId on any finalize path (resolve, complete, or error). */
   onOwnStreamFinalize?: (event: { messageId: string }) => void;
+  /**
+   * Fires when a remote user submits a message in this channel. Filters out
+   * own-tab broadcasts (the originator's `useChat` already appended) and
+   * stale-room events. Consumers append to their own messages array.
+   */
+  onUserMessage?: (message: UIMessage, payload: ChatUserMessagePayload) => void;
 }
 
 /** Subscribes a component to a channel's AI streaming lifecycle: DB-replay on mount, live socket events, SSE join, store cleanup on unmount. Pass `undefined` channelId to no-op. */
@@ -33,9 +44,11 @@ export function useChannelStreamSocket(
   const onStreamCompleteRef = useRef(options?.onStreamComplete);
   const onOwnStreamBootstrapRef = useRef(options?.onOwnStreamBootstrap);
   const onOwnStreamFinalizeRef = useRef(options?.onOwnStreamFinalize);
+  const onUserMessageRef = useRef(options?.onUserMessage);
   onStreamCompleteRef.current = options?.onStreamComplete;
   onOwnStreamBootstrapRef.current = options?.onOwnStreamBootstrap;
   onOwnStreamFinalizeRef.current = options?.onOwnStreamFinalize;
+  onUserMessageRef.current = options?.onUserMessage;
 
   useEffect(() => {
     if (!socket || !channelId) return;
@@ -165,13 +178,21 @@ export function useChannelStreamSocket(
       }
     };
 
+    const handleUserMessage = (payload: ChatUserMessagePayload) => {
+      if (payload.pageId !== channelId) return;
+      if (isOwnStream(payload.triggeredBy, localBrowserSessionId)) return;
+      onUserMessageRef.current?.(payload.message, payload);
+    };
+
     socket.on('chat:stream_start', handleStreamStart);
     socket.on('chat:stream_complete', handleStreamComplete);
+    socket.on('chat:user_message', handleUserMessage);
 
     return () => {
       cancelled = true;
       socket.off('chat:stream_start', handleStreamStart);
       socket.off('chat:stream_complete', handleStreamComplete);
+      socket.off('chat:user_message', handleUserMessage);
       for (const controller of controllers.values()) {
         controller.abort();
       }

--- a/apps/web/src/hooks/useChannelStreamSocket.ts
+++ b/apps/web/src/hooks/useChannelStreamSocket.ts
@@ -27,9 +27,21 @@ export interface UseChannelStreamSocketOptions {
   /** Fires once per own-bootstrapped messageId on any finalize path (resolve, complete, or error). */
   onOwnStreamFinalize?: (event: { messageId: string }) => void;
   /**
-   * Fires when a remote user submits a message in this channel. Filters out
-   * own-tab broadcasts (the originator's `useChat` already appended) and
-   * stale-room events. Consumers append to their own messages array.
+   * Fires when a remote user submits a message in this channel.
+   *
+   * Filters applied before invocation:
+   *   1. Stale-room: events for a different `pageId` are dropped.
+   *   2. Own-tab dedup: events whose `triggeredBy.browserSessionId` matches
+   *      the local session are dropped (the originator's `useChat` already
+   *      appended the message locally).
+   *
+   * Server-side ordering: the broadcast fires AFTER `saveMessageToDatabase`
+   * resolves and BEFORE the assistant `chat:stream_start` event, so consumers
+   * always see the user message land before the assistant ghost text begins.
+   *
+   * Consumers must dedup against their existing messages by `message.id`
+   * (the bootstrap REST GET may also surface the message if it ran after
+   * the save and before the broadcast was processed locally).
    */
   onUserMessage?: (message: UIMessage, payload: ChatUserMessagePayload) => void;
 }

--- a/apps/web/src/lib/websocket/__tests__/socket-utils.test.ts
+++ b/apps/web/src/lib/websocket/__tests__/socket-utils.test.ts
@@ -41,6 +41,8 @@ import {
   broadcastTaskEvent,
   broadcastUsageEvent,
   broadcastAiStreamStart,
+  broadcastChatUserMessage,
+  type ChatUserMessagePayload,
   broadcastAiStreamComplete,
   createPageEventPayload,
   createDriveEventPayload,
@@ -436,6 +438,40 @@ describe('socket-utils', () => {
       await expect(
         broadcastAiStreamComplete({ messageId: 'msg-1', pageId: 'page-1' })
       ).resolves.not.toThrow();
+    });
+  });
+
+  describe('broadcastChatUserMessage', () => {
+    const payload: ChatUserMessagePayload = {
+      message: { id: 'msg-1', role: 'user', parts: [{ type: 'text', text: 'hello' }] },
+      pageId: 'page-1',
+      conversationId: 'conv-1',
+      triggeredBy: { userId: 'user-1', displayName: 'Alice', browserSessionId: 'session-1' },
+    };
+
+    it('given a valid payload, should route to the {pageId} channel with chat:user_message event', async () => {
+      await broadcastChatUserMessage(payload);
+
+      const fetchCall = mockFetch.mock.calls[0];
+      const requestBody = JSON.parse(fetchCall[1].body);
+
+      expect(requestBody.channelId).toBe('page-1');
+      expect(requestBody.event).toBe('chat:user_message');
+      expect(requestBody.payload).toEqual(payload);
+    });
+
+    it('given no INTERNAL_REALTIME_URL, should not call fetch', async () => {
+      process.env.INTERNAL_REALTIME_URL = '';
+
+      await broadcastChatUserMessage(payload);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('given fetch throws, should not throw', async () => {
+      mockFetch.mockRejectedValue(new Error('Network error'));
+
+      await expect(broadcastChatUserMessage(payload)).resolves.not.toThrow();
     });
   });
 

--- a/apps/web/src/lib/websocket/socket-utils.ts
+++ b/apps/web/src/lib/websocket/socket-utils.ts
@@ -509,6 +509,13 @@ export interface AiStreamCompletePayload {
   aborted?: boolean;
 }
 
+export interface ChatUserMessagePayload {
+  message: import('ai').UIMessage;
+  pageId: string;
+  conversationId: string;
+  triggeredBy: { userId: string; displayName: string; browserSessionId: string };
+}
+
 export async function broadcastAiStreamStart(payload: AiStreamStartPayload): Promise<void> {
   const realtimeUrl = getEnvVar('INTERNAL_REALTIME_URL');
   if (!realtimeUrl) {
@@ -571,6 +578,40 @@ export async function broadcastAiStreamComplete(payload: AiStreamCompletePayload
       error instanceof Error ? error : undefined,
       {
         event: 'ai_stream_complete',
+        channel: maskIdentifier(payload.pageId),
+      }
+    );
+  }
+}
+
+export async function broadcastChatUserMessage(payload: ChatUserMessagePayload): Promise<void> {
+  const realtimeUrl = getEnvVar('INTERNAL_REALTIME_URL');
+  if (!realtimeUrl) {
+    realtimeLogger.warn('Realtime URL not configured, skipping chat user-message broadcast', {
+      event: 'chat:user_message',
+    });
+    return;
+  }
+
+  try {
+    const requestBody = JSON.stringify({
+      channelId: payload.pageId,
+      event: 'chat:user_message',
+      payload,
+    });
+
+    await fetch(`${realtimeUrl}/api/broadcast`, {
+      method: 'POST',
+      headers: createSignedBroadcastHeaders(requestBody),
+      body: requestBody,
+      signal: AbortSignal.timeout(5000),
+    });
+  } catch (error) {
+    realtimeLogger.error(
+      'Failed to broadcast chat user-message',
+      error instanceof Error ? error : undefined,
+      {
+        event: 'chat:user_message',
         channel: maskIdentifier(payload.pageId),
       }
     );


### PR DESCRIPTION
## Summary

Closes the gap left by [#1182](https://github.com/2witstudios/PageSpace/pull/1182): assistant streams multicast in real time, but the prompts that triggered them were invisible to co-mounted remote viewers until refresh. Now User A's user message broadcasts the moment it's saved.

- **New socket event** \`chat:user_message\` carries the saved \`UIMessage\` plus the same envelope as \`chat:stream_start\` (pageId / conversationId / triggeredBy.browserSessionId for own-tab dedup).
- **Producers**: page chat route + global assistant route both call \`broadcastChatUserMessage\` after \`saveMessageToDatabase\` resolves and before the stream lifecycle starts. Save failure short-circuits before the broadcast; broadcast failure never blocks the stream.
- **Consumers**: \`useChannelStreamSocket\` exposes a new optional \`onUserMessage\` callback. \`AiChatView\`, \`useAgentChannelMultiplayer\` (used by GlobalAssistantView + SidebarChatTab), and \`GlobalChatContext\` all wire it through to their respective \`setMessages\` paths, gated on \`conversationId\` match and deduped by \`messageId\`.

No realtime-server change needed — its \`/api/broadcast\` endpoint already forwards arbitrary events to the channel room. No wire-shape change for assistant streams. No new pure helpers (the existing \`isOwnStream\` already handles own-tab dedup).

## Test plan

- [x] Strict TDD, RED → GREEN → REFACTOR per Given/should, one commit per cycle.
- [x] \`broadcastChatUserMessage\` unit tests (3): routes correctly, no-ops when realtime URL unset, swallows fetch failures.
- [x] Page route integration tests (3): broadcasts after save, skips broadcast on save failure, broadcast failure doesn't block.
- [x] Global route integration tests (3): same Givens routed to per-user global channel.
- [x] Hook tests (4): affirmative call, stale-room skip, own-tab dedup, reconnect re-registration.
- [x] Component tests for AiChatView (3), useAgentChannelMultiplayer (3), GlobalChatContext (2): conv-match append, conv-mismatch skip, messageId dedup.
- [x] \`pnpm typecheck\` green
- [x] \`pnpm test --filter web\` — **6,571 / 6,571** passing
- [x] \`pnpm lint\` green (only a pre-existing warning in QuickCreatePalette.tsx unrelated to this PR)
- [ ] Manual two-tab smoke: open the same AI chat in two windows, send "what pages do I have?" from window A, verify window B sees the prompt land before the assistant starts streaming.

## Out of scope

- Reasoning multicast, source-part / file-part, tool-input streaming-state — same out-of-scope list as #1182.
- Channel chat (non-AI) message broadcast — already done via \`new_message\`.
- Pending-streams store extensions — user messages aren't pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)