### PR TITLE
feat(threads): UI — panel, store, hover, footer (PR 4/5)

### DIFF
--- a/apps/web/src/app/dashboard/channels/[pageId]/page.tsx
+++ b/apps/web/src/app/dashboard/channels/[pageId]/page.tsx
@@ -660,7 +660,7 @@ export default function InboxChannelPage() {
                             onClick={() =>
                               openThread({ source: 'channel', contextId: pageId, parentId: m.id })
                             }
-                            className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors opacity-0 group-hover/msg:opacity-100 focus:opacity-100 transition-opacity"
+                            className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
                           >
                             <MessageSquareReply size={14} aria-hidden />
                           </button>

--- a/apps/web/src/app/dashboard/channels/[pageId]/page.tsx
+++ b/apps/web/src/app/dashboard/channels/[pageId]/page.tsx
@@ -5,7 +5,7 @@ import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import useSWR from 'swr';
 import { toast } from 'sonner';
-import { Hash, ExternalLink, Lock, Pencil, Trash2, Check, X, MoreHorizontal } from 'lucide-react';
+import { Hash, ExternalLink, Lock, Pencil, Trash2, Check, X, MoreHorizontal, MessageSquareReply } from 'lucide-react';
 import { MessageAttachment } from '@/components/shared/MessageAttachment';
 import { useAuth } from '@/hooks/useAuth';
 import { usePermissions, getPermissionErrorMessage } from '@/hooks/usePermissions';
@@ -14,7 +14,8 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { StreamingMarkdown } from '@/components/ai/shared/chat/StreamingMarkdown';
-import { ChannelInput, type ChannelInputRef, type FileAttachment } from '@/components/layout/middle-content/page-views/channel/ChannelInput';
+import { type ChannelInputRef, type FileAttachment } from '@/components/layout/middle-content/page-views/channel/ChannelInput';
+import { MessageInput } from '@/components/shared/MessageInput';
 import { MessageDropZone } from '@/components/layout/middle-content/page-views/channel/MessageDropZone';
 import { MessageReactions, type Reaction } from '@/components/shared/MessageReactions';
 import { PullToRefresh } from '@/components/ui/pull-to-refresh';
@@ -31,6 +32,11 @@ import {
   type AttachmentMeta,
   type FileRelation,
 } from '@/lib/attachment-utils';
+import { useThreadPanelStore } from '@/stores/useThreadPanelStore';
+import { ThreadPanel } from '@/components/layout/middle-content/page-views/thread/ThreadPanel';
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
+import { useMobile } from '@/hooks/useMobile';
+import { formatDistanceToNow } from 'date-fns';
 
 const fetcher = async (url: string) => {
   const response = await fetchWithAuth(url);
@@ -64,6 +70,9 @@ interface MessageWithUser {
     agentPageId?: string;
   } | null;
   editedAt?: string | null;
+  parentId?: string | null;
+  replyCount?: number;
+  lastReplyAt?: string | null;
 }
 
 interface Page {
@@ -94,6 +103,30 @@ export default function InboxChannelPage() {
   const connect = useSocketStore((state) => state.connect);
   const { permissions } = usePermissions(pageId);
   const canEdit = permissions?.canEdit || false;
+  const isMobile = useMobile();
+
+  // Thread panel state — generic across channels and DMs.
+  const threadPanelOpen = useThreadPanelStore((state) => state.open);
+  const threadPanelSource = useThreadPanelStore((state) => state.source);
+  const threadPanelContextId = useThreadPanelStore((state) => state.contextId);
+  const threadPanelParentId = useThreadPanelStore((state) => state.parentId);
+  const openThread = useThreadPanelStore((state) => state.openThread);
+  const closeThread = useThreadPanelStore((state) => state.close);
+
+  // Close any open thread when the user navigates between channels — the
+  // store is global, so a stale parentId from a previous page would render
+  // a panel against an unrelated message list otherwise.
+  useEffect(() => {
+    closeThread();
+    // Only fire on context switch.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pageId]);
+
+  const isThreadVisible =
+    threadPanelOpen &&
+    threadPanelSource === 'channel' &&
+    threadPanelContextId === pageId &&
+    !!threadPanelParentId;
 
   // Fetch page details
   const { data: page, error: pageError } = useSWR<Page>(
@@ -142,6 +175,10 @@ export default function InboxChannelPage() {
     socket.emit('join_channel', pageId);
 
     const handleNewMessage = (message: MessageWithUser) => {
+      // Thread replies live on the same room but belong to the panel — keep
+      // them out of the top-level stream. The panel listens to the same
+      // event and filters to its open root.
+      if (message.parentId) return;
       setMessages((prev) => {
         if (prev.find((m) => m.id === message.id)) {
           return prev;
@@ -150,10 +187,26 @@ export default function InboxChannelPage() {
       });
     };
 
+    const handleThreadCountUpdated = (data: {
+      rootId: string;
+      replyCount: number;
+      lastReplyAt: string;
+    }) => {
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === data.rootId
+            ? { ...m, replyCount: data.replyCount, lastReplyAt: data.lastReplyAt }
+            : m,
+        ),
+      );
+    };
+
     socket.on('new_message', handleNewMessage);
+    socket.on('thread_reply_count_updated', handleThreadCountUpdated);
 
     return () => {
       socket.off('new_message', handleNewMessage);
+      socket.off('thread_reply_count_updated', handleThreadCountUpdated);
     };
   }, [socket, connectionStatus, pageId]);
 
@@ -168,21 +221,24 @@ export default function InboxChannelPage() {
     }
   }, [messages]);
 
-  const handleSubmit = async (content: string, attachment?: FileAttachment) => {
+  const handleTopLevelSubmit = async ({
+    content,
+    attachment,
+  }: {
+    content: string;
+    attachment?: FileAttachment;
+  }) => {
     if (!user || !pageId) return;
-
     if (!canEdit) {
       toast.error(getPermissionErrorMessage('send', 'channel'));
       return;
     }
 
-    const messageContent = typeof content === 'string' ? content : JSON.stringify(content);
-
     const tempId = `temp-${Date.now()}`;
     const optimisticMessage: MessageWithUser = {
       id: tempId,
       pageId,
-      content: messageContent,
+      content,
       userId: user.id,
       createdAt: new Date(),
       role: 'user',
@@ -194,42 +250,37 @@ export default function InboxChannelPage() {
         image: null,
       },
       fileId: attachment?.id || null,
-      attachmentMeta: attachment ? {
-        originalName: attachment.originalName,
-        size: attachment.size,
-        mimeType: attachment.mimeType,
-        contentHash: attachment.contentHash,
-      } : null,
+      attachmentMeta: attachment
+        ? {
+            originalName: attachment.originalName,
+            size: attachment.size,
+            mimeType: attachment.mimeType,
+            contentHash: attachment.contentHash,
+          }
+        : null,
     };
 
     setMessages((prev) => [...prev, optimisticMessage]);
+    setInputValue('');
+    channelInputRef.current?.clear();
 
     try {
       await post(`/api/channels/${pageId}/messages`, {
-        content: messageContent,
+        content,
         fileId: attachment?.id,
-        attachmentMeta: attachment ? {
-          originalName: attachment.originalName,
-          size: attachment.size,
-          mimeType: attachment.mimeType,
-          contentHash: attachment.contentHash,
-        } : undefined,
+        attachmentMeta: attachment
+          ? {
+              originalName: attachment.originalName,
+              size: attachment.size,
+              mimeType: attachment.mimeType,
+              contentHash: attachment.contentHash,
+            }
+          : undefined,
       });
     } catch (error) {
       setMessages((prev) => prev.filter((m) => m.id !== tempId));
       console.error('Error sending message:', error);
     }
-  };
-
-  const handleSendMessage = (attachment?: FileAttachment) => {
-    if (!inputValue.trim() && !attachment) return;
-    if (!canEdit) {
-      toast.error(getPermissionErrorMessage('send', 'channel'));
-      return;
-    }
-    handleSubmit(inputValue, attachment);
-    channelInputRef.current?.clear();
-    setInputValue('');
   };
 
   const handleRefresh = useCallback(async () => {
@@ -455,8 +506,77 @@ export default function InboxChannelPage() {
     );
   }
 
+  const threadParent = isThreadVisible
+    ? messages.find((m) => m.id === threadPanelParentId) ?? null
+    : null;
+
+  const renderParentSlot = () => {
+    if (!threadParent) {
+      return (
+        <div className="text-sm text-muted-foreground italic">
+          Original message unavailable
+        </div>
+      );
+    }
+    const m = threadParent;
+    const isAi = !!m.aiMeta;
+    const displayName = isAi ? m.aiMeta!.senderName : m.user?.name;
+    const avatarFallback = isAi
+      ? m.aiMeta!.senderType === 'agent'
+        ? 'A'
+        : m.aiMeta!.senderName?.[0]
+      : m.user?.name?.[0];
+    return (
+      <div className="flex items-start gap-3">
+        <Avatar className="shrink-0">
+          {!isAi && <AvatarImage src={m.user?.image || ''} />}
+          <AvatarFallback>{avatarFallback}</AvatarFallback>
+        </Avatar>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="font-semibold text-sm">{displayName}</span>
+            <span className="text-xs text-muted-foreground">
+              {new Date(m.createdAt).toLocaleTimeString()}
+            </span>
+          </div>
+          {m.content && (
+            <div className="prose prose-sm dark:prose-invert max-w-none">
+              <StreamingMarkdown content={m.content} isStreaming={false} />
+            </div>
+          )}
+          <MessageAttachment message={m} />
+        </div>
+      </div>
+    );
+  };
+
+  const resolveThreadAuthor = (authorId: string | null | undefined, fallbackName?: string | null) => {
+    const fromList = messages.find((mm) => mm.userId === authorId);
+    if (fromList?.user) {
+      return { name: fromList.user.name, image: fromList.user.image };
+    }
+    if (authorId === user?.id) {
+      return { name: user?.name ?? 'You', image: null };
+    }
+    return { name: fallbackName ?? 'Member', image: null };
+  };
+
+  const threadPanel = isThreadVisible && threadPanelParentId ? (
+    <ThreadPanel
+      source="channel"
+      contextId={pageId}
+      parentId={threadPanelParentId}
+      currentUserId={user?.id ?? null}
+      parentSlot={renderParentSlot()}
+      resolveAuthor={resolveThreadAuthor}
+      replyCountHint={threadParent?.replyCount}
+      onClose={closeThread}
+    />
+  ) : null;
+
   return (
-    <MessageDropZone inputRef={channelInputRef} enabled={canEdit} className="flex flex-col h-full">
+    <div className="flex h-full w-full">
+    <MessageDropZone inputRef={channelInputRef} enabled={canEdit} className="flex flex-col h-full flex-1 min-w-0">
       {/* Header */}
       <div className="flex-shrink-0 border-b border-border p-4">
         <div className="flex items-center justify-between max-w-4xl mx-auto">
@@ -510,8 +630,9 @@ export default function InboxChannelPage() {
                   : m.user?.name?.[0];
 
                 const isOwnMessage = !isAi && m.userId === user?.id;
+                const replyCount = m.replyCount ?? 0;
                 return (
-                <div key={m.id} className="flex items-start gap-4">
+                <div key={m.id} className="group/msg flex items-start gap-4">
                   <Avatar className="shrink-0">
                     {!isAi && <AvatarImage src={m.user?.image || ''} />}
                     <AvatarFallback>{avatarFallback}</AvatarFallback>
@@ -530,12 +651,26 @@ export default function InboxChannelPage() {
                       {m.editedAt && (
                         <span className="text-xs text-muted-foreground italic">(Edited)</span>
                       )}
+                      <div className="ml-auto flex items-center gap-1 opacity-0 group-hover/msg:opacity-100 focus-within:opacity-100 transition-opacity">
+                        {!isAi && !m.id.startsWith('temp-') && (
+                          <button
+                            type="button"
+                            aria-label="Reply in thread"
+                            data-testid={`reply-in-thread-${m.id}`}
+                            onClick={() =>
+                              openThread({ source: 'channel', contextId: pageId, parentId: m.id })
+                            }
+                            className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                          >
+                            <MessageSquareReply size={14} aria-hidden />
+                          </button>
+                        )}
                       {isOwnMessage && !m.id.startsWith('temp-') && editingMessageId !== m.id && (
                         <DropdownMenu>
                           <DropdownMenuTrigger asChild>
                             <button
                               aria-label="Message options"
-                              className="ml-auto p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                              className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
                               type="button"
                             >
                               <MoreHorizontal size={14} aria-hidden />
@@ -557,6 +692,7 @@ export default function InboxChannelPage() {
                           </DropdownMenuContent>
                         </DropdownMenu>
                       )}
+                      </div>
                     </div>
                     {editingMessageId === m.id ? (
                       <div className="mt-1 flex flex-col gap-2">
@@ -601,6 +737,21 @@ export default function InboxChannelPage() {
                       </div>
                     ) : null}
                     <MessageAttachment message={m} />
+                    {replyCount > 0 && (
+                      <button
+                        type="button"
+                        onClick={() =>
+                          openThread({ source: 'channel', contextId: pageId, parentId: m.id })
+                        }
+                        data-testid={`thread-footer-${m.id}`}
+                        className="mt-1 self-start text-xs text-muted-foreground hover:text-foreground hover:underline"
+                      >
+                        {replyCount} {replyCount === 1 ? 'reply' : 'replies'}
+                        {m.lastReplyAt
+                          ? ` · last reply ${formatDistanceToNow(new Date(m.lastReplyAt), { addSuffix: true })}`
+                          : ''}
+                      </button>
+                    )}
                     {/* Reactions */}
                     {user && !m.id.startsWith('temp-') && (
                       <MessageReactions
@@ -624,14 +775,14 @@ export default function InboxChannelPage() {
       <div className="flex-shrink-0 border-t border-border p-4">
         <div className="max-w-4xl mx-auto">
           {canEdit ? (
-            <ChannelInput
+            <MessageInput
               ref={channelInputRef}
+              source="channel"
+              contextId={page.id}
               value={inputValue}
               onChange={setInputValue}
-              onSend={handleSendMessage}
-              placeholder="Type a message... (use @ to mention, supports **markdown**)"
+              onSubmit={handleTopLevelSubmit}
               driveId={page.driveId}
-              channelId={page.id}
               attachmentsEnabled
             />
           ) : (
@@ -645,5 +796,19 @@ export default function InboxChannelPage() {
         </div>
       </div>
     </MessageDropZone>
+    {threadPanel && !isMobile && (
+      <div className="hidden md:flex w-[420px] shrink-0 h-full">
+        {threadPanel}
+      </div>
+    )}
+    {threadPanel && isMobile && (
+      <Sheet open onOpenChange={(o) => { if (!o) closeThread(); }}>
+        <SheetContent side="right" className="w-full sm:max-w-full p-0">
+          <SheetTitle className="sr-only">Thread</SheetTitle>
+          {threadPanel}
+        </SheetContent>
+      </Sheet>
+    )}
+    </div>
   );
 }

--- a/apps/web/src/app/dashboard/channels/[pageId]/page.tsx
+++ b/apps/web/src/app/dashboard/channels/[pageId]/page.tsx
@@ -651,7 +651,7 @@ export default function InboxChannelPage() {
                       {m.editedAt && (
                         <span className="text-xs text-muted-foreground italic">(Edited)</span>
                       )}
-                      <div className="ml-auto flex items-center gap-1 opacity-0 group-hover/msg:opacity-100 focus-within:opacity-100 transition-opacity">
+                      <div className="ml-auto flex items-center gap-1">
                         {!isAi && !m.id.startsWith('temp-') && (
                           <button
                             type="button"
@@ -660,7 +660,7 @@ export default function InboxChannelPage() {
                             onClick={() =>
                               openThread({ source: 'channel', contextId: pageId, parentId: m.id })
                             }
-                            className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                            className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors opacity-0 group-hover/msg:opacity-100 focus:opacity-100 transition-opacity"
                           >
                             <MessageSquareReply size={14} aria-hidden />
                           </button>

--- a/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
@@ -9,7 +9,8 @@ import {
   ConversationContent,
   ConversationScrollButton,
 } from '@/components/ai/ui/conversation';
-import { ChannelInput, type ChannelInputRef } from '@/components/layout/middle-content/page-views/channel/ChannelInput';
+import { type ChannelInputRef } from '@/components/layout/middle-content/page-views/channel/ChannelInput';
+import { MessageInput } from '@/components/shared/MessageInput';
 import { MessageDropZone } from '@/components/layout/middle-content/page-views/channel/MessageDropZone';
 import type { FileAttachment } from '@/hooks/useAttachmentUpload';
 import { MessageAttachment } from '@/components/shared/MessageAttachment';
@@ -20,7 +21,12 @@ import useSWR from 'swr';
 import { toast } from 'sonner';
 import { useSocket } from '@/hooks/useSocket';
 import { post, patch, del, fetchWithAuth } from '@/lib/auth/auth-fetch';
-import { Pencil, Trash2, Check, X, MoreHorizontal } from 'lucide-react';
+import { Pencil, Trash2, Check, X, MoreHorizontal, MessageSquareReply } from 'lucide-react';
+import { useThreadPanelStore } from '@/stores/useThreadPanelStore';
+import { ThreadPanel } from '@/components/layout/middle-content/page-views/thread/ThreadPanel';
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
+import { useMobile } from '@/hooks/useMobile';
+import { formatDistanceToNow } from 'date-fns';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -52,6 +58,8 @@ interface Message {
   attachmentMeta?: AttachmentMeta | null;
   reactions?: Reaction[];
   parentId?: string | null;
+  replyCount?: number;
+  lastReplyAt?: string | null;
 }
 
 interface DmConversation {
@@ -101,6 +109,26 @@ export default function InboxDMPage() {
   const [editContent, setEditContent] = useState('');
   const chatInputRef = useRef<ChannelInputRef>(null);
   const socket = useSocket();
+  const isMobile = useMobile();
+
+  const threadPanelOpen = useThreadPanelStore((state) => state.open);
+  const threadPanelSource = useThreadPanelStore((state) => state.source);
+  const threadPanelContextId = useThreadPanelStore((state) => state.contextId);
+  const threadPanelParentId = useThreadPanelStore((state) => state.parentId);
+  const openThread = useThreadPanelStore((state) => state.openThread);
+  const closeThread = useThreadPanelStore((state) => state.close);
+
+  // Close any open thread when navigating between conversations.
+  useEffect(() => {
+    closeThread();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [conversationId]);
+
+  const isThreadVisible =
+    threadPanelOpen &&
+    threadPanelSource === 'dm' &&
+    threadPanelContextId === conversationId &&
+    !!threadPanelParentId;
 
   // Fetch conversation details (single conversation, not the full list)
   const { data: conversationData } = useSWR<{ conversation: DmConversation }>(
@@ -180,14 +208,30 @@ export default function InboxDMPage() {
       );
     };
 
+    const handleThreadCountUpdated = (data: {
+      rootId: string;
+      replyCount: number;
+      lastReplyAt: string;
+    }) => {
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === data.rootId
+            ? { ...m, replyCount: data.replyCount, lastReplyAt: data.lastReplyAt }
+            : m,
+        ),
+      );
+    };
+
     socket.on('new_dm_message', handleNewMessage);
     socket.on('reaction_added', handleReactionAdded);
     socket.on('reaction_removed', handleReactionRemoved);
+    socket.on('thread_reply_count_updated', handleThreadCountUpdated);
 
     return () => {
       socket.off('new_dm_message', handleNewMessage);
       socket.off('reaction_added', handleReactionAdded);
       socket.off('reaction_removed', handleReactionRemoved);
+      socket.off('thread_reply_count_updated', handleThreadCountUpdated);
       socket.emit('leave_dm_conversation', conversationId);
     };
   }, [conversationId, user, socket]);
@@ -288,10 +332,14 @@ export default function InboxDMPage() {
     }
   }, [conversationId]);
 
-  const handleSendMessage = async (attachment?: FileAttachment) => {
+  const handleTopLevelSubmit = async ({
+    content,
+    attachment,
+  }: {
+    content: string;
+    attachment?: FileAttachment;
+  }) => {
     if (!user || !conversationId) return;
-    const content = inputValue;
-    if (!content.trim() && !attachment) return;
 
     setInputValue('');
 
@@ -355,8 +403,72 @@ export default function InboxDMPage() {
   const otherUser = conversation.otherUser;
   const displayName = otherUser.displayName || otherUser.name;
 
+  const threadParent = isThreadVisible
+    ? messages.find((m) => m.id === threadPanelParentId) ?? null
+    : null;
+
+  const renderParentSlot = () => {
+    if (!threadParent) {
+      return (
+        <div className="text-sm text-muted-foreground italic">
+          Original message unavailable
+        </div>
+      );
+    }
+    const m = threadParent;
+    const isOwn = m.senderId === user?.id;
+    const name = isOwn ? user?.name ?? 'You' : displayName;
+    const initial = (name?.charAt(0) ?? '?').toUpperCase();
+    return (
+      <div className="flex items-start gap-3">
+        <Avatar className="h-8 w-8 shrink-0">
+          {!isOwn && <AvatarImage src={otherUser.image || otherUser.avatarUrl || ''} />}
+          <AvatarFallback>{initial}</AvatarFallback>
+        </Avatar>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="font-semibold text-sm">{name}</span>
+            <span className="text-xs text-muted-foreground">
+              {new Date(m.createdAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+            </span>
+          </div>
+          {m.content && (
+            <div className="text-sm break-words [overflow-wrap:anywhere]">
+              {renderMessageParts(convertToMessageParts(m.content))}
+            </div>
+          )}
+          <MessageAttachment message={m} />
+        </div>
+      </div>
+    );
+  };
+
+  const resolveThreadAuthor = (authorId: string | null | undefined, fallbackName?: string | null) => {
+    if (authorId === user?.id) {
+      return { name: user?.name ?? 'You', image: null };
+    }
+    if (authorId === otherUser.id) {
+      return { name: displayName, image: otherUser.image || otherUser.avatarUrl };
+    }
+    return { name: fallbackName ?? displayName, image: null };
+  };
+
+  const threadPanel = isThreadVisible && threadPanelParentId ? (
+    <ThreadPanel
+      source="dm"
+      contextId={conversationId}
+      parentId={threadPanelParentId}
+      currentUserId={user?.id ?? null}
+      parentSlot={renderParentSlot()}
+      resolveAuthor={resolveThreadAuthor}
+      replyCountHint={threadParent?.replyCount}
+      onClose={closeThread}
+    />
+  ) : null;
+
   return (
-    <MessageDropZone inputRef={chatInputRef} enabled className="flex flex-col h-full">
+    <div className="flex h-full w-full">
+    <MessageDropZone inputRef={chatInputRef} enabled className="flex flex-col h-full flex-1 min-w-0">
       {/* Header */}
       <div className="flex-shrink-0 border-b border-border p-4">
         <div className="flex items-center gap-3 max-w-4xl mx-auto">
@@ -388,6 +500,8 @@ export default function InboxDMPage() {
               );
               const rowSpacing = i === 0 ? '' : isFirst ? 'mt-4' : 'mt-0.5';
               const showMenu = isOwnMessage && editingMessageId !== message.id;
+              const replyCount = message.replyCount ?? 0;
+              const showReplyInThread = !message.id.startsWith('temp-');
 
               return (
                 <div key={message.id} className={`group/msg flex items-start gap-4 ${rowSpacing}`}>
@@ -428,12 +542,26 @@ export default function InboxDMPage() {
                         {message.isRead && isOwnMessage && (
                           <span className="text-xs text-muted-foreground">Read</span>
                         )}
-                        {showMenu && (
+                        <div className="ml-auto flex items-center gap-1">
+                          {showReplyInThread && (
+                            <button
+                              type="button"
+                              aria-label="Reply in thread"
+                              data-testid={`reply-in-thread-${message.id}`}
+                              onClick={() =>
+                                openThread({ source: 'dm', contextId: conversationId, parentId: message.id })
+                              }
+                              className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                            >
+                              <MessageSquareReply size={14} aria-hidden />
+                            </button>
+                          )}
+                          {showMenu && (
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
                               <button
                                 aria-label="Message options"
-                                className="ml-auto p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                                className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
                                 type="button"
                               >
                                 <MoreHorizontal size={14} aria-hidden />
@@ -454,7 +582,8 @@ export default function InboxDMPage() {
                               </DropdownMenuItem>
                             </DropdownMenuContent>
                           </DropdownMenu>
-                        )}
+                          )}
+                        </div>
                       </div>
                     )}
 
@@ -516,32 +645,64 @@ export default function InboxDMPage() {
                         )}
                       </div>
                     )}
-                    {!isFirst && showMenu && (
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
+                    {!isFirst && (
+                      <div className="absolute top-0 right-0 flex items-center gap-1 opacity-0 group-hover/msg:opacity-100 focus-within:opacity-100 transition-opacity">
+                        {showReplyInThread && (
                           <button
-                            aria-label="Message options"
-                            className="absolute top-0 right-0 p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
                             type="button"
+                            aria-label="Reply in thread"
+                            data-testid={`reply-in-thread-${message.id}`}
+                            onClick={() =>
+                              openThread({ source: 'dm', contextId: conversationId, parentId: message.id })
+                            }
+                            className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
                           >
-                            <MoreHorizontal size={14} aria-hidden />
+                            <MessageSquareReply size={14} aria-hidden />
                           </button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end">
-                          <DropdownMenuItem
-                            onClick={() => { setEditingMessageId(message.id); setEditContent(message.content); }}
-                          >
-                            <Pencil className="mr-2 h-4 w-4" /> Edit
-                          </DropdownMenuItem>
-                          <DropdownMenuSeparator />
-                          <DropdownMenuItem
-                            onClick={() => handleDeleteMessage(message.id)}
-                            className="text-destructive focus:text-destructive"
-                          >
-                            <Trash2 className="mr-2 h-4 w-4" /> Delete
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
+                        )}
+                        {showMenu && (
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <button
+                                aria-label="Message options"
+                                className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                                type="button"
+                              >
+                                <MoreHorizontal size={14} aria-hidden />
+                              </button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                              <DropdownMenuItem
+                                onClick={() => { setEditingMessageId(message.id); setEditContent(message.content); }}
+                              >
+                                <Pencil className="mr-2 h-4 w-4" /> Edit
+                              </DropdownMenuItem>
+                              <DropdownMenuSeparator />
+                              <DropdownMenuItem
+                                onClick={() => handleDeleteMessage(message.id)}
+                                className="text-destructive focus:text-destructive"
+                              >
+                                <Trash2 className="mr-2 h-4 w-4" /> Delete
+                              </DropdownMenuItem>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        )}
+                      </div>
+                    )}
+                    {replyCount > 0 && (
+                      <button
+                        type="button"
+                        onClick={() =>
+                          openThread({ source: 'dm', contextId: conversationId, parentId: message.id })
+                        }
+                        data-testid={`thread-footer-${message.id}`}
+                        className="mt-1 self-start text-xs text-muted-foreground hover:text-foreground hover:underline"
+                      >
+                        {replyCount} {replyCount === 1 ? 'reply' : 'replies'}
+                        {message.lastReplyAt
+                          ? ` · last reply ${formatDistanceToNow(new Date(message.lastReplyAt), { addSuffix: true })}`
+                          : ''}
+                      </button>
                     )}
                     {user && !message.id.startsWith('temp-') && (
                       <MessageReactions
@@ -563,17 +724,31 @@ export default function InboxDMPage() {
       {/* Input */}
       <div className="flex-shrink-0 border-t border-border p-4">
         <div className="max-w-4xl mx-auto">
-          <ChannelInput
+          <MessageInput
             ref={chatInputRef}
+            source="dm"
+            contextId={conversationId}
             value={inputValue}
             onChange={setInputValue}
-            onSend={handleSendMessage}
-            placeholder="Type a message... (use @ to mention, supports **markdown**)"
-            conversationId={conversationId}
+            onSubmit={handleTopLevelSubmit}
             attachmentsEnabled
           />
         </div>
       </div>
     </MessageDropZone>
+    {threadPanel && !isMobile && (
+      <div className="hidden md:flex w-[420px] shrink-0 h-full">
+        {threadPanel}
+      </div>
+    )}
+    {threadPanel && isMobile && (
+      <Sheet open onOpenChange={(o) => { if (!o) closeThread(); }}>
+        <SheetContent side="right" className="w-full sm:max-w-full p-0">
+          <SheetTitle className="sr-only">Thread</SheetTitle>
+          {threadPanel}
+        </SheetContent>
+      </Sheet>
+    )}
+    </div>
   );
 }

--- a/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
@@ -551,7 +551,7 @@ export default function InboxDMPage() {
                               onClick={() =>
                                 openThread({ source: 'dm', contextId: conversationId, parentId: message.id })
                               }
-                              className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors opacity-0 group-hover/msg:opacity-100 focus:opacity-100 transition-opacity"
+                              className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
                             >
                               <MessageSquareReply size={14} aria-hidden />
                             </button>
@@ -655,7 +655,7 @@ export default function InboxDMPage() {
                             onClick={() =>
                               openThread({ source: 'dm', contextId: conversationId, parentId: message.id })
                             }
-                            className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors opacity-0 group-hover/msg:opacity-100 focus:opacity-100 transition-opacity"
+                            className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
                           >
                             <MessageSquareReply size={14} aria-hidden />
                           </button>

--- a/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
@@ -551,7 +551,7 @@ export default function InboxDMPage() {
                               onClick={() =>
                                 openThread({ source: 'dm', contextId: conversationId, parentId: message.id })
                               }
-                              className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                              className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors opacity-0 group-hover/msg:opacity-100 focus:opacity-100 transition-opacity"
                             >
                               <MessageSquareReply size={14} aria-hidden />
                             </button>
@@ -646,7 +646,7 @@ export default function InboxDMPage() {
                       </div>
                     )}
                     {!isFirst && (
-                      <div className="absolute top-0 right-0 flex items-center gap-1 opacity-0 group-hover/msg:opacity-100 focus-within:opacity-100 transition-opacity">
+                      <div className="absolute top-0 right-0 flex items-center gap-1">
                         {showReplyInThread && (
                           <button
                             type="button"
@@ -655,7 +655,7 @@ export default function InboxDMPage() {
                             onClick={() =>
                               openThread({ source: 'dm', contextId: conversationId, parentId: message.id })
                             }
-                            className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                            className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors opacity-0 group-hover/msg:opacity-100 focus:opacity-100 transition-opacity"
                           >
                             <MessageSquareReply size={14} aria-hidden />
                           </button>

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInput.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInput.tsx
@@ -9,16 +9,22 @@ import { ChatTextarea, type ChatTextareaRef } from '@/components/ai/chat/input/C
 import { ChannelInputFooter } from './ChannelInputFooter';
 import { useAttachmentUpload, type FileAttachment } from '@/hooks/useAttachmentUpload';
 import { formatFileSize } from '@/lib/attachment-utils';
+import { useEditingSession } from '@/stores/useEditingSession';
 
 export type { FileAttachment };
+
+export interface ChannelInputSendOptions {
+  /** When true (thread mode), the reply should be mirrored as a top-level message in the parent context */
+  alsoSendToParent?: boolean;
+}
 
 export interface ChannelInputProps {
   /** Current input value */
   value: string;
   /** Input change handler */
   onChange: (value: string) => void;
-  /** Send message handler - receives optional attachment */
-  onSend: (attachment?: FileAttachment) => void;
+  /** Send message handler - receives optional attachment and thread options */
+  onSend: (attachment?: FileAttachment, options?: ChannelInputSendOptions) => void;
   /** Whether the input is disabled */
   disabled?: boolean;
   /** Placeholder text */
@@ -33,6 +39,12 @@ export interface ChannelInputProps {
   channelId?: string;
   /** DM conversation ID for uploads (used when this input is rendered in a DM context) */
   conversationId?: string;
+  /** Thread root id — when set, this input composes a reply for that thread */
+  parentId?: string;
+  /** Render the "Also send to channel/DM" checkbox in the footer (thread composer only) */
+  showAlsoSendToParent?: boolean;
+  /** Stable key used to register the draft with useEditingStore so SWR can't clobber unsent text */
+  editingSessionKey?: string;
   /** Additional class names */
   className?: string;
 }
@@ -77,6 +89,9 @@ export const ChannelInput = forwardRef<ChannelInputRef, ChannelInputProps>(
       attachmentsEnabled = false,
       channelId,
       conversationId,
+      parentId,
+      showAlsoSendToParent = false,
+      editingSessionKey,
       className,
     },
     ref
@@ -85,6 +100,18 @@ export const ChannelInput = forwardRef<ChannelInputRef, ChannelInputProps>(
     const fileInputRef = useRef<HTMLInputElement>(null);
     const shouldReduceMotion = useReducedMotion();
     const [isFocused, setIsFocused] = useState(false);
+    const [alsoSendToParent, setAlsoSendToParent] = useState(false);
+
+    // Hold an editing-store session whenever the user has unsent draft text in
+    // this composer instance. Prevents SWR refreshes / auth refreshes from
+    // unmounting or clobbering the in-progress message — see useEditingStore
+    // for the broader contract.
+    useEditingSession(
+      editingSessionKey ?? '',
+      Boolean(editingSessionKey) && value.trim().length > 0,
+      'form',
+      { componentName: 'ChannelInput', pageId: channelId, conversationId },
+    );
 
     const uploadUrl = channelId
       ? `/api/channels/${channelId}/upload`
@@ -115,8 +142,13 @@ export const ChannelInput = forwardRef<ChannelInputRef, ChannelInputProps>(
 
     const handleSend = () => {
       if ((value.trim() || attachment) && !disabled && !isUploading) {
-        onSend(attachment || undefined);
+        if (parentId) {
+          onSend(attachment || undefined, { alsoSendToParent });
+        } else {
+          onSend(attachment || undefined);
+        }
         clearAttachment();
+        if (parentId) setAlsoSendToParent(false);
       }
     };
 
@@ -325,6 +357,12 @@ export const ChannelInput = forwardRef<ChannelInputRef, ChannelInputProps>(
             onAttachmentClick={handleAttachmentClick}
             attachmentsEnabled={attachmentsEnabled && hasUploadTarget}
             disabled={disabled || isUploading}
+            alsoSendToParentEnabled={Boolean(parentId) && showAlsoSendToParent}
+            alsoSendToParentLabel={
+              conversationId && !channelId ? 'Also send to DM' : 'Also send to channel'
+            }
+            alsoSendToParent={alsoSendToParent}
+            onAlsoSendToParentChange={setAlsoSendToParent}
           />
         </InputCard>
       </div>

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInputFooter.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInputFooter.tsx
@@ -37,6 +37,14 @@ export interface ChannelInputFooterProps {
   attachmentsEnabled?: boolean;
   /** Whether input is disabled */
   disabled?: boolean;
+  /** Render the "Also send to {parent}" checkbox (thread composer only) */
+  alsoSendToParentEnabled?: boolean;
+  /** Label shown next to the also-send checkbox (e.g. "Also send to channel") */
+  alsoSendToParentLabel?: string;
+  /** Current checkbox value */
+  alsoSendToParent?: boolean;
+  /** Checkbox change handler */
+  onAlsoSendToParentChange?: (checked: boolean) => void;
   /** Additional class names */
   className?: string;
 }
@@ -73,6 +81,10 @@ export function ChannelInputFooter({
   onMentionClick,
   attachmentsEnabled = false,
   disabled = false,
+  alsoSendToParentEnabled = false,
+  alsoSendToParentLabel = 'Also send to channel',
+  alsoSendToParent = false,
+  onAlsoSendToParentChange,
   className,
 }: ChannelInputFooterProps) {
   const [emojiPickerOpen, setEmojiPickerOpen] = useState(false);
@@ -196,8 +208,21 @@ export function ChannelInputFooter({
         </EmojiPickerPopover>
       </div>
 
-      {/* Right group - Attachments (future) */}
-      <div className="flex items-center gap-1">
+      {/* Right group - Attachments + thread also-send toggle */}
+      <div className="flex items-center gap-2">
+        {alsoSendToParentEnabled && (
+          <label className="flex items-center gap-1.5 text-xs text-muted-foreground select-none cursor-pointer">
+            <input
+              type="checkbox"
+              data-testid="also-send-to-parent"
+              checked={alsoSendToParent}
+              disabled={disabled}
+              onChange={(e) => onAlsoSendToParentChange?.(e.target.checked)}
+              className="h-3.5 w-3.5 rounded border-border accent-primary"
+            />
+            {alsoSendToParentLabel}
+          </label>
+        )}
         {attachmentsEnabled && (
           <Tooltip>
             <TooltipTrigger asChild>

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInputFooter.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInputFooter.tsx
@@ -211,7 +211,12 @@ export function ChannelInputFooter({
       {/* Right group - Attachments + thread also-send toggle */}
       <div className="flex items-center gap-2">
         {alsoSendToParentEnabled && (
-          <label className="flex items-center gap-1.5 text-xs text-muted-foreground select-none cursor-pointer">
+          <label
+            className={cn(
+              'flex items-center gap-1.5 text-xs text-muted-foreground select-none',
+              disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer',
+            )}
+          >
             <input
               type="checkbox"
               data-testid="also-send-to-parent"

--- a/apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx
@@ -22,7 +22,7 @@
  * `useEditingStore` automatically by the underlying ChannelInput.
  */
 
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import useSWR from 'swr';
 import { X } from 'lucide-react';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
@@ -156,6 +156,14 @@ export function ThreadPanel({
   const [optimisticReplies, setOptimisticReplies] = useState<ThreadReply[]>([]);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
+  // Identity ref guards async work against thread switches: a send may
+  // outlive the panel's current parentId if the user opens another thread
+  // before the network call resolves. The ref reflects the live mount.
+  const activeThreadKeyRef = useRef(`${source}:${contextId}:${parentId}`);
+  useEffect(() => {
+    activeThreadKeyRef.current = `${source}:${contextId}:${parentId}`;
+  }, [source, contextId, parentId]);
+
   const listUrl = buildListUrl(source, contextId, parentId);
   const swrFetcher = useMemo(() => fetcher ?? defaultFetcher, [fetcher]);
 
@@ -189,9 +197,19 @@ export function ThreadPanel({
         },
         { revalidate: false },
       );
-      // Drop a matching optimistic temp row if the server-confirmed version
-      // arrives back via realtime.
-      setOptimisticReplies((prev) => prev.filter((r) => !r.id.startsWith('temp-') || r.content !== raw.content));
+      // Drop ONE matching optimistic temp row when the server-confirmed
+      // version arrives — content+author. Filtering by content alone would
+      // wipe both rows when the user fires the same reply twice in a row.
+      setOptimisticReplies((prev) => {
+        const idx = prev.findIndex(
+          (r) =>
+            r.id.startsWith('temp-') &&
+            r.content === raw.content &&
+            (r.authorId ?? null) === (raw.userId ?? raw.senderId ?? null),
+        );
+        if (idx === -1) return prev;
+        return [...prev.slice(0, idx), ...prev.slice(idx + 1)];
+      });
     };
 
     const handleEdited = (data: { messageId: string; content: string; editedAt: string }) => {
@@ -248,6 +266,9 @@ export function ThreadPanel({
       alsoSendToParent: boolean;
     }) => {
       if (!currentUserId) return;
+      // Snapshot the thread identity at send time so async results bound to
+      // the OLD thread can't leak state into a thread the user switched to.
+      const submitThreadKey = `${source}:${contextId}:${parentId}`;
       const tempId = `temp-${Date.now()}`;
       const optimistic: ThreadReply = {
         id: tempId,
@@ -261,19 +282,46 @@ export function ThreadPanel({
       setSubmitError(null);
 
       try {
-        await post(buildPostUrl(source, contextId), {
+        const response = (await post(buildPostUrl(source, contextId), {
           content,
           parentId,
           ...(alsoSendToParent ? { alsoSendToParent: true } : {}),
-        });
+        })) as RawReply | { message: RawReply } | undefined;
+        if (activeThreadKeyRef.current !== submitThreadKey) return;
+        // Use the POST response to upsert the persisted reply directly.
+        // Without this the temp row would stay stuck on "sending…" whenever
+        // realtime broadcast is unavailable (e.g. INTERNAL_REALTIME_URL unset
+        // or socket disconnected) — the websocket echo isn't the only signal.
+        // Channel returns the reply at the top level; DM wraps it in
+        // { message }.
+        const persisted: RawReply | null = response
+          ? 'message' in (response as { message?: RawReply })
+            ? ((response as { message: RawReply }).message ?? null)
+            : ((response as RawReply).id ? (response as RawReply) : null)
+          : null;
+        if (persisted) {
+          mutate(
+            (current) => {
+              const base: ListResponse = current ?? { messages: [], hasMore: false, nextCursor: null };
+              if (base.messages.some((m) => m.id === persisted.id)) return base;
+              return { ...base, messages: [...base.messages, persisted] };
+            },
+            { revalidate: false },
+          );
+          // Remove the specific optimistic row we created for this send;
+          // realtime echo may also fire and target the same tempId, but a
+          // double-removal is a no-op.
+          setOptimisticReplies((prev) => prev.filter((r) => r.id !== tempId));
+        }
       } catch (err) {
         console.error('Thread reply failed', err);
+        if (activeThreadKeyRef.current !== submitThreadKey) return;
         setOptimisticReplies((prev) => prev.filter((r) => r.id !== tempId));
         setDraft(content);
         setSubmitError('Failed to send reply');
       }
     },
-    [currentUserId, source, contextId, parentId],
+    [currentUserId, source, contextId, parentId, mutate],
   );
 
   // Once we have a fetch response, count the actual visible rows (server +

--- a/apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx
@@ -1,0 +1,424 @@
+'use client';
+
+/**
+ * ThreadPanel
+ *
+ * Right-side panel that overlays the channel/DM message list to render a
+ * one-level-deep thread. Generic across channels and DMs — the parent and
+ * reply author resolution are injected by the mounting page so the panel
+ * can stay agnostic of channel vs DM message shape.
+ *
+ * Routing:
+ *   - Channel replies: GET/POST /api/channels/<contextId>/messages?parentId=<root>
+ *   - DM replies:      GET/POST /api/messages/<contextId>?parentId=<root>
+ *
+ * Realtime: subscribes to the same channel/DM room the page already joined
+ * and filters incoming new_message / new_dm_message by parentId === root.
+ * The page is responsible for parent-footer reply-count updates;
+ * thread_reply_count_updated is broadcast for that purpose elsewhere.
+ *
+ * The composer is a `MessageInput` configured with `parentId` + the
+ * "Also send to channel/DM" toggle. Draft text is registered with
+ * `useEditingStore` automatically by the underlying ChannelInput.
+ */
+
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+import useSWR from 'swr';
+import { X } from 'lucide-react';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import { StreamingMarkdown } from '@/components/ai/shared/chat/StreamingMarkdown';
+import { MessageAttachment } from '@/components/shared/MessageAttachment';
+import { MessageInput } from '@/components/shared/MessageInput';
+import { fetchWithAuth, post } from '@/lib/auth/auth-fetch';
+import { useSocketStore } from '@/stores/useSocketStore';
+import type { AttachmentMeta, FileRelation } from '@/lib/attachment-utils';
+import type { Reaction } from '@/components/shared/MessageReactions';
+import { renderMessageParts, convertToMessageParts } from '@/components/messages/MessagePartRenderer';
+
+export type ThreadSource = 'channel' | 'dm';
+
+/**
+ * Minimal reply shape used inside the panel — covers both channel and DM
+ * message formats. `authorId` is `userId` for channel replies and `senderId`
+ * for DM replies; the resolver maps it back to a display name + avatar.
+ */
+export interface ThreadReply {
+  id: string;
+  content: string;
+  createdAt: string;
+  authorId: string | null;
+  authorName?: string | null;
+  authorImage?: string | null;
+  fileId?: string | null;
+  attachmentMeta?: AttachmentMeta | null;
+  file?: FileRelation | null;
+  reactions?: Reaction[];
+  aiSenderName?: string | null;
+  parentId?: string | null;
+}
+
+export interface ThreadAuthor {
+  name: string;
+  image: string | null;
+}
+
+export interface ThreadPanelProps {
+  source: ThreadSource;
+  contextId: string;
+  parentId: string;
+  currentUserId: string | null;
+  /** Pre-rendered parent message header (page provides; preserves consistency with the main list) */
+  parentSlot: ReactNode;
+  /** Resolve a reply's author to a display name + avatar */
+  resolveAuthor: (authorId: string | null | undefined, fallbackName?: string | null) => ThreadAuthor;
+  /** Optional reply-count hint for the divider; the page knows it from the parent */
+  replyCountHint?: number;
+  onClose: () => void;
+  /**
+   * Test seam: lets tests inject a synchronous fetcher / SWR stub so the
+   * harness does not need to wire up a global fetcher. Production callers
+   * leave this undefined.
+   */
+  fetcher?: (url: string) => Promise<unknown>;
+}
+
+interface ListResponse {
+  messages: RawReply[];
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+
+interface RawReply {
+  id: string;
+  content: string;
+  createdAt: string | Date;
+  // channel shape
+  userId?: string | null;
+  user?: { id: string; name: string | null; image: string | null } | null;
+  aiMeta?: { senderName: string } | null;
+  // dm shape
+  senderId?: string | null;
+  // common
+  fileId?: string | null;
+  attachmentMeta?: AttachmentMeta | null;
+  file?: FileRelation | null;
+  reactions?: Reaction[];
+  parentId?: string | null;
+}
+
+const defaultFetcher = async (url: string) => {
+  const res = await fetchWithAuth(url);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch: ${res.status}`);
+  }
+  return res.json();
+};
+
+const buildListUrl = (source: ThreadSource, contextId: string, parentId: string) =>
+  source === 'channel'
+    ? `/api/channels/${contextId}/messages?parentId=${encodeURIComponent(parentId)}`
+    : `/api/messages/${contextId}?parentId=${encodeURIComponent(parentId)}`;
+
+const buildPostUrl = (source: ThreadSource, contextId: string) =>
+  source === 'channel'
+    ? `/api/channels/${contextId}/messages`
+    : `/api/messages/${contextId}`;
+
+const normalizeReply = (raw: RawReply): ThreadReply => ({
+  id: raw.id,
+  content: raw.content,
+  createdAt:
+    typeof raw.createdAt === 'string' ? raw.createdAt : new Date(raw.createdAt).toISOString(),
+  authorId: raw.userId ?? raw.senderId ?? null,
+  authorName: raw.user?.name ?? raw.aiMeta?.senderName ?? null,
+  authorImage: raw.user?.image ?? null,
+  fileId: raw.fileId ?? null,
+  attachmentMeta: raw.attachmentMeta ?? null,
+  file: raw.file ?? null,
+  reactions: raw.reactions ?? [],
+  aiSenderName: raw.aiMeta?.senderName ?? null,
+  parentId: raw.parentId ?? null,
+});
+
+export function ThreadPanel({
+  source,
+  contextId,
+  parentId,
+  currentUserId,
+  parentSlot,
+  resolveAuthor,
+  replyCountHint,
+  onClose,
+  fetcher,
+}: ThreadPanelProps) {
+  const [draft, setDraft] = useState('');
+  const [optimisticReplies, setOptimisticReplies] = useState<ThreadReply[]>([]);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const listUrl = buildListUrl(source, contextId, parentId);
+  const swrFetcher = useMemo(() => fetcher ?? defaultFetcher, [fetcher]);
+
+  const { data, error, mutate, isLoading } = useSWR<ListResponse>(listUrl, swrFetcher);
+
+  // Reset optimistic state when the open thread switches.
+  useEffect(() => {
+    setOptimisticReplies([]);
+    setDraft('');
+    setSubmitError(null);
+  }, [parentId, contextId, source]);
+
+  const socket = useSocketStore((state) => state.socket);
+  const connectionStatus = useSocketStore((state) => state.connectionStatus);
+
+  // Realtime: append matching thread replies as they arrive on the room the
+  // page already joined. Filtering by `parentId === root` keeps us scoped to
+  // this thread; the page handles top-level rows on its side.
+  useEffect(() => {
+    if (!socket || connectionStatus !== 'connected') return;
+    const eventName = source === 'channel' ? 'new_message' : 'new_dm_message';
+
+    const handler = (raw: RawReply) => {
+      if (!raw || raw.parentId !== parentId) return;
+      // The reply may have been seen via SWR already; mutate dedupes by id.
+      mutate(
+        (current) => {
+          if (!current) return current;
+          if (current.messages.some((m) => m.id === raw.id)) return current;
+          return { ...current, messages: [...current.messages, raw] };
+        },
+        { revalidate: false },
+      );
+      // Drop a matching optimistic temp row if the server-confirmed version
+      // arrives back via realtime.
+      setOptimisticReplies((prev) => prev.filter((r) => !r.id.startsWith('temp-') || r.content !== raw.content));
+    };
+
+    const handleEdited = (data: { messageId: string; content: string; editedAt: string }) => {
+      mutate(
+        (current) => {
+          if (!current) return current;
+          let touched = false;
+          const next = current.messages.map((m) => {
+            if (m.id !== data.messageId) return m;
+            touched = true;
+            return { ...m, content: data.content };
+          });
+          return touched ? { ...current, messages: next } : current;
+        },
+        { revalidate: false },
+      );
+    };
+
+    const handleDeleted = (data: { messageId: string }) => {
+      mutate(
+        (current) => {
+          if (!current) return current;
+          const next = current.messages.filter((m) => m.id !== data.messageId);
+          return next.length === current.messages.length ? current : { ...current, messages: next };
+        },
+        { revalidate: false },
+      );
+    };
+
+    socket.on(eventName, handler);
+    socket.on('message_edited', handleEdited);
+    socket.on('message_deleted', handleDeleted);
+    return () => {
+      socket.off(eventName, handler);
+      socket.off('message_edited', handleEdited);
+      socket.off('message_deleted', handleDeleted);
+    };
+  }, [socket, connectionStatus, source, parentId, mutate]);
+
+  const replies = useMemo<ThreadReply[]>(() => {
+    const fromServer = (data?.messages ?? []).map(normalizeReply);
+    const seen = new Set(fromServer.map((r) => r.id));
+    const merged = [...fromServer, ...optimisticReplies.filter((r) => !seen.has(r.id))];
+    return merged;
+  }, [data, optimisticReplies]);
+
+  const handleSubmit = useCallback(
+    async ({
+      content,
+      alsoSendToParent,
+    }: {
+      content: string;
+      attachment?: unknown;
+      alsoSendToParent: boolean;
+    }) => {
+      if (!currentUserId) return;
+      const tempId = `temp-${Date.now()}`;
+      const optimistic: ThreadReply = {
+        id: tempId,
+        content,
+        createdAt: new Date().toISOString(),
+        authorId: currentUserId,
+        parentId,
+      };
+      setOptimisticReplies((prev) => [...prev, optimistic]);
+      setDraft('');
+      setSubmitError(null);
+
+      try {
+        await post(buildPostUrl(source, contextId), {
+          content,
+          parentId,
+          ...(alsoSendToParent ? { alsoSendToParent: true } : {}),
+        });
+      } catch (err) {
+        console.error('Thread reply failed', err);
+        setOptimisticReplies((prev) => prev.filter((r) => r.id !== tempId));
+        setDraft(content);
+        setSubmitError('Failed to send reply');
+      }
+    },
+    [currentUserId, source, contextId, parentId],
+  );
+
+  const replyCount = data?.messages.length ?? replyCountHint ?? 0;
+
+  return (
+    <aside
+      data-testid="thread-panel"
+      aria-label="Thread"
+      className="flex h-full w-full flex-col border-l border-border bg-background"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-border px-4 py-3">
+        <div className="flex flex-col">
+          <span className="text-sm font-semibold">Thread</span>
+          {replyCount > 0 && (
+            <span className="text-xs text-muted-foreground">
+              {replyCount} {replyCount === 1 ? 'reply' : 'replies'}
+            </span>
+          )}
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onClose}
+          aria-label="Close thread"
+          data-testid="thread-panel-close"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {/* Body */}
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+        <div className="px-4 py-3">{parentSlot}</div>
+
+        <div className="flex items-center gap-3 px-4 py-2 text-xs text-muted-foreground">
+          <span className="h-px flex-1 bg-border" />
+          <span data-testid="thread-divider-count">
+            {replyCount} {replyCount === 1 ? 'reply' : 'replies'}
+          </span>
+          <span className="h-px flex-1 bg-border" />
+        </div>
+
+        {error && (
+          <div className="mx-4 mb-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            <div className="flex items-center justify-between gap-3">
+              <span>Failed to load replies</span>
+              <button
+                type="button"
+                onClick={() => mutate()}
+                className="rounded px-2 py-1 text-xs hover:bg-destructive/20"
+              >
+                Retry
+              </button>
+            </div>
+          </div>
+        )}
+
+        {isLoading && !error && (
+          <div className="flex flex-col gap-3 px-4 py-2" data-testid="thread-loading">
+            <div className="h-4 w-1/2 animate-pulse rounded bg-muted" />
+            <div className="h-4 w-2/3 animate-pulse rounded bg-muted" />
+          </div>
+        )}
+
+        {!isLoading && !error && replies.length === 0 && (
+          <div className="px-4 py-6 text-center text-sm text-muted-foreground">
+            Start the thread
+          </div>
+        )}
+
+        <div className="flex flex-col gap-3 px-4 pb-3">
+          {replies.map((reply) => {
+            const fallback = resolveAuthor(reply.authorId, reply.aiSenderName);
+            const author: ThreadAuthor = {
+              name: reply.authorName ?? fallback.name,
+              image: reply.authorImage ?? fallback.image,
+            };
+            const isOwn = reply.authorId === currentUserId;
+            const initial = author.name?.charAt(0).toUpperCase() ?? '?';
+            return (
+              <div key={reply.id} className="flex items-start gap-3" data-testid="thread-reply">
+                <Avatar className="h-8 w-8 shrink-0">
+                  {author.image && <AvatarImage src={author.image} />}
+                  <AvatarFallback>{initial}</AvatarFallback>
+                </Avatar>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-semibold">{author.name}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {new Date(reply.createdAt).toLocaleTimeString([], {
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      })}
+                    </span>
+                    {isOwn && reply.id.startsWith('temp-') && (
+                      <span className="text-xs italic text-muted-foreground">sending…</span>
+                    )}
+                  </div>
+                  {reply.content && (
+                    <div className="prose prose-sm dark:prose-invert max-w-none break-words [overflow-wrap:anywhere]">
+                      {source === 'channel' ? (
+                        <StreamingMarkdown content={reply.content} isStreaming={false} />
+                      ) : (
+                        renderMessageParts(convertToMessageParts(reply.content))
+                      )}
+                    </div>
+                  )}
+                  {(reply.fileId || reply.attachmentMeta) && (
+                    <MessageAttachment
+                      message={{
+                        fileId: reply.fileId ?? null,
+                        attachmentMeta: reply.attachmentMeta ?? null,
+                        file: reply.file ?? null,
+                      }}
+                    />
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Composer */}
+      <div className="border-t border-border p-3">
+        {submitError && (
+          <div className="mb-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-1.5 text-xs text-destructive">
+            {submitError}
+          </div>
+        )}
+        <MessageInput
+          source={source}
+          contextId={contextId}
+          parentId={parentId}
+          showAlsoSendToParent
+          value={draft}
+          onChange={setDraft}
+          onSubmit={handleSubmit}
+          attachmentsEnabled={false}
+          placeholder="Reply…"
+        />
+      </div>
+    </aside>
+  );
+}
+
+export default ThreadPanel;

--- a/apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx
@@ -276,7 +276,10 @@ export function ThreadPanel({
     [currentUserId, source, contextId, parentId],
   );
 
-  const replyCount = data?.messages.length ?? replyCountHint ?? 0;
+  // Once we have a fetch response, count the actual visible rows (server +
+  // optimistic temps); before the first response, fall back to the parent's
+  // hint so the header doesn't flash "0 replies" then jump to N.
+  const replyCount = data ? replies.length : replyCountHint ?? 0;
 
   return (
     <aside

--- a/apps/web/src/components/layout/middle-content/page-views/thread/__tests__/ThreadPanel.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/thread/__tests__/ThreadPanel.test.tsx
@@ -1,0 +1,353 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+vi.mock('motion/react', () => {
+  const passthrough = (Tag: keyof React.JSX.IntrinsicElements) => {
+    const C = React.forwardRef<HTMLElement, React.HTMLAttributes<HTMLElement>>(
+      ({ children, ...props }, ref) =>
+        React.createElement(
+          Tag,
+          {
+            ...Object.fromEntries(
+              Object.entries(props).filter(
+                ([k]) =>
+                  !k.startsWith('initial') &&
+                  !k.startsWith('animate') &&
+                  !k.startsWith('exit') &&
+                  !k.startsWith('whileTap') &&
+                  !k.startsWith('whileHover') &&
+                  !k.startsWith('transition') &&
+                  !k.startsWith('layout'),
+              ),
+            ),
+            ref,
+          },
+          children,
+        ),
+    );
+    C.displayName = `motion.${String(Tag)}`;
+    return C;
+  };
+  return {
+    motion: new Proxy(
+      {},
+      {
+        get: (_t, prop: string) => passthrough(prop as keyof React.JSX.IntrinsicElements),
+      },
+    ),
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    useReducedMotion: () => false,
+  };
+});
+
+vi.mock('@/components/ai/chat/input/ChatTextarea', () => {
+  interface MockProps {
+    value: string;
+    onChange: (v: string) => void;
+    onSend: () => void;
+    placeholder?: string;
+    canSendEmpty?: boolean;
+    disabled?: boolean;
+  }
+  const MockChatTextarea = React.forwardRef<
+    { focus: () => void; clear: () => void },
+    MockProps
+  >((props, ref) => {
+    React.useImperativeHandle(ref, () => ({ focus: vi.fn(), clear: vi.fn() }));
+    return (
+      <textarea
+        data-testid="chat-textarea"
+        value={props.value}
+        placeholder={props.placeholder}
+        disabled={props.disabled}
+        onChange={(e) => props.onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            if ((props.value.trim() || props.canSendEmpty) && !props.disabled) {
+              props.onSend();
+            }
+          }
+        }}
+      />
+    );
+  });
+  MockChatTextarea.displayName = 'MockChatTextarea';
+  return { ChatTextarea: MockChatTextarea };
+});
+
+vi.mock('@/hooks/useAttachmentUpload', () => ({
+  useAttachmentUpload: () => ({
+    attachment: null,
+    isUploading: false,
+    uploadFile: vi.fn(),
+    clearAttachment: vi.fn(),
+  }),
+}));
+
+const postSpy = vi.fn<(url: string, body: unknown) => Promise<unknown>>(async () => ({ ok: true }));
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: vi.fn(),
+  post: (url: string, body: unknown) => postSpy(url, body),
+}));
+
+const mockSocketHandlers = new Map<string, (payload: unknown) => void>();
+const mockSocket = {
+  on: vi.fn((event: string, handler: (p: unknown) => void) => {
+    mockSocketHandlers.set(event, handler);
+  }),
+  off: vi.fn((event: string) => {
+    mockSocketHandlers.delete(event);
+  }),
+};
+
+vi.mock('@/stores/useSocketStore', () => ({
+  useSocketStore: (selector: (s: { socket: typeof mockSocket; connectionStatus: string }) => unknown) =>
+    selector({ socket: mockSocket, connectionStatus: 'connected' }),
+}));
+
+import { ThreadPanel, type ThreadAuthor } from '../ThreadPanel';
+import { useEditingStore } from '@/stores/useEditingStore';
+import { SWRConfig } from 'swr';
+
+const FreshCache = ({ children }: { children: React.ReactNode }) => (
+  <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>{children}</SWRConfig>
+);
+
+const baseAuthor = (id: string | null | undefined): ThreadAuthor => ({
+  name: id === 'u-self' ? 'Me' : id === 'u-other' ? 'Other' : 'Unknown',
+  image: null,
+});
+
+const renderPanel = (overrides: Partial<React.ComponentProps<typeof ThreadPanel>> = {}) => {
+  const onClose = vi.fn();
+  const fetcher =
+    overrides.fetcher ??
+    vi.fn(async () => ({
+      messages: [
+        {
+          id: 'r1',
+          content: 'first reply',
+          createdAt: new Date('2026-05-05T12:00:00Z').toISOString(),
+          userId: 'u-other',
+          parentId: 'p1',
+        },
+      ],
+      hasMore: false,
+      nextCursor: null,
+    }));
+  const utils = render(
+    <FreshCache>
+      <ThreadPanel
+        source="channel"
+        contextId="page-1"
+        parentId="p1"
+        currentUserId="u-self"
+        parentSlot={<div data-testid="parent-slot">Parent message</div>}
+        resolveAuthor={baseAuthor}
+        onClose={onClose}
+        fetcher={fetcher}
+        {...overrides}
+      />
+    </FreshCache>,
+  );
+  return { ...utils, onClose, fetcher };
+};
+
+describe('ThreadPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSocketHandlers.clear();
+    useEditingStore.setState({ activeSessions: new Map(), pendingSends: new Set() });
+  });
+
+  it('given an opened channel thread, should render the parent slot and the divider count', async () => {
+    renderPanel();
+
+    await waitFor(() => expect(screen.getByTestId('parent-slot')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId('thread-divider-count').textContent).toContain('1 reply'));
+
+    expect({
+      given: 'an opened channel thread with one reply',
+      should: 'show parent slot + divider count',
+      actual: !!screen.getByTestId('parent-slot') && !!screen.getByTestId('thread-divider-count'),
+      expected: true,
+    }).toEqual({
+      given: 'an opened channel thread with one reply',
+      should: 'show parent slot + divider count',
+      actual: true,
+      expected: true,
+    });
+  });
+
+  it('given a draft typed into the composer, should register an editing session keyed by thread:source:contextId:parentId', async () => {
+    const user = userEvent.setup();
+    renderPanel();
+    await waitFor(() => expect(screen.getByTestId('chat-textarea')).toBeInTheDocument());
+
+    await user.type(screen.getByTestId('chat-textarea'), 'draft text');
+
+    await waitFor(() => {
+      const sessions = useEditingStore.getState().getActiveSessions();
+      const ids = sessions.map((s) => s.id);
+      expect(ids).toContain('thread:channel:page-1:p1');
+    });
+
+    const sessions = useEditingStore.getState().getActiveSessions();
+    const found = sessions.find((s) => s.id === 'thread:channel:page-1:p1');
+
+    expect({
+      given: 'a draft typed in the thread composer',
+      should: 'register an editing session with the thread session key',
+      actual: Boolean(found),
+      expected: true,
+    }).toEqual({
+      given: 'a draft typed in the thread composer',
+      should: 'register an editing session with the thread session key',
+      actual: true,
+      expected: true,
+    });
+  });
+
+  it('given the also-send checkbox is checked, should POST with alsoSendToParent=true', async () => {
+    const user = userEvent.setup();
+    renderPanel();
+    await waitFor(() => expect(screen.getByTestId('chat-textarea')).toBeInTheDocument());
+
+    await user.click(screen.getByTestId('also-send-to-parent'));
+    await user.type(screen.getByTestId('chat-textarea'), 'mirror reply{enter}');
+
+    await waitFor(() => expect(postSpy).toHaveBeenCalled());
+    const [url, body] = postSpy.mock.calls[0];
+
+    expect({
+      given: 'reply sent with also-send checked',
+      should: 'POST to the channel endpoint with parentId and alsoSendToParent=true',
+      actual: { url, body },
+      expected: {
+        url: '/api/channels/page-1/messages',
+        body: { content: 'mirror reply', parentId: 'p1', alsoSendToParent: true },
+      },
+    }).toEqual({
+      given: 'reply sent with also-send checked',
+      should: 'POST to the channel endpoint with parentId and alsoSendToParent=true',
+      actual: {
+        url: '/api/channels/page-1/messages',
+        body: { content: 'mirror reply', parentId: 'p1', alsoSendToParent: true },
+      },
+      expected: {
+        url: '/api/channels/page-1/messages',
+        body: { content: 'mirror reply', parentId: 'p1', alsoSendToParent: true },
+      },
+    });
+  });
+
+  it('given a realtime new_message arrives with matching parentId, should append it to the reply list', async () => {
+    renderPanel();
+    await waitFor(() =>
+      expect(screen.getAllByTestId('thread-reply').length).toBeGreaterThanOrEqual(1),
+    );
+
+    const handler = mockSocketHandlers.get('new_message');
+    expect(typeof handler).toBe('function');
+
+    act(() => {
+      handler!({
+        id: 'r2',
+        content: 'live reply',
+        createdAt: new Date().toISOString(),
+        userId: 'u-other',
+        parentId: 'p1',
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('thread-reply').length).toBe(2);
+    });
+
+    expect({
+      given: 'a realtime reply arrives with matching parentId',
+      should: 'append it to the reply list',
+      actual: screen.getAllByTestId('thread-reply').length,
+      expected: 2,
+    }).toEqual({
+      given: 'a realtime reply arrives with matching parentId',
+      should: 'append it to the reply list',
+      actual: 2,
+      expected: 2,
+    });
+  });
+
+  it('given a realtime new_message arrives with a non-matching parentId, should NOT append it', async () => {
+    renderPanel();
+    await waitFor(() =>
+      expect(screen.getAllByTestId('thread-reply').length).toBeGreaterThanOrEqual(1),
+    );
+
+    const handler = mockSocketHandlers.get('new_message');
+    act(() => {
+      handler!({
+        id: 'r3',
+        content: 'unrelated',
+        createdAt: new Date().toISOString(),
+        userId: 'u-other',
+        parentId: 'different-root',
+      });
+    });
+
+    expect({
+      given: 'a realtime reply with non-matching parentId',
+      should: 'leave reply count unchanged',
+      actual: screen.getAllByTestId('thread-reply').length,
+      expected: 1,
+    }).toEqual({
+      given: 'a realtime reply with non-matching parentId',
+      should: 'leave reply count unchanged',
+      actual: 1,
+      expected: 1,
+    });
+  });
+
+  it('given an empty reply list, should render the empty state', async () => {
+    renderPanel({
+      fetcher: vi.fn(async () => ({ messages: [], hasMore: false, nextCursor: null })),
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/start the thread/i)).toBeInTheDocument(),
+    );
+
+    expect({
+      given: 'an empty reply list',
+      should: 'render the empty state',
+      actual: !!screen.queryByText(/start the thread/i),
+      expected: true,
+    }).toEqual({
+      given: 'an empty reply list',
+      should: 'render the empty state',
+      actual: true,
+      expected: true,
+    });
+  });
+
+  it('given the close button is clicked, should call onClose', async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderPanel();
+
+    await user.click(screen.getByTestId('thread-panel-close'));
+
+    expect({
+      given: 'close button clicked',
+      should: 'call onClose',
+      actual: onClose.mock.calls.length,
+      expected: 1,
+    }).toEqual({
+      given: 'close button clicked',
+      should: 'call onClose',
+      actual: 1,
+      expected: 1,
+    });
+  });
+});

--- a/apps/web/src/components/layout/middle-content/page-views/thread/__tests__/ThreadPanel.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/thread/__tests__/ThreadPanel.test.tsx
@@ -332,6 +332,127 @@ describe('ThreadPanel', () => {
     });
   });
 
+  it('given a successful POST, should upsert the persisted reply via SWR even when realtime never echoes', async () => {
+    const user = userEvent.setup();
+    postSpy.mockImplementationOnce(async () => ({
+      id: 'r-server',
+      content: 'no echo reply',
+      createdAt: new Date('2026-05-05T12:30:00Z').toISOString(),
+      userId: 'u-self',
+      parentId: 'p1',
+      reactions: [],
+    }));
+    renderPanel({
+      fetcher: vi.fn(async () => ({ messages: [], hasMore: false, nextCursor: null })),
+    });
+
+    await waitFor(() => expect(screen.getByTestId('chat-textarea')).toBeInTheDocument());
+    await user.type(screen.getByTestId('chat-textarea'), 'no echo reply{enter}');
+
+    // POST resolves; no socket event is fired; the persisted row should still
+    // appear and the optimistic temp row should be reconciled away.
+    await waitFor(() => {
+      const replies = screen.getAllByTestId('thread-reply');
+      expect(replies.length).toBe(1);
+    });
+    expect({
+      given: 'a successful POST without realtime echo',
+      should: 'upsert the persisted reply and clear the optimistic temp',
+      actual: screen.getAllByTestId('thread-reply').length,
+      expected: 1,
+    }).toEqual({
+      given: 'a successful POST without realtime echo',
+      should: 'upsert the persisted reply and clear the optimistic temp',
+      actual: 1,
+      expected: 1,
+    });
+  });
+
+  it('given a DM thread send, should accept POST responses wrapped as { message }', async () => {
+    const user = userEvent.setup();
+    postSpy.mockImplementationOnce(async () => ({
+      message: {
+        id: 'r-dm-server',
+        content: 'wrapped reply',
+        createdAt: new Date('2026-05-05T12:31:00Z').toISOString(),
+        senderId: 'u-self',
+        parentId: 'p1',
+      },
+    }));
+    renderPanel({
+      source: 'dm',
+      contextId: 'conv-1',
+      fetcher: vi.fn(async () => ({ messages: [], hasMore: false, nextCursor: null })),
+    });
+
+    await waitFor(() => expect(screen.getByTestId('chat-textarea')).toBeInTheDocument());
+    await user.type(screen.getByTestId('chat-textarea'), 'wrapped reply{enter}');
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('thread-reply').length).toBe(1);
+    });
+    expect({
+      given: 'a DM thread send with { message }-wrapped POST response',
+      should: 'unwrap and upsert the persisted reply',
+      actual: screen.getAllByTestId('thread-reply').length,
+      expected: 1,
+    }).toEqual({
+      given: 'a DM thread send with { message }-wrapped POST response',
+      should: 'unwrap and upsert the persisted reply',
+      actual: 1,
+      expected: 1,
+    });
+  });
+
+  it('given two consecutive optimistic sends with identical content, should drop only one temp per server echo', async () => {
+    const user = userEvent.setup();
+    let postsCount = 0;
+    postSpy.mockImplementation(async () => {
+      // Don't return a usable id — force the panel to wait for the realtime
+      // echo so the assertion is on the per-temp dedup logic, not the
+      // POST-response upsert path.
+      postsCount += 1;
+      return undefined;
+    });
+    renderPanel({
+      fetcher: vi.fn(async () => ({ messages: [], hasMore: false, nextCursor: null })),
+    });
+
+    await waitFor(() => expect(screen.getByTestId('chat-textarea')).toBeInTheDocument());
+    const ta = screen.getByTestId('chat-textarea');
+    await user.type(ta, 'dup{enter}');
+    await user.type(ta, 'dup{enter}');
+
+    await waitFor(() => expect(screen.getAllByTestId('thread-reply').length).toBe(2));
+
+    const handler = mockSocketHandlers.get('new_message');
+    expect(typeof handler).toBe('function');
+    act(() => {
+      handler!({
+        id: 'r-echo-1',
+        content: 'dup',
+        createdAt: new Date().toISOString(),
+        userId: 'u-self',
+        parentId: 'p1',
+      });
+    });
+
+    // After ONE echo: 1 temp dropped, 1 server row added → still 2 visible.
+    await waitFor(() => expect(screen.getAllByTestId('thread-reply').length).toBe(2));
+
+    expect({
+      given: 'two duplicate-content optimistic sends and one realtime echo',
+      should: 'only drop a single optimistic temp (not both)',
+      actual: { posts: postsCount, replies: screen.getAllByTestId('thread-reply').length },
+      expected: { posts: 2, replies: 2 },
+    }).toEqual({
+      given: 'two duplicate-content optimistic sends and one realtime echo',
+      should: 'only drop a single optimistic temp (not both)',
+      actual: { posts: 2, replies: 2 },
+      expected: { posts: 2, replies: 2 },
+    });
+  });
+
   it('given the close button is clicked, should call onClose', async () => {
     const user = userEvent.setup();
     const { onClose } = renderPanel();

--- a/apps/web/src/components/shared/MessageInput.tsx
+++ b/apps/web/src/components/shared/MessageInput.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+/**
+ * MessageInput
+ *
+ * Thin wrapper around `ChannelInput` that exposes a source-aware composer for
+ * channels, DMs, and threads. The wrapper itself is presentational — it picks
+ * the right upload target (channelId vs conversationId), assembles the
+ * editing-store session key (so unsent drafts survive SWR refreshes), and
+ * forwards `parentId` / "also send to parent" props through to the input.
+ *
+ * Send orchestration (optimistic insert, POST, rollback) lives on the page or
+ * panel that owns the message list — each surface has its own reconciliation
+ * strategy and we keep them in their own files. Callers receive a fully
+ * shaped `onSubmit({ content, attachment, alsoSendToParent })` callback.
+ */
+
+import { forwardRef, useCallback } from 'react';
+import {
+  ChannelInput,
+  type ChannelInputRef,
+  type ChannelInputSendOptions,
+  type FileAttachment,
+} from '@/components/layout/middle-content/page-views/channel/ChannelInput';
+
+export type MessageInputSource = 'channel' | 'dm';
+
+export interface MessageInputSubmit {
+  content: string;
+  attachment?: FileAttachment;
+  alsoSendToParent: boolean;
+}
+
+export interface MessageInputProps {
+  /** Which surface is composing — picks editing-store key namespace and upload target */
+  source: MessageInputSource;
+  /** pageId for `channel`, conversationId for `dm` */
+  contextId: string;
+  /** Current input value */
+  value: string;
+  /** Input change handler */
+  onChange: (value: string) => void;
+  /** Called when the user attempts to send — caller does optimistic update + POST */
+  onSubmit: (info: MessageInputSubmit) => void;
+  /** Drive ID (channel only — used for mention suggestions) */
+  driveId?: string;
+  /** Whether attachments are enabled */
+  attachmentsEnabled?: boolean;
+  /** Thread root id — set when this composer is rendered inside ThreadPanel */
+  parentId?: string;
+  /** Render the "Also send to channel/DM" checkbox in the footer (thread mode only) */
+  showAlsoSendToParent?: boolean;
+  /** Placeholder text */
+  placeholder?: string;
+}
+
+/**
+ * Stable session key for useEditingStore. Includes the parentId so a
+ * top-level draft and a thread draft on the same page do not share state.
+ */
+export const buildEditingSessionKey = (
+  source: MessageInputSource,
+  contextId: string,
+  parentId?: string,
+): string =>
+  parentId
+    ? `thread:${source}:${contextId}:${parentId}`
+    : `compose:${source}:${contextId}`;
+
+export const MessageInput = forwardRef<ChannelInputRef, MessageInputProps>(
+  function MessageInput(
+    {
+      source,
+      contextId,
+      value,
+      onChange,
+      onSubmit,
+      driveId,
+      attachmentsEnabled = true,
+      parentId,
+      showAlsoSendToParent = false,
+      placeholder,
+    },
+    ref,
+  ) {
+    const handleSend = useCallback(
+      (attachment?: FileAttachment, options?: ChannelInputSendOptions) => {
+        const content = value;
+        if (!content.trim() && !attachment) return;
+        onSubmit({
+          content,
+          attachment,
+          alsoSendToParent: Boolean(options?.alsoSendToParent),
+        });
+      },
+      [value, onSubmit],
+    );
+
+    return (
+      <ChannelInput
+        ref={ref}
+        value={value}
+        onChange={onChange}
+        onSend={handleSend}
+        placeholder={
+          placeholder ?? 'Type a message... (use @ to mention, supports **markdown**)'
+        }
+        driveId={source === 'channel' ? driveId : undefined}
+        channelId={source === 'channel' ? contextId : undefined}
+        conversationId={source === 'dm' ? contextId : undefined}
+        attachmentsEnabled={attachmentsEnabled}
+        parentId={parentId}
+        showAlsoSendToParent={showAlsoSendToParent}
+        editingSessionKey={buildEditingSessionKey(source, contextId, parentId)}
+      />
+    );
+  },
+);
+
+export default MessageInput;

--- a/apps/web/src/components/shared/__tests__/MessageInput.test.tsx
+++ b/apps/web/src/components/shared/__tests__/MessageInput.test.tsx
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+vi.mock('motion/react', () => {
+  const passthrough = (Tag: keyof React.JSX.IntrinsicElements) => {
+    const C = React.forwardRef<HTMLElement, React.HTMLAttributes<HTMLElement>>(
+      ({ children, ...props }, ref) =>
+        React.createElement(
+          Tag,
+          {
+            ...Object.fromEntries(
+              Object.entries(props).filter(
+                ([k]) =>
+                  !k.startsWith('initial') &&
+                  !k.startsWith('animate') &&
+                  !k.startsWith('exit') &&
+                  !k.startsWith('whileTap') &&
+                  !k.startsWith('whileHover') &&
+                  !k.startsWith('transition') &&
+                  !k.startsWith('layout'),
+              ),
+            ),
+            ref,
+          },
+          children,
+        ),
+    );
+    C.displayName = `motion.${String(Tag)}`;
+    return C;
+  };
+  return {
+    motion: new Proxy(
+      {},
+      {
+        get: (_t, prop: string) => passthrough(prop as keyof React.JSX.IntrinsicElements),
+      },
+    ),
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    useReducedMotion: () => false,
+  };
+});
+
+vi.mock('@/components/ai/chat/input/ChatTextarea', () => {
+  interface MockProps {
+    value: string;
+    onChange: (v: string) => void;
+    onSend: () => void;
+    placeholder?: string;
+    canSendEmpty?: boolean;
+    disabled?: boolean;
+  }
+  const MockChatTextarea = React.forwardRef<
+    { focus: () => void; clear: () => void },
+    MockProps
+  >((props, ref) => {
+    React.useImperativeHandle(ref, () => ({ focus: vi.fn(), clear: vi.fn() }));
+    return (
+      <textarea
+        data-testid="chat-textarea"
+        value={props.value}
+        placeholder={props.placeholder}
+        disabled={props.disabled}
+        onChange={(e) => props.onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            if ((props.value.trim() || props.canSendEmpty) && !props.disabled) {
+              props.onSend();
+            }
+          }
+        }}
+      />
+    );
+  });
+  MockChatTextarea.displayName = 'MockChatTextarea';
+  return { ChatTextarea: MockChatTextarea };
+});
+
+vi.mock('@/hooks/useAttachmentUpload', () => ({
+  useAttachmentUpload: () => ({
+    attachment: null,
+    isUploading: false,
+    uploadFile: vi.fn(),
+    clearAttachment: vi.fn(),
+  }),
+}));
+
+import {
+  MessageInput,
+  buildEditingSessionKey,
+  type MessageInputSubmit,
+} from '../MessageInput';
+
+const Harness = ({
+  initialValue = '',
+  source,
+  contextId,
+  parentId,
+  showAlsoSendToParent,
+  onSubmit,
+}: {
+  initialValue?: string;
+  source: 'channel' | 'dm';
+  contextId: string;
+  parentId?: string;
+  showAlsoSendToParent?: boolean;
+  onSubmit: (info: MessageInputSubmit) => void;
+}) => {
+  const [value, setValue] = React.useState(initialValue);
+  return (
+    <MessageInput
+      source={source}
+      contextId={contextId}
+      value={value}
+      onChange={setValue}
+      onSubmit={onSubmit}
+      parentId={parentId}
+      showAlsoSendToParent={showAlsoSendToParent}
+    />
+  );
+};
+
+describe('buildEditingSessionKey', () => {
+  it('given a top-level compose, should build a compose-prefixed key', () => {
+    const actual = buildEditingSessionKey('channel', 'page-1');
+    const expected = 'compose:channel:page-1';
+    expect({ given: 'channel top-level compose', should: 'use compose: prefix', actual, expected })
+      .toEqual({ given: 'channel top-level compose', should: 'use compose: prefix', actual: expected, expected });
+  });
+
+  it('given a thread reply, should build a thread-prefixed key including parentId', () => {
+    const actual = buildEditingSessionKey('dm', 'conv-9', 'msg-7');
+    const expected = 'thread:dm:conv-9:msg-7';
+    expect({ given: 'dm thread reply', should: 'use thread: prefix and include parentId', actual, expected })
+      .toEqual({ given: 'dm thread reply', should: 'use thread: prefix and include parentId', actual: expected, expected });
+  });
+});
+
+describe('MessageInput', () => {
+  it('given a channel source and Enter, should submit with content and no parentId metadata', async () => {
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Harness source="channel" contextId="page-1" onSubmit={onSubmit} initialValue="hello channel" />,
+    );
+
+    await user.type(screen.getByTestId('chat-textarea'), '{enter}');
+
+    expect({
+      given: 'a channel-source compose with content',
+      should: 'call onSubmit with content + alsoSendToParent=false',
+      actual: onSubmit.mock.calls[0]?.[0],
+      expected: { content: 'hello channel', attachment: undefined, alsoSendToParent: false },
+    }).toEqual({
+      given: 'a channel-source compose with content',
+      should: 'call onSubmit with content + alsoSendToParent=false',
+      actual: { content: 'hello channel', attachment: undefined, alsoSendToParent: false },
+      expected: { content: 'hello channel', attachment: undefined, alsoSendToParent: false },
+    });
+  });
+
+  it('given a thread reply with the also-send checkbox checked, should submit alsoSendToParent=true', async () => {
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Harness
+        source="channel"
+        contextId="page-1"
+        parentId="msg-1"
+        showAlsoSendToParent
+        onSubmit={onSubmit}
+        initialValue="reply text"
+      />,
+    );
+
+    await user.click(screen.getByTestId('also-send-to-parent'));
+    await user.type(screen.getByTestId('chat-textarea'), '{enter}');
+
+    expect({
+      given: 'a thread reply with also-send checked',
+      should: 'submit with alsoSendToParent=true',
+      actual: onSubmit.mock.calls[0]?.[0]?.alsoSendToParent,
+      expected: true,
+    }).toEqual({
+      given: 'a thread reply with also-send checked',
+      should: 'submit with alsoSendToParent=true',
+      actual: true,
+      expected: true,
+    });
+  });
+
+  it('given a thread reply with the checkbox unchecked, should submit alsoSendToParent=false', async () => {
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Harness
+        source="dm"
+        contextId="conv-1"
+        parentId="msg-1"
+        showAlsoSendToParent
+        onSubmit={onSubmit}
+        initialValue="dm thread reply"
+      />,
+    );
+
+    await user.type(screen.getByTestId('chat-textarea'), '{enter}');
+
+    expect({
+      given: 'a DM thread reply without checking also-send',
+      should: 'submit with alsoSendToParent=false',
+      actual: onSubmit.mock.calls[0]?.[0]?.alsoSendToParent,
+      expected: false,
+    }).toEqual({
+      given: 'a DM thread reply without checking also-send',
+      should: 'submit with alsoSendToParent=false',
+      actual: false,
+      expected: false,
+    });
+  });
+
+  it('given top-level compose mode, should not render the also-send checkbox', () => {
+    const onSubmit = vi.fn();
+    render(<Harness source="channel" contextId="page-1" onSubmit={onSubmit} />);
+
+    expect({
+      given: 'top-level compose',
+      should: 'not render also-send checkbox',
+      actual: screen.queryByTestId('also-send-to-parent') === null,
+      expected: true,
+    }).toEqual({
+      given: 'top-level compose',
+      should: 'not render also-send checkbox',
+      actual: true,
+      expected: true,
+    });
+  });
+});

--- a/apps/web/src/stores/__tests__/useThreadPanelStore.test.ts
+++ b/apps/web/src/stores/__tests__/useThreadPanelStore.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useThreadPanelStore } from '../useThreadPanelStore';
+
+const reset = () =>
+  useThreadPanelStore.setState({
+    open: false,
+    source: null,
+    contextId: null,
+    parentId: null,
+  });
+
+describe('useThreadPanelStore', () => {
+  beforeEach(() => {
+    reset();
+  });
+
+  it('given a fresh store, should be closed with null fields', () => {
+    const state = useThreadPanelStore.getState();
+
+    expect({
+      given: 'a fresh store',
+      should: 'be closed with null fields',
+      actual: { open: state.open, source: state.source, contextId: state.contextId, parentId: state.parentId },
+      expected: { open: false, source: null, contextId: null, parentId: null },
+    }).toEqual({
+      given: 'a fresh store',
+      should: 'be closed with null fields',
+      actual: { open: false, source: null, contextId: null, parentId: null },
+      expected: { open: false, source: null, contextId: null, parentId: null },
+    });
+  });
+
+  it('given openThread is called, should set source/contextId/parentId and mark open', () => {
+    useThreadPanelStore
+      .getState()
+      .openThread({ source: 'channel', contextId: 'page-1', parentId: 'msg-9' });
+
+    const state = useThreadPanelStore.getState();
+    const actual = {
+      open: state.open,
+      source: state.source,
+      contextId: state.contextId,
+      parentId: state.parentId,
+    };
+    const expected = {
+      open: true,
+      source: 'channel' as const,
+      contextId: 'page-1',
+      parentId: 'msg-9',
+    };
+
+    expect({
+      given: 'openThread is called',
+      should: 'set source/contextId/parentId and mark open',
+      actual,
+      expected,
+    }).toEqual({
+      given: 'openThread is called',
+      should: 'set source/contextId/parentId and mark open',
+      actual: expected,
+      expected,
+    });
+  });
+
+  it('given an open DM thread, when openThread fires for a different parent, should swap fields without closing', () => {
+    useThreadPanelStore
+      .getState()
+      .openThread({ source: 'dm', contextId: 'conv-1', parentId: 'msg-1' });
+    useThreadPanelStore
+      .getState()
+      .openThread({ source: 'dm', contextId: 'conv-1', parentId: 'msg-2' });
+
+    const state = useThreadPanelStore.getState();
+    const actual = { open: state.open, parentId: state.parentId };
+    const expected = { open: true, parentId: 'msg-2' };
+
+    expect({
+      given: 'an open DM thread',
+      should: 'swap parentId without closing on a second openThread',
+      actual,
+      expected,
+    }).toEqual({
+      given: 'an open DM thread',
+      should: 'swap parentId without closing on a second openThread',
+      actual: expected,
+      expected,
+    });
+  });
+
+  it('given an open thread, when close is called, should reset every field', () => {
+    useThreadPanelStore
+      .getState()
+      .openThread({ source: 'channel', contextId: 'page-1', parentId: 'msg-9' });
+    useThreadPanelStore.getState().close();
+
+    const state = useThreadPanelStore.getState();
+    const actual = {
+      open: state.open,
+      source: state.source,
+      contextId: state.contextId,
+      parentId: state.parentId,
+    };
+    const expected = { open: false, source: null, contextId: null, parentId: null };
+
+    expect({
+      given: 'an open thread',
+      should: 'reset every field on close',
+      actual,
+      expected,
+    }).toEqual({
+      given: 'an open thread',
+      should: 'reset every field on close',
+      actual: expected,
+      expected,
+    });
+  });
+});

--- a/apps/web/src/stores/useThreadPanelStore.ts
+++ b/apps/web/src/stores/useThreadPanelStore.ts
@@ -1,0 +1,41 @@
+/**
+ * Thread Panel Store
+ *
+ * Tracks the open/closed state of the right-side ThreadPanel that overlays
+ * channel and DM message lists. The panel is generic across both surfaces;
+ * `source` + `contextId` discriminate which channel/DM the open thread
+ * belongs to so the mounting page can render the panel only when the
+ * context still matches the route.
+ *
+ * Stores are pure: navigation cleanup (close-on-context-change) is performed
+ * by the mounting page via `useEffect`, not from inside the store.
+ */
+
+import { create } from 'zustand';
+
+export type ThreadPanelSource = 'channel' | 'dm';
+
+export interface OpenThreadArgs {
+  source: ThreadPanelSource;
+  contextId: string;
+  parentId: string;
+}
+
+export interface ThreadPanelState {
+  open: boolean;
+  source: ThreadPanelSource | null;
+  contextId: string | null;
+  parentId: string | null;
+  openThread: (args: OpenThreadArgs) => void;
+  close: () => void;
+}
+
+export const useThreadPanelStore = create<ThreadPanelState>((set) => ({
+  open: false,
+  source: null,
+  contextId: null,
+  parentId: null,
+  openThread: ({ source, contextId, parentId }) =>
+    set({ open: true, source, contextId, parentId }),
+  close: () => set({ open: false, source: null, contextId: null, parentId: null }),
+}));

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -21,6 +21,22 @@ vi.mock('next/navigation', () => ({
   useSearchParams: vi.fn(() => new URLSearchParams()),
 }))
 
+// jsdom does not implement matchMedia. Provide a permissive default that
+// returns false (i.e. desktop, non-touch) so hooks like useMobile / useTouchDevice
+// can boot during component tests without each test re-stubbing it.
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+}
+
 // Mock environment variables - only set if not already provided (allows CI to override)
 process.env.DATABASE_URL = process.env.DATABASE_URL || 'postgresql://test:test@localhost:5432/pagespace_test'
 process.env.CSRF_SECRET = process.env.CSRF_SECRET || 'test-csrf-secret-key-minimum-32-characters'


### PR DESCRIPTION
## Summary
- New `useThreadPanelStore` + `ThreadPanel` component (generic, channel + DM)
- `ChannelInput` accepts `parentId` + `showAlsoSendToParent`; registers an editing-store session keyed by `thread:<source>:<contextId>:<parentId>` so SWR refreshes can't clobber unsent text
- New shared `MessageInput` wrapper (channel page, DM page, ThreadPanel) handles source-aware editing-store key + upload target
- Hover toolbar gains a "Reply in thread" action — kept **always-visible** to honor f5d4e9bca's touch-parity invariant (PageSpace runs on iOS/Android via Capacitor; actionable controls must reach touch users)
- Parent footer "N replies · last reply Xm ago" with live updates via `thread_reply_count_updated`
- Panel mounts as a 420px right-side sibling on desktop and a full-screen `Sheet` on mobile (`useMobile`)
- Test setup gains a permissive `window.matchMedia` stub so any component using `useMobile` boots under jsdom

PR 4 of 5 in the threads epic. Plan: `/Users/jono/.claude/plans/channels-and-dm-s-need-imperative-bird.md`

## Reliability fixes addressed in-review
- **POST response is the primary signal, not the websocket echo.** `handleSubmit` upserts the persisted reply directly from the POST response (channel returns the row at the top level; DM wraps it as `{ message }`). Realtime echo, when it arrives, is an idempotent no-op via id-dedup. This means thread sends still reconcile cleanly when `INTERNAL_REALTIME_URL` is unset or the socket is briefly disconnected.
- **Single-temp dedup on duplicate-content sends.** Optimistic-temp cleanup uses `findIndex` + `slice` keyed on `content + authorId`, so each server echo cancels exactly one temp row (not all temps with the same text).
- **Stale-thread guard.** `handleSubmit` snapshots a thread-identity string at send time and compares against an `activeThreadKeyRef` that mirrors the live mount; both success-upsert and failure-restore paths bail if the panel switched threads mid-flight.
- Disabled also-send checkbox shows `cursor-not-allowed` + dimmed label.

## Anti-scope (deferred to PR 5)
- Auto-follow upserts / `thread_updated` inbox bumps
- Follow / unfollow endpoints + UI toggle
- Mention-responder thread awareness

## Known v1 gap (out of scope, follow-up)
- Thread replies do not yet render reactions or inline edit/delete. The panel composer also has `attachmentsEnabled={false}`. The repository + API plumbing already exists from PR 2/3; surfacing it in the panel is a follow-up to keep PR 4 within the plan's UI-scope.

## Verification (run locally)
- [x] `pnpm --filter web typecheck` — passes
- [x] `pnpm --filter web lint` — passes (one pre-existing warning in `QuickCreatePalette.tsx`, untouched here)
- [x] `pnpm --filter web exec vitest run` for new + adjacent files — 50+ tests pass (store, MessageInput, ThreadPanel, ChannelInput, DM page)
- [x] `pnpm --filter web build` — passes
- [ ] Live browser smoke (`pnpm dev`) — **not exercised in this run**: starting the full dev stack (web + realtime + processor + Postgres) wasn't viable in this session. Acceptance-criteria walk-through below should be run before merge.

## Test plan (manual)
- [ ] Hover a channel message → "Reply in thread" appears → opens panel with parent
- [ ] Reply without "Also send to channel" → only panel updates; parent shows "1 reply · last reply just now"
- [ ] Reply with "Also send to channel" → both panel and channel get the row
- [ ] Second tab posts a reply → first tab's panel + parent footer update via realtime
- [ ] Repeat in a DM
- [ ] Mobile viewport opens the panel as a full-screen Sheet
- [ ] Navigating away from the channel/DM closes the panel
- [ ] AI-sent messages don't show the "Reply in thread" hover button
- [ ] With `INTERNAL_REALTIME_URL` unset, sending a reply still reconciles (no stuck "sending…")

🤖 Generated with [Claude Code](https://claude.com/claude-code)