### PR TITLE
fix(auth): allow DM attachment file reads

### DIFF
--- a/apps/processor/src/services/__tests__/authorization.test.ts
+++ b/apps/processor/src/services/__tests__/authorization.test.ts
@@ -3,12 +3,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const VALID_HASH = 'a'.repeat(64);
 
 const mockGetLinksForFile = vi.fn();
+const mockGetConversationLinksForFile = vi.fn();
 const mockGetFileDriveId = vi.fn();
 const mockGetUserAccessLevel = vi.fn();
 const mockGetUserDrivePermissions = vi.fn();
 
 vi.mock('../file-links', () => ({
   getLinksForFile: (...args: unknown[]) => mockGetLinksForFile(...args),
+  getConversationLinksForFile: (...args: unknown[]) => mockGetConversationLinksForFile(...args),
   getFileDriveId: (...args: unknown[]) => mockGetFileDriveId(...args),
 }));
 
@@ -50,6 +52,7 @@ describe('authorizeFileAccess', () => {
     vi.clearAllMocks();
 
     mockGetLinksForFile.mockResolvedValue([]);
+    mockGetConversationLinksForFile.mockResolvedValue([]);
     mockGetFileDriveId.mockResolvedValue('drive-1');
     mockGetUserAccessLevel.mockResolvedValue(null);
     mockGetUserDrivePermissions.mockResolvedValue(null);
@@ -153,6 +156,41 @@ describe('authorizeFileAccess', () => {
       expect(decision.allowed).toBe(false);
       expect(decision.binding.matchType).toBe('mismatch');
       expect(decision.denial?.stage).toBe('binding');
+    });
+
+    it('allows a file-bound token for a conversation-linked null-drive file when user is a participant', async () => {
+      mockGetFileDriveId.mockResolvedValue(undefined);
+      mockGetConversationLinksForFile.mockResolvedValue([
+        { fileId: VALID_HASH, conversationId: 'conv-1', participant1Id: 'user-1', participant2Id: 'user-2' },
+      ]);
+
+      const auth = createAuth({
+        resourceBinding: { type: 'file', id: VALID_HASH },
+      });
+      const decision = await authorizeFileAccess(auth, VALID_HASH, 'view');
+
+      expect(decision.allowed).toBe(true);
+      expect(decision.binding.matchType).toBe('exact');
+      expect(decision.permission?.grantedVia).toBe('conversation_participant');
+      expect(decision.context?.conversationId).toBe('conv-1');
+      expect(mockGetUserDrivePermissions).not.toHaveBeenCalled();
+      expect(mockGetUserAccessLevel).not.toHaveBeenCalled();
+    });
+
+    it('denies a file-bound token for a conversation-linked file when user is not a participant', async () => {
+      mockGetFileDriveId.mockResolvedValue(undefined);
+      mockGetConversationLinksForFile.mockResolvedValue([
+        { fileId: VALID_HASH, conversationId: 'conv-1', participant1Id: 'alice', participant2Id: 'bob' },
+      ]);
+
+      const auth = createAuth({
+        resourceBinding: { type: 'file', id: VALID_HASH },
+      });
+      const decision = await authorizeFileAccess(auth, VALID_HASH, 'view');
+
+      expect(decision.allowed).toBe(false);
+      expect(decision.denial?.stage).toBe('permission');
+      expect(decision.binding.matchType).toBe('exact');
     });
   });
 

--- a/apps/processor/src/services/authorization.ts
+++ b/apps/processor/src/services/authorization.ts
@@ -1,7 +1,13 @@
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getUserAccessLevel, getUserDrivePermissions } from '@pagespace/lib/permissions/permissions';
 import type { EnforcedAuthContext, ResourceBinding } from '../middleware/auth';
-import { getLinksForFile, getFileDriveId, type FileLink } from './file-links';
+import {
+  getLinksForFile,
+  getConversationLinksForFile,
+  getFileDriveId,
+  type ConversationFileLink,
+  type FileLink,
+} from './file-links';
 
 export type AccessRequirement = 'view' | 'edit';
 
@@ -25,7 +31,7 @@ export interface AuthorizationDecision {
 
   permission?: {
     required: AccessRequirement;
-    grantedVia: 'page_permission' | 'drive_permission' | null;
+    grantedVia: 'page_permission' | 'drive_permission' | 'conversation_participant' | null;
   };
 
   denial?: {
@@ -35,6 +41,7 @@ export interface AuthorizationDecision {
   context?: {
     pageId?: string;
     driveId?: string;
+    conversationId?: string;
   };
 }
 
@@ -77,8 +84,8 @@ function buildAllowedDecision(
   binding: ResourceBinding | null,
   matchType: BindingMatchType,
   requirement: AccessRequirement,
-  grantedVia: 'page_permission' | 'drive_permission',
-  context: { pageId?: string; driveId?: string }
+  grantedVia: 'page_permission' | 'drive_permission' | 'conversation_participant',
+  context: { pageId?: string; driveId?: string; conversationId?: string }
 ): AuthorizationDecision {
   return {
     allowed: true,
@@ -103,6 +110,7 @@ function determineBindingMatchType(
   binding: ResourceBinding | null,
   contentHash: string,
   links: FileLink[],
+  conversationLinks: ConversationFileLink[],
   fileDriveId?: string
 ): BindingMatchType {
   if (!binding) {
@@ -123,6 +131,8 @@ function determineBindingMatchType(
         return 'hierarchical';
       }
       return 'mismatch';
+    case 'conversation':
+      return conversationLinks.some(link => link.conversationId === binding.id) ? 'hierarchical' : 'mismatch';
     default:
       return 'mismatch';
   }
@@ -146,6 +156,24 @@ function getScopedLinks(links: FileLink[], binding: ResourceBinding | null): Fil
   }
 }
 
+function getScopedConversationLinks(
+  links: ConversationFileLink[],
+  binding: ResourceBinding | null
+): ConversationFileLink[] {
+  if (!binding) {
+    return links;
+  }
+
+  switch (binding.type) {
+    case 'conversation':
+      return links.filter(link => link.conversationId === binding.id);
+    case 'file':
+      return links;
+    default:
+      return [];
+  }
+}
+
 async function checkPagePermissions(
   userId: string,
   links: FileLink[],
@@ -163,6 +191,24 @@ async function checkPagePermissions(
 
     if (requirement === 'edit' && (perms.canEdit || perms.canShare)) {
       return { allowed: true, pageId: link.pageId, driveId: link.driveId };
+    }
+  }
+
+  return { allowed: false };
+}
+
+function checkConversationPermissions(
+  userId: string,
+  links: ConversationFileLink[],
+  requirement: AccessRequirement
+): { allowed: boolean; conversationId?: string } {
+  if (requirement !== 'view') {
+    return { allowed: false };
+  }
+
+  for (const link of links) {
+    if (link.participant1Id === userId || link.participant2Id === userId) {
+      return { allowed: true, conversationId: link.conversationId };
     }
   }
 
@@ -208,13 +254,20 @@ export async function authorizeFileAccess(
   }
 
   // Step 2: Fetch file context
-  const [links, fileDriveId] = await Promise.all([
+  const [links, conversationLinks, fileDriveId] = await Promise.all([
     getLinksForFile(normalizedHash),
+    getConversationLinksForFile(normalizedHash),
     getFileDriveId(normalizedHash),
   ]);
 
   // Step 3: Check binding
-  const matchType = determineBindingMatchType(binding, normalizedHash, links, fileDriveId);
+  const matchType = determineBindingMatchType(
+    binding,
+    normalizedHash,
+    links,
+    conversationLinks,
+    fileDriveId
+  );
 
   if (matchType === 'mismatch') {
     const decision = buildDeniedDecision('binding', binding, matchType, requirement);
@@ -225,12 +278,89 @@ export async function authorizeFileAccess(
       bindingType: binding?.type,
       bindingId: binding?.id,
       linksCount: links.length,
+      conversationLinksCount: conversationLinks.length,
       decision,
     });
     return decision;
   }
 
-  // Step 4: Handle orphan files (no links)
+  // Step 4: Check explicit page/conversation linkages before any fallback.
+  if (links.length > 0 || conversationLinks.length > 0) {
+    const scopedLinks = getScopedLinks(links, binding);
+    const scopedConversationLinks = getScopedConversationLinks(conversationLinks, binding);
+
+    if (scopedLinks.length === 0 && scopedConversationLinks.length === 0) {
+      const decision = buildDeniedDecision('binding', binding, matchType, requirement);
+      loggers.security.warn('file-access denied: no links within binding scope', {
+        userId: auth.userId,
+        contentHash: normalizedHash,
+        requirement,
+        bindingType: binding?.type,
+        bindingId: binding?.id,
+        totalLinks: links.length,
+        totalConversationLinks: conversationLinks.length,
+        scopedLinks: 0,
+        scopedConversationLinks: 0,
+        decision,
+      });
+      return decision;
+    }
+
+    const pageResult = await checkPagePermissions(auth.userId, scopedLinks, requirement);
+
+    if (pageResult.allowed) {
+      const decision = buildAllowedDecision(binding, matchType, requirement, 'page_permission', {
+        pageId: pageResult.pageId,
+        driveId: pageResult.driveId,
+      });
+      loggers.security.info('file-access granted: page permission', {
+        userId: auth.userId,
+        contentHash: normalizedHash,
+        requirement,
+        pageId: pageResult.pageId,
+        driveId: pageResult.driveId,
+        matchType,
+      });
+      return decision;
+    }
+
+    const conversationResult = checkConversationPermissions(
+      auth.userId,
+      scopedConversationLinks,
+      requirement
+    );
+
+    if (conversationResult.allowed) {
+      const decision = buildAllowedDecision(
+        binding,
+        matchType,
+        requirement,
+        'conversation_participant',
+        { conversationId: conversationResult.conversationId }
+      );
+      loggers.security.info('file-access granted: conversation participant', {
+        userId: auth.userId,
+        contentHash: normalizedHash,
+        requirement,
+        conversationId: conversationResult.conversationId,
+        matchType,
+      });
+      return decision;
+    }
+
+    const decision = buildDeniedDecision('permission', binding, matchType, requirement);
+    loggers.security.warn('file-access denied: no qualifying linked-resource permission', {
+      userId: auth.userId,
+      contentHash: normalizedHash,
+      requirement,
+      scopedLinksCount: scopedLinks.length,
+      scopedConversationLinksCount: scopedConversationLinks.length,
+      decision,
+    });
+    return decision;
+  }
+
+  // Step 5: Handle orphan files (no links)
   if (links.length === 0) {
     if (!fileDriveId) {
       const decision = buildDeniedDecision('not_found', binding, matchType, requirement);
@@ -271,51 +401,14 @@ export async function authorizeFileAccess(
     return decision;
   }
 
-  // Step 5: Scope links and check page permissions
-  const scopedLinks = getScopedLinks(links, binding);
-
-  /* c8 ignore next 15 */
-  if (scopedLinks.length === 0) {
-    // File has links but none within token's scope
-    const decision = buildDeniedDecision('binding', binding, matchType, requirement);
-    loggers.security.warn('file-access denied: no links within binding scope', {
-      userId: auth.userId,
-      contentHash: normalizedHash,
-      requirement,
-      bindingType: binding?.type,
-      bindingId: binding?.id,
-      totalLinks: links.length,
-      scopedLinks: 0,
-      decision,
-    });
-    return decision;
-  }
-
-  const pageResult = await checkPagePermissions(auth.userId, scopedLinks, requirement);
-
-  if (!pageResult.allowed) {
-    const decision = buildDeniedDecision('permission', binding, matchType, requirement);
-    loggers.security.warn('file-access denied: no page permission', {
-      userId: auth.userId,
-      contentHash: normalizedHash,
-      requirement,
-      scopedLinksCount: scopedLinks.length,
-      decision,
-    });
-    return decision;
-  }
-
-  const decision = buildAllowedDecision(binding, matchType, requirement, 'page_permission', {
-    pageId: pageResult.pageId,
-    driveId: pageResult.driveId,
-  });
-  loggers.security.info('file-access granted: page permission', {
+  const decision = buildDeniedDecision('not_found', binding, matchType, requirement);
+  loggers.security.warn('file-access denied: unreachable file authorization state', {
     userId: auth.userId,
     contentHash: normalizedHash,
     requirement,
-    pageId: pageResult.pageId,
-    driveId: pageResult.driveId,
-    matchType,
+    linksCount: links.length,
+    conversationLinksCount: conversationLinks.length,
+    decision,
   });
   return decision;
 }

--- a/apps/processor/src/services/file-links.ts
+++ b/apps/processor/src/services/file-links.ts
@@ -1,12 +1,20 @@
 import { db } from '@pagespace/db/db';
 import { eq } from '@pagespace/db/operators';
-import { filePages, files } from '@pagespace/db/schema/storage';
+import { fileConversations, filePages, files } from '@pagespace/db/schema/storage';
 import { pages } from '@pagespace/db/schema/core';
+import { dmConversations } from '@pagespace/db/schema/social';
 
 export interface FileLink {
   fileId: string;
   pageId: string;
   driveId: string;
+}
+
+export interface ConversationFileLink {
+  fileId: string;
+  conversationId: string;
+  participant1Id: string;
+  participant2Id: string;
 }
 
 export async function ensureFileLinked(options: {
@@ -57,6 +65,21 @@ export async function getLinksForFile(fileId: string): Promise<FileLink[]> {
     .from(filePages)
     .innerJoin(pages, eq(pages.id, filePages.pageId))
     .where(eq(filePages.fileId, fileId));
+
+  return results;
+}
+
+export async function getConversationLinksForFile(fileId: string): Promise<ConversationFileLink[]> {
+  const results = await db
+    .select({
+      fileId: fileConversations.fileId,
+      conversationId: fileConversations.conversationId,
+      participant1Id: dmConversations.participant1Id,
+      participant2Id: dmConversations.participant2Id,
+    })
+    .from(fileConversations)
+    .innerJoin(dmConversations, eq(dmConversations.id, fileConversations.conversationId))
+    .where(eq(fileConversations.fileId, fileId));
 
   return results;
 }

--- a/apps/web/src/app/api/files/[id]/download/__tests__/route.test.ts
+++ b/apps/web/src/app/api/files/[id]/download/__tests__/route.test.ts
@@ -38,6 +38,7 @@ vi.mock('@pagespace/lib/content/page-types.config', () => ({
 vi.mock('@pagespace/lib/services/validated-service-token', () => ({
     createPageServiceToken: vi.fn().mockResolvedValue({ token: 'mock-token' }),
     createDriveServiceToken: vi.fn().mockResolvedValue({ token: 'mock-token' }),
+    createFileServiceToken: vi.fn().mockResolvedValue({ token: 'mock-file-token' }),
 }));
 
 vi.mock('@pagespace/lib/permissions/file-access', () => ({
@@ -65,6 +66,8 @@ import { GET } from '../route';
 import { verifyAuth } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { db } from '@pagespace/db/db';
+import { canUserAccessFile } from '@pagespace/lib/permissions/file-access';
+import { createFileServiceToken } from '@pagespace/lib/services/validated-service-token';
 
 const mockUserId = 'user_123';
 const mockFileId = 'file-1';
@@ -96,6 +99,35 @@ describe('GET /api/files/[id]/download audit', () => {
     expect(auditRequest).toHaveBeenCalledWith(
       request,
       { eventType: 'data.read', userId: mockUserId, resourceType: 'file', resourceId: mockFileId, details: { action: 'download' } }
+    );
+  });
+
+  it('downloads a DM-linked null-drive file with a file-bound read token', async () => {
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue(null as never);
+    vi.mocked(db.query.files.findFirst).mockResolvedValue({
+      id: mockFileId,
+      driveId: null,
+      storagePath: 'a'.repeat(64),
+      mimeType: 'image/png',
+      sizeBytes: 10,
+    } as never);
+    vi.mocked(canUserAccessFile).mockResolvedValue(true);
+
+    const request = new Request('http://localhost/api/files/file-1/download?filename=dm.png');
+    const response = await GET(request as never, { params: Promise.resolve({ id: mockFileId }) });
+
+    expect(response.status).toBe(200);
+    expect(createFileServiceToken).toHaveBeenCalledWith(
+      mockUserId,
+      mockFileId,
+      ['files:read'],
+      '5m'
+    );
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'http://processor:3003/cache/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/original',
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer mock-file-token' },
+      })
     );
   });
 });

--- a/apps/web/src/app/api/files/[id]/download/route.ts
+++ b/apps/web/src/app/api/files/[id]/download/route.ts
@@ -7,7 +7,7 @@ import { files } from '@pagespace/db/schema/storage';
 import { PageType } from '@pagespace/lib/utils/enums'
 import { canUserViewPage } from '@pagespace/lib/permissions/permissions'
 import { isFilePage } from '@pagespace/lib/content/page-types.config'
-import { createPageServiceToken, createDriveServiceToken } from '@pagespace/lib/services/validated-service-token';
+import { createPageServiceToken, createDriveServiceToken, createFileServiceToken } from '@pagespace/lib/services/validated-service-token';
 import { canUserAccessFile } from '@pagespace/lib/permissions/file-access';
 import { sanitizeFilenameForHeader } from '@pagespace/lib/utils/file-security';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
@@ -137,23 +137,13 @@ export async function GET(
       return NextResponse.json({ error: 'You do not have access to this file' }, { status: 403 });
     }
 
-    // Conversation-uploaded files (driveId === null) require a conversation-scoped
-    // token mint that lands with the polymorphic upload core. Until then no such
-    // files exist in production, so this guard is dead at runtime but keeps the
-    // type narrow.
-    if (file.driveId === null) {
-      return NextResponse.json({ error: 'Not yet supported' }, { status: 503 });
-    }
-
     const contentHash = file.storagePath || file.id;
 
     try {
-      const { token: serviceToken } = await createDriveServiceToken(
-        user.id,
-        file.driveId,
-        ['files:read'],
-        '5m'
-      );
+      const { token: serviceToken } =
+        file.driveId === null
+          ? await createFileServiceToken(user.id, file.id, ['files:read'], '5m')
+          : await createDriveServiceToken(user.id, file.driveId, ['files:read'], '5m');
 
       const response = await fetchAndDownloadFile(
         contentHash,

--- a/apps/web/src/app/api/files/[id]/view/__tests__/route.test.ts
+++ b/apps/web/src/app/api/files/[id]/view/__tests__/route.test.ts
@@ -38,6 +38,7 @@ vi.mock('@pagespace/lib/content/page-types.config', () => ({
 vi.mock('@pagespace/lib/services/validated-service-token', () => ({
     createPageServiceToken: vi.fn().mockResolvedValue({ token: 'mock-token' }),
     createDriveServiceToken: vi.fn().mockResolvedValue({ token: 'mock-token' }),
+    createFileServiceToken: vi.fn().mockResolvedValue({ token: 'mock-file-token' }),
 }));
 
 vi.mock('@pagespace/lib/permissions/file-access', () => ({
@@ -67,6 +68,8 @@ import { GET } from '../route';
 import { verifyAuth } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { db } from '@pagespace/db/db';
+import { canUserAccessFile } from '@pagespace/lib/permissions/file-access';
+import { createFileServiceToken } from '@pagespace/lib/services/validated-service-token';
 
 const mockUserId = 'user_123';
 const mockFileId = 'file-1';
@@ -98,6 +101,35 @@ describe('GET /api/files/[id]/view audit', () => {
     expect(auditRequest).toHaveBeenCalledWith(
       request,
       { eventType: 'data.read', userId: mockUserId, resourceType: 'file', resourceId: mockFileId }
+    );
+  });
+
+  it('serves a DM-linked null-drive file with a file-bound read token', async () => {
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue(null as never);
+    vi.mocked(db.query.files.findFirst).mockResolvedValue({
+      id: mockFileId,
+      driveId: null,
+      storagePath: 'a'.repeat(64),
+      mimeType: 'image/png',
+      sizeBytes: 10,
+    } as never);
+    vi.mocked(canUserAccessFile).mockResolvedValue(true);
+
+    const request = new Request('http://localhost/api/files/file-1/view?filename=dm.png');
+    const response = await GET(request as never, { params: Promise.resolve({ id: mockFileId }) });
+
+    expect(response.status).toBe(200);
+    expect(createFileServiceToken).toHaveBeenCalledWith(
+      mockUserId,
+      mockFileId,
+      ['files:read'],
+      '5m'
+    );
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'http://processor:3003/cache/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/original',
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer mock-file-token' },
+      })
     );
   });
 });

--- a/apps/web/src/app/api/files/[id]/view/route.ts
+++ b/apps/web/src/app/api/files/[id]/view/route.ts
@@ -7,7 +7,7 @@ import { files } from '@pagespace/db/schema/storage';
 import { PageType } from '@pagespace/lib/utils/enums'
 import { canUserViewPage } from '@pagespace/lib/permissions/permissions'
 import { isFilePage } from '@pagespace/lib/content/page-types.config'
-import { createPageServiceToken, createDriveServiceToken } from '@pagespace/lib/services/validated-service-token';
+import { createPageServiceToken, createDriveServiceToken, createFileServiceToken } from '@pagespace/lib/services/validated-service-token';
 import { canUserAccessFile } from '@pagespace/lib/permissions/file-access';
 import { sanitizeFilenameForHeader, isDangerousMimeType, getCSPHeaderForFile } from '@pagespace/lib/utils/file-security';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
@@ -145,23 +145,13 @@ export async function GET(
       return NextResponse.json({ error: 'You do not have access to this file' }, { status: 403 });
     }
 
-    // Conversation-uploaded files (driveId === null) require a conversation-scoped
-    // token mint that lands with the polymorphic upload core. Until then no such
-    // files exist in production, so this guard is dead at runtime but keeps the
-    // type narrow.
-    if (file.driveId === null) {
-      return NextResponse.json({ error: 'Not yet supported' }, { status: 503 });
-    }
-
     const contentHash = file.storagePath || file.id;
 
     try {
-      const { token: serviceToken } = await createDriveServiceToken(
-        user.id,
-        file.driveId,
-        ['files:read'],
-        '5m'
-      );
+      const { token: serviceToken } =
+        file.driveId === null
+          ? await createFileServiceToken(user.id, file.id, ['files:read'], '5m')
+          : await createDriveServiceToken(user.id, file.driveId, ['files:read'], '5m');
 
       const response = await fetchAndServeFile(
         contentHash,

--- a/packages/lib/src/services/__tests__/validated-service-token.test.ts
+++ b/packages/lib/src/services/__tests__/validated-service-token.test.ts
@@ -474,13 +474,15 @@ describe('createValidatedServiceToken', () => {
     });
 
     it('createFileServiceToken creates an exact file-scoped read token after file access validation', async () => {
+      mockFileFindFirst.mockResolvedValue({ driveId: 'drive-1', storagePath: 'stored-content-hash' });
+
       const result = await createFileServiceToken('user-1', 'file-1', ['files:read', 'files:write']);
 
       expect(result.grantedScopes).toEqual(['files:read']);
       expect(canUserAccessFile).toHaveBeenCalledWith('user-1', 'file-1', 'drive-1');
       expect(mockCreateSession).toHaveBeenCalledWith(
         expect.objectContaining({
-          resourceId: 'file-1',
+          resourceId: 'stored-content-hash',
           resourceType: 'file',
           userId: 'user-1',
           scopes: ['files:read'],

--- a/packages/lib/src/services/__tests__/validated-service-token.test.ts
+++ b/packages/lib/src/services/__tests__/validated-service-token.test.ts
@@ -3,6 +3,7 @@ import {
   createValidatedServiceToken,
   createPageServiceToken,
   createDriveServiceToken,
+  createFileServiceToken,
   createUserServiceToken,
   createUploadServiceToken,
   createSystemFileDeleteToken,
@@ -13,6 +14,7 @@ import {
 
 // Mock the database module
 const mockFindFirst = vi.fn();
+const mockFileFindFirst = vi.fn();
 const mockOnConflictDoNothing = vi.fn().mockResolvedValue(undefined);
 const mockInsertValues = vi.fn(() => ({ onConflictDoNothing: mockOnConflictDoNothing }));
 const mockInsert = vi.fn((_table: unknown) => ({ values: mockInsertValues }));
@@ -21,6 +23,9 @@ vi.mock('@pagespace/db/db', () => ({
     query: {
       pages: {
         findFirst: (...args: unknown[]) => mockFindFirst(...args),
+      },
+      files: {
+        findFirst: (...args: unknown[]) => mockFileFindFirst(...args),
       },
     },
     insert: (table: unknown) => mockInsert(table),
@@ -32,6 +37,9 @@ vi.mock('@pagespace/db/schema/core', () => ({
 vi.mock('@pagespace/db/schema/auth', () => ({
   users: { id: 'users.id', email: 'users.email' },
 }));
+vi.mock('@pagespace/db/schema/storage', () => ({
+  files: { id: 'files.id' },
+}));
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((field: string, value: unknown) => ({ field, value })),
 }));
@@ -40,6 +48,9 @@ vi.mock('@pagespace/db/operators', () => ({
 vi.mock('../../permissions/permissions', () => ({
   getUserAccessLevel: vi.fn(),
   getUserDrivePermissions: vi.fn(),
+}));
+vi.mock('../../permissions/file-access', () => ({
+  canUserAccessFile: vi.fn(),
 }));
 
 // Mock the session service
@@ -63,12 +74,15 @@ vi.mock('../../logging/logger-config', () => ({
 }));
 
 import { getUserAccessLevel, getUserDrivePermissions } from '../../permissions/permissions';
+import { canUserAccessFile } from '../../permissions/file-access';
 import { sessionService } from '../../auth/session-service';
 import { loggers } from '../../logging/logger-config';
 
 describe('createValidatedServiceToken', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockFileFindFirst.mockResolvedValue({ driveId: 'drive-1' });
+    (canUserAccessFile as ReturnType<typeof vi.fn>).mockResolvedValue(true);
   });
 
   describe('page resource type', () => {
@@ -455,6 +469,21 @@ describe('createValidatedServiceToken', () => {
           resourceId: 'user-1',
           resourceType: 'user',
           userId: 'user-1',
+        })
+      );
+    });
+
+    it('createFileServiceToken creates an exact file-scoped read token after file access validation', async () => {
+      const result = await createFileServiceToken('user-1', 'file-1', ['files:read', 'files:write']);
+
+      expect(result.grantedScopes).toEqual(['files:read']);
+      expect(canUserAccessFile).toHaveBeenCalledWith('user-1', 'file-1', 'drive-1');
+      expect(mockCreateSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resourceId: 'file-1',
+          resourceType: 'file',
+          userId: 'user-1',
+          scopes: ['files:read'],
         })
       );
     });

--- a/packages/lib/src/services/validated-service-token.ts
+++ b/packages/lib/src/services/validated-service-token.ts
@@ -120,7 +120,7 @@ export function isPermissionDeniedError(
   );
 }
 
-export type ResourceType = 'page' | 'drive' | 'user' | 'file';
+export type ResourceType = 'page' | 'drive' | 'user';
 
 /**
  * Permission set representing what a user can do with a resource
@@ -288,28 +288,6 @@ async function getPermissionsForResource(
       };
     }
 
-    case 'file': {
-      const file = await db.query.files.findFirst({
-        where: eq(files.id, resourceId),
-        columns: { driveId: true },
-      });
-      if (!file) {
-        return null;
-      }
-
-      const canAccess = await canUserAccessFile(userId, resourceId, file.driveId);
-      if (!canAccess) {
-        return null;
-      }
-
-      return {
-        canView: true,
-        canEdit: false,
-        canDelete: false,
-        isOwner: false,
-      };
-    }
-
     default:
       return null;
   }
@@ -422,13 +400,72 @@ export async function createFileServiceToken(
   scopes: ServiceScope[],
   expiresIn?: string
 ): Promise<ValidatedTokenResult> {
-  return createValidatedServiceToken({
-    userId,
-    resourceType: 'file',
-    resourceId: fileId,
-    requestedScopes: scopes,
-    expiresIn,
+  const file = await db.query.files.findFirst({
+    where: eq(files.id, fileId),
+    columns: { driveId: true, storagePath: true },
   });
+
+  if (!file) {
+    loggers.api.warn('File service token denied: file not found', {
+      userId,
+      fileId,
+      requestedScopes: scopes,
+    });
+    throw new Error(`User has no access to file:${fileId}`);
+  }
+
+  const hasAccess = await canUserAccessFile(userId, fileId, file.driveId);
+  if (!hasAccess) {
+    loggers.api.warn('File service token denied: no access to file', {
+      userId,
+      fileId,
+      requestedScopes: scopes,
+    });
+    throw new Error(`User has no access to file:${fileId}`);
+  }
+
+  const permissions: PermissionSet = {
+    canView: true,
+    canEdit: false,
+    canDelete: false,
+    isOwner: false,
+  };
+  const grantedScopes = filterScopesByPermissions(scopes, permissions);
+
+  if (grantedScopes.length === 0) {
+    loggers.api.warn('File service token denied: no authorized scopes', {
+      userId,
+      fileId,
+      requestedScopes: scopes,
+    });
+    throw new Error(`User lacks permissions for requested scopes: ${scopes.join(', ')}`);
+  }
+
+  const contentHash = file.storagePath || fileId;
+
+  loggers.api.info('File service token scope grant', {
+    userId,
+    fileId,
+    contentHash,
+    requested: scopes,
+    granted: grantedScopes,
+    filtered: scopes.length !== grantedScopes.length,
+  });
+
+  const token = await sessionService.createSession({
+    userId,
+    type: 'service',
+    scopes: grantedScopes as string[],
+    resourceType: 'file',
+    resourceId: contentHash,
+    expiresInMs: durationToMs(expiresIn ?? '5m'),
+    createdByService: 'web',
+  });
+
+  return {
+    token,
+    grantedScopes,
+  };
 }
 
 /** Scopes granted for file upload operations */

--- a/packages/lib/src/services/validated-service-token.ts
+++ b/packages/lib/src/services/validated-service-token.ts
@@ -10,11 +10,13 @@
 import { db } from '@pagespace/db/db';
 import { eq } from '@pagespace/db/operators';
 import { pages } from '@pagespace/db/schema/core';
+import { files } from '@pagespace/db/schema/storage';
 import { users } from '@pagespace/db/schema/auth';
 import {
   getUserAccessLevel,
   getUserDrivePermissions,
 } from '../permissions/permissions';
+import { canUserAccessFile } from '../permissions/file-access';
 import { sessionService } from '../auth/session-service';
 import { loggers } from '../logging/logger-config';
 
@@ -118,7 +120,7 @@ export function isPermissionDeniedError(
   );
 }
 
-export type ResourceType = 'page' | 'drive' | 'user';
+export type ResourceType = 'page' | 'drive' | 'user' | 'file';
 
 /**
  * Permission set representing what a user can do with a resource
@@ -286,6 +288,28 @@ async function getPermissionsForResource(
       };
     }
 
+    case 'file': {
+      const file = await db.query.files.findFirst({
+        where: eq(files.id, resourceId),
+        columns: { driveId: true },
+      });
+      if (!file) {
+        return null;
+      }
+
+      const canAccess = await canUserAccessFile(userId, resourceId, file.driveId);
+      if (!canAccess) {
+        return null;
+      }
+
+      return {
+        canView: true,
+        canEdit: false,
+        canDelete: false,
+        isOwner: false,
+      };
+    }
+
     default:
       return null;
   }
@@ -379,6 +403,29 @@ export async function createUserServiceToken(
     userId,
     resourceType: 'user',
     resourceId: userId,
+    requestedScopes: scopes,
+    expiresIn,
+  });
+}
+
+/**
+ * Convenience function for creating a file-scoped read token.
+ *
+ * This is used for files whose authorization is not drive-bound, such as DM
+ * attachments. The token is still bound to the exact content hash, and scope
+ * grants are filtered through canUserAccessFile before the service session is
+ * minted.
+ */
+export async function createFileServiceToken(
+  userId: string,
+  fileId: string,
+  scopes: ServiceScope[],
+  expiresIn?: string
+): Promise<ValidatedTokenResult> {
+  return createValidatedServiceToken({
+    userId,
+    resourceType: 'file',
+    resourceId: fileId,
     requestedScopes: scopes,
     expiresIn,
   });

--- a/tasks/dm-file-attachments.md
+++ b/tasks/dm-file-attachments.md
@@ -76,6 +76,7 @@ Update `canUserAccessFile()` to accept a nullable `driveId` and add a second lin
 - Given Carol who is not a participant, should be denied access.
 - Given a file linked to both a page and a conversation, should grant access if either path qualifies, without leaking page access to non-page-viewers or conversation membership to non-participants.
 - Given a file with no linkages and `driveId === null`, should be denied (no fall-through to "anyone can see it").
+- Given a conversation-linked file with `driveId === null`, should still be served by `/api/files/[id]/{view,download}` for DM participants using a file-bound read token instead of requiring drive membership.
 
 ---
 


### PR DESCRIPTION
## Summary
- Allow null-drive DM attachment files to be served through the existing `/api/files/[id]/view` and `/download` routes.
- Add file-scoped read service tokens for files authorized by explicit file access policy instead of drive membership.
- Extend processor-side file authorization to validate `file_conversations` participant membership before serving blobs.
- Document the missing DM file-serving requirement in the DM attachments epic.

## Root Cause
DM uploads create files with `driveId = null` and authorize them through `file_conversations`, but the file serving routes still assumed non-page file reads could mint drive-scoped processor tokens. That left DM participants blocked even after upload/message authorization succeeded.

## Validation
- `pnpm --filter web exec vitest run 'src/app/api/files/[id]/view/__tests__/route.test.ts' 'src/app/api/files/[id]/download/__tests__/route.test.ts'`
- `pnpm --filter @pagespace/processor exec vitest run src/services/__tests__/authorization.test.ts`
- `pnpm --filter @pagespace/lib exec vitest run src/services/__tests__/validated-service-token.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter @pagespace/processor typecheck`
- `pnpm --filter @pagespace/lib typecheck`
- `pnpm --filter @pagespace/lib build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Files linked to conversations are now accessible to conversation participants with proper authorization checks
  * Direct message file attachments can now be viewed and downloaded with secure file-scoped access tokens
  * Authorization system now tracks conversation-based file access grants alongside existing page and drive permissions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->