### PR TITLE
feat(threads): notifications, follow, mentions (PR 5/5)

### DIFF
--- a/apps/web/src/app/api/channels/[pageId]/messages/[messageId]/follow/__tests__/route.test.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/[messageId]/follow/__tests__/route.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Contract tests for /api/channels/[pageId]/messages/[messageId]/follow
+ *
+ * The repository seam (`channelMessageRepository`) is mocked so the route's
+ * authz, validation, and audit-log behavior are exercised without touching the
+ * ORM chain.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn(
+    (r: unknown) => typeof r === 'object' && r !== null && 'error' in r
+  ),
+}));
+
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  canUserViewPage: vi.fn().mockResolvedValue(true),
+}));
+
+const mockFindChannelMessageInPage = vi.fn();
+const mockAddChannelThreadFollower = vi.fn();
+const mockRemoveChannelThreadFollower = vi.fn();
+vi.mock('@pagespace/lib/services/channel-message-repository', () => ({
+  channelMessageRepository: {
+    findChannelMessageInPage: (...args: unknown[]) => mockFindChannelMessageInPage(...args),
+    addChannelThreadFollower: (...args: unknown[]) => mockAddChannelThreadFollower(...args),
+    removeChannelThreadFollower: (...args: unknown[]) => mockRemoveChannelThreadFollower(...args),
+  },
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+
+import { POST, DELETE } from '../route';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import type { SessionAuthResult, AuthError } from '@/lib/auth';
+
+const PAGE_ID = 'page_chan';
+const MSG_ID = 'msg_root';
+const USER_ID = 'user_a';
+
+const sessionAuth = (): SessionAuthResult => ({
+  userId: USER_ID,
+  tokenVersion: 0,
+  tokenType: 'session',
+  sessionId: 'sess_test',
+  role: 'user',
+  adminRoleVersion: 0,
+});
+
+const authError = (status = 401): AuthError => ({
+  error: NextResponse.json({ error: 'Unauthorized' }, { status }),
+});
+
+const callPost = () =>
+  POST(new Request(`http://localhost/api/channels/${PAGE_ID}/messages/${MSG_ID}/follow`, { method: 'POST' }), {
+    params: Promise.resolve({ pageId: PAGE_ID, messageId: MSG_ID }),
+  });
+
+const callDelete = () =>
+  DELETE(new Request(`http://localhost/api/channels/${PAGE_ID}/messages/${MSG_ID}/follow`, { method: 'DELETE' }), {
+    params: Promise.resolve({ pageId: PAGE_ID, messageId: MSG_ID }),
+  });
+
+describe('POST /api/channels/[pageId]/messages/[messageId]/follow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(sessionAuth());
+    vi.mocked(canUserViewPage).mockResolvedValue(true);
+    mockFindChannelMessageInPage.mockResolvedValue({
+      id: MSG_ID,
+      pageId: PAGE_ID,
+      parentId: null,
+      isActive: true,
+    });
+    mockAddChannelThreadFollower.mockResolvedValue(undefined);
+  });
+
+  it('adds the caller as a follower when the message is a top-level root', async () => {
+    const res = await callPost();
+    expect(res.status).toBe(200);
+    expect(mockAddChannelThreadFollower).toHaveBeenCalledWith(MSG_ID, USER_ID);
+    expect(await res.json()).toEqual({ following: true });
+  });
+
+  it('is idempotent — a second POST does not error (delegated to onConflictDoNothing)', async () => {
+    await callPost();
+    await callPost();
+    expect(mockAddChannelThreadFollower).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(authError(401));
+    const res = await callPost();
+    expect(res.status).toBe(401);
+    expect(mockAddChannelThreadFollower).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when caller lacks view permission on the channel', async () => {
+    vi.mocked(canUserViewPage).mockResolvedValue(false);
+    const res = await callPost();
+    expect(res.status).toBe(403);
+    expect(mockAddChannelThreadFollower).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the message does not exist in this channel', async () => {
+    mockFindChannelMessageInPage.mockResolvedValueOnce(null);
+    const res = await callPost();
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when the message is soft-deleted', async () => {
+    mockFindChannelMessageInPage.mockResolvedValueOnce({
+      id: MSG_ID,
+      pageId: PAGE_ID,
+      parentId: null,
+      isActive: false,
+    });
+    const res = await callPost();
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 when the message is itself a thread reply (followers attach to roots only)', async () => {
+    mockFindChannelMessageInPage.mockResolvedValueOnce({
+      id: MSG_ID,
+      pageId: PAGE_ID,
+      parentId: 'some-other-parent',
+      isActive: true,
+    });
+    const res = await callPost();
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('DELETE /api/channels/[pageId]/messages/[messageId]/follow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(sessionAuth());
+    vi.mocked(canUserViewPage).mockResolvedValue(true);
+    mockFindChannelMessageInPage.mockResolvedValue({
+      id: MSG_ID,
+      pageId: PAGE_ID,
+      parentId: null,
+      isActive: true,
+    });
+    mockRemoveChannelThreadFollower.mockResolvedValue(undefined);
+  });
+
+  it('removes the caller as a follower', async () => {
+    const res = await callDelete();
+    expect(res.status).toBe(200);
+    expect(mockRemoveChannelThreadFollower).toHaveBeenCalledWith(MSG_ID, USER_ID);
+    expect(await res.json()).toEqual({ following: false });
+  });
+
+  it('is idempotent — DELETE on a non-followed root succeeds silently', async () => {
+    await callDelete();
+    await callDelete();
+    expect(mockRemoveChannelThreadFollower).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns 403 when caller lacks view permission', async () => {
+    vi.mocked(canUserViewPage).mockResolvedValue(false);
+    const res = await callDelete();
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when the message does not belong to this channel', async () => {
+    mockFindChannelMessageInPage.mockResolvedValueOnce(null);
+    const res = await callDelete();
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/web/src/app/api/channels/[pageId]/messages/[messageId]/follow/route.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/[messageId]/follow/route.ts
@@ -1,0 +1,105 @@
+import { NextResponse } from 'next/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { channelMessageRepository } from '@pagespace/lib/services/channel-message-repository';
+
+const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
+
+type RouteParams = { params: Promise<{ pageId: string; messageId: string }> };
+
+/**
+ * POST /api/channels/[pageId]/messages/[messageId]/follow
+ *
+ * Idempotently subscribes the caller to thread updates for the given root
+ * message. The repository upsert relies on a unique
+ * (rootMessageId, userId) index, so a second POST is a no-op.
+ *
+ * Authz: caller must be able to view the channel (matches the read path).
+ * Validation: the message must exist in this channel, be active, and itself
+ * be a top-level message — followers attach to thread roots, not replies.
+ */
+export async function POST(req: Request, { params }: RouteParams) {
+  const { pageId, messageId } = await params;
+
+  const auth = await authenticateRequestWithOptions(req, AUTH_OPTIONS);
+  if (isAuthError(auth)) return auth.error;
+  const userId = auth.userId;
+
+  const canView = await canUserViewPage(userId, pageId);
+  if (!canView) {
+    return NextResponse.json(
+      { error: 'You need view permission to follow threads in this channel' },
+      { status: 403 }
+    );
+  }
+
+  const message = await channelMessageRepository.findChannelMessageInPage({
+    messageId,
+    pageId,
+  });
+
+  if (!message || !message.isActive) {
+    return NextResponse.json({ error: 'Message not found' }, { status: 404 });
+  }
+  if (message.parentId !== null) {
+    return NextResponse.json(
+      { error: 'Followers attach to top-level messages only' },
+      { status: 400 }
+    );
+  }
+
+  await channelMessageRepository.addChannelThreadFollower(messageId, userId);
+
+  auditRequest(req, {
+    eventType: 'data.write',
+    userId,
+    resourceType: 'channel_thread_follower',
+    resourceId: messageId,
+  });
+
+  return NextResponse.json({ following: true });
+}
+
+/**
+ * DELETE /api/channels/[pageId]/messages/[messageId]/follow
+ *
+ * Removes the caller's follower row. Idempotent — deleting a row that does not
+ * exist is treated as success so clients do not need to track local state to
+ * avoid 404s on rapid toggle.
+ */
+export async function DELETE(req: Request, { params }: RouteParams) {
+  const { pageId, messageId } = await params;
+
+  const auth = await authenticateRequestWithOptions(req, AUTH_OPTIONS);
+  if (isAuthError(auth)) return auth.error;
+  const userId = auth.userId;
+
+  const canView = await canUserViewPage(userId, pageId);
+  if (!canView) {
+    return NextResponse.json(
+      { error: 'You need view permission to manage thread follows' },
+      { status: 403 }
+    );
+  }
+
+  const message = await channelMessageRepository.findChannelMessageInPage({
+    messageId,
+    pageId,
+  });
+
+  if (!message) {
+    return NextResponse.json({ error: 'Message not found' }, { status: 404 });
+  }
+
+  await channelMessageRepository.removeChannelThreadFollower(messageId, userId);
+
+  auditRequest(req, {
+    eventType: 'data.delete',
+    userId,
+    resourceType: 'channel_thread_follower',
+    resourceId: messageId,
+  });
+
+  return NextResponse.json({ following: false });
+}

--- a/apps/web/src/app/api/channels/[pageId]/messages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/__tests__/route.test.ts
@@ -40,6 +40,7 @@ const mockInsertChannelThreadReply = vi.fn();
 const mockUpsertChannelReadStatus = vi.fn();
 const mockLoadChannelMessageWithRelations = vi.fn();
 const mockFileExists = vi.fn();
+const mockListChannelThreadFollowers = vi.fn();
 vi.mock('@pagespace/lib/services/channel-message-repository', () => ({
   channelMessageRepository: {
     listChannelMessages: (...args: unknown[]) => mockListChannelMessages(...args),
@@ -50,6 +51,7 @@ vi.mock('@pagespace/lib/services/channel-message-repository', () => ({
     upsertChannelReadStatus: (...args: unknown[]) => mockUpsertChannelReadStatus(...args),
     loadChannelMessageWithRelations: (...args: unknown[]) => mockLoadChannelMessageWithRelations(...args),
     fileExists: (...args: unknown[]) => mockFileExists(...args),
+    listChannelThreadFollowers: (...args: unknown[]) => mockListChannelThreadFollowers(...args),
   },
 }));
 
@@ -173,6 +175,9 @@ describe('GET /api/channels/[pageId]/messages', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue(sessionAuth());
+    // PR 5: thread GET also looks up followers to populate isFollowing.
+    // Default to an empty list so non-thread paths don't trip on undefined.
+    mockListChannelThreadFollowers.mockResolvedValue([]);
   });
 
   it('routes to listChannelThreadReplies when ?parentId= is provided', async () => {
@@ -255,6 +260,8 @@ describe('POST /api/channels/[pageId]/messages (thread reply)', () => {
     vi.stubGlobal('fetch', fetchMock);
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue(sessionAuth());
     mockBroadcastThreadReplyCountUpdated.mockResolvedValue(undefined);
+    mockListChannelThreadFollowers.mockResolvedValue([]);
+    mockBroadcastInboxEvent.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -377,6 +384,94 @@ describe('POST /api/channels/[pageId]/messages (thread reply)', () => {
     const res = await callPost({ content: 'x', parentId: 'reply-as-parent' });
 
     expect(res.status).toBe(400);
+  });
+
+  it('fans out thread_updated to followers but EXCLUDES the reply author', async () => {
+    const replyCreatedAt = new Date('2026-05-04T12:00:00Z');
+    mockInsertChannelThreadReply.mockResolvedValueOnce({
+      kind: 'ok',
+      reply: { id: 'reply-1', createdAt: replyCreatedAt },
+      mirror: null,
+      rootId: PARENT_ID,
+      replyCount: 2,
+      lastReplyAt: replyCreatedAt,
+    });
+    mockLoadChannelMessageWithRelations.mockResolvedValueOnce({
+      id: 'reply-1',
+      parentId: PARENT_ID,
+      pageId: PAGE_ID,
+      content: 'in-thread',
+      createdAt: replyCreatedAt.toISOString(),
+      user: { id: USER_ID, name: 'Sender', image: null },
+    });
+    mockListChannelThreadFollowers.mockResolvedValueOnce([USER_ID, 'follower-1', 'follower-2']);
+
+    await callPost({ content: 'in-thread', parentId: PARENT_ID });
+
+    const threadUpdatedCalls = mockBroadcastInboxEvent.mock.calls.filter(
+      ([, payload]) => (payload as { operation: string }).operation === 'thread_updated'
+    );
+    const recipients = threadUpdatedCalls.map(([userId]) => userId);
+    expect(recipients).toEqual(expect.arrayContaining(['follower-1', 'follower-2']));
+    expect(recipients).not.toContain(USER_ID);
+
+    // Each thread_updated payload carries the new contract fields.
+    const payload = threadUpdatedCalls[0][1] as {
+      operation: string;
+      type: string;
+      id: string;
+      rootMessageId: string;
+      lastReplyAt: string;
+      lastReplyPreview: string;
+      lastReplySender: { id: string; name: string };
+    };
+    expect(payload.type).toBe('channel');
+    expect(payload.id).toBe(PAGE_ID);
+    expect(payload.rootMessageId).toBe(PARENT_ID);
+    expect(payload.lastReplyAt).toBe(replyCreatedAt.toISOString());
+  });
+
+  it('emits channel_updated to a mentioned non-follower (targeted bump rule)', async () => {
+    const replyCreatedAt = new Date('2026-05-04T12:00:00Z');
+    mockInsertChannelThreadReply.mockResolvedValueOnce({
+      kind: 'ok',
+      reply: { id: 'reply-1', createdAt: replyCreatedAt },
+      mirror: null,
+      rootId: PARENT_ID,
+      replyCount: 1,
+      lastReplyAt: replyCreatedAt,
+    });
+    mockLoadChannelMessageWithRelations.mockResolvedValueOnce({
+      id: 'reply-1',
+      parentId: PARENT_ID,
+      pageId: PAGE_ID,
+      content: 'hey @[Bob](user-bob:user)',
+      createdAt: replyCreatedAt.toISOString(),
+      user: { id: USER_ID, name: 'Sender', image: null },
+    });
+    mockListChannelThreadFollowers.mockResolvedValueOnce([USER_ID]);
+    // Override the pages findFirst stub for this test so the route can
+    // resolve the channel's driveId (which gates the mention bump).
+    const dbModule = (await import('@pagespace/db/db')) as unknown as {
+      db: { query: { pages: { findFirst: ReturnType<typeof vi.fn> } } };
+    };
+    dbModule.db.query.pages.findFirst.mockResolvedValueOnce({
+      driveId: 'drive-1',
+      title: 'General',
+      drive: { ownerId: 'owner-1', name: 'Workspace', slug: 'workspace' },
+    });
+
+    await callPost({
+      content: 'hey @[Bob](user-bob:user)',
+      parentId: PARENT_ID,
+    });
+
+    const channelUpdatedCalls = mockBroadcastInboxEvent.mock.calls.filter(
+      ([, payload]) =>
+        (payload as { operation: string; type: string }).operation === 'channel_updated'
+    );
+    const recipients = channelUpdatedCalls.map(([userId]) => userId);
+    expect(recipients).toContain('user-bob');
   });
 });
 

--- a/apps/web/src/app/api/channels/[pageId]/messages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/__tests__/route.test.ts
@@ -476,6 +476,62 @@ describe('POST /api/channels/[pageId]/messages (thread reply)', () => {
     expect(recipients).toContain('user-bob');
   });
 
+  it('does NOT fire the targeted mention bump when alsoSendToParent is set (broad fan-out covers everyone)', async () => {
+    const replyCreatedAt = new Date('2026-05-04T12:00:00Z');
+    mockInsertChannelThreadReply.mockResolvedValueOnce({
+      kind: 'ok',
+      reply: { id: 'reply-1', createdAt: replyCreatedAt },
+      mirror: { id: 'mirror-1', createdAt: replyCreatedAt },
+      rootId: PARENT_ID,
+      replyCount: 1,
+      lastReplyAt: replyCreatedAt,
+    });
+    mockLoadChannelMessageWithRelations
+      .mockResolvedValueOnce({
+        id: 'reply-1',
+        parentId: PARENT_ID,
+        content: 'hey @[Bob](user-bob:user)',
+        createdAt: replyCreatedAt.toISOString(),
+        user: { id: USER_ID, name: 'Sender', image: null },
+      })
+      .mockResolvedValueOnce({ id: 'mirror-1', mirroredFromId: 'reply-1', parentId: null });
+    mockListChannelThreadFollowers.mockResolvedValueOnce([USER_ID]);
+
+    const dbModule = (await import('@pagespace/db/db')) as unknown as {
+      db: {
+        query: { pages: { findFirst: ReturnType<typeof vi.fn> } };
+        select: ReturnType<typeof vi.fn>;
+      };
+    };
+    dbModule.db.query.pages.findFirst.mockResolvedValueOnce({
+      driveId: 'drive-1',
+      title: 'General',
+      drive: { ownerId: 'owner-1', name: 'Workspace', slug: 'workspace' },
+    });
+
+    await callPost({
+      content: 'hey @[Bob](user-bob:user)',
+      parentId: PARENT_ID,
+      alsoSendToParent: true,
+    });
+
+    // When alsoSendToParent is set, the mirror's broad fan-out covers viewable
+    // members. The targeted mention bump is short-circuited so user-bob does
+    // NOT receive two channel_updated payloads for the same underlying event.
+    const channelUpdatedCalls = mockBroadcastInboxEvent.mock.calls.filter(
+      ([, payload]) => (payload as { operation: string }).operation === 'channel_updated'
+    );
+    const recipientCounts = channelUpdatedCalls.reduce<Record<string, number>>(
+      (acc, [uid]) => {
+        const id = uid as string;
+        acc[id] = (acc[id] ?? 0) + 1;
+        return acc;
+      },
+      {}
+    );
+    expect(recipientCounts['user-bob'] ?? 0).toBeLessThanOrEqual(1);
+  });
+
   it('does NOT emit channel_updated to a mentioned user who cannot view the channel', async () => {
     const replyCreatedAt = new Date('2026-05-04T12:00:00Z');
     mockInsertChannelThreadReply.mockResolvedValueOnce({

--- a/apps/web/src/app/api/channels/[pageId]/messages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/__tests__/route.test.ts
@@ -431,7 +431,7 @@ describe('POST /api/channels/[pageId]/messages (thread reply)', () => {
     expect(payload.lastReplyAt).toBe(replyCreatedAt.toISOString());
   });
 
-  it('emits channel_updated to a mentioned non-follower (targeted bump rule)', async () => {
+  it('emits channel_updated to a mentioned non-follower who can view the channel', async () => {
     const replyCreatedAt = new Date('2026-05-04T12:00:00Z');
     mockInsertChannelThreadReply.mockResolvedValueOnce({
       kind: 'ok',
@@ -450,8 +450,6 @@ describe('POST /api/channels/[pageId]/messages (thread reply)', () => {
       user: { id: USER_ID, name: 'Sender', image: null },
     });
     mockListChannelThreadFollowers.mockResolvedValueOnce([USER_ID]);
-    // Override the pages findFirst stub for this test so the route can
-    // resolve the channel's driveId (which gates the mention bump).
     const dbModule = (await import('@pagespace/db/db')) as unknown as {
       db: { query: { pages: { findFirst: ReturnType<typeof vi.fn> } } };
     };
@@ -460,6 +458,10 @@ describe('POST /api/channels/[pageId]/messages (thread reply)', () => {
       title: 'General',
       drive: { ownerId: 'owner-1', name: 'Workspace', slug: 'workspace' },
     });
+    // Default canUserViewPage mock returns true, so the mentioned user passes
+    // the view-permission gate.
+    const { canUserViewPage } = await import('@pagespace/lib/permissions/permissions');
+    vi.mocked(canUserViewPage).mockResolvedValue(true);
 
     await callPost({
       content: 'hey @[Bob](user-bob:user)',
@@ -472,6 +474,50 @@ describe('POST /api/channels/[pageId]/messages (thread reply)', () => {
     );
     const recipients = channelUpdatedCalls.map(([userId]) => userId);
     expect(recipients).toContain('user-bob');
+  });
+
+  it('does NOT emit channel_updated to a mentioned user who cannot view the channel', async () => {
+    const replyCreatedAt = new Date('2026-05-04T12:00:00Z');
+    mockInsertChannelThreadReply.mockResolvedValueOnce({
+      kind: 'ok',
+      reply: { id: 'reply-1', createdAt: replyCreatedAt },
+      mirror: null,
+      rootId: PARENT_ID,
+      replyCount: 1,
+      lastReplyAt: replyCreatedAt,
+    });
+    mockLoadChannelMessageWithRelations.mockResolvedValueOnce({
+      id: 'reply-1',
+      parentId: PARENT_ID,
+      pageId: PAGE_ID,
+      content: 'hey @[Stranger](user-outsider:user)',
+      createdAt: replyCreatedAt.toISOString(),
+      user: { id: USER_ID, name: 'Sender', image: null },
+    });
+    mockListChannelThreadFollowers.mockResolvedValueOnce([USER_ID]);
+    const dbModule = (await import('@pagespace/db/db')) as unknown as {
+      db: { query: { pages: { findFirst: ReturnType<typeof vi.fn> } } };
+    };
+    dbModule.db.query.pages.findFirst.mockResolvedValueOnce({
+      driveId: 'drive-1',
+      title: 'General',
+      drive: { ownerId: 'owner-1', name: 'Workspace', slug: 'workspace' },
+    });
+    // Sender (USER_ID) passes; the mentioned outsider does not.
+    const { canUserViewPage } = await import('@pagespace/lib/permissions/permissions');
+    vi.mocked(canUserViewPage).mockImplementation(async (uid) => uid === USER_ID);
+
+    await callPost({
+      content: 'hey @[Stranger](user-outsider:user)',
+      parentId: PARENT_ID,
+    });
+
+    const channelUpdatedCalls = mockBroadcastInboxEvent.mock.calls.filter(
+      ([, payload]) =>
+        (payload as { operation: string; type: string }).operation === 'channel_updated'
+    );
+    const recipients = channelUpdatedCalls.map(([uid]) => uid);
+    expect(recipients).not.toContain('user-outsider');
   });
 });
 

--- a/apps/web/src/app/api/channels/[pageId]/messages/route.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/route.ts
@@ -407,9 +407,25 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
 
       if (replyContent.trim().length > 0 && channel?.driveId) {
         const mentionedUserIds = extractMentionedUserIds(replyContent);
-        const mentionTargets = mentionedUserIds.filter(
+        const candidateTargets = mentionedUserIds.filter(
           (id: string) => id !== userId && !followerSet.has(id)
         );
+
+        // Mention IDs come from message text, which is sender-controlled — so
+        // before we broadcast a channel_updated payload (which leaks the channel
+        // id, drive id, preview, and sender name), every candidate must pass
+        // the channel's view-permission check. Without this gate a sender could
+        // craft mentions for arbitrary user IDs and surface this channel to
+        // users who have no access.
+        const viewabilityChecks = await Promise.all(
+          candidateTargets.map(async (id: string) => ({
+            id,
+            canView: await canUserViewPage(id, pageId),
+          }))
+        );
+        const mentionTargets = viewabilityChecks
+          .filter((entry) => entry.canView)
+          .map((entry) => entry.id);
 
         await Promise.all(
           mentionTargets.map((memberId: string) =>

--- a/apps/web/src/app/api/channels/[pageId]/messages/route.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/route.ts
@@ -404,7 +404,14 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
         },
       });
 
-      if (replyContent.trim().length > 0 && channel?.driveId) {
+      // The mention-targeted bump is only meaningful for thread-only replies.
+      // When `alsoSendToParent` is set, the mirror row triggers the broad
+      // `fanOutChannelInboxUpdate` below, which already reaches every viewable
+      // member including the mentioned user — running this targeted path too
+      // would deliver a duplicate `channel_updated` for the same underlying
+      // event, inflating the recipient's unread count by 2 instead of 1.
+      const isThreadOnlyReply = !mirrorWithRelations;
+      if (isThreadOnlyReply && replyContent.trim().length > 0 && channel?.driveId) {
         const mentionedUserIds = extractMentionedUserIds(replyContent);
         const candidateTargets = mentionedUserIds.filter(
           (id: string) => id !== userId && !followerSet.has(id)

--- a/apps/web/src/app/api/channels/[pageId]/messages/route.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/route.ts
@@ -11,6 +11,7 @@ import { createSignedBroadcastHeaders } from '@pagespace/lib/auth/broadcast-auth
 import { broadcastInboxEvent, broadcastThreadReplyCountUpdated } from '@/lib/websocket/socket-utils';
 import { channelMessageRepository } from '@pagespace/lib/services/channel-message-repository';
 import { extractMentionedUserIds } from '@/lib/channels/extract-user-mentions';
+import { buildThreadPreview } from '@/lib/channels/build-thread-preview';
 import type { AttachmentMeta } from '@pagespace/lib/types';
 
 interface ChannelInboxFanoutInput {
@@ -37,19 +38,18 @@ async function fanOutChannelInboxUpdate(
 ): Promise<Set<string>> {
   const { pageId, driveId, driveOwnerId, senderUserId } = input;
 
-  const members = await db.query.driveMembers.findMany({
+  const driveMembersRows = await db.query.driveMembers.findMany({
     where: eq(driveMembers.driveId, driveId),
     columns: { userId: true },
   });
 
-  const memberUserIds = new Set(members.map((m) => m.userId));
-  if (driveOwnerId && !memberUserIds.has(driveOwnerId)) {
-    members.push({ userId: driveOwnerId });
+  // Build a local member set so we never mutate the ORM-returned array.
+  // Drive owner is always a recipient even if they have no explicit row.
+  const memberUserIds = new Set(driveMembersRows.map((m) => m.userId));
+  if (driveOwnerId) {
+    memberUserIds.add(driveOwnerId);
   }
-
-  const otherMemberIds = members
-    .filter((m) => m.userId !== senderUserId)
-    .map((m) => m.userId);
+  const otherMemberIds = [...memberUserIds].filter((id) => id !== senderUserId);
 
   const viewableUserIds = new Set<string>();
   if (otherMemberIds.length === 0) {
@@ -105,9 +105,8 @@ async function fanOutChannelInboxUpdate(
   return viewableUserIds;
 }
 
-function buildPreview(content: string): string {
-  return content.length > 100 ? content.substring(0, 100) + '...' : content;
-}
+// Local alias kept so the existing call sites in this file stay terse.
+const buildPreview = buildThreadPreview;
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };

--- a/apps/web/src/app/api/channels/[pageId]/messages/route.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/route.ts
@@ -10,7 +10,104 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { createSignedBroadcastHeaders } from '@pagespace/lib/auth/broadcast-auth';
 import { broadcastInboxEvent, broadcastThreadReplyCountUpdated } from '@/lib/websocket/socket-utils';
 import { channelMessageRepository } from '@pagespace/lib/services/channel-message-repository';
+import { extractMentionedUserIds } from '@/lib/channels/extract-user-mentions';
 import type { AttachmentMeta } from '@pagespace/lib/types';
+
+interface ChannelInboxFanoutInput {
+  pageId: string;
+  driveId: string;
+  driveOwnerId: string | null | undefined;
+  senderUserId: string;
+  lastMessageAt: string;
+  lastMessagePreview: string;
+  lastMessageSender: string | undefined;
+}
+
+/**
+ * Fans out `channel_updated` to every drive member who can view the channel
+ * (excluding the sender). Mirrors the auth/permission logic of the top-level
+ * POST path so a thread reply with `alsoSendToParent=true` can drive the same
+ * channel-level inbox bump as a regular send.
+ *
+ * Returns the set of viewable user IDs so callers can use it to skip duplicate
+ * bumps (e.g. when also targeting mentioned non-follower recipients).
+ */
+async function fanOutChannelInboxUpdate(
+  input: ChannelInboxFanoutInput
+): Promise<Set<string>> {
+  const { pageId, driveId, driveOwnerId, senderUserId } = input;
+
+  const members = await db.query.driveMembers.findMany({
+    where: eq(driveMembers.driveId, driveId),
+    columns: { userId: true },
+  });
+
+  const memberUserIds = new Set(members.map((m) => m.userId));
+  if (driveOwnerId && !memberUserIds.has(driveOwnerId)) {
+    members.push({ userId: driveOwnerId });
+  }
+
+  const otherMemberIds = members
+    .filter((m) => m.userId !== senderUserId)
+    .map((m) => m.userId);
+
+  const viewableUserIds = new Set<string>();
+  if (otherMemberIds.length === 0) {
+    return viewableUserIds;
+  }
+
+  if (driveOwnerId && otherMemberIds.includes(driveOwnerId)) {
+    viewableUserIds.add(driveOwnerId);
+  }
+
+  const adminMembers = await db.select({ userId: driveMembers.userId })
+    .from(driveMembers)
+    .where(and(
+      eq(driveMembers.driveId, driveId),
+      inArray(driveMembers.userId, otherMemberIds),
+      eq(driveMembers.role, 'ADMIN')
+    ));
+  for (const admin of adminMembers) {
+    viewableUserIds.add(admin.userId);
+  }
+
+  const remainingIds = otherMemberIds.filter((id) => !viewableUserIds.has(id));
+  if (remainingIds.length > 0) {
+    const permittedMembers = await db.select({ userId: pagePermissions.userId })
+      .from(pagePermissions)
+      .where(and(
+        eq(pagePermissions.pageId, pageId),
+        inArray(pagePermissions.userId, remainingIds),
+        eq(pagePermissions.canView, true),
+        or(isNull(pagePermissions.expiresAt), gt(pagePermissions.expiresAt, new Date()))
+      ));
+    for (const pm of permittedMembers) {
+      viewableUserIds.add(pm.userId);
+    }
+  }
+
+  await Promise.all(
+    otherMemberIds
+      .filter((id) => viewableUserIds.has(id))
+      .map((memberId) =>
+        broadcastInboxEvent(memberId, {
+          operation: 'channel_updated',
+          type: 'channel',
+          id: pageId,
+          driveId,
+          lastMessageAt: input.lastMessageAt,
+          lastMessagePreview: input.lastMessagePreview,
+          lastMessageSender: input.lastMessageSender,
+        })
+      )
+  );
+
+  return viewableUserIds;
+}
+
+function buildPreview(content: string): string {
+  return content.length > 100 ? content.substring(0, 100) + '...' : content;
+}
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
@@ -73,11 +170,14 @@ export async function GET(req: Request, { params }: { params: Promise<{ pageId: 
       return NextResponse.json({ error: 'Parent must be a top-level message' }, { status: 400 });
     }
 
-    const replies = await channelMessageRepository.listChannelThreadReplies({
-      rootId: parentId,
-      limit: limit + 1,
-      after: parsedCursor,
-    });
+    const [replies, followers] = await Promise.all([
+      channelMessageRepository.listChannelThreadReplies({
+        rootId: parentId,
+        limit: limit + 1,
+        after: parsedCursor,
+      }),
+      channelMessageRepository.listChannelThreadFollowers(parentId),
+    ]);
 
     const hasMore = replies.length > limit;
     const page = hasMore ? replies.slice(0, limit) : replies;
@@ -87,9 +187,13 @@ export async function GET(req: Request, { params }: { params: Promise<{ pageId: 
       ? `${last.createdAt.toISOString()}|${last.id}`
       : null;
 
+    // Reflect the persisted follower row, not just local state, per PR 5's
+    // locked requirement. The follow toggle in the panel header reads this.
+    const isFollowing = followers.includes(userId);
+
     auditRequest(req, { eventType: 'data.read', userId: auth.userId, resourceType: 'channel_thread', resourceId: parentId, details: { replyCount: page.length } });
 
-    return NextResponse.json({ messages: page, nextCursor, hasMore });
+    return NextResponse.json({ messages: page, nextCursor, hasMore, isFollowing });
   }
 
   // Fetch limit+1 in DESC order to determine if more exist, then reverse for chronological display
@@ -237,6 +341,134 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
       lastReplyAt: result.lastReplyAt.toISOString(),
     });
 
+    // PR 5: thread_updated inbox fan-out + selective channel-level bumps.
+    //
+    // Followers of the root receive a `thread_updated` inbox event so they can
+    // surface an unread-thread badge on the channel row WITHOUT bumping the
+    // top-level channel unread (a thread reply is not a top-level message).
+    //
+    // The reply author is excluded — we never notify someone of their own post.
+    // PR 3's `insertChannelThreadReply` upserts `(parentAuthor, replier)` into
+    // `channelThreadFollowers`, so by the time we read followers below, both
+    // the parent author and the current replier are guaranteed to be in the
+    // set; filtering out the replier is what excludes self-notifications.
+    //
+    // Failure handling: any of these broadcasts may fail because the realtime
+    // sidecar is unhealthy. We log and continue — the DB commit is already
+    // durable and a missed inbox bump is recoverable on the next refresh.
+    try {
+      const replyContent = messageContent;
+      const replyPreview = buildPreview(replyContent);
+      const replySender = {
+        id: userId,
+        name:
+          replyWithRelations?.aiMeta?.senderName ||
+          replyWithRelations?.user?.name ||
+          'Member',
+      };
+      const replyCreatedAt = result.lastReplyAt.toISOString();
+
+      const followers = await channelMessageRepository.listChannelThreadFollowers(result.rootId);
+      const followerSet = new Set(followers);
+
+      await Promise.all(
+        followers
+          .filter((followerId: string) => followerId !== userId)
+          .map((followerId: string) =>
+            broadcastInboxEvent(followerId, {
+              operation: 'thread_updated',
+              type: 'channel',
+              id: pageId,
+              rootMessageId: result.rootId,
+              lastReplyAt: replyCreatedAt,
+              lastReplyPreview: replyPreview,
+              lastReplySender: replySender,
+            })
+          )
+      );
+
+      // Channel-level unread for thread replies is suppressed by default;
+      // the two exceptions are (a) `alsoSendToParent` (the mirror is a real
+      // top-level message) and (b) `@`-mentions of users who are NOT followers
+      // of the thread, which need to surface in the channel row's main unread.
+      //
+      // For (b) we use the simpler safe rule from the plan: bump
+      // `channel_updated` for mentioned users specifically (never broadly),
+      // because broad scanning for non-follower mentions is brittle.
+      const channel = await db.query.pages.findFirst({
+        where: eq(pages.id, pageId),
+        columns: { driveId: true, title: true },
+        with: {
+          drive: {
+            columns: { ownerId: true, name: true, slug: true },
+          },
+        },
+      });
+
+      if (replyContent.trim().length > 0 && channel?.driveId) {
+        const mentionedUserIds = extractMentionedUserIds(replyContent);
+        const mentionTargets = mentionedUserIds.filter(
+          (id: string) => id !== userId && !followerSet.has(id)
+        );
+
+        await Promise.all(
+          mentionTargets.map((memberId: string) =>
+            broadcastInboxEvent(memberId, {
+              operation: 'channel_updated',
+              type: 'channel',
+              id: pageId,
+              driveId: channel.driveId!,
+              lastMessageAt: replyCreatedAt,
+              lastMessagePreview: replyPreview,
+              lastMessageSender: replySender.name,
+            })
+          )
+        );
+      }
+
+      if (mirrorWithRelations && channel?.driveId) {
+        const mirrorPreview = buildPreview(replyContent);
+        await fanOutChannelInboxUpdate({
+          pageId,
+          driveId: channel.driveId,
+          driveOwnerId: channel.drive?.ownerId ?? null,
+          senderUserId: userId,
+          lastMessageAt: mirrorWithRelations.createdAt
+            ? new Date(mirrorWithRelations.createdAt).toISOString()
+            : replyCreatedAt,
+          lastMessagePreview: mirrorPreview,
+          lastMessageSender: replySender.name,
+        });
+      }
+
+      // Mention-responder: an @-mentioned AI agent inside a thread should
+      // reply IN THE THREAD, not at the top level. The responder is loaded
+      // dynamically (same as the top-level path) so a build-time circular
+      // dep cannot wire itself in at module load.
+      if (replyContent.trim().length > 0) {
+        void import('@/lib/channels/agent-mention-responder')
+          .then(({ triggerMentionedAgentResponses }) =>
+            triggerMentionedAgentResponses({
+              userId,
+              channelId: pageId,
+              channelTitle: channel?.title || 'Channel',
+              channelType: 'CHANNEL',
+              sourceMessageId: result.reply.id,
+              content: replyContent,
+              parentId: result.rootId,
+              driveId: channel?.driveId || null,
+              driveName: channel?.drive?.name || null,
+              driveSlug: channel?.drive?.slug || null,
+            })
+          )
+          .catch((error) => {
+            loggers.realtime.error('Failed to load channel mention responder module:', error as Error);
+          });
+      }
+    } catch (error) {
+      loggers.realtime.error('Failed to broadcast thread inbox update:', error as Error);
+    }
+
     return NextResponse.json(replyWithRelations, { status: 201 });
   }
 
@@ -317,85 +549,17 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
     }
 
     if (channel?.driveId) {
-      // Get all drive members
-      const members = await db.query.driveMembers.findMany({
-        where: eq(driveMembers.driveId, channel.driveId),
-        columns: { userId: true },
+      const messagePreview = buildPreview(messageContent);
+
+      await fanOutChannelInboxUpdate({
+        pageId,
+        driveId: channel.driveId,
+        driveOwnerId: channel.drive?.ownerId ?? null,
+        senderUserId: userId,
+        lastMessageAt: newMessage?.createdAt?.toISOString() || new Date().toISOString(),
+        lastMessagePreview: messagePreview,
+        lastMessageSender: newMessage?.aiMeta?.senderName || newMessage?.user?.name || undefined,
       });
-
-      // Include drive owner in recipient list (if not already a member)
-      const driveOwnerId = channel.drive?.ownerId;
-      const memberUserIds = new Set(members.map(m => m.userId));
-      if (driveOwnerId && !memberUserIds.has(driveOwnerId)) {
-        members.push({ userId: driveOwnerId });
-      }
-
-      // Create message preview
-      const messagePreview = messageContent.length > 100
-        ? messageContent.substring(0, 100) + '...'
-        : messageContent;
-
-      // Batch permission check: mirrors getUserAccessLevel logic from @pagespace/lib.
-      // If that logic changes (e.g. new roles), update this batch version in sync.
-      // Drive owner and admins always have access; others need explicit page permissions.
-      const otherMemberIds = members
-        .filter(m => m.userId !== userId)
-        .map(m => m.userId);
-
-      let viewableUserIds: Set<string>;
-      if (otherMemberIds.length === 0) {
-        viewableUserIds = new Set();
-      } else {
-        // Drive owner always has access
-        viewableUserIds = new Set<string>();
-        if (driveOwnerId && otherMemberIds.includes(driveOwnerId)) {
-          viewableUserIds.add(driveOwnerId);
-        }
-
-        // Drive admins always have access
-        const adminMembers = await db.select({ userId: driveMembers.userId })
-          .from(driveMembers)
-          .where(and(
-            eq(driveMembers.driveId, channel.driveId),
-            inArray(driveMembers.userId, otherMemberIds),
-            eq(driveMembers.role, 'ADMIN')
-          ));
-        for (const admin of adminMembers) {
-          viewableUserIds.add(admin.userId);
-        }
-
-        // Check explicit page permissions for remaining members
-        const remainingIds = otherMemberIds.filter(id => !viewableUserIds.has(id));
-        if (remainingIds.length > 0) {
-          const permittedMembers = await db.select({ userId: pagePermissions.userId })
-            .from(pagePermissions)
-            .where(and(
-              eq(pagePermissions.pageId, pageId),
-              inArray(pagePermissions.userId, remainingIds),
-              eq(pagePermissions.canView, true),
-              or(isNull(pagePermissions.expiresAt), gt(pagePermissions.expiresAt, new Date()))
-            ));
-          for (const pm of permittedMembers) {
-            viewableUserIds.add(pm.userId);
-          }
-        }
-      }
-
-      const broadcastPromises = otherMemberIds
-        .filter(id => viewableUserIds.has(id))
-        .map(memberId =>
-          broadcastInboxEvent(memberId, {
-            operation: 'channel_updated',
-            type: 'channel',
-            id: pageId,
-            driveId: channel.driveId,
-            lastMessageAt: newMessage?.createdAt?.toISOString() || new Date().toISOString(),
-            lastMessagePreview: messagePreview,
-            lastMessageSender: newMessage?.aiMeta?.senderName || newMessage?.user?.name || undefined,
-          })
-        );
-
-      await Promise.all(broadcastPromises);
 
       // Broadcast read status change to sender to update their unread count
       await broadcastInboxEvent(userId, {

--- a/apps/web/src/app/api/messages/[conversationId]/[messageId]/follow/__tests__/route.test.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/[messageId]/follow/__tests__/route.test.ts
@@ -17,12 +17,14 @@ vi.mock('@/lib/auth', () => ({
 
 const mockFindConversationForParticipant = vi.fn();
 const mockFindActiveMessage = vi.fn();
+const mockFindMessageInConversation = vi.fn();
 const mockAddDmThreadFollower = vi.fn();
 const mockRemoveDmThreadFollower = vi.fn();
 vi.mock('@pagespace/lib/services/dm-message-repository', () => ({
   dmMessageRepository: {
     findConversationForParticipant: (...args: unknown[]) => mockFindConversationForParticipant(...args),
     findActiveMessage: (...args: unknown[]) => mockFindActiveMessage(...args),
+    findMessageInConversation: (...args: unknown[]) => mockFindMessageInConversation(...args),
     addDmThreadFollower: (...args: unknown[]) => mockAddDmThreadFollower(...args),
     removeDmThreadFollower: (...args: unknown[]) => mockRemoveDmThreadFollower(...args),
   },
@@ -124,10 +126,11 @@ describe('DELETE /api/messages/[conversationId]/[messageId]/follow', () => {
       participant1Id: USER_ID,
       participant2Id: 'user_b',
     });
-    mockFindActiveMessage.mockResolvedValue({
+    mockFindMessageInConversation.mockResolvedValue({
       id: MSG_ID,
       conversationId: CONV_ID,
       parentId: null,
+      isActive: true,
     });
     mockRemoveDmThreadFollower.mockResolvedValue(undefined);
   });
@@ -137,6 +140,21 @@ describe('DELETE /api/messages/[conversationId]/[messageId]/follow', () => {
     expect(res.status).toBe(200);
     expect(mockRemoveDmThreadFollower).toHaveBeenCalledWith(MSG_ID, USER_ID);
     expect(await res.json()).toEqual({ following: false });
+  });
+
+  it('still removes the follower row when the parent has been soft-deleted (idempotent unfollow)', async () => {
+    // findMessageInConversation does NOT filter by isActive, so the route can
+    // unfollow a tombstoned thread root (which findActiveMessage would have
+    // returned null for, leaving stale subscriptions impossible to clear).
+    mockFindMessageInConversation.mockResolvedValueOnce({
+      id: MSG_ID,
+      conversationId: CONV_ID,
+      parentId: null,
+      isActive: false,
+    });
+    const res = await callDelete();
+    expect(res.status).toBe(200);
+    expect(mockRemoveDmThreadFollower).toHaveBeenCalledWith(MSG_ID, USER_ID);
   });
 
   it('returns 404 when the caller is not a participant', async () => {

--- a/apps/web/src/app/api/messages/[conversationId]/[messageId]/follow/__tests__/route.test.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/[messageId]/follow/__tests__/route.test.ts
@@ -162,4 +162,18 @@ describe('DELETE /api/messages/[conversationId]/[messageId]/follow', () => {
     const res = await callDelete();
     expect(res.status).toBe(404);
   });
+
+  it('returns 401 when unauthenticated', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(authError(401));
+    const res = await callDelete();
+    expect(res.status).toBe(401);
+    expect(mockRemoveDmThreadFollower).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the message does not belong to this conversation', async () => {
+    mockFindMessageInConversation.mockResolvedValueOnce(null);
+    const res = await callDelete();
+    expect(res.status).toBe(404);
+    expect(mockRemoveDmThreadFollower).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/app/api/messages/[conversationId]/[messageId]/follow/__tests__/route.test.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/[messageId]/follow/__tests__/route.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Contract tests for /api/messages/[conversationId]/[messageId]/follow
+ *
+ * The repository seam is mocked so the route's authz, validation, and audit
+ * behavior are exercised without the ORM chain.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn(
+    (r: unknown) => typeof r === 'object' && r !== null && 'error' in r
+  ),
+}));
+
+const mockFindConversationForParticipant = vi.fn();
+const mockFindActiveMessage = vi.fn();
+const mockAddDmThreadFollower = vi.fn();
+const mockRemoveDmThreadFollower = vi.fn();
+vi.mock('@pagespace/lib/services/dm-message-repository', () => ({
+  dmMessageRepository: {
+    findConversationForParticipant: (...args: unknown[]) => mockFindConversationForParticipant(...args),
+    findActiveMessage: (...args: unknown[]) => mockFindActiveMessage(...args),
+    addDmThreadFollower: (...args: unknown[]) => mockAddDmThreadFollower(...args),
+    removeDmThreadFollower: (...args: unknown[]) => mockRemoveDmThreadFollower(...args),
+  },
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+
+import { POST, DELETE } from '../route';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+import type { SessionAuthResult, AuthError } from '@/lib/auth';
+
+const CONV_ID = 'conv_dm';
+const MSG_ID = 'msg_root';
+const USER_ID = 'user_a';
+
+const sessionAuth = (): SessionAuthResult => ({
+  userId: USER_ID,
+  tokenVersion: 0,
+  tokenType: 'session',
+  sessionId: 'sess_test',
+  role: 'user',
+  adminRoleVersion: 0,
+});
+
+const authError = (status = 401): AuthError => ({
+  error: NextResponse.json({ error: 'Unauthorized' }, { status }),
+});
+
+const callPost = () =>
+  POST(new Request(`http://localhost/api/messages/${CONV_ID}/${MSG_ID}/follow`, { method: 'POST' }), {
+    params: Promise.resolve({ conversationId: CONV_ID, messageId: MSG_ID }),
+  });
+
+const callDelete = () =>
+  DELETE(new Request(`http://localhost/api/messages/${CONV_ID}/${MSG_ID}/follow`, { method: 'DELETE' }), {
+    params: Promise.resolve({ conversationId: CONV_ID, messageId: MSG_ID }),
+  });
+
+describe('POST /api/messages/[conversationId]/[messageId]/follow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(sessionAuth());
+    mockFindConversationForParticipant.mockResolvedValue({
+      id: CONV_ID,
+      participant1Id: USER_ID,
+      participant2Id: 'user_b',
+    });
+    mockFindActiveMessage.mockResolvedValue({
+      id: MSG_ID,
+      conversationId: CONV_ID,
+      parentId: null,
+    });
+    mockAddDmThreadFollower.mockResolvedValue(undefined);
+  });
+
+  it('adds the caller as a follower for a top-level DM root', async () => {
+    const res = await callPost();
+    expect(res.status).toBe(200);
+    expect(mockAddDmThreadFollower).toHaveBeenCalledWith(MSG_ID, USER_ID);
+    expect(await res.json()).toEqual({ following: true });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(authError(401));
+    const res = await callPost();
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 when the caller is not a participant in the conversation', async () => {
+    mockFindConversationForParticipant.mockResolvedValueOnce(null);
+    const res = await callPost();
+    expect(res.status).toBe(404);
+    expect(mockAddDmThreadFollower).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the message does not exist or is soft-deleted', async () => {
+    mockFindActiveMessage.mockResolvedValueOnce(null);
+    const res = await callPost();
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 when the message is a thread reply (followers attach to roots only)', async () => {
+    mockFindActiveMessage.mockResolvedValueOnce({
+      id: MSG_ID,
+      conversationId: CONV_ID,
+      parentId: 'some-other-parent',
+    });
+    const res = await callPost();
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('DELETE /api/messages/[conversationId]/[messageId]/follow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(sessionAuth());
+    mockFindConversationForParticipant.mockResolvedValue({
+      id: CONV_ID,
+      participant1Id: USER_ID,
+      participant2Id: 'user_b',
+    });
+    mockFindActiveMessage.mockResolvedValue({
+      id: MSG_ID,
+      conversationId: CONV_ID,
+      parentId: null,
+    });
+    mockRemoveDmThreadFollower.mockResolvedValue(undefined);
+  });
+
+  it('removes the caller as a follower', async () => {
+    const res = await callDelete();
+    expect(res.status).toBe(200);
+    expect(mockRemoveDmThreadFollower).toHaveBeenCalledWith(MSG_ID, USER_ID);
+    expect(await res.json()).toEqual({ following: false });
+  });
+
+  it('returns 404 when the caller is not a participant', async () => {
+    mockFindConversationForParticipant.mockResolvedValueOnce(null);
+    const res = await callDelete();
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/web/src/app/api/messages/[conversationId]/[messageId]/follow/route.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/[messageId]/follow/route.ts
@@ -1,0 +1,101 @@
+import { NextResponse } from 'next/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { dmMessageRepository } from '@pagespace/lib/services/dm-message-repository';
+
+const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
+
+type RouteParams = { params: Promise<{ conversationId: string; messageId: string }> };
+
+/**
+ * POST /api/messages/[conversationId]/[messageId]/follow
+ *
+ * Idempotently subscribes the caller to thread updates for the given root DM.
+ * Authz: caller must be a participant in the conversation (the existing
+ * `findConversationForParticipant` lookup enforces this — non-participants
+ * receive 404 rather than 403 to match the rest of the DM surface).
+ */
+export async function POST(req: Request, { params }: RouteParams) {
+  const { conversationId, messageId } = await params;
+
+  const auth = await authenticateRequestWithOptions(req, AUTH_OPTIONS);
+  if (isAuthError(auth)) return auth.error;
+  const userId = auth.userId;
+
+  const conversation = await dmMessageRepository.findConversationForParticipant(
+    conversationId,
+    userId
+  );
+  if (!conversation) {
+    return NextResponse.json({ error: 'Conversation not found' }, { status: 404 });
+  }
+
+  const message = await dmMessageRepository.findActiveMessage({
+    messageId,
+    conversationId,
+  });
+  if (!message) {
+    return NextResponse.json({ error: 'Message not found' }, { status: 404 });
+  }
+  if (message.parentId !== null) {
+    return NextResponse.json(
+      { error: 'Followers attach to top-level messages only' },
+      { status: 400 }
+    );
+  }
+
+  await dmMessageRepository.addDmThreadFollower(messageId, userId);
+
+  auditRequest(req, {
+    eventType: 'data.write',
+    userId,
+    resourceType: 'dm_thread_follower',
+    resourceId: messageId,
+  });
+
+  return NextResponse.json({ following: true });
+}
+
+/**
+ * DELETE /api/messages/[conversationId]/[messageId]/follow
+ *
+ * Removes the caller's DM follower row. Idempotent — deleting a non-existent
+ * row is treated as success so rapid toggle does not race.
+ */
+export async function DELETE(req: Request, { params }: RouteParams) {
+  const { conversationId, messageId } = await params;
+
+  const auth = await authenticateRequestWithOptions(req, AUTH_OPTIONS);
+  if (isAuthError(auth)) return auth.error;
+  const userId = auth.userId;
+
+  const conversation = await dmMessageRepository.findConversationForParticipant(
+    conversationId,
+    userId
+  );
+  if (!conversation) {
+    return NextResponse.json({ error: 'Conversation not found' }, { status: 404 });
+  }
+
+  // Use findActiveMessage to validate the message belongs to this conversation;
+  // a soft-deleted parent still allows unfollow so a user can clear stale
+  // subscriptions after the parent is tombstoned.
+  const message = await dmMessageRepository.findActiveMessage({
+    messageId,
+    conversationId,
+  });
+  if (!message) {
+    return NextResponse.json({ error: 'Message not found' }, { status: 404 });
+  }
+
+  await dmMessageRepository.removeDmThreadFollower(messageId, userId);
+
+  auditRequest(req, {
+    eventType: 'data.delete',
+    userId,
+    resourceType: 'dm_thread_follower',
+    resourceId: messageId,
+  });
+
+  return NextResponse.json({ following: false });
+}

--- a/apps/web/src/app/api/messages/[conversationId]/[messageId]/follow/route.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/[messageId]/follow/route.ts
@@ -77,10 +77,12 @@ export async function DELETE(req: Request, { params }: RouteParams) {
     return NextResponse.json({ error: 'Conversation not found' }, { status: 404 });
   }
 
-  // Use findActiveMessage to validate the message belongs to this conversation;
-  // a soft-deleted parent still allows unfollow so a user can clear stale
-  // subscriptions after the parent is tombstoned.
-  const message = await dmMessageRepository.findActiveMessage({
+  // DELETE intentionally uses the non-active variant so a tombstoned parent
+  // still allows unfollow — without it, soft-deleting a thread root would
+  // strand stale subscriptions that can never be cleared. We still scope the
+  // lookup to (messageId, conversationId) so this route cannot be used to
+  // probe for messages in other conversations.
+  const message = await dmMessageRepository.findMessageInConversation({
     messageId,
     conversationId,
   });

--- a/apps/web/src/app/api/messages/[conversationId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/__tests__/route.test.ts
@@ -936,6 +936,37 @@ describe('POST /api/messages/[conversationId] (thread reply)', () => {
     expect(res.status).toBe(400);
   });
 
+  it('does NOT emit dm_updated to a mentioned non-participant (sender-controlled IDs cannot leak into other users\' inboxes)', async () => {
+    const replyCreatedAt = new Date('2026-05-04T12:00:00Z');
+    mockInsertDmThreadReply.mockResolvedValueOnce({
+      kind: 'ok',
+      reply: {
+        id: 'reply-1',
+        parentId: PARENT_ID,
+        conversationId: CONVERSATION_ID,
+        senderId: SENDER_ID,
+        content: 'hi @[Outsider](user-outsider:user)',
+        createdAt: replyCreatedAt,
+      },
+      mirror: null,
+      rootId: PARENT_ID,
+      replyCount: 1,
+      lastReplyAt: replyCreatedAt,
+    });
+    mockListDmThreadFollowers.mockResolvedValueOnce([SENDER_ID]);
+
+    await callRoute({
+      content: 'hi @[Outsider](user-outsider:user)',
+      parentId: PARENT_ID,
+    });
+
+    const dmUpdatedCalls = mockBroadcastInboxEvent.mock.calls.filter(
+      ([, payload]) => (payload as { operation: string }).operation === 'dm_updated'
+    );
+    const recipients = dmUpdatedCalls.map(([uid]) => uid);
+    expect(recipients).not.toContain('user-outsider');
+  });
+
   it('fans out thread_updated to DM thread followers but EXCLUDES the reply author', async () => {
     const replyCreatedAt = new Date('2026-05-04T12:00:00Z');
     mockInsertDmThreadReply.mockResolvedValueOnce({

--- a/apps/web/src/app/api/messages/[conversationId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/__tests__/route.test.ts
@@ -35,6 +35,7 @@ const mockUpdateConversationLastRead = vi.fn();
 const mockInsertDmThreadReply = vi.fn();
 const mockListDmThreadReplies = vi.fn();
 const mockFindActiveMessage = vi.fn();
+const mockListDmThreadFollowers = vi.fn();
 vi.mock('@pagespace/lib/services/dm-message-repository', () => ({
   dmMessageRepository: {
     findConversationForParticipant: (...args: unknown[]) =>
@@ -52,6 +53,7 @@ vi.mock('@pagespace/lib/services/dm-message-repository', () => ({
     insertDmThreadReply: (...args: unknown[]) => mockInsertDmThreadReply(...args),
     listDmThreadReplies: (...args: unknown[]) => mockListDmThreadReplies(...args),
     findActiveMessage: (...args: unknown[]) => mockFindActiveMessage(...args),
+    listDmThreadFollowers: (...args: unknown[]) => mockListDmThreadFollowers(...args),
   },
 }));
 
@@ -743,6 +745,8 @@ describe('GET /api/messages/[conversationId] (?parentId=)', () => {
     vi.clearAllMocks();
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue(sessionAuth());
     mockFindConversationForParticipant.mockResolvedValue(mockConversation());
+    // PR 5: GET also fetches followers to populate isFollowing.
+    mockListDmThreadFollowers.mockResolvedValue([]);
   });
 
   it('routes to listDmThreadReplies when ?parentId= is provided and the parent is top-level', async () => {
@@ -800,6 +804,8 @@ describe('POST /api/messages/[conversationId] (thread reply)', () => {
     vi.mocked(isEmailVerified).mockResolvedValue(true);
     mockFindConversationForParticipant.mockResolvedValue(mockConversation());
     mockBroadcastThreadReplyCountUpdated.mockResolvedValue(undefined);
+    mockListDmThreadFollowers.mockResolvedValue([]);
+    mockBroadcastInboxEvent.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -843,8 +849,13 @@ describe('POST /api/messages/[conversationId] (thread reply)', () => {
     // No mirror → conversation preview should not bump for the thread-only reply.
     expect(mockUpdateConversationLastMessage).not.toHaveBeenCalled();
     expect(mockCreateOrUpdateMessageNotification).not.toHaveBeenCalled();
-    // Thread-only reply does NOT touch the conversation inbox bump path.
-    expect(mockBroadcastInboxEvent).not.toHaveBeenCalled();
+    // PR 5: thread-only reply with NO followers (default mock) emits no inbox events.
+    // Earlier assertion was "no inbox bumps at all"; now it remains true only because
+    // no followers exist — once followers are populated, thread_updated will fan out.
+    const dmUpdates = mockBroadcastInboxEvent.mock.calls.filter(
+      ([, payload]) => (payload as { operation: string }).operation === 'dm_updated'
+    );
+    expect(dmUpdates).toHaveLength(0);
 
     const broadcasts = fetchMock.mock.calls
       .filter(([url]) => typeof url === 'string' && url.includes('/api/broadcast'))
@@ -923,5 +934,35 @@ describe('POST /api/messages/[conversationId] (thread reply)', () => {
     const res = await callRoute({ content: 'x', parentId: 'reply-as-parent' });
 
     expect(res.status).toBe(400);
+  });
+
+  it('fans out thread_updated to DM thread followers but EXCLUDES the reply author', async () => {
+    const replyCreatedAt = new Date('2026-05-04T12:00:00Z');
+    mockInsertDmThreadReply.mockResolvedValueOnce({
+      kind: 'ok',
+      reply: {
+        id: 'reply-1',
+        parentId: PARENT_ID,
+        conversationId: CONVERSATION_ID,
+        senderId: SENDER_ID,
+        content: 'in-thread',
+        createdAt: replyCreatedAt,
+      },
+      mirror: null,
+      rootId: PARENT_ID,
+      replyCount: 2,
+      lastReplyAt: replyCreatedAt,
+    });
+    mockListDmThreadFollowers.mockResolvedValueOnce([SENDER_ID, RECIPIENT_ID]);
+
+    await callRoute({ content: 'in-thread', parentId: PARENT_ID });
+
+    const threadUpdated = mockBroadcastInboxEvent.mock.calls.filter(
+      ([, payload]) => (payload as { operation: string }).operation === 'thread_updated'
+    );
+    expect(threadUpdated).toHaveLength(1);
+    const [recipientId, payload] = threadUpdated[0];
+    expect(recipientId).toBe(RECIPIENT_ID);
+    expect((payload as { rootMessageId: string }).rootMessageId).toBe(PARENT_ID);
   });
 });

--- a/apps/web/src/app/api/messages/[conversationId]/route.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/route.ts
@@ -8,6 +8,7 @@ import { createSignedBroadcastHeaders } from '@pagespace/lib/auth/broadcast-auth
 import { dmMessageRepository } from '@pagespace/lib/services/dm-message-repository';
 import { broadcastInboxEvent, broadcastThreadReplyCountUpdated } from '@/lib/websocket/socket-utils';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
+import { extractMentionedUserIds } from '@/lib/channels/extract-user-mentions';
 import type { AttachmentMeta } from '@pagespace/lib/types';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
@@ -95,11 +96,14 @@ export async function GET(
         );
       }
 
-      const replies = await dmMessageRepository.listDmThreadReplies({
-        rootId: parentId,
-        limit: limit + 1,
-        after: parsedAfter,
-      });
+      const [replies, followers] = await Promise.all([
+        dmMessageRepository.listDmThreadReplies({
+          rootId: parentId,
+          limit: limit + 1,
+          after: parsedAfter,
+        }),
+        dmMessageRepository.listDmThreadFollowers(parentId),
+      ]);
 
       const hasMore = replies.length > limit;
       const page = hasMore ? replies.slice(0, limit) : replies;
@@ -107,6 +111,8 @@ export async function GET(
       const nextCursor = hasMore && last
         ? `${last.createdAt.toISOString()}|${last.id}`
         : null;
+
+      const isFollowing = followers.includes(userId);
 
       auditRequest(request, {
         eventType: 'data.read',
@@ -116,7 +122,7 @@ export async function GET(
         details: { replyCount: page.length },
       });
 
-      return NextResponse.json({ messages: page, nextCursor, hasMore });
+      return NextResponse.json({ messages: page, nextCursor, hasMore, isFollowing });
     }
 
     const messages = await dmMessageRepository.listActiveMessages({
@@ -404,6 +410,60 @@ export async function POST(
         replyCount: result.replyCount,
         lastReplyAt: result.lastReplyAt.toISOString(),
       });
+
+      // PR 5: thread_updated inbox fan-out to followers, plus mentioned
+      // non-follower DM-level bumps. Mirrors the channel route's logic at a
+      // smaller scale — DMs only have two participants, so the "non-follower
+      // mention" path is rare but kept for symmetry. Failures are logged and
+      // swallowed; the DB commit is durable.
+      try {
+        const previewSource = buildLastMessagePreview(content, attachmentMeta);
+        const replyCreatedAt = result.lastReplyAt.toISOString();
+        const replySender = {
+          id: userId,
+          name: 'Member',
+        };
+
+        const followers = await dmMessageRepository.listDmThreadFollowers(result.rootId);
+        const followerSet = new Set(followers);
+
+        await Promise.all(
+          followers
+            .filter((followerId: string) => followerId !== userId)
+            .map((followerId: string) =>
+              broadcastInboxEvent(followerId, {
+                operation: 'thread_updated',
+                type: 'dm',
+                id: conversationId,
+                rootMessageId: result.rootId,
+                lastReplyAt: replyCreatedAt,
+                lastReplyPreview: previewSource,
+                lastReplySender: replySender,
+              })
+            )
+        );
+
+        if (content.trim().length > 0) {
+          const mentionedUserIds = extractMentionedUserIds(content);
+          const mentionTargets = mentionedUserIds.filter(
+            (id: string) => id !== userId && !followerSet.has(id)
+          );
+          await Promise.all(
+            mentionTargets.map((memberId: string) =>
+              broadcastInboxEvent(memberId, {
+                operation: 'dm_updated',
+                type: 'dm',
+                id: conversationId,
+                lastMessageAt: replyCreatedAt,
+                lastMessagePreview: previewSource,
+                attachmentMeta,
+              })
+            )
+          );
+        }
+      } catch (error) {
+        loggers.realtime.error('Failed to broadcast DM thread inbox update:', error as Error);
+      }
 
       return NextResponse.json({ message: result.reply });
     }

--- a/apps/web/src/app/api/messages/[conversationId]/route.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/route.ts
@@ -444,9 +444,20 @@ export async function POST(
         );
 
         if (content.trim().length > 0) {
+          // DM mention IDs come from sender-controlled markup — the recipient
+          // set MUST be intersected with the conversation's actual participants.
+          // Without this, a sender could craft a `:user` mention for any user
+          // id and trigger a `dm_updated` payload (containing the conversation
+          // id, preview, and attachment metadata) to fan out to non-participants.
+          const otherParticipantId =
+            conversation.participant1Id === userId
+              ? conversation.participant2Id
+              : conversation.participant1Id;
+          const allowedTargets = new Set<string>([otherParticipantId]);
           const mentionedUserIds = extractMentionedUserIds(content);
           const mentionTargets = mentionedUserIds.filter(
-            (id: string) => id !== userId && !followerSet.has(id)
+            (id: string) =>
+              id !== userId && !followerSet.has(id) && allowedTargets.has(id)
           );
           await Promise.all(
             mentionTargets.map((memberId: string) =>

--- a/apps/web/src/app/api/messages/[conversationId]/route.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/route.ts
@@ -443,7 +443,12 @@ export async function POST(
             )
         );
 
-        if (content.trim().length > 0) {
+        // The mention-targeted bump is only meaningful for thread-only DM
+        // replies. When `alsoSendToParent` is set, the mirror branch above
+        // already fired `dm_updated` to the other participant — duplicating
+        // it here would inflate their unread count by 2 instead of 1.
+        const isThreadOnlyReply = !result.mirror;
+        if (isThreadOnlyReply && content.trim().length > 0) {
           // DM mention IDs come from sender-controlled markup — the recipient
           // set MUST be intersected with the conversation's actual participants.
           // Without this, a sender could craft a `:user` mention for any user

--- a/apps/web/src/components/inbox/ChannelsCenterList.tsx
+++ b/apps/web/src/components/inbox/ChannelsCenterList.tsx
@@ -12,6 +12,7 @@ import { cn } from '@/lib/utils';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useInboxSocket } from '@/hooks/useInboxSocket';
 import { isEditingActive } from '@/stores/useEditingStore';
+import { ThreadUnreadBadge } from '@/components/inbox/ThreadUnreadBadge';
 import type { InboxItem, InboxResponse } from '@pagespace/lib/types';
 
 const fetcher = async (url: string) => {
@@ -197,6 +198,7 @@ export default function ChannelsCenterList({ driveId }: ChannelsCenterListProps)
                         {formatDistanceToNow(new Date(item.lastMessageAt), { addSuffix: false })}
                       </span>
                     )}
+                    <ThreadUnreadBadge source="channel" contextId={item.id} />
                     {item.unreadCount > 0 && (
                       <span className="inline-flex items-center justify-center h-5 min-w-[20px] px-1.5 rounded-full bg-primary text-primary-foreground text-xs font-medium">
                         {item.unreadCount}

--- a/apps/web/src/components/inbox/DMCenterList.tsx
+++ b/apps/web/src/components/inbox/DMCenterList.tsx
@@ -14,6 +14,7 @@ import { cn } from '@/lib/utils';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useInboxSocket } from '@/hooks/useInboxSocket';
 import { isEditingActive } from '@/stores/useEditingStore';
+import { ThreadUnreadBadge } from '@/components/inbox/ThreadUnreadBadge';
 import type { InboxItem, InboxResponse } from '@pagespace/lib/types';
 
 const fetcher = async (url: string) => {
@@ -185,6 +186,7 @@ export default function DMCenterList() {
                         {formatDistanceToNow(new Date(item.lastMessageAt), { addSuffix: false })}
                       </span>
                     )}
+                    <ThreadUnreadBadge source="dm" contextId={item.id} />
                     {item.unreadCount > 0 && (
                       <span className="inline-flex items-center justify-center h-5 min-w-[20px] px-1.5 rounded-full bg-primary text-primary-foreground text-xs font-medium">
                         {item.unreadCount}

--- a/apps/web/src/components/inbox/ThreadUnreadBadge.tsx
+++ b/apps/web/src/components/inbox/ThreadUnreadBadge.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+/**
+ * ThreadUnreadBadge
+ *
+ * Per-row indicator that surfaces the count of distinct thread roots in a
+ * channel or DM that have unread replies the caller hasn't opened. Reads
+ * directly from `useThreadInboxStore` so it stays in sync with realtime
+ * `inbox:thread_updated` events without re-rendering the whole inbox list.
+ *
+ * Renders nothing when the count is 0 — keeps the row visually quiet until
+ * there is actually something to surface.
+ */
+
+import { MessageSquare } from 'lucide-react';
+import { useThreadInboxStore, type ThreadInboxSource } from '@/stores/useThreadInboxStore';
+import { cn } from '@/lib/utils';
+
+interface ThreadUnreadBadgeProps {
+  source: ThreadInboxSource;
+  contextId: string;
+  className?: string;
+}
+
+export function ThreadUnreadBadge({ source, contextId, className }: ThreadUnreadBadgeProps) {
+  // Inline selector (rather than calling contextUnreadCount) so Zustand can
+  // shallow-compare the returned number and skip re-render when other
+  // contexts mutate.
+  const count = useThreadInboxStore((state) => {
+    const ctx = state.contexts[`${source}:${contextId}`];
+    if (!ctx) return 0;
+    let n = 0;
+    for (const k of Object.keys(ctx.byRoot)) {
+      if (ctx.byRoot[k] > 0) n += 1;
+    }
+    return n;
+  });
+
+  if (count === 0) return null;
+
+  return (
+    <span
+      data-testid="thread-unread-badge"
+      aria-label={`${count} thread${count === 1 ? '' : 's'} with new replies`}
+      className={cn(
+        'inline-flex items-center gap-0.5 rounded-full bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground',
+        className,
+      )}
+    >
+      <MessageSquare className="h-2.5 w-2.5" />
+      {count}
+    </span>
+  );
+}

--- a/apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx
@@ -215,6 +215,12 @@ export function ThreadPanel({
   const handleToggleFollow = useCallback(async () => {
     if (followInFlight) return;
     if (!followStateKnown) return;
+    // Snapshot the thread identity at the start of the request: if the user
+    // switches to another thread before the response arrives, we must NOT
+    // write the previous thread's optimistic state back into the store —
+    // optimisticFollowing takes precedence over server data, so leaking it
+    // across a thread switch would silently mislabel the new panel header.
+    const submitThreadKey = activeThreadKeyRef.current;
     const next = !isFollowing;
     setOptimisticFollowing(next);
     setFollowError(null);
@@ -226,6 +232,7 @@ export function ThreadPanel({
       if (!res.ok) {
         throw new Error(`Follow toggle failed: ${res.status}`);
       }
+      if (activeThreadKeyRef.current !== submitThreadKey) return;
       // Refresh SWR so the server-truth replaces the optimistic value on the
       // next render; mutate without revalidate is enough since we already
       // know the new state.
@@ -236,10 +243,13 @@ export function ThreadPanel({
       setOptimisticFollowing(undefined);
     } catch (err) {
       console.error('Follow toggle failed', err);
+      if (activeThreadKeyRef.current !== submitThreadKey) return;
       setOptimisticFollowing(!next);
       setFollowError('Could not update follow state');
     } finally {
-      setFollowInFlight(false);
+      if (activeThreadKeyRef.current === submitThreadKey) {
+        setFollowInFlight(false);
+      }
     }
   }, [followInFlight, followStateKnown, isFollowing, buildFollowUrl, mutate]);
 

--- a/apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx
@@ -24,7 +24,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import useSWR from 'swr';
-import { X } from 'lucide-react';
+import { Bell, BellOff, X } from 'lucide-react';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { StreamingMarkdown } from '@/components/ai/shared/chat/StreamingMarkdown';
@@ -32,6 +32,7 @@ import { MessageAttachment } from '@/components/shared/MessageAttachment';
 import { MessageInput } from '@/components/shared/MessageInput';
 import { fetchWithAuth, post } from '@/lib/auth/auth-fetch';
 import { useSocketStore } from '@/stores/useSocketStore';
+import { useThreadInboxStore } from '@/stores/useThreadInboxStore';
 import type { AttachmentMeta, FileRelation } from '@/lib/attachment-utils';
 import type { Reaction } from '@/components/shared/MessageReactions';
 import { renderMessageParts, convertToMessageParts } from '@/components/messages/MessagePartRenderer';
@@ -87,6 +88,13 @@ interface ListResponse {
   messages: RawReply[];
   hasMore: boolean;
   nextCursor: string | null;
+  /**
+   * Server-truth follow state for the requesting user. PR 5 added this so
+   * the toggle reflects the persisted follower row, not just local state.
+   * Older servers (pre-PR-5) omit the field; the panel treats `undefined` as
+   * "not following yet known" and disables the toggle until first refresh.
+   */
+  isFollowing?: boolean;
 }
 
 interface RawReply {
@@ -155,6 +163,20 @@ export function ThreadPanel({
   const [draft, setDraft] = useState('');
   const [optimisticReplies, setOptimisticReplies] = useState<ThreadReply[]>([]);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  // Optimistic follow state: starts undefined until SWR returns. Once we have
+  // the server truth, optimistic updates lead the UI and the toggle reverts on
+  // POST/DELETE failure (mirrors the reaction toggle pattern elsewhere).
+  const [optimisticFollowing, setOptimisticFollowing] = useState<boolean | undefined>(undefined);
+  const [followError, setFollowError] = useState<string | null>(null);
+  const [followInFlight, setFollowInFlight] = useState(false);
+
+  // Clear the unread-thread badge for this root the moment the panel opens.
+  // Subsequent fan-outs while the panel is open could re-bump the badge; the
+  // page-side mount unsubscribes from the badge by closing the panel.
+  const clearThreadBadge = useThreadInboxStore((state) => state.clearRoot);
+  useEffect(() => {
+    clearThreadBadge({ source, contextId, rootMessageId: parentId });
+  }, [source, contextId, parentId, clearThreadBadge]);
 
   // Identity ref guards async work against thread switches: a send may
   // outlive the panel's current parentId if the user opens another thread
@@ -174,7 +196,52 @@ export function ThreadPanel({
     setOptimisticReplies([]);
     setDraft('');
     setSubmitError(null);
+    setOptimisticFollowing(undefined);
+    setFollowError(null);
+    setFollowInFlight(false);
   }, [parentId, contextId, source]);
+
+  // Effective follow state: optimistic value wins while the toggle is
+  // settling, otherwise the server-truth from SWR.
+  const isFollowing = optimisticFollowing ?? data?.isFollowing ?? false;
+  const followStateKnown = optimisticFollowing !== undefined || data?.isFollowing !== undefined;
+
+  const buildFollowUrl = useCallback(() => {
+    return source === 'channel'
+      ? `/api/channels/${contextId}/messages/${parentId}/follow`
+      : `/api/messages/${contextId}/${parentId}/follow`;
+  }, [source, contextId, parentId]);
+
+  const handleToggleFollow = useCallback(async () => {
+    if (followInFlight) return;
+    if (!followStateKnown) return;
+    const next = !isFollowing;
+    setOptimisticFollowing(next);
+    setFollowError(null);
+    setFollowInFlight(true);
+    try {
+      const res = await fetchWithAuth(buildFollowUrl(), {
+        method: next ? 'POST' : 'DELETE',
+      });
+      if (!res.ok) {
+        throw new Error(`Follow toggle failed: ${res.status}`);
+      }
+      // Refresh SWR so the server-truth replaces the optimistic value on the
+      // next render; mutate without revalidate is enough since we already
+      // know the new state.
+      mutate(
+        (current) => (current ? { ...current, isFollowing: next } : current),
+        { revalidate: false },
+      );
+      setOptimisticFollowing(undefined);
+    } catch (err) {
+      console.error('Follow toggle failed', err);
+      setOptimisticFollowing(!next);
+      setFollowError('Could not update follow state');
+    } finally {
+      setFollowInFlight(false);
+    }
+  }, [followInFlight, followStateKnown, isFollowing, buildFollowUrl, mutate]);
 
   const socket = useSocketStore((state) => state.socket);
   const connectionStatus = useSocketStore((state) => state.connectionStatus);
@@ -345,15 +412,37 @@ export function ThreadPanel({
             </span>
           )}
         </div>
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={onClose}
-          aria-label="Close thread"
-          data-testid="thread-panel-close"
-        >
-          <X className="h-4 w-4" />
-        </Button>
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleToggleFollow}
+            disabled={followInFlight || !followStateKnown}
+            aria-pressed={isFollowing}
+            aria-label={isFollowing ? 'Unfollow thread' : 'Follow thread'}
+            data-testid="thread-follow-toggle"
+            title={
+              followError
+                ? followError
+                : isFollowing
+                ? 'Following — click to stop receiving inbox bumps'
+                : 'Not following — click to receive inbox bumps for new replies'
+            }
+            className="gap-1.5 text-xs"
+          >
+            {isFollowing ? <Bell className="h-3.5 w-3.5" /> : <BellOff className="h-3.5 w-3.5" />}
+            <span>{isFollowing ? 'Following' : 'Not following'}</span>
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onClose}
+            aria-label="Close thread"
+            data-testid="thread-panel-close"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
       </div>
 
       {/* Body */}

--- a/apps/web/src/components/layout/middle-content/page-views/thread/__tests__/ThreadPanel.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/thread/__tests__/ThreadPanel.test.tsx
@@ -471,4 +471,92 @@ describe('ThreadPanel', () => {
       expected: 1,
     });
   });
+
+  it('given the GET response includes isFollowing=true, should label the toggle as Following', async () => {
+    renderPanel({
+      fetcher: vi.fn(async () => ({
+        messages: [],
+        hasMore: false,
+        nextCursor: null,
+        isFollowing: true,
+      })),
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('thread-follow-toggle').textContent).toContain('Following');
+    });
+    expect({
+      given: 'a server response with isFollowing=true',
+      should: 'render the header toggle in the Following state',
+      actual: screen.getByTestId('thread-follow-toggle').getAttribute('aria-pressed'),
+      expected: 'true',
+    }).toEqual({
+      given: 'a server response with isFollowing=true',
+      should: 'render the header toggle in the Following state',
+      actual: 'true',
+      expected: 'true',
+    });
+  });
+
+  it('given the user clicks the follow toggle, should POST to the follow endpoint and flip the label optimistically', async () => {
+    const user = userEvent.setup();
+    const { fetchWithAuth } = await import('@/lib/auth/auth-fetch');
+    vi.mocked(fetchWithAuth).mockResolvedValue(new Response('{}', { status: 200 }));
+    renderPanel({
+      fetcher: vi.fn(async () => ({
+        messages: [],
+        hasMore: false,
+        nextCursor: null,
+        isFollowing: false,
+      })),
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('thread-follow-toggle').textContent).toContain('Not following');
+    });
+
+    await user.click(screen.getByTestId('thread-follow-toggle'));
+
+    await waitFor(() => {
+      expect(vi.mocked(fetchWithAuth)).toHaveBeenCalledWith(
+        '/api/channels/page-1/messages/p1/follow',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('thread-follow-toggle').textContent).toContain('Following');
+    });
+  });
+
+  it('given a follow POST that fails, should revert the label to its prior state', async () => {
+    const user = userEvent.setup();
+    const { fetchWithAuth } = await import('@/lib/auth/auth-fetch');
+    vi.mocked(fetchWithAuth).mockResolvedValue(new Response('nope', { status: 500 }));
+    renderPanel({
+      fetcher: vi.fn(async () => ({
+        messages: [],
+        hasMore: false,
+        nextCursor: null,
+        isFollowing: false,
+      })),
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('thread-follow-toggle').textContent).toContain('Not following');
+    });
+
+    await user.click(screen.getByTestId('thread-follow-toggle'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('thread-follow-toggle').textContent).toContain('Not following');
+    });
+    expect({
+      given: 'a follow POST that returns 500',
+      should: 'revert the label back to the pre-click state',
+      actual: screen.getByTestId('thread-follow-toggle').textContent?.includes('Not following'),
+      expected: true,
+    }).toEqual({
+      given: 'a follow POST that returns 500',
+      should: 'revert the label back to the pre-click state',
+      actual: true,
+      expected: true,
+    });
+  });
 });

--- a/apps/web/src/hooks/useInboxSocket.ts
+++ b/apps/web/src/hooks/useInboxSocket.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef, useCallback } from 'react';
 import { useSWRConfig } from 'swr';
 import { useSocket } from './useSocket';
 import { isEditingActive } from '@/stores/useEditingStore';
+import { useThreadInboxStore } from '@/stores/useThreadInboxStore';
 import type { InboxEventPayload } from '@/lib/websocket/socket-utils';
 import type { InboxResponse } from '@pagespace/lib/types';
 
@@ -90,15 +91,31 @@ export function useInboxSocket({ driveId, hasLoadedRef: externalRef }: UseInboxS
       );
     };
 
+    // PR 5: thread_updated bumps a per-row "unread thread" badge in
+    // useThreadInboxStore WITHOUT touching the SWR cache or top-level unread
+    // count. The handler is intentionally separate so we can keep the existing
+    // dm/channel/read handler unchanged.
+    const handleThreadUpdated = (payload: InboxEventPayload) => {
+      if (payload.operation !== 'thread_updated' || !payload.rootMessageId) return;
+      if (!hasLoadedRef.current) return;
+      useThreadInboxStore.getState().bump({
+        source: payload.type,
+        contextId: payload.id,
+        rootMessageId: payload.rootMessageId,
+      });
+    };
+
     // Listen for all inbox event types
     socket.on('inbox:dm_updated', handleInboxUpdate);
     socket.on('inbox:channel_updated', handleInboxUpdate);
     socket.on('inbox:read_status_changed', handleInboxUpdate);
+    socket.on('inbox:thread_updated', handleThreadUpdated);
 
     return () => {
       socket.off('inbox:dm_updated', handleInboxUpdate);
       socket.off('inbox:channel_updated', handleInboxUpdate);
       socket.off('inbox:read_status_changed', handleInboxUpdate);
+      socket.off('inbox:thread_updated', handleThreadUpdated);
     };
   }, [socket, getCacheKey, mutate, hasLoadedRef]);
 

--- a/apps/web/src/lib/channels/__tests__/agent-mention-responder.test.ts
+++ b/apps/web/src/lib/channels/__tests__/agent-mention-responder.test.ts
@@ -54,6 +54,28 @@ vi.mock('@/lib/ai/tools/channel-tools', () => ({
   },
 }));
 
+const mockInsertChannelThreadReply = vi.fn();
+const mockLoadChannelMessageWithRelations = vi.fn();
+const mockListChannelThreadFollowers = vi.fn();
+vi.mock('@pagespace/lib/services/channel-message-repository', () => ({
+  channelMessageRepository: {
+    insertChannelThreadReply: (...args: unknown[]) => mockInsertChannelThreadReply(...args),
+    loadChannelMessageWithRelations: (...args: unknown[]) => mockLoadChannelMessageWithRelations(...args),
+    listChannelThreadFollowers: (...args: unknown[]) => mockListChannelThreadFollowers(...args),
+  },
+}));
+
+vi.mock('@pagespace/lib/auth/broadcast-auth', () => ({
+  createSignedBroadcastHeaders: vi.fn(() => ({ 'x-signed': 'yes' })),
+}));
+
+const mockBroadcastInboxEvent = vi.fn();
+const mockBroadcastThreadReplyCountUpdated = vi.fn();
+vi.mock('@/lib/websocket/socket-utils', () => ({
+  broadcastInboxEvent: (...args: unknown[]) => mockBroadcastInboxEvent(...args),
+  broadcastThreadReplyCountUpdated: (...args: unknown[]) => mockBroadcastThreadReplyCountUpdated(...args),
+}));
+
 import { db } from '@pagespace/db/db';
 import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
 import { agentCommunicationTools } from '@/lib/ai/tools/agent-communication-tools';
@@ -143,6 +165,22 @@ describe('agent-mention-responder', () => {
     mockCanUserViewPage.mockResolvedValue(true);
     mockAskAgentExecute.mockResolvedValue(createAskAgentSuccess('Agent reply'));
     mockSendChannelExecute.mockResolvedValue(createSendChannelSuccess());
+    mockInsertChannelThreadReply.mockResolvedValue({
+      kind: 'ok',
+      reply: { id: 'agent-reply-1', createdAt: new Date('2026-05-05T12:00:00Z') },
+      mirror: null,
+      rootId: 'parent-thread',
+      replyCount: 2,
+      lastReplyAt: new Date('2026-05-05T12:00:00Z'),
+    });
+    mockLoadChannelMessageWithRelations.mockResolvedValue({
+      id: 'agent-reply-1',
+      parentId: 'parent-thread',
+      createdAt: new Date('2026-05-05T12:00:00Z').toISOString(),
+    });
+    mockListChannelThreadFollowers.mockResolvedValue([]);
+    mockBroadcastInboxEvent.mockResolvedValue(undefined);
+    mockBroadcastThreadReplyCountUpdated.mockResolvedValue(undefined);
   });
 
   it('given message with no mentions, should not query agents or post responses', async () => {
@@ -279,5 +317,75 @@ describe('agent-mention-responder', () => {
 
     expect(mockAskAgentExecute).not.toHaveBeenCalled();
     expect(mockSendChannelExecute).not.toHaveBeenCalled();
+  });
+
+  it('given parentId is set, routes the agent reply via insertChannelThreadReply with aiMeta', async () => {
+    mockPagesFindMany.mockResolvedValue([
+      { id: 'agent-1', title: 'Budget Agent', enabledTools: ['send_channel_message'] },
+    ]);
+    mockAskAgentExecute.mockResolvedValue(
+      createAskAgentSuccess('In-thread reply')
+    );
+
+    await triggerMentionedAgentResponses({
+      ...baseParams,
+      sourceMessageId: 'thread-reply-1',
+      parentId: 'parent-thread',
+      content: 'Hey @[Budget Agent](agent-1:page) what do you think?',
+    });
+
+    expect(mockInsertChannelThreadReply).toHaveBeenCalledTimes(1);
+    const insertArgs = mockInsertChannelThreadReply.mock.calls[0][0];
+    expect(insertArgs.parentId).toBe('parent-thread');
+    expect(insertArgs.pageId).toBe('channel-1');
+    expect(insertArgs.userId).toBe('user-1');
+    expect(insertArgs.content).toBe('In-thread reply');
+    expect(insertArgs.aiMeta).toEqual({
+      senderType: 'agent',
+      senderName: 'Budget Agent',
+      agentPageId: 'agent-1',
+    });
+
+    // Top-level path must NOT fire when parentId is set.
+    expect(mockSendChannelExecute).not.toHaveBeenCalled();
+    // Parent footer refresh must fire so the channel-stream view updates.
+    expect(mockBroadcastThreadReplyCountUpdated).toHaveBeenCalledWith(
+      'channel-1',
+      expect.objectContaining({ rootId: 'parent-thread' })
+    );
+  });
+
+  it('given parentId is set, fans out thread_updated to followers excluding the human user', async () => {
+    mockPagesFindMany.mockResolvedValue([
+      { id: 'agent-1', title: 'Budget Agent', enabledTools: ['send_channel_message'] },
+    ]);
+    mockListChannelThreadFollowers.mockResolvedValue(['user-1', 'user-other', 'user-third']);
+
+    await triggerMentionedAgentResponses({
+      ...baseParams,
+      parentId: 'parent-thread',
+      content: 'Reply @[Budget Agent](agent-1:page)',
+    });
+
+    const recipients = mockBroadcastInboxEvent.mock.calls
+      .filter(([, payload]) => (payload as { operation: string }).operation === 'thread_updated')
+      .map(([userId]) => userId);
+    expect(recipients).toEqual(expect.arrayContaining(['user-other', 'user-third']));
+    expect(recipients).not.toContain('user-1');
+  });
+
+  it('given parentId is empty, falls back to the existing top-level send path', async () => {
+    mockPagesFindMany.mockResolvedValue([
+      { id: 'agent-1', title: 'Budget Agent', enabledTools: ['send_channel_message'] },
+    ]);
+
+    await triggerMentionedAgentResponses({
+      ...baseParams,
+      parentId: '',
+      content: 'Reply @[Budget Agent](agent-1:page)',
+    });
+
+    expect(mockInsertChannelThreadReply).not.toHaveBeenCalled();
+    expect(mockSendChannelExecute).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/lib/channels/__tests__/extract-user-mentions.test.ts
+++ b/apps/web/src/lib/channels/__tests__/extract-user-mentions.test.ts
@@ -1,0 +1,43 @@
+import { describe, it } from 'vitest';
+import { assert } from '@/stores/__tests__/riteway';
+import { extractMentionedUserIds } from '../extract-user-mentions';
+
+describe('extractMentionedUserIds', () => {
+  it('returns user IDs from `:user` mentions and skips `:page` mentions', () => {
+    assert({
+      given: 'a body with two `:user` mentions and one `:page` mention',
+      should: 'extract only the user IDs in first-seen order',
+      actual: extractMentionedUserIds(
+        'hi @[Alice](u-alice:user) and @[Doc](p-doc:page) and @[Bob](u-bob:user)'
+      ),
+      expected: ['u-alice', 'u-bob'],
+    });
+  });
+
+  it('dedupes the same user mentioned twice', () => {
+    assert({
+      given: 'a body that mentions the same user twice',
+      should: 'collapse duplicates into one ID',
+      actual: extractMentionedUserIds('@[Alice](u1:user) hello @[Alice](u1:user)'),
+      expected: ['u1'],
+    });
+  });
+
+  it('returns an empty array when content has no mentions', () => {
+    assert({
+      given: 'plain content with no mentions',
+      should: 'return an empty array',
+      actual: extractMentionedUserIds('hello world'),
+      expected: [],
+    });
+  });
+
+  it('returns an empty array for empty content', () => {
+    assert({
+      given: 'empty input',
+      should: 'return an empty array',
+      actual: extractMentionedUserIds(''),
+      expected: [],
+    });
+  });
+});

--- a/apps/web/src/lib/channels/agent-mention-responder.ts
+++ b/apps/web/src/lib/channels/agent-mention-responder.ts
@@ -11,6 +11,7 @@ import {
   broadcastThreadReplyCountUpdated,
 } from '@/lib/websocket/socket-utils';
 import { processMentionsInMessage } from '@/lib/ai/core/mention-processor';
+import { buildThreadPreview } from '@/lib/channels/build-thread-preview';
 import type { ToolExecutionContext } from '@/lib/ai/core';
 
 const channelMentionLogger = loggers.ai.child({ module: 'channel-agent-mentions' });
@@ -247,9 +248,7 @@ async function postAgentThreadReply(input: {
 
   try {
     const followers = await channelMessageRepository.listChannelThreadFollowers(result.rootId);
-    const replyPreview = input.content.length > 100
-      ? input.content.substring(0, 100) + '...'
-      : input.content;
+    const replyPreview = buildThreadPreview(input.content);
     await Promise.all(
       followers
         .filter((followerId: string) => followerId !== input.userId)

--- a/apps/web/src/lib/channels/agent-mention-responder.ts
+++ b/apps/web/src/lib/channels/agent-mention-responder.ts
@@ -4,6 +4,12 @@ import { pages } from '@pagespace/db/schema/core'
 import { channelMessages } from '@pagespace/db/schema/chat';
 import { canUserViewPage } from '@pagespace/lib/permissions/permissions'
 import { loggers } from '@pagespace/lib/logging/logger-config';
+import { channelMessageRepository } from '@pagespace/lib/services/channel-message-repository';
+import { createSignedBroadcastHeaders } from '@pagespace/lib/auth/broadcast-auth';
+import {
+  broadcastInboxEvent,
+  broadcastThreadReplyCountUpdated,
+} from '@/lib/websocket/socket-utils';
 import { processMentionsInMessage } from '@/lib/ai/core/mention-processor';
 import type { ToolExecutionContext } from '@/lib/ai/core';
 
@@ -26,6 +32,13 @@ export interface TriggerMentionedAgentResponsesParams {
   channelType?: string;
   sourceMessageId: string;
   content: string;
+  /**
+   * When the originating message is itself a thread reply, the agent's reply
+   * MUST land in the same thread, not at the top level. The route forwards
+   * the thread root id here; absent (or empty) means the original was top-level
+   * and the agent should reply at the top level (existing behavior).
+   */
+  parentId?: string;
   driveId?: string | null;
   driveName?: string | null;
   driveSlug?: string | null;
@@ -158,6 +171,109 @@ function canAgentSendChannelMessages(enabledTools: string[] | null): boolean {
   return Array.isArray(enabledTools) && enabledTools.includes('send_channel_message');
 }
 
+/**
+ * Post an agent's reply into a thread.
+ *
+ * Mirrors the thread-reply path in the channel POST route: insert via the
+ * transactional helper, broadcast `new_message` to the channel room (so the
+ * panel renders it), bump the parent footer via `thread_reply_count_updated`,
+ * and fan out `thread_updated` to followers (excluding the userId, which is
+ * the human who triggered the agent — they do not need a self-bump).
+ *
+ * Failures are logged and swallowed so a stalled realtime sidecar does not
+ * abort the originating user-facing request.
+ */
+async function postAgentThreadReply(input: {
+  userId: string;
+  channelId: string;
+  content: string;
+  parentId: string;
+  agent: MentionedAgent;
+}): Promise<void> {
+  const result = await channelMessageRepository.insertChannelThreadReply({
+    parentId: input.parentId,
+    pageId: input.channelId,
+    userId: input.userId,
+    content: input.content,
+    fileId: null,
+    attachmentMeta: null,
+    aiMeta: {
+      senderType: 'agent',
+      senderName: input.agent.title,
+      agentPageId: input.agent.id,
+    },
+  });
+
+  if (result.kind !== 'ok') {
+    channelMentionLogger.warn('Agent thread reply rejected by repository', {
+      channelId: input.channelId,
+      parentId: input.parentId,
+      kind: result.kind,
+    });
+    return;
+  }
+
+  const replyWithRelations = await channelMessageRepository.loadChannelMessageWithRelations(
+    result.reply.id
+  );
+
+  if (process.env.INTERNAL_REALTIME_URL && replyWithRelations) {
+    try {
+      const requestBody = JSON.stringify({
+        channelId: input.channelId,
+        event: 'new_message',
+        payload: replyWithRelations,
+      });
+      await fetch(`${process.env.INTERNAL_REALTIME_URL}/api/broadcast`, {
+        method: 'POST',
+        headers: createSignedBroadcastHeaders(requestBody),
+        body: requestBody,
+        signal: AbortSignal.timeout(5000),
+      });
+    } catch (error) {
+      channelMentionLogger.error(
+        'Failed to broadcast agent thread reply',
+        error instanceof Error ? error : undefined,
+        { channelId: input.channelId, parentId: input.parentId }
+      );
+    }
+  }
+
+  await broadcastThreadReplyCountUpdated(input.channelId, {
+    rootId: result.rootId,
+    replyCount: result.replyCount,
+    lastReplyAt: result.lastReplyAt.toISOString(),
+  });
+
+  try {
+    const followers = await channelMessageRepository.listChannelThreadFollowers(result.rootId);
+    const replyPreview = input.content.length > 100
+      ? input.content.substring(0, 100) + '...'
+      : input.content;
+    await Promise.all(
+      followers
+        .filter((followerId: string) => followerId !== input.userId)
+        .map((followerId: string) =>
+          broadcastInboxEvent(followerId, {
+            operation: 'thread_updated',
+            type: 'channel',
+            id: input.channelId,
+            rootMessageId: result.rootId,
+            lastReplyAt: result.lastReplyAt.toISOString(),
+            lastReplyPreview: replyPreview,
+            lastReplySender: { id: input.userId, name: input.agent.title },
+          })
+        )
+    );
+  } catch (error) {
+    channelMentionLogger.error(
+      'Failed to fan out thread_updated for agent thread reply',
+      error instanceof Error ? error : undefined,
+      { channelId: input.channelId, parentId: input.parentId }
+    );
+  }
+}
+
 export async function triggerMentionedAgentResponses(
   params: TriggerMentionedAgentResponsesParams
 ): Promise<void> {
@@ -268,27 +384,45 @@ export async function triggerMentionedAgentResponses(
           continue;
         }
 
-        await sendChannelExecute(
-          {
+        const replyContent = askResult.response.trim();
+        const trimmedParent = (params.parentId ?? '').trim();
+        if (trimmedParent.length > 0) {
+          // Thread-reply branch: route through the same transactional helper
+          // users use, with `aiMeta` set so the reply renders as the agent's
+          // identity and not the human user's. Auto-follow is handled inside
+          // the repository (PR 3); we still need to fan out `thread_updated`
+          // to the resulting follower set so other followers see the reply
+          // in their inbox even though it was posted by the agent.
+          await postAgentThreadReply({
+            userId: params.userId,
             channelId: params.channelId,
-            content: askResult.response.trim(),
-          },
-          {
-            toolCallId: `channel-mention-send-${params.sourceMessageId}-${agent.id}`,
-            messages: [],
-            experimental_context: {
-              userId: params.userId,
-              conversationId: mentionConversationId,
-              locationContext,
-              requestOrigin: 'agent',
-              chatSource: {
-                type: 'page',
-                agentPageId: agent.id,
-                agentTitle: agent.title,
-              },
-            } as ToolExecutionContext,
-          }
-        );
+            content: replyContent,
+            parentId: trimmedParent,
+            agent,
+          });
+        } else {
+          await sendChannelExecute(
+            {
+              channelId: params.channelId,
+              content: replyContent,
+            },
+            {
+              toolCallId: `channel-mention-send-${params.sourceMessageId}-${agent.id}`,
+              messages: [],
+              experimental_context: {
+                userId: params.userId,
+                conversationId: mentionConversationId,
+                locationContext,
+                requestOrigin: 'agent',
+                chatSource: {
+                  type: 'page',
+                  agentPageId: agent.id,
+                  agentTitle: agent.title,
+                },
+              } as ToolExecutionContext,
+            }
+          );
+        }
       } catch (error) {
         channelMentionLogger.error(
           'Failed to generate or post mentioned agent response',

--- a/apps/web/src/lib/channels/build-thread-preview.ts
+++ b/apps/web/src/lib/channels/build-thread-preview.ts
@@ -1,0 +1,11 @@
+/**
+ * Truncate channel/DM message content for inbox + thread previews.
+ *
+ * Centralized so the channel POST route, the agent mention responder, and any
+ * future callers all surface the same shape (100-char ellipsis). Keeping this
+ * in one place means a future change (e.g. grapheme-aware truncation) lands
+ * once and propagates.
+ */
+export function buildThreadPreview(content: string, limit = 100): string {
+  return content.length > limit ? content.substring(0, limit) + '...' : content;
+}

--- a/apps/web/src/lib/channels/extract-user-mentions.ts
+++ b/apps/web/src/lib/channels/extract-user-mentions.ts
@@ -1,0 +1,25 @@
+/**
+ * Pull `:user` mention IDs out of a channel/DM message body.
+ *
+ * Messages use the `@[Label](id:type)` markdown convention; user mentions are
+ * the `type === 'user'` rows. Page mentions (`:page`) are handled by the AI
+ * mention processor and are intentionally ignored here.
+ *
+ * Returned IDs are deduped, in first-seen order. The function never throws —
+ * unparseable content yields an empty array.
+ */
+export function extractMentionedUserIds(content: string): string[] {
+  if (!content || content.length === 0) return [];
+  const re = /@\[[^\]]{1,500}\]\(([^:)]{1,200}):user\)/g;
+  const seen = new Set<string>();
+  const out: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(content)) !== null) {
+    const id = m[1];
+    if (id && !seen.has(id)) {
+      seen.add(id);
+      out.push(id);
+    }
+  }
+  return out;
+}

--- a/apps/web/src/lib/websocket/socket-utils.ts
+++ b/apps/web/src/lib/websocket/socket-utils.ts
@@ -19,7 +19,7 @@ export type TaskOperation = 'task_list_created' | 'task_added' | 'task_updated' 
 export type UsageOperation = 'updated';
 export type ActivityOperation = 'logged';
 export type KickReason = 'member_removed' | 'role_changed' | 'permission_revoked' | 'session_revoked';
-export type InboxOperation = 'dm_updated' | 'channel_updated' | 'read_status_changed';
+export type InboxOperation = 'dm_updated' | 'channel_updated' | 'read_status_changed' | 'thread_updated';
 
 export interface ActivityEventPayload {
   activityId: string;
@@ -112,6 +112,14 @@ export interface InboxEventPayload {
   lastMessageSender?: string;
   unreadCount?: number;
   attachmentMeta?: AttachmentMeta | null;
+  // thread_updated-only fields. Added inline (rather than as a discriminated
+  // union) so existing call sites keep compiling — only thread_updated emitters
+  // populate these. Recipients are computed at the call site from
+  // `listFollowers`; the payload itself does not carry a recipient list.
+  rootMessageId?: string;
+  lastReplyAt?: string;
+  lastReplyPreview?: string;
+  lastReplySender?: { id: string; name: string };
 }
 
 /**

--- a/apps/web/src/stores/__tests__/useThreadInboxStore.test.ts
+++ b/apps/web/src/stores/__tests__/useThreadInboxStore.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, beforeEach } from 'vitest';
+import { assert } from './riteway';
+import { useThreadInboxStore } from '../useThreadInboxStore';
+
+const reset = () => {
+  useThreadInboxStore.setState({ contexts: {} });
+};
+
+describe('useThreadInboxStore', () => {
+  beforeEach(reset);
+
+  it('contributes one badge per distinct root after bump', () => {
+    useThreadInboxStore.getState().bump({ source: 'channel', contextId: 'c1', rootMessageId: 'r1' });
+    assert({
+      given: 'a single bump for one root',
+      should: 'report a context unread count of 1',
+      actual: useThreadInboxStore.getState().contextUnreadCount('channel', 'c1'),
+      expected: 1,
+    });
+  });
+
+  it('keys by (source, contextId, rootMessageId) — same channel can carry multiple unread roots', () => {
+    useThreadInboxStore.getState().bump({ source: 'channel', contextId: 'c1', rootMessageId: 'r1' });
+    useThreadInboxStore.getState().bump({ source: 'channel', contextId: 'c1', rootMessageId: 'r2' });
+    assert({
+      given: 'bumps for two distinct roots in the same channel',
+      should: 'count both roots toward the channel badge',
+      actual: useThreadInboxStore.getState().contextUnreadCount('channel', 'c1'),
+      expected: 2,
+    });
+  });
+
+  it('clearing one root leaves siblings in the same context untouched', () => {
+    useThreadInboxStore.getState().bump({ source: 'channel', contextId: 'c1', rootMessageId: 'r1' });
+    useThreadInboxStore.getState().bump({ source: 'channel', contextId: 'c1', rootMessageId: 'r2' });
+    useThreadInboxStore.getState().clearRoot({ source: 'channel', contextId: 'c1', rootMessageId: 'r1' });
+    assert({
+      given: 'two unread roots followed by a clear of one',
+      should: 'leave the other root contributing to the count',
+      actual: useThreadInboxStore.getState().contextUnreadCount('channel', 'c1'),
+      expected: 1,
+    });
+  });
+
+  it('does not mix counts between channel and DM with the same contextId string', () => {
+    useThreadInboxStore.getState().bump({ source: 'channel', contextId: 'shared', rootMessageId: 'r1' });
+    assert({
+      given: 'a channel bump for context "shared"',
+      should: 'NOT contribute to the DM-side count for "shared"',
+      actual: useThreadInboxStore.getState().contextUnreadCount('dm', 'shared'),
+      expected: 0,
+    });
+  });
+
+  it('clearing a root that was never bumped is a no-op', () => {
+    useThreadInboxStore.getState().bump({ source: 'channel', contextId: 'c1', rootMessageId: 'r1' });
+    useThreadInboxStore.getState().clearRoot({ source: 'channel', contextId: 'c1', rootMessageId: 'unknown' });
+    assert({
+      given: 'a clear for a root that was never bumped',
+      should: 'leave the existing badge count unchanged',
+      actual: useThreadInboxStore.getState().contextUnreadCount('channel', 'c1'),
+      expected: 1,
+    });
+  });
+
+  it('multiple bumps for the same root still count as one unread root', () => {
+    useThreadInboxStore.getState().bump({ source: 'channel', contextId: 'c1', rootMessageId: 'r1' });
+    useThreadInboxStore.getState().bump({ source: 'channel', contextId: 'c1', rootMessageId: 'r1' });
+    assert({
+      given: 'two bumps for the same root',
+      should: 'count the root once toward the badge',
+      actual: useThreadInboxStore.getState().contextUnreadCount('channel', 'c1'),
+      expected: 1,
+    });
+  });
+});

--- a/apps/web/src/stores/useThreadInboxStore.ts
+++ b/apps/web/src/stores/useThreadInboxStore.ts
@@ -1,0 +1,108 @@
+/**
+ * Thread Inbox Store
+ *
+ * Tracks unread thread roots per channel/DM context so the inbox sidebar can
+ * surface a per-row "thread badge" without bumping the existing top-level
+ * unread count. The server emits `thread_updated` inbox events to followers
+ * (excluding the reply author); this store accumulates those events into a
+ * `(source, contextId, rootMessageId)` triple and clears the contribution
+ * when the user opens the thread panel for that root.
+ *
+ * Keyed deliberately by all three fields:
+ *   - `(source, contextId)` identifies the channel or DM row to badge.
+ *   - `rootMessageId` lets a single channel carry multiple unread thread
+ *     roots; opening one thread should NOT clear the others.
+ *
+ * The store is intentionally pure: realtime fan-in lives in `useInboxSocket`
+ * and panel-open clearing lives where ThreadPanel mounts. Tests can drive it
+ * directly via `useThreadInboxStore.getState()`.
+ */
+
+import { create } from 'zustand';
+
+export type ThreadInboxSource = 'channel' | 'dm';
+
+interface BumpArgs {
+  source: ThreadInboxSource;
+  contextId: string;
+  rootMessageId: string;
+}
+
+interface ClearArgs {
+  source: ThreadInboxSource;
+  contextId: string;
+  rootMessageId: string;
+}
+
+interface ContextUnread {
+  /** Per-root counts within this context */
+  byRoot: Record<string, number>;
+}
+
+type Key = string;
+
+const buildKey = (source: ThreadInboxSource, contextId: string): Key =>
+  `${source}:${contextId}`;
+
+export interface ThreadInboxState {
+  /** Per-context unread-thread state, keyed by `${source}:${contextId}` */
+  contexts: Record<Key, ContextUnread>;
+  /**
+   * Bump the per-root count for an inbox `thread_updated` arrival. Does NOT
+   * suppress duplicates by reply id; the calling event listener guarantees
+   * one bump per fan-out hop.
+   */
+  bump: (args: BumpArgs) => void;
+  /**
+   * Clear the count for one specific root (e.g. the user opens the thread
+   * panel for it). Other roots in the same context are unaffected.
+   */
+  clearRoot: (args: ClearArgs) => void;
+  /**
+   * Convenience accessor: total unread thread roots in a context. A "root"
+   * with count 0 does not contribute. Returns 0 when the context is empty.
+   */
+  contextUnreadCount: (source: ThreadInboxSource, contextId: string) => number;
+}
+
+export const useThreadInboxStore = create<ThreadInboxState>((set, get) => ({
+  contexts: {},
+  bump: ({ source, contextId, rootMessageId }) =>
+    set((state) => {
+      const key = buildKey(source, contextId);
+      const ctx = state.contexts[key] ?? { byRoot: {} };
+      const current = ctx.byRoot[rootMessageId] ?? 0;
+      return {
+        contexts: {
+          ...state.contexts,
+          [key]: {
+            byRoot: { ...ctx.byRoot, [rootMessageId]: current + 1 },
+          },
+        },
+      };
+    }),
+  clearRoot: ({ source, contextId, rootMessageId }) =>
+    set((state) => {
+      const key = buildKey(source, contextId);
+      const ctx = state.contexts[key];
+      if (!ctx) return state;
+      if (ctx.byRoot[rootMessageId] === undefined) return state;
+      const { [rootMessageId]: _removed, ...remaining } = ctx.byRoot;
+      void _removed;
+      return {
+        contexts: {
+          ...state.contexts,
+          [key]: { byRoot: remaining },
+        },
+      };
+    }),
+  contextUnreadCount: (source, contextId) => {
+    const ctx = get().contexts[buildKey(source, contextId)];
+    if (!ctx) return 0;
+    let n = 0;
+    for (const k of Object.keys(ctx.byRoot)) {
+      if (ctx.byRoot[k] > 0) n += 1;
+    }
+    return n;
+  },
+}));

--- a/packages/lib/src/services/channel-message-repository.ts
+++ b/packages/lib/src/services/channel-message-repository.ts
@@ -312,6 +312,16 @@ export interface InsertChannelThreadReplyInput {
   fileId: string | null;
   attachmentMeta: AttachmentMeta | null;
   alsoSendToParent?: boolean;
+  // Optional aiMeta passthrough — agent-authored replies (mention responder)
+  // need senderType + senderName so the rendered row reads "AgentTitle (User)"
+  // instead of the user's display name. Auto-follow logic is unchanged: PR 3
+  // upserts (parentAuthor, replier) regardless of aiMeta, and aiMeta only
+  // affects how the reply itself is shown.
+  aiMeta?: {
+    senderType: 'global_assistant' | 'agent';
+    senderName: string;
+    agentPageId?: string;
+  } | null;
 }
 
 export type InsertChannelThreadReplyResult =
@@ -367,6 +377,7 @@ async function insertChannelThreadReply(
         fileId: input.fileId,
         attachmentMeta: input.attachmentMeta,
         parentId: input.parentId,
+        aiMeta: input.aiMeta ?? undefined,
       })
       .returning();
 

--- a/packages/lib/src/services/dm-message-repository.ts
+++ b/packages/lib/src/services/dm-message-repository.ts
@@ -156,6 +156,26 @@ async function findActiveMessage(
   return row ?? null;
 }
 
+/**
+ * Look up a DM message by id + conversationId WITHOUT filtering on isActive.
+ *
+ * Use this for operations that need to act on a message regardless of its
+ * tombstone state — e.g. unfollowing a thread after the parent has been soft
+ * deleted (`findActiveMessage` would return null and a stale subscription
+ * could never be cleared).
+ */
+async function findMessageInConversation(
+  input: ActiveMessageLookupInput
+): Promise<DmMessageRow | null> {
+  const row = await db.query.directMessages.findFirst({
+    where: and(
+      eq(directMessages.id, input.messageId),
+      eq(directMessages.conversationId, input.conversationId)
+    ),
+  });
+  return row ?? null;
+}
+
 async function softDeleteMessage(messageId: string): Promise<number> {
   // Soft-deleting a thread reply must decrement the parent's replyCount in the
   // same transaction so the footer count never drifts above the real number of
@@ -631,6 +651,7 @@ export const dmMessageRepository = {
   insertDmMessage,
   updateConversationLastMessage,
   findActiveMessage,
+  findMessageInConversation,
   softDeleteMessage,
   restoreDmMessage,
   purgeInactiveMessages,


### PR DESCRIPTION
## Summary
- broadcastInboxEvent thread_updated operation; fan out to followers excluding reply author
- POST/DELETE follow endpoints (channel + DM); follow toggle in thread panel header
- Inbox unread-thread badge per row, cleared when panel opens
- triggerMentionedAgentResponses accepts parentId; AI replies route into thread when mentioned inside one
- Channel/DM-level unread bump suppressed for thread-only replies (unless alsoSendToParent or non-follower mention)

PR 5 of 5 in the threads epic — closes the loop. Plan: /Users/jono/.claude/plans/channels-and-dm-s-need-imperative-bird.md

## Implementation notes
- **Mention bump rule:** the simpler of the two options in the plan — bump channel/DM-level unread for **mentioned users specifically**, not for any non-follower mention pattern. Keeps the rule deterministic.
- **alsoSendToParent fan-out:** the channel route's top-level inbox fan-out was extracted into a helper (`fanOutChannelInboxUpdate`) so both the regular POST path and the thread+alsoSendToParent path bump every viewable channel member identically.
- **isFollowing in GET:** the thread fetch endpoints (channel + DM) now return an `isFollowing` field for the requesting user, populated from the persisted follower row, so the toggle reflects server truth, not local state.
- **Agent thread routing:** `insertChannelThreadReply` gained an optional `aiMeta` passthrough (no change to auto-follow logic). The mention responder writes directly via the repository when `parentId` is set, broadcasts `new_message` to the channel room, bumps the parent footer, and fans out `thread_updated` to followers excluding the human user.

## Post-review hardening
Addressing Codex (3) + CodeRabbit (5) review comments + 2 nitpicks + 1 self-found double-bump:

1. **Channel mention authz (P1):** mention-targeted `channel_updated` now intersects with `canUserViewPage(uid, pageId)` — sender-controlled mention IDs can no longer surface a channel's preview to users without view access.
2. **DM mention participant restriction (P1):** mention-targeted `dm_updated` now intersects with the conversation's other participant — non-participants can no longer be reached via crafted `:user` mentions.
3. **DM follow DELETE on tombstoned parent (P2):** added `findMessageInConversation` (no `isActive` filter) so soft-deleted thread roots can still be unfollowed; otherwise stale subscriptions could never be cleared.
4. **Follow toggle race:** `handleToggleFollow` now snapshots `activeThreadKeyRef` and short-circuits if the user switches threads mid-request, preventing stale optimistic state from contaminating a newly-opened panel.
5. **Double-bump suppression:** when `alsoSendToParent` is set AND the reply mentions a non-follower viewable participant, the targeted mention bump is now skipped (the broad fan-out covers them) — prevents double-incrementing that user's unread count.
6. **Nitpick: shared `buildThreadPreview` helper** (`apps/web/src/lib/channels/build-thread-preview.ts`) used by both the channel POST route and the agent mention responder.
7. **Nitpick: `fanOutChannelInboxUpdate` no longer mutates** the array returned by `db.query.driveMembers.findMany`.
8. **DELETE coverage:** added `401` and `404` (message-not-found) tests for the DM follow DELETE suite to reach parity with POST.

## Test plan
- [x] Followers receive thread_updated inbox events; reply author does not
- [x] Inbox badge increments on thread_updated and clears on panel open
- [x] alsoSendToParent triggers the channel-level fan-out (existing channel_updated reaches every viewable member)
- [x] @mention in thread → mentioned non-follower receives a targeted channel_updated bump (gated by view permission)
- [x] DM mention bump restricted to the other participant
- [x] DM follow DELETE works on a tombstoned parent (idempotent unfollow)
- [x] Follow toggle persists; cannot leak optimistic state across thread switch
- [x] alsoSendToParent + mention does NOT double-bump a recipient
- [x] AI agent @mentioned in thread replies via insertChannelThreadReply with aiMeta; AI mentioned at top level still uses the existing path
- [x] All previously merged thread tests still pass
- [ ] Manual smoke: verify the UI flow end-to-end in `pnpm dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)