### PR TITLE
feat(tasks): always-visible row menu + long-press

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -40,6 +40,12 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from '@/components/ui/context-menu';
+import {
   Plus,
   Search,
   MoreHorizontal,
@@ -313,10 +319,11 @@ interface SortableTaskRowProps {
   task: TaskItem;
   canEdit: boolean;
   isCompleted: boolean;
+  contextMenu?: React.ReactNode;
   children: React.ReactNode;
 }
 
-function SortableTaskRow({ task, canEdit, isCompleted, children }: SortableTaskRowProps) {
+function SortableTaskRow({ task, canEdit, isCompleted, contextMenu, children }: SortableTaskRowProps) {
   const {
     attributes,
     listeners,
@@ -331,12 +338,11 @@ function SortableTaskRow({ task, canEdit, isCompleted, children }: SortableTaskR
     transition,
   };
 
-  return (
+  const row = (
     <TableRow
       ref={setNodeRef}
       style={style}
       className={cn(
-        'group',
         isCompleted && 'opacity-60',
         isDragging && 'opacity-50 bg-muted'
       )}
@@ -355,6 +361,15 @@ function SortableTaskRow({ task, canEdit, isCompleted, children }: SortableTaskR
       </TableCell>
       {children}
     </TableRow>
+  );
+
+  if (!contextMenu) return row;
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>{row}</ContextMenuTrigger>
+      {contextMenu}
+    </ContextMenu>
   );
 }
 
@@ -929,6 +944,32 @@ function TaskListView({ page }: TaskListViewProps) {
                         task={task}
                         canEdit={canEdit}
                         isCompleted={isCompletedStatus(task.status, statusConfigs)}
+                        contextMenu={
+                          <ContextMenuContent>
+                            {task.pageId && (
+                              <ContextMenuItem onSelect={() => router.push(`/dashboard/${page.driveId}/${task.pageId}`)}>
+                                <FileText className="h-4 w-4 mr-2" />
+                                Open
+                              </ContextMenuItem>
+                            )}
+                            <ContextMenuItem onSelect={() => handleStartEdit(task)} disabled={!canEdit}>
+                              <Pencil className="h-4 w-4 mr-2" />
+                              Rename
+                            </ContextMenuItem>
+                            <ContextMenuItem onSelect={() => setTriggerDialogTask(task)} disabled={!canEdit}>
+                              <Zap className="h-4 w-4 mr-2" />
+                              Agent triggers…
+                            </ContextMenuItem>
+                            <ContextMenuItem
+                              onSelect={() => handleDeleteTask(task.id)}
+                              className="text-destructive"
+                              disabled={!canEdit}
+                            >
+                              <Trash2 className="h-4 w-4 mr-2" />
+                              Delete
+                            </ContextMenuItem>
+                          </ContextMenuContent>
+                        }
                       >
                         {/* Checkbox */}
                         <TableCell>
@@ -1059,39 +1100,37 @@ function TaskListView({ page }: TaskListViewProps) {
 
                         {/* Actions */}
                         <TableCell>
-                          <div className="opacity-0 group-hover:opacity-100 transition-opacity">
-                            <DropdownMenu>
-                              <DropdownMenuTrigger asChild>
-                                <Button variant="ghost" size="icon" className="h-8 w-8">
-                                  <MoreHorizontal className="h-4 w-4" />
-                                </Button>
-                              </DropdownMenuTrigger>
-                              <DropdownMenuContent align="end">
-                                {task.pageId && (
-                                  <DropdownMenuItem onClick={() => router.push(`/dashboard/${page.driveId}/${task.pageId}`)}>
-                                    <FileText className="h-4 w-4 mr-2" />
-                                    Open
-                                  </DropdownMenuItem>
-                                )}
-                                <DropdownMenuItem onClick={() => handleStartEdit(task)} disabled={!canEdit}>
-                                  <Pencil className="h-4 w-4 mr-2" />
-                                  Rename
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <Button variant="ghost" size="icon" className="h-8 w-8">
+                                <MoreHorizontal className="h-4 w-4" />
+                              </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                              {task.pageId && (
+                                <DropdownMenuItem onClick={() => router.push(`/dashboard/${page.driveId}/${task.pageId}`)}>
+                                  <FileText className="h-4 w-4 mr-2" />
+                                  Open
                                 </DropdownMenuItem>
-                                <DropdownMenuItem onClick={() => setTriggerDialogTask(task)} disabled={!canEdit}>
-                                  <Zap className="h-4 w-4 mr-2" />
-                                  Agent triggers…
-                                </DropdownMenuItem>
-                                <DropdownMenuItem
-                                  onClick={() => handleDeleteTask(task.id)}
-                                  className="text-destructive"
-                                  disabled={!canEdit}
-                                >
-                                  <Trash2 className="h-4 w-4 mr-2" />
-                                  Delete
-                                </DropdownMenuItem>
-                              </DropdownMenuContent>
-                            </DropdownMenu>
-                          </div>
+                              )}
+                              <DropdownMenuItem onClick={() => handleStartEdit(task)} disabled={!canEdit}>
+                                <Pencil className="h-4 w-4 mr-2" />
+                                Rename
+                              </DropdownMenuItem>
+                              <DropdownMenuItem onClick={() => setTriggerDialogTask(task)} disabled={!canEdit}>
+                                <Zap className="h-4 w-4 mr-2" />
+                                Agent triggers…
+                              </DropdownMenuItem>
+                              <DropdownMenuItem
+                                onClick={() => handleDeleteTask(task.id)}
+                                className="text-destructive"
+                                disabled={!canEdit}
+                              >
+                                <Trash2 className="h-4 w-4 mr-2" />
+                                Delete
+                              </DropdownMenuItem>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
                         </TableCell>
                       </SortableTaskRow>
                     ))}

--- a/apps/web/src/components/tasks/TaskTableRow.tsx
+++ b/apps/web/src/components/tasks/TaskTableRow.tsx
@@ -20,6 +20,12 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from '@/components/ui/context-menu';
 import { TableRow, TableCell } from '@/components/ui/table';
 import { cn } from '@/lib/utils';
 import { DueDatePicker } from '@/components/layout/middle-content/page-views/task-list/DueDatePicker';
@@ -76,7 +82,9 @@ export function TaskTableRow({
   const taskStatusOrder = getStatusOrder(statusConfigs);
 
   return (
-    <TableRow className={cn('group', isCompleted && 'opacity-60')}>
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+    <TableRow className={cn(isCompleted && 'opacity-60')}>
       <TableCell>
         <Checkbox
           checked={isCompleted}
@@ -209,32 +217,48 @@ export function TaskTableRow({
       </TableCell>
 
       <TableCell>
-        <div className="opacity-0 group-hover:opacity-100 transition-opacity">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon" className="h-8 w-8">
-                <MoreHorizontal className="h-4 w-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              {task.pageId && (
-                <DropdownMenuItem onClick={() => onNavigate(task)}>
-                  <FileText className="h-4 w-4 mr-2" />
-                  Open
-                </DropdownMenuItem>
-              )}
-              <DropdownMenuItem onClick={() => onStartEdit(task)}>
-                <Pencil className="h-4 w-4 mr-2" />
-                Rename
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" className="h-8 w-8">
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {task.pageId && (
+              <DropdownMenuItem onClick={() => onNavigate(task)}>
+                <FileText className="h-4 w-4 mr-2" />
+                Open
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => onDelete(task)} className="text-destructive">
-                <Trash2 className="h-4 w-4 mr-2" />
-                Delete
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
+            )}
+            <DropdownMenuItem onClick={() => onStartEdit(task)}>
+              <Pencil className="h-4 w-4 mr-2" />
+              Rename
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => onDelete(task)} className="text-destructive">
+              <Trash2 className="h-4 w-4 mr-2" />
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </TableCell>
     </TableRow>
+      </ContextMenuTrigger>
+      <ContextMenuContent>
+        {task.pageId && (
+          <ContextMenuItem onSelect={() => onNavigate(task)}>
+            <FileText className="h-4 w-4 mr-2" />
+            Open
+          </ContextMenuItem>
+        )}
+        <ContextMenuItem onSelect={() => onStartEdit(task)}>
+          <Pencil className="h-4 w-4 mr-2" />
+          Rename
+        </ContextMenuItem>
+        <ContextMenuItem onSelect={() => onDelete(task)} className="text-destructive">
+          <Trash2 className="h-4 w-4 mr-2" />
+          Delete
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }


### PR DESCRIPTION
## Summary
- Task-list rows no longer hide their 3-dot menu behind a hover state — the kebab button is always visible, making the actions discoverable and reachable on touch devices.
- Each row is now wrapped in a Radix `ContextMenu` (shadcn primitive) so right-click on desktop and native long-press on touch open the same Open / Rename / Agent triggers / Delete actions. Mirrors the existing pattern in `PageTreeItem.tsx`.

## Files
- `apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx` — Task List page-type view
- `apps/web/src/components/tasks/TaskTableRow.tsx` — global Tasks dashboard rows

`TaskMobileCard.tsx` already showed the menu unconditionally and is unchanged.

## Test plan
- [ ] Desktop: open a Task List page, confirm 3-dots are visible without hovering; right-click any row and confirm the context menu shows Open / Rename / Agent triggers… / Delete with working handlers.
- [ ] Desktop: open the global Tasks dashboard (`/dashboard/tasks`), confirm 3-dots always visible on `TaskTableRow`; right-click opens Open / Rename / Delete.
- [ ] Touch: in DevTools mobile emulation (or a real device), long-press a task row; the same context menu opens. (Radix uses native long-press; behavior in pure emulation may vary — prefer a real device check.)
- [ ] `pnpm --filter web typecheck` passes.
- [ ] `pnpm --filter web lint` clean for changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)