### PR TITLE
docs(marketing): scrub remaining BYOK references and announce key retirement

### DIFF
--- a/apps/marketing/src/app/blog/[slug]/data.ts
+++ b/apps/marketing/src/app/blog/[slug]/data.ts
@@ -21,6 +21,44 @@ export function formatDate(dateString: string): string {
 }
 
 export const blogPosts: Record<string, BlogPost> = {
+  "managed-provider-keys": {
+    slug: "managed-provider-keys",
+    title: "PageSpace now manages AI provider keys for you",
+    description:
+      "Per-user API keys (\"BYOK\") are gone. Provider credentials and quotas are now handled at the platform level — your AI chats keep working without any setup. Here's what changes for existing users.",
+    content: `
+## What changed
+
+If you ever pasted an API key into **Settings > AI** to use Claude, GPT, Gemini, or any non-default provider, that flow is retired. The settings page no longer asks for a key, and every key you'd stored has been deleted from our database.
+
+In practice nothing breaks. Open an AI Chat, pick a model, send a message. The model picker shows whichever providers PageSpace has enabled for your deployment — you don't manage credentials for any of them.
+
+## What this means in practice
+
+- **Your AI conversations keep working.** No setup, no key to paste, no encryption details to think about.
+- **Your previously-stored keys are gone from our side.** We've deleted them. Your accounts at OpenAI, Anthropic, Google AI, and the other providers are untouched — those keys still exist with the upstream provider. Revoke them there if you want, but you don't have to.
+- **Provider availability is now a deployment-level concern.** On pagespace.ai cloud, that's whatever PageSpace has enabled. On a self-hosted install, it's whatever your operator has configured via environment variables.
+
+## Standard vs pro tier
+
+Every paid plan has a daily AI quota split into two tiers:
+
+- **Standard** covers smaller and mid-tier models — Gemini Flash, Claude Haiku, GPT mini variants, GLM 4.7, and similar.
+- **Pro** covers frontier flagships — Claude Opus, the GPT-5 family, OpenAI o3, and GLM-5.
+
+If you regularly hit the pro daily limit, [upgrade to a higher plan](/pricing) for more pro capacity.
+
+## Why we did this
+
+Two reasons. Key management was the biggest setup hurdle for new users — most never finished configuring providers, and the experience suffered. Holding encrypted keys for every user was also a meaningful security surface area we didn't need to own. Operators provision once at the deployment level; there's nothing per-user to leak.
+
+If a provider you used regularly has disappeared from your model picker, or a model isn't behaving the way you expect, reach out on Discord or email hello@pagespace.ai.
+    `,
+    author: "Jono",
+    date: "2026-05-01",
+    readTime: "3 min read",
+    category: "Product",
+  },
   "your-workspace-is-the-context": {
     slug: "your-workspace-is-the-context",
     title:

--- a/apps/marketing/src/app/docs/features/ai/page.tsx
+++ b/apps/marketing/src/app/docs/features/ai/page.tsx
@@ -18,7 +18,7 @@ AI in PageSpace isn't bolted on — it's a behaviour the whole product shares. A
 - @mention an AI Chat page from a document, channel, sheet cell, or another AI Chat to pull that agent into the thread.
 - Use the **global assistant** in the right-hand sidebar to work across every drive you can see.
 - Ask one agent to consult another by name — the called agent runs under its own prompt and tools, then returns a single response.
-- Pick your provider and model in **Settings > AI**. Bring your own key for any supported provider, or use the built-in PageSpace provider with no key at all.
+- Pick your provider and model in **Settings > AI**. The list shows whichever providers your deployment has enabled — your account-level pick sets the default and any individual AI Chat page can override it.
 - Restrict any agent to a specific toolset by editing its AI Chat page's allow-list.
 - Toggle **Read-only mode** on any AI Chat page to guarantee it cannot create, edit, or delete anything.
 - Toggle **Web search** on any AI Chat page to let that agent look things up outside your workspace.
@@ -26,7 +26,7 @@ AI in PageSpace isn't bolted on — it's a behaviour the whole product shares. A
 
 ## How it works
 
-**Providers.** PageSpace routes your conversation to one of several AI providers through a single underlying pipe. You pick the provider in settings; models show up once the provider is configured. Keys are encrypted at rest and scoped to your account — they are never shared with teammates, so each user configures their own.
+**Providers.** PageSpace routes your conversation to one of several AI providers through a single underlying pipe. Provider credentials are held by the deployment operator — on cloud, that's PageSpace; on a self-hosted install, it's whoever runs the server. The model picker only lists providers the operator has enabled, so anything unconfigured is hidden rather than failing at call time. Calls count against your plan's standard or pro daily AI quota depending on the model you pick.
 
 **Permissions.** When an agent acts, it acts as **you**. It can only see pages you can see and only change pages you can change. Share a page with a teammate and *their* agents can now see it too, under their account. Revoke access and the agents lose access immediately — there is no AI back-door.
 

--- a/apps/marketing/src/app/docs/getting-started/page.tsx
+++ b/apps/marketing/src/app/docs/getting-started/page.tsx
@@ -59,24 +59,23 @@ Documents use a TipTap rich-text editor with:
 
 ## 4. Set Up AI
 
-PageSpace routes every model through the Vercel AI SDK across 12 providers:
+PageSpace routes every model through the Vercel AI SDK across 12 providers. Provider credentials are managed by the deployment operator (on pagespace.ai cloud, that's PageSpace; on self-hosted, that's whoever runs the server) — you don't need to supply API keys.
 
-| Provider | What it is | Key required |
-|----------|-----------|--------------|
-| PageSpace | Hosted GLM models (default — \`glm-4.7\` standard, \`glm-5\` pro) | No — included |
-| OpenRouter (Paid) | Any model in OpenRouter's catalog | Your OpenRouter key |
-| OpenRouter (Free) | Free-tier models curated in the config | Your OpenRouter key |
-| Google AI | Gemini 3 and 2.5 families | Your Google AI key |
-| OpenAI | GPT-5.4 / 5.3 / 5.2 families | Your OpenAI key |
-| Anthropic | Claude 4.6 / 4.5 / 4.1 families | Your Anthropic key |
-| xAI | Grok 4 family | Your xAI key |
-| Azure OpenAI | Models from your Azure deployment | Endpoint + key |
-| GLM | GLM-5, 4.7, 4.6, 4.5 Air | Your GLM key |
-| MiniMax | MiniMax M2.x models | Your MiniMax key |
-| Ollama | Models discovered from a local Ollama server | Local server URL |
-| LM Studio | Models discovered from a running LM Studio server | Local server URL |
+| Provider | What it is |
+|----------|-----------|
+| PageSpace | Hosted GLM models (default — \`glm-4.7\` on the standard tier, \`glm-5\` on the pro tier) |
+| OpenRouter | Paid and free-tier models from OpenRouter's catalog |
+| Google AI | Gemini 3 and 2.5 families |
+| OpenAI | GPT-5.4 / 5.3 / 5.2 families |
+| Anthropic | Claude 4.6 / 4.5 / 4.1 families |
+| xAI | Grok 4 family |
+| Azure OpenAI | Models from a configured Azure deployment |
+| GLM | GLM-5, 4.7, 4.6, 4.5 Air |
+| MiniMax | MiniMax M2.x models |
+| Ollama | Models discovered from a configured Ollama server |
+| LM Studio | Models discovered from a configured LM Studio server |
 
-To configure a provider, go to **Settings > AI** and enter your key. The provider and model default to your account-level choice, and any individual AI Chat page can override both. The full list of available models updates as providers publish new ones.
+Open **Settings > AI** to pick a provider and model. The picker only shows providers your deployment has enabled — anything unconfigured is hidden. The provider and model you pick become your account-level default; any individual AI Chat page can override both. Calls count against your plan's standard or pro daily AI quota depending on the model.
 
 ## 5. Create an AI Agent
 

--- a/apps/marketing/src/app/docs/security/page.tsx
+++ b/apps/marketing/src/app/docs/security/page.tsx
@@ -3,7 +3,7 @@ import { createMetadata } from "@/lib/metadata";
 
 export const metadata = createMetadata({
   title: "Security",
-  description: "PageSpace security overview: opaque session tokens, direct-permission RBAC, account lockout, OAuth PKCE, encrypted API keys, rate limiting, continuously verified audit logs, SSRF and path-traversal hardening.",
+  description: "PageSpace security overview: opaque session tokens, direct-permission RBAC, account lockout, OAuth PKCE, encrypted secrets, rate limiting, continuously verified audit logs, SSRF and path-traversal hardening.",
   path: "/docs/security",
   keywords: ["security", "authentication", "permissions", "encryption", "audit log", "account lockout", "PKCE", "SSRF", "path traversal", "HMAC cron"],
 });
@@ -37,7 +37,7 @@ This section documents PageSpace's authentication system, permission model, and 
 
 ### Data Protection
 
-- **Encrypted API keys** — AI provider keys are encrypted at rest with AES-256-GCM (scrypt KDF, unique salt+IV per write).
+- **Encrypted secrets** — OAuth tokens for connected integrations and other application-layer secrets are encrypted at rest with AES-256-GCM (scrypt KDF, unique salt+IV per write). AI provider credentials are held by the deployment operator, not stored per user.
 - **HTTP-only cookies** — session cookies are inaccessible to JavaScript.
 - **SameSite cookies** — \`strict\` by default; relaxed to \`lax\` only for multi-subdomain deployments.
 - **CSRF tokens** — HMAC-signed, bound to the session, required on state-changing requests.
@@ -56,7 +56,7 @@ This section documents PageSpace's authentication system, permission model, and 
 
 Page content, conversation messages, and file metadata live in PostgreSQL, encrypted at rest via volume-level encryption and delivered over TLS in transit. Content is stored queryable so full-text search, regex tools, and AI agents can operate on it directly — the alternative (searchable-encryption schemes or decrypt-on-every-query) trades significant latency and capability for protection the volume layer already provides.
 
-Secrets are a different story: API keys, OAuth tokens, and stored credentials are encrypted at the application layer with a key PageSpace holds, so losing a disk or leaking a DB dump doesn't leak them.
+Secrets are a different story: OAuth tokens and stored integration credentials are encrypted at the application layer with a key PageSpace holds, so losing a disk or leaking a DB dump doesn't leak them.
 
 **What protects page content**:
 

--- a/apps/marketing/src/app/docs/security/zero-trust/page.tsx
+++ b/apps/marketing/src/app/docs/security/zero-trust/page.tsx
@@ -105,9 +105,9 @@ Blocked:
 
 User-generated HTML is sanitized before render. Canvas pages render inside Shadow DOM, isolating arbitrary author styles and scripts from the rest of the app. Mentions and links are validated server-side before rendering.
 
-### API Key Encryption
+### Application Secret Encryption
 
-AI provider API keys are encrypted at rest with AES-256-GCM using scrypt-derived keys, a unique salt per write, and a unique IV per encryption. Keys are decrypted only on the request path that makes the provider call, are never returned in API responses, and are deletable by the user at any time.
+OAuth tokens for connected integrations and other application-layer secrets are encrypted at rest with AES-256-GCM using scrypt-derived keys, a unique salt per write, and a unique IV per encryption. Stored secrets are decrypted only on the request path that needs them and are never returned in API responses. AI provider credentials are held by the deployment operator at the infrastructure layer and are not stored per user.
 `;
 
 export default function ZeroTrustPage() {

--- a/apps/marketing/src/app/privacy/page.tsx
+++ b/apps/marketing/src/app/privacy/page.tsx
@@ -31,7 +31,7 @@ export default function PrivacyPolicy() {
             <ul className="list-disc pl-6 mb-4">
               <li><strong>Secure Cloud Storage:</strong> Your data is stored in our cloud infrastructure with access controls and security logging</li>
               <li><strong>Authentication Security:</strong> Passwordless authentication via passkeys and magic links, with sessions managed using opaque tokens</li>
-              <li><strong>Data Protection:</strong> Sensitive information like API keys is encrypted using AES-256-GCM encryption. Note that document content and chat messages are stored as plain text to enable search functionality</li>
+              <li><strong>Data Protection:</strong> Sensitive secrets like OAuth tokens for connected integrations are encrypted using AES-256-GCM encryption. Note that document content and chat messages are stored as plain text to enable search functionality</li>
               <li><strong>Transparency:</strong> Clear information about how we handle your data and what security measures we implement</li>
             </ul>
           </section>
@@ -49,7 +49,7 @@ export default function PrivacyPolicy() {
               <li>Application settings and preferences</li>
               <li>Chat messages and AI conversation history (stored as plain text in our database)</li>
               <li>Usage analytics and subscription billing information (via Stripe)</li>
-              <li>Your personal API keys for AI services (encrypted using AES-256-GCM)</li>
+              <li>OAuth tokens for connected integrations such as Google Calendar and Google Drive (encrypted using AES-256-GCM)</li>
             </ul>
 
             <h3 className="text-xl font-semibold mb-3">3.2 Technical Information</h3>
@@ -68,17 +68,12 @@ export default function PrivacyPolicy() {
           <section className="mb-8">
             <h2 className="text-2xl font-semibold mb-4">4. Third-Party AI Services</h2>
             <p className="mb-4">
-              When you use AI features, we work with external AI providers, each subject to that provider&#39;s own privacy policy. Supported providers include:
+              When you use AI features, we work with external AI providers, each subject to that provider&#39;s own privacy policy. Provider routing is managed by PageSpace at the deployment level — you no longer supply or store provider API keys yourself. Supported providers include:
             </p>
             <ul className="list-disc pl-6 mb-4">
-              <li><strong>PageSpace-hosted (default):</strong> included free tier, backed by a GLM inference provider</li>
-              <li><strong>OpenRouter:</strong> paid and free-tier model catalogs</li>
-              <li><strong>Anthropic (Claude):</strong> direct API access with your key</li>
-              <li><strong>OpenAI:</strong> direct API access with your key</li>
-              <li><strong>Google AI (Gemini):</strong> direct API access with your key</li>
-              <li><strong>xAI (Grok):</strong> direct API access with your key</li>
-              <li><strong>Azure OpenAI, GLM, MiniMax:</strong> direct API access with your key</li>
-              <li><strong>Ollama and LM Studio:</strong> self-managed endpoints you configure; prompts and selected context are sent only to that configured server. When the endpoint is a local process, content stays on the machine running it — verify your deployment to confirm</li>
+              <li><strong>PageSpace-hosted (default):</strong> included on every plan, currently backed by GLM inference. Standard and pro models are metered separately against your plan&#39;s daily AI call quotas</li>
+              <li><strong>OpenRouter, Google AI (Gemini), Anthropic (Claude), OpenAI, xAI (Grok), Azure OpenAI, GLM, MiniMax:</strong> routed through provider credentials managed by PageSpace. Availability of any individual provider depends on whether it is configured for your deployment</li>
+              <li><strong>Ollama and LM Studio (self-hosted deployments only):</strong> the deployment operator configures the endpoint; prompts and selected context are sent only to that configured server. When the endpoint is a local process, content stays on the machine running it</li>
             </ul>
             <p className="mb-4">
               <strong>Important:</strong> When using AI services, we send your prompts and relevant context to AI providers to generate responses. We do not share your personal information or unrelated workspace data with AI providers.
@@ -106,7 +101,7 @@ export default function PrivacyPolicy() {
             <ul className="list-disc pl-6 mb-4">
               <li><strong>Access Controls:</strong> Database access is restricted to authorized services and personnel, with all operations logged for security analysis</li>
               <li><strong>Authentication Security:</strong> Passwordless authentication via passkeys and magic links</li>
-              <li><strong>API Key Encryption:</strong> Personal AI service API keys are encrypted using AES-256-GCM</li>
+              <li><strong>Secret Encryption:</strong> OAuth tokens for connected integrations and other application secrets are encrypted using AES-256-GCM</li>
               <li><strong>Connection Security:</strong> Database connections use secure protocols</li>
               <li><strong>Content Storage:</strong> Document content and chat messages are stored as plain text in our database to enable full-text search and collaboration features. This means content is not encrypted at rest in the database</li>
             </ul>
@@ -138,7 +133,7 @@ export default function PrivacyPolicy() {
               <li><strong>Data in Transit:</strong> Secure HTTPS connections for all web traffic</li>
               <li><strong>Authentication Security:</strong> Passwordless authentication eliminates credential-based attack vectors</li>
               <li><strong>Session Management:</strong> Opaque session tokens with proper expiration and validation</li>
-              <li><strong>API Key Protection:</strong> AES-256-GCM encryption for user-provided AI service keys</li>
+              <li><strong>Secret Protection:</strong> AES-256-GCM encryption for OAuth tokens and stored integration credentials</li>
               <li><strong>Database Access:</strong> Restricted access controls with comprehensive logging of operations, errors, and security events</li>
               <li><strong>Input Validation:</strong> Comprehensive sanitization and validation of user inputs</li>
               <li><strong>Rate Limiting:</strong> Protection against abuse and excessive API usage</li>


### PR DESCRIPTION
## Summary

Follow-up to #1191 (BYOK retirement). Cleans up the marketing surfaces that PR's scrub didn't touch and ships a user-facing announcement post.

- **Audit results.** Six marketing files referenced per-user provider keys outside #1191's diff:
  - `apps/marketing/src/app/privacy/page.tsx` (Data Protection, account-data list, Third-Party AI Services list, Database Storage, Data Security)
  - `apps/marketing/src/app/docs/security/page.tsx` (metadata description, "Encrypted API keys" bullet, secrets paragraph)
  - `apps/marketing/src/app/docs/security/zero-trust/page.tsx` ("API Key Encryption" section)
  - `apps/marketing/src/app/docs/features/ai/page.tsx` ("Bring your own key" line, Providers paragraph)
  - `apps/marketing/src/app/docs/getting-started/page.tsx` (Set Up AI table + instructions)
- **Reframing.** Where the old copy talked about user-managed AI provider keys being encrypted at rest, the new copy describes secret encryption in terms of OAuth tokens and integration credentials, and notes that AI provider credentials are now held at the deployment level (PageSpace on cloud, the operator on self-hosted). The model picker is described as showing whichever providers the deployment has enabled.
- **Blog post.** Adds `/blog/managed-provider-keys` (2026-05-01, "PageSpace now manages AI provider keys for you") aimed at existing users who'd configured BYOK. ~360 words. Leads with practical impact (their stored keys are gone, AI chats keep working, upstream OpenAI/Anthropic/Google AI accounts are untouched), then explains standard vs pro tier metering and links to `/pricing` for upgrades.

No changes to files already touched by #1191 (`pricing/page.tsx`, `faq/page.tsx`, `lib/metadata.ts`, `lib/schema.tsx`, `lib/search-data.ts`, `OSS-COMPLIANCE.md`).

## Test plan

- [x] `pnpm --filter marketing typecheck` passes
- [x] `pnpm --filter marketing build` passes (new slug `/blog/managed-provider-keys` appears in SSG output)
- [ ] After #1191 merges + marketing redeploy, verify pagespace.ai/pricing and pagespace.ai/faq render the new copy (no BYOK row, no "bring your own key" Q&A)
- [ ] After this PR merges + redeploy, verify pagespace.ai/privacy, /docs/security, /docs/security/zero-trust, /docs/features/ai, /docs/getting-started, /blog/managed-provider-keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)