### PR TITLE
fix(connections): single-click send request

### DIFF
--- a/apps/web/src/app/dashboard/connections/page.tsx
+++ b/apps/web/src/app/dashboard/connections/page.tsx
@@ -9,7 +9,7 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
-import { Search, UserPlus, UserMinus, UserCheck, UserX, MessageSquare, MoreVertical, User } from 'lucide-react';
+import { UserPlus, UserMinus, UserCheck, UserX, MessageSquare, MoreVertical, User } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -51,24 +51,12 @@ interface Connection {
   isRequester: boolean;
 }
 
-interface SearchResult {
-  id: string;
-  name: string;
-  email: string;
-  image: string | null;
-  displayName: string | null;
-  bio: string | null;
-  avatarUrl: string | null;
-}
-
 export default function ConnectionsPage() {
   const { } = useAuth();
   const router = useRouter();
   const socket = useSocket();
   const [searchQuery, setSearchQuery] = useState('');
-  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
-  const [isSearching, setIsSearching] = useState(false);
-  const [sendingRequest, setSendingRequest] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [showVerificationAlert, setShowVerificationAlert] = useState(false);
 
   // Fetch accepted connections
@@ -102,43 +90,30 @@ export default function ConnectionsPage() {
     return () => { socket.off('notification:new', handleNotification); };
   }, [socket]);
 
-  const handleSearch = async () => {
-    if (!searchQuery.trim()) return;
+  const handleSendConnectionRequest = async () => {
+    const email = searchQuery.trim();
+    if (!email) return;
 
-    setIsSearching(true);
-    setSearchResults([]);
-
+    setIsSubmitting(true);
     try {
-      const response = await fetchWithAuth(`/api/connections/search?email=${encodeURIComponent(searchQuery)}`);
-      if (!response.ok) throw new Error('Search failed');
+      const response = await fetchWithAuth(`/api/connections/search?email=${encodeURIComponent(email)}`);
+      if (!response.ok) throw new Error('Failed to send connection request');
 
       const data = await response.json();
 
-      if (data.error) {
-        toast.error(data.error);
-      } else if (data.user) {
-        setSearchResults([data.user]);
-      } else {
-        toast.info('No user found with this email address');
+      if (!data.user) {
+        toast.error(data.error || 'No user found with this email address');
+        return;
       }
-    } catch (error) {
-      toast.error('Failed to search users');
-      console.error('Search error:', error);
-    } finally {
-      setIsSearching(false);
-    }
-  };
 
-  const handleSendRequest = async (targetUserId: string) => {
-    setSendingRequest(targetUserId);
-    try {
-      await post('/api/connections', { targetUserId });
+      const targetUser = data.user;
+      await post('/api/connections', { targetUserId: targetUser.id });
 
-      toast.success('Connection request sent');
-      setSearchResults(prev => prev.filter(u => u.id !== targetUserId));
+      const recipientLabel = targetUser.displayName || targetUser.name;
+      toast.success(`Connection request sent to ${recipientLabel} (${targetUser.email})`);
+      setSearchQuery('');
       mutate('/api/connections?status=PENDING');
     } catch (error) {
-      // Check if this is a verification required error
       const errorMessage = (error as Error).message;
       if (errorMessage.includes('requiresEmailVerification') || errorMessage.includes('verification')) {
         setShowVerificationAlert(true);
@@ -147,7 +122,7 @@ export default function ConnectionsPage() {
 
       toast.error(errorMessage || 'Failed to send connection request');
     } finally {
-      setSendingRequest(null);
+      setIsSubmitting(false);
     }
   };
 
@@ -401,49 +376,17 @@ export default function ConnectionsPage() {
                     placeholder="Enter email address"
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
-                    onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+                    onKeyDown={(e) => e.key === 'Enter' && handleSendConnectionRequest()}
+                    disabled={isSubmitting}
                   />
-                  <Button onClick={handleSearch} disabled={isSearching || !searchQuery.trim()}>
-                    <Search className="h-4 w-4 mr-2" />
-                    Add
+                  <Button
+                    onClick={handleSendConnectionRequest}
+                    disabled={isSubmitting || !searchQuery.trim()}
+                  >
+                    <UserPlus className="h-4 w-4 mr-2" />
+                    {isSubmitting ? 'Sending...' : 'Send Request'}
                   </Button>
                 </div>
-
-                {searchResults.length > 0 && (
-                  <div className="space-y-4">
-                    {searchResults.map((user) => {
-                      const displayName = user.displayName || user.name;
-                      return (
-                        <div key={user.id} className="flex items-center justify-between p-4 border rounded-lg">
-                          <div className="flex items-center gap-4">
-                            <Avatar className="h-10 w-10">
-                              <AvatarImage src={user.image || user.avatarUrl || ''} />
-                              <AvatarFallback>{displayName.charAt(0).toUpperCase()}</AvatarFallback>
-                            </Avatar>
-                            <div>
-                              <p className="font-medium">{displayName}</p>
-                              <p className="text-sm text-muted-foreground">{user.email}</p>
-                              {user.bio && (
-                                <p className="text-sm text-muted-foreground line-clamp-1 mt-1">{user.bio}</p>
-                              )}
-                            </div>
-                          </div>
-                          <Button
-                            onClick={() => handleSendRequest(user.id)}
-                            disabled={sendingRequest === user.id}
-                          >
-                            <UserPlus className="h-4 w-4 mr-2" />
-                            {sendingRequest === user.id ? 'Sending...' : 'Send Request'}
-                          </Button>
-                        </div>
-                      );
-                    })}
-                  </div>
-                )}
-
-                {isSearching && (
-                  <p className="text-center text-muted-foreground py-8">Searching...</p>
-                )}
               </div>
             </CardContent>
           </Card>

--- a/apps/web/src/app/dashboard/connections/page.tsx
+++ b/apps/web/src/app/dashboard/connections/page.tsx
@@ -55,7 +55,7 @@ export default function ConnectionsPage() {
   const { } = useAuth();
   const router = useRouter();
   const socket = useSocket();
-  const [searchQuery, setSearchQuery] = useState('');
+  const [email, setEmail] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showVerificationAlert, setShowVerificationAlert] = useState(false);
 
@@ -91,12 +91,12 @@ export default function ConnectionsPage() {
   }, [socket]);
 
   const handleSendConnectionRequest = async () => {
-    const email = searchQuery.trim();
-    if (!email) return;
+    const trimmedEmail = email.trim();
+    if (!trimmedEmail) return;
 
     setIsSubmitting(true);
     try {
-      const response = await fetchWithAuth(`/api/connections/search?email=${encodeURIComponent(email)}`);
+      const response = await fetchWithAuth(`/api/connections/search?email=${encodeURIComponent(trimmedEmail)}`);
       if (!response.ok) throw new Error('Failed to send connection request');
 
       const data = await response.json();
@@ -111,7 +111,7 @@ export default function ConnectionsPage() {
 
       const recipientLabel = targetUser.displayName || targetUser.name;
       toast.success(`Connection request sent to ${recipientLabel} (${targetUser.email})`);
-      setSearchQuery('');
+      setEmail('');
       mutate('/api/connections?status=PENDING');
     } catch (error) {
       const errorMessage = (error as Error).message;
@@ -374,14 +374,14 @@ export default function ConnectionsPage() {
                   <Input
                     type="email"
                     placeholder="Enter email address"
-                    value={searchQuery}
-                    onChange={(e) => setSearchQuery(e.target.value)}
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
                     onKeyDown={(e) => e.key === 'Enter' && handleSendConnectionRequest()}
                     disabled={isSubmitting}
                   />
                   <Button
                     onClick={handleSendConnectionRequest}
-                    disabled={isSubmitting || !searchQuery.trim()}
+                    disabled={isSubmitting || !email.trim()}
                   >
                     <UserPlus className="h-4 w-4 mr-2" />
                     {isSubmitting ? 'Sending...' : 'Send Request'}


### PR DESCRIPTION
## Summary
- Collapses the **Add Connection** tab's two-step flow (click *Add* to reveal a preview card, then click *Send Request*) into one click on a single **Send Request** button.
- Same handler runs on Enter from the email input.
- Success toast now names the recipient (`Connection request sent to {name} ({email})`), preserving the "did I get the right person?" feedback the preview card was providing.
- Errors from the existing `/api/connections/search` endpoint (no user found, already connected, request pending, blocked, self) surface as a single error toast; input stays populated so the user can correct it.
- No API changes — the same two round-trips happen, just chained on one click.

## Test plan
- [ ] `/dashboard/connections` → **Add Connection** tab: type a valid email, press Enter or click Send Request → success toast names recipient, input clears, request appears under **Pending**.
- [ ] Already-connected email → error toast `Already connected with this user`, input retained.
- [ ] Email with pending request → `Connection request already pending`.
- [ ] Own email → `Cannot connect with yourself`.
- [ ] Nonexistent email → `No user found with this email address`.
- [ ] Unverified user → `VerificationRequiredAlert` shows (existing behavior preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streamlined the connection discovery flow—send requests directly by email without multi-step search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->