### PR TITLE
fix(ai-chat): lock observer input on remote AI stream

### DIFF
--- a/apps/web/src/components/ai/chat/input/ChatInput.tsx
+++ b/apps/web/src/components/ai/chat/input/ChatInput.tsx
@@ -134,8 +134,7 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
     },
     ref
   ) => {
-    const isRemoteLocked = remoteStreamingUser !== null;
-    const effectiveDisabled = disabled || isRemoteLocked;
+    const effectiveDisabled = disabled || remoteStreamingUser !== null;
     const textareaRef = useRef<ChatTextareaRef>(null);
 
     // Get settings from centralized store
@@ -230,7 +229,7 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
           />
         )}
 
-        {isRemoteLocked && remoteStreamingUser && (
+        {remoteStreamingUser && (
           <div
             className="flex items-center gap-2 px-3 pt-2 pb-1 text-xs text-muted-foreground"
             role="status"

--- a/apps/web/src/components/ai/chat/input/ChatInput.tsx
+++ b/apps/web/src/components/ai/chat/input/ChatInput.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { forwardRef, useRef, useImperativeHandle, useEffect, useCallback } from 'react';
+import { Lock } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ChatTextarea, type ChatTextareaRef } from './ChatTextarea';
 import { InputActions } from './InputActions';
@@ -71,6 +72,11 @@ export interface ChatInputProps {
   onRemoveFile?: (id: string) => void;
   /** Whether the current model supports vision */
   hasVision?: boolean;
+  /** When set, another user (or another tab/device for the same user) is currently
+   * streaming an AI reply on this surface. Locks the textarea + send button and
+   * shows a banner naming the active streamer. The Stop button is gated separately
+   * on `isStreaming` so observers never see a Stop button. */
+  remoteStreamingUser?: { userId: string; displayName: string } | null;
 }
 
 export interface ChatInputRef {
@@ -124,9 +130,12 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
       onAddFiles,
       onRemoveFile,
       hasVision = false,
+      remoteStreamingUser = null,
     },
     ref
   ) => {
+    const isRemoteLocked = remoteStreamingUser !== null;
+    const effectiveDisabled = disabled || isRemoteLocked;
     const textareaRef = useRef<ChatTextareaRef>(null);
 
     // Get settings from centralized store
@@ -181,13 +190,13 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
     const handleSend = () => {
       const hasText = value.trim().length > 0;
       const hasImages = (attachments?.length ?? 0) > 0;
-      if ((hasText || hasImages) && !disabled && !isStreaming) {
+      if ((hasText || hasImages) && !effectiveDisabled && !isStreaming) {
         keyboard.dismiss();
         onSend();
       }
     };
 
-    const canSend = (value.trim().length > 0 || (attachments?.length ?? 0) > 0) && !disabled && !isStreaming;
+    const canSend = (value.trim().length > 0 || (attachments?.length ?? 0) > 0) && !effectiveDisabled && !isStreaming;
 
     // Drag-and-drop handler for images
     const handleDragOver = useCallback((e: React.DragEvent) => {
@@ -221,13 +230,26 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
           />
         )}
 
+        {isRemoteLocked && remoteStreamingUser && (
+          <div
+            className="flex items-center gap-2 px-3 pt-2 pb-1 text-xs text-muted-foreground"
+            role="status"
+            aria-live="polite"
+          >
+            <Lock className="h-3 w-3 shrink-0" />
+            <span className="truncate">
+              {remoteStreamingUser.displayName} is chatting with the AI…
+            </span>
+          </div>
+        )}
+
         {/* Input row */}
         <div className="flex items-start gap-2 p-3 min-w-0">
           {/* Attach button (shown when model supports vision) */}
           {hasVision && onAddFiles && (
             <AttachButton
               onFiles={onAddFiles}
-              disabled={isStreaming || disabled}
+              disabled={isStreaming || effectiveDisabled}
             />
           )}
 
@@ -239,7 +261,7 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
             placeholder={placeholder}
             driveId={driveId}
             crossDrive={crossDrive}
-            disabled={disabled}
+            disabled={effectiveDisabled}
             variant={variant}
             popupPlacement={popupPlacement}
             onPasteFiles={hasVision && onAddFiles ? onAddFiles : undefined}
@@ -280,7 +302,7 @@ export const ChatInput = forwardRef<ChatInputRef, ChatInputProps>(
           selectedModel={currentModel}
           onProviderModelChange={handleProviderModelChange}
           hideModelSelector={hideModelSelector}
-          disabled={isStreaming || disabled}
+          disabled={isStreaming || effectiveDisabled}
         />
       </div>
     );

--- a/apps/web/src/components/ai/chat/input/__tests__/ChatInput.remoteStreamingUser.test.tsx
+++ b/apps/web/src/components/ai/chat/input/__tests__/ChatInput.remoteStreamingUser.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+vi.mock('@/stores/useAssistantSettingsStore', () => ({
+  useAssistantSettingsStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      webSearchEnabled: false,
+      writeMode: false,
+      showPageTree: false,
+      toggleWebSearch: vi.fn(),
+      toggleWriteMode: vi.fn(),
+      toggleShowPageTree: vi.fn(),
+      currentProvider: 'anthropic',
+      currentModel: 'claude-opus-4-7',
+      setProviderSettings: vi.fn(),
+      loadSettings: vi.fn(),
+    }),
+}));
+
+vi.mock('@/hooks/useSpeechRecognition', () => ({
+  useSpeechRecognition: () => ({
+    isListening: false,
+    isSupported: false,
+    error: null,
+    toggleListening: vi.fn(),
+    clearError: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useMobileKeyboard', () => ({
+  useMobileKeyboard: () => ({ dismiss: vi.fn() }),
+}));
+
+vi.mock('../ChatTextarea', () => ({
+  ChatTextarea: ({ disabled, value }: { disabled?: boolean; value: string }) => (
+    <textarea data-testid="chat-textarea" disabled={disabled} value={value} readOnly />
+  ),
+}));
+
+vi.mock('../InputActions', () => ({
+  InputActions: ({ isStreaming, disabled }: { isStreaming: boolean; disabled: boolean }) => (
+    <div
+      data-testid="input-actions"
+      data-streaming={String(isStreaming)}
+      data-disabled={String(disabled)}
+    />
+  ),
+}));
+
+vi.mock('../AttachButton', () => ({
+  AttachButton: ({ disabled }: { disabled?: boolean }) => (
+    <div data-testid="attach-button" data-disabled={String(disabled ?? false)} />
+  ),
+}));
+
+vi.mock('../AttachmentPreviewStrip', () => ({
+  AttachmentPreviewStrip: () => null,
+}));
+
+vi.mock('@/components/ui/floating-input', () => ({
+  InputFooter: ({ disabled }: { disabled: boolean }) => (
+    <div data-testid="input-footer" data-disabled={String(disabled)} />
+  ),
+}));
+
+import { ChatInput } from '../ChatInput';
+
+const baseProps = {
+  value: '',
+  onChange: vi.fn(),
+  onSend: vi.fn(),
+  onStop: vi.fn(),
+  isStreaming: false,
+};
+
+describe('ChatInput — remoteStreamingUser lock', () => {
+  it('given no remoteStreamingUser, the textarea is not forced disabled and no lock banner renders', () => {
+    render(<ChatInput {...baseProps} />);
+
+    expect(screen.getByTestId('chat-textarea')).not.toBeDisabled();
+    expect(screen.queryByRole('status')).toBeNull();
+    expect(screen.queryByText(/is chatting with the AI/)).toBeNull();
+  });
+
+  it('given remoteStreamingUser is set, renders the lock banner naming the streamer', () => {
+    render(
+      <ChatInput
+        {...baseProps}
+        remoteStreamingUser={{ userId: 'u-alice', displayName: 'Alice' }}
+      />
+    );
+
+    const banner = screen.getByRole('status');
+    expect(banner).toHaveTextContent('Alice is chatting with the AI');
+    expect(banner.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('given remoteStreamingUser is set, forces the textarea + footer + attach button into disabled', () => {
+    render(
+      <ChatInput
+        {...baseProps}
+        hasVision
+        onAddFiles={vi.fn()}
+        remoteStreamingUser={{ userId: 'u-alice', displayName: 'Alice' }}
+      />
+    );
+
+    expect(screen.getByTestId('chat-textarea')).toBeDisabled();
+    expect(screen.getByTestId('input-footer').getAttribute('data-disabled')).toBe('true');
+    expect(screen.getByTestId('attach-button').getAttribute('data-disabled')).toBe('true');
+  });
+
+  it('given remoteStreamingUser is set and isStreaming=false, InputActions stays in send mode (disabled), never the destructive Stop button', () => {
+    render(
+      <ChatInput
+        {...baseProps}
+        value="hello"
+        remoteStreamingUser={{ userId: 'u-alice', displayName: 'Alice' }}
+      />
+    );
+
+    const actions = screen.getByTestId('input-actions');
+    expect(actions.getAttribute('data-streaming')).toBe('false');
+    expect(actions.getAttribute('data-disabled')).toBe('true');
+  });
+
+  it('given remoteStreamingUser is null, behaves identically to the prop being omitted', () => {
+    const { rerender } = render(<ChatInput {...baseProps} remoteStreamingUser={null} />);
+    expect(screen.queryByRole('status')).toBeNull();
+    expect(screen.getByTestId('chat-textarea')).not.toBeDisabled();
+
+    rerender(<ChatInput {...baseProps} />);
+    expect(screen.queryByRole('status')).toBeNull();
+    expect(screen.getByTestId('chat-textarea')).not.toBeDisabled();
+  });
+});

--- a/apps/web/src/components/ai/shared/chat/ChatMessagesArea.tsx
+++ b/apps/web/src/components/ai/shared/chat/ChatMessagesArea.tsx
@@ -149,6 +149,10 @@ const ChatMessagesAreaInner = forwardRef<ChatMessagesAreaRef, ChatMessagesAreaPr
       () => (remoteStreams ?? []).filter((s) => !messageIds.has(s.messageId)),
       [remoteStreams, messageIds]
     );
+    const hasRemoteStream = useMemo(
+      () => (remoteStreams ?? []).some((s) => !s.isOwn),
+      [remoteStreams]
+    );
 
     // Memoized render function for virtualized list
     const renderMessage = useCallback((message: UIMessage, _idx: number) => (
@@ -250,7 +254,7 @@ const ChatMessagesAreaInner = forwardRef<ChatMessagesAreaRef, ChatMessagesAreaPr
             />
           ))}
 
-          {isStreaming && !isLoading && (
+          {(isStreaming || hasRemoteStream) && !isLoading && (
             <StreamingIndicator />
           )}
         </ConversationContent>

--- a/apps/web/src/components/ai/shared/chat/__tests__/ChatMessagesArea.remoteStreams.test.tsx
+++ b/apps/web/src/components/ai/shared/chat/__tests__/ChatMessagesArea.remoteStreams.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import type { UIMessage } from 'ai';
 import type { PendingStream } from '@/stores/usePendingStreamsStore';
 
@@ -209,5 +209,44 @@ describe('ChatMessagesArea — remoteStreams rendering', () => {
     );
 
     expect(remoteRendererCalls()).toHaveLength(0);
+  });
+
+  it('given a non-own remote stream and isStreaming=false, renders the StreamingIndicator (observer "Thinking…" cue)', () => {
+    render(
+      <ChatMessagesArea
+        messages={[]}
+        isLoading={false}
+        isStreaming={false}
+        remoteStreams={[makeStream({ messageId: 'remote-x', parts: [textPart('partial')], isOwn: false })]}
+      />
+    );
+
+    expect(screen.getByTestId('streaming-indicator')).toBeInTheDocument();
+  });
+
+  it('given remoteStreams contains only own streams and isStreaming=false, does NOT render the StreamingIndicator', () => {
+    render(
+      <ChatMessagesArea
+        messages={[]}
+        isLoading={false}
+        isStreaming={false}
+        remoteStreams={[makeStream({ messageId: 'own-x', parts: [textPart('partial')], isOwn: true })]}
+      />
+    );
+
+    expect(screen.queryByTestId('streaming-indicator')).toBeNull();
+  });
+
+  it('given no remoteStreams and isStreaming=false, does NOT render the StreamingIndicator', () => {
+    render(
+      <ChatMessagesArea
+        messages={[makeMessage('m-1', 'user', 'hi')]}
+        isLoading={false}
+        isStreaming={false}
+        remoteStreams={[]}
+      />
+    );
+
+    expect(screen.queryByTestId('streaming-indicator')).toBeNull();
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -338,6 +338,10 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
 
   const effectiveIsStreaming = isStreaming || ownStreamMessageId !== undefined;
 
+  const remoteStreamingUser = !effectiveIsStreaming
+    ? remoteStreams.find((s) => !s.isOwn)?.triggeredBy ?? null
+    : null;
+
   const effectiveStop = useCallback(() => {
     if (isStreaming) {
       stop();
@@ -815,6 +819,7 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
                   onAddFiles={addFiles}
                   onRemoveFile={removeFile}
                   hasVision={hasVision}
+                  remoteStreamingUser={remoteStreamingUser}
                 />
               </>
             )}

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -367,6 +367,10 @@ const GlobalAssistantView: React.FC = () => {
     contextIsStreaming,
     contextStopStreaming,
   });
+
+  const remoteStreamingUser = !effectiveIsStreaming
+    ? remoteStreams.find((s) => !s.isOwn)?.triggeredBy ?? null
+    : null;
   // Agent mode: initialized when we have a conversationId and not loading
   // Global mode: use globalIsInitialized from context
   const agentIsInitialized = selectedAgent ? (!!agentConversationId && !agentIsLoading) : false;
@@ -952,6 +956,7 @@ const GlobalAssistantView: React.FC = () => {
               hasVision={hasVisionCapability(
                 (selectedAgent ? agentSelectedModel : currentModel) || ''
               )}
+              remoteStreamingUser={remoteStreamingUser}
             />
           </>
         )}

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -283,6 +283,10 @@ const SidebarChatTab: React.FC = () => {
     ),
   );
 
+  const remoteStreamingUser = !displayIsStreaming
+    ? remoteStreams.find((s) => !s.isOwn)?.triggeredBy ?? null
+    : null;
+
   // Agent-mode wiring (Tasks 4 + 5 + 6 for the sidebar). No-op when
   // selectedAgent is null. Joins the agent socket room, bootstrap-replays
   // in-flight streams, claims the dashboard stop slot under co-mount safety,
@@ -925,6 +929,7 @@ const SidebarChatTab: React.FC = () => {
           hasVision={hasVisionCapability(
             (selectedAgent ? selectedAgent.aiModel : currentModel) || ''
           )}
+          remoteStreamingUser={remoteStreamingUser}
         />
       </div>
 


### PR DESCRIPTION
## Summary

- When User A sends a prompt on a shared AI Chat page, User B (and any other observer) now sees their input locked with a banner *"{name} is chatting with the AI…"* and the *Thinking…* spinner — no more competing-prompt races and no more guessing whether the stream is still in flight.
- Stop button stays initiator-only (already correctly gated on `ownStreamMessageId`) — this PR doesn't touch that path.
- Same UX applies to the Global Assistant + Sidebar Chat Tab so cross-tab/device sessions for a single user are consistent.

## Changes

- `ChatInput.tsx` — new optional `remoteStreamingUser` prop. When set: textarea + send + footer + attach forced disabled, `role="status"` lock banner rendered with `aria-live="polite"`. Stop-button branch (`isStreaming`) untouched.
- `AiChatView.tsx`, `GlobalAssistantView.tsx`, `SidebarChatTab.tsx` — derive `remoteStreamingUser` from existing remote-stream selectors (filter `!isOwn`, gated on own streaming so initiator never sees the banner during same-frame races). Pass to `ChatInput`.
- `ChatMessagesArea.tsx` — expand `StreamingIndicator` condition to `(isStreaming || hasRemoteStream)` using existing `remoteStreams` prop; `hasRemoteStream` filters `!s.isOwn` to avoid double-firing on the initiator's own in-flight stream.

No wire-protocol or store changes — `chat:stream_start` / `chat:stream_complete` already carry `triggeredBy.displayName`, and `usePendingStreamsStore` already distinguishes `isOwn`.

## Tests

New unit coverage:
- `ChatInput.remoteStreamingUser.test.tsx` — 5 cases: no banner without prop, banner with displayName when set, textarea/footer/attach forced disabled when locked, `InputActions` stays in send-mode (never Stop) for observers, `null` is equivalent to omitted.
- `ChatMessagesArea.remoteStreams.test.tsx` — 3 added cases: indicator fires for non-own remote streams, suppressed for own-only streams, suppressed when no streams at all.

## Test plan

- [ ] Two-browser test on a shared AI Chat page: initiator sees Stop + Thinking… (unchanged); observer sees lock banner with initiator's display name, disabled send, Thinking… spinner.
- [ ] Stream completes naturally → both inputs return to normal.
- [ ] Initiator clicks Stop mid-stream → observer's lock + spinner clear in same frame.
- [ ] Reload observer's tab mid-stream → DB-backed bootstrap repopulates lock + spinner on mount.
- [ ] Same-frame race: both users hit Send simultaneously → first to land takes the stream; loser's UI flips to observer lock; no double Stop button.
- [ ] Global Assistant + Sidebar: open same agent in two tabs as one user → tab 2 shows lock + spinner while tab 1 streams. Different conversations on each tab → no false lock (selector filters by \`conversationId\`).
- [x] \`pnpm --filter web typecheck\` clean
- [x] \`pnpm --filter web lint\` clean (only pre-existing warning)
- [x] \`ChatInput.remoteStreamingUser\` + \`ChatMessagesArea.remoteStreams\` + \`ChatLayout.remoteStreams\` tests pass (18/18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)