### PR TITLE
fix(tasks): persist filter preferences per scope

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -11,6 +11,7 @@ import { useDriveStore } from '@/hooks/useDrive';
 import { useEditingStore } from '@/stores/useEditingStore';
 import { useEditingSession } from '@/stores/useEditingSession';
 import { useLayoutStore } from '@/stores/useLayoutStore';
+import { useTaskListPageFilter } from './useTaskListPageFilter';
 import { TreePage } from '@/hooks/usePageTree';
 import { fetchWithAuth, post, patch, del } from '@/lib/auth/auth-fetch';
 import { useSocketStore } from '@/stores/useSocketStore';
@@ -367,7 +368,7 @@ function TaskListView({ page }: TaskListViewProps) {
   const canManageWorkflows = canManageDrive(drive);
   const isAnyActive = useEditingStore(state => state.isAnyActive());
 
-  const [filter, setFilter] = useState<'all' | 'active' | 'completed'>('all');
+  const [filter, setFilter] = useTaskListPageFilter(page.id);
   const [search, setSearch] = useState('');
   const [newTaskTitle, setNewTaskTitle] = useState('');
   const [editingTaskId, setEditingTaskId] = useState<string | null>(null);

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/useTaskListPageFilter.test.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/useTaskListPageFilter.test.ts
@@ -1,0 +1,60 @@
+/**
+ * useTaskListPageFilter Tests
+ * Verifies the TaskListView filter wiring reads from and writes to useLayoutStore.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTaskListPageFilter } from '../useTaskListPageFilter';
+import { useLayoutStore } from '@/stores/useLayoutStore';
+
+const initialSnapshot = useLayoutStore.getState();
+
+describe('useTaskListPageFilter', () => {
+  beforeEach(() => {
+    useLayoutStore.setState(
+      { ...initialSnapshot, taskListPageFilters: {} },
+      true,
+    );
+    localStorage.clear();
+  });
+
+  it('given no entry stored for the page, should default to "all"', () => {
+    const { result } = renderHook(() => useTaskListPageFilter('page-1'));
+
+    expect(result.current[0]).toBe('all');
+  });
+
+  it('given the store has a filter for the page, should return that filter', () => {
+    useLayoutStore.setState({
+      ...useLayoutStore.getState(),
+      taskListPageFilters: { 'page-1': 'completed' },
+    });
+
+    const { result } = renderHook(() => useTaskListPageFilter('page-1'));
+
+    expect(result.current[0]).toBe('completed');
+  });
+
+  it('given the setter is called, should write through to the store under that pageId', () => {
+    const { result } = renderHook(() => useTaskListPageFilter('page-1'));
+
+    act(() => {
+      result.current[1]('active');
+    });
+
+    expect(useLayoutStore.getState().taskListPageFilters['page-1']).toBe('active');
+    expect(result.current[0]).toBe('active');
+  });
+
+  it('given a different pageId, should not be affected by another page’s filter', () => {
+    useLayoutStore.setState({
+      ...useLayoutStore.getState(),
+      taskListPageFilters: { 'page-other': 'completed' },
+    });
+
+    const { result } = renderHook(() => useTaskListPageFilter('page-1'));
+
+    expect(result.current[0]).toBe('all');
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/useTaskListPageFilter.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/useTaskListPageFilter.ts
@@ -1,0 +1,14 @@
+import { useCallback } from 'react';
+import { useLayoutStore, type TaskListPageFilter } from '@/stores/useLayoutStore';
+
+export function useTaskListPageFilter(
+  pageId: string,
+): [TaskListPageFilter, (next: TaskListPageFilter) => void] {
+  const filter = useLayoutStore((s) => s.taskListPageFilters[pageId]) ?? 'all';
+  const setStored = useLayoutStore((s) => s.setTaskListPageFilter);
+  const setFilter = useCallback(
+    (next: TaskListPageFilter) => setStored(pageId, next),
+    [pageId, setStored],
+  );
+  return [filter, setFilter];
+}

--- a/apps/web/src/components/tasks/TasksDashboard.tsx
+++ b/apps/web/src/components/tasks/TasksDashboard.tsx
@@ -42,6 +42,8 @@ import {
   pickInitialFilters,
   toStoredDashboardFilters,
   fromStoredOrDefaults,
+  type DueDateFilter,
+  type AssigneeFilter,
 } from './dashboardFiltersPersistence';
 import { useEditingStore } from '@/stores/useEditingStore';
 import { useMobile } from '@/hooks/useMobile';
@@ -69,9 +71,6 @@ interface TasksDashboardProps {
   driveId?: string;
   driveName?: string;
 }
-
-type DueDateFilter = 'all' | 'overdue' | 'today' | 'this_week' | 'upcoming';
-type AssigneeFilter = 'mine' | 'all';
 
 interface ExtendedFilters extends TaskFilters {
   search?: string;

--- a/apps/web/src/components/tasks/TasksDashboard.tsx
+++ b/apps/web/src/components/tasks/TasksDashboard.tsx
@@ -41,6 +41,7 @@ import {
   scopeKeyFor,
   pickInitialFilters,
   toStoredDashboardFilters,
+  fromStoredOrDefaults,
 } from './dashboardFiltersPersistence';
 import { useEditingStore } from '@/stores/useEditingStore';
 import { useMobile } from '@/hooks/useMobile';
@@ -111,10 +112,10 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
   // Filter state — URL params win on mount; otherwise fall back to per-scope persisted prefs.
   const [selectedDriveId, setSelectedDriveId] = useState<string | undefined>(initialDriveId);
   const persistDashboardFilter = useLayoutStore((state) => state.setTasksDashboardFilter);
-  const initialScopeKey = scopeKeyFor(context, initialDriveId);
   const [filters, setFilters] = useState<ExtendedFilters>(() => {
+    const initialScopeKey = scopeKeyFor(context, initialDriveId);
     const stored = useLayoutStore.getState().tasksDashboardFilters[initialScopeKey];
-    return pickInitialFilters(searchParams, stored) as ExtendedFilters;
+    return pickInitialFilters(searchParams, stored);
   });
 
   // Track last data refresh time
@@ -323,7 +324,8 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
   const handleDriveChange = (driveId: string) => {
     if (context === 'drive') {
       setSelectedDriveId(driveId);
-      const updatedFilters = { ...filters };
+      const stored = useLayoutStore.getState().tasksDashboardFilters[scopeKeyFor('drive', driveId)];
+      const updatedFilters = fromStoredOrDefaults(stored);
       setFilters(updatedFilters);
       updateUrl(updatedFilters, driveId);
     } else {

--- a/apps/web/src/components/tasks/TasksDashboard.tsx
+++ b/apps/web/src/components/tasks/TasksDashboard.tsx
@@ -37,6 +37,11 @@ import { cn } from '@/lib/utils';
 import { PullToRefresh } from '@/components/ui/pull-to-refresh';
 import { CustomScrollArea } from '@/components/ui/custom-scroll-area';
 import { useLayoutStore } from '@/stores/useLayoutStore';
+import {
+  scopeKeyFor,
+  pickInitialFilters,
+  toStoredDashboardFilters,
+} from './dashboardFiltersPersistence';
 import { useEditingStore } from '@/stores/useEditingStore';
 import { useMobile } from '@/hooks/useMobile';
 import { useCapacitor } from '@/hooks/useCapacitor';
@@ -103,16 +108,14 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
   const [detailSheetOpen, setDetailSheetOpen] = useState(false);
   const [filterSheetOpen, setFilterSheetOpen] = useState(false);
 
-  // Filter state from URL params
+  // Filter state — URL params win on mount; otherwise fall back to per-scope persisted prefs.
   const [selectedDriveId, setSelectedDriveId] = useState<string | undefined>(initialDriveId);
-  const [filters, setFilters] = useState<ExtendedFilters>(() => ({
-    status: searchParams.get('status') || undefined,
-    priority: (searchParams.get('priority') as TaskPriority) || undefined,
-    driveId: searchParams.get('driveId') || undefined,
-    search: searchParams.get('search') || undefined,
-    dueDateFilter: (searchParams.get('dueDateFilter') as DueDateFilter) || undefined,
-    assigneeFilter: (searchParams.get('assigneeFilter') as AssigneeFilter) || 'mine',
-  }));
+  const persistDashboardFilter = useLayoutStore((state) => state.setTasksDashboardFilter);
+  const initialScopeKey = scopeKeyFor(context, initialDriveId);
+  const [filters, setFilters] = useState<ExtendedFilters>(() => {
+    const stored = useLayoutStore.getState().tasksDashboardFilters[initialScopeKey];
+    return pickInitialFilters(searchParams, stored) as ExtendedFilters;
+  });
 
   // Track last data refresh time
   const [lastRefreshTime, setLastRefreshTime] = useState<Date>(new Date());
@@ -137,7 +140,7 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
     };
   }, []);
 
-  // Update URL when filters change
+  // Update URL when filters change, and persist the filter state per scope.
   const updateUrl = useCallback((newFilters: ExtendedFilters, newDriveId?: string) => {
     const params = new URLSearchParams();
 
@@ -168,7 +171,9 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
     const newUrl = queryString ? `${basePath}?${queryString}` : basePath;
 
     router.replace(newUrl, { scroll: false });
-  }, [router]);
+
+    persistDashboardFilter(scopeKeyFor(context, newDriveId), toStoredDashboardFilters(newFilters));
+  }, [router, persistDashboardFilter, context]);
 
   // Handle search with debounce
   const handleSearchChange = useCallback((value: string) => {

--- a/apps/web/src/components/tasks/TasksDashboard.tsx
+++ b/apps/web/src/components/tasks/TasksDashboard.tsx
@@ -326,6 +326,13 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
       setSelectedDriveId(driveId);
       const stored = useLayoutStore.getState().tasksDashboardFilters[scopeKeyFor('drive', driveId)];
       const updatedFilters = fromStoredOrDefaults(stored);
+      // Cancel any in-flight debounced search and sync the input to the restored filter
+      // so the search box doesn't display the previous drive's text.
+      if (searchTimeoutRef.current) {
+        clearTimeout(searchTimeoutRef.current);
+        searchTimeoutRef.current = null;
+      }
+      setSearchValue(updatedFilters.search || '');
       setFilters(updatedFilters);
       updateUrl(updatedFilters, driveId);
     } else {

--- a/apps/web/src/components/tasks/__tests__/dashboardFiltersPersistence.test.ts
+++ b/apps/web/src/components/tasks/__tests__/dashboardFiltersPersistence.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Pure helpers that wire TasksDashboard filter state to useLayoutStore.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  scopeKeyFor,
+  pickInitialFilters,
+  toStoredDashboardFilters,
+  DEFAULT_DASHBOARD_FILTERS,
+} from '../dashboardFiltersPersistence';
+import type { StoredDashboardFilters } from '@/stores/useLayoutStore';
+
+const params = (entries: Record<string, string>): URLSearchParams => new URLSearchParams(entries);
+
+describe('scopeKeyFor', () => {
+  it('given user context, should return "user"', () => {
+    expect(scopeKeyFor('user', undefined)).toBe('user');
+  });
+
+  it('given drive context with driveId, should return "drive:<driveId>"', () => {
+    expect(scopeKeyFor('drive', 'abc')).toBe('drive:abc');
+  });
+
+  it('given drive context with no driveId yet, should return "drive:" placeholder', () => {
+    expect(scopeKeyFor('drive', undefined)).toBe('drive:');
+  });
+});
+
+describe('pickInitialFilters', () => {
+  it('given URL has any persistable param, should ignore stored prefs and use URL', () => {
+    const stored: StoredDashboardFilters = { assigneeFilter: 'all', status: 'pending' };
+
+    const result = pickInitialFilters(params({ status: 'in_progress' }), stored);
+
+    expect(result.status).toBe('in_progress');
+    expect(result.assigneeFilter).toBe('mine');
+  });
+
+  it('given URL is bare and stored prefs exist, should use stored prefs', () => {
+    const stored: StoredDashboardFilters = {
+      assigneeFilter: 'all',
+      status: 'in_progress',
+      dueDateFilter: 'overdue',
+    };
+
+    const result = pickInitialFilters(params({}), stored);
+
+    expect(result.status).toBe('in_progress');
+    expect(result.assigneeFilter).toBe('all');
+    expect(result.dueDateFilter).toBe('overdue');
+  });
+
+  it('given URL bare and no stored prefs, should fall back to defaults', () => {
+    const result = pickInitialFilters(params({}), undefined);
+
+    expect(result).toEqual(DEFAULT_DASHBOARD_FILTERS);
+  });
+
+  it('given URL has driveId param, should treat that as a persistable param triggering URL precedence', () => {
+    const stored: StoredDashboardFilters = { assigneeFilter: 'all' };
+
+    const result = pickInitialFilters(params({ driveId: 'd1' }), stored);
+
+    expect(result.driveId).toBe('d1');
+    expect(result.assigneeFilter).toBe('mine');
+  });
+
+  it('given URL has only assigneeFilter=mine, should still treat as URL precedence (explicit)', () => {
+    const stored: StoredDashboardFilters = { assigneeFilter: 'all' };
+
+    const result = pickInitialFilters(params({ assigneeFilter: 'mine' }), stored);
+
+    expect(result.assigneeFilter).toBe('mine');
+  });
+});
+
+describe('toStoredDashboardFilters', () => {
+  it('given full ExtendedFilters, should retain only the persistable subset', () => {
+    const result = toStoredDashboardFilters({
+      status: 'pending',
+      priority: 'high',
+      driveId: 'd1',
+      search: 'budget',
+      dueDateFilter: 'overdue',
+      assigneeFilter: 'all',
+    });
+
+    expect(result).toEqual({
+      status: 'pending',
+      priority: 'high',
+      search: 'budget',
+      dueDateFilter: 'overdue',
+      assigneeFilter: 'all',
+    });
+  });
+
+  it('given undefined fields, should omit them from the stored shape', () => {
+    const result = toStoredDashboardFilters({ assigneeFilter: 'mine' });
+
+    expect(result).toEqual({ assigneeFilter: 'mine' });
+  });
+});

--- a/apps/web/src/components/tasks/__tests__/dashboardFiltersPersistence.test.ts
+++ b/apps/web/src/components/tasks/__tests__/dashboardFiltersPersistence.test.ts
@@ -7,6 +7,7 @@ import {
   scopeKeyFor,
   pickInitialFilters,
   toStoredDashboardFilters,
+  fromStoredOrDefaults,
   DEFAULT_DASHBOARD_FILTERS,
 } from '../dashboardFiltersPersistence';
 import type { StoredDashboardFilters } from '@/stores/useLayoutStore';
@@ -72,6 +73,25 @@ describe('pickInitialFilters', () => {
     const result = pickInitialFilters(params({ assigneeFilter: 'mine' }), stored);
 
     expect(result.assigneeFilter).toBe('mine');
+  });
+});
+
+describe('fromStoredOrDefaults', () => {
+  it('given undefined stored prefs, should return defaults', () => {
+    expect(fromStoredOrDefaults(undefined)).toEqual(DEFAULT_DASHBOARD_FILTERS);
+  });
+
+  it('given partial stored prefs, should merge over defaults', () => {
+    const result = fromStoredOrDefaults({ status: 'in_progress' });
+
+    expect(result.status).toBe('in_progress');
+    expect(result.assigneeFilter).toBe('mine');
+  });
+
+  it('given stored prefs that override the default assignee, should respect the override', () => {
+    const result = fromStoredOrDefaults({ assigneeFilter: 'all' });
+
+    expect(result.assigneeFilter).toBe('all');
   });
 });
 

--- a/apps/web/src/components/tasks/dashboardFiltersPersistence.ts
+++ b/apps/web/src/components/tasks/dashboardFiltersPersistence.ts
@@ -43,6 +43,15 @@ function readFromUrl(searchParams: URLSearchParams): PersistableFilters {
   };
 }
 
+export function fromStoredOrDefaults(
+  stored: StoredDashboardFilters | undefined,
+): PersistableFilters {
+  if (stored) {
+    return { ...DEFAULT_DASHBOARD_FILTERS, ...stored };
+  }
+  return { ...DEFAULT_DASHBOARD_FILTERS };
+}
+
 export function pickInitialFilters(
   searchParams: URLSearchParams,
   stored: StoredDashboardFilters | undefined,
@@ -50,10 +59,7 @@ export function pickInitialFilters(
   if (urlHasAnyPersistableParam(searchParams)) {
     return readFromUrl(searchParams);
   }
-  if (stored) {
-    return { ...DEFAULT_DASHBOARD_FILTERS, ...stored };
-  }
-  return { ...DEFAULT_DASHBOARD_FILTERS };
+  return fromStoredOrDefaults(stored);
 }
 
 export function toStoredDashboardFilters(filters: PersistableFilters): StoredDashboardFilters {

--- a/apps/web/src/components/tasks/dashboardFiltersPersistence.ts
+++ b/apps/web/src/components/tasks/dashboardFiltersPersistence.ts
@@ -1,0 +1,67 @@
+import type { TaskPriority } from './types';
+import type { StoredDashboardFilters } from '@/stores/useLayoutStore';
+
+export type DueDateFilter = 'all' | 'overdue' | 'today' | 'this_week' | 'upcoming';
+export type AssigneeFilter = 'mine' | 'all';
+
+export interface PersistableFilters {
+  status?: string;
+  priority?: TaskPriority;
+  search?: string;
+  dueDateFilter?: DueDateFilter;
+  assigneeFilter?: AssigneeFilter;
+  driveId?: string;
+}
+
+export const DEFAULT_DASHBOARD_FILTERS: PersistableFilters = {
+  status: undefined,
+  priority: undefined,
+  driveId: undefined,
+  search: undefined,
+  dueDateFilter: undefined,
+  assigneeFilter: 'mine',
+};
+
+const URL_FILTER_KEYS = ['status', 'priority', 'driveId', 'search', 'dueDateFilter', 'assigneeFilter'] as const;
+
+export function scopeKeyFor(context: 'user' | 'drive', driveId: string | undefined): string {
+  return context === 'user' ? 'user' : `drive:${driveId ?? ''}`;
+}
+
+function urlHasAnyPersistableParam(searchParams: URLSearchParams): boolean {
+  return URL_FILTER_KEYS.some((key) => searchParams.has(key));
+}
+
+function readFromUrl(searchParams: URLSearchParams): PersistableFilters {
+  return {
+    status: searchParams.get('status') || undefined,
+    priority: (searchParams.get('priority') as TaskPriority) || undefined,
+    driveId: searchParams.get('driveId') || undefined,
+    search: searchParams.get('search') || undefined,
+    dueDateFilter: (searchParams.get('dueDateFilter') as DueDateFilter) || undefined,
+    assigneeFilter: (searchParams.get('assigneeFilter') as AssigneeFilter) || 'mine',
+  };
+}
+
+export function pickInitialFilters(
+  searchParams: URLSearchParams,
+  stored: StoredDashboardFilters | undefined,
+): PersistableFilters {
+  if (urlHasAnyPersistableParam(searchParams)) {
+    return readFromUrl(searchParams);
+  }
+  if (stored) {
+    return { ...DEFAULT_DASHBOARD_FILTERS, ...stored };
+  }
+  return { ...DEFAULT_DASHBOARD_FILTERS };
+}
+
+export function toStoredDashboardFilters(filters: PersistableFilters): StoredDashboardFilters {
+  const out: StoredDashboardFilters = {};
+  if (filters.status !== undefined) out.status = filters.status;
+  if (filters.priority !== undefined) out.priority = filters.priority;
+  if (filters.search !== undefined) out.search = filters.search;
+  if (filters.dueDateFilter !== undefined) out.dueDateFilter = filters.dueDateFilter;
+  if (filters.assigneeFilter !== undefined) out.assigneeFilter = filters.assigneeFilter;
+  return out;
+}

--- a/apps/web/src/stores/__tests__/useLayoutStore.test.ts
+++ b/apps/web/src/stores/__tests__/useLayoutStore.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
-import { useLayoutStore } from '../useLayoutStore';
+import { useLayoutStore, type StoredDashboardFilters } from '../useLayoutStore';
 
 const initialSnapshot = useLayoutStore.getState();
 
@@ -14,6 +14,7 @@ describe('useLayoutStore', () => {
       {
         ...initialSnapshot,
         taskListPageFilters: {},
+        tasksDashboardFilters: {},
       },
       true,
     );
@@ -54,6 +55,57 @@ describe('useLayoutStore', () => {
       setTaskListPageFilter('page-a', 'completed');
 
       expect(useLayoutStore.getState().taskListPageFilters['page-a']).toBe('completed');
+    });
+  });
+
+  describe('tasksDashboardFilters', () => {
+    it('given no entries written, should default to an empty record', () => {
+      expect(useLayoutStore.getState().tasksDashboardFilters).toEqual({});
+    });
+
+    it('given setTasksDashboardFilter called for the user scope, should store the filters', () => {
+      const { setTasksDashboardFilter } = useLayoutStore.getState();
+      const filters: StoredDashboardFilters = {
+        assigneeFilter: 'all',
+        status: 'in_progress',
+        dueDateFilter: 'overdue',
+      };
+
+      setTasksDashboardFilter('user', filters);
+
+      expect(useLayoutStore.getState().tasksDashboardFilters.user).toEqual(filters);
+    });
+
+    it('given two scope keys, should keep both entries independently', () => {
+      const { setTasksDashboardFilter } = useLayoutStore.getState();
+
+      setTasksDashboardFilter('user', { assigneeFilter: 'all' });
+      setTasksDashboardFilter('drive:abc', { priority: 'high' });
+
+      expect(useLayoutStore.getState().tasksDashboardFilters).toEqual({
+        user: { assigneeFilter: 'all' },
+        'drive:abc': { priority: 'high' },
+      });
+    });
+
+    it('given partial filters, should round-trip the persisted shape exactly', () => {
+      const { setTasksDashboardFilter } = useLayoutStore.getState();
+      const partial: StoredDashboardFilters = { search: 'budget' };
+
+      setTasksDashboardFilter('drive:xyz', partial);
+
+      expect(useLayoutStore.getState().tasksDashboardFilters['drive:xyz']).toEqual(partial);
+    });
+
+    it('given the same scope set twice, should replace the previous value', () => {
+      const { setTasksDashboardFilter } = useLayoutStore.getState();
+
+      setTasksDashboardFilter('user', { assigneeFilter: 'all', status: 'pending' });
+      setTasksDashboardFilter('user', { assigneeFilter: 'mine' });
+
+      expect(useLayoutStore.getState().tasksDashboardFilters.user).toEqual({
+        assigneeFilter: 'mine',
+      });
     });
   });
 });

--- a/apps/web/src/stores/__tests__/useLayoutStore.test.ts
+++ b/apps/web/src/stores/__tests__/useLayoutStore.test.ts
@@ -1,0 +1,59 @@
+/**
+ * useLayoutStore Tests
+ * Tests for persisted layout/UI preferences.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useLayoutStore } from '../useLayoutStore';
+
+const initialSnapshot = useLayoutStore.getState();
+
+describe('useLayoutStore', () => {
+  beforeEach(() => {
+    useLayoutStore.setState(
+      {
+        ...initialSnapshot,
+        taskListPageFilters: {},
+      },
+      true,
+    );
+    localStorage.clear();
+  });
+
+  describe('taskListPageFilters', () => {
+    it('given no entries written, should default to an empty record', () => {
+      expect(useLayoutStore.getState().taskListPageFilters).toEqual({});
+    });
+
+    it('given setTaskListPageFilter called for a pageId, should store the value under that key', () => {
+      const { setTaskListPageFilter } = useLayoutStore.getState();
+
+      setTaskListPageFilter('page-a', 'completed');
+
+      expect(useLayoutStore.getState().taskListPageFilters).toEqual({
+        'page-a': 'completed',
+      });
+    });
+
+    it('given two different pageIds, should keep both entries independently', () => {
+      const { setTaskListPageFilter } = useLayoutStore.getState();
+
+      setTaskListPageFilter('page-a', 'active');
+      setTaskListPageFilter('page-b', 'completed');
+
+      expect(useLayoutStore.getState().taskListPageFilters).toEqual({
+        'page-a': 'active',
+        'page-b': 'completed',
+      });
+    });
+
+    it('given the same pageId set twice, should overwrite the previous value', () => {
+      const { setTaskListPageFilter } = useLayoutStore.getState();
+
+      setTaskListPageFilter('page-a', 'active');
+      setTaskListPageFilter('page-a', 'completed');
+
+      expect(useLayoutStore.getState().taskListPageFilters['page-a']).toBe('completed');
+    });
+  });
+});

--- a/apps/web/src/stores/useLayoutStore.ts
+++ b/apps/web/src/stores/useLayoutStore.ts
@@ -4,6 +4,18 @@ import { persist } from 'zustand/middleware';
 type TaskListViewMode = 'table' | 'kanban';
 export type TaskListPageFilter = 'all' | 'active' | 'completed';
 
+export type TaskDashboardDueDateFilter = 'all' | 'overdue' | 'today' | 'this_week' | 'upcoming';
+export type TaskDashboardAssigneeFilter = 'mine' | 'all';
+export type TaskDashboardPriority = 'low' | 'medium' | 'high';
+
+export interface StoredDashboardFilters {
+  status?: string;
+  priority?: TaskDashboardPriority;
+  search?: string;
+  dueDateFilter?: TaskDashboardDueDateFilter;
+  assigneeFilter?: TaskDashboardAssigneeFilter;
+}
+
 interface LayoutState {
   // UI panels state (PERSISTED)
   leftSidebarOpen: boolean;
@@ -12,6 +24,7 @@ interface LayoutState {
   rightSidebarSize: number;
   taskListViewMode: TaskListViewMode;
   taskListPageFilters: Record<string, TaskListPageFilter>;
+  tasksDashboardFilters: Record<string, StoredDashboardFilters>;
   driveFooterCollapsed: boolean;
   dashboardFooterCollapsed: boolean;
   pulseCollapsed: boolean;
@@ -37,6 +50,7 @@ interface LayoutState {
   setRightSheetOpen: (open: boolean) => void;
   setTaskListViewMode: (mode: TaskListViewMode) => void;
   setTaskListPageFilter: (pageId: string, filter: TaskListPageFilter) => void;
+  setTasksDashboardFilter: (scopeKey: string, filters: StoredDashboardFilters) => void;
   setDriveFooterCollapsed: (collapsed: boolean) => void;
   setDashboardFooterCollapsed: (collapsed: boolean) => void;
   setPulseCollapsed: (collapsed: boolean) => void;
@@ -54,6 +68,7 @@ export const useLayoutStore = create<LayoutState>()(
       rightSidebarSize: 18,
       taskListViewMode: 'table',
       taskListPageFilters: {},
+      tasksDashboardFilters: {},
       driveFooterCollapsed: true,
       dashboardFooterCollapsed: true,
       pulseCollapsed: false,
@@ -79,6 +94,12 @@ export const useLayoutStore = create<LayoutState>()(
       setTaskListPageFilter: (pageId: string, filter: TaskListPageFilter) => {
         set((state) => ({
           taskListPageFilters: { ...state.taskListPageFilters, [pageId]: filter },
+        }));
+      },
+
+      setTasksDashboardFilter: (scopeKey: string, filters: StoredDashboardFilters) => {
+        set((state) => ({
+          tasksDashboardFilters: { ...state.tasksDashboardFilters, [scopeKey]: filters },
         }));
       },
 
@@ -135,6 +156,7 @@ export const useLayoutStore = create<LayoutState>()(
         rightSidebarSize: state.rightSidebarSize,
         taskListViewMode: state.taskListViewMode,
         taskListPageFilters: state.taskListPageFilters,
+        tasksDashboardFilters: state.tasksDashboardFilters,
         driveFooterCollapsed: state.driveFooterCollapsed,
         dashboardFooterCollapsed: state.dashboardFooterCollapsed,
         pulseCollapsed: state.pulseCollapsed,

--- a/apps/web/src/stores/useLayoutStore.ts
+++ b/apps/web/src/stores/useLayoutStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 type TaskListViewMode = 'table' | 'kanban';
+export type TaskListPageFilter = 'all' | 'active' | 'completed';
 
 interface LayoutState {
   // UI panels state (PERSISTED)
@@ -10,6 +11,7 @@ interface LayoutState {
   leftSidebarSize: number;
   rightSidebarSize: number;
   taskListViewMode: TaskListViewMode;
+  taskListPageFilters: Record<string, TaskListPageFilter>;
   driveFooterCollapsed: boolean;
   dashboardFooterCollapsed: boolean;
   pulseCollapsed: boolean;
@@ -34,6 +36,7 @@ interface LayoutState {
   setLeftSheetOpen: (open: boolean) => void;
   setRightSheetOpen: (open: boolean) => void;
   setTaskListViewMode: (mode: TaskListViewMode) => void;
+  setTaskListPageFilter: (pageId: string, filter: TaskListPageFilter) => void;
   setDriveFooterCollapsed: (collapsed: boolean) => void;
   setDashboardFooterCollapsed: (collapsed: boolean) => void;
   setPulseCollapsed: (collapsed: boolean) => void;
@@ -50,6 +53,7 @@ export const useLayoutStore = create<LayoutState>()(
       leftSidebarSize: 18,
       rightSidebarSize: 18,
       taskListViewMode: 'table',
+      taskListPageFilters: {},
       driveFooterCollapsed: true,
       dashboardFooterCollapsed: true,
       pulseCollapsed: false,
@@ -70,6 +74,12 @@ export const useLayoutStore = create<LayoutState>()(
 
       setTaskListViewMode: (mode: TaskListViewMode) => {
         set({ taskListViewMode: mode });
+      },
+
+      setTaskListPageFilter: (pageId: string, filter: TaskListPageFilter) => {
+        set((state) => ({
+          taskListPageFilters: { ...state.taskListPageFilters, [pageId]: filter },
+        }));
       },
 
       toggleLeftSidebar: () => {
@@ -124,6 +134,7 @@ export const useLayoutStore = create<LayoutState>()(
         leftSidebarSize: state.leftSidebarSize,
         rightSidebarSize: state.rightSidebarSize,
         taskListViewMode: state.taskListViewMode,
+        taskListPageFilters: state.taskListPageFilters,
         driveFooterCollapsed: state.driveFooterCollapsed,
         dashboardFooterCollapsed: state.dashboardFooterCollapsed,
         pulseCollapsed: state.pulseCollapsed,

--- a/apps/web/src/stores/useLayoutStore.ts
+++ b/apps/web/src/stores/useLayoutStore.ts
@@ -4,16 +4,12 @@ import { persist } from 'zustand/middleware';
 type TaskListViewMode = 'table' | 'kanban';
 export type TaskListPageFilter = 'all' | 'active' | 'completed';
 
-export type TaskDashboardDueDateFilter = 'all' | 'overdue' | 'today' | 'this_week' | 'upcoming';
-export type TaskDashboardAssigneeFilter = 'mine' | 'all';
-export type TaskDashboardPriority = 'low' | 'medium' | 'high';
-
 export interface StoredDashboardFilters {
   status?: string;
-  priority?: TaskDashboardPriority;
+  priority?: 'low' | 'medium' | 'high';
   search?: string;
-  dueDateFilter?: TaskDashboardDueDateFilter;
-  assigneeFilter?: TaskDashboardAssigneeFilter;
+  dueDateFilter?: 'all' | 'overdue' | 'today' | 'this_week' | 'upcoming';
+  assigneeFilter?: 'mine' | 'all';
 }
 
 interface LayoutState {


### PR DESCRIPTION
## Summary

- Task List filter (All / Active / Completed) is now remembered **per page** across reloads and navigation, instead of resetting to "All" every visit.
- Dashboard tasks (`/dashboard/tasks`) and drive tasks (`/dashboard/<driveId>/tasks`) now remember their full filter set (status, priority, search, due date, assignee) **per scope** — `user` for the dashboard view, `drive:<driveId>` for each drive view.
- Switching drives in the drive context loads the destination drive's stored filter (or defaults) instead of carrying the previous drive's filter into the new scope, and the search input is synced (with any pending debounce cancelled) so the visible UI matches the applied filter.
- Persistence is per-user-per-browser via `localStorage`, mirroring the existing `taskListViewMode` pattern in `useLayoutStore`. URL params still win on mount so shared/bookmarked URLs remain deterministic.
- Global defaults are unchanged (`All` for the page-level filter; `assigneeFilter: 'mine'` for the dashboard).

## Implementation

Strict TDD across the persistence wiring, plus follow-up fixes from review feedback. One commit per change:

1. `feat(tasks): persist per-page filter in store` — `taskListPageFilters: Record<pageId, 'all'|'active'|'completed'>` + setter on `useLayoutStore`, added to `partialize`.
2. `feat(tasks): persist dashboard filter scopes` — `tasksDashboardFilters: Record<scopeKey, StoredDashboardFilters>` + setter + type, added to `partialize`.
3. `fix(tasks): persist task list filter per page` — `useTaskListPageFilter(pageId)` hook; `TaskListView` reads/writes through it.
4. `fix(tasks): persist dashboard and drive filters` — pure helpers `scopeKeyFor`, `pickInitialFilters`, `toStoredDashboardFilters`; `TasksDashboard` initial state honors URL > store > defaults; every filter change persists alongside `router.replace`.
5. `fix(tasks): load destination drive's stored filter on switch` — `fromStoredOrDefaults` helper; `handleDriveChange` (drive context) loads the destination drive's stored filter so a drive switch no longer overwrites the saved filter at the destination scope.
6. `fix(tasks): sync search input on drive switch` — cancel any pending search-debounce timer and call `setSearchValue(updatedFilters.search || '')` in `handleDriveChange` so the search input reflects the restored drive's filter immediately (Codex P2).

26 new vitest cases (4 hook + 9 store + 13 helper). 420/420 tests pass across the touched scopes (`stores/`, `components/tasks/`, `page-views/task-list/`). No DB migration, no API changes.

## Test plan

- [x] `pnpm --filter web exec vitest run src/stores/ src/components/tasks/ src/components/layout/middle-content/page-views/task-list/` — all green.
- [x] `pnpm --filter web lint` — clean for touched files.
- [x] `pnpm --filter web exec tsc --noEmit -p tsconfig.json` — no errors in touched files.
- [ ] Manual: open a TASK_LIST page, click "Completed", reload → still "Completed".
- [ ] Manual: open a different TASK_LIST page → defaults to "All", unaffected by the first.
- [ ] Manual: visit `/dashboard/tasks`, change `assigneeFilter` to `all`, navigate away and return → restored.
- [ ] Manual: visit `/dashboard/<driveA>/tasks`, set filters; switch to `/dashboard/<driveB>/tasks` via drive selector → drive B shows its own previously stored filter (or defaults), search input matches, drive A's filter remains intact when switching back.
- [ ] Manual: visit `/dashboard/tasks?status=in_progress` from a fresh tab → URL wins regardless of stored prefs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)