### PR TITLE
test(threads): hardening — UI/store edge cases (PR 6c)

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/thread/__tests__/ThreadPanel.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/thread/__tests__/ThreadPanel.test.tsx
@@ -289,10 +289,14 @@ describe('ThreadPanel', () => {
     const handler = mockSocketHandlers.get('new_message');
     expect(typeof handler).toBe('function');
 
+    // Distinct content per event makes leakage text-detectable: the message
+    // id is not rendered, so we can't probe by id. In production both bodies
+    // are identical (same user message, mirrored); using different strings
+    // here only matters to the test, not the contract under test.
     act(() => {
       handler!({
         id: 'reply-1',
-        content: 'mirrored body',
+        content: 'reply-body-A',
         createdAt: new Date('2026-05-05T12:00:00Z').toISOString(),
         userId: 'u-other',
         parentId: 'p1',
@@ -300,7 +304,7 @@ describe('ThreadPanel', () => {
       });
       handler!({
         id: 'mirror-1',
-        content: 'mirrored body',
+        content: 'mirror-body-B',
         createdAt: new Date('2026-05-05T12:00:01Z').toISOString(),
         userId: 'u-other',
         parentId: null,
@@ -311,21 +315,24 @@ describe('ThreadPanel', () => {
     await waitFor(() => expect(screen.getAllByTestId('thread-reply').length).toBe(1));
 
     const replies = screen.getAllByTestId('thread-reply');
-    const replyText = replies.map((r) => r.textContent ?? '');
-    const mirrorLeaked = replyText.some((t) => t.includes('mirror-1'));
+    const allText = replies.map((r) => r.textContent ?? '').join('\n');
 
     expect({
       given: 'reply (parentId=root) and mirror (parentId=null) twin events',
       should:
         'show exactly the reply in the thread list — the mirror is the page-side stream concern, not the panel',
-      actual: { count: replies.length, mirrorInThread: mirrorLeaked },
-      expected: { count: 1, mirrorInThread: false },
+      actual: {
+        count: replies.length,
+        replyShown: allText.includes('reply-body-A'),
+        mirrorShown: allText.includes('mirror-body-B'),
+      },
+      expected: { count: 1, replyShown: true, mirrorShown: false },
     }).toEqual({
       given: 'reply (parentId=root) and mirror (parentId=null) twin events',
       should:
         'show exactly the reply in the thread list — the mirror is the page-side stream concern, not the panel',
-      actual: { count: 1, mirrorInThread: false },
-      expected: { count: 1, mirrorInThread: false },
+      actual: { count: 1, replyShown: true, mirrorShown: false },
+      expected: { count: 1, replyShown: true, mirrorShown: false },
     });
   });
 

--- a/apps/web/src/components/layout/middle-content/page-views/thread/__tests__/ThreadPanel.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/thread/__tests__/ThreadPanel.test.tsx
@@ -289,10 +289,7 @@ describe('ThreadPanel', () => {
     const handler = mockSocketHandlers.get('new_message');
     expect(typeof handler).toBe('function');
 
-    // Distinct content per event makes leakage text-detectable: the message
-    // id is not rendered, so we can't probe by id. In production both bodies
-    // are identical (same user message, mirrored); using different strings
-    // here only matters to the test, not the contract under test.
+    // Distinct content per event so DOM-text probing can detect a leak (ids aren't rendered).
     act(() => {
       handler!({
         id: 'reply-1',

--- a/apps/web/src/components/layout/middle-content/page-views/thread/__tests__/ThreadPanel.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/thread/__tests__/ThreadPanel.test.tsx
@@ -280,6 +280,92 @@ describe('ThreadPanel', () => {
     });
   });
 
+  it('given alsoSendToParent twin events (reply + mirror), should append the reply but NOT the mirror to the thread list', async () => {
+    renderPanel({
+      fetcher: vi.fn(async () => ({ messages: [], hasMore: false, nextCursor: null })),
+    });
+    await waitFor(() => expect(screen.getByTestId('thread-divider-count')).toBeInTheDocument());
+
+    const handler = mockSocketHandlers.get('new_message');
+    expect(typeof handler).toBe('function');
+
+    act(() => {
+      handler!({
+        id: 'reply-1',
+        content: 'mirrored body',
+        createdAt: new Date('2026-05-05T12:00:00Z').toISOString(),
+        userId: 'u-other',
+        parentId: 'p1',
+        mirroredFromId: null,
+      });
+      handler!({
+        id: 'mirror-1',
+        content: 'mirrored body',
+        createdAt: new Date('2026-05-05T12:00:01Z').toISOString(),
+        userId: 'u-other',
+        parentId: null,
+        mirroredFromId: 'reply-1',
+      });
+    });
+
+    await waitFor(() => expect(screen.getAllByTestId('thread-reply').length).toBe(1));
+
+    const replies = screen.getAllByTestId('thread-reply');
+    const replyText = replies.map((r) => r.textContent ?? '');
+    const mirrorLeaked = replyText.some((t) => t.includes('mirror-1'));
+
+    expect({
+      given: 'reply (parentId=root) and mirror (parentId=null) twin events',
+      should:
+        'show exactly the reply in the thread list — the mirror is the page-side stream concern, not the panel',
+      actual: { count: replies.length, mirrorInThread: mirrorLeaked },
+      expected: { count: 1, mirrorInThread: false },
+    }).toEqual({
+      given: 'reply (parentId=root) and mirror (parentId=null) twin events',
+      should:
+        'show exactly the reply in the thread list — the mirror is the page-side stream concern, not the panel',
+      actual: { count: 1, mirrorInThread: false },
+      expected: { count: 1, mirrorInThread: false },
+    });
+  });
+
+  it('given the same id is broadcast twice (network double-fire), should not duplicate', async () => {
+    renderPanel({
+      fetcher: vi.fn(async () => ({ messages: [], hasMore: false, nextCursor: null })),
+    });
+    await waitFor(() => expect(screen.getByTestId('thread-divider-count')).toBeInTheDocument());
+
+    const handler = mockSocketHandlers.get('new_message');
+    expect(typeof handler).toBe('function');
+
+    const payload = {
+      id: 'reply-dup',
+      content: 'doubled echo',
+      createdAt: new Date('2026-05-05T12:02:00Z').toISOString(),
+      userId: 'u-other',
+      parentId: 'p1',
+    };
+
+    act(() => {
+      handler!(payload);
+      handler!(payload);
+    });
+
+    await waitFor(() => expect(screen.getAllByTestId('thread-reply').length).toBe(1));
+
+    expect({
+      given: 'the same realtime id is broadcast twice',
+      should: 'render exactly one row (id-based dedupe in the realtime handler)',
+      actual: screen.getAllByTestId('thread-reply').length,
+      expected: 1,
+    }).toEqual({
+      given: 'the same realtime id is broadcast twice',
+      should: 'render exactly one row (id-based dedupe in the realtime handler)',
+      actual: 1,
+      expected: 1,
+    });
+  });
+
   it('given a realtime new_message arrives with a non-matching parentId, should NOT append it', async () => {
     renderPanel();
     await waitFor(() =>

--- a/apps/web/src/stores/__tests__/useThreadInboxStore.test.ts
+++ b/apps/web/src/stores/__tests__/useThreadInboxStore.test.ts
@@ -73,4 +73,88 @@ describe('useThreadInboxStore', () => {
       expected: 1,
     });
   });
+
+  it('bump with empty rootMessageId is a no-op (defensive guard against malformed inbox events)', () => {
+    useThreadInboxStore.getState().bump({ source: 'channel', contextId: 'page-1', rootMessageId: '' });
+    assert({
+      given: 'a bump with rootMessageId === ""',
+      should: 'leave the store untouched (no phantom empty-key root)',
+      actual: useThreadInboxStore.getState().contexts,
+      expected: {},
+    });
+  });
+
+  it('bump with null/undefined rootMessageId is a no-op at runtime', () => {
+    // The TS signature forbids null/undefined; assert runtime defensiveness so
+    // a malformed payload from the inbox socket can't poison the store.
+    useThreadInboxStore
+      .getState()
+      // @ts-expect-error — runtime defensiveness for malformed event payloads
+      .bump({ source: 'channel', contextId: 'page-1', rootMessageId: null });
+    useThreadInboxStore
+      .getState()
+      // @ts-expect-error — runtime defensiveness for malformed event payloads
+      .bump({ source: 'channel', contextId: 'page-1', rootMessageId: undefined });
+
+    assert({
+      given: 'bumps with rootMessageId === null and undefined',
+      should: 'leave the store empty (no String(null)/String(undefined) keys)',
+      actual: useThreadInboxStore.getState().contexts,
+      expected: {},
+    });
+  });
+
+  it('alternating bump/clearRoot for the same root converges deterministically and never goes negative', () => {
+    const args = { source: 'channel' as const, contextId: 'page-1', rootMessageId: 'root-1' };
+    const reads: number[] = [];
+    const readCount = () =>
+      useThreadInboxStore.getState().contexts['channel:page-1']?.byRoot[args.rootMessageId] ?? 0;
+
+    useThreadInboxStore.getState().bump(args);
+    useThreadInboxStore.getState().bump(args);
+    useThreadInboxStore.getState().bump(args);
+    reads.push(readCount());
+    useThreadInboxStore.getState().clearRoot(args);
+    reads.push(readCount());
+    useThreadInboxStore.getState().bump(args);
+    reads.push(readCount());
+    useThreadInboxStore.getState().clearRoot(args);
+    reads.push(readCount());
+    useThreadInboxStore.getState().bump(args);
+    reads.push(readCount());
+    useThreadInboxStore.getState().clearRoot(args);
+    reads.push(readCount());
+
+    assert({
+      given: 'alternating bump/clearRoot for the same root',
+      should: 'follow last-write-wins; counts never go negative or NaN at any step',
+      actual: {
+        intermediate: reads,
+        finalCount: useThreadInboxStore.getState().contextUnreadCount('channel', 'page-1'),
+        anyNegative: reads.some((n) => n < 0),
+        anyNaN: reads.some((n) => Number.isNaN(n)),
+      },
+      expected: {
+        intermediate: [3, 0, 1, 0, 1, 0],
+        finalCount: 0,
+        anyNegative: false,
+        anyNaN: false,
+      },
+    });
+  });
+
+  it('clearRoot for a non-existent root in an empty store is a no-op (does not throw)', () => {
+    // No prior bumps — store starts empty. clearRoot must not throw and must
+    // leave state observably unchanged.
+    useThreadInboxStore
+      .getState()
+      .clearRoot({ source: 'channel', contextId: 'page-1', rootMessageId: 'root-1' });
+
+    assert({
+      given: 'a clearRoot call against an empty store',
+      should: 'be a silent no-op with no contexts created',
+      actual: useThreadInboxStore.getState().contexts,
+      expected: {},
+    });
+  });
 });

--- a/apps/web/src/stores/__tests__/useThreadInboxStore.test.ts
+++ b/apps/web/src/stores/__tests__/useThreadInboxStore.test.ts
@@ -85,8 +85,7 @@ describe('useThreadInboxStore', () => {
   });
 
   it('bump with null/undefined rootMessageId is a no-op at runtime', () => {
-    // The TS signature forbids null/undefined; assert runtime defensiveness so
-    // a malformed payload from the inbox socket can't poison the store.
+    // TS forbids null/undefined; assert runtime defensiveness against malformed socket payloads.
     useThreadInboxStore
       .getState()
       // @ts-expect-error — runtime defensiveness for malformed event payloads
@@ -144,8 +143,7 @@ describe('useThreadInboxStore', () => {
   });
 
   it('clearRoot for a non-existent root in an empty store is a no-op (does not throw)', () => {
-    // No prior bumps — store starts empty. clearRoot must not throw and must
-    // leave state observably unchanged.
+    // Empty store: clearRoot must not throw and must leave state untouched.
     useThreadInboxStore
       .getState()
       .clearRoot({ source: 'channel', contextId: 'page-1', rootMessageId: 'root-1' });

--- a/apps/web/src/stores/useThreadInboxStore.ts
+++ b/apps/web/src/stores/useThreadInboxStore.ts
@@ -68,11 +68,7 @@ export interface ThreadInboxState {
 export const useThreadInboxStore = create<ThreadInboxState>((set, get) => ({
   contexts: {},
   bump: ({ source, contextId, rootMessageId }) => {
-    // Inbox events from realtime are programmatic and should always carry a
-    // non-empty root id; an empty/null payload here is a sentinel for an
-    // upstream bug, not user input. Drop silently rather than poison the
-    // store with "", "null", or "undefined" keys that would inflate badge
-    // counts and never get cleared by a panel-mount with the real root id.
+    // Drop malformed realtime payloads — empty/null keys would inflate the badge with nothing to clear them.
     if (!rootMessageId) return;
     set((state) => {
       const key = buildKey(source, contextId);

--- a/apps/web/src/stores/useThreadInboxStore.ts
+++ b/apps/web/src/stores/useThreadInboxStore.ts
@@ -67,7 +67,13 @@ export interface ThreadInboxState {
 
 export const useThreadInboxStore = create<ThreadInboxState>((set, get) => ({
   contexts: {},
-  bump: ({ source, contextId, rootMessageId }) =>
+  bump: ({ source, contextId, rootMessageId }) => {
+    // Inbox events from realtime are programmatic and should always carry a
+    // non-empty root id; an empty/null payload here is a sentinel for an
+    // upstream bug, not user input. Drop silently rather than poison the
+    // store with "", "null", or "undefined" keys that would inflate badge
+    // counts and never get cleared by a panel-mount with the real root id.
+    if (!rootMessageId) return;
     set((state) => {
       const key = buildKey(source, contextId);
       const ctx = state.contexts[key] ?? { byRoot: {} };
@@ -80,7 +86,8 @@ export const useThreadInboxStore = create<ThreadInboxState>((set, get) => ({
           },
         },
       };
-    }),
+    });
+  },
   clearRoot: ({ source, contextId, rootMessageId }) =>
     set((state) => {
       const key = buildKey(source, contextId);


### PR DESCRIPTION
## Summary
- ThreadPanel: `alsoSendToParent` twin-event path tested — reply (parentId=root) is appended to the thread list, mirror (parentId=null, mirroredFromId=reply id) is filtered out. The page-side stream owns the parent SWR cache, not the panel; panel boundary verified.
- ThreadPanel: same-id realtime double-fire now covered — id-based dedupe in the realtime mutate path is asserted.
- useThreadInboxStore: `bump()` with `''`, `null`, or `undefined` rootMessageId is a runtime no-op (prior behavior poisoned the store with `""`/`"null"`/`"undefined"` keys that nothing could clear).
- useThreadInboxStore: bump/clearRoot interleaved for the same root converges deterministically (last-write-wins) and never goes negative or NaN.
- useThreadInboxStore: `clearRoot()` against an empty store is a silent no-op.
- One impl change: a one-line `if (!rootMessageId) return;` guard at the top of `bump()` with a colocated rationale comment. Mutation-tested.

Part of the threads hardening epic. Plan: `/Users/jono/.claude/plans/channels-and-dm-s-need-imperative-bird.md`. Sibling PRs: 6a (impl fixes), 6b (repo test discipline) — file-disjoint.

## Architecture clarification
The plan's wording ("the panel triggers `mutate` on the parent stream key") doesn't match the current architecture: the panel only owns its thread SWR key; the channel/DM page that mounts the panel runs its own `new_message` subscriber and owns the top-level stream (verified at `apps/web/src/app/dashboard/channels/[pageId]/page.tsx:177-188` — handler explicitly drops `parentId`-set messages and accepts mirrors with `parentId: null`). The new test verifies the correct boundary — the panel ignores mirror events with `parentId === null` rather than reaching across to mutate someone else's cache. If a follow-up wants the panel to do its own parent-stream merge, that's a behavior change for a separate PR.

## Mutation-test verification (zero-trust)
- [x] Removed the `raw.parentId !== parentId` filter in the panel's realtime handler → twin-event test failed (mirror leaked into the thread list, count became 2; `mirrorShown` probe also turned true under the mutation)
- [x] Removed the id-based dedupe in the realtime `mutate` callback → double-fire test failed (count became 2 from one duplicate broadcast)
- [x] Removed the `if (!rootMessageId) return;` guard from `bump` → empty-string and null/undefined no-op tests both failed (store contained `""` / `"null"` / `"undefined"` keys)
- [x] All mutations restored before each commit; verified clean state with the full file's tests passing

## Convergence-pass refinements (post-initial-PR)
- The first revision of the twin-event probe used `t.includes('mirror-1')` against rendered DOM text — but the message id is never rendered, so the probe was tautologically false. Replaced with distinct content per event (`reply-body-A` vs `mirror-body-B`) so leakage is genuinely text-detectable. Mutation-test re-confirmed.
- Trimmed multi-line inline comments on the store guard and three test cases to one-line form per CLAUDE.md ("one short line max"). Each preserves the why.

## Test plan
- [x] `npx vitest run src/components/layout/middle-content/page-views/thread/__tests__/ThreadPanel.test.tsx src/stores/__tests__/useThreadInboxStore.test.ts` → 25/25 passing
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (verified per-file via eslint)
- [x] No new mocks on React/Zustand internals; mocks at socket + SWRConfig boundary, store driven via `getState()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)