### PR TITLE
fix(ai): multicast failed tool calls so remote viewers see error state, not perpetual pending

### DIFF
--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -426,6 +426,30 @@ describe('POST /api/ai/chat — lifecycle handoff', () => {
       });
     });
 
+    it('given a tool-error chunk, should forward an output-error tool part with errorText to lifecycle.pushPart', async () => {
+      await POST(makeRequest());
+      await captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() });
+
+      captured.streamTextOptions.onChunk?.({
+        chunk: {
+          type: 'tool-error',
+          toolCallId: 'tc1',
+          toolName: 'list_pages',
+          input: { driveId: 'd1' },
+          error: new Error('drive permission denied'),
+        },
+      });
+
+      expect(mockLifecyclePushPart).toHaveBeenCalledWith({
+        type: 'tool-list_pages',
+        toolCallId: 'tc1',
+        toolName: 'list_pages',
+        state: 'output-error',
+        input: { driveId: 'd1' },
+        errorText: 'drive permission denied',
+      });
+    });
+
     it('given a chunk type out of v1 multicast scope, should not forward anything', async () => {
       await POST(makeRequest());
       await captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() });

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
@@ -487,6 +487,30 @@ describe('POST /api/ai/global/[id]/messages — lifecycle handoff', () => {
       });
     });
 
+    it('given a tool-error chunk, should forward an output-error tool part with errorText', async () => {
+      await POST(makeRequest(), makeContext());
+      await captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() });
+
+      captured.streamTextOptions.onChunk?.({
+        chunk: {
+          type: 'tool-error',
+          toolCallId: 'tc1',
+          toolName: 'list_pages',
+          input: { driveId: 'd1' },
+          error: new Error('quota exceeded'),
+        },
+      });
+
+      expect(mockLifecyclePushPart).toHaveBeenCalledWith({
+        type: 'tool-list_pages',
+        toolCallId: 'tc1',
+        toolName: 'list_pages',
+        state: 'output-error',
+        input: { driveId: 'd1' },
+        errorText: 'quota exceeded',
+      });
+    });
+
     it('given a chunk type out of v1 multicast scope, should not forward anything', async () => {
       await POST(makeRequest(), makeContext());
       await captured.createUIMessageStreamOptions.execute?.({ write: vi.fn() });

--- a/apps/web/src/lib/ai/core/__tests__/message-utils.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/message-utils.test.ts
@@ -4,6 +4,7 @@ import {
   extractMessageContent,
   extractToolCalls,
   extractToolResults,
+  convertDbMessageToUIMessage,
 } from '../message-utils';
 
 /** Helper to build a UIMessage with typed parts */
@@ -77,5 +78,108 @@ describe('extractToolResults', () => {
     // @ts-expect-error testing missing parts
     const msg: UIMessage = { id: 'x', role: 'assistant' };
     expect(extractToolResults(msg)).toEqual([]);
+  });
+
+  it('given an output-error tool part with errorText, should preserve errorText in the extracted result so a refresh can re-render the error', () => {
+    const errorPart = {
+      type: 'tool-list_pages',
+      toolCallId: 'tc1',
+      toolName: 'list_pages',
+      state: 'output-error',
+      input: { driveId: 'd1' },
+      errorText: 'drive permission denied',
+    } as unknown as UIMessage['parts'][number];
+    const msg = makeMessage([errorPart]);
+
+    expect(extractToolResults(msg)).toEqual([
+      {
+        toolCallId: 'tc1',
+        toolName: 'list_pages',
+        state: 'output-error',
+        output: undefined,
+        errorText: 'drive permission denied',
+      },
+    ]);
+  });
+});
+
+describe('convertDbMessageToUIMessage — output-error round-trip', () => {
+  it('given a persisted message whose toolResults state is output-error, should reconstruct a tool part with state=output-error and the original errorText', () => {
+    const partsOrder = [{ index: 0, type: 'tool-list_pages', toolCallId: 'tc1' }];
+    const dbMessage = {
+      id: 'msg-err',
+      pageId: 'page-1',
+      userId: 'user-1',
+      role: 'assistant',
+      content: JSON.stringify({
+        textParts: [],
+        partsOrder,
+        originalContent: '',
+      }),
+      toolCalls: JSON.stringify([
+        {
+          toolCallId: 'tc1',
+          toolName: 'list_pages',
+          input: { driveId: 'd1' },
+          state: 'output-error',
+        },
+      ]),
+      toolResults: JSON.stringify([
+        {
+          toolCallId: 'tc1',
+          toolName: 'list_pages',
+          output: undefined,
+          state: 'output-error',
+          errorText: 'drive permission denied',
+        },
+      ]),
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+      isActive: true,
+    };
+
+    const reconstructed = convertDbMessageToUIMessage(dbMessage);
+
+    expect(reconstructed.parts).toEqual([
+      {
+        type: 'tool-list_pages',
+        toolCallId: 'tc1',
+        toolName: 'list_pages',
+        input: { driveId: 'd1' },
+        state: 'output-error',
+        errorText: 'drive permission denied',
+      },
+    ]);
+  });
+
+  it('given a persisted message whose toolResults state is output-available, should reconstruct a tool part with state=output-available (no regression)', () => {
+    const partsOrder = [{ index: 0, type: 'tool-list_pages', toolCallId: 'tc1' }];
+    const dbMessage = {
+      id: 'msg-ok',
+      pageId: 'page-1',
+      userId: 'user-1',
+      role: 'assistant',
+      content: JSON.stringify({ textParts: [], partsOrder, originalContent: '' }),
+      toolCalls: JSON.stringify([
+        { toolCallId: 'tc1', toolName: 'list_pages', input: { driveId: 'd1' }, state: 'output-available' },
+      ]),
+      toolResults: JSON.stringify([
+        { toolCallId: 'tc1', toolName: 'list_pages', output: { pages: [] }, state: 'output-available' },
+      ]),
+      createdAt: new Date('2026-01-01T00:00:00Z'),
+      isActive: true,
+    };
+
+    const reconstructed = convertDbMessageToUIMessage(dbMessage);
+
+    expect(reconstructed.parts).toEqual([
+      {
+        type: 'tool-list_pages',
+        toolCallId: 'tc1',
+        toolName: 'list_pages',
+        input: { driveId: 'd1' },
+        output: { pages: [] },
+        state: 'output-available',
+      },
+    ]);
   });
 });

--- a/apps/web/src/lib/ai/core/message-utils.ts
+++ b/apps/web/src/lib/ai/core/message-utils.ts
@@ -68,6 +68,8 @@ interface ToolResult {
   toolName: string;
   output: unknown;
   state: 'output-available' | 'output-error';
+  /** Populated when state is 'output-error' so the renderer can show the failure after refresh. */
+  errorText?: string;
 }
 
 /** Local tool part shape for reconstructing parts from database data */
@@ -193,12 +195,20 @@ export function extractToolResults(message: UIMessage): ToolResult[] {
   return message.parts
     .filter(isToolInvocationPart)
     .filter(toolPart => toolPart.state === 'output-available' || toolPart.state === 'output-error')
-    .map(toolPart => ({
-      toolCallId: toolPart.toolCallId,
-      toolName: toolPart.toolName || toolPart.type.replace('tool-', ''),
-      output: 'output' in toolPart ? toolPart.output : undefined,
-      state: toolPart.state as 'output-available' | 'output-error',
-    }));
+    .map(toolPart => {
+      const state = toolPart.state as 'output-available' | 'output-error';
+      const result: ToolResult = {
+        toolCallId: toolPart.toolCallId,
+        toolName: toolPart.toolName || toolPart.type.replace('tool-', ''),
+        output: 'output' in toolPart ? toolPart.output : undefined,
+        state,
+      };
+      if (state === 'output-error') {
+        const errorText = (toolPart as { errorText?: unknown }).errorText;
+        if (typeof errorText === 'string') result.errorText = errorText;
+      }
+      return result;
+    });
 }
 
 /**
@@ -319,14 +329,19 @@ function reconstructFromStructuredContent(
       const toolResult = toolResultsMap.get(partOrder.toolCallId);
 
       if (toolCall) {
-        parts.push({
+        const reconstructed: ToolPart = {
           type: partOrder.type,
           toolCallId: toolCall.toolCallId,
           toolName: toolCall.toolName,
           input: toolCall.input,
-          output: toolResult?.output,
-          state: toolResult ? 'output-available' : 'input-available',
-        });
+          state: toolResult?.state ?? 'input-available',
+        };
+        if (reconstructed.state === 'output-error' && toolResult?.errorText) {
+          (reconstructed as ToolPart & { errorText?: string }).errorText = toolResult.errorText;
+        } else if (toolResult && reconstructed.state !== 'output-error') {
+          reconstructed.output = toolResult.output;
+        }
+        parts.push(reconstructed);
       }
     } else if (partOrder.type === 'step-start') {
       // Skip step-start parts for now - they're AI SDK internal

--- a/apps/web/src/lib/ai/streams/__tests__/chunkToPart.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/chunkToPart.test.ts
@@ -86,6 +86,83 @@ describe('chunkToPart', () => {
     ).toBeNull();
   });
 
+  it('given a tool-error chunk with an Error instance, should return a tool part with state output-error and the error.message as errorText', () => {
+    expect(
+      chunkToPart({
+        type: 'tool-error',
+        toolCallId: 'tc1',
+        toolName: 'list_pages',
+        input: { driveId: 'd1' },
+        error: new Error('drive not found'),
+      } as never),
+    ).toEqual({
+      type: 'tool-list_pages',
+      toolCallId: 'tc1',
+      toolName: 'list_pages',
+      state: 'output-error',
+      input: { driveId: 'd1' },
+      errorText: 'drive not found',
+    });
+  });
+
+  it('given a tool-error chunk with a string error, should use the string verbatim as errorText', () => {
+    expect(
+      chunkToPart({
+        type: 'tool-error',
+        toolCallId: 'tc2',
+        toolName: 'read_page',
+        input: { pageId: 'p1' },
+        error: 'permission denied',
+      } as never),
+    ).toEqual({
+      type: 'tool-read_page',
+      toolCallId: 'tc2',
+      toolName: 'read_page',
+      state: 'output-error',
+      input: { pageId: 'p1' },
+      errorText: 'permission denied',
+    });
+  });
+
+  it('given a tool-error chunk with a non-Error non-string error, should fall back to a generic errorText (renderer expects a string)', () => {
+    const part = chunkToPart({
+      type: 'tool-error',
+      toolCallId: 'tc3',
+      toolName: 'list_pages',
+      input: { driveId: 'd1' },
+      error: { code: 500 },
+    } as never);
+    expect(part).toMatchObject({
+      type: 'tool-list_pages',
+      toolCallId: 'tc3',
+      state: 'output-error',
+    });
+    expect(typeof (part as { errorText: unknown }).errorText).toBe('string');
+    expect((part as { errorText: string }).errorText.length).toBeGreaterThan(0);
+  });
+
+  it('given a tool-error chunk missing toolName, should return null', () => {
+    expect(
+      chunkToPart({
+        type: 'tool-error',
+        toolCallId: 'tc1',
+        input: { driveId: 'd1' },
+        error: new Error('boom'),
+      } as never),
+    ).toBeNull();
+  });
+
+  it('given a tool-error chunk missing toolCallId, should return null (idempotency key required so the error replaces the in-flight tool part)', () => {
+    expect(
+      chunkToPart({
+        type: 'tool-error',
+        toolName: 'list_pages',
+        input: { driveId: 'd1' },
+        error: new Error('boom'),
+      } as never),
+    ).toBeNull();
+  });
+
   it.each([
     ['start'],
     ['start-step'],

--- a/apps/web/src/lib/ai/streams/__tests__/multicast-outcome.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/multicast-outcome.test.ts
@@ -147,4 +147,58 @@ describe('multicast outcome — text + tool-call + tool-result render parity', (
 
     expect(currentParts(messageId)!).toEqual([finalToolPart]);
   });
+
+  it('given a failed tool call (input-available followed by tool-error), should transition the part to output-error rather than leave it pending', () => {
+    const messageId = 'msg-tool-failure';
+    const { addStream, appendPart } = usePendingStreamsStore.getState();
+    const currentParts = (id: string) => usePendingStreamsStore.getState().streams.get(id)?.parts;
+
+    addStream({
+      messageId,
+      pageId: 'page-1',
+      conversationId: 'conv-1',
+      triggeredBy: { userId: 'user-author', displayName: 'Author' },
+      isOwn: false,
+    });
+
+    const callPart = chunkToPart({
+      type: 'tool-call',
+      toolCallId: 'tc-fail',
+      toolName: 'list_pages',
+      input: { driveId: 'd1' },
+    } as never);
+    appendPart(messageId, callPart!);
+
+    // Mid-flight, remote viewer sees input-available — exactly as the originator does.
+    expect(currentParts(messageId)).toEqual([
+      {
+        type: 'tool-list_pages',
+        toolCallId: 'tc-fail',
+        toolName: 'list_pages',
+        state: 'input-available',
+        input: { driveId: 'd1' },
+      },
+    ]);
+
+    const errorPart = chunkToPart({
+      type: 'tool-error',
+      toolCallId: 'tc-fail',
+      toolName: 'list_pages',
+      input: { driveId: 'd1' },
+      error: new Error('drive permission denied'),
+    } as never);
+    appendPart(messageId, errorPart!);
+
+    // After the error chunk lands, the same toolCallId is replaced with an
+    // output-error part — the renderer transitions from "pending tool" to
+    // "tool failed", matching the originator's view.
+    const final = currentParts(messageId)!;
+    expect(final).toHaveLength(1);
+    expect(final[0]).toMatchObject({
+      type: 'tool-list_pages',
+      toolCallId: 'tc-fail',
+      state: 'output-error',
+      errorText: 'drive permission denied',
+    });
+  });
 });

--- a/apps/web/src/lib/ai/streams/chunkToPart.ts
+++ b/apps/web/src/lib/ai/streams/chunkToPart.ts
@@ -6,9 +6,10 @@ interface ToolPart {
   type: `tool-${string}`;
   toolCallId: string;
   toolName: string;
-  state: 'input-available' | 'output-available';
+  state: 'input-available' | 'output-available' | 'output-error';
   input: unknown;
   output?: unknown;
+  errorText?: string;
 }
 
 interface AISDKChunk {
@@ -18,8 +19,19 @@ interface AISDKChunk {
   toolCallId?: string;
   input?: unknown;
   output?: unknown;
+  error?: unknown;
   [key: string]: unknown;
 }
+
+const errorTextFor = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return 'Tool execution failed';
+  }
+};
 
 const toolPart = (
   state: ToolPart['state'],
@@ -31,6 +43,7 @@ const toolPart = (
   state,
   input: chunk.input,
   ...(state === 'output-available' ? { output: chunk.output } : {}),
+  ...(state === 'output-error' ? { errorText: errorTextFor(chunk.error) } : {}),
 });
 
 /**
@@ -46,11 +59,16 @@ export const chunkToPart = (chunk: AISDKChunk): AnyPart | null => {
     return { type: 'text', text: chunk.text };
   }
   if (
-    (chunk.type === 'tool-call' || chunk.type === 'tool-result') &&
+    (chunk.type === 'tool-call' || chunk.type === 'tool-result' || chunk.type === 'tool-error') &&
     typeof chunk.toolName === 'string' &&
     typeof chunk.toolCallId === 'string'
   ) {
-    const state = chunk.type === 'tool-call' ? 'input-available' : 'output-available';
+    const state =
+      chunk.type === 'tool-call'
+        ? 'input-available'
+        : chunk.type === 'tool-result'
+        ? 'output-available'
+        : 'output-error';
     return toolPart(state, { ...chunk, toolName: chunk.toolName, toolCallId: chunk.toolCallId }) as unknown as AnyPart;
   }
   return null;


### PR DESCRIPTION
## Summary

Closes the last gap from the multiplayer streaming epic ([#1182](https://github.com/2witstudios/PageSpace/pull/1182), [#1193](https://github.com/2witstudios/PageSpace/pull/1193)): a tool call that fails was invisible to remote viewers as a *failure* — they kept seeing the input-available "pending" render forever, while the originator's bubble had already flipped to the error UI.

Two related fixes, one PR:

### 1. Wire: multicast the failure (the user-reported bug)

**Root cause:** \`chunkToPart\` only forwarded \`tool-call\` (input-available) and \`tool-result\` (output-available). The AI SDK's \`tool-error\` chunk fell through to the default \`return null\`, so the multicast wire silently dropped failures.

**Fix:** route \`tool-error\` chunks through the same \`toolPart\` factory with \`state: 'output-error'\` and an \`errorText\` derived from the chunk's \`error\` field:

| \`error\` shape | \`errorText\` |
|---|---|
| \`Error\` instance | \`error.message\` |
| \`string\` | verbatim |
| anything else | \`JSON.stringify\` (with a \`'Tool execution failed'\` fallback if that throws) |

Client-side \`appendPart\` already replaces tool parts by \`toolCallId\`, so the in-flight \`input-available\` part is naturally replaced by the \`output-error\` part when the error chunk arrives. \`isValidPartFrame\` already accepts tool-prefixed parts in any state. \`ToolCallRenderer\` already renders \`output-error\` with \`errorText\`. **No client-side change required** for the wire — only the server-side translator was missing the case.

### 2. Persistence: preserve the failure across refresh

Self-review surfaced an adjacent bug introduced by #1182's persistence layer. \`reconstructFromStructuredContent\` hardcoded the reconstructed tool-part state to either \`'input-available'\` or \`'output-available'\` (line 327–328), silently dropping \`'output-error'\` on the DB → UIMessage path. Same data-loss symptom from a different angle: live multicast now correctly surfaces the error, but a refresh would revert the part to a fake \`'output-available'\` with no errorText.

Three related changes:
- \`ToolResult\` interface now carries optional \`errorText\` (the persisted shape).
- \`extractToolResults\` copies \`errorText\` into the saved \`ToolResult\` when state is \`'output-error'\`.
- \`reconstructFromStructuredContent\` uses \`toolResult.state\` directly instead of the binary hardcode, and restores \`errorText\` (no \`output\` field) for output-error parts. \`output-available\` behavior is unchanged.

## Test plan

Strict TDD, RED → GREEN, four commits.

- [x] **\`chunkToPart\` unit tests (5)**: Error instance → \`error.message\` as errorText; string error → verbatim; non-Error non-string → fallback string; missing toolName → null; missing toolCallId → null.
- [x] **Outcome integration test**: stream goes input-available → tool-error → final parts array contains a single \`output-error\` part keyed by \`toolCallId\` with the error text. The bug-symptom test.
- [x] **Page route integration test**: \`tool-error\` chunks forward an output-error tool part to \`lifecycle.pushPart\`.
- [x] **Global route integration test**: same Given.
- [x] **\`extractToolResults\` test**: output-error part preserves \`errorText\` in the extracted result.
- [x] **\`convertDbMessageToUIMessage\` round-trip test (2)**: output-error round-trip restores state + errorText; output-available round-trip is a no-regression baseline.
- [x] \`pnpm typecheck\` green
- [x] \`pnpm test --filter web\` — **6,593 / 6,593** passing
- [x] \`pnpm lint\` green (only the pre-existing QuickCreatePalette warning unrelated to this PR)
- [ ] Manual two-tab smoke: open the same AI chat in two windows, ask the assistant to invoke a tool with an input that will fail (e.g. read a page they don't have permission to). Verify window B sees the tool transition from "running" → "errored" rather than sitting stuck. Refresh both windows and verify the error persists.

## Out of scope

- New \`tool-input-streaming\` chunk types (still skipped — same v1 minimal scope as #1182).
- \`sanitizeMessagesForModel\` filters output-error parts before sending to the model on retry — pre-existing behavior unchanged. If a user's retry-after-failure ergonomics suffer, that's a follow-up PR.
- Any UI changes to ToolCallRenderer (it already supports \`output-error\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)