### PR TITLE
fix(ai): wire integration tools to consult route

### DIFF
--- a/apps/web/src/app/api/ai/page-agents/consult/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { convertToModelMessages, generateText, stepCountIs, hasToolCall } from 'ai';
 import { finishTool, FINISH_TOOL_NAME } from '@/lib/ai/tools/finish-tool';
+import { mergeToolSets } from '@/lib/ai/core/tool-utils';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
 import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
@@ -293,6 +294,24 @@ export async function POST(request: Request) {
         )
       : {};
 
+    // INTEGRATION TOOLS: resolve and merge integration tools for this agent
+    let toolsForRun: Record<string, unknown> = availableTools;
+    let integrationToolCount = 0;
+    try {
+      const { resolvePageAgentIntegrationTools } = await import('@/lib/ai/core/integration-tool-resolver');
+      const integrationTools = await resolvePageAgentIntegrationTools({
+        agentId,
+        userId,
+        driveId: agent.driveId,
+      });
+      integrationToolCount = Object.keys(integrationTools).length;
+      if (integrationToolCount > 0) {
+        toolsForRun = mergeToolSets(toolsForRun as Parameters<typeof mergeToolSets>[0], integrationTools);
+      }
+    } catch (error) {
+      loggers.api.error('Agent consultation: failed to resolve integration tools', error as Error);
+    }
+
     // Generate response using the AI model
     let responseText = '';
     try {
@@ -311,11 +330,13 @@ export async function POST(request: Request) {
         agentTitle: agent.title,
         toolsEnabled: Array.isArray(enabledTools) ? enabledTools.length : 0,
         availableToolsCount: Object.keys(availableTools).length,
+        integrationToolCount,
+        totalToolsForRun: Object.keys(toolsForRun).length,
         enabledToolsList: enabledTools,
         hasDriveContext: !!drive
       });
 
-      const result = Object.keys(availableTools).length > 0
+      const result = Object.keys(toolsForRun).length > 0
         ? await generateText({
             model,
             system: enhancedSystemPrompt,
@@ -324,7 +345,7 @@ export async function POST(request: Request) {
               content: m.content,
               parts: [{ type: 'text', text: m.content }]
             }))),
-            tools: { ...availableTools, ...finishTool },
+            tools: { ...toolsForRun, ...finishTool },
             toolChoice: 'auto',
             temperature: 0.7,
             maxRetries: 3,


### PR DESCRIPTION
## Summary

- Agents invoked through `/api/ai/page-agents/consult` (workflows, MCP, external automation) were running with built-in PageSpace tools only — integration grants for GitHub, Calendar, Drive, etc. were never resolved.
- Models attempting to call `int__github__<id>__get_commit` (and any other integration tool) failed with `Model tried to call unavailable tool …`, surfacing as `Agent consultation tool execution errors` warnings in production logs.
- Fix mirrors the resolution pattern already used by `/api/ai/chat` and the in-process `ask_agent` tool: after the `enabledTools` filter, resolve integration tools via `resolvePageAgentIntegrationTools` and merge them before handing tools to `generateText`.

## Why this was missed

Integration tools landed in #1150, which updated the page-chat route and `ask_agent`. The standalone consult HTTP endpoint has no internal callers in the monorepo, so it slipped through — every workflow call that hit it was broken.

## Files changed

- `apps/web/src/app/api/ai/page-agents/consult/route.ts` — adds `mergeToolSets` import, resolves integration tools after the built-in filter, threads a single `toolsForRun` map into both `generateText` branches, and adds `integrationToolCount` / `totalToolsForRun` to the diagnostic debug log.

## Test plan

- [ ] Find/create an AI_CHAT agent with an active GitHub integration grant.
- [ ] Trigger the failing workflow (or POST directly to `/api/ai/page-agents/consult`) with a question like *"look up commit `<sha>` in `2witstudios/MiQv1`"*.
- [ ] Confirm the new debug line shows `integrationToolCount > 0`.
- [ ] Confirm no `Agent consultation tool execution errors` warning fires for `int__github__…__get_commit`.
- [ ] Confirm the model returns commit details rather than "I don't have access to that tool".
- [ ] `pnpm --filter web typecheck` passes (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)