### PR TITLE
feat(messages): group consecutive author messages

### DIFF
--- a/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
@@ -28,6 +28,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { isFirstInGroup } from '@/lib/messages/grouping';
 
 const fetcher = async (url: string) => {
   const response = await fetchWithAuth(url);
@@ -369,70 +370,87 @@ export default function InboxDMPage() {
       {/* Messages */}
       <div className="flex-grow overflow-hidden relative">
         <Conversation className="h-full">
-          <ConversationContent className="gap-4 max-w-4xl mx-auto p-4">
-            {messages.map((message) => {
+          <ConversationContent className="max-w-4xl mx-auto p-4">
+            {messages.map((message, i) => {
               const isOwnMessage = message.senderId === user?.id;
               const senderName = isOwnMessage ? 'You' : displayName;
               const senderAvatar = isOwnMessage ? user?.name : displayName;
+              const previous = messages[i - 1];
+              const isFirst = isFirstInGroup(
+                { authorKey: message.senderId, createdAt: message.createdAt },
+                previous ? { authorKey: previous.senderId, createdAt: previous.createdAt } : undefined,
+              );
+              const rowSpacing = i === 0 ? '' : isFirst ? 'mt-4' : 'mt-0.5';
+              const showMenu = isOwnMessage && editingMessageId !== message.id;
 
               return (
-                <div key={message.id} className="flex items-start gap-4">
-                  <Avatar className="h-10 w-10 flex-shrink-0">
-                    {isOwnMessage ? (
-                      <AvatarFallback className="bg-primary text-primary-foreground">
-                        {senderAvatar?.charAt(0).toUpperCase()}
-                      </AvatarFallback>
-                    ) : (
-                      <>
-                        <AvatarImage src={otherUser.image || otherUser.avatarUrl || ''} />
-                        <AvatarFallback>{senderAvatar?.charAt(0).toUpperCase()}</AvatarFallback>
-                      </>
-                    )}
-                  </Avatar>
-
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 mb-1">
-                      <span className="font-semibold text-sm">{senderName}</span>
-                      <span className="text-xs text-muted-foreground">
-                        {new Date(message.createdAt).toLocaleTimeString([], {
-                          hour: '2-digit',
-                          minute: '2-digit'
-                        })}
+                <div key={message.id} className={`group/msg flex items-start gap-4 ${rowSpacing}`}>
+                  {isFirst ? (
+                    <Avatar className="h-10 w-10 flex-shrink-0">
+                      {isOwnMessage ? (
+                        <AvatarFallback className="bg-primary text-primary-foreground">
+                          {senderAvatar?.charAt(0).toUpperCase()}
+                        </AvatarFallback>
+                      ) : (
+                        <>
+                          <AvatarImage src={otherUser.image || otherUser.avatarUrl || ''} />
+                          <AvatarFallback>{senderAvatar?.charAt(0).toUpperCase()}</AvatarFallback>
+                        </>
+                      )}
+                    </Avatar>
+                  ) : (
+                    <div className="h-10 w-10 flex-shrink-0 relative" aria-hidden>
+                      <span className="absolute inset-y-0 right-2 flex items-center text-[10px] text-muted-foreground opacity-0 group-hover/msg:opacity-100 transition-opacity tabular-nums">
+                        {new Date(message.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
                       </span>
-                      {message.isEdited && (
-                        <span className="text-xs text-muted-foreground italic">(edited)</span>
-                      )}
-                      {message.isRead && isOwnMessage && (
-                        <span className="text-xs text-muted-foreground">Read</span>
-                      )}
-                      {isOwnMessage && editingMessageId !== message.id && (
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <button
-                              aria-label="Message options"
-                              className="ml-auto p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
-                              type="button"
-                            >
-                              <MoreHorizontal size={14} aria-hidden />
-                            </button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="end">
-                            <DropdownMenuItem
-                              onClick={() => { setEditingMessageId(message.id); setEditContent(message.content); }}
-                            >
-                              <Pencil className="mr-2 h-4 w-4" /> Edit
-                            </DropdownMenuItem>
-                            <DropdownMenuSeparator />
-                            <DropdownMenuItem
-                              onClick={() => handleDeleteMessage(message.id)}
-                              className="text-destructive focus:text-destructive"
-                            >
-                              <Trash2 className="mr-2 h-4 w-4" /> Delete
-                            </DropdownMenuItem>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      )}
                     </div>
+                  )}
+
+                  <div className="flex-1 min-w-0 relative">
+                    {isFirst && (
+                      <div className="flex items-center gap-2 mb-1">
+                        <span className="font-semibold text-sm">{senderName}</span>
+                        <span className="text-xs text-muted-foreground">
+                          {new Date(message.createdAt).toLocaleTimeString([], {
+                            hour: '2-digit',
+                            minute: '2-digit'
+                          })}
+                        </span>
+                        {message.isEdited && (
+                          <span className="text-xs text-muted-foreground italic">(edited)</span>
+                        )}
+                        {message.isRead && isOwnMessage && (
+                          <span className="text-xs text-muted-foreground">Read</span>
+                        )}
+                        {showMenu && (
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <button
+                                aria-label="Message options"
+                                className="ml-auto p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                                type="button"
+                              >
+                                <MoreHorizontal size={14} aria-hidden />
+                              </button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                              <DropdownMenuItem
+                                onClick={() => { setEditingMessageId(message.id); setEditContent(message.content); }}
+                              >
+                                <Pencil className="mr-2 h-4 w-4" /> Edit
+                              </DropdownMenuItem>
+                              <DropdownMenuSeparator />
+                              <DropdownMenuItem
+                                onClick={() => handleDeleteMessage(message.id)}
+                                className="text-destructive focus:text-destructive"
+                              >
+                                <Trash2 className="mr-2 h-4 w-4" /> Delete
+                              </DropdownMenuItem>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        )}
+                      </div>
+                    )}
 
                     {editingMessageId === message.id ? (
                       <div className="mt-1 flex flex-col gap-2">
@@ -480,7 +498,44 @@ export default function InboxDMPage() {
                           </div>
                         )}
                         <MessageAttachment message={message} />
+                        {!isFirst && (
+                          <div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
+                            {message.isEdited && (
+                              <span className="italic">(edited)</span>
+                            )}
+                            {message.isRead && isOwnMessage && (
+                              <span>Read</span>
+                            )}
+                          </div>
+                        )}
                       </div>
+                    )}
+                    {!isFirst && showMenu && (
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <button
+                            aria-label="Message options"
+                            className="absolute top-0 right-0 p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors opacity-0 group-hover/msg:opacity-100"
+                            type="button"
+                          >
+                            <MoreHorizontal size={14} aria-hidden />
+                          </button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem
+                            onClick={() => { setEditingMessageId(message.id); setEditContent(message.content); }}
+                          >
+                            <Pencil className="mr-2 h-4 w-4" /> Edit
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            onClick={() => handleDeleteMessage(message.id)}
+                            className="text-destructive focus:text-destructive"
+                          >
+                            <Trash2 className="mr-2 h-4 w-4" /> Delete
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
                     )}
                     {user && !message.id.startsWith('temp-') && (
                       <MessageReactions

--- a/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
@@ -515,7 +515,7 @@ export default function InboxDMPage() {
                         <DropdownMenuTrigger asChild>
                           <button
                             aria-label="Message options"
-                            className="absolute top-0 right-0 p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors opacity-0 group-hover/msg:opacity-100"
+                            className="absolute top-0 right-0 p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
                             type="button"
                           >
                             <MoreHorizontal size={14} aria-hidden />

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -31,6 +31,7 @@ import {
   type AttachmentMeta,
   type FileRelation,
 } from '@/lib/attachment-utils';
+import { isFirstInGroup } from '@/lib/messages/grouping';
 
 interface ChannelViewProps {
   page: TreePage;
@@ -391,7 +392,7 @@ function ChannelView({ page }: ChannelViewProps) {
     <MessageDropZone inputRef={channelInputRef} enabled={canEdit} className="flex flex-col h-full">
         <div className="flex-grow overflow-hidden relative">
           <Conversation className="h-full">
-            <ConversationContent className="gap-4 max-w-4xl mx-auto p-4">
+            <ConversationContent className="max-w-4xl mx-auto p-4">
                     {hasMore && (
                       <div className="flex justify-center py-2">
                         <button
@@ -403,7 +404,7 @@ function ChannelView({ page }: ChannelViewProps) {
                         </button>
                       </div>
                     )}
-                    {messages.map((m) => {
+                    {messages.map((m, i) => {
                         const isAi = !!m.aiMeta;
                         const displayName = isAi ? m.aiMeta!.senderName : m.user?.name;
                         const aiLabel = isAi
@@ -415,54 +416,79 @@ function ChannelView({ page }: ChannelViewProps) {
                           ? m.aiMeta!.senderType === 'agent' ? 'A' : m.aiMeta!.senderName?.[0]
                           : m.user?.name?.[0];
                         const isOwnMessage = !isAi && m.userId === user?.id;
+                        const authorKey = isAi ? `ai:${m.aiMeta!.senderName}` : m.userId ?? '';
+                        const previous = messages[i - 1];
+                        const isFirst = isFirstInGroup(
+                          { authorKey, createdAt: m.createdAt },
+                          previous
+                            ? {
+                                authorKey: previous.aiMeta
+                                  ? `ai:${previous.aiMeta.senderName}`
+                                  : previous.userId ?? '',
+                                createdAt: previous.createdAt,
+                              }
+                            : undefined,
+                        );
+                        const rowSpacing = i === 0 ? '' : isFirst ? 'mt-4' : 'mt-0.5';
+                        const showMenu = isOwnMessage && !m.id.startsWith('temp-') && editingMessageId !== m.id;
                         return (
-                        <div key={m.id} className="flex items-start gap-4">
-                            <Avatar className="shrink-0">
-                                {!isAi && <AvatarImage src={m.user?.image || ''} />}
-                                <AvatarFallback>{avatarFallback}</AvatarFallback>
-                            </Avatar>
-                            <div className="flex flex-col min-w-0 flex-1">
-                                <div className="flex items-center gap-2">
-                                    <span className="font-semibold text-sm">{displayName}</span>
-                                    {aiLabel && (
-                                      <span className="text-xs px-1.5 py-0.5 rounded-full bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-300 font-medium">
-                                        {aiLabel}
+                        <div key={m.id} className={`group/msg flex items-start gap-4 ${rowSpacing}`}>
+                            {isFirst ? (
+                              <Avatar className="shrink-0">
+                                  {!isAi && <AvatarImage src={m.user?.image || ''} />}
+                                  <AvatarFallback>{avatarFallback}</AvatarFallback>
+                              </Avatar>
+                            ) : (
+                              <div className="size-8 shrink-0 relative" aria-hidden>
+                                <span className="absolute inset-y-0 right-2 flex items-center text-[10px] text-muted-foreground opacity-0 group-hover/msg:opacity-100 transition-opacity tabular-nums">
+                                  {new Date(m.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                                </span>
+                              </div>
+                            )}
+                            <div className="flex flex-col min-w-0 flex-1 relative">
+                                {isFirst && (
+                                  <div className="flex items-center gap-2">
+                                      <span className="font-semibold text-sm">{displayName}</span>
+                                      {aiLabel && (
+                                        <span className="text-xs px-1.5 py-0.5 rounded-full bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-300 font-medium">
+                                          {aiLabel}
+                                        </span>
+                                      )}
+                                      <span className="text-xs text-muted-foreground">
+                                          {new Date(m.createdAt).toLocaleTimeString()}
                                       </span>
-                                    )}
-                                    <span className="text-xs text-muted-foreground">
-                                        {new Date(m.createdAt).toLocaleTimeString()}
-                                    </span>
-                                    {m.editedAt && (
-                                      <span className="text-xs text-muted-foreground italic">(Edited)</span>
-                                    )}
-                                    {isOwnMessage && !m.id.startsWith('temp-') && editingMessageId !== m.id && (
-                                      <DropdownMenu>
-                                        <DropdownMenuTrigger asChild>
-                                          <button
-                                            aria-label="Message options"
-                                            className="ml-auto p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
-                                            type="button"
-                                          >
-                                            <MoreHorizontal size={14} aria-hidden />
-                                          </button>
-                                        </DropdownMenuTrigger>
-                                        <DropdownMenuContent align="end">
-                                          <DropdownMenuItem
-                                            onClick={() => { setEditingMessageId(m.id); setEditContent(m.content); }}
-                                          >
-                                            <Pencil className="mr-2 h-4 w-4" /> Edit
-                                          </DropdownMenuItem>
-                                          <DropdownMenuSeparator />
-                                          <DropdownMenuItem
-                                            onClick={() => handleDeleteMessage(m.id)}
-                                            className="text-destructive focus:text-destructive"
-                                          >
-                                            <Trash2 className="mr-2 h-4 w-4" /> Delete
-                                          </DropdownMenuItem>
-                                        </DropdownMenuContent>
-                                      </DropdownMenu>
-                                    )}
-                                </div>
+                                      {m.editedAt && (
+                                        <span className="text-xs text-muted-foreground italic">(Edited)</span>
+                                      )}
+                                      {showMenu && (
+                                        <DropdownMenu>
+                                          <DropdownMenuTrigger asChild>
+                                            <button
+                                              aria-label="Message options"
+                                              className="ml-auto p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                                              type="button"
+                                            >
+                                              <MoreHorizontal size={14} aria-hidden />
+                                            </button>
+                                          </DropdownMenuTrigger>
+                                          <DropdownMenuContent align="end">
+                                            <DropdownMenuItem
+                                              onClick={() => { setEditingMessageId(m.id); setEditContent(m.content); }}
+                                            >
+                                              <Pencil className="mr-2 h-4 w-4" /> Edit
+                                            </DropdownMenuItem>
+                                            <DropdownMenuSeparator />
+                                            <DropdownMenuItem
+                                              onClick={() => handleDeleteMessage(m.id)}
+                                              className="text-destructive focus:text-destructive"
+                                            >
+                                              <Trash2 className="mr-2 h-4 w-4" /> Delete
+                                            </DropdownMenuItem>
+                                          </DropdownMenuContent>
+                                        </DropdownMenu>
+                                      )}
+                                  </div>
+                                )}
                                 {editingMessageId === m.id ? (
                                   <div className="mt-1 flex flex-col gap-2">
                                     <textarea
@@ -503,10 +529,39 @@ function ChannelView({ page }: ChannelViewProps) {
                                       content={m.content}
                                       isStreaming={false}
                                     />
+                                    {!isFirst && m.editedAt && (
+                                      <span className="ml-1 text-xs text-muted-foreground italic">(Edited)</span>
+                                    )}
                                   </div>
                                 ) : null}
                                 <MessageAttachment message={m} />
-                                {/* Reactions */}
+                                {!isFirst && showMenu && (
+                                  <DropdownMenu>
+                                    <DropdownMenuTrigger asChild>
+                                      <button
+                                        aria-label="Message options"
+                                        className="absolute top-0 right-0 p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors opacity-0 group-hover/msg:opacity-100"
+                                        type="button"
+                                      >
+                                        <MoreHorizontal size={14} aria-hidden />
+                                      </button>
+                                    </DropdownMenuTrigger>
+                                    <DropdownMenuContent align="end">
+                                      <DropdownMenuItem
+                                        onClick={() => { setEditingMessageId(m.id); setEditContent(m.content); }}
+                                      >
+                                        <Pencil className="mr-2 h-4 w-4" /> Edit
+                                      </DropdownMenuItem>
+                                      <DropdownMenuSeparator />
+                                      <DropdownMenuItem
+                                        onClick={() => handleDeleteMessage(m.id)}
+                                        className="text-destructive focus:text-destructive"
+                                      >
+                                        <Trash2 className="mr-2 h-4 w-4" /> Delete
+                                      </DropdownMenuItem>
+                                    </DropdownMenuContent>
+                                  </DropdownMenu>
+                                )}
                                 {user && !m.id.startsWith('temp-') && (
                                   <MessageReactions
                                     reactions={m.reactions || []}

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -542,7 +542,7 @@ function ChannelView({ page }: ChannelViewProps) {
                                     <DropdownMenuTrigger asChild>
                                       <button
                                         aria-label="Message options"
-                                        className="absolute top-0 right-0 p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors opacity-0 group-hover/msg:opacity-100"
+                                        className="absolute top-0 right-0 p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
                                         type="button"
                                       >
                                         <MoreHorizontal size={14} aria-hidden />

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -524,15 +524,17 @@ function ChannelView({ page }: ChannelViewProps) {
                                     </div>
                                   </div>
                                 ) : m.content ? (
-                                  <div className="prose prose-sm dark:prose-invert max-w-none">
-                                    <StreamingMarkdown
-                                      content={m.content}
-                                      isStreaming={false}
-                                    />
+                                  <>
+                                    <div className="prose prose-sm dark:prose-invert max-w-none">
+                                      <StreamingMarkdown
+                                        content={m.content}
+                                        isStreaming={false}
+                                      />
+                                    </div>
                                     {!isFirst && m.editedAt && (
-                                      <span className="ml-1 text-xs text-muted-foreground italic">(Edited)</span>
+                                      <span className="text-xs text-muted-foreground italic">(Edited)</span>
                                     )}
-                                  </div>
+                                  </>
                                 ) : null}
                                 <MessageAttachment message={m} />
                                 {!isFirst && showMenu && (

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -523,19 +523,21 @@ function ChannelView({ page }: ChannelViewProps) {
                                       <span className="opacity-60">Enter to save · Esc to cancel</span>
                                     </div>
                                   </div>
-                                ) : m.content ? (
+                                ) : (
                                   <>
-                                    <div className="prose prose-sm dark:prose-invert max-w-none">
-                                      <StreamingMarkdown
-                                        content={m.content}
-                                        isStreaming={false}
-                                      />
-                                    </div>
+                                    {m.content && (
+                                      <div className="prose prose-sm dark:prose-invert max-w-none">
+                                        <StreamingMarkdown
+                                          content={m.content}
+                                          isStreaming={false}
+                                        />
+                                      </div>
+                                    )}
                                     {!isFirst && m.editedAt && (
                                       <span className="text-xs text-muted-foreground italic">(Edited)</span>
                                     )}
                                   </>
-                                ) : null}
+                                )}
                                 <MessageAttachment message={m} />
                                 {!isFirst && showMenu && (
                                   <DropdownMenu>

--- a/apps/web/src/lib/messages/__tests__/grouping.test.ts
+++ b/apps/web/src/lib/messages/__tests__/grouping.test.ts
@@ -45,4 +45,24 @@ describe('isFirstInGroup', () => {
       ),
     ).toBe(false);
   });
+
+  it('groups when the gap is exactly 5 minutes (boundary is exclusive)', () => {
+    const exactlyFive = new Date(t0.getTime() + 5 * 60 * 1000);
+    expect(
+      isFirstInGroup(
+        { authorKey: 'u1', createdAt: exactlyFive },
+        { authorKey: 'u1', createdAt: t0 },
+      ),
+    ).toBe(false);
+  });
+
+  it('breaks when the gap is just over 5 minutes', () => {
+    const justOver = new Date(t0.getTime() + 5 * 60 * 1000 + 1);
+    expect(
+      isFirstInGroup(
+        { authorKey: 'u1', createdAt: justOver },
+        { authorKey: 'u1', createdAt: t0 },
+      ),
+    ).toBe(true);
+  });
 });

--- a/apps/web/src/lib/messages/__tests__/grouping.test.ts
+++ b/apps/web/src/lib/messages/__tests__/grouping.test.ts
@@ -65,4 +65,19 @@ describe('isFirstInGroup', () => {
       ),
     ).toBe(true);
   });
+
+  it('breaks the group when either timestamp is unparseable', () => {
+    expect(
+      isFirstInGroup(
+        { authorKey: 'u1', createdAt: 'not a date' },
+        { authorKey: 'u1', createdAt: t0 },
+      ),
+    ).toBe(true);
+    expect(
+      isFirstInGroup(
+        { authorKey: 'u1', createdAt: t0 },
+        { authorKey: 'u1', createdAt: 'not a date' },
+      ),
+    ).toBe(true);
+  });
 });

--- a/apps/web/src/lib/messages/__tests__/grouping.test.ts
+++ b/apps/web/src/lib/messages/__tests__/grouping.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { isFirstInGroup } from '../grouping';
+
+describe('isFirstInGroup', () => {
+  const t0 = new Date('2026-05-04T12:00:00Z');
+  const t1min = new Date('2026-05-04T12:01:00Z');
+  const t6min = new Date('2026-05-04T12:06:00Z');
+
+  it('returns true when there is no previous message', () => {
+    expect(isFirstInGroup({ authorKey: 'u1', createdAt: t0 }, undefined)).toBe(true);
+  });
+
+  it('returns false for same author within the 5 minute window', () => {
+    expect(
+      isFirstInGroup(
+        { authorKey: 'u1', createdAt: t1min },
+        { authorKey: 'u1', createdAt: t0 },
+      ),
+    ).toBe(false);
+  });
+
+  it('returns true for same author past the 5 minute window', () => {
+    expect(
+      isFirstInGroup(
+        { authorKey: 'u1', createdAt: t6min },
+        { authorKey: 'u1', createdAt: t0 },
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true when authors differ even within the window', () => {
+    expect(
+      isFirstInGroup(
+        { authorKey: 'u2', createdAt: t1min },
+        { authorKey: 'u1', createdAt: t0 },
+      ),
+    ).toBe(true);
+  });
+
+  it('accepts ISO string createdAt values', () => {
+    expect(
+      isFirstInGroup(
+        { authorKey: 'u1', createdAt: t1min.toISOString() },
+        { authorKey: 'u1', createdAt: t0.toISOString() },
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/lib/messages/grouping.ts
+++ b/apps/web/src/lib/messages/grouping.ts
@@ -13,5 +13,6 @@ export function isFirstInGroup(
   if (current.authorKey !== previous.authorKey) return true;
   const currentMs = new Date(current.createdAt).getTime();
   const previousMs = new Date(previous.createdAt).getTime();
+  if (!Number.isFinite(currentMs) || !Number.isFinite(previousMs)) return true;
   return currentMs - previousMs > GROUP_BREAK_MS;
 }

--- a/apps/web/src/lib/messages/grouping.ts
+++ b/apps/web/src/lib/messages/grouping.ts
@@ -1,0 +1,17 @@
+const GROUP_BREAK_MS = 5 * 60 * 1000;
+
+export interface GroupableMessage {
+  authorKey: string;
+  createdAt: Date | string;
+}
+
+export function isFirstInGroup(
+  current: GroupableMessage,
+  previous: GroupableMessage | undefined,
+): boolean {
+  if (!previous) return true;
+  if (current.authorKey !== previous.authorKey) return true;
+  const currentMs = new Date(current.createdAt).getTime();
+  const previousMs = new Date(previous.createdAt).getTime();
+  return currentMs - previousMs > GROUP_BREAK_MS;
+}


### PR DESCRIPTION
## Summary
- Channel and DM message lists now collapse consecutive messages from the same author within a 5-minute window into Slack/Discord-style groups: only the first message in a run shows the avatar + author header; continuations render tighter, with hover-revealed timestamp and edit menu.
- AI senders in channels group on `ai:${senderName}` so consecutive replies from the same agent fold together; a user message between two agent replies breaks the group.
- Vertical spacing switched from parent `gap-4` to per-row `mt-4` (between groups) / `mt-0.5` (within group) for differentiated within-group vs between-group spacing.
- New small pure helper `isFirstInGroup` in `apps/web/src/lib/messages/grouping.ts` used by both renderers; channel and DM renderers stay separate (the threads epic PR series will likely unify them later).

## Files changed
- `apps/web/src/lib/messages/grouping.ts` (new) — pure helper.
- `apps/web/src/lib/messages/__tests__/grouping.test.ts` (new) — 5 unit tests.
- `apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx`
- `apps/web/src/app/dashboard/dms/[conversationId]/page.tsx`

## Test plan
- [x] `pnpm --filter web test src/lib/messages` — 5/5 pass
- [x] `pnpm --filter web typecheck` — clean on all four touched files (pre-existing unrelated errors elsewhere)
- [x] `pnpm --filter web lint` — clean (only pre-existing warning in `QuickCreatePalette.tsx`)
- [ ] Channel — three single-line messages from same user → one header, two tighter continuations; hover reveals timestamp and edit menu
- [ ] Channel — author switch breaks the group
- [ ] Channel — same author after 5+ min gap breaks the group
- [ ] Channel — two consecutive AI agent replies fold; a user message between them breaks the group
- [ ] DM — same checks as channel; bubble alignment (`ml-8`/`mr-8`) still correct on continuations
- [ ] DM — `(edited)` and `Read` flags on continuations render below the bubble
- [ ] Editing a continuation message — textarea renders in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Consecutive messages from the same sender are now visually grouped together
  * Sender information and timestamps appear only at the beginning of each message group
  * Improved spacing and layout for message conversations with grouped senders
  * Message controls repositioned for optimal display in grouped message view

<!-- end of auto-generated comment: release notes by coderabbit.ai -->