### PR TITLE
feat(messages): drop files anywhere in channel/DM message window

### DIFF
--- a/apps/web/src/app/dashboard/inbox/channel/[pageId]/page.tsx
+++ b/apps/web/src/app/dashboard/inbox/channel/[pageId]/page.tsx
@@ -15,6 +15,7 @@ import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { StreamingMarkdown } from '@/components/ai/shared/chat/StreamingMarkdown';
 import { ChannelInput, type ChannelInputRef, type FileAttachment } from '@/components/layout/middle-content/page-views/channel/ChannelInput';
+import { MessageDropZone } from '@/components/layout/middle-content/page-views/channel/MessageDropZone';
 import { MessageReactions, type Reaction } from '@/components/layout/middle-content/page-views/channel/MessageReactions';
 import { PullToRefresh } from '@/components/ui/pull-to-refresh';
 import { post, del, patch, fetchWithAuth } from '@/lib/auth/auth-fetch';
@@ -455,7 +456,7 @@ export default function InboxChannelPage() {
   }
 
   return (
-    <div className="flex flex-col h-full">
+    <MessageDropZone inputRef={channelInputRef} enabled={canEdit} className="flex flex-col h-full">
       {/* Header */}
       <div className="flex-shrink-0 border-b border-border p-4">
         <div className="flex items-center justify-between max-w-4xl mx-auto">
@@ -643,6 +644,6 @@ export default function InboxChannelPage() {
           )}
         </div>
       </div>
-    </div>
+    </MessageDropZone>
   );
 }

--- a/apps/web/src/app/dashboard/inbox/dm/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/inbox/dm/[conversationId]/page.tsx
@@ -10,6 +10,7 @@ import {
   ConversationScrollButton,
 } from '@/components/ai/ui/conversation';
 import { ChannelInput, type ChannelInputRef } from '@/components/layout/middle-content/page-views/channel/ChannelInput';
+import { MessageDropZone } from '@/components/layout/middle-content/page-views/channel/MessageDropZone';
 import type { FileAttachment } from '@/hooks/useAttachmentUpload';
 import { MessageAttachment } from '@/components/shared/MessageAttachment';
 import { renderMessageParts, convertToMessageParts } from '@/components/messages/MessagePartRenderer';
@@ -234,7 +235,7 @@ export default function InboxDMPage() {
   const displayName = otherUser.displayName || otherUser.name;
 
   return (
-    <div className="flex flex-col h-full">
+    <MessageDropZone inputRef={chatInputRef} enabled className="flex flex-col h-full">
       {/* Header */}
       <div className="flex-shrink-0 border-b border-border p-4">
         <div className="flex items-center gap-3 max-w-4xl mx-auto">
@@ -390,6 +391,6 @@ export default function InboxDMPage() {
           />
         </div>
       </div>
-    </div>
+    </MessageDropZone>
   );
 }

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInput.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInput.tsx
@@ -44,6 +44,10 @@ export interface ChannelInputRef {
   clear: () => void;
   /** Insert text at cursor position */
   insertText: (text: string) => void;
+  /** Upload a file into the composer's attachment slot (used for drops outside the composer) */
+  uploadFile: (file: File) => void;
+  /** Whether the composer can currently accept a new attachment */
+  canAcceptDrop: () => boolean;
 }
 
 /**
@@ -102,6 +106,11 @@ export const ChannelInput = forwardRef<ChannelInputRef, ChannelInputProps>(
         onChange(value + text);
         textareaRef.current?.focus();
       },
+      uploadFile: (file: File) => {
+        if (!canUpload) return;
+        void uploadFile(file);
+      },
+      canAcceptDrop: () => canUpload,
     }));
 
     const handleSend = () => {

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -13,6 +13,7 @@ import {
   ConversationScrollButton,
 } from '@/components/ai/ui/conversation';
 import { ChannelInput, type ChannelInputRef, type FileAttachment } from './ChannelInput';
+import { MessageDropZone } from './MessageDropZone';
 import { MessageReactions, type Reaction } from './MessageReactions';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Lock, Pencil, Trash2, Check, X, MoreHorizontal } from 'lucide-react';
@@ -387,7 +388,7 @@ function ChannelView({ page }: ChannelViewProps) {
   }, [page.id]);
 
   return (
-    <div className="flex flex-col h-full">
+    <MessageDropZone inputRef={channelInputRef} enabled={canEdit} className="flex flex-col h-full">
         <div className="flex-grow overflow-hidden relative">
           <Conversation>
             <ConversationContent className="gap-4 max-w-4xl mx-auto p-4">
@@ -546,7 +547,7 @@ function ChannelView({ page }: ChannelViewProps) {
             )}
           </div>
         </div>
-    </div>
+    </MessageDropZone>
   );
 }
 

--- a/apps/web/src/components/layout/middle-content/page-views/channel/MessageDropZone.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/MessageDropZone.tsx
@@ -46,16 +46,25 @@ export function MessageDropZone({
     if (!enabled) reset();
   }, [enabled, reset]);
 
-  // Catch drags that leave the window entirely (no dragleave fires on the wrapper
-  // in that case, so the counter would stay > 0).
+  // Reset the overlay for cases the wrapper's own handlers will not catch:
+  // 1. Drop on a child target that calls stopPropagation (e.g. the composer).
+  //    Capture phase fires before the target handler can stop propagation.
+  // 2. Drag pointer exits the document entirely (no balanced dragleave on the
+  //    wrapper). On most browsers this fires a dragleave on document with
+  //    relatedTarget === null.
+  // 3. Internal drag source completes (dragend bubbles).
   useEffect(() => {
-    const onWindowDragEnd = () => reset();
-    const onWindowDrop = () => reset();
-    window.addEventListener('dragend', onWindowDragEnd);
-    window.addEventListener('drop', onWindowDrop);
+    const handleReset = () => reset();
+    const handleDocumentDragLeave = (e: DragEvent) => {
+      if (e.relatedTarget === null) reset();
+    };
+    window.addEventListener('drop', handleReset, true);
+    window.addEventListener('dragend', handleReset, true);
+    document.addEventListener('dragleave', handleDocumentDragLeave);
     return () => {
-      window.removeEventListener('dragend', onWindowDragEnd);
-      window.removeEventListener('drop', onWindowDrop);
+      window.removeEventListener('drop', handleReset, true);
+      window.removeEventListener('dragend', handleReset, true);
+      document.removeEventListener('dragleave', handleDocumentDragLeave);
     };
   }, [reset]);
 

--- a/apps/web/src/components/layout/middle-content/page-views/channel/MessageDropZone.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/MessageDropZone.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Upload } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { ChannelInputRef } from './ChannelInput';
+
+export interface MessageDropZoneProps {
+  /** Ref to the ChannelInput composer that owns the attachment slot */
+  inputRef: React.RefObject<ChannelInputRef | null>;
+  /** Whether dropping is allowed (e.g., user has send permission) */
+  enabled: boolean;
+  /** Optional className applied to the wrapper div */
+  className?: string;
+  children: React.ReactNode;
+}
+
+const hasFiles = (dataTransfer: DataTransfer | null) => {
+  if (!dataTransfer) return false;
+  // dataTransfer.types is a DOMStringList in Safari; Array.from normalizes it.
+  return Array.from(dataTransfer.types).includes('Files');
+};
+
+/**
+ * MessageDropZone - wraps a channel/DM view so the entire message pane accepts
+ * file drops. On drop, the first file is forwarded to the composer's attachment
+ * slot via the imperative `uploadFile` handle.
+ */
+export function MessageDropZone({
+  inputRef,
+  enabled,
+  className,
+  children,
+}: MessageDropZoneProps) {
+  const [isDragging, setIsDragging] = useState(false);
+  const dragCounter = useRef(0);
+
+  const reset = useCallback(() => {
+    dragCounter.current = 0;
+    setIsDragging(false);
+  }, []);
+
+  // If the drop target gets disabled mid-drag (permission revoked, route change),
+  // make sure the overlay doesn't get stuck on.
+  useEffect(() => {
+    if (!enabled) reset();
+  }, [enabled, reset]);
+
+  // Catch drags that leave the window entirely (no dragleave fires on the wrapper
+  // in that case, so the counter would stay > 0).
+  useEffect(() => {
+    const onWindowDragEnd = () => reset();
+    const onWindowDrop = () => reset();
+    window.addEventListener('dragend', onWindowDragEnd);
+    window.addEventListener('drop', onWindowDrop);
+    return () => {
+      window.removeEventListener('dragend', onWindowDragEnd);
+      window.removeEventListener('drop', onWindowDrop);
+    };
+  }, [reset]);
+
+  const handleDragEnter = (e: React.DragEvent) => {
+    if (!enabled || !hasFiles(e.dataTransfer)) return;
+    if (!inputRef.current?.canAcceptDrop()) return;
+    e.preventDefault();
+    dragCounter.current += 1;
+    if (dragCounter.current === 1) setIsDragging(true);
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    if (!enabled || !hasFiles(e.dataTransfer)) return;
+    e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = 'copy';
+  };
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    if (!enabled || !hasFiles(e.dataTransfer)) return;
+    dragCounter.current = Math.max(0, dragCounter.current - 1);
+    if (dragCounter.current === 0) setIsDragging(false);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    if (!enabled || !hasFiles(e.dataTransfer)) return;
+    e.preventDefault();
+    e.stopPropagation();
+    reset();
+    if (!inputRef.current?.canAcceptDrop()) return;
+    const file = Array.from(e.dataTransfer?.files ?? [])[0];
+    if (file) inputRef.current.uploadFile(file);
+  };
+
+  return (
+    <div
+      className={cn('relative', className)}
+      onDragEnter={handleDragEnter}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+      data-testid="message-drop-zone"
+    >
+      {children}
+      {isDragging && (
+        <div
+          className="pointer-events-none absolute inset-2 z-50 flex items-center justify-center rounded-lg border-2 border-dashed border-primary/60 bg-primary/5 backdrop-blur-[1px]"
+          aria-hidden
+        >
+          <div className="flex flex-col items-center gap-2 text-primary">
+            <Upload className="h-8 w-8" />
+            <p className="text-sm font-medium">Drop file to attach</p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default MessageDropZone;

--- a/apps/web/src/components/layout/middle-content/page-views/channel/__tests__/MessageDropZone.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/__tests__/MessageDropZone.test.tsx
@@ -1,0 +1,192 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, fireEvent, screen, act } from '@testing-library/react';
+import React from 'react';
+
+import { MessageDropZone } from '../MessageDropZone';
+import type { ChannelInputRef } from '../ChannelInput';
+
+const makeInputRef = (overrides: Partial<ChannelInputRef> = {}) => {
+  const uploadFile = vi.fn();
+  const canAcceptDrop = vi.fn(() => true);
+  const ref: React.RefObject<ChannelInputRef | null> = {
+    current: {
+      focus: vi.fn(),
+      clear: vi.fn(),
+      insertText: vi.fn(),
+      uploadFile,
+      canAcceptDrop,
+      ...overrides,
+    } satisfies ChannelInputRef,
+  };
+  return { ref, uploadFile, canAcceptDrop };
+};
+
+const fireDragEvent = (
+  el: Element,
+  type: 'dragEnter' | 'dragOver' | 'dragLeave' | 'drop',
+  init: { files?: File[]; types?: string[] } = {},
+) => {
+  const types = init.types ?? (init.files ? ['Files'] : []);
+  const files = init.files ?? [];
+  fireEvent[type](el, {
+    dataTransfer: {
+      files,
+      types,
+      items: files.map((f) => ({ kind: 'file', type: f.type })),
+      // dropEffect is set by the handler; provide a settable shape.
+      dropEffect: 'none',
+    },
+  });
+};
+
+const renderZone = (
+  inputRef: React.RefObject<ChannelInputRef | null>,
+  enabled = true,
+) =>
+  render(
+    <MessageDropZone inputRef={inputRef} enabled={enabled}>
+      <div data-testid="zone-children">children</div>
+    </MessageDropZone>,
+  );
+
+const dropZone = () => screen.getByTestId('message-drop-zone');
+
+describe('MessageDropZone', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('drop_withFile_callsUploadFile_withFirstFile', () => {
+    const { ref, uploadFile } = makeInputRef();
+    renderZone(ref);
+
+    const file = new File(['x'], 'a.png', { type: 'image/png' });
+    fireDragEvent(dropZone(), 'drop', { files: [file] });
+
+    expect(uploadFile).toHaveBeenCalledTimes(1);
+    expect(uploadFile).toHaveBeenCalledWith(file);
+  });
+
+  it('drop_withMultipleFiles_callsUploadFile_withFirstOnly', () => {
+    const { ref, uploadFile } = makeInputRef();
+    renderZone(ref);
+
+    const f1 = new File(['1'], 'one.png', { type: 'image/png' });
+    const f2 = new File(['2'], 'two.png', { type: 'image/png' });
+    fireDragEvent(dropZone(), 'drop', { files: [f1, f2] });
+
+    expect(uploadFile).toHaveBeenCalledTimes(1);
+    expect(uploadFile).toHaveBeenCalledWith(f1);
+  });
+
+  it('drop_withoutFilesType_isIgnored', () => {
+    const { ref, uploadFile } = makeInputRef();
+    renderZone(ref);
+
+    // Simulate an in-app drag (e.g. a URL or text), not a file drag.
+    fireDragEvent(dropZone(), 'drop', { types: ['text/plain'] });
+
+    expect(uploadFile).not.toHaveBeenCalled();
+  });
+
+  it('drop_whenDisabled_isIgnored', () => {
+    const { ref, uploadFile } = makeInputRef();
+    renderZone(ref, /* enabled */ false);
+
+    const file = new File(['x'], 'a.png', { type: 'image/png' });
+    fireDragEvent(dropZone(), 'drop', { files: [file] });
+
+    expect(uploadFile).not.toHaveBeenCalled();
+  });
+
+  it('drop_whenCanAcceptDropFalse_isIgnored', () => {
+    const { ref, uploadFile, canAcceptDrop } = makeInputRef();
+    canAcceptDrop.mockReturnValue(false);
+    renderZone(ref);
+
+    const file = new File(['x'], 'a.png', { type: 'image/png' });
+    fireDragEvent(dropZone(), 'drop', { files: [file] });
+
+    expect(uploadFile).not.toHaveBeenCalled();
+  });
+
+  it('dragEnter_withFiles_showsOverlay_dragLeaveHidesIt', () => {
+    const { ref } = makeInputRef();
+    renderZone(ref);
+
+    expect(screen.queryByText('Drop file to attach')).toBeNull();
+
+    fireDragEvent(dropZone(), 'dragEnter', { files: [new File([''], 'a')] });
+    expect(screen.getByText('Drop file to attach')).toBeInTheDocument();
+
+    fireDragEvent(dropZone(), 'dragLeave', { files: [new File([''], 'a')] });
+    expect(screen.queryByText('Drop file to attach')).toBeNull();
+  });
+
+  it('dragEnter_withoutFilesType_doesNotShowOverlay', () => {
+    const { ref } = makeInputRef();
+    renderZone(ref);
+
+    fireDragEvent(dropZone(), 'dragEnter', { types: ['text/plain'] });
+    expect(screen.queryByText('Drop file to attach')).toBeNull();
+  });
+
+  it('dragEnter_whenDisabled_doesNotShowOverlay', () => {
+    const { ref } = makeInputRef();
+    renderZone(ref, false);
+
+    fireDragEvent(dropZone(), 'dragEnter', { files: [new File([''], 'a')] });
+    expect(screen.queryByText('Drop file to attach')).toBeNull();
+  });
+
+  it('dragEnter_whenCanAcceptDropFalse_doesNotShowOverlay', () => {
+    const { ref, canAcceptDrop } = makeInputRef();
+    canAcceptDrop.mockReturnValue(false);
+    renderZone(ref);
+
+    fireDragEvent(dropZone(), 'dragEnter', { files: [new File([''], 'a')] });
+    expect(screen.queryByText('Drop file to attach')).toBeNull();
+  });
+
+  it('drop_resetsOverlay_evenAfterMultipleDragEnters', () => {
+    const { ref } = makeInputRef();
+    renderZone(ref);
+
+    // Multiple dragEnter events (children causing storm)
+    const file = new File(['x'], 'a.png', { type: 'image/png' });
+    fireDragEvent(dropZone(), 'dragEnter', { files: [file] });
+    fireDragEvent(dropZone(), 'dragEnter', { files: [file] });
+    expect(screen.getByText('Drop file to attach')).toBeInTheDocument();
+
+    fireDragEvent(dropZone(), 'drop', { files: [file] });
+    expect(screen.queryByText('Drop file to attach')).toBeNull();
+  });
+
+  it('windowDrop_event_resetsOverlay_whenUserDragsOutOfWindow', () => {
+    const { ref } = makeInputRef();
+    renderZone(ref);
+
+    fireDragEvent(dropZone(), 'dragEnter', { files: [new File([''], 'a')] });
+    expect(screen.getByText('Drop file to attach')).toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(new Event('drop'));
+    });
+    expect(screen.queryByText('Drop file to attach')).toBeNull();
+  });
+
+  it('enabledFalse_afterMount_resetsOverlayIfActive', () => {
+    const { ref } = makeInputRef();
+    const { rerender } = renderZone(ref, true);
+
+    fireDragEvent(dropZone(), 'dragEnter', { files: [new File([''], 'a')] });
+    expect(screen.getByText('Drop file to attach')).toBeInTheDocument();
+
+    rerender(
+      <MessageDropZone inputRef={ref} enabled={false}>
+        <div>children</div>
+      </MessageDropZone>,
+    );
+    expect(screen.queryByText('Drop file to attach')).toBeNull();
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/channel/__tests__/MessageDropZone.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/__tests__/MessageDropZone.test.tsx
@@ -175,6 +175,63 @@ describe('MessageDropZone', () => {
     expect(screen.queryByText('Drop file to attach')).toBeNull();
   });
 
+  it('childDropStopsPropagation_overlayStillResets_viaCaptureListener', () => {
+    // Reproduces the composer-drop-with-stopPropagation case: an inner element
+    // calls stopPropagation, so MessageDropZone's own onDrop never fires.
+    // The capture-phase window listener must still reset the overlay.
+    const { ref } = makeInputRef();
+    render(
+      <MessageDropZone inputRef={ref} enabled>
+        <button
+          data-testid="inner-target"
+          onDrop={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          }}
+        >
+          inner
+        </button>
+      </MessageDropZone>,
+    );
+
+    const file = new File(['x'], 'a.png', { type: 'image/png' });
+    fireDragEvent(dropZone(), 'dragEnter', { files: [file] });
+    expect(screen.getByText('Drop file to attach')).toBeInTheDocument();
+
+    fireDragEvent(screen.getByTestId('inner-target'), 'drop', { files: [file] });
+    expect(screen.queryByText('Drop file to attach')).toBeNull();
+  });
+
+  it('documentDragLeave_withNullRelatedTarget_resetsOverlay', () => {
+    const { ref } = makeInputRef();
+    renderZone(ref);
+
+    fireDragEvent(dropZone(), 'dragEnter', { files: [new File([''], 'a')] });
+    expect(screen.getByText('Drop file to attach')).toBeInTheDocument();
+
+    act(() => {
+      const ev = new Event('dragleave', { bubbles: true });
+      Object.defineProperty(ev, 'relatedTarget', { value: null });
+      document.dispatchEvent(ev);
+    });
+    expect(screen.queryByText('Drop file to attach')).toBeNull();
+  });
+
+  it('documentDragLeave_withRelatedTarget_doesNotReset', () => {
+    const { ref } = makeInputRef();
+    renderZone(ref);
+
+    fireDragEvent(dropZone(), 'dragEnter', { files: [new File([''], 'a')] });
+    expect(screen.getByText('Drop file to attach')).toBeInTheDocument();
+
+    act(() => {
+      const ev = new Event('dragleave', { bubbles: true });
+      Object.defineProperty(ev, 'relatedTarget', { value: document.body });
+      document.dispatchEvent(ev);
+    });
+    expect(screen.getByText('Drop file to attach')).toBeInTheDocument();
+  });
+
   it('enabledFalse_afterMount_resetsOverlayIfActive', () => {
     const { ref } = makeInputRef();
     const { rerender } = renderZone(ref, true);


### PR DESCRIPTION
## Summary
- Whole message pane (header + scrollable list + composer) is now a file drop target across **all three** channel/DM message surfaces — matches Slack/Discord behavior
- Adds shared `MessageDropZone` wrapper with dashed-border overlay, drag counter, files-only filter, and **capture-phase** window listeners (so the overlay reset survives even when the composer's drop handler calls `stopPropagation`)
- Extends `ChannelInputRef` with `uploadFile` + `canAcceptDrop` to forward drops into the existing `useAttachmentUpload` pipeline (no new upload state)
- Composer-internal drop handlers untouched; read-only channels still fall through to default browser behavior

## Files
- `apps/web/src/components/layout/middle-content/page-views/channel/MessageDropZone.tsx` (new)
- `apps/web/src/components/layout/middle-content/page-views/channel/__tests__/MessageDropZone.test.tsx` (new — 15 tests)
- `apps/web/src/components/layout/middle-content/page-views/channel/ChannelInput.tsx` (extends `ChannelInputRef`)
- `apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx` (in-drive channel view)
- `apps/web/src/app/dashboard/inbox/dm/[conversationId]/page.tsx` (DM page)
- `apps/web/src/app/dashboard/inbox/channel/[pageId]/page.tsx` (inbox channel page — added in 29cc868 for parity)

## Test plan
- [ ] Channel happy path (in-drive `/dashboard/<drive>/<page>`): drop image from Finder over the message list → overlay appears, file lands in composer attachment preview, send succeeds
- [ ] Inbox channel (`/dashboard/inbox/channel/<pageId>`): same flow
- [ ] DM (`/dashboard/inbox/dm/<conversationId>`): same flow
- [ ] Drop directly on composer card still uploads (no double-handling, overlay clears — capture-phase reset)
- [ ] Start an upload, drag a second file over the message area → overlay does not appear
- [ ] Read-only channel (no `canEdit`) → no overlay, drop falls through to browser
- [ ] In-app drag (mention chip, link) over message area → overlay does not appear (Files-only filter)
- [ ] Drag file in → out of window → back in: overlay state does not stick (document dragleave + null relatedTarget)
- [x] Existing 14 ChannelInput tests still pass
- [x] Existing 8 DM page tests still pass
- [x] 15 new MessageDropZone tests pass

## Review feedback addressed
- chatgpt-codex-connector flagged that the original window `drop`/`dragend` listeners (bubble phase) wouldn't fire when the composer called `stopPropagation` — fixed in 0857697 with capture-phase listeners + document dragleave fallback, plus three regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)