### PR TITLE
fix(tasks): task page mobile toolbar layout — stack action buttons on small viewports

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -722,7 +722,7 @@ function TaskListView({ page }: TaskListViewProps) {
   }
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full min-w-0">
       {/* Toolbar */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 px-4 py-3 border-b bg-background">
         <div className="flex flex-col sm:flex-row sm:items-center gap-2">
@@ -756,56 +756,58 @@ function TaskListView({ page }: TaskListViewProps) {
           </div>
         </div>
 
-        <div className="flex items-center gap-2">
-          {/* View toggle (desktop only) */}
-          <div className="hidden md:flex items-center bg-muted rounded-md p-0.5">
-            <button
-              onClick={() => setViewMode('table')}
-              className={cn(
-                'p-1.5 rounded transition-colors',
-                viewMode === 'table'
-                  ? 'bg-background text-foreground shadow-sm'
-                  : 'text-muted-foreground hover:text-foreground'
-              )}
-              title="Table view"
-              aria-label="Table view"
-            >
-              <LayoutList className="h-4 w-4" />
-            </button>
-            <button
-              onClick={() => setViewMode('kanban')}
-              className={cn(
-                'p-1.5 rounded transition-colors',
-                viewMode === 'kanban'
-                  ? 'bg-background text-foreground shadow-sm'
-                  : 'text-muted-foreground hover:text-foreground'
-              )}
-              title="Kanban view"
-              aria-label="Kanban view"
-            >
-              <Kanban className="h-4 w-4" />
-            </button>
+        <div className="flex flex-col sm:flex-row sm:items-center gap-2 w-full sm:w-auto">
+          <div className="flex items-center gap-2 sm:contents">
+            {/* View toggle (desktop only) */}
+            <div className="hidden md:flex items-center bg-muted rounded-md p-0.5">
+              <button
+                onClick={() => setViewMode('table')}
+                className={cn(
+                  'p-1.5 rounded transition-colors',
+                  viewMode === 'table'
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground'
+                )}
+                title="Table view"
+                aria-label="Table view"
+              >
+                <LayoutList className="h-4 w-4" />
+              </button>
+              <button
+                onClick={() => setViewMode('kanban')}
+                className={cn(
+                  'p-1.5 rounded transition-colors',
+                  viewMode === 'kanban'
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground'
+                )}
+                title="Kanban view"
+                aria-label="Kanban view"
+              >
+                <Kanban className="h-4 w-4" />
+              </button>
+            </div>
+
+            {canEdit && (
+              <StatusConfigManager
+                pageId={page.id}
+                statusConfigs={statusConfigs}
+                onConfigsChanged={() => mutate(`/api/pages/${page.id}/tasks`)}
+              />
+            )}
+
+            {canManageWorkflows && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 gap-1"
+                onClick={() => setWorkflowsDialogOpen(true)}
+              >
+                <Zap className="h-3.5 w-3.5" />
+                <span className="hidden sm:inline">Workflows</span>
+              </Button>
+            )}
           </div>
-
-          {canEdit && (
-            <StatusConfigManager
-              pageId={page.id}
-              statusConfigs={statusConfigs}
-              onConfigsChanged={() => mutate(`/api/pages/${page.id}/tasks`)}
-            />
-          )}
-
-          {canManageWorkflows && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-8 gap-1"
-              onClick={() => setWorkflowsDialogOpen(true)}
-            >
-              <Zap className="h-3.5 w-3.5" />
-              <span className="hidden sm:inline">Workflows</span>
-            </Button>
-          )}
 
           {canEdit && viewMode === 'table' && (
             <Button


### PR DESCRIPTION
## Root cause

The task page toolbar's right-side action button group (StatusConfigManager + Workflows + New Task) was hardcoded to a single horizontal flex row at every breakpoint. The New Task button used `w-full sm:w-auto` — but with row-direction siblings, `w-full` makes it compete for 100% of the row's main-axis width instead of stretching properly. That produces the "super wide" button and pushes total content past the mobile viewport, which the parent `CustomScrollArea` (`overflow-auto` on both axes) then exposes as horizontal page scroll.

## Fix

`apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx`

- **Right-section container** (was `flex items-center gap-2`): now `flex flex-col sm:flex-row sm:items-center gap-2 w-full sm:w-auto`. On mobile the section becomes a column, so `w-full` on the New Task button correctly stretches it to a single full-width row.
- **Inner icon-button wrapper** (new): the view toggle, StatusConfigManager, and Workflows button are wrapped in `<div className="flex items-center gap-2 sm:contents">`. On mobile this groups them on one row above the New Task button. At `sm+`, `sm:contents` collapses the wrapper out of the box tree so the desktop layout is byte-identical to before.
- **Root `<div>`** (line 725): added `min-w-0` for defense-in-depth so any future toolbar overflow can't force the page wider than the scroll-area viewport.

Net diff is one component, +52/-50 lines, almost all of which is added indentation from the new wrapper div.

## Out of scope (per task brief)

- `TasksDashboard` (drive root / dashboard task list) — already works on mobile via dedicated `useMobile()` layout.
- Desktop table column widths at line 909–916 — only renders at `md+` and is wrapped in its own `overflow-x-auto`. User instructed not to touch desktop.
- `CustomScrollArea` — global, used across every page type; risk of regression elsewhere is too high.

## Verification

Static checks done in the worktree:
- `pnpm --filter web typecheck` → clean
- `pnpm --filter web lint` → no new warnings

**Browser testing not performed in this environment** (no headless browser tooling and dev server requires Postgres + processor + realtime services I haven't started). The change is a pure Tailwind class adjustment with a structurally transparent `sm:contents` wrapper at desktop, but please verify visually before merging:

- [ ] Mobile (~375px): no horizontal page scroll. Filter tabs and search stack on their own rows. Statuses + Workflows icons sit on one row. New Task button stretches full-width on its own row beneath them.
- [ ] Tablet (~768px): toolbar collapses back to a single horizontal row (left section + right section). View toggle visible. Desktop table renders normally.
- [ ] Desktop (~1280px+): visually identical to before this PR (the `sm:contents` wrapper is transparent at this breakpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style & Layout**
  * Enhanced responsive layout behavior throughout the task list view to improve appearance and usability across different screen sizes and devices.
  * Improved overflow and content wrapping behavior in the main container for better visual stability.
  * Optimized toolbar section layout with refined responsive spacing, ensuring buttons and controls display properly on all viewport sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->