### PR TITLE
feat(ai): broadcast message edits, deletes, undo, and new conversations to remote viewers

### DIFF
--- a/apps/web/src/app/api/ai/chat/messages/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/chat/messages/[messageId]/route.ts
@@ -12,6 +12,9 @@ import { db } from '@pagespace/db/db'
 import { eq } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core';
 import { getActorInfo, logMessageActivity } from '@pagespace/lib/monitoring/activity-logger';
+import { broadcastAiMessageEdited, broadcastAiMessageDeleted } from '@/lib/websocket/socket-utils';
+import { resolveTriggeredBy } from '@/lib/websocket/broadcast-triggered-by';
+import { convertDbMessageToUIMessage } from '@/lib/ai/core/message-utils';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 
@@ -99,6 +102,38 @@ export async function PATCH(
 
     // Update the message content and set editedAt
     await chatMessageRepository.updateMessageContent(messageId, updatedContent);
+
+    // Broadcast to remote viewers. Failure must never break the request.
+    void (async () => {
+      try {
+        const updated = await chatMessageRepository.getMessageById(messageId);
+        if (!updated) return;
+        const triggeredBy = await resolveTriggeredBy(userId, request);
+        const uiMessage = convertDbMessageToUIMessage({
+          id: updated.id,
+          role: updated.role as 'user' | 'assistant' | 'system',
+          content: updated.content,
+          createdAt: updated.createdAt,
+          editedAt: updated.editedAt,
+          messageType: updated.messageType,
+          toolCalls: updated.toolCalls,
+          toolResults: updated.toolResults,
+        });
+        await broadcastAiMessageEdited({
+          messageId,
+          pageId: message.pageId,
+          conversationId: updated.conversationId,
+          parts: uiMessage.parts,
+          editedAt: (updated.editedAt ?? new Date()).toISOString(),
+          triggeredBy,
+        });
+      } catch (broadcastError) {
+        loggers.api.error('Failed to broadcast chat message edit', broadcastError as Error, {
+          messageId: maskIdentifier(messageId),
+          pageId: maskIdentifier(message.pageId),
+        });
+      }
+    })();
 
     // Log activity for audit trail (non-blocking)
     try {
@@ -196,6 +231,24 @@ export async function DELETE(
 
     // Soft delete the message
     await chatMessageRepository.softDeleteMessage(messageId);
+
+    // Broadcast to remote viewers. Failure must never break the request.
+    void (async () => {
+      try {
+        const triggeredBy = await resolveTriggeredBy(userId, request);
+        await broadcastAiMessageDeleted({
+          messageId,
+          pageId: message.pageId,
+          conversationId: message.conversationId,
+          triggeredBy,
+        });
+      } catch (broadcastError) {
+        loggers.api.error('Failed to broadcast chat message delete', broadcastError as Error, {
+          messageId: maskIdentifier(messageId),
+          pageId: maskIdentifier(message.pageId),
+        });
+      }
+    })();
 
     // Log activity for audit trail (non-blocking)
     try {

--- a/apps/web/src/app/api/ai/chat/messages/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/chat/messages/[messageId]/route.ts
@@ -109,16 +109,7 @@ export async function PATCH(
         const updated = await chatMessageRepository.getMessageById(messageId);
         if (!updated) return;
         const triggeredBy = await resolveTriggeredBy(userId, request);
-        const uiMessage = convertDbMessageToUIMessage({
-          id: updated.id,
-          role: updated.role as 'user' | 'assistant' | 'system',
-          content: updated.content,
-          createdAt: updated.createdAt,
-          editedAt: updated.editedAt,
-          messageType: updated.messageType,
-          toolCalls: updated.toolCalls,
-          toolResults: updated.toolResults,
-        });
+        const uiMessage = convertDbMessageToUIMessage(updated);
         await broadcastAiMessageEdited({
           messageId,
           pageId: message.pageId,

--- a/apps/web/src/app/api/ai/chat/messages/[messageId]/undo/route.ts
+++ b/apps/web/src/app/api/ai/chat/messages/[messageId]/undo/route.ts
@@ -8,7 +8,10 @@ import { maskIdentifier } from '@/lib/logging/mask';
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 import { previewAiUndo, executeAiUndo, type AiUndoPreview } from '@/services/api';
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
+import { broadcastAiUndoApplied } from '@/lib/websocket/socket-utils';
+import { resolveTriggeredBy } from '@/lib/websocket/broadcast-triggered-by';
 import { createSignedBroadcastHeaders } from '@pagespace/lib/auth/broadcast-auth';
+import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
 
 // Request body schema for POST /undo
 const undoBodySchema = z.object({
@@ -218,6 +221,34 @@ export async function POST(
         { status: 500 }
       );
     }
+
+    // Broadcast chat:undo_applied so remote viewers refresh their conversation.
+    // Page-event broadcasts below cover the page-domain side; this one covers the
+    // chat-domain side (conversation history). Failure must never break the request.
+    void (async () => {
+      try {
+        const triggeredBy = await resolveTriggeredBy(userId, request);
+        const broadcastPageId = preview.source === 'page_chat' && preview.pageId
+          ? preview.pageId
+          : globalChannelId(userId);
+        const messageIdsFromActivities = preview.activitiesAffected
+          .filter((a) => a.resourceType === 'message')
+          .map((a) => a.resourceId);
+        const affectedMessageIds = Array.from(new Set([messageId, ...messageIdsFromActivities]));
+        await broadcastAiUndoApplied({
+          conversationId: preview.conversationId,
+          pageId: broadcastPageId,
+          mode,
+          affectedMessageIds,
+          triggeredBy,
+        });
+      } catch (broadcastError) {
+        loggers.api.error('Failed to broadcast chat undo-applied', broadcastError as Error, {
+          messageId: maskIdentifier(messageId),
+          conversationId: maskIdentifier(preview.conversationId),
+        });
+      }
+    })();
 
     // Broadcast real-time updates for affected pages and channels
     if (mode === 'messages_and_changes') {

--- a/apps/web/src/app/api/ai/global/[id]/messages/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/[messageId]/route.ts
@@ -6,6 +6,9 @@ import { maskIdentifier } from '@/lib/logging/mask';
 import { globalConversationRepository } from '@/lib/repositories/global-conversation-repository';
 import { processMessageContentUpdate } from '@/lib/repositories/chat-message-repository';
 import { getActorInfo, logMessageActivity } from '@pagespace/lib/monitoring/activity-logger';
+import { broadcastAiMessageEdited, broadcastAiMessageDeleted } from '@/lib/websocket/socket-utils';
+import { resolveTriggeredBy } from '@/lib/websocket/broadcast-triggered-by';
+import { globalChannelId } from '@pagespace/lib/ai/global-channel-id';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 
@@ -60,6 +63,26 @@ export async function PATCH(
 
     // Update the message content
     await globalConversationRepository.updateMessageContent(messageId, updatedContent);
+
+    // Broadcast to remote viewers (other tabs of this user). Failure must never break the request.
+    void (async () => {
+      try {
+        const triggeredBy = await resolveTriggeredBy(userId, request);
+        await broadcastAiMessageEdited({
+          messageId,
+          pageId: globalChannelId(userId),
+          conversationId,
+          parts: [{ type: 'text', text: updatedContent }],
+          editedAt: new Date().toISOString(),
+          triggeredBy,
+        });
+      } catch (broadcastError) {
+        loggers.api.error('Failed to broadcast global message edit', broadcastError as Error, {
+          messageId: maskIdentifier(messageId),
+          conversationId: maskIdentifier(conversationId),
+        });
+      }
+    })();
 
     // Log activity for audit trail (non-blocking)
     try {
@@ -144,6 +167,24 @@ export async function DELETE(
 
     // Soft delete the message
     await globalConversationRepository.softDeleteMessage(messageId);
+
+    // Broadcast to remote viewers (other tabs of this user). Failure must never break the request.
+    void (async () => {
+      try {
+        const triggeredBy = await resolveTriggeredBy(userId, request);
+        await broadcastAiMessageDeleted({
+          messageId,
+          pageId: globalChannelId(userId),
+          conversationId,
+          triggeredBy,
+        });
+      } catch (broadcastError) {
+        loggers.api.error('Failed to broadcast global message delete', broadcastError as Error, {
+          messageId: maskIdentifier(messageId),
+          conversationId: maskIdentifier(conversationId),
+        });
+      }
+    })();
 
     // Log activity for audit trail (non-blocking)
     try {

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/[messageId]/route.ts
@@ -91,16 +91,7 @@ export async function PATCH(
         const updated = await chatMessageRepository.getMessageById(messageId);
         if (!updated) return;
         const triggeredBy = await resolveTriggeredBy(userId, request);
-        const uiMessage = convertDbMessageToUIMessage({
-          id: updated.id,
-          role: updated.role as 'user' | 'assistant' | 'system',
-          content: updated.content,
-          createdAt: updated.createdAt,
-          editedAt: updated.editedAt,
-          messageType: updated.messageType,
-          toolCalls: updated.toolCalls,
-          toolResults: updated.toolResults,
-        });
+        const uiMessage = convertDbMessageToUIMessage(updated);
         await broadcastAiMessageEdited({
           messageId,
           pageId: agentId,

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/messages/[messageId]/route.ts
@@ -9,6 +9,9 @@ import {
   processMessageContentUpdate,
 } from '@/lib/repositories/chat-message-repository';
 import { getActorInfo, logMessageActivity } from '@pagespace/lib/monitoring/activity-logger';
+import { broadcastAiMessageEdited, broadcastAiMessageDeleted } from '@/lib/websocket/socket-utils';
+import { resolveTriggeredBy } from '@/lib/websocket/broadcast-triggered-by';
+import { convertDbMessageToUIMessage } from '@/lib/ai/core/message-utils';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 
@@ -80,6 +83,39 @@ export async function PATCH(
 
     // Update the message content and set editedAt
     await chatMessageRepository.updateMessageContent(messageId, updatedContent);
+
+    // Broadcast to remote viewers so their message bubble re-renders without a refetch.
+    // Failure to broadcast must never break the request — wrapped in catch.
+    void (async () => {
+      try {
+        const updated = await chatMessageRepository.getMessageById(messageId);
+        if (!updated) return;
+        const triggeredBy = await resolveTriggeredBy(userId, request);
+        const uiMessage = convertDbMessageToUIMessage({
+          id: updated.id,
+          role: updated.role as 'user' | 'assistant' | 'system',
+          content: updated.content,
+          createdAt: updated.createdAt,
+          editedAt: updated.editedAt,
+          messageType: updated.messageType,
+          toolCalls: updated.toolCalls,
+          toolResults: updated.toolResults,
+        });
+        await broadcastAiMessageEdited({
+          messageId,
+          pageId: agentId,
+          conversationId,
+          parts: uiMessage.parts,
+          editedAt: (updated.editedAt ?? new Date()).toISOString(),
+          triggeredBy,
+        });
+      } catch (broadcastError) {
+        loggers.api.error('Failed to broadcast agent message edit', broadcastError as Error, {
+          messageId: maskIdentifier(messageId),
+          agentId: maskIdentifier(agentId),
+        });
+      }
+    })();
 
     // Log activity for audit trail
     try {
@@ -183,6 +219,24 @@ export async function DELETE(
 
     // Soft delete the message
     await chatMessageRepository.softDeleteMessage(messageId);
+
+    // Broadcast to remote viewers. Failure must never break the request.
+    void (async () => {
+      try {
+        const triggeredBy = await resolveTriggeredBy(userId, request);
+        await broadcastAiMessageDeleted({
+          messageId,
+          pageId: agentId,
+          conversationId,
+          triggeredBy,
+        });
+      } catch (broadcastError) {
+        loggers.api.error('Failed to broadcast agent message delete', broadcastError as Error, {
+          messageId: maskIdentifier(messageId),
+          agentId: maskIdentifier(agentId),
+        });
+      }
+    })();
 
     // Log activity for audit trail
     try {

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/route.ts
@@ -10,6 +10,9 @@ import {
   generateTitle,
 } from '@/lib/repositories/conversation-repository';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
+import { broadcastAiConversationAdded } from '@/lib/websocket/socket-utils';
+import { resolveTriggeredBy } from '@/lib/websocket/broadcast-triggered-by';
+import { maskIdentifier } from '@/lib/logging/mask';
 
 // Auth options: GET is read-only, POST creates new conversations
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
@@ -186,6 +189,29 @@ export async function POST(
       title: customTitle || 'New conversation',
       createdAt: new Date(),
     };
+
+    // Broadcast to other viewers of this shared agent so their history pane prepends the new
+    // conversation. Note: the conversation row is materialized lazily on first message save —
+    // remote viewers will see the entry appear here and become populated when messages arrive.
+    void (async () => {
+      try {
+        const triggeredBy = await resolveTriggeredBy(auth.userId, request);
+        await broadcastAiConversationAdded({
+          agentId,
+          conversation: {
+            id: conversationId,
+            title: response.title,
+            createdAt: response.createdAt.toISOString(),
+          },
+          triggeredBy,
+        });
+      } catch (broadcastError) {
+        loggers.ai.error('Failed to broadcast chat conversation-added', broadcastError as Error, {
+          agentId: maskIdentifier(agentId),
+          conversationId: maskIdentifier(conversationId),
+        });
+      }
+    })();
 
     auditRequest(request, { eventType: 'data.write', userId: auth.userId, resourceType: 'page_agent_conversation', resourceId: conversationId, details: {
       action: 'create_conversation',

--- a/apps/web/src/components/ai/shared/chat/UndoAiChangesDialog.tsx
+++ b/apps/web/src/components/ai/shared/chat/UndoAiChangesDialog.tsx
@@ -19,6 +19,7 @@ import { Switch } from '@/components/ui/switch';
 import { fetchWithAuth, post } from '@/lib/auth/auth-fetch';
 import type { AiUndoPreview, UndoMode } from '@/services/api';
 import { createClientLogger } from '@/lib/logging/client-logger';
+import { getBrowserSessionId } from '@/lib/ai/core/browser-session-id';
 
 const logger = createClientLogger({ namespace: 'rollback', component: 'UndoAiChangesDialog' });
 
@@ -94,8 +95,12 @@ export const UndoAiChangesDialog: React.FC<UndoAiChangesDialogProps> = ({
     setError(null);
 
     try {
-      // post() returns parsed JSON and throws on errors
-      await post(`/api/ai/chat/messages/${messageId}/undo`, { mode, force });
+      // post() returns parsed JSON and throws on errors. X-Browser-Session-Id
+      // lets the server include the originator in the chat:undo_applied
+      // broadcast so the originator's other tabs can dedup.
+      await post(`/api/ai/chat/messages/${messageId}/undo`, { mode, force }, {
+        headers: { 'X-Browser-Session-Id': getBrowserSessionId() },
+      });
 
       logger.debug('[AiUndo:Execute] Undo completed successfully', { mode });
       onOpenChange(false);

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -357,16 +357,16 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
     onMessageEdited: (payload) => {
       if (payload.conversationId !== currentConversationId) return;
       setMessages((prev) =>
-        applyMessageEdit(prev as never, {
+        applyMessageEdit(prev, {
           messageId: payload.messageId,
           parts: payload.parts,
           editedAt: new Date(payload.editedAt),
-        }) as typeof prev,
+        }),
       );
     },
     onMessageDeleted: (payload) => {
       if (payload.conversationId !== currentConversationId) return;
-      setMessages((prev) => applyMessageDelete(prev, payload.messageId) as typeof prev);
+      setMessages((prev) => applyMessageDelete(prev, payload.messageId));
     },
     onUndoApplied: (payload) => {
       if (!shouldRefreshAfterUndo(payload, currentConversationId, getBrowserSessionId())) return;

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -34,6 +34,8 @@ import { usePageSocketRoom } from '@/hooks/usePageSocketRoom';
 import { useChannelStreamSocket } from '@/hooks/useChannelStreamSocket';
 import { usePendingStreamsStore } from '@/stores/usePendingStreamsStore';
 import { synthesizeAssistantMessage } from '@/lib/ai/streams/synthesizeAssistantMessage';
+import { applyMessageEdit } from '@/lib/ai/streams/applyMessageEdit';
+import { applyMessageDelete } from '@/lib/ai/streams/applyMessageDelete';
 import { useShallow } from 'zustand/react/shallow';
 
 // Shared hooks and components
@@ -347,6 +349,20 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
     onUserMessage: (message, payload) => {
       if (payload.conversationId !== currentConversationId) return;
       setMessages((prev) => (prev.some((m) => m.id === message.id) ? prev : [...prev, message]));
+    },
+    onMessageEdited: (payload) => {
+      if (payload.conversationId !== currentConversationId) return;
+      setMessages((prev) =>
+        applyMessageEdit(prev as never, {
+          messageId: payload.messageId,
+          parts: payload.parts,
+          editedAt: new Date(payload.editedAt),
+        }) as typeof prev,
+      );
+    },
+    onMessageDeleted: (payload) => {
+      if (payload.conversationId !== currentConversationId) return;
+      setMessages((prev) => applyMessageDelete(prev, payload.messageId) as typeof prev);
     },
     onStreamComplete: (messageId) => {
       const stream = usePendingStreamsStore.getState().streams.get(messageId);

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -36,6 +36,8 @@ import { usePendingStreamsStore } from '@/stores/usePendingStreamsStore';
 import { synthesizeAssistantMessage } from '@/lib/ai/streams/synthesizeAssistantMessage';
 import { applyMessageEdit } from '@/lib/ai/streams/applyMessageEdit';
 import { applyMessageDelete } from '@/lib/ai/streams/applyMessageDelete';
+import { shouldRefreshAfterUndo } from '@/lib/ai/streams/shouldRefreshAfterUndo';
+import { getBrowserSessionId } from '@/lib/ai/core/browser-session-id';
 import { useShallow } from 'zustand/react/shallow';
 
 // Shared hooks and components
@@ -363,6 +365,10 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
     onMessageDeleted: (payload) => {
       if (payload.conversationId !== currentConversationId) return;
       setMessages((prev) => applyMessageDelete(prev, payload.messageId) as typeof prev);
+    },
+    onUndoApplied: (payload) => {
+      if (!shouldRefreshAfterUndo(payload, currentConversationId, getBrowserSessionId())) return;
+      void loadConversation(payload.conversationId);
     },
     onStreamComplete: (messageId) => {
       const stream = usePendingStreamsStore.getState().streams.get(messageId);

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -37,6 +37,7 @@ import { synthesizeAssistantMessage } from '@/lib/ai/streams/synthesizeAssistant
 import { applyMessageEdit } from '@/lib/ai/streams/applyMessageEdit';
 import { applyMessageDelete } from '@/lib/ai/streams/applyMessageDelete';
 import { shouldRefreshAfterUndo } from '@/lib/ai/streams/shouldRefreshAfterUndo';
+import { shouldPrependConversation } from '@/lib/ai/streams/shouldPrependConversation';
 import { getBrowserSessionId } from '@/lib/ai/core/browser-session-id';
 import { useShallow } from 'zustand/react/shallow';
 
@@ -155,6 +156,7 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
     loadConversation,
     createConversation,
     deleteConversation,
+    prependConversationOptimistic,
   } = useConversations({
     agentId: page.id,
     currentConversationId,
@@ -369,6 +371,10 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
     onUndoApplied: (payload) => {
       if (!shouldRefreshAfterUndo(payload, currentConversationId, getBrowserSessionId())) return;
       void loadConversation(payload.conversationId);
+    },
+    onConversationAdded: (payload) => {
+      if (!shouldPrependConversation(payload, getBrowserSessionId(), conversations)) return;
+      prependConversationOptimistic(payload.conversation);
     },
     onStreamComplete: (messageId) => {
       const stream = usePendingStreamsStore.getState().streams.get(messageId);

--- a/apps/web/src/contexts/GlobalChatContext.tsx
+++ b/apps/web/src/contexts/GlobalChatContext.tsx
@@ -285,16 +285,16 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
     onMessageEdited: (payload) => {
       if (payload.conversationId !== currentConversationId) return;
       setMessages((prev) =>
-        applyMessageEdit(prev as never, {
+        applyMessageEdit(prev, {
           messageId: payload.messageId,
           parts: payload.parts,
           editedAt: new Date(payload.editedAt),
-        }) as typeof prev,
+        }),
       );
     },
     onMessageDeleted: (payload) => {
       if (payload.conversationId !== currentConversationId) return;
-      setMessages((prev) => applyMessageDelete(prev, payload.messageId) as typeof prev);
+      setMessages((prev) => applyMessageDelete(prev, payload.messageId));
     },
     onUndoApplied: (payload) => {
       if (!shouldRefreshAfterUndo(payload, currentConversationId, getBrowserSessionId())) return;

--- a/apps/web/src/contexts/GlobalChatContext.tsx
+++ b/apps/web/src/contexts/GlobalChatContext.tsx
@@ -9,6 +9,8 @@ import { useChatTransport, useStreamingRegistration } from '@/lib/ai/shared';
 import { shouldRefreshOnReconnect } from '@/lib/ai/streams/shouldRefreshOnReconnect';
 import { applyMessageEdit } from '@/lib/ai/streams/applyMessageEdit';
 import { applyMessageDelete } from '@/lib/ai/streams/applyMessageDelete';
+import { shouldRefreshAfterUndo } from '@/lib/ai/streams/shouldRefreshAfterUndo';
+import { getBrowserSessionId } from '@/lib/ai/core/browser-session-id';
 import { useSocketStore } from '@/stores/useSocketStore';
 import { useAuth } from '@/hooks/useAuth';
 import { useChannelStreamSocket } from '@/hooks/useChannelStreamSocket';
@@ -293,6 +295,10 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
     onMessageDeleted: (payload) => {
       if (payload.conversationId !== currentConversationId) return;
       setMessages((prev) => applyMessageDelete(prev, payload.messageId) as typeof prev);
+    },
+    onUndoApplied: (payload) => {
+      if (!shouldRefreshAfterUndo(payload, currentConversationId, getBrowserSessionId())) return;
+      refreshConversationRef.current();
     },
     onStreamComplete: () => {
       refreshConversationRef.current();

--- a/apps/web/src/contexts/GlobalChatContext.tsx
+++ b/apps/web/src/contexts/GlobalChatContext.tsx
@@ -7,6 +7,8 @@ import { conversationState } from '@/lib/ai/core/conversation-state';
 import { getAgentId, getConversationId, setConversationId } from '@/lib/url-state';
 import { useChatTransport, useStreamingRegistration } from '@/lib/ai/shared';
 import { shouldRefreshOnReconnect } from '@/lib/ai/streams/shouldRefreshOnReconnect';
+import { applyMessageEdit } from '@/lib/ai/streams/applyMessageEdit';
+import { applyMessageDelete } from '@/lib/ai/streams/applyMessageDelete';
 import { useSocketStore } from '@/stores/useSocketStore';
 import { useAuth } from '@/hooks/useAuth';
 import { useChannelStreamSocket } from '@/hooks/useChannelStreamSocket';
@@ -277,6 +279,20 @@ export function GlobalChatProvider({ children }: { children: ReactNode }) {
     onUserMessage: (message, payload) => {
       if (payload.conversationId !== currentConversationId) return;
       setMessages((prev) => (prev.some((m) => m.id === message.id) ? prev : [...prev, message]));
+    },
+    onMessageEdited: (payload) => {
+      if (payload.conversationId !== currentConversationId) return;
+      setMessages((prev) =>
+        applyMessageEdit(prev as never, {
+          messageId: payload.messageId,
+          parts: payload.parts,
+          editedAt: new Date(payload.editedAt),
+        }) as typeof prev,
+      );
+    },
+    onMessageDeleted: (payload) => {
+      if (payload.conversationId !== currentConversationId) return;
+      setMessages((prev) => applyMessageDelete(prev, payload.messageId) as typeof prev);
     },
     onStreamComplete: () => {
       refreshConversationRef.current();

--- a/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
+++ b/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
@@ -96,6 +96,7 @@ import type {
   ChatMessageEditedPayload,
   ChatMessageDeletedPayload,
   ChatUndoAppliedPayload,
+  ChatConversationAddedPayload,
 } from '@/lib/websocket/socket-utils';
 
 const START_PAYLOAD: AiStreamStartPayload = {
@@ -138,6 +139,16 @@ const UNDO_APPLIED_PAYLOAD: ChatUndoAppliedPayload = {
   pageId: 'page-a',
   mode: 'messages_and_changes',
   affectedMessageIds: ['msg-1', 'msg-2'],
+  triggeredBy: { userId: 'user-2', displayName: 'Alice', browserSessionId: SESSION_ID_REMOTE },
+};
+
+const CONVERSATION_ADDED_PAYLOAD: ChatConversationAddedPayload = {
+  agentId: 'page-a',
+  conversation: {
+    id: 'conv-new',
+    title: 'New conversation',
+    createdAt: '2026-05-01T00:00:00.000Z',
+  },
   triggeredBy: { userId: 'user-2', displayName: 'Alice', browserSessionId: SESSION_ID_REMOTE },
 };
 
@@ -455,6 +466,43 @@ describe('useChannelStreamSocket', () => {
       });
 
       expect(onUndoApplied).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('chat:conversation_added', () => {
+    it('given a chat:conversation_added from another tab for the current agent room, should call onConversationAdded with the payload', () => {
+      const onConversationAdded = vi.fn();
+      renderHook(() => useChannelStreamSocket('page-a', { onConversationAdded }));
+
+      act(() => { mockSocket._trigger('chat:conversation_added', CONVERSATION_ADDED_PAYLOAD); });
+
+      expect(onConversationAdded).toHaveBeenCalledTimes(1);
+      expect(onConversationAdded).toHaveBeenCalledWith(CONVERSATION_ADDED_PAYLOAD);
+    });
+
+    it('given chat:conversation_added with a different agentId, should NOT call onConversationAdded (stale-room guard)', () => {
+      const onConversationAdded = vi.fn();
+      renderHook(() => useChannelStreamSocket('page-a', { onConversationAdded }));
+
+      act(() => {
+        mockSocket._trigger('chat:conversation_added', { ...CONVERSATION_ADDED_PAYLOAD, agentId: 'page-b' });
+      });
+
+      expect(onConversationAdded).not.toHaveBeenCalled();
+    });
+
+    it('given chat:conversation_added whose triggeredBy.browserSessionId matches the local session, should NOT call onConversationAdded (own-tab dedup)', () => {
+      const onConversationAdded = vi.fn();
+      renderHook(() => useChannelStreamSocket('page-a', { onConversationAdded }));
+
+      act(() => {
+        mockSocket._trigger('chat:conversation_added', {
+          ...CONVERSATION_ADDED_PAYLOAD,
+          triggeredBy: { ...CONVERSATION_ADDED_PAYLOAD.triggeredBy, browserSessionId: SESSION_ID_LOCAL },
+        });
+      });
+
+      expect(onConversationAdded).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
+++ b/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
@@ -95,6 +95,7 @@ import type {
   ChatUserMessagePayload,
   ChatMessageEditedPayload,
   ChatMessageDeletedPayload,
+  ChatUndoAppliedPayload,
 } from '@/lib/websocket/socket-utils';
 
 const START_PAYLOAD: AiStreamStartPayload = {
@@ -129,6 +130,14 @@ const MESSAGE_DELETED_PAYLOAD: ChatMessageDeletedPayload = {
   messageId: 'msg-1',
   pageId: 'page-a',
   conversationId: 'conv-1',
+  triggeredBy: { userId: 'user-2', displayName: 'Alice', browserSessionId: SESSION_ID_REMOTE },
+};
+
+const UNDO_APPLIED_PAYLOAD: ChatUndoAppliedPayload = {
+  conversationId: 'conv-1',
+  pageId: 'page-a',
+  mode: 'messages_and_changes',
+  affectedMessageIds: ['msg-1', 'msg-2'],
   triggeredBy: { userId: 'user-2', displayName: 'Alice', browserSessionId: SESSION_ID_REMOTE },
 };
 
@@ -409,6 +418,43 @@ describe('useChannelStreamSocket', () => {
       act(() => { mockSocket._trigger('chat:message_deleted', MESSAGE_DELETED_PAYLOAD); });
 
       expect(onMessageDeleted).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('chat:undo_applied', () => {
+    it('given a chat:undo_applied from another tab for the current channel, should call onUndoApplied with the payload', () => {
+      const onUndoApplied = vi.fn();
+      renderHook(() => useChannelStreamSocket('page-a', { onUndoApplied }));
+
+      act(() => { mockSocket._trigger('chat:undo_applied', UNDO_APPLIED_PAYLOAD); });
+
+      expect(onUndoApplied).toHaveBeenCalledTimes(1);
+      expect(onUndoApplied).toHaveBeenCalledWith(UNDO_APPLIED_PAYLOAD);
+    });
+
+    it('given chat:undo_applied with a different pageId, should NOT call onUndoApplied (stale-room guard)', () => {
+      const onUndoApplied = vi.fn();
+      renderHook(() => useChannelStreamSocket('page-a', { onUndoApplied }));
+
+      act(() => {
+        mockSocket._trigger('chat:undo_applied', { ...UNDO_APPLIED_PAYLOAD, pageId: 'page-b' });
+      });
+
+      expect(onUndoApplied).not.toHaveBeenCalled();
+    });
+
+    it('given chat:undo_applied whose triggeredBy.browserSessionId matches the local session, should NOT call onUndoApplied (own-tab dedup)', () => {
+      const onUndoApplied = vi.fn();
+      renderHook(() => useChannelStreamSocket('page-a', { onUndoApplied }));
+
+      act(() => {
+        mockSocket._trigger('chat:undo_applied', {
+          ...UNDO_APPLIED_PAYLOAD,
+          triggeredBy: { ...UNDO_APPLIED_PAYLOAD.triggeredBy, browserSessionId: SESSION_ID_LOCAL },
+        });
+      });
+
+      expect(onUndoApplied).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
+++ b/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
@@ -93,6 +93,8 @@ import type {
   AiStreamStartPayload,
   AiStreamCompletePayload,
   ChatUserMessagePayload,
+  ChatMessageEditedPayload,
+  ChatMessageDeletedPayload,
 } from '@/lib/websocket/socket-utils';
 
 const START_PAYLOAD: AiStreamStartPayload = {
@@ -109,6 +111,22 @@ const COMPLETE_PAYLOAD: AiStreamCompletePayload = {
 
 const USER_MESSAGE_PAYLOAD: ChatUserMessagePayload = {
   message: { id: 'msg-1', role: 'user', parts: [{ type: 'text', text: 'hi' }] },
+  pageId: 'page-a',
+  conversationId: 'conv-1',
+  triggeredBy: { userId: 'user-2', displayName: 'Alice', browserSessionId: SESSION_ID_REMOTE },
+};
+
+const MESSAGE_EDITED_PAYLOAD: ChatMessageEditedPayload = {
+  messageId: 'msg-1',
+  pageId: 'page-a',
+  conversationId: 'conv-1',
+  parts: [{ type: 'text', text: 'updated' }],
+  editedAt: '2026-05-01T00:00:00.000Z',
+  triggeredBy: { userId: 'user-2', displayName: 'Alice', browserSessionId: SESSION_ID_REMOTE },
+};
+
+const MESSAGE_DELETED_PAYLOAD: ChatMessageDeletedPayload = {
+  messageId: 'msg-1',
   pageId: 'page-a',
   conversationId: 'conv-1',
   triggeredBy: { userId: 'user-2', displayName: 'Alice', browserSessionId: SESSION_ID_REMOTE },
@@ -294,6 +312,103 @@ describe('useChannelStreamSocket', () => {
       act(() => { mockSocket._trigger('chat:user_message', USER_MESSAGE_PAYLOAD); });
 
       expect(onUserMessage).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('chat:message_edited', () => {
+    it('given a chat:message_edited from another tab for the current channel, should call onMessageEdited with the payload', () => {
+      const onMessageEdited = vi.fn();
+      renderHook(() => useChannelStreamSocket('page-a', { onMessageEdited }));
+
+      act(() => { mockSocket._trigger('chat:message_edited', MESSAGE_EDITED_PAYLOAD); });
+
+      expect(onMessageEdited).toHaveBeenCalledTimes(1);
+      expect(onMessageEdited).toHaveBeenCalledWith(MESSAGE_EDITED_PAYLOAD);
+    });
+
+    it('given chat:message_edited with a different pageId, should NOT call onMessageEdited (stale-room guard)', () => {
+      const onMessageEdited = vi.fn();
+      renderHook(() => useChannelStreamSocket('page-a', { onMessageEdited }));
+
+      act(() => {
+        mockSocket._trigger('chat:message_edited', { ...MESSAGE_EDITED_PAYLOAD, pageId: 'page-b' });
+      });
+
+      expect(onMessageEdited).not.toHaveBeenCalled();
+    });
+
+    it('given chat:message_edited whose triggeredBy.browserSessionId matches the local session, should NOT call onMessageEdited (own-tab dedup)', () => {
+      const onMessageEdited = vi.fn();
+      renderHook(() => useChannelStreamSocket('page-a', { onMessageEdited }));
+
+      act(() => {
+        mockSocket._trigger('chat:message_edited', {
+          ...MESSAGE_EDITED_PAYLOAD,
+          triggeredBy: { ...MESSAGE_EDITED_PAYLOAD.triggeredBy, browserSessionId: SESSION_ID_LOCAL },
+        });
+      });
+
+      expect(onMessageEdited).not.toHaveBeenCalled();
+    });
+
+    it('given onMessageEdited reference changes between renders, should invoke the latest callback', () => {
+      let callback = vi.fn();
+      const { rerender } = renderHook(() => useChannelStreamSocket('page-a', { onMessageEdited: callback }));
+
+      const second = vi.fn();
+      callback = second;
+      rerender();
+
+      act(() => { mockSocket._trigger('chat:message_edited', MESSAGE_EDITED_PAYLOAD); });
+
+      expect(second).toHaveBeenCalledWith(MESSAGE_EDITED_PAYLOAD);
+    });
+  });
+
+  describe('chat:message_deleted', () => {
+    it('given a chat:message_deleted from another tab for the current channel, should call onMessageDeleted with the payload', () => {
+      const onMessageDeleted = vi.fn();
+      renderHook(() => useChannelStreamSocket('page-a', { onMessageDeleted }));
+
+      act(() => { mockSocket._trigger('chat:message_deleted', MESSAGE_DELETED_PAYLOAD); });
+
+      expect(onMessageDeleted).toHaveBeenCalledTimes(1);
+      expect(onMessageDeleted).toHaveBeenCalledWith(MESSAGE_DELETED_PAYLOAD);
+    });
+
+    it('given chat:message_deleted with a different pageId, should NOT call onMessageDeleted (stale-room guard)', () => {
+      const onMessageDeleted = vi.fn();
+      renderHook(() => useChannelStreamSocket('page-a', { onMessageDeleted }));
+
+      act(() => {
+        mockSocket._trigger('chat:message_deleted', { ...MESSAGE_DELETED_PAYLOAD, pageId: 'page-b' });
+      });
+
+      expect(onMessageDeleted).not.toHaveBeenCalled();
+    });
+
+    it('given chat:message_deleted whose triggeredBy.browserSessionId matches the local session, should NOT call onMessageDeleted (own-tab dedup)', () => {
+      const onMessageDeleted = vi.fn();
+      renderHook(() => useChannelStreamSocket('page-a', { onMessageDeleted }));
+
+      act(() => {
+        mockSocket._trigger('chat:message_deleted', {
+          ...MESSAGE_DELETED_PAYLOAD,
+          triggeredBy: { ...MESSAGE_DELETED_PAYLOAD.triggeredBy, browserSessionId: SESSION_ID_LOCAL },
+        });
+      });
+
+      expect(onMessageDeleted).not.toHaveBeenCalled();
+    });
+
+    it('given the hook unmounts, should remove the chat:message_deleted listener', () => {
+      const onMessageDeleted = vi.fn();
+      const { unmount } = renderHook(() => useChannelStreamSocket('page-a', { onMessageDeleted }));
+
+      unmount();
+      act(() => { mockSocket._trigger('chat:message_deleted', MESSAGE_DELETED_PAYLOAD); });
+
+      expect(onMessageDeleted).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/hooks/useAgentChannelMultiplayer.ts
+++ b/apps/web/src/hooks/useAgentChannelMultiplayer.ts
@@ -9,6 +9,8 @@ import { useStreamingRegistration } from '@/lib/ai/shared';
 import { abortActiveStreamByMessageId } from '@/lib/ai/core/stream-abort-client';
 import { synthesizeAssistantMessage } from '@/lib/ai/streams/synthesizeAssistantMessage';
 import { shouldClaimAgentStopSlot } from '@/lib/ai/streams/shouldClaimAgentStopSlot';
+import { applyMessageEdit } from '@/lib/ai/streams/applyMessageEdit';
+import { applyMessageDelete } from '@/lib/ai/streams/applyMessageDelete';
 import {
   shouldRefreshOnReconnect,
   type ConnectionStatus,
@@ -95,6 +97,20 @@ export function useAgentChannelMultiplayer({
       setLocalMessagesRef.current((prev) =>
         prev.some((m) => m.id === message.id) ? prev : [...prev, message],
       );
+    },
+    onMessageEdited: (payload) => {
+      if (payload.conversationId !== agentConversationIdRef.current) return;
+      setLocalMessagesRef.current((prev) =>
+        applyMessageEdit(prev as never, {
+          messageId: payload.messageId,
+          parts: payload.parts,
+          editedAt: new Date(payload.editedAt),
+        }) as typeof prev,
+      );
+    },
+    onMessageDeleted: (payload) => {
+      if (payload.conversationId !== agentConversationIdRef.current) return;
+      setLocalMessagesRef.current((prev) => applyMessageDelete(prev, payload.messageId) as typeof prev);
     },
     onStreamComplete: (messageId) => {
       const stream = usePendingStreamsStore.getState().streams.get(messageId);

--- a/apps/web/src/hooks/useAgentChannelMultiplayer.ts
+++ b/apps/web/src/hooks/useAgentChannelMultiplayer.ts
@@ -101,16 +101,16 @@ export function useAgentChannelMultiplayer({
     onMessageEdited: (payload) => {
       if (payload.conversationId !== agentConversationIdRef.current) return;
       setLocalMessagesRef.current((prev) =>
-        applyMessageEdit(prev as never, {
+        applyMessageEdit(prev, {
           messageId: payload.messageId,
           parts: payload.parts,
           editedAt: new Date(payload.editedAt),
-        }) as typeof prev,
+        }),
       );
     },
     onMessageDeleted: (payload) => {
       if (payload.conversationId !== agentConversationIdRef.current) return;
-      setLocalMessagesRef.current((prev) => applyMessageDelete(prev, payload.messageId) as typeof prev);
+      setLocalMessagesRef.current((prev) => applyMessageDelete(prev, payload.messageId));
     },
     onStreamComplete: (messageId) => {
       const stream = usePendingStreamsStore.getState().streams.get(messageId);

--- a/apps/web/src/hooks/useChannelStreamSocket.ts
+++ b/apps/web/src/hooks/useChannelStreamSocket.ts
@@ -12,6 +12,7 @@ import type {
   ChatUserMessagePayload,
   ChatMessageEditedPayload,
   ChatMessageDeletedPayload,
+  ChatUndoAppliedPayload,
 } from '@/lib/websocket/socket-utils';
 import type { UIMessage } from 'ai';
 
@@ -58,6 +59,13 @@ export interface UseChannelStreamSocketOptions {
    * conversation-id guard before mutating their local messages.
    */
   onMessageDeleted?: (payload: ChatMessageDeletedPayload) => void;
+  /**
+   * Fires when a remote tab applies an AI undo on this channel. Same stale-room
+   * + own-tab dedup as `onUserMessage`. Surfaces typically respond by
+   * refreshing the conversation, gated by `shouldRefreshAfterUndo` so a
+   * cross-conversation undo doesn't disturb the active surface.
+   */
+  onUndoApplied?: (payload: ChatUndoAppliedPayload) => void;
 }
 
 /** Subscribes a component to a channel's AI streaming lifecycle: DB-replay on mount, live socket events, SSE join, store cleanup on unmount. Pass `undefined` channelId to no-op. */
@@ -73,12 +81,14 @@ export function useChannelStreamSocket(
   const onUserMessageRef = useRef(options?.onUserMessage);
   const onMessageEditedRef = useRef(options?.onMessageEdited);
   const onMessageDeletedRef = useRef(options?.onMessageDeleted);
+  const onUndoAppliedRef = useRef(options?.onUndoApplied);
   onStreamCompleteRef.current = options?.onStreamComplete;
   onOwnStreamBootstrapRef.current = options?.onOwnStreamBootstrap;
   onOwnStreamFinalizeRef.current = options?.onOwnStreamFinalize;
   onUserMessageRef.current = options?.onUserMessage;
   onMessageEditedRef.current = options?.onMessageEdited;
   onMessageDeletedRef.current = options?.onMessageDeleted;
+  onUndoAppliedRef.current = options?.onUndoApplied;
 
   useEffect(() => {
     if (!socket || !channelId) return;
@@ -226,11 +236,18 @@ export function useChannelStreamSocket(
       onMessageDeletedRef.current?.(payload);
     };
 
+    const handleUndoApplied = (payload: ChatUndoAppliedPayload) => {
+      if (payload.pageId !== channelId) return;
+      if (isOwnStream(payload.triggeredBy, localBrowserSessionId)) return;
+      onUndoAppliedRef.current?.(payload);
+    };
+
     socket.on('chat:stream_start', handleStreamStart);
     socket.on('chat:stream_complete', handleStreamComplete);
     socket.on('chat:user_message', handleUserMessage);
     socket.on('chat:message_edited', handleMessageEdited);
     socket.on('chat:message_deleted', handleMessageDeleted);
+    socket.on('chat:undo_applied', handleUndoApplied);
 
     return () => {
       cancelled = true;
@@ -239,6 +256,7 @@ export function useChannelStreamSocket(
       socket.off('chat:user_message', handleUserMessage);
       socket.off('chat:message_edited', handleMessageEdited);
       socket.off('chat:message_deleted', handleMessageDeleted);
+      socket.off('chat:undo_applied', handleUndoApplied);
       for (const controller of controllers.values()) {
         controller.abort();
       }

--- a/apps/web/src/hooks/useChannelStreamSocket.ts
+++ b/apps/web/src/hooks/useChannelStreamSocket.ts
@@ -10,6 +10,8 @@ import type {
   AiStreamStartPayload,
   AiStreamCompletePayload,
   ChatUserMessagePayload,
+  ChatMessageEditedPayload,
+  ChatMessageDeletedPayload,
 } from '@/lib/websocket/socket-utils';
 import type { UIMessage } from 'ai';
 
@@ -44,6 +46,18 @@ export interface UseChannelStreamSocketOptions {
    * the save and before the broadcast was processed locally).
    */
   onUserMessage?: (message: UIMessage, payload: ChatUserMessagePayload) => void;
+  /**
+   * Fires when a remote tab edits a message in this channel. Same stale-room
+   * + own-tab dedup as `onUserMessage`. Consumers should still apply a
+   * conversation-id guard before mutating their local messages.
+   */
+  onMessageEdited?: (payload: ChatMessageEditedPayload) => void;
+  /**
+   * Fires when a remote tab deletes a message in this channel. Same stale-room
+   * + own-tab dedup as `onUserMessage`. Consumers should still apply a
+   * conversation-id guard before mutating their local messages.
+   */
+  onMessageDeleted?: (payload: ChatMessageDeletedPayload) => void;
 }
 
 /** Subscribes a component to a channel's AI streaming lifecycle: DB-replay on mount, live socket events, SSE join, store cleanup on unmount. Pass `undefined` channelId to no-op. */
@@ -57,10 +71,14 @@ export function useChannelStreamSocket(
   const onOwnStreamBootstrapRef = useRef(options?.onOwnStreamBootstrap);
   const onOwnStreamFinalizeRef = useRef(options?.onOwnStreamFinalize);
   const onUserMessageRef = useRef(options?.onUserMessage);
+  const onMessageEditedRef = useRef(options?.onMessageEdited);
+  const onMessageDeletedRef = useRef(options?.onMessageDeleted);
   onStreamCompleteRef.current = options?.onStreamComplete;
   onOwnStreamBootstrapRef.current = options?.onOwnStreamBootstrap;
   onOwnStreamFinalizeRef.current = options?.onOwnStreamFinalize;
   onUserMessageRef.current = options?.onUserMessage;
+  onMessageEditedRef.current = options?.onMessageEdited;
+  onMessageDeletedRef.current = options?.onMessageDeleted;
 
   useEffect(() => {
     if (!socket || !channelId) return;
@@ -196,15 +214,31 @@ export function useChannelStreamSocket(
       onUserMessageRef.current?.(payload.message, payload);
     };
 
+    const handleMessageEdited = (payload: ChatMessageEditedPayload) => {
+      if (payload.pageId !== channelId) return;
+      if (isOwnStream(payload.triggeredBy, localBrowserSessionId)) return;
+      onMessageEditedRef.current?.(payload);
+    };
+
+    const handleMessageDeleted = (payload: ChatMessageDeletedPayload) => {
+      if (payload.pageId !== channelId) return;
+      if (isOwnStream(payload.triggeredBy, localBrowserSessionId)) return;
+      onMessageDeletedRef.current?.(payload);
+    };
+
     socket.on('chat:stream_start', handleStreamStart);
     socket.on('chat:stream_complete', handleStreamComplete);
     socket.on('chat:user_message', handleUserMessage);
+    socket.on('chat:message_edited', handleMessageEdited);
+    socket.on('chat:message_deleted', handleMessageDeleted);
 
     return () => {
       cancelled = true;
       socket.off('chat:stream_start', handleStreamStart);
       socket.off('chat:stream_complete', handleStreamComplete);
       socket.off('chat:user_message', handleUserMessage);
+      socket.off('chat:message_edited', handleMessageEdited);
+      socket.off('chat:message_deleted', handleMessageDeleted);
       for (const controller of controllers.values()) {
         controller.abort();
       }

--- a/apps/web/src/hooks/useChannelStreamSocket.ts
+++ b/apps/web/src/hooks/useChannelStreamSocket.ts
@@ -13,6 +13,7 @@ import type {
   ChatMessageEditedPayload,
   ChatMessageDeletedPayload,
   ChatUndoAppliedPayload,
+  ChatConversationAddedPayload,
 } from '@/lib/websocket/socket-utils';
 import type { UIMessage } from 'ai';
 
@@ -66,6 +67,13 @@ export interface UseChannelStreamSocketOptions {
    * cross-conversation undo doesn't disturb the active surface.
    */
   onUndoApplied?: (payload: ChatUndoAppliedPayload) => void;
+  /**
+   * Fires when a remote tab creates a new conversation in this agent room.
+   * Same stale-room (`agentId !== channelId`) + own-tab dedup as
+   * `onUserMessage`. Surfaces typically respond by prepending the
+   * conversation to their history list, gated by `shouldPrependConversation`.
+   */
+  onConversationAdded?: (payload: ChatConversationAddedPayload) => void;
 }
 
 /** Subscribes a component to a channel's AI streaming lifecycle: DB-replay on mount, live socket events, SSE join, store cleanup on unmount. Pass `undefined` channelId to no-op. */
@@ -82,6 +90,7 @@ export function useChannelStreamSocket(
   const onMessageEditedRef = useRef(options?.onMessageEdited);
   const onMessageDeletedRef = useRef(options?.onMessageDeleted);
   const onUndoAppliedRef = useRef(options?.onUndoApplied);
+  const onConversationAddedRef = useRef(options?.onConversationAdded);
   onStreamCompleteRef.current = options?.onStreamComplete;
   onOwnStreamBootstrapRef.current = options?.onOwnStreamBootstrap;
   onOwnStreamFinalizeRef.current = options?.onOwnStreamFinalize;
@@ -89,6 +98,7 @@ export function useChannelStreamSocket(
   onMessageEditedRef.current = options?.onMessageEdited;
   onMessageDeletedRef.current = options?.onMessageDeleted;
   onUndoAppliedRef.current = options?.onUndoApplied;
+  onConversationAddedRef.current = options?.onConversationAdded;
 
   useEffect(() => {
     if (!socket || !channelId) return;
@@ -242,12 +252,19 @@ export function useChannelStreamSocket(
       onUndoAppliedRef.current?.(payload);
     };
 
+    const handleConversationAdded = (payload: ChatConversationAddedPayload) => {
+      if (payload.agentId !== channelId) return;
+      if (isOwnStream(payload.triggeredBy, localBrowserSessionId)) return;
+      onConversationAddedRef.current?.(payload);
+    };
+
     socket.on('chat:stream_start', handleStreamStart);
     socket.on('chat:stream_complete', handleStreamComplete);
     socket.on('chat:user_message', handleUserMessage);
     socket.on('chat:message_edited', handleMessageEdited);
     socket.on('chat:message_deleted', handleMessageDeleted);
     socket.on('chat:undo_applied', handleUndoApplied);
+    socket.on('chat:conversation_added', handleConversationAdded);
 
     return () => {
       cancelled = true;
@@ -257,6 +274,7 @@ export function useChannelStreamSocket(
       socket.off('chat:message_edited', handleMessageEdited);
       socket.off('chat:message_deleted', handleMessageDeleted);
       socket.off('chat:undo_applied', handleUndoApplied);
+      socket.off('chat:conversation_added', handleConversationAdded);
       for (const controller of controllers.values()) {
         controller.abort();
       }

--- a/apps/web/src/lib/ai/shared/agent-conversations.ts
+++ b/apps/web/src/lib/ai/shared/agent-conversations.ts
@@ -1,5 +1,6 @@
 import type { UIMessage } from 'ai';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { getBrowserSessionId } from '@/lib/ai/core/browser-session-id';
 
 export interface AgentConversationSummary {
   id: string;
@@ -105,7 +106,10 @@ export async function fetchMostRecentAgentConversation(
 export async function createAgentConversation(agentId: string): Promise<string> {
   const response = await fetchWithAuth(`/api/ai/page-agents/${agentId}/conversations`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Browser-Session-Id': getBrowserSessionId(),
+    },
     body: JSON.stringify({}),
   });
   if (!response.ok) {

--- a/apps/web/src/lib/ai/shared/hooks/useConversations.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useConversations.ts
@@ -7,6 +7,7 @@ import { useCallback, useMemo, useRef } from 'react';
 import useSWR, { mutate } from 'swr';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { toast } from 'sonner';
+import { getBrowserSessionId } from '@/lib/ai/core/browser-session-id';
 import type { UIMessage } from 'ai';
 import { isEditingActive } from '@/stores/useEditingStore';
 import {
@@ -50,6 +51,13 @@ interface UseConversationsResult {
   deleteConversation: (conversationId: string) => Promise<void>;
   /** Refresh conversations list */
   refreshConversations: () => void;
+  /**
+   * Optimistically prepend a conversation to the SWR cache. Use when a
+   * remote tab created the conversation (chat:conversation_added broadcast)
+   * — the server row is materialized lazily on first message save, so a
+   * naive refetch would not surface it. Skips if the id is already present.
+   */
+  prependConversationOptimistic: (entry: { id: string; title: string; createdAt: string }) => void;
   /** SWR key for manual cache invalidation */
   swrKey: string | null;
 }
@@ -139,7 +147,10 @@ export function useConversations({
 
       const response = await fetchWithAuth(createUrl, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Browser-Session-Id': getBrowserSessionId(),
+        },
         body: JSON.stringify(isAgentMode ? {} : { type: 'global' }),
       });
 
@@ -199,6 +210,31 @@ export function useConversations({
     }
   }, [swrKey]);
 
+  const prependConversationOptimistic = useCallback(
+    (entry: { id: string; title: string; createdAt: string }) => {
+      if (!swrKey) return;
+      mutate(
+        swrKey,
+        (current: { conversations?: RawConversationData[] } | undefined) => {
+          const existing = current?.conversations ?? [];
+          if (existing.some((c) => c.id === entry.id)) return current;
+          const optimisticEntry: RawConversationData = {
+            id: entry.id,
+            title: entry.title,
+            createdAt: entry.createdAt,
+            updatedAt: entry.createdAt,
+            preview: '',
+            messageCount: 0,
+            lastMessage: { role: '', timestamp: entry.createdAt },
+          };
+          return { ...current, conversations: [optimisticEntry, ...existing] };
+        },
+        { revalidate: false },
+      );
+    },
+    [swrKey],
+  );
+
   return {
     conversations,
     isLoading,
@@ -206,6 +242,7 @@ export function useConversations({
     createConversation,
     deleteConversation,
     refreshConversations,
+    prependConversationOptimistic,
     swrKey,
   };
 }

--- a/apps/web/src/lib/ai/shared/hooks/useConversations.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useConversations.ts
@@ -67,7 +67,7 @@ interface UseConversationsResult {
    * lazily on first message save and would not yet appear in a server fetch.
    * The store entry is auto-pruned once the SWR fetch confirms the row.
    */
-  prependConversationOptimistic: (entry: { id: string; title: string; createdAt: string }) => void;
+  prependConversationOptimistic: (entry: OptimisticConversationEntry) => void;
   /** SWR key for manual cache invalidation */
   swrKey: string | null;
 }
@@ -258,7 +258,7 @@ export function useConversations({
 
   const addOptimistic = useOptimisticConversationsStore((state) => state.add);
   const prependConversationOptimistic = useCallback(
-    (entry: { id: string; title: string; createdAt: string }) => {
+    (entry: OptimisticConversationEntry) => {
       addOptimistic(cacheKey, entry);
     },
     [cacheKey, addOptimistic],

--- a/apps/web/src/lib/ai/shared/hooks/useConversations.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useConversations.ts
@@ -3,18 +3,24 @@
  * Used by both Agent engine and Global Assistant engine
  */
 
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import useSWR, { mutate } from 'swr';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { toast } from 'sonner';
 import { getBrowserSessionId } from '@/lib/ai/core/browser-session-id';
 import type { UIMessage } from 'ai';
 import { isEditingActive } from '@/stores/useEditingStore';
+import { useOptimisticConversationsStore } from '@/stores/useOptimisticConversationsStore';
 import {
   ConversationData,
   RawConversationData,
   parseConversationsData,
 } from '../chat-types';
+import type { OptimisticConversationEntry } from '@/stores/useOptimisticConversationsStore';
+
+// Stable empty array so the Zustand selector returns a referentially-stable
+// value when no optimistic entries exist (prevents unnecessary re-renders).
+const EMPTY_OPTIMISTIC: OptimisticConversationEntry[] = [];
 
 interface UseConversationsOptions {
   /**
@@ -52,10 +58,14 @@ interface UseConversationsResult {
   /** Refresh conversations list */
   refreshConversations: () => void;
   /**
-   * Optimistically prepend a conversation to the SWR cache. Use when a
-   * remote tab created the conversation (chat:conversation_added broadcast)
-   * — the server row is materialized lazily on first message save, so a
-   * naive refetch would not surface it. Skips if the id is already present.
+   * Optimistically prepend a conversation to the locally-rendered list. Use
+   * when a remote tab created the conversation (chat:conversation_added
+   * broadcast). Persists in a Zustand store keyed by the cache URL so the
+   * entry survives the (1) hook-disabled state when `enabled === false`
+   * (e.g. AiChatView's history tab not yet active), and (2) the SWR refetch
+   * triggered when the hook later enables — page-agent rows are materialized
+   * lazily on first message save and would not yet appear in a server fetch.
+   * The store entry is auto-pruned once the SWR fetch confirms the row.
    */
   prependConversationOptimistic: (entry: { id: string; title: string; createdAt: string }) => void;
   /** SWR key for manual cache invalidation */
@@ -80,13 +90,19 @@ export function useConversations({
   // Track if initial data has been loaded to avoid blocking first fetch
   const hasLoadedRef = useRef(false);
 
-  // SWR key for conversations list
-  const swrKey = useMemo(() => {
-    if (!enabled) return null;
-    return isAgentMode
-      ? `/api/ai/page-agents/${agentId}/conversations`
-      : `/api/ai/global`;
-  }, [enabled, isAgentMode, agentId]);
+  // Cache key — always computed regardless of `enabled` so the optimistic
+  // store can be addressed across hook-mount lifetimes (e.g. when a
+  // chat:conversation_added broadcast arrives while the history tab is
+  // closed).
+  const cacheKey = useMemo(
+    () =>
+      isAgentMode
+        ? `/api/ai/page-agents/${agentId}/conversations`
+        : `/api/ai/global`,
+    [isAgentMode, agentId],
+  );
+  // SWR key for conversations list — null disables the SWR fetch.
+  const swrKey = enabled ? cacheKey : null;
 
   // Fetch conversations with SWR
   const { data, isLoading } = useSWR(
@@ -108,11 +124,41 @@ export function useConversations({
     }
   );
 
-  // Parse conversations data
+  // Optimistic-conversation entries received via chat:conversation_added
+  // broadcasts before this hook's SWR fetch can confirm them.
+  const optimisticEntries = useOptimisticConversationsStore(
+    (state) => state.byKey[cacheKey] ?? EMPTY_OPTIMISTIC,
+  );
+  const pruneOptimistic = useOptimisticConversationsStore((state) => state.prune);
+
+  // Parse + merge SWR data and optimistic entries, dedup by id.
   const conversations = useMemo<ConversationData[]>(() => {
-    if (!data?.conversations) return [];
-    return parseConversationsData(data.conversations as RawConversationData[]);
-  }, [data]);
+    const fromSwr = data?.conversations
+      ? parseConversationsData(data.conversations as RawConversationData[])
+      : [];
+    if (optimisticEntries.length === 0) return fromSwr;
+    const knownIds = new Set(fromSwr.map((c) => c.id));
+    const optimisticParsed = optimisticEntries
+      .filter((e) => !knownIds.has(e.id))
+      .map<ConversationData>((e) => ({
+        id: e.id,
+        title: e.title,
+        preview: '',
+        createdAt: new Date(e.createdAt),
+        updatedAt: new Date(e.createdAt),
+        messageCount: 0,
+        lastMessage: { role: '', timestamp: new Date(e.createdAt) },
+      }));
+    return [...optimisticParsed, ...fromSwr];
+  }, [data, optimisticEntries]);
+
+  // Prune optimistic entries whose id has been confirmed by the server fetch.
+  useEffect(() => {
+    if (!data?.conversations) return;
+    const ids = (data.conversations as RawConversationData[]).map((c) => c.id);
+    if (ids.length === 0) return;
+    pruneOptimistic(cacheKey, ids);
+  }, [data, cacheKey, pruneOptimistic]);
 
   // Load a specific conversation
   const loadConversation = useCallback(
@@ -210,29 +256,12 @@ export function useConversations({
     }
   }, [swrKey]);
 
+  const addOptimistic = useOptimisticConversationsStore((state) => state.add);
   const prependConversationOptimistic = useCallback(
     (entry: { id: string; title: string; createdAt: string }) => {
-      if (!swrKey) return;
-      mutate(
-        swrKey,
-        (current: { conversations?: RawConversationData[] } | undefined) => {
-          const existing = current?.conversations ?? [];
-          if (existing.some((c) => c.id === entry.id)) return current;
-          const optimisticEntry: RawConversationData = {
-            id: entry.id,
-            title: entry.title,
-            createdAt: entry.createdAt,
-            updatedAt: entry.createdAt,
-            preview: '',
-            messageCount: 0,
-            lastMessage: { role: '', timestamp: entry.createdAt },
-          };
-          return { ...current, conversations: [optimisticEntry, ...existing] };
-        },
-        { revalidate: false },
-      );
+      addOptimistic(cacheKey, entry);
     },
-    [swrKey],
+    [cacheKey, addOptimistic],
   );
 
   return {

--- a/apps/web/src/lib/ai/shared/hooks/useMessageActions.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useMessageActions.ts
@@ -7,6 +7,11 @@ import { useCallback, useRef } from 'react';
 import { fetchWithAuth, patch, del } from '@/lib/auth/auth-fetch';
 import { toast } from 'sonner';
 import type { UIMessage } from 'ai';
+import { getBrowserSessionId } from '@/lib/ai/core/browser-session-id';
+
+const browserSessionHeaders = (): Record<string, string> => ({
+  'X-Browser-Session-Id': getBrowserSessionId(),
+});
 
 type SetMessagesAction = UIMessage[] | ((previousMessages: UIMessage[]) => UIMessage[]);
 
@@ -95,12 +100,14 @@ export function useMessageActions({
         if (isAgentMode) {
           await patch(
             `/api/ai/page-agents/${agentId}/conversations/${conversationId}/messages/${messageId}`,
-            { content: newContent }
+            { content: newContent },
+            { headers: browserSessionHeaders() }
           );
         } else {
           await patch(
             `/api/ai/global/${conversationId}/messages/${messageId}`,
-            { content: newContent }
+            { content: newContent },
+            { headers: browserSessionHeaders() }
           );
         }
 
@@ -159,10 +166,16 @@ export function useMessageActions({
       try {
         if (isAgentMode) {
           await del(
-            `/api/ai/page-agents/${agentId}/conversations/${conversationId}/messages/${messageId}`
+            `/api/ai/page-agents/${agentId}/conversations/${conversationId}/messages/${messageId}`,
+            undefined,
+            { headers: browserSessionHeaders() }
           );
         } else {
-          await del(`/api/ai/global/${conversationId}/messages/${messageId}`);
+          await del(
+            `/api/ai/global/${conversationId}/messages/${messageId}`,
+            undefined,
+            { headers: browserSessionHeaders() }
+          );
         }
 
         toast.success('Message deleted');
@@ -213,7 +226,7 @@ export function useMessageActions({
           const url = isAgentMode
             ? `/api/ai/page-agents/${agentId}/conversations/${conversationId}/messages/${msg.id}`
             : `/api/ai/global/${conversationId}/messages/${msg.id}`;
-          return del(url).catch((error) => {
+          return del(url, undefined, { headers: browserSessionHeaders() }).catch((error) => {
             console.error('Failed to delete old assistant message:', error);
           });
         })

--- a/apps/web/src/lib/ai/streams/__tests__/applyMessageDelete.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/applyMessageDelete.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import type { UIMessage } from 'ai';
+import { applyMessageDelete } from '../applyMessageDelete';
+
+const makeTextMessage = (id: string, text: string): UIMessage => ({
+  id,
+  role: 'user',
+  parts: [{ type: 'text', text }],
+});
+
+describe('applyMessageDelete', () => {
+  it('given a target messageId in the array, should return a new array with that message removed', () => {
+    const messages: UIMessage[] = [
+      makeTextMessage('m1', 'hello'),
+      makeTextMessage('m2', 'world'),
+      makeTextMessage('m3', 'goodbye'),
+    ];
+
+    const next = applyMessageDelete(messages, 'm2');
+
+    expect(next).toEqual([makeTextMessage('m1', 'hello'), makeTextMessage('m3', 'goodbye')]);
+  });
+
+  it('given a messageId not present in the array, should return the input array reference unchanged', () => {
+    const messages: UIMessage[] = [makeTextMessage('m1', 'hello')];
+
+    const next = applyMessageDelete(messages, 'unknown');
+
+    expect(next).toBe(messages);
+  });
+
+  it('given any input array, should not mutate the input — the original messages remain byte-for-byte equal after the call', () => {
+    const messages: UIMessage[] = [
+      makeTextMessage('m1', 'hello'),
+      makeTextMessage('m2', 'world'),
+    ];
+    const snapshot = JSON.parse(JSON.stringify(messages));
+
+    applyMessageDelete(messages, 'm2');
+
+    expect(messages).toEqual(snapshot);
+  });
+});

--- a/apps/web/src/lib/ai/streams/__tests__/applyMessageEdit.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/applyMessageEdit.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import type { UIMessage } from 'ai';
+import { applyMessageEdit, type MessageEditPayload } from '../applyMessageEdit';
+
+type EditableMessage = UIMessage & { editedAt?: Date | null };
+
+const makeTextMessage = (id: string, text: string, role: 'user' | 'assistant' = 'user'): EditableMessage => ({
+  id,
+  role,
+  parts: [{ type: 'text', text }],
+});
+
+describe('applyMessageEdit', () => {
+  it('given a target messageId in the array, should return a new array with the target message parts replaced and editedAt set', () => {
+    const messages: EditableMessage[] = [
+      makeTextMessage('m1', 'hello'),
+      makeTextMessage('m2', 'world'),
+    ];
+    const editedAt = new Date('2026-05-01T00:00:00.000Z');
+    const payload: MessageEditPayload = {
+      messageId: 'm2',
+      parts: [{ type: 'text', text: 'updated' }],
+      editedAt,
+    };
+
+    const next = applyMessageEdit(messages, payload);
+
+    expect(next).toEqual([
+      makeTextMessage('m1', 'hello'),
+      { id: 'm2', role: 'user', parts: [{ type: 'text', text: 'updated' }], editedAt },
+    ]);
+  });
+
+  it('given a messageId not present in the array, should return the input array reference unchanged', () => {
+    const messages: EditableMessage[] = [makeTextMessage('m1', 'hello')];
+    const payload: MessageEditPayload = {
+      messageId: 'unknown',
+      parts: [{ type: 'text', text: 'updated' }],
+      editedAt: new Date(),
+    };
+
+    const next = applyMessageEdit(messages, payload);
+
+    expect(next).toBe(messages);
+  });
+
+  it('given any input array, should not mutate the input — the original messages remain byte-for-byte equal after the call', () => {
+    const messages: EditableMessage[] = [
+      makeTextMessage('m1', 'hello'),
+      makeTextMessage('m2', 'world'),
+    ];
+    const snapshot = JSON.parse(JSON.stringify(messages));
+
+    applyMessageEdit(messages, {
+      messageId: 'm2',
+      parts: [{ type: 'text', text: 'updated' }],
+      editedAt: new Date('2026-05-01T00:00:00.000Z'),
+    });
+
+    expect(messages).toEqual(snapshot);
+  });
+});

--- a/apps/web/src/lib/ai/streams/__tests__/shouldPrependConversation.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/shouldPrependConversation.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { shouldPrependConversation } from '../shouldPrependConversation';
+
+describe('shouldPrependConversation', () => {
+  it('given a payload from a different browserSessionId whose id is not in the existing list, should return true', () => {
+    const payload = {
+      conversation: { id: 'conv-new' },
+      triggeredBy: { browserSessionId: 'session-other' },
+    };
+    expect(shouldPrependConversation(payload, 'session-mine', [{ id: 'conv-1' }])).toBe(true);
+  });
+
+  it('given a payload from the local browserSessionId, should return false (originator already added optimistically)', () => {
+    const payload = {
+      conversation: { id: 'conv-new' },
+      triggeredBy: { browserSessionId: 'session-mine' },
+    };
+    expect(shouldPrependConversation(payload, 'session-mine', [{ id: 'conv-1' }])).toBe(false);
+  });
+
+  it('given a payload whose conversation id is already in the existing list, should return false (race-condition dedup)', () => {
+    const payload = {
+      conversation: { id: 'conv-new' },
+      triggeredBy: { browserSessionId: 'session-other' },
+    };
+    expect(
+      shouldPrependConversation(payload, 'session-mine', [{ id: 'conv-1' }, { id: 'conv-new' }]),
+    ).toBe(false);
+  });
+
+  it('given an empty existing conversations list, should return true (first-conversation case)', () => {
+    const payload = {
+      conversation: { id: 'conv-new' },
+      triggeredBy: { browserSessionId: 'session-other' },
+    };
+    expect(shouldPrependConversation(payload, 'session-mine', [])).toBe(true);
+  });
+});

--- a/apps/web/src/lib/ai/streams/__tests__/shouldRefreshAfterUndo.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/shouldRefreshAfterUndo.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { shouldRefreshAfterUndo } from '../shouldRefreshAfterUndo';
+
+describe('shouldRefreshAfterUndo', () => {
+  it('given a payload from a different browserSessionId whose conversationId matches the surface, should return true', () => {
+    const payload = {
+      conversationId: 'conv-1',
+      triggeredBy: { browserSessionId: 'session-other' },
+    };
+    expect(shouldRefreshAfterUndo(payload, 'conv-1', 'session-mine')).toBe(true);
+  });
+
+  it('given a payload from the local browserSessionId, should return false (originator already refreshed)', () => {
+    const payload = {
+      conversationId: 'conv-1',
+      triggeredBy: { browserSessionId: 'session-mine' },
+    };
+    expect(shouldRefreshAfterUndo(payload, 'conv-1', 'session-mine')).toBe(false);
+  });
+
+  it('given a payload whose conversationId differs from the surface, should return false (cross-conversation isolation)', () => {
+    const payload = {
+      conversationId: 'conv-other',
+      triggeredBy: { browserSessionId: 'session-other' },
+    };
+    expect(shouldRefreshAfterUndo(payload, 'conv-1', 'session-mine')).toBe(false);
+  });
+
+  it('given a null currentConversationId, should return false (surface has no active conversation)', () => {
+    const payload = {
+      conversationId: 'conv-1',
+      triggeredBy: { browserSessionId: 'session-other' },
+    };
+    expect(shouldRefreshAfterUndo(payload, null, 'session-mine')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/ai/streams/applyMessageDelete.ts
+++ b/apps/web/src/lib/ai/streams/applyMessageDelete.ts
@@ -6,9 +6,9 @@ import type { UIMessage } from 'ai';
  * unchanged when the messageId is not present. Pure — never mutates input.
  */
 export const applyMessageDelete = <T extends UIMessage>(
-  messages: readonly T[],
+  messages: T[],
   messageId: string,
-): readonly T[] => {
+): T[] => {
   const idx = messages.findIndex((m) => m.id === messageId);
   if (idx < 0) return messages;
   return messages.filter((m) => m.id !== messageId);

--- a/apps/web/src/lib/ai/streams/applyMessageDelete.ts
+++ b/apps/web/src/lib/ai/streams/applyMessageDelete.ts
@@ -9,7 +9,6 @@ export const applyMessageDelete = <T extends UIMessage>(
   messages: T[],
   messageId: string,
 ): T[] => {
-  const idx = messages.findIndex((m) => m.id === messageId);
-  if (idx < 0) return messages;
-  return messages.filter((m) => m.id !== messageId);
+  const next = messages.filter((m) => m.id !== messageId);
+  return next.length === messages.length ? messages : next;
 };

--- a/apps/web/src/lib/ai/streams/applyMessageDelete.ts
+++ b/apps/web/src/lib/ai/streams/applyMessageDelete.ts
@@ -1,0 +1,15 @@
+import type { UIMessage } from 'ai';
+
+/**
+ * Apply a remote delete broadcast to a local messages array. Returns a new
+ * array with the matched message filtered out, or returns the input reference
+ * unchanged when the messageId is not present. Pure — never mutates input.
+ */
+export const applyMessageDelete = <T extends UIMessage>(
+  messages: readonly T[],
+  messageId: string,
+): readonly T[] => {
+  const idx = messages.findIndex((m) => m.id === messageId);
+  if (idx < 0) return messages;
+  return messages.filter((m) => m.id !== messageId);
+};

--- a/apps/web/src/lib/ai/streams/applyMessageEdit.ts
+++ b/apps/web/src/lib/ai/streams/applyMessageEdit.ts
@@ -15,9 +15,9 @@ type EditableMessage = UIMessage & { editedAt?: Date | null };
  * mutates input.
  */
 export const applyMessageEdit = <T extends EditableMessage>(
-  messages: readonly T[],
+  messages: T[],
   payload: MessageEditPayload,
-): readonly T[] => {
+): T[] => {
   const idx = messages.findIndex((m) => m.id === payload.messageId);
   if (idx < 0) return messages;
   const next = messages.slice();

--- a/apps/web/src/lib/ai/streams/applyMessageEdit.ts
+++ b/apps/web/src/lib/ai/streams/applyMessageEdit.ts
@@ -1,0 +1,26 @@
+import type { UIMessage } from 'ai';
+
+export interface MessageEditPayload {
+  messageId: string;
+  parts: UIMessage['parts'];
+  editedAt: Date;
+}
+
+type EditableMessage = UIMessage & { editedAt?: Date | null };
+
+/**
+ * Apply a remote edit broadcast to a local messages array. Returns a new array
+ * with the matched message's `parts` replaced and `editedAt` set. Returns the
+ * input reference unchanged when the messageId is not present. Pure — never
+ * mutates input.
+ */
+export const applyMessageEdit = <T extends EditableMessage>(
+  messages: readonly T[],
+  payload: MessageEditPayload,
+): readonly T[] => {
+  const idx = messages.findIndex((m) => m.id === payload.messageId);
+  if (idx < 0) return messages;
+  const next = messages.slice();
+  next[idx] = { ...messages[idx], parts: payload.parts, editedAt: payload.editedAt } as T;
+  return next;
+};

--- a/apps/web/src/lib/ai/streams/shouldPrependConversation.ts
+++ b/apps/web/src/lib/ai/streams/shouldPrependConversation.ts
@@ -1,0 +1,15 @@
+/**
+ * Decide whether to prepend a remotely-added conversation onto the local
+ * history list. True only when the event is from a different browser session
+ * AND the conversation id is not already present (originator's POST response
+ * already added it; race-condition dedup). Pure — no I/O.
+ */
+export const shouldPrependConversation = (
+  payload: { conversation: { id: string }; triggeredBy: { browserSessionId: string } },
+  localBrowserSessionId: string,
+  currentConversations: readonly { id: string }[],
+): boolean => {
+  if (payload.triggeredBy.browserSessionId === localBrowserSessionId) return false;
+  if (currentConversations.some((c) => c.id === payload.conversation.id)) return false;
+  return true;
+};

--- a/apps/web/src/lib/ai/streams/shouldRefreshAfterUndo.ts
+++ b/apps/web/src/lib/ai/streams/shouldRefreshAfterUndo.ts
@@ -1,0 +1,16 @@
+/**
+ * Decide whether the local surface should refresh its conversation in
+ * response to a remote chat:undo_applied broadcast. Refresh only when the
+ * event is from a different browser session AND its conversationId matches
+ * the surface's currently-loaded conversation. Pure — no I/O.
+ */
+export const shouldRefreshAfterUndo = (
+  payload: { conversationId: string; triggeredBy: { browserSessionId: string } },
+  currentConversationId: string | null,
+  localBrowserSessionId: string,
+): boolean => {
+  if (!currentConversationId) return false;
+  if (payload.conversationId !== currentConversationId) return false;
+  if (payload.triggeredBy.browserSessionId === localBrowserSessionId) return false;
+  return true;
+};

--- a/apps/web/src/lib/websocket/__tests__/socket-utils.test.ts
+++ b/apps/web/src/lib/websocket/__tests__/socket-utils.test.ts
@@ -42,7 +42,11 @@ import {
   broadcastUsageEvent,
   broadcastAiStreamStart,
   broadcastChatUserMessage,
+  broadcastAiMessageEdited,
+  broadcastAiMessageDeleted,
   type ChatUserMessagePayload,
+  type ChatMessageEditedPayload,
+  type ChatMessageDeletedPayload,
   broadcastAiStreamComplete,
   createPageEventPayload,
   createDriveEventPayload,
@@ -513,6 +517,76 @@ describe('socket-utils', () => {
       mockFetch.mockRejectedValue(new Error('Network error'));
 
       await expect(broadcastChatUserMessage(payload)).resolves.not.toThrow();
+    });
+  });
+
+  describe('broadcastAiMessageEdited', () => {
+    const payload: ChatMessageEditedPayload = {
+      messageId: 'msg-1',
+      pageId: 'page-1',
+      conversationId: 'conv-1',
+      parts: [{ type: 'text', text: 'updated' }],
+      editedAt: '2026-05-01T00:00:00.000Z',
+      triggeredBy: { userId: 'user-1', displayName: 'Alice', browserSessionId: 'session-1' },
+    };
+
+    it('given a valid payload, should route to the {pageId} channel with chat:message_edited event', async () => {
+      await broadcastAiMessageEdited(payload);
+
+      const fetchCall = mockFetch.mock.calls[0];
+      const requestBody = JSON.parse(fetchCall[1].body);
+
+      expect(requestBody.channelId).toBe('page-1');
+      expect(requestBody.event).toBe('chat:message_edited');
+      expect(requestBody.payload).toEqual(payload);
+    });
+
+    it('given no INTERNAL_REALTIME_URL, should not call fetch', async () => {
+      process.env.INTERNAL_REALTIME_URL = '';
+
+      await broadcastAiMessageEdited(payload);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('given fetch throws, should not throw', async () => {
+      mockFetch.mockRejectedValue(new Error('Network error'));
+
+      await expect(broadcastAiMessageEdited(payload)).resolves.not.toThrow();
+    });
+  });
+
+  describe('broadcastAiMessageDeleted', () => {
+    const payload: ChatMessageDeletedPayload = {
+      messageId: 'msg-1',
+      pageId: 'page-1',
+      conversationId: 'conv-1',
+      triggeredBy: { userId: 'user-1', displayName: 'Alice', browserSessionId: 'session-1' },
+    };
+
+    it('given a valid payload, should route to the {pageId} channel with chat:message_deleted event', async () => {
+      await broadcastAiMessageDeleted(payload);
+
+      const fetchCall = mockFetch.mock.calls[0];
+      const requestBody = JSON.parse(fetchCall[1].body);
+
+      expect(requestBody.channelId).toBe('page-1');
+      expect(requestBody.event).toBe('chat:message_deleted');
+      expect(requestBody.payload).toEqual(payload);
+    });
+
+    it('given no INTERNAL_REALTIME_URL, should not call fetch', async () => {
+      process.env.INTERNAL_REALTIME_URL = '';
+
+      await broadcastAiMessageDeleted(payload);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('given fetch throws, should not throw', async () => {
+      mockFetch.mockRejectedValue(new Error('Network error'));
+
+      await expect(broadcastAiMessageDeleted(payload)).resolves.not.toThrow();
     });
   });
 

--- a/apps/web/src/lib/websocket/__tests__/socket-utils.test.ts
+++ b/apps/web/src/lib/websocket/__tests__/socket-utils.test.ts
@@ -45,10 +45,12 @@ import {
   broadcastAiMessageEdited,
   broadcastAiMessageDeleted,
   broadcastAiUndoApplied,
+  broadcastAiConversationAdded,
   type ChatUserMessagePayload,
   type ChatMessageEditedPayload,
   type ChatMessageDeletedPayload,
   type ChatUndoAppliedPayload,
+  type ChatConversationAddedPayload,
   broadcastAiStreamComplete,
   createPageEventPayload,
   createDriveEventPayload,
@@ -624,6 +626,43 @@ describe('socket-utils', () => {
       mockFetch.mockRejectedValue(new Error('Network error'));
 
       await expect(broadcastAiUndoApplied(payload)).resolves.not.toThrow();
+    });
+  });
+
+  describe('broadcastAiConversationAdded', () => {
+    const payload: ChatConversationAddedPayload = {
+      agentId: 'agent-1',
+      conversation: {
+        id: 'conv-new',
+        title: 'New conversation',
+        createdAt: '2026-05-01T00:00:00.000Z',
+      },
+      triggeredBy: { userId: 'user-1', displayName: 'Alice', browserSessionId: 'session-1' },
+    };
+
+    it('given a valid payload, should route to the {agentId} channel with chat:conversation_added event', async () => {
+      await broadcastAiConversationAdded(payload);
+
+      const fetchCall = mockFetch.mock.calls[0];
+      const requestBody = JSON.parse(fetchCall[1].body);
+
+      expect(requestBody.channelId).toBe('agent-1');
+      expect(requestBody.event).toBe('chat:conversation_added');
+      expect(requestBody.payload).toEqual(payload);
+    });
+
+    it('given no INTERNAL_REALTIME_URL, should not call fetch', async () => {
+      process.env.INTERNAL_REALTIME_URL = '';
+
+      await broadcastAiConversationAdded(payload);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('given fetch throws, should not throw', async () => {
+      mockFetch.mockRejectedValue(new Error('Network error'));
+
+      await expect(broadcastAiConversationAdded(payload)).resolves.not.toThrow();
     });
   });
 

--- a/apps/web/src/lib/websocket/__tests__/socket-utils.test.ts
+++ b/apps/web/src/lib/websocket/__tests__/socket-utils.test.ts
@@ -44,9 +44,11 @@ import {
   broadcastChatUserMessage,
   broadcastAiMessageEdited,
   broadcastAiMessageDeleted,
+  broadcastAiUndoApplied,
   type ChatUserMessagePayload,
   type ChatMessageEditedPayload,
   type ChatMessageDeletedPayload,
+  type ChatUndoAppliedPayload,
   broadcastAiStreamComplete,
   createPageEventPayload,
   createDriveEventPayload,
@@ -587,6 +589,41 @@ describe('socket-utils', () => {
       mockFetch.mockRejectedValue(new Error('Network error'));
 
       await expect(broadcastAiMessageDeleted(payload)).resolves.not.toThrow();
+    });
+  });
+
+  describe('broadcastAiUndoApplied', () => {
+    const payload: ChatUndoAppliedPayload = {
+      conversationId: 'conv-1',
+      pageId: 'page-1',
+      mode: 'messages_and_changes',
+      affectedMessageIds: ['msg-2', 'msg-3'],
+      triggeredBy: { userId: 'user-1', displayName: 'Alice', browserSessionId: 'session-1' },
+    };
+
+    it('given a valid payload, should route to the {pageId} channel with chat:undo_applied event', async () => {
+      await broadcastAiUndoApplied(payload);
+
+      const fetchCall = mockFetch.mock.calls[0];
+      const requestBody = JSON.parse(fetchCall[1].body);
+
+      expect(requestBody.channelId).toBe('page-1');
+      expect(requestBody.event).toBe('chat:undo_applied');
+      expect(requestBody.payload).toEqual(payload);
+    });
+
+    it('given no INTERNAL_REALTIME_URL, should not call fetch', async () => {
+      process.env.INTERNAL_REALTIME_URL = '';
+
+      await broadcastAiUndoApplied(payload);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('given fetch throws, should not throw', async () => {
+      mockFetch.mockRejectedValue(new Error('Network error'));
+
+      await expect(broadcastAiUndoApplied(payload)).resolves.not.toThrow();
     });
   });
 

--- a/apps/web/src/lib/websocket/broadcast-triggered-by.ts
+++ b/apps/web/src/lib/websocket/broadcast-triggered-by.ts
@@ -1,6 +1,7 @@
 import { db } from '@pagespace/db/db';
 import { eq } from '@pagespace/db/operators';
-import { users, userProfiles } from '@pagespace/db/schema/core';
+import { users } from '@pagespace/db/schema/auth';
+import { userProfiles } from '@pagespace/db/schema/members';
 import { validateBrowserSessionIdHeader } from '@/lib/ai/core/browser-session-id-validation';
 
 export interface TriggeredBy {

--- a/apps/web/src/lib/websocket/broadcast-triggered-by.ts
+++ b/apps/web/src/lib/websocket/broadcast-triggered-by.ts
@@ -35,7 +35,11 @@ export async function resolveTriggeredBy(
     .where(eq(userProfiles.userId, userId))
     .limit(1)
     .catch((err: unknown) => {
-      triggeredByLogger.debug({ err, query: 'userProfiles', userId }, 'displayName query failed; falling back');
+      triggeredByLogger.debug('displayName query failed; falling back', {
+        err,
+        query: 'userProfiles',
+        userId,
+      });
       return [] as { displayName: string | null }[];
     });
 
@@ -47,7 +51,11 @@ export async function resolveTriggeredBy(
       .where(eq(users.id, userId))
       .limit(1)
       .catch((err: unknown) => {
-        triggeredByLogger.debug({ err, query: 'users', userId }, 'displayName query failed; falling back');
+        triggeredByLogger.debug('displayName query failed; falling back', {
+          err,
+          query: 'users',
+          userId,
+        });
         return [] as { name: string | null }[];
       });
     displayName = user?.name ?? 'Someone';

--- a/apps/web/src/lib/websocket/broadcast-triggered-by.ts
+++ b/apps/web/src/lib/websocket/broadcast-triggered-by.ts
@@ -1,0 +1,47 @@
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { users, userProfiles } from '@pagespace/db/schema/core';
+import { validateBrowserSessionIdHeader } from '@/lib/ai/core/browser-session-id-validation';
+
+export interface TriggeredBy {
+  userId: string;
+  displayName: string;
+  browserSessionId: string;
+}
+
+/**
+ * Resolve the `triggeredBy` block for chat broadcasts (edits, deletes, undo,
+ * conversation creation). Reads the X-Browser-Session-Id header (graceful
+ * fail-open: empty string when missing, since these are mutation broadcasts
+ * — not stream lifecycle events that require a session id) and resolves the
+ * actor's display name from userProfiles → users.name → "Someone".
+ */
+export async function resolveTriggeredBy(
+  userId: string,
+  request: Request,
+): Promise<TriggeredBy> {
+  const sessionResult = validateBrowserSessionIdHeader(
+    request.headers.get('X-Browser-Session-Id'),
+  );
+  const browserSessionId = sessionResult.ok ? sessionResult.browserSessionId : '';
+
+  const [profile] = await db
+    .select({ displayName: userProfiles.displayName })
+    .from(userProfiles)
+    .where(eq(userProfiles.userId, userId))
+    .limit(1)
+    .catch(() => [] as { displayName: string | null }[]);
+
+  let displayName = profile?.displayName ?? null;
+  if (!displayName) {
+    const [user] = await db
+      .select({ name: users.name })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1)
+      .catch(() => [] as { name: string | null }[]);
+    displayName = user?.name ?? 'Someone';
+  }
+
+  return { userId, displayName, browserSessionId };
+}

--- a/apps/web/src/lib/websocket/broadcast-triggered-by.ts
+++ b/apps/web/src/lib/websocket/broadcast-triggered-by.ts
@@ -2,7 +2,10 @@ import { db } from '@pagespace/db/db';
 import { eq } from '@pagespace/db/operators';
 import { users } from '@pagespace/db/schema/auth';
 import { userProfiles } from '@pagespace/db/schema/members';
+import { browserLoggers } from '@pagespace/lib/logging/logger-browser';
 import { validateBrowserSessionIdHeader } from '@/lib/ai/core/browser-session-id-validation';
+
+const triggeredByLogger = browserLoggers.realtime.child({ module: 'broadcast-triggered-by' });
 
 export interface TriggeredBy {
   userId: string;
@@ -31,7 +34,10 @@ export async function resolveTriggeredBy(
     .from(userProfiles)
     .where(eq(userProfiles.userId, userId))
     .limit(1)
-    .catch(() => [] as { displayName: string | null }[]);
+    .catch((err: unknown) => {
+      triggeredByLogger.debug({ err, query: 'userProfiles', userId }, 'displayName query failed; falling back');
+      return [] as { displayName: string | null }[];
+    });
 
   let displayName = profile?.displayName ?? null;
   if (!displayName) {
@@ -40,7 +46,10 @@ export async function resolveTriggeredBy(
       .from(users)
       .where(eq(users.id, userId))
       .limit(1)
-      .catch(() => [] as { name: string | null }[]);
+      .catch((err: unknown) => {
+        triggeredByLogger.debug({ err, query: 'users', userId }, 'displayName query failed; falling back');
+        return [] as { name: string | null }[];
+      });
     displayName = user?.name ?? 'Someone';
   }
 

--- a/apps/web/src/lib/websocket/socket-utils.ts
+++ b/apps/web/src/lib/websocket/socket-utils.ts
@@ -530,6 +530,22 @@ export interface ChatUserMessagePayload {
   triggeredBy: { userId: string; displayName: string; browserSessionId: string };
 }
 
+export interface ChatMessageEditedPayload {
+  messageId: string;
+  pageId: string;
+  conversationId: string;
+  parts: import('ai').UIMessage['parts'];
+  editedAt: string;
+  triggeredBy: { userId: string; displayName: string; browserSessionId: string };
+}
+
+export interface ChatMessageDeletedPayload {
+  messageId: string;
+  pageId: string;
+  conversationId: string;
+  triggeredBy: { userId: string; displayName: string; browserSessionId: string };
+}
+
 export async function broadcastAiStreamStart(payload: AiStreamStartPayload): Promise<void> {
   const realtimeUrl = getEnvVar('INTERNAL_REALTIME_URL');
   if (!realtimeUrl) {
@@ -626,6 +642,74 @@ export async function broadcastChatUserMessage(payload: ChatUserMessagePayload):
       error instanceof Error ? error : undefined,
       {
         event: 'chat:user_message',
+        channel: maskIdentifier(payload.pageId),
+      }
+    );
+  }
+}
+
+export async function broadcastAiMessageEdited(payload: ChatMessageEditedPayload): Promise<void> {
+  const realtimeUrl = getEnvVar('INTERNAL_REALTIME_URL');
+  if (!realtimeUrl) {
+    realtimeLogger.warn('Realtime URL not configured, skipping chat message-edited broadcast', {
+      event: 'chat:message_edited',
+    });
+    return;
+  }
+
+  try {
+    const requestBody = JSON.stringify({
+      channelId: payload.pageId,
+      event: 'chat:message_edited',
+      payload,
+    });
+
+    await fetch(`${realtimeUrl}/api/broadcast`, {
+      method: 'POST',
+      headers: createSignedBroadcastHeaders(requestBody),
+      body: requestBody,
+      signal: AbortSignal.timeout(5000),
+    });
+  } catch (error) {
+    realtimeLogger.error(
+      'Failed to broadcast chat message-edited',
+      error instanceof Error ? error : undefined,
+      {
+        event: 'chat:message_edited',
+        channel: maskIdentifier(payload.pageId),
+      }
+    );
+  }
+}
+
+export async function broadcastAiMessageDeleted(payload: ChatMessageDeletedPayload): Promise<void> {
+  const realtimeUrl = getEnvVar('INTERNAL_REALTIME_URL');
+  if (!realtimeUrl) {
+    realtimeLogger.warn('Realtime URL not configured, skipping chat message-deleted broadcast', {
+      event: 'chat:message_deleted',
+    });
+    return;
+  }
+
+  try {
+    const requestBody = JSON.stringify({
+      channelId: payload.pageId,
+      event: 'chat:message_deleted',
+      payload,
+    });
+
+    await fetch(`${realtimeUrl}/api/broadcast`, {
+      method: 'POST',
+      headers: createSignedBroadcastHeaders(requestBody),
+      body: requestBody,
+      signal: AbortSignal.timeout(5000),
+    });
+  } catch (error) {
+    realtimeLogger.error(
+      'Failed to broadcast chat message-deleted',
+      error instanceof Error ? error : undefined,
+      {
+        event: 'chat:message_deleted',
         channel: maskIdentifier(payload.pageId),
       }
     );

--- a/apps/web/src/lib/websocket/socket-utils.ts
+++ b/apps/web/src/lib/websocket/socket-utils.ts
@@ -546,6 +546,14 @@ export interface ChatMessageDeletedPayload {
   triggeredBy: { userId: string; displayName: string; browserSessionId: string };
 }
 
+export interface ChatUndoAppliedPayload {
+  conversationId: string;
+  pageId: string;
+  mode: 'messages_only' | 'messages_and_changes';
+  affectedMessageIds: string[];
+  triggeredBy: { userId: string; displayName: string; browserSessionId: string };
+}
+
 export async function broadcastAiStreamStart(payload: AiStreamStartPayload): Promise<void> {
   const realtimeUrl = getEnvVar('INTERNAL_REALTIME_URL');
   if (!realtimeUrl) {
@@ -710,6 +718,40 @@ export async function broadcastAiMessageDeleted(payload: ChatMessageDeletedPaylo
       error instanceof Error ? error : undefined,
       {
         event: 'chat:message_deleted',
+        channel: maskIdentifier(payload.pageId),
+      }
+    );
+  }
+}
+
+export async function broadcastAiUndoApplied(payload: ChatUndoAppliedPayload): Promise<void> {
+  const realtimeUrl = getEnvVar('INTERNAL_REALTIME_URL');
+  if (!realtimeUrl) {
+    realtimeLogger.warn('Realtime URL not configured, skipping chat undo-applied broadcast', {
+      event: 'chat:undo_applied',
+    });
+    return;
+  }
+
+  try {
+    const requestBody = JSON.stringify({
+      channelId: payload.pageId,
+      event: 'chat:undo_applied',
+      payload,
+    });
+
+    await fetch(`${realtimeUrl}/api/broadcast`, {
+      method: 'POST',
+      headers: createSignedBroadcastHeaders(requestBody),
+      body: requestBody,
+      signal: AbortSignal.timeout(5000),
+    });
+  } catch (error) {
+    realtimeLogger.error(
+      'Failed to broadcast chat undo-applied',
+      error instanceof Error ? error : undefined,
+      {
+        event: 'chat:undo_applied',
         channel: maskIdentifier(payload.pageId),
       }
     );

--- a/apps/web/src/lib/websocket/socket-utils.ts
+++ b/apps/web/src/lib/websocket/socket-utils.ts
@@ -554,6 +554,16 @@ export interface ChatUndoAppliedPayload {
   triggeredBy: { userId: string; displayName: string; browserSessionId: string };
 }
 
+export interface ChatConversationAddedPayload {
+  agentId: string;
+  conversation: {
+    id: string;
+    title: string;
+    createdAt: string;
+  };
+  triggeredBy: { userId: string; displayName: string; browserSessionId: string };
+}
+
 export async function broadcastAiStreamStart(payload: AiStreamStartPayload): Promise<void> {
   const realtimeUrl = getEnvVar('INTERNAL_REALTIME_URL');
   if (!realtimeUrl) {
@@ -753,6 +763,40 @@ export async function broadcastAiUndoApplied(payload: ChatUndoAppliedPayload): P
       {
         event: 'chat:undo_applied',
         channel: maskIdentifier(payload.pageId),
+      }
+    );
+  }
+}
+
+export async function broadcastAiConversationAdded(payload: ChatConversationAddedPayload): Promise<void> {
+  const realtimeUrl = getEnvVar('INTERNAL_REALTIME_URL');
+  if (!realtimeUrl) {
+    realtimeLogger.warn('Realtime URL not configured, skipping chat conversation-added broadcast', {
+      event: 'chat:conversation_added',
+    });
+    return;
+  }
+
+  try {
+    const requestBody = JSON.stringify({
+      channelId: payload.agentId,
+      event: 'chat:conversation_added',
+      payload,
+    });
+
+    await fetch(`${realtimeUrl}/api/broadcast`, {
+      method: 'POST',
+      headers: createSignedBroadcastHeaders(requestBody),
+      body: requestBody,
+      signal: AbortSignal.timeout(5000),
+    });
+  } catch (error) {
+    realtimeLogger.error(
+      'Failed to broadcast chat conversation-added',
+      error instanceof Error ? error : undefined,
+      {
+        event: 'chat:conversation_added',
+        channel: maskIdentifier(payload.agentId),
       }
     );
   }

--- a/apps/web/src/stores/__tests__/useOptimisticConversationsStore.test.ts
+++ b/apps/web/src/stores/__tests__/useOptimisticConversationsStore.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useOptimisticConversationsStore } from '../useOptimisticConversationsStore';
+
+const reset = () => useOptimisticConversationsStore.setState({ byKey: {} });
+
+describe('useOptimisticConversationsStore', () => {
+  beforeEach(reset);
+
+  it('given an empty store, when adding an entry, should expose it under the cache key', () => {
+    useOptimisticConversationsStore.getState().add('/key/a', {
+      id: 'conv-1',
+      title: 'Hello',
+      createdAt: '2026-05-01T00:00:00.000Z',
+    });
+
+    expect(useOptimisticConversationsStore.getState().byKey['/key/a']).toEqual([
+      { id: 'conv-1', title: 'Hello', createdAt: '2026-05-01T00:00:00.000Z' },
+    ]);
+  });
+
+  it('given two entries added in sequence, should preserve insertion order with the newest first', () => {
+    const { add } = useOptimisticConversationsStore.getState();
+    add('/key/a', { id: 'conv-1', title: 'First', createdAt: '2026-05-01T00:00:00.000Z' });
+    add('/key/a', { id: 'conv-2', title: 'Second', createdAt: '2026-05-01T00:00:01.000Z' });
+
+    const entries = useOptimisticConversationsStore.getState().byKey['/key/a'];
+    expect(entries.map((e) => e.id)).toEqual(['conv-2', 'conv-1']);
+  });
+
+  it('given an entry with an id already present, should be a no-op (dedup)', () => {
+    const { add } = useOptimisticConversationsStore.getState();
+    add('/key/a', { id: 'conv-1', title: 'Original', createdAt: '2026-05-01T00:00:00.000Z' });
+    add('/key/a', { id: 'conv-1', title: 'Different', createdAt: '2026-05-01T00:00:01.000Z' });
+
+    const entries = useOptimisticConversationsStore.getState().byKey['/key/a'];
+    expect(entries).toHaveLength(1);
+    expect(entries[0].title).toBe('Original');
+  });
+
+  it('given entries under different cache keys, should keep them isolated', () => {
+    const { add } = useOptimisticConversationsStore.getState();
+    add('/key/a', { id: 'conv-a', title: 'A', createdAt: '2026-05-01T00:00:00.000Z' });
+    add('/key/b', { id: 'conv-b', title: 'B', createdAt: '2026-05-01T00:00:01.000Z' });
+
+    expect(useOptimisticConversationsStore.getState().byKey['/key/a'].map((e) => e.id)).toEqual(['conv-a']);
+    expect(useOptimisticConversationsStore.getState().byKey['/key/b'].map((e) => e.id)).toEqual(['conv-b']);
+  });
+
+  it('given prune called with ids matching stored entries, should remove those entries', () => {
+    const { add, prune } = useOptimisticConversationsStore.getState();
+    add('/key/a', { id: 'conv-1', title: 'One', createdAt: '2026-05-01T00:00:00.000Z' });
+    add('/key/a', { id: 'conv-2', title: 'Two', createdAt: '2026-05-01T00:00:01.000Z' });
+    add('/key/a', { id: 'conv-3', title: 'Three', createdAt: '2026-05-01T00:00:02.000Z' });
+
+    prune('/key/a', ['conv-1', 'conv-3']);
+
+    const entries = useOptimisticConversationsStore.getState().byKey['/key/a'];
+    expect(entries.map((e) => e.id)).toEqual(['conv-2']);
+  });
+
+  it('given prune called with no matching ids, should leave the bucket unchanged (referential identity preserved)', () => {
+    const { add, prune } = useOptimisticConversationsStore.getState();
+    add('/key/a', { id: 'conv-1', title: 'One', createdAt: '2026-05-01T00:00:00.000Z' });
+    const before = useOptimisticConversationsStore.getState().byKey['/key/a'];
+
+    prune('/key/a', ['conv-other']);
+
+    expect(useOptimisticConversationsStore.getState().byKey['/key/a']).toBe(before);
+  });
+
+  it('given prune called for a cache key with no entries, should be a no-op', () => {
+    const { prune } = useOptimisticConversationsStore.getState();
+    prune('/key/missing', ['conv-1']);
+
+    expect(useOptimisticConversationsStore.getState().byKey).toEqual({});
+  });
+});

--- a/apps/web/src/stores/useOptimisticConversationsStore.ts
+++ b/apps/web/src/stores/useOptimisticConversationsStore.ts
@@ -1,0 +1,44 @@
+import { create } from 'zustand';
+
+export interface OptimisticConversationEntry {
+  id: string;
+  title: string;
+  createdAt: string;
+}
+
+interface OptimisticConversationsState {
+  /**
+   * Optimistic conversation entries received from chat:conversation_added
+   * broadcasts, keyed by the SWR cache URL of the owning conversation list.
+   * Survives the moment where the list hook is disabled (history tab not yet
+   * mounted) and the moment where SWR refetches without the lazily-materialized
+   * row. Entries are pruned by `prune()` once the server-confirmed conversation
+   * list includes them.
+   */
+  byKey: Record<string, OptimisticConversationEntry[]>;
+  add: (cacheKey: string, entry: OptimisticConversationEntry) => void;
+  prune: (cacheKey: string, knownIds: string[]) => void;
+}
+
+export const useOptimisticConversationsStore = create<OptimisticConversationsState>((set) => ({
+  byKey: {},
+  add: (cacheKey, entry) =>
+    set((state) => {
+      const existing = state.byKey[cacheKey] ?? [];
+      if (existing.some((e) => e.id === entry.id)) return state;
+      return {
+        byKey: { ...state.byKey, [cacheKey]: [entry, ...existing] },
+      };
+    }),
+  prune: (cacheKey, knownIds) =>
+    set((state) => {
+      const existing = state.byKey[cacheKey];
+      if (!existing || existing.length === 0) return state;
+      const known = new Set(knownIds);
+      const filtered = existing.filter((e) => !known.has(e.id));
+      if (filtered.length === existing.length) return state;
+      return {
+        byKey: { ...state.byKey, [cacheKey]: filtered },
+      };
+    }),
+}));


### PR DESCRIPTION
## Summary

Bundled implementation of Tasks 3, 4, and 5 from the [AI Multiplayer Event Broadcast epic](../../tasks/ai-multiplayer-event-broadcast.md). Closes the four chat-side multiplayer breakers that mutated the DB but emitted no socket events:

- **Task 3** — `chat:message_edited` and `chat:message_deleted` so remote viewers re-render edits/deletes within one socket frame.
- **Task 4** — `chat:undo_applied` so remote viewers refresh their conversation when user A undoes AI changes.
- **Task 5** — `chat:conversation_added` so co-viewers of a shared page-agent see new conversations appear in the history pane.

Tasks 1 (#1182) and 2 (#1193) shipped in Wave 1 and established the broadcast/listen/dedup pattern; this PR extends it.

## Why one PR

The three tasks touch the same files (`socket-utils.ts`, `useChannelStreamSocket.ts`, three surface components) and follow the same shape. The AHA gate is built in: each task ships standalone helpers/listeners, then a final review evaluates whether a real abstraction emerged.

## Commit batches

**Batch 1 — Task 3 (chat:message_edited + chat:message_deleted)**
- `bfbbc62b3` add applyMessageEdit pure helper
- `927c85bda` add applyMessageDelete pure helper
- `c6a0e1f4c` add broadcastAiMessageEdited / broadcastAiMessageDeleted helpers
- `e10905d88` wire chat:message_edited and chat:message_deleted listeners in useChannelStreamSocket
- `776875b23` emit chat:message_edited and chat:message_deleted from edit/delete routes (page-chat, page-agent, global)
- `57d501bd2` wire chat:message_edited and chat:message_deleted into AiChatView, useAgentChannelMultiplayer, GlobalChatContext

**Batch 2 — Task 4 (chat:undo_applied)**
- `d9fcc23dd` add shouldRefreshAfterUndo predicate
- `b4ee662b4` add broadcastAiUndoApplied helper
- `f86bd784f` broadcast chat:undo_applied from undo POST + wire listener + surface callbacks

**Batch 3 — Task 5 (chat:conversation_added)**
- `ee8396959` add shouldPrependConversation predicate
- `a16cdb00b` broadcast chat:conversation_added on page-agent conversation POST + wire listener + history-pane optimistic prepend
- `ec0672904` **Codex P2 fix**: persist optimistic conversation entries in a dedicated Zustand store so they survive (1) the hook-disabled state (`enabled: activeTab === 'history'`) and (2) the SWR refetch on tab activation. The original SWR-cache write silently dropped events when the history tab was closed and was clobbered by SWR refetches once the tab opened — page-agent rows are materialized lazily on first message save, so a naive refetch wouldn't surface the new conversation.

## AHA decision: kept separate

After Task 5, the four `handle*` callbacks in `useChannelStreamSocket` share four lines of dedup boilerplate (stale-room + own-tab) but use a different channel-id field — `pageId` for messages/undo, `agentId` for conversations. Extracting a wrapper would either lose the field-name distinction (less type safety) or require a generic key parameter (more indirection for ~20 lines saved). The existing `isOwnStream` already abstracts the per-tab dedup half. **No further extraction.**

## Test plan

- [x] Pure-helper unit tests (no mocks, Riteway shape) for `applyMessageEdit`, `applyMessageDelete`, `shouldRefreshAfterUndo`, `shouldPrependConversation`
- [x] `useOptimisticConversationsStore` unit tests (7 Givens: add, ordering, dedup-by-id, multi-key isolation, prune matching ids, prune no-op-with-referential-identity, prune empty bucket)
- [x] Broadcast-helper tests for the four new helpers (route-correctly, no-fetch-when-no-url, swallow-failure)
- [x] Listener tests in `useChannelStreamSocket.test.ts` for `chat:message_edited`, `chat:message_deleted`, `chat:undo_applied`, `chat:conversation_added` — happy path, stale-room, own-tab, callback stability
- [x] Existing route + component tests stay green (1648 web tests across `src/lib/ai`, `src/lib/websocket`, `src/hooks`, `src/contexts`, `src/components/ai`, `src/app/api/ai`, `src/stores`)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (only a pre-existing warning in QuickCreatePalette.tsx unrelated to this PR)
- [ ] Manual two-browser verification post-merge: shared page-agent, edit/delete/undo/create-conversation in window A, observe live updates in window B

## Notes / known limitations

- **Task 5 lazy-row materialization**: page-agent conversations are generated server-side at POST time but the DB row is materialized lazily on first message save. Resolved via the `useOptimisticConversationsStore` Zustand store — broadcast entries persist cross-tab-state and merge into the rendered list, auto-pruned when the server-confirmed list later includes them.
- **Global edit broadcast** carries `parts: [{ type: 'text', text: newContent }]` rather than reconstructed parts (the global Message repository row doesn't expose tool/file structure to the route layer). Page-chat edits use full `convertDbMessageToUIMessage` reconstruction.
- **Page-agent dashboard/sidebar** surfaces (`useAgentChannelMultiplayer`) intentionally do not subscribe to `onUndoApplied` or `onConversationAdded` — primary surfaces (AiChatView, GlobalChatContext) own the conversation refresh, secondary surfaces refresh on next view switch.

Do not auto-merge — ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)