### PR TITLE
feat(uploads): DM attachment upload route (epic item 8)

### DIFF
--- a/apps/web/src/app/api/messages/[conversationId]/upload/__tests__/route.test.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/upload/__tests__/route.test.ts
@@ -33,7 +33,11 @@ vi.mock('@pagespace/db/db', () => ({
     },
   },
 }));
-vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn() }));
+vi.mock('@pagespace/db/operators', () => ({
+  and: vi.fn(),
+  eq: vi.fn(),
+  or: vi.fn(),
+}));
 vi.mock('@pagespace/db/schema/social', () => ({
   dmConversations: { id: 'dm_conversations.id' },
 }));
@@ -142,36 +146,25 @@ describe('POST /api/messages/[conversationId]/upload (thin wrapper)', () => {
     expect(mockProcessAttachmentUpload).not.toHaveBeenCalled();
   });
 
-  it('POST_dmUpload_nonParticipant_returns403_viaPipeline_PermissionDeniedError', async () => {
-    // Wrapper does NOT duplicate the participant check — the pipeline owns it.
-    // Even when the caller is not a participant, the wrapper still delegates;
-    // the pipeline returns 403 via createAttachmentUploadServiceToken's
-    // PermissionDeniedError flow. This test pins that architectural decision.
-    mockDmConversationsFindFirst.mockResolvedValue({
-      id: 'conv-1',
-      participant1Id: 'someone-else',
-      participant2Id: 'another-person',
-    });
-    mockProcessAttachmentUpload.mockResolvedValue(
-      new Response(JSON.stringify({ error: 'Permission denied for file upload' }), {
-        status: 403,
-        headers: { 'content-type': 'application/json' },
-      }),
-    );
+  it('POST_dmUpload_nonParticipant_returns404_withoutCallingPipeline_toPreventExistenceLeak', async () => {
+    // The wrapper queries dmConversations scoped to the calling user (id AND
+    // participant), so a real DM the caller is not part of yields no row —
+    // indistinguishable from a missing conversation. This prevents id
+    // enumeration via a 404/403 status split. The pipeline's own participant
+    // check (PermissionDeniedError → 403) remains the canonical authority for
+    // any path that reaches it.
+    mockDmConversationsFindFirst.mockResolvedValue(undefined);
 
     const res = await POST(makeRequest() as never, {
       params: Promise.resolve({ conversationId: 'conv-1' }),
     });
     const body = await res.json();
 
-    expect(res.status).toBe(403);
-    expect(body.error).toMatch(/permission denied/i);
-    expect(mockProcessAttachmentUpload).toHaveBeenCalledTimes(1);
-    expect(mockProcessAttachmentUpload).toHaveBeenCalledWith({
-      request: expect.any(Request),
-      target: { type: 'conversation', conversationId: 'conv-1' },
-      userId: 'user-1',
-    });
+    expect(res.status).toBe(404);
+    expect(body.error).toMatch(/not found/i);
+    expect(mockProcessAttachmentUpload).not.toHaveBeenCalled();
+    // Email-verify is not consulted once the lookup fails — short-circuit.
+    expect(vi.mocked(isEmailVerified)).not.toHaveBeenCalled();
   });
 
   it('POST_dmUpload_unauthenticated_returns401_fromAuthenticateRequestWithOptions_withoutCallingPipeline', async () => {

--- a/apps/web/src/app/api/messages/[conversationId]/upload/__tests__/route.test.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/upload/__tests__/route.test.ts
@@ -33,10 +33,13 @@ vi.mock('@pagespace/db/db', () => ({
     },
   },
 }));
+// Tagged tokens so the test can introspect the structure of the where clause
+// the route builds. This pins the participant-scoped lookup against regression
+// (a security fix; see Codex P2 review on PR #1215).
 vi.mock('@pagespace/db/operators', () => ({
-  and: vi.fn(),
-  eq: vi.fn(),
-  or: vi.fn(),
+  and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
+  eq: vi.fn((column: unknown, value: unknown) => ({ op: 'eq', column, value })),
+  or: vi.fn((...args: unknown[]) => ({ op: 'or', args })),
 }));
 vi.mock('@pagespace/db/schema/social', () => ({
   dmConversations: { id: 'dm_conversations.id' },
@@ -230,6 +233,35 @@ describe('POST /api/messages/[conversationId]/upload (thin wrapper)', () => {
     expect(res.status).toBe(500);
     expect(typeof body.error).toBe('string');
     expect(body.error.length).toBeGreaterThan(0);
+  });
+
+  it('POST_dmUpload_dbLookup_isScopedToConversationIdAndCallingParticipant_pinningCodexP2Fix', async () => {
+    // Regression guard for the Codex P2 fix (50d6029e7): the wrapper must scope
+    // findFirst to (id AND (participant1=user OR participant2=user)) so a
+    // non-participant cannot distinguish "conversation does not exist" from
+    // "you are not in this conversation". If a future change drops the
+    // participant clauses, this test fails before the enumeration vector reopens.
+    await POST(makeRequest() as never, {
+      params: Promise.resolve({ conversationId: 'conv-1' }),
+    });
+
+    expect(mockDmConversationsFindFirst).toHaveBeenCalledTimes(1);
+    const callArg = mockDmConversationsFindFirst.mock.calls[0][0] as {
+      where: { op: string; args: unknown[] };
+    };
+
+    expect(callArg.where.op).toBe('and');
+    const andArgs = callArg.where.args as Array<{ op: string; column?: unknown; value?: unknown; args?: unknown[] }>;
+
+    // First clause: id == conversationId
+    expect(andArgs[0]).toMatchObject({ op: 'eq', value: 'conv-1' });
+
+    // Second clause: participant1Id == userId OR participant2Id == userId
+    const orClause = andArgs[1];
+    expect(orClause.op).toBe('or');
+    const orArgs = orClause.args as Array<{ op: string; value: unknown }>;
+    expect(orArgs).toHaveLength(2);
+    expect(orArgs.every((c) => c.op === 'eq' && c.value === 'user-1')).toBe(true);
   });
 
   it('POST_dmUpload_responseShape_matchesChannelRoute_onSuccess', async () => {

--- a/apps/web/src/app/api/messages/[conversationId]/upload/__tests__/route.test.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/upload/__tests__/route.test.ts
@@ -45,11 +45,15 @@ vi.mock('@pagespace/db/schema/social', () => ({
   dmConversations: { id: 'dm_conversations.id' },
 }));
 
-// --- Logger seam ---------------------------------------------------------------
+// --- Logger + audit seams ------------------------------------------------------
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
   loggers: {
     api: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
   },
+}));
+const mockAuditRequest = vi.fn();
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: (...args: unknown[]) => mockAuditRequest(...args),
 }));
 
 // --- Service seam --------------------------------------------------------------
@@ -134,6 +138,18 @@ describe('POST /api/messages/[conversationId]/upload (thin wrapper)', () => {
     expect(body.requiresEmailVerification).toBe(true);
     expect(body.error).toMatch(/email/i);
     expect(mockProcessAttachmentUpload).not.toHaveBeenCalled();
+    // SIEM-visible denial: emit authz.access.denied with a discriminator so
+    // the email-verification denial path is observable downstream.
+    expect(mockAuditRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        eventType: 'authz.access.denied',
+        userId: 'user-1',
+        resourceType: 'dm_upload',
+        resourceId: 'conv-1',
+        details: expect.objectContaining({ reason: 'email_not_verified' }),
+      }),
+    );
   });
 
   it('POST_dmUpload_missingConversation_returns404_withoutCallingPipeline', async () => {

--- a/apps/web/src/app/api/messages/[conversationId]/upload/__tests__/route.test.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/upload/__tests__/route.test.ts
@@ -1,0 +1,275 @@
+/**
+ * DM upload route tests.
+ *
+ * Mirrors the channel upload wrapper contract: auth → conversation lookup →
+ * email-verify gate → build target → delegate to processAttachmentUpload.
+ * The pipeline (quota, semaphore, dedup, participant check, audit) is exercised
+ * by the lib package's own tests; here we only verify the wrapper.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// --- Auth -----------------------------------------------------------------------
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn(
+    (r: unknown) => typeof r === 'object' && r !== null && 'error' in r,
+  ),
+}));
+
+// --- Email verification gate ---------------------------------------------------
+vi.mock('@pagespace/lib/auth/verification-utils', () => ({
+  isEmailVerified: vi.fn(),
+}));
+
+// --- Database boundary mocks ---------------------------------------------------
+const mockDmConversationsFindFirst = vi.fn();
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: {
+      dmConversations: {
+        findFirst: (...args: unknown[]) => mockDmConversationsFindFirst(...args),
+      },
+    },
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn() }));
+vi.mock('@pagespace/db/schema/social', () => ({
+  dmConversations: { id: 'dm_conversations.id' },
+}));
+
+// --- Logger seam ---------------------------------------------------------------
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  },
+}));
+
+// --- Service seam --------------------------------------------------------------
+const mockProcessAttachmentUpload = vi.fn();
+vi.mock('@pagespace/lib/services/attachment-upload', () => ({
+  processAttachmentUpload: (...args: unknown[]) =>
+    mockProcessAttachmentUpload(...args),
+}));
+
+// --- Imports under test --------------------------------------------------------
+import { POST } from '../route';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+import { isEmailVerified } from '@pagespace/lib/auth/verification-utils';
+
+const SUCCESS_RESPONSE_BODY = {
+  success: true,
+  file: { id: 'h', originalName: 'a.png', sanitizedName: 'a.png', size: 1, mimeType: 'image/png', contentHash: 'h' },
+  storageInfo: undefined,
+};
+
+function makeRequest(): Request {
+  return new Request('http://localhost/api/messages/conv-1/upload', {
+    method: 'POST',
+  });
+}
+
+function makeAuthSuccess(userId = 'user-1') {
+  return {
+    userId,
+    role: 'user' as const,
+    tokenVersion: 1,
+    adminRoleVersion: 1,
+    sessionId: 's',
+    tokenType: 'session' as const,
+  };
+}
+
+function successResponse(body: unknown = SUCCESS_RESPONSE_BODY): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('POST /api/messages/[conversationId]/upload (thin wrapper)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(makeAuthSuccess());
+    vi.mocked(isEmailVerified).mockResolvedValue(true);
+    mockDmConversationsFindFirst.mockResolvedValue({
+      id: 'conv-1',
+      participant1Id: 'user-1',
+      participant2Id: 'user-2',
+    });
+    mockProcessAttachmentUpload.mockResolvedValue(successResponse());
+  });
+
+  it('POST_dmUpload_validParticipantWithVerifiedEmail_delegatesToProcessAttachmentUpload_withConversationTarget', async () => {
+    const request = makeRequest();
+    const res = await POST(request as never, {
+      params: Promise.resolve({ conversationId: 'conv-1' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockProcessAttachmentUpload).toHaveBeenCalledTimes(1);
+    expect(mockProcessAttachmentUpload).toHaveBeenCalledWith({
+      request,
+      target: { type: 'conversation', conversationId: 'conv-1' },
+      userId: 'user-1',
+    });
+  });
+
+  it('POST_dmUpload_unverifiedEmail_returns403_withRequiresEmailVerificationFlag_andDoesNotCallPipeline', async () => {
+    vi.mocked(isEmailVerified).mockResolvedValue(false);
+
+    const res = await POST(makeRequest() as never, {
+      params: Promise.resolve({ conversationId: 'conv-1' }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body.requiresEmailVerification).toBe(true);
+    expect(body.error).toMatch(/email/i);
+    expect(mockProcessAttachmentUpload).not.toHaveBeenCalled();
+  });
+
+  it('POST_dmUpload_missingConversation_returns404_withoutCallingPipeline', async () => {
+    mockDmConversationsFindFirst.mockResolvedValue(undefined);
+
+    const res = await POST(makeRequest() as never, {
+      params: Promise.resolve({ conversationId: 'conv-1' }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.error).toMatch(/not found/i);
+    expect(mockProcessAttachmentUpload).not.toHaveBeenCalled();
+  });
+
+  it('POST_dmUpload_nonParticipant_returns403_viaPipeline_PermissionDeniedError', async () => {
+    // Wrapper does NOT duplicate the participant check — the pipeline owns it.
+    // Even when the caller is not a participant, the wrapper still delegates;
+    // the pipeline returns 403 via createAttachmentUploadServiceToken's
+    // PermissionDeniedError flow. This test pins that architectural decision.
+    mockDmConversationsFindFirst.mockResolvedValue({
+      id: 'conv-1',
+      participant1Id: 'someone-else',
+      participant2Id: 'another-person',
+    });
+    mockProcessAttachmentUpload.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Permission denied for file upload' }), {
+        status: 403,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    const res = await POST(makeRequest() as never, {
+      params: Promise.resolve({ conversationId: 'conv-1' }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body.error).toMatch(/permission denied/i);
+    expect(mockProcessAttachmentUpload).toHaveBeenCalledTimes(1);
+    expect(mockProcessAttachmentUpload).toHaveBeenCalledWith({
+      request: expect.any(Request),
+      target: { type: 'conversation', conversationId: 'conv-1' },
+      userId: 'user-1',
+    });
+  });
+
+  it('POST_dmUpload_unauthenticated_returns401_fromAuthenticateRequestWithOptions_withoutCallingPipeline', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue({
+      error: new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { 'content-type': 'application/json' },
+      }),
+    } as never);
+
+    const res = await POST(makeRequest() as never, {
+      params: Promise.resolve({ conversationId: 'conv-1' }),
+    });
+
+    expect(res.status).toBe(401);
+    expect(mockProcessAttachmentUpload).not.toHaveBeenCalled();
+    expect(mockDmConversationsFindFirst).not.toHaveBeenCalled();
+    expect(vi.mocked(isEmailVerified)).not.toHaveBeenCalled();
+  });
+
+  it('POST_dmUpload_pipelineReturns413_quotaExceeded_routePropagatesAs413', async () => {
+    mockProcessAttachmentUpload.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Storage quota exceeded' }), {
+        status: 413,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    const res = await POST(makeRequest() as never, {
+      params: Promise.resolve({ conversationId: 'conv-1' }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(413);
+    expect(body.error).toMatch(/quota/i);
+  });
+
+  it('POST_dmUpload_pipelineReturns429_concurrentLimit_routePropagatesAs429', async () => {
+    mockProcessAttachmentUpload.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'Too many concurrent uploads.' }), {
+        status: 429,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    const res = await POST(makeRequest() as never, {
+      params: Promise.resolve({ conversationId: 'conv-1' }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(429);
+    expect(body.error).toMatch(/too many/i);
+  });
+
+  it('POST_dmUpload_pipelineThrowsUnexpected_returns500_withStructuredError', async () => {
+    mockProcessAttachmentUpload.mockRejectedValue(new Error('boom'));
+
+    const res = await POST(makeRequest() as never, {
+      params: Promise.resolve({ conversationId: 'conv-1' }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(typeof body.error).toBe('string');
+    expect(body.error.length).toBeGreaterThan(0);
+  });
+
+  it('POST_dmUpload_responseShape_matchesChannelRoute_onSuccess', async () => {
+    // The success body must keep the same top-level keys the channel route's
+    // pipeline emits — `success`, `file`, `storageInfo` — so useAttachmentUpload
+    // does not have to branch on target type.
+    const channelLikeBody = {
+      success: true,
+      file: {
+        id: 'hash-1',
+        originalName: 'photo.png',
+        sanitizedName: 'photo.png',
+        size: 1234,
+        mimeType: 'image/png',
+        contentHash: 'hash-1',
+      },
+      storageInfo: {
+        used: 100,
+        quota: 1000,
+        formattedUsed: '100 B',
+        formattedQuota: '1 KB',
+      },
+    };
+    mockProcessAttachmentUpload.mockResolvedValue(successResponse(channelLikeBody));
+
+    const res = await POST(makeRequest() as never, {
+      params: Promise.resolve({ conversationId: 'conv-1' }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(Object.keys(body).sort()).toEqual(['file', 'storageInfo', 'success']);
+    expect(body.file).toEqual(channelLikeBody.file);
+    expect(body.storageInfo).toEqual(channelLikeBody.storageInfo);
+  });
+});

--- a/apps/web/src/app/api/messages/[conversationId]/upload/route.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/upload/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { dmConversations } from '@pagespace/db/schema/social';
+import { isEmailVerified } from '@pagespace/lib/auth/verification-utils';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import {
+  processAttachmentUpload,
+  type AttachmentTarget,
+} from '@pagespace/lib/services/attachment-upload';
+
+const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
+
+/**
+ * DM file upload endpoint.
+ *
+ * Thin wrapper that validates the conversation exists and the caller's email
+ * is verified, then delegates to the polymorphic upload pipeline. Quota,
+ * semaphore, dedup, audit, storage accounting, and participant authorization
+ * live in @pagespace/lib/services/attachment-upload — the participant check is
+ * intentionally NOT duplicated here so the pipeline remains the single source
+ * of truth for DM access control.
+ *
+ * Wrapper-stage awaits (auth, conversation lookup, email-verify) are wrapped in
+ * try/catch so unexpected failures still return the structured `{ error }`
+ * JSON contract instead of bubbling as framework HTML errors.
+ */
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ conversationId: string }> }
+) {
+  const { conversationId } = await context.params;
+
+  try {
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
+    if (isAuthError(auth)) {
+      return auth.error;
+    }
+
+    const conversation = await db.query.dmConversations.findFirst({
+      where: eq(dmConversations.id, conversationId),
+    });
+
+    if (!conversation) {
+      return NextResponse.json({ error: 'Conversation not found' }, { status: 404 });
+    }
+
+    const emailVerified = await isEmailVerified(auth.userId);
+    if (!emailVerified) {
+      return NextResponse.json(
+        {
+          error: 'Email verification required. Please verify your email to perform this action.',
+          requiresEmailVerification: true,
+        },
+        { status: 403 }
+      );
+    }
+
+    const target: AttachmentTarget = {
+      type: 'conversation',
+      conversationId,
+    };
+
+    return await processAttachmentUpload({ request, target, userId: auth.userId });
+  } catch (error) {
+    loggers.api.error('DM upload wrapper error', error as Error, { conversationId });
+    return NextResponse.json({ error: 'Failed to upload file' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/messages/[conversationId]/upload/route.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/upload/route.ts
@@ -4,6 +4,7 @@ import { db } from '@pagespace/db/db';
 import { and, eq, or } from '@pagespace/db/operators';
 import { dmConversations } from '@pagespace/db/schema/social';
 import { isEmailVerified } from '@pagespace/lib/auth/verification-utils';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import {
   processAttachmentUpload,
@@ -59,6 +60,13 @@ export async function POST(
 
     const emailVerified = await isEmailVerified(auth.userId);
     if (!emailVerified) {
+      auditRequest(request, {
+        eventType: 'authz.access.denied',
+        userId: auth.userId,
+        resourceType: 'dm_upload',
+        resourceId: conversationId,
+        details: { reason: 'email_not_verified' },
+      });
       return NextResponse.json(
         {
           error: 'Email verification required. Please verify your email to perform this action.',

--- a/apps/web/src/app/api/messages/[conversationId]/upload/route.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/upload/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db } from '@pagespace/db/db';
-import { eq } from '@pagespace/db/operators';
+import { and, eq, or } from '@pagespace/db/operators';
 import { dmConversations } from '@pagespace/db/schema/social';
 import { isEmailVerified } from '@pagespace/lib/auth/verification-utils';
 import { loggers } from '@pagespace/lib/logging/logger-config';
@@ -15,12 +15,14 @@ const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 /**
  * DM file upload endpoint.
  *
- * Thin wrapper that validates the conversation exists and the caller's email
- * is verified, then delegates to the polymorphic upload pipeline. Quota,
- * semaphore, dedup, audit, storage accounting, and participant authorization
- * live in @pagespace/lib/services/attachment-upload — the participant check is
- * intentionally NOT duplicated here so the pipeline remains the single source
- * of truth for DM access control.
+ * Thin wrapper that scopes the conversation lookup to the calling participant
+ * (mirroring `apps/web/src/app/api/messages/[conversationId]/route.ts`), enforces
+ * the email-verification gate, then delegates to the polymorphic upload pipeline.
+ * Quota, semaphore, dedup, audit, storage accounting, and authoritative
+ * participant authorization live in @pagespace/lib/services/attachment-upload —
+ * the wrapper's participant-scoped lookup is purely defensive (it both prevents
+ * existence enumeration via the 404/403 status split and avoids any pipeline
+ * work for non-participants); the pipeline still owns the canonical access check.
  *
  * Wrapper-stage awaits (auth, conversation lookup, email-verify) are wrapped in
  * try/catch so unexpected failures still return the structured `{ error }`
@@ -38,8 +40,17 @@ export async function POST(
       return auth.error;
     }
 
+    // Scope to participant so non-participants and non-existent conversations are
+    // indistinguishable from the outside (both return 404). This matches the
+    // existing DM message routes and prevents conversation-id enumeration.
     const conversation = await db.query.dmConversations.findFirst({
-      where: eq(dmConversations.id, conversationId),
+      where: and(
+        eq(dmConversations.id, conversationId),
+        or(
+          eq(dmConversations.participant1Id, auth.userId),
+          eq(dmConversations.participant2Id, auth.userId),
+        ),
+      ),
     });
 
     if (!conversation) {


### PR DESCRIPTION
## Summary

PR 4 of 5 in the DM file attachments epic (`tasks/dm-file-attachments.md` item 8). Adds `POST /api/messages/[conversationId]/upload` as a thin wrapper over the polymorphic upload pipeline merged in #1212.

The wrapper does these things and then delegates:

1. **Authenticates** via `authenticateRequestWithOptions` with `{ allow: ['session'], requireCSRF: true }`.
2. **Scopes the conversation lookup to the calling participant** — `where: and(eq(id), or(eq(participant1Id, userId), eq(participant2Id, userId)))` — mirroring `apps/web/src/app/api/messages/[conversationId]/route.ts:158-170`. Non-participants and non-existent conversations are externally indistinguishable (both 404), closing the conversation-id enumeration vector flagged by Codex.
3. **Enforces email verification** via `isEmailVerified`, returning 403 with `requiresEmailVerification: true` (mirrors DM POST at `apps/web/src/app/api/messages/[conversationId]/route.ts:134-144` so the client can render the same prompt for both flows).
4. **Audits denial events** — `auditRequest({ eventType: 'authz.access.denied', resourceType: 'dm_upload', details: { reason: 'email_not_verified' } })` on the email-verification path so SIEM can detect probing of unverified accounts. Mirrors the channel route's wrapper-stage denial audit.

Quota, semaphore, dedup, audit, storage accounting, and the canonical participant-authorization check continue to live in `processAttachmentUpload`. The wrapper-level participant-scoped lookup is purely defensive — the pipeline's `PermissionDeniedError` flow remains the single source of truth for DM access control.

Depends on #1212. Runs in parallel with PR 5 (DM POST attachment field — different file). PR 6 (composer) depends on this.

## Status-code note (intentional divergence from epic text)

The epic at `tasks/dm-file-attachments.md:82` reads "non-participant... should return 403", but the existing DM POST route at `apps/web/src/app/api/messages/[conversationId]/route.ts:172-177` already returns **404** for both missing-conversation and non-participant cases (via the same participant-scoped query). This PR matches that established pattern (and Codex's security feedback) rather than the epic's literal text — divergence is deliberate so DM upload status codes stay consistent with DM read/write status codes and existence-enumeration stays closed.

## Changes

- `apps/web/src/app/api/messages/[conversationId]/upload/route.ts` (new, ~95 lines)
- `apps/web/src/app/api/messages/[conversationId]/upload/__tests__/route.test.ts` (new, 10 wrapper-contract tests, RED-first)

## Review feedback addressed

- **Codex P2** (existence-leak via 404/403 split) → 50d6029e7: scoped the conversation lookup to participant; non-participants now also get 404, eliminating the enumeration vector.
- **Self-review** (regression risk on Codex P2 fix) → 2647275b9: added test 10 with tagged-token operator mocks asserting the where clause structurally references both participant columns; verified by reverting the route to id-only and observing the new test fail.
- **CI fix — `security-audit-coverage` meta-test** → bb332844c: every new API route file must call an audit function or be exempt. Added `auditRequest` on the email-verify denial path (mirrors channel route's wrapper-stage denial audit) and extended test 2 to pin the audit payload shape.

## Test plan

- [x] RED-first: route file absent → import-resolution failure
- [x] All 10 wrapper tests green (`pnpm --filter web test 'src/app/api/messages/[conversationId]/upload'`)
- [x] Security-audit-coverage meta-test green
- [x] `pnpm --filter web typecheck` clean
- [x] `pnpm --filter web lint` clean (only pre-existing warning unrelated to this PR)
- [ ] CI green (re-running after audit fix)
- [ ] Manual smoke once PR 6 (composer) lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)