### PR TITLE
fix(editor): add hyperlink tool to toolbar

### DIFF
--- a/apps/web/src/components/editors/LinkButton.tsx
+++ b/apps/web/src/components/editors/LinkButton.tsx
@@ -105,6 +105,7 @@ const LinkButton = ({ editor, variant = 'toolbar' }: LinkButtonProps) => {
         <button
           type="button"
           aria-label={isActive ? 'Edit link' : 'Add link'}
+          aria-keyshortcuts={variant === 'toolbar' ? 'Meta+K Control+K' : undefined}
           onMouseDown={(e) => e.preventDefault()}
           className={triggerClass}
         >

--- a/apps/web/src/components/editors/LinkButton.tsx
+++ b/apps/web/src/components/editors/LinkButton.tsx
@@ -31,6 +31,7 @@ const LinkButton = ({ editor, variant = 'toolbar' }: LinkButtonProps) => {
   const inputId = React.useId();
 
   const isActive = editor.isActive('link');
+  const submittable = Boolean(normalizeUrl(value));
 
   const handleOpenChange = (next: boolean) => {
     if (next) {
@@ -40,25 +41,40 @@ const LinkButton = ({ editor, variant = 'toolbar' }: LinkButtonProps) => {
     setOpen(next);
   };
 
+  // Bind Mod-K to open the popover from the toolbar instance only — the bubble
+  // menu's instance is unmounted when there's no selection, and we want a
+  // single, predictable handler regardless of selection state.
+  React.useEffect(() => {
+    if (variant !== 'toolbar') return;
+    const root = editor.view.dom as HTMLElement;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && (event.key === 'k' || event.key === 'K')) {
+        event.preventDefault();
+        const existing = (editor.getAttributes('link').href as string | undefined) ?? '';
+        setValue(existing);
+        setOpen(true);
+      }
+    };
+    root.addEventListener('keydown', onKeyDown);
+    return () => root.removeEventListener('keydown', onKeyDown);
+  }, [editor, variant]);
+
   const apply = () => {
     const href = normalizeUrl(value);
+    if (!href) return;
     const existingAttrs = editor.getAttributes('link');
     const chain = editor.chain().focus().extendMarkRange('link');
-    if (!href) {
-      chain.unsetLink().run();
+    const { from, to } = editor.state.selection;
+    if (from === to && !isActive) {
+      chain
+        .insertContent({
+          type: 'text',
+          text: href,
+          marks: [{ type: 'link', attrs: { href } }],
+        })
+        .run();
     } else {
-      const { from, to } = editor.state.selection;
-      if (from === to && !isActive) {
-        chain
-          .insertContent({
-            type: 'text',
-            text: href,
-            marks: [{ type: 'link', attrs: { href } }],
-          })
-          .run();
-      } else {
-        chain.setLink({ ...existingAttrs, href }).run();
-      }
+      chain.setLink({ ...existingAttrs, href }).run();
     }
     setOpen(false);
   };
@@ -71,7 +87,7 @@ const LinkButton = ({ editor, variant = 'toolbar' }: LinkButtonProps) => {
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter') {
       event.preventDefault();
-      apply();
+      if (submittable) apply();
     } else if (event.key === 'Escape') {
       event.preventDefault();
       setOpen(false);
@@ -115,7 +131,7 @@ const LinkButton = ({ editor, variant = 'toolbar' }: LinkButtonProps) => {
                 Remove
               </Button>
             )}
-            <Button type="button" size="sm" onClick={apply}>
+            <Button type="button" size="sm" onClick={apply} disabled={!submittable}>
               {isActive ? 'Update' : 'Save'}
             </Button>
           </div>

--- a/apps/web/src/components/editors/LinkButton.tsx
+++ b/apps/web/src/components/editors/LinkButton.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { Editor } from '@tiptap/react';
+import { Link as LinkIcon } from 'lucide-react';
+import React from 'react';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+interface LinkButtonProps {
+  editor: Editor;
+  variant?: 'toolbar' | 'bubble';
+}
+
+const normalizeUrl = (raw: string): string => {
+  const trimmed = raw.trim();
+  if (!trimmed) return '';
+  if (/^(https?:\/\/|mailto:|tel:|#|\/)/i.test(trimmed)) return trimmed;
+  return `https://${trimmed}`;
+};
+
+const LinkButton = ({ editor, variant = 'toolbar' }: LinkButtonProps) => {
+  const [open, setOpen] = React.useState(false);
+  const [value, setValue] = React.useState('');
+
+  const isActive = editor.isActive('link');
+
+  const handleOpenChange = (next: boolean) => {
+    if (next) {
+      const existing = (editor.getAttributes('link').href as string | undefined) ?? '';
+      setValue(existing);
+    }
+    setOpen(next);
+  };
+
+  const apply = () => {
+    const href = normalizeUrl(value);
+    const chain = editor.chain().focus().extendMarkRange('link');
+    if (!href) {
+      chain.unsetLink().run();
+    } else {
+      const { from, to } = editor.state.selection;
+      if (from === to && !isActive) {
+        chain
+          .insertContent({
+            type: 'text',
+            text: href,
+            marks: [{ type: 'link', attrs: { href } }],
+          })
+          .run();
+      } else {
+        chain.setLink({ href }).run();
+      }
+    }
+    setOpen(false);
+  };
+
+  const remove = () => {
+    editor.chain().focus().extendMarkRange('link').unsetLink().run();
+    setOpen(false);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      apply();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      setOpen(false);
+    }
+  };
+
+  const triggerClass =
+    variant === 'toolbar'
+      ? `p-2 rounded-md transition-colors ${isActive ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'}`
+      : `p-2 rounded ${isActive ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'}`;
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label={isActive ? 'Edit link' : 'Add link'}
+          onMouseDown={(e) => e.preventDefault()}
+          className={triggerClass}
+        >
+          <LinkIcon size={16} />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-80 p-3"
+        onOpenAutoFocus={(e) => {
+          // Let our autoFocus on the input handle focus instead of Radix's default.
+          e.preventDefault();
+        }}
+      >
+        <div className="flex flex-col gap-2">
+          <label className="text-xs font-medium text-muted-foreground" htmlFor="link-url-input">
+            URL
+          </label>
+          <Input
+            id="link-url-input"
+            type="url"
+            inputMode="url"
+            placeholder="https://example.com"
+            value={value}
+            autoFocus
+            onChange={(e) => setValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+          />
+          <div className="flex items-center justify-end gap-2 pt-1">
+            {isActive && (
+              <Button type="button" variant="ghost" size="sm" onClick={remove}>
+                Remove
+              </Button>
+            )}
+            <Button type="button" size="sm" onClick={apply}>
+              {isActive ? 'Update' : 'Save'}
+            </Button>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export default LinkButton;

--- a/apps/web/src/components/editors/LinkButton.tsx
+++ b/apps/web/src/components/editors/LinkButton.tsx
@@ -13,13 +13,16 @@ interface LinkButtonProps {
 }
 
 const DANGEROUS_PROTOCOL = /^\s*(javascript|data|vbscript):/i;
+const ABSOLUTE_OR_RELATIVE = /^(https?:\/\/|ftp:\/\/|mailto:|tel:|#|\/|\?|\.{1,2}\/)/i;
+const LOOKS_LIKE_HOSTNAME = /^[^\s/?#]+\.[^\s]+/;
 
 const normalizeUrl = (raw: string): string => {
   const trimmed = raw.trim();
   if (!trimmed) return '';
   if (DANGEROUS_PROTOCOL.test(trimmed)) return '';
-  if (/^(https?:\/\/|mailto:|tel:|#|\/)/i.test(trimmed)) return trimmed;
-  return `https://${trimmed}`;
+  if (ABSOLUTE_OR_RELATIVE.test(trimmed)) return trimmed;
+  if (LOOKS_LIKE_HOSTNAME.test(trimmed)) return `https://${trimmed}`;
+  return trimmed;
 };
 
 const LinkButton = ({ editor, variant = 'toolbar' }: LinkButtonProps) => {

--- a/apps/web/src/components/editors/LinkButton.tsx
+++ b/apps/web/src/components/editors/LinkButton.tsx
@@ -16,7 +16,7 @@ const DANGEROUS_PROTOCOL = /^\s*(javascript|data|vbscript):/i;
 const ABSOLUTE_OR_RELATIVE = /^(https?:\/\/|ftp:\/\/|mailto:|tel:|#|\/|\?|\.{1,2}\/)/i;
 const LOOKS_LIKE_HOSTNAME = /^[^\s/?#]+\.[^\s]+/;
 
-const normalizeUrl = (raw: string): string => {
+export const normalizeUrl = (raw: string): string => {
   const trimmed = raw.trim();
   if (!trimmed) return '';
   if (DANGEROUS_PROTOCOL.test(trimmed)) return '';

--- a/apps/web/src/components/editors/LinkButton.tsx
+++ b/apps/web/src/components/editors/LinkButton.tsx
@@ -12,9 +12,12 @@ interface LinkButtonProps {
   variant?: 'toolbar' | 'bubble';
 }
 
+const DANGEROUS_PROTOCOL = /^\s*(javascript|data|vbscript):/i;
+
 const normalizeUrl = (raw: string): string => {
   const trimmed = raw.trim();
   if (!trimmed) return '';
+  if (DANGEROUS_PROTOCOL.test(trimmed)) return '';
   if (/^(https?:\/\/|mailto:|tel:|#|\/)/i.test(trimmed)) return trimmed;
   return `https://${trimmed}`;
 };
@@ -22,6 +25,7 @@ const normalizeUrl = (raw: string): string => {
 const LinkButton = ({ editor, variant = 'toolbar' }: LinkButtonProps) => {
   const [open, setOpen] = React.useState(false);
   const [value, setValue] = React.useState('');
+  const inputId = React.useId();
 
   const isActive = editor.isActive('link');
 
@@ -35,6 +39,7 @@ const LinkButton = ({ editor, variant = 'toolbar' }: LinkButtonProps) => {
 
   const apply = () => {
     const href = normalizeUrl(value);
+    const existingAttrs = editor.getAttributes('link');
     const chain = editor.chain().focus().extendMarkRange('link');
     if (!href) {
       chain.unsetLink().run();
@@ -49,7 +54,7 @@ const LinkButton = ({ editor, variant = 'toolbar' }: LinkButtonProps) => {
           })
           .run();
       } else {
-        chain.setLink({ href }).run();
+        chain.setLink({ ...existingAttrs, href }).run();
       }
     }
     setOpen(false);
@@ -87,25 +92,17 @@ const LinkButton = ({ editor, variant = 'toolbar' }: LinkButtonProps) => {
           <LinkIcon size={16} />
         </button>
       </PopoverTrigger>
-      <PopoverContent
-        align="start"
-        className="w-80 p-3"
-        onOpenAutoFocus={(e) => {
-          // Let our autoFocus on the input handle focus instead of Radix's default.
-          e.preventDefault();
-        }}
-      >
+      <PopoverContent align="start" className="w-80 p-3">
         <div className="flex flex-col gap-2">
-          <label className="text-xs font-medium text-muted-foreground" htmlFor="link-url-input">
+          <label className="text-xs font-medium text-muted-foreground" htmlFor={inputId}>
             URL
           </label>
           <Input
-            id="link-url-input"
+            id={inputId}
             type="url"
             inputMode="url"
             placeholder="https://example.com"
             value={value}
-            autoFocus
             onChange={(e) => setValue(e.target.value)}
             onKeyDown={handleKeyDown}
           />

--- a/apps/web/src/components/editors/RichEditor.tsx
+++ b/apps/web/src/components/editors/RichEditor.tsx
@@ -15,6 +15,7 @@ import { PaginationPlus } from '@/lib/editor/pagination';
 import { CodeBlockShiki } from '@/lib/editor/code-block';
 import { FontFormatting } from '@/lib/editor/font-formatting';
 import { subscribeToNavigationEvents } from '@/lib/navigation/app-navigation';
+import LinkButton from './LinkButton';
 
 interface RichEditorProps {
   value: string;
@@ -274,6 +275,7 @@ const RichEditor = ({ value, onChange, onEditorChange, readOnly = false, isPagin
           <button onClick={() => editor.chain().focus().toggleItalic().run()} className={`p-2 rounded ${editor.isActive('italic') ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'}`}><Italic size={16} /></button>
           <button onClick={() => editor.chain().focus().toggleStrike().run()} className={`p-2 rounded ${editor.isActive('strike') ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'}`}><Strikethrough size={16} /></button>
           <button onClick={() => editor.chain().focus().toggleCode().run()} className={`p-2 rounded ${editor.isActive('code') ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'}`}><Code size={16} /></button>
+          <LinkButton editor={editor} variant="bubble" />
           <div className="w-[1px] h-6 bg-muted-foreground/50 mx-2" />
           <button onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()} className={`p-2 rounded ${editor.isActive('heading', { level: 1 }) ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'}`}><Heading1 size={16} /></button>
           <button onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()} className={`p-2 rounded ${editor.isActive('heading', { level: 2 }) ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'}`}><Heading2 size={16} /></button>

--- a/apps/web/src/components/editors/RichEditor.tsx
+++ b/apps/web/src/components/editors/RichEditor.tsx
@@ -72,6 +72,9 @@ const RichEditor = ({ value, onChange, onEditorChange, readOnly = false, isPagin
         },
         link: {
           openOnClick: true,
+          autolink: true,
+          linkOnPaste: true,
+          defaultProtocol: 'https',
         },
         codeBlock: false,
       }),

--- a/apps/web/src/components/editors/Toolbar.tsx
+++ b/apps/web/src/components/editors/Toolbar.tsx
@@ -6,6 +6,7 @@ import {
 } from 'lucide-react';
 import React from 'react';
 import TableMenu from './TableMenu';
+import LinkButton from './LinkButton';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 
 interface ToolbarProps {
@@ -159,6 +160,7 @@ const Toolbar = ({ editor, contentMode = 'html' }: ToolbarProps) => {
         <button onMouseDown={(e) => e.preventDefault()} onClick={() => editor.chain().focus().toggleItalic().run()} className={`p-2 rounded-md transition-colors ${editor.isActive('italic') ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'}`}><Italic size={16} /></button>
         <button onMouseDown={(e) => e.preventDefault()} onClick={() => editor.chain().focus().toggleStrike().run()} className={`p-2 rounded-md transition-colors ${editor.isActive('strike') ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'}`}><Strikethrough size={16} /></button>
         <button onMouseDown={(e) => e.preventDefault()} onClick={() => editor.chain().focus().toggleCode().run()} className={`p-2 rounded-md transition-colors ${editor.isActive('code') ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'}`}><Code size={16} /></button>
+        <LinkButton editor={editor} variant="toolbar" />
         <div className="w-[1px] h-6 bg-border mx-1" />
         <button onMouseDown={(e) => e.preventDefault()} onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()} className={`p-2 rounded-md transition-colors ${editor.isActive('heading', { level: 1 }) ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'}`}><Heading1 size={16} /></button>
         <button onMouseDown={(e) => e.preventDefault()} onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()} className={`p-2 rounded-md transition-colors ${editor.isActive('heading', { level: 2 }) ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'}`}><Heading2 size={16} /></button>

--- a/apps/web/src/components/editors/__tests__/normalizeUrl.test.ts
+++ b/apps/web/src/components/editors/__tests__/normalizeUrl.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeUrl } from '../LinkButton';
+
+describe('normalizeUrl', () => {
+  it('returns empty string for empty input', () => {
+    expect(normalizeUrl('')).toBe('');
+    expect(normalizeUrl('   ')).toBe('');
+  });
+
+  it('preserves absolute URLs', () => {
+    expect(normalizeUrl('https://example.com')).toBe('https://example.com');
+    expect(normalizeUrl('http://example.com/path?q=1')).toBe('http://example.com/path?q=1');
+    expect(normalizeUrl('ftp://ftp.example.com/file')).toBe('ftp://ftp.example.com/file');
+  });
+
+  it('preserves mailto and tel URIs', () => {
+    expect(normalizeUrl('mailto:user@example.com')).toBe('mailto:user@example.com');
+    expect(normalizeUrl('tel:+15551234567')).toBe('tel:+15551234567');
+  });
+
+  it('preserves relative paths and fragments', () => {
+    expect(normalizeUrl('/foo/bar')).toBe('/foo/bar');
+    expect(normalizeUrl('#section')).toBe('#section');
+    expect(normalizeUrl('?view=compact')).toBe('?view=compact');
+    expect(normalizeUrl('./doc')).toBe('./doc');
+    expect(normalizeUrl('../parent')).toBe('../parent');
+  });
+
+  it('passes bare paths without dots through unchanged', () => {
+    expect(normalizeUrl('bar/baz')).toBe('bar/baz');
+    expect(normalizeUrl('localhost')).toBe('localhost');
+  });
+
+  it('prepends https:// to bare hostnames', () => {
+    expect(normalizeUrl('example.com')).toBe('https://example.com');
+    expect(normalizeUrl('example.com/path')).toBe('https://example.com/path');
+    expect(normalizeUrl('sub.example.co.uk')).toBe('https://sub.example.co.uk');
+  });
+
+  it('trims surrounding whitespace before normalizing', () => {
+    expect(normalizeUrl('  example.com  ')).toBe('https://example.com');
+    expect(normalizeUrl('  /foo  ')).toBe('/foo');
+  });
+
+  it('rejects javascript:, data:, and vbscript: URIs as XSS vectors', () => {
+    expect(normalizeUrl('javascript:alert(1)')).toBe('');
+    expect(normalizeUrl('JavaScript:alert(1)')).toBe('');
+    expect(normalizeUrl('  javascript:alert(1)')).toBe('');
+    expect(normalizeUrl('data:text/html,<script>alert(1)</script>')).toBe('');
+    expect(normalizeUrl('vbscript:msgbox')).toBe('');
+  });
+});

--- a/apps/web/src/styles/tiptap.css
+++ b/apps/web/src/styles/tiptap.css
@@ -93,4 +93,15 @@
     border-top: 2px solid rgba(#0d0d0d, 0.1);
     margin: 2rem 0;
   }
+
+  a {
+    color: var(--primary);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    cursor: pointer;
+  }
+
+  a:hover {
+    opacity: 0.8;
+  }
 }


### PR DESCRIPTION
Closes #1206

## Summary

Fixes "missing hyperlink creation tool" in the document text editor (TipTap).

The Link mark was already enabled via `StarterKit` in `RichEditor.tsx:72-77`, but no UI existed to create, edit, or remove a link, and the legacy config inherited `defaultProtocol: 'http'` from TipTap defaults. Users had no way to insert hyperlinks short of dropping into raw markdown mode.

## What changed

- **`LinkButton` component** (new) — popover with URL input. Pre-fills the existing href when editing, normalizes input, inserts URL-as-text when there's no selection, and offers a Remove action when a link is active.
- **Toolbar wiring** — Link button after Code in the inline-formatting cluster.
- **Bubble menu wiring** — Link button after Code, so selecting text → click link icon is one move.
- **Mod-K / Cmd-K shortcut** — bound on the toolbar instance, opens the popover (pre-filled if cursor is in an existing link). Advertised via `aria-keyshortcuts`.
- **Paste & autolink** — explicit `autolink: true`, `linkOnPaste: true`, `defaultProtocol: 'https'` on the StarterKit Link config, so typed/pasted bare hostnames are detected and default to https rather than http.
- **`normalizeUrl`** — exported pure function with 8 vitest cases covering absolute (http/https/ftp/mailto/tel), relative (`/foo`, `#anchor`, `?query`, `./doc`, `../parent`), bare hostnames, whitespace trimming, and rejection of `javascript:` / `data:` / `vbscript:` URIs as XSS vectors. Defense-in-depth alongside TipTap's built-in protocol allowlist.
- **Anchor styling** in `tiptap.css` — primary color + underline so links are visually distinct in both edit and read-only modes.
- **Hardening** — `React.useId()` for the input id (avoids duplicate ids on multi-editor pages); existing link attributes preserved on update; Save/Update button disabled when input is empty/invalid (clearing no longer silently `unsetLink()`s).

## Files changed

- `apps/web/src/components/editors/LinkButton.tsx` *(new)*
- `apps/web/src/components/editors/__tests__/normalizeUrl.test.ts` *(new, 8 tests)*
- `apps/web/src/components/editors/Toolbar.tsx` — Link button after Code
- `apps/web/src/components/editors/RichEditor.tsx` — Link button in BubbleMenu, autolink/linkOnPaste/defaultProtocol explicit
- `apps/web/src/styles/tiptap.css` — `.tiptap a` styling

## Maps to #1206 expected behaviors

- [x] Select text and convert it to a hyperlink — bubble menu + toolbar
- [x] Paste a URL and have it automatically detected — `linkOnPaste: true`
- [x] Use a toolbar button or keyboard shortcut to create links — both
- [x] Edit existing hyperlinks — popover pre-fills href when cursor is inside a link

## Review feedback addressed

- **Codex (P2)**: relative URLs preserved in `normalizeUrl` (commit 206c21c)
- **CodeRabbit (potential issue)**: Save/Update disabled on empty input — explicit Remove required (commit 28feb14)
- **CodeRabbit (nitpick)**: Mod-K shortcut wired (commit 28feb14)

## Test plan

- [ ] `pnpm --filter web dev`, open any Document page
- [ ] **Toolbar**: click into editor → click link icon → enter `example.com` → Save → linked to `https://example.com`
- [ ] **Bubble**: select text → bubble menu → click link icon → URL → Save → selection becomes a link
- [ ] **Edit**: cursor inside an existing link → popover shows current href → Update changes it
- [ ] **Remove**: cursor inside a link → popover → Remove → mark unwrapped
- [ ] **Mod-K**: Cmd-K (Ctrl-K) opens popover from anywhere in the editor
- [ ] **Auto-detect**: paste `https://example.com` into the editor → it auto-links
- [ ] **Relative URLs**: `?view=compact` / `./sibling` preserved as-is
- [ ] **XSS**: typing `javascript:alert(1)` disables Save and is silently rejected by `normalizeUrl`
- [ ] Links render with primary-color underline in both edit and read-only modes
- [ ] Markdown mode roundtrips a link as `[text](url)`
- [x] `normalizeUrl` unit tests (8/8 passing locally)
- [x] `pnpm --filter web lint` clean
- [x] `pnpm --filter web typecheck` clean for touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)