### PR TITLE
feat(messaging): scroll-to-bottom parity with AI chat for channels and DMs

### DIFF
--- a/apps/web/src/app/dashboard/inbox/dm/[conversationId]/__tests__/page.test.tsx
+++ b/apps/web/src/app/dashboard/inbox/dm/[conversationId]/__tests__/page.test.tsx
@@ -76,6 +76,13 @@ vi.mock('swr', () => ({
   },
 }));
 
+// Conversation primitives — bypass use-stick-to-bottom (needs ResizeObserver, missing in jsdom)
+vi.mock('@/components/ai/ui/conversation', () => ({
+  Conversation: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ConversationContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ConversationScrollButton: () => null,
+}));
+
 // MessagePartRenderer — render content as plain text for assertions
 vi.mock('@/components/messages/MessagePartRenderer', () => ({
   renderMessageParts: (parts: Array<{ text?: string }>) =>

--- a/apps/web/src/app/dashboard/inbox/dm/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/inbox/dm/[conversationId]/page.tsx
@@ -3,8 +3,12 @@
 import { useEffect, useState, useRef, useCallback } from 'react';
 import { useParams } from 'next/navigation';
 import { useAuth } from '@/hooks/useAuth';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import {
+  Conversation,
+  ConversationContent,
+  ConversationScrollButton,
+} from '@/components/ai/ui/conversation';
 import { ChannelInput, type ChannelInputRef } from '@/components/layout/middle-content/page-views/channel/ChannelInput';
 import type { FileAttachment } from '@/hooks/useAttachmentUpload';
 import { MessageAttachment } from '@/components/shared/MessageAttachment';
@@ -90,7 +94,6 @@ export default function InboxDMPage() {
   const [inputValue, setInputValue] = useState('');
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
   const [editContent, setEditContent] = useState('');
-  const scrollAreaRef = useRef<HTMLDivElement>(null);
   const chatInputRef = useRef<ChannelInputRef>(null);
   const socket = useSocket();
 
@@ -140,13 +143,6 @@ export default function InboxDMPage() {
       socket.emit('leave_dm_conversation', conversationId);
     };
   }, [conversationId, user, socket]);
-
-  // Auto-scroll to bottom
-  useEffect(() => {
-    if (scrollAreaRef.current) {
-      scrollAreaRef.current.scrollTop = scrollAreaRef.current.scrollHeight;
-    }
-  }, [messages]);
 
   const handleEditMessage = useCallback(async (messageId: string, content: string) => {
     const editedAt = new Date().toISOString();
@@ -256,9 +252,9 @@ export default function InboxDMPage() {
       </div>
 
       {/* Messages */}
-      <div className="flex-grow overflow-hidden">
-        <ScrollArea className="h-full p-4" ref={scrollAreaRef}>
-          <div className="space-y-4 max-w-4xl mx-auto">
+      <div className="flex-grow overflow-hidden relative">
+        <Conversation>
+          <ConversationContent className="space-y-4 max-w-4xl mx-auto p-4">
             {messages.map((message) => {
               const isOwnMessage = message.senderId === user?.id;
               const senderName = isOwnMessage ? 'You' : displayName;
@@ -375,8 +371,9 @@ export default function InboxDMPage() {
                 </div>
               );
             })}
-          </div>
-        </ScrollArea>
+          </ConversationContent>
+          <ConversationScrollButton className="z-20 bottom-6" />
+        </Conversation>
       </div>
 
       {/* Input */}

--- a/apps/web/src/app/dashboard/inbox/dm/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/inbox/dm/[conversationId]/page.tsx
@@ -254,7 +254,7 @@ export default function InboxDMPage() {
       {/* Messages */}
       <div className="flex-grow overflow-hidden relative">
         <Conversation>
-          <ConversationContent className="space-y-4 max-w-4xl mx-auto p-4">
+          <ConversationContent className="gap-4 max-w-4xl mx-auto p-4">
             {messages.map((message) => {
               const isOwnMessage = message.senderId === user?.id;
               const senderName = isOwnMessage ? 'You' : displayName;

--- a/apps/web/src/app/dashboard/inbox/dm/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/inbox/dm/[conversationId]/page.tsx
@@ -49,7 +49,7 @@ interface Message {
   attachmentMeta?: AttachmentMeta | null;
 }
 
-interface Conversation {
+interface DmConversation {
   id: string;
   participant1Id: string;
   participant2Id: string;
@@ -98,7 +98,7 @@ export default function InboxDMPage() {
   const socket = useSocket();
 
   // Fetch conversation details (single conversation, not the full list)
-  const { data: conversationData } = useSWR<{ conversation: Conversation }>(
+  const { data: conversationData } = useSWR<{ conversation: DmConversation }>(
     conversationId ? `/api/messages/conversations/${conversationId}` : null,
     fetcher
   );

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -4,10 +4,14 @@ import { useState, useEffect, useRef, useCallback, memo } from 'react';
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
 import { usePermissions, getPermissionErrorMessage } from '@/hooks/usePermissions';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { TreePage, MessageWithUser } from '@/hooks/usePageTree';
 import { StreamingMarkdown } from '@/components/ai/shared/chat/StreamingMarkdown';
+import {
+  Conversation,
+  ConversationContent,
+  ConversationScrollButton,
+} from '@/components/ai/ui/conversation';
 import { ChannelInput, type ChannelInputRef, type FileAttachment } from './ChannelInput';
 import { MessageReactions, type Reaction } from './MessageReactions';
 import { Alert, AlertDescription } from '@/components/ui/alert';
@@ -22,7 +26,6 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { useSocketStore } from '@/stores/useSocketStore';
-import { PullToRefresh } from '@/components/ui/pull-to-refresh';
 import {
   type AttachmentMeta,
   type FileRelation,
@@ -53,7 +56,6 @@ function ChannelView({ page }: ChannelViewProps) {
   const { user } = useAuth();
   const [messages, setMessages] = useState<MessageWithReactions[]>([]);
   const [inputValue, setInputValue] = useState('');
-  const scrollAreaRef = useRef<HTMLDivElement>(null);
   const channelInputRef = useRef<ChannelInputRef>(null);
 
   // Use centralized socket store for proper authentication
@@ -67,7 +69,6 @@ function ChannelView({ page }: ChannelViewProps) {
   const [hasMore, setHasMore] = useState(false);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [loadingOlder, setLoadingOlder] = useState(false);
-  const skipAutoScrollRef = useRef(false);
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
   const [editContent, setEditContent] = useState('');
 
@@ -119,16 +120,6 @@ function ChannelView({ page }: ChannelViewProps) {
       socket.off('new_message', handleNewMessage);
     };
   }, [socket, connectionStatus, page.id]);
-
-  useEffect(() => {
-    if (skipAutoScrollRef.current) {
-      skipAutoScrollRef.current = false;
-      return;
-    }
-    if (scrollAreaRef.current) {
-      scrollAreaRef.current.scrollTop = scrollAreaRef.current.scrollHeight;
-    }
-  }, [messages]);
 
   const handleSubmit = async (content: string, attachment?: FileAttachment) => {
     if (!user) return;
@@ -209,7 +200,6 @@ function ChannelView({ page }: ChannelViewProps) {
       const res = await fetchWithAuth(`/api/channels/${page.id}/messages?cursor=${encodeURIComponent(nextCursor)}`);
       const data = await res.json();
       const olderMessages: MessageWithReactions[] = data.messages ?? data;
-      skipAutoScrollRef.current = true;
       setMessages((prev) => [...olderMessages, ...prev]);
       setHasMore(data.hasMore ?? false);
       setNextCursor(data.nextCursor ?? null);
@@ -219,19 +209,6 @@ function ChannelView({ page }: ChannelViewProps) {
       setLoadingOlder(false);
     }
   }, [page.id, hasMore, loadingOlder, nextCursor]);
-
-  // Pull-to-refresh handler for mobile - re-fetch messages if real-time missed any
-  const handleRefresh = useCallback(async () => {
-    try {
-      const res = await fetchWithAuth(`/api/channels/${page.id}/messages`);
-      const data = await res.json();
-      setMessages(data.messages ?? data);
-      setHasMore(data.hasMore ?? false);
-      setNextCursor(data.nextCursor ?? null);
-    } catch (error) {
-      console.error('Failed to refresh messages:', error);
-    }
-  }, [page.id]);
 
   // Reaction handlers
   const handleAddReaction = useCallback(async (messageId: string, emoji: string) => {
@@ -411,10 +388,9 @@ function ChannelView({ page }: ChannelViewProps) {
 
   return (
     <div className="flex flex-col h-full">
-        <div className="flex-grow overflow-hidden">
-          <PullToRefresh direction="top" onRefresh={handleRefresh}>
-            <ScrollArea className="h-full" ref={scrollAreaRef}>
-                <div className="p-4 space-y-4 max-w-4xl mx-auto">
+        <div className="flex-grow overflow-hidden relative">
+          <Conversation>
+            <ConversationContent className="p-4 space-y-4 max-w-4xl mx-auto">
                     {hasMore && (
                       <div className="flex justify-center py-2">
                         <button
@@ -543,9 +519,9 @@ function ChannelView({ page }: ChannelViewProps) {
                         </div>
                         );
                     })}
-                </div>
-            </ScrollArea>
-          </PullToRefresh>
+            </ConversationContent>
+            <ConversationScrollButton className="z-20 bottom-6" />
+          </Conversation>
         </div>
         <div className="flex-shrink-0 border-t border-border p-4">
           <div className="max-w-4xl mx-auto">

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -390,7 +390,7 @@ function ChannelView({ page }: ChannelViewProps) {
     <div className="flex flex-col h-full">
         <div className="flex-grow overflow-hidden relative">
           <Conversation>
-            <ConversationContent className="p-4 space-y-4 max-w-4xl mx-auto">
+            <ConversationContent className="gap-4 p-4 max-w-4xl mx-auto">
                     {hasMore && (
                       <div className="flex justify-center py-2">
                         <button

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -390,7 +390,7 @@ function ChannelView({ page }: ChannelViewProps) {
     <div className="flex flex-col h-full">
         <div className="flex-grow overflow-hidden relative">
           <Conversation>
-            <ConversationContent className="gap-4 p-4 max-w-4xl mx-auto">
+            <ConversationContent className="gap-4 max-w-4xl mx-auto p-4">
                     {hasMore && (
                       <div className="flex justify-center py-2">
                         <button


### PR DESCRIPTION
## Summary
- Channels and DMs now use the same `Conversation` / `ConversationContent` / `ConversationScrollButton` primitives the AI chat already uses (`apps/web/src/components/ai/ui/conversation.tsx`, backed by `use-stick-to-bottom`).
- Behaviors gained on both surfaces:
  - **Auto-scroll on initial render** — opening a channel or DM lands you at the newest message.
  - **Smart pinned scrolling** — new socket messages no longer yank you to the bottom while you're reading history; if you were pinned, they smoothly follow.
  - **Floating scroll-to-bottom button** — appears when you're not at the bottom; clears when you are.
- Removes dead/superseded code:
  - DM `scrollAreaRef` + manual `useEffect` that did `scrollTop = scrollHeight` on every messages change.
  - Channel `scrollAreaRef`, `skipAutoScrollRef`, and the same manual scroll effect.
  - Channel `PullToRefresh` wrapper + `handleRefresh` callback. The "Load older messages" button covers the same use case, AI chat doesn't use `PullToRefresh` either, and the wrapper would not have functioned correctly when wrapping `<Conversation>` (its child-cloning ref needs a directly scrollable element).

## Files changed
- `apps/web/src/app/dashboard/inbox/dm/[conversationId]/page.tsx`
- `apps/web/src/app/dashboard/inbox/dm/[conversationId]/__tests__/page.test.tsx` — mock `@/components/ai/ui/conversation` (matches AI chat test pattern; `use-stick-to-bottom` requires `ResizeObserver`, missing in jsdom).
- `apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx`

## Notes / follow-ups handled in-PR
- Renamed local `interface Conversation` → `DmConversation` in the DM page to avoid shadowing the imported component name.
- Overrode `ConversationContent`'s default `gap-8` with `gap-4` so message spacing matches the prior 16px instead of being silently widened (tailwind-merge will not merge `gap-*` and `space-y-*`, so naive `space-y-4` would have stacked on top of the default gap).

## Test plan
- [ ] Open a channel with existing messages → viewport lands at the newest message.
- [ ] Open a DM with existing messages → viewport lands at the newest message.
- [ ] Send a message while pinned at bottom (both surfaces) → smoothly scrolls to show new message.
- [ ] Scroll up to read history, have someone send a message (both surfaces) → position preserved; floating arrow-down button appears.
- [ ] Click the scroll-to-bottom button → smoothly scrolls to bottom; button disappears.
- [ ] Channel: scroll up, click "Load older messages" → older messages prepend; scroll position stays put (no jump to bottom).
- [ ] Resize the window (desktop) → re-pins to bottom if previously pinned.
- [ ] Sanity-check: AI chat scroll behavior unchanged (we did not modify `conversation.tsx`).

## Out of scope
- Pull-to-refresh on channels (mobile). If we want it back, follow the AI-chat pattern (`useChatPullToRefresh` + touch handlers on `ConversationContent`) in a separate change.
- Virtualization for channels/DMs. AI chat virtualizes >50 messages; channels and DMs do not, and this PR doesn't change that.
- Read-receipts, unread-divider, or "jump to unread" affordances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)