### PR TITLE
feat(invites): resend pending invitation

### DIFF
--- a/apps/web/src/app/api/drives/[driveId]/members/[userId]/resend/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/[userId]/resend/__tests__/route.test.ts
@@ -1,0 +1,414 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+import type { SessionAuthResult, AuthError } from '@/lib/auth';
+
+// ============================================================================
+// Contract tests for POST /api/drives/[driveId]/members/[userId]/resend
+//
+// Mocks the driveInviteRepository seam, magic-link service, email helper,
+// and rate limiter. No ORM chain mocking — Drizzle is never poked here.
+// ============================================================================
+
+vi.mock('@/lib/repositories/drive-invite-repository', () => ({
+  driveInviteRepository: {
+    findDriveById: vi.fn(),
+    findAdminMembership: vi.fn(),
+    findExistingMember: vi.fn(),
+    findUserEmail: vi.fn(),
+    findInviterDisplay: vi.fn(),
+    bumpInvitedAt: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/auth/verification-utils', () => ({
+  isEmailVerified: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  },
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/auth/magic-link-service', () => ({
+  createMagicLinkToken: vi.fn(),
+  INVITATION_LINK_EXPIRY_MINUTES: 60 * 24 * 7,
+}));
+
+vi.mock('@pagespace/lib/services/notification-email-service', () => ({
+  sendPendingDriveInvitationEmail: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+  checkDistributedRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
+  DISTRIBUTED_RATE_LIMITS: {
+    DRIVE_INVITE_RESEND: {
+      maxAttempts: 3,
+      windowMs: 24 * 60 * 60 * 1000,
+      blockDurationMs: 24 * 60 * 60 * 1000,
+    },
+  },
+}));
+
+import { POST } from '../route';
+import { driveInviteRepository } from '@/lib/repositories/drive-invite-repository';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { isEmailVerified } from '@pagespace/lib/auth/verification-utils';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { createMagicLinkToken } from '@pagespace/lib/auth/magic-link-service';
+import { sendPendingDriveInvitationEmail } from '@pagespace/lib/services/notification-email-service';
+import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
+
+const mockWebAuth = (userId: string): SessionAuthResult => ({
+  userId,
+  tokenVersion: 0,
+  tokenType: 'session',
+  sessionId: 'test-session-id',
+  role: 'user',
+  adminRoleVersion: 0,
+});
+
+const mockAuthErrorResponse = (status = 401): AuthError => ({
+  error: NextResponse.json({ error: 'Unauthorized' }, { status }),
+});
+
+const mockUserId = 'user_inviter';
+const mockDriveId = 'drive_abc';
+const mockTargetUserId = 'user_target';
+const mockTargetEmail = 'target@example.com';
+
+const mockDrive = {
+  id: mockDriveId,
+  name: 'Test Drive',
+  slug: 'test-drive',
+  ownerId: mockUserId,
+};
+
+const createContext = (driveId: string, userId: string) => ({
+  params: Promise.resolve({ driveId, userId }),
+});
+
+const buildPost = (driveId: string, userId: string) =>
+  new Request(`https://example.com/api/drives/${driveId}/members/${userId}/resend`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe('POST /api/drives/[driveId]/members/[userId]/resend', () => {
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.WEB_APP_URL = 'https://app.example.com';
+    delete process.env.NEXT_PUBLIC_APP_URL;
+
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockWebAuth(mockUserId));
+    vi.mocked(isAuthError).mockReturnValue(false);
+    vi.mocked(isEmailVerified).mockResolvedValue(true);
+
+    vi.mocked(driveInviteRepository.findDriveById).mockResolvedValue(mockDrive as never);
+    vi.mocked(driveInviteRepository.findAdminMembership).mockResolvedValue(null as never);
+    vi.mocked(driveInviteRepository.findExistingMember).mockResolvedValue({
+      id: 'mem_pending',
+      userId: mockTargetUserId,
+      acceptedAt: null,
+    } as never);
+    vi.mocked(driveInviteRepository.findUserEmail).mockResolvedValue(mockTargetEmail);
+    vi.mocked(driveInviteRepository.findInviterDisplay).mockResolvedValue({
+      name: 'Inviter Name',
+      email: 'inviter@example.com',
+    } as never);
+    vi.mocked(driveInviteRepository.bumpInvitedAt).mockResolvedValue(undefined);
+
+    vi.mocked(checkDistributedRateLimit).mockResolvedValue({ allowed: true });
+    vi.mocked(createMagicLinkToken).mockResolvedValue({
+      ok: true,
+      data: { token: 'ps_magic_xyz', userId: mockTargetUserId, isNewUser: false },
+    } as never);
+  });
+
+  describe('auth + authorization', () => {
+    it('given an unauthenticated request, responds 401', async () => {
+      vi.mocked(isAuthError).mockReturnValue(true);
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthErrorResponse(401));
+
+      const response = await POST(
+        buildPost(mockDriveId, mockTargetUserId),
+        createContext(mockDriveId, mockTargetUserId)
+      );
+      expect(response.status).toBe(401);
+    });
+
+    it('given an inviter without verified email, responds 403 with requiresEmailVerification', async () => {
+      vi.mocked(isEmailVerified).mockResolvedValue(false);
+
+      const response = await POST(
+        buildPost(mockDriveId, mockTargetUserId),
+        createContext(mockDriveId, mockTargetUserId)
+      );
+      const json = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(json.requiresEmailVerification).toBe(true);
+    });
+
+    it('given an inviter who is not owner/accepted-admin, responds 403 and emits authz.access.denied', async () => {
+      vi.mocked(driveInviteRepository.findDriveById).mockResolvedValue({
+        ...mockDrive,
+        ownerId: 'someone_else',
+      } as never);
+      vi.mocked(driveInviteRepository.findAdminMembership).mockResolvedValue(null as never);
+
+      const response = await POST(
+        buildPost(mockDriveId, mockTargetUserId),
+        createContext(mockDriveId, mockTargetUserId)
+      );
+
+      expect(response.status).toBe(403);
+      expect(auditRequest).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({ eventType: 'authz.access.denied' })
+      );
+    });
+
+    it('given a pending admin (acceptedAt IS NULL), responds 403 — Epic 1 gate', async () => {
+      vi.mocked(driveInviteRepository.findDriveById).mockResolvedValue({
+        ...mockDrive,
+        ownerId: 'someone_else',
+      } as never);
+      // findAdminMembership filters acceptedAt IS NOT NULL — pending admin returns null.
+      vi.mocked(driveInviteRepository.findAdminMembership).mockResolvedValue(null as never);
+
+      const response = await POST(
+        buildPost(mockDriveId, mockTargetUserId),
+        createContext(mockDriveId, mockTargetUserId)
+      );
+      expect(response.status).toBe(403);
+    });
+
+    it('given a non-existent drive, responds 404', async () => {
+      vi.mocked(driveInviteRepository.findDriveById).mockResolvedValue(null as never);
+
+      const response = await POST(
+        buildPost(mockDriveId, mockTargetUserId),
+        createContext(mockDriveId, mockTargetUserId)
+      );
+      expect(response.status).toBe(404);
+    });
+  });
+
+  describe('state', () => {
+    it('given a non-existent member, responds 404', async () => {
+      vi.mocked(driveInviteRepository.findExistingMember).mockResolvedValue(null as never);
+
+      const response = await POST(
+        buildPost(mockDriveId, mockTargetUserId),
+        createContext(mockDriveId, mockTargetUserId)
+      );
+      expect(response.status).toBe(404);
+      expect(createMagicLinkToken).not.toHaveBeenCalled();
+      expect(sendPendingDriveInvitationEmail).not.toHaveBeenCalled();
+    });
+
+    it('given a member who has already joined (acceptedAt set), responds 400', async () => {
+      vi.mocked(driveInviteRepository.findExistingMember).mockResolvedValue({
+        id: 'mem_already_accepted',
+        userId: mockTargetUserId,
+        acceptedAt: new Date('2026-01-01'),
+      } as never);
+
+      const response = await POST(
+        buildPost(mockDriveId, mockTargetUserId),
+        createContext(mockDriveId, mockTargetUserId)
+      );
+      expect(response.status).toBe(400);
+      expect(createMagicLinkToken).not.toHaveBeenCalled();
+      expect(sendPendingDriveInvitationEmail).not.toHaveBeenCalled();
+    });
+
+    it('given a pending member with no email on file, responds 404', async () => {
+      vi.mocked(driveInviteRepository.findUserEmail).mockResolvedValue(undefined);
+
+      const response = await POST(
+        buildPost(mockDriveId, mockTargetUserId),
+        createContext(mockDriveId, mockTargetUserId)
+      );
+      expect(response.status).toBe(404);
+      expect(createMagicLinkToken).not.toHaveBeenCalled();
+      expect(sendPendingDriveInvitationEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('rate limiting', () => {
+    it('given the (driveId, userId) limit exceeded, responds 429 with Retry-After and emits security.rate.limited', async () => {
+      vi.mocked(checkDistributedRateLimit).mockResolvedValue({ allowed: false, retryAfter: 3600 });
+
+      const response = await POST(
+        buildPost(mockDriveId, mockTargetUserId),
+        createContext(mockDriveId, mockTargetUserId)
+      );
+
+      expect(response.status).toBe(429);
+      expect(response.headers.get('Retry-After')).toBe('3600');
+      expect(auditRequest).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({ eventType: 'security.rate.limited' })
+      );
+      expect(createMagicLinkToken).not.toHaveBeenCalled();
+      expect(sendPendingDriveInvitationEmail).not.toHaveBeenCalled();
+    });
+
+    it('uses drive_invite_resend:${driveId}:${userId} as the rate-limit key', async () => {
+      await POST(
+        buildPost(mockDriveId, mockTargetUserId),
+        createContext(mockDriveId, mockTargetUserId)
+      );
+
+      expect(checkDistributedRateLimit).toHaveBeenCalledWith(
+        `drive_invite_resend:${mockDriveId}:${mockTargetUserId}`,
+        expect.objectContaining({
+          maxAttempts: 3,
+          windowMs: 24 * 60 * 60 * 1000,
+          blockDurationMs: 24 * 60 * 60 * 1000,
+        })
+      );
+    });
+  });
+
+  describe('happy path', () => {
+    it('given a valid pending member, mints a fresh magic-link token and sends the email with it', async () => {
+      const response = await POST(
+        buildPost(mockDriveId, mockTargetUserId),
+        createContext(mockDriveId, mockTargetUserId)
+      );
+      const json = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(json.success).toBe(true);
+
+      expect(createMagicLinkToken).toHaveBeenCalledWith({
+        email: mockTargetEmail,
+        expiryMinutes: 60 * 24 * 7,
+      });
+      expect(sendPendingDriveInvitationEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          recipientEmail: mockTargetEmail,
+          inviterName: 'Inviter Name',
+          driveName: 'Test Drive',
+          magicLinkUrl: expect.stringContaining(
+            'https://app.example.com/api/auth/magic-link/verify?token=ps_magic_xyz'
+          ),
+        })
+      );
+    });
+
+    it('given createMagicLinkToken returns USER_SUSPENDED, responds 403 and does NOT send email', async () => {
+      vi.mocked(createMagicLinkToken).mockResolvedValue({
+        ok: false,
+        error: { code: 'USER_SUSPENDED', userId: mockTargetUserId },
+      } as never);
+
+      const response = await POST(
+        buildPost(mockDriveId, mockTargetUserId),
+        createContext(mockDriveId, mockTargetUserId)
+      );
+
+      expect(response.status).toBe(403);
+      expect(sendPendingDriveInvitationEmail).not.toHaveBeenCalled();
+      expect(driveInviteRepository.bumpInvitedAt).not.toHaveBeenCalled();
+    });
+
+    it('given a successful resend, calls bumpInvitedAt with the member id', async () => {
+      await POST(
+        buildPost(mockDriveId, mockTargetUserId),
+        createContext(mockDriveId, mockTargetUserId)
+      );
+
+      expect(driveInviteRepository.bumpInvitedAt).toHaveBeenCalledWith('mem_pending');
+    });
+
+    it('given a successful resend, fires audit event data.share with operation: resend_invitation', async () => {
+      await POST(
+        buildPost(mockDriveId, mockTargetUserId),
+        createContext(mockDriveId, mockTargetUserId)
+      );
+
+      expect(auditRequest).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          eventType: 'data.share',
+          userId: mockUserId,
+          resourceType: 'drive',
+          resourceId: mockDriveId,
+          details: expect.objectContaining({
+            targetUserId: mockTargetUserId,
+            operation: 'resend_invitation',
+          }),
+        })
+      );
+    });
+
+    it('given the email send throws, responds 502 and does NOT bumpInvitedAt', async () => {
+      vi.mocked(sendPendingDriveInvitationEmail).mockRejectedValueOnce(new Error('SMTP unreachable'));
+
+      const response = await POST(
+        buildPost(mockDriveId, mockTargetUserId),
+        createContext(mockDriveId, mockTargetUserId)
+      );
+
+      expect(response.status).toBe(502);
+      expect(driveInviteRepository.bumpInvitedAt).not.toHaveBeenCalled();
+    });
+
+    it('given an accepted-admin inviter (not owner), allows resend', async () => {
+      vi.mocked(driveInviteRepository.findDriveById).mockResolvedValue({
+        ...mockDrive,
+        ownerId: 'someone_else',
+      } as never);
+      vi.mocked(driveInviteRepository.findAdminMembership).mockResolvedValue({
+        id: 'mem_admin',
+        role: 'ADMIN',
+        acceptedAt: new Date('2025-01-01'),
+      } as never);
+
+      const response = await POST(
+        buildPost(mockDriveId, mockTargetUserId),
+        createContext(mockDriveId, mockTargetUserId)
+      );
+
+      expect(response.status).toBe(200);
+      expect(sendPendingDriveInvitationEmail).toHaveBeenCalled();
+    });
+  });
+
+  describe('appUrl env validation', () => {
+    it('given neither WEB_APP_URL nor NEXT_PUBLIC_APP_URL is set, responds 500 and does NOT send email', async () => {
+      delete process.env.WEB_APP_URL;
+      delete process.env.NEXT_PUBLIC_APP_URL;
+
+      const response = await POST(
+        buildPost(mockDriveId, mockTargetUserId),
+        createContext(mockDriveId, mockTargetUserId)
+      );
+
+      expect(response.status).toBe(500);
+      expect(createMagicLinkToken).not.toHaveBeenCalled();
+      expect(sendPendingDriveInvitationEmail).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/app/api/drives/[driveId]/members/[userId]/resend/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/[userId]/resend/route.ts
@@ -152,8 +152,8 @@ export async function POST(
         magicLinkUrl,
       });
     } catch (emailError) {
-      // Don't include recipientEmail in metadata — it's PII and driveId +
-      // targetUserId is enough to triage. (CodeRabbit PR #1245)
+      // Metadata intentionally omits recipientEmail (PII) — driveId +
+      // targetUserId is enough to triage and avoids log-retention exposure.
       loggers.api.error(
         'Failed to send drive invitation resend email',
         emailError instanceof Error ? emailError : new Error(String(emailError)),

--- a/apps/web/src/app/api/drives/[driveId]/members/[userId]/resend/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/[userId]/resend/route.ts
@@ -1,0 +1,181 @@
+import { NextResponse } from 'next/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { isEmailVerified } from '@pagespace/lib/auth/verification-utils';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { driveInviteRepository } from '@/lib/repositories/drive-invite-repository';
+import {
+  createMagicLinkToken,
+  INVITATION_LINK_EXPIRY_MINUTES,
+} from '@pagespace/lib/auth/magic-link-service';
+import { sendPendingDriveInvitationEmail } from '@pagespace/lib/services/notification-email-service';
+import {
+  checkDistributedRateLimit,
+  DISTRIBUTED_RATE_LIMITS,
+} from '@pagespace/lib/security/distributed-rate-limit';
+
+const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
+
+function resolveAppUrl(): string | null {
+  const url = process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL;
+  if (!url) return null;
+  return url.replace(/\/+$/, '');
+}
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ driveId: string; userId: string }> }
+) {
+  try {
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
+    if (isAuthError(auth)) return auth.error;
+    const inviterUserId = auth.userId;
+
+    const { driveId, userId: targetUserId } = await context.params;
+
+    const emailVerified = await isEmailVerified(inviterUserId);
+    if (!emailVerified) {
+      return NextResponse.json(
+        {
+          error: 'Email verification required. Please verify your email to perform this action.',
+          requiresEmailVerification: true,
+        },
+        { status: 403 }
+      );
+    }
+
+    const drive = await driveInviteRepository.findDriveById(driveId);
+    if (!drive) {
+      return NextResponse.json({ error: 'Drive not found' }, { status: 404 });
+    }
+
+    const isOwner = drive.ownerId === inviterUserId;
+    let isAcceptedAdmin = false;
+    if (!isOwner) {
+      // findAdminMembership filters acceptedAt IS NOT NULL — Epic 1's gate.
+      const adminMembership = await driveInviteRepository.findAdminMembership(driveId, inviterUserId);
+      isAcceptedAdmin = adminMembership !== null;
+    }
+    if (!isOwner && !isAcceptedAdmin) {
+      auditRequest(request, {
+        eventType: 'authz.access.denied',
+        userId: inviterUserId,
+        resourceType: 'drive',
+        resourceId: driveId,
+        details: { targetUserId, operation: 'resend_invitation' },
+      });
+      return NextResponse.json(
+        { error: 'Only drive owners and admins can resend invitations' },
+        { status: 403 }
+      );
+    }
+
+    const member = await driveInviteRepository.findExistingMember(driveId, targetUserId);
+    if (!member) {
+      return NextResponse.json({ error: 'Member not found' }, { status: 404 });
+    }
+    if (member.acceptedAt !== null) {
+      return NextResponse.json(
+        { error: 'Member has already accepted the invitation.' },
+        { status: 400 }
+      );
+    }
+
+    const targetEmail = await driveInviteRepository.findUserEmail(targetUserId);
+    if (!targetEmail) {
+      return NextResponse.json(
+        { error: 'No email on file for this pending member.' },
+        { status: 404 }
+      );
+    }
+
+    const rateLimitKey = `drive_invite_resend:${driveId}:${targetUserId}`;
+    const rl = await checkDistributedRateLimit(
+      rateLimitKey,
+      DISTRIBUTED_RATE_LIMITS.DRIVE_INVITE_RESEND
+    );
+    if (!rl.allowed) {
+      auditRequest(request, {
+        eventType: 'security.rate.limited',
+        userId: inviterUserId,
+        resourceType: 'drive',
+        resourceId: driveId,
+        details: {
+          targetUserId,
+          operation: 'resend_invitation',
+          retryAfter: rl.retryAfter,
+        },
+      });
+      return NextResponse.json(
+        { error: 'Too many resend attempts. Please try again later.' },
+        { status: 429, headers: { 'Retry-After': String(rl.retryAfter ?? 86400) } }
+      );
+    }
+
+    const appUrl = resolveAppUrl();
+    if (!appUrl) {
+      loggers.api.error(
+        'Drive invite resend cannot be sent: WEB_APP_URL and NEXT_PUBLIC_APP_URL both unset'
+      );
+      return NextResponse.json(
+        { error: 'Email delivery is not configured on this deployment.' },
+        { status: 500 }
+      );
+    }
+
+    const tokenResult = await createMagicLinkToken({
+      email: targetEmail,
+      expiryMinutes: INVITATION_LINK_EXPIRY_MINUTES,
+    });
+
+    if (!tokenResult.ok) {
+      if (tokenResult.error.code === 'USER_SUSPENDED') {
+        return NextResponse.json(
+          { error: 'This account is suspended and cannot be invited.' },
+          { status: 403 }
+        );
+      }
+      loggers.api.error('Failed to create magic link token for drive invite resend', undefined, {
+        code: tokenResult.error.code,
+      });
+      return NextResponse.json({ error: 'Failed to resend invitation' }, { status: 500 });
+    }
+
+    const inviter = await driveInviteRepository.findInviterDisplay(inviterUserId);
+    const magicLinkUrl = `${appUrl}/api/auth/magic-link/verify?token=${encodeURIComponent(tokenResult.data.token)}`;
+
+    try {
+      await sendPendingDriveInvitationEmail({
+        recipientEmail: targetEmail,
+        inviterName: inviter?.name ?? 'A teammate',
+        driveName: drive.name,
+        magicLinkUrl,
+      });
+    } catch (emailError) {
+      loggers.api.error(
+        'Failed to send drive invitation resend email',
+        emailError instanceof Error ? emailError : new Error(String(emailError)),
+        { driveId, targetUserId, recipientEmail: targetEmail }
+      );
+      return NextResponse.json(
+        { error: 'Failed to send invitation email. Please try again.' },
+        { status: 502 }
+      );
+    }
+
+    await driveInviteRepository.bumpInvitedAt(member.id);
+
+    auditRequest(request, {
+      eventType: 'data.share',
+      userId: inviterUserId,
+      resourceType: 'drive',
+      resourceId: driveId,
+      details: { targetUserId, operation: 'resend_invitation' },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    loggers.api.error('Error resending drive invitation:', error as Error);
+    return NextResponse.json({ error: 'Failed to resend invitation' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/drives/[driveId]/members/[userId]/resend/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/[userId]/resend/route.ts
@@ -152,10 +152,12 @@ export async function POST(
         magicLinkUrl,
       });
     } catch (emailError) {
+      // Don't include recipientEmail in metadata — it's PII and driveId +
+      // targetUserId is enough to triage. (CodeRabbit PR #1245)
       loggers.api.error(
         'Failed to send drive invitation resend email',
         emailError instanceof Error ? emailError : new Error(String(emailError)),
-        { driveId, targetUserId, recipientEmail: targetEmail }
+        { driveId, targetUserId }
       );
       return NextResponse.json(
         { error: 'Failed to send invitation email. Please try again.' },

--- a/apps/web/src/components/members/DriveMembers.tsx
+++ b/apps/web/src/components/members/DriveMembers.tsx
@@ -7,7 +7,7 @@ import { UserPlus } from 'lucide-react';
 import { MemberRow } from './MemberRow';
 import { useToast } from '@/hooks/useToast';
 import { useSocket } from '@/hooks/useSocket';
-import { del, fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { del, fetchWithAuth, post } from '@/lib/auth/auth-fetch';
 
 interface DriveMember {
   id: string;
@@ -110,6 +110,26 @@ export function DriveMembers({ driveId }: DriveMembersProps) {
     };
   }, [socket, driveId, fetchMembers]);
 
+  const handleResendInvitation = async (userId: string) => {
+    try {
+      await post(`/api/drives/${driveId}/members/${userId}/resend`);
+      toast({
+        title: 'Success',
+        description: 'Invitation resent. A new invitation email has been sent.',
+      });
+      // Refetch so invitedAt-derived UI ("last sent N minutes ago") updates.
+      fetchMembers();
+    } catch (error) {
+      const description =
+        error instanceof Error ? error.message : 'Failed to resend invitation';
+      toast({
+        title: 'Error',
+        description,
+        variant: 'destructive',
+      });
+    }
+  };
+
   const handleRemoveMember = async (userId: string, isPending: boolean) => {
     const message = isPending
       ? 'Are you sure you want to revoke this invitation?'
@@ -198,6 +218,7 @@ export function DriveMembers({ driveId }: DriveMembersProps) {
                 driveId={driveId}
                 currentUserRole={currentUserRole}
                 onRemove={() => handleRemoveMember(member.userId, true)}
+                onResend={() => handleResendInvitation(member.userId)}
               />
             ))}
           </div>

--- a/apps/web/src/components/members/__tests__/DriveMembers.test.tsx
+++ b/apps/web/src/components/members/__tests__/DriveMembers.test.tsx
@@ -5,9 +5,11 @@ import { DriveMembers } from '../DriveMembers';
 
 const mockFetchWithAuth = vi.fn();
 const mockDel = vi.fn();
+const mockPost = vi.fn();
 vi.mock('@/lib/auth/auth-fetch', () => ({
   fetchWithAuth: (...a: unknown[]) => mockFetchWithAuth(...a),
   del: (...a: unknown[]) => mockDel(...a),
+  post: (...a: unknown[]) => mockPost(...a),
 }));
 const stableToast = vi.fn();
 vi.mock('@/hooks/useToast', () => ({
@@ -156,5 +158,94 @@ describe('DriveMembers', () => {
 
     unmount();
     EVENTS.forEach((e) => expect(socket.__count(e)).toBe(0));
+  });
+
+  describe('Resend invitation', () => {
+    it('Given a pending row\'s Resend is clicked, POSTs to the resend endpoint with empty body', async () => {
+      mockFetchWithAuth.mockImplementation(() =>
+        okMembers([member({ userId: 'p1', acceptedAt: null })])
+      );
+      mockPost.mockResolvedValue({});
+
+      render(<DriveMembers driveId="drive-1" />);
+      await screen.findByText('Pending invitations (1)');
+
+      await userEvent.setup().click(screen.getByRole('button', { name: /resend invitation/i }));
+
+      await waitFor(() =>
+        expect(mockPost).toHaveBeenCalledWith('/api/drives/drive-1/members/p1/resend')
+      );
+    });
+
+    it('Given a 200 response, toasts success and refetches members', async () => {
+      mockFetchWithAuth.mockImplementation(() =>
+        okMembers([member({ userId: 'p1', acceptedAt: null })])
+      );
+      mockPost.mockResolvedValue({ success: true });
+
+      render(<DriveMembers driveId="drive-1" />);
+      await screen.findByText('Pending invitations (1)');
+      expect(mockFetchWithAuth).toHaveBeenCalledTimes(1);
+
+      await userEvent.setup().click(screen.getByRole('button', { name: /resend invitation/i }));
+
+      await waitFor(() =>
+        expect(stableToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            description: expect.stringMatching(/invitation resent/i),
+          })
+        )
+      );
+      // Refetch fires so invitedAt-derived UI updates.
+      await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalledTimes(2));
+    });
+
+    it('Given a 429 response, surfaces the rate-limit error message in a destructive toast', async () => {
+      mockFetchWithAuth.mockImplementation(() =>
+        okMembers([member({ userId: 'p1', acceptedAt: null })])
+      );
+      mockPost.mockRejectedValue(
+        Object.assign(new Error('Too many resend attempts. Please try again later.'), {
+          status: 429,
+        })
+      );
+
+      render(<DriveMembers driveId="drive-1" />);
+      await screen.findByText('Pending invitations (1)');
+
+      await userEvent.setup().click(screen.getByRole('button', { name: /resend invitation/i }));
+
+      await waitFor(() =>
+        expect(stableToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            variant: 'destructive',
+            description: expect.stringMatching(/too many resend/i),
+          })
+        )
+      );
+      // No refetch on failure.
+      expect(mockFetchWithAuth).toHaveBeenCalledTimes(1);
+    });
+
+    it('Given a generic error, surfaces the message in a destructive toast', async () => {
+      mockFetchWithAuth.mockImplementation(() =>
+        okMembers([member({ userId: 'p1', acceptedAt: null })])
+      );
+      mockPost.mockRejectedValue(new Error('Network down'));
+
+      render(<DriveMembers driveId="drive-1" />);
+      await screen.findByText('Pending invitations (1)');
+
+      await userEvent.setup().click(screen.getByRole('button', { name: /resend invitation/i }));
+
+      await waitFor(() =>
+        expect(stableToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            variant: 'destructive',
+            description: expect.stringMatching(/network down/i),
+          })
+        )
+      );
+    });
   });
 });

--- a/apps/web/src/lib/repositories/__tests__/drive-invite-repository.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/drive-invite-repository.test.ts
@@ -48,6 +48,7 @@ vi.mock('@pagespace/db/schema/members', () => ({
     userId: 'driveMembers.userId',
     role: 'driveMembers.role',
     acceptedAt: 'driveMembers.acceptedAt',
+    invitedAt: 'driveMembers.invitedAt',
   },
   pagePermissions: {
     id: 'pagePermissions.id',
@@ -332,5 +333,22 @@ describe('driveInviteRepository.acceptPendingMember', () => {
   it('given a concurrent acceptance has already set acceptedAt, the conditional UPDATE matches zero rows and returns false', async () => {
     setupConditionalUpdate([]);
     expect(await driveInviteRepository.acceptPendingMember('mem_already_accepted')).toBe(false);
+  });
+});
+
+describe('driveInviteRepository.bumpInvitedAt', () => {
+  // REVIEW: confirm overwrite acceptable for compliance.
+  // bumpInvitedAt overwrites the original invitedAt rather than persisting a
+  // separate lastInvitedAt column. The product requirement is "last sent N
+  // minutes ago" which only needs the most recent send time. If audit/legal
+  // ever needs the original-invite timestamp, add a lastInvitedAt column and
+  // stop overwriting. PR #1229 review flagged this as the simpler path.
+  it('given a member id, sets invitedAt to a fresh Date filtered by the member id', async () => {
+    const { set } = setupUpdate();
+
+    await driveInviteRepository.bumpInvitedAt('mem_1');
+
+    const setArg = set.mock.calls[0]?.[0] as { invitedAt?: Date };
+    expect(setArg?.invitedAt).toBeInstanceOf(Date);
   });
 });

--- a/apps/web/src/lib/repositories/__tests__/drive-invite-repository.test.ts
+++ b/apps/web/src/lib/repositories/__tests__/drive-invite-repository.test.ts
@@ -343,12 +343,16 @@ describe('driveInviteRepository.bumpInvitedAt', () => {
   // minutes ago" which only needs the most recent send time. If audit/legal
   // ever needs the original-invite timestamp, add a lastInvitedAt column and
   // stop overwriting. PR #1229 review flagged this as the simpler path.
-  it('given a member id, sets invitedAt to a fresh Date filtered by the member id', async () => {
-    const { set } = setupUpdate();
+  it('given a member id, sets invitedAt to a fresh Date filtered by the member id (scoped, not mass)', async () => {
+    const { set, where } = setupUpdate();
 
     await driveInviteRepository.bumpInvitedAt('mem_1');
 
     const setArg = set.mock.calls[0]?.[0] as { invitedAt?: Date };
     expect(setArg?.invitedAt).toBeInstanceOf(Date);
+    // Guard against accidental mass-update: WHERE must scope to this id.
+    expect(where).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'eq', field: 'driveMembers.id', value: 'mem_1' })
+    );
   });
 });

--- a/apps/web/src/lib/repositories/drive-invite-repository.ts
+++ b/apps/web/src/lib/repositories/drive-invite-repository.ts
@@ -244,6 +244,18 @@ export const driveInviteRepository = {
       );
   },
 
+  // REVIEW: confirm overwrite acceptable for compliance.
+  // Overwrites the original invitedAt instead of persisting a separate
+  // lastInvitedAt column. The product surface ("last sent N minutes ago")
+  // only needs the most recent send time. If audit/legal later needs the
+  // original-invite timestamp, add a lastInvitedAt column and stop overwriting.
+  async bumpInvitedAt(memberId: string): Promise<void> {
+    await db
+      .update(driveMembers)
+      .set({ invitedAt: new Date() })
+      .where(eq(driveMembers.id, memberId));
+  },
+
   async acceptPendingMember(memberId: string): Promise<boolean> {
     const updated = await db
       .update(driveMembers)

--- a/packages/lib/src/security/distributed-rate-limit.ts
+++ b/packages/lib/src/security/distributed-rate-limit.ts
@@ -564,6 +564,12 @@ export const DISTRIBUTED_RATE_LIMITS = {
     blockDurationMs: 15 * 60 * 1000,
     progressiveDelay: false,
   },
+  DRIVE_INVITE_RESEND: {
+    maxAttempts: 3,
+    windowMs: 24 * 60 * 60 * 1000,
+    blockDurationMs: 24 * 60 * 60 * 1000,
+    progressiveDelay: false,
+  },
 } as const;
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Adds `POST /api/drives/[driveId]/members/[userId]/resend` to remint a magic-link token and re-send the invitation email for a pending member.
- Adds `bumpInvitedAt` repo method that overwrites `invitedAt` so the UI can show "last sent N minutes ago".
- Wires the `Resend` button in `DriveMembers` to call the new endpoint, with success/429/error toasts and a refetch on success.

## Slices
- **6.1 — `bumpInvitedAt`** (`apps/web/src/lib/repositories/drive-invite-repository.ts`): new method, `// REVIEW` comment flagging that it overwrites `invitedAt` rather than persisting a separate `lastInvitedAt` column. Test mocks `update().set().where()` and asserts `invitedAt` is set to a fresh `Date`.
- **6.2 — Resend route** (`apps/web/src/app/api/drives/[driveId]/members/[userId]/resend/route.ts`): auth (401), email-verified (403 + `requiresEmailVerification`), authz with `authz.access.denied` audit on deny (403), drive 404, member 404, already-accepted 400, no-email 404, distributed rate-limit (429 + `Retry-After` + `security.rate.limited` audit), `appUrl` env validation (500), `createMagicLinkToken` `USER_SUSPENDED` → 403, email-send failure → 502 (no `bumpInvitedAt` if email fails), happy path → `bumpInvitedAt` + `data.share` audit + `{ success: true }`.
- **6.3 — UI wiring** (`apps/web/src/components/members/DriveMembers.tsx`): hooks `MemberRow.onResend` to `POST /api/drives/{id}/members/{uid}/resend`. Toasts success/error; refetches members on success so `invitedAt`-derived UI updates.

## Rate limiting
- Key: `drive_invite_resend:${driveId}:${userId}`
- Config: `maxAttempts: 3, windowMs: 24h, blockDurationMs: 24h` (new `DRIVE_INVITE_RESEND` constant in `packages/lib/src/security/distributed-rate-limit.ts`).

## Out of scope
- Adding a separate `lastInvitedAt` column (flagged via `// REVIEW` comment per the plan).
- Resend for non-pending rows (revoked/accepted go through different flows).

## Test plan
- [x] `pnpm --filter @pagespace/lib lint`, `typecheck`, and `distributed-rate-limit.test.ts` (39 tests) — green
- [x] `pnpm --filter web lint`, `typecheck` — green
- [x] `vitest run resend` (17 tests, route) — green
- [x] `vitest run DriveMembers` (13 tests, UI) — green
- [x] `vitest run src/lib/repositories` (21 tests, repo seam) — green
- [x] Broader scope `vitest run src/components/members src/lib/repositories src/app/api/drives` — 621 / 621 green

## Self-review against rubric
- **Boundary obligations**: rate-limit assertion checks the boundary payload (key + config), not just `toHaveBeenCalled`.
- **Audit events**: `data.share` on success, `authz.access.denied` on authz refusal, `security.rate.limited` on 429 — covered by tests.
- **No DB mocking in route tests**: route test mocks `driveInviteRepository`, `createMagicLinkToken`, `sendPendingDriveInvitationEmail`, `checkDistributedRateLimit`. ORM is only mocked at the repo seam test.
- **PR size**: ~744 LOC (~222 production, ~523 tests). Above the 500-LOC plan target — driven by the comprehensive G/W/S coverage required for auth/authz/state/rate-limit/happy-path. Calling it out per rubric.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Members can now resend pending drive invitations with a rate limit of 3 attempts per 24-hour period.

* **Tests**
  * Added comprehensive test coverage for invitation resend functionality, including authorization, rate limiting, and email delivery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->