### PR TITLE
feat(invites): pending invitations UI

### DIFF
--- a/apps/web/src/app/dashboard/[driveId]/members/invite/__tests__/page.test.tsx
+++ b/apps/web/src/app/dashboard/[driveId]/members/invite/__tests__/page.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('next/navigation', () => ({
+  useParams: () => ({ driveId: 'drive-1' }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn(), back: vi.fn() }),
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+const mockToast = vi.fn();
+vi.mock('@/hooks/useToast', () => ({ useToast: () => ({ toast: mockToast }) }));
+
+const mockPost = vi.fn();
+const mockFetchWithAuth = vi.fn();
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  post: (...a: unknown[]) => mockPost(...a),
+  fetchWithAuth: (...a: unknown[]) => mockFetchWithAuth(...a),
+}));
+
+vi.mock('@/components/members/PermissionsGrid', () => ({
+  PermissionsGrid: () => <div data-testid="permissions-grid" />,
+}));
+vi.mock('@/hooks/useDebounce', () => ({ useDebounce: <T,>(v: T) => v }));
+
+import InviteMemberPage from '../page';
+
+const okJson = (d: unknown) => Promise.resolve({ ok: true, json: () => Promise.resolve(d) });
+
+const setupRolesAndSearch = () => {
+  mockFetchWithAuth.mockImplementation((url: string) =>
+    url.includes('/roles') ? okJson({ roles: [] }) : okJson({ users: [] })
+  );
+};
+
+const triggerEmailInvite = async (email: string) => {
+  const user = userEvent.setup();
+  await user.type(await screen.findByPlaceholderText(/search by username/i), email);
+  await user.click(await screen.findByRole('button', { name: new RegExp(`invite ${email}`, 'i') }));
+  await user.click(await screen.findByRole('button', { name: /invite member/i }));
+  return user;
+};
+
+describe('InviteMemberPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupRolesAndSearch();
+  });
+
+  it('Given an admin types an email with no matching user, the CTA fires handleInviteEmail and surfaces pending state', async () => {
+    const user = userEvent.setup();
+    render(<InviteMemberPage />);
+    await user.type(await screen.findByPlaceholderText(/search by username/i), 'newuser@example.com');
+    await user.click(
+      await screen.findByRole('button', { name: /invite newuser@example.com/i })
+    );
+    expect(screen.getByText('newuser@example.com')).toBeInTheDocument();
+    expect((await screen.findAllByText(/will receive an email invitation/i)).length).toBeGreaterThan(0);
+  });
+
+  it('Given Invite is clicked with a pending email, POSTs { email, role, customRoleId, permissions }', async () => {
+    mockPost.mockResolvedValue({ kind: 'invited', email: 'newuser@example.com' });
+    render(<InviteMemberPage />);
+    await triggerEmailInvite('newuser@example.com');
+
+    await waitFor(() => expect(mockPost).toHaveBeenCalledTimes(1));
+    expect(mockPost.mock.calls[0][0]).toBe('/api/drives/drive-1/members/invite');
+    expect(mockPost.mock.calls[0][1]).toMatchObject({
+      email: 'newuser@example.com',
+      role: 'MEMBER',
+      customRoleId: null,
+      permissions: [],
+    });
+  });
+
+  it('Given the response has kind: invited, toast shows "Invitation sent to [email]"', async () => {
+    mockPost.mockResolvedValue({ kind: 'invited', email: 'a@b.com' });
+    render(<InviteMemberPage />);
+    await triggerEmailInvite('a@b.com');
+
+    await waitFor(() =>
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ description: 'Invitation sent to a@b.com' })
+      )
+    );
+  });
+
+  it('Given the response has kind: added, toast shows "Member invited successfully"', async () => {
+    mockPost.mockResolvedValue({ kind: 'added', memberId: 'm-1' });
+    render(<InviteMemberPage />);
+    await triggerEmailInvite('existing@example.com');
+
+    await waitFor(() =>
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ description: 'Member invited successfully' })
+      )
+    );
+  });
+
+  it('Given the response is 409 (already pending), toast shows the conflict message', async () => {
+    mockPost.mockRejectedValue(new Error('An invitation is already pending for this email.'));
+    render(<InviteMemberPage />);
+    await triggerEmailInvite('newuser@example.com');
+
+    await waitFor(() =>
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description: 'An invitation is already pending for this email.',
+          variant: 'destructive',
+        })
+      )
+    );
+  });
+
+  it('Snapshots the email at submit time so the toast renders the right address even if state churns', async () => {
+    let resolvePost!: (v: { kind: 'invited' }) => void;
+    mockPost.mockImplementation(() => new Promise((resolve) => { resolvePost = resolve; }));
+
+    render(<InviteMemberPage />);
+    await triggerEmailInvite('snapshot@example.com');
+
+    resolvePost({ kind: 'invited' });
+
+    await waitFor(() =>
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ description: 'Invitation sent to snapshot@example.com' })
+      )
+    );
+  });
+});

--- a/apps/web/src/app/dashboard/[driveId]/members/invite/page.tsx
+++ b/apps/web/src/app/dashboard/[driveId]/members/invite/page.tsx
@@ -8,7 +8,7 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { PermissionsGrid, PermissionsGridRef } from '@/components/members/PermissionsGrid';
 import { UserSearch } from '@/components/members/UserSearch';
-import { ChevronLeft, UserPlus, User, RefreshCw, Shield } from 'lucide-react';
+import { ChevronLeft, UserPlus, User, RefreshCw, Shield, Mail } from 'lucide-react';
 import { useToast } from '@/hooks/useToast';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectSeparator, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -43,6 +43,7 @@ export default function InviteMemberPage() {
   const driveId = params.driveId as string;
 
   const [selectedUser, setSelectedUser] = useState<SelectedUser | null>(null);
+  const [pendingEmail, setPendingEmail] = useState<string | null>(null);
   const [customRoles, setCustomRoles] = useState<CustomRole[]>([]);
   const [selectedUnifiedRole, setSelectedUnifiedRole] = useState<UnifiedRole>(null);
   const [permissions, setPermissions] = useState<Map<string, { canView: boolean; canEdit: boolean; canShare: boolean }>>(new Map());
@@ -104,10 +105,17 @@ export default function InviteMemberPage() {
 
   const handleUserSelect = (user: SelectedUser) => {
     setSelectedUser(user);
+    setPendingEmail(null);
+  };
+
+  const handleInviteEmail = (email: string) => {
+    setPendingEmail(email);
+    setSelectedUser(null);
   };
 
   const handleClearUser = () => {
     setSelectedUser(null);
+    setPendingEmail(null);
     setPermissions(new Map());
     setSelectedUnifiedRole(null);
   };
@@ -121,84 +129,83 @@ export default function InviteMemberPage() {
   };
 
   const handleInvite = async () => {
-    if (!selectedUser) return;
+    if (!selectedUser && !pendingEmail) return;
 
-    // Map unified role back to backend model
     const backendRole = selectedUnifiedRole?.type === 'admin' ? 'ADMIN' : 'MEMBER';
     const backendCustomRoleId = selectedUnifiedRole?.type === 'custom'
       ? selectedUnifiedRole.roleId
       : null;
+    const isAdmin = selectedUnifiedRole?.type === 'admin';
 
-    // Skip permission validation for Admin
-    if (selectedUnifiedRole?.type === 'admin') {
-      setSaving(true);
-      try {
-        await post(`/api/drives/${driveId}/members/invite`, {
-          userId: selectedUser.userId,
-          role: 'ADMIN',
-          customRoleId: null,
-          permissions: [],
-        });
+    // Snapshot the email at submit time so the toast renders the right address
+    // even if pendingEmail changes before the async response resolves.
+    const submittedEmail = pendingEmail;
 
+    let payload: Record<string, unknown>;
+    if (pendingEmail) {
+      // Email-payload path: page permissions cannot be granted to a user who
+      // has not joined yet, so we always send an empty permissions array.
+      payload = {
+        email: pendingEmail,
+        role: backendRole,
+        customRoleId: backendCustomRoleId,
+        permissions: [],
+      };
+    } else if (isAdmin) {
+      payload = {
+        userId: selectedUser!.userId,
+        role: 'ADMIN',
+        customRoleId: null,
+        permissions: [],
+      };
+    } else {
+      const permissionArray = Array.from(permissions.entries())
+        .filter(([, perms]) => perms.canView || perms.canEdit || perms.canShare)
+        .map(([pageId, perms]) => ({
+          pageId,
+          canView: perms.canView,
+          canEdit: perms.canEdit,
+          canShare: perms.canShare,
+        }));
+
+      if (permissionArray.length === 0) {
         toast({
-          title: 'Success',
-          description: 'Admin invited successfully',
-        });
-
-        router.push(`/dashboard/${driveId}/members`);
-      } catch (error) {
-        if (error instanceof Error && 'requiresEmailVerification' in error) {
-          setShowVerificationAlert(true);
-          return;
-        }
-        console.error('Error adding member:', error);
-        toast({
-          title: 'Error',
-          description: error instanceof Error ? error.message : 'Failed to add member',
+          title: 'No permissions selected',
+          description: 'Please select at least one permission to grant',
           variant: 'destructive',
         });
-      } finally {
-        setSaving(false);
+        return;
       }
-      return;
-    }
 
-    // For non-admin, convert permissions map to array format
-    const permissionArray = Array.from(permissions.entries())
-      .filter(([, perms]) => perms.canView || perms.canEdit || perms.canShare)
-      .map(([pageId, perms]) => ({
-        pageId,
-        canView: perms.canView,
-        canEdit: perms.canEdit,
-        canShare: perms.canShare,
-      }));
-
-    if (permissionArray.length === 0) {
-      toast({
-        title: 'No permissions selected',
-        description: 'Please select at least one permission to grant',
-        variant: 'destructive',
-      });
-      return;
+      payload = {
+        userId: selectedUser!.userId,
+        role: backendRole,
+        customRoleId: backendCustomRoleId,
+        permissions: permissionArray,
+      };
     }
 
     setSaving(true);
     try {
-      await post(`/api/drives/${driveId}/members/invite`, {
-        userId: selectedUser.userId,
-        role: backendRole,
-        customRoleId: backendCustomRoleId,
-        permissions: permissionArray,
-      });
+      const response = await post<{ kind?: 'invited' | 'added'; email?: string }>(
+        `/api/drives/${driveId}/members/invite`,
+        payload
+      );
 
-      toast({
-        title: 'Success',
-        description: 'Member invited successfully',
-      });
+      if (response?.kind === 'invited' && submittedEmail) {
+        toast({
+          title: 'Invitation sent',
+          description: `Invitation sent to ${submittedEmail}`,
+        });
+      } else {
+        toast({
+          title: 'Success',
+          description: isAdmin ? 'Admin invited successfully' : 'Member invited successfully',
+        });
+      }
 
       router.push(`/dashboard/${driveId}/members`);
     } catch (error) {
-      // Check if this is a verification required error
       if (error instanceof Error && 'requiresEmailVerification' in error) {
         setShowVerificationAlert(true);
         return;
@@ -257,7 +264,9 @@ export default function InviteMemberPage() {
             <CardDescription>
               {selectedUser
                 ? 'User selected. You can change your selection below.'
-                : 'Search for a user to invite to this drive'
+                : pendingEmail
+                  ? 'No matching user — they will receive an email invitation.'
+                  : 'Search for a user to invite to this drive'
               }
             </CardDescription>
           </CardHeader>
@@ -285,14 +294,31 @@ export default function InviteMemberPage() {
                   Change User
                 </Button>
               </div>
+            ) : pendingEmail ? (
+              <div className="flex items-center justify-between p-4 bg-muted rounded-lg">
+                <div className="flex items-center space-x-4">
+                  <Avatar className="w-12 h-12">
+                    <AvatarFallback>
+                      <Mail className="w-5 h-5" />
+                    </AvatarFallback>
+                  </Avatar>
+                  <div>
+                    <p className="font-medium">{pendingEmail}</p>
+                    <p className="text-sm text-muted-foreground">Will receive an email invitation</p>
+                  </div>
+                </div>
+                <Button variant="outline" size="sm" onClick={handleClearUser}>
+                  Change
+                </Button>
+              </div>
             ) : (
-              <UserSearch onSelect={handleUserSelect} />
+              <UserSearch onSelect={handleUserSelect} onInviteEmail={handleInviteEmail} />
             )}
           </CardContent>
         </Card>
 
-        {/* Role & Permissions - Only show when user is selected */}
-        {selectedUser && (
+        {/* Role & Permissions - Show when user is selected OR an email invitation is pending */}
+        {(selectedUser || pendingEmail) && (
           <>
             {/* Unified Role Selection Card */}
             <Card className="mb-6">
@@ -362,8 +388,8 @@ export default function InviteMemberPage() {
               </CardContent>
             </Card>
 
-            {/* Permissions Card - Hidden when Admin is selected */}
-            {selectedUnifiedRole?.type !== 'admin' && (
+            {/* Permissions Card - Hidden when Admin is selected or for pending email invites */}
+            {selectedUnifiedRole?.type !== 'admin' && !pendingEmail && (
               <Card className="mb-6">
                 <CardHeader>
                   <div className="flex items-center justify-between">

--- a/apps/web/src/components/members/DriveMembers.tsx
+++ b/apps/web/src/components/members/DriveMembers.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { UserPlus } from 'lucide-react';
 import { MemberRow } from './MemberRow';
 import { useToast } from '@/hooks/useToast';
+import { useSocket } from '@/hooks/useSocket';
 import { del, fetchWithAuth } from '@/lib/auth/auth-fetch';
 
 interface DriveMember {
@@ -13,7 +14,7 @@ interface DriveMember {
   userId: string;
   role: string;
   invitedAt: string;
-  acceptedAt?: string;
+  acceptedAt: string | null;
   user: {
     id: string;
     email: string;
@@ -40,14 +41,27 @@ interface DriveMembersProps {
   driveId: string;
 }
 
+interface DriveMemberSocketEvent {
+  driveId: string;
+  userId?: string;
+  operation?: string;
+}
+
+const DRIVE_MEMBER_EVENTS = [
+  'drive:member_added',
+  'drive:member_removed',
+  'drive:member_role_changed',
+] as const;
+
 export function DriveMembers({ driveId }: DriveMembersProps) {
   const [members, setMembers] = useState<DriveMember[]>([]);
   const [currentUserRole, setCurrentUserRole] = useState<'OWNER' | 'ADMIN' | 'MEMBER'>('MEMBER');
   const [loading, setLoading] = useState(true);
   const router = useRouter();
   const { toast } = useToast();
+  const socket = useSocket();
 
-  const fetchMembers = async () => {
+  const fetchMembers = useCallback(async () => {
     try {
       const response = await fetchWithAuth(`/api/drives/${driveId}/members`);
       if (!response.ok) throw new Error('Failed to fetch members');
@@ -64,30 +78,51 @@ export function DriveMembers({ driveId }: DriveMembersProps) {
     } finally {
       setLoading(false);
     }
-  };
+  }, [driveId, toast]);
 
   useEffect(() => {
     fetchMembers();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [driveId]);
+  }, [fetchMembers]);
 
-  const handleRemoveMember = async (memberId: string) => {
-    if (!confirm('Are you sure you want to remove this member?')) return;
+  useEffect(() => {
+    if (!socket) return;
+
+    const handler = (event: DriveMemberSocketEvent) => {
+      if (event?.driveId !== driveId) return;
+      fetchMembers();
+    };
+
+    DRIVE_MEMBER_EVENTS.forEach((eventName) => {
+      socket.on(eventName, handler);
+    });
+
+    return () => {
+      DRIVE_MEMBER_EVENTS.forEach((eventName) => {
+        socket.off(eventName, handler);
+      });
+    };
+  }, [socket, driveId, fetchMembers]);
+
+  const handleRemoveMember = async (userId: string, isPending: boolean) => {
+    const message = isPending
+      ? 'Are you sure you want to revoke this invitation?'
+      : 'Are you sure you want to remove this member?';
+    if (!confirm(message)) return;
 
     try {
-      await del(`/api/drives/${driveId}/members/${memberId}`);
+      await del(`/api/drives/${driveId}/members/${userId}`);
+
+      setMembers((prev) => prev.filter((m) => m.userId !== userId));
 
       toast({
         title: 'Success',
-        description: 'Member removed successfully',
+        description: isPending ? 'Invitation revoked' : 'Member removed successfully',
       });
-
-      fetchMembers();
     } catch (error) {
       console.error('Error removing member:', error);
       toast({
         title: 'Error',
-        description: 'Failed to remove member',
+        description: isPending ? 'Failed to revoke invitation' : 'Failed to remove member',
         variant: 'destructive',
       });
     }
@@ -101,12 +136,15 @@ export function DriveMembers({ driveId }: DriveMembersProps) {
     );
   }
 
+  // Strict null check: undefined from a malformed payload must not classify as pending.
+  const acceptedMembers = members.filter((m) => m.acceptedAt != null);
+  const pendingMembers = members.filter((m) => m.acceptedAt === null);
+
   return (
     <div className="space-y-6">
-      {/* Header with Invite Button */}
       <div className="flex justify-between items-center">
         <div>
-          <h2 className="text-lg font-semibold">Members ({members.length})</h2>
+          <h2 className="text-lg font-semibold">Members ({acceptedMembers.length})</h2>
           <p className="text-sm text-gray-600 dark:text-gray-400">
             People with access to this drive
           </p>
@@ -119,25 +157,45 @@ export function DriveMembers({ driveId }: DriveMembersProps) {
         )}
       </div>
 
-      {/* Members List */}
       <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 divide-y divide-gray-200 dark:divide-gray-700">
-        {members.length === 0 ? (
+        {acceptedMembers.length === 0 ? (
           <div className="p-8 text-center text-gray-500 dark:text-gray-400">
             No members yet. Invite someone to collaborate!
           </div>
         ) : (
-          members.map((member) => (
+          acceptedMembers.map((member) => (
             <MemberRow
               key={member.id}
               member={member}
               driveId={driveId}
               currentUserRole={currentUserRole}
-              onRemove={() => handleRemoveMember(member.id)}
+              onRemove={() => handleRemoveMember(member.userId, false)}
             />
           ))
         )}
       </div>
 
+      {pendingMembers.length > 0 && (
+        <div>
+          <div className="mb-3">
+            <h2 className="text-lg font-semibold">Pending invitations ({pendingMembers.length})</h2>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              People invited but not yet joined
+            </p>
+          </div>
+          <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 divide-y divide-gray-200 dark:divide-gray-700">
+            {pendingMembers.map((member) => (
+              <MemberRow
+                key={member.id}
+                member={member}
+                driveId={driveId}
+                currentUserRole={currentUserRole}
+                onRemove={() => handleRemoveMember(member.userId, true)}
+              />
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/members/DriveMembers.tsx
+++ b/apps/web/src/components/members/DriveMembers.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { UserPlus } from 'lucide-react';
@@ -60,15 +60,22 @@ export function DriveMembers({ driveId }: DriveMembersProps) {
   const router = useRouter();
   const { toast } = useToast();
   const socket = useSocket();
+  // Sequence guard: socket events can fire fetchMembers while a prior fetch is
+  // in flight. Only the latest request commits state to avoid a stale response
+  // overwriting a newer one.
+  const requestSeqRef = useRef(0);
 
   const fetchMembers = useCallback(async () => {
+    const currentSeq = ++requestSeqRef.current;
     try {
       const response = await fetchWithAuth(`/api/drives/${driveId}/members`);
       if (!response.ok) throw new Error('Failed to fetch members');
       const data = await response.json();
+      if (currentSeq !== requestSeqRef.current) return;
       setMembers(data.members);
       setCurrentUserRole(data.currentUserRole || 'MEMBER');
     } catch (error) {
+      if (currentSeq !== requestSeqRef.current) return;
       console.error('Error fetching members:', error);
       toast({
         title: 'Error',
@@ -76,7 +83,7 @@ export function DriveMembers({ driveId }: DriveMembersProps) {
         variant: 'destructive',
       });
     } finally {
-      setLoading(false);
+      if (currentSeq === requestSeqRef.current) setLoading(false);
     }
   }, [driveId, toast]);
 

--- a/apps/web/src/components/members/MemberRow.tsx
+++ b/apps/web/src/components/members/MemberRow.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Trash2, Eye, Edit, Share, User } from 'lucide-react';
+import { Trash2, Eye, Edit, Share, User, Mail } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
@@ -12,7 +12,7 @@ interface MemberRowProps {
     userId: string;
     role: string;
     invitedAt: string;
-    acceptedAt?: string;
+    acceptedAt: string | null;
     user: {
       id: string;
       email: string;
@@ -37,10 +37,13 @@ interface MemberRowProps {
   driveId: string;
   currentUserRole: 'OWNER' | 'ADMIN' | 'MEMBER';
   onRemove: () => void;
+  onResend?: () => void;
 }
 
-export function MemberRow({ member, driveId, currentUserRole, onRemove }: MemberRowProps) {
-  const displayName = member.profile?.displayName || member.user.name || 'Unknown User';
+export function MemberRow({ member, driveId, currentUserRole, onRemove, onResend }: MemberRowProps) {
+  const isPending = member.acceptedAt === null;
+  const canManage = currentUserRole === 'OWNER' || currentUserRole === 'ADMIN';
+  const displayName = member.profile?.displayName || member.user.name || member.user.email || 'Unknown User';
   const initials = displayName
     .split(' ')
     .map(n => n[0])
@@ -48,7 +51,6 @@ export function MemberRow({ member, driveId, currentUserRole, onRemove }: Member
     .toUpperCase()
     .slice(0, 2);
 
-  // Get color classes for custom role badges
   const getCustomRoleColorClasses = (color?: string | null) => {
     switch (color) {
       case 'blue':
@@ -72,8 +74,6 @@ export function MemberRow({ member, driveId, currentUserRole, onRemove }: Member
     }
   };
 
-  // Unified role badge - shows role name based on priority:
-  // Owner > Admin > Custom Role > Member (fallback)
   const getRoleBadge = () => {
     if (member.role === 'OWNER') {
       return (
@@ -96,7 +96,6 @@ export function MemberRow({ member, driveId, currentUserRole, onRemove }: Member
         </Badge>
       );
     }
-    // Fallback for members without a custom role assigned
     return (
       <Badge className="bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300">
         Member
@@ -107,13 +106,11 @@ export function MemberRow({ member, driveId, currentUserRole, onRemove }: Member
   return (
     <div className="p-4 flex items-center justify-between hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
       <div className="flex items-center space-x-4">
-        {/* Avatar */}
         <Avatar>
           <AvatarImage src={member.profile?.avatarUrl} alt={displayName} />
           <AvatarFallback>{initials}</AvatarFallback>
         </Avatar>
 
-        {/* User Info */}
         <div>
           <div className="flex items-center space-x-2">
             <p className="font-medium">{displayName}</p>
@@ -121,36 +118,54 @@ export function MemberRow({ member, driveId, currentUserRole, onRemove }: Member
               <span className="text-sm text-gray-500 dark:text-gray-400">@{member.profile.username}</span>
             )}
             {getRoleBadge()}
+            {isPending && (
+              <Badge
+                variant="outline"
+                className="border-yellow-500/50 bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300"
+              >
+                Pending
+              </Badge>
+            )}
           </div>
           <p className="text-sm text-gray-600 dark:text-gray-400">{member.user.email}</p>
-          
-          {/* Permission Summary */}
-          <div className="flex items-center space-x-4 mt-1">
-            {member.permissionCounts.view > 0 && (
-              <div className="flex items-center space-x-1 text-xs text-gray-500 dark:text-gray-400">
-                <Eye className="w-3 h-3" />
-                <span>{member.permissionCounts.view} pages</span>
-              </div>
-            )}
-            {member.permissionCounts.edit > 0 && (
-              <div className="flex items-center space-x-1 text-xs text-gray-500 dark:text-gray-400">
-                <Edit className="w-3 h-3" />
-                <span>{member.permissionCounts.edit} pages</span>
-              </div>
-            )}
-            {member.permissionCounts.share > 0 && (
-              <div className="flex items-center space-x-1 text-xs text-gray-500 dark:text-gray-400">
-                <Share className="w-3 h-3" />
-                <span>{member.permissionCounts.share} pages</span>
-              </div>
-            )}
-          </div>
+
+          {!isPending && (
+            <div className="flex items-center space-x-4 mt-1">
+              {member.permissionCounts.view > 0 && (
+                <div className="flex items-center space-x-1 text-xs text-gray-500 dark:text-gray-400">
+                  <Eye className="w-3 h-3" />
+                  <span>{member.permissionCounts.view} pages</span>
+                </div>
+              )}
+              {member.permissionCounts.edit > 0 && (
+                <div className="flex items-center space-x-1 text-xs text-gray-500 dark:text-gray-400">
+                  <Edit className="w-3 h-3" />
+                  <span>{member.permissionCounts.edit} pages</span>
+                </div>
+              )}
+              {member.permissionCounts.share > 0 && (
+                <div className="flex items-center space-x-1 text-xs text-gray-500 dark:text-gray-400">
+                  <Share className="w-3 h-3" />
+                  <span>{member.permissionCounts.share} pages</span>
+                </div>
+              )}
+            </div>
+          )}
         </div>
       </div>
 
-      {/* Actions */}
       <div className="flex items-center space-x-2">
-        {(currentUserRole === 'OWNER' || currentUserRole === 'ADMIN') && (
+        {canManage && isPending && onResend && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onResend}
+            title="Resend invitation"
+          >
+            <Mail className="w-4 h-4" />
+          </Button>
+        )}
+        {canManage && !isPending && (
           <Link href={`/dashboard/${driveId}/members/${member.userId}`}>
             <Button
               variant="ghost"
@@ -161,13 +176,13 @@ export function MemberRow({ member, driveId, currentUserRole, onRemove }: Member
             </Button>
           </Link>
         )}
-        {(currentUserRole === 'OWNER' || currentUserRole === 'ADMIN') && member.role !== 'OWNER' && (
+        {canManage && member.role !== 'OWNER' && (
           <Button
             variant="ghost"
             size="sm"
             onClick={onRemove}
             className="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
-            title="Remove Member"
+            title={isPending ? 'Revoke Invitation' : 'Remove Member'}
           >
             <Trash2 className="w-4 h-4" />
           </Button>

--- a/apps/web/src/components/members/UserSearch.tsx
+++ b/apps/web/src/components/members/UserSearch.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Input } from '@/components/ui/input';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
@@ -29,6 +29,10 @@ export function UserSearch({ onSelect, onInviteEmail }: UserSearchProps) {
   const [results, setResults] = useState<SearchResult[]>([]);
   const [loading, setLoading] = useState(false);
   const debouncedQuery = useDebounce(query, 300);
+  // Sequence guard: typeahead can issue overlapping fetches; only the latest
+  // response is allowed to commit state so a slow earlier request can't clobber
+  // a newer one.
+  const requestIdRef = useRef(0);
 
   useEffect(() => {
     if (debouncedQuery.length < 2) {
@@ -36,6 +40,7 @@ export function UserSearch({ onSelect, onInviteEmail }: UserSearchProps) {
       return;
     }
 
+    const currentId = ++requestIdRef.current;
     const searchUsers = async () => {
       setLoading(true);
       try {
@@ -48,12 +53,14 @@ export function UserSearch({ onSelect, onInviteEmail }: UserSearchProps) {
         const response = await fetchWithAuth(`/api/users/search?q=${encodeURIComponent(searchQuery)}`);
         if (!response.ok) throw new Error('Search failed');
         const data = await response.json();
+        if (requestIdRef.current !== currentId) return;
         setResults(data.users || []);
       } catch (error) {
+        if (requestIdRef.current !== currentId) return;
         console.error('Error searching users:', error);
         setResults([]);
       } finally {
-        setLoading(false);
+        if (requestIdRef.current === currentId) setLoading(false);
       }
     };
 

--- a/apps/web/src/components/members/UserSearch.tsx
+++ b/apps/web/src/components/members/UserSearch.tsx
@@ -39,7 +39,13 @@ export function UserSearch({ onSelect, onInviteEmail }: UserSearchProps) {
     const searchUsers = async () => {
       setLoading(true);
       try {
-        const response = await fetchWithAuth(`/api/users/search?q=${encodeURIComponent(debouncedQuery)}`);
+        // Auth normalizes emails to lowercase on signup, and the search API
+        // does an exact `eq(users.email, q)` match. Lowercase email-shaped
+        // queries here so a typed "User@Example.COM" still finds an existing
+        // account, instead of falling through to the new-user CTA.
+        const trimmed = debouncedQuery.trim();
+        const searchQuery = EMAIL_REGEX.test(trimmed) ? trimmed.toLowerCase() : debouncedQuery;
+        const response = await fetchWithAuth(`/api/users/search?q=${encodeURIComponent(searchQuery)}`);
         if (!response.ok) throw new Error('Search failed');
         const data = await response.json();
         setResults(data.users || []);

--- a/apps/web/src/components/members/UserSearch.tsx
+++ b/apps/web/src/components/members/UserSearch.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect } from 'react';
 import { Input } from '@/components/ui/input';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { Search, User } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Mail, Search, User } from 'lucide-react';
 import { useDebounce } from '@/hooks/useDebounce';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 
@@ -18,9 +19,12 @@ interface SearchResult {
 
 interface UserSearchProps {
   onSelect: (user: SearchResult) => void;
+  onInviteEmail?: (email: string) => void;
 }
 
-export function UserSearch({ onSelect }: UserSearchProps) {
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function UserSearch({ onSelect, onInviteEmail }: UserSearchProps) {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<SearchResult[]>([]);
   const [loading, setLoading] = useState(false);
@@ -121,13 +125,33 @@ export function UserSearch({ onSelect }: UserSearchProps) {
       )}
 
       {/* No Results */}
-      {!loading && query.length >= 2 && results.length === 0 && (
-        <div className="text-center py-8 text-muted-foreground">
-          <User className="w-12 h-12 mx-auto mb-2 opacity-50" />
-          <p>No users found</p>
-          <p className="text-sm mt-1">Try searching by email address</p>
-        </div>
-      )}
+      {!loading && query.length >= 2 && results.length === 0 && (() => {
+        const normalizedEmail = query.trim().toLowerCase();
+        const isEmail = EMAIL_REGEX.test(normalizedEmail);
+        if (isEmail && onInviteEmail) {
+          return (
+            <div className="text-center py-8 text-muted-foreground">
+              <Mail className="w-12 h-12 mx-auto mb-2 opacity-50" />
+              <p>No matching user found</p>
+              <Button
+                type="button"
+                variant="outline"
+                className="mt-3"
+                onClick={() => onInviteEmail(normalizedEmail)}
+              >
+                Invite {normalizedEmail} to PageSpace
+              </Button>
+            </div>
+          );
+        }
+        return (
+          <div className="text-center py-8 text-muted-foreground">
+            <User className="w-12 h-12 mx-auto mb-2 opacity-50" />
+            <p>No users found</p>
+            <p className="text-sm mt-1">Try searching by email address</p>
+          </div>
+        );
+      })()}
     </div>
   );
 }

--- a/apps/web/src/components/members/__tests__/DriveMembers.test.tsx
+++ b/apps/web/src/components/members/__tests__/DriveMembers.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { DriveMembers } from '../DriveMembers';
+
+const mockFetchWithAuth = vi.fn();
+const mockDel = vi.fn();
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: (...a: unknown[]) => mockFetchWithAuth(...a),
+  del: (...a: unknown[]) => mockDel(...a),
+}));
+const stableToast = vi.fn();
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ toast: stableToast }),
+}));
+
+type SocketHandler = (p: { driveId: string }) => void;
+type Sock = {
+  on: (e: string, h: SocketHandler) => void;
+  off: (e: string, h: SocketHandler) => void;
+  __emit: (e: string, p: { driveId: string }) => void;
+  __count: (e: string) => number;
+};
+
+const makeSocket = (): Sock => {
+  const m = new Map<string, SocketHandler[]>();
+  return {
+    on: (e, h) => m.set(e, [...(m.get(e) ?? []), h]),
+    off: (e, h) => m.set(e, (m.get(e) ?? []).filter((x) => x !== h)),
+    __emit: (e, p) => (m.get(e) ?? []).forEach((h) => h(p)),
+    __count: (e) => (m.get(e) ?? []).length,
+  };
+};
+
+let socket: Sock;
+vi.mock('@/hooks/useSocket', () => ({ useSocket: () => socket }));
+
+const member = (overrides: { userId?: string; acceptedAt?: string | null } = {}) => ({
+  id: `dm-${overrides.userId ?? 'u-1'}`,
+  userId: overrides.userId ?? 'u-1',
+  role: 'MEMBER',
+  invitedAt: '2026-05-01T00:00:00Z',
+  acceptedAt: overrides.acceptedAt === undefined ? '2026-05-02T00:00:00Z' : overrides.acceptedAt,
+  user: { id: overrides.userId ?? 'u-1', email: `${overrides.userId ?? 'u-1'}@x.test`, name: 'X' },
+  profile: { displayName: 'X' },
+  customRole: null,
+  permissionCounts: { view: 0, edit: 0, share: 0 },
+});
+
+const okMembers = (members: ReturnType<typeof member>[], currentUserRole = 'OWNER') =>
+  Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({ currentUserRole, members }),
+  });
+
+const EVENTS = ['drive:member_added', 'drive:member_removed', 'drive:member_role_changed'] as const;
+
+describe('DriveMembers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    socket = makeSocket();
+    window.confirm = vi.fn(() => true);
+  });
+
+  it('Given a mix of pending + accepted, renders two distinct sections with correct counts', async () => {
+    mockFetchWithAuth.mockImplementation(() =>
+      okMembers([
+        member({ userId: 'a1' }),
+        member({ userId: 'a2' }),
+        member({ userId: 'p1', acceptedAt: null }),
+      ])
+    );
+    render(<DriveMembers driveId="drive-1" />);
+
+    expect(await screen.findByText('Members (2)')).toBeInTheDocument();
+    expect(screen.getByText('Pending invitations (1)')).toBeInTheDocument();
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+  });
+
+  it('Strict null check: acceptedAt undefined must NOT classify as pending', async () => {
+    mockFetchWithAuth.mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            currentUserRole: 'OWNER',
+            members: [{ ...member({ userId: 'm1' }), acceptedAt: undefined }],
+          }),
+      })
+    );
+    render(<DriveMembers driveId="drive-1" />);
+    await screen.findByText(/members \(/i);
+    expect(screen.queryByText(/pending invitations/i)).not.toBeInTheDocument();
+  });
+
+  it('Given Revoke succeeds on a pending row, removes it from local state without a refetch', async () => {
+    mockFetchWithAuth.mockImplementation(() =>
+      okMembers([
+        member({ userId: 'a1' }),
+        member({ userId: 'p1', acceptedAt: null }),
+      ])
+    );
+    mockDel.mockResolvedValue(undefined);
+
+    render(<DriveMembers driveId="drive-1" />);
+    await screen.findByText('Pending invitations (1)');
+    expect(mockFetchWithAuth).toHaveBeenCalledTimes(1);
+
+    await userEvent.setup().click(screen.getByRole('button', { name: /revoke invitation/i }));
+    await waitFor(() =>
+      expect(screen.queryByText(/pending invitations/i)).not.toBeInTheDocument()
+    );
+    expect(mockDel).toHaveBeenCalledWith('/api/drives/drive-1/members/p1');
+    expect(mockFetchWithAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it('Given the component mounts, subscribes to all three drive member events', async () => {
+    mockFetchWithAuth.mockImplementation(() => okMembers([]));
+    render(<DriveMembers driveId="drive-1" />);
+    await screen.findByText('Members (0)');
+    EVENTS.forEach((e) => expect(socket.__count(e)).toBe(1));
+  });
+
+  it.each(EVENTS)('Given %s fires for current driveId, refetches the member list', async (event) => {
+    mockFetchWithAuth.mockImplementation(() => okMembers([]));
+    render(<DriveMembers driveId="drive-1" />);
+    await screen.findByText('Members (0)');
+    expect(mockFetchWithAuth).toHaveBeenCalledTimes(1);
+
+    socket.__emit(event, { driveId: 'drive-1' });
+    await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalledTimes(2));
+  });
+
+  it('Does NOT refetch when the event is for a different driveId', async () => {
+    mockFetchWithAuth.mockImplementation(() => okMembers([]));
+    render(<DriveMembers driveId="drive-1" />);
+    await screen.findByText('Members (0)');
+    expect(mockFetchWithAuth).toHaveBeenCalledTimes(1);
+
+    socket.__emit('drive:member_added', { driveId: 'other' });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(mockFetchWithAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it('Given the component unmounts, unsubscribes from all three events', async () => {
+    mockFetchWithAuth.mockImplementation(() => okMembers([]));
+    const { unmount } = render(<DriveMembers driveId="drive-1" />);
+    await screen.findByText('Members (0)');
+    EVENTS.forEach((e) => expect(socket.__count(e)).toBe(1));
+
+    unmount();
+    EVENTS.forEach((e) => expect(socket.__count(e)).toBe(0));
+  });
+});

--- a/apps/web/src/components/members/__tests__/DriveMembers.test.tsx
+++ b/apps/web/src/components/members/__tests__/DriveMembers.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { DriveMembers } from '../DriveMembers';
@@ -56,10 +56,16 @@ const okMembers = (members: ReturnType<typeof member>[], currentUserRole = 'OWNE
 const EVENTS = ['drive:member_added', 'drive:member_removed', 'drive:member_role_changed'] as const;
 
 describe('DriveMembers', () => {
+  const originalConfirm = window.confirm;
+
   beforeEach(() => {
     vi.clearAllMocks();
     socket = makeSocket();
     window.confirm = vi.fn(() => true);
+  });
+
+  afterEach(() => {
+    window.confirm = originalConfirm;
   });
 
   it('Given a mix of pending + accepted, renders two distinct sections with correct counts', async () => {

--- a/apps/web/src/components/members/__tests__/MemberRow.test.tsx
+++ b/apps/web/src/components/members/__tests__/MemberRow.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemberRow } from '../MemberRow';
+
+const buildMember = (acceptedAt: string | null, role = 'MEMBER') => ({
+  id: 'dm-1',
+  userId: 'user-1',
+  role,
+  invitedAt: '2026-05-01T00:00:00Z',
+  acceptedAt,
+  user: { id: 'user-1', email: 'test@example.com', name: 'Test User' },
+  profile: { displayName: 'Test User', username: 'testuser' },
+  customRole: null,
+  permissionCounts: { view: 2, edit: 1, share: 0 },
+});
+
+const renderRow = (
+  acceptedAt: string | null,
+  opts: {
+    currentUserRole?: 'OWNER' | 'ADMIN' | 'MEMBER';
+    onResend?: () => void;
+    onRemove?: () => void;
+    role?: string;
+  } = {}
+) =>
+  render(
+    <MemberRow
+      member={buildMember(acceptedAt, opts.role)}
+      driveId="drive-1"
+      currentUserRole={opts.currentUserRole ?? 'OWNER'}
+      onRemove={opts.onRemove ?? vi.fn()}
+      onResend={opts.onResend}
+    />
+  );
+
+describe('MemberRow', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('Given a pending member row (acceptedAt === null)', () => {
+    it('renders a Pending badge', () => {
+      renderRow(null);
+      expect(screen.getByText('Pending')).toBeInTheDocument();
+    });
+
+    it('hides the Member Settings button', () => {
+      renderRow(null);
+      expect(screen.queryByRole('button', { name: /member settings/i })).not.toBeInTheDocument();
+    });
+
+    it.each([['OWNER' as const], ['ADMIN' as const]])(
+      'exposes a Revoke button to %s and fires onRemove on click',
+      async (role) => {
+        const onRemove = vi.fn();
+        renderRow(null, { currentUserRole: role, onRemove });
+        await userEvent.setup().click(screen.getByRole('button', { name: /revoke invitation/i }));
+        expect(onRemove).toHaveBeenCalledOnce();
+      }
+    );
+
+    it('does NOT expose a Revoke button to MEMBER', () => {
+      renderRow(null, { currentUserRole: 'MEMBER' });
+      expect(screen.queryByRole('button', { name: /revoke invitation/i })).not.toBeInTheDocument();
+    });
+
+    it('renders a Resend button only when onResend is provided', async () => {
+      const onResend = vi.fn();
+      const { rerender } = render(
+        <MemberRow
+          member={buildMember(null)}
+          driveId="drive-1"
+          currentUserRole="OWNER"
+          onRemove={vi.fn()}
+        />
+      );
+      expect(screen.queryByRole('button', { name: /resend invitation/i })).not.toBeInTheDocument();
+
+      rerender(
+        <MemberRow
+          member={buildMember(null)}
+          driveId="drive-1"
+          currentUserRole="OWNER"
+          onRemove={vi.fn()}
+          onResend={onResend}
+        />
+      );
+      await userEvent.setup().click(screen.getByRole('button', { name: /resend invitation/i }));
+      expect(onResend).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('Given an accepted member row (acceptedAt !== null)', () => {
+    it('does NOT render a Pending badge and shows Member Settings + Remove for OWNER', async () => {
+      const onRemove = vi.fn();
+      renderRow('2026-05-02T00:00:00Z', { onRemove });
+      expect(screen.queryByText('Pending')).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /member settings/i })).toBeInTheDocument();
+      await userEvent.setup().click(screen.getByRole('button', { name: /remove member/i }));
+      expect(onRemove).toHaveBeenCalledOnce();
+    });
+
+    it('does NOT render a Remove button for OWNER role', () => {
+      renderRow('2026-05-02T00:00:00Z', { role: 'OWNER' });
+      expect(screen.queryByRole('button', { name: /remove member/i })).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/members/__tests__/UserSearch.test.tsx
+++ b/apps/web/src/components/members/__tests__/UserSearch.test.tsx
@@ -55,4 +55,20 @@ describe('UserSearch', () => {
     await user.click(await screen.findByRole('button', { name: /invite foo@bar\.com/i }));
     expect(onInviteEmail).toHaveBeenCalledWith('foo@bar.com');
   });
+
+  it('Lowercases email-shaped queries before hitting the search API (auth stores emails normalized)', async () => {
+    render(<UserSearch onSelect={vi.fn()} onInviteEmail={vi.fn()} />);
+    await typeQuery('Mixed.Case@Example.COM');
+    await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalled());
+    const url = mockFetchWithAuth.mock.calls.at(-1)?.[0] as string;
+    expect(url).toContain(`q=${encodeURIComponent('mixed.case@example.com')}`);
+  });
+
+  it('Does NOT lowercase non-email queries', async () => {
+    render(<UserSearch onSelect={vi.fn()} onInviteEmail={vi.fn()} />);
+    await typeQuery('Alice');
+    await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalled());
+    const url = mockFetchWithAuth.mock.calls.at(-1)?.[0] as string;
+    expect(url).toContain('q=Alice');
+  });
 });

--- a/apps/web/src/components/members/__tests__/UserSearch.test.tsx
+++ b/apps/web/src/components/members/__tests__/UserSearch.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { UserSearch } from '../UserSearch';
+
+const mockFetchWithAuth = vi.fn();
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: (...a: unknown[]) => mockFetchWithAuth(...a),
+}));
+vi.mock('@/hooks/useDebounce', () => ({
+  useDebounce: <T,>(v: T) => v,
+}));
+
+const emptyOk = () =>
+  Promise.resolve({ ok: true, json: () => Promise.resolve({ users: [] }) });
+
+const typeQuery = async (text: string) => {
+  const user = userEvent.setup();
+  await user.type(screen.getByPlaceholderText(/search by username/i), text);
+  return user;
+};
+
+describe('UserSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchWithAuth.mockImplementation(emptyOk);
+  });
+
+  it('Given a 2+ char query matching email regex with zero results AND onInviteEmail provided, renders an "Invite [email] to PageSpace" button (lowercased + trimmed)', async () => {
+    render(<UserSearch onSelect={vi.fn()} onInviteEmail={vi.fn()} />);
+    await typeQuery('  Mixed.Case@Example.COM  ');
+    expect(
+      await screen.findByRole('button', { name: /invite mixed\.case@example\.com to pagespace/i })
+    ).toBeInTheDocument();
+  });
+
+  it('Given a 2+ char query that does NOT match email regex with zero results, renders "no users found"', async () => {
+    render(<UserSearch onSelect={vi.fn()} onInviteEmail={vi.fn()} />);
+    await typeQuery('just-a-name');
+    expect(await screen.findByText(/no users found/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /invite/i })).not.toBeInTheDocument();
+  });
+
+  it('Given an email query but no onInviteEmail prop, hides the CTA', async () => {
+    render(<UserSearch onSelect={vi.fn()} />);
+    await typeQuery('newuser@example.com');
+    await waitFor(() => expect(screen.getByText(/no users found/i)).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: /invite/i })).not.toBeInTheDocument();
+  });
+
+  it('Given the invite CTA is clicked, calls onInviteEmail(normalizedEmail)', async () => {
+    const onInviteEmail = vi.fn();
+    render(<UserSearch onSelect={vi.fn()} onInviteEmail={onInviteEmail} />);
+    const user = await typeQuery('  Foo@Bar.com  ');
+    await user.click(await screen.findByRole('button', { name: /invite foo@bar\.com/i }));
+    expect(onInviteEmail).toHaveBeenCalledWith('foo@bar.com');
+  });
+});


### PR DESCRIPTION
## Summary

Epic 5 of 6 in the email-invite series. Adds the UI surface for pending drive invitations (email path landed in Epic 4, PR #1239) and closes the realtime listener gap from PR #1229.

## Changes

**Slice 5.1 — UserSearch invite-by-email CTA**
- New `onInviteEmail?: (email: string) => void` prop on `UserSearch`. When the query is 2+ chars, matches an email regex, and yields zero search results, the empty state surfaces an "Invite [email] to PageSpace" button with a normalized (trimmed + lowercased) email. Falls back to today's "no users found" copy for non-email queries or when the prop is omitted.
- Lowercases email-shaped queries client-side before hitting the search API. Auth normalizes emails to lowercase on signup (`magic-link-service.ts`, `passkey-service.ts`), but the search route does exact `eq(users.email, q)` — so a typed `User@Example.COM` previously missed the search and fell through to the new-user CTA, where the invite API would resolve the same address (after its own lowercasing) to the existing verified user and add them via `handleUserIdPath` with `permissions: []`. After this fix, existing users (regardless of profile privacy or input casing) are found via search and admins keep the full permissions UI; the CTA only fires for genuinely unregistered addresses.

**Slice 5.2 — Pending section in `DriveMembers` + `MemberRow`**
- `DriveMembers` now splits members into two distinct sections: **Members (N)** (accepted) and **Pending invitations (N)**. Strict null check (`acceptedAt === null` for pending; `acceptedAt != null` for accepted) so a malformed `undefined` payload never classifies as pending.
- `MemberRow` renders a **Pending** badge for pending rows, hides the Member Settings button (no per-page permissions yet to configure), exposes a Revoke action to OWNER/ADMIN, and renders a Resend button only when the optional `onResend` prop is provided (Epic 6 will wire the handler).
- Revoke optimistically removes the row from local state instead of refetching.
- Fixes the existing remove-member call site to pass `member.userId` rather than the drive_members PK, matching the `[userId]` route signature.

**Slice 5.3 — Realtime listeners (closes the PR #1229 gap)**
- `DriveMembers` now subscribes to `drive:member_added`, `drive:member_removed`, **and `drive:member_role_changed`** on mount, refetches the member list when an event fires for the current drive, and unsubscribes on unmount. PR #1229 added the `member_role_changed` broadcast on the API side but never wired the listener — that gap is closed here.

**Slice 5.4 — Wire the invite page to the email-payload backend**
- Invite page tracks a separate `pendingEmail` state when the UserSearch CTA fires.
- For pending-email submits, POSTs `{ email, role, customRoleId, permissions: [] }` (the API rejects page-level permissions for not-yet-joined users).
- Distinguishes the response shape: `kind: 'invited'` → "Invitation sent to [email]"; `kind: 'added'` → existing "Member/Admin invited successfully" toast; 409 → conflict message from the API (rendered via the thrown error).
- Snapshots the email at submit time so the success toast renders the originally submitted address even if state mutates before the async response (matches PR #1229 behavior).

## Reviewer feedback addressed

- **[Codex P2]** "Reuse selected permissions when inviting by email" — addressed in 757f12851 by normalizing email-shaped queries in `UserSearch`. Root-cause fix: the regression occurred because case-mismatched queries fell through to the email-CTA path. Normalizing queries client-side ensures the CTA only fires for genuinely new users, where `permissions: []` is correct. See the inline reply for the full reasoning.

## Test plan

- [x] `apps/web/src/components/members/__tests__/UserSearch.test.tsx` — 6 G/W/S tests: CTA, email normalization (CTA email + search query), non-email query passthrough, missing-prop guard, click handler
- [x] `apps/web/src/components/members/__tests__/MemberRow.test.tsx` — 8 G/W/S tests covering pending vs accepted state, Revoke (parametrized OWNER/ADMIN), MEMBER gating, conditional Resend, and OWNER role protection
- [x] `apps/web/src/components/members/__tests__/DriveMembers.test.tsx` — 9 tests covering split sections, strict null check, optimistic revoke, mount subscription to all three events (parametrized), driveId scoping, and unmount cleanup
- [x] `apps/web/src/app/dashboard/[driveId]/members/invite/__tests__/page.test.tsx` — 6 tests covering CTA → pending state, email payload shape, `kind: 'invited'` toast, `kind: 'added'` toast, 409 conflict, and the email-snapshot guarantee
- [x] `pnpm typecheck` (workspace, including build) ✅
- [x] `pnpm exec next lint` on changed files ✅
- [x] **29/29** component/page tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)