### PR TITLE
fix(ai): charge quota on workflows and ask_agent

### DIFF
--- a/apps/web/src/app/api/ai/page-agents/consult/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/route.ts
@@ -4,6 +4,9 @@ import { finishTool, FINISH_TOOL_NAME } from '@/lib/ai/tools/finish-tool';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
 import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
+import { getCurrentUsage, incrementUsage } from '@/lib/subscription/usage-service';
+import { createRateLimitResponse } from '@/lib/subscription/rate-limit-middleware';
+import { getPageSpaceModelTier } from '@/lib/ai/core/ai-providers-config';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 import {
@@ -293,6 +296,17 @@ export async function POST(request: Request) {
         )
       : {};
 
+    // Charge quota only for PageSpace-subsidized inference. BYO-key calls pass through uncharged.
+    const chargesQuota = (agent.aiProvider || 'pagespace') === 'pagespace';
+    const providerType = getPageSpaceModelTier(agent.aiModel || 'glm-4.5-air') ?? 'standard';
+
+    if (chargesQuota) {
+      const currentUsage = await getCurrentUsage(userId, providerType);
+      if (!currentUsage.success || currentUsage.remainingCalls <= 0) {
+        return createRateLimitResponse(providerType, currentUsage.limit);
+      }
+    }
+
     // Generate response using the AI model
     let responseText = '';
     try {
@@ -451,6 +465,18 @@ export async function POST(request: Request) {
         driveId: agent.driveId,
         success: true,
       });
+
+      if (chargesQuota) {
+        try {
+          await incrementUsage(userId, providerType);
+        } catch (usageError) {
+          loggers.api.error('Agent consultation usage tracking failed', usageError as Error, {
+            userId,
+            agentId,
+            providerType,
+          });
+        }
+      }
     } catch (aiError) {
       loggers.api.error('Agent consultation AI generation error:', aiError as Error);
       return NextResponse.json(

--- a/apps/web/src/app/api/ai/page-agents/consult/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/route.ts
@@ -296,7 +296,7 @@ export async function POST(request: Request) {
         )
       : {};
 
-    // Charge quota only for PageSpace-subsidized inference. BYO-key calls pass through uncharged.
+    // Only charge for subsidized inference; BYO-key calls pass through uncharged.
     const chargesQuota = (agent.aiProvider || 'pagespace') === 'pagespace';
     const providerType = getPageSpaceModelTier(agent.aiModel || 'glm-4.5-air') ?? 'standard';
 

--- a/apps/web/src/lib/ai/core/__tests__/ai-providers-config.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/ai-providers-config.test.ts
@@ -85,10 +85,13 @@ describe('ai-providers-config', () => {
       expect(getPageSpaceModelTier('some-other-model')).toBe(null);
     });
 
-    it('should return null for alias names (not resolved models)', () => {
-      // Aliases are names like "standard", "pro" - not the actual model IDs
-      expect(getPageSpaceModelTier('standard')).toBe(null);
-      expect(getPageSpaceModelTier('pro')).toBe(null);
+    it('should resolve aliases to their tier', () => {
+      // Agents may store aliases ('standard', 'pro') instead of concrete model IDs.
+      // The helper resolves the alias before doing the reverse lookup.
+      expect(getPageSpaceModelTier('standard')).toBe('standard');
+      expect(getPageSpaceModelTier('pro')).toBe('pro');
+      expect(getPageSpaceModelTier('STANDARD')).toBe('standard');
+      expect(getPageSpaceModelTier('PRO')).toBe('pro');
     });
   });
 

--- a/apps/web/src/lib/ai/core/ai-providers-config.ts
+++ b/apps/web/src/lib/ai/core/ai-providers-config.ts
@@ -31,16 +31,14 @@ export function isPageSpaceModelAlias(model: string): boolean {
 }
 
 /**
- * Get the PageSpace tier ('standard' or 'pro') for a given model
- * Returns null if the model is not a PageSpace tier model
- *
- * This is the reverse lookup of PAGESPACE_MODEL_ALIASES - given a model ID,
- * find which tier it belongs to. Used for rate limiting and subscription checks.
+ * Get the PageSpace tier ('standard' or 'pro') for a given model.
+ * Accepts either an alias ('standard'/'pro') or a concrete model ID ('glm-4.7'/'glm-5').
+ * Returns null when the input is neither. Used for rate limiting and subscription checks.
  */
 export function getPageSpaceModelTier(model: string): 'standard' | 'pro' | null {
-  const modelLower = model.toLowerCase();
+  const resolvedLower = resolvePageSpaceModel(model).toLowerCase();
   for (const [tier, tierModel] of Object.entries(PAGESPACE_MODEL_ALIASES)) {
-    if (tierModel.toLowerCase() === modelLower) {
+    if (tierModel.toLowerCase() === resolvedLower) {
       return tier as 'standard' | 'pro';
     }
   }

--- a/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
@@ -77,6 +77,15 @@ vi.mock('../../core/integration-tool-resolver', () => ({
   resolvePageAgentIntegrationTools: vi.fn().mockResolvedValue({}),
 }));
 
+vi.mock('@/lib/subscription/usage-service', () => ({
+  getCurrentUsage: vi.fn(),
+  incrementUsage: vi.fn(),
+}));
+
+vi.mock('@/lib/ai/core/ai-providers-config', () => ({
+  getPageSpaceModelTier: vi.fn(() => 'standard'),
+}));
+
 // Mock core AI modules
 vi.mock('../../core', () => ({
   sanitizeMessagesForModel: vi.fn((msgs) => msgs),
@@ -96,6 +105,7 @@ import { createAIProvider, saveMessageToDatabase } from '../../core';
 import type { ToolExecutionContext } from '../../core';
 import { generateText } from 'ai';
 import { resolvePageAgentIntegrationTools } from '../../core/integration-tool-resolver';
+import { getCurrentUsage, incrementUsage } from '@/lib/subscription/usage-service';
 
 const mockDb = vi.mocked(db);
 const mockCanUserViewPage = vi.mocked(canUserViewPage);
@@ -189,6 +199,12 @@ describe('agent-communication-tools', () => {
         steps: [],
       } as unknown as ReturnType<typeof generateText> extends Promise<infer T> ? T : never);
       vi.mocked(saveMessageToDatabase).mockResolvedValue(undefined);
+      vi.mocked(getCurrentUsage).mockResolvedValue({
+        success: true, remainingCalls: 99, currentCount: 1, limit: 100,
+      });
+      vi.mocked(incrementUsage).mockResolvedValue({
+        success: true, remainingCalls: 98, currentCount: 2, limit: 100,
+      });
     });
 
     it('has correct tool definition', () => {
@@ -697,6 +713,81 @@ describe('agent-communication-tools', () => {
         const toolsArg = vi.mocked(generateText).mock.calls[0][0].tools as Record<string, unknown> | undefined;
         // When built-in tool set is empty, generateText is called with no tools at all
         expect(toolsArg?.github_list_repos).toBeUndefined();
+      });
+    });
+
+    describe('quota tracking', () => {
+      const pagespaceAgent = {
+        id: 'agent-1',
+        title: 'PageSpace Agent',
+        type: 'AI_CHAT',
+        driveId: 'drive-1',
+        systemPrompt: 'I am a helpful agent',
+        enabledTools: null,
+        aiProvider: null, // null === pagespace default
+        aiModel: null,
+        isTrashed: false,
+      };
+
+      beforeEach(() => {
+        mockDb.query.pages.findFirst = vi.fn().mockResolvedValue(pagespaceAgent);
+      });
+
+      it('charges quota for pagespace target agents', async () => {
+        const context = {
+          toolCallId: '1', messages: [],
+          experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+        };
+
+        await agentCommunicationTools.ask_agent!.execute!(
+          { agentPath: '/drive/agent', agentId: 'agent-1', question: 'Test' },
+          context
+        );
+
+        expect(getCurrentUsage).toHaveBeenCalledWith('user-123', 'standard');
+        expect(incrementUsage).toHaveBeenCalledWith('user-123', 'standard');
+      });
+
+      it('returns quota-exceeded error before invoking the model', async () => {
+        vi.mocked(getCurrentUsage).mockResolvedValue({
+          success: true, remainingCalls: 0, currentCount: 100, limit: 100,
+        });
+
+        const context = {
+          toolCallId: '1', messages: [],
+          experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+        };
+
+        const result = await agentCommunicationTools.ask_agent!.execute!(
+          { agentPath: '/drive/agent', agentId: 'agent-1', question: 'Test' },
+          context
+        );
+
+        if (!('error' in result)) throw new Error('Expected error result');
+        expect(result.success).toBe(false);
+        expect(result.error).toContain('Daily AI quota exceeded');
+        expect(generateText).not.toHaveBeenCalled();
+        expect(incrementUsage).not.toHaveBeenCalled();
+      });
+
+      it('does not charge quota for BYO-key target agents', async () => {
+        mockDb.query.pages.findFirst = vi.fn().mockResolvedValue({
+          ...pagespaceAgent,
+          aiProvider: 'anthropic',
+        });
+
+        const context = {
+          toolCallId: '1', messages: [],
+          experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+        };
+
+        await agentCommunicationTools.ask_agent!.execute!(
+          { agentPath: '/drive/agent', agentId: 'agent-1', question: 'Test' },
+          context
+        );
+
+        expect(getCurrentUsage).not.toHaveBeenCalled();
+        expect(incrementUsage).not.toHaveBeenCalled();
       });
     });
   });

--- a/apps/web/src/lib/ai/tools/agent-communication-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-communication-tools.ts
@@ -26,6 +26,8 @@ import { searchTools } from './search-tools';
 import { taskManagementTools } from './task-management-tools';
 import { agentTools } from './agent-tools';
 import { loggers } from '@pagespace/lib/logging/logger-config';
+import { getCurrentUsage, incrementUsage } from '@/lib/subscription/usage-service';
+import { getPageSpaceModelTier } from '@/lib/ai/core/ai-providers-config';
 
 // Nesting cap. Intent is 3+ for richer agent-to-agent composition, but held at 2
 // until inner stepCountIs budget is reworked — see PR #713. Raising this without
@@ -433,6 +435,27 @@ export const agentCommunicationTools = {
           throw new Error(`Insufficient permissions to consult agent "${targetAgent.title}"`);
         }
 
+        // 2b. Quota check — only PageSpace-subsidized inference is metered.
+        // Each ask_agent call invokes a separate model run, so it counts as its own credit
+        // even when nested inside another agent's chat that already counted one.
+        const chargesQuota = (targetAgent.aiProvider || 'pagespace') === 'pagespace';
+        const providerType = getPageSpaceModelTier(targetAgent.aiModel || 'glm-4.5-air') ?? 'standard';
+
+        if (chargesQuota) {
+          const currentUsage = await getCurrentUsage(userId, providerType);
+          if (!currentUsage.success || currentUsage.remainingCalls <= 0) {
+            await logAgentInteraction({
+              requestingUserId: userId,
+              requestingAgent: executionContext?.locationContext?.currentPage?.id,
+              targetAgent: agentId,
+              question,
+              success: false,
+              error: 'Daily AI quota exceeded'
+            });
+            throw new Error(`Daily AI quota exceeded — cannot consult agent "${targetAgent.title}"`);
+          }
+        }
+
         // 3. Create or use existing conversation
         const activeConversationId = conversationId || createId();
 
@@ -603,6 +626,19 @@ export const agentCommunicationTools = {
             agentId,
             errors: toolErrors,
           });
+        }
+
+        // Charge one quota credit for the sub-agent's LLM invocation.
+        if (chargesQuota) {
+          try {
+            await incrementUsage(userId, providerType);
+          } catch (usageError) {
+            loggers.ai.error('ask_agent usage tracking failed', usageError as Error, {
+              userId,
+              agentId,
+              providerType,
+            });
+          }
         }
 
         // 13. Save assistant's response to database

--- a/apps/web/src/lib/ai/tools/agent-communication-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-communication-tools.ts
@@ -435,9 +435,8 @@ export const agentCommunicationTools = {
           throw new Error(`Insufficient permissions to consult agent "${targetAgent.title}"`);
         }
 
-        // 2b. Quota check — only PageSpace-subsidized inference is metered.
-        // Each ask_agent call invokes a separate model run, so it counts as its own credit
-        // even when nested inside another agent's chat that already counted one.
+        // 2b. Quota check — each ask_agent invocation runs its own model call, so it
+        // costs its own credit even when nested inside a parent agent's already-charged chat.
         const chargesQuota = (targetAgent.aiProvider || 'pagespace') === 'pagespace';
         const providerType = getPageSpaceModelTier(targetAgent.aiModel || 'glm-4.5-air') ?? 'standard';
 

--- a/apps/web/src/lib/workflows/__tests__/calendar-trigger-executor.test.ts
+++ b/apps/web/src/lib/workflows/__tests__/calendar-trigger-executor.test.ts
@@ -5,7 +5,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // ============================================================================
 
 const {
-  mockIncrementUsage,
   mockExecuteWorkflow,
   mockSelect,
   mockSelectFrom,
@@ -25,7 +24,6 @@ const {
     child: vi.fn(() => makeChildLogger()),
   });
   return {
-    mockIncrementUsage: vi.fn(),
     mockExecuteWorkflow: vi.fn(),
     mockSelect: vi.fn(),
     mockSelectFrom: vi.fn(),
@@ -81,10 +79,6 @@ vi.mock('@pagespace/db/schema/calendar-triggers', () => ({
 
 vi.mock('@/lib/workflows/workflow-executor', () => ({
   executeWorkflow: mockExecuteWorkflow,
-}));
-
-vi.mock('@/lib/subscription/usage-service', () => ({
-  incrementUsage: mockIncrementUsage,
 }));
 
 vi.mock('@/lib/logging/mask', () => ({
@@ -171,9 +165,6 @@ describe('executeCalendarTrigger', () => {
     // Default: scheduling user still has drive access
     mockIsUserDriveMember.mockResolvedValue(true);
 
-    // Default: rate limit passes
-    mockIncrementUsage.mockResolvedValue({ success: true });
-
     // Default select chain: agent page preflight → attendees → etc.
     mockSelect.mockReturnValue({ from: mockSelectFrom });
     mockSelectFrom.mockReturnValue({
@@ -254,16 +245,6 @@ describe('executeCalendarTrigger', () => {
     const syntheticWorkflow = mockExecuteWorkflow.mock.calls[0][0];
     expect(syntheticWorkflow.prompt).toContain('Alice');
     expect(syntheticWorkflow.prompt).toContain('bob@test.com');
-  });
-
-  it('fails when daily AI call limit is reached', async () => {
-    mockIncrementUsage.mockResolvedValue({ success: false });
-
-    const result = await executeCalendarTrigger(createTrigger(), createEvent());
-
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('limit');
-    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
   });
 
   it('updates trigger status to completed on success', async () => {
@@ -383,7 +364,7 @@ describe('executeCalendarTrigger', () => {
     expect(mockExecuteWorkflow).not.toHaveBeenCalled();
   });
 
-  it('fails without consuming usage when agent page is missing', async () => {
+  it('fails without invoking the workflow when agent page is missing', async () => {
     // Override default: agent page preflight returns empty (deleted since scheduling)
     mockSelectWhere.mockReset();
     mockSelectWhere.mockResolvedValue([]);
@@ -392,7 +373,6 @@ describe('executeCalendarTrigger', () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain('agent');
-    expect(mockIncrementUsage).not.toHaveBeenCalled();
     expect(mockExecuteWorkflow).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/workflows/__tests__/workflow-executor.test.ts
+++ b/apps/web/src/lib/workflows/__tests__/workflow-executor.test.ts
@@ -10,11 +10,17 @@ const {
   mockSelectFrom,
   mockSelect,
   mockResolvePageAgentIntegrationTools,
+  mockGetCurrentUsage,
+  mockIncrementUsage,
+  mockGetPageSpaceModelTier,
 } = vi.hoisted(() => ({
   mockSelectWhere: vi.fn(),
   mockSelectFrom: vi.fn(),
   mockSelect: vi.fn(),
   mockResolvePageAgentIntegrationTools: vi.fn(),
+  mockGetCurrentUsage: vi.fn(),
+  mockIncrementUsage: vi.fn(),
+  mockGetPageSpaceModelTier: vi.fn(),
 }));
 
 vi.mock('@pagespace/db/db', () => ({
@@ -67,6 +73,15 @@ vi.mock('@/lib/ai/core/integration-tool-resolver', () => ({
 
 vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
   AIMonitoring: { trackUsage: vi.fn() },
+}));
+
+vi.mock('@/lib/subscription/usage-service', () => ({
+  getCurrentUsage: mockGetCurrentUsage,
+  incrementUsage: mockIncrementUsage,
+}));
+
+vi.mock('@/lib/ai/core/ai-providers-config', () => ({
+  getPageSpaceModelTier: mockGetPageSpaceModelTier,
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
@@ -165,6 +180,9 @@ describe('executeWorkflow', () => {
     vi.mocked(isProviderError).mockReturnValue(false);
     vi.mocked(createAIProvider).mockResolvedValue(mockProviderResult as never);
     mockResolvePageAgentIntegrationTools.mockResolvedValue({});
+    mockGetCurrentUsage.mockResolvedValue({ success: true, remainingCalls: 99, currentCount: 1, limit: 100 });
+    mockIncrementUsage.mockResolvedValue({ success: true, remainingCalls: 98, currentCount: 2, limit: 100 });
+    mockGetPageSpaceModelTier.mockReturnValue('standard');
     vi.mocked(generateText).mockResolvedValue({
       text: 'Report complete',
       steps: [{ text: 'Report complete', toolCalls: [{}] }],
@@ -364,5 +382,60 @@ describe('executeWorkflow', () => {
     expect(result.success).toBe(false);
     expect(result.error).toBe('Network timeout');
     expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  // --------------------------------------------------------------------------
+  // Quota tracking
+  // --------------------------------------------------------------------------
+
+  test('charges quota for pagespace agents on success', async () => {
+    setupSelectChain([mockAgent], [mockDrive]);
+
+    const result = await executeWorkflow(createWorkflowFixture());
+
+    expect(result.success).toBe(true);
+    expect(mockGetCurrentUsage).toHaveBeenCalledWith('user_123', 'standard');
+    expect(mockIncrementUsage).toHaveBeenCalledWith('user_123', 'standard');
+  });
+
+  test('returns quota-exceeded error before invoking the model', async () => {
+    setupSelectChain([mockAgent], [mockDrive]);
+    mockGetCurrentUsage.mockResolvedValue({ success: true, remainingCalls: 0, currentCount: 100, limit: 100 });
+
+    const result = await executeWorkflow(createWorkflowFixture());
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Daily AI quota exceeded');
+    expect(generateText).not.toHaveBeenCalled();
+    expect(mockIncrementUsage).not.toHaveBeenCalled();
+  });
+
+  test('charges pro tier when agent uses a pro model', async () => {
+    setupSelectChain([{ ...mockAgent, aiModel: 'glm-5' }], [mockDrive]);
+    mockGetPageSpaceModelTier.mockReturnValue('pro');
+
+    await executeWorkflow(createWorkflowFixture());
+
+    expect(mockGetCurrentUsage).toHaveBeenCalledWith('user_123', 'pro');
+    expect(mockIncrementUsage).toHaveBeenCalledWith('user_123', 'pro');
+  });
+
+  test('does not charge quota when agent uses a BYO provider', async () => {
+    setupSelectChain([{ ...mockAgent, aiProvider: 'anthropic' }], [mockDrive]);
+
+    const result = await executeWorkflow(createWorkflowFixture());
+
+    expect(result.success).toBe(true);
+    expect(mockGetCurrentUsage).not.toHaveBeenCalled();
+    expect(mockIncrementUsage).not.toHaveBeenCalled();
+  });
+
+  test('still returns success when incrementUsage throws', async () => {
+    setupSelectChain([mockAgent], [mockDrive]);
+    mockIncrementUsage.mockRejectedValue(new Error('rate-limit cache offline'));
+
+    const result = await executeWorkflow(createWorkflowFixture());
+
+    expect(result.success).toBe(true);
   });
 });

--- a/apps/web/src/lib/workflows/calendar-trigger-executor.ts
+++ b/apps/web/src/lib/workflows/calendar-trigger-executor.ts
@@ -45,9 +45,8 @@ export async function executeCalendarTrigger(
       return { success: false, durationMs: Date.now() - startTime, error };
     }
 
-    // 3. Build prompt from trigger instructions + instruction page + event context
-    //    Quota is charged inside executeWorkflow so the correct tier (standard/pro)
-    //    is billed based on the agent's actual model.
+    // 3. Build prompt from trigger instructions + instruction page + event context.
+    //    Quota is charged inside executeWorkflow against the agent's actual model tier.
     const prompt = await buildTriggerPrompt(trigger, event);
 
     // 4. Construct synthetic WorkflowRow that executeWorkflow can consume.

--- a/apps/web/src/lib/workflows/calendar-trigger-executor.ts
+++ b/apps/web/src/lib/workflows/calendar-trigger-executor.ts
@@ -7,7 +7,6 @@ import { calendarTriggers } from '@pagespace/db/schema/calendar-triggers';
 import type { CalendarEvent } from '@pagespace/db/schema/calendar'
 import type { CalendarTrigger } from '@pagespace/db/schema/calendar-triggers';
 import { executeWorkflow, type WorkflowExecutionResult } from './workflow-executor';
-import { incrementUsage } from '@/lib/subscription/usage-service';
 import { isUserDriveMember } from '@pagespace/lib/permissions/permissions';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 
@@ -46,18 +45,12 @@ export async function executeCalendarTrigger(
       return { success: false, durationMs: Date.now() - startTime, error };
     }
 
-    // 3. Rate-limit check: consume one standard AI call from the scheduler's budget
-    const usageResult = await incrementUsage(trigger.scheduledById, 'standard');
-    if (!usageResult.success) {
-      const error = 'Daily AI call limit reached for scheduling user';
-      await markTriggerFailed(trigger.id, error, Date.now() - startTime);
-      return { success: false, durationMs: Date.now() - startTime, error };
-    }
-
-    // 4. Build prompt from trigger instructions + instruction page + event context
+    // 3. Build prompt from trigger instructions + instruction page + event context
+    //    Quota is charged inside executeWorkflow so the correct tier (standard/pro)
+    //    is billed based on the agent's actual model.
     const prompt = await buildTriggerPrompt(trigger, event);
 
-    // 5. Construct synthetic WorkflowRow that executeWorkflow can consume.
+    // 4. Construct synthetic WorkflowRow that executeWorkflow can consume.
     //    We only populate the fields the executor actually reads.
     const syntheticWorkflow = {
       id: trigger.id,
@@ -85,10 +78,10 @@ export async function executeCalendarTrigger(
       updatedAt: trigger.updatedAt,
     };
 
-    // 6. Execute via the standard workflow executor
+    // 5. Execute via the standard workflow executor
     const result = await executeWorkflow(syntheticWorkflow);
 
-    // 7. Update trigger with execution results
+    // 6. Update trigger with execution results
     await db
       .update(calendarTriggers)
       .set({

--- a/apps/web/src/lib/workflows/workflow-executor.ts
+++ b/apps/web/src/lib/workflows/workflow-executor.ts
@@ -10,8 +10,10 @@ import {
   type ToolExecutionContext,
   type ProviderRequest,
 } from '@/lib/ai/core';
+import { getPageSpaceModelTier } from '@/lib/ai/core/ai-providers-config';
 import { saveMessageToDatabase } from '@/lib/ai/core/message-utils';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
+import { getCurrentUsage, incrementUsage } from '@/lib/subscription/usage-service';
 import { db } from '@pagespace/db/db'
 import { eq, and, inArray } from '@pagespace/db/operators'
 import { users } from '@pagespace/db/schema/auth'
@@ -134,6 +136,22 @@ export async function executeWorkflow(workflow: WorkflowRow): Promise<WorkflowEx
       return { success: false, durationMs: Date.now() - startTime, error: `AI provider error: ${providerResult.error}` };
     }
 
+    // Charge quota only for PageSpace-subsidized inference. BYO-key calls (anthropic/openai/etc.)
+    // pass through uncharged, matching the chat route's gating.
+    const chargesQuota = selectedProvider === 'pagespace';
+    const providerType = getPageSpaceModelTier(selectedModel ?? 'glm-4.5-air') ?? 'standard';
+
+    if (chargesQuota) {
+      const currentUsage = await getCurrentUsage(workflow.createdBy, providerType);
+      if (!currentUsage.success || currentUsage.remainingCalls <= 0) {
+        return {
+          success: false,
+          durationMs: Date.now() - startTime,
+          error: 'Daily AI quota exceeded',
+        };
+      }
+    }
+
     // 6. Filter tools based on agent's enabled tools
     const enabledTools = (agent.enabledTools as string[] | null) ?? [];
     let availableTools: ToolSet = enabledTools.length > 0
@@ -233,6 +251,18 @@ export async function executeWorkflow(workflow: WorkflowRow): Promise<WorkflowEx
       (count, step) => count + (step.toolCalls?.length || 0),
       0
     ) || 0;
+
+    // Charge one quota credit. Mirrors chat route: log on failure, never fail the workflow on tracking errors.
+    if (chargesQuota) {
+      try {
+        await incrementUsage(workflow.createdBy, providerType);
+      } catch (usageError) {
+        loggers.api.error('Workflow usage tracking failed', usageError as Error, {
+          workflowId: workflow.id,
+          providerType,
+        });
+      }
+    }
 
     // 9. Save user prompt + AI response as chat messages
     const userMessageId = createId();

--- a/apps/web/src/lib/workflows/workflow-executor.ts
+++ b/apps/web/src/lib/workflows/workflow-executor.ts
@@ -136,8 +136,7 @@ export async function executeWorkflow(workflow: WorkflowRow): Promise<WorkflowEx
       return { success: false, durationMs: Date.now() - startTime, error: `AI provider error: ${providerResult.error}` };
     }
 
-    // Charge quota only for PageSpace-subsidized inference. BYO-key calls (anthropic/openai/etc.)
-    // pass through uncharged, matching the chat route's gating.
+    // Only charge for subsidized inference; BYO-key calls pass through uncharged (matches chat route).
     const chargesQuota = selectedProvider === 'pagespace';
     const providerType = getPageSpaceModelTier(selectedModel ?? 'glm-4.5-air') ?? 'standard';
 
@@ -252,7 +251,7 @@ export async function executeWorkflow(workflow: WorkflowRow): Promise<WorkflowEx
       0
     ) || 0;
 
-    // Charge one quota credit. Mirrors chat route: log on failure, never fail the workflow on tracking errors.
+    // Mirrors chat route: tracking errors log but never fail the workflow.
     if (chargesQuota) {
       try {
         await incrementUsage(workflow.createdBy, providerType);


### PR DESCRIPTION
## Summary

Plugs free-inference holes where AI surfaces called the PageSpace-subsidized provider without decrementing the user's daily quota counter.

- `workflow-executor` — central charge site. Preflight `getCurrentUsage` + postflight `incrementUsage`, gated on `selectedProvider === 'pagespace'`. Covers every workflow path: calendar triggers, cron-expression workflows, task-due-date triggers, task-completion fire-and-forget.
- `calendar-trigger-executor` — drop the redundant pre-charge that always billed `'standard'` regardless of the agent's actual model. Workflow-executor now charges with the correct tier.
- MCP `ask_agent` (`/api/ai/page-agents/consult`) — same two-phase charge.
- In-app `ask_agent` tool (`agent-communication-tools.ts`) — each nested call costs its own credit. Parent's chat call already counted one; the sub-agent invocation is a separate model run.
- BYO-key calls (anthropic / openai / etc. with user-supplied keys) stay uncharged, matching the `/api/ai/chat` route's gating.

## Out of scope

- Pulse routes (`/api/pulse/cron`, `/api/pulse/generate`) — same loophole, deferred.
- Memory services (`apps/web/src/lib/memory/{compaction,discovery,integration}-service.ts`, fired from `/api/memory/cron`) — same loophole, deferred for a separate decision on whether daily background work charges the user.
- Per-token metering — lands later as full metered billing.

## Test plan

- [x] `pnpm --filter web typecheck` — clean
- [x] 54 quota-related unit tests pass: workflow-executor, calendar-trigger-executor, agent-communication-tools
- [x] Full web vitest run: 6603 pass, 26 pre-existing failures unrelated (admin-role-version + gift-subscription tests need a real Postgres connection)
- [ ] Manual e2e: as a non-business user with a pagespace agent, fire a task-completion trigger; confirm `rate_limit_buckets` for `ai-usage:{userId}:standard` increments by 1; run until daily limit hits and confirm subsequent runs return `error: 'Daily AI quota exceeded'`
- [ ] Trigger MCP `ask_agent` from an external MCP client and the in-app `ask_agent` tool from inside a chat — both should bump the bucket
- [ ] Negative test: configure an agent with `aiProvider: 'anthropic'` + a user-supplied key, run a workflow, verify the bucket did NOT increment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daily AI quota enforcement activated for PageSpace-subsidized AI operations
  * Users exceeding daily limits receive a "Daily AI quota exceeded" error message before processing
  * Quota consumption tracked per subscription tier across agent consultations and automated workflows
  * Custom API key users continue without quota restrictions

* **Tests**
  * Added comprehensive quota enforcement validation and usage tracking tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->