### PR TITLE
feat(dm): POST accepts file attachments and broadcasts them (PR 5/7)

### DIFF
--- a/apps/web/src/app/api/messages/[conversationId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/__tests__/route.test.ts
@@ -1,0 +1,495 @@
+/**
+ * Contract tests for POST /api/messages/[conversationId]
+ *
+ * These tests verify the Request → Response contract and boundary obligations
+ * for sending DMs with optional file attachments. The repository seam
+ * (`dmMessageRepository`) is mocked so assertions exercise the route's
+ * validation, persistence payload, preview synthesis, and realtime fanout
+ * without touching the ORM chain.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+
+// --- Auth boundary --------------------------------------------------------------
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn(
+    (r: unknown) => typeof r === 'object' && r !== null && 'error' in r
+  ),
+}));
+
+// --- Email verification gate ---------------------------------------------------
+vi.mock('@pagespace/lib/auth/verification-utils', () => ({
+  isEmailVerified: vi.fn(),
+}));
+
+// --- DM repository seam (the boundary the route must delegate to) --------------
+const mockFindConversationForParticipant = vi.fn();
+const mockValidateAttachmentForDm = vi.fn();
+const mockInsertDmMessage = vi.fn();
+const mockUpdateConversationLastMessage = vi.fn();
+vi.mock('@pagespace/lib/services/dm-message-repository', () => ({
+  dmMessageRepository: {
+    findConversationForParticipant: (...args: unknown[]) =>
+      mockFindConversationForParticipant(...args),
+    validateAttachmentForDm: (...args: unknown[]) =>
+      mockValidateAttachmentForDm(...args),
+    insertDmMessage: (...args: unknown[]) => mockInsertDmMessage(...args),
+    updateConversationLastMessage: (...args: unknown[]) =>
+      mockUpdateConversationLastMessage(...args),
+  },
+}));
+
+// --- Audit + logger seams ------------------------------------------------------
+const mockAuditRequest = vi.fn();
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: (...args: unknown[]) => mockAuditRequest(...args),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    realtime: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  },
+}));
+
+// --- Notifications -------------------------------------------------------------
+const mockCreateOrUpdateMessageNotification = vi.fn();
+vi.mock('@pagespace/lib/notifications/notifications', () => ({
+  createOrUpdateMessageNotification: (...args: unknown[]) =>
+    mockCreateOrUpdateMessageNotification(...args),
+}));
+
+// --- Realtime broadcast helpers ------------------------------------------------
+vi.mock('@pagespace/lib/auth/broadcast-auth', () => ({
+  createSignedBroadcastHeaders: vi.fn(() => ({ 'x-signed': 'yes' })),
+}));
+
+const mockBroadcastInboxEvent = vi.fn();
+vi.mock('@/lib/websocket/socket-utils', () => ({
+  broadcastInboxEvent: (...args: unknown[]) => mockBroadcastInboxEvent(...args),
+}));
+
+// --- Imports under test (must come after vi.mock blocks) -----------------------
+import { POST } from '../route';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+import { isEmailVerified } from '@pagespace/lib/auth/verification-utils';
+import type { SessionAuthResult, AuthError } from '@/lib/auth';
+import type { AttachmentMeta } from '@pagespace/lib/types';
+
+// --- Fixtures ------------------------------------------------------------------
+const SENDER_ID = 'user_sender';
+const RECIPIENT_ID = 'user_recipient';
+const CONVERSATION_ID = 'conv_1';
+const FILE_ID = 'file_abc123';
+
+const sessionAuth = (userId = SENDER_ID): SessionAuthResult => ({
+  userId,
+  tokenVersion: 0,
+  tokenType: 'session',
+  sessionId: 'sess_test',
+  role: 'user',
+  adminRoleVersion: 0,
+});
+
+const authError = (status = 401): AuthError => ({
+  error: NextResponse.json({ error: 'Unauthorized' }, { status }),
+});
+
+const mockConversation = (overrides: Partial<{
+  id: string;
+  participant1Id: string;
+  participant2Id: string;
+}> = {}) => ({
+  id: overrides.id ?? CONVERSATION_ID,
+  participant1Id: overrides.participant1Id ?? SENDER_ID,
+  participant2Id: overrides.participant2Id ?? RECIPIENT_ID,
+});
+
+const mockInsertedRow = (overrides: Partial<{
+  id: string;
+  conversationId: string;
+  senderId: string;
+  content: string;
+  fileId: string | null;
+  attachmentMeta: AttachmentMeta | null;
+}> = {}) => ({
+  id: overrides.id ?? 'msg_1',
+  conversationId: overrides.conversationId ?? CONVERSATION_ID,
+  senderId: overrides.senderId ?? SENDER_ID,
+  content: overrides.content ?? '',
+  fileId: overrides.fileId ?? null,
+  attachmentMeta: overrides.attachmentMeta ?? null,
+  isRead: false,
+  readAt: null,
+  isEdited: false,
+  editedAt: null,
+  createdAt: new Date('2026-05-02T00:00:00Z'),
+});
+
+const imageMeta: AttachmentMeta = {
+  originalName: 'cat.png',
+  size: 12345,
+  mimeType: 'image/png',
+  contentHash: 'sha256-cat',
+};
+
+const pdfMeta: AttachmentMeta = {
+  originalName: 'report.pdf',
+  size: 67890,
+  mimeType: 'application/pdf',
+  contentHash: 'sha256-pdf',
+};
+
+function makeRequest(body: unknown): Request {
+  return new Request(`http://localhost/api/messages/${CONVERSATION_ID}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+const callRoute = (body: unknown) =>
+  POST(makeRequest(body), {
+    params: Promise.resolve({ conversationId: CONVERSATION_ID }),
+  });
+
+// --- Default success-path mocks ------------------------------------------------
+function setupHappyPath() {
+  vi.mocked(authenticateRequestWithOptions).mockResolvedValue(sessionAuth());
+  vi.mocked(isEmailVerified).mockResolvedValue(true);
+  mockFindConversationForParticipant.mockResolvedValue(mockConversation());
+  mockValidateAttachmentForDm.mockResolvedValue({ kind: 'ok' });
+  mockInsertDmMessage.mockImplementation(async (input) => mockInsertedRow(input));
+  mockUpdateConversationLastMessage.mockResolvedValue(undefined);
+  mockCreateOrUpdateMessageNotification.mockResolvedValue(undefined);
+  mockBroadcastInboxEvent.mockResolvedValue(undefined);
+}
+
+// --- Helpers to inspect the realtime broadcast --------------------------------
+function captureRealtimeBroadcasts(fetchMock: ReturnType<typeof vi.fn>) {
+  return fetchMock.mock.calls
+    .filter(([url]) => typeof url === 'string' && url.includes('/api/broadcast'))
+    .map(([, init]) => {
+      const body = (init as RequestInit).body;
+      if (typeof body !== 'string') return null;
+      try {
+        return JSON.parse(body);
+      } catch {
+        return null;
+      }
+    })
+    .filter((p): p is { channelId: string; event: string; payload: unknown } => p !== null);
+}
+
+// --- Tests ---------------------------------------------------------------------
+describe('POST /api/messages/[conversationId]', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  const originalRealtimeUrl = process.env.INTERNAL_REALTIME_URL;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.INTERNAL_REALTIME_URL = 'http://realtime.test';
+    fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    setupHappyPath();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (originalRealtimeUrl === undefined) {
+      delete process.env.INTERNAL_REALTIME_URL;
+    } else {
+      process.env.INTERNAL_REALTIME_URL = originalRealtimeUrl;
+    }
+  });
+
+  // ===== 1. Body validation =====
+  describe('body validation', () => {
+    it('persists content and broadcasts it for content-only messages (today\'s behavior)', async () => {
+      const res = await callRoute({ content: 'hello world' });
+
+      expect(res.status).toBe(200);
+      expect(mockInsertDmMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          conversationId: CONVERSATION_ID,
+          senderId: SENDER_ID,
+          content: 'hello world',
+          fileId: null,
+          attachmentMeta: null,
+        })
+      );
+      const broadcasts = captureRealtimeBroadcasts(fetchMock);
+      expect(broadcasts).toHaveLength(1);
+      expect(broadcasts[0].event).toBe('new_dm_message');
+      const payload = broadcasts[0].payload as Record<string, unknown>;
+      expect(payload.content).toBe('hello world');
+      expect(payload.fileId).toBeNull();
+    });
+
+    it('persists empty content and the file fields when only fileId+attachmentMeta provided', async () => {
+      const res = await callRoute({ fileId: FILE_ID, attachmentMeta: imageMeta });
+
+      expect(res.status).toBe(200);
+      expect(mockInsertDmMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: '',
+          fileId: FILE_ID,
+          attachmentMeta: imageMeta,
+        })
+      );
+      const broadcasts = captureRealtimeBroadcasts(fetchMock);
+      expect(broadcasts[0].event).toBe('new_dm_message');
+      const payload = broadcasts[0].payload as Record<string, unknown>;
+      expect(payload.fileId).toBe(FILE_ID);
+      expect(payload.attachmentMeta).toEqual(imageMeta);
+    });
+
+    it('persists both content and file fields when caption + attachment are provided', async () => {
+      const res = await callRoute({
+        content: 'see attached',
+        fileId: FILE_ID,
+        attachmentMeta: pdfMeta,
+      });
+
+      expect(res.status).toBe(200);
+      expect(mockInsertDmMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: 'see attached',
+          fileId: FILE_ID,
+          attachmentMeta: pdfMeta,
+        })
+      );
+      const broadcasts = captureRealtimeBroadcasts(fetchMock);
+      const payload = broadcasts[0].payload as Record<string, unknown>;
+      expect(payload.content).toBe('see attached');
+      expect(payload.fileId).toBe(FILE_ID);
+      expect(payload.attachmentMeta).toEqual(pdfMeta);
+    });
+
+    it('returns 400 when both content is empty and no fileId provided', async () => {
+      const res = await callRoute({ content: '' });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(/content or file is required/i);
+      expect(mockInsertDmMessage).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when fileId is provided without attachmentMeta', async () => {
+      const res = await callRoute({ fileId: FILE_ID });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(/attachmentmeta required when fileid/i);
+      expect(mockInsertDmMessage).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when attachmentMeta has the wrong shape', async () => {
+      const res = await callRoute({
+        fileId: FILE_ID,
+        attachmentMeta: { originalName: 'x.png' },
+      });
+
+      expect(res.status).toBe(400);
+      expect(mockInsertDmMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===== 2. Ownership + linkage =====
+  describe('ownership and conversation linkage', () => {
+    it('returns 403 + authz.access.denied audit and does not insert when file is not owned by sender', async () => {
+      mockValidateAttachmentForDm.mockResolvedValue({ kind: 'wrong_owner' });
+
+      const res = await callRoute({ fileId: FILE_ID, attachmentMeta: imageMeta });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toMatch(/do not own this file/i);
+      expect(mockInsertDmMessage).not.toHaveBeenCalled();
+      expect(mockAuditRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          eventType: 'authz.access.denied',
+          userId: SENDER_ID,
+          resourceType: 'dm_message',
+          resourceId: FILE_ID,
+        })
+      );
+    });
+
+    it('returns 403 + authz.access.denied audit when file is not linked to this conversation (anti-smuggling)', async () => {
+      mockValidateAttachmentForDm.mockResolvedValue({ kind: 'not_linked' });
+
+      const res = await callRoute({ fileId: FILE_ID, attachmentMeta: imageMeta });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.error).toMatch(/not linked to this conversation/i);
+      expect(mockInsertDmMessage).not.toHaveBeenCalled();
+      expect(mockAuditRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          eventType: 'authz.access.denied',
+          userId: SENDER_ID,
+          resourceType: 'dm_message',
+          resourceId: FILE_ID,
+        })
+      );
+    });
+
+    it('returns 404 when fileId does not exist', async () => {
+      mockValidateAttachmentForDm.mockResolvedValue({ kind: 'not_found' });
+
+      const res = await callRoute({ fileId: FILE_ID, attachmentMeta: imageMeta });
+
+      expect(res.status).toBe(404);
+      const body = await res.json();
+      expect(body.error).toMatch(/file not found/i);
+      expect(mockInsertDmMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===== 3. Persistence =====
+  describe('persistence payload', () => {
+    it('inserts the directMessages row with fileId and attachmentMeta and broadcasts it', async () => {
+      const inserted = mockInsertedRow({
+        fileId: FILE_ID,
+        attachmentMeta: imageMeta,
+      });
+      mockInsertDmMessage.mockResolvedValue(inserted);
+
+      const res = await callRoute({ fileId: FILE_ID, attachmentMeta: imageMeta });
+
+      expect(res.status).toBe(200);
+      const responseBody = await res.json();
+      expect(responseBody.message).toMatchObject({
+        fileId: FILE_ID,
+        attachmentMeta: imageMeta,
+      });
+      const broadcasts = captureRealtimeBroadcasts(fetchMock);
+      const payload = broadcasts[0].payload as Record<string, unknown>;
+      expect(payload).toMatchObject({
+        id: inserted.id,
+        fileId: FILE_ID,
+        attachmentMeta: imageMeta,
+      });
+    });
+  });
+
+  // ===== 4. Preview synthesis =====
+  describe('lastMessagePreview synthesis', () => {
+    it('uses [image: name] for image attachments with empty content', async () => {
+      await callRoute({ fileId: FILE_ID, attachmentMeta: imageMeta });
+
+      expect(mockUpdateConversationLastMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          conversationId: CONVERSATION_ID,
+          lastMessagePreview: `[image: ${imageMeta.originalName}]`,
+        })
+      );
+      expect(mockCreateOrUpdateMessageNotification).toHaveBeenCalledWith(
+        RECIPIENT_ID,
+        CONVERSATION_ID,
+        `[image: ${imageMeta.originalName}]`,
+        SENDER_ID
+      );
+    });
+
+    it('uses [file: name] for non-image attachments with empty content', async () => {
+      await callRoute({ fileId: FILE_ID, attachmentMeta: pdfMeta });
+
+      expect(mockUpdateConversationLastMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          lastMessagePreview: `[file: ${pdfMeta.originalName}]`,
+        })
+      );
+    });
+
+    it('prefers content over the attachment placeholder when both are present', async () => {
+      await callRoute({
+        content: 'caption',
+        fileId: FILE_ID,
+        attachmentMeta: imageMeta,
+      });
+
+      expect(mockUpdateConversationLastMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ lastMessagePreview: 'caption' })
+      );
+    });
+
+    it('truncates content longer than 100 chars with an ellipsis', async () => {
+      const long = 'x'.repeat(150);
+      await callRoute({ content: long });
+
+      const expected = long.substring(0, 100) + '...';
+      expect(mockUpdateConversationLastMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ lastMessagePreview: expected })
+      );
+    });
+  });
+
+  // ===== 5. Realtime fanout =====
+  describe('realtime fanout', () => {
+    it('broadcasts new_dm_message with fileId and attachmentMeta in the payload', async () => {
+      const inserted = mockInsertedRow({ fileId: FILE_ID, attachmentMeta: pdfMeta });
+      mockInsertDmMessage.mockResolvedValue(inserted);
+
+      await callRoute({ fileId: FILE_ID, attachmentMeta: pdfMeta });
+
+      const broadcasts = captureRealtimeBroadcasts(fetchMock);
+      expect(broadcasts).toHaveLength(1);
+      expect(broadcasts[0].channelId).toBe(`dm:${CONVERSATION_ID}`);
+      expect(broadcasts[0].event).toBe('new_dm_message');
+      const payload = broadcasts[0].payload as Record<string, unknown>;
+      expect(payload.fileId).toBe(FILE_ID);
+      expect(payload.attachmentMeta).toEqual(pdfMeta);
+    });
+
+    it('includes attachmentMeta in the inbox event payload', async () => {
+      await callRoute({ fileId: FILE_ID, attachmentMeta: imageMeta });
+
+      expect(mockBroadcastInboxEvent).toHaveBeenCalledWith(
+        RECIPIENT_ID,
+        expect.objectContaining({
+          operation: 'dm_updated',
+          type: 'dm',
+          id: CONVERSATION_ID,
+          attachmentMeta: imageMeta,
+        })
+      );
+    });
+  });
+
+  // ===== 6. Existing-behavior preservation =====
+  describe('existing-behavior preservation', () => {
+    it('returns 403 when email is unverified', async () => {
+      vi.mocked(isEmailVerified).mockResolvedValue(false);
+
+      const res = await callRoute({ content: 'hi' });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.requiresEmailVerification).toBe(true);
+      expect(mockInsertDmMessage).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when caller is not a participant', async () => {
+      mockFindConversationForParticipant.mockResolvedValue(null);
+
+      const res = await callRoute({ content: 'hi' });
+
+      expect(res.status).toBe(404);
+      expect(mockInsertDmMessage).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 when unauthenticated', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(authError(401));
+
+      const res = await callRoute({ content: 'hi' });
+
+      expect(res.status).toBe(401);
+      expect(mockInsertDmMessage).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/app/api/messages/[conversationId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/__tests__/route.test.ts
@@ -406,6 +406,26 @@ describe('POST /api/messages/[conversationId]', () => {
       );
     });
 
+    it('falls back to the attachment placeholder when caption is whitespace-only', async () => {
+      await callRoute({
+        content: '   ',
+        fileId: FILE_ID,
+        attachmentMeta: imageMeta,
+      });
+
+      expect(mockUpdateConversationLastMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          lastMessagePreview: `[image: ${imageMeta.originalName}]`,
+        })
+      );
+      expect(mockCreateOrUpdateMessageNotification).toHaveBeenCalledWith(
+        RECIPIENT_ID,
+        CONVERSATION_ID,
+        `[image: ${imageMeta.originalName}]`,
+        SENDER_ID
+      );
+    });
+
     it('prefers content over the attachment placeholder when both are present', async () => {
       await callRoute({
         content: 'caption',

--- a/apps/web/src/app/api/messages/[conversationId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/__tests__/route.test.ts
@@ -294,6 +294,22 @@ describe('POST /api/messages/[conversationId]', () => {
       expect(res.status).toBe(400);
       expect(mockInsertDmMessage).not.toHaveBeenCalled();
     });
+
+    it.each([
+      { label: 'missing originalName', meta: { size: 1, mimeType: 'image/png', contentHash: 'h' } },
+      { label: 'missing size', meta: { originalName: 'x', mimeType: 'image/png', contentHash: 'h' } },
+      { label: 'missing mimeType', meta: { originalName: 'x', size: 1, contentHash: 'h' } },
+      { label: 'missing contentHash', meta: { originalName: 'x', size: 1, mimeType: 'image/png' } },
+      { label: 'size as string', meta: { originalName: 'x', size: '1', mimeType: 'image/png', contentHash: 'h' } },
+      { label: 'attachmentMeta is array', meta: ['not', 'an', 'object'] },
+      { label: 'attachmentMeta is string', meta: 'definitely-not-an-object' },
+      { label: 'attachmentMeta is number', meta: 42 },
+    ])('returns 400 when attachmentMeta is malformed ($label)', async ({ meta }) => {
+      const res = await callRoute({ fileId: FILE_ID, attachmentMeta: meta });
+
+      expect(res.status).toBe(400);
+      expect(mockInsertDmMessage).not.toHaveBeenCalled();
+    });
   });
 
   // ===== 2. Ownership + linkage =====

--- a/apps/web/src/app/api/messages/[conversationId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/__tests__/route.test.ts
@@ -442,6 +442,23 @@ describe('POST /api/messages/[conversationId]', () => {
       );
     });
 
+    it('normalizes whitespace-only caption to empty string before persistence and broadcast', async () => {
+      mockInsertDmMessage.mockImplementation(async (input) => mockInsertedRow(input));
+
+      await callRoute({
+        content: '   \t\n  ',
+        fileId: FILE_ID,
+        attachmentMeta: imageMeta,
+      });
+
+      expect(mockInsertDmMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ content: '' })
+      );
+      const broadcasts = captureRealtimeBroadcasts(fetchMock);
+      const payload = broadcasts[0].payload as Record<string, unknown>;
+      expect(payload.content).toBe('');
+    });
+
     it('prefers content over the attachment placeholder when both are present', async () => {
       await callRoute({
         content: 'caption',

--- a/apps/web/src/app/api/messages/[conversationId]/route.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/route.ts
@@ -8,8 +8,10 @@ import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { createOrUpdateMessageNotification } from '@pagespace/lib/notifications/notifications'
 import { isEmailVerified } from '@pagespace/lib/auth/verification-utils';
 import { createSignedBroadcastHeaders } from '@pagespace/lib/auth/broadcast-auth';
+import { dmMessageRepository } from '@pagespace/lib/services/dm-message-repository';
 import { broadcastInboxEvent } from '@/lib/websocket/socket-utils';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
+import type { AttachmentMeta } from '@pagespace/lib/types';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
@@ -121,6 +123,33 @@ export async function GET(
   }
 }
 
+function isValidAttachmentMeta(value: unknown): value is AttachmentMeta {
+  if (typeof value !== 'object' || value === null) return false;
+  const m = value as Record<string, unknown>;
+  return (
+    typeof m.originalName === 'string' &&
+    typeof m.size === 'number' &&
+    typeof m.mimeType === 'string' &&
+    typeof m.contentHash === 'string'
+  );
+}
+
+function buildLastMessagePreview(
+  content: string,
+  attachmentMeta: AttachmentMeta | null
+): string {
+  if (content.length > 0) {
+    return content.length > 100 ? content.substring(0, 100) + '...' : content;
+  }
+  if (attachmentMeta) {
+    const isImage = attachmentMeta.mimeType.startsWith('image/');
+    return isImage
+      ? `[image: ${attachmentMeta.originalName}]`
+      : `[file: ${attachmentMeta.originalName}]`;
+  }
+  return '';
+}
+
 // POST /api/messages/[conversationId] - Send a message
 export async function POST(
   request: Request,
@@ -131,7 +160,6 @@ export async function POST(
     if (isAuthError(auth)) return auth.error;
     const userId = auth.userId;
 
-    // Check email verification
     const emailVerified = await isEmailVerified(userId);
     if (!emailVerified) {
       return NextResponse.json(
@@ -144,30 +172,45 @@ export async function POST(
     }
 
     const { conversationId } = await context.params;
-    const body = await request.json();
-    const { content } = body;
+    const body = await request.json() as {
+      content?: unknown;
+      fileId?: unknown;
+      attachmentMeta?: unknown;
+    };
 
-    if (!content || content.trim().length === 0) {
+    const content = typeof body.content === 'string' ? body.content : '';
+    const fileId = typeof body.fileId === 'string' && body.fileId.length > 0 ? body.fileId : null;
+    const rawAttachmentMeta = body.attachmentMeta ?? null;
+
+    if (content.trim().length === 0 && !fileId) {
       return NextResponse.json(
-        { error: 'Message content is required' },
+        { error: 'Message content or file is required' },
         { status: 400 }
       );
     }
 
-    // Verify user is participant in conversation
-    const [conversation] = await db
-      .select()
-      .from(dmConversations)
-      .where(
-        and(
-          eq(dmConversations.id, conversationId),
-          or(
-            eq(dmConversations.participant1Id, userId),
-            eq(dmConversations.participant2Id, userId)
-          )
-        )
-      )
-      .limit(1);
+    if (fileId && rawAttachmentMeta === null) {
+      return NextResponse.json(
+        { error: 'attachmentMeta required when fileId is provided' },
+        { status: 400 }
+      );
+    }
+
+    let attachmentMeta: AttachmentMeta | null = null;
+    if (fileId) {
+      if (!isValidAttachmentMeta(rawAttachmentMeta)) {
+        return NextResponse.json(
+          { error: 'Invalid attachmentMeta shape' },
+          { status: 400 }
+        );
+      }
+      attachmentMeta = rawAttachmentMeta;
+    }
+
+    const conversation = await dmMessageRepository.findConversationForParticipant(
+      conversationId,
+      userId
+    );
 
     if (!conversation) {
       return NextResponse.json(
@@ -176,32 +219,67 @@ export async function POST(
       );
     }
 
-    // Create the message
-    const [newMessage] = await db
-      .insert(directMessages)
-      .values({
+    if (fileId) {
+      const validation = await dmMessageRepository.validateAttachmentForDm({
+        fileId,
         conversationId,
         senderId: userId,
-        content,
-      })
-      .returning();
+      });
 
-    auditRequest(request, { eventType: 'data.write', userId, resourceType: 'message', resourceId: newMessage.id });
+      if (validation.kind === 'not_found') {
+        return NextResponse.json({ error: 'File not found' }, { status: 404 });
+      }
+      if (validation.kind === 'wrong_owner') {
+        auditRequest(request, {
+          eventType: 'authz.access.denied',
+          userId,
+          resourceType: 'dm_message',
+          resourceId: fileId,
+          details: { reason: 'file_owner_mismatch', conversationId },
+        });
+        return NextResponse.json(
+          { error: 'You do not own this file' },
+          { status: 403 }
+        );
+      }
+      if (validation.kind === 'not_linked') {
+        auditRequest(request, {
+          eventType: 'authz.access.denied',
+          userId,
+          resourceType: 'dm_message',
+          resourceId: fileId,
+          details: { reason: 'file_not_linked_to_conversation', conversationId },
+        });
+        return NextResponse.json(
+          { error: 'File is not linked to this conversation' },
+          { status: 403 }
+        );
+      }
+    }
 
-    // Update conversation's last message info
-    const messagePreview = content.length > 100
-      ? content.substring(0, 100) + '...'
-      : content;
+    const newMessage = await dmMessageRepository.insertDmMessage({
+      conversationId,
+      senderId: userId,
+      content,
+      fileId,
+      attachmentMeta,
+    });
 
-    await db
-      .update(dmConversations)
-      .set({
-        lastMessageAt: new Date(),
-        lastMessagePreview: messagePreview,
-      })
-      .where(eq(dmConversations.id, conversationId));
+    auditRequest(request, {
+      eventType: 'data.write',
+      userId,
+      resourceType: 'message',
+      resourceId: newMessage.id,
+    });
 
-    // Send notification to recipient
+    const messagePreview = buildLastMessagePreview(content, attachmentMeta);
+
+    await dmMessageRepository.updateConversationLastMessage({
+      conversationId,
+      lastMessageAt: newMessage.createdAt,
+      lastMessagePreview: messagePreview,
+    });
+
     const recipientId = conversation.participant1Id === userId
       ? conversation.participant2Id
       : conversation.participant1Id;
@@ -213,7 +291,6 @@ export async function POST(
       userId
     );
 
-    // Broadcast the new message to the DM room for realtime updates
     if (process.env.INTERNAL_REALTIME_URL) {
       try {
         const requestBody = JSON.stringify({
@@ -232,16 +309,21 @@ export async function POST(
       }
     }
 
-    // Broadcast inbox update to recipient for real-time inbox refresh
     await broadcastInboxEvent(recipientId, {
       operation: 'dm_updated',
       type: 'dm',
       id: conversationId,
       lastMessageAt: newMessage.createdAt.toISOString(),
       lastMessagePreview: messagePreview,
+      attachmentMeta,
     });
 
-    auditRequest(request, { eventType: 'data.write', userId, resourceType: 'conversation', resourceId: conversationId });
+    auditRequest(request, {
+      eventType: 'data.write',
+      userId,
+      resourceType: 'conversation',
+      resourceId: conversationId,
+    });
 
     return NextResponse.json({ message: newMessage });
   } catch (error) {

--- a/apps/web/src/app/api/messages/[conversationId]/route.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/route.ts
@@ -179,11 +179,12 @@ export async function POST(
       attachmentMeta?: unknown;
     };
 
-    const content = typeof body.content === 'string' ? body.content : '';
+    const rawContent = typeof body.content === 'string' ? body.content : '';
+    const content = rawContent.trim().length > 0 ? rawContent : '';
     const fileId = typeof body.fileId === 'string' && body.fileId.length > 0 ? body.fileId : null;
     const rawAttachmentMeta = body.attachmentMeta ?? null;
 
-    if (content.trim().length === 0 && !fileId) {
+    if (content.length === 0 && !fileId) {
       return NextResponse.json(
         { error: 'Message content or file is required' },
         { status: 400 }

--- a/apps/web/src/app/api/messages/[conversationId]/route.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/route.ts
@@ -138,8 +138,9 @@ function buildLastMessagePreview(
   content: string,
   attachmentMeta: AttachmentMeta | null
 ): string {
-  if (content.length > 0) {
-    return content.length > 100 ? content.substring(0, 100) + '...' : content;
+  const trimmed = content.trim();
+  if (trimmed.length > 0) {
+    return trimmed.length > 100 ? trimmed.substring(0, 100) + '...' : trimmed;
   }
   if (attachmentMeta) {
     const isImage = attachmentMeta.mimeType.startsWith('image/');

--- a/apps/web/src/lib/websocket/socket-utils.ts
+++ b/apps/web/src/lib/websocket/socket-utils.ts
@@ -5,6 +5,7 @@
 import { createSignedBroadcastHeaders } from '@pagespace/lib/auth/broadcast-auth';
 import { browserLoggers } from '@pagespace/lib/logging/logger-browser';
 import { isNodeEnvironment } from '@pagespace/lib/utils/environment';
+import type { AttachmentMeta } from '@pagespace/lib/types';
 import { maskIdentifier } from '@/lib/logging/mask';
 
 // Use browser-safe logger for all environments
@@ -110,6 +111,7 @@ export interface InboxEventPayload {
   lastMessagePreview?: string;
   lastMessageSender?: string;
   unreadCount?: number;
+  attachmentMeta?: AttachmentMeta | null;
 }
 
 // Presence types - re-export from shared lib

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -186,6 +186,11 @@
       "import": "./dist/services/attachment-upload-repository.js",
       "require": "./dist/services/attachment-upload-repository.js"
     },
+    "./services/dm-message-repository": {
+      "types": "./dist/services/dm-message-repository.d.ts",
+      "import": "./dist/services/dm-message-repository.js",
+      "require": "./dist/services/dm-message-repository.js"
+    },
     "./services/date-utils": {
       "types": "./dist/services/date-utils.d.ts",
       "import": "./dist/services/date-utils.js",
@@ -740,6 +745,9 @@
       ],
       "services/attachment-upload-repository": [
         "./dist/services/attachment-upload-repository.d.ts"
+      ],
+      "services/dm-message-repository": [
+        "./dist/services/dm-message-repository.d.ts"
       ],
       "services/date-utils": [
         "./dist/services/date-utils.d.ts"

--- a/packages/lib/src/services/dm-message-repository.ts
+++ b/packages/lib/src/services/dm-message-repository.ts
@@ -8,7 +8,7 @@
  */
 
 import { db } from '@pagespace/db/db';
-import { and, eq, or, type InferSelectModel } from '@pagespace/db/operators';
+import { and, eq, isNull, lt, or, type InferSelectModel } from '@pagespace/db/operators';
 import { dmConversations, directMessages } from '@pagespace/db/schema/social';
 import { fileConversations, files, type AttachmentMeta } from '@pagespace/db/schema/storage';
 
@@ -118,13 +118,24 @@ export interface UpdateConversationLastMessageInput {
 async function updateConversationLastMessage(
   input: UpdateConversationLastMessageInput
 ): Promise<void> {
+  // Guard against out-of-order writes: only apply when the stored timestamp
+  // is null or strictly older than the new row's createdAt. Two concurrent
+  // sends can otherwise let an older message overwrite the inbox preview.
   await db
     .update(dmConversations)
     .set({
       lastMessageAt: input.lastMessageAt,
       lastMessagePreview: input.lastMessagePreview,
     })
-    .where(eq(dmConversations.id, input.conversationId));
+    .where(
+      and(
+        eq(dmConversations.id, input.conversationId),
+        or(
+          isNull(dmConversations.lastMessageAt),
+          lt(dmConversations.lastMessageAt, input.lastMessageAt)
+        )
+      )
+    );
 }
 
 export const dmMessageRepository = {

--- a/packages/lib/src/services/dm-message-repository.ts
+++ b/packages/lib/src/services/dm-message-repository.ts
@@ -1,0 +1,147 @@
+/**
+ * Persistence seam for the DM message POST pipeline.
+ *
+ * Tests mock this module to assert validation outcomes and the insert/update
+ * payloads without touching the ORM chain (per unit-test-rubric §4).
+ *
+ * @module @pagespace/lib/services/dm-message-repository
+ */
+
+import { db } from '@pagespace/db/db';
+import { and, eq, or } from '@pagespace/db/operators';
+import { dmConversations, directMessages } from '@pagespace/db/schema/social';
+import { fileConversations, files, type AttachmentMeta } from '@pagespace/db/schema/storage';
+
+export interface DmConversationParticipants {
+  id: string;
+  participant1Id: string;
+  participant2Id: string;
+}
+
+async function findConversationForParticipant(
+  conversationId: string,
+  userId: string
+): Promise<DmConversationParticipants | null> {
+  const row = await db.query.dmConversations.findFirst({
+    where: and(
+      eq(dmConversations.id, conversationId),
+      or(
+        eq(dmConversations.participant1Id, userId),
+        eq(dmConversations.participant2Id, userId)
+      )
+    ),
+    columns: {
+      id: true,
+      participant1Id: true,
+      participant2Id: true,
+    },
+  });
+
+  return row ?? null;
+}
+
+export type AttachmentValidation =
+  | { kind: 'ok' }
+  | { kind: 'not_found' }
+  | { kind: 'wrong_owner' }
+  | { kind: 'not_linked' };
+
+export interface ValidateAttachmentForDmInput {
+  fileId: string;
+  conversationId: string;
+  senderId: string;
+}
+
+async function validateAttachmentForDm(
+  input: ValidateAttachmentForDmInput
+): Promise<AttachmentValidation> {
+  const { fileId, conversationId, senderId } = input;
+
+  const file = await db.query.files.findFirst({
+    where: eq(files.id, fileId),
+    columns: { id: true, createdBy: true },
+  });
+
+  if (!file) {
+    return { kind: 'not_found' };
+  }
+
+  if (file.createdBy !== senderId) {
+    return { kind: 'wrong_owner' };
+  }
+
+  const link = await db.query.fileConversations.findFirst({
+    where: and(
+      eq(fileConversations.fileId, fileId),
+      eq(fileConversations.conversationId, conversationId)
+    ),
+    columns: { fileId: true },
+  });
+
+  if (!link) {
+    return { kind: 'not_linked' };
+  }
+
+  return { kind: 'ok' };
+}
+
+export interface InsertDmMessageInput {
+  conversationId: string;
+  senderId: string;
+  content: string;
+  fileId: string | null;
+  attachmentMeta: AttachmentMeta | null;
+}
+
+export interface DmMessageRow {
+  id: string;
+  conversationId: string;
+  senderId: string;
+  content: string;
+  fileId: string | null;
+  attachmentMeta: AttachmentMeta | null;
+  isRead: boolean;
+  readAt: Date | null;
+  isEdited: boolean;
+  editedAt: Date | null;
+  createdAt: Date;
+}
+
+async function insertDmMessage(input: InsertDmMessageInput): Promise<DmMessageRow> {
+  const [row] = await db
+    .insert(directMessages)
+    .values({
+      conversationId: input.conversationId,
+      senderId: input.senderId,
+      content: input.content,
+      fileId: input.fileId,
+      attachmentMeta: input.attachmentMeta,
+    })
+    .returning();
+  return row as DmMessageRow;
+}
+
+export interface UpdateConversationLastMessageInput {
+  conversationId: string;
+  lastMessageAt: Date;
+  lastMessagePreview: string;
+}
+
+async function updateConversationLastMessage(
+  input: UpdateConversationLastMessageInput
+): Promise<void> {
+  await db
+    .update(dmConversations)
+    .set({
+      lastMessageAt: input.lastMessageAt,
+      lastMessagePreview: input.lastMessagePreview,
+    })
+    .where(eq(dmConversations.id, input.conversationId));
+}
+
+export const dmMessageRepository = {
+  findConversationForParticipant,
+  validateAttachmentForDm,
+  insertDmMessage,
+  updateConversationLastMessage,
+};

--- a/packages/lib/src/services/dm-message-repository.ts
+++ b/packages/lib/src/services/dm-message-repository.ts
@@ -8,7 +8,7 @@
  */
 
 import { db } from '@pagespace/db/db';
-import { and, eq, or } from '@pagespace/db/operators';
+import { and, eq, or, type InferSelectModel } from '@pagespace/db/operators';
 import { dmConversations, directMessages } from '@pagespace/db/schema/social';
 import { fileConversations, files, type AttachmentMeta } from '@pagespace/db/schema/storage';
 
@@ -93,19 +93,7 @@ export interface InsertDmMessageInput {
   attachmentMeta: AttachmentMeta | null;
 }
 
-export interface DmMessageRow {
-  id: string;
-  conversationId: string;
-  senderId: string;
-  content: string;
-  fileId: string | null;
-  attachmentMeta: AttachmentMeta | null;
-  isRead: boolean;
-  readAt: Date | null;
-  isEdited: boolean;
-  editedAt: Date | null;
-  createdAt: Date;
-}
+export type DmMessageRow = InferSelectModel<typeof directMessages>;
 
 async function insertDmMessage(input: InsertDmMessageInput): Promise<DmMessageRow> {
   const [row] = await db
@@ -118,7 +106,7 @@ async function insertDmMessage(input: InsertDmMessageInput): Promise<DmMessageRo
       attachmentMeta: input.attachmentMeta,
     })
     .returning();
-  return row as DmMessageRow;
+  return row;
 }
 
 export interface UpdateConversationLastMessageInput {


### PR DESCRIPTION
## Summary

- DM POST at `apps/web/src/app/api/messages/[conversationId]/route.ts` now accepts `{ content?, fileId?, attachmentMeta? }`. Attachment-only messages are allowed (content stored as `''`).
- New repo seam `dmMessageRepository` (`packages/lib/src/services/dm-message-repository.ts`) owns participant lookup, file validation, message insert, and conversation preview update. Route tests mock the seam, never the ORM chain.
- `new_dm_message` realtime payload and `broadcastInboxEvent` payload both carry `fileId` + `attachmentMeta` so the recipient sees the attachment without a refetch.

## Validation rules (all tested)

When `fileId` is present:

| Condition | HTTP | Audit |
|---|---|---|
| File doesn't exist | 404 | — |
| File not owned by sender | 403 | `authz.access.denied` (`resourceType: dm_message`, `resourceId: <fileId>`) |
| File not linked to this conversation | 403 | same — **anti-smuggling** |
| `fileId` without `attachmentMeta` | 400 | — |
| `attachmentMeta` wrong shape | 400 | — |
| Empty content + no `fileId` | 400 | — |

The anti-smuggling check is the load-bearing piece: a sender who uploaded a file to DM A cannot reference that fileId in a message sent to DM B. The check looks at `file_conversations` (the join table PR 3 added).

## `lastMessagePreview` synthesis

- Image attachment, empty (or whitespace-only) caption → `[image: name.png]`
- Non-image attachment, empty (or whitespace-only) caption → `[file: name.pdf]`
- Caption + attachment → caption wins (trimmed, truncated at 100 chars with `...`)
- Caption only → today's behavior unchanged

A whitespace-only caption falls through to the placeholder so attachment-only messages don't render a blank preview in the inbox (regression caught by Codex review, fixed in 8557ff9).

## Sequencing

- **Depends on**: #1212 (PR 3, polymorphic upload core — landed)
- **Parallel with**: PR 4 (DM upload route — different file)
- **Blocks**: PR 6 (DM composer/renderer)
- **Out of scope**: GET `isActive` filter for soft-deleted attachment messages — that's PR 7, which will sequence after this PR (touches the GET in this same file)
- **Follow-up**: #1217 — unify DM and channel attachment-message paths into a transactional create operation (deferred from CodeRabbit review on this PR)

## Test plan

- [ ] CI: `pnpm --filter web test src/app/api/messages` — 29/29 green
- [ ] CI: `pnpm typecheck` clean
- [ ] CI: `pnpm lint` clean
- [ ] Manual: send a DM with image, confirm recipient sees `[image: ...]` in inbox preview without a hard refresh
- [ ] Manual: send a DM with PDF + caption, confirm caption wins as preview
- [ ] Manual: send a DM with image + a whitespace-only caption, confirm preview falls back to `[image: ...]`
- [ ] Manual: try to reuse a fileId from another DM — expect 403 with `authz.access.denied` audit row

🤖 Generated with [Claude Code](https://claude.com/claude-code)


