### PR TITLE
feat(push): iOS notifications + badge sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -156,3 +156,14 @@ CRON_SECRET=generate_a_secure_cron_secret_for_scheduled_tasks
 # Generate a read-only GitHub PAT with packages:read scope
 # Used by: docker login ghcr.io -u <github-user> -p $REGISTRY_TOKEN
 REGISTRY_TOKEN=ghp_your_github_personal_access_token_here
+
+# Apple Push Notification service (iOS Capacitor app)
+# From developer.apple.com → Certificates, Identifiers & Profiles → Keys.
+# APNS_PRIVATE_KEY is the .p8 file contents in PEM format. When placed in a
+# .env file, the linebreaks must be preserved as literal \n so the variable
+# stays single-line, e.g.:
+#   APNS_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nMIGT...\n-----END PRIVATE KEY-----"
+APNS_TEAM_ID=your_10_char_apple_team_id
+APNS_KEY_ID=your_10_char_apns_key_id
+APNS_PRIVATE_KEY=your_p8_private_key_pem
+APNS_BUNDLE_ID=ai.pagespace.ios

--- a/apps/ios/ios/App/App.xcodeproj/project.pbxproj
+++ b/apps/ios/ios/App/App.xcodeproj/project.pbxproj
@@ -130,7 +130,6 @@
 					504EC3031FED79650016851F = {
 						CreatedOnToolsVersion = 9.2;
 						LastSwiftMigration = 1100;
-						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -347,6 +346,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = M96WTV3CKX;
@@ -361,6 +361,7 @@
 				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = ai.pagespace.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/apps/ios/ios/App/App.xcodeproj/xcshareddata/xcschemes/App.xcscheme
+++ b/apps/ios/ios/App/App.xcodeproj/xcshareddata/xcschemes/App.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "504EC3031FED79650016851F"
+               BuildableName = "App.app"
+               BlueprintName = "App"
+               ReferencedContainer = "container:App.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "504EC3031FED79650016851F"
+            BuildableName = "App.app"
+            BlueprintName = "App"
+            ReferencedContainer = "container:App.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Debug"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "504EC3031FED79650016851F"
+            BuildableName = "App.app"
+            BlueprintName = "App"
+            ReferencedContainer = "container:App.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/apps/ios/ios/App/App/Info.plist
+++ b/apps/ios/ios/App/App/Info.plist
@@ -53,6 +53,10 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>arm64</string>

--- a/apps/web/src/app/dashboard/DashboardLayoutClient.tsx
+++ b/apps/web/src/app/dashboard/DashboardLayoutClient.tsx
@@ -3,6 +3,7 @@
 import { usePathname } from "next/navigation";
 import Layout from "@/components/layout/Layout";
 import { PushNotificationManager } from "@/components/PushNotificationManager";
+import { PushActionHandler } from "@/components/PushActionHandler";
 import QuickCreatePalette from "@/components/create/QuickCreatePalette";
 import { useHotkeyPreferences } from "@/hooks/useHotkeyPreferences";
 import { useDesktopExchangeHandler } from "@/hooks/useDesktopExchangeHandler";
@@ -36,6 +37,7 @@ export default function DashboardLayoutClient({ children }: { children: React.Re
   return (
     <>
       <PushNotificationManager />
+      <PushActionHandler />
       <QuickCreatePalette />
       {isFullPageRoute ? <Layout>{children}</Layout> : <Layout />}
     </>

--- a/apps/web/src/components/PushActionHandler.tsx
+++ b/apps/web/src/components/PushActionHandler.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useNotificationStore } from '@/stores/useNotificationStore';
+
+interface PushNotificationSchema {
+  title?: string;
+  body?: string;
+  id: string;
+  data: Record<string, unknown>;
+}
+
+interface ActionPerformed {
+  actionId: string;
+  notification: PushNotificationSchema;
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+function resolveDestination(data: Record<string, unknown>): string | null {
+  const type = asString(data.type);
+  if (!type) return null;
+
+  if (type === 'EMAIL_VERIFICATION_REQUIRED') {
+    return '/settings/account';
+  }
+
+  if (type === 'TOS_PRIVACY_UPDATED') {
+    return asString(data.documentUrl) ?? '/dashboard';
+  }
+
+  if (type === 'NEW_DIRECT_MESSAGE') {
+    const conversationId = asString(data.conversationId);
+    return conversationId ? `/dashboard/inbox/dm/${conversationId}` : '/dashboard/inbox';
+  }
+
+  if (type === 'MENTION' || type === 'TASK_ASSIGNED') {
+    const driveId = asString(data.driveId);
+    const pageId = asString(data.pageId) ?? asString(data.taskListPageId);
+    if (driveId && pageId) {
+      const taskId = asString(data.taskId);
+      return type === 'TASK_ASSIGNED' && taskId
+        ? `/dashboard/${driveId}/${pageId}?task=${taskId}`
+        : `/dashboard/${driveId}/${pageId}`;
+    }
+  }
+
+  if (
+    type === 'PAGE_SHARED' ||
+    type === 'PERMISSION_GRANTED' ||
+    type === 'PERMISSION_UPDATED' ||
+    type === 'PERMISSION_REVOKED'
+  ) {
+    const driveId = asString(data.driveId);
+    const pageId = asString(data.pageId);
+    if (driveId && pageId) return `/dashboard/${driveId}/${pageId}`;
+    if (driveId) return `/dashboard/${driveId}`;
+  }
+
+  if (
+    type === 'DRIVE_INVITED' ||
+    type === 'DRIVE_JOINED' ||
+    type === 'DRIVE_ROLE_CHANGED'
+  ) {
+    const driveId = asString(data.driveId);
+    if (driveId) return `/dashboard/${driveId}`;
+  }
+
+  if (
+    type === 'CONNECTION_REQUEST' ||
+    type === 'CONNECTION_ACCEPTED' ||
+    type === 'CONNECTION_REJECTED'
+  ) {
+    return '/dashboard/connections';
+  }
+
+  return '/dashboard';
+}
+
+export function PushActionHandler() {
+  const router = useRouter();
+  const handleNotificationRead = useNotificationStore((s) => s.handleNotificationRead);
+
+  useEffect(() => {
+    const onAction = (event: Event) => {
+      const detail = (event as CustomEvent<ActionPerformed>).detail;
+      const data = detail?.notification?.data ?? {};
+
+      const notificationId = asString(data.notificationId);
+      if (notificationId) {
+        void handleNotificationRead(notificationId);
+      }
+
+      const destination = resolveDestination(data);
+      if (destination) {
+        router.push(destination);
+      }
+    };
+
+    window.addEventListener('push:action', onAction as EventListener);
+    return () => window.removeEventListener('push:action', onAction as EventListener);
+  }, [router, handleNotificationRead]);
+
+  return null;
+}

--- a/packages/lib/src/notifications/__tests__/notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/notifications.test.ts
@@ -132,6 +132,12 @@ function setupDeleteChain() {
 beforeEach(() => {
   vi.clearAllMocks();
   global.fetch = vi.fn().mockResolvedValue({ ok: true });
+
+  // Default db.select chain so getUnreadNotificationCount (used by sendBadgedPush
+  // and sendSilentBadgeUpdate) resolves to 0 unless a test overrides it.
+  const defaultWhereFn = vi.fn().mockResolvedValue([{ count: 0 }]);
+  const defaultFromFn = vi.fn().mockReturnValue({ where: defaultWhereFn });
+  vi.mocked(db.select).mockReturnValue({ from: defaultFromFn } as unknown as ReturnType<typeof db.select>);
 });
 
 describe('createNotification', () => {
@@ -203,9 +209,12 @@ describe('createNotification', () => {
       driveId: 'drive-1',
     });
 
+    // sendBadgedPush is fire-and-forget (awaits unread-count first); flush microtasks.
+    await vi.waitFor(() => expect(sendPushNotification).toHaveBeenCalled());
     expect(sendPushNotification).toHaveBeenCalledWith('user-1', expect.objectContaining({
       title: 'Test',
       body: 'Test message',
+      badge: 0,
     }));
   });
 
@@ -220,6 +229,7 @@ describe('createNotification', () => {
       driveId: 'drive-1',
     });
 
+    await vi.waitFor(() => expect(sendPushNotification).toHaveBeenCalled());
     expect(sendPushNotification).toHaveBeenCalledWith('user-1', expect.objectContaining({
       data: expect.objectContaining({ pageId: 'page-1', driveId: 'drive-1' }),
     }));

--- a/packages/lib/src/notifications/__tests__/push-notifications.test.ts
+++ b/packages/lib/src/notifications/__tests__/push-notifications.test.ts
@@ -73,6 +73,7 @@ function setupUpdateChain() {
   return { setFn, whereFn };
 }
 
+
 function setupInsertChain() {
   const valuesFn = vi.fn().mockResolvedValue(undefined);
   vi.mocked(db.insert).mockReturnValue({ values: valuesFn } as unknown as ReturnType<typeof db.insert>);
@@ -532,6 +533,9 @@ describe('APNs JWT token generation', () => {
     expect(result.errors.length).toBeGreaterThan(0);
   });
 
+  // DER trim branches need a stale JWT cache so crypto.createSign actually
+  // runs with our crafted DER signature. Earlier tests populate the
+  // module-level cache, so we advance system time past its expiry.
   it('handles DER signature with r > 32 bytes (trimming)', async () => {
     process.env.APNS_TEAM_ID = 'team-id';
     process.env.APNS_KEY_ID = 'key-id';
@@ -539,7 +543,6 @@ describe('APNs JWT token generation', () => {
 
     vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([tokenRecord({ platform: 'ios' })] as never);
 
-    // DER with 33-byte r (leading zero) and 32-byte s
     const rLen = 33;
     const sLen = 32;
     const derLen = 2 + rLen + 2 + sLen;
@@ -557,11 +560,149 @@ describe('APNs JWT token generation', () => {
       sign: vi.fn().mockReturnValue(der),
     };
     vi.mocked(crypto.createSign).mockReturnValue(mockSign as unknown as ReturnType<typeof crypto.createSign>);
+    vi.mocked(global.fetch).mockResolvedValue({ ok: true, headers: new Headers() } as Response);
+    setupUpdateChain();
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2099-01-01T00:00:00Z'));
+    try {
+      const result = await sendPushNotification('user-1', payload);
+      expect(mockSign.sign).toHaveBeenCalledTimes(1);
+      expect(result.sent + result.failed).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('handles DER signature with s > 32 bytes (trimming)', async () => {
+    process.env.APNS_TEAM_ID = 'team-id';
+    process.env.APNS_KEY_ID = 'key-id';
+    process.env.APNS_PRIVATE_KEY = '-----BEGIN PRIVATE KEY-----\nfakekey\n-----END PRIVATE KEY-----';
+
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([tokenRecord({ platform: 'ios' })] as never);
+
+    const rLen = 32;
+    const sLen = 33;
+    const derLen = 2 + rLen + 2 + sLen;
+    const der = Buffer.alloc(2 + derLen, 0);
+    der[0] = 0x30;
+    der[1] = derLen;
+    der[2] = 0x02;
+    der[3] = rLen;
+    der[4 + rLen] = 0x02;
+    der[4 + rLen + 1] = sLen;
+
+    const mockSign = {
+      update: vi.fn().mockReturnThis(),
+      end: vi.fn().mockReturnThis(),
+      sign: vi.fn().mockReturnValue(der),
+    };
+    vi.mocked(crypto.createSign).mockReturnValue(mockSign as unknown as ReturnType<typeof crypto.createSign>);
+    vi.mocked(global.fetch).mockResolvedValue({ ok: true, headers: new Headers() } as Response);
+    setupUpdateChain();
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2099-06-01T00:00:00Z'));
+    try {
+      const result = await sendPushNotification('user-1', payload);
+      expect(mockSign.sign).toHaveBeenCalledTimes(1);
+      expect(result.sent + result.failed).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Silent (content-available) APNs payload
+// ---------------------------------------------------------------------------
+describe('silent push payload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    delete process.env.APNS_TEAM_ID;
+    delete process.env.APNS_KEY_ID;
+    delete process.env.APNS_PRIVATE_KEY;
+    delete process.env.APNS_BUNDLE_ID;
+    delete process.env.NODE_ENV;
+  });
+
+  function primeApnsSign() {
+    const fakeSignature = Buffer.alloc(72, 0);
+    fakeSignature[0] = 0x30; fakeSignature[1] = 70;
+    fakeSignature[2] = 0x02; fakeSignature[3] = 32;
+    fakeSignature[36] = 0x02; fakeSignature[37] = 32;
+    const mockSign = {
+      update: vi.fn().mockReturnThis(),
+      end: vi.fn().mockReturnThis(),
+      sign: vi.fn().mockReturnValue(fakeSignature),
+    };
+    vi.mocked(crypto.createSign).mockReturnValue(mockSign as unknown as ReturnType<typeof crypto.createSign>);
+  }
+
+  it('sends content-available silent payload with background priority', async () => {
+    process.env.APNS_TEAM_ID = 'team-id';
+    process.env.APNS_KEY_ID = 'key-id';
+    process.env.APNS_PRIVATE_KEY = '-----BEGIN PRIVATE KEY-----\nfakekey\n-----END PRIVATE KEY-----';
+
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([tokenRecord({ platform: 'ios' })] as never);
+    primeApnsSign();
     vi.mocked(global.fetch).mockResolvedValue({ ok: true } as Response);
     setupUpdateChain();
 
-    const result = await sendPushNotification('user-1', payload);
-    // Should not throw - either sent or failed (depending on cache)
-    expect(result.sent + result.failed).toBe(1);
+    await sendPushNotification('user-1', { silent: true, badge: 3 });
+
+    const fetchMock = vi.mocked(global.fetch);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0]!;
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers['apns-push-type']).toBe('background');
+    expect(headers['apns-priority']).toBe('5');
+
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.aps['content-available']).toBe(1);
+    expect(body.aps.badge).toBe(3);
+    expect(body.aps.alert).toBeUndefined();
+    expect(body.aps.sound).toBeUndefined();
+  });
+
+  it('sends silent payload without badge when badge is omitted', async () => {
+    process.env.APNS_TEAM_ID = 'team-id';
+    process.env.APNS_KEY_ID = 'key-id';
+    process.env.APNS_PRIVATE_KEY = '-----BEGIN PRIVATE KEY-----\nfakekey\n-----END PRIVATE KEY-----';
+
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([tokenRecord({ platform: 'ios' })] as never);
+    primeApnsSign();
+    vi.mocked(global.fetch).mockResolvedValue({ ok: true } as Response);
+    setupUpdateChain();
+
+    await sendPushNotification('user-1', { silent: true });
+
+    const fetchMock = vi.mocked(global.fetch);
+    const body = JSON.parse(((fetchMock.mock.calls[0]![1]) as RequestInit).body as string);
+    expect(body.aps['content-available']).toBe(1);
+    expect('badge' in body.aps).toBe(false);
+  });
+
+  it('uses production APNs host when NODE_ENV=production', async () => {
+    process.env.APNS_TEAM_ID = 'team-id';
+    process.env.APNS_KEY_ID = 'key-id';
+    process.env.APNS_PRIVATE_KEY = '-----BEGIN PRIVATE KEY-----\nfakekey\n-----END PRIVATE KEY-----';
+    process.env.NODE_ENV = 'production';
+
+    vi.mocked(db.query.pushNotificationTokens.findMany).mockResolvedValue([tokenRecord({ platform: 'ios' })] as never);
+    primeApnsSign();
+    vi.mocked(global.fetch).mockResolvedValue({ ok: true } as Response);
+    setupUpdateChain();
+
+    await sendPushNotification('user-1', payload);
+
+    const fetchMock = vi.mocked(global.fetch);
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toContain('api.push.apple.com');
+    expect(String(url)).not.toContain('sandbox');
   });
 });

--- a/packages/lib/src/notifications/notifications.ts
+++ b/packages/lib/src/notifications/notifications.ts
@@ -6,12 +6,30 @@ import { notifications } from '@pagespace/db/schema/notifications';
 import { createId } from '@paralleldrive/cuid2';
 import { sendNotificationEmail } from '../services/notification-email-service';
 import { createSignedBroadcastHeaders } from '../auth/broadcast-auth';
-import { sendPushNotification } from './push-notifications';
+import { sendPushNotification, type PushNotificationPayload } from './push-notifications';
 
 // Export types and guards
 export * from './types';
 export * from './guards';
 import type { NotificationType } from './types';
+
+async function sendBadgedPush(userId: string, payload: PushNotificationPayload) {
+  try {
+    const badge = await getUnreadNotificationCount(userId);
+    await sendPushNotification(userId, { ...payload, badge });
+  } catch (error) {
+    console.error('Failed to send badged push notification:', error);
+  }
+}
+
+async function sendSilentBadgeUpdate(userId: string) {
+  try {
+    const badge = await getUnreadNotificationCount(userId);
+    await sendPushNotification(userId, { silent: true, badge });
+  } catch (error) {
+    console.error('Failed to send silent badge update:', error);
+  }
+}
 
 async function broadcastNotification(userId: string, notification: unknown) {
   try {
@@ -60,8 +78,8 @@ export async function createNotification(params: CreateNotificationParams) {
     metadata: params.metadata || {},
   });
 
-  // Send push notification (fire-and-forget - don't block on push sending)
-  void sendPushNotification(params.userId, {
+  // Send push notification with current unread badge count (fire-and-forget)
+  void sendBadgedPush(params.userId, {
     title: params.title,
     body: params.message,
     data: {
@@ -71,8 +89,6 @@ export async function createNotification(params: CreateNotificationParams) {
       ...(params.driveId && { driveId: params.driveId }),
       ...params.metadata,
     },
-  }).catch((error) => {
-    console.error('Failed to send push notification:', error);
   });
 
   return notification[0];
@@ -132,7 +148,7 @@ export async function getUnreadCount(userId: string) {
 export async function markNotificationAsRead(notificationId: string, userId: string) {
   const updated = await db
     .update(notifications)
-    .set({ 
+    .set({
       isRead: true,
       readAt: new Date(),
     })
@@ -144,13 +160,15 @@ export async function markNotificationAsRead(notificationId: string, userId: str
     )
     .returning();
 
+  void sendSilentBadgeUpdate(userId);
+
   return updated[0];
 }
 
 export async function markAllNotificationsAsRead(userId: string) {
   await db
     .update(notifications)
-    .set({ 
+    .set({
       isRead: true,
       readAt: new Date(),
     })
@@ -160,6 +178,8 @@ export async function markAllNotificationsAsRead(userId: string) {
         eq(notifications.isRead, false)
       )
     );
+
+  void sendSilentBadgeUpdate(userId);
 }
 
 export async function markConnectionRequestActioned(
@@ -187,6 +207,8 @@ export async function markConnectionRequestActioned(
       },
     })
     .where(eq(notifications.id, notification.id));
+
+  void sendSilentBadgeUpdate(userId);
 }
 
 export async function deleteNotification(notificationId: string, userId: string) {
@@ -198,6 +220,8 @@ export async function deleteNotification(notificationId: string, userId: string)
         eq(notifications.userId, userId)
       )
     );
+
+  void sendSilentBadgeUpdate(userId);
 }
 
 export async function createPermissionNotification(
@@ -373,6 +397,18 @@ export async function createOrUpdateMessageNotification(
         conversationId,
         senderName,
         messagePreview,
+      },
+    });
+
+    // Push the updated DM so 2nd, 3rd, ... messages still surface and bump the badge
+    void sendBadgedPush(targetUserId, {
+      title: senderName ? `${senderName}` : 'New Direct Message',
+      body: messagePreview,
+      threadId: `dm:${conversationId}`,
+      data: {
+        notificationId: updatedNotification[0].id,
+        type: 'NEW_DIRECT_MESSAGE',
+        conversationId,
       },
     });
 

--- a/packages/lib/src/notifications/push-notifications.ts
+++ b/packages/lib/src/notifications/push-notifications.ts
@@ -6,14 +6,15 @@ import * as crypto from 'crypto';
 
 type PushPlatform = 'ios' | 'android' | 'web';
 
-interface PushNotificationPayload {
-  title: string;
-  body: string;
+export interface PushNotificationPayload {
+  title?: string;
+  body?: string;
   badge?: number;
   sound?: string;
   data?: Record<string, unknown>;
   category?: string;
   threadId?: string;
+  silent?: boolean;
 }
 
 interface SendPushResult {
@@ -134,19 +135,36 @@ async function sendToApns(
   try {
     const jwtToken = getApnsJwtToken();
 
-    const apnsPayload = {
-      aps: {
-        alert: {
-          title: payload.title,
-          body: payload.body,
-        },
-        badge: payload.badge,
-        sound: payload.sound || 'default',
-        'thread-id': payload.threadId,
-        category: payload.category,
-      },
-      ...payload.data,
-    };
+    const isSilent = payload.silent === true;
+    const apnsPayload: Record<string, unknown> = isSilent
+      ? {
+          aps: {
+            'content-available': 1,
+            ...(payload.badge !== undefined && { badge: payload.badge }),
+          },
+          ...payload.data,
+        }
+      : {
+          aps: {
+            alert: {
+              title: payload.title ?? '',
+              body: payload.body ?? '',
+            },
+            badge: payload.badge,
+            sound: payload.sound || 'default',
+            'thread-id': payload.threadId,
+            category: payload.category,
+          },
+          ...payload.data,
+        };
+
+    console.log('[APNs] send', {
+      host: apnsHost,
+      bundleId,
+      tokenId,
+      tokenPrefix: deviceToken.slice(0, 8),
+      isSilent,
+    });
 
     const response = await fetch(
       `https://${apnsHost}/3/device/${deviceToken}`,
@@ -155,20 +173,32 @@ async function sendToApns(
         headers: {
           'authorization': `bearer ${jwtToken}`,
           'apns-topic': bundleId,
-          'apns-push-type': 'alert',
-          'apns-priority': '10',
+          'apns-push-type': isSilent ? 'background' : 'alert',
+          'apns-priority': isSilent ? '5' : '10',
           'content-type': 'application/json',
         },
         body: JSON.stringify(apnsPayload),
       }
     );
 
+    const apnsId = response.headers?.get?.('apns-id') ?? null;
+
     if (response.ok) {
+      console.log('[APNs] accepted', { tokenId, apnsId });
       return { success: true, tokenId };
     }
 
     const errorBody = await response.json().catch(() => ({}));
     const reason = (errorBody as { reason?: string }).reason || 'Unknown error';
+
+    console.error('[APNs] reject', {
+      status: response.status,
+      reason,
+      apnsId,
+      host: apnsHost,
+      bundleId,
+      tokenId,
+    });
 
     // Check if token should be removed (invalid or unregistered)
     const invalidTokenReasons = [
@@ -185,7 +215,12 @@ async function sendToApns(
       shouldRemoveToken: invalidTokenReasons.includes(reason),
     };
   } catch (error) {
-    console.error('APNs send error:', error);
+    console.error('[APNs] send error', {
+      tokenId,
+      host: apnsHost,
+      bundleId,
+      error: error instanceof Error ? error.message : error,
+    });
     return {
       success: false,
       tokenId,
@@ -293,8 +328,16 @@ export async function sendPushNotification(
   });
 
   if (tokens.length === 0) {
+    console.warn('[push] no active tokens', { userId });
     return { sent: 0, failed: 0, errors: [] };
   }
+
+  console.log('[push] dispatching', {
+    userId,
+    tokenCount: tokens.length,
+    platforms: tokens.map((t) => t.platform),
+    silent: payload.silent === true,
+  });
 
   const results: SendPushResult[] = [];
 


### PR DESCRIPTION
## Summary
- Wires up iOS push notifications end-to-end: entitlements/Info.plist enable the `remote-notification` background mode, project shares `App.xcscheme`, and `.env.example` documents `APNS_TEAM_ID/KEY_ID/PRIVATE_KEY/BUNDLE_ID`.
- Server now sends a **badged** alert push when a notification is created and a **silent** `content-available` push on read / mark-all / action / delete so the iOS badge count stays in sync without re-alerting.
- DMs re-push on subsequent messages (the 2nd, 3rd, ... still surface and bump the badge), instead of being suppressed by the existing in-app dedupe.
- New `PushActionHandler` client component handles notification taps: marks the source notification read and routes by `data.type` (DM, mention, task assigned, page/permission share, drive invite, connection, email verification, ToS update).
- Surfaces APNs request/response and missing-token paths in `sendPushNotification` so silent send failures (BadDeviceToken / InvalidProviderToken / DeviceTokenNotForTopic / no active token / JWT signing exceptions) are diagnosable in production logs.
- Tests: covers silent-push payload shape (`content-available`, background priority, badge-omitted), production APNs host selection, and DER-trim branches for r/s > 32 bytes (working around the module-level JWT cache via fake timers so `crypto.createSign` actually executes).

## Test plan
- [x] `pnpm --filter @pagespace/lib typecheck` passes.
- [x] `pnpm --filter @pagespace/lib test src/notifications` passes (push-notifications.ts: 99.1% lines / 88.5% branches; notifications.ts: 100% / 96%).
- [ ] Production: trigger a notification (e.g., DM, mention, share) to a TestFlight device and confirm the alert + badge arrive; tap each type and verify routing lands on the right screen.
- [ ] Production: mark a notification read in-app and verify the badge decrements via the silent push (no banner shown).
- [ ] Production server logs: a normal send shows `[push] dispatching` -> `[APNs] send` -> `[APNs] accepted` (with `apns-id`); failures show a `[APNs] reject` line with `reason` for triage.
- [ ] Confirm tokens older than 5 consecutive failures are auto-deactivated and re-register cleanly on next launch.