### PR TITLE
feat(uploads): allow any file type in DM/channel attachments

### DIFF
--- a/apps/processor/src/api/__tests__/upload.test.ts
+++ b/apps/processor/src/api/__tests__/upload.test.ts
@@ -961,7 +961,7 @@ describe('upload router - magika content-type detection', () => {
     ['svg', 'image/svg+xml'],
     ['xhtml', 'application/xhtml+xml'],
     ['javascript', 'application/javascript'],
-  ])('rejects single-upload with HTTP 415 when magika labels content as script-active %s', async (label, mimeType) => {
+  ])('accepts single-upload when magika labels content as script-active %s (Slack-style: opaque attachment)', async (label, mimeType) => {
     mockDetectContentType.mockResolvedValue({
       label,
       mimeType,
@@ -983,15 +983,14 @@ describe('upload router - magika content-type detection', () => {
       .post('/upload/single')
       .send({ driveId: 'drive-1', pageId: 'page-1' });
 
-    expect(response.status).toBe(415);
-    expect(response.body.error).toContain('Unsupported file type');
-    expect(response.body.detectedLabel).toBe(label);
-    expect(mockFsUnlink).toHaveBeenCalledWith(TEMP_PATH);
-    expect(mockAddJob).not.toHaveBeenCalled();
-    expect(mockSaveOriginalFromFile).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    expect(mockAddJob).toHaveBeenCalledWith('ingest-file', expect.objectContaining({
+      mimeType,
+      detectedLabel: label,
+    }));
   });
 
-  it('rejects single-upload with HTTP 415 when magika label is denylisted', async () => {
+  it('accepts single-upload when magika labels content as a binary executable (download-only)', async () => {
     mockDetectContentType.mockResolvedValue({
       label: 'macho',
       mimeType: 'application/x-mach-binary',
@@ -1013,12 +1012,11 @@ describe('upload router - magika content-type detection', () => {
       .post('/upload/single')
       .send({ driveId: 'drive-1', pageId: 'page-1' });
 
-    expect(response.status).toBe(415);
-    expect(response.body.error).toContain('Unsupported file type');
-    expect(response.body.detectedLabel).toBe('macho');
-    expect(mockFsUnlink).toHaveBeenCalledWith(TEMP_PATH);
-    expect(mockAddJob).not.toHaveBeenCalled();
-    expect(mockSaveOriginalFromFile).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    expect(mockAddJob).toHaveBeenCalledWith('ingest-file', expect.objectContaining({
+      mimeType: 'application/x-mach-binary',
+      detectedLabel: 'macho',
+    }));
   });
 
   it('passes verified mimeType and detectedLabel into the ingest job for single uploads', async () => {
@@ -1054,7 +1052,7 @@ describe('upload router - magika content-type detection', () => {
     }));
   });
 
-  it('rejects single-upload with HTTP 415 when magika falls back (fail-closed on unverified content)', async () => {
+  it('accepts single-upload when magika falls back (unknown content stored as octet-stream)', async () => {
     mockDetectContentType.mockResolvedValue({
       label: 'unknown',
       mimeType: 'application/octet-stream',
@@ -1075,15 +1073,14 @@ describe('upload router - magika content-type detection', () => {
       .post('/upload/single')
       .send({ driveId: 'drive-1', pageId: 'page-1' });
 
-    expect(response.status).toBe(415);
-    expect(response.body.error).toBe('Unable to verify file type');
-    expect(response.body.detectedLabel).toBe('unknown');
-    expect(mockAddJob).not.toHaveBeenCalled();
-    expect(mockSaveOriginalFromFile).not.toHaveBeenCalled();
-    expect(mockFsUnlink).toHaveBeenCalledWith(TEMP_PATH);
+    expect(response.status).toBe(200);
+    expect(mockAddJob).toHaveBeenCalledWith('ingest-file', expect.objectContaining({
+      mimeType: 'application/octet-stream',
+      detectedLabel: 'unknown',
+    }));
   });
 
-  it('rejects single-upload with HTTP 415 when magika returns an `unknown` label from a real classification', async () => {
+  it('accepts single-upload when magika returns an `unknown` label from a real classification', async () => {
     mockDetectContentType.mockResolvedValue({
       label: 'unknown',
       mimeType: 'application/octet-stream',
@@ -1104,12 +1101,14 @@ describe('upload router - magika content-type detection', () => {
       .post('/upload/single')
       .send({ driveId: 'drive-1', pageId: 'page-1' });
 
-    expect(response.status).toBe(415);
-    expect(response.body.error).toBe('Unable to verify file type');
-    expect(mockAddJob).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    expect(mockAddJob).toHaveBeenCalledWith('ingest-file', expect.objectContaining({
+      mimeType: 'application/octet-stream',
+      detectedLabel: 'unknown',
+    }));
   });
 
-  it('rejects denylisted entries inside multi-upload while still processing siblings', async () => {
+  it('accepts both image and executable entries in multi-upload (no content denylist)', async () => {
     mockDetectContentType
       .mockResolvedValueOnce({
         label: 'png',
@@ -1145,23 +1144,21 @@ describe('upload router - magika content-type detection', () => {
     expect(response.status).toBe(200);
     expect(response.body.files).toHaveLength(2);
 
-    const accepted = response.body.files[0];
-    const rejected = response.body.files[1];
+    const first = response.body.files[0];
+    const second = response.body.files[1];
 
-    expect(accepted.contentHash).toBeDefined();
-    expect(rejected.success).toBe(false);
-    expect(rejected.error).toContain('Unsupported file type');
-    expect(rejected.detectedLabel).toBe('elf');
+    expect(first.contentHash).toBeDefined();
+    expect(second.contentHash).toBeDefined();
 
-    expect(mockAddJob).toHaveBeenCalledTimes(1);
+    expect(mockAddJob).toHaveBeenCalledTimes(2);
     expect(mockAddJob).toHaveBeenCalledWith('ingest-file', expect.objectContaining({
       mimeType: 'image/png',
       detectedLabel: 'png',
     }));
-
-    // Both temp files should be unlinked: one from rejection, one from batch cleanup
-    expect(mockFsUnlink).toHaveBeenCalledWith(`${UPLOAD_TEMP_DIR}/temp-file-2.jpg`);
-    expect(mockFsUnlink).toHaveBeenCalledWith(TEMP_PATH);
+    expect(mockAddJob).toHaveBeenCalledWith('ingest-file', expect.objectContaining({
+      mimeType: 'application/x-executable',
+      detectedLabel: 'elf',
+    }));
   });
 });
 

--- a/apps/processor/src/api/upload.ts
+++ b/apps/processor/src/api/upload.ts
@@ -10,28 +10,8 @@ import { processorLogger } from '../logger';
 import { rateLimitUpload } from '../middleware/rate-limit';
 import { hasAuthScope } from '../middleware/auth';
 import { resolvePathWithin, sanitizeExtension } from '../utils/security';
-import { detectContentType, type DetectedContentType } from '../services/content-detector';
+import { detectContentType } from '../services/content-detector';
 import { getMaxFileSizeBytes } from './upload-multer-config';
-
-const DENIED_LABELS: ReadonlySet<string> = new Set([
-  'pebin',
-  'elf',
-  'macho',
-  'dex',
-  'html',
-  'svg',
-  'xhtml',
-  'javascript',
-]);
-
-// Fail closed on unverified content: when Magika can't initialize or falls back
-// to the `unknown` label, we treat the upload as unsafe rather than letting it
-// bypass the denylist. Without this, a broken model / native binding would
-// accept renamed executables because `detected.label` defaults to 'unknown'
-// and escapes DENIED_LABELS.
-function isUnverifiedDetection(detected: DetectedContentType): boolean {
-  return detected.source === 'fallback' || detected.label === 'unknown';
-}
 
 const router = Router();
 
@@ -199,31 +179,6 @@ router.post('/single', upload.single('file'), async (req, res) => {
     });
 
     const detected = await detectContentType(tempPath);
-    if (DENIED_LABELS.has(detected.label) || isUnverifiedDetection(detected)) {
-      try {
-        await fs.unlink(tempPath);
-      } catch (cleanupError) {
-        processorLogger.warn('Failed to clean up temp upload after denylist rejection', {
-          tempPath,
-          error: cleanupError instanceof Error ? cleanupError.message : cleanupError
-        });
-      }
-      tempFilePath = undefined;
-      const unverified = isUnverifiedDetection(detected);
-      if (unverified) {
-        processorLogger.warn('Rejecting upload with unverified content type', {
-          tempPath,
-          originalname,
-          source: detected.source,
-          label: detected.label,
-        });
-      }
-      return res.status(415).json({
-        error: unverified ? 'Unable to verify file type' : 'Unsupported file type',
-        detectedLabel: detected.label
-      });
-    }
-
     const verifiedMimeType = detected.mimeType;
     const detectedLabel = detected.label;
 
@@ -415,35 +370,6 @@ router.post('/multiple', upload.array('files', 10), async (req, res) => {
 
       try {
         const detected = await detectContentType(tempPath);
-        if (DENIED_LABELS.has(detected.label) || isUnverifiedDetection(detected)) {
-          try {
-            await fs.unlink(tempPath);
-          } catch (cleanupError) {
-            processorLogger.warn('Failed to clean up temp upload after denylist rejection', {
-              tempPath,
-              error: cleanupError instanceof Error ? cleanupError.message : cleanupError
-            });
-          }
-          const idx = tempFilePaths.indexOf(tempPath);
-          if (idx >= 0) tempFilePaths.splice(idx, 1);
-          const unverified = isUnverifiedDetection(detected);
-          if (unverified) {
-            processorLogger.warn('Rejecting upload with unverified content type', {
-              tempPath,
-              originalname,
-              source: detected.source,
-              label: detected.label,
-            });
-          }
-          results.push({
-            originalname,
-            error: unverified ? 'Unable to verify file type' : 'Unsupported file type',
-            detectedLabel: detected.label,
-            success: false
-          });
-          continue;
-        }
-
         const verifiedMimeType = detected.mimeType;
         const detectedLabel = detected.label;
 

--- a/apps/processor/src/services/__tests__/content-detector.test.ts
+++ b/apps/processor/src/services/__tests__/content-detector.test.ts
@@ -161,10 +161,10 @@ describe('detectContentType', () => {
       expect(result.source).toBe('magika');
     }
 
-    // Each fixture must classify as its canonical label — this is what proves
-    // the DENIED_LABELS denylist would actually catch a renamed executable at
-    // upload time. If we loosen these expectations we lose the load-bearing
-    // evidence that Magika is working.
+    // Each fixture must classify as its canonical label — Magika's label feeds
+    // the MIME mapping table, which the ingest worker branches on to pick
+    // thumbnail vs text-extraction paths. If we loosen these expectations we
+    // lose the evidence that Magika is correctly classifying real bytes.
     expect(png.label).toBe('png');
     expect(py.label).toBe('python');
     expect(pdf.label).toBe('pdf');

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInput.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInput.tsx
@@ -218,7 +218,6 @@ export const ChannelInput = forwardRef<ChannelInputRef, ChannelInputProps>(
           type="file"
           className="hidden"
           onChange={handleFileSelect}
-          accept="image/*,.pdf,.doc,.docx,.txt,.md"
         />
 
         <InputCard

--- a/apps/web/src/components/layout/middle-content/page-views/channel/__tests__/ChannelInput.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/__tests__/ChannelInput.test.tsx
@@ -370,6 +370,14 @@ describe('ChannelInput — DM upload mode (conversationId)', () => {
     expect(mockUploadFile).toHaveBeenCalledWith(file);
   });
 
+  it('filePicker_hasNoAcceptRestriction_allowsAnyFileType', () => {
+    const { container } = renderInput();
+
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(fileInput).toBeTruthy();
+    expect(fileInput.getAttribute('accept')).toBeNull();
+  });
+
   it('attachmentsDisabled_doesNotShowPicker_andIgnoresPaste', () => {
     renderInput({ attachmentsEnabled: false });
 


### PR DESCRIPTION
## Summary

- Drop the picker `accept` filter (`image/*,.pdf,.doc,.docx,.txt,.md`) on the DM/channel composer so JSON, CSV, code files, archives, audio, video, etc. are all selectable. Drag-drop already accepted any file; this brings the picker into line.
- Remove the processor `DENIED_LABELS` denylist (html, svg, xhtml, javascript, pebin, elf, macho, dex) and the fail-closed unverified-content rejection. Files now flow through to the ingest job regardless of Magika's verdict; unknown content stays as `application/octet-stream`.

Slack/iMessage-style: any file goes through, but it's served as an opaque download — never rendered inline. JSON, HTML, code files, and other "normal" files can now be DM'd.

## Why this is safe

The download endpoint (`/api/files/[id]/download`) always sets:
- `Content-Disposition: attachment`
- `X-Content-Type-Options: nosniff`
- `Content-Security-Policy: default-src 'none';`

So even an HTML/SVG/JS payload downloads as a blob instead of executing. The chat renderer (`MessageAttachment.tsx`) only embeds inline (`<img src>`) for `image/*` MIME — everything else falls through to a generic download card pointing at `/download`. Same posture as Slack/Gmail.

## Changes

**Picker filter** (`apps/web/src/components/.../channel/ChannelInput.tsx`)
- Remove the `accept="image/*,.pdf,..."` attribute on the hidden file input.
- New regression test asserts no `accept` attribute is set.

**Processor denylist** (`apps/processor/src/api/upload.ts`)
- Delete `DENIED_LABELS` and `isUnverifiedDetection` from both `/upload/single` and `/upload/multiple` paths.
- Magika detection (`detectContentType`) is preserved for MIME mapping — its label still drives the ingest worker's image-vs-text-extraction branching.

**Tests**
- 8 processor tests flipped from 415 expectations to 200/ingest-job assertions: html, svg, xhtml, javascript, macho, fallback-source, unknown-label, multi-upload-with-executable.
- Stale comment in `content-detector.test.ts` updated to drop its denylist reference.

## Test plan

- [x] `pnpm --filter processor test` — 936/936 ✓
- [x] `pnpm --filter @pagespace/lib test` — 3,860/3,860 ✓
- [x] ChannelInput, DM upload route, channel upload route, DM messages route tests — 87/87 ✓
- [x] `pnpm typecheck` on web and processor — clean
- [ ] Manual smoke test (reviewer or merger):
  - Upload `evil.html` containing `<script>alert(1)</script>` into a DM and a channel
  - Verify it appears as a generic download card (not an inline render)
  - Verify clicking it downloads the file (response: `Content-Disposition: attachment` in DevTools Network panel)
  - Repeat with `.json`, `.svg`, `.zip`, `.exe` for breadth
  - Regression: PNG still renders inline as `<img>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)