### PR TITLE
fix(socket): stop force-reconnecting healthy sockets on auth:refreshed

### DIFF
--- a/apps/web/src/__tests__/socket-integration.test.ts
+++ b/apps/web/src/__tests__/socket-integration.test.ts
@@ -312,40 +312,42 @@ describe('Socket.IO Integration', () => {
     });
   });
 
-  describe('proactive reconnection', () => {
-    it('given auth:refreshed event while connected, should force reconnect with new token', async () => {
+  describe('auth:refreshed handling', () => {
+    it('given auth:refreshed event while connected, should leave the live socket untouched', async () => {
       const { connect } = useSocketStore.getState();
       await connect();
 
       mockSocket.connected = true;
       mockSocket._trigger('connect');
 
-      // Verify initial connection
       expect(useSocketStore.getState().connectionStatus).toBe('connected');
 
-      // Simulate token refresh event
+      const disconnectsBefore = mockSocket.disconnect.mock.calls.length;
+      vi.mocked(io).mockClear();
+
       const event = new Event('auth:refreshed');
       windowEventMock.dispatchEvent(event);
 
-      // Should trigger disconnect for reconnect
-      expect(mockSocket.disconnect).toHaveBeenCalled();
+      // Healthy socket stays authenticated — reconnecting it would force
+      // chat surfaces (GlobalChatContext, agent multiplayer) to refetch
+      // and snap their message lists to the bottom.
+      expect(mockSocket.disconnect.mock.calls.length).toBe(disconnectsBefore);
+      expect(io).not.toHaveBeenCalled();
     });
 
-    it('given auth:refreshed event while disconnected, should not attempt reconnect', async () => {
+    it('given auth:refreshed event while disconnected, should reconnect with the fresh token', async () => {
       const { connect } = useSocketStore.getState();
       await connect();
 
-      // Socket not connected
       mockSocket.connected = false;
+      const disconnectsBefore = mockSocket.disconnect.mock.calls.length;
 
-      const disconnectCallCount = mockSocket.disconnect.mock.calls.length;
-
-      // Simulate token refresh event
       const event = new Event('auth:refreshed');
       windowEventMock.dispatchEvent(event);
 
-      // Should not trigger additional disconnect
-      expect(mockSocket.disconnect.mock.calls.length).toBe(disconnectCallCount);
+      // Stalled socket: fresh token unblocks the retry. connect(true) calls
+      // disconnect on the existing socket synchronously before re-handshaking.
+      expect(mockSocket.disconnect.mock.calls.length).toBe(disconnectsBefore + 1);
     });
   });
 

--- a/apps/web/src/stores/__tests__/useSocketStore.test.ts
+++ b/apps/web/src/stores/__tests__/useSocketStore.test.ts
@@ -387,38 +387,42 @@ describe('useSocketStore', () => {
     });
   });
 
-  describe('proactive reconnect', () => {
-    it('given auth:refreshed event fires while connected, should force reconnect', async () => {
+  describe('auth:refreshed handling', () => {
+    it('given socket connected when auth:refreshed fires, should leave the live connection alone', async () => {
       const { connect } = useSocketStore.getState();
       await connect();
 
       mockSocket.connected = true;
       mockSocket._trigger('connect');
 
-      // Dispatch auth:refreshed event
+      const disconnectsBefore = mockSocket.disconnect.mock.calls.length;
+      vi.mocked(io).mockClear();
+
       const event = new Event('auth:refreshed');
       windowEventMock.dispatchEvent(event);
 
-      // The connect function should have been called again with forceReconnect
-      // Note: Since we're testing the store behavior, we verify the disconnect was called
-      expect(mockSocket.disconnect).toHaveBeenCalled();
+      // Token refresh on a healthy socket would cascade into chat refetches
+      // (GlobalChatContext, agent multiplayer) and snap message lists to the
+      // bottom mid-read. The token is consumed at handshake only, so a connected
+      // socket stays authenticated — no reconnect needed.
+      expect(mockSocket.disconnect.mock.calls.length).toBe(disconnectsBefore);
+      expect(io).not.toHaveBeenCalled();
     });
 
-    it('given socket not connected when auth:refreshed fires, should not attempt reconnect', async () => {
+    it('given socket disconnected when auth:refreshed fires, should reconnect with the fresh token', async () => {
       const { connect } = useSocketStore.getState();
       await connect();
 
-      // Socket is not connected
       mockSocket.connected = false;
+      const disconnectsBefore = mockSocket.disconnect.mock.calls.length;
 
-      const disconnectCallCount = mockSocket.disconnect.mock.calls.length;
-
-      // Dispatch auth:refreshed event
       const event = new Event('auth:refreshed');
       windowEventMock.dispatchEvent(event);
 
-      // Should not have called disconnect again
-      expect(mockSocket.disconnect.mock.calls.length).toBe(disconnectCallCount);
+      // Stalled socket: fresh token unblocks the next handshake. connect(true)
+      // synchronously calls disconnect on the existing socket before kicking
+      // off the async re-handshake.
+      expect(mockSocket.disconnect.mock.calls.length).toBe(disconnectsBefore + 1);
     });
   });
 

--- a/apps/web/src/stores/useSocketStore.ts
+++ b/apps/web/src/stores/useSocketStore.ts
@@ -215,13 +215,18 @@ export const useSocketStore = create<SocketStore>((set, get) => ({
           window.removeEventListener('auth:refreshed', handleAuthRefresh);
         }
 
-        // Create new handler that captures the current store reference
+        // Socket.IO consumes the auth token only at handshake. A live, connected
+        // socket stays authenticated regardless of cookie/session refreshes, so
+        // forcing a reconnect here is pure churn — and it cascades into chat
+        // surfaces that refetch on reconnect (GlobalChatContext, agent multiplayer),
+        // which snaps the message list back to the bottom. Only retry when the
+        // socket is currently down; the connect_error path covers fresh-token
+        // recovery for handshakes that the server actually rejects.
         handleAuthRefresh = () => {
           const currentSocket = get().socket;
-          if (currentSocket?.connected) {
-            console.log('🔄 Token refreshed, proactively reconnecting socket...');
-            get().connect(true); // Force reconnect with new token
-          }
+          if (!currentSocket || currentSocket.connected) return;
+          console.log('🔄 Token refreshed, retrying disconnected socket...');
+          get().connect(true);
         };
 
         window.addEventListener('auth:refreshed', handleAuthRefresh);

--- a/apps/web/src/stores/useSocketStore.ts
+++ b/apps/web/src/stores/useSocketStore.ts
@@ -208,20 +208,15 @@ export const useSocketStore = create<SocketStore>((set, get) => ({
         isInitialized: true
       });
 
-      // Listen for token refresh events to proactively reconnect
       if (typeof window !== 'undefined') {
-        // Remove any existing listener to prevent duplicates
         if (handleAuthRefresh) {
           window.removeEventListener('auth:refreshed', handleAuthRefresh);
         }
 
-        // Socket.IO consumes the auth token only at handshake. A live, connected
-        // socket stays authenticated regardless of cookie/session refreshes, so
-        // forcing a reconnect here is pure churn — and it cascades into chat
-        // surfaces that refetch on reconnect (GlobalChatContext, agent multiplayer),
-        // which snaps the message list back to the bottom. Only retry when the
-        // socket is currently down; the connect_error path covers fresh-token
-        // recovery for handshakes that the server actually rejects.
+        // Token is consumed only at handshake — a connected socket stays
+        // authenticated. Reconnecting it on every refresh cascades into chat
+        // refetches (GlobalChatContext, agent multiplayer) that snap the
+        // message list to the bottom. Only retry when the socket is down.
         handleAuthRefresh = () => {
           const currentSocket = get().socket;
           if (!currentSocket || currentSocket.connected) return;


### PR DESCRIPTION
## Summary

- AI chat (Global Assistant) was randomly snapping to the bottom mid-read whenever the tab regained focus or the desktop token-refresh timer fired.
- Root cause: `useSocketStore` was force-reconnecting the Socket.IO client on every `auth:refreshed` event, even when the socket was already connected. The reconnect flipped `connectionStatus`, which `GlobalChatContext` interprets as a missed-events signal and reloads messages — replacing the `initialMessages` array, recomputing `chatConfig`, remounting `MessageRenderer`s, and tripping `use-stick-to-bottom`'s grow-from-zero auto-scroll.
- Socket.IO consumes the auth token only at handshake. A live connection stays authenticated regardless of cookie/session refreshes, so the proactive reconnect was pure churn. The handler now no-ops when the socket is connected; the existing `connect_error` path still recovers genuinely-rejected handshakes with a fresh token.

The same chain runs for multi-user agent chat via `useAgentChannelMultiplayer`, so it benefits too. Channels and inbox channels just rejoin via socket on reconnect — they don't refetch — so they were unaffected and remain so.

## Test plan

- [ ] `pnpm dev`, open a global AI chat with enough history to scroll
- [ ] Scroll up to leave the view above the bottom
- [ ] In devtools console: `window.dispatchEvent(new CustomEvent('auth:refreshed'))` — scroll position should stay put; no "proactively reconnecting" log; no "retrying disconnected socket" log either (because socket is connected)
- [ ] Background the tab >12 minutes, return — same expectation (visibility-change refresh path)
- [ ] Force a real disconnect: DevTools → Network → Offline, wait for `connectionStatus: 'disconnected'`, then Online — socket reconnects, chat is functional, the disconnected-retry branch fires if `auth:refreshed` happens to land during the gap
- [ ] `pnpm --filter web typecheck` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)