### PR TITLE
fix(voice): stop dropping or stuttering TTS text

### DIFF
--- a/apps/web/src/components/ai/voice/VoiceCallPanel.tsx
+++ b/apps/web/src/components/ai/voice/VoiceCallPanel.tsx
@@ -100,9 +100,8 @@ export function VoiceCallPanel({
     pendingTextRef.current = '';
   }, [isAIStreaming]);
 
-  // When stream ends, always flush any buffered tail. If the user has actually
-  // barged in, bargeIn() clears the speech queue, so an enqueued tail is
-  // discarded there — gating here just races and silently drops content.
+  // When stream ends, flush any buffered tail. queueSentence drops chunks
+  // when the user is mid-barge-in (listening/processing), so this is safe.
   useEffect(() => {
     if (isAIStreaming) return;
     const tail = pendingTextRef.current;

--- a/apps/web/src/components/ai/voice/VoiceCallPanel.tsx
+++ b/apps/web/src/components/ai/voice/VoiceCallPanel.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { useVoiceMode } from '@/hooks/useVoiceMode';
 import { useVoiceModeStore, type VoiceModeOwner } from '@/stores/useVoiceModeStore';
+import { chunkStreamingForTts, flushForTts } from '@/lib/voice/chunkForTts';
 import { VoiceModeSettings } from './VoiceModeSettings';
 
 export interface VoiceResponse {
@@ -54,7 +55,6 @@ export function VoiceCallPanel({
     disable,
     startListening,
     stopListening,
-    speak,
     queueSentence,
     bargeIn,
     interactionMode,
@@ -88,14 +88,9 @@ export function VoiceCallPanel({
     pendingTextRef.current += newChunk;
     streamingSpokenRef.current = streamingText.length;
 
-    const sentenceRe = /[^.!?\n]+[.!?\n]+(?=\s|$)/g;
-    let match: RegExpExecArray | null;
-    let lastIndex = 0;
-    while ((match = sentenceRe.exec(pendingTextRef.current)) !== null) {
-      queueSentence(match[0].trim());
-      lastIndex = sentenceRe.lastIndex;
-    }
-    pendingTextRef.current = pendingTextRef.current.slice(lastIndex);
+    const { ready, pending } = chunkStreamingForTts(pendingTextRef.current);
+    pendingTextRef.current = pending;
+    for (const chunk of ready) queueSentence(chunk);
   }, [streamingText, isAIStreaming, isOwnerActive, queueSentence]);
 
   // Reset streamed marker and pending buffer when a new stream begins
@@ -105,16 +100,15 @@ export function VoiceCallPanel({
     pendingTextRef.current = '';
   }, [isAIStreaming]);
 
-  // When stream ends, flush any buffered tail — skip if barge-in already started capture
+  // When stream ends, always flush any buffered tail. If the user has actually
+  // barged in, bargeIn() clears the speech queue, so an enqueued tail is
+  // discarded there — gating here just races and silently drops content.
   useEffect(() => {
     if (isAIStreaming) return;
-    const tail = pendingTextRef.current.trim();
+    const tail = pendingTextRef.current;
     pendingTextRef.current = '';
-    if (!tail) return;
-    const { voiceState: liveState } = useVoiceModeStore.getState();
-    if (liveState !== 'listening' && liveState !== 'processing') {
-      queueSentence(tail);
-    }
+    if (!tail.trim()) return;
+    for (const chunk of flushForTts(tail)) queueSentence(chunk);
   }, [isAIStreaming, queueSentence]);
 
   // Fallback: speak full message when voice mode was activated after streaming ended
@@ -126,8 +120,17 @@ export function VoiceCallPanel({
     if (streamingSpokenRef.current > 0) return;
 
     spokenMessageIdsRef.current.add(latestAssistantMessage.id);
-    void speak(latestAssistantMessage.text);
-  }, [latestAssistantMessage, isAIStreaming, isOwnerActive, isListening, isProcessing, speak]);
+    for (const chunk of flushForTts(latestAssistantMessage.text)) {
+      queueSentence(chunk);
+    }
+  }, [
+    latestAssistantMessage,
+    isAIStreaming,
+    isOwnerActive,
+    isListening,
+    isProcessing,
+    queueSentence,
+  ]);
 
   const handleClose = useCallback(() => {
     disable();

--- a/apps/web/src/hooks/useVoiceMode.ts
+++ b/apps/web/src/hooks/useVoiceMode.ts
@@ -691,6 +691,9 @@ export function useVoiceMode({
     (text: string) => {
       if (!text.trim()) return;
       const { voiceState: currentState } = useVoiceModeStore.getState();
+      // Don't talk over the user. If they are speaking or being transcribed,
+      // drop incoming TTS chunks — barge-in already cleared the existing queue.
+      if (currentState === 'listening' || currentState === 'processing') return;
       if (currentState === 'speaking') {
         speechQueueRef.current.push(text);
       } else {

--- a/apps/web/src/hooks/useVoiceMode.ts
+++ b/apps/web/src/hooks/useVoiceMode.ts
@@ -3,7 +3,10 @@
 import { useRef, useCallback, useEffect } from 'react';
 import { useVoiceModeStore, type TTSVoice, type VoiceModeOwner } from '@/stores/useVoiceModeStore';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { splitOversizedForTts } from '@/lib/voice/chunkForTts';
 import { createId } from '@paralleldrive/cuid2';
+
+const TTS_MAX_CHARS = 1500;
 
 function getMicPermissionErrorMessage(err: unknown): string {
   const isDesktop = typeof window !== 'undefined' && !!window.electron?.isDesktop;
@@ -564,6 +567,15 @@ export function useVoiceMode({
     async (text: string) => {
       if (!text.trim()) return;
 
+      // Safety net: if a chunk somehow exceeds the OpenAI TTS 4096-char limit,
+      // hard-split on word boundary and queue the remainder so nothing is dropped.
+      let chunkToSpeak = text;
+      if (chunkToSpeak.length > TTS_MAX_CHARS) {
+        const pieces = splitOversizedForTts(chunkToSpeak, TTS_MAX_CHARS);
+        chunkToSpeak = pieces[0];
+        speechQueueRef.current.unshift(...pieces.slice(1));
+      }
+
       try {
         setError(null);
         const audioId = createId();
@@ -575,7 +587,7 @@ export function useVoiceMode({
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({
-            text,
+            text: chunkToSpeak,
             voice: ttsVoice,
             speed: ttsSpeed,
           }),
@@ -644,6 +656,14 @@ export function useVoiceMode({
         setError(message);
         callbacksRef.current.onError?.(message);
         stopBargeInMonitoring();
+
+        // Don't let a single failed chunk mute the rest of the queue —
+        // drain the next item rather than abandoning playback entirely.
+        if (speechQueueRef.current.length > 0) {
+          const next = speechQueueRef.current.shift()!;
+          void speak(next);
+          return;
+        }
         stopSpeakingStore();
       }
     },

--- a/apps/web/src/lib/voice/__tests__/chunkForTts.test.ts
+++ b/apps/web/src/lib/voice/__tests__/chunkForTts.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeForSpeech,
+  chunkStreamingForTts,
+  flushForTts,
+  splitOversizedForTts,
+} from '../chunkForTts';
+
+describe('normalizeForSpeech', () => {
+  it('strips fenced code blocks', () => {
+    const input = 'Hello.\n```js\nconst x = 1;\n```\nWorld.';
+    const out = normalizeForSpeech(input);
+    expect(out).not.toContain('```');
+    expect(out).not.toContain('const x');
+    expect(out).toContain('Hello');
+    expect(out).toContain('World');
+  });
+
+  it('unwraps inline code', () => {
+    expect(normalizeForSpeech('Use `foo` here.')).toBe('Use foo here.');
+  });
+
+  it('removes heading hashes', () => {
+    expect(normalizeForSpeech('# Title\n\nBody.')).toBe('Title. Body.');
+  });
+
+  it('removes bullet list markers', () => {
+    const out = normalizeForSpeech('- First.\n- Second.\n- Third.');
+    expect(out).not.toMatch(/^-/);
+    expect(out).toContain('First');
+    expect(out).toContain('Second');
+    expect(out).toContain('Third');
+  });
+
+  it('removes ordered list markers', () => {
+    const out = normalizeForSpeech('1. One.\n2. Two.\n3. Three.');
+    expect(out).not.toMatch(/^\d+\./);
+    expect(out).toContain('One');
+    expect(out).toContain('Two');
+  });
+
+  it('strips bold and italic markers', () => {
+    expect(normalizeForSpeech('This is **bold** and _italic_ text.')).toBe(
+      'This is bold and italic text.'
+    );
+  });
+
+  it('keeps link text and drops the URL', () => {
+    expect(normalizeForSpeech('See [the docs](https://example.com) now.')).toBe(
+      'See the docs now.'
+    );
+  });
+
+  it('drops images entirely', () => {
+    const out = normalizeForSpeech('Look ![alt](https://img.png) here.');
+    expect(out).not.toContain('img.png');
+    expect(out).not.toContain('alt');
+  });
+
+  it('treats paragraph breaks as sentence boundaries', () => {
+    expect(normalizeForSpeech('First paragraph\n\nSecond paragraph')).toBe(
+      'First paragraph. Second paragraph'
+    );
+  });
+
+  it('does not split single newlines inside a paragraph', () => {
+    expect(normalizeForSpeech('Line one\nstill same sentence.')).toBe(
+      'Line one still same sentence.'
+    );
+  });
+
+  it('collapses repeated whitespace', () => {
+    expect(normalizeForSpeech('a   b\t\tc')).toBe('a b c');
+  });
+
+  it('removes blockquote markers', () => {
+    expect(normalizeForSpeech('> quoted text')).toBe('quoted text');
+  });
+
+  it('removes horizontal rules', () => {
+    const out = normalizeForSpeech('Above.\n\n---\n\nBelow.');
+    expect(out).toContain('Above');
+    expect(out).toContain('Below');
+    expect(out).not.toContain('---');
+  });
+});
+
+describe('chunkStreamingForTts', () => {
+  it('returns the buffer as pending when no terminator is present', () => {
+    const result = chunkStreamingForTts('Hello world without a period');
+    expect(result.ready).toEqual([]);
+    expect(result.pending).toBe('Hello world without a period');
+  });
+
+  it('emits a complete sentence and clears pending', () => {
+    const result = chunkStreamingForTts('Hello world. ');
+    expect(result.ready).toEqual(['Hello world.']);
+    expect(result.pending).toBe('');
+  });
+
+  it('keeps the unfinished tail in pending across chunks', () => {
+    const result = chunkStreamingForTts('First sentence. Partial seco');
+    expect(result.ready).toEqual(['First sentence.']);
+    expect(result.pending).toBe('Partial seco');
+  });
+
+  it('treats a paragraph break as a hard boundary', () => {
+    const result = chunkStreamingForTts('No period here\n\nNext bit');
+    expect(result.ready.length).toBeGreaterThan(0);
+    expect(result.ready.join(' ')).toContain('No period here');
+    expect(result.pending).toBe('Next bit');
+  });
+
+  it('does not split on a single newline inside a paragraph', () => {
+    const result = chunkStreamingForTts('Line one\nLine two\nLine three.');
+    expect(result.ready).toEqual(['Line one Line two Line three.']);
+  });
+
+  it('packs multiple short sentences into a single chunk', () => {
+    const input = 'One. Two. Three. Four. Five. ';
+    const result = chunkStreamingForTts(input, { maxChars: 1500 });
+    expect(result.ready.length).toBe(1);
+    expect(result.ready[0]).toContain('One');
+    expect(result.ready[0]).toContain('Five');
+  });
+
+  it('respects maxChars when packing', () => {
+    const sentence = 'This is a sample sentence. ';
+    const input = sentence.repeat(50);
+    const result = chunkStreamingForTts(input, { maxChars: 100 });
+    for (const chunk of result.ready) {
+      expect(chunk.length).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it('strips markdown noise before shipping', () => {
+    const result = chunkStreamingForTts('# Title\n\n- bullet item.\n\n');
+    expect(result.ready.join(' ')).not.toContain('#');
+    expect(result.ready.join(' ')).not.toMatch(/^-/);
+  });
+
+  it('returns empty result for empty input', () => {
+    expect(chunkStreamingForTts('')).toEqual({ ready: [], pending: '' });
+  });
+
+  it('returns empty ready when buffer normalizes to nothing', () => {
+    const result = chunkStreamingForTts('```\njust code\n```\n\n');
+    expect(result.ready).toEqual([]);
+  });
+});
+
+describe('flushForTts', () => {
+  it('ships text without a terminator on final flush', () => {
+    const out = flushForTts('Tail text without period');
+    expect(out).toEqual(['Tail text without period']);
+  });
+
+  it('returns empty for empty input', () => {
+    expect(flushForTts('')).toEqual([]);
+  });
+
+  it('splits oversized tail across multiple chunks', () => {
+    const long = 'word '.repeat(500).trim();
+    const out = flushForTts(long, { maxChars: 200 });
+    expect(out.length).toBeGreaterThan(1);
+    for (const chunk of out) {
+      expect(chunk.length).toBeLessThanOrEqual(200);
+    }
+  });
+
+  it('strips markdown on flush', () => {
+    const out = flushForTts('# Heading\n\n- item without period');
+    expect(out.join(' ')).not.toContain('#');
+    expect(out.join(' ')).toContain('Heading');
+    expect(out.join(' ')).toContain('item without period');
+  });
+});
+
+describe('splitOversizedForTts', () => {
+  it('returns the input unchanged when under the limit', () => {
+    expect(splitOversizedForTts('short text', 100)).toEqual(['short text']);
+  });
+
+  it('splits a long string on word boundaries', () => {
+    const text = 'word '.repeat(100).trim();
+    const out = splitOversizedForTts(text, 50);
+    expect(out.length).toBeGreaterThan(1);
+    for (const chunk of out) {
+      expect(chunk.length).toBeLessThanOrEqual(50);
+      expect(chunk).not.toMatch(/^ /);
+      expect(chunk).not.toMatch(/ $/);
+    }
+  });
+
+  it('never produces empty chunks', () => {
+    const out = splitOversizedForTts('a '.repeat(200).trim(), 10);
+    for (const chunk of out) {
+      expect(chunk.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('hard-cuts when no whitespace exists', () => {
+    const noSpace = 'a'.repeat(120);
+    const out = splitOversizedForTts(noSpace, 50);
+    expect(out.length).toBeGreaterThan(1);
+    for (const chunk of out) {
+      expect(chunk.length).toBeLessThanOrEqual(50);
+    }
+  });
+
+  it('preserves all content (no characters dropped)', () => {
+    const input = 'one two three four five six seven eight nine ten';
+    const out = splitOversizedForTts(input, 15);
+    const recombined = out.join(' ');
+    for (const word of input.split(' ')) {
+      expect(recombined).toContain(word);
+    }
+  });
+});
+
+describe('streaming end-to-end simulation', () => {
+  it('handles a markdown response with a code block without dropping content', () => {
+    let buffer = '';
+    const tokens = [
+      'Here is some code:\n\n',
+      '```js\n',
+      'const x = 1;\n',
+      'console.log(x);\n',
+      '```\n\n',
+      'Done.',
+    ];
+    const allReady: string[] = [];
+    for (const t of tokens) {
+      buffer += t;
+      const r = chunkStreamingForTts(buffer);
+      allReady.push(...r.ready);
+      buffer = r.pending;
+    }
+    allReady.push(...flushForTts(buffer));
+    const combined = allReady.join(' ');
+    expect(combined).toContain('Here is some code');
+    expect(combined).toContain('Done');
+    expect(combined).not.toContain('```');
+    expect(combined).not.toContain('const x');
+  });
+
+  it('handles a long unpunctuated paragraph by flushing it at end', () => {
+    const long = 'word '.repeat(800).trim();
+    let buffer = '';
+    const allReady: string[] = [];
+    for (const t of long.match(/.{1,40}/g) ?? []) {
+      buffer += t;
+      const r = chunkStreamingForTts(buffer);
+      allReady.push(...r.ready);
+      buffer = r.pending;
+    }
+    allReady.push(...flushForTts(buffer));
+    expect(allReady.length).toBeGreaterThan(0);
+    const combined = allReady.join(' ');
+    expect(combined.replace(/\s+/g, ' ').trim()).toContain('word word');
+    expect(combined.split(/\s+/).filter(Boolean).length).toBe(800);
+  });
+});

--- a/apps/web/src/lib/voice/chunkForTts.ts
+++ b/apps/web/src/lib/voice/chunkForTts.ts
@@ -61,17 +61,13 @@ export interface ChunkOptions {
  */
 function findLastSafeBoundary(buffer: string): number {
   let last = -1;
-
-  SENTENCE_BOUNDARY.lastIndex = 0;
-  while (SENTENCE_BOUNDARY.exec(buffer) !== null) {
-    last = SENTENCE_BOUNDARY.lastIndex;
+  for (const m of buffer.matchAll(SENTENCE_BOUNDARY)) {
+    last = m.index + m[0].length;
   }
-
-  PARAGRAPH_BREAK.lastIndex = 0;
-  while (PARAGRAPH_BREAK.exec(buffer) !== null) {
-    if (PARAGRAPH_BREAK.lastIndex > last) last = PARAGRAPH_BREAK.lastIndex;
+  for (const m of buffer.matchAll(PARAGRAPH_BREAK)) {
+    const end = m.index + m[0].length;
+    if (end > last) last = end;
   }
-
   return last;
 }
 

--- a/apps/web/src/lib/voice/chunkForTts.ts
+++ b/apps/web/src/lib/voice/chunkForTts.ts
@@ -1,0 +1,175 @@
+/**
+ * Voice mode TTS chunking utilities.
+ *
+ * Streaming assistant text arrives token-by-token with raw markdown. The TTS
+ * pipeline needs to ship reasonably-sized, speakable chunks to OpenAI's TTS
+ * API (4096 char hard limit) without splitting on every newline (which causes
+ * audible gaps between line-by-line synthesis calls).
+ */
+
+const FENCED_CODE = /```[\s\S]*?```/g;
+const INLINE_CODE = /`([^`\n]+)`/g;
+const IMAGE = /!\[[^\]]*\]\([^)]*\)/g;
+const LINK = /\[([^\]]+)\]\([^)]+\)/g;
+const HORIZONTAL_RULE = /^[ \t]*[-*_]{3,}[ \t]*$/gm;
+const BLOCKQUOTE = /^[ \t]*>\s?/gm;
+const HEADING = /^[ \t]*#{1,6}[ \t]+/gm;
+const LIST_BULLET = /^[ \t]*[-*+][ \t]+/gm;
+const LIST_ORDERED = /^[ \t]*\d+[.)][ \t]+/gm;
+const BOLD = /(\*\*|__)([^*_\n]+?)\1/g;
+const ITALIC = /(?<![*_\w])([*_])([^*_\n]+?)\1(?![*_\w])/g;
+
+const SENTENCE_BOUNDARY = /[.!?]+(?=\s|$)/g;
+const PARAGRAPH_BREAK = /\n{2,}/g;
+
+const DEFAULT_MAX_CHARS = 1500;
+
+export function normalizeForSpeech(text: string): string {
+  let s = text;
+  s = s.replace(IMAGE, '');
+  s = s.replace(FENCED_CODE, ' ');
+  s = s.replace(LINK, '$1');
+  s = s.replace(HORIZONTAL_RULE, '');
+  s = s.replace(BLOCKQUOTE, '');
+  s = s.replace(HEADING, '');
+  s = s.replace(LIST_BULLET, '');
+  s = s.replace(LIST_ORDERED, '');
+  s = s.replace(BOLD, '$2');
+  s = s.replace(ITALIC, '$2');
+  s = s.replace(INLINE_CODE, '$1');
+  s = s.replace(/\n{2,}/g, '. ');
+  s = s.replace(/\n/g, ' ');
+  s = s.replace(/[ \t]+/g, ' ');
+  s = s.replace(/\s+([.!?,;:])/g, '$1');
+  s = s.replace(/([.!?])\1{2,}/g, '$1');
+  return s.trim();
+}
+
+export interface ChunkResult {
+  ready: string[];
+  pending: string;
+}
+
+export interface ChunkOptions {
+  maxChars?: number;
+}
+
+/**
+ * Find the index of the last "safe" cut point in a streaming raw buffer.
+ * Returns the index *after* the last sentence terminator or paragraph break,
+ * or -1 if the buffer has no complete sentence yet.
+ */
+function findLastSafeBoundary(buffer: string): number {
+  let last = -1;
+
+  SENTENCE_BOUNDARY.lastIndex = 0;
+  while (SENTENCE_BOUNDARY.exec(buffer) !== null) {
+    last = SENTENCE_BOUNDARY.lastIndex;
+  }
+
+  PARAGRAPH_BREAK.lastIndex = 0;
+  while (PARAGRAPH_BREAK.exec(buffer) !== null) {
+    if (PARAGRAPH_BREAK.lastIndex > last) last = PARAGRAPH_BREAK.lastIndex;
+  }
+
+  return last;
+}
+
+function packSentences(text: string, maxChars: number): string[] {
+  const sentences: string[] = [];
+  const re = /[^.!?]+[.!?]+(?:\s+|$)|[^.!?]+$/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    const s = m[0].trim();
+    if (s) sentences.push(s);
+  }
+
+  const out: string[] = [];
+  let cur = '';
+  for (const s of sentences) {
+    if (s.length > maxChars) {
+      if (cur) {
+        out.push(cur);
+        cur = '';
+      }
+      for (const sub of splitOversizedForTts(s, maxChars)) out.push(sub);
+      continue;
+    }
+    if (!cur) {
+      cur = s;
+      continue;
+    }
+    if (cur.length + 1 + s.length <= maxChars) {
+      cur += ' ' + s;
+    } else {
+      out.push(cur);
+      cur = s;
+    }
+  }
+  if (cur) out.push(cur);
+  return out;
+}
+
+/**
+ * Process a streaming raw buffer of assistant text. Returns chunks that are
+ * ready to be sent to TTS, plus the unfinished tail to keep buffered.
+ *
+ * The returned `pending` is RAW (unnormalized) so the caller can keep
+ * appending new stream tokens to it before re-processing.
+ */
+export function chunkStreamingForTts(
+  buffer: string,
+  opts: ChunkOptions = {}
+): ChunkResult {
+  const maxChars = opts.maxChars ?? DEFAULT_MAX_CHARS;
+
+  if (!buffer) return { ready: [], pending: '' };
+
+  const cutPoint = findLastSafeBoundary(buffer);
+  if (cutPoint <= 0) {
+    return { ready: [], pending: buffer };
+  }
+
+  const completeRaw = buffer.slice(0, cutPoint);
+  const pending = buffer.slice(cutPoint).replace(/^\s+/, '');
+
+  const normalized = normalizeForSpeech(completeRaw);
+  if (!normalized) return { ready: [], pending };
+
+  const ready = packSentences(normalized, maxChars);
+  return { ready, pending };
+}
+
+/**
+ * Final-flush variant: normalize the whole buffer (including any unfinished
+ * tail) and return all packed chunks. Use this when the AI stream has ended
+ * and any remaining text must be spoken.
+ */
+export function flushForTts(
+  buffer: string,
+  opts: ChunkOptions = {}
+): string[] {
+  const maxChars = opts.maxChars ?? DEFAULT_MAX_CHARS;
+  if (!buffer) return [];
+  const normalized = normalizeForSpeech(buffer);
+  if (!normalized) return [];
+  return packSentences(normalized, maxChars);
+}
+
+/**
+ * Split a single oversized chunk on word boundaries so each piece fits under
+ * the TTS API's character limit. Used as a final safety net inside `speak()`.
+ */
+export function splitOversizedForTts(text: string, maxChars: number): string[] {
+  const out: string[] = [];
+  let remaining = text.trim();
+  while (remaining.length > maxChars) {
+    let cut = remaining.lastIndexOf(' ', maxChars);
+    if (cut <= 0) cut = maxChars;
+    const piece = remaining.slice(0, cut).trim();
+    if (piece) out.push(piece);
+    remaining = remaining.slice(cut).trim();
+  }
+  if (remaining) out.push(remaining);
+  return out;
+}


### PR DESCRIPTION
## Summary
Voice mode reads streamed assistant text via OpenAI TTS. Three audible bugs traced to one chunker:

1. **Long pauses on line breaks** — old regex treated every `\n` as a sentence terminator, so paragraphs/lists/code blocks fragmented into one TTS round-trip per line.
2. **Skips text** — long unpunctuated runs sat unflushed and could exceed the 4096-char API limit; the failure was swallowed silently.
3. **Doesn't read big portions** — a single failed `speak()` left the queue stranded; subsequent sentences never played.

## Changes
- **New `apps/web/src/lib/voice/chunkForTts.ts`** — markdown-aware streaming chunker:
  - `normalizeForSpeech` strips fenced/inline code, headings, list markers, blockquotes, links/images, bold/italic.
  - `chunkStreamingForTts` packs sentences into ~1500-char chunks; treats `\n\n` as a sentence boundary while keeping single `\n` as intra-paragraph whitespace.
  - `flushForTts` final-flush variant for stream-end and late-fallback paths.
  - `splitOversizedForTts` word-boundary safety net for the 4096-char API limit.
- **`VoiceCallPanel.tsx`** — uses the chunker for streaming, stream-end flush, and the post-stream "voice activated late" fallback.
- **`useVoiceMode.ts`**:
  - `speak()` hard-splits oversized chunks before hitting the API and drains the next queued sentence on per-chunk failure (previously one bad request muted the rest of the response).
  - `queueSentence()` drops chunks when `voiceState` is `listening` or `processing` so any caller (streaming, stream-end flush, late fallback) is safe and won't talk over a user mid-barge-in.

## Test plan
- [x] `pnpm --filter web test src/lib/voice/__tests__/chunkForTts.test.ts` — 34 cases covering normalize, streaming chunk, final flush, oversized split, and an end-to-end streaming simulation
- [x] `npx tsc --noEmit` (apps/web) — no new errors in changed files
- [x] `next lint` on the changed files — clean
- [x] CI: Unit Tests + Lint & TypeScript Check + CodeRabbit all green
- [ ] Manual: open an AI chat with voice mode, ask the model for (a) a code block, (b) a bulleted list, (c) a long paragraph with no terminators, (d) barge in mid-stream — verify no per-line stutter, no dropped tail, no muted response after a failure, no talk-over after barge-in

## Reviewer notes
- Codex flagged the original removal of the stream-end `liveState` guard as a barge-in regression. The fix moved the guard down into `queueSentence` itself so every caller is gated, not just the stream-end path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)