### PR TITLE
fix(authz): gate drive member queries on acceptedAt

### DIFF
--- a/apps/web/src/app/api/__tests__/drive-member-gate-coverage.test.ts
+++ b/apps/web/src/app/api/__tests__/drive-member-gate-coverage.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Drive Member acceptedAt Gate — Route Coverage
+ *
+ * Locks in the Epic 1 authz hardening: any API route that reads
+ * `driveMembers` for an authorization decision MUST filter on
+ * `isNotNull(driveMembers.acceptedAt)` so pending invitation rows
+ * (acceptedAt IS NULL) cannot exercise authority.
+ *
+ * Routes that intentionally surface pending rows (e.g., the member-detail
+ * view used to render "Invitation pending" in the UI) or that perform
+ * non-authz reads/writes (e.g., DELETE by composite key, count helpers)
+ * are explicitly allow-listed below with a justification.
+ *
+ * Regression caught: a new authz route is added under apps/web/src/app/api/**
+ * that reads `driveMembers` without the gate and without an allow-list entry —
+ * the test fails and forces the author to either gate the query or document
+ * why the gate is intentionally skipped.
+ */
+
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join } from 'path';
+
+const API_DIR = join(__dirname, '..');
+
+/** Files that read `driveMembers` but are intentionally exempt from the gate. */
+const ACCEPTED_AT_GATE_EXEMPT = new Map<string, string>([
+  [
+    'drives/[driveId]/members/[userId]',
+    'GET intentionally surfaces pending rows for the member-detail UI ("Invitation pending"); DELETE/PATCH operate by composite (driveId, userId) key and do not branch on acceptedAt.',
+  ],
+  [
+    'account/drives-status',
+    'Followup: admin lookup for drive-transfer UI should gate on acceptedAt — tracked in plan.md.',
+  ],
+  [
+    'account/handle-drive',
+    'Followup: drive-transfer POST should reject pending admins — tracked in plan.md.',
+  ],
+  [
+    'admin/global-prompt',
+    'Followup: admin drive picker should hide pending invitations — tracked in plan.md.',
+  ],
+  [
+    'channels/[pageId]/messages',
+    'Followup: pending admins should not receive @mention broadcast — tracked in plan.md.',
+  ],
+  [
+    'pages/bulk-copy',
+    'Followup: cross-drive copy authz should reject pending target-drive members — tracked in plan.md.',
+  ],
+  [
+    'pages/bulk-move',
+    'Followup: cross-drive move authz should reject pending target-drive members — tracked in plan.md.',
+  ],
+  [
+    'pages/tree',
+    'Followup: tree-render authz should reject pending members — tracked in plan.md.',
+  ],
+]);
+
+const DRIVE_MEMBERS_REFERENCE = /\bdriveMembers\b/;
+const ACCEPTED_AT_GATE = /isNotNull\s*\(\s*driveMembers\.acceptedAt\s*\)/;
+
+function collectRouteFiles(dir: string): string[] {
+  const results: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (entry === 'node_modules' || entry === '.next' || entry === '__tests__') continue;
+    if (statSync(full).isDirectory()) {
+      results.push(...collectRouteFiles(full));
+    } else if (entry === 'route.ts') {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+function toLogicalPath(absolutePath: string): string {
+  const relative = absolutePath.replace(API_DIR + '/', '');
+  return relative.replace(/\/route\.ts$/, '');
+}
+
+describe('Drive Member acceptedAt Gate Coverage', () => {
+  const routeFiles = collectRouteFiles(API_DIR);
+  const routes = routeFiles.map((f) => ({ path: toLogicalPath(f), file: f }));
+
+  it('given any route that reads driveMembers, should compose isNotNull(driveMembers.acceptedAt) or be explicitly allow-listed', () => {
+    const violations: string[] = [];
+
+    for (const route of routes) {
+      const content = readFileSync(route.file, 'utf-8');
+      if (!DRIVE_MEMBERS_REFERENCE.test(content)) continue;
+      if (ACCEPTED_AT_GATE.test(content)) continue;
+      if (ACCEPTED_AT_GATE_EXEMPT.has(route.path)) continue;
+      violations.push(route.path);
+    }
+
+    expect(violations).toEqual([]);
+    if (violations.length > 0) {
+      console.error(
+        `\nDrive member authz gate missing for ${violations.length} route(s):\n` +
+          violations.map((v) => `  - ${v}`).join('\n') +
+          `\n\nFix: Add isNotNull(driveMembers.acceptedAt) to the WHERE clause` +
+          `\n     of every authz read of driveMembers, OR add the route to` +
+          `\n     ACCEPTED_AT_GATE_EXEMPT with a one-line justification.\n`
+      );
+    }
+  });
+
+  it('allow-list should not contain stale entries for routes that no longer reference driveMembers', () => {
+    const stale: string[] = [];
+
+    for (const [pattern] of ACCEPTED_AT_GATE_EXEMPT) {
+      const route = routes.find((r) => r.path === pattern);
+      if (!route) {
+        stale.push(`${pattern} (route file not found)`);
+        continue;
+      }
+      const content = readFileSync(route.file, 'utf-8');
+      if (!DRIVE_MEMBERS_REFERENCE.test(content)) {
+        stale.push(`${pattern} (no longer references driveMembers)`);
+      }
+    }
+
+    expect(stale).toEqual([]);
+    if (stale.length > 0) {
+      console.error(
+        `\nStale ACCEPTED_AT_GATE_EXEMPT entries:\n` +
+          stale.map((s) => `  - ${s}`).join('\n') +
+          `\n\nRemove these entries from the allow-list.\n`
+      );
+    }
+  });
+
+  it('allow-list entries should each carry a justification (no empty reasons)', () => {
+    const empty: string[] = [];
+    for (const [pattern, reason] of ACCEPTED_AT_GATE_EXEMPT) {
+      if (!reason || reason.trim().length < 10) {
+        empty.push(pattern);
+      }
+    }
+    expect(empty).toEqual([]);
+  });
+
+  it('coverage scan should discover a non-trivial number of routes (sanity check)', () => {
+    expect(routes.length).toBeGreaterThanOrEqual(50);
+  });
+});

--- a/apps/web/src/app/api/activity/summary/__tests__/route.test.ts
+++ b/apps/web/src/app/api/activity/summary/__tests__/route.test.ts
@@ -42,6 +42,7 @@ vi.mock('@pagespace/db/operators', () => ({
   ne: vi.fn(),
   sql: Object.assign(vi.fn(), { join: vi.fn() }),
   count: vi.fn(),
+  isNotNull: vi.fn(),
 }));
 vi.mock('@pagespace/db/schema/core', () => ({
   pages: { driveId: 'driveId', isTrashed: 'isTrashed', updatedAt: 'updatedAt' },

--- a/apps/web/src/app/api/activity/summary/route.ts
+++ b/apps/web/src/app/api/activity/summary/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db } from '@pagespace/db/db'
-import { eq, and, or, lt, gte, ne, sql, count } from '@pagespace/db/operators'
+import { eq, and, or, lt, gte, ne, sql, count, isNotNull } from '@pagespace/db/operators'
 import { pages, drives } from '@pagespace/db/schema/core'
 import { driveMembers } from '@pagespace/db/schema/members'
 import { taskItems } from '@pagespace/db/schema/tasks'
@@ -126,7 +126,10 @@ export async function GET(req: Request) {
     // First get drives user has access to (both owned and member drives)
     const [ownedDrives, memberDrives] = await Promise.all([
       db.select({ driveId: drives.id }).from(drives).where(eq(drives.ownerId, userId)),
-      db.select({ driveId: driveMembers.driveId }).from(driveMembers).where(eq(driveMembers.userId, userId)),
+      db.select({ driveId: driveMembers.driveId }).from(driveMembers).where(and(
+        eq(driveMembers.userId, userId),
+        isNotNull(driveMembers.acceptedAt)
+      )),
     ]);
 
     // Combine and deduplicate drive IDs

--- a/apps/web/src/app/api/drives/[driveId]/assignees/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/assignees/__tests__/route.test.ts
@@ -27,6 +27,7 @@ vi.mock('@pagespace/db/db', () => ({
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((a: unknown, b: unknown) => ({ _type: 'eq', a, b })),
   and: vi.fn((...args: unknown[]) => ({ _type: 'and', args })),
+  isNotNull: vi.fn((a: unknown) => ({ _type: 'isNotNull', a })),
 }));
 vi.mock('@pagespace/db/schema/auth', () => ({
   users: {

--- a/apps/web/src/app/api/drives/[driveId]/assignees/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/assignees/route.ts
@@ -3,7 +3,7 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log'
 import { getUserDriveAccess, canUserViewPage } from '@pagespace/lib/permissions/permissions';
 import { db } from '@pagespace/db/db'
-import { eq, and } from '@pagespace/db/operators'
+import { eq, and, isNotNull } from '@pagespace/db/operators'
 import { users } from '@pagespace/db/schema/auth'
 import { pages, drives } from '@pagespace/db/schema/core'
 import { driveMembers, userProfiles } from '@pagespace/db/schema/members';
@@ -76,7 +76,10 @@ export async function GET(
       .from(driveMembers)
       .leftJoin(users, eq(driveMembers.userId, users.id))
       .leftJoin(userProfiles, eq(driveMembers.userId, userProfiles.userId))
-      .where(eq(driveMembers.driveId, driveId));
+      .where(and(
+        eq(driveMembers.driveId, driveId),
+        isNotNull(driveMembers.acceptedAt)
+      ));
 
     // Fetch AI agents in the drive
     const allAgents = await db

--- a/apps/web/src/app/api/drives/[driveId]/pages/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/pages/route.ts
@@ -111,7 +111,8 @@ export async function GET(
         .where(and(
           eq(driveMembers.driveId, drive.id),
           eq(driveMembers.userId, userId),
-          eq(driveMembers.role, 'ADMIN')
+          eq(driveMembers.role, 'ADMIN'),
+          isNotNull(driveMembers.acceptedAt)
         ))
         .limit(1);
 

--- a/apps/web/src/app/api/drives/[driveId]/permissions-tree/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/permissions-tree/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { db } from '@pagespace/db/db'
-import { eq, and } from '@pagespace/db/operators';
+import { eq, and, isNotNull } from '@pagespace/db/operators';
 import { drives, pages } from '@pagespace/db/schema/core'
 import { pagePermissions, driveMembers } from '@pagespace/db/schema/members';
 import { verifyAuth } from '@/lib/auth';
@@ -53,7 +53,8 @@ export async function GET(
         .where(and(
           eq(driveMembers.driveId, driveId),
           eq(driveMembers.userId, user.id),
-          eq(driveMembers.role, 'ADMIN')
+          eq(driveMembers.role, 'ADMIN'),
+          isNotNull(driveMembers.acceptedAt)
         ))
         .limit(1);
 

--- a/apps/web/src/app/api/drives/[driveId]/trash/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/trash/__tests__/route.test.ts
@@ -25,6 +25,7 @@ vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((a, b) => ({ field: a, value: b })),
   and: vi.fn((...args: unknown[]) => args),
   asc: vi.fn((col) => ({ column: col, direction: 'asc' })),
+  isNotNull: vi.fn((a) => ({ field: a, op: 'isNotNull' })),
 }));
 vi.mock('@pagespace/db/schema/core', () => ({
   drives: { id: 'drives.id', ownerId: 'drives.ownerId' },

--- a/apps/web/src/app/api/drives/[driveId]/trash/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/trash/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { db } from '@pagespace/db/db'
-import { and, eq, asc } from '@pagespace/db/operators'
+import { and, eq, asc, isNotNull } from '@pagespace/db/operators'
 import { drives, pages } from '@pagespace/db/schema/core'
 import { driveMembers } from '@pagespace/db/schema/members';
 import { buildTree } from '@pagespace/lib/content/tree-utils'
@@ -50,7 +50,8 @@ export async function GET(request: Request, context: { params: Promise<DrivePara
         .where(and(
           eq(driveMembers.driveId, driveId),
           eq(driveMembers.userId, auth.userId),
-          eq(driveMembers.role, 'ADMIN')
+          eq(driveMembers.role, 'ADMIN'),
+          isNotNull(driveMembers.acceptedAt)
         ))
         .limit(1);
 

--- a/apps/web/src/app/api/pulse/cron/route.ts
+++ b/apps/web/src/app/api/pulse/cron/route.ts
@@ -10,7 +10,7 @@ import {
   formatDateInTimezone,
 } from '@/lib/ai/core';
 import { db } from '@pagespace/db/db'
-import { eq, and, or, lt, gte, ne, desc, inArray, isNull } from '@pagespace/db/operators'
+import { eq, and, or, lt, gte, ne, desc, inArray, isNull, isNotNull } from '@pagespace/db/operators'
 import { users } from '@pagespace/db/schema/auth'
 import { sessions } from '@pagespace/db/schema/sessions'
 import { pages, drives, userMentions, chatMessages } from '@pagespace/db/schema/core'
@@ -145,7 +145,10 @@ async function generatePulseForUser(userId: string, now: Date): Promise<void> {
   const userDrives = await db
     .select({ driveId: driveMembers.driveId })
     .from(driveMembers)
-    .where(eq(driveMembers.userId, userId));
+    .where(and(
+      eq(driveMembers.userId, userId),
+      isNotNull(driveMembers.acceptedAt)
+    ));
   const driveIds = userDrives.map(d => d.driveId);
 
   // ========================================
@@ -174,7 +177,8 @@ async function generatePulseForUser(userId: string, now: Date): Promise<void> {
     .leftJoin(users, eq(users.id, driveMembers.userId))
     .where(and(
       inArray(driveMembers.driveId, driveIds),
-      ne(driveMembers.userId, userId)
+      ne(driveMembers.userId, userId),
+      isNotNull(driveMembers.acceptedAt)
     )) : [];
 
   const teamByDrive = teamMembers.reduce((acc, m) => {

--- a/apps/web/src/app/api/pulse/generate/route.ts
+++ b/apps/web/src/app/api/pulse/generate/route.ts
@@ -12,7 +12,7 @@ import {
   formatDateInTimezone,
 } from '@/lib/ai/core';
 import { db } from '@pagespace/db/db'
-import { eq, and, or, lt, gte, ne, desc, inArray } from '@pagespace/db/operators'
+import { eq, and, or, lt, gte, ne, desc, inArray, isNotNull } from '@pagespace/db/operators'
 import { users } from '@pagespace/db/schema/auth'
 import { pages, drives, userMentions, chatMessages } from '@pagespace/db/schema/core'
 import { activityLogs } from '@pagespace/db/schema/monitoring'
@@ -81,7 +81,10 @@ export async function POST(req: Request) {
     const userDrives = await db
       .select({ driveId: driveMembers.driveId })
       .from(driveMembers)
-      .where(eq(driveMembers.userId, userId));
+      .where(and(
+        eq(driveMembers.userId, userId),
+        isNotNull(driveMembers.acceptedAt)
+      ));
     const driveIds = userDrives.map(d => d.driveId);
 
     // ========================================
@@ -110,7 +113,8 @@ export async function POST(req: Request) {
       .leftJoin(users, eq(users.id, driveMembers.userId))
       .where(and(
         inArray(driveMembers.driveId, driveIds),
-        ne(driveMembers.userId, userId)
+        ne(driveMembers.userId, userId),
+        isNotNull(driveMembers.acceptedAt)
       )) : [];
 
     const teamByDrive = teamMembers.reduce((acc, m) => {

--- a/apps/web/src/app/api/pulse/route.ts
+++ b/apps/web/src/app/api/pulse/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { db } from '@pagespace/db/db'
-import { eq, and, or, lt, gte, ne, desc, count, inArray, isNull } from '@pagespace/db/operators'
+import { eq, and, or, lt, gte, ne, desc, count, inArray, isNull, isNotNull } from '@pagespace/db/operators'
 import { users } from '@pagespace/db/schema/auth'
 import { pages } from '@pagespace/db/schema/core'
 import { driveMembers } from '@pagespace/db/schema/members'
@@ -94,7 +94,10 @@ export async function GET(req: Request) {
       // User's drives
       db.select({ driveId: driveMembers.driveId })
         .from(driveMembers)
-        .where(eq(driveMembers.userId, userId)),
+        .where(and(
+          eq(driveMembers.userId, userId),
+          isNotNull(driveMembers.acceptedAt)
+        )),
       // Tasks overdue
       db.select({ count: count() })
         .from(taskItems)

--- a/packages/lib/src/__tests__/acceptedAt-gate.test.ts
+++ b/packages/lib/src/__tests__/acceptedAt-gate.test.ts
@@ -1,0 +1,157 @@
+/**
+ * acceptedAt Authz Gate — packages/lib structural coverage
+ *
+ * The Epic 1 hardening composes `isNotNull(driveMembers.acceptedAt)` into
+ * every authorization query that reads `drive_members`. These tests pin that
+ * structure into source so a future contributor cannot silently remove the
+ * gate from any covered function.
+ *
+ * Why structural source assertions instead of behavioural mocks: the existing
+ * service code calls Drizzle's query-builder chain directly. Mocking that
+ * chain per-test couples tests to query order and shape (which is exactly the
+ * brittle pattern Epic 2 will retire). A structural read of the source
+ * proves the gate is composed into the right WHERE clause without inventing a
+ * fake DB. The seam will move to a repository in Epic 2; these tests stay
+ * useful as long as the source has the function name they pin to.
+ *
+ * Each `it(...)` names the regression it catches.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const SRC = join(__dirname, '..');
+
+function read(rel: string): string {
+  return readFileSync(join(SRC, rel), 'utf-8');
+}
+
+/**
+ * Extract the body of a top-level exported async function by name.
+ * Returns the substring from the function declaration up to the next
+ * top-level `export ` token (or end-of-file).
+ */
+function extractFunctionBody(source: string, fnName: string): string {
+  const start = source.indexOf(`export async function ${fnName}`);
+  if (start === -1) {
+    throw new Error(`Function not found: ${fnName}`);
+  }
+  // Find next top-level export (function, const, etc.) after the declaration.
+  const restAfterStart = source.slice(start + 1);
+  const nextExportRel = restAfterStart.search(/\nexport (async function|function|const|interface|type)/);
+  const end = nextExportRel === -1 ? source.length : start + 1 + nextExportRel;
+  return source.slice(start, end);
+}
+
+const GATE = /isNotNull\s*\(\s*driveMembers\.acceptedAt\s*\)/;
+
+describe('drive-member-service.ts', () => {
+  const source = read('services/drive-member-service.ts');
+
+  it('given a non-owner caller, checkDriveAccess membership lookup gates pending rows (regression: pending row would otherwise grant isMember=true)', () => {
+    const body = extractFunctionBody(source, 'checkDriveAccess');
+    expect(body).toMatch(GATE);
+  });
+
+  it('given a non-owner caller, checkDriveAccess membership lookup must not grant ADMIN to pending rows (regression: pending admin would otherwise pass isAdmin=true)', () => {
+    const body = extractFunctionBody(source, 'checkDriveAccess');
+    expect(body).toMatch(GATE);
+    expect(body).toMatch(/role\s*===\s*'ADMIN'/);
+  });
+
+  it('getDriveMemberUserIds gates pending rows out of authz member lists (regression: pending row would surface in authz allow-lists)', () => {
+    const body = extractFunctionBody(source, 'getDriveMemberUserIds');
+    expect(body).toMatch(GATE);
+  });
+
+  it('getDriveRecipientUserIds gates pending rows out of broadcast recipient sets (regression: pending member would receive realtime events for a drive they have not accepted)', () => {
+    const body = extractFunctionBody(source, 'getDriveRecipientUserIds');
+    expect(body).toMatch(GATE);
+  });
+
+  it('isMemberOfDrive returns false for pending rows (regression: pending row would pass membership check)', () => {
+    const body = extractFunctionBody(source, 'isMemberOfDrive');
+    expect(body).toMatch(GATE);
+  });
+
+  it('owners (drive.ownerId) bypass membership lookup so the gate cannot lock them out (regression: gate must not affect drive owners)', () => {
+    const body = extractFunctionBody(source, 'checkDriveAccess');
+    expect(body).toMatch(/drive\.ownerId\s*===\s*userId/);
+    expect(body).toMatch(/isOwner: true, isAdmin: true, isMember: true/);
+  });
+});
+
+describe('drive-service.ts', () => {
+  const source = read('services/drive-service.ts');
+
+  it('listAccessibleDrives memberDrives query gates pending rows (regression: pending member would see drive in their accessible-drives list)', () => {
+    const body = extractFunctionBody(source, 'listAccessibleDrives');
+    expect(body).toMatch(GATE);
+  });
+
+  it('getDriveAccess non-owner branch gates pending rows (regression: pending row would return isMember=true through the bare access lookup)', () => {
+    const body = extractFunctionBody(source, 'getDriveAccess');
+    expect(body).toMatch(GATE);
+  });
+
+  it('getDriveAccessWithDrive non-owner branch gates pending rows (regression: bundled lookup would surface pending row as a member)', () => {
+    const body = extractFunctionBody(source, 'getDriveAccessWithDrive');
+    expect(body).toMatch(GATE);
+  });
+
+  describe('updateDriveLastAccessed (Slice 1.3 owner self-heal)', () => {
+    const body = extractFunctionBody(source, 'updateDriveLastAccessed');
+
+    it('given a legacy owner row with acceptedAt IS NULL, sets acceptedAt = now() via COALESCE on conflict (regression: gate would otherwise hide the owner from authz queries)', () => {
+      expect(body).toMatch(/onConflictDoUpdate/);
+      expect(body).toMatch(/acceptedAt:\s*sql`COALESCE\(\$\{driveMembers\.acceptedAt\},\s*\$\{now\}\)`/);
+    });
+
+    it('given the owner has no drive_members row at all, inserts one with acceptedAt = now() and role = OWNER (regression: missing row plus gate would lock the owner out)', () => {
+      expect(body).toMatch(/role:\s*'OWNER'/);
+      expect(body).toMatch(/acceptedAt:\s*now/);
+      expect(body).toMatch(/\.insert\(driveMembers\)/);
+    });
+
+    it('given a non-owner with acceptedAt IS NULL, only updates lastAccessedAt — never touches acceptedAt (regression: auto-accepting pending invitations on any drive access would defeat the invite flow)', () => {
+      // The non-owner path is the .update() branch. Capture it specifically by
+      // looking at the section AFTER the owner-branch return.
+      const ownerReturn = body.indexOf('return;');
+      expect(ownerReturn).toBeGreaterThan(-1);
+      const nonOwnerSection = body.slice(ownerReturn);
+      expect(nonOwnerSection).toMatch(/\.update\(driveMembers\)/);
+      expect(nonOwnerSection).toMatch(/lastAccessedAt:\s*now/);
+      expect(nonOwnerSection).not.toMatch(/acceptedAt/);
+    });
+  });
+});
+
+describe('permissions/permissions.ts', () => {
+  const source = read('permissions/permissions.ts');
+
+  it('getDriveIdsForUser memberDrives query gates pending rows (regression: pending member drives would appear in the access-list used by callers like search and pulse)', () => {
+    const body = extractFunctionBody(source, 'getDriveIdsForUser');
+    expect(body).toMatch(GATE);
+  });
+});
+
+describe('permissions/permission-mutations.ts', () => {
+  const source = read('permissions/permission-mutations.ts');
+
+  it('getPageIfCanShare admin-membership lookup gates pending rows (regression: pending admin would be able to grant or revoke share on pages in the drive they have not accepted)', () => {
+    // getPageIfCanShare is module-private; locate by name.
+    const start = source.indexOf('async function getPageIfCanShare');
+    expect(start).toBeGreaterThan(-1);
+    const restAfterStart = source.slice(start + 1);
+    const nextExportRel = restAfterStart.search(/\n(export |async function )/);
+    const end = nextExportRel === -1 ? source.length : start + 1 + nextExportRel;
+    const body = source.slice(start, end);
+
+    // The function has multiple driveMembers branches; assert the gate is in
+    // the admin lookup specifically by checking the same fragment is adjacent
+    // to the ADMIN role check.
+    expect(body).toMatch(/eq\(driveMembers\.role,\s*'ADMIN'\)/);
+    expect(body).toMatch(GATE);
+  });
+});

--- a/packages/lib/src/__tests__/multi-tenant-isolation.test.ts
+++ b/packages/lib/src/__tests__/multi-tenant-isolation.test.ts
@@ -65,6 +65,7 @@ vi.mock('@pagespace/db/schema/storage', () => ({
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((field: string, value: unknown) => ({ field, value })),
   and: vi.fn((...conditions: unknown[]) => ({ conditions })),
+  isNotNull: vi.fn((a: unknown) => ({ isNotNull: a })),
 }));
 
 // Mock permissions functions

--- a/packages/lib/src/permissions/__tests__/permission-mutations-unit.test.ts
+++ b/packages/lib/src/permissions/__tests__/permission-mutations-unit.test.ts
@@ -29,6 +29,7 @@ vi.mock('@pagespace/db/schema/auth', () => ({
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((_a, _b) => 'eq'),
   and: vi.fn((...args) => ({ and: args })),
+  isNotNull: vi.fn((a) => ({ isNotNull: a })),
 }));
 
 vi.mock('@paralleldrive/cuid2', () => ({

--- a/packages/lib/src/permissions/permission-mutations.ts
+++ b/packages/lib/src/permissions/permission-mutations.ts
@@ -8,7 +8,7 @@
 
 import { z } from 'zod';
 import { db } from '@pagespace/db/db';
-import { and, eq } from '@pagespace/db/operators';
+import { and, eq, isNotNull } from '@pagespace/db/operators';
 import { users } from '@pagespace/db/schema/auth';
 import { pages, drives } from '@pagespace/db/schema/core';
 import { driveMembers, pagePermissions } from '@pagespace/db/schema/members';
@@ -130,7 +130,8 @@ async function getPageIfCanShare(
       and(
         eq(driveMembers.driveId, page.driveId),
         eq(driveMembers.userId, userId),
-        eq(driveMembers.role, 'ADMIN')
+        eq(driveMembers.role, 'ADMIN'),
+        isNotNull(driveMembers.acceptedAt)
       )
     )
     .limit(1);

--- a/packages/lib/src/permissions/permissions.ts
+++ b/packages/lib/src/permissions/permissions.ts
@@ -47,7 +47,10 @@ export async function getDriveIdsForUser(userId: string): Promise<string[]> {
 
   const memberDrives = await db.select({ driveId: driveMembers.driveId })
     .from(driveMembers)
-    .where(eq(driveMembers.userId, userId));
+    .where(and(
+      eq(driveMembers.userId, userId),
+      isNotNull(driveMembers.acceptedAt),
+    ));
 
   for (const membership of memberDrives) {
     driveIdSet.add(membership.driveId);

--- a/packages/lib/src/services/__tests__/drive-member-service.test.ts
+++ b/packages/lib/src/services/__tests__/drive-member-service.test.ts
@@ -52,6 +52,7 @@ vi.mock('@pagespace/db/schema/members', () => ({
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((a, b) => ({ op: 'eq', a, b })),
   and: vi.fn((...args: unknown[]) => ({ op: 'and', args })),
+  isNotNull: vi.fn((a) => ({ op: 'isNotNull', a })),
   sql: vi.fn(),
 }));
 

--- a/packages/lib/src/services/__tests__/drive-service.test.ts
+++ b/packages/lib/src/services/__tests__/drive-service.test.ts
@@ -37,6 +37,7 @@ vi.mock('@pagespace/db/operators', () => ({
   and: vi.fn((...args) => ({ op: 'and', args })),
   not: vi.fn((a) => ({ op: 'not', a })),
   inArray: vi.fn((a, b) => ({ op: 'inArray', a, b })),
+  isNotNull: vi.fn((a) => ({ op: 'isNotNull', a })),
 }));
 
 import { db } from '@pagespace/db/db';

--- a/packages/lib/src/services/drive-member-service.ts
+++ b/packages/lib/src/services/drive-member-service.ts
@@ -6,7 +6,7 @@
  */
 
 import { db } from '@pagespace/db/db';
-import { eq, and, sql } from '@pagespace/db/operators';
+import { eq, and, sql, isNotNull } from '@pagespace/db/operators';
 import { users } from '@pagespace/db/schema/auth';
 import { drives, pages } from '@pagespace/db/schema/core';
 import { driveMembers, userProfiles, driveRoles, pagePermissions } from '@pagespace/db/schema/members';
@@ -92,7 +92,11 @@ export async function checkDriveAccess(
   const membership = await db
     .select({ role: driveMembers.role })
     .from(driveMembers)
-    .where(and(eq(driveMembers.driveId, driveId), eq(driveMembers.userId, userId)))
+    .where(and(
+      eq(driveMembers.driveId, driveId),
+      eq(driveMembers.userId, userId),
+      isNotNull(driveMembers.acceptedAt),
+    ))
     .limit(1);
 
   if (membership.length === 0) {
@@ -116,7 +120,10 @@ export async function getDriveMemberUserIds(driveId: string): Promise<string[]> 
   const members = await db
     .select({ userId: driveMembers.userId })
     .from(driveMembers)
-    .where(eq(driveMembers.driveId, driveId));
+    .where(and(
+      eq(driveMembers.driveId, driveId),
+      isNotNull(driveMembers.acceptedAt),
+    ));
 
   return members.map((m) => m.userId);
 }
@@ -138,7 +145,10 @@ export async function getDriveRecipientUserIds(driveId: string): Promise<string[
   const members = await db
     .select({ userId: driveMembers.userId })
     .from(driveMembers)
-    .where(eq(driveMembers.driveId, driveId));
+    .where(and(
+      eq(driveMembers.driveId, driveId),
+      isNotNull(driveMembers.acceptedAt),
+    ));
 
   const userIds = new Set([drive.ownerId, ...members.map((m) => m.userId)]);
   return Array.from(userIds);
@@ -214,7 +224,11 @@ export async function isMemberOfDrive(driveId: string, userId: string): Promise<
   const existing = await db
     .select({ id: driveMembers.id })
     .from(driveMembers)
-    .where(and(eq(driveMembers.driveId, driveId), eq(driveMembers.userId, userId)))
+    .where(and(
+      eq(driveMembers.driveId, driveId),
+      eq(driveMembers.userId, userId),
+      isNotNull(driveMembers.acceptedAt),
+    ))
     .limit(1);
 
   return existing.length > 0;

--- a/packages/lib/src/services/drive-service.ts
+++ b/packages/lib/src/services/drive-service.ts
@@ -387,10 +387,13 @@ export async function restoreDrive(driveId: string): Promise<typeof drives.$infe
 /**
  * Update a user's last accessed timestamp for a drive.
  *
- * Owner self-heal: the new acceptedAt gate (Epic 1) hides any drive_members
- * row with acceptedAt IS NULL from authz queries. Legacy owner rows without
- * acceptedAt would therefore stop authorizing the owner. To avoid that, the
- * owner path upserts and backfills acceptedAt via COALESCE on conflict.
+ * Owner self-heal: the new acceptedAt gate (Epic 1) excludes drive_members
+ * rows with acceptedAt IS NULL from member-list queries (lastAccessedAt
+ * lookup, sidebar role display, recipient broadcast). Owners reach drives
+ * via drives.ownerId so they are not locked out of authz, but a legacy
+ * owner row with acceptedAt = NULL would stop populating those member-list
+ * paths. The owner branch upserts and backfills acceptedAt via COALESCE on
+ * conflict so the gate becomes a no-op for owner rows.
  *
  * Non-owners are never auto-accepted — pending invitations must be claimed
  * through the post-login acceptance flow (Epic 3).

--- a/packages/lib/src/services/drive-service.ts
+++ b/packages/lib/src/services/drive-service.ts
@@ -6,7 +6,7 @@
  */
 
 import { db } from '@pagespace/db/db';
-import { eq, and, not, inArray } from '@pagespace/db/operators';
+import { eq, and, not, inArray, isNotNull, sql } from '@pagespace/db/operators';
 import { drives, pages } from '@pagespace/db/schema/core';
 import { driveMembers, pagePermissions } from '@pagespace/db/schema/members';
 import { slugify } from '../utils/utils';
@@ -77,7 +77,10 @@ export async function listAccessibleDrives(
   const memberDrives = await db
     .selectDistinct({ driveId: driveMembers.driveId, role: driveMembers.role, lastAccessedAt: driveMembers.lastAccessedAt })
     .from(driveMembers)
-    .where(eq(driveMembers.userId, userId));
+    .where(and(
+      eq(driveMembers.userId, userId),
+      isNotNull(driveMembers.acceptedAt),
+    ));
 
   // 3. Get drives where user has page-level permissions
   // Skip this if tokenScopable is true (only owned + member drives can be scoped to tokens)
@@ -212,7 +215,11 @@ export async function getDriveAccess(
   const membership = await db
     .select({ role: driveMembers.role })
     .from(driveMembers)
-    .where(and(eq(driveMembers.driveId, driveId), eq(driveMembers.userId, userId)))
+    .where(and(
+      eq(driveMembers.driveId, driveId),
+      eq(driveMembers.userId, userId),
+      isNotNull(driveMembers.acceptedAt),
+    ))
     .limit(1);
 
   if (membership.length > 0) {
@@ -260,7 +267,11 @@ export async function getDriveAccessWithDrive(
   const membership = await db
     .select({ role: driveMembers.role })
     .from(driveMembers)
-    .where(and(eq(driveMembers.driveId, driveId), eq(driveMembers.userId, userId)))
+    .where(and(
+      eq(driveMembers.driveId, driveId),
+      eq(driveMembers.userId, userId),
+      isNotNull(driveMembers.acceptedAt),
+    ))
     .limit(1);
 
   if (membership.length > 0) {
@@ -375,25 +386,18 @@ export async function restoreDrive(driveId: string): Promise<typeof drives.$infe
 
 /**
  * Update a user's last accessed timestamp for a drive.
- * Tries updating an existing driveMembers row first. If no row was affected
- * (e.g., drive owner without a driveMembers entry), inserts one with OWNER role
- * only when the user actually owns the drive.
+ *
+ * Owner self-heal: the new acceptedAt gate (Epic 1) hides any drive_members
+ * row with acceptedAt IS NULL from authz queries. Legacy owner rows without
+ * acceptedAt would therefore stop authorizing the owner. To avoid that, the
+ * owner path upserts and backfills acceptedAt via COALESCE on conflict.
+ *
+ * Non-owners are never auto-accepted — pending invitations must be claimed
+ * through the post-login acceptance flow (Epic 3).
  */
 export async function updateDriveLastAccessed(userId: string, driveId: string): Promise<void> {
   const now = new Date();
 
-  // Try updating existing membership row
-  const updated = await db.update(driveMembers)
-    .set({ lastAccessedAt: now })
-    .where(and(
-      eq(driveMembers.userId, userId),
-      eq(driveMembers.driveId, driveId)
-    ))
-    .returning({ id: driveMembers.id });
-
-  if (updated.length > 0) return;
-
-  // No membership row — check if user is the drive owner before inserting
   const [drive] = await db.select({ ownerId: drives.ownerId })
     .from(drives)
     .where(eq(drives.id, driveId))
@@ -405,12 +409,24 @@ export async function updateDriveLastAccessed(userId: string, driveId: string): 
         driveId,
         userId,
         role: 'OWNER',
-        lastAccessedAt: now,
         invitedAt: now,
+        acceptedAt: now,
+        lastAccessedAt: now,
       })
       .onConflictDoUpdate({
         target: [driveMembers.driveId, driveMembers.userId],
-        set: { lastAccessedAt: now },
+        set: {
+          lastAccessedAt: now,
+          acceptedAt: sql`COALESCE(${driveMembers.acceptedAt}, ${now})`,
+        },
       });
+    return;
   }
+
+  await db.update(driveMembers)
+    .set({ lastAccessedAt: now })
+    .where(and(
+      eq(driveMembers.userId, userId),
+      eq(driveMembers.driveId, driveId)
+    ));
 }

--- a/plan.md
+++ b/plan.md
@@ -34,6 +34,9 @@ justification, and should be revisited as a follow-up:
   can't pull pages into a drive they haven't accepted into.
 - `apps/web/src/app/api/pages/tree/route.ts` — drive membership lookup for
   the tree-rendering authz check; same gate.
+- `packages/lib/src/services/drive-role-service.ts` — `checkDriveAccessForRoles`
+  membership lookup; same `acceptedAt` gate needed so a pending member
+  can't read or modify drive roles before accepting their invitation.
 
 ## Recently Completed
 

--- a/plan.md
+++ b/plan.md
@@ -8,6 +8,33 @@
 - [E2E and Load Testing](tasks/e2e-and-load-testing.md) — Playwright e2e for core user journeys + k6 load scenarios with Grafana dashboard for API latency and Postgres pool monitoring.
 - [Task List Agent Triggers Follow-up](tasks/task-list-agent-triggers-followup.md) — close PR #1177 post-merge gaps: cross-surface discoverability via TaskDetailSheet, page-scoped task broadcasts for collaborative real-time, agent-parity (instructionPageId + contextPageIds) in the trigger dialog, "anchored to" clarity in the page-level Workflows dialog, and small polish + correctness fixes.
 
+## Drive Invites by Email — followups
+
+Follow-up authz queries on `drive_members` discovered during Epic 1 gate
+hardening. These were left out of Epic 1 to keep the PR tight (security
+hardening only); each callsite is allow-listed in
+`apps/web/src/app/api/__tests__/drive-member-gate-coverage.test.ts` with a
+justification, and should be revisited as a follow-up:
+
+- `apps/web/src/app/api/account/drives-status/route.ts` — admin lookup for the
+  drive-transfer UI; should gate on `acceptedAt` so a pending admin can't be
+  offered as a transfer target.
+- `apps/web/src/app/api/account/handle-drive/route.ts` — drive-transfer POST
+  validates the new owner is an admin; same gate needed so transfer to a
+  pending admin is rejected.
+- `apps/web/src/app/api/admin/global-prompt/route.ts` — admin tool listing
+  member drives for global-prompt scoping; gate so pending invitations don't
+  surface in the admin's drive picker.
+- `apps/web/src/app/api/channels/[pageId]/messages/route.ts` — admin
+  membership lookup for mention notifications; pending admins shouldn't
+  receive @mentions before accepting.
+- `apps/web/src/app/api/pages/bulk-copy/route.ts`,
+  `apps/web/src/app/api/pages/bulk-move/route.ts` — target-drive membership
+  check used to authorise cross-drive copy/move; gate so a pending member
+  can't pull pages into a drive they haven't accepted into.
+- `apps/web/src/app/api/pages/tree/route.ts` — drive membership lookup for
+  the tree-rendering authz check; same gate.
+
 ## Recently Completed
 
 - [BYOK Retirement](tasks/archive/2026-05-01-byok-retirement.md) — ✅ 2026-05-01 — Drop `user_ai_settings`, route all AI calls through `*_DEFAULT_API_KEY` env vars, broaden per-tier rate-limit gate to every managed provider; breaking change for self-hosters.


### PR DESCRIPTION
## Summary

Epic 1 of 6 in the `pu/invites` redo. Closes the dormant authz gap where the
`drive_members` schema permits `acceptedAt IS NULL` (pending invitations) but
most authz queries did not filter on it. Today the gap is harmless — nothing
creates pending rows — but Epic 4 will. Shipping the gate first means Epic 4's
pending-row creation is born safe.

**No behavior change for current users.** Every existing `drive_members` row
has `acceptedAt` set, so the new filters are no-ops on production data.

This PR is split into four slices, each shipped as its own commit:

### Slice 1.1 — service-level authz queries (`fix(authz): gate drive member service queries on acceptedAt`)
Compose `isNotNull(driveMembers.acceptedAt)` into:
- `checkDriveAccess`, `getDriveMemberUserIds`, `getDriveRecipientUserIds`,
  `isMemberOfDrive` (`packages/lib/src/services/drive-member-service.ts`)
- `listAccessibleDrives` member query, `getDriveAccess`,
  `getDriveAccessWithDrive` (`packages/lib/src/services/drive-service.ts`)
- `getDriveIdsForUser` (`packages/lib/src/permissions/permissions.ts`)
- `getPageIfCanShare` admin lookup
  (`packages/lib/src/permissions/permission-mutations.ts`)

Owners (drive ownership via `drives.ownerId`) are unaffected — they bypass
the membership lookup entirely.

### Slice 1.2 — read-side route surfaces (`fix(authz): gate read-side route queries on acceptedAt`)
Same gate applied to read-side route queries that compute access lists:
`drives/[driveId]/{pages,permissions-tree,trash,assignees}`,
`pulse/{cron,generate}`, `pulse`, `activity/summary`.

### Slice 1.3 — owner row self-heal (folded into commit 1)
`updateDriveLastAccessed` now upserts the owner row with
`acceptedAt = COALESCE(existing, now())` so legacy owner rows with
`acceptedAt IS NULL` get backfilled on next access. Non-owner rows are
left alone — pending invitations are claimed through the post-login
flow (Epic 3), never auto-accepted.

### Slice 1.4 — adversarial coverage gate (`test(authz): coverage gate for drive member acceptedAt`)
Static-analysis test
(`apps/web/src/app/api/__tests__/drive-member-gate-coverage.test.ts`)
that scans every API route for `driveMembers` references and fails unless
the file either composes the gate or appears in an explicit allow-list
with a justification. Companion tests prevent stale allow-list entries
and missing justifications.

The allow-list captures the intentional pending-visibility surface
(`drives/[driveId]/members/[userId]` GET, used to render "Invitation pending"
in the UI) and seven follow-up routes whose authz reads of `driveMembers`
need the same gate but were left out of Epic 1 to keep the diff tight.
A separate follow-up was discovered in `packages/lib/src/services/drive-role-service.ts`
(`checkDriveAccessForRoles`). All follow-ups are recorded in `plan.md`
under "Drive Invites by Email — followups".

## Inspiration source

PR #1229 (`pu/invites`, ~3k LOC, 131 review comments) bundled this gate
with refactor + auth-flow + email-invite work and was too big to land
cleanly. This is one of six properly-scoped PRs replacing it.

## Test plan

- [x] `pnpm --filter @pagespace/lib exec vitest run src/__tests__/acceptedAt-gate.test.ts` — 14/14 pass
- [x] `pnpm --filter web exec vitest run src/app/api/__tests__/drive-member-gate-coverage.test.ts` — 4/4 pass
- [x] Full lib test suite — 156 files / 3874 tests pass after rebase on latest master
- [x] Existing service/permission unit tests still green after `isNotNull` added to operator mocks
- [x] `pnpm --filter @pagespace/lib typecheck` — clean
- [x] Monorepo `pnpm typecheck` — clean (exit 0)
- [x] ESLint clean on every changed file
- [x] Branch rebased on latest master (no merge conflicts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)