### PR TITLE
feat(dm): composer uploads + renderer wired end-to-end (PR 6/7)

### DIFF
--- a/apps/web/src/app/dashboard/inbox/dm/[conversationId]/__tests__/page.test.tsx
+++ b/apps/web/src/app/dashboard/inbox/dm/[conversationId]/__tests__/page.test.tsx
@@ -1,0 +1,324 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import React from 'react';
+
+import type { FileAttachment } from '@/hooks/useAttachmentUpload';
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ conversationId: 'conv-1' }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+const mockUser = { id: 'user-me', name: 'Me', email: 'me@x.test', image: null };
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: mockUser }),
+}));
+
+// Controllable socket mock
+type Handler = (...args: unknown[]) => void;
+const socketHandlers: Record<string, Handler[]> = {};
+const fakeSocket = {
+  emit: vi.fn(),
+  on: vi.fn((event: string, handler: Handler) => {
+    socketHandlers[event] = (socketHandlers[event] ?? []).concat(handler);
+  }),
+  off: vi.fn((event: string, handler: Handler) => {
+    socketHandlers[event] = (socketHandlers[event] ?? []).filter((h) => h !== handler);
+  }),
+};
+vi.mock('@/hooks/useSocket', () => ({
+  useSocket: () => fakeSocket,
+}));
+
+// auth-fetch
+const mockPost = vi.fn<(url: string, body?: unknown) => Promise<unknown>>(
+  async () => ({}),
+);
+const mockPatch = vi.fn<(url: string, body?: unknown) => Promise<unknown>>(
+  async () => ({}),
+);
+const mockDel = vi.fn<(url: string, body?: unknown) => Promise<unknown>>(
+  async () => ({}),
+);
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  post: (url: string, body?: unknown) => mockPost(url, body),
+  patch: (url: string, body?: unknown) => mockPatch(url, body),
+  del: (url: string, body?: unknown) => mockDel(url, body),
+  fetchWithAuth: vi.fn(async () => ({ ok: true, json: async () => ({}) })),
+}));
+
+// SWR — return controllable data per URL
+type SwrData = { messages: unknown[] } | { conversation: unknown } | undefined;
+let swrMessages: SwrData = { messages: [] };
+const swrConversation: SwrData = {
+  conversation: {
+    id: 'conv-1',
+    participant1Id: 'user-me',
+    participant2Id: 'user-other',
+    otherUser: {
+      id: 'user-other',
+      name: 'Bob',
+      email: 'bob@x.test',
+      image: null,
+      username: 'bob',
+      displayName: 'Bob',
+      avatarUrl: null,
+    },
+  },
+};
+vi.mock('swr', () => ({
+  default: (key: string | null) => {
+    if (!key) return { data: undefined };
+    if (key.includes('/conversations/')) return { data: swrConversation };
+    return { data: swrMessages };
+  },
+}));
+
+// MessagePartRenderer — render content as plain text for assertions
+vi.mock('@/components/messages/MessagePartRenderer', () => ({
+  renderMessageParts: (parts: Array<{ text?: string }>) =>
+    parts?.[0]?.text ?? null,
+  convertToMessageParts: (content: string) =>
+    content ? [{ type: 'text', text: content }] : [],
+}));
+
+// MessageAttachment — sentinel for inspection
+const messageAttachmentCalls = vi.fn();
+vi.mock('@/components/shared/MessageAttachment', () => ({
+  MessageAttachment: ({ message }: { message: { fileId?: string | null } }) => {
+    messageAttachmentCalls(message);
+    if (!message.fileId) return null;
+    return <div data-testid={`attachment-${message.fileId}`}>attachment</div>;
+  },
+}));
+
+// ChannelInput — capture props so tests can drive onSend / inspect conversationId
+type ChannelInputProps = {
+  value: string;
+  onChange: (v: string) => void;
+  onSend: (a?: FileAttachment) => void;
+  conversationId?: string;
+  channelId?: string;
+  attachmentsEnabled?: boolean;
+};
+const { lastChannelInputPropsRef } = vi.hoisted(() => ({
+  lastChannelInputPropsRef: { current: null as ChannelInputProps | null },
+}));
+vi.mock(
+  '@/components/layout/middle-content/page-views/channel/ChannelInput',
+  () => {
+    const Mock = React.forwardRef<unknown, ChannelInputProps>(
+      (props, _ref) => {
+        lastChannelInputPropsRef.current = props;
+        return (
+          <div data-testid="channel-input-mock">
+            <button
+              data-testid="send-text-only"
+              onClick={() => props.onSend(undefined)}
+            />
+            <button
+              data-testid="send-with-attachment"
+              onClick={() =>
+                props.onSend({
+                  id: 'file-x',
+                  originalName: 'pic.png',
+                  size: 1024,
+                  mimeType: 'image/png',
+                  contentHash: 'hash-x',
+                })
+              }
+            />
+          </div>
+        );
+      },
+    );
+    Mock.displayName = 'MockChannelInput';
+    return { ChannelInput: Mock };
+  },
+);
+
+// ── Module under test (import after mocks) ────────────────────────────
+import InboxDMPage from '../page';
+
+const sampleAttachment: FileAttachment = {
+  id: 'file-x',
+  originalName: 'pic.png',
+  size: 1024,
+  mimeType: 'image/png',
+  contentHash: 'hash-x',
+};
+
+describe('InboxDMPage — attachments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.keys(socketHandlers).forEach((k) => delete socketHandlers[k]);
+    swrMessages = { messages: [] };
+    lastChannelInputPropsRef.current = null;
+  });
+
+  it('passesConversationId_andEnablesAttachments_onChannelInput', async () => {
+    await act(async () => {
+      render(<InboxDMPage />);
+    });
+    expect(lastChannelInputPropsRef.current).not.toBeNull();
+    expect(lastChannelInputPropsRef.current!.conversationId).toBe('conv-1');
+    expect(lastChannelInputPropsRef.current!.attachmentsEnabled).toBe(true);
+  });
+
+  it('sendWithAttachment_postsBodyIncludesFileIdAndAttachmentMeta', async () => {
+    await act(async () => {
+      render(<InboxDMPage />);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('send-with-attachment'));
+    });
+
+    expect(mockPost).toHaveBeenCalledTimes(1);
+    const call = mockPost.mock.calls[0];
+    expect(call[0]).toBe('/api/messages/conv-1');
+    expect(call[1]).toMatchObject({
+      fileId: sampleAttachment.id,
+      attachmentMeta: {
+        originalName: sampleAttachment.originalName,
+        size: sampleAttachment.size,
+        mimeType: sampleAttachment.mimeType,
+        contentHash: sampleAttachment.contentHash,
+      },
+    });
+  });
+
+  it('sendWithoutAttachment_postsBodyOmitsFileFields', async () => {
+    swrMessages = { messages: [] };
+    await act(async () => {
+      render(<InboxDMPage />);
+    });
+
+    // Set inputValue via ChannelInput.onChange so handleSendMessage has content
+    await act(async () => {
+      lastChannelInputPropsRef.current!.onChange('hello');
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('send-text-only'));
+    });
+
+    expect(mockPost).toHaveBeenCalledTimes(1);
+    const call = mockPost.mock.calls[0];
+    expect(call[0]).toBe('/api/messages/conv-1');
+    const body = call[1] as { content?: string; fileId?: unknown; attachmentMeta?: unknown };
+    expect(body).toMatchObject({ content: 'hello' });
+    expect(body.fileId).toBeUndefined();
+    expect(body.attachmentMeta).toBeUndefined();
+  });
+
+  it('renderMessage_withFileId_rendersMessageAttachment', async () => {
+    swrMessages = {
+      messages: [
+        {
+          id: 'm1',
+          conversationId: 'conv-1',
+          senderId: 'user-other',
+          content: 'here is the file',
+          isRead: false,
+          readAt: null,
+          isEdited: false,
+          editedAt: null,
+          createdAt: '2026-01-01T00:00:00Z',
+          fileId: 'file-rendered',
+          attachmentMeta: {
+            originalName: 'doc.pdf',
+            size: 5,
+            mimeType: 'application/pdf',
+            contentHash: 'h',
+          },
+        },
+      ],
+    };
+
+    await act(async () => {
+      render(<InboxDMPage />);
+    });
+
+    expect(screen.getByTestId('attachment-file-rendered')).toBeInTheDocument();
+  });
+
+  it('renderMessage_withoutFileId_doesNotRenderMessageAttachment', async () => {
+    swrMessages = {
+      messages: [
+        {
+          id: 'm2',
+          conversationId: 'conv-1',
+          senderId: 'user-me',
+          content: 'plain text',
+          isRead: false,
+          readAt: null,
+          isEdited: false,
+          editedAt: null,
+          createdAt: '2026-01-01T00:00:00Z',
+          fileId: null,
+          attachmentMeta: null,
+        },
+      ],
+    };
+
+    await act(async () => {
+      render(<InboxDMPage />);
+    });
+
+    // The MessageAttachment mock returns null when fileId is missing; assert no
+    // attachment node exists for any id.
+    expect(
+      document.querySelector('[data-testid^="attachment-"]'),
+    ).toBeNull();
+  });
+
+  it('optimisticAppend_includesAttachmentFields_onLocalEcho', async () => {
+    await act(async () => {
+      render(<InboxDMPage />);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('send-with-attachment'));
+    });
+
+    // Optimistic append should immediately render the attachment for the
+    // freshly-sent message, before the realtime echo arrives.
+    expect(screen.getByTestId('attachment-file-x')).toBeInTheDocument();
+  });
+
+  it('realtimeNewDmMessage_withAttachment_appendsRowAndRendersAttachment_withoutRefetch', async () => {
+    await act(async () => {
+      render(<InboxDMPage />);
+    });
+
+    // Fire the real-time event the way the realtime service does
+    const handlers = socketHandlers['new_dm_message'] ?? [];
+    expect(handlers.length).toBeGreaterThan(0);
+    await act(async () => {
+      handlers.forEach((h) =>
+        h({
+          id: 'm-rt',
+          conversationId: 'conv-1',
+          senderId: 'user-other',
+          content: 'realtime',
+          isRead: false,
+          readAt: null,
+          isEdited: false,
+          editedAt: null,
+          createdAt: '2026-01-01T00:00:00Z',
+          fileId: 'file-rt',
+          attachmentMeta: {
+            originalName: 'rt.png',
+            size: 9,
+            mimeType: 'image/png',
+            contentHash: 'h',
+          },
+        }),
+      );
+    });
+
+    expect(screen.getByTestId('attachment-file-rt')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/dashboard/inbox/dm/[conversationId]/__tests__/page.test.tsx
+++ b/apps/web/src/app/dashboard/inbox/dm/[conversationId]/__tests__/page.test.tsx
@@ -288,6 +288,46 @@ describe('InboxDMPage — attachments', () => {
     expect(screen.getByTestId('attachment-file-x')).toBeInTheDocument();
   });
 
+  it('realtimeEchoForOwnOptimisticDm_replacesTempRowWithoutDuplicatingAttachment', async () => {
+    await act(async () => {
+      render(<InboxDMPage />);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('send-with-attachment'));
+    });
+    expect(screen.getAllByTestId('attachment-file-x')).toHaveLength(1);
+
+    const handlers = socketHandlers['new_dm_message'] ?? [];
+    expect(handlers.length).toBeGreaterThan(0);
+
+    await act(async () => {
+      handlers.forEach((h) =>
+        h({
+          id: 'm-server',
+          conversationId: 'conv-1',
+          senderId: 'user-me',
+          content: '',
+          isRead: false,
+          readAt: null,
+          isEdited: false,
+          editedAt: null,
+          createdAt: '2026-01-01T00:00:00Z',
+          fileId: sampleAttachment.id,
+          attachmentMeta: {
+            originalName: sampleAttachment.originalName,
+            size: sampleAttachment.size,
+            mimeType: sampleAttachment.mimeType,
+            contentHash: sampleAttachment.contentHash,
+          },
+        }),
+      );
+    });
+
+    expect(screen.getAllByTestId('attachment-file-x')).toHaveLength(1);
+    expect(mockPatch).not.toHaveBeenCalledWith('/api/messages/conv-1');
+  });
+
   it('realtimeNewDmMessage_withAttachment_appendsRowAndRendersAttachment_withoutRefetch', async () => {
     await act(async () => {
       render(<InboxDMPage />);

--- a/apps/web/src/app/dashboard/inbox/dm/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/inbox/dm/[conversationId]/page.tsx
@@ -6,7 +6,10 @@ import { useAuth } from '@/hooks/useAuth';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { ChannelInput, type ChannelInputRef } from '@/components/layout/middle-content/page-views/channel/ChannelInput';
+import type { FileAttachment } from '@/hooks/useAttachmentUpload';
+import { MessageAttachment } from '@/components/shared/MessageAttachment';
 import { renderMessageParts, convertToMessageParts } from '@/components/messages/MessagePartRenderer';
+import type { AttachmentMeta } from '@/lib/attachment-utils';
 import useSWR from 'swr';
 import { toast } from 'sonner';
 import { useSocket } from '@/hooks/useSocket';
@@ -38,6 +41,8 @@ interface Message {
   isEdited: boolean;
   editedAt: string | null;
   createdAt: string;
+  fileId?: string | null;
+  attachmentMeta?: AttachmentMeta | null;
 }
 
 interface Conversation {
@@ -146,17 +151,51 @@ export default function InboxDMPage() {
     }
   }, [conversationId]);
 
-  const handleSendMessage = async () => {
-    if (!user || !conversationId || !inputValue.trim()) return;
-
+  const handleSendMessage = async (attachment?: FileAttachment) => {
+    if (!user || !conversationId) return;
     const content = inputValue;
+    if (!content.trim() && !attachment) return;
+
     setInputValue('');
 
+    const attachmentMeta: AttachmentMeta | null = attachment
+      ? {
+          originalName: attachment.originalName,
+          size: attachment.size,
+          mimeType: attachment.mimeType,
+          contentHash: attachment.contentHash,
+        }
+      : null;
+
+    const tempId = `temp-${Date.now()}`;
+    const optimistic: Message = {
+      id: tempId,
+      conversationId,
+      senderId: user.id,
+      content,
+      isRead: false,
+      readAt: null,
+      isEdited: false,
+      editedAt: null,
+      createdAt: new Date().toISOString(),
+      fileId: attachment?.id ?? null,
+      attachmentMeta,
+    };
+    setMessages((prev) => [...prev, optimistic]);
+
     try {
-      await post(`/api/messages/${conversationId}`, { content });
+      const body: { content: string; fileId?: string; attachmentMeta?: AttachmentMeta } = {
+        content,
+      };
+      if (attachment) {
+        body.fileId = attachment.id;
+        body.attachmentMeta = attachmentMeta!;
+      }
+      await post(`/api/messages/${conversationId}`, body);
     } catch (error) {
       toast.error('Failed to send message');
       console.error('Error sending message:', error);
+      setMessages((prev) => prev.filter((m) => m.id !== tempId));
       setInputValue(content);
     }
   };
@@ -301,9 +340,12 @@ export default function InboxDMPage() {
                           ? 'bg-primary/5 dark:bg-primary/10 ml-8'
                           : 'bg-gray-50 dark:bg-gray-800/50 mr-8'
                       }`}>
-                        <div className="text-gray-900 dark:text-gray-100 break-words [overflow-wrap:anywhere] min-w-0">
-                          {renderMessageParts(convertToMessageParts(message.content))}
-                        </div>
+                        {message.content && (
+                          <div className="text-gray-900 dark:text-gray-100 break-words [overflow-wrap:anywhere] min-w-0">
+                            {renderMessageParts(convertToMessageParts(message.content))}
+                          </div>
+                        )}
+                        <MessageAttachment message={message} />
                       </div>
                     )}
                   </div>
@@ -323,6 +365,8 @@ export default function InboxDMPage() {
             onChange={setInputValue}
             onSend={handleSendMessage}
             placeholder="Type a message... (use @ to mention, supports **markdown**)"
+            conversationId={conversationId}
+            attachmentsEnabled
           />
         </div>
       </div>

--- a/apps/web/src/app/dashboard/inbox/dm/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/inbox/dm/[conversationId]/page.tsx
@@ -60,6 +60,28 @@ interface Conversation {
   };
 }
 
+const isMatchingOptimisticMessage = (optimistic: Message, message: Message) =>
+  optimistic.id.startsWith('temp-') &&
+  optimistic.conversationId === message.conversationId &&
+  optimistic.senderId === message.senderId &&
+  optimistic.content === message.content &&
+  (optimistic.fileId ?? null) === (message.fileId ?? null);
+
+const reconcileMessage = (prev: Message[], message: Message) => {
+  const optimisticIndex = prev.findIndex((m) => isMatchingOptimisticMessage(m, message));
+
+  if (optimisticIndex !== -1) {
+    return prev.reduce<Message[]>((next, current, index) => {
+      if (current.id === message.id) return next;
+      next.push(index === optimisticIndex ? message : current);
+      return next;
+    }, []);
+  }
+
+  if (prev.find((m) => m.id === message.id)) return prev;
+  return [...prev, message];
+};
+
 export default function InboxDMPage() {
   const params = useParams();
   const conversationId = params.conversationId as string;
@@ -103,10 +125,7 @@ export default function InboxDMPage() {
 
     const handleNewMessage = (message: Message) => {
       if (message.conversationId === conversationId) {
-        setMessages((prev) => {
-          if (prev.find((m) => m.id === message.id)) return prev;
-          return [...prev, message];
-        });
+        setMessages((prev) => reconcileMessage(prev, message));
 
         if (message.senderId !== user.id) {
           patch(`/api/messages/${conversationId}`);
@@ -191,7 +210,11 @@ export default function InboxDMPage() {
         body.fileId = attachment.id;
         body.attachmentMeta = attachmentMeta!;
       }
-      await post(`/api/messages/${conversationId}`, body);
+      const response = await post<{ message?: Message }>(`/api/messages/${conversationId}`, body);
+      const persistedMessage = response.message;
+      if (persistedMessage) {
+        setMessages((prev) => reconcileMessage(prev, persistedMessage));
+      }
     } catch (error) {
       toast.error('Failed to send message');
       console.error('Error sending message:', error);

--- a/apps/web/src/components/ai/chat/input/ChatTextarea.tsx
+++ b/apps/web/src/components/ai/chat/input/ChatTextarea.tsx
@@ -21,6 +21,8 @@ export interface ChatTextareaProps {
   onChange: (value: string) => void;
   /** Send message handler (triggered on Enter without Shift) */
   onSend: () => void;
+  /** Allow Enter to send when the textarea is empty, for attachment-only sends */
+  canSendEmpty?: boolean;
   /** Placeholder text */
   placeholder?: string;
   /** Drive ID for mention suggestions */
@@ -56,6 +58,7 @@ const ChatTextareaInner = forwardRef<ChatTextareaRef, ChatTextareaProps>(
       value,
       onChange,
       onSend,
+      canSendEmpty = false,
       placeholder = 'Type your message...',
       driveId,
       crossDrive = false,
@@ -115,7 +118,7 @@ const ChatTextareaInner = forwardRef<ChatTextareaRef, ChatTextareaProps>(
           return;
         }
         e.preventDefault();
-        if (value.trim() && !disabled) {
+        if ((value.trim() || canSendEmpty) && !disabled) {
           onSend();
         }
       }

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInput.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInput.tsx
@@ -285,6 +285,7 @@ export const ChannelInput = forwardRef<ChannelInputRef, ChannelInputProps>(
               value={value}
               onChange={onChange}
               onSend={handleSend}
+              canSendEmpty={!!attachment}
               placeholder={placeholder}
               driveId={driveId}
               crossDrive={crossDrive}

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInput.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInput.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { forwardRef, useImperativeHandle, useRef, useState } from 'react';
+import React, { forwardRef, useImperativeHandle, useRef, useState } from 'react';
 import { motion, useReducedMotion } from 'motion/react';
 import { ArrowUp, X, FileIcon, ImageIcon, FileText } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -29,8 +29,10 @@ export interface ChannelInputProps {
   crossDrive?: boolean;
   /** Whether attachments are enabled */
   attachmentsEnabled?: boolean;
-  /** Channel page ID for uploads */
+  /** Channel page ID for uploads (mutually exclusive with conversationId; channelId wins if both set) */
   channelId?: string;
+  /** DM conversation ID for uploads (used when this input is rendered in a DM context) */
+  conversationId?: string;
   /** Additional class names */
   className?: string;
 }
@@ -70,6 +72,7 @@ export const ChannelInput = forwardRef<ChannelInputRef, ChannelInputProps>(
       crossDrive = false,
       attachmentsEnabled = false,
       channelId,
+      conversationId,
       className,
     },
     ref
@@ -79,8 +82,15 @@ export const ChannelInput = forwardRef<ChannelInputRef, ChannelInputProps>(
     const shouldReduceMotion = useReducedMotion();
     const [isFocused, setIsFocused] = useState(false);
 
+    const uploadUrl = channelId
+      ? `/api/channels/${channelId}/upload`
+      : conversationId
+        ? `/api/messages/${conversationId}/upload`
+        : null;
+    const hasUploadTarget = !!uploadUrl;
+
     const { attachment, isUploading, uploadFile, clearAttachment } = useAttachmentUpload({
-      uploadUrl: channelId ? `/api/channels/${channelId}/upload` : null,
+      uploadUrl,
       onUploaded: () => textareaRef.current?.focus(),
     });
 
@@ -113,6 +123,28 @@ export const ChannelInput = forwardRef<ChannelInputRef, ChannelInputProps>(
 
     const handleAttachmentClick = () => {
       fileInputRef.current?.click();
+    };
+
+    const canUpload = attachmentsEnabled && hasUploadTarget && !isUploading;
+
+    const handlePasteFiles = (files: File[]) => {
+      if (!canUpload) return;
+      const first = files[0];
+      if (first) void uploadFile(first);
+    };
+
+    const handleDragOver = (e: React.DragEvent) => {
+      if (!canUpload) return;
+      e.preventDefault();
+      e.stopPropagation();
+    };
+
+    const handleDrop = (e: React.DragEvent) => {
+      if (!canUpload) return;
+      e.preventDefault();
+      e.stopPropagation();
+      const file = Array.from(e.dataTransfer?.files ?? [])[0];
+      if (file) void uploadFile(file);
     };
 
     const getFileIcon = (mimeType: string) => {
@@ -174,7 +206,12 @@ export const ChannelInput = forwardRef<ChannelInputRef, ChannelInputProps>(
     );
 
     return (
-      <div className={cn('w-full', className)}>
+      <div
+        className={cn('w-full', className)}
+        data-testid="channel-input-root"
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
+      >
         {/* Hidden file input */}
         <input
           ref={fileInputRef}
@@ -254,6 +291,7 @@ export const ChannelInput = forwardRef<ChannelInputRef, ChannelInputProps>(
               disabled={disabled}
               variant="main"
               popupPlacement="top"
+              onPasteFiles={canUpload ? handlePasteFiles : undefined}
             />
 
             {/* Send button with press animation */}
@@ -276,7 +314,7 @@ export const ChannelInput = forwardRef<ChannelInputRef, ChannelInputProps>(
             onMentionClick={handleMentionClick}
             onEmojiSelect={handleEmojiSelect}
             onAttachmentClick={handleAttachmentClick}
-            attachmentsEnabled={attachmentsEnabled && !!channelId}
+            attachmentsEnabled={attachmentsEnabled && hasUploadTarget}
             disabled={disabled || isUploading}
           />
         </InputCard>

--- a/apps/web/src/components/layout/middle-content/page-views/channel/__tests__/ChannelInput.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/__tests__/ChannelInput.test.tsx
@@ -60,6 +60,7 @@ vi.mock('@/components/ai/chat/input/ChatTextarea', () => {
     driveId?: string;
     onPasteFiles?: (files: File[]) => void;
     disabled?: boolean;
+    canSendEmpty?: boolean;
   }
   const MockChatTextarea = React.forwardRef<
     { focus: () => void; clear: () => void },
@@ -77,7 +78,9 @@ vi.mock('@/components/ai/chat/input/ChatTextarea', () => {
         onKeyDown={(e) => {
           if (e.key === 'Enter' && !e.shiftKey) {
             e.preventDefault();
-            props.onSend();
+            if ((props.value.trim() || props.canSendEmpty) && !props.disabled) {
+              props.onSend();
+            }
           }
         }}
         onPaste={(e) => {

--- a/apps/web/src/components/layout/middle-content/page-views/channel/__tests__/ChannelInput.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/__tests__/ChannelInput.test.tsx
@@ -1,0 +1,397 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import type { FileAttachment } from '@/hooks/useAttachmentUpload';
+
+// Mock motion/react to render-through children synchronously
+vi.mock('motion/react', () => {
+  const passthrough = (Tag: keyof React.JSX.IntrinsicElements) => {
+    const C = React.forwardRef<HTMLElement, React.HTMLAttributes<HTMLElement>>(
+      ({ children, ...props }, ref) =>
+        React.createElement(
+          Tag,
+          {
+            ...Object.fromEntries(
+              Object.entries(props).filter(
+                ([k]) =>
+                  !k.startsWith('initial') &&
+                  !k.startsWith('animate') &&
+                  !k.startsWith('exit') &&
+                  !k.startsWith('whileTap') &&
+                  !k.startsWith('whileHover') &&
+                  !k.startsWith('transition') &&
+                  !k.startsWith('layout'),
+              ),
+            ),
+            ref,
+          },
+          children,
+        ),
+    );
+    C.displayName = `motion.${String(Tag)}`;
+    return C;
+  };
+  return {
+    motion: new Proxy(
+      {},
+      {
+        get: (_t, prop: string) => passthrough(prop as keyof React.JSX.IntrinsicElements),
+      },
+    ),
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    useReducedMotion: () => false,
+  };
+});
+
+// Mock ChatTextarea so we can drive paste/keyboard without booting the suggestion stack.
+// Captures the props it received so tests can assert on `onPasteFiles`, `driveId`, etc.
+// `vi.hoisted` lets the value be referenced from `vi.mock` factories (which are hoisted).
+const { chatTextareaProps } = vi.hoisted(() => ({
+  chatTextareaProps: vi.fn(),
+}));
+vi.mock('@/components/ai/chat/input/ChatTextarea', () => {
+  interface MockProps {
+    value: string;
+    onChange: (v: string) => void;
+    onSend: () => void;
+    placeholder?: string;
+    driveId?: string;
+    onPasteFiles?: (files: File[]) => void;
+    disabled?: boolean;
+  }
+  const MockChatTextarea = React.forwardRef<
+    { focus: () => void; clear: () => void },
+    MockProps
+  >((props, ref) => {
+    chatTextareaProps(props);
+    React.useImperativeHandle(ref, () => ({ focus: vi.fn(), clear: vi.fn() }));
+    return (
+      <textarea
+        data-testid="chat-textarea"
+        value={props.value}
+        placeholder={props.placeholder}
+        disabled={props.disabled}
+        onChange={(e) => props.onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            props.onSend();
+          }
+        }}
+        onPaste={(e) => {
+          if (!props.onPasteFiles) return;
+          const items = Array.from(e.clipboardData?.items ?? []);
+          const files: File[] = [];
+          for (const it of items) {
+            if (it.kind === 'file' && it.type.startsWith('image/')) {
+              const f = it.getAsFile();
+              if (f) files.push(f);
+            }
+          }
+          if (files.length > 0) {
+            e.preventDefault();
+            props.onPasteFiles(files);
+          }
+        }}
+      />
+    );
+  });
+  MockChatTextarea.displayName = 'MockChatTextarea';
+  return { ChatTextarea: MockChatTextarea };
+});
+
+// Mock the footer so test queries don't fight popovers/tooltips
+vi.mock('../ChannelInputFooter', () => ({
+  ChannelInputFooter: ({
+    onAttachmentClick,
+    attachmentsEnabled,
+    disabled,
+  }: {
+    onAttachmentClick?: () => void;
+    attachmentsEnabled?: boolean;
+    disabled?: boolean;
+  }) => (
+    <div data-testid="channel-input-footer">
+      {attachmentsEnabled && (
+        <button
+          type="button"
+          data-testid="attach-button"
+          onClick={onAttachmentClick}
+          disabled={disabled}
+        >
+          Attach
+        </button>
+      )}
+    </div>
+  ),
+}));
+
+// Capture useAttachmentUpload args + expose a controllable mock state
+const uploadHookCalls: Array<{
+  uploadUrl: string | null | undefined;
+  onUploaded?: (a: FileAttachment) => void;
+}> = [];
+let mockAttachment: FileAttachment | null = null;
+let mockIsUploading = false;
+const mockUploadFile = vi.fn(async (_file: File) => {});
+const mockClearAttachment = vi.fn(() => {
+  mockAttachment = null;
+});
+vi.mock('@/hooks/useAttachmentUpload', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/hooks/useAttachmentUpload')>(
+      '@/hooks/useAttachmentUpload',
+    );
+  return {
+    ...actual,
+    useAttachmentUpload: (opts: {
+      uploadUrl: string | null | undefined;
+      onUploaded?: (a: FileAttachment) => void;
+    }) => {
+      uploadHookCalls.push(opts);
+      return {
+        attachment: mockAttachment,
+        isUploading: mockIsUploading,
+        uploadFile: mockUploadFile,
+        clearAttachment: mockClearAttachment,
+      };
+    },
+  };
+});
+
+import { ChannelInput } from '../ChannelInput';
+
+const sampleAttachment: FileAttachment = {
+  id: 'file-abc',
+  originalName: 'photo.png',
+  size: 12345,
+  mimeType: 'image/png',
+  contentHash: 'hash-abc',
+};
+
+const renderInput = (overrides: Partial<React.ComponentProps<typeof ChannelInput>> = {}) => {
+  const onChange = vi.fn();
+  const onSend = vi.fn();
+  const utils = render(
+    <ChannelInput
+      value=""
+      onChange={onChange}
+      onSend={onSend}
+      attachmentsEnabled
+      conversationId="conv-1"
+      {...overrides}
+    />,
+  );
+  return { ...utils, onChange, onSend };
+};
+
+describe('ChannelInput — DM upload mode (conversationId)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    uploadHookCalls.length = 0;
+    chatTextareaProps.mockClear();
+    mockAttachment = null;
+    mockIsUploading = false;
+  });
+
+  it('uploadUrl_isComputedFromConversationId_whenChannelIdAbsent', () => {
+    renderInput({ conversationId: 'conv-42', channelId: undefined });
+
+    expect(uploadHookCalls.length).toBeGreaterThan(0);
+    expect(uploadHookCalls[uploadHookCalls.length - 1].uploadUrl).toBe(
+      '/api/messages/conv-42/upload',
+    );
+  });
+
+  it('uploadUrl_prefersChannelId_whenBothProvided', () => {
+    renderInput({ conversationId: 'conv-42', channelId: 'page-7' });
+
+    expect(uploadHookCalls[uploadHookCalls.length - 1].uploadUrl).toBe(
+      '/api/channels/page-7/upload',
+    );
+  });
+
+  it('uploadUrl_isNull_whenNeitherChannelIdNorConversationIdProvided', () => {
+    renderInput({ conversationId: undefined, channelId: undefined });
+
+    expect(uploadHookCalls[uploadHookCalls.length - 1].uploadUrl).toBeNull();
+  });
+
+  it('textOnly_send_callsOnSendWithoutAttachment', async () => {
+    const user = userEvent.setup();
+    const { onSend } = renderInput({ value: 'hello world' });
+
+    const textarea = screen.getByTestId('chat-textarea');
+    await user.type(textarea, '{enter}');
+
+    expect(onSend).toHaveBeenCalledWith(undefined);
+  });
+
+  it('textAndAttachment_send_callsOnSendWithAttachmentObject', async () => {
+    mockAttachment = sampleAttachment;
+    const user = userEvent.setup();
+    const { onSend } = renderInput({ value: 'with file' });
+
+    await user.type(screen.getByTestId('chat-textarea'), '{enter}');
+
+    expect(onSend).toHaveBeenCalledWith(sampleAttachment);
+    expect(mockClearAttachment).toHaveBeenCalledTimes(1);
+  });
+
+  it('attachmentOnly_emptyText_send_callsOnSendWithAttachment_andDoesNotBlockSend', async () => {
+    mockAttachment = sampleAttachment;
+    const user = userEvent.setup();
+    const { onSend } = renderInput({ value: '' });
+
+    // Empty textarea + Enter should still send because there is an attachment.
+    await user.type(screen.getByTestId('chat-textarea'), '{enter}');
+
+    expect(onSend).toHaveBeenCalledWith(sampleAttachment);
+  });
+
+  it('isUploading_disablesSendButton_andEnterToSend', async () => {
+    mockIsUploading = true;
+    const user = userEvent.setup();
+    const { onSend } = renderInput({ value: 'hello' });
+
+    const sendBtn = screen.getByRole('button', { name: /send message/i });
+    expect(sendBtn).toBeDisabled();
+
+    await user.type(screen.getByTestId('chat-textarea'), '{enter}');
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('clearAttachment_removesPreview_andRevertsCanSendToTextOnly', async () => {
+    mockAttachment = sampleAttachment;
+    const user = userEvent.setup();
+    const { rerender } = renderInput({ value: '' });
+
+    // Preview is visible
+    expect(screen.getByText('photo.png')).toBeInTheDocument();
+    const remove = screen.getByRole('button', { name: /remove attachment/i });
+    await user.click(remove);
+    expect(mockClearAttachment).toHaveBeenCalledTimes(1);
+
+    // Simulate the hook clearing by re-rendering with attachment null + empty value
+    mockAttachment = null;
+    rerender(
+      <ChannelInput
+        value=""
+        onChange={vi.fn()}
+        onSend={vi.fn()}
+        attachmentsEnabled
+        conversationId="conv-1"
+      />,
+    );
+    const sendBtn = screen.getByRole('button', { name: /send message/i });
+    expect(sendBtn).toBeDisabled();
+  });
+
+  it('pasteImageFile_invokesUploadFile_withTheFile', () => {
+    renderInput();
+
+    const file = new File(['x'], 'pasted.png', { type: 'image/png' });
+    const textarea = screen.getByTestId('chat-textarea');
+
+    fireEvent.paste(textarea, {
+      clipboardData: {
+        items: [
+          {
+            kind: 'file',
+            type: 'image/png',
+            getAsFile: () => file,
+          },
+        ],
+      },
+    });
+
+    expect(mockUploadFile).toHaveBeenCalledTimes(1);
+    expect(mockUploadFile).toHaveBeenCalledWith(file);
+  });
+
+  it('pastePlainText_doesNotInvokeUploadFile', () => {
+    renderInput();
+    const textarea = screen.getByTestId('chat-textarea');
+
+    fireEvent.paste(textarea, {
+      clipboardData: {
+        items: [
+          {
+            kind: 'string',
+            type: 'text/plain',
+            getAsFile: () => null,
+          },
+        ],
+      },
+    });
+
+    expect(mockUploadFile).not.toHaveBeenCalled();
+  });
+
+  it('dragDropImageFile_invokesUploadFile_withTheFile', () => {
+    const { container } = renderInput();
+
+    const file = new File(['x'], 'dropped.png', { type: 'image/png' });
+    const wrapper = container.querySelector('[data-testid="channel-input-root"]');
+    expect(wrapper).not.toBeNull();
+
+    fireEvent.dragOver(wrapper as Element, {
+      dataTransfer: { files: [file], types: ['Files'] },
+    });
+    fireEvent.drop(wrapper as Element, {
+      dataTransfer: {
+        files: [file],
+        types: ['Files'],
+      },
+    });
+
+    expect(mockUploadFile).toHaveBeenCalledTimes(1);
+    expect(mockUploadFile).toHaveBeenCalledWith(file);
+  });
+
+  it('filePickerButton_choosingFile_invokesUploadFile', () => {
+    const { container } = renderInput();
+
+    const attach = screen.getByTestId('attach-button');
+    fireEvent.click(attach);
+
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(fileInput).toBeTruthy();
+
+    const file = new File(['x'], 'picked.pdf', { type: 'application/pdf' });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    expect(mockUploadFile).toHaveBeenCalledTimes(1);
+    expect(mockUploadFile).toHaveBeenCalledWith(file);
+  });
+
+  it('attachmentsDisabled_doesNotShowPicker_andIgnoresPaste', () => {
+    renderInput({ attachmentsEnabled: false });
+
+    expect(screen.queryByTestId('attach-button')).toBeNull();
+
+    const file = new File(['x'], 'pasted.png', { type: 'image/png' });
+    const textarea = screen.getByTestId('chat-textarea');
+    fireEvent.paste(textarea, {
+      clipboardData: {
+        items: [{ kind: 'file', type: 'image/png', getAsFile: () => file }],
+      },
+    });
+
+    expect(mockUploadFile).not.toHaveBeenCalled();
+  });
+
+  it('mentionsAndIme_propsForwardedToChatTextarea_unchangedByAttachmentFeature', () => {
+    mockAttachment = sampleAttachment;
+    renderInput({ driveId: 'drive-1', crossDrive: true });
+
+    const last = chatTextareaProps.mock.calls.at(-1)?.[0] as
+      | { driveId?: string; crossDrive?: boolean; popupPlacement?: string; variant?: string }
+      | undefined;
+    expect(last?.driveId).toBe('drive-1');
+    expect(last?.crossDrive).toBe(true);
+    expect(last?.popupPlacement).toBe('top');
+  });
+});

--- a/tasks/dm-file-attachments.md
+++ b/tasks/dm-file-attachments.md
@@ -95,6 +95,7 @@ Update `apps/web/src/app/api/messages/[conversationId]/route.ts` POST to accept 
 - Given a `fileId` for a file the sender did not upload, should return 403.
 - Given a `fileId` for a file not linked to this conversation, should return 403 (prevents cross-DM file smuggling).
 - Given a delivered DM with a file, the receiver's client should receive the full payload over Socket.IO without an extra fetch.
+- Given the sender is subscribed to realtime and receives their persisted DM echo, should replace the optimistic local row rather than rendering a duplicate.
 - Given a DM whose only payload is an attachment, `dmConversations.lastMessagePreview` should render a synthetic preview (`[image: name.png]` or `[file: name.pdf]`) so inbox lists are meaningful.
 
 ---
@@ -105,6 +106,7 @@ Update `apps/web/src/components/messages/ChatInput.tsx` to consume `useAttachmen
 
 **Requirements**:
 - Given a user pastes, drops, or picks a file in the DM composer, should upload optimistically and send on submit with the same UX as channels.
+- Given an uploaded attachment and empty composer text, should send the attachment once when the user presses Enter on a desktop keyboard.
 - Given a received DM with an image, should render a clickable thumbnail; with a non-image, should render the download card — pixel-identical to channels.
 
 ---


### PR DESCRIPTION
## Summary

PR 6 of the DM file-attachments epic. Wires the DM composer + renderer to the upload route shipped in PR 4 (#1215) and the broadcast plumbing shipped in PR 5 (#1216). After this PR, two browsers can DM each other a file and see it instantly.

- **`ChannelInput`** now accepts a `conversationId` prop (paired with the existing `channelId`). When set, the upload URL is `/api/messages/${conversationId}/upload`. While here, `onPasteFiles` is wired through to `ChatTextarea` and wrapper-level drag/drop handlers are added — all gated on a real upload target. Channel callsites are unchanged (channelId still wins).
- **DM page** now passes `conversationId={conversationId}` + `attachmentsEnabled` to `ChannelInput`, accepts the optional `FileAttachment` in its send handler, and POSTs `fileId` + `attachmentMeta` when present. Optimistic local echo includes the attachment fields. `<MessageAttachment message={m} />` is rendered after the text body so images and download cards show inline.
- The realtime `new_dm_message` payload already carries `fileId` + `attachmentMeta` as of #1216, so no extra socket plumbing.

## Brief deviation (called out in the PR plan)

The brief assumed the DM composer was `apps/web/src/components/messages/ChatInput.tsx`. In reality, the DM page already imports `ChannelInput` from `…/page-views/channel/ChannelInput.tsx`; `ChatInput` is now used only by AI surfaces (`AiInput.tsx`, `ChatInputArea.tsx`). I confirmed the deviation with the orchestrator before any code was written and extended the actually-rendered component instead of duplicating its upload UX into a parallel implementation. Test names + paths follow the component being tested.

## Tests

- `apps/web/src/components/layout/middle-content/page-views/channel/__tests__/ChannelInput.test.tsx` — 14 cases covering URL computation (DM, channel, neither), text-only / text+attachment / attachment-only send, isUploading lockout, clearAttachment behavior, paste-image / paste-text, drag-drop, picker, attachmentsDisabled, and that mention/IME props are still forwarded unchanged.
- `apps/web/src/app/dashboard/inbox/dm/[conversationId]/__tests__/page.test.tsx` — 7 cases covering conversationId pass-through, send body shape with/without attachment, `MessageAttachment` rendering with/without fileId, optimistic append, and realtime `new_dm_message` rendering without refetch.

All tests RED-first; total 21/21 green.

## CI

- `pnpm --filter web typecheck` ✅
- `pnpm --filter web lint` ✅ (only pre-existing warning unrelated to this PR — `QuickCreatePalette.tsx:260`)
- Affected vitest suites ✅ 21/21

## Browser verification

I do not have a browser in this environment, so I cannot personally exercise the dev-server flows. The CLAUDE.md UI-verification rule asks for human spot-checks of:

- drag-drop / paste-image / picker → upload → send
- text-only DM, attachment-only DM, mixed
- send disabled mid-upload
- two-browser realtime delivery (Alice → Bob without refresh, image thumb + PDF card)

Please run those before merge; the test suite proves the wire-up shape but not the rendered visuals.

## Test plan

- [ ] Drag-drop an image into the DM composer; verify thumbnail appears, send, recipient sees it without refresh.
- [ ] Cmd-V an image into the DM composer; verify same flow.
- [ ] Click the paperclip; pick a PDF; send; recipient sees a download card.
- [ ] Send while an upload is mid-flight (the send button should be disabled).
- [ ] Send an attachment-only message (empty text); verify both sides render it.
- [ ] Send a text+attachment message; verify both render in order.
- [ ] Confirm channel-side composer (existing flow) still uploads via `/api/channels/...`.

## Refs

- Epic item 10 in `tasks/dm-file-attachments.md`
- Depends on #1212 (PR 3), #1215 (PR 4), #1216 (PR 5)
- Runs in parallel with PR 7 (backend filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)