### PR TITLE
refactor(workflows): decompose into execution + per-domain triggers

### DIFF
--- a/apps/web/src/app/api/calendar/events/route.ts
+++ b/apps/web/src/app/api/calendar/events/route.ts
@@ -6,6 +6,7 @@ import { calendarEvents, eventAttendees } from '@pagespace/db/schema/calendar'
 import { calendarTriggers } from '@pagespace/db/schema/calendar-triggers'
 import { pages } from '@pagespace/db/schema/core'
 import { workflows } from '@pagespace/db/schema/workflows';
+import { createCalendarTriggerWorkflow } from '@/lib/workflows/calendar-trigger-helpers';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getDriveMemberUserIds } from '@pagespace/lib/services/drive-member-service';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
@@ -558,14 +559,19 @@ export async function POST(request: Request) {
       }
 
       if (data.agentTrigger && agentPageId && data.driveId) {
-        await tx.insert(calendarTriggers).values({
-          calendarEventId: created.id,
-          agentPageId,
+        await createCalendarTriggerWorkflow({
+          tx,
           driveId: data.driveId,
           scheduledById: userId,
-          prompt: data.agentTrigger.prompt,
+          calendarEventId: created.id,
           triggerAt: startAt,
-          contextPageIds: [],
+          timezone: data.timezone,
+          agentTrigger: {
+            agentPageId,
+            prompt: data.agentTrigger.prompt,
+            instructionPageId: null,
+            contextPageIds: [],
+          },
         });
       }
 

--- a/apps/web/src/app/api/cron/task-triggers/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/task-triggers/__tests__/route.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+
+// ============================================================================
+// Contract tests for /api/cron/task-triggers
+// ============================================================================
+
+const {
+  mockReturning,
+  mockUpdateWhere,
+  mockUpdateSet,
+  mockUpdate,
+  mockSelectWhere,
+  mockSelectFrom,
+  mockSelect,
+  mockOrderBy,
+  mockLimit,
+} = vi.hoisted(() => ({
+  mockReturning: vi.fn().mockResolvedValue([]),
+  mockUpdateWhere: vi.fn(),
+  mockUpdateSet: vi.fn(),
+  mockUpdate: vi.fn(),
+  mockSelectWhere: vi.fn(),
+  mockSelectFrom: vi.fn(),
+  mockSelect: vi.fn(),
+  mockOrderBy: vi.fn(),
+  mockLimit: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@/lib/auth/cron-auth', () => ({
+  validateSignedCronRequest: vi.fn(),
+}));
+
+vi.mock('@/lib/workflows/workflow-executor', () => ({
+  executeWorkflow: vi.fn(),
+}));
+
+const mockAudit = vi.hoisted(() => vi.fn());
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+      child: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() })),
+    },
+  },
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  audit: mockAudit,
+}));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    select: mockSelect,
+    update: mockUpdate,
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((field, value) => ({ op: 'eq', field, value })),
+  and: vi.fn((...conds) => ({ op: 'and', conds })),
+  lte: vi.fn((field, value) => ({ op: 'lte', field, value })),
+  inArray: vi.fn((field, values) => ({ op: 'inArray', field, values })),
+  isNull: vi.fn((field) => ({ op: 'isNull', field })),
+  asc: vi.fn((field) => field),
+}));
+vi.mock('@pagespace/db/schema/workflows', () => ({
+  workflows: {
+    id: 'id',
+  },
+}));
+vi.mock('@pagespace/db/schema/task-triggers', () => ({
+  taskTriggers: {
+    id: 'id',
+    workflowId: 'workflowId',
+    taskItemId: 'taskItemId',
+    triggerType: 'triggerType',
+    isEnabled: 'isEnabled',
+    nextRunAt: 'nextRunAt',
+    lastFiredAt: 'lastFiredAt',
+    lastFireError: 'lastFireError',
+  },
+}));
+vi.mock('@pagespace/db/schema/tasks', () => ({
+  taskItems: { id: 'id', completedAt: 'completedAt', dueDate: 'dueDate' },
+}));
+
+import { POST } from '../route';
+import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
+import { executeWorkflow } from '@/lib/workflows/workflow-executor';
+import { isNull } from '@pagespace/db/operators';
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+const MOCK_TRIGGER = {
+  id: 'trg_1',
+  workflowId: 'wf_1',
+  taskItemId: 'task_1',
+  triggerType: 'due_date' as const,
+  nextRunAt: new Date('2025-01-01T09:00:00Z'),
+  lastFiredAt: null,
+  lastFireError: null,
+  isEnabled: true,
+  createdAt: new Date('2024-01-01'),
+  updatedAt: new Date('2024-01-01'),
+};
+
+const MOCK_WORKFLOW = {
+  id: 'wf_1',
+  driveId: 'drive_1',
+  createdBy: 'user_1',
+  name: 'task-trigger-due_date-task_1',
+  agentPageId: 'agent_1',
+  prompt: 'Do the thing',
+  contextPageIds: [],
+  triggerType: 'cron',
+  cronExpression: null,
+  timezone: 'UTC',
+  instructionPageId: null,
+  isEnabled: true,
+};
+
+const MOCK_TASK = {
+  id: 'task_1',
+  completedAt: null,
+  dueDate: new Date('2025-01-01T09:00:00Z'),
+};
+
+// The route's select chains have two shapes:
+//   A) due-trigger discovery: select().from(taskTriggers).where(...).orderBy(...).limit(N)
+//   B) row lookups:           select().from(workflows|taskItems).where(...)
+// We support both by making `where` return a thenable that ALSO carries
+// an `.orderBy().limit()` chain. When awaited it resolves to the lookup
+// row array; when chained it resolves to the discovery row array.
+//
+// Test fixtures push results onto two FIFO queues:
+//   discoveryQueue: each element is the rows the next .limit() call returns
+//   lookupQueue:    each element is the rows the next awaited .where(...) returns
+const discoveryQueue: unknown[][] = [];
+const lookupQueue: unknown[][] = [];
+
+function pushDiscoveryRows(rows: unknown[]) { discoveryQueue.push(rows); }
+function pushLookupRows(rows: unknown[]) { lookupQueue.push(rows); }
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('POST /api/cron/task-triggers', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(validateSignedCronRequest).mockReturnValue(null);
+
+    discoveryQueue.length = 0;
+    lookupQueue.length = 0;
+
+    mockSelect.mockReturnValue({ from: mockSelectFrom });
+    mockSelectFrom.mockReturnValue({ where: mockSelectWhere });
+    // Lazy thenable: only pop the lookup queue when actually awaited.
+    // Plain `Promise.resolve(...)` would pop eagerly when where() is called,
+    // and the discovery `.where().orderBy().limit()` chain (which never
+    // awaits the where return) would silently consume a lookup row.
+    mockSelectWhere.mockImplementation(() => ({
+      then(onFulfilled: (rows: unknown[]) => void) {
+        const lookupRows = lookupQueue.shift() ?? [];
+        onFulfilled(lookupRows);
+      },
+      orderBy: mockOrderBy,
+    }));
+    mockOrderBy.mockReturnValue({ limit: mockLimit });
+    mockLimit.mockImplementation(() => Promise.resolve(discoveryQueue.shift() ?? []));
+
+    mockUpdate.mockReturnValue({ set: mockUpdateSet });
+    mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
+    mockUpdateWhere.mockImplementation(() => {
+      const p = Promise.resolve(undefined) as Promise<undefined> & { returning: typeof mockReturning };
+      p.returning = mockReturning;
+      return p;
+    });
+    mockReturning.mockResolvedValue([]);
+  });
+
+  it('returns auth error when cron request is invalid', async () => {
+    const errorResponse = NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    vi.mocked(validateSignedCronRequest).mockReturnValue(errorResponse);
+
+    const request = new Request('https://example.com/api/cron/task-triggers', { method: 'POST' });
+    const response = await POST(request);
+
+    expect(response.status).toBe(401);
+  });
+
+  it('returns success with 0 executed when no triggers are due', async () => {
+    pushDiscoveryRows([]);
+
+    const request = new Request('https://example.com/api/cron/task-triggers', { method: 'POST' });
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.executed).toBe(0);
+    expect(body.message).toBe('No task triggers due');
+  });
+
+  it('atomically claims due triggers with a lastFiredAt IS NULL guard', async () => {
+    pushDiscoveryRows([MOCK_TRIGGER]);
+    mockReturning.mockResolvedValueOnce([MOCK_TRIGGER]);
+    pushLookupRows([MOCK_WORKFLOW]); // workflow lookup
+    pushLookupRows([MOCK_TASK]);     // task lookup
+    vi.mocked(executeWorkflow).mockResolvedValue({ success: true, durationMs: 50 });
+
+    const request = new Request('https://example.com/api/cron/task-triggers', { method: 'POST' });
+    await POST(request);
+
+    // The claim WHERE must include isNull(taskTriggers.lastFiredAt)
+    const guardedFields = vi.mocked(isNull).mock.calls.map((c) => c[0]);
+    expect(guardedFields).toContain('lastFiredAt');
+  });
+
+  it('skips firing when the linked task is completed', async () => {
+    pushDiscoveryRows([MOCK_TRIGGER]);
+    mockReturning.mockResolvedValueOnce([MOCK_TRIGGER]);
+    pushLookupRows([MOCK_WORKFLOW]);
+    pushLookupRows([{ ...MOCK_TASK, completedAt: new Date() }]);
+
+    const request = new Request('https://example.com/api/cron/task-triggers', { method: 'POST' });
+    await POST(request);
+
+    expect(executeWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('skips firing when the linked task has no due date (was cleared)', async () => {
+    pushDiscoveryRows([MOCK_TRIGGER]);
+    mockReturning.mockResolvedValueOnce([MOCK_TRIGGER]);
+    pushLookupRows([MOCK_WORKFLOW]);
+    pushLookupRows([{ ...MOCK_TASK, dueDate: null }]);
+
+    const request = new Request('https://example.com/api/cron/task-triggers', { method: 'POST' });
+    await POST(request);
+
+    expect(executeWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('skips firing when the linked task due date was postponed past now', async () => {
+    pushDiscoveryRows([MOCK_TRIGGER]);
+    mockReturning.mockResolvedValueOnce([MOCK_TRIGGER]);
+    pushLookupRows([MOCK_WORKFLOW]);
+    const future = new Date(Date.now() + 1000 * 60 * 60 * 24);
+    pushLookupRows([{ ...MOCK_TASK, dueDate: future }]);
+
+    const request = new Request('https://example.com/api/cron/task-triggers', { method: 'POST' });
+    await POST(request);
+
+    expect(executeWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('marks trigger as disabled with error when linked workflow is missing', async () => {
+    pushDiscoveryRows([MOCK_TRIGGER]);
+    mockReturning.mockResolvedValueOnce([MOCK_TRIGGER]);
+    pushLookupRows([]);             // workflow lookup empty
+    pushLookupRows([MOCK_TASK]);    // task lookup (batch-loaded regardless)
+
+    const request = new Request('https://example.com/api/cron/task-triggers', { method: 'POST' });
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    expect(executeWorkflow).not.toHaveBeenCalled();
+    const setArgs = mockUpdateSet.mock.calls.map((c) => c[0]);
+    const found = setArgs.find((arg) =>
+      typeof arg === 'object' && arg !== null && 'lastFireError' in arg
+        && (arg as { lastFireError?: string }).lastFireError === 'Linked workflow not found',
+    );
+    expect(found).toBeDefined();
+  });
+
+  it('successfully fires an eligible due trigger and composes WorkflowExecutionInput with taskContext', async () => {
+    pushDiscoveryRows([MOCK_TRIGGER]);
+    mockReturning.mockResolvedValueOnce([MOCK_TRIGGER]);
+    pushLookupRows([MOCK_WORKFLOW]);
+    pushLookupRows([MOCK_TASK]);
+    vi.mocked(executeWorkflow).mockResolvedValue({ success: true, durationMs: 100 });
+
+    const request = new Request('https://example.com/api/cron/task-triggers', { method: 'POST' });
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.executed).toBe(1);
+    expect(executeWorkflow).toHaveBeenCalledWith(expect.objectContaining({
+      workflowId: MOCK_WORKFLOW.id,
+      agentPageId: MOCK_WORKFLOW.agentPageId,
+      prompt: MOCK_WORKFLOW.prompt,
+      taskContext: { taskItemId: MOCK_TRIGGER.taskItemId, triggerType: MOCK_TRIGGER.triggerType },
+    }));
+  });
+
+  it('disables the trigger after firing (one-shot semantics)', async () => {
+    pushDiscoveryRows([MOCK_TRIGGER]);
+    mockReturning.mockResolvedValueOnce([MOCK_TRIGGER]);
+    pushLookupRows([MOCK_WORKFLOW]);
+    pushLookupRows([MOCK_TASK]);
+    vi.mocked(executeWorkflow).mockResolvedValue({ success: true, durationMs: 50 });
+
+    const request = new Request('https://example.com/api/cron/task-triggers', { method: 'POST' });
+    await POST(request);
+
+    const setArgs = mockUpdateSet.mock.calls.map((c) => c[0]);
+    const disablingCall = setArgs.find((arg) =>
+      typeof arg === 'object' && arg !== null && 'isEnabled' in arg
+        && (arg as { isEnabled?: boolean }).isEnabled === false,
+    );
+    expect(disablingCall).toBeDefined();
+  });
+});

--- a/apps/web/src/app/api/cron/task-triggers/route.ts
+++ b/apps/web/src/app/api/cron/task-triggers/route.ts
@@ -1,0 +1,185 @@
+import { NextResponse } from 'next/server';
+import { db } from '@pagespace/db/db'
+import { eq, and, lte, inArray, isNull, asc } from '@pagespace/db/operators'
+import { workflows } from '@pagespace/db/schema/workflows';
+import { taskTriggers } from '@pagespace/db/schema/task-triggers';
+import { taskItems } from '@pagespace/db/schema/tasks';
+import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
+import { executeWorkflow, type WorkflowExecutionInput } from '@/lib/workflows/workflow-executor';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { audit } from '@pagespace/lib/audit/audit-log';
+
+const MAX_CONCURRENT_TRIGGERS = 5;
+const MAX_DUE_TRIGGERS = 50;
+
+const logger = loggers.api.child({ module: 'cron-task-triggers' });
+
+/**
+ * POST /api/cron/task-triggers — fire due task triggers (one-shot, due_date).
+ *
+ * Picks task_triggers rows where isEnabled = true, nextRunAt <= NOW(),
+ * lastFiredAt IS NULL. Atomically claims by setting lastFiredAt = NOW()
+ * with a returning() clause so concurrent invocations cannot double-fire,
+ * then loads the linked workflow and pre-checks the underlying task before
+ * executing.
+ */
+export async function POST(req: Request) {
+  const authError = validateSignedCronRequest(req);
+  if (authError) return authError;
+
+  try {
+    const now = new Date();
+
+    const dueTriggers = await db
+      .select()
+      .from(taskTriggers)
+      .where(
+        and(
+          eq(taskTriggers.isEnabled, true),
+          lte(taskTriggers.nextRunAt, now),
+          isNull(taskTriggers.lastFiredAt),
+        ),
+      )
+      .orderBy(asc(taskTriggers.nextRunAt))
+      .limit(MAX_DUE_TRIGGERS);
+
+    if (dueTriggers.length === 0) {
+      audit({ eventType: 'data.write', resourceType: 'cron_job', resourceId: 'task_triggers', details: { executed: 0, failed: 0 } });
+      return NextResponse.json({ message: 'No task triggers due', executed: 0 });
+    }
+
+    logger.info(`Task trigger cron: Found ${dueTriggers.length} due triggers`);
+
+    let executed = 0;
+    let totalClaimed = 0;
+    const errors: string[] = [];
+
+    for (let i = 0; i < dueTriggers.length; i += MAX_CONCURRENT_TRIGGERS) {
+      const batch = dueTriggers.slice(i, i + MAX_CONCURRENT_TRIGGERS);
+      const batchIds = batch.map(t => t.id);
+
+      // Atomically claim: lastFiredAt IS NULL guard prevents double-fire
+      const claimed = await db
+        .update(taskTriggers)
+        .set({ lastFiredAt: now })
+        .where(
+          and(
+            inArray(taskTriggers.id, batchIds),
+            eq(taskTriggers.isEnabled, true),
+            isNull(taskTriggers.lastFiredAt),
+            lte(taskTriggers.nextRunAt, now),
+          ),
+        )
+        .returning();
+
+      if (claimed.length === 0) continue;
+      totalClaimed += claimed.length;
+
+      // Load linked workflows
+      const workflowIds = [...new Set(claimed.map(t => t.workflowId))];
+      const linkedWorkflows = await db
+        .select()
+        .from(workflows)
+        .where(inArray(workflows.id, workflowIds));
+      const workflowMap = new Map(linkedWorkflows.map(w => [w.id, w]));
+
+      // Load linked tasks (for pre-execution skip check on due_date triggers)
+      const taskIds = [...new Set(claimed.map(t => t.taskItemId))];
+      const tasks = await db
+        .select({ id: taskItems.id, completedAt: taskItems.completedAt, dueDate: taskItems.dueDate })
+        .from(taskItems)
+        .where(inArray(taskItems.id, taskIds));
+      const taskMap = new Map(tasks.map(t => [t.id, t]));
+
+      const batchResults = await Promise.allSettled(
+        claimed.map(async (trigger) => {
+          const workflow = workflowMap.get(trigger.workflowId);
+          if (!workflow) {
+            await db.update(taskTriggers).set({
+              isEnabled: false,
+              lastFireError: 'Linked workflow not found',
+            }).where(eq(taskTriggers.id, trigger.id));
+            return { trigger, result: { success: false, durationMs: 0, error: 'Linked workflow not found' } as const };
+          }
+
+          // Pre-execution skip for due_date triggers whose task became ineligible
+          if (trigger.triggerType === 'due_date') {
+            const task = taskMap.get(trigger.taskItemId);
+            const skipReason = !task
+              ? 'Task not found'
+              : task.completedAt
+                ? 'Task completed before due date'
+                : (!task.dueDate || task.dueDate.getTime() > now.getTime())
+                  ? 'Task due date cleared or postponed'
+                  : null;
+
+            if (skipReason) {
+              await db.update(taskTriggers).set({
+                isEnabled: false,
+                lastFireError: skipReason,
+              }).where(eq(taskTriggers.id, trigger.id));
+              return { trigger, result: { success: false, durationMs: 0, error: skipReason } as const };
+            }
+          }
+
+          const input: WorkflowExecutionInput = {
+            workflowId: workflow.id,
+            workflowName: workflow.name,
+            driveId: workflow.driveId,
+            createdBy: workflow.createdBy,
+            agentPageId: workflow.agentPageId,
+            prompt: workflow.prompt,
+            contextPageIds: (workflow.contextPageIds as string[] | null) ?? [],
+            instructionPageId: workflow.instructionPageId,
+            timezone: workflow.timezone,
+            taskContext: { taskItemId: trigger.taskItemId, triggerType: trigger.triggerType },
+          };
+
+          const result = await executeWorkflow(input);
+
+          await db.update(taskTriggers).set({
+            isEnabled: false,
+            lastFireError: result.error || null,
+          }).where(eq(taskTriggers.id, trigger.id));
+
+          return { trigger, result };
+        }),
+      );
+
+      for (let j = 0; j < batchResults.length; j++) {
+        const settled = batchResults[j];
+        if (settled.status === 'fulfilled') {
+          if (settled.value.result.success) {
+            executed++;
+          } else {
+            errors.push(`task-trigger-${settled.value.trigger.id}: ${settled.value.result.error}`);
+          }
+        } else {
+          const trigger = claimed[j];
+          const errorMsg = settled.reason instanceof Error ? settled.reason.message : String(settled.reason);
+          logger.error('Task trigger execution rejected', { triggerId: trigger.id, error: errorMsg });
+          errors.push(`task-trigger-${trigger.id}: ${errorMsg}`);
+
+          await db.update(taskTriggers).set({
+            isEnabled: false,
+            lastFireError: errorMsg,
+          }).where(eq(taskTriggers.id, trigger.id));
+        }
+      }
+    }
+
+    logger.info(`Task trigger cron: Complete. Executed ${executed}/${totalClaimed}`);
+
+    audit({ eventType: 'data.write', resourceType: 'cron_job', resourceId: 'task_triggers', details: { executed, failed: errors.length } });
+
+    return NextResponse.json({
+      message: 'Task trigger cron complete',
+      executed,
+      total: totalClaimed,
+      errors: errors.length > 0 ? errors : undefined,
+    });
+  } catch (error) {
+    logger.error('Task trigger cron error:', error as Error);
+    return NextResponse.json({ error: 'Task trigger cron job failed' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/cron/workflows/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/workflows/__tests__/route.test.ts
@@ -170,7 +170,15 @@ describe('POST /api/cron/workflows', () => {
     const body = await response.json();
     expect(body.executed).toBe(1);
     expect(body.total).toBe(1);
-    expect(executeWorkflow).toHaveBeenCalledWith(MOCK_WORKFLOW);
+    expect(executeWorkflow).toHaveBeenCalledWith(expect.objectContaining({
+      workflowId: MOCK_WORKFLOW.id,
+      workflowName: MOCK_WORKFLOW.name,
+      driveId: MOCK_WORKFLOW.driveId,
+      createdBy: MOCK_WORKFLOW.createdBy,
+      agentPageId: MOCK_WORKFLOW.agentPageId,
+      prompt: MOCK_WORKFLOW.prompt,
+      timezone: MOCK_WORKFLOW.timezone,
+    }));
   });
 
   it('should handle workflow execution errors gracefully', async () => {

--- a/apps/web/src/app/api/cron/workflows/route.ts
+++ b/apps/web/src/app/api/cron/workflows/route.ts
@@ -1,17 +1,15 @@
 import { NextResponse } from 'next/server';
 import { db } from '@pagespace/db/db'
 import { eq, and, lte, ne, inArray } from '@pagespace/db/operators'
-import { taskItems } from '@pagespace/db/schema/tasks'
 import { workflows } from '@pagespace/db/schema/workflows';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
-import { executeWorkflow } from '@/lib/workflows/workflow-executor';
+import { executeWorkflow, type WorkflowExecutionInput } from '@/lib/workflows/workflow-executor';
 import { getNextRunDate } from '@/lib/workflows/cron-utils';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { audit } from '@pagespace/lib/audit/audit-log';
 
 const STUCK_WORKFLOW_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 const MAX_CONCURRENT_WORKFLOWS = 5;
-const POLLED_TRIGGER_TYPES: ('cron' | 'task_due_date')[] = ['cron', 'task_due_date'];
 
 export async function POST(req: Request) {
   const authError = validateSignedCronRequest(req);
@@ -20,28 +18,23 @@ export async function POST(req: Request) {
   try {
     const now = new Date();
 
-    // Reset stuck polled workflows (running for >10 min) and advance their nextRunAt
+    // Reset stuck cron workflows (running for >10 min) and advance nextRunAt
     // so they aren't immediately re-claimed in the same cron invocation.
-    // Scoped to polled trigger types to avoid incorrectly resetting long-running event workflows.
     const stuckCutoff = new Date(now.getTime() - STUCK_WORKFLOW_TIMEOUT_MS);
     const stuckWorkflows = await db
       .update(workflows)
       .set({ lastRunStatus: 'error', lastRunError: 'Workflow timed out (stuck in running state)' })
       .where(
         and(
-          inArray(workflows.triggerType, POLLED_TRIGGER_TYPES),
+          eq(workflows.triggerType, 'cron'),
           eq(workflows.lastRunStatus, 'running'),
           lte(workflows.lastRunAt, stuckCutoff)
         )
       )
       .returning();
 
-    // Advance nextRunAt for stuck workflows so they schedule their next proper run.
-    // One-shot triggers (task_due_date) get disabled instead of rescheduled.
     for (const wf of stuckWorkflows) {
-      if (wf.triggerType === 'task_due_date') {
-        await db.update(workflows).set({ isEnabled: false, nextRunAt: null }).where(eq(workflows.id, wf.id));
-      } else if (wf.cronExpression) {
+      if (wf.cronExpression) {
         try {
           const nextRunAt = getNextRunDate(wf.cronExpression, wf.timezone);
           await db.update(workflows).set({ nextRunAt }).where(eq(workflows.id, wf.id));
@@ -49,14 +42,14 @@ export async function POST(req: Request) {
       }
     }
 
-    // Discover which polled workflows are due (cron + task_due_date)
+    // Discover which cron workflows are due
     const dueWorkflows = await db
       .select()
       .from(workflows)
       .where(
         and(
           eq(workflows.isEnabled, true),
-          inArray(workflows.triggerType, POLLED_TRIGGER_TYPES),
+          eq(workflows.triggerType, 'cron'),
           lte(workflows.nextRunAt, now),
           ne(workflows.lastRunStatus, 'running')
         )
@@ -71,41 +64,23 @@ export async function POST(req: Request) {
 
     type WorkflowRow = typeof dueWorkflows[number];
 
+    const toExecutionInput = (workflow: WorkflowRow): WorkflowExecutionInput => ({
+      workflowId: workflow.id,
+      workflowName: workflow.name,
+      driveId: workflow.driveId,
+      createdBy: workflow.createdBy,
+      agentPageId: workflow.agentPageId,
+      prompt: workflow.prompt,
+      contextPageIds: (workflow.contextPageIds as string[] | null) ?? [],
+      instructionPageId: workflow.instructionPageId,
+      timezone: workflow.timezone,
+    });
+
     const executeOne = async (workflow: WorkflowRow) => {
-      const isOneShot = workflow.triggerType === 'task_due_date';
-
-      // Pre-execution check: skip task_due_date triggers whose task is completed,
-      // deleted, or whose due date was cleared/postponed after the workflow was claimed
-      if (isOneShot && workflow.taskItemId) {
-        const [task] = await db
-          .select({ completedAt: taskItems.completedAt, dueDate: taskItems.dueDate })
-          .from(taskItems)
-          .where(eq(taskItems.id, workflow.taskItemId));
-
-        const skipReason = !task
-          ? 'Task not found'
-          : task.completedAt
-            ? 'Task completed before due date'
-            : (!task.dueDate || task.dueDate.getTime() > now.getTime())
-              ? 'Task due date cleared or postponed'
-              : null;
-
-        if (skipReason) {
-          await db.update(workflows).set({
-            lastRunAt: new Date(),
-            lastRunStatus: 'error',
-            lastRunError: skipReason,
-            isEnabled: false,
-            nextRunAt: null,
-          }).where(eq(workflows.id, workflow.id));
-          return { workflow, result: { success: false, durationMs: 0, error: skipReason } as const };
-        }
-      }
-
-      const result = await executeWorkflow(workflow);
+      const result = await executeWorkflow(toExecutionInput(workflow));
 
       let nextRunAt: Date | undefined;
-      if (!isOneShot && workflow.cronExpression) {
+      if (workflow.cronExpression) {
         try {
           nextRunAt = getNextRunDate(workflow.cronExpression, workflow.timezone);
         } catch {
@@ -120,7 +95,6 @@ export async function POST(req: Request) {
           lastRunStatus: result.success ? 'success' : 'error',
           lastRunError: result.error || null,
           lastRunDurationMs: result.durationMs,
-          ...(isOneShot ? { isEnabled: false, nextRunAt: null } : {}),
           ...(nextRunAt ? { nextRunAt } : {}),
         })
         .where(eq(workflows.id, workflow.id));
@@ -128,8 +102,6 @@ export async function POST(req: Request) {
       return { workflow, result };
     };
 
-    // Claim and execute in batches to avoid the stuck-workflow timeout racing
-    // against not-yet-started items from a single large claim.
     let executed = 0;
     let totalClaimed = 0;
     const errors: string[] = [];
@@ -138,8 +110,8 @@ export async function POST(req: Request) {
       const batch = dueWorkflows.slice(i, i + MAX_CONCURRENT_WORKFLOWS);
       const batchIds = batch.map(w => w.id);
 
-      // Atomically claim this batch (UPDATE...RETURNING prevents double-execution)
-      // Re-check eligibility predicates to guard against state changes between discovery and claim
+      // Atomically claim this batch (UPDATE...RETURNING prevents double-execution).
+      // Re-check eligibility predicates to guard against state changes between discovery and claim.
       const claimed = await db
         .update(workflows)
         .set({ lastRunStatus: 'running', lastRunAt: new Date() })
@@ -147,7 +119,7 @@ export async function POST(req: Request) {
           and(
             inArray(workflows.id, batchIds),
             eq(workflows.isEnabled, true),
-            inArray(workflows.triggerType, POLLED_TRIGGER_TYPES),
+            eq(workflows.triggerType, 'cron'),
             lte(workflows.nextRunAt, now),
             ne(workflows.lastRunStatus, 'running')
           )
@@ -173,9 +145,8 @@ export async function POST(req: Request) {
           loggers.api.error(`Workflow cron: Failed for workflow ${workflow.id}`, { error: errorMsg });
           errors.push(`${workflow.name}: ${errorMsg}`);
 
-          const isOneShot = workflow.triggerType === 'task_due_date';
           let nextRunAt: Date | undefined;
-          if (!isOneShot && workflow.cronExpression) {
+          if (workflow.cronExpression) {
             try {
               nextRunAt = getNextRunDate(workflow.cronExpression, workflow.timezone);
             } catch { /* invalid cron — leave nextRunAt as-is */ }
@@ -186,7 +157,6 @@ export async function POST(req: Request) {
             .set({
               lastRunStatus: 'error',
               lastRunError: errorMsg,
-              ...(isOneShot ? { isEnabled: false, nextRunAt: null } : {}),
               ...(nextRunAt ? { nextRunAt } : {}),
             })
             .where(eq(workflows.id, workflow.id));

--- a/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/route.ts
@@ -459,11 +459,12 @@ export async function DELETE(
   const linkedPageId = existingTask.pageId;
 
   if (!linkedPageId) {
-    // Task without a page (conversation-based) - delete the task record directly
+    // Task without a page (conversation-based) - hard-delete the task row.
+    // disableTaskTriggers MUST run BEFORE the task delete: task_triggers
+    // has ON DELETE CASCADE on taskItemId, so deleting the task first wipes
+    // the trigger rows and leaves orphan workflows rows behind.
+    await disableTaskTriggers(taskId, 'Task deleted');
     await db.delete(taskItems).where(eq(taskItems.id, taskId));
-
-    // Disable triggers only after successful deletion
-    void disableTaskTriggers(taskId, 'Task deleted');
 
     await broadcastTaskEvent({
       type: 'task_deleted',

--- a/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
@@ -3,7 +3,7 @@ import { db } from '@pagespace/db/db'
 import { eq, and, desc, asc, inArray, count } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core'
 import { taskLists, taskItems, taskStatusConfigs, taskAssignees } from '@pagespace/db/schema/tasks';
-import { workflows } from '@pagespace/db/schema/workflows';
+import { taskTriggers } from '@pagespace/db/schema/task-triggers';
 import { createTaskTriggerWorkflow } from '@/lib/workflows/task-trigger-helpers';
 import { DEFAULT_TASK_STATUSES } from '@pagespace/db/schema/tasks';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
@@ -208,22 +208,22 @@ export async function GET(req: Request, { params }: { params: Promise<{ pageId: 
     );
   }
 
-  // Ground-truth active trigger count from the workflows table so badges don't
-  // go stale when an agent page is trashed and the workflow row cascade-deletes.
+  // Ground-truth active trigger count from task_triggers so badges don't go
+  // stale when an agent page is trashed: the workflows row cascade-deletes,
+  // which in turn cascade-deletes the task_triggers row.
   const triggerCountByTaskId = new Map<string, number>();
   if (tasks.length > 0) {
     const taskIdList = tasks.map((t) => t.id);
     const triggerRows = await db
-      .select({ taskItemId: workflows.taskItemId, total: count() })
-      .from(workflows)
+      .select({ taskItemId: taskTriggers.taskItemId, total: count() })
+      .from(taskTriggers)
       .where(and(
-        inArray(workflows.taskItemId, taskIdList),
-        eq(workflows.isEnabled, true),
-        inArray(workflows.triggerType, ['task_due_date', 'task_completion']),
+        inArray(taskTriggers.taskItemId, taskIdList),
+        eq(taskTriggers.isEnabled, true),
       ))
-      .groupBy(workflows.taskItemId);
+      .groupBy(taskTriggers.taskItemId);
     for (const row of triggerRows) {
-      if (row.taskItemId) triggerCountByTaskId.set(row.taskItemId, Number(row.total));
+      triggerCountByTaskId.set(row.taskItemId, Number(row.total));
     }
   }
 

--- a/apps/web/src/app/api/tasks/[taskId]/triggers/[triggerType]/route.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/triggers/[triggerType]/route.ts
@@ -7,7 +7,7 @@ import { db } from '@pagespace/db/db';
 import { eq, and } from '@pagespace/db/operators';
 import { pages } from '@pagespace/db/schema/core';
 import { taskItems, taskLists } from '@pagespace/db/schema/tasks';
-import { workflows } from '@pagespace/db/schema/workflows';
+import { taskTriggers } from '@pagespace/db/schema/task-triggers';
 import { recomputeTaskTriggerMetadata } from '@/lib/workflows/task-trigger-helpers';
 import { broadcastTaskEvent } from '@/lib/websocket';
 
@@ -30,7 +30,7 @@ export async function DELETE(
   if (!parsedType.success) {
     return NextResponse.json({ error: 'Invalid trigger type' }, { status: 400 });
   }
-  const triggerTypeDb = parsedType.data === 'completion' ? 'task_completion' as const : 'task_due_date' as const;
+  const triggerTypeValue = parsedType.data;
 
   const task = await db.query.taskItems.findFirst({ where: eq(taskItems.id, taskId) });
   if (!task) {
@@ -56,9 +56,9 @@ export async function DELETE(
   }
 
   await db
-    .update(workflows)
-    .set({ isEnabled: false, lastRunError: 'Disabled by user', nextRunAt: null })
-    .where(and(eq(workflows.taskItemId, taskId), eq(workflows.triggerType, triggerTypeDb)));
+    .update(taskTriggers)
+    .set({ isEnabled: false, lastFireError: 'Disabled by user', nextRunAt: null })
+    .where(and(eq(taskTriggers.taskItemId, taskId), eq(taskTriggers.triggerType, triggerTypeValue)));
 
   await recomputeTaskTriggerMetadata(db, taskId, task.metadata as Record<string, unknown> | null);
 
@@ -67,7 +67,7 @@ export async function DELETE(
     userId,
     resourceType: 'task_triggers',
     resourceId: taskId,
-    details: { triggerType: triggerTypeDb },
+    details: { triggerType: triggerTypeValue },
   });
 
   void broadcastTaskEvent({
@@ -76,7 +76,7 @@ export async function DELETE(
     taskListId: task.taskListId,
     userId,
     pageId: taskList.pageId,
-    data: { id: taskId, removedTriggerType: triggerTypeDb },
+    data: { id: taskId, removedTriggerType: triggerTypeValue },
   });
 
   return NextResponse.json({ success: true });

--- a/apps/web/src/app/api/tasks/[taskId]/triggers/__tests__/route.test.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/triggers/__tests__/route.test.ts
@@ -38,6 +38,7 @@ vi.mock('@pagespace/db/db', () => ({
     },
     select: vi.fn(() => ({
       from: vi.fn(() => ({
+        innerJoin: vi.fn(() => ({ where: vi.fn().mockResolvedValue([]) })),
         where: vi.fn().mockResolvedValue([]),
       })),
     })),
@@ -57,7 +58,8 @@ vi.mock('@pagespace/db/operators', () => ({
 
 vi.mock('@pagespace/db/schema/core', () => ({ pages: {} }));
 vi.mock('@pagespace/db/schema/tasks', () => ({ taskItems: {}, taskLists: {} }));
-vi.mock('@pagespace/db/schema/workflows', () => ({ workflows: { taskItemId: 't', triggerType: 'tt' } }));
+vi.mock('@pagespace/db/schema/workflows', () => ({ workflows: { id: 'id', agentPageId: 'agentPageId', prompt: 'prompt', instructionPageId: 'instructionPageId', contextPageIds: 'contextPageIds' } }));
+vi.mock('@pagespace/db/schema/task-triggers', () => ({ taskTriggers: { id: 'id', taskItemId: 'taskItemId', triggerType: 'triggerType', workflowId: 'workflowId', isEnabled: 'isEnabled', nextRunAt: 'nextRunAt', lastFiredAt: 'lastFiredAt', lastFireError: 'lastFireError', createdAt: 'createdAt', updatedAt: 'updatedAt' } }));
 
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
@@ -92,7 +94,10 @@ describe('Task triggers API', () => {
       set: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
     } as never);
     vi.mocked(db.select).mockReturnValue({
-      from: vi.fn(() => ({ where: vi.fn().mockResolvedValue([]) })),
+      from: vi.fn(() => ({
+        innerJoin: vi.fn(() => ({ where: vi.fn().mockResolvedValue([]) })),
+        where: vi.fn().mockResolvedValue([]),
+      })),
     } as never);
   });
 
@@ -131,16 +136,18 @@ describe('Task triggers API', () => {
       vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: taskListId, pageId } as never);
       vi.mocked(db.query.pages.findFirst).mockResolvedValue({ id: pageId, driveId, isTrashed: false } as never);
       vi.mocked(canUserEditPage).mockResolvedValue(true);
-      const triggerRow = { id: 'wf-1', triggerType: 'task_completion', agentPageId, prompt: 'do it', isEnabled: true };
+      const triggerRow = { id: 'trg-1', triggerType: 'completion', agentPageId, prompt: 'do it', isEnabled: true, workflowId: 'wf-1' };
       vi.mocked(db.select).mockReturnValueOnce({
-        from: vi.fn(() => ({ where: vi.fn().mockResolvedValue([triggerRow]) })),
+        from: vi.fn(() => ({
+          innerJoin: vi.fn(() => ({ where: vi.fn().mockResolvedValue([triggerRow]) })),
+        })),
       } as never);
 
       const res = await GET(mkRequest('GET'), { params: mkParams() });
       const body = await res.json();
       expect(res.status).toBe(200);
       expect(body.triggers).toHaveLength(1);
-      expect(body.triggers[0].id).toBe('wf-1');
+      expect(body.triggers[0].id).toBe('trg-1');
     });
   });
 
@@ -190,7 +197,9 @@ describe('Task triggers API', () => {
       vi.mocked(canUserEditPage).mockResolvedValue(true);
       vi.mocked(db.select).mockReturnValueOnce({
         from: vi.fn(() => ({
-          where: vi.fn().mockResolvedValue([{ id: 'wf-2', triggerType: 'task_completion' }]),
+          innerJoin: vi.fn(() => ({
+            where: vi.fn().mockResolvedValue([{ id: 'trg-2', triggerType: 'completion', workflowId: 'wf-2' }]),
+          })),
         })),
       } as never);
 
@@ -210,7 +219,9 @@ describe('Task triggers API', () => {
       vi.mocked(canUserEditPage).mockResolvedValue(true);
       // Simulate the post-upsert re-query coming back empty (race / constraint loss)
       vi.mocked(db.select).mockReturnValueOnce({
-        from: vi.fn(() => ({ where: vi.fn().mockResolvedValue([]) })),
+        from: vi.fn(() => ({
+          innerJoin: vi.fn(() => ({ where: vi.fn().mockResolvedValue([]) })),
+        })),
       } as never);
 
       const res = await PUT(
@@ -234,7 +245,7 @@ describe('Task triggers API', () => {
 
     it('disables trigger and delegates metadata recompute to the helper', async () => {
       vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId } as never);
-      const taskMetadata = { hasTrigger: true, triggerTypes: ['task_completion', 'task_due_date'] };
+      const taskMetadata = { hasTrigger: true, triggerTypes: ['completion', 'due_date'] };
       vi.mocked(db.query.taskItems.findFirst).mockResolvedValue({
         id: taskId,
         taskListId,

--- a/apps/web/src/app/api/tasks/[taskId]/triggers/route.ts
+++ b/apps/web/src/app/api/tasks/[taskId]/triggers/route.ts
@@ -8,6 +8,7 @@ import { eq, and } from '@pagespace/db/operators';
 import { pages } from '@pagespace/db/schema/core';
 import { taskItems, taskLists } from '@pagespace/db/schema/tasks';
 import { workflows } from '@pagespace/db/schema/workflows';
+import { taskTriggers } from '@pagespace/db/schema/task-triggers';
 import { createTaskTriggerWorkflow } from '@/lib/workflows/task-trigger-helpers';
 import { broadcastTaskEvent } from '@/lib/websocket';
 import { loggers } from '@pagespace/lib/logging/logger-config';
@@ -81,9 +82,25 @@ export async function GET(request: Request, context: { params: Promise<{ taskId:
   }
 
   const rows = await db
-    .select()
-    .from(workflows)
-    .where(and(eq(workflows.taskItemId, taskId)));
+    .select({
+      id: taskTriggers.id,
+      taskItemId: taskTriggers.taskItemId,
+      triggerType: taskTriggers.triggerType,
+      nextRunAt: taskTriggers.nextRunAt,
+      lastFiredAt: taskTriggers.lastFiredAt,
+      lastFireError: taskTriggers.lastFireError,
+      isEnabled: taskTriggers.isEnabled,
+      createdAt: taskTriggers.createdAt,
+      updatedAt: taskTriggers.updatedAt,
+      workflowId: workflows.id,
+      agentPageId: workflows.agentPageId,
+      prompt: workflows.prompt,
+      instructionPageId: workflows.instructionPageId,
+      contextPageIds: workflows.contextPageIds,
+    })
+    .from(taskTriggers)
+    .innerJoin(workflows, eq(taskTriggers.workflowId, workflows.id))
+    .where(eq(taskTriggers.taskItemId, taskId));
 
   auditRequest(request, {
     eventType: 'data.read',
@@ -159,14 +176,30 @@ export async function PUT(request: Request, context: { params: Promise<{ taskId:
     return NextResponse.json({ error: message }, { status: 400 });
   }
 
-  const triggerTypeDb = parsed.data.triggerType === 'completion' ? 'task_completion' : 'task_due_date';
+  const triggerType = parsed.data.triggerType;
   const [saved] = await db
-    .select()
-    .from(workflows)
-    .where(and(eq(workflows.taskItemId, taskId), eq(workflows.triggerType, triggerTypeDb)));
+    .select({
+      id: taskTriggers.id,
+      taskItemId: taskTriggers.taskItemId,
+      triggerType: taskTriggers.triggerType,
+      nextRunAt: taskTriggers.nextRunAt,
+      lastFiredAt: taskTriggers.lastFiredAt,
+      lastFireError: taskTriggers.lastFireError,
+      isEnabled: taskTriggers.isEnabled,
+      createdAt: taskTriggers.createdAt,
+      updatedAt: taskTriggers.updatedAt,
+      workflowId: workflows.id,
+      agentPageId: workflows.agentPageId,
+      prompt: workflows.prompt,
+      instructionPageId: workflows.instructionPageId,
+      contextPageIds: workflows.contextPageIds,
+    })
+    .from(taskTriggers)
+    .innerJoin(workflows, eq(taskTriggers.workflowId, workflows.id))
+    .where(and(eq(taskTriggers.taskItemId, taskId), eq(taskTriggers.triggerType, triggerType)));
 
   if (!saved) {
-    logger.error('Trigger row missing after upsert', { taskId, triggerType: triggerTypeDb });
+    logger.error('Trigger row missing after upsert', { taskId, triggerType });
     return NextResponse.json({ error: 'Failed to retrieve saved trigger' }, { status: 500 });
   }
 
@@ -175,7 +208,7 @@ export async function PUT(request: Request, context: { params: Promise<{ taskId:
     userId,
     resourceType: 'task_triggers',
     resourceId: taskId,
-    details: { triggerType: triggerTypeDb },
+    details: { triggerType },
   });
 
   void broadcastTaskEvent({
@@ -184,7 +217,7 @@ export async function PUT(request: Request, context: { params: Promise<{ taskId:
     taskListId: ctx.task.taskListId,
     userId,
     pageId: ctx.taskListPageId,
-    data: { id: taskId, triggerType: triggerTypeDb },
+    data: { id: taskId, triggerType },
   });
 
   return NextResponse.json({ trigger: saved }, { status: 200 });

--- a/apps/web/src/app/api/workflows/[workflowId]/route.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/route.ts
@@ -29,7 +29,10 @@ async function getWorkflowWithAuth(workflowId: string, userId: string) {
     .from(workflows)
     .where(eq(workflows.id, workflowId));
 
-  if (!workflow || workflow.triggerType !== MANAGEABLE_TRIGGER_TYPE) {
+  // 404 backing workflows (cronExpression IS NULL) the same way we 404
+  // unknown rows: they're owned by task_triggers / calendar_triggers and
+  // must not be editable from the cron management surface.
+  if (!workflow || workflow.triggerType !== MANAGEABLE_TRIGGER_TYPE || !workflow.cronExpression) {
     return { error: NextResponse.json({ error: 'Workflow not found' }, { status: 404 }) };
   }
 

--- a/apps/web/src/app/api/workflows/[workflowId]/run/__tests__/route.test.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/run/__tests__/route.test.ts
@@ -229,7 +229,15 @@ describe('POST /api/workflows/[workflowId]/run', () => {
     expect(body.success).toBe(true);
     expect(body.responseText).toBe('Report generated');
     expect(body.toolCallCount).toBe(3);
-    expect(executeWorkflow).toHaveBeenCalledWith(mockWorkflow);
+    expect(executeWorkflow).toHaveBeenCalledWith(expect.objectContaining({
+      workflowId: mockWorkflow.id,
+      workflowName: mockWorkflow.name,
+      driveId: mockWorkflow.driveId,
+      createdBy: mockWorkflow.createdBy,
+      agentPageId: mockWorkflow.agentPageId,
+      prompt: mockWorkflow.prompt,
+      timezone: mockWorkflow.timezone,
+    }));
   });
 
   test('non-scheduled workflow is treated as not found', async () => {

--- a/apps/web/src/app/api/workflows/[workflowId]/run/route.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/run/route.ts
@@ -5,7 +5,7 @@ import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { db } from '@pagespace/db/db'
 import { eq, and, ne } from '@pagespace/db/operators'
 import { workflows } from '@pagespace/db/schema/workflows';
-import { executeWorkflow } from '@/lib/workflows/workflow-executor';
+import { executeWorkflow, type WorkflowExecutionInput } from '@/lib/workflows/workflow-executor';
 import { getNextRunDate } from '@/lib/workflows/cron-utils';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
@@ -49,10 +49,22 @@ export async function POST(
     return NextResponse.json({ error: 'Workflow is already running' }, { status: 409 });
   }
 
+  const executionInput: WorkflowExecutionInput = {
+    workflowId: workflow.id,
+    workflowName: workflow.name,
+    driveId: workflow.driveId,
+    createdBy: workflow.createdBy,
+    agentPageId: workflow.agentPageId,
+    prompt: workflow.prompt,
+    contextPageIds: (workflow.contextPageIds as string[] | null) ?? [],
+    instructionPageId: workflow.instructionPageId,
+    timezone: workflow.timezone,
+  };
+
   // Execute
   let result;
   try {
-    result = await executeWorkflow(workflow);
+    result = await executeWorkflow(executionInput);
   } catch (error) {
     const errorMsg = error instanceof Error ? error.message : String(error);
     await db

--- a/apps/web/src/app/api/workflows/[workflowId]/run/route.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/run/route.ts
@@ -26,7 +26,10 @@ export async function POST(
     .from(workflows)
     .where(eq(workflows.id, workflowId));
 
-  if (!workflow || workflow.triggerType !== MANAGEABLE_TRIGGER_TYPE) {
+  // Backing workflows (those owned by task_triggers / calendar_triggers)
+  // share triggerType='cron' but have cronExpression=null. They are not
+  // user-runnable through this surface — fire them via their own trigger.
+  if (!workflow || workflow.triggerType !== MANAGEABLE_TRIGGER_TYPE || !workflow.cronExpression) {
     return NextResponse.json({ error: 'Workflow not found' }, { status: 404 });
   }
 

--- a/apps/web/src/app/api/workflows/__tests__/route.test.ts
+++ b/apps/web/src/app/api/workflows/__tests__/route.test.ts
@@ -60,14 +60,15 @@ vi.mock('@pagespace/db/db', () => ({
   },
 }));
 vi.mock('@pagespace/db/operators', () => ({
-  eq: vi.fn(),
-  and: vi.fn(),
+  eq: vi.fn((field, value) => ({ op: 'eq', field, value })),
+  and: vi.fn((...conds) => ({ op: 'and', conds })),
+  isNotNull: vi.fn((field) => ({ op: 'isNotNull', field })),
 }));
 vi.mock('@pagespace/db/schema/core', () => ({
   pages: { id: 'id', driveId: 'driveId' },
 }));
 vi.mock('@pagespace/db/schema/workflows', () => ({
-  workflows: { driveId: 'driveId', createdAt: 'createdAt' },
+  workflows: { driveId: 'driveId', createdAt: 'createdAt', triggerType: 'triggerType', cronExpression: 'cronExpression' },
 }));
 
 import { GET, POST } from '../route';
@@ -189,6 +190,29 @@ describe('GET /api/workflows', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body).toEqual(mockWorkflows);
+  });
+
+  it('should filter out backing workflows (cronExpression IS NOT NULL guard)', async () => {
+    // Task-trigger and calendar-trigger backing workflows are tagged
+    // triggerType='cron' but have cronExpression=null. Without an
+    // isNotNull(cronExpression) gate they'd leak into this list and be
+    // editable/deletable from the cron management UI.
+    mockOrderBy.mockResolvedValue([]);
+    vi.mocked(checkDriveAccess).mockResolvedValue(createAccessFixture({
+      isOwner: true,
+      isMember: true,
+      drive: createDriveFixture({ id: mockDriveId, name: 'Test' }),
+    }));
+
+    const { isNotNull } = await import('@pagespace/db/operators');
+    const isNotNullMock = vi.mocked(isNotNull);
+    isNotNullMock.mockClear();
+
+    const request = new Request(`https://example.com/api/workflows?driveId=${mockDriveId}`);
+    await GET(request);
+
+    const guardedFields = isNotNullMock.mock.calls.map((call) => call[0]);
+    expect(guardedFields).toContain('cronExpression');
   });
 });
 

--- a/apps/web/src/app/api/workflows/route.ts
+++ b/apps/web/src/app/api/workflows/route.ts
@@ -4,7 +4,7 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { db } from '@pagespace/db/db'
-import { eq, and } from '@pagespace/db/operators'
+import { eq, and, isNotNull } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core'
 import { workflows } from '@pagespace/db/schema/workflows';
 import { validateCronExpression, validateTimezone, getNextRunDate } from '@/lib/workflows/cron-utils';
@@ -44,10 +44,19 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'Only drive owners and admins can manage workflows' }, { status: 403 });
   }
 
+  // The cronExpression IS NOT NULL guard distinguishes user-managed cron
+  // workflows (which always carry a cron expression) from backing workflows
+  // owned by task_triggers / calendar_triggers (which use triggerType='cron'
+  // for the executor but have no cron expression). Without this gate the
+  // backing rows leak into the management UI and become user-editable.
   const results = await db
     .select()
     .from(workflows)
-    .where(and(eq(workflows.driveId, driveId), eq(workflows.triggerType, MANAGEABLE_TRIGGER_TYPE)))
+    .where(and(
+      eq(workflows.driveId, driveId),
+      eq(workflows.triggerType, MANAGEABLE_TRIGGER_TYPE),
+      isNotNull(workflows.cronExpression),
+    ))
     .orderBy(workflows.createdAt);
 
   auditRequest(request, { eventType: 'data.read', userId, resourceType: 'workflow', resourceId: driveId, details: { count: results.length } });

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskAgentTriggersDialog.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskAgentTriggersDialog.tsx
@@ -35,8 +35,7 @@ import { TriggerPagePicker } from './TriggerPagePicker';
 
 const MAX_CONTEXT_PAGES = 10;
 
-type ApiTriggerType = 'task_due_date' | 'task_completion';
-type UiTriggerType = 'due_date' | 'completion';
+type TriggerType = 'due_date' | 'completion';
 
 interface DriveAgent {
   id: string;
@@ -45,15 +44,24 @@ interface DriveAgent {
 
 interface TriggerRow {
   id: string;
-  triggerType: ApiTriggerType;
+  triggerType: TriggerType;
   agentPageId: string;
   prompt: string;
   isEnabled: boolean;
-  lastRunStatus: 'never_run' | 'success' | 'error' | 'running';
-  lastRunAt: string | null;
+  lastFiredAt: string | null;
+  lastFireError: string | null;
   instructionPageId: string | null;
   contextPageIds: string[] | null;
 }
+
+type LastRunStatus = 'never_run' | 'success' | 'error';
+
+const lastRunStatusFor = (row: TriggerRow): LastRunStatus =>
+  row.lastFiredAt === null
+    ? 'never_run'
+    : row.lastFireError
+      ? 'error'
+      : 'success';
 
 interface TaskAgentTriggersDialogProps {
   open: boolean;
@@ -66,22 +74,20 @@ interface TaskAgentTriggersDialogProps {
   onSaved?: () => void;
 }
 
-const TRIGGER_TYPES: { ui: UiTriggerType; api: ApiTriggerType; label: string; help: string }[] = [
+const TRIGGER_TYPES: { ui: TriggerType; label: string; help: string }[] = [
   {
     ui: 'due_date',
-    api: 'task_due_date',
     label: 'Run when due date arrives',
     help: 'Requires a due date on this task. The agent runs once at the scheduled time.',
   },
   {
     ui: 'completion',
-    api: 'task_completion',
     label: 'Run when task is completed',
     help: 'Fires the moment the task is moved to a status in the Done group.',
   },
 ];
 
-export const statusToneClass = (status: TriggerRow['lastRunStatus']) =>
+export const statusToneClass = (status: LastRunStatus) =>
   status === 'error' ? 'text-xs text-destructive' : 'text-xs text-muted-foreground';
 
 const triggersFetcher = async (url: string): Promise<{ triggers: TriggerRow[] }> => {
@@ -158,12 +164,12 @@ export function TaskAgentTriggersDialog({
 
   const agents = agentsData?.agents ?? [];
 
-  const [sections, setSections] = useState<Record<UiTriggerType, SectionState>>({
+  const [sections, setSections] = useState<Record<TriggerType, SectionState>>({
     due_date: { ...EMPTY_SECTION },
     completion: { ...EMPTY_SECTION },
   });
-  const [savingType, setSavingType] = useState<UiTriggerType | null>(null);
-  const [removingType, setRemovingType] = useState<UiTriggerType | null>(null);
+  const [savingType, setSavingType] = useState<TriggerType | null>(null);
+  const [removingType, setRemovingType] = useState<TriggerType | null>(null);
 
   useEditingSession(`task-triggers:${taskId}`, open, 'form', {
     pageId,
@@ -172,12 +178,12 @@ export function TaskAgentTriggersDialog({
 
   useEffect(() => {
     if (!open) return;
-    const next: Record<UiTriggerType, SectionState> = {
+    const next: Record<TriggerType, SectionState> = {
       due_date: { ...EMPTY_SECTION },
       completion: { ...EMPTY_SECTION },
     };
     for (const row of triggersData?.triggers ?? []) {
-      const ui: UiTriggerType = row.triggerType === 'task_completion' ? 'completion' : 'due_date';
+      const ui: TriggerType = row.triggerType;
       next[ui] = {
         enabled: row.isEnabled,
         agentPageId: row.agentPageId,
@@ -189,11 +195,11 @@ export function TaskAgentTriggersDialog({
     setSections(next);
   }, [open, triggersData]);
 
-  const updateSection = (type: UiTriggerType, patch: Partial<SectionState>) => {
+  const updateSection = (type: TriggerType, patch: Partial<SectionState>) => {
     setSections((prev) => ({ ...prev, [type]: { ...prev[type], ...patch } }));
   };
 
-  const handleSave = async (type: UiTriggerType) => {
+  const handleSave = async (type: TriggerType) => {
     const section = sections[type];
     if (!section.agentPageId) {
       toast.error('Pick an agent first');
@@ -229,7 +235,7 @@ export function TaskAgentTriggersDialog({
     }
   };
 
-  const handleRemove = async (type: UiTriggerType) => {
+  const handleRemove = async (type: TriggerType) => {
     setRemovingType(type);
     try {
       await del(`/api/tasks/${taskId}/triggers/${type}`);
@@ -273,8 +279,9 @@ export function TaskAgentTriggersDialog({
             {TRIGGER_TYPES.map(({ ui, label, help }) => {
               const section = sections[ui];
               const existing = (triggersData?.triggers ?? []).find(
-                (t) => t.triggerType === (ui === 'completion' ? 'task_completion' : 'task_due_date'),
+                (t) => t.triggerType === ui,
               );
+              const existingStatus: LastRunStatus | null = existing ? lastRunStatusFor(existing) : null;
               const disabled = noAgents || (ui === 'due_date' && !hasDueDate);
               return (
                 <div key={ui} className="space-y-3 rounded-md border p-3">
@@ -385,14 +392,14 @@ export function TaskAgentTriggersDialog({
                         </CollapsibleContent>
                       </Collapsible>
 
-                      {existing?.lastRunStatus && existing.lastRunStatus !== 'never_run' && (
-                        <p className={statusToneClass(existing.lastRunStatus)}>
-                          {existing.lastRunStatus === 'error' && (
+                      {existingStatus && existingStatus !== 'never_run' && (
+                        <p className={statusToneClass(existingStatus)}>
+                          {existingStatus === 'error' && (
                             <AlertCircle className="h-3 w-3 inline mr-1" aria-hidden="true" />
                           )}
-                          Last run: <span className="font-medium">{existing.lastRunStatus}</span>
-                          {existing.lastRunAt
-                            ? ` • ${new Date(existing.lastRunAt).toLocaleString()}`
+                          Last run: <span className="font-medium">{existingStatus}</span>
+                          {existing?.lastFiredAt
+                            ? ` • ${new Date(existing.lastFiredAt).toLocaleString()}`
                             : ''}
                         </p>
                       )}

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/TaskAgentTriggersDialog.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/TaskAgentTriggersDialog.test.tsx
@@ -25,12 +25,12 @@ const TRIGGERS_URL = `/api/tasks/${TASK_ID}/triggers`;
 
 const remoteTrigger = () => ({
   id: 'trig-1',
-  triggerType: 'task_due_date' as const,
+  triggerType: 'due_date' as const,
   agentPageId: 'agent-1',
   prompt: 'remote-prompt',
   isEnabled: true,
-  lastRunStatus: 'never_run' as const,
-  lastRunAt: null,
+  lastFiredAt: null,
+  lastFireError: null,
 });
 
 const remoteAgent = () => ({ id: 'agent-1', title: 'Triage Bot' });
@@ -71,7 +71,7 @@ const renderDialog = () =>
 describe('statusToneClass', () => {
   test('error status maps to destructive tone', () => {
     assert({
-      given: 'lastRunStatus = "error"',
+      given: 'last-run status = "error"',
       should: 'return the destructive tone class',
       actual: statusToneClass('error'),
       expected: 'text-xs text-destructive',
@@ -80,11 +80,10 @@ describe('statusToneClass', () => {
 
   test('non-error statuses map to muted tone', () => {
     assert({
-      given: 'lastRunStatus values that are not "error"',
+      given: 'last-run status values that are not "error"',
       should: 'return the muted-foreground tone class',
-      actual: (['success', 'running', 'never_run'] as const).map(statusToneClass),
+      actual: (['success', 'never_run'] as const).map(statusToneClass),
       expected: [
-        'text-xs text-muted-foreground',
         'text-xs text-muted-foreground',
         'text-xs text-muted-foreground',
       ],

--- a/apps/web/src/lib/ai/tools/__tests__/calendar-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/calendar-write-tools.test.ts
@@ -186,6 +186,13 @@ const createAuthContext = (userId = 'user-123') => ({
 describe('calendar-write-tools', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default transaction: invoke the callback with `mockDb` so existing
+    // chains (insert/values/returning) keep working without per-test setup.
+    // Tests that need fine-grained tx control (e.g. agentTrigger paths)
+    // override this with their own mockImplementation.
+    (mockDb.transaction as ReturnType<typeof vi.fn>).mockImplementation(
+      async (fn: (tx: unknown) => unknown) => fn(mockDb),
+    );
   });
 
   describe('create_calendar_event', () => {
@@ -765,26 +772,32 @@ describe('calendar-write-tools', () => {
           }),
         });
 
-        // Event creation
+        // The full create flow runs inside one db.transaction now (event +
+        // attendees + helper-driven trigger pair + metadata update). Build a
+        // tx mock whose insert chain returns event-then-workflow-then-trigger
+        // returning rows in that order, and supports update().set().where().
         const newEvent = createMockEvent({ id: 'event-new' });
-        (mockDb.insert as ReturnType<typeof vi.fn>).mockReturnValueOnce({
-          values: vi.fn().mockReturnValue({
-            returning: vi.fn().mockResolvedValue([newEvent]),
-          }),
-        });
-
-        // Creator attendee insertion
-        (mockDb.insert as ReturnType<typeof vi.fn>).mockReturnValueOnce({
-          values: vi.fn().mockResolvedValue(undefined),
-        });
-
-        // Transaction: trigger creation + metadata update
+        let insertCount = 0;
         (mockDb.transaction as ReturnType<typeof vi.fn>).mockImplementation(async (fn: (tx: unknown) => unknown) => {
           const mockTx = {
-            insert: vi.fn().mockReturnValue({
-              values: vi.fn().mockReturnValue({
-                returning: vi.fn().mockResolvedValue([{ id: 'trg-1' }]),
-              }),
+            insert: vi.fn().mockImplementation(() => {
+              insertCount += 1;
+              // Order:
+              //   1: calendarEvents (returning [event])
+              //   2: eventAttendees (creator) — no returning
+              //   3: eventAttendees (others) — only when otherAttendees > 0
+              //   workflows + calendar_triggers via helper, with returning
+              const isOtherAttendeesPresent = false; // this fixture has no otherAttendees
+              const valuesReturn = (() => {
+                if (insertCount === 1) return { returning: vi.fn().mockResolvedValue([newEvent]) };
+                if (insertCount === 2) return undefined; // creator attendee, no .returning
+                // From here on, helper inserts workflows then calendar_triggers, both with returning.
+                const helperStep = isOtherAttendeesPresent ? insertCount - 3 : insertCount - 2;
+                if (helperStep === 1) return { returning: vi.fn().mockResolvedValue([{ id: 'wf-1' }]) };
+                if (helperStep === 2) return { returning: vi.fn().mockResolvedValue([{ id: 'trg-1' }]) };
+                return undefined;
+              })();
+              return { values: vi.fn().mockReturnValue(valuesReturn) };
             }),
             update: vi.fn().mockReturnValue({
               set: vi.fn().mockReturnValue({

--- a/apps/web/src/lib/ai/tools/calendar-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/calendar-write-tools.ts
@@ -6,6 +6,7 @@ import { pages } from '@pagespace/db/schema/core'
 import { calendarEvents, eventAttendees } from '@pagespace/db/schema/calendar'
 import { calendarTriggers } from '@pagespace/db/schema/calendar-triggers';
 import type { CalendarTriggerMetadata } from '@pagespace/db/schema/calendar-triggers';
+import { createCalendarTriggerWorkflow } from '@/lib/workflows/calendar-trigger-helpers';
 import { isUserDriveMember } from '@pagespace/lib/permissions/permissions';
 import { getDriveMemberUserIds } from '@pagespace/lib/services/drive-member-service';
 import { loggers } from '@pagespace/lib/logging/logger-config';
@@ -304,24 +305,23 @@ export const calendarWriteTools = {
         // Create agent trigger if requested (atomically with event metadata)
         let triggerId: string | null = null;
         if (agentTrigger && driveId && validatedAgent) {
-          const triggerPrompt = agentTrigger.prompt || 'Execute instructions from linked page.';
           const scheduledByAgentPageId = (ctx as ToolExecutionContext)?.chatSource?.agentPageId;
 
-          const { trigger } = await db.transaction(async (tx) => {
-            const [trg] = await tx
-              .insert(calendarTriggers)
-              .values({
-                calendarEventId: event.id,
+          triggerId = await db.transaction(async (tx) => {
+            const { triggerId: createdTriggerId } = await createCalendarTriggerWorkflow({
+              tx,
+              driveId,
+              scheduledById: userId,
+              calendarEventId: event.id,
+              triggerAt: parsedStartAt,
+              timezone,
+              agentTrigger: {
                 agentPageId: agentTrigger.agentPageId,
-                driveId,
-                scheduledById: userId,
-                prompt: triggerPrompt,
+                prompt: agentTrigger.prompt,
                 instructionPageId: agentTrigger.instructionPageId ?? null,
                 contextPageIds: agentTrigger.contextPageIds ?? [],
-                status: 'pending',
-                triggerAt: parsedStartAt,
-              })
-              .returning();
+              },
+            });
 
             await tx
               .update(calendarEvents)
@@ -329,16 +329,14 @@ export const calendarWriteTools = {
                 metadata: {
                   isTrigger: true,
                   triggerType: 'agent_execution',
-                  triggerId: trg.id,
+                  triggerId: createdTriggerId,
                   scheduledByAgentPageId,
                 } satisfies CalendarTriggerMetadata,
               })
               .where(eq(calendarEvents.id, event.id));
 
-            return { trigger: trg };
+            return createdTriggerId;
           });
-
-          triggerId = trigger.id;
         }
 
         // Broadcast event creation (best-effort)

--- a/apps/web/src/lib/ai/tools/calendar-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/calendar-write-tools.ts
@@ -260,59 +260,60 @@ export const calendarWriteTools = {
           }
         }
 
-        // Create the event
-        const [event] = await db
-          .insert(calendarEvents)
-          .values({
-            driveId: driveId ?? null,
-            createdById: userId,
-            pageId: pageId ?? null,
-            title,
-            description: description ?? null,
-            location: location ?? null,
-            startAt: parsedStartAt,
-            endAt: parsedEndAt,
-            allDay,
-            timezone,
-            recurrenceRule: recurrence ?? null,
-            visibility,
-            color,
-            updatedAt: new Date(),
-          })
-          .returning();
+        // Event + attendees + (optional) agent trigger setup are written
+        // atomically. Aligns with the REST POST path (apps/web/src/app/api/
+        // calendar/events/route.ts): a failure during trigger creation must
+        // roll back the event so we never leave an orphan event in the
+        // calendar without its scheduled fire.
+        const scheduledByAgentPageId = (ctx as ToolExecutionContext)?.chatSource?.agentPageId;
 
-        // Add creator as organizer attendee
-        await db.insert(eventAttendees).values({
-          eventId: event.id,
-          userId: userId,
-          status: 'ACCEPTED',
-          isOrganizer: true,
-          respondedAt: new Date(),
-        });
+        const { event, triggerId: createdTriggerIdInTx } = await db.transaction(async (tx) => {
+          const [createdEvent] = await tx
+            .insert(calendarEvents)
+            .values({
+              driveId: driveId ?? null,
+              createdById: userId,
+              pageId: pageId ?? null,
+              title,
+              description: description ?? null,
+              location: location ?? null,
+              startAt: parsedStartAt,
+              endAt: parsedEndAt,
+              allDay,
+              timezone,
+              recurrenceRule: recurrence ?? null,
+              visibility,
+              color,
+              updatedAt: new Date(),
+            })
+            .returning();
 
-        // Add other attendees if provided
-        if (otherAttendees.length > 0) {
-          await db.insert(eventAttendees).values(
-            otherAttendees.map((attendeeId) => ({
-              eventId: event.id,
-              userId: attendeeId,
-              status: 'PENDING' as const,
-              isOrganizer: false,
-            }))
-          );
-        }
+          await tx.insert(eventAttendees).values({
+            eventId: createdEvent.id,
+            userId: userId,
+            status: 'ACCEPTED',
+            isOrganizer: true,
+            respondedAt: new Date(),
+          });
 
-        // Create agent trigger if requested (atomically with event metadata)
-        let triggerId: string | null = null;
-        if (agentTrigger && driveId && validatedAgent) {
-          const scheduledByAgentPageId = (ctx as ToolExecutionContext)?.chatSource?.agentPageId;
+          if (otherAttendees.length > 0) {
+            await tx.insert(eventAttendees).values(
+              otherAttendees.map((attendeeId) => ({
+                eventId: createdEvent.id,
+                userId: attendeeId,
+                status: 'PENDING' as const,
+                isOrganizer: false,
+              }))
+            );
+          }
 
-          triggerId = await db.transaction(async (tx) => {
-            const { triggerId: createdTriggerId } = await createCalendarTriggerWorkflow({
+          let createdTriggerIdLocal: string | null = null;
+          if (agentTrigger && driveId && validatedAgent) {
+            const { triggerId: newTriggerId } = await createCalendarTriggerWorkflow({
               tx,
               driveId,
               scheduledById: userId,
-              calendarEventId: event.id,
+              calendarEventId: createdEvent.id,
               triggerAt: parsedStartAt,
               timezone,
               agentTrigger: {
@@ -329,15 +330,19 @@ export const calendarWriteTools = {
                 metadata: {
                   isTrigger: true,
                   triggerType: 'agent_execution',
-                  triggerId: createdTriggerId,
+                  triggerId: newTriggerId,
                   scheduledByAgentPageId,
                 } satisfies CalendarTriggerMetadata,
               })
-              .where(eq(calendarEvents.id, event.id));
+              .where(eq(calendarEvents.id, createdEvent.id));
 
-            return createdTriggerId;
-          });
-        }
+            createdTriggerIdLocal = newTriggerId;
+          }
+
+          return { event: createdEvent, triggerId: createdTriggerIdLocal };
+        });
+
+        const triggerId: string | null = createdTriggerIdInTx;
 
         // Broadcast event creation (best-effort)
         try {

--- a/apps/web/src/lib/ai/tools/task-management-tools.ts
+++ b/apps/web/src/lib/ai/tools/task-management-tools.ts
@@ -200,6 +200,12 @@ Agent Triggers:
             const linkedPageId = existingTask.pageId;
             const actorInfo = await getActorInfo(userId);
 
+            // disableTaskTriggers MUST run BEFORE the taskItems delete:
+            // task_triggers has ON DELETE CASCADE on taskItemId, so deleting
+            // the task first wipes the trigger rows and the helper's SELECT
+            // returns empty — leaking orphan workflows rows.
+            await disableTaskTriggers(taskId, 'Task deleted via update_task');
+
             // Trash linked DOCUMENT page (if any) and hard-delete the task row in one transaction.
             // taskAssignees rows cascade-delete via FK on taskItems.
             // applyPageMutation returns a deferredTrigger that callers passing their own tx
@@ -250,8 +256,6 @@ Agent Triggers:
               }
               throw error;
             }
-
-            void disableTaskTriggers(taskId, 'Task deleted via update_task');
 
             // Look up driveId for the page-trashed broadcast (best-effort)
             let deletedDriveId: string | undefined;

--- a/apps/web/src/lib/workflows/__tests__/calendar-trigger-executor.test.ts
+++ b/apps/web/src/lib/workflows/__tests__/calendar-trigger-executor.test.ts
@@ -78,6 +78,11 @@ vi.mock('@pagespace/db/schema/calendar-triggers', () => ({
     status: 'status',
   },
 }));
+vi.mock('@pagespace/db/schema/workflows', () => ({
+  workflows: {
+    id: 'id',
+  },
+}));
 
 vi.mock('@/lib/workflows/workflow-executor', () => ({
   executeWorkflow: mockExecuteWorkflow,
@@ -112,13 +117,10 @@ import type { CalendarTrigger } from '@pagespace/db/schema/calendar-triggers';
 
 const createTrigger = (overrides: Partial<CalendarTrigger> = {}): CalendarTrigger => ({
   id: 'trg-1',
+  workflowId: 'wf-1',
   calendarEventId: 'evt-1',
-  agentPageId: 'agent-1',
   driveId: 'drive-1',
   scheduledById: 'user-123',
-  prompt: 'Check deploy status',
-  instructionPageId: null,
-  contextPageIds: [],
   status: 'running',
   triggerAt: new Date('2026-01-15T10:00:00Z'),
   claimedAt: new Date(),
@@ -132,6 +134,32 @@ const createTrigger = (overrides: Partial<CalendarTrigger> = {}): CalendarTrigge
   updatedAt: new Date(),
   ...overrides,
 } as CalendarTrigger);
+
+const createWorkflowRow = (overrides: Record<string, unknown> = {}) => ({
+  id: 'wf-1',
+  driveId: 'drive-1',
+  createdBy: 'user-123',
+  name: 'wf-1',
+  agentPageId: 'agent-1',
+  prompt: 'Check deploy status',
+  contextPageIds: [],
+  cronExpression: null,
+  timezone: 'UTC',
+  triggerType: 'cron',
+  eventTriggers: null,
+  watchedFolderIds: null,
+  eventDebounceSecs: null,
+  instructionPageId: null,
+  isEnabled: true,
+  lastRunAt: null,
+  nextRunAt: null,
+  lastRunStatus: 'never_run',
+  lastRunError: null,
+  lastRunDurationMs: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+});
 
 const createEvent = (overrides: Partial<CalendarEvent> = {}): CalendarEvent => ({
   id: 'evt-1',
@@ -168,31 +196,26 @@ describe('executeCalendarTrigger', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // Default: scheduling user still has drive access
     mockIsUserDriveMember.mockResolvedValue(true);
-
-    // Default: rate limit passes
     mockIncrementUsage.mockResolvedValue({ success: true });
 
-    // Default select chain: agent page preflight → attendees → etc.
+    // Default select chain.
+    // Call order in executor: 1=workflow load, 2=agent preflight, 3=attendees
     mockSelect.mockReturnValue({ from: mockSelectFrom });
     mockSelectFrom.mockReturnValue({
       innerJoin: mockInnerJoin,
       where: mockSelectWhere,
     });
     mockInnerJoin.mockReturnValue({ where: mockSelectWhere });
-    // First call: agent page preflight (exists, not trashed)
-    // Subsequent calls: empty (no attendees, etc.)
     mockSelectWhere
-      .mockResolvedValueOnce([{ id: 'agent-1', isTrashed: false }])
-      .mockResolvedValue([]);
+      .mockResolvedValueOnce([createWorkflowRow()])                    // workflow load
+      .mockResolvedValueOnce([{ id: 'agent-1', isTrashed: false }])    // agent preflight
+      .mockResolvedValue([]);                                           // attendees + anything else
 
-    // Default: update succeeds
     mockUpdate.mockReturnValue({ set: mockUpdateSet });
     mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
     mockUpdateWhere.mockResolvedValue(undefined);
 
-    // Default: workflow execution succeeds
     mockExecuteWorkflow.mockResolvedValue({
       success: true,
       durationMs: 500,
@@ -207,23 +230,30 @@ describe('executeCalendarTrigger', () => {
     expect(result.durationMs).toBeGreaterThanOrEqual(0);
   });
 
-  it('passes a synthetic workflow to executeWorkflow with correct fields', async () => {
-    const trigger = createTrigger({ prompt: 'Do the thing' });
+  it('passes a WorkflowExecutionInput composed from the linked workflow row', async () => {
+    const workflow = createWorkflowRow({ prompt: 'Do the thing', agentPageId: 'agent-9' });
+    mockSelectWhere.mockReset();
+    mockSelectWhere
+      .mockResolvedValueOnce([workflow])
+      .mockResolvedValueOnce([{ id: 'agent-9', isTrashed: false }])
+      .mockResolvedValue([]);
+    const trigger = createTrigger();
     const event = createEvent({ timezone: 'America/New_York' });
 
     await executeCalendarTrigger(trigger, event);
 
     expect(mockExecuteWorkflow).toHaveBeenCalledOnce();
-    const syntheticWorkflow = mockExecuteWorkflow.mock.calls[0][0];
-    expect(syntheticWorkflow.id).toBe(trigger.id);
-    expect(syntheticWorkflow.driveId).toBe(trigger.driveId);
-    expect(syntheticWorkflow.createdBy).toBe(trigger.scheduledById);
-    expect(syntheticWorkflow.agentPageId).toBe(trigger.agentPageId);
-    expect(syntheticWorkflow.timezone).toBe('America/New_York');
-    expect(syntheticWorkflow.prompt).toContain('Do the thing');
+    const input = mockExecuteWorkflow.mock.calls[0][0];
+    expect(input.workflowId).toBe('wf-1');
+    expect(input.driveId).toBe(workflow.driveId);
+    expect(input.createdBy).toBe(trigger.scheduledById);
+    expect(input.agentPageId).toBe('agent-9');
+    expect(input.timezone).toBe('America/New_York');
+    expect(input.eventContext?.promptOverride).toContain('Do the thing');
+    expect(input.prompt).toBe('Do the thing');
   });
 
-  it('includes event context in the prompt', async () => {
+  it('includes event context in the prompt override', async () => {
     const event = createEvent({
       title: 'Weekly standup',
       description: 'Team sync',
@@ -232,16 +262,17 @@ describe('executeCalendarTrigger', () => {
 
     await executeCalendarTrigger(createTrigger(), event);
 
-    const syntheticWorkflow = mockExecuteWorkflow.mock.calls[0][0];
-    expect(syntheticWorkflow.prompt).toContain('Weekly standup');
-    expect(syntheticWorkflow.prompt).toContain('Team sync');
-    expect(syntheticWorkflow.prompt).toContain('Room 42');
+    const input = mockExecuteWorkflow.mock.calls[0][0];
+    const promptOverride = input.eventContext?.promptOverride ?? '';
+    expect(promptOverride).toContain('Weekly standup');
+    expect(promptOverride).toContain('Team sync');
+    expect(promptOverride).toContain('Room 42');
   });
 
-  it('includes attendees in the prompt when present', async () => {
-    // Reset beforeEach chain, set up: agent preflight → attendees
+  it('includes attendees in the prompt override when present', async () => {
     mockSelectWhere.mockReset();
     mockSelectWhere
+      .mockResolvedValueOnce([createWorkflowRow()])
       .mockResolvedValueOnce([{ id: 'agent-1', isTrashed: false }])
       .mockResolvedValueOnce([
         { name: 'Alice', email: 'alice@test.com' },
@@ -251,9 +282,9 @@ describe('executeCalendarTrigger', () => {
 
     await executeCalendarTrigger(createTrigger(), createEvent());
 
-    const syntheticWorkflow = mockExecuteWorkflow.mock.calls[0][0];
-    expect(syntheticWorkflow.prompt).toContain('Alice');
-    expect(syntheticWorkflow.prompt).toContain('bob@test.com');
+    const promptOverride = mockExecuteWorkflow.mock.calls[0][0].eventContext?.promptOverride ?? '';
+    expect(promptOverride).toContain('Alice');
+    expect(promptOverride).toContain('bob@test.com');
   });
 
   it('fails when daily AI call limit is reached', async () => {
@@ -269,7 +300,6 @@ describe('executeCalendarTrigger', () => {
   it('updates trigger status to completed on success', async () => {
     await executeCalendarTrigger(createTrigger(), createEvent());
 
-    // The update call that writes completed status
     expect(mockUpdate).toHaveBeenCalled();
     const setCalls = mockUpdateSet.mock.calls;
     const completionCall = setCalls.find(
@@ -303,60 +333,6 @@ describe('executeCalendarTrigger', () => {
     expect(result.error).toBe('Unexpected explosion');
   });
 
-  it('re-checks instruction page access at execution time', async () => {
-    const trigger = createTrigger({ instructionPageId: 'instr-page-1' });
-
-    // Call order: 1=agent preflight, 2=attendees, 3=instruction page
-    mockSelectWhere.mockReset();
-    let callCount = 0;
-    mockSelectWhere.mockImplementation(() => {
-      callCount++;
-      if (callCount === 1) return Promise.resolve([{ id: 'agent-1', isTrashed: false }]); // agent preflight
-      if (callCount === 2) return Promise.resolve([]); // attendees
-      // instruction page — belongs to a different drive
-      return Promise.resolve([{
-        title: 'Instructions',
-        content: 'Do X then Y',
-        driveId: 'other-drive',
-      }]);
-    });
-
-    // First call: drive access check (pass), second call: instruction page drive (deny)
-    mockIsUserDriveMember.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
-
-    await executeCalendarTrigger(trigger, createEvent());
-
-    // Workflow should still run — instruction page content is just omitted
-    expect(mockExecuteWorkflow).toHaveBeenCalledOnce();
-    const prompt = mockExecuteWorkflow.mock.calls[0][0].prompt;
-    expect(prompt).not.toContain('Do X then Y');
-  });
-
-  it('includes instruction page content when access is valid', async () => {
-    const trigger = createTrigger({ instructionPageId: 'instr-page-1' });
-
-    mockSelectWhere.mockReset();
-    let callCount = 0;
-    mockSelectWhere.mockImplementation(() => {
-      callCount++;
-      if (callCount === 1) return Promise.resolve([{ id: 'agent-1', isTrashed: false }]); // agent preflight
-      if (callCount === 2) return Promise.resolve([]); // attendees
-      return Promise.resolve([{
-        title: 'Instructions',
-        content: 'Do X then Y',
-        driveId: 'drive-1', // same drive as trigger
-      }]);
-    });
-
-    mockIsUserDriveMember.mockResolvedValue(true);
-
-    await executeCalendarTrigger(trigger, createEvent());
-
-    const prompt = mockExecuteWorkflow.mock.calls[0][0].prompt;
-    expect(prompt).toContain('Do X then Y');
-    expect(prompt).toContain('Instructions');
-  });
-
   it('saves conversationId when workflow returns one', async () => {
     mockExecuteWorkflow.mockResolvedValue({
       success: true,
@@ -383,10 +359,23 @@ describe('executeCalendarTrigger', () => {
     expect(mockExecuteWorkflow).not.toHaveBeenCalled();
   });
 
-  it('fails without consuming usage when agent page is missing', async () => {
-    // Override default: agent page preflight returns empty (deleted since scheduling)
+  it('fails when the linked workflow row is missing', async () => {
     mockSelectWhere.mockReset();
-    mockSelectWhere.mockResolvedValue([]);
+    mockSelectWhere.mockResolvedValueOnce([]); // workflow load returns nothing
+
+    const result = await executeCalendarTrigger(createTrigger(), createEvent());
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('workflow');
+    expect(mockIncrementUsage).not.toHaveBeenCalled();
+    expect(mockExecuteWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('fails without consuming usage when agent page is missing', async () => {
+    mockSelectWhere.mockReset();
+    mockSelectWhere
+      .mockResolvedValueOnce([createWorkflowRow()])
+      .mockResolvedValueOnce([]); // agent preflight returns empty
 
     const result = await executeCalendarTrigger(createTrigger(), createEvent());
 

--- a/apps/web/src/lib/workflows/__tests__/calendar-trigger-helpers.test.ts
+++ b/apps/web/src/lib/workflows/__tests__/calendar-trigger-helpers.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@pagespace/db/schema/workflows', () => ({
+  workflows: { id: 'id' },
+}));
+vi.mock('@pagespace/db/schema/calendar-triggers', () => ({
+  calendarTriggers: { id: 'id' },
+}));
+
+import { createCalendarTriggerWorkflow } from '../calendar-trigger-helpers';
+
+// Build a fresh tx mock that records the order/identity of each insert and
+// captures the values payload so we can assert atomicity (both inserts
+// happen, both within the same callback) and shape.
+function makeTxMock(opts: {
+  workflowReturn?: unknown[];
+  triggerReturn?: unknown[];
+} = {}) {
+  const insertCalls: { table: unknown; values: unknown }[] = [];
+
+  // Two inserts in order: workflows then calendar_triggers.
+  const wfReturning = vi.fn().mockResolvedValue(opts.workflowReturn ?? [{ id: 'wf-1' }]);
+  const trgReturning = vi.fn().mockResolvedValue(opts.triggerReturn ?? [{ id: 'trg-1' }]);
+
+  let insertCount = 0;
+  const insertValues = vi.fn((values: unknown) => {
+    const last = insertCalls[insertCalls.length - 1];
+    if (last) last.values = values;
+    return { returning: insertCount === 1 ? wfReturning : trgReturning };
+  });
+
+  const insert = vi.fn((table: unknown) => {
+    insertCount++;
+    insertCalls.push({ table, values: undefined });
+    return { values: insertValues };
+  });
+
+  const tx = { insert };
+  return { tx, insert, insertCalls };
+}
+
+describe('createCalendarTriggerWorkflow', () => {
+  const baseParams = {
+    driveId: 'drive-1',
+    scheduledById: 'user-1',
+    calendarEventId: 'evt-1',
+    triggerAt: new Date('2026-05-01T09:00:00Z'),
+    timezone: 'UTC',
+    agentTrigger: {
+      agentPageId: 'agent-1',
+      prompt: 'Run check',
+      instructionPageId: null,
+      contextPageIds: [],
+    },
+  };
+
+  it('inserts the workflows row and the calendar_triggers row in that order on the supplied tx', async () => {
+    const captured = makeTxMock();
+
+    const result = await createCalendarTriggerWorkflow({
+      ...baseParams,
+      // Cast: the helper takes a real tx; the test only needs insert().
+      tx: captured.tx as unknown as Parameters<typeof createCalendarTriggerWorkflow>[0]['tx'],
+    });
+
+    expect(captured.insert).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ workflowId: 'wf-1', triggerId: 'trg-1' });
+
+    const [wfInsert, trgInsert] = captured.insertCalls;
+    const wfValues = wfInsert.values as Record<string, unknown>;
+    expect(wfValues.driveId).toBe('drive-1');
+    expect(wfValues.agentPageId).toBe('agent-1');
+    expect(wfValues.prompt).toBe('Run check');
+    // Backing workflow always carries triggerType='cron' but cronExpression
+    // stays null — this is what the management-route filter keys off.
+    expect(wfValues.triggerType).toBe('cron');
+    expect(wfValues.cronExpression).toBeUndefined();
+
+    const trgValues = trgInsert.values as Record<string, unknown>;
+    expect(trgValues.calendarEventId).toBe('evt-1');
+    expect(trgValues.workflowId).toBe('wf-1');
+    expect(trgValues.scheduledById).toBe('user-1');
+    expect(trgValues.status).toBe('pending');
+  });
+
+  it('falls back to a stock prompt when the caller passes none', async () => {
+    const captured = makeTxMock();
+
+    await createCalendarTriggerWorkflow({
+      ...baseParams,
+      agentTrigger: { ...baseParams.agentTrigger, prompt: undefined },
+      tx: captured.tx as unknown as Parameters<typeof createCalendarTriggerWorkflow>[0]['tx'],
+    });
+
+    const wfValues = captured.insertCalls[0].values as Record<string, unknown>;
+    expect(wfValues.prompt).toBe('Execute instructions from linked page.');
+  });
+
+  it('passes through instructionPageId and contextPageIds onto the workflow row', async () => {
+    const captured = makeTxMock();
+
+    await createCalendarTriggerWorkflow({
+      ...baseParams,
+      agentTrigger: {
+        agentPageId: 'agent-1',
+        prompt: 'Run check',
+        instructionPageId: 'page-instr',
+        contextPageIds: ['ctx-a', 'ctx-b'],
+      },
+      tx: captured.tx as unknown as Parameters<typeof createCalendarTriggerWorkflow>[0]['tx'],
+    });
+
+    const wfValues = captured.insertCalls[0].values as Record<string, unknown>;
+    expect(wfValues.instructionPageId).toBe('page-instr');
+    expect(wfValues.contextPageIds).toEqual(['ctx-a', 'ctx-b']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Call-site atomicity tests
+// ---------------------------------------------------------------------------
+//
+// The two call sites that invoke this helper (calendar/events POST and the
+// AI create_calendar_event tool) MUST do so inside db.transaction so a
+// failed trigger insert rolls back the workflows insert. We verify by
+// asserting the helper is invoked with a tx-like object whose insert calls
+// happen inside the same callback the route opens.
+//
+// We assert this at the helper level: a caller that forgot the transaction
+// would have to call createCalendarTriggerWorkflow with the bare db
+// reference, but the helper's signature requires a tx, so a forgotten tx
+// would be a typecheck failure. The structural test above proves the helper
+// uses the tx parameter rather than the global db.

--- a/apps/web/src/lib/workflows/__tests__/task-trigger-helpers.test.ts
+++ b/apps/web/src/lib/workflows/__tests__/task-trigger-helpers.test.ts
@@ -51,9 +51,10 @@ vi.mock('@pagespace/db/db', () => ({
   },
 }));
 vi.mock('@pagespace/db/operators', () => ({
-  eq: vi.fn(),
-  and: vi.fn(),
-  inArray: vi.fn(),
+  eq: vi.fn((field, value) => ({ op: 'eq', field, value })),
+  and: vi.fn((...conds) => ({ op: 'and', conds })),
+  inArray: vi.fn((field, values) => ({ op: 'inArray', field, values })),
+  isNull: vi.fn((field) => ({ op: 'isNull', field })),
 }));
 vi.mock('@pagespace/db/schema/core', () => ({
   pages: { id: 'id', type: 'type', isTrashed: 'isTrashed', driveId: 'driveId' },
@@ -110,6 +111,7 @@ import {
 } from '../task-trigger-helpers';
 import { executeWorkflow } from '../workflow-executor';
 import { db } from '@pagespace/db/db';
+import { isNull } from '@pagespace/db/operators';
 
 // Helper: build a fresh tx-shaped mock that records insert/update/select calls.
 // The real createTaskTriggerWorkflow runs all reads + writes inside one tx, so
@@ -260,6 +262,24 @@ describe('task-trigger-helpers', () => {
         agentPageId: 'agent-1',
         taskContext: { taskItemId: 'task-1', triggerType: 'completion' },
       }));
+    });
+
+    it('given the claim UPDATE, should gate on lastFiredAt IS NULL so concurrent callers cannot double-fire', async () => {
+      // SELECT(taskTriggers) → trigger row, then claim UPDATE, then SELECT(workflows)
+      mockFrom
+        .mockImplementationOnce(() => ({ where: vi.fn().mockResolvedValueOnce([mockTrigger]) }))
+        .mockImplementationOnce(() => ({ where: vi.fn().mockResolvedValueOnce([mockWorkflow]) }));
+      mockReturning.mockResolvedValueOnce([mockTrigger]);
+      vi.mocked(executeWorkflow).mockResolvedValueOnce({ success: true, durationMs: 50 });
+
+      await fireCompletionTrigger('task-1');
+
+      // The claim WHERE must include `isNull(taskTriggers.lastFiredAt)` —
+      // without it, two concurrent workers can both pass the SELECT (both
+      // see lastFiredAt=null) and both UPDATE successfully = duplicate fires.
+      const isNullCalls = vi.mocked(isNull).mock.calls;
+      const guardedFields = isNullCalls.map((call) => call[0]);
+      expect(guardedFields).toContain('lastFiredAt');
     });
 
     it('given the claim UPDATE returns 0 rows (race lost), should NOT execute the workflow', async () => {

--- a/apps/web/src/lib/workflows/__tests__/task-trigger-helpers.test.ts
+++ b/apps/web/src/lib/workflows/__tests__/task-trigger-helpers.test.ts
@@ -1,19 +1,43 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockUpdate, mockSet, mockWhere, mockReturning, mockFrom, mockSelect, mockSelectWhere, mockInsert, mockValues, mockOnConflict, mockQueryPages } = vi.hoisted(() => {
+const {
+  mockUpdate, mockSet, mockWhere, mockReturning,
+  mockFrom, mockSelect, mockSelectWhere,
+  mockInsert,
+  mockDelete, mockDeleteWhere,
+  mockQueryPages,
+  mockTransaction,
+} = vi.hoisted(() => {
+  // Top-level db chain (used outside transactions): select / update / delete.
   const mockReturning = vi.fn().mockResolvedValue([]);
   const mockWhere = vi.fn(() => ({ returning: mockReturning }));
   const mockSet = vi.fn(() => ({ where: mockWhere }));
-  // db.select(...).from(...).where(...) resolves directly to a row array (no .returning())
   const mockSelectWhere = vi.fn().mockResolvedValue([]);
   const mockFrom = vi.fn(() => ({ where: mockSelectWhere }));
   const mockUpdate = vi.fn(() => ({ set: mockSet }));
   const mockSelect = vi.fn(() => ({ from: mockFrom }));
-  const mockOnConflict = vi.fn().mockResolvedValue(undefined);
-  const mockValues = vi.fn(() => ({ onConflictDoUpdate: mockOnConflict }));
-  const mockInsert = vi.fn(() => ({ values: mockValues }));
+  const mockDeleteWhere = vi.fn().mockResolvedValue(undefined);
+  const mockDelete = vi.fn(() => ({ where: mockDeleteWhere }));
+
+  // Insert is only used inside transactions; the tx mock supplies its own
+  // chain. These top-level mocks exist so a stray call would still be observable.
+  const mockInsertReturning = vi.fn().mockResolvedValue([{ id: 'wf-new' }]);
+  const mockInsertValues = vi.fn(() => ({ returning: mockInsertReturning }));
+  const mockInsert = vi.fn(() => ({ values: mockInsertValues }));
+
   const mockQueryPages = { findFirst: vi.fn(), findMany: vi.fn() };
-  return { mockUpdate, mockSet, mockWhere, mockReturning, mockFrom, mockSelect, mockSelectWhere, mockInsert, mockValues, mockOnConflict, mockQueryPages };
+
+  // Default transaction implementation: callback receives a tx whose select /
+  // insert / update / delete share the same mocks as the top-level db chain.
+  const mockTransaction = vi.fn();
+
+  return {
+    mockUpdate, mockSet, mockWhere, mockReturning,
+    mockFrom, mockSelect, mockSelectWhere,
+    mockInsert,
+    mockDelete, mockDeleteWhere,
+    mockQueryPages, mockTransaction,
+  };
 });
 
 vi.mock('@pagespace/db/db', () => ({
@@ -21,7 +45,9 @@ vi.mock('@pagespace/db/db', () => ({
     select: mockSelect,
     update: mockUpdate,
     insert: mockInsert,
+    delete: mockDelete,
     query: { pages: mockQueryPages },
+    transaction: mockTransaction,
   },
 }));
 vi.mock('@pagespace/db/operators', () => ({
@@ -38,14 +64,21 @@ vi.mock('@pagespace/db/schema/tasks', () => ({
 vi.mock('@pagespace/db/schema/workflows', () => ({
   workflows: {
     id: 'id',
+    name: 'name',
+    triggerType: 'triggerType',
+    isEnabled: 'isEnabled',
+  },
+}));
+vi.mock('@pagespace/db/schema/task-triggers', () => ({
+  taskTriggers: {
+    id: 'id',
+    workflowId: 'workflowId',
     taskItemId: 'taskItemId',
     triggerType: 'triggerType',
     isEnabled: 'isEnabled',
-    lastRunStatus: 'lastRunStatus',
-    lastRunAt: 'lastRunAt',
-    lastRunError: 'lastRunError',
-    lastRunDurationMs: 'lastRunDurationMs',
     nextRunAt: 'nextRunAt',
+    lastFiredAt: 'lastFiredAt',
+    lastFireError: 'lastFireError',
   },
 }));
 
@@ -78,10 +111,53 @@ import {
 import { executeWorkflow } from '../workflow-executor';
 import { db } from '@pagespace/db/db';
 
+// Helper: build a fresh tx-shaped mock that records insert/update/select calls.
+// The real createTaskTriggerWorkflow runs all reads + writes inside one tx, so
+// each test that exercises that path supplies its own chain. The transaction
+// mock executes the callback synchronously with this tx.
+function makeTxMock(opts: {
+  existingTriggers?: unknown[];
+  insertReturnRows?: { workflows?: unknown[]; taskTriggers?: unknown[] };
+} = {}) {
+  const txSelectWhere = vi.fn().mockResolvedValue(opts.existingTriggers ?? []);
+  const txSelectFrom = vi.fn(() => ({ where: txSelectWhere }));
+  const txSelect = vi.fn(() => ({ from: txSelectFrom }));
+
+  const txInsertReturningWorkflows = vi.fn().mockResolvedValue(opts.insertReturnRows?.workflows ?? [{ id: 'wf-new' }]);
+  const txInsertReturningTaskTriggers = vi.fn().mockResolvedValue(opts.insertReturnRows?.taskTriggers ?? [{ id: 'trg-new' }]);
+
+  const insertCalls: { table: unknown; values: unknown }[] = [];
+  let insertCount = 0;
+  const txInsertValues = vi.fn((values: unknown) => {
+    const calledFor = insertCalls[insertCalls.length - 1];
+    if (calledFor) calledFor.values = values;
+    return {
+      // First insert in the helper is workflows, second is taskTriggers
+      returning: insertCount === 1 ? txInsertReturningWorkflows : txInsertReturningTaskTriggers,
+    };
+  });
+  const txInsert = vi.fn((table: unknown) => {
+    insertCount++;
+    insertCalls.push({ table, values: undefined });
+    return { values: txInsertValues };
+  });
+
+  const txUpdateWhere = vi.fn().mockResolvedValue(undefined);
+  const txUpdateSet = vi.fn(() => ({ where: txUpdateWhere }));
+  const txUpdate = vi.fn(() => ({ set: txUpdateSet }));
+
+  const tx = {
+    select: txSelect,
+    insert: txInsert,
+    update: txUpdate,
+  };
+
+  return { tx, txInsert, txInsertValues, txUpdate, txUpdateSet, txSelect, insertCalls };
+}
+
 describe('task-trigger-helpers', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Reset chain defaults
     mockUpdate.mockImplementation(() => ({ set: mockSet }));
     mockSet.mockImplementation(() => ({ where: mockWhere }));
     mockWhere.mockImplementation(() => ({ returning: mockReturning }));
@@ -89,10 +165,18 @@ describe('task-trigger-helpers', () => {
     mockSelect.mockImplementation(() => ({ from: mockFrom }));
     mockFrom.mockImplementation(() => ({ where: mockSelectWhere }));
     mockSelectWhere.mockResolvedValue([]);
+    mockDelete.mockImplementation(() => ({ where: mockDeleteWhere }));
+    mockDeleteWhere.mockResolvedValue(undefined);
+
+    // Default: transaction runs the callback against a fresh tx mock.
+    mockTransaction.mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) => {
+      const { tx } = makeTxMock();
+      return cb(tx);
+    });
   });
 
   describe('syncTaskDueDateTrigger', () => {
-    it('given a new due date, should update nextRunAt on matching enabled never_run triggers', async () => {
+    it('given a new due date, should update nextRunAt on matching enabled triggers', async () => {
       const dueDate = new Date('2026-05-01T00:00:00Z');
       await syncTaskDueDateTrigger('task-1', dueDate);
 
@@ -103,10 +187,9 @@ describe('task-trigger-helpers', () => {
     it('given null due date, should disable trigger and clear nextRunAt', async () => {
       await syncTaskDueDateTrigger('task-1', null);
 
-      expect(mockUpdate).toHaveBeenCalled();
       expect(mockSet).toHaveBeenCalledWith(expect.objectContaining({
         isEnabled: false,
-        lastRunError: 'Due date cleared',
+        lastFireError: 'Due date cleared',
         nextRunAt: null,
       }));
     });
@@ -122,10 +205,9 @@ describe('task-trigger-helpers', () => {
     it('given a task ID and reason, should disable the trigger with the reason', async () => {
       await cancelTaskDueDateTrigger('task-1', 'Task completed');
 
-      expect(mockUpdate).toHaveBeenCalled();
       expect(mockSet).toHaveBeenCalledWith(expect.objectContaining({
         isEnabled: false,
-        lastRunError: 'Task completed',
+        lastFireError: 'Task completed',
       }));
     });
 
@@ -137,32 +219,51 @@ describe('task-trigger-helpers', () => {
   });
 
   describe('fireCompletionTrigger', () => {
-    const mockWorkflow = {
-      id: 'wf-1',
+    const mockTrigger = {
+      id: 'trg-1',
+      workflowId: 'wf-1',
       taskItemId: 'task-1',
-      triggerType: 'task_completion',
+      triggerType: 'completion',
       isEnabled: true,
-      lastRunStatus: 'never_run',
+      lastFiredAt: null,
+      lastFireError: null,
     };
 
-    it('given a matching completion workflow, should claim it atomically and execute', async () => {
-      // SELECT returns the workflow
-      mockFrom.mockImplementationOnce(() => ({ where: vi.fn().mockResolvedValueOnce([mockWorkflow]) }));
-      // UPDATE claim returns the claimed row (atomic confirmation)
-      mockReturning.mockResolvedValueOnce([mockWorkflow]);
+    const mockWorkflow = {
+      id: 'wf-1',
+      name: 'task-trigger-completion-task-1',
+      driveId: 'drive-1',
+      createdBy: 'user-1',
+      agentPageId: 'agent-1',
+      prompt: 'Do thing',
+      contextPageIds: [],
+      instructionPageId: null,
+      timezone: 'UTC',
+    };
+
+    it('given a matching completion trigger, should claim it atomically and execute the linked workflow', async () => {
+      // SELECT(taskTriggers) → trigger row
+      // UPDATE(taskTriggers) claim → returns row (atomic confirmation)
+      // SELECT(workflows) → workflow row
+      mockFrom
+        .mockImplementationOnce(() => ({ where: vi.fn().mockResolvedValueOnce([mockTrigger]) }))
+        .mockImplementationOnce(() => ({ where: vi.fn().mockResolvedValueOnce([mockWorkflow]) }));
+      mockReturning.mockResolvedValueOnce([mockTrigger]);
 
       const mockExecute = vi.mocked(executeWorkflow);
       mockExecute.mockResolvedValueOnce({ success: true, durationMs: 100 });
 
       await fireCompletionTrigger('task-1');
 
-      expect(mockExecute).toHaveBeenCalledWith(mockWorkflow);
+      expect(mockExecute).toHaveBeenCalledWith(expect.objectContaining({
+        workflowId: 'wf-1',
+        agentPageId: 'agent-1',
+        taskContext: { taskItemId: 'task-1', triggerType: 'completion' },
+      }));
     });
 
     it('given the claim UPDATE returns 0 rows (race lost), should NOT execute the workflow', async () => {
-      // SELECT returns the workflow
-      mockFrom.mockImplementationOnce(() => ({ where: vi.fn().mockResolvedValueOnce([mockWorkflow]) }));
-      // UPDATE claim returns empty (another caller already claimed it)
+      mockFrom.mockImplementationOnce(() => ({ where: vi.fn().mockResolvedValueOnce([mockTrigger]) }));
       mockReturning.mockResolvedValueOnce([]);
 
       const mockExecute = vi.mocked(executeWorkflow);
@@ -172,8 +273,19 @@ describe('task-trigger-helpers', () => {
       expect(mockExecute).not.toHaveBeenCalled();
     });
 
-    it('given no matching workflow, should return without executing', async () => {
+    it('given no matching trigger, should return without executing', async () => {
       mockFrom.mockImplementationOnce(() => ({ where: vi.fn().mockResolvedValueOnce([]) }));
+
+      const mockExecute = vi.mocked(executeWorkflow);
+
+      await fireCompletionTrigger('task-1');
+
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it('given trigger with non-null lastFiredAt (already fired), should NOT execute', async () => {
+      const fired = { ...mockTrigger, lastFiredAt: new Date() };
+      mockFrom.mockImplementationOnce(() => ({ where: vi.fn().mockResolvedValueOnce([fired]) }));
 
       const mockExecute = vi.mocked(executeWorkflow);
 
@@ -190,18 +302,33 @@ describe('task-trigger-helpers', () => {
   });
 
   describe('disableTaskTriggers', () => {
-    it('given a task ID and reason, should disable all enabled triggers for that task', async () => {
+    it('given a task ID with active triggers, should disable triggers and delete linked workflow rows', async () => {
+      // First select returns trigger rows with workflow IDs
+      mockFrom.mockImplementationOnce(() => ({ where: vi.fn().mockResolvedValueOnce([
+        { id: 'trg-1', workflowId: 'wf-1' },
+        { id: 'trg-2', workflowId: 'wf-2' },
+      ]) }));
+
       await disableTaskTriggers('task-1', 'Task deleted');
 
-      expect(mockUpdate).toHaveBeenCalled();
       expect(mockSet).toHaveBeenCalledWith(expect.objectContaining({
         isEnabled: false,
-        lastRunError: 'Task deleted',
+        lastFireError: 'Task deleted',
       }));
+      expect(mockDelete).toHaveBeenCalled();
+    });
+
+    it('given no triggers for the task, should return without writing', async () => {
+      mockFrom.mockImplementationOnce(() => ({ where: vi.fn().mockResolvedValueOnce([]) }));
+
+      await disableTaskTriggers('task-1', 'Task deleted');
+
+      expect(mockUpdate).not.toHaveBeenCalled();
+      expect(mockDelete).not.toHaveBeenCalled();
     });
 
     it('given a DB error, should not throw (internal try/catch)', async () => {
-      mockUpdate.mockImplementationOnce(() => { throw new Error('DB connection lost'); });
+      mockSelect.mockImplementationOnce(() => { throw new Error('DB connection lost'); });
 
       await expect(disableTaskTriggers('task-1', 'reason')).resolves.toBeUndefined();
     });
@@ -224,35 +351,48 @@ describe('task-trigger-helpers', () => {
     };
 
     beforeEach(() => {
-      // Agent page exists and is in same drive
       mockQueryPages.findFirst.mockResolvedValue({ id: 'agent-1', type: 'AI_CHAT', driveId: 'drive-1' });
-      // Context pages (none by default)
       mockQueryPages.findMany.mockResolvedValue([]);
     });
 
-    it('given valid params, should insert a workflow and update task metadata', async () => {
+    it('given valid params (no existing trigger), should insert workflows + task_triggers atomically and update task metadata', async () => {
+      const captured = makeTxMock({ existingTriggers: [] });
+      mockTransaction.mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) => cb(captured.tx));
+
       await createTaskTriggerWorkflow(validParams);
 
-      expect(mockInsert).toHaveBeenCalled();
-      expect(mockValues).toHaveBeenCalledWith(expect.objectContaining({
-        driveId: 'drive-1',
-        createdBy: 'user-1',
-        agentPageId: 'agent-1',
-        triggerType: 'task_due_date',
-        taskItemId: 'task-1',
-        isEnabled: true,
-      }));
+      // Two inserts (workflows then task_triggers)
+      expect(captured.txInsert).toHaveBeenCalledTimes(2);
+      const [workflowsInsert, taskTriggersInsert] = captured.insertCalls;
+      expect((workflowsInsert.values as Record<string, unknown>).agentPageId).toBe('agent-1');
+      expect((taskTriggersInsert.values as Record<string, unknown>).triggerType).toBe('due_date');
+      expect((taskTriggersInsert.values as Record<string, unknown>).workflowId).toBe('wf-new');
+      // Trailing metadata recompute
+      expect(mockSelect).toHaveBeenCalled();
     });
 
-    it('given triggerType completion, should set triggerType to task_completion', async () => {
+    it('given triggerType completion, should write triggerType "completion" on task_triggers (no enum mapping)', async () => {
+      const captured = makeTxMock({ existingTriggers: [] });
+      mockTransaction.mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) => cb(captured.tx));
+
       await createTaskTriggerWorkflow({
         ...validParams,
         agentTrigger: { ...validParams.agentTrigger, triggerType: 'completion' },
       });
 
-      expect(mockValues).toHaveBeenCalledWith(expect.objectContaining({
-        triggerType: 'task_completion',
-      }));
+      const taskTriggersInsert = captured.insertCalls[1];
+      expect((taskTriggersInsert.values as Record<string, unknown>).triggerType).toBe('completion');
+    });
+
+    it('given an existing trigger row (upsert), should update both workflows and task_triggers in place', async () => {
+      const captured = makeTxMock({ existingTriggers: [{ workflowId: 'wf-old' }] });
+      mockTransaction.mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) => cb(captured.tx));
+
+      await createTaskTriggerWorkflow(validParams);
+
+      // No inserts; both UPDATEs (workflows + task_triggers) ran
+      expect(captured.txInsert).not.toHaveBeenCalled();
+      expect(captured.txUpdate).toHaveBeenCalledTimes(2);
     });
 
     it('given due_date trigger without dueDate, should throw', async () => {
@@ -284,9 +424,7 @@ describe('task-trigger-helpers', () => {
     });
 
     it('given invalid instructionPageId, should throw', async () => {
-      // findFirst: agent page OK
       mockQueryPages.findFirst.mockResolvedValueOnce({ id: 'agent-1', type: 'AI_CHAT', driveId: 'drive-1' });
-      // findFirst: instruction page not found
       mockQueryPages.findFirst.mockResolvedValueOnce(null);
 
       await expect(createTaskTriggerWorkflow({
@@ -299,9 +437,7 @@ describe('task-trigger-helpers', () => {
     });
 
     it('given contextPageIds with pages not in the same drive, should throw', async () => {
-      // findFirst for agent page succeeds
       mockQueryPages.findFirst.mockResolvedValueOnce({ id: 'agent-1', type: 'AI_CHAT', driveId: 'drive-1' });
-      // findMany returns fewer pages than requested (some not in same drive)
       mockQueryPages.findMany.mockResolvedValueOnce([{ id: 'ctx-1' }]);
 
       await expect(createTaskTriggerWorkflow({
@@ -312,27 +448,19 @@ describe('task-trigger-helpers', () => {
         },
       })).rejects.toThrow('Some context pages were not found or are not in the same drive');
     });
-
-    it('given duplicate trigger (onConflictDoUpdate), should upsert instead of throwing', async () => {
-      await createTaskTriggerWorkflow(validParams);
-
-      expect(mockOnConflict).toHaveBeenCalled();
-    });
   });
 
   describe('recomputeTaskTriggerMetadata', () => {
-    it('writes triggerTypes and hasTrigger from the live workflows table, ignoring stale baseMetadata', async () => {
-      // Live DB state: only due_date is enabled (completion was just disabled)
-      mockSelectWhere.mockResolvedValueOnce([{ triggerType: 'task_due_date' }]);
-      // Caller passes stale baseMetadata claiming both types are active
-      const stale = { hasTrigger: true, triggerTypes: ['task_completion', 'task_due_date'], otherKey: 'preserved' };
+    it('writes triggerTypes and hasTrigger from the live task_triggers table, ignoring stale baseMetadata', async () => {
+      mockSelectWhere.mockResolvedValueOnce([{ triggerType: 'due_date' }]);
+      const stale = { hasTrigger: true, triggerTypes: ['completion', 'due_date'], otherKey: 'preserved' };
 
       await recomputeTaskTriggerMetadata(db, 'task-1', stale);
 
       expect(mockSet).toHaveBeenCalledWith({
         metadata: {
           otherKey: 'preserved',
-          triggerTypes: ['task_due_date'],
+          triggerTypes: ['due_date'],
           hasTrigger: true,
         },
       });
@@ -341,7 +469,7 @@ describe('task-trigger-helpers', () => {
     it('clears hasTrigger when no enabled triggers remain', async () => {
       mockSelectWhere.mockResolvedValueOnce([]);
 
-      await recomputeTaskTriggerMetadata(db, 'task-1', { hasTrigger: true, triggerTypes: ['task_completion'] });
+      await recomputeTaskTriggerMetadata(db, 'task-1', { hasTrigger: true, triggerTypes: ['completion'] });
 
       expect(mockSet).toHaveBeenCalledWith({
         metadata: {
@@ -352,13 +480,13 @@ describe('task-trigger-helpers', () => {
     });
 
     it('handles null baseMetadata', async () => {
-      mockSelectWhere.mockResolvedValueOnce([{ triggerType: 'task_completion' }]);
+      mockSelectWhere.mockResolvedValueOnce([{ triggerType: 'completion' }]);
 
       await recomputeTaskTriggerMetadata(db, 'task-1', null);
 
       expect(mockSet).toHaveBeenCalledWith({
         metadata: {
-          triggerTypes: ['task_completion'],
+          triggerTypes: ['completion'],
           hasTrigger: true,
         },
       });

--- a/apps/web/src/lib/workflows/__tests__/task-trigger-helpers.test.ts
+++ b/apps/web/src/lib/workflows/__tests__/task-trigger-helpers.test.ts
@@ -322,19 +322,14 @@ describe('task-trigger-helpers', () => {
   });
 
   describe('disableTaskTriggers', () => {
-    it('given a task ID with active triggers, should disable triggers and delete linked workflow rows', async () => {
-      // First select returns trigger rows with workflow IDs
+    it('given a task ID with active triggers, should delete linked workflow rows (cascade wipes task_triggers)', async () => {
       mockFrom.mockImplementationOnce(() => ({ where: vi.fn().mockResolvedValueOnce([
-        { id: 'trg-1', workflowId: 'wf-1' },
-        { id: 'trg-2', workflowId: 'wf-2' },
+        { workflowId: 'wf-1' },
+        { workflowId: 'wf-2' },
       ]) }));
 
       await disableTaskTriggers('task-1', 'Task deleted');
 
-      expect(mockSet).toHaveBeenCalledWith(expect.objectContaining({
-        isEnabled: false,
-        lastFireError: 'Task deleted',
-      }));
       expect(mockDelete).toHaveBeenCalled();
     });
 
@@ -343,8 +338,21 @@ describe('task-trigger-helpers', () => {
 
       await disableTaskTriggers('task-1', 'Task deleted');
 
-      expect(mockUpdate).not.toHaveBeenCalled();
       expect(mockDelete).not.toHaveBeenCalled();
+    });
+
+    it('drops the redundant UPDATE-then-delete bookkeeping (Nit 1)', async () => {
+      // The pre-fix code did SELECT → UPDATE(isEnabled=false) → DELETE workflows.
+      // The UPDATE is wasted: deleting the workflows row cascade-deletes the
+      // task_triggers row via task_triggers.workflowId FK, so the UPDATE never
+      // observably happens. Assert there is no top-level db.update call.
+      mockFrom.mockImplementationOnce(() => ({ where: vi.fn().mockResolvedValueOnce([
+        { workflowId: 'wf-1' },
+      ]) }));
+
+      await disableTaskTriggers('task-1', 'Task deleted');
+
+      expect(mockUpdate).not.toHaveBeenCalled();
     });
 
     it('given a DB error, should not throw (internal try/catch)', async () => {

--- a/apps/web/src/lib/workflows/__tests__/workflow-executor.test.ts
+++ b/apps/web/src/lib/workflows/__tests__/workflow-executor.test.ts
@@ -4,7 +4,6 @@ import { describe, test, expect, beforeEach, vi } from 'vitest';
 // Tests for workflow-executor.ts
 // ============================================================================
 
-// Hoist mock functions
 const {
   mockSelectWhere,
   mockSelectFrom,
@@ -18,19 +17,24 @@ const {
 }));
 
 vi.mock('@pagespace/db/db', () => ({
-  db: { select: mockSelect },
+  db: { select: mockSelect, query: { taskItems: { findFirst: vi.fn() } } },
 }));
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn(),
   and: vi.fn(),
   inArray: vi.fn(),
 }));
+vi.mock('@pagespace/db/schema/auth', () => ({
+  users: { id: 'id', name: 'name' },
+}));
 vi.mock('@pagespace/db/schema/core', () => ({
   pages: { id: 'id', isTrashed: 'isTrashed', title: 'title', content: 'content', parentId: 'parentId', driveId: 'driveId' },
   drives: { id: 'id' },
 }));
-vi.mock('@pagespace/db/schema/workflows', () => ({
-  workflows: { $inferSelect: {} },
+vi.mock('@pagespace/db/schema/tasks', () => ({
+  taskItems: { id: 'id' },
+  taskAssignees: { taskId: 'taskId', userId: 'userId', agentPageId: 'agentPageId' },
+  taskStatusConfigs: { taskListId: 'taskListId', slug: 'slug' },
 }));
 
 vi.mock('ai', () => ({
@@ -69,47 +73,32 @@ vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
   AIMonitoring: { trackUsage: vi.fn() },
 }));
 
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  isUserDriveMember: vi.fn(),
+}));
+
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
     loggers: {
     api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
   },
-
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
 
-import { executeWorkflow } from '../workflow-executor';
+import { executeWorkflow, type WorkflowExecutionInput } from '../workflow-executor';
 import { generateText } from 'ai';
 import { createAIProvider, isProviderError } from '@/lib/ai/core';
 import { saveMessageToDatabase } from '@/lib/ai/core/message-utils';
 
-// ============================================================================
-// Fixtures
-// ============================================================================
-
-const createWorkflowFixture = (overrides: Record<string, unknown> = {}) => ({
-  id: 'wf_1',
+const createInputFixture = (overrides: Partial<WorkflowExecutionInput> = {}): WorkflowExecutionInput => ({
+  workflowId: 'wf_1',
+  workflowName: 'Test Workflow',
   driveId: 'drive_abc',
   createdBy: 'user_123',
-  name: 'Test Workflow',
   agentPageId: 'agent_1',
   prompt: 'Generate a report',
   contextPageIds: [],
-  cronExpression: '0 9 * * 1-5',
-  timezone: 'UTC',
-  triggerType: 'cron' as const,
-  eventTriggers: null,
-  watchedFolderIds: null,
-  eventDebounceSecs: null,
-  taskItemId: null,
   instructionPageId: null,
-  isEnabled: true,
-  lastRunAt: null,
-  nextRunAt: null,
-  lastRunStatus: 'never_run' as const,
-  lastRunError: null,
-  lastRunDurationMs: null,
-  createdAt: new Date('2024-01-01'),
-  updatedAt: new Date('2024-01-01'),
+  timezone: 'UTC',
   ...overrides,
 });
 
@@ -139,11 +128,6 @@ const mockProviderResult = {
   modelName: 'glm-4.5-air',
 };
 
-// ============================================================================
-// Helpers
-// ============================================================================
-
-/** Set up the mock DB select chain to return specific values in sequence. */
 function setupSelectChain(...results: unknown[][]) {
   let callIdx = 0;
   mockSelectWhere.mockImplementation(async () => {
@@ -154,10 +138,6 @@ function setupSelectChain(...results: unknown[][]) {
   mockSelect.mockReturnValue({ from: mockSelectFrom });
   mockSelectFrom.mockReturnValue({ where: mockSelectWhere });
 }
-
-// ============================================================================
-// Tests
-// ============================================================================
 
 describe('executeWorkflow', () => {
   beforeEach(() => {
@@ -172,14 +152,10 @@ describe('executeWorkflow', () => {
     } as never);
   });
 
-  // --------------------------------------------------------------------------
-  // Agent validation
-  // --------------------------------------------------------------------------
-
   test('missing agent page returns error', async () => {
-    setupSelectChain([]); // No agent found
+    setupSelectChain([]);
 
-    const result = await executeWorkflow(createWorkflowFixture());
+    const result = await executeWorkflow(createInputFixture());
 
     expect(result.success).toBe(false);
     expect(result.error).toBe('Agent page not found');
@@ -189,59 +165,45 @@ describe('executeWorkflow', () => {
   test('trashed agent page returns error', async () => {
     setupSelectChain([{ ...mockAgent, isTrashed: true }]);
 
-    const result = await executeWorkflow(createWorkflowFixture());
+    const result = await executeWorkflow(createInputFixture());
 
     expect(result.success).toBe(false);
     expect(result.error).toBe('Agent page is in trash');
-    expect(generateText).not.toHaveBeenCalled();
   });
 
   test('non-AI_CHAT agent returns error', async () => {
     setupSelectChain([{ ...mockAgent, type: 'DOCUMENT' }]);
 
-    const result = await executeWorkflow(createWorkflowFixture());
+    const result = await executeWorkflow(createInputFixture());
 
     expect(result.success).toBe(false);
     expect(result.error).toBe('Agent page is not an AI_CHAT type');
   });
 
-  // --------------------------------------------------------------------------
-  // Drive validation
-  // --------------------------------------------------------------------------
-
   test('missing drive returns error', async () => {
-    setupSelectChain([mockAgent], []); // Agent found, no drive
+    setupSelectChain([mockAgent], []);
 
-    const result = await executeWorkflow(createWorkflowFixture());
+    const result = await executeWorkflow(createInputFixture());
 
     expect(result.success).toBe(false);
     expect(result.error).toBe('Drive not found');
   });
-
-  // --------------------------------------------------------------------------
-  // Provider errors
-  // --------------------------------------------------------------------------
 
   test('AI provider error returns error', async () => {
     setupSelectChain([mockAgent], [mockDrive]);
     vi.mocked(isProviderError).mockReturnValue(true);
     vi.mocked(createAIProvider).mockResolvedValue({ error: 'No API key' } as never);
 
-    const result = await executeWorkflow(createWorkflowFixture());
+    const result = await executeWorkflow(createInputFixture());
 
     expect(result.success).toBe(false);
     expect(result.error).toContain('AI provider error');
-    expect(generateText).not.toHaveBeenCalled();
   });
-
-  // --------------------------------------------------------------------------
-  // Happy path
-  // --------------------------------------------------------------------------
 
   test('successful execution with tools', async () => {
     setupSelectChain([mockAgent], [mockDrive]);
 
-    const result = await executeWorkflow(createWorkflowFixture());
+    const result = await executeWorkflow(createInputFixture());
 
     expect(result.success).toBe(true);
     expect(result.responseText).toBe('Report complete');
@@ -249,7 +211,6 @@ describe('executeWorkflow', () => {
     expect(result.durationMs).toBeGreaterThanOrEqual(0);
     expect(generateText).toHaveBeenCalledTimes(1);
 
-    // Verify tools were filtered to only enabled ones
     const genCall = vi.mocked(generateText).mock.calls[0][0] as Record<string, unknown>;
     expect(genCall.tools).toBeDefined();
     const toolKeys = Object.keys(genCall.tools as object);
@@ -267,7 +228,7 @@ describe('executeWorkflow', () => {
       github_create_issue: { name: 'github_create_issue' },
     });
 
-    const result = await executeWorkflow(createWorkflowFixture());
+    const result = await executeWorkflow(createInputFixture());
 
     expect(result.success).toBe(true);
     expect(mockResolvePageAgentIntegrationTools).toHaveBeenCalledWith({
@@ -277,7 +238,6 @@ describe('executeWorkflow', () => {
     });
 
     const genCall = vi.mocked(generateText).mock.calls[0][0] as Record<string, unknown>;
-    expect(genCall.tools).toBeDefined();
     const toolKeys = Object.keys(genCall.tools as object);
     expect(toolKeys).toContain('github_create_issue');
   });
@@ -288,30 +248,24 @@ describe('executeWorkflow', () => {
       [mockDrive],
     );
 
-    const result = await executeWorkflow(createWorkflowFixture());
+    const result = await executeWorkflow(createInputFixture());
 
     expect(result.success).toBe(true);
-    // No tools property when empty
     const genCall = vi.mocked(generateText).mock.calls[0][0] as Record<string, unknown>;
     expect(genCall.tools).toBeUndefined();
   });
-
-  // --------------------------------------------------------------------------
-  // Context pages
-  // --------------------------------------------------------------------------
 
   test('appends context page content to prompt', async () => {
     setupSelectChain(
       [mockAgent],
       [mockDrive],
-      [{ id: 'ctx_1', title: 'Meeting Notes', content: 'Discussed Q4 goals' }], // context pages
+      [{ id: 'ctx_1', title: 'Meeting Notes', content: 'Discussed Q4 goals' }],
     );
 
-    const workflow = createWorkflowFixture({ contextPageIds: ['ctx_1'] });
-    const result = await executeWorkflow(workflow);
+    const input = createInputFixture({ contextPageIds: ['ctx_1'] });
+    const result = await executeWorkflow(input);
 
     expect(result.success).toBe(true);
-    // The user message should contain context docs
     const saveCall = vi.mocked(saveMessageToDatabase).mock.calls[0][0];
     expect(saveCall.content).toContain('Meeting Notes');
     expect(saveCall.content).toContain('Discussed Q4 goals');
@@ -325,24 +279,33 @@ describe('executeWorkflow', () => {
       [{ id: 'ctx_1', title: 'Same Drive Page', content: 'Safe content' }],
     );
 
-    const workflow = createWorkflowFixture({ contextPageIds: ['ctx_1'] });
-    await executeWorkflow(workflow);
+    const input = createInputFixture({ contextPageIds: ['ctx_1'] });
+    await executeWorkflow(input);
 
-    // The third select call is for context pages — verify `and()` was called
-    // with driveId filter (eq(pages.driveId, workflow.driveId))
     expect(and).toHaveBeenCalled();
     expect(eq).toHaveBeenCalledWith('driveId', 'drive_abc');
     expect(inArray).toHaveBeenCalledWith('id', ['ctx_1']);
   });
 
-  // --------------------------------------------------------------------------
-  // Message saving
-  // --------------------------------------------------------------------------
+  test('eventContext.promptOverride replaces the workflow prompt for this run', async () => {
+    setupSelectChain([mockAgent], [mockDrive]);
+
+    const input = createInputFixture({
+      prompt: 'Stored workflow prompt',
+      eventContext: { promptOverride: '<scheduled-event>...event prompt...</scheduled-event>' },
+    });
+    const result = await executeWorkflow(input);
+
+    expect(result.success).toBe(true);
+    const saveCall = vi.mocked(saveMessageToDatabase).mock.calls[0][0];
+    expect(saveCall.content).toContain('event prompt');
+    expect(saveCall.content).not.toContain('Stored workflow prompt');
+  });
 
   test('saves user and assistant messages to database', async () => {
     setupSelectChain([mockAgent], [mockDrive]);
 
-    await executeWorkflow(createWorkflowFixture());
+    await executeWorkflow(createInputFixture());
 
     expect(saveMessageToDatabase).toHaveBeenCalledTimes(2);
     const [userSave, assistantSave] = vi.mocked(saveMessageToDatabase).mock.calls;
@@ -351,15 +314,11 @@ describe('executeWorkflow', () => {
     expect(assistantSave[0].content).toBe('Report complete');
   });
 
-  // --------------------------------------------------------------------------
-  // Error handling
-  // --------------------------------------------------------------------------
-
   test('thrown exception returns error with duration', async () => {
     setupSelectChain([mockAgent], [mockDrive]);
     vi.mocked(generateText).mockRejectedValue(new Error('Network timeout'));
 
-    const result = await executeWorkflow(createWorkflowFixture());
+    const result = await executeWorkflow(createInputFixture());
 
     expect(result.success).toBe(false);
     expect(result.error).toBe('Network timeout');

--- a/apps/web/src/lib/workflows/calendar-trigger-executor.ts
+++ b/apps/web/src/lib/workflows/calendar-trigger-executor.ts
@@ -1,12 +1,13 @@
 import { db } from '@pagespace/db/db'
-import { eq, and } from '@pagespace/db/operators'
+import { eq } from '@pagespace/db/operators'
 import { users } from '@pagespace/db/schema/auth'
 import { pages } from '@pagespace/db/schema/core'
 import { eventAttendees } from '@pagespace/db/schema/calendar'
 import { calendarTriggers } from '@pagespace/db/schema/calendar-triggers';
+import { workflows } from '@pagespace/db/schema/workflows';
 import type { CalendarEvent } from '@pagespace/db/schema/calendar'
 import type { CalendarTrigger } from '@pagespace/db/schema/calendar-triggers';
-import { executeWorkflow, type WorkflowExecutionResult } from './workflow-executor';
+import { executeWorkflow, type WorkflowExecutionResult, type WorkflowExecutionInput } from './workflow-executor';
 import { incrementUsage } from '@/lib/subscription/usage-service';
 import { isUserDriveMember } from '@pagespace/lib/permissions/permissions';
 import { loggers } from '@pagespace/lib/logging/logger-config';
@@ -16,8 +17,10 @@ const logger = loggers.api.child({ module: 'calendar-trigger-executor' });
 /**
  * Execute a calendar-triggered LLM agent invocation.
  *
- * Builds the prompt from the trigger's short instruction, optional instruction page,
- * and calendar event context, then delegates to the existing workflow executor.
+ * Loads the linked workflows row by trigger.workflowId, composes a
+ * WorkflowExecutionInput with the calendar event prompt as override,
+ * and delegates to the workflow executor. The executor never sees a
+ * synthetic row — input is built from authoritative state.
  */
 export async function executeCalendarTrigger(
   trigger: CalendarTrigger,
@@ -34,19 +37,31 @@ export async function executeCalendarTrigger(
       return { success: false, durationMs: Date.now() - startTime, error };
     }
 
-    // 2. Cheap preflight: verify agent page still exists before consuming a usage credit
-    const [agentPage] = await db
-      .select({ id: pages.id, isTrashed: pages.isTrashed })
-      .from(pages)
-      .where(eq(pages.id, trigger.agentPageId));
+    // 2. Load the linked workflows row (the trigger holds only "when"; payload lives on workflows)
+    const [workflow] = await db
+      .select()
+      .from(workflows)
+      .where(eq(workflows.id, trigger.workflowId));
 
-    if (!agentPage || agentPage.isTrashed) {
-      const error = `Trigger agent page ${trigger.agentPageId} not found or trashed`;
+    if (!workflow) {
+      const error = `Linked workflow ${trigger.workflowId} not found`;
       await markTriggerFailed(trigger.id, error, Date.now() - startTime);
       return { success: false, durationMs: Date.now() - startTime, error };
     }
 
-    // 3. Rate-limit check: consume one standard AI call from the scheduler's budget
+    // 3. Cheap preflight: verify agent page still exists before consuming a usage credit
+    const [agentPage] = await db
+      .select({ id: pages.id, isTrashed: pages.isTrashed })
+      .from(pages)
+      .where(eq(pages.id, workflow.agentPageId));
+
+    if (!agentPage || agentPage.isTrashed) {
+      const error = `Trigger agent page ${workflow.agentPageId} not found or trashed`;
+      await markTriggerFailed(trigger.id, error, Date.now() - startTime);
+      return { success: false, durationMs: Date.now() - startTime, error };
+    }
+
+    // 4. Rate-limit check: consume one standard AI call from the scheduler's budget
     const usageResult = await incrementUsage(trigger.scheduledById, 'standard');
     if (!usageResult.success) {
       const error = 'Daily AI call limit reached for scheduling user';
@@ -54,39 +69,26 @@ export async function executeCalendarTrigger(
       return { success: false, durationMs: Date.now() - startTime, error };
     }
 
-    // 4. Build prompt from trigger instructions + instruction page + event context
-    const prompt = await buildTriggerPrompt(trigger, event);
+    // 5. Build the prompt from the workflow's stored prompt + event context.
+    //    The instruction page is loaded by executeWorkflow (input.instructionPageId),
+    //    so we don't double-inject it here.
+    const promptOverride = await buildTriggerPrompt(workflow.prompt, event);
 
-    // 5. Construct synthetic WorkflowRow that executeWorkflow can consume.
-    //    We only populate the fields the executor actually reads.
-    const syntheticWorkflow = {
-      id: trigger.id,
-      driveId: trigger.driveId,
+    // 6. Compose execution input — no synthetic WorkflowRow
+    const input: WorkflowExecutionInput = {
+      workflowId: workflow.id,
+      workflowName: `calendar-trigger-${trigger.id}`,
+      driveId: workflow.driveId,
       createdBy: trigger.scheduledById,
-      name: `calendar-trigger-${trigger.id}`,
-      agentPageId: trigger.agentPageId,
-      prompt,
-      contextPageIds: trigger.contextPageIds,
-      cronExpression: null,
+      agentPageId: workflow.agentPageId,
+      prompt: workflow.prompt,
+      contextPageIds: (workflow.contextPageIds as string[] | null) ?? [],
+      instructionPageId: workflow.instructionPageId,
       timezone: event.timezone,
-      triggerType: 'cron' as const,
-      eventTriggers: null,
-      watchedFolderIds: null,
-      eventDebounceSecs: null,
-      taskItemId: null,
-      instructionPageId: null, // already loaded by buildTriggerPrompt — avoid double injection
-      isEnabled: true,
-      lastRunAt: null,
-      nextRunAt: null,
-      lastRunStatus: 'never_run' as const,
-      lastRunError: null,
-      lastRunDurationMs: null,
-      createdAt: trigger.createdAt,
-      updatedAt: trigger.updatedAt,
+      eventContext: { promptOverride },
     };
 
-    // 6. Execute via the standard workflow executor
-    const result = await executeWorkflow(syntheticWorkflow);
+    const result = await executeWorkflow(input);
 
     // 7. Update trigger with execution results
     await db
@@ -102,7 +104,8 @@ export async function executeCalendarTrigger(
 
     logger.info('Calendar trigger executed', {
       triggerId: trigger.id,
-      agentPageId: trigger.agentPageId,
+      workflowId: workflow.id,
+      agentPageId: workflow.agentPageId,
       success: result.success,
       durationMs: result.durationMs,
     });
@@ -124,7 +127,7 @@ export async function executeCalendarTrigger(
   }
 }
 
-async function buildTriggerPrompt(trigger: CalendarTrigger, event: CalendarEvent): Promise<string> {
+async function buildTriggerPrompt(workflowPrompt: string, event: CalendarEvent): Promise<string> {
   const parts: string[] = [];
 
   // Event context
@@ -146,32 +149,8 @@ async function buildTriggerPrompt(trigger: CalendarTrigger, event: CalendarEvent
   }
   parts.push('</scheduled-event>');
 
-  // Instruction page content (if linked) — verify access hasn't been revoked since scheduling
-  if (trigger.instructionPageId) {
-    const [instructionPage] = await db
-      .select({ title: pages.title, content: pages.content, driveId: pages.driveId })
-      .from(pages)
-      .where(and(eq(pages.id, trigger.instructionPageId), eq(pages.isTrashed, false)));
-
-    if (instructionPage?.content) {
-      // Re-check access: scheduler must still have access to the instruction page's drive
-      let hasAccess = true;
-      if (instructionPage.driveId) {
-        hasAccess = await isUserDriveMember(trigger.scheduledById, instructionPage.driveId);
-      } else {
-        hasAccess = false; // personal pages rejected at schedule time, guard here too
-      }
-
-      if (hasAccess) {
-        parts.push('\n--- Detailed Instructions ---');
-        parts.push(`## ${instructionPage.title}`);
-        parts.push(instructionPage.content);
-      }
-    }
-  }
-
-  // Agent's short prompt instruction
-  parts.push(`\n${trigger.prompt}`);
+  // The workflow's stored prompt becomes the instruction line at the end
+  parts.push(`\n${workflowPrompt}`);
 
   return parts.join('\n');
 }
@@ -194,3 +173,4 @@ async function markTriggerFailed(triggerId: string, error: string, durationMs: n
     });
   }
 }
+

--- a/apps/web/src/lib/workflows/calendar-trigger-helpers.ts
+++ b/apps/web/src/lib/workflows/calendar-trigger-helpers.ts
@@ -1,0 +1,58 @@
+import type { db as DbType } from '@pagespace/db/db';
+import { workflows } from '@pagespace/db/schema/workflows';
+import { calendarTriggers } from '@pagespace/db/schema/calendar-triggers';
+
+export interface CalendarAgentTriggerInput {
+  agentPageId: string;
+  prompt?: string;
+  instructionPageId?: string | null;
+  contextPageIds?: string[];
+}
+
+export interface CreateCalendarTriggerWorkflowParams {
+  tx: Parameters<Parameters<typeof DbType.transaction>[0]>[0];
+  driveId: string;
+  scheduledById: string;
+  calendarEventId: string;
+  triggerAt: Date;
+  timezone: string;
+  agentTrigger: CalendarAgentTriggerInput;
+}
+
+/**
+ * Atomically write the workflows row (execution payload) and the
+ * calendar_triggers row (the "when") inside a caller-supplied transaction.
+ * Validation of the agent / instruction / context pages is the caller's
+ * responsibility — by this point those checks must have passed.
+ */
+export async function createCalendarTriggerWorkflow(
+  params: CreateCalendarTriggerWorkflowParams,
+): Promise<{ workflowId: string; triggerId: string }> {
+  const { tx, driveId, scheduledById, calendarEventId, triggerAt, timezone, agentTrigger } = params;
+  const triggerPrompt = agentTrigger.prompt || 'Execute instructions from linked page.';
+
+  const [createdWorkflow] = await tx.insert(workflows).values({
+    driveId,
+    createdBy: scheduledById,
+    name: `calendar-trigger-${calendarEventId}`,
+    agentPageId: agentTrigger.agentPageId,
+    prompt: triggerPrompt,
+    instructionPageId: agentTrigger.instructionPageId ?? null,
+    contextPageIds: agentTrigger.contextPageIds ?? [],
+    triggerType: 'cron',
+    timezone,
+    isEnabled: true,
+    lastRunStatus: 'never_run',
+  }).returning({ id: workflows.id });
+
+  const [createdTrigger] = await tx.insert(calendarTriggers).values({
+    workflowId: createdWorkflow.id,
+    calendarEventId,
+    driveId,
+    scheduledById,
+    status: 'pending',
+    triggerAt,
+  }).returning({ id: calendarTriggers.id });
+
+  return { workflowId: createdWorkflow.id, triggerId: createdTrigger.id };
+}

--- a/apps/web/src/lib/workflows/task-trigger-helpers.ts
+++ b/apps/web/src/lib/workflows/task-trigger-helpers.ts
@@ -333,30 +333,30 @@ export async function fireCompletionTrigger(taskId: string): Promise<void> {
 
 /**
  * Disable all task triggers for a given task and delete their linked workflows
- * rows. Used when a task is deleted or trashed. The workflows row is the
- * execution definition; once no trigger references it, it's garbage — explicit
- * cleanup keeps the workflows table free of orphans (cascade goes the other
- * way: deleting a workflow cascades to its task_triggers row, but the inverse
- * is what we need here).
+ * rows. MUST be called BEFORE the task is hard-deleted: task_triggers.taskItemId
+ * has ON DELETE CASCADE, so deleting taskItems first wipes task_triggers and
+ * the SELECT here returns empty, leaking orphan workflows rows.
+ *
+ * The function deletes the workflows rows; cascade wipes the task_triggers
+ * rows via task_triggers.workflowId FK. No bookkeeping UPDATE is needed —
+ * that earlier UPDATE was wasted work since the rows were about to be gone.
+ *
+ * The reason parameter is logged on failure but is not persisted (the rows
+ * are deleted, not flagged).
  */
 export async function disableTaskTriggers(taskId: string, reason: string): Promise<void> {
   try {
     const triggerRows = await db
-      .select({ id: taskTriggers.id, workflowId: taskTriggers.workflowId })
+      .select({ workflowId: taskTriggers.workflowId })
       .from(taskTriggers)
       .where(eq(taskTriggers.taskItemId, taskId));
 
     if (triggerRows.length === 0) return;
 
-    await db.update(taskTriggers).set({
-      isEnabled: false,
-      lastFireError: reason,
-    }).where(eq(taskTriggers.taskItemId, taskId));
-
     const workflowIds = triggerRows.map(r => r.workflowId);
     await db.delete(workflows).where(inArray(workflows.id, workflowIds));
   } catch (err) {
     const errorMsg = err instanceof Error ? err.message : String(err);
-    logger.error('Failed to disable task triggers', { taskItemId: taskId, error: errorMsg });
+    logger.error('Failed to disable task triggers', { taskItemId: taskId, reason, error: errorMsg });
   }
 }

--- a/apps/web/src/lib/workflows/task-trigger-helpers.ts
+++ b/apps/web/src/lib/workflows/task-trigger-helpers.ts
@@ -58,10 +58,16 @@ export async function recomputeTaskTriggerMetadata(
 
 /**
  * Create (or upsert) a task trigger.
- * Validates agent page, instruction page, and context pages, then atomically writes
- * one workflows row (execution payload) and one task_triggers row (the "when") in
- * a transaction. Uses onConflictDoUpdate on task_triggers (taskItemId, triggerType)
- * to handle duplicates — the matching workflows row is updated in-place.
+ *
+ * Validates agent page, instruction page, and context pages, then atomically
+ * writes one workflows row (execution payload) and one task_triggers row
+ * (the "when") in a single transaction. The transaction reads the existing
+ * task_triggers row (if any) by (taskItemId, triggerType) and either updates
+ * the linked workflow + trigger in place, or inserts a fresh pair. The
+ * select-then-branch shape is intentional: a single onConflictDoUpdate would
+ * orphan the previously-linked workflows row when the workflowId changes,
+ * and reusing the same workflowId across upserts means the workflow update
+ * targets a known id rather than a returned excluded.workflowId.
  */
 export async function createTaskTriggerWorkflow(params: CreateTaskTriggerWorkflowParams): Promise<void> {
   const { database, driveId, userId, taskId, taskMetadata, agentTrigger, dueDate, timezone } = params;

--- a/apps/web/src/lib/workflows/task-trigger-helpers.ts
+++ b/apps/web/src/lib/workflows/task-trigger-helpers.ts
@@ -3,7 +3,8 @@ import { eq, and, inArray } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core'
 import { taskItems } from '@pagespace/db/schema/tasks'
 import { workflows } from '@pagespace/db/schema/workflows';
-import { executeWorkflow } from './workflow-executor';
+import { taskTriggers } from '@pagespace/db/schema/task-triggers';
+import { executeWorkflow, type WorkflowExecutionInput } from './workflow-executor';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 
 export interface AgentTriggerInput {
@@ -27,13 +28,11 @@ export interface CreateTaskTriggerWorkflowParams {
 
 const logger = loggers.api.child({ module: 'task-trigger-helpers' });
 
-const TASK_TRIGGER_TYPES: ('task_due_date' | 'task_completion')[] = ['task_due_date', 'task_completion'];
-
 /**
- * Recompute taskItems.metadata.triggerTypes / hasTrigger from the live workflows table.
+ * Recompute taskItems.metadata.triggerTypes / hasTrigger from the live taskTriggers table.
  * Use this after any insert/upsert/disable so metadata never drifts from DB truth — in
- * particular it stays correct when an agent page cascade-deletes a workflow row without
- * touching the task.
+ * particular it stays correct when an agent page cascade-deletes a workflow row, which
+ * cascades to its task_triggers row, without touching the task itself.
  */
 export async function recomputeTaskTriggerMetadata(
   database: typeof db,
@@ -41,12 +40,11 @@ export async function recomputeTaskTriggerMetadata(
   baseMetadata: Record<string, unknown> | null,
 ): Promise<void> {
   const rows = await database
-    .select({ triggerType: workflows.triggerType })
-    .from(workflows)
+    .select({ triggerType: taskTriggers.triggerType })
+    .from(taskTriggers)
     .where(and(
-      eq(workflows.taskItemId, taskId),
-      eq(workflows.isEnabled, true),
-      inArray(workflows.triggerType, TASK_TRIGGER_TYPES),
+      eq(taskTriggers.taskItemId, taskId),
+      eq(taskTriggers.isEnabled, true),
     ));
   const triggerTypes = Array.from(new Set(rows.map((r) => r.triggerType)));
   await database.update(taskItems).set({
@@ -59,22 +57,23 @@ export async function recomputeTaskTriggerMetadata(
 }
 
 /**
- * Create (or upsert) a task trigger workflow.
- * Validates agent page, instruction page, and context pages before inserting.
- * Uses onConflictDoUpdate on (taskItemId, triggerType) to handle duplicates.
+ * Create (or upsert) a task trigger.
+ * Validates agent page, instruction page, and context pages, then atomically writes
+ * one workflows row (execution payload) and one task_triggers row (the "when") in
+ * a transaction. Uses onConflictDoUpdate on task_triggers (taskItemId, triggerType)
+ * to handle duplicates — the matching workflows row is updated in-place.
  */
 export async function createTaskTriggerWorkflow(params: CreateTaskTriggerWorkflowParams): Promise<void> {
   const { database, driveId, userId, taskId, taskMetadata, agentTrigger, dueDate, timezone } = params;
-  const triggerType = agentTrigger.triggerType === 'completion' ? 'task_completion' as const : 'task_due_date' as const;
+  const triggerType = agentTrigger.triggerType;
 
-  if (triggerType === 'task_due_date' && !dueDate) {
+  if (triggerType === 'due_date' && !dueDate) {
     throw new Error('Due date is required for due_date triggers');
   }
   if (!agentTrigger.prompt && !agentTrigger.instructionPageId) {
     throw new Error('Agent trigger needs either a prompt or instructionPageId');
   }
 
-  // Validate agent page
   const triggerAgent = await database.query.pages.findFirst({
     where: and(eq(pages.id, agentTrigger.agentPageId), eq(pages.type, 'AI_CHAT'), eq(pages.isTrashed, false)),
     columns: { id: true, driveId: true },
@@ -82,7 +81,6 @@ export async function createTaskTriggerWorkflow(params: CreateTaskTriggerWorkflo
   if (!triggerAgent) throw new Error('Agent trigger target not found or not an AI agent');
   if (triggerAgent.driveId !== driveId) throw new Error('Agent must be in the same drive as the task list');
 
-  // Validate instruction page if provided
   if (agentTrigger.instructionPageId) {
     const instrPage = await database.query.pages.findFirst({
       where: and(eq(pages.id, agentTrigger.instructionPageId), eq(pages.driveId, driveId), eq(pages.isTrashed, false)),
@@ -91,7 +89,6 @@ export async function createTaskTriggerWorkflow(params: CreateTaskTriggerWorkflo
     if (!instrPage) throw new Error('Instruction page not found or not in the same drive');
   }
 
-  // Validate context pages if provided
   const contextPageIds = agentTrigger.contextPageIds ?? [];
   if (contextPageIds.length > 0) {
     const validPages = await database.query.pages.findMany({
@@ -108,66 +105,91 @@ export async function createTaskTriggerWorkflow(params: CreateTaskTriggerWorkflo
   }
 
   const triggerPrompt = agentTrigger.prompt || 'Execute instructions from linked page.';
-  const workflowData = {
-    driveId,
-    createdBy: userId,
-    name: `task-trigger-${triggerType}-${taskId}`,
-    agentPageId: agentTrigger.agentPageId,
-    prompt: triggerPrompt,
-    instructionPageId: agentTrigger.instructionPageId ?? null,
-    contextPageIds,
-    triggerType,
-    taskItemId: taskId,
-    timezone,
-    isEnabled: true,
-    nextRunAt: triggerType === 'task_due_date' && dueDate ? dueDate : null,
-    lastRunStatus: 'never_run' as const,
-  };
+  const nextRunAt = triggerType === 'due_date' && dueDate ? dueDate : null;
 
-  await database.insert(workflows).values(workflowData).onConflictDoUpdate({
-    target: [workflows.taskItemId, workflows.triggerType],
-    set: {
-      agentPageId: workflowData.agentPageId,
-      prompt: workflowData.prompt,
-      instructionPageId: workflowData.instructionPageId,
-      contextPageIds: workflowData.contextPageIds,
-      nextRunAt: workflowData.nextRunAt,
-      isEnabled: true,
-      lastRunStatus: 'never_run',
-      lastRunError: null,
-    },
+  await database.transaction(async (tx) => {
+    const existing = await tx
+      .select({ workflowId: taskTriggers.workflowId })
+      .from(taskTriggers)
+      .where(and(
+        eq(taskTriggers.taskItemId, taskId),
+        eq(taskTriggers.triggerType, triggerType),
+      ));
+
+    if (existing.length > 0) {
+      const workflowId = existing[0].workflowId;
+      await tx.update(workflows).set({
+        agentPageId: agentTrigger.agentPageId,
+        prompt: triggerPrompt,
+        instructionPageId: agentTrigger.instructionPageId ?? null,
+        contextPageIds,
+        timezone,
+        isEnabled: true,
+        lastRunStatus: 'never_run',
+        lastRunError: null,
+      }).where(eq(workflows.id, workflowId));
+
+      await tx.update(taskTriggers).set({
+        nextRunAt,
+        lastFiredAt: null,
+        lastFireError: null,
+        isEnabled: true,
+      }).where(and(
+        eq(taskTriggers.taskItemId, taskId),
+        eq(taskTriggers.triggerType, triggerType),
+      ));
+    } else {
+      const [createdWorkflow] = await tx.insert(workflows).values({
+        driveId,
+        createdBy: userId,
+        name: `task-trigger-${triggerType}-${taskId}`,
+        agentPageId: agentTrigger.agentPageId,
+        prompt: triggerPrompt,
+        instructionPageId: agentTrigger.instructionPageId ?? null,
+        contextPageIds,
+        triggerType: 'cron',
+        timezone,
+        isEnabled: true,
+        lastRunStatus: 'never_run',
+      }).returning({ id: workflows.id });
+
+      await tx.insert(taskTriggers).values({
+        workflowId: createdWorkflow.id,
+        taskItemId: taskId,
+        triggerType,
+        nextRunAt,
+        isEnabled: true,
+      });
+    }
   });
 
-  // Recompute metadata from the live workflows table so it never drifts from DB truth.
   await recomputeTaskTriggerMetadata(database, taskId, taskMetadata);
 }
 
 /**
  * Update the nextRunAt for a task's due-date trigger when the due date changes.
- * Only affects pending (never_run) triggers.
+ * Only affects rows that haven't fired yet (lastFiredAt IS NULL).
  */
 export async function syncTaskDueDateTrigger(taskId: string, newDueDate: Date | null): Promise<void> {
   try {
     if (newDueDate) {
-      await db.update(workflows).set({ nextRunAt: newDueDate }).where(
+      await db.update(taskTriggers).set({ nextRunAt: newDueDate }).where(
         and(
-          eq(workflows.taskItemId, taskId),
-          eq(workflows.triggerType, 'task_due_date'),
-          eq(workflows.isEnabled, true),
-          eq(workflows.lastRunStatus, 'never_run'),
+          eq(taskTriggers.taskItemId, taskId),
+          eq(taskTriggers.triggerType, 'due_date'),
+          eq(taskTriggers.isEnabled, true),
         ),
       );
     } else {
-      // Due date cleared — disable the trigger
-      await db.update(workflows).set({
+      await db.update(taskTriggers).set({
         isEnabled: false,
-        lastRunError: 'Due date cleared',
+        lastFireError: 'Due date cleared',
         nextRunAt: null,
       }).where(
         and(
-          eq(workflows.taskItemId, taskId),
-          eq(workflows.triggerType, 'task_due_date'),
-          eq(workflows.isEnabled, true),
+          eq(taskTriggers.taskItemId, taskId),
+          eq(taskTriggers.triggerType, 'due_date'),
+          eq(taskTriggers.isEnabled, true),
         ),
       );
     }
@@ -182,15 +204,14 @@ export async function syncTaskDueDateTrigger(taskId: string, newDueDate: Date | 
  */
 export async function cancelTaskDueDateTrigger(taskId: string, reason: string): Promise<void> {
   try {
-    await db.update(workflows).set({
+    await db.update(taskTriggers).set({
       isEnabled: false,
-      lastRunError: reason,
+      lastFireError: reason,
     }).where(
       and(
-        eq(workflows.taskItemId, taskId),
-        eq(workflows.triggerType, 'task_due_date'),
-        eq(workflows.isEnabled, true),
-        eq(workflows.lastRunStatus, 'never_run'),
+        eq(taskTriggers.taskItemId, taskId),
+        eq(taskTriggers.triggerType, 'due_date'),
+        eq(taskTriggers.isEnabled, true),
       ),
     );
   } catch (err) {
@@ -201,57 +222,77 @@ export async function cancelTaskDueDateTrigger(taskId: string, reason: string): 
 
 /**
  * Fire a task's completion trigger.
- * Uses .returning() on the claim UPDATE to prevent double-execution under concurrency.
+ * Atomically claims the matching task_triggers row (lastFiredAt IS NULL guard) so
+ * one fire ever happens per row, then loads the linked workflow and executes it.
  */
 export async function fireCompletionTrigger(taskId: string): Promise<void> {
   try {
-    const [completionWorkflow] = await db
+    const [completionTrigger] = await db
       .select()
-      .from(workflows)
+      .from(taskTriggers)
       .where(
         and(
-          eq(workflows.taskItemId, taskId),
-          eq(workflows.triggerType, 'task_completion'),
-          eq(workflows.isEnabled, true),
-          eq(workflows.lastRunStatus, 'never_run'),
+          eq(taskTriggers.taskItemId, taskId),
+          eq(taskTriggers.triggerType, 'completion'),
+          eq(taskTriggers.isEnabled, true),
         ),
       );
 
-    if (!completionWorkflow) return;
+    if (!completionTrigger || completionTrigger.lastFiredAt !== null) return;
 
-    // Atomically claim — only proceed if we actually updated a row
-    // Re-check isEnabled to guard against concurrent disableTaskTriggers
-    const claimed = await db.update(workflows).set({
-      lastRunStatus: 'running',
-      lastRunAt: new Date(),
+    const claimed = await db.update(taskTriggers).set({
+      lastFiredAt: new Date(),
     }).where(
       and(
-        eq(workflows.id, completionWorkflow.id),
-        eq(workflows.lastRunStatus, 'never_run'),
-        eq(workflows.isEnabled, true),
+        eq(taskTriggers.id, completionTrigger.id),
+        eq(taskTriggers.isEnabled, true),
       ),
     ).returning();
 
-    if (claimed.length === 0) return; // Another caller already claimed it
+    if (claimed.length === 0) return;
 
-    // Fire-and-forget execution with fully guarded promise chain
-    void executeWorkflow(completionWorkflow).then(async (result) => {
+    const [workflow] = await db
+      .select()
+      .from(workflows)
+      .where(eq(workflows.id, completionTrigger.workflowId));
+
+    if (!workflow) {
+      await db.update(taskTriggers).set({
+        isEnabled: false,
+        lastFireError: 'Linked workflow not found',
+      }).where(eq(taskTriggers.id, completionTrigger.id));
+      return;
+    }
+
+    const input: WorkflowExecutionInput = {
+      workflowId: workflow.id,
+      workflowName: workflow.name,
+      driveId: workflow.driveId,
+      createdBy: workflow.createdBy,
+      agentPageId: workflow.agentPageId,
+      prompt: workflow.prompt,
+      contextPageIds: (workflow.contextPageIds as string[] | null) ?? [],
+      instructionPageId: workflow.instructionPageId,
+      timezone: workflow.timezone,
+      taskContext: { taskItemId: taskId, triggerType: 'completion' },
+    };
+
+    void executeWorkflow(input).then(async (result) => {
       try {
-        await db.update(workflows).set({
-          lastRunStatus: result.success ? 'success' : 'error',
-          lastRunError: result.error || null,
-          lastRunDurationMs: result.durationMs,
+        await db.update(taskTriggers).set({
+          lastFireError: result.error || null,
           isEnabled: false,
-        }).where(eq(workflows.id, completionWorkflow.id));
+        }).where(eq(taskTriggers.id, completionTrigger.id));
       } catch (dbErr) {
-        logger.error('Failed to update workflow status after execution', {
-          workflowId: completionWorkflow.id,
+        logger.error('Failed to update task_trigger after execution', {
+          triggerId: completionTrigger.id,
           error: dbErr instanceof Error ? dbErr.message : String(dbErr),
         });
       }
 
       logger.info('Completion trigger executed', {
-        workflowId: completionWorkflow.id,
+        triggerId: completionTrigger.id,
+        workflowId: workflow.id,
         taskItemId: taskId,
         success: result.success,
         durationMs: result.durationMs,
@@ -259,19 +300,19 @@ export async function fireCompletionTrigger(taskId: string): Promise<void> {
     }).catch(async (err) => {
       const errorMsg = err instanceof Error ? err.message : String(err);
       logger.error('Completion trigger execution failed', {
-        workflowId: completionWorkflow.id,
+        triggerId: completionTrigger.id,
+        workflowId: workflow.id,
         taskItemId: taskId,
         error: errorMsg,
       });
       try {
-        await db.update(workflows).set({
-          lastRunStatus: 'error',
-          lastRunError: errorMsg,
+        await db.update(taskTriggers).set({
+          lastFireError: errorMsg,
           isEnabled: false,
-        }).where(eq(workflows.id, completionWorkflow.id));
+        }).where(eq(taskTriggers.id, completionTrigger.id));
       } catch (dbErr) {
-        logger.error('Failed to update workflow error status', {
-          workflowId: completionWorkflow.id,
+        logger.error('Failed to update task_trigger error status', {
+          triggerId: completionTrigger.id,
           error: dbErr instanceof Error ? dbErr.message : String(dbErr),
         });
       }
@@ -283,20 +324,29 @@ export async function fireCompletionTrigger(taskId: string): Promise<void> {
 }
 
 /**
- * Disable all task trigger workflows for a given task.
- * Used when a task is deleted or trashed.
+ * Disable all task triggers for a given task and delete their linked workflows
+ * rows. Used when a task is deleted or trashed. The workflows row is the
+ * execution definition; once no trigger references it, it's garbage — explicit
+ * cleanup keeps the workflows table free of orphans (cascade goes the other
+ * way: deleting a workflow cascades to its task_triggers row, but the inverse
+ * is what we need here).
  */
 export async function disableTaskTriggers(taskId: string, reason: string): Promise<void> {
   try {
-    await db.update(workflows).set({
+    const triggerRows = await db
+      .select({ id: taskTriggers.id, workflowId: taskTriggers.workflowId })
+      .from(taskTriggers)
+      .where(eq(taskTriggers.taskItemId, taskId));
+
+    if (triggerRows.length === 0) return;
+
+    await db.update(taskTriggers).set({
       isEnabled: false,
-      lastRunError: reason,
-    }).where(
-      and(
-        eq(workflows.taskItemId, taskId),
-        eq(workflows.isEnabled, true),
-      ),
-    );
+      lastFireError: reason,
+    }).where(eq(taskTriggers.taskItemId, taskId));
+
+    const workflowIds = triggerRows.map(r => r.workflowId);
+    await db.delete(workflows).where(inArray(workflows.id, workflowIds));
   } catch (err) {
     const errorMsg = err instanceof Error ? err.message : String(err);
     logger.error('Failed to disable task triggers', { taskItemId: taskId, error: errorMsg });

--- a/apps/web/src/lib/workflows/task-trigger-helpers.ts
+++ b/apps/web/src/lib/workflows/task-trigger-helpers.ts
@@ -243,12 +243,17 @@ export async function fireCompletionTrigger(taskId: string): Promise<void> {
 
     if (!completionTrigger || completionTrigger.lastFiredAt !== null) return;
 
+    // Atomic claim: lastFiredAt IS NULL guard prevents double-fire under
+    // concurrent callers. Both might pass the SELECT above (both see
+    // lastFiredAt=null) but only the first UPDATE will match — the second
+    // sees the now-set lastFiredAt and updates 0 rows.
     const claimed = await db.update(taskTriggers).set({
       lastFiredAt: new Date(),
     }).where(
       and(
         eq(taskTriggers.id, completionTrigger.id),
         eq(taskTriggers.isEnabled, true),
+        isNull(taskTriggers.lastFiredAt),
       ),
     ).returning();
 

--- a/apps/web/src/lib/workflows/task-trigger-helpers.ts
+++ b/apps/web/src/lib/workflows/task-trigger-helpers.ts
@@ -1,5 +1,5 @@
 import { db } from '@pagespace/db/db'
-import { eq, and, inArray } from '@pagespace/db/operators'
+import { eq, and, inArray, isNull } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core'
 import { taskItems } from '@pagespace/db/schema/tasks'
 import { workflows } from '@pagespace/db/schema/workflows';
@@ -178,6 +178,7 @@ export async function syncTaskDueDateTrigger(taskId: string, newDueDate: Date | 
           eq(taskTriggers.taskItemId, taskId),
           eq(taskTriggers.triggerType, 'due_date'),
           eq(taskTriggers.isEnabled, true),
+          isNull(taskTriggers.lastFiredAt),
         ),
       );
     } else {
@@ -190,6 +191,7 @@ export async function syncTaskDueDateTrigger(taskId: string, newDueDate: Date | 
           eq(taskTriggers.taskItemId, taskId),
           eq(taskTriggers.triggerType, 'due_date'),
           eq(taskTriggers.isEnabled, true),
+          isNull(taskTriggers.lastFiredAt),
         ),
       );
     }
@@ -212,6 +214,7 @@ export async function cancelTaskDueDateTrigger(taskId: string, reason: string): 
         eq(taskTriggers.taskItemId, taskId),
         eq(taskTriggers.triggerType, 'due_date'),
         eq(taskTriggers.isEnabled, true),
+        isNull(taskTriggers.lastFiredAt),
       ),
     );
   } catch (err) {

--- a/apps/web/src/lib/workflows/workflow-executor.ts
+++ b/apps/web/src/lib/workflows/workflow-executor.ts
@@ -17,7 +17,6 @@ import { eq, and, inArray } from '@pagespace/db/operators'
 import { users } from '@pagespace/db/schema/auth'
 import { pages, drives } from '@pagespace/db/schema/core'
 import { taskItems, taskAssignees, taskStatusConfigs } from '@pagespace/db/schema/tasks'
-import { workflows as workflowsTable } from '@pagespace/db/schema/workflows';
 import { isUserDriveMember } from '@pagespace/lib/permissions/permissions';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 
@@ -31,9 +30,32 @@ export interface WorkflowExecutionResult {
   conversationId?: string;
 }
 
-type WorkflowRow = typeof workflowsTable.$inferSelect;
+/**
+ * Minimum execution-relevant shape consumed by executeWorkflow().
+ *
+ * Decoupled from the workflows table row so callers (cron pollers,
+ * task-trigger fires, calendar-trigger fires, manual /run) can compose
+ * input from their own source of truth without forging fake rows.
+ *
+ * `taskContext` and `eventContext` are optional, mutually exclusive
+ * augmentations injected by the trigger-fire path so executeWorkflow
+ * doesn't need to know which kind of trigger it serves.
+ */
+export interface WorkflowExecutionInput {
+  workflowId: string;
+  workflowName: string;
+  driveId: string;
+  createdBy: string;
+  agentPageId: string;
+  prompt: string;
+  contextPageIds: string[];
+  instructionPageId: string | null;
+  timezone: string;
+  taskContext?: { taskItemId: string; triggerType: 'due_date' | 'completion' };
+  eventContext?: { promptOverride: string };
+}
 
-export async function executeWorkflow(workflow: WorkflowRow): Promise<WorkflowExecutionResult> {
+export async function executeWorkflow(input: WorkflowExecutionInput): Promise<WorkflowExecutionResult> {
   const startTime = Date.now();
 
   try {
@@ -41,7 +63,7 @@ export async function executeWorkflow(workflow: WorkflowRow): Promise<WorkflowEx
     const [agent] = await db
       .select()
       .from(pages)
-      .where(eq(pages.id, workflow.agentPageId));
+      .where(eq(pages.id, input.agentPageId));
 
     if (!agent) {
       return { success: false, durationMs: Date.now() - startTime, error: 'Agent page not found' };
@@ -57,7 +79,7 @@ export async function executeWorkflow(workflow: WorkflowRow): Promise<WorkflowEx
     const [drive] = await db
       .select()
       .from(drives)
-      .where(eq(drives.id, workflow.driveId));
+      .where(eq(drives.id, input.driveId));
 
     if (!drive) {
       return { success: false, durationMs: Date.now() - startTime, error: 'Drive not found' };
@@ -71,7 +93,7 @@ export async function executeWorkflow(workflow: WorkflowRow): Promise<WorkflowEx
       enhancedSystemPrompt += `\n\n${drive.drivePrompt}`;
     }
 
-    enhancedSystemPrompt += `\n\n${buildTimestampSystemPrompt(workflow.timezone)}`;
+    enhancedSystemPrompt += `\n\n${buildTimestampSystemPrompt(input.timezone)}`;
 
     enhancedSystemPrompt += `\n\nCONTEXT AWARENESS:\n`;
     enhancedSystemPrompt += `- Current Drive: ${drive.name} (${drive.slug})\n`;
@@ -79,10 +101,10 @@ export async function executeWorkflow(workflow: WorkflowRow): Promise<WorkflowEx
     enhancedSystemPrompt += `\nYou are operating within this drive. Use this drive ID (${drive.id}) as the default when using tools like list_pages, create_page, etc. unless explicitly told otherwise.`;
     enhancedSystemPrompt += `\n\nThis is an automated workflow execution. Execute the requested task thoroughly and completely.`;
 
-    // 4. Build user message with context documents
-    let userMessage = workflow.prompt;
+    // 4. Build user message — start from event override (if any) or workflow prompt
+    let userMessage = input.eventContext?.promptOverride ?? input.prompt;
 
-    const contextPageIds = (workflow.contextPageIds as string[] | null) ?? [];
+    const contextPageIds = input.contextPageIds ?? [];
     if (contextPageIds.length > 0) {
       const validContextPages = await db
         .select({ id: pages.id, title: pages.title, content: pages.content })
@@ -90,7 +112,7 @@ export async function executeWorkflow(workflow: WorkflowRow): Promise<WorkflowEx
         .where(
           and(
             inArray(pages.id, contextPageIds),
-            eq(pages.driveId, workflow.driveId),
+            eq(pages.driveId, input.driveId),
             eq(pages.isTrashed, false)
           )
         );
@@ -103,17 +125,17 @@ export async function executeWorkflow(workflow: WorkflowRow): Promise<WorkflowEx
       }
     }
 
-    // 4b. Inject task context when this is a task trigger workflow
-    if (workflow.taskItemId) {
-      const taskContext = await buildTaskContext(workflow.taskItemId, workflow.triggerType);
+    // 4b. Inject task context when this fire was triggered by a task event
+    if (input.taskContext) {
+      const taskContext = await buildTaskContext(input.taskContext.taskItemId, input.taskContext.triggerType);
       if (taskContext) {
         userMessage = taskContext + '\n\n' + userMessage;
       }
     }
 
     // 4c. Load instruction page content if present
-    if (workflow.instructionPageId) {
-      const instrContent = await loadInstructionPage(workflow.instructionPageId, workflow.createdBy);
+    if (input.instructionPageId) {
+      const instrContent = await loadInstructionPage(input.instructionPageId, input.createdBy);
       if (instrContent) {
         userMessage += '\n\n--- Detailed Instructions ---\n' + instrContent;
       }
@@ -128,7 +150,7 @@ export async function executeWorkflow(workflow: WorkflowRow): Promise<WorkflowEx
       selectedModel,
     };
 
-    const providerResult = await createAIProvider(workflow.createdBy, providerRequest);
+    const providerResult = await createAIProvider(input.createdBy, providerRequest);
 
     if (isProviderError(providerResult)) {
       return { success: false, durationMs: Date.now() - startTime, error: `AI provider error: ${providerResult.error}` };
@@ -150,14 +172,14 @@ export async function executeWorkflow(workflow: WorkflowRow): Promise<WorkflowEx
       const { resolvePageAgentIntegrationTools } = await import('@/lib/ai/core/integration-tool-resolver');
       const integrationTools = await resolvePageAgentIntegrationTools({
         agentId: agent.id,
-        userId: workflow.createdBy,
-        driveId: workflow.driveId,
+        userId: input.createdBy,
+        driveId: input.driveId,
       });
 
       if (Object.keys(integrationTools).length > 0) {
         availableTools = mergeToolSets(availableTools, integrationTools);
         loggers.api.info('Workflow executor: merged integration tools', {
-          workflowId: workflow.id,
+          workflowId: input.workflowId,
           agentId: agent.id,
           integrationToolCount: Object.keys(integrationTools).length,
           totalTools: Object.keys(availableTools).length,
@@ -165,16 +187,16 @@ export async function executeWorkflow(workflow: WorkflowRow): Promise<WorkflowEx
       }
     } catch (error) {
       loggers.api.error('Workflow executor: failed to resolve integration tools', error as Error, {
-        workflowId: workflow.id,
+        workflowId: input.workflowId,
         agentId: agent.id,
       });
     }
 
     // 7. Build execution context
-    const conversationId = `workflow-${workflow.id}-${Date.now()}`;
+    const conversationId = `workflow-${input.workflowId}-${Date.now()}`;
     const executionContext: ToolExecutionContext = {
-      userId: workflow.createdBy,
-      timezone: workflow.timezone,
+      userId: input.createdBy,
+      timezone: input.timezone,
       aiProvider: agent.aiProvider ?? undefined,
       aiModel: agent.aiModel ?? undefined,
       conversationId,
@@ -242,7 +264,7 @@ export async function executeWorkflow(workflow: WorkflowRow): Promise<WorkflowEx
       messageId: userMessageId,
       pageId: agent.id,
       conversationId,
-      userId: workflow.createdBy,
+      userId: input.createdBy,
       role: 'user',
       content: userMessage,
     });
@@ -259,22 +281,22 @@ export async function executeWorkflow(workflow: WorkflowRow): Promise<WorkflowEx
     // 10. Track usage
     const usage = result.usage;
     AIMonitoring.trackUsage({
-      userId: workflow.createdBy,
+      userId: input.createdBy,
       provider: providerResult.provider,
       model: providerResult.modelName,
       inputTokens: usage?.inputTokens,
       outputTokens: usage?.outputTokens,
       totalTokens: usage ? ((usage.inputTokens ?? 0) + (usage.outputTokens ?? 0)) : undefined,
       pageId: agent.id,
-      driveId: workflow.driveId,
+      driveId: input.driveId,
       success: true,
     });
 
     const durationMs = Date.now() - startTime;
 
     loggers.api.info('Workflow executed successfully', {
-      workflowId: workflow.id,
-      workflowName: workflow.name,
+      workflowId: input.workflowId,
+      workflowName: input.workflowName,
       agentId: agent.id,
       agentTitle: agent.title,
       responseLength: responseText.length,
@@ -296,7 +318,7 @@ export async function executeWorkflow(workflow: WorkflowRow): Promise<WorkflowEx
     const errorMessage = error instanceof Error ? error.message : String(error);
 
     loggers.api.error('Workflow execution failed', {
-      workflowId: workflow.id,
+      workflowId: input.workflowId,
       error: errorMessage,
       durationMs,
     });
@@ -312,7 +334,7 @@ export async function executeWorkflow(workflow: WorkflowRow): Promise<WorkflowEx
 /**
  * Build a task context block for task trigger workflows.
  */
-async function buildTaskContext(taskItemId: string, triggerType: string): Promise<string | null> {
+async function buildTaskContext(taskItemId: string, triggerType: 'due_date' | 'completion'): Promise<string | null> {
   const task = await db.query.taskItems.findFirst({
     where: eq(taskItems.id, taskItemId),
     with: {
@@ -363,10 +385,9 @@ async function buildTaskContext(taskItemId: string, triggerType: string): Promis
     parts.push(`Assignees: ${names.join(', ')}`);
   }
 
-  // Trigger type context
-  if (triggerType === 'task_due_date') {
+  if (triggerType === 'due_date') {
     parts.push('Trigger: This task\'s due date has arrived.');
-  } else if (triggerType === 'task_completion') {
+  } else if (triggerType === 'completion') {
     parts.push('Trigger: This task was just completed.');
   }
 
@@ -374,9 +395,6 @@ async function buildTaskContext(taskItemId: string, triggerType: string): Promis
   return parts.join('\n');
 }
 
-/**
- * Load instruction page content for a workflow, re-checking drive access at execution time.
- */
 async function loadInstructionPage(pageId: string, userId: string): Promise<string | null> {
   const [instrPage] = await db
     .select({ title: pages.title, content: pages.content, driveId: pages.driveId, isTrashed: pages.isTrashed })
@@ -385,12 +403,11 @@ async function loadInstructionPage(pageId: string, userId: string): Promise<stri
 
   if (!instrPage || instrPage.isTrashed || !instrPage.content) return null;
 
-  // Re-check drive access at execution time
   if (instrPage.driveId) {
     const hasAccess = await isUserDriveMember(userId, instrPage.driveId);
     if (!hasAccess) return null;
   } else {
-    return null; // Personal pages not allowed
+    return null;
   }
 
   return `## ${instrPage.title}\n${instrPage.content}`;

--- a/packages/db/drizzle/0115_soft_kinsey_walden.sql
+++ b/packages/db/drizzle/0115_soft_kinsey_walden.sql
@@ -1,0 +1,88 @@
+-- Workflow Trigger Decomposition (PR 1/2):
+--
+--   * Drop workflows.taskItemId and remove the task_due_date / task_completion
+--     enum values from WorkflowTriggerType — task triggers move to a peer
+--     table.
+--   * Create task_triggers (workflowId FK + taskItemId + triggerType +
+--     scheduling fields) — one row per (taskItem, triggerType).
+--   * Add calendar_triggers.workflowId NOT NULL FK and drop the duplicated
+--     execution-payload columns (prompt, agentPageId, instructionPageId,
+--     contextPageIds); the workflows row referenced by workflowId is now the
+--     single source of truth for execution payload.
+--
+-- Hard cutover (no nullable bridge column, no dual-write). None of these
+-- tables hold meaningful prod data yet, so we TRUNCATE calendar_triggers and
+-- drop task-flavored workflows rows so the NOT NULL workflowId column and the
+-- recreated enum can be applied without leftover rows violating either.
+
+-- Hard-cutover wipe: remove rows that reference the columns/values being dropped.
+TRUNCATE TABLE "calendar_triggers";--> statement-breakpoint
+DELETE FROM "workflows" WHERE "triggerType" IN ('task_due_date', 'task_completion');--> statement-breakpoint
+
+-- Drop and recreate WorkflowTriggerType to remove the task-flavored values
+-- (Postgres has no DROP VALUE for an enum). Cast through text so any
+-- still-valid 'cron' / 'event' rows survive.
+ALTER TABLE "workflows" ALTER COLUMN "triggerType" DROP DEFAULT;--> statement-breakpoint
+ALTER TYPE "WorkflowTriggerType" RENAME TO "WorkflowTriggerType_old";--> statement-breakpoint
+CREATE TYPE "WorkflowTriggerType" AS ENUM('cron', 'event');--> statement-breakpoint
+ALTER TABLE "workflows" ALTER COLUMN "triggerType" TYPE "WorkflowTriggerType" USING ("triggerType"::text::"WorkflowTriggerType");--> statement-breakpoint
+ALTER TABLE "workflows" ALTER COLUMN "triggerType" SET DEFAULT 'cron';--> statement-breakpoint
+DROP TYPE "WorkflowTriggerType_old";--> statement-breakpoint
+
+DO $$ BEGIN
+ CREATE TYPE "public"."TaskTriggerType" AS ENUM('due_date', 'completion');
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "task_triggers" (
+	"id" text PRIMARY KEY NOT NULL,
+	"workflowId" text NOT NULL,
+	"taskItemId" text NOT NULL,
+	"triggerType" "TaskTriggerType" NOT NULL,
+	"nextRunAt" timestamp,
+	"lastFiredAt" timestamp,
+	"lastFireError" text,
+	"isEnabled" boolean DEFAULT true NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	"updatedAt" timestamp NOT NULL,
+	CONSTRAINT "task_triggers_task_item_trigger_type_key" UNIQUE("taskItemId","triggerType")
+);
+--> statement-breakpoint
+ALTER TABLE "workflows" DROP CONSTRAINT "workflows_task_item_trigger_type_key";--> statement-breakpoint
+ALTER TABLE "calendar_triggers" DROP CONSTRAINT "calendar_triggers_agentPageId_pages_id_fk";
+--> statement-breakpoint
+ALTER TABLE "calendar_triggers" DROP CONSTRAINT "calendar_triggers_instructionPageId_pages_id_fk";
+--> statement-breakpoint
+ALTER TABLE "workflows" DROP CONSTRAINT "workflows_taskItemId_task_items_id_fk";
+--> statement-breakpoint
+DROP INDEX IF EXISTS "calendar_triggers_agent_page_idx";--> statement-breakpoint
+DROP INDEX IF EXISTS "workflows_task_item_id_idx";--> statement-breakpoint
+ALTER TABLE "calendar_triggers" ADD COLUMN "workflowId" text NOT NULL;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "task_triggers" ADD CONSTRAINT "task_triggers_workflowId_workflows_id_fk" FOREIGN KEY ("workflowId") REFERENCES "public"."workflows"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "task_triggers" ADD CONSTRAINT "task_triggers_taskItemId_task_items_id_fk" FOREIGN KEY ("taskItemId") REFERENCES "public"."task_items"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "task_triggers_workflow_id_idx" ON "task_triggers" USING btree ("workflowId");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "task_triggers_task_item_id_idx" ON "task_triggers" USING btree ("taskItemId");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "task_triggers_enabled_next_run_idx" ON "task_triggers" USING btree ("isEnabled","nextRunAt");--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "calendar_triggers" ADD CONSTRAINT "calendar_triggers_workflowId_workflows_id_fk" FOREIGN KEY ("workflowId") REFERENCES "public"."workflows"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "calendar_triggers_workflow_id_idx" ON "calendar_triggers" USING btree ("workflowId");--> statement-breakpoint
+ALTER TABLE "calendar_triggers" DROP COLUMN IF EXISTS "agentPageId";--> statement-breakpoint
+ALTER TABLE "calendar_triggers" DROP COLUMN IF EXISTS "prompt";--> statement-breakpoint
+ALTER TABLE "calendar_triggers" DROP COLUMN IF EXISTS "instructionPageId";--> statement-breakpoint
+ALTER TABLE "calendar_triggers" DROP COLUMN IF EXISTS "contextPageIds";--> statement-breakpoint
+ALTER TABLE "workflows" DROP COLUMN IF EXISTS "taskItemId";

--- a/packages/db/drizzle/meta/0115_snapshot.json
+++ b/packages/db/drizzle/meta/0115_snapshot.json
@@ -1,0 +1,13561 @@
+{
+  "id": "85b543c7-3482-4def-9265-6a010b7046e2",
+  "prevId": "57ff0f4b-bcd3-478e-9680-3261a55d732b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.device_tokens": {
+      "name": "device_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceId": {
+          "name": "deviceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "PlatformType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceName": {
+          "name": "deviceName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastIpAddress": {
+          "name": "lastIpAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trustScore": {
+          "name": "trustScore",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "suspiciousActivityCount": {
+          "name": "suspiciousActivityCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedReason": {
+          "name": "revokedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replacedByTokenId": {
+          "name": "replacedByTokenId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "device_tokens_user_id_idx": {
+          "name": "device_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_token_hash_idx": {
+          "name": "device_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_device_id_idx": {
+          "name": "device_tokens_device_id_idx",
+          "columns": [
+            {
+              "expression": "deviceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_expires_at_idx": {
+          "name": "device_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "device_tokens_active_device_idx": {
+          "name": "device_tokens_active_device_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deviceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"device_tokens\".\"revokedAt\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_tokens_userId_users_id_fk": {
+          "name": "device_tokens_userId_users_id_fk",
+          "tableFrom": "device_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_tokens_tokenHash_unique": {
+          "name": "device_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      }
+    },
+    "public.email_unsubscribe_tokens": {
+      "name": "email_unsubscribe_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_unsubscribe_tokens_token_hash_idx": {
+          "name": "email_unsubscribe_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_unsubscribe_tokens_user_id_idx": {
+          "name": "email_unsubscribe_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_unsubscribe_tokens_expires_at_idx": {
+          "name": "email_unsubscribe_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_unsubscribe_tokens_user_id_users_id_fk": {
+          "name": "email_unsubscribe_tokens_user_id_users_id_fk",
+          "tableFrom": "email_unsubscribe_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_unsubscribe_tokens_token_hash_unique": {
+          "name": "email_unsubscribe_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      }
+    },
+    "public.mcp_token_drives": {
+      "name": "mcp_token_drives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tokenId": {
+          "name": "tokenId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_token_drives_token_id_idx": {
+          "name": "mcp_token_drives_token_id_idx",
+          "columns": [
+            {
+              "expression": "tokenId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_token_drives_drive_id_idx": {
+          "name": "mcp_token_drives_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_token_drives_token_drive_unique": {
+          "name": "mcp_token_drives_token_drive_unique",
+          "columns": [
+            {
+              "expression": "tokenId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_token_drives_tokenId_mcp_tokens_id_fk": {
+          "name": "mcp_token_drives_tokenId_mcp_tokens_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "mcp_tokens",
+          "columnsFrom": [
+            "tokenId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_token_drives_driveId_drives_id_fk": {
+          "name": "mcp_token_drives_driveId_drives_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.mcp_tokens": {
+      "name": "mcp_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isScoped": {
+          "name": "isScoped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastUsed": {
+          "name": "lastUsed",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "mcp_tokens_user_id_idx": {
+          "name": "mcp_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_tokens_token_hash_idx": {
+          "name": "mcp_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_tokens_userId_users_id_fk": {
+          "name": "mcp_tokens_userId_users_id_fk",
+          "tableFrom": "mcp_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mcp_tokens_tokenHash_unique": {
+          "name": "mcp_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      }
+    },
+    "public.passkeys": {
+      "name": "passkeys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "passkeys_user_id_idx": {
+          "name": "passkeys_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkeys_credential_id_idx": {
+          "name": "passkeys_credential_id_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkeys_user_id_users_id_fk": {
+          "name": "passkeys_user_id_users_id_fk",
+          "tableFrom": "passkeys",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "passkeys_credential_id_unique": {
+          "name": "passkeys_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      }
+    },
+    "public.socket_tokens": {
+      "name": "socket_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "socket_tokens_user_id_idx": {
+          "name": "socket_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "socket_tokens_token_hash_idx": {
+          "name": "socket_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "socket_tokens_expires_at_idx": {
+          "name": "socket_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "socket_tokens_userId_users_id_fk": {
+          "name": "socket_tokens_userId_users_id_fk",
+          "tableFrom": "socket_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "socket_tokens_tokenHash_unique": {
+          "name": "socket_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      }
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleId": {
+          "name": "googleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appleId": {
+          "name": "appleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "AuthProvider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'email'"
+        },
+        "tokenVersion": {
+          "name": "tokenVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "role": {
+          "name": "role",
+          "type": "UserRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "adminRoleVersion": {
+          "name": "adminRoleVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currentAiProvider": {
+          "name": "currentAiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pagespace'"
+        },
+        "currentAiModel": {
+          "name": "currentAiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'glm-4.7'"
+        },
+        "storageUsedBytes": {
+          "name": "storageUsedBytes",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "activeUploads": {
+          "name": "activeUploads",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastStorageCalculated": {
+          "name": "lastStorageCalculated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscriptionTier": {
+          "name": "subscriptionTier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "tosAcceptedAt": {
+          "name": "tosAcceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failedLoginAttempts": {
+          "name": "failedLoginAttempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lockedUntil": {
+          "name": "lockedUntil",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspendedAt": {
+          "name": "suspendedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspendedReason": {
+          "name": "suspendedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_googleId_unique": {
+          "name": "users_googleId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "googleId"
+          ]
+        },
+        "users_appleId_unique": {
+          "name": "users_appleId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "appleId"
+          ]
+        },
+        "users_stripeCustomerId_unique": {
+          "name": "users_stripeCustomerId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripeCustomerId"
+          ]
+        }
+      }
+    },
+    "public.verification_tokens": {
+      "name": "verification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenHash": {
+          "name": "tokenHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenPrefix": {
+          "name": "tokenPrefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "usedAt": {
+          "name": "usedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "verification_tokens_user_id_idx": {
+          "name": "verification_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_tokens_token_hash_idx": {
+          "name": "verification_tokens_token_hash_idx",
+          "columns": [
+            {
+              "expression": "tokenHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "verification_tokens_type_idx": {
+          "name": "verification_tokens_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "verification_tokens_userId_users_id_fk": {
+          "name": "verification_tokens_userId_users_id_fk",
+          "tableFrom": "verification_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "verification_tokens_tokenHash_unique": {
+          "name": "verification_tokens_tokenHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenHash"
+          ]
+        }
+      }
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_version": {
+          "name": "token_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "admin_role_version": {
+          "name": "admin_role_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by_service": {
+          "name": "created_by_service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_ip": {
+          "name": "created_by_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_ip": {
+          "name": "last_used_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_expires_at_idx": {
+          "name": "sessions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_user_active_idx": {
+          "name": "sessions_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revoked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sessions_user_device_idx": {
+          "name": "sessions_user_device_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      }
+    },
+    "public.chat_messages": {
+      "name": "chat_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolCalls": {
+          "name": "toolCalls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toolResults": {
+          "name": "toolResults",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sourceAgentId": {
+          "name": "sourceAgentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messageType": {
+          "name": "messageType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        }
+      },
+      "indexes": {
+        "chat_messages_page_id_idx": {
+          "name": "chat_messages_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_user_id_idx": {
+          "name": "chat_messages_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_conversation_id_idx": {
+          "name": "chat_messages_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_page_id_conversation_id_idx": {
+          "name": "chat_messages_page_id_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_messages_page_id_is_active_created_at_idx": {
+          "name": "chat_messages_page_id_is_active_created_at_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_messages_pageId_pages_id_fk": {
+          "name": "chat_messages_pageId_pages_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_messages_userId_users_id_fk": {
+          "name": "chat_messages_userId_users_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_messages_sourceAgentId_pages_id_fk": {
+          "name": "chat_messages_sourceAgentId_pages_id_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "sourceAgentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.drives": {
+      "name": "drives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drivePrompt": {
+          "name": "drivePrompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drives_owner_id_idx": {
+          "name": "drives_owner_id_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drives_owner_id_slug_key": {
+          "name": "drives_owner_id_slug_key",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drives_ownerId_users_id_fk": {
+          "name": "drives_ownerId_users_id_fk",
+          "tableFrom": "drives",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ownerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.favorites": {
+      "name": "favorites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "itemType": {
+          "name": "itemType",
+          "type": "FavoriteItemType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'page'"
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "favorites_user_id_page_id_key": {
+          "name": "favorites_user_id_page_id_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "favorites_user_id_drive_id_key": {
+          "name": "favorites_user_id_drive_id_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "favorites_user_id_position_idx": {
+          "name": "favorites_user_id_position_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "favorites_userId_users_id_fk": {
+          "name": "favorites_userId_users_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_pageId_pages_id_fk": {
+          "name": "favorites_pageId_pages_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_driveId_drives_id_fk": {
+          "name": "favorites_driveId_drives_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.mentions": {
+      "name": "mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sourcePageId": {
+          "name": "sourcePageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetPageId": {
+          "name": "targetPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mentions_source_page_id_target_page_id_key": {
+          "name": "mentions_source_page_id_target_page_id_key",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "targetPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mentions_source_page_id_idx": {
+          "name": "mentions_source_page_id_idx",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mentions_target_page_id_idx": {
+          "name": "mentions_target_page_id_idx",
+          "columns": [
+            {
+              "expression": "targetPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mentions_sourcePageId_pages_id_fk": {
+          "name": "mentions_sourcePageId_pages_id_fk",
+          "tableFrom": "mentions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "sourcePageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mentions_targetPageId_pages_id_fk": {
+          "name": "mentions_targetPageId_pages_id_fk",
+          "tableFrom": "mentions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "targetPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.page_tags": {
+      "name": "page_tags",
+      "schema": "",
+      "columns": {
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "page_tags_pageId_pages_id_fk": {
+          "name": "page_tags_pageId_pages_id_fk",
+          "tableFrom": "page_tags",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_tags_tagId_tags_id_fk": {
+          "name": "page_tags_tagId_tags_id_fk",
+          "tableFrom": "page_tags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tagId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "page_tags_pageId_tagId_pk": {
+          "name": "page_tags_pageId_tagId_pk",
+          "columns": [
+            "pageId",
+            "tagId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.pages": {
+      "name": "pages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "PageType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "contentMode": {
+          "name": "contentMode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'html'"
+        },
+        "isPaginated": {
+          "name": "isPaginated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "aiProvider": {
+          "name": "aiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiModel": {
+          "name": "aiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "systemPrompt": {
+          "name": "systemPrompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabledTools": {
+          "name": "enabledTools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "includeDrivePrompt": {
+          "name": "includeDrivePrompt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "agentDefinition": {
+          "name": "agentDefinition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibleToGlobalAssistant": {
+          "name": "visibleToGlobalAssistant",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "includePageTree": {
+          "name": "includePageTree",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pageTreeScope": {
+          "name": "pageTreeScope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'children'"
+        },
+        "fileSize": {
+          "name": "fileSize",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalFileName": {
+          "name": "originalFileName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filePath": {
+          "name": "filePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fileMetadata": {
+          "name": "fileMetadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processingStatus": {
+          "name": "processingStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "processingError": {
+          "name": "processingError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extractionMethod": {
+          "name": "extractionMethod",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extractionMetadata": {
+          "name": "extractionMetadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentHash": {
+          "name": "contentHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excludeFromSearch": {
+          "name": "excludeFromSearch",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "stateHash": {
+          "name": "stateHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalParentId": {
+          "name": "originalParentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pages_drive_id_idx": {
+          "name": "pages_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_parent_id_idx": {
+          "name": "pages_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_parent_id_position_idx": {
+          "name": "pages_parent_id_position_idx",
+          "columns": [
+            {
+              "expression": "parentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pages_drive_id_is_trashed_type_idx": {
+          "name": "pages_drive_id_is_trashed_type_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isTrashed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pages_driveId_drives_id_fk": {
+          "name": "pages_driveId_drives_id_fk",
+          "tableFrom": "pages",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.storage_events": {
+      "name": "storage_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sizeDelta": {
+          "name": "sizeDelta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalSizeAfter": {
+          "name": "totalSizeAfter",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "storage_events_user_id_idx": {
+          "name": "storage_events_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "storage_events_created_at_idx": {
+          "name": "storage_events_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "storage_events_userId_users_id_fk": {
+          "name": "storage_events_userId_users_id_fk",
+          "tableFrom": "storage_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "storage_events_pageId_pages_id_fk": {
+          "name": "storage_events_pageId_pages_id_fk",
+          "tableFrom": "storage_events",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.user_mentions": {
+      "name": "user_mentions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sourcePageId": {
+          "name": "sourcePageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetUserId": {
+          "name": "targetUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mentionedByUserId": {
+          "name": "mentionedByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_mentions_source_page_id_target_user_id_key": {
+          "name": "user_mentions_source_page_id_target_user_id_key",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "targetUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_mentions_source_page_id_idx": {
+          "name": "user_mentions_source_page_id_idx",
+          "columns": [
+            {
+              "expression": "sourcePageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_mentions_target_user_id_idx": {
+          "name": "user_mentions_target_user_id_idx",
+          "columns": [
+            {
+              "expression": "targetUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_mentions_sourcePageId_pages_id_fk": {
+          "name": "user_mentions_sourcePageId_pages_id_fk",
+          "tableFrom": "user_mentions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "sourcePageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_mentions_targetUserId_users_id_fk": {
+          "name": "user_mentions_targetUserId_users_id_fk",
+          "tableFrom": "user_mentions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "targetUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_mentions_mentionedByUserId_users_id_fk": {
+          "name": "user_mentions_mentionedByUserId_users_id_fk",
+          "tableFrom": "user_mentions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "mentionedByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.permissions": {
+      "name": "permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "PermissionAction",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subjectType": {
+          "name": "subjectType",
+          "type": "SubjectType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subjectId": {
+          "name": "subjectId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "permissions_page_id_idx": {
+          "name": "permissions_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permissions_subject_id_subject_type_idx": {
+          "name": "permissions_subject_id_subject_type_idx",
+          "columns": [
+            {
+              "expression": "subjectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subjectType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "permissions_page_id_subject_id_subject_type_idx": {
+          "name": "permissions_page_id_subject_id_subject_type_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subjectId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subjectType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "permissions_pageId_pages_id_fk": {
+          "name": "permissions_pageId_pages_id_fk",
+          "tableFrom": "permissions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.drive_members": {
+      "name": "drive_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEMBER'"
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedBy": {
+          "name": "invitedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastAccessedAt": {
+          "name": "lastAccessedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_members_drive_id_idx": {
+          "name": "drive_members_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_members_user_id_idx": {
+          "name": "drive_members_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_members_role_idx": {
+          "name": "drive_members_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_members_custom_role_id_idx": {
+          "name": "drive_members_custom_role_id_idx",
+          "columns": [
+            {
+              "expression": "customRoleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_members_driveId_drives_id_fk": {
+          "name": "drive_members_driveId_drives_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_members_userId_users_id_fk": {
+          "name": "drive_members_userId_users_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_members_customRoleId_drive_roles_id_fk": {
+          "name": "drive_members_customRoleId_drive_roles_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "customRoleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "drive_members_invitedBy_users_id_fk": {
+          "name": "drive_members_invitedBy_users_id_fk",
+          "tableFrom": "drive_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invitedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_members_drive_user_key": {
+          "name": "drive_members_drive_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId",
+            "userId"
+          ]
+        }
+      }
+    },
+    "public.drive_roles": {
+      "name": "drive_roles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "drive_roles_drive_id_idx": {
+          "name": "drive_roles_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_roles_position_idx": {
+          "name": "drive_roles_position_idx",
+          "columns": [
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_roles_driveId_drives_id_fk": {
+          "name": "drive_roles_driveId_drives_id_fk",
+          "tableFrom": "drive_roles",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "drive_roles_drive_name_key": {
+          "name": "drive_roles_drive_name_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "driveId",
+            "name"
+          ]
+        }
+      }
+    },
+    "public.page_permissions": {
+      "name": "page_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canView": {
+          "name": "canView",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canEdit": {
+          "name": "canEdit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canShare": {
+          "name": "canShare",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canDelete": {
+          "name": "canDelete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "grantedBy": {
+          "name": "grantedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grantedAt": {
+          "name": "grantedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "page_permissions_page_id_idx": {
+          "name": "page_permissions_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_permissions_user_id_idx": {
+          "name": "page_permissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_permissions_expires_at_idx": {
+          "name": "page_permissions_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_permissions_pageId_pages_id_fk": {
+          "name": "page_permissions_pageId_pages_id_fk",
+          "tableFrom": "page_permissions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_permissions_userId_users_id_fk": {
+          "name": "page_permissions_userId_users_id_fk",
+          "tableFrom": "page_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_permissions_grantedBy_users_id_fk": {
+          "name": "page_permissions_grantedBy_users_id_fk",
+          "tableFrom": "page_permissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "grantedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "page_permissions_page_user_key": {
+          "name": "page_permissions_page_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pageId",
+            "userId"
+          ]
+        }
+      }
+    },
+    "public.user_profiles": {
+      "name": "user_profiles",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatarUrl": {
+          "name": "avatarUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_profiles_is_public_idx": {
+          "name": "user_profiles_is_public_idx",
+          "columns": [
+            {
+              "expression": "isPublic",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_profiles_userId_users_id_fk": {
+          "name": "user_profiles_userId_users_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.channel_message_reactions": {
+      "name": "channel_message_reactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "messageId": {
+          "name": "messageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_reaction_idx": {
+          "name": "unique_reaction_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "emoji",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reaction_message_idx": {
+          "name": "reaction_message_idx",
+          "columns": [
+            {
+              "expression": "messageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_message_reactions_messageId_channel_messages_id_fk": {
+          "name": "channel_message_reactions_messageId_channel_messages_id_fk",
+          "tableFrom": "channel_message_reactions",
+          "tableTo": "channel_messages",
+          "columnsFrom": [
+            "messageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_message_reactions_userId_users_id_fk": {
+          "name": "channel_message_reactions_userId_users_id_fk",
+          "tableFrom": "channel_message_reactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.channel_messages": {
+      "name": "channel_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachmentMeta": {
+          "name": "attachmentMeta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiMeta": {
+          "name": "aiMeta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "channel_messages_page_id_idx": {
+          "name": "channel_messages_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_file_id_idx": {
+          "name": "channel_messages_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_messages_pageId_pages_id_fk": {
+          "name": "channel_messages_pageId_pages_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_messages_userId_users_id_fk": {
+          "name": "channel_messages_userId_users_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_messages_fileId_files_id_fk": {
+          "name": "channel_messages_fileId_files_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.channel_read_status": {
+      "name": "channel_read_status",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channelId": {
+          "name": "channelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastReadAt": {
+          "name": "lastReadAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_read_status_user_id_idx": {
+          "name": "channel_read_status_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_read_status_channel_id_idx": {
+          "name": "channel_read_status_channel_id_idx",
+          "columns": [
+            {
+              "expression": "channelId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_read_status_userId_users_id_fk": {
+          "name": "channel_read_status_userId_users_id_fk",
+          "tableFrom": "channel_read_status",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_read_status_channelId_pages_id_fk": {
+          "name": "channel_read_status_channelId_pages_id_fk",
+          "tableFrom": "channel_read_status",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "channelId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "channel_read_status_userId_channelId_pk": {
+          "name": "channel_read_status_userId_channelId_pk",
+          "columns": [
+            "userId",
+            "channelId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.user_ai_settings": {
+      "name": "user_ai_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryptedApiKey": {
+          "name": "encryptedApiKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "baseUrl": {
+          "name": "baseUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_ai_settings_userId_users_id_fk": {
+          "name": "user_ai_settings_userId_users_id_fk",
+          "tableFrom": "user_ai_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_provider_unique": {
+          "name": "user_provider_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId",
+            "provider"
+          ]
+        }
+      }
+    },
+    "public.pulse_summaries": {
+      "name": "pulse_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "greeting": {
+          "name": "greeting",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "pulse_summary_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "contextData": {
+          "name": "contextData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiProvider": {
+          "name": "aiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiModel": {
+          "name": "aiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "periodStart": {
+          "name": "periodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "periodEnd": {
+          "name": "periodEnd",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generatedAt": {
+          "name": "generatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_pulse_summaries_user_id": {
+          "name": "idx_pulse_summaries_user_id",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pulse_summaries_generated_at": {
+          "name": "idx_pulse_summaries_generated_at",
+          "columns": [
+            {
+              "expression": "generatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pulse_summaries_expires_at": {
+          "name": "idx_pulse_summaries_expires_at",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pulse_summaries_user_generated": {
+          "name": "idx_pulse_summaries_user_generated",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pulse_summaries_userId_users_id_fk": {
+          "name": "pulse_summaries_userId_users_id_fk",
+          "tableFrom": "pulse_summaries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.user_dashboards": {
+      "name": "user_dashboards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_dashboards_userId_users_id_fk": {
+          "name": "user_dashboards_userId_users_id_fk",
+          "tableFrom": "user_dashboards",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_dashboards_userId_unique": {
+          "name": "user_dashboards_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      }
+    },
+    "public.conversations": {
+      "name": "conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contextId": {
+          "name": "contextId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {
+        "conversations_user_id_idx": {
+          "name": "conversations_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_user_id_type_idx": {
+          "name": "conversations_user_id_type_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_user_id_last_message_at_idx": {
+          "name": "conversations_user_id_last_message_at_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "conversations_context_id_idx": {
+          "name": "conversations_context_id_idx",
+          "columns": [
+            {
+              "expression": "contextId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "conversations_userId_users_id_fk": {
+          "name": "conversations_userId_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.messages": {
+      "name": "messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messageType": {
+          "name": "messageType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "toolCalls": {
+          "name": "toolCalls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toolResults": {
+          "name": "toolResults",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "messages_conversation_id_idx": {
+          "name": "messages_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_conversation_id_created_at_idx": {
+          "name": "messages_conversation_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "messages_user_id_idx": {
+          "name": "messages_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "messages_conversationId_conversations_id_fk": {
+          "name": "messages_conversationId_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "messages_userId_users_id_fk": {
+          "name": "messages_userId_users_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isRead": {
+          "name": "isRead",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggeredByUserId": {
+          "name": "triggeredByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_id_is_read_idx": {
+          "name": "notifications_user_id_is_read_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_user_id_is_read_created_at_idx": {
+          "name": "notifications_user_id_is_read_created_at_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_created_at_idx": {
+          "name": "notifications_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notifications_type_idx": {
+          "name": "notifications_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_userId_users_id_fk": {
+          "name": "notifications_userId_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_pageId_pages_id_fk": {
+          "name": "notifications_pageId_pages_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_driveId_drives_id_fk": {
+          "name": "notifications_driveId_drives_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_triggeredByUserId_users_id_fk": {
+          "name": "notifications_triggeredByUserId_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggeredByUserId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.email_notification_log": {
+      "name": "email_notification_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notificationId": {
+          "name": "notificationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notificationType": {
+          "name": "notificationType",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipientEmail": {
+          "name": "recipientEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sentAt": {
+          "name": "sentAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_notification_log_user_idx": {
+          "name": "email_notification_log_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_notification_log_sent_at_idx": {
+          "name": "email_notification_log_sent_at_idx",
+          "columns": [
+            {
+              "expression": "sentAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_notification_log_notification_id_idx": {
+          "name": "email_notification_log_notification_id_idx",
+          "columns": [
+            {
+              "expression": "notificationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_notification_log_userId_users_id_fk": {
+          "name": "email_notification_log_userId_users_id_fk",
+          "tableFrom": "email_notification_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.email_notification_preferences": {
+      "name": "email_notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notificationType": {
+          "name": "notificationType",
+          "type": "NotificationType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailEnabled": {
+          "name": "emailEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_notification_preferences_user_type_idx": {
+          "name": "email_notification_preferences_user_type_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "notificationType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_notification_preferences_userId_users_id_fk": {
+          "name": "email_notification_preferences_userId_users_id_fk",
+          "tableFrom": "email_notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.display_preferences": {
+      "name": "display_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preferenceType": {
+          "name": "preferenceType",
+          "type": "display_preference_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "display_preferences_user_type_idx": {
+          "name": "display_preferences_user_type_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "preferenceType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "display_preferences_userId_users_id_fk": {
+          "name": "display_preferences_userId_users_id_fk",
+          "tableFrom": "display_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.activity_logs": {
+      "name": "activity_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorEmail": {
+          "name": "actorEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'legacy@unknown'"
+        },
+        "actorDisplayName": {
+          "name": "actorDisplayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isAiGenerated": {
+          "name": "isAiGenerated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "aiProvider": {
+          "name": "aiProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiModel": {
+          "name": "aiModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiConversationId": {
+          "name": "aiConversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceType": {
+          "name": "resourceType",
+          "type": "activity_resource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceId": {
+          "name": "resourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceTitle": {
+          "name": "resourceTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentSnapshot": {
+          "name": "contentSnapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentFormat": {
+          "name": "contentFormat",
+          "type": "content_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentRef": {
+          "name": "contentRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentSize": {
+          "name": "contentSize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackFromActivityId": {
+          "name": "rollbackFromActivityId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackSourceOperation": {
+          "name": "rollbackSourceOperation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackSourceTimestamp": {
+          "name": "rollbackSourceTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rollbackSourceTitle": {
+          "name": "rollbackSourceTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedFields": {
+          "name": "updatedFields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previousValues": {
+          "name": "previousValues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "newValues": {
+          "name": "newValues",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streamId": {
+          "name": "streamId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streamSeq": {
+          "name": "streamSeq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupId": {
+          "name": "changeGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupType": {
+          "name": "changeGroupType",
+          "type": "activity_change_group_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stateHashBefore": {
+          "name": "stateHashBefore",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stateHashAfter": {
+          "name": "stateHashAfter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isArchived": {
+          "name": "isArchived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "chainSeq": {
+          "name": "chainSeq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previousLogHash": {
+          "name": "previousLogHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logHash": {
+          "name": "logHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chainSeed": {
+          "name": "chainSeed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_activity_logs_timestamp": {
+          "name": "idx_activity_logs_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_user_timestamp": {
+          "name": "idx_activity_logs_user_timestamp",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_drive_timestamp": {
+          "name": "idx_activity_logs_drive_timestamp",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_page_timestamp": {
+          "name": "idx_activity_logs_page_timestamp",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_archived": {
+          "name": "idx_activity_logs_archived",
+          "columns": [
+            {
+              "expression": "isArchived",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_rollback_from": {
+          "name": "idx_activity_logs_rollback_from",
+          "columns": [
+            {
+              "expression": "rollbackFromActivityId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_stream": {
+          "name": "idx_activity_logs_stream",
+          "columns": [
+            {
+              "expression": "streamId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "streamSeq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"activity_logs\".\"streamId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_change_group": {
+          "name": "idx_activity_logs_change_group",
+          "columns": [
+            {
+              "expression": "changeGroupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"activity_logs\".\"changeGroupId\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_log_hash": {
+          "name": "idx_activity_logs_log_hash",
+          "columns": [
+            {
+              "expression": "logHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"activity_logs\".\"logHash\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_activity_logs_chain_seq": {
+          "name": "idx_activity_logs_chain_seq",
+          "columns": [
+            {
+              "expression": "chainSeq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_logs_userId_users_id_fk": {
+          "name": "activity_logs_userId_users_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "activity_logs_driveId_drives_id_fk": {
+          "name": "activity_logs_driveId_drives_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "activity_logs_pageId_pages_id_fk": {
+          "name": "activity_logs_pageId_pages_id_fk",
+          "tableFrom": "activity_logs",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.ai_usage_logs": {
+      "name": "ai_usage_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'USD'"
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "streaming_duration": {
+          "name": "streaming_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_messages": {
+          "name": "context_messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_size": {
+          "name": "context_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system_prompt_tokens": {
+          "name": "system_prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_definition_tokens": {
+          "name": "tool_definition_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversation_tokens": {
+          "name": "conversation_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_count": {
+          "name": "message_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "was_truncated": {
+          "name": "was_truncated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "truncation_strategy": {
+          "name": "truncation_strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_ai_usage_timestamp": {
+          "name": "idx_ai_usage_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_user_id": {
+          "name": "idx_ai_usage_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_provider": {
+          "name": "idx_ai_usage_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_cost": {
+          "name": "idx_ai_usage_cost",
+          "columns": [
+            {
+              "expression": "cost",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_conversation": {
+          "name": "idx_ai_usage_conversation",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_context": {
+          "name": "idx_ai_usage_context",
+          "columns": [
+            {
+              "expression": "conversation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_context_size": {
+          "name": "idx_ai_usage_context_size",
+          "columns": [
+            {
+              "expression": "context_size",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_usage_expires_at": {
+          "name": "idx_ai_usage_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.api_metrics": {
+      "name": "api_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "http_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_size": {
+          "name": "request_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_size": {
+          "name": "response_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_hit": {
+          "name": "cache_hit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "cache_key": {
+          "name": "cache_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_api_metrics_timestamp": {
+          "name": "idx_api_metrics_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_endpoint": {
+          "name": "idx_api_metrics_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_user_id": {
+          "name": "idx_api_metrics_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_status": {
+          "name": "idx_api_metrics_status",
+          "columns": [
+            {
+              "expression": "status_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_metrics_duration": {
+          "name": "idx_api_metrics_duration",
+          "columns": [
+            {
+              "expression": "duration",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.error_logs": {
+      "name": "error_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stack": {
+          "name": "stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "http_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "column": {
+          "name": "column",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_errors_timestamp": {
+          "name": "idx_errors_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_name": {
+          "name": "idx_errors_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_user_id": {
+          "name": "idx_errors_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_resolved": {
+          "name": "idx_errors_resolved",
+          "columns": [
+            {
+              "expression": "resolved",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_errors_endpoint": {
+          "name": "idx_errors_endpoint",
+          "columns": [
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.siem_delivery_cursors": {
+      "name": "siem_delivery_cursors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lastDeliveredId": {
+          "name": "lastDeliveredId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastDeliveredAt": {
+          "name": "lastDeliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastErrorAt": {
+          "name": "lastErrorAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deliveryCount": {
+          "name": "deliveryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.siem_delivery_receipts": {
+      "name": "siem_delivery_receipts",
+      "schema": "",
+      "columns": {
+        "receiptId": {
+          "name": "receiptId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "deliveryId": {
+          "name": "deliveryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryId": {
+          "name": "firstEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryId": {
+          "name": "lastEntryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "firstEntryTimestamp": {
+          "name": "firstEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastEntryTimestamp": {
+          "name": "lastEntryTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entryCount": {
+          "name": "entryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deliveredAt": {
+          "name": "deliveredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhookStatus": {
+          "name": "webhookStatus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhookResponseHash": {
+          "name": "webhookResponseHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ackReceivedAt": {
+          "name": "ackReceivedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "siem_delivery_receipts_delivery_source_unique": {
+          "name": "siem_delivery_receipts_delivery_source_unique",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_delivery_id": {
+          "name": "idx_siem_receipts_delivery_id",
+          "columns": [
+            {
+              "expression": "deliveryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_first_entry": {
+          "name": "idx_siem_receipts_first_entry",
+          "columns": [
+            {
+              "expression": "firstEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_last_entry": {
+          "name": "idx_siem_receipts_last_entry",
+          "columns": [
+            {
+              "expression": "lastEntryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_delivered_at": {
+          "name": "idx_siem_receipts_delivered_at",
+          "columns": [
+            {
+              "expression": "deliveredAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_siem_receipts_source_range": {
+          "name": "idx_siem_receipts_source_range",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "firstEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastEntryTimestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.system_logs": {
+      "name": "system_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "level": {
+          "name": "level",
+          "type": "log_level",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "http_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_name": {
+          "name": "error_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_used": {
+          "name": "memory_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "memory_total": {
+          "name": "memory_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hostname": {
+          "name": "hostname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pid": {
+          "name": "pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_system_logs_timestamp": {
+          "name": "idx_system_logs_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_level": {
+          "name": "idx_system_logs_level",
+          "columns": [
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_category": {
+          "name": "idx_system_logs_category",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_user_id": {
+          "name": "idx_system_logs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_request_id": {
+          "name": "idx_system_logs_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_system_logs_error": {
+          "name": "idx_system_logs_error",
+          "columns": [
+            {
+              "expression": "error_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.user_activities": {
+      "name": "user_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_user_activities_timestamp": {
+          "name": "idx_user_activities_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_activities_user_id": {
+          "name": "idx_user_activities_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_activities_action": {
+          "name": "idx_user_activities_action",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_activities_resource": {
+          "name": "idx_user_activities_resource",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.drive_backup_files": {
+      "name": "drive_backup_files",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storagePath": {
+          "name": "storagePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizeBytes": {
+          "name": "sizeBytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksumVersion": {
+          "name": "checksumVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_files_backup_idx": {
+          "name": "drive_backup_files_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_files_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_files_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_files",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_files_backupId_fileId_pk": {
+          "name": "drive_backup_files_backupId_fileId_pk",
+          "columns": [
+            "backupId",
+            "fileId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.drive_backup_members": {
+      "name": "drive_backup_members",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedBy": {
+          "name": "invitedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_members_backup_idx": {
+          "name": "drive_backup_members_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_members_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_members_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_members",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_members_backupId_userId_pk": {
+          "name": "drive_backup_members_backupId_userId_pk",
+          "columns": [
+            "backupId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.drive_backup_pages": {
+      "name": "drive_backup_pages",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageVersionId": {
+          "name": "pageVersionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parentId": {
+          "name": "parentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalParentId": {
+          "name": "originalParentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_pages_backup_idx": {
+          "name": "drive_backup_pages_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_pages_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_pages_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_pages",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_backup_pages_pageVersionId_page_versions_id_fk": {
+          "name": "drive_backup_pages_pageVersionId_page_versions_id_fk",
+          "tableFrom": "drive_backup_pages",
+          "tableTo": "page_versions",
+          "columnsFrom": [
+            "pageVersionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_pages_backupId_pageId_pk": {
+          "name": "drive_backup_pages_backupId_pageId_pk",
+          "columns": [
+            "backupId",
+            "pageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.drive_backup_permissions": {
+      "name": "drive_backup_permissions",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canView": {
+          "name": "canView",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "canEdit": {
+          "name": "canEdit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canShare": {
+          "name": "canShare",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "canDelete": {
+          "name": "canDelete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "grantedBy": {
+          "name": "grantedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_permissions_backup_idx": {
+          "name": "drive_backup_permissions_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_permissions_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_permissions_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_permissions",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_permissions_backupId_pageId_userId_pk": {
+          "name": "drive_backup_permissions_backupId_pageId_userId_pk",
+          "columns": [
+            "backupId",
+            "pageId",
+            "userId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.drive_backup_roles": {
+      "name": "drive_backup_roles",
+      "schema": "",
+      "columns": {
+        "backupId": {
+          "name": "backupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roleId": {
+          "name": "roleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isDefault": {
+          "name": "isDefault",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backup_roles_backup_idx": {
+          "name": "drive_backup_roles_backup_idx",
+          "columns": [
+            {
+              "expression": "backupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backup_roles_backupId_drive_backups_id_fk": {
+          "name": "drive_backup_roles_backupId_drive_backups_id_fk",
+          "tableFrom": "drive_backup_roles",
+          "tableTo": "drive_backups",
+          "columnsFrom": [
+            "backupId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "drive_backup_roles_backupId_roleId_pk": {
+          "name": "drive_backup_roles_backupId_roleId_pk",
+          "columns": [
+            "backupId",
+            "roleId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.drive_backups": {
+      "name": "drive_backups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "drive_backup_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "status": {
+          "name": "status",
+          "type": "drive_backup_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupId": {
+          "name": "changeGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupType": {
+          "name": "changeGroupType",
+          "type": "activity_change_group_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failedAt": {
+          "name": "failedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failureReason": {
+          "name": "failureReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "drive_backups_drive_created_at_idx": {
+          "name": "drive_backups_drive_created_at_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "drive_backups_status_idx": {
+          "name": "drive_backups_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "drive_backups_driveId_drives_id_fk": {
+          "name": "drive_backups_driveId_drives_id_fk",
+          "tableFrom": "drive_backups",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "drive_backups_createdBy_users_id_fk": {
+          "name": "drive_backups_createdBy_users_id_fk",
+          "tableFrom": "drive_backups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.page_versions": {
+      "name": "page_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "page_version_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupId": {
+          "name": "changeGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changeGroupType": {
+          "name": "changeGroupType",
+          "type": "activity_change_group_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentRef": {
+          "name": "contentRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentFormat": {
+          "name": "contentFormat",
+          "type": "content_format",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contentSize": {
+          "name": "contentSize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stateHash": {
+          "name": "stateHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageRevision": {
+          "name": "pageRevision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "isPinned": {
+          "name": "isPinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "page_versions_page_created_at_idx": {
+          "name": "page_versions_page_created_at_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_versions_drive_created_at_idx": {
+          "name": "page_versions_drive_created_at_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_versions_pinned_idx": {
+          "name": "page_versions_pinned_idx",
+          "columns": [
+            {
+              "expression": "isPinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "page_versions_page_id_is_pinned_created_at_idx": {
+          "name": "page_versions_page_id_is_pinned_created_at_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isPinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "page_versions_pageId_pages_id_fk": {
+          "name": "page_versions_pageId_pages_id_fk",
+          "tableFrom": "page_versions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_versions_driveId_drives_id_fk": {
+          "name": "page_versions_driveId_drives_id_fk",
+          "tableFrom": "page_versions",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_versions_createdBy_users_id_fk": {
+          "name": "page_versions_createdBy_users_id_fk",
+          "tableFrom": "page_versions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user1Id": {
+          "name": "user1Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user2Id": {
+          "name": "user2Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "ConnectionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "requestedBy": {
+          "name": "requestedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requestMessage": {
+          "name": "requestMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestedAt": {
+          "name": "requestedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockedBy": {
+          "name": "blockedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockedAt": {
+          "name": "blockedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "connections_user1_id_idx": {
+          "name": "connections_user1_id_idx",
+          "columns": [
+            {
+              "expression": "user1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_user2_id_idx": {
+          "name": "connections_user2_id_idx",
+          "columns": [
+            {
+              "expression": "user2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_status_idx": {
+          "name": "connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_user1_status_idx": {
+          "name": "connections_user1_status_idx",
+          "columns": [
+            {
+              "expression": "user1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_user2_status_idx": {
+          "name": "connections_user2_status_idx",
+          "columns": [
+            {
+              "expression": "user2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connections_user1Id_users_id_fk": {
+          "name": "connections_user1Id_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user1Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_user2Id_users_id_fk": {
+          "name": "connections_user2Id_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user2Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_requestedBy_users_id_fk": {
+          "name": "connections_requestedBy_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "requestedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connections_blockedBy_users_id_fk": {
+          "name": "connections_blockedBy_users_id_fk",
+          "tableFrom": "connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "blockedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connections_user_pair_key": {
+          "name": "connections_user_pair_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user1Id",
+            "user2Id"
+          ]
+        }
+      }
+    },
+    "public.direct_messages": {
+      "name": "direct_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "senderId": {
+          "name": "senderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachmentMeta": {
+          "name": "attachmentMeta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isRead": {
+          "name": "isRead",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "readAt": {
+          "name": "readAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEdited": {
+          "name": "isEdited",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "editedAt": {
+          "name": "editedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "direct_messages_conversation_id_idx": {
+          "name": "direct_messages_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_sender_id_idx": {
+          "name": "direct_messages_sender_id_idx",
+          "columns": [
+            {
+              "expression": "senderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_created_at_idx": {
+          "name": "direct_messages_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_file_id_idx": {
+          "name": "direct_messages_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_conversation_created_idx": {
+          "name": "direct_messages_conversation_created_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_conversation_is_read_idx": {
+          "name": "direct_messages_conversation_is_read_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "direct_messages_unread_count_idx": {
+          "name": "direct_messages_unread_count_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "senderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isRead",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "direct_messages_conversationId_dm_conversations_id_fk": {
+          "name": "direct_messages_conversationId_dm_conversations_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "dm_conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "direct_messages_senderId_users_id_fk": {
+          "name": "direct_messages_senderId_users_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "senderId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "direct_messages_fileId_files_id_fk": {
+          "name": "direct_messages_fileId_files_id_fk",
+          "tableFrom": "direct_messages",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.dm_conversations": {
+      "name": "dm_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "participant1Id": {
+          "name": "participant1Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant2Id": {
+          "name": "participant2Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastMessagePreview": {
+          "name": "lastMessagePreview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant1LastRead": {
+          "name": "participant1LastRead",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participant2LastRead": {
+          "name": "participant2LastRead",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "dm_conversations_participant1_id_idx": {
+          "name": "dm_conversations_participant1_id_idx",
+          "columns": [
+            {
+              "expression": "participant1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_participant2_id_idx": {
+          "name": "dm_conversations_participant2_id_idx",
+          "columns": [
+            {
+              "expression": "participant2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_last_message_at_idx": {
+          "name": "dm_conversations_last_message_at_idx",
+          "columns": [
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_participant1_last_message_idx": {
+          "name": "dm_conversations_participant1_last_message_idx",
+          "columns": [
+            {
+              "expression": "participant1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dm_conversations_participant2_last_message_idx": {
+          "name": "dm_conversations_participant2_last_message_idx",
+          "columns": [
+            {
+              "expression": "participant2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dm_conversations_participant1Id_users_id_fk": {
+          "name": "dm_conversations_participant1Id_users_id_fk",
+          "tableFrom": "dm_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "participant1Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dm_conversations_participant2Id_users_id_fk": {
+          "name": "dm_conversations_participant2Id_users_id_fk",
+          "tableFrom": "dm_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "participant2Id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dm_conversations_participant_pair_key": {
+          "name": "dm_conversations_participant_pair_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "participant1Id",
+            "participant2Id"
+          ]
+        }
+      }
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processedAt": {
+          "name": "processedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_events_type_idx": {
+          "name": "stripe_events_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_events_processed_at_idx": {
+          "name": "stripe_events_processed_at_idx",
+          "columns": [
+            {
+              "expression": "processedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripeSubscriptionId": {
+          "name": "stripeSubscriptionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripePriceId": {
+          "name": "stripePriceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentPeriodStart": {
+          "name": "currentPeriodStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentPeriodEnd": {
+          "name": "currentPeriodEnd",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancelAtPeriodEnd": {
+          "name": "cancelAtPeriodEnd",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeScheduleId": {
+          "name": "stripeScheduleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledPriceId": {
+          "name": "scheduledPriceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduledChangeDate": {
+          "name": "scheduledChangeDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscriptions_user_id_idx": {
+          "name": "subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_stripe_subscription_id_idx": {
+          "name": "subscriptions_stripe_subscription_id_idx",
+          "columns": [
+            {
+              "expression": "stripeSubscriptionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "subscriptions_stripe_schedule_id_idx": {
+          "name": "subscriptions_stripe_schedule_id_idx",
+          "columns": [
+            {
+              "expression": "stripeScheduleId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscriptions_userId_users_id_fk": {
+          "name": "subscriptions_userId_users_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscriptions_stripeSubscriptionId_unique": {
+          "name": "subscriptions_stripeSubscriptionId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripeSubscriptionId"
+          ]
+        }
+      }
+    },
+    "public.contact_submissions": {
+      "name": "contact_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_submissions_email_idx": {
+          "name": "contact_submissions_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contact_submissions_created_at_idx": {
+          "name": "contact_submissions_created_at_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.feedback_submissions": {
+      "name": "feedback_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "screen_size": {
+          "name": "screen_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "viewport_size": {
+          "name": "viewport_size",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_version": {
+          "name": "app_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "console_errors": {
+          "name": "console_errors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "feedback_submissions_user_id_idx": {
+          "name": "feedback_submissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_submissions_status_idx": {
+          "name": "feedback_submissions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "feedback_submissions_created_at_idx": {
+          "name": "feedback_submissions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "feedback_submissions_user_id_users_id_fk": {
+          "name": "feedback_submissions_user_id_users_id_fk",
+          "tableFrom": "feedback_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.file_conversations": {
+      "name": "file_conversations",
+      "schema": "",
+      "columns": {
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linkedBy": {
+          "name": "linkedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedAt": {
+          "name": "linkedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "linkSource": {
+          "name": "linkSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "file_conversations_file_id_idx": {
+          "name": "file_conversations_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_conversations_conversation_id_idx": {
+          "name": "file_conversations_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_conversations_fileId_files_id_fk": {
+          "name": "file_conversations_fileId_files_id_fk",
+          "tableFrom": "file_conversations",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_conversations_conversationId_dm_conversations_id_fk": {
+          "name": "file_conversations_conversationId_dm_conversations_id_fk",
+          "tableFrom": "file_conversations",
+          "tableTo": "dm_conversations",
+          "columnsFrom": [
+            "conversationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_conversations_linkedBy_users_id_fk": {
+          "name": "file_conversations_linkedBy_users_id_fk",
+          "tableFrom": "file_conversations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "linkedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "file_conversations_fileId_conversationId_pk": {
+          "name": "file_conversations_fileId_conversationId_pk",
+          "columns": [
+            "fileId",
+            "conversationId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.file_pages": {
+      "name": "file_pages",
+      "schema": "",
+      "columns": {
+        "fileId": {
+          "name": "fileId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linkedBy": {
+          "name": "linkedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedAt": {
+          "name": "linkedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "linkSource": {
+          "name": "linkSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "file_pages_file_id_idx": {
+          "name": "file_pages_file_id_idx",
+          "columns": [
+            {
+              "expression": "fileId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_pages_page_id_idx": {
+          "name": "file_pages_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_pages_fileId_files_id_fk": {
+          "name": "file_pages_fileId_files_id_fk",
+          "tableFrom": "file_pages",
+          "tableTo": "files",
+          "columnsFrom": [
+            "fileId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_pages_pageId_pages_id_fk": {
+          "name": "file_pages_pageId_pages_id_fk",
+          "tableFrom": "file_pages",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "file_pages_linkedBy_users_id_fk": {
+          "name": "file_pages_linkedBy_users_id_fk",
+          "tableFrom": "file_pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "linkedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "file_pages_fileId_pageId_pk": {
+          "name": "file_pages_fileId_pageId_pk",
+          "columns": [
+            "fileId",
+            "pageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.files": {
+      "name": "files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sizeBytes": {
+          "name": "sizeBytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mimeType": {
+          "name": "mimeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storagePath": {
+          "name": "storagePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksumVersion": {
+          "name": "checksumVersion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastAccessedAt": {
+          "name": "lastAccessedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "files_drive_id_idx": {
+          "name": "files_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "files_driveId_drives_id_fk": {
+          "name": "files_driveId_drives_id_fk",
+          "tableFrom": "files",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "files_createdBy_users_id_fk": {
+          "name": "files_createdBy_users_id_fk",
+          "tableFrom": "files",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.task_assignees": {
+      "name": "task_assignees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "taskId": {
+          "name": "taskId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentPageId": {
+          "name": "agentPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_assignees_task_id_idx": {
+          "name": "task_assignees_task_id_idx",
+          "columns": [
+            {
+              "expression": "taskId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_assignees_user_id_idx": {
+          "name": "task_assignees_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_assignees_agent_page_id_idx": {
+          "name": "task_assignees_agent_page_id_idx",
+          "columns": [
+            {
+              "expression": "agentPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_assignees_taskId_task_items_id_fk": {
+          "name": "task_assignees_taskId_task_items_id_fk",
+          "tableFrom": "task_assignees",
+          "tableTo": "task_items",
+          "columnsFrom": [
+            "taskId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_assignees_userId_users_id_fk": {
+          "name": "task_assignees_userId_users_id_fk",
+          "tableFrom": "task_assignees",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_assignees_agentPageId_pages_id_fk": {
+          "name": "task_assignees_agentPageId_pages_id_fk",
+          "tableFrom": "task_assignees",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agentPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_assignees_task_user": {
+          "name": "task_assignees_task_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskId",
+            "userId"
+          ]
+        },
+        "task_assignees_task_agent": {
+          "name": "task_assignees_task_agent",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskId",
+            "agentPageId"
+          ]
+        }
+      }
+    },
+    "public.task_items": {
+      "name": "task_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "taskListId": {
+          "name": "taskListId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigneeId": {
+          "name": "assigneeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigneeAgentId": {
+          "name": "assigneeAgentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "dueDate": {
+          "name": "dueDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_items_task_list_id_idx": {
+          "name": "task_items_task_list_id_idx",
+          "columns": [
+            {
+              "expression": "taskListId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_items_task_list_status_idx": {
+          "name": "task_items_task_list_status_idx",
+          "columns": [
+            {
+              "expression": "taskListId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_items_assignee_id_idx": {
+          "name": "task_items_assignee_id_idx",
+          "columns": [
+            {
+              "expression": "assigneeId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_items_assignee_agent_id_idx": {
+          "name": "task_items_assignee_agent_id_idx",
+          "columns": [
+            {
+              "expression": "assigneeAgentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_items_page_id_idx": {
+          "name": "task_items_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_items_due_date_idx": {
+          "name": "task_items_due_date_idx",
+          "columns": [
+            {
+              "expression": "dueDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_items_taskListId_task_lists_id_fk": {
+          "name": "task_items_taskListId_task_lists_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "task_lists",
+          "columnsFrom": [
+            "taskListId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_items_userId_users_id_fk": {
+          "name": "task_items_userId_users_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_items_assigneeId_users_id_fk": {
+          "name": "task_items_assigneeId_users_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigneeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_items_assigneeAgentId_pages_id_fk": {
+          "name": "task_items_assigneeAgentId_pages_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "assigneeAgentId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "task_items_pageId_pages_id_fk": {
+          "name": "task_items_pageId_pages_id_fk",
+          "tableFrom": "task_items",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.task_lists": {
+      "name": "task_lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_lists_page_id_idx": {
+          "name": "task_lists_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_lists_conversation_id_idx": {
+          "name": "task_lists_conversation_id_idx",
+          "columns": [
+            {
+              "expression": "conversationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_lists_user_id_idx": {
+          "name": "task_lists_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_lists_userId_users_id_fk": {
+          "name": "task_lists_userId_users_id_fk",
+          "tableFrom": "task_lists",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_lists_pageId_pages_id_fk": {
+          "name": "task_lists_pageId_pages_id_fk",
+          "tableFrom": "task_lists",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.task_status_configs": {
+      "name": "task_status_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "taskListId": {
+          "name": "taskListId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group": {
+          "name": "group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "task_status_configs_task_list_id_idx": {
+          "name": "task_status_configs_task_list_id_idx",
+          "columns": [
+            {
+              "expression": "taskListId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_status_configs_taskListId_task_lists_id_fk": {
+          "name": "task_status_configs_taskListId_task_lists_id_fk",
+          "tableFrom": "task_status_configs",
+          "tableTo": "task_lists",
+          "columnsFrom": [
+            "taskListId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_status_configs_task_list_slug": {
+          "name": "task_status_configs_task_list_slug",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskListId",
+            "slug"
+          ]
+        }
+      }
+    },
+    "public.security_audit_log": {
+      "name": "security_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service_id": {
+          "name": "service_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geo_location": {
+          "name": "geo_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "risk_score": {
+          "name": "risk_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anomaly_flags": {
+          "name": "anomaly_flags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "chain_seq": {
+          "name": "chain_seq",
+          "type": "bigserial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_hash": {
+          "name": "previous_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_hash": {
+          "name": "event_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_security_audit_timestamp": {
+          "name": "idx_security_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_user_timestamp": {
+          "name": "idx_security_audit_user_timestamp",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_event_type": {
+          "name": "idx_security_audit_event_type",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_resource": {
+          "name": "idx_security_audit_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_ip": {
+          "name": "idx_security_audit_ip",
+          "columns": [
+            {
+              "expression": "ip_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_event_hash": {
+          "name": "idx_security_audit_event_hash",
+          "columns": [
+            {
+              "expression": "event_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_chain_seq": {
+          "name": "idx_security_audit_chain_seq",
+          "columns": [
+            {
+              "expression": "chain_seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_risk_score": {
+          "name": "idx_security_audit_risk_score",
+          "columns": [
+            {
+              "expression": "risk_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_security_audit_session": {
+          "name": "idx_security_audit_session",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "security_audit_log_user_id_users_id_fk": {
+          "name": "security_audit_log_user_id_users_id_fk",
+          "tableFrom": "security_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.user_page_views": {
+      "name": "user_page_views",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewedAt": {
+          "name": "viewedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_page_views_user_id_idx": {
+          "name": "user_page_views_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_page_views_page_id_idx": {
+          "name": "user_page_views_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_page_views_user_page_idx": {
+          "name": "user_page_views_user_page_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_page_views_userId_users_id_fk": {
+          "name": "user_page_views_userId_users_id_fk",
+          "tableFrom": "user_page_views",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_page_views_pageId_pages_id_fk": {
+          "name": "user_page_views_pageId_pages_id_fk",
+          "tableFrom": "user_page_views",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_page_views_userId_pageId_pk": {
+          "name": "user_page_views_userId_pageId_pk",
+          "columns": [
+            "userId",
+            "pageId"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.user_hotkey_preferences": {
+      "name": "user_hotkey_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hotkeyId": {
+          "name": "hotkeyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding": {
+          "name": "binding",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_hotkey_preferences_user_hotkey_idx": {
+          "name": "user_hotkey_preferences_user_hotkey_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "hotkeyId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_hotkey_preferences_user_idx": {
+          "name": "user_hotkey_preferences_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_hotkey_preferences_userId_users_id_fk": {
+          "name": "user_hotkey_preferences_userId_users_id_fk",
+          "tableFrom": "user_hotkey_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.push_notification_tokens": {
+      "name": "push_notification_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "PushPlatformType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deviceId": {
+          "name": "deviceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceName": {
+          "name": "deviceName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "webPushSubscription": {
+          "name": "webPushSubscription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failedAttempts": {
+          "name": "failedAttempts",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "lastFailedAt": {
+          "name": "lastFailedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "push_notification_tokens_user_id_idx": {
+          "name": "push_notification_tokens_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tokens_token_idx": {
+          "name": "push_notification_tokens_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tokens_platform_idx": {
+          "name": "push_notification_tokens_platform_idx",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_notification_tokens_active_idx": {
+          "name": "push_notification_tokens_active_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_notification_tokens_userId_users_id_fk": {
+          "name": "push_notification_tokens_userId_users_id_fk",
+          "tableFrom": "push_notification_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.global_assistant_config": {
+      "name": "global_assistant_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled_user_integrations": {
+          "name": "enabled_user_integrations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_overrides": {
+          "name": "drive_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inherit_drive_integrations": {
+          "name": "inherit_drive_integrations",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "global_assistant_config_user_id_users_id_fk": {
+          "name": "global_assistant_config_user_id_users_id_fk",
+          "tableFrom": "global_assistant_config",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "global_assistant_config_user_id_unique": {
+          "name": "global_assistant_config_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      }
+    },
+    "public.integration_audit_log": {
+      "name": "integration_audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_summary": {
+          "name": "input_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_code": {
+          "name": "response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_audit_log_drive_id_idx": {
+          "name": "integration_audit_log_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_audit_log_connection_id_idx": {
+          "name": "integration_audit_log_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_audit_log_created_at_idx": {
+          "name": "integration_audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_audit_log_drive_created_at_idx": {
+          "name": "integration_audit_log_drive_created_at_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_audit_log_drive_id_drives_id_fk": {
+          "name": "integration_audit_log_drive_id_drives_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_audit_log_agent_id_pages_id_fk": {
+          "name": "integration_audit_log_agent_id_pages_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "integration_audit_log_user_id_users_id_fk": {
+          "name": "integration_audit_log_user_id_users_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "integration_audit_log_connection_id_integration_connections_id_fk": {
+          "name": "integration_audit_log_connection_id_integration_connections_id_fk",
+          "tableFrom": "integration_audit_log",
+          "tableTo": "integration_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "integration_connection_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "base_url_override": {
+          "name": "base_url_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_overrides": {
+          "name": "config_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_metadata": {
+          "name": "account_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "integration_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'owned_drives'"
+        },
+        "oauth_state": {
+          "name": "oauth_state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_by": {
+          "name": "connected_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_health_check": {
+          "name": "last_health_check",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_connections_provider_id_idx": {
+          "name": "integration_connections_provider_id_idx",
+          "columns": [
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connections_user_id_idx": {
+          "name": "integration_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_connections_drive_id_idx": {
+          "name": "integration_connections_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_connections_provider_id_integration_providers_id_fk": {
+          "name": "integration_connections_provider_id_integration_providers_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "integration_providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_user_id_users_id_fk": {
+          "name": "integration_connections_user_id_users_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_drive_id_drives_id_fk": {
+          "name": "integration_connections_drive_id_drives_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_connected_by_users_id_fk": {
+          "name": "integration_connections_connected_by_users_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "connected_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "integration_connections_user_provider": {
+          "name": "integration_connections_user_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "provider_id"
+          ]
+        },
+        "integration_connections_drive_provider": {
+          "name": "integration_connections_drive_provider",
+          "nullsNotDistinct": false,
+          "columns": [
+            "drive_id",
+            "provider_id"
+          ]
+        }
+      }
+    },
+    "public.integration_providers": {
+      "name": "integration_providers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "documentation_url": {
+          "name": "documentation_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_type": {
+          "name": "provider_type",
+          "type": "integration_provider_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "openapi_spec": {
+          "name": "openapi_spec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drive_id": {
+          "name": "drive_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_providers_slug_idx": {
+          "name": "integration_providers_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_providers_drive_id_idx": {
+          "name": "integration_providers_drive_id_idx",
+          "columns": [
+            {
+              "expression": "drive_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_providers_created_by_users_id_fk": {
+          "name": "integration_providers_created_by_users_id_fk",
+          "tableFrom": "integration_providers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "integration_providers_drive_id_drives_id_fk": {
+          "name": "integration_providers_drive_id_drives_id_fk",
+          "tableFrom": "integration_providers",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "drive_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "integration_providers_slug_unique": {
+          "name": "integration_providers_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      }
+    },
+    "public.integration_tool_grants": {
+      "name": "integration_tool_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "denied_tools": {
+          "name": "denied_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_only": {
+          "name": "read_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "rate_limit_override": {
+          "name": "rate_limit_override",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "integration_tool_grants_agent_id_idx": {
+          "name": "integration_tool_grants_agent_id_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "integration_tool_grants_connection_id_idx": {
+          "name": "integration_tool_grants_connection_id_idx",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_tool_grants_agent_id_pages_id_fk": {
+          "name": "integration_tool_grants_agent_id_pages_id_fk",
+          "tableFrom": "integration_tool_grants",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_tool_grants_connection_id_integration_connections_id_fk": {
+          "name": "integration_tool_grants_connection_id_integration_connections_id_fk",
+          "tableFrom": "integration_tool_grants",
+          "tableTo": "integration_connections",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "integration_tool_grants_agent_connection": {
+          "name": "integration_tool_grants_agent_connection",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agent_id",
+            "connection_id"
+          ]
+        }
+      }
+    },
+    "public.user_personalization": {
+      "name": "user_personalization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "writingStyle": {
+          "name": "writingStyle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rules": {
+          "name": "rules",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_personalization_user_idx": {
+          "name": "user_personalization_user_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_personalization_userId_users_id_fk": {
+          "name": "user_personalization_userId_users_id_fk",
+          "tableFrom": "user_personalization",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.calendar_events": {
+      "name": "calendar_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pageId": {
+          "name": "pageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startAt": {
+          "name": "startAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endAt": {
+          "name": "endAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "allDay": {
+          "name": "allDay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "recurrenceRule": {
+          "name": "recurrenceRule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrenceExceptions": {
+          "name": "recurrenceExceptions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "recurringEventId": {
+          "name": "recurringEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalStartAt": {
+          "name": "originalStartAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "EventVisibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRIVE'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isTrashed": {
+          "name": "isTrashed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trashedAt": {
+          "name": "trashedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleEventId": {
+          "name": "googleEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleCalendarId": {
+          "name": "googleCalendarId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncedFromGoogle": {
+          "name": "syncedFromGoogle",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastGoogleSync": {
+          "name": "lastGoogleSync",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "googleSyncReadOnly": {
+          "name": "googleSyncReadOnly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "calendar_events_drive_id_idx": {
+          "name": "calendar_events_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_created_by_id_idx": {
+          "name": "calendar_events_created_by_id_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_page_id_idx": {
+          "name": "calendar_events_page_id_idx",
+          "columns": [
+            {
+              "expression": "pageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_start_at_idx": {
+          "name": "calendar_events_start_at_idx",
+          "columns": [
+            {
+              "expression": "startAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_end_at_idx": {
+          "name": "calendar_events_end_at_idx",
+          "columns": [
+            {
+              "expression": "endAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_drive_id_start_at_idx": {
+          "name": "calendar_events_drive_id_start_at_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_recurring_event_id_idx": {
+          "name": "calendar_events_recurring_event_id_idx",
+          "columns": [
+            {
+              "expression": "recurringEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_is_trashed_idx": {
+          "name": "calendar_events_is_trashed_idx",
+          "columns": [
+            {
+              "expression": "isTrashed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_google_event_id_idx": {
+          "name": "calendar_events_google_event_id_idx",
+          "columns": [
+            {
+              "expression": "googleEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_events_synced_from_google_idx": {
+          "name": "calendar_events_synced_from_google_idx",
+          "columns": [
+            {
+              "expression": "syncedFromGoogle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_events_driveId_drives_id_fk": {
+          "name": "calendar_events_driveId_drives_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_events_createdById_users_id_fk": {
+          "name": "calendar_events_createdById_users_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdById"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_events_pageId_pages_id_fk": {
+          "name": "calendar_events_pageId_pages_id_fk",
+          "tableFrom": "calendar_events",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "pageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_events_google_source_per_user_key": {
+          "name": "calendar_events_google_source_per_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "createdById",
+            "googleCalendarId",
+            "googleEventId"
+          ]
+        }
+      }
+    },
+    "public.event_attendees": {
+      "name": "event_attendees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "AttendeeStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "responseNote": {
+          "name": "responseNote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isOrganizer": {
+          "name": "isOrganizer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isOptional": {
+          "name": "isOptional",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "respondedAt": {
+          "name": "respondedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "event_attendees_event_id_idx": {
+          "name": "event_attendees_event_id_idx",
+          "columns": [
+            {
+              "expression": "eventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_attendees_user_id_idx": {
+          "name": "event_attendees_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_attendees_status_idx": {
+          "name": "event_attendees_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_attendees_user_id_status_idx": {
+          "name": "event_attendees_user_id_status_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_attendees_eventId_calendar_events_id_fk": {
+          "name": "event_attendees_eventId_calendar_events_id_fk",
+          "tableFrom": "event_attendees",
+          "tableTo": "calendar_events",
+          "columnsFrom": [
+            "eventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_attendees_userId_users_id_fk": {
+          "name": "event_attendees_userId_users_id_fk",
+          "tableFrom": "event_attendees",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_attendees_event_user_key": {
+          "name": "event_attendees_event_user_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "eventId",
+            "userId"
+          ]
+        }
+      }
+    },
+    "public.google_calendar_connections": {
+      "name": "google_calendar_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokenExpiresAt": {
+          "name": "tokenExpiresAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "googleEmail": {
+          "name": "googleEmail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "googleAccountId": {
+          "name": "googleAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "GoogleCalendarConnectionStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "statusMessage": {
+          "name": "statusMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "targetDriveId": {
+          "name": "targetDriveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "selectedCalendars": {
+          "name": "selectedCalendars",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "syncFrequencyMinutes": {
+          "name": "syncFrequencyMinutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "markAsReadOnly": {
+          "name": "markAsReadOnly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastSyncAt": {
+          "name": "lastSyncAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSyncError": {
+          "name": "lastSyncError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "syncCursor": {
+          "name": "syncCursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhookChannels": {
+          "name": "webhookChannels",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "google_calendar_connections_user_id_idx": {
+          "name": "google_calendar_connections_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "google_calendar_connections_status_idx": {
+          "name": "google_calendar_connections_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "google_calendar_connections_target_drive_id_idx": {
+          "name": "google_calendar_connections_target_drive_id_idx",
+          "columns": [
+            {
+              "expression": "targetDriveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "google_calendar_connections_userId_users_id_fk": {
+          "name": "google_calendar_connections_userId_users_id_fk",
+          "tableFrom": "google_calendar_connections",
+          "tableTo": "users",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "google_calendar_connections_targetDriveId_drives_id_fk": {
+          "name": "google_calendar_connections_targetDriveId_drives_id_fk",
+          "tableFrom": "google_calendar_connections",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "targetDriveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "google_calendar_connections_userId_unique": {
+          "name": "google_calendar_connections_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      }
+    },
+    "public.calendar_triggers": {
+      "name": "calendar_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calendarEventId": {
+          "name": "calendarEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduledById": {
+          "name": "scheduledById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "CalendarTriggerStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "triggerAt": {
+          "name": "triggerAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimedAt": {
+          "name": "claimedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "durationMs": {
+          "name": "durationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "conversationId": {
+          "name": "conversationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurrenceDate": {
+          "name": "occurrenceDate",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1970-01-01T00:00:00.000Z'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "calendar_triggers_status_trigger_at_idx": {
+          "name": "calendar_triggers_status_trigger_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_triggers_scheduled_by_idx": {
+          "name": "calendar_triggers_scheduled_by_idx",
+          "columns": [
+            {
+              "expression": "scheduledById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_triggers_calendar_event_idx": {
+          "name": "calendar_triggers_calendar_event_idx",
+          "columns": [
+            {
+              "expression": "calendarEventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "calendar_triggers_workflow_id_idx": {
+          "name": "calendar_triggers_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "calendar_triggers_workflowId_workflows_id_fk": {
+          "name": "calendar_triggers_workflowId_workflows_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_triggers_calendarEventId_calendar_events_id_fk": {
+          "name": "calendar_triggers_calendarEventId_calendar_events_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "calendar_events",
+          "columnsFrom": [
+            "calendarEventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_triggers_driveId_drives_id_fk": {
+          "name": "calendar_triggers_driveId_drives_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "calendar_triggers_scheduledById_users_id_fk": {
+          "name": "calendar_triggers_scheduledById_users_id_fk",
+          "tableFrom": "calendar_triggers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "scheduledById"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "calendar_triggers_event_occurrence_key": {
+          "name": "calendar_triggers_event_occurrence_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "calendarEventId",
+            "occurrenceDate"
+          ]
+        }
+      }
+    },
+    "public.workflows": {
+      "name": "workflows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentPageId": {
+          "name": "agentPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contextPageIds": {
+          "name": "contextPageIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "cronExpression": {
+          "name": "cronExpression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "WorkflowTriggerType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'cron'"
+        },
+        "eventTriggers": {
+          "name": "eventTriggers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "watchedFolderIds": {
+          "name": "watchedFolderIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventDebounceSecs": {
+          "name": "eventDebounceSecs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30
+        },
+        "instructionPageId": {
+          "name": "instructionPageId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "lastRunAt": {
+          "name": "lastRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nextRunAt": {
+          "name": "nextRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastRunStatus": {
+          "name": "lastRunStatus",
+          "type": "WorkflowRunStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'never_run'"
+        },
+        "lastRunError": {
+          "name": "lastRunError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastRunDurationMs": {
+          "name": "lastRunDurationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "workflows_drive_id_idx": {
+          "name": "workflows_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_created_by_idx": {
+          "name": "workflows_created_by_idx",
+          "columns": [
+            {
+              "expression": "createdBy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_agent_page_id_idx": {
+          "name": "workflows_agent_page_id_idx",
+          "columns": [
+            {
+              "expression": "agentPageId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_enabled_next_run_idx": {
+          "name": "workflows_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextRunAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "workflows_enabled_trigger_type_idx": {
+          "name": "workflows_enabled_trigger_type_idx",
+          "columns": [
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "triggerType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workflows_driveId_drives_id_fk": {
+          "name": "workflows_driveId_drives_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_createdBy_users_id_fk": {
+          "name": "workflows_createdBy_users_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_agentPageId_pages_id_fk": {
+          "name": "workflows_agentPageId_pages_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "agentPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workflows_instructionPageId_pages_id_fk": {
+          "name": "workflows_instructionPageId_pages_id_fk",
+          "tableFrom": "workflows",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "instructionPageId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.task_triggers": {
+      "name": "task_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workflowId": {
+          "name": "workflowId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taskItemId": {
+          "name": "taskItemId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggerType": {
+          "name": "triggerType",
+          "type": "TaskTriggerType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nextRunAt": {
+          "name": "nextRunAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFiredAt": {
+          "name": "lastFiredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastFireError": {
+          "name": "lastFireError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isEnabled": {
+          "name": "isEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "task_triggers_workflow_id_idx": {
+          "name": "task_triggers_workflow_id_idx",
+          "columns": [
+            {
+              "expression": "workflowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_triggers_task_item_id_idx": {
+          "name": "task_triggers_task_item_id_idx",
+          "columns": [
+            {
+              "expression": "taskItemId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "task_triggers_enabled_next_run_idx": {
+          "name": "task_triggers_enabled_next_run_idx",
+          "columns": [
+            {
+              "expression": "isEnabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nextRunAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "task_triggers_workflowId_workflows_id_fk": {
+          "name": "task_triggers_workflowId_workflows_id_fk",
+          "tableFrom": "task_triggers",
+          "tableTo": "workflows",
+          "columnsFrom": [
+            "workflowId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "task_triggers_taskItemId_task_items_id_fk": {
+          "name": "task_triggers_taskItemId_task_items_id_fk",
+          "tableFrom": "task_triggers",
+          "tableTo": "task_items",
+          "columnsFrom": [
+            "taskItemId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "task_triggers_task_item_trigger_type_key": {
+          "name": "task_triggers_task_item_trigger_type_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "taskItemId",
+            "triggerType"
+          ]
+        }
+      }
+    },
+    "public.rate_limit_buckets": {
+      "name": "rate_limit_buckets",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "rate_limit_buckets_expires_at_idx": {
+          "name": "rate_limit_buckets_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "rate_limit_buckets_key_window_start_pk": {
+          "name": "rate_limit_buckets_key_window_start_pk",
+          "columns": [
+            "key",
+            "window_start"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.revoked_service_tokens": {
+      "name": "revoked_service_tokens",
+      "schema": "",
+      "columns": {
+        "jti": {
+          "name": "jti",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "revoked_service_tokens_expires_at_idx": {
+          "name": "revoked_service_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.auth_handoff_tokens": {
+      "name": "auth_handoff_tokens",
+      "schema": "",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "auth_handoff_tokens_expires_at_idx": {
+          "name": "auth_handoff_tokens_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "auth_handoff_tokens_kind_expires_at_idx": {
+          "name": "auth_handoff_tokens_kind_expires_at_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "auth_handoff_tokens_token_hash_kind_pk": {
+          "name": "auth_handoff_tokens_token_hash_kind_pk",
+          "columns": [
+            "token_hash",
+            "kind"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.ai_stream_sessions": {
+      "name": "ai_stream_sessions",
+      "schema": "",
+      "columns": {
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Someone'"
+        },
+        "browser_session_id": {
+          "name": "browser_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'streaming'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ai_stream_sessions_channel_status_idx": {
+          "name": "ai_stream_sessions_channel_status_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.AuthProvider": {
+      "name": "AuthProvider",
+      "schema": "public",
+      "values": [
+        "email",
+        "google",
+        "apple"
+      ]
+    },
+    "public.PlatformType": {
+      "name": "PlatformType",
+      "schema": "public",
+      "values": [
+        "web",
+        "desktop",
+        "ios",
+        "android"
+      ]
+    },
+    "public.UserRole": {
+      "name": "UserRole",
+      "schema": "public",
+      "values": [
+        "user",
+        "admin"
+      ]
+    },
+    "public.FavoriteItemType": {
+      "name": "FavoriteItemType",
+      "schema": "public",
+      "values": [
+        "page",
+        "drive"
+      ]
+    },
+    "public.PageType": {
+      "name": "PageType",
+      "schema": "public",
+      "values": [
+        "FOLDER",
+        "DOCUMENT",
+        "CHANNEL",
+        "AI_CHAT",
+        "CANVAS",
+        "FILE",
+        "SHEET",
+        "TASK_LIST",
+        "CODE",
+        "TERMINAL"
+      ]
+    },
+    "public.PermissionAction": {
+      "name": "PermissionAction",
+      "schema": "public",
+      "values": [
+        "VIEW",
+        "EDIT",
+        "SHARE",
+        "DELETE"
+      ]
+    },
+    "public.SubjectType": {
+      "name": "SubjectType",
+      "schema": "public",
+      "values": [
+        "USER"
+      ]
+    },
+    "public.MemberRole": {
+      "name": "MemberRole",
+      "schema": "public",
+      "values": [
+        "OWNER",
+        "ADMIN",
+        "MEMBER"
+      ]
+    },
+    "public.pulse_summary_type": {
+      "name": "pulse_summary_type",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "on_demand",
+        "welcome"
+      ]
+    },
+    "public.NotificationType": {
+      "name": "NotificationType",
+      "schema": "public",
+      "values": [
+        "PERMISSION_GRANTED",
+        "PERMISSION_REVOKED",
+        "PERMISSION_UPDATED",
+        "PAGE_SHARED",
+        "DRIVE_INVITED",
+        "DRIVE_JOINED",
+        "DRIVE_ROLE_CHANGED",
+        "CONNECTION_REQUEST",
+        "CONNECTION_ACCEPTED",
+        "CONNECTION_REJECTED",
+        "NEW_DIRECT_MESSAGE",
+        "EMAIL_VERIFICATION_REQUIRED",
+        "TOS_PRIVACY_UPDATED",
+        "MENTION",
+        "TASK_ASSIGNED"
+      ]
+    },
+    "public.display_preference_type": {
+      "name": "display_preference_type",
+      "schema": "public",
+      "values": [
+        "SHOW_TOKEN_COUNTS",
+        "SHOW_CODE_TOGGLE",
+        "DEFAULT_MARKDOWN_MODE"
+      ]
+    },
+    "public.activity_change_group_type": {
+      "name": "activity_change_group_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "ai",
+        "automation",
+        "system"
+      ]
+    },
+    "public.activity_resource": {
+      "name": "activity_resource",
+      "schema": "public",
+      "values": [
+        "page",
+        "drive",
+        "permission",
+        "agent",
+        "user",
+        "member",
+        "role",
+        "file",
+        "token",
+        "device",
+        "message",
+        "conversation"
+      ]
+    },
+    "public.content_format": {
+      "name": "content_format",
+      "schema": "public",
+      "values": [
+        "text",
+        "html",
+        "json",
+        "tiptap"
+      ]
+    },
+    "public.http_method": {
+      "name": "http_method",
+      "schema": "public",
+      "values": [
+        "GET",
+        "POST",
+        "PUT",
+        "DELETE",
+        "PATCH",
+        "HEAD",
+        "OPTIONS"
+      ]
+    },
+    "public.log_level": {
+      "name": "log_level",
+      "schema": "public",
+      "values": [
+        "trace",
+        "debug",
+        "info",
+        "warn",
+        "error",
+        "fatal"
+      ]
+    },
+    "public.drive_backup_source": {
+      "name": "drive_backup_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "scheduled",
+        "pre_restore",
+        "system"
+      ]
+    },
+    "public.drive_backup_status": {
+      "name": "drive_backup_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.page_version_source": {
+      "name": "page_version_source",
+      "schema": "public",
+      "values": [
+        "manual",
+        "auto",
+        "pre_ai",
+        "pre_restore",
+        "restore",
+        "system"
+      ]
+    },
+    "public.ConnectionStatus": {
+      "name": "ConnectionStatus",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED",
+        "BLOCKED"
+      ]
+    },
+    "public.PushPlatformType": {
+      "name": "PushPlatformType",
+      "schema": "public",
+      "values": [
+        "ios",
+        "android",
+        "web"
+      ]
+    },
+    "public.integration_connection_status": {
+      "name": "integration_connection_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "error",
+        "pending",
+        "revoked"
+      ]
+    },
+    "public.integration_provider_type": {
+      "name": "integration_provider_type",
+      "schema": "public",
+      "values": [
+        "builtin",
+        "openapi",
+        "custom",
+        "mcp",
+        "webhook"
+      ]
+    },
+    "public.integration_visibility": {
+      "name": "integration_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "owned_drives",
+        "all_drives"
+      ]
+    },
+    "public.AttendeeStatus": {
+      "name": "AttendeeStatus",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACCEPTED",
+        "DECLINED",
+        "TENTATIVE"
+      ]
+    },
+    "public.EventVisibility": {
+      "name": "EventVisibility",
+      "schema": "public",
+      "values": [
+        "DRIVE",
+        "ATTENDEES_ONLY",
+        "PRIVATE"
+      ]
+    },
+    "public.GoogleCalendarConnectionStatus": {
+      "name": "GoogleCalendarConnectionStatus",
+      "schema": "public",
+      "values": [
+        "active",
+        "expired",
+        "error",
+        "disconnected"
+      ]
+    },
+    "public.RecurrenceFrequency": {
+      "name": "RecurrenceFrequency",
+      "schema": "public",
+      "values": [
+        "DAILY",
+        "WEEKLY",
+        "MONTHLY",
+        "YEARLY"
+      ]
+    },
+    "public.CalendarTriggerStatus": {
+      "name": "CalendarTriggerStatus",
+      "schema": "public",
+      "values": [
+        "pending",
+        "claimed",
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "public.WorkflowRunStatus": {
+      "name": "WorkflowRunStatus",
+      "schema": "public",
+      "values": [
+        "never_run",
+        "success",
+        "error",
+        "running"
+      ]
+    },
+    "public.WorkflowTriggerType": {
+      "name": "WorkflowTriggerType",
+      "schema": "public",
+      "values": [
+        "cron",
+        "event"
+      ]
+    },
+    "public.TaskTriggerType": {
+      "name": "TaskTriggerType",
+      "schema": "public",
+      "values": [
+        "due_date",
+        "completion"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -806,6 +806,13 @@
       "when": 1777642298349,
       "tag": "0114_nifty_true_believers",
       "breakpoints": true
+    },
+    {
+      "idx": 115,
+      "version": "7",
+      "when": 1777678513513,
+      "tag": "0115_soft_kinsey_walden",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -139,6 +139,10 @@
       "types": "./dist/schema/tasks.d.ts",
       "default": "./dist/schema/tasks.js"
     },
+    "./schema/task-triggers": {
+      "types": "./dist/schema/task-triggers.d.ts",
+      "default": "./dist/schema/task-triggers.js"
+    },
     "./schema/versioning": {
       "types": "./dist/schema/versioning.d.ts",
       "default": "./dist/schema/versioning.js"

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -27,6 +27,7 @@ export * from './schema/personalization';
 export * from './schema/calendar';
 export * from './schema/calendar-triggers';
 export * from './schema/workflows';
+export * from './schema/task-triggers';
 export * from './schema/rate-limit-buckets';
 export * from './schema/revoked-service-tokens';
 export * from './schema/auth-handoff-tokens';
@@ -61,6 +62,7 @@ import * as personalization from './schema/personalization';
 import * as calendar from './schema/calendar';
 import * as calendarTriggers from './schema/calendar-triggers';
 import * as workflows from './schema/workflows';
+import * as taskTriggers from './schema/task-triggers';
 import * as rateLimitBuckets from './schema/rate-limit-buckets';
 import * as revokedServiceTokens from './schema/revoked-service-tokens';
 import * as authHandoffTokens from './schema/auth-handoff-tokens';
@@ -96,6 +98,7 @@ export const schema = {
   ...calendar,
   ...calendarTriggers,
   ...workflows,
+  ...taskTriggers,
   ...rateLimitBuckets,
   ...revokedServiceTokens,
   ...authHandoffTokens,

--- a/packages/db/src/schema/calendar-triggers.ts
+++ b/packages/db/src/schema/calendar-triggers.ts
@@ -1,9 +1,10 @@
-import { pgTable, text, timestamp, jsonb, integer, index, unique, pgEnum } from 'drizzle-orm/pg-core';
+import { pgTable, text, timestamp, integer, index, unique, pgEnum } from 'drizzle-orm/pg-core';
 import { relations } from 'drizzle-orm';
 import { createId } from '@paralleldrive/cuid2';
 import { users } from './auth';
-import { drives, pages } from './core';
+import { drives } from './core';
 import { calendarEvents } from './calendar';
+import { workflows } from './workflows';
 
 export const calendarTriggerStatus = pgEnum('CalendarTriggerStatus', [
   'pending',
@@ -17,29 +18,24 @@ export const calendarTriggerStatus = pgEnum('CalendarTriggerStatus', [
 /**
  * Calendar Triggers
  *
- * Tracks scheduled LLM agent executions tied to calendar events.
- * When a calendar event's time arrives the cron poller claims the
- * trigger row and fires the target agent with the stored prompt.
+ * The "when" half of a calendar-driven workflow. The execution payload
+ * (prompt, agent, instruction page, context pages) lives on the linked
+ * workflows row referenced by `workflowId`. The cron calendar-triggers
+ * poller claims these rows and delegates to the workflow executor.
  */
 export const calendarTriggers = pgTable('calendar_triggers', {
   id: text('id').primaryKey().$defaultFn(() => createId()),
 
+  workflowId: text('workflowId').notNull().references(() => workflows.id, { onDelete: 'cascade' }),
+
   // Link to the calendar event that represents this trigger visually
   calendarEventId: text('calendarEventId').notNull().references(() => calendarEvents.id, { onDelete: 'cascade' }),
 
-  // Target agent to execute
-  agentPageId: text('agentPageId').notNull().references(() => pages.id, { onDelete: 'cascade' }),
-
-  // Drive context for execution
+  // Drive context for execution and access checks
   driveId: text('driveId').notNull().references(() => drives.id, { onDelete: 'cascade' }),
 
   // Human responsible for cost (rate-limit / API key resolution)
   scheduledById: text('scheduledById').notNull().references(() => users.id, { onDelete: 'cascade' }),
-
-  // Instructions for the agent
-  prompt: text('prompt').notNull(),
-  instructionPageId: text('instructionPageId').references(() => pages.id, { onDelete: 'set null' }),
-  contextPageIds: jsonb('contextPageIds').$type<string[]>().default([]),
 
   // Execution state
   status: calendarTriggerStatus('status').notNull().default('pending'),
@@ -65,34 +61,23 @@ export const calendarTriggers = pgTable('calendar_triggers', {
   updatedAt: timestamp('updatedAt', { mode: 'date' }).notNull().$onUpdate(() => new Date()),
 }, (table) => {
   return {
-    // Cron polling: find pending triggers that are due
     statusTriggerAtIdx: index('calendar_triggers_status_trigger_at_idx').on(table.status, table.triggerAt),
-    // User's scheduled triggers
     scheduledByIdx: index('calendar_triggers_scheduled_by_idx').on(table.scheduledById),
-    // Agent's scheduled work
-    agentPageIdx: index('calendar_triggers_agent_page_idx').on(table.agentPageId),
-    // FK lookup
     calendarEventIdx: index('calendar_triggers_calendar_event_idx').on(table.calendarEventId),
-    // Prevent duplicate triggers for the same event occurrence
+    workflowIdx: index('calendar_triggers_workflow_id_idx').on(table.workflowId),
     eventOccurrenceKey: unique('calendar_triggers_event_occurrence_key').on(table.calendarEventId, table.occurrenceDate),
   };
 });
 
 // Relations
 export const calendarTriggersRelations = relations(calendarTriggers, ({ one }) => ({
+  workflow: one(workflows, {
+    fields: [calendarTriggers.workflowId],
+    references: [workflows.id],
+  }),
   calendarEvent: one(calendarEvents, {
     fields: [calendarTriggers.calendarEventId],
     references: [calendarEvents.id],
-  }),
-  agentPage: one(pages, {
-    fields: [calendarTriggers.agentPageId],
-    references: [pages.id],
-    relationName: 'triggerAgent',
-  }),
-  instructionPage: one(pages, {
-    fields: [calendarTriggers.instructionPageId],
-    references: [pages.id],
-    relationName: 'triggerInstructions',
   }),
   drive: one(drives, {
     fields: [calendarTriggers.driveId],

--- a/packages/db/src/schema/task-triggers.ts
+++ b/packages/db/src/schema/task-triggers.ts
@@ -1,0 +1,54 @@
+import { pgTable, text, timestamp, boolean, index, unique, pgEnum } from 'drizzle-orm/pg-core';
+import { relations } from 'drizzle-orm';
+import { createId } from '@paralleldrive/cuid2';
+import { taskItems } from './tasks';
+import { workflows } from './workflows';
+
+export const taskTriggerType = pgEnum('TaskTriggerType', ['due_date', 'completion']);
+
+/**
+ * Task Triggers
+ *
+ * The "when" half of a task-driven workflow. Pairs a taskItem with the
+ * workflows row that holds the execution payload (prompt, agent, context).
+ * The cron task-triggers poller picks rows where isEnabled = true,
+ * nextRunAt <= NOW() and lastFiredAt IS NULL; completion fires resolve
+ * the matching row in fireCompletionTrigger.
+ */
+export const taskTriggers = pgTable('task_triggers', {
+  id: text('id').primaryKey().$defaultFn(() => createId()),
+
+  workflowId: text('workflowId').notNull().references(() => workflows.id, { onDelete: 'cascade' }),
+  taskItemId: text('taskItemId').notNull().references(() => taskItems.id, { onDelete: 'cascade' }),
+
+  triggerType: taskTriggerType('triggerType').notNull(),
+
+  nextRunAt: timestamp('nextRunAt', { mode: 'date' }),
+  lastFiredAt: timestamp('lastFiredAt', { mode: 'date' }),
+  lastFireError: text('lastFireError'),
+  isEnabled: boolean('isEnabled').default(true).notNull(),
+
+  createdAt: timestamp('createdAt', { mode: 'date' }).defaultNow().notNull(),
+  updatedAt: timestamp('updatedAt', { mode: 'date' }).notNull().$onUpdate(() => new Date()),
+}, (table) => {
+  return {
+    workflowIdx: index('task_triggers_workflow_id_idx').on(table.workflowId),
+    taskItemIdx: index('task_triggers_task_item_id_idx').on(table.taskItemId),
+    enabledNextRunIdx: index('task_triggers_enabled_next_run_idx').on(table.isEnabled, table.nextRunAt),
+    taskItemTriggerTypeKey: unique('task_triggers_task_item_trigger_type_key').on(table.taskItemId, table.triggerType),
+  };
+});
+
+export const taskTriggersRelations = relations(taskTriggers, ({ one }) => ({
+  workflow: one(workflows, {
+    fields: [taskTriggers.workflowId],
+    references: [workflows.id],
+  }),
+  taskItem: one(taskItems, {
+    fields: [taskTriggers.taskItemId],
+    references: [taskItems.id],
+  }),
+}));
+
+export type TaskTrigger = typeof taskTriggers.$inferSelect;
+export type NewTaskTrigger = typeof taskTriggers.$inferInsert;

--- a/packages/db/src/schema/workflows.ts
+++ b/packages/db/src/schema/workflows.ts
@@ -1,9 +1,8 @@
-import { pgTable, text, timestamp, jsonb, boolean, integer, index, pgEnum, unique } from 'drizzle-orm/pg-core';
+import { pgTable, text, timestamp, jsonb, boolean, integer, index, pgEnum } from 'drizzle-orm/pg-core';
 import { relations } from 'drizzle-orm';
 import { createId } from '@paralleldrive/cuid2';
 import { users } from './auth';
 import { drives, pages } from './core';
-import { taskItems } from './tasks';
 
 export const workflowRunStatus = pgEnum('WorkflowRunStatus', [
   'never_run',
@@ -12,7 +11,7 @@ export const workflowRunStatus = pgEnum('WorkflowRunStatus', [
   'running',
 ]);
 
-export const workflowTriggerType = pgEnum('WorkflowTriggerType', ['cron', 'event', 'task_due_date', 'task_completion']);
+export const workflowTriggerType = pgEnum('WorkflowTriggerType', ['cron', 'event']);
 
 export type EventTrigger = {
   operation: string;
@@ -34,8 +33,6 @@ export const workflows = pgTable('workflows', {
   watchedFolderIds: jsonb('watchedFolderIds').$type<string[]>(),
   eventDebounceSecs: integer('eventDebounceSecs').default(30),
 
-  // Task trigger fields (for task_due_date / task_completion trigger types)
-  taskItemId: text('taskItemId').references(() => taskItems.id, { onDelete: 'cascade' }),
   instructionPageId: text('instructionPageId').references(() => pages.id, { onDelete: 'set null' }),
 
   isEnabled: boolean('isEnabled').default(true).notNull(),
@@ -53,8 +50,6 @@ export const workflows = pgTable('workflows', {
     agentPageIdx: index('workflows_agent_page_id_idx').on(table.agentPageId),
     enabledNextRunIdx: index('workflows_enabled_next_run_idx').on(table.isEnabled, table.nextRunAt),
     enabledTriggerTypeIdx: index('workflows_enabled_trigger_type_idx').on(table.isEnabled, table.triggerType),
-    taskItemIdx: index('workflows_task_item_id_idx').on(table.taskItemId),
-    taskItemTriggerTypeKey: unique('workflows_task_item_trigger_type_key').on(table.taskItemId, table.triggerType),
   };
 });
 
@@ -70,10 +65,6 @@ export const workflowsRelations = relations(workflows, ({ one }) => ({
   agentPage: one(pages, {
     fields: [workflows.agentPageId],
     references: [pages.id],
-  }),
-  taskItem: one(taskItems, {
-    fields: [workflows.taskItemId],
-    references: [taskItems.id],
   }),
   instructionPage: one(pages, {
     fields: [workflows.instructionPageId],

--- a/tasks/workflow-trigger-decomposition.md
+++ b/tasks/workflow-trigger-decomposition.md
@@ -1,0 +1,43 @@
+# Workflow Trigger Decomposition Epic
+
+**Status**: 📋 IN PROGRESS — combined PR 1 in flight
+**Goal**: Split `workflows` into a pure execution-definition table with per-domain trigger tables (`taskTriggers`, `calendarTriggers`) referencing it, and a unified `workflow_runs` audit table — so one agent can be reused across N triggers and one new trigger source no longer requires another nullable FK on `workflows`.
+
+## Overview
+
+The current `workflows` table conflates trigger config (taskItemId, task-flavored triggerType enum values, cronExpression, eventTriggers, nextRunAt) with execution payload (prompt, agentPageId, instructionPageId, contextPageIds), so adding a new trigger source means another nullable column and another enum case, and one agent definition cannot be reused across multiple triggers without duplicating its execution row. `calendarTriggers` already split out as a peer table but inverted the mistake — it correctly separates "when" from "what" yet duplicates the execution-payload columns on its own schema and papers over that with a synthetic-WorkflowRow hack inside `calendar-trigger-executor.ts`. This epic resolves both: workflows becomes a pure execution definition, taskTriggers becomes a peer of calendarTriggers (both holding workflowId FK only, no payload columns), `executeWorkflow()` accepts a typed `WorkflowExecutionInput` instead of a literal row, and `workflow_runs` replaces the overwritten `lastRun*` fields plus the per-fire state currently living on calendarTriggers — yielding one unified history surface. None of these tables hold meaningful prod data yet, so every migration is a hard cutover with no bridge columns, no dual-write, no backfill.
+
+---
+
+## Decompose workflows: schema split + executor refactor + per-domain triggers
+
+Combined task: drop task-specific columns/enum values from `workflows`; introduce `taskTriggers` (`workflowId` FK + `taskItemId` + `triggerType ('due_date'|'completion')` + scheduling fields); add `workflowId` FK to `calendarTriggers` and drop its duplicated payload columns; refactor `executeWorkflow()` to accept a typed `WorkflowExecutionInput` (not a literal `WorkflowRow`); delete the synthetic-row construction in `calendar-trigger-executor.ts`; rewire all callers (helpers, cron pollers, REST APIs, AI tools) to the new shape. One migration, one coherent diff.
+
+**Requirements**:
+- Given an empty database, applying the migration should drop `workflows.taskItemId`, drop the `task_due_date` and `task_completion` enum values from `workflowTriggerType`, create the `taskTriggers` table, add `calendarTriggers.workflowId` (NOT NULL FK, cascade), and drop `calendarTriggers.{prompt, agentPageId, instructionPageId, contextPageIds}` — all in a single migration with no nullable bridge column.
+- Given the existing UI flow that creates a task trigger, the API endpoint should produce one `workflows` row (execution) and one `taskTriggers` row (when) atomically in a transaction.
+- Given the AI agent's `update_task` tool with an `agentTrigger` payload, the helper path should write the same split shape as the UI route and not insert directly into the DB.
+- Given a calendar event being created with an `agentTrigger` payload (REST or AI tool), the handler should write one `workflows` row and one `calendarTriggers` row atomically.
+- Given a task whose `dueDate` is updated, `syncTaskDueDateTrigger` should mutate `taskTriggers.nextRunAt` (not `workflows.nextRunAt`) and only when `lastFiredAt IS NULL`.
+- Given a task moving into a "done" status group, `fireCompletionTrigger` should atomically claim the matching `taskTriggers` row (one fire per row, ever), execute the linked workflow, then write `lastFiredAt` and `isEnabled=false`.
+- Given the cron workflows poller runs, it should query only `triggerType='cron'` workflows and never touch task-flavored rows (which no longer exist).
+- Given the new cron task-triggers poller runs, it should pick `taskTriggers` rows where `isEnabled=true AND nextRunAt <= NOW() AND lastFiredAt IS NULL`, claim atomically, execute, and write back.
+- Given a deleted task, both its `taskTriggers` row and its linked `workflows` row should be removed (cascade or explicit delete in `disableTaskTriggers` — pick one, document why in commit).
+- Given `executeWorkflow()` after refactor, it should accept `WorkflowExecutionInput` (the minimum execution-relevant shape) and not depend on a literal `workflows` table row, so any caller can compose the input without forging fake rows.
+- Given the calendar trigger executor after refactor, it should load the linked `workflows` row by `calendarTriggers.workflowId` and call `executeWorkflow()` with composed input — no synthetic-WorkflowRow construction remains in the file.
+- Given the cron, manual-fire (`/run`), task-completion, and task-due-date callers, all should pass `WorkflowExecutionInput` instead of `WorkflowRow`.
+- Given the test suite runs after the change, every existing task-trigger and calendar-trigger test should pass against the new schema (no skipped tests).
+
+---
+
+## Add workflow_runs and retire lastRun*
+
+Introduce `workflow_runs` as the canonical per-fire audit table; drop `lastRunAt` / `lastRunStatus` / `lastRunError` / `lastRunDurationMs` from `workflows`; drop the per-fire state columns (`status`, `claimedAt`, `startedAt`, `completedAt`, `error`, `durationMs`, `conversationId`) from `calendarTriggers`. Every workflow execution writes one row to `workflow_runs` at start (status='running') and updates it at end (status='success'|'error', endedAt, durationMs, error, conversationId). Cron pollers, manual-fire, task-trigger fires, and calendar-trigger fires all write through `workflow_runs`.
+
+**Requirements**:
+- Given an empty database, the migration should create `workflow_runs` with `(workflowId, sourceTable, sourceId, triggerAt, startedAt, endedAt, status, error, durationMs, conversationId)` and drop the eleven columns above from their current homes in a single migration.
+- Given any workflow execution path (cron / task / calendar / manual), exactly one new row should appear in `workflow_runs` per fire, with `sourceTable` set to the originating trigger table or `'cron'`/`'manual'`.
+- Given a stuck-run cleanup sweep, it should mark `workflow_runs` rows in `status='running'` for >10 minutes as `status='error'` with an explanatory error message; trigger-table state is no longer involved in stuck-run detection.
+- Given the workflows UI dashboard, "last run" status should be derived from a join on `workflow_runs` ordered by `startedAt DESC`, not from columns on `workflows`.
+- Given a workflow with N successful fires, `SELECT COUNT(*) FROM workflow_runs WHERE workflow_id = X` should return N.
+- Given the calendar-triggers cron poller, "find unfired triggers" should be expressed as `calendarTriggers` rows where `triggerAt <= NOW()` AND no `workflow_runs` row exists with `(sourceTable='calendarTriggers', sourceId=calendarTriggers.id, status IN ('running','success'))` — verify the EXPLAIN plan is acceptable; add an index if needed.


### PR DESCRIPTION
## Summary

Decomposes the `workflows` god-table into a pure execution-definition table with per-domain trigger peer tables (`task_triggers`, `calendar_triggers`) referencing it. Refactors `executeWorkflow()` to accept a typed `WorkflowExecutionInput` so any caller (cron poller, manual /run, task-trigger fire, calendar-trigger fire) can compose input from its own source of truth without forging synthetic rows.

Implements the first named task of the [Workflow Trigger Decomposition Epic](tasks/workflow-trigger-decomposition.md). The second task (`workflow_runs` + retire `lastRun*`) is a separate follow-up PR.

## Schema migration (`0115_soft_kinsey_walden.sql`)

- Drop `workflows.taskItemId` and the `task_due_date` / `task_completion` enum values from `WorkflowTriggerType` (now just `cron` | `event`)
- Create `task_triggers` (`workflowId` FK + `taskItemId` + `triggerType` ('due_date'|'completion') + `nextRunAt` / `lastFiredAt` / `lastFireError` / `isEnabled`); unique on `(taskItemId, triggerType)`
- Add `calendar_triggers.workflowId` (NOT NULL FK, cascade) and drop the duplicated execution-payload columns (`prompt`, `agentPageId`, `instructionPageId`, `contextPageIds`)
- Hard cutover — `TRUNCATE calendar_triggers` + `DELETE` task-flavored workflows rows so the NOT NULL workflowId and recreated enum apply cleanly

## Updated callers of `executeWorkflow`

- `apps/web/src/app/api/cron/workflows/route.ts` — polls only `triggerType='cron'`; the `task_due_date` branch is gone
- `apps/web/src/app/api/cron/task-triggers/route.ts` — **new** — picks `task_triggers` rows where `isEnabled AND nextRunAt <= NOW() AND lastFiredAt IS NULL`, atomically claims via `lastFiredAt = NOW()` returning(), pre-checks the underlying task before executing
- `apps/web/src/app/api/cron/calendar-triggers/route.ts` — unchanged (delegates to `executeCalendarTrigger`, which composes the input)
- `apps/web/src/app/api/workflows/[workflowId]/run/route.ts` — composes `WorkflowExecutionInput` before calling `executeWorkflow`
- `apps/web/src/lib/workflows/task-trigger-helpers.ts:fireCompletionTrigger` — atomically claims the matching `task_triggers` row (one fire ever, ever), then loads the linked workflow and executes
- `apps/web/src/lib/workflows/calendar-trigger-executor.ts` — loads the linked workflows row by `trigger.workflowId`; the synthetic-WorkflowRow construction is gone

## Other surface changes

- `apps/web/src/app/api/tasks/[taskId]/triggers` (REST GET/PUT/DELETE) — joins `task_triggers ↔ workflows`; returns flat rows
- `apps/web/src/lib/ai/tools/task-management-tools.ts` `update_task` — calls `createTaskTriggerWorkflow` (helper writes both rows in a tx; no direct DB inserts in the tool)
- `apps/web/src/app/api/calendar/events/route.ts` (POST) and `apps/web/src/lib/ai/tools/calendar-write-tools.ts` (`create_calendar_event`) — call new `createCalendarTriggerWorkflow` helper for the atomic `workflows` + `calendar_triggers` dual insert
- `TaskAgentTriggersDialog.tsx` — drops the legacy api/ui enum split; both are `'due_date' | 'completion'` now. Last-run status is derived from `lastFiredAt` + `lastFireError`.

## Test plan

Given/should checklist mirroring the epic's first named task:

- [x] Migration drops `workflows.taskItemId` + task-flavored enum values, creates `task_triggers`, adds `calendar_triggers.workflowId` (NOT NULL FK), drops payload columns — single migration, no nullable bridge
- [x] UI flow that creates a task trigger writes one workflows row + one task_triggers row atomically (transaction)
- [x] AI `update_task` agentTrigger path goes through the helper (no direct DB inserts in the tool)
- [x] Calendar event create (REST + AI tool) writes one workflows row + one calendar_triggers row atomically
- [x] `syncTaskDueDateTrigger` mutates `task_triggers.nextRunAt`, only when `lastFiredAt IS NULL`
- [x] `fireCompletionTrigger` atomically claims one task_triggers row (one fire per row, ever), executes, then writes `lastFiredAt` + `isEnabled=false`
- [x] cron workflows poller queries only `triggerType='cron'`; never touches task-flavored rows
- [x] cron task-triggers poller picks rows by `isEnabled / nextRunAt / lastFiredAt`, claims atomically, executes
- [x] Deleted task: `disableTaskTriggers` deletes the linked workflows rows (cascade goes the other way; explicit cleanup keeps workflows table free of orphans)
- [x] `executeWorkflow()` accepts `WorkflowExecutionInput` (minimum execution-relevant shape); no caller forges fake rows
- [x] `executeCalendarTrigger` loads the linked workflows row and composes input — no synthetic-WorkflowRow remains
- [x] All callers (cron / manual-fire / task-completion / task-due-date) pass `WorkflowExecutionInput`
- [x] Test suite passes against the new schema (no skipped tests)

Gates:
- `pnpm db:generate` — exactly one new migration file
- `pnpm typecheck` — green
- `pnpm lint` — green
- `pnpm --filter web test` — green for all workflow / trigger tests (pre-existing failures in admin-role-version + gift-subscription security tests are DB-connection-required and untouched by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)