### PR TITLE
fix(ai): truncate long tool call titles to prevent mobile overflow

### DIFF
--- a/apps/web/src/components/ai/ui/tool.tsx
+++ b/apps/web/src/components/ai/ui/tool.tsx
@@ -63,13 +63,16 @@ export const ToolHeader = ({
     )}
     {...props}
   >
-    <div className="flex items-center gap-2">
-      {getStatusIcon(state)}
-      <span className="font-medium text-sm">
+    <div className="flex min-w-0 flex-1 items-center gap-2">
+      <span className="flex-shrink-0">{getStatusIcon(state)}</span>
+      <span
+        className="min-w-0 flex-1 truncate font-medium text-sm text-left"
+        title={title ?? type.split("-").slice(1).join("-")}
+      >
         {title ?? type.split("-").slice(1).join("-")}
       </span>
     </div>
-    <ChevronDownIcon className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+    <ChevronDownIcon className="size-4 flex-shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
   </CollapsibleTrigger>
 );
 


### PR DESCRIPTION
Long descriptive titles like "Get Repository Content: owner/repo/long/path/..."
overflowed the viewport on mobile because ToolHeader's inner flex container
lacked min-w-0 and the title span had no truncation. Constrain both with
min-w-0 + flex-1 + truncate so the title ellipsizes within the trigger,
matching CompactToolCallRenderer behavior. Native title tooltip preserves
full text on hover.