### PR TITLE
feat(tasks): allow empty prompt when instructionPageId is set (T4/5)

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskAgentTriggersDialog.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskAgentTriggersDialog.tsx
@@ -199,8 +199,8 @@ export function TaskAgentTriggersDialog({
       toast.error('Pick an agent first');
       return;
     }
-    if (!section.prompt.trim()) {
-      toast.error('Enter a prompt for the agent');
+    if (!section.prompt.trim() && !section.instructionPageId) {
+      toast.error('Enter a prompt or pick an instruction page');
       return;
     }
     if (type === 'due_date' && !hasDueDate) {
@@ -331,6 +331,9 @@ export function TaskAgentTriggersDialog({
                           onChange={(e) => updateSection(ui, { prompt: e.target.value })}
                           rows={3}
                         />
+                        <p className="text-xs text-muted-foreground">
+                          Optional when an instruction page is set.
+                        </p>
                       </div>
 
                       <Collapsible>


### PR DESCRIPTION
## Summary

Final T4/5 of the [agent-triggers follow-up epic](../blob/master/tasks/task-list-agent-triggers-followup.md). Closes the last UI/API drift on the per-task agent-trigger dialog: the dialog now accepts a save when an instruction page is set, even with an empty prompt — matching the rule the API and helper already enforce.

## Why

T3 (#1188) added the `instructionPageId` and `contextPageIds` pickers to `TaskAgentTriggersDialog` and plumbed both through the PUT body. But the dialog's `handleSave` still ran a hard `if (!section.prompt.trim()) ...` guard, leaving it **strictly more restrictive** than the API:

- Route schema — `apps/web/src/app/api/tasks/[taskId]/triggers/route.ts:20` (`upsertTriggerSchema.refine((d) => Boolean(d.prompt?.trim()) || Boolean(d.instructionPageId))`)
- Helper — `apps/web/src/lib/workflows/task-trigger-helpers.ts:73` (`createTaskTriggerWorkflow` throws unless one of the two is set)

Both already accept "either prompt or instructionPageId". The dialog was the only surface still requiring a prompt.

Epic requirement (Section "Agent parity in trigger dialog"):

> Given a user who selects an instruction page and leaves the prompt empty, should accept and save the trigger (matching the helper-level "either prompt or instructionPageId" rule), rather than block on a prompt-required validation.

## What changed

**`TaskAgentTriggersDialog.tsx`** — only file touched.

- `handleSave` — relax the prompt-required guard to fire only when **both** `prompt.trim()` and `instructionPageId` are empty. Toast rephrased from "Enter a prompt for the agent" to **"Enter a prompt or pick an instruction page"** so the new semantics are fail-loud rather than silently passing through.
- Subtle hint under the prompt textarea: **"Optional when an instruction page is set."** — same muted-foreground tone as the existing "Additional pages the agent can read for context (max 10)." copy in the Advanced section. No required-marker, no `<Label>` change.

The agent-required guard above stays as-is (separate concern, separate fail-loud message). The due-date guard below stays as-is.

## Why no new test

The route schema's "either/or" rule is already covered end-to-end in `apps/web/src/app/api/tasks/[taskId]/triggers/__tests__/route.test.ts` (11 tests, all green). Extracting a `sectionIsSavable` predicate and unit-testing its truth table would test a tautology — it wouldn't catch the only regression that matters (someone removing the call in `handleSave`). Existing dialog coverage (`statusToneClass` + the editing-store contract test) is unchanged and still passes. Manual UX in the test plan covers the dialog-side flip.

## Test plan

- [x] `pnpm --filter @pagespace/db build && pnpm --filter @pagespace/lib build` — clean
- [x] `pnpm --filter web typecheck` — clean
- [x] `pnpm --filter web lint` — clean except the pre-existing `QuickCreatePalette` `useCallback` warning (unchanged by this PR)
- [x] `vitest run` on `src/app/api/tasks` (route + mcp-scope + triggers schema) and `src/components/layout/middle-content/page-views/task-list` (T1's editing-store contract) — **41/41 pass**
- [ ] Manual UX (reviewer): open trigger dialog → pick agent → leave prompt empty → pick an instruction page → click Save: succeeds, no error toast.
- [ ] Manual UX: open trigger dialog → pick agent → leave both prompt and instruction page empty → click Save: fail-loud toast "Enter a prompt or pick an instruction page".
- [ ] Manual UX: existing prompt-only flow (agent + non-empty prompt, no instruction page) continues to work.

## Related

- Epic: [`tasks/task-list-agent-triggers-followup.md`](../blob/master/tasks/task-list-agent-triggers-followup.md)
- Builds on: #1188 (T3 — `instructionPageId` + `contextPageIds` pickers)
- Companion to: #1184 (T1), #1185 (T2), #1186 (T5), #1187 (T6) — all merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)