### PR TITLE
fix(authz): close pending-state authority bypass surfaces

### DIFF
--- a/apps/web/src/app/api/__tests__/drive-member-gate-coverage.test.ts
+++ b/apps/web/src/app/api/__tests__/drive-member-gate-coverage.test.ts
@@ -23,6 +23,10 @@ import { readdirSync, readFileSync, statSync } from 'fs';
 import { join } from 'path';
 
 const API_DIR = join(__dirname, '..');
+// Lib-level call sites also read driveMembers for authz decisions (AI tools,
+// memory discovery). Review C2 found four such sites the original API-only
+// scan could not see; this directory is now part of the regression sweep.
+const LIB_DIR = join(__dirname, '..', '..', '..', 'lib');
 
 /** Files that read `driveMembers` but are intentionally exempt from the gate. */
 const ACCEPTED_AT_GATE_EXEMPT = new Map<string, string>([
@@ -32,36 +36,37 @@ const ACCEPTED_AT_GATE_EXEMPT = new Map<string, string>([
   ],
   [
     'account/drives-status',
-    'Followup: admin lookup for drive-transfer UI should gate on acceptedAt — tracked in plan.md.',
-  ],
-  [
-    'account/handle-drive',
-    'Followup: drive-transfer POST should reject pending admins — tracked in plan.md.',
+    'Followup #4: admin lookup for drive-transfer UI should gate on acceptedAt — tracked in followup-4 (invite UX/audit hardening).',
   ],
   [
     'admin/global-prompt',
-    'Followup: admin drive picker should hide pending invitations — tracked in plan.md.',
+    'Followup #4: admin drive picker should hide pending invitations — tracked in followup-4.',
   ],
   [
     'channels/[pageId]/messages',
-    'Followup: pending admins should not receive @mention broadcast — tracked in plan.md.',
+    'Followup #4: pending admins should not receive @mention broadcast — tracked in followup-4.',
   ],
+]);
+
+/**
+ * Lib-level files that read `driveMembers` but are intentionally exempt.
+ * The repository file is the canonical seam; all reads through it carry
+ * their own gate logic specific to the operation (e.g. findActivePendingMember
+ * deliberately filters acceptedAt IS NULL to surface pending rows for the
+ * pending-list UI).
+ */
+const LIB_ACCEPTED_AT_GATE_EXEMPT = new Map<string, string>([
   [
-    'pages/bulk-copy',
-    'Followup: cross-drive copy authz should reject pending target-drive members — tracked in plan.md.',
-  ],
-  [
-    'pages/bulk-move',
-    'Followup: cross-drive move authz should reject pending target-drive members — tracked in plan.md.',
-  ],
-  [
-    'pages/tree',
-    'Followup: tree-render authz should reject pending members — tracked in plan.md.',
+    'repositories/drive-invite-repository.ts',
+    'Repository seam — each query carries its own gate (findAdminMembership filters IS NOT NULL; findActivePendingMemberByEmail intentionally filters IS NULL to surface pending rows; createDriveMember/findExistingMember/updateDriveMemberRole operate by composite key or memberId and do not branch on acceptedAt).',
   ],
 ]);
 
 const DRIVE_MEMBERS_REFERENCE = /\bdriveMembers\b/;
 const ACCEPTED_AT_GATE = /isNotNull\s*\(\s*driveMembers\.acceptedAt\s*\)/;
+// findActivePendingMemberByEmail intentionally filters IS NULL — that file is
+// allow-listed via LIB_ACCEPTED_AT_GATE_EXEMPT, so this constant is unused
+// today but documents the inverse case for future reviewers.
 
 function collectRouteFiles(dir: string): string[] {
   const results: string[] = [];
@@ -77,9 +82,28 @@ function collectRouteFiles(dir: string): string[] {
   return results;
 }
 
+function collectLibFiles(dir: string): string[] {
+  const results: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (entry === 'node_modules' || entry === '__tests__') continue;
+    if (entry.endsWith('.test.ts') || entry.endsWith('.test.tsx')) continue;
+    if (statSync(full).isDirectory()) {
+      results.push(...collectLibFiles(full));
+    } else if (entry.endsWith('.ts') || entry.endsWith('.tsx')) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
 function toLogicalPath(absolutePath: string): string {
   const relative = absolutePath.replace(API_DIR + '/', '');
   return relative.replace(/\/route\.ts$/, '');
+}
+
+function toLibLogicalPath(absolutePath: string): string {
+  return absolutePath.replace(LIB_DIR + '/', '');
 }
 
 describe('Drive Member acceptedAt Gate Coverage', () => {
@@ -146,5 +170,41 @@ describe('Drive Member acceptedAt Gate Coverage', () => {
 
   it('coverage scan should discover a non-trivial number of routes (sanity check)', () => {
     expect(routes.length).toBeGreaterThanOrEqual(50);
+  });
+
+  // Review C2: the scan now extends into apps/web/src/lib/** so AI tools and
+  // memory discovery cannot silently bypass the gate. Without this sweep, four
+  // lib-level read sites used to live as invisible escape hatches.
+  describe('lib/** coverage (Review C2: lib-level call-site sweep)', () => {
+    const libFiles = collectLibFiles(LIB_DIR);
+
+    it('given any lib file that reads driveMembers, should compose isNotNull(driveMembers.acceptedAt) or be explicitly allow-listed', () => {
+      const violations: string[] = [];
+
+      for (const file of libFiles) {
+        const content = readFileSync(file, 'utf-8');
+        if (!DRIVE_MEMBERS_REFERENCE.test(content)) continue;
+        if (ACCEPTED_AT_GATE.test(content)) continue;
+        const logical = toLibLogicalPath(file);
+        if (LIB_ACCEPTED_AT_GATE_EXEMPT.has(logical)) continue;
+        violations.push(logical);
+      }
+
+      expect(violations).toEqual([]);
+      if (violations.length > 0) {
+        console.error(
+          `\nDrive member authz gate missing for ${violations.length} lib file(s):\n` +
+            violations.map((v) => `  - ${v}`).join('\n') +
+            `\n\nFix: Add isNotNull(driveMembers.acceptedAt) to the WHERE clause` +
+            `\n     of every authz read of driveMembers in apps/web/src/lib/**, OR` +
+            `\n     add the file to LIB_ACCEPTED_AT_GATE_EXEMPT with a one-line` +
+            `\n     justification.\n`
+        );
+      }
+    });
+
+    it('lib coverage scan should discover a non-trivial number of files (sanity check)', () => {
+      expect(libFiles.length).toBeGreaterThanOrEqual(50);
+    });
   });
 });

--- a/apps/web/src/app/api/__tests__/drive-member-gate-coverage.test.ts
+++ b/apps/web/src/app/api/__tests__/drive-member-gate-coverage.test.ts
@@ -206,5 +206,33 @@ describe('Drive Member acceptedAt Gate Coverage', () => {
     it('lib coverage scan should discover a non-trivial number of files (sanity check)', () => {
       expect(libFiles.length).toBeGreaterThanOrEqual(50);
     });
+
+    it('lib allow-list should not contain stale entries for files that no longer reference driveMembers', () => {
+      const stale: string[] = [];
+
+      for (const [pattern] of LIB_ACCEPTED_AT_GATE_EXEMPT) {
+        const file = libFiles.find((f) => toLibLogicalPath(f) === pattern);
+        if (!file) {
+          stale.push(`${pattern} (lib file not found)`);
+          continue;
+        }
+        const content = readFileSync(file, 'utf-8');
+        if (!DRIVE_MEMBERS_REFERENCE.test(content)) {
+          stale.push(`${pattern} (no longer references driveMembers)`);
+        }
+      }
+
+      expect(stale).toEqual([]);
+    });
+
+    it('lib allow-list entries should each carry a justification (no empty reasons)', () => {
+      const empty: string[] = [];
+      for (const [pattern, reason] of LIB_ACCEPTED_AT_GATE_EXEMPT) {
+        if (!reason || reason.trim().length < 10) {
+          empty.push(pattern);
+        }
+      }
+      expect(empty).toEqual([]);
+    });
   });
 });

--- a/apps/web/src/app/api/account/handle-drive/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/handle-drive/__tests__/route.test.ts
@@ -21,12 +21,13 @@ vi.mock('@pagespace/db/db', () => ({
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((field: unknown, value: unknown) => ({ field, value, type: 'eq' })),
   and: vi.fn((...args: unknown[]) => ({ args, type: 'and' })),
+  isNotNull: vi.fn((field: unknown) => ({ field, type: 'isNotNull' })),
 }));
 vi.mock('@pagespace/db/schema/core', () => ({
   drives: {},
 }));
 vi.mock('@pagespace/db/schema/members', () => ({
-  driveMembers: {},
+  driveMembers: { acceptedAt: 'driveMembers.acceptedAt' },
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
@@ -353,6 +354,30 @@ describe('POST /api/account/handle-drive', () => {
 
       // The query filters by driveId, so this should return null
       expect(response.status).toBe(400);
+    });
+
+    // Review C2 — borderline-CRIT. A leaving owner used to be able to transfer
+    // ownership to a never-accepted invitee. This test pins the gate that
+    // refuses pending admins as transfer targets.
+    it('rejects transfer to pending admin (acceptedAt IS NULL) — adversarial drive-ownership-transfer-to-pending-admin path', async () => {
+      // Simulate the gate filtering the pending row out — the query now
+      // requires acceptedAt IS NOT NULL so the pending admin is invisible.
+      vi.mocked(db.query.driveMembers.findFirst).mockResolvedValue(undefined);
+
+      const request = new Request('https://example.com/api/account/handle-drive', {
+        method: 'POST',
+        body: JSON.stringify({
+          driveId: mockDriveId,
+          action: 'transfer',
+          newOwnerId: mockNewOwnerId,
+        }),
+      });
+
+      const response = await POST(request);
+
+      expect(response.status).toBe(400);
+      const { isNotNull } = await import('@pagespace/db/operators');
+      expect(isNotNull).toHaveBeenCalledWith('driveMembers.acceptedAt');
     });
   });
 

--- a/apps/web/src/app/api/account/handle-drive/route.ts
+++ b/apps/web/src/app/api/account/handle-drive/route.ts
@@ -1,5 +1,5 @@
 import { db } from '@pagespace/db/db'
-import { eq, and } from '@pagespace/db/operators'
+import { eq, and, isNotNull } from '@pagespace/db/operators'
 import { drives } from '@pagespace/db/schema/core'
 import { driveMembers } from '@pagespace/db/schema/members';
 import { loggers } from '@pagespace/lib/logging/logger-config';
@@ -52,12 +52,15 @@ export async function POST(req: Request) {
     }
 
     if (action === 'transfer') {
-      // Verify the new owner is an admin in the drive
+      // Verify the new owner is an *accepted* admin in the drive. A pending
+      // admin (acceptedAt IS NULL) must not receive ownership — they have
+      // never authenticated to the drive and cannot consent. Closes Review C2.
       const newOwnerMembership = await db.query.driveMembers.findFirst({
         where: and(
           eq(driveMembers.driveId, driveId),
           eq(driveMembers.userId, newOwnerId),
-          eq(driveMembers.role, 'ADMIN')
+          eq(driveMembers.role, 'ADMIN'),
+          isNotNull(driveMembers.acceptedAt)
         ),
       });
 

--- a/apps/web/src/app/api/drives/[driveId]/members/invite/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/invite/__tests__/route.test.ts
@@ -16,6 +16,7 @@ vi.mock('@/lib/repositories/drive-invite-repository', () => ({
     findAdminMembership: vi.fn(),
     findExistingMember: vi.fn(),
     findUserIdByEmail: vi.fn(),
+    findUserVerificationStatusById: vi.fn(),
     findActivePendingMemberByEmail: vi.fn(),
     findInviterDisplay: vi.fn(),
     createDriveMember: vi.fn(),
@@ -192,6 +193,11 @@ describe('POST /api/drives/[driveId]/members/invite', () => {
     vi.mocked(driveInviteRepository.createPagePermission).mockResolvedValue({ id: 'perm_1' } as never);
     vi.mocked(driveInviteRepository.updatePagePermission).mockResolvedValue({ id: 'perm_1' } as never);
     vi.mocked(driveInviteRepository.findUserEmail).mockResolvedValue('invited@example.com');
+    vi.mocked(driveInviteRepository.findUserVerificationStatusById).mockResolvedValue({
+      email: 'invited@example.com',
+      emailVerified: new Date('2026-01-01'),
+      suspendedAt: null,
+    } as never);
 
     vi.mocked(checkDistributedRateLimit).mockResolvedValue({ allowed: true });
     vi.mocked(getDriveRecipientUserIds).mockResolvedValue([]);
@@ -363,6 +369,83 @@ describe('POST /api/drives/[driveId]/members/invite', () => {
       await POST(buildPost(mockDriveId, userIdBody), createContext(mockDriveId));
       expect(driveInviteRepository.findUserIdByEmail).not.toHaveBeenCalled();
       expect(driveInviteRepository.findActivePendingMemberByEmail).not.toHaveBeenCalled();
+    });
+
+    // Review C1 — closes the path "create temp user via email invite to drive A
+    // → revoke that invite → admin uses /users/search to re-invite by userId on
+    // drive B". Before this gate, the userId path called
+    // createAcceptedMemberWithPermissions on a never-authenticated account.
+    describe('emailVerified gate on userId path (Review C1: temp-user-via-userId-path adversarial path)', () => {
+      it('routes unverified target through invitation flow — must NOT call createAcceptedMemberWithPermissions', async () => {
+        vi.mocked(driveInviteRepository.findUserVerificationStatusById).mockResolvedValue({
+          email: 'unverified@example.com',
+          emailVerified: null,
+          suspendedAt: null,
+        } as never);
+
+        const response = await POST(
+          buildPost(mockDriveId, {
+            userId: 'temp_user_id',
+            role: 'MEMBER',
+            permissions: [],
+          }),
+          createContext(mockDriveId)
+        );
+        const json = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(json.kind).toBe('invited');
+        expect(driveInviteRepository.createAcceptedMemberWithPermissions).not.toHaveBeenCalled();
+        expect(driveInviteRepository.createDriveMember).toHaveBeenCalledWith(
+          expect.objectContaining({ acceptedAt: null, role: 'MEMBER', driveId: mockDriveId })
+        );
+        expect(createMagicLinkToken).toHaveBeenCalledWith({
+          email: 'unverified@example.com',
+          expiryMinutes: 60 * 24 * 7,
+        });
+        expect(sendPendingDriveInvitationEmail).toHaveBeenCalledWith(
+          expect.objectContaining({ recipientEmail: 'unverified@example.com' })
+        );
+      });
+
+      it('rejects suspended target user with 403 even on userId path', async () => {
+        vi.mocked(driveInviteRepository.findUserVerificationStatusById).mockResolvedValue({
+          email: 'banned@example.com',
+          emailVerified: new Date('2026-01-01'),
+          suspendedAt: new Date('2026-02-01'),
+        } as never);
+
+        const response = await POST(
+          buildPost(mockDriveId, { userId: 'suspended_user', role: 'MEMBER', permissions: [] }),
+          createContext(mockDriveId)
+        );
+
+        expect(response.status).toBe(403);
+        expect(driveInviteRepository.createAcceptedMemberWithPermissions).not.toHaveBeenCalled();
+        expect(driveInviteRepository.createDriveMember).not.toHaveBeenCalled();
+      });
+
+      it('returns 404 when invited userId resolves to no user record', async () => {
+        vi.mocked(driveInviteRepository.findUserVerificationStatusById).mockResolvedValue(null as never);
+
+        const response = await POST(
+          buildPost(mockDriveId, { userId: 'ghost_user', role: 'MEMBER', permissions: [] }),
+          createContext(mockDriveId)
+        );
+
+        expect(response.status).toBe(404);
+        expect(driveInviteRepository.createAcceptedMemberWithPermissions).not.toHaveBeenCalled();
+      });
+
+      it('verified target preserves Epic 2 behavior (auto-accept add path)', async () => {
+        // findUserVerificationStatusById defaults to a verified user in beforeEach.
+        const response = await POST(buildPost(mockDriveId, userIdBody), createContext(mockDriveId));
+        const json = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(json.kind).toBe('added');
+        expect(driveInviteRepository.createAcceptedMemberWithPermissions).toHaveBeenCalledTimes(1);
+      });
     });
   });
 

--- a/apps/web/src/app/api/drives/[driveId]/members/invite/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/invite/__tests__/route.test.ts
@@ -437,6 +437,33 @@ describe('POST /api/drives/[driveId]/members/invite', () => {
         expect(driveInviteRepository.createAcceptedMemberWithPermissions).not.toHaveBeenCalled();
       });
 
+      // Codex P2: unverified-userId-path reroutes to handleEmailPath but used
+      // to hardcode permissions: [], silently dropping caller-supplied page
+      // permissions while returning kind: invited. The fix forwards the
+      // original permissions so the email path's existing 422 fires.
+      it('rejects 422 when permissions[] non-empty on unverified-userId path — adversarial silently-dropped-permissions path', async () => {
+        vi.mocked(driveInviteRepository.findUserVerificationStatusById).mockResolvedValue({
+          email: 'unverified@example.com',
+          emailVerified: null,
+          suspendedAt: null,
+        } as never);
+
+        const response = await POST(
+          buildPost(mockDriveId, {
+            userId: 'temp_user_id',
+            role: 'MEMBER',
+            permissions: [{ pageId: 'page_1', canView: true, canEdit: false, canShare: false }],
+          }),
+          createContext(mockDriveId)
+        );
+
+        expect(response.status).toBe(422);
+        // Critically: nothing should have been written — no token, no member.
+        expect(createMagicLinkToken).not.toHaveBeenCalled();
+        expect(driveInviteRepository.createDriveMember).not.toHaveBeenCalled();
+        expect(sendPendingDriveInvitationEmail).not.toHaveBeenCalled();
+      });
+
       it('verified target preserves Epic 2 behavior (auto-accept add path)', async () => {
         // findUserVerificationStatusById defaults to a verified user in beforeEach.
         const response = await POST(buildPost(mockDriveId, userIdBody), createContext(mockDriveId));

--- a/apps/web/src/app/api/drives/[driveId]/members/invite/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/invite/route.ts
@@ -167,9 +167,45 @@ async function handleUserIdPath(args: {
   // Set when we arrived here via an email-payload fall-through. Lets the
   // audit trail record the original email selector even after lookup.
   sourceEmail?: string;
+  // Set when the email path has already validated the target's verification
+  // status. Skips the redundant lookup and prevents the verified-existing-user
+  // shortcut from infinite-recursing through the gate added below.
+  skipVerificationCheck?: boolean;
 }): Promise<Response> {
-  const { request, body, drive, driveId, inviterUserId, sourceEmail } = args;
+  const { request, body, drive, driveId, inviterUserId, sourceEmail, skipVerificationCheck } = args;
   const { userId: invitedUserId, role, customRoleId, permissions } = body;
+
+  // Review C1: a never-authenticated user (emailVerified IS NULL) must not be
+  // auto-accepted into a drive. Route them through the invitation flow so they
+  // explicitly consent via magic-link click. Suspended users are refused
+  // outright. Missing user → 404 since the userId came from a client-supplied
+  // selector and a stale userId should not silently create membership.
+  if (!skipVerificationCheck) {
+    const targetStatus = await driveInviteRepository.findUserVerificationStatusById(invitedUserId);
+    if (!targetStatus) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+    if (targetStatus.suspendedAt) {
+      return NextResponse.json(
+        { error: 'This account is suspended and cannot be invited.' },
+        { status: 403 }
+      );
+    }
+    if (!targetStatus.emailVerified) {
+      return await handleEmailPath({
+        request,
+        body: {
+          email: targetStatus.email,
+          role,
+          customRoleId: customRoleId ?? null,
+          permissions: [],
+        },
+        drive,
+        driveId,
+        inviterUserId,
+      });
+    }
+  }
 
   const validPageIds = new Set(await driveInviteRepository.getValidPageIds(driveId));
   const existingMember = await driveInviteRepository.findExistingMember(driveId, invitedUserId);
@@ -335,6 +371,7 @@ async function handleEmailPath(args: {
       driveId,
       inviterUserId,
       sourceEmail: email,
+      skipVerificationCheck: true,
     });
   }
 

--- a/apps/web/src/app/api/drives/[driveId]/members/invite/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/invite/route.ts
@@ -192,13 +192,18 @@ async function handleUserIdPath(args: {
       );
     }
     if (!targetStatus.emailVerified) {
+      // Forward the caller-supplied permissions verbatim. The email path
+      // returns 422 when `permissions.length > 0` for not-yet-registered
+      // targets — that's the correct behavior here too. Hardcoding `[]`
+      // would silently drop the permissions and return kind:invited,
+      // misleading admins into thinking page-level grants applied.
       return await handleEmailPath({
         request,
         body: {
           email: targetStatus.email,
           role,
           customRoleId: customRoleId ?? null,
-          permissions: [],
+          permissions,
         },
         drive,
         driveId,

--- a/apps/web/src/app/api/pages/bulk-copy/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/bulk-copy/__tests__/route.test.ts
@@ -90,13 +90,14 @@ vi.mock('@pagespace/db/operators', () => ({
   inArray: vi.fn((a: unknown, b: unknown) => [a, b]),
   desc: vi.fn((a: unknown) => a),
   isNull: vi.fn((a: unknown) => a),
+  isNotNull: vi.fn((a: unknown) => ({ _isNotNull: true, col: a })),
 }));
 vi.mock('@pagespace/db/schema/core', () => ({
   pages: { id: 'id', driveId: 'driveId', parentId: 'parentId', position: 'position', isTrashed: 'isTrashed' },
   drives: { id: 'id' },
 }));
 vi.mock('@pagespace/db/schema/members', () => ({
-  driveMembers: { driveId: 'driveId', userId: 'userId' },
+  driveMembers: { driveId: 'driveMembers.driveId', userId: 'driveMembers.userId', acceptedAt: 'driveMembers.acceptedAt' },
 }));
 
 // ── Imports (after mocks) ───────────────────────────────────────────────
@@ -358,6 +359,20 @@ describe('POST /api/pages/bulk-copy', () => {
 
       expect(response.status).toBe(403);
       expect(body.error).toMatch(/permission.*copy/i);
+    });
+
+    // Review C2 — pending ADMIN escalation. Adversarial pin against drift back
+    // to the role-only predicate that allowed pending invitees to write into
+    // a drive they had not joined.
+    it('rejects pending ADMIN (acceptedAt IS NULL) — adversarial pending-admin-can-bulk-copy-into-unaccepted-drive path', async () => {
+      vi.mocked(db.query.drives.findFirst).mockResolvedValue({ id: mockDriveId, ownerId: 'other-user' } as never);
+      vi.mocked(db.query.driveMembers.findFirst).mockResolvedValue(undefined as never);
+
+      const response = await POST(createRequest(validBody));
+
+      expect(response.status).toBe(403);
+      const { isNotNull } = await import('@pagespace/db/operators');
+      expect(isNotNull).toHaveBeenCalledWith('driveMembers.acceptedAt');
     });
   });
 

--- a/apps/web/src/app/api/pages/bulk-copy/route.ts
+++ b/apps/web/src/app/api/pages/bulk-copy/route.ts
@@ -4,7 +4,7 @@ import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { db } from '@pagespace/db/db'
-import { and, eq, inArray, desc, isNull } from '@pagespace/db/operators'
+import { and, eq, inArray, desc, isNull, isNotNull } from '@pagespace/db/operators'
 import { pages, drives } from '@pagespace/db/schema/core'
 import { driveMembers } from '@pagespace/db/schema/members';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope, getAllowedDriveIds, isMCPAuthResult } from '@/lib/auth';
@@ -62,10 +62,14 @@ export async function POST(request: Request) {
     let canEditDrive = isOwner;
 
     if (!isOwner) {
+      // Authz read: a pending invitee (acceptedAt IS NULL) with role ADMIN
+      // would otherwise pass the role check and be allowed to write into a
+      // drive they have not accepted into. Closes Review C2.
       const membership = await db.query.driveMembers.findFirst({
         where: and(
           eq(driveMembers.driveId, targetDriveId),
-          eq(driveMembers.userId, userId)
+          eq(driveMembers.userId, userId),
+          isNotNull(driveMembers.acceptedAt)
         ),
       });
       canEditDrive = membership?.role === 'OWNER' || membership?.role === 'ADMIN';

--- a/apps/web/src/app/api/pages/bulk-move/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/bulk-move/__tests__/route.test.ts
@@ -90,13 +90,14 @@ vi.mock('@pagespace/db/operators', () => ({
   inArray: vi.fn((a: unknown, b: unknown) => [a, b]),
   desc: vi.fn((a: unknown) => a),
   isNull: vi.fn((a: unknown) => a),
+  isNotNull: vi.fn((a: unknown) => ({ _isNotNull: true, col: a })),
 }));
 vi.mock('@pagespace/db/schema/core', () => ({
   pages: { id: 'id', driveId: 'driveId', parentId: 'parentId', position: 'position', isTrashed: 'isTrashed' },
   drives: { id: 'id' },
 }));
 vi.mock('@pagespace/db/schema/members', () => ({
-  driveMembers: { driveId: 'driveId', userId: 'userId' },
+  driveMembers: { driveId: 'driveMembers.driveId', userId: 'driveMembers.userId', acceptedAt: 'driveMembers.acceptedAt', role: 'driveMembers.role' },
 }));
 
 // ── Imports (after mocks) ───────────────────────────────────────────────
@@ -323,6 +324,27 @@ describe('POST /api/pages/bulk-move', () => {
 
       expect(response.status).toBe(403);
       expect(body.error).toMatch(/permission.*move/i);
+    });
+
+    // Review C2 — pending ADMIN escalation. Pre-fix, the membership predicate
+    // only checked role IN (OWNER, ADMIN); a pending invitee with role=ADMIN
+    // (acceptedAt: null) passed and could write into a drive they had not
+    // joined. Adversarial test pins the gate by asserting the WHERE clause
+    // composes isNotNull(driveMembers.acceptedAt).
+    it('rejects pending ADMIN (acceptedAt IS NULL) — adversarial pending-admin-can-bulk-move-into-unaccepted-drive path', async () => {
+      vi.mocked(db.query.drives.findFirst).mockResolvedValue({ id: mockTargetDriveId, ownerId: 'other-user' } as never);
+      // Simulate the gate filtering out the pending row (post-fix, the DB
+      // returns nothing for an acceptedAt IS NULL membership).
+      vi.mocked(db.query.driveMembers.findFirst).mockResolvedValue(undefined as never);
+
+      const response = await POST(createRequest(validBody));
+
+      expect(response.status).toBe(403);
+      // Force the route to compose the gate; without isNotNull on
+      // driveMembers.acceptedAt, the regression test cannot detect a
+      // future drift back to the old predicate.
+      const { isNotNull } = await import('@pagespace/db/operators');
+      expect(isNotNull).toHaveBeenCalledWith('driveMembers.acceptedAt');
     });
   });
 

--- a/apps/web/src/app/api/pages/bulk-move/route.ts
+++ b/apps/web/src/app/api/pages/bulk-move/route.ts
@@ -4,7 +4,7 @@ import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { db } from '@pagespace/db/db'
-import { and, eq, inArray, desc, isNull } from '@pagespace/db/operators'
+import { and, eq, inArray, desc, isNull, isNotNull } from '@pagespace/db/operators'
 import { pages, drives } from '@pagespace/db/schema/core'
 import { driveMembers } from '@pagespace/db/schema/members';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope, getAllowedDriveIds, isMCPAuthResult } from '@/lib/auth';
@@ -61,10 +61,14 @@ export async function POST(request: Request) {
     let canEditDrive = isOwner;
 
     if (!isOwner) {
+      // Authz read: a pending invitee (acceptedAt IS NULL) with role ADMIN
+      // would otherwise pass the role check and be allowed to write into a
+      // drive they have not accepted into. Closes Review C2.
       const membership = await db.query.driveMembers.findFirst({
         where: and(
           eq(driveMembers.driveId, targetDriveId),
-          eq(driveMembers.userId, userId)
+          eq(driveMembers.userId, userId),
+          isNotNull(driveMembers.acceptedAt)
         ),
       });
       canEditDrive = membership?.role === 'OWNER' || membership?.role === 'ADMIN';

--- a/apps/web/src/app/api/pages/tree/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/tree/__tests__/route.test.ts
@@ -50,13 +50,14 @@ vi.mock('@pagespace/db/operators', () => ({
   and: vi.fn((...args: unknown[]) => args),
   eq: vi.fn((a: unknown, b: unknown) => [a, b]),
   asc: vi.fn((col: unknown) => col),
+  isNotNull: vi.fn((a: unknown) => ({ _isNotNull: true, col: a })),
 }));
 vi.mock('@pagespace/db/schema/core', () => ({
   pages: { driveId: 'driveId', isTrashed: 'isTrashed', position: 'position' },
   drives: { id: 'drives.id' },
 }));
 vi.mock('@pagespace/db/schema/members', () => ({
-  driveMembers: { driveId: 'driveMembers.driveId', userId: 'driveMembers.userId' },
+  driveMembers: { driveId: 'driveMembers.driveId', userId: 'driveMembers.userId', acceptedAt: 'driveMembers.acceptedAt' },
 }));
 
 import { POST } from '../route';
@@ -200,6 +201,25 @@ describe('POST /api/pages/tree', () => {
 
       expect(response.status).toBe(403);
       expect(body.error).toMatch(/access denied/i);
+    });
+
+    // Review C2 — pending member can read full page tree of a drive they have
+    // not joined. The tree leaks every non-trashed page (id, title, type,
+    // parentId, position, isTrashed). Adversarial pin against that path.
+    it('rejects pending member (acceptedAt IS NULL) — adversarial pending-member-reads-page-tree path', async () => {
+      // @ts-expect-error - partial mock data
+      vi.mocked(db.query.drives.findFirst).mockResolvedValue({
+        id: mockDriveId,
+        ownerId: 'other_user',
+      });
+      // Post-fix the gate filters this row out and findFirst returns undefined.
+      vi.mocked(db.query.driveMembers.findFirst).mockResolvedValue(undefined);
+
+      const response = await POST(createRequest({ driveId: mockDriveId }));
+
+      expect(response.status).toBe(403);
+      const { isNotNull } = await import('@pagespace/db/operators');
+      expect(isNotNull).toHaveBeenCalledWith('driveMembers.acceptedAt');
     });
   });
 

--- a/apps/web/src/app/api/pages/tree/route.ts
+++ b/apps/web/src/app/api/pages/tree/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod/v4';
 import { buildTree } from '@pagespace/lib/content/tree-utils';
 import { db } from '@pagespace/db/db'
-import { and, eq, asc } from '@pagespace/db/operators'
+import { and, eq, asc, isNotNull } from '@pagespace/db/operators'
 import { pages, drives } from '@pagespace/db/schema/core'
 import { driveMembers } from '@pagespace/db/schema/members';
 import { loggers } from '@pagespace/lib/logging/logger-config'
@@ -53,10 +53,13 @@ export async function POST(request: Request) {
     let hasAccess = isOwner;
 
     if (!isOwner) {
+      // Authz read: pending invitee (acceptedAt IS NULL) must not read the
+      // page tree of a drive they have not joined. Closes Review C2.
       const membership = await db.query.driveMembers.findFirst({
         where: and(
           eq(driveMembers.driveId, driveId),
-          eq(driveMembers.userId, userId)
+          eq(driveMembers.userId, userId),
+          isNotNull(driveMembers.acceptedAt)
         ),
       });
       hasAccess = !!membership;

--- a/apps/web/src/app/api/users/search/__tests__/route.test.ts
+++ b/apps/web/src/app/api/users/search/__tests__/route.test.ts
@@ -103,7 +103,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { verifyAuth } from '@/lib/auth';
 import { db } from '@pagespace/db/db';
-import { and, eq, isNotNull } from '@pagespace/db/operators';
+import { and, isNotNull } from '@pagespace/db/operators';
 
 // ============================================================================
 // Test Helpers

--- a/apps/web/src/app/api/users/search/__tests__/route.test.ts
+++ b/apps/web/src/app/api/users/search/__tests__/route.test.ts
@@ -73,12 +73,14 @@ vi.mock('@pagespace/db/operators', () => ({
   and: vi.fn((...args: unknown[]) => ({ _and: true, args })),
   or: vi.fn((...args: unknown[]) => ({ _or: true, args })),
   ilike: vi.fn((col: unknown, val: unknown) => ({ _ilike: true, col, val })),
+  isNotNull: vi.fn((col: unknown) => ({ _isNotNull: true, col })),
 }));
 vi.mock('@pagespace/db/schema/auth', () => ({
   users: {
     id: 'users.id',
     email: 'users.email',
     name: 'users.name',
+    emailVerified: 'users.emailVerified',
   },
 }));
 vi.mock('@pagespace/db/schema/members', () => ({
@@ -101,6 +103,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { verifyAuth } from '@/lib/auth';
 import { db } from '@pagespace/db/db';
+import { and, eq, isNotNull } from '@pagespace/db/operators';
 
 // ============================================================================
 // Test Helpers
@@ -346,6 +349,44 @@ describe('GET /api/users/search', () => {
 
       expect(response.status).toBe(200);
       expect(body.users).toHaveLength(2);
+    });
+  });
+
+  describe('emailVerified gate (Review C1: temp-user-via-search re-invite path)', () => {
+    it('given an email-shaped query, the email-match where-clause MUST compose isNotNull(users.emailVerified) so temp users (emailVerified IS NULL) cannot surface in search results', async () => {
+      const request = new Request('https://example.com/api/users/search?q=temp@example.com');
+      await GET(request);
+
+      // The route's email lookup must restrict to verified users — otherwise an
+      // admin can pick a temp user (created by a prior pending invite) and
+      // fall through to the userId-path which auto-accepts. See Review 1
+      // finding C1 / Review 2 §1.
+      expect(isNotNull).toHaveBeenCalledWith('users.emailVerified');
+      const emailWhereCall = vi.mocked(and).mock.calls.find((args) =>
+        args.some((a) => (a as { _eq?: true; col?: unknown }).col === 'users.email')
+      );
+      expect(emailWhereCall, 'email lookup should use and(eq(email,...), isNotNull(emailVerified))').toBeDefined();
+      expect(emailWhereCall).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ _isNotNull: true, col: 'users.emailVerified' }),
+        ])
+      );
+    });
+
+    it('given a temp-user record (emailVerified: null) returned by the DB, the route must NOT include it in results (defense in depth)', async () => {
+      // Even if the DB layer somehow returned a temp user, the route should not
+      // surface them. This is belt-and-suspenders against future regressions.
+      const tempUserResults = [
+        { userId: 'temp_user', email: 'temp@example.com', name: 'Temp', emailVerified: null },
+      ];
+      setupDbChains([], tempUserResults, []);
+
+      const request = new Request('https://example.com/api/users/search?q=temp@example.com');
+      const response = await GET(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.users.find((u: { userId: string }) => u.userId === 'temp_user')).toBeUndefined();
     });
   });
 

--- a/apps/web/src/app/api/users/search/route.ts
+++ b/apps/web/src/app/api/users/search/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { db } from '@pagespace/db/db'
-import { eq, and, or, ilike } from '@pagespace/db/operators'
+import { eq, and, or, ilike, isNotNull } from '@pagespace/db/operators'
 import { users } from '@pagespace/db/schema/auth'
 import { userProfiles } from '@pagespace/db/schema/members';
 import { verifyAuth } from '@/lib/auth';
@@ -31,7 +31,10 @@ export async function GET(request: Request) {
     // Only search public profiles or exact email matches
     const searchPattern = `%${query}%`;
 
-    // First, search in user profiles (public only)
+    // First, search in user profiles (public only).
+    // The inner join on users + isNotNull(emailVerified) excludes temp users
+    // created by pending magic-link invites — those accounts have no human
+    // behind them and must not surface as invite targets.
     const profileResults = await db.select({
       userId: userProfiles.userId,
       username: userProfiles.username,
@@ -45,6 +48,7 @@ export async function GET(request: Request) {
     .where(
       and(
         eq(userProfiles.isPublic, true),
+        isNotNull(users.emailVerified),
         or(
           ilike(userProfiles.username, searchPattern),
           ilike(userProfiles.displayName, searchPattern)
@@ -53,14 +57,19 @@ export async function GET(request: Request) {
     )
     .limit(limit);
 
-    // Also search by email (exact match for privacy)
+    // Also search by email (exact match for privacy).
+    // emailVerified IS NOT NULL is the gate that closes Review C1: an admin
+    // searching `bob@example.com` while bob holds only a pending invite from
+    // another drive used to get a clickable result and could fall into the
+    // userId path which auto-accepts. Temp users now stay invisible.
     const emailResults = await db.select({
       userId: users.id,
       email: users.email,
       name: users.name,
+      emailVerified: users.emailVerified,
     })
     .from(users)
-    .where(eq(users.email, query))
+    .where(and(eq(users.email, query), isNotNull(users.emailVerified)))
     .limit(1);
 
     // Combine results, avoiding duplicates
@@ -78,8 +87,11 @@ export async function GET(request: Request) {
       });
     }
 
-    // Add email results if not already in map
+    // Add email results if not already in map.
+    // Defense in depth: even if the DB layer returns an unverified row,
+    // drop it here so search can never surface a temp user.
     for (const result of emailResults) {
+      if (result.emailVerified === null) continue;
       if (!userMap.has(result.userId)) {
         // Check if this user has a profile
         const profile = await db.select()

--- a/apps/web/src/lib/ai/tools/__tests__/channel-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/channel-tools.test.ts
@@ -27,12 +27,13 @@ vi.mock('@pagespace/db/db', () => ({
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn(),
   and: vi.fn(),
+  isNotNull: vi.fn(),
 }));
 vi.mock('@pagespace/db/schema/core', () => ({
   pages: { id: 'id', isTrashed: 'isTrashed' },
 }));
 vi.mock('@pagespace/db/schema/members', () => ({
-  driveMembers: { driveId: 'driveId' },
+  driveMembers: { driveId: 'driveId', acceptedAt: 'acceptedAt' },
 }));
 vi.mock('@pagespace/db/schema/chat', () => ({
   channelMessages: {},

--- a/apps/web/src/lib/ai/tools/activity-tools.ts
+++ b/apps/web/src/lib/ai/tools/activity-tools.ts
@@ -1,7 +1,7 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 import { db } from '@pagespace/db/db'
-import { eq, and, or, desc, gte, ne, isNull, inArray } from '@pagespace/db/operators'
+import { eq, and, or, desc, gte, ne, isNull, isNotNull, inArray } from '@pagespace/db/operators'
 import { sessions } from '@pagespace/db/schema/sessions'
 import { drives } from '@pagespace/db/schema/core'
 import { activityLogs } from '@pagespace/db/schema/monitoring'
@@ -350,8 +350,10 @@ When summarizing multiple changes, group them thematically and describe the over
           }
         } else {
           // Single query to get all accessible drive IDs:
-          // 1. Drives user is a member of (via driveMembers)
+          // 1. Drives user is a member of (via driveMembers, accepted only)
           // 2. Drives user owns (via drives.ownerId)
+          // Pending invitees (acceptedAt IS NULL) must not surface drives they
+          // have not joined.
           const [memberDrives, ownedDrives] = await Promise.all([
             db
               .select({ driveId: driveMembers.driveId })
@@ -360,6 +362,7 @@ When summarizing multiple changes, group them thematically and describe the over
               .where(
                 and(
                   eq(driveMembers.userId, userId),
+                  isNotNull(driveMembers.acceptedAt),
                   eq(drives.isTrashed, false)
                 )
               ),

--- a/apps/web/src/lib/ai/tools/channel-tools.ts
+++ b/apps/web/src/lib/ai/tools/channel-tools.ts
@@ -4,7 +4,7 @@ import { canUserEditPage, canUserViewPage } from '@pagespace/lib/permissions/per
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getActorInfo, logMessageActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { db } from '@pagespace/db/db'
-import { eq, and } from '@pagespace/db/operators'
+import { eq, and, isNotNull } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core'
 import { driveMembers } from '@pagespace/db/schema/members'
 import { channelMessages, channelReadStatus } from '@pagespace/db/schema/chat';
@@ -192,8 +192,13 @@ export const channelTools = {
         // Broadcast inbox updates to channel members
         try {
           if (channel.driveId) {
+            // Pending admins (acceptedAt IS NULL) must not receive inbox
+            // notifications for channels in a drive they have not joined.
             const members = await db.query.driveMembers.findMany({
-              where: eq(driveMembers.driveId, channel.driveId),
+              where: and(
+                eq(driveMembers.driveId, channel.driveId),
+                isNotNull(driveMembers.acceptedAt)
+              ),
               columns: { userId: true },
             });
 

--- a/apps/web/src/lib/ai/tools/drive-tools.ts
+++ b/apps/web/src/lib/ai/tools/drive-tools.ts
@@ -1,7 +1,7 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 import { db } from '@pagespace/db/db'
-import { eq, and, ne } from '@pagespace/db/operators'
+import { eq, and, ne, isNotNull } from '@pagespace/db/operators'
 import { pages, drives } from '@pagespace/db/schema/core'
 import { driveMembers, pagePermissions } from '@pagespace/db/schema/members';
 import { slugify } from '@pagespace/lib/utils/utils';
@@ -70,6 +70,7 @@ export const driveTools = {
           .leftJoin(drives, eq(driveMembers.driveId, drives.id))
           .where(and(
             eq(driveMembers.userId, userId),
+            isNotNull(driveMembers.acceptedAt),
             ne(drives.ownerId, userId) // Exclude owned drives
           ));
 

--- a/apps/web/src/lib/memory/__tests__/discovery-service.test.ts
+++ b/apps/web/src/lib/memory/__tests__/discovery-service.test.ts
@@ -28,6 +28,7 @@ vi.mock('@pagespace/db/operators', () => ({
   gte: vi.fn(),
   desc: vi.fn(),
   inArray: vi.fn(),
+  isNotNull: vi.fn(),
 }));
 vi.mock('@pagespace/db/schema/core', () => ({
   chatMessages: { content: 'content', role: 'role', pageId: 'pageId', userId: 'userId', isActive: 'isActive', createdAt: 'createdAt' },
@@ -37,7 +38,7 @@ vi.mock('@pagespace/db/schema/monitoring', () => ({
   activityLogs: { operation: 'operation', resourceType: 'resourceType', resourceTitle: 'resourceTitle', userId: 'userId', driveId: 'driveId', timestamp: 'timestamp' },
 }));
 vi.mock('@pagespace/db/schema/members', () => ({
-  driveMembers: { driveId: 'driveId', userId: 'userId' },
+  driveMembers: { driveId: 'driveId', userId: 'userId', acceptedAt: 'acceptedAt' },
 }));
 vi.mock('@pagespace/db/schema/conversations', () => ({
   conversations: { id: 'id', userId: 'userId' },

--- a/apps/web/src/lib/memory/discovery-service.ts
+++ b/apps/web/src/lib/memory/discovery-service.ts
@@ -8,7 +8,7 @@
 
 import { generateText } from 'ai';
 import { db } from '@pagespace/db/db'
-import { eq, and, gte, desc, inArray } from '@pagespace/db/operators'
+import { eq, and, gte, desc, inArray, isNotNull } from '@pagespace/db/operators'
 import { chatMessages, pages } from '@pagespace/db/schema/core'
 import { activityLogs } from '@pagespace/db/schema/monitoring'
 import { driveMembers } from '@pagespace/db/schema/members'
@@ -108,10 +108,12 @@ async function gatherRecentConversations(
   );
 
   // 2. Page agent conversations (chatMessages)
+  // acceptedAt IS NOT NULL filters pending invitations — a not-yet-accepted
+  // member must not see prior conversations from the inviting drive.
   const userDrives = await db
     .select({ driveId: driveMembers.driveId })
     .from(driveMembers)
-    .where(eq(driveMembers.userId, userId));
+    .where(and(eq(driveMembers.userId, userId), isNotNull(driveMembers.acceptedAt)));
   const driveIds = userDrives.map((d) => d.driveId);
 
   if (driveIds.length > 0) {
@@ -158,10 +160,11 @@ async function gatherRecentActivity(
   const lookbackDate = new Date();
   lookbackDate.setDate(lookbackDate.getDate() - lookbackDays);
 
+  // Same gate as gatherRecentConversations — exclude pending invitations.
   const userDrives = await db
     .select({ driveId: driveMembers.driveId })
     .from(driveMembers)
-    .where(eq(driveMembers.userId, userId));
+    .where(and(eq(driveMembers.userId, userId), isNotNull(driveMembers.acceptedAt)));
   const driveIds = userDrives.map((d) => d.driveId);
 
   if (driveIds.length === 0) return [];

--- a/apps/web/src/lib/repositories/drive-invite-repository.ts
+++ b/apps/web/src/lib/repositories/drive-invite-repository.ts
@@ -156,6 +156,18 @@ export const driveInviteRepository = {
       : null;
   },
 
+  async findUserVerificationStatusById(
+    userId: string
+  ): Promise<{ email: string; emailVerified: Date | null; suspendedAt: Date | null } | null> {
+    const user = await db.query.users.findFirst({
+      where: eq(users.id, userId),
+      columns: { email: true, emailVerified: true, suspendedAt: true },
+    });
+    return user
+      ? { email: user.email, emailVerified: user.emailVerified, suspendedAt: user.suspendedAt }
+      : null;
+  },
+
   async findActivePendingMemberByEmail(driveId: string, email: string): Promise<{ id: string } | null> {
     const results = await db
       .select({ id: driveMembers.id })

--- a/packages/lib/src/auth/__tests__/magic-link-service.test.ts
+++ b/packages/lib/src/auth/__tests__/magic-link-service.test.ts
@@ -96,8 +96,6 @@ describe('magic-link-service', () => {
         id: 'user-1',
         suspendedAt: null,
       } as never);
-      const mockDelete = vi.fn();
-      vi.mocked(db.delete).mockReturnValue({ where: mockDelete } as never);
       const mockValues = vi.fn();
       vi.mocked(db.insert).mockReturnValue({ values: mockValues } as never);
 
@@ -108,6 +106,33 @@ describe('magic-link-service', () => {
         expect(result.data.userId).toBe('user-1');
         expect(result.data.isNewUser).toBe(false);
       }
+    });
+
+    // Review H1 — adversarial multi-token isolation. Pre-fix, the function
+    // ran a blind `delete from verificationTokens where userId=? and
+    // type='magic_link' and usedAt is null` before each insert, which
+    // silently invalidated:
+    //   - a 7-day pending invitation token when a 5-min sign-in token issued
+    //   - a drive-A invitation token when a drive-B invitation issued
+    //   - the original email's link when admin clicked Resend on the same drive
+    // Issuing a new token MUST NOT delete prior unused tokens for the user.
+    // Tokens age out via expiresAt instead.
+    it('does NOT delete prior unused magic_link tokens — adversarial concurrent-invitations-from-two-drives path', async () => {
+      vi.mocked(db.query.users.findFirst).mockResolvedValue({
+        id: 'user-1',
+        suspendedAt: null,
+      } as never);
+      const mockDeleteWhere = vi.fn();
+      vi.mocked(db.delete).mockReturnValue({ where: mockDeleteWhere } as never);
+      vi.mocked(db.insert).mockReturnValue({ values: vi.fn() } as never);
+
+      const result = await createMagicLinkToken({ email: 'user@test.com' });
+
+      expect(result.ok).toBe(true);
+      // The blind pre-insert delete is gone — neither db.delete nor its
+      // chained where is called by createMagicLinkToken.
+      expect(db.delete).not.toHaveBeenCalled();
+      expect(mockDeleteWhere).not.toHaveBeenCalled();
     });
 
     it('should create new user when email not found', async () => {

--- a/packages/lib/src/auth/magic-link-service.test.ts
+++ b/packages/lib/src/auth/magic-link-service.test.ts
@@ -285,27 +285,48 @@ describe('Magic Link Service', () => {
       });
     });
 
-    it('cleans up old unused tokens for same user', async () => {
-      // Create first token
-      await createMagicLinkToken({ email: testUserEmail });
+    // Review H1 — multi-token isolation. Pre-fix, createMagicLinkToken ran a
+    // blind delete of all unused magic_link tokens for the user before
+    // inserting the new one. That silently invalidated:
+    //   - a 7-day pending drive invitation when a 5-min sign-in token issued
+    //   - a drive-A invitation when a drive-B invitation issued for same email
+    //   - the original email's link when admin clicked Resend on the same drive
+    // The fix: stop the pre-insert deletion entirely. Tokens have a TTL and a
+    // unique tokenHash; verifyMagicLinkToken refuses expired/used rows.
+    it('preserves prior unused tokens — adversarial concurrent-invitations-from-two-drives path', async () => {
+      const first = await createMagicLinkToken({ email: testUserEmail });
+      const second = await createMagicLinkToken({ email: testUserEmail });
 
-      const firstCount = await db.query.verificationTokens.findMany({
-        where: eq(verificationTokens.userId, testUserId),
-      });
-      expect(firstCount).toHaveLength(1);
+      if (!first.ok || !second.ok) {
+        throw new Error('Setup failed: both creates should succeed');
+      }
 
-      // Create second token - should clean up first
-      await createMagicLinkToken({ email: testUserEmail });
-
-      const secondCount = await db.query.verificationTokens.findMany({
+      const stored = await db.query.verificationTokens.findMany({
         where: eq(verificationTokens.userId, testUserId),
       });
 
       assert({
-        given: 'multiple magic link requests',
-        should: 'only keep latest token',
-        actual: secondCount.length,
-        expected: 1,
+        given: 'two concurrent invitations for the same user',
+        should: 'preserve both unused tokens (no blind type-wide cleanup)',
+        actual: stored.length,
+        expected: 2,
+      });
+
+      // Both tokens must remain clickable.
+      const verifyFirst = await verifyMagicLinkToken({ token: first.data.token });
+      assert({
+        given: 'the first invitation token after a second was issued',
+        should: 'still verify successfully (T1 is not invalidated by T2)',
+        actual: verifyFirst.ok,
+        expected: true,
+      });
+
+      const verifySecond = await verifyMagicLinkToken({ token: second.data.token });
+      assert({
+        given: 'the second invitation token',
+        should: 'verify successfully',
+        actual: verifySecond.ok,
+        expected: true,
       });
     });
   });

--- a/packages/lib/src/auth/magic-link-service.ts
+++ b/packages/lib/src/auth/magic-link-service.ts
@@ -12,7 +12,7 @@ import { db } from '@pagespace/db/db';
 import { eq, and, isNull } from '@pagespace/db/operators';
 import { users, verificationTokens } from '@pagespace/db/schema/auth';
 import { createId } from '@paralleldrive/cuid2';
-import { generateToken, hashToken, getTokenPrefix } from './token-utils';
+import { generateToken, hashToken } from './token-utils';
 import { secureCompare } from './secure-compare';
 
 // Token expiry: 5 minutes for magic links
@@ -156,18 +156,12 @@ export async function createMagicLinkToken(input: unknown): Promise<CreateMagicL
     }
   }
 
-  // Clean up old unused magic link tokens for this user
-  await db
-    .delete(verificationTokens)
-    .where(
-      and(
-        eq(verificationTokens.userId, userId),
-        eq(verificationTokens.type, 'magic_link'),
-        isNull(verificationTokens.usedAt)
-      )
-    );
-
-  // Generate secure token with ps_magic_ prefix
+  // Review H1: do NOT delete prior unused magic_link tokens here. The blind
+  // type-wide cleanup invalidated multi-token scenarios — a 7-day drive
+  // invitation could be silently nuked by a 5-min sign-in (or by an invitation
+  // from a second drive, or by Resend on the same drive). Tokens carry their
+  // own TTL via expiresAt and a unique tokenHash; verifyMagicLinkToken refuses
+  // expired/used rows. Stale entries age out naturally.
   const { token, hash, tokenPrefix } = generateToken('ps_magic');
   const expiresAt = new Date(Date.now() + effectiveExpiryMinutes * 60 * 1000);
 


### PR DESCRIPTION
## Summary

Closes the three corroborated criticals tier findings from the 4-agent review battery on the drive invite-by-email epic (PRs #1233, #1234, #1236, #1239, #1243, #1245). All three findings share the same mental model — *a pending or never-authenticated identity must not exercise authority* — so they ship in one bundled PR.

### Slice 1.1 — Close userId-path emailVerified bypass

**Review C1** (`/tmp/review-1-end-to-end-report.md` finding 3 + `/tmp/review-2-zero-trust-report.md` §1):

- `apps/web/src/app/api/users/search/route.ts:63` returned temp users (created by a prior pending magic-link invite) on exact-email match. An admin could pick the temp user and the userId branch of `/api/drives/[driveId]/members/invite/route.ts:118-126,161-228` called `createAcceptedMemberWithPermissions` — admitting a never-authenticated account.

**Fix:**
- `users/search` now filters `isNotNull(users.emailVerified)` on both the profile-search join and the email-exact-match query, with a JS-side defense-in-depth drop.
- `handleUserIdPath` looks up target verification status before any membership write. Suspended → 403, missing → 404, unverified → routes through `handleEmailPath` (issues fresh magic-link, writes `acceptedAt: null`, sends invitation email). Verified path unchanged.
- New repository method `findUserVerificationStatusById`.

### Slice 1.2 — Close gate-coverage allow-list escalations

**Review C2** (`/tmp/review-2-zero-trust-report.md` §1, §2 Invariant 1):

- `apps/web/src/app/api/pages/bulk-move/route.ts:64-71` and `/bulk-copy/route.ts:65-72` (HIGH) — pending ADMIN could write into target drive
- `apps/web/src/app/api/pages/tree/route.ts:55-62` (HIGH) — pending member could read full page tree
- `apps/web/src/app/api/account/handle-drive/route.ts:56-62` (borderline-CRIT) — drive ownership transfer to pending admin
- Four lib-level call sites the regression test couldn't see:
  - `apps/web/src/lib/memory/discovery-service.ts:111-114, 161-164`
  - `apps/web/src/lib/ai/tools/drive-tools.ts:69-72`
  - `apps/web/src/lib/ai/tools/channel-tools.ts:194-197`
  - `apps/web/src/lib/ai/tools/activity-tools.ts:357-362`

**Fix:** all eight read sites gated on `isNotNull(driveMembers.acceptedAt)`. Gate-coverage regression test extended to scan `apps/web/src/lib/**`. Three previously-allow-listed route exemptions removed; remaining allow-list entries point to follow-up #4. The repository seam carries a single allow-list entry that documents why `findActivePendingMemberByEmail` intentionally inverts the gate (it surfaces pending rows for the pending-list UI).

### Slice 1.3 — Magic-link token isolation

**Review H1** (`/tmp/review-1-end-to-end-report.md` finding 1):

- `packages/lib/src/auth/magic-link-service.ts:160-168` ran a blind type-wide delete of unused magic-link tokens before each insert. That broke three flows:
  - 7-day pending invitation token nuked when user requested 5-min sign-in
  - drive-A invitation nuked when invitation issued for drive-B same email
  - Resend on same drive — original email's link dies first time admin clicks

**Fix:** stop the pre-insert deletion entirely. Tokens have a TTL via `expiresAt` and a unique `tokenHash`; `verifyMagicLinkToken` refuses expired/used rows. Stale unused tokens age out naturally.

## Adversarial tests

Each slice carries an adversarial test that cites the specific exploit path in the test name:
- `users/search`: temp-user-via-search re-invite path (verified by spy on `isNotNull(users.emailVerified)`)
- `invite/route`: temp-user-via-userId-path adversarial path (asserts `createAcceptedMemberWithPermissions` not called for unverified target)
- `bulk-move`, `bulk-copy`, `pages/tree`, `account/handle-drive`: pending-admin-can-X path (each pins `isNotNull(driveMembers.acceptedAt)` on the WHERE clause via the operators-mock spy, so a future drift back to the role-only predicate trips immediately)
- `magic-link-service`: concurrent-invitations-from-two-drives path (two tokens issued, both remain clickable, both verify)

## Out of scope (per follow-up plan)

This PR is one of five slated follow-ups. Not addressed here:

- Email canonicalization (lowercasing, citext, OAuth callbacks) — Follow-up 3
- Redirect-to-invited-drive UX (`?inviteDriveId` append) — Follow-up 4
- Audit gaps (deny / rate-limit / per-row acceptance) — Follow-up 4
- Trashed-drive invite guard, self-invite race, localhost fallback — Follow-up 4
- `member_removed` fan-out, `Promise.allSettled` Response.ok check, ralph-loop cleanup — Follow-up 2

The four `Followup` allow-list entries that remain reference Follow-up #4 explicitly; the rest are closed.

## Test plan

- [x] `pnpm lint` green
- [x] `pnpm typecheck` green (via `pnpm build`)
- [x] All 157 lib unit test files pass (3952 tests)
- [x] All 226 tests across the 10 touched apps/web test files pass
- [x] 26 pre-existing integration-test failures (gift-subscription / admin-role-version) confirmed identical on `master` — not introduced by this PR
- [x] Diff: 23 files, +469/-74 (well under 800 LOC ceiling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)