### PR TITLE
fix(threads): hardening — DM relations, askResult guard, follow root-only (PR 6a)

### DIFF
--- a/apps/web/src/app/api/channels/[pageId]/messages/[messageId]/follow/__tests__/route.test.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/[messageId]/follow/__tests__/route.test.ts
@@ -123,7 +123,7 @@ describe('POST /api/channels/[pageId]/messages/[messageId]/follow', () => {
     expect(res.status).toBe(404);
   });
 
-  it('returns 400 when the message is itself a thread reply (followers attach to roots only)', async () => {
+  it('returns 400 with parent_not_top_level when the message is itself a thread reply (followers attach to roots only)', async () => {
     mockFindChannelMessageInPage.mockResolvedValueOnce({
       id: MSG_ID,
       pageId: PAGE_ID,
@@ -132,6 +132,8 @@ describe('POST /api/channels/[pageId]/messages/[messageId]/follow', () => {
     });
     const res = await callPost();
     expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'parent_not_top_level' });
+    expect(mockAddChannelThreadFollower).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/app/api/channels/[pageId]/messages/[messageId]/follow/route.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/[messageId]/follow/route.ts
@@ -44,7 +44,7 @@ export async function POST(req: Request, { params }: RouteParams) {
   }
   if (message.parentId !== null) {
     return NextResponse.json(
-      { error: 'Followers attach to top-level messages only' },
+      { error: 'parent_not_top_level' },
       { status: 400 }
     );
   }

--- a/apps/web/src/app/api/channels/[pageId]/messages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/__tests__/route.test.ts
@@ -412,7 +412,8 @@ describe('POST /api/channels/[pageId]/messages (thread reply)', () => {
       ([, payload]) => (payload as { operation: string }).operation === 'thread_updated'
     );
     const recipients = threadUpdatedCalls.map(([userId]) => userId);
-    expect(recipients).toEqual(expect.arrayContaining(['follower-1', 'follower-2']));
+    // Explicit recipient set: only the non-author followers, exactly once each, never the reply author.
+    expect(recipients.sort()).toEqual(['follower-1', 'follower-2']);
     expect(recipients).not.toContain(USER_ID);
 
     // Each thread_updated payload carries the new contract fields.
@@ -429,6 +430,40 @@ describe('POST /api/channels/[pageId]/messages (thread reply)', () => {
     expect(payload.id).toBe(PAGE_ID);
     expect(payload.rootMessageId).toBe(PARENT_ID);
     expect(payload.lastReplyAt).toBe(replyCreatedAt.toISOString());
+    expect(typeof payload.lastReplyPreview).toBe('string');
+    expect(payload.lastReplyPreview.length).toBeGreaterThan(0);
+  });
+
+  it('does not emit thread_updated when the parent has zero followers, but still completes the reply-count bump', async () => {
+    const replyCreatedAt = new Date('2026-05-04T12:00:00Z');
+    mockInsertChannelThreadReply.mockResolvedValueOnce({
+      kind: 'ok',
+      reply: { id: 'reply-1', createdAt: replyCreatedAt },
+      mirror: null,
+      rootId: PARENT_ID,
+      replyCount: 1,
+      lastReplyAt: replyCreatedAt,
+    });
+    mockLoadChannelMessageWithRelations.mockResolvedValueOnce({
+      id: 'reply-1',
+      parentId: PARENT_ID,
+      pageId: PAGE_ID,
+      content: 'in-thread',
+      createdAt: replyCreatedAt.toISOString(),
+      user: { id: USER_ID, name: 'Sender', image: null },
+    });
+    mockListChannelThreadFollowers.mockResolvedValueOnce([]);
+
+    const res = await callPost({ content: 'in-thread', parentId: PARENT_ID });
+
+    expect(res.status).toBe(201);
+    const threadUpdated = mockBroadcastInboxEvent.mock.calls.filter(
+      ([, payload]) => (payload as { operation: string }).operation === 'thread_updated'
+    );
+    expect(threadUpdated).toHaveLength(0);
+    // The reply-count fanout still happens regardless of follower set — it's
+    // scoped to viewers of the parent thread, not the follower list.
+    expect(mockBroadcastThreadReplyCountUpdated).toHaveBeenCalled();
   });
 
   it('emits channel_updated to a mentioned non-follower who can view the channel', async () => {

--- a/apps/web/src/app/api/channels/[pageId]/messages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/__tests__/route.test.ts
@@ -413,7 +413,8 @@ describe('POST /api/channels/[pageId]/messages (thread reply)', () => {
     );
     const recipients = threadUpdatedCalls.map(([userId]) => userId);
     // Explicit recipient set: only the non-author followers, exactly once each, never the reply author.
-    expect(recipients.sort()).toEqual(['follower-1', 'follower-2']);
+    // Sorting a copy detects ordering drift and duplicate emission without mutating the source array.
+    expect([...recipients].sort()).toEqual(['follower-1', 'follower-2']);
     expect(recipients).not.toContain(USER_ID);
 
     // Each thread_updated payload carries the new contract fields.
@@ -462,8 +463,16 @@ describe('POST /api/channels/[pageId]/messages (thread reply)', () => {
     );
     expect(threadUpdated).toHaveLength(0);
     // The reply-count fanout still happens regardless of follower set — it's
-    // scoped to viewers of the parent thread, not the follower list.
-    expect(mockBroadcastThreadReplyCountUpdated).toHaveBeenCalled();
+    // scoped to viewers of the parent thread, not the follower list. Pin the
+    // exact args so a regression that drops the bump is caught.
+    expect(mockBroadcastThreadReplyCountUpdated).toHaveBeenCalledWith(
+      PAGE_ID,
+      expect.objectContaining({
+        rootId: PARENT_ID,
+        replyCount: 1,
+        lastReplyAt: replyCreatedAt.toISOString(),
+      })
+    );
   });
 
   it('emits channel_updated to a mentioned non-follower who can view the channel', async () => {

--- a/apps/web/src/app/api/messages/[conversationId]/[messageId]/follow/__tests__/route.test.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/[messageId]/follow/__tests__/route.test.ts
@@ -106,7 +106,7 @@ describe('POST /api/messages/[conversationId]/[messageId]/follow', () => {
     expect(res.status).toBe(404);
   });
 
-  it('returns 400 when the message is a thread reply (followers attach to roots only)', async () => {
+  it('returns 400 with parent_not_top_level when the message is a thread reply (followers attach to roots only)', async () => {
     mockFindActiveMessage.mockResolvedValueOnce({
       id: MSG_ID,
       conversationId: CONV_ID,
@@ -114,6 +114,8 @@ describe('POST /api/messages/[conversationId]/[messageId]/follow', () => {
     });
     const res = await callPost();
     expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'parent_not_top_level' });
+    expect(mockAddDmThreadFollower).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/src/app/api/messages/[conversationId]/[messageId]/follow/route.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/[messageId]/follow/route.ts
@@ -39,7 +39,7 @@ export async function POST(req: Request, { params }: RouteParams) {
   }
   if (message.parentId !== null) {
     return NextResponse.json(
-      { error: 'Followers attach to top-level messages only' },
+      { error: 'parent_not_top_level' },
       { status: 400 }
     );
   }

--- a/apps/web/src/app/api/messages/[conversationId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/__tests__/route.test.ts
@@ -994,6 +994,40 @@ describe('POST /api/messages/[conversationId] (thread reply)', () => {
     expect(threadUpdated).toHaveLength(1);
     const [recipientId, payload] = threadUpdated[0];
     expect(recipientId).toBe(RECIPIENT_ID);
-    expect((payload as { rootMessageId: string }).rootMessageId).toBe(PARENT_ID);
+    expect(recipientId).not.toBe(SENDER_ID);
+    const typed = payload as { rootMessageId: string; lastReplyAt: string; lastReplyPreview: string };
+    expect(typed.rootMessageId).toBe(PARENT_ID);
+    expect(typed.lastReplyAt).toBe(replyCreatedAt.toISOString());
+    expect(typeof typed.lastReplyPreview).toBe('string');
+    expect(typed.lastReplyPreview.length).toBeGreaterThan(0);
+  });
+
+  it('does not emit thread_updated when the DM thread has zero followers, but still completes the reply-count bump', async () => {
+    const replyCreatedAt = new Date('2026-05-04T12:00:00Z');
+    mockInsertDmThreadReply.mockResolvedValueOnce({
+      kind: 'ok',
+      reply: {
+        id: 'reply-1',
+        parentId: PARENT_ID,
+        conversationId: CONVERSATION_ID,
+        senderId: SENDER_ID,
+        content: 'lonely-reply',
+        createdAt: replyCreatedAt,
+      },
+      mirror: null,
+      rootId: PARENT_ID,
+      replyCount: 1,
+      lastReplyAt: replyCreatedAt,
+    });
+    mockListDmThreadFollowers.mockResolvedValueOnce([]);
+
+    const res = await callRoute({ content: 'lonely-reply', parentId: PARENT_ID });
+
+    expect(res.status).toBe(200);
+    const threadUpdated = mockBroadcastInboxEvent.mock.calls.filter(
+      ([, payload]) => (payload as { operation: string }).operation === 'thread_updated'
+    );
+    expect(threadUpdated).toHaveLength(0);
+    expect(mockBroadcastThreadReplyCountUpdated).toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/messages/[conversationId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/__tests__/route.test.ts
@@ -1023,11 +1023,21 @@ describe('POST /api/messages/[conversationId] (thread reply)', () => {
 
     const res = await callRoute({ content: 'lonely-reply', parentId: PARENT_ID });
 
+    // DM thread-reply path returns 200 (channel returns 201) — the two routes
+    // diverge here intentionally; do not "fix" the asymmetry without checking
+    // both route handlers.
     expect(res.status).toBe(200);
     const threadUpdated = mockBroadcastInboxEvent.mock.calls.filter(
       ([, payload]) => (payload as { operation: string }).operation === 'thread_updated'
     );
     expect(threadUpdated).toHaveLength(0);
-    expect(mockBroadcastThreadReplyCountUpdated).toHaveBeenCalled();
+    expect(mockBroadcastThreadReplyCountUpdated).toHaveBeenCalledWith(
+      `dm:${CONVERSATION_ID}`,
+      expect.objectContaining({
+        rootId: PARENT_ID,
+        replyCount: 1,
+        lastReplyAt: replyCreatedAt.toISOString(),
+      })
+    );
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx
@@ -107,6 +107,7 @@ interface RawReply {
   aiMeta?: { senderName: string } | null;
   // dm shape
   senderId?: string | null;
+  sender?: { id: string; name: string | null; image: string | null } | null;
   // common
   fileId?: string | null;
   attachmentMeta?: AttachmentMeta | null;
@@ -139,8 +140,8 @@ const normalizeReply = (raw: RawReply): ThreadReply => ({
   createdAt:
     typeof raw.createdAt === 'string' ? raw.createdAt : new Date(raw.createdAt).toISOString(),
   authorId: raw.userId ?? raw.senderId ?? null,
-  authorName: raw.user?.name ?? raw.aiMeta?.senderName ?? null,
-  authorImage: raw.user?.image ?? null,
+  authorName: raw.user?.name ?? raw.sender?.name ?? raw.aiMeta?.senderName ?? null,
+  authorImage: raw.user?.image ?? raw.sender?.image ?? null,
   fileId: raw.fileId ?? null,
   attachmentMeta: raw.attachmentMeta ?? null,
   file: raw.file ?? null,

--- a/apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx
@@ -139,6 +139,9 @@ const normalizeReply = (raw: RawReply): ThreadReply => ({
   content: raw.content,
   createdAt:
     typeof raw.createdAt === 'string' ? raw.createdAt : new Date(raw.createdAt).toISOString(),
+  // Channel rows carry { userId, user }; DM rows carry { senderId, sender }.
+  // The two pairs travel together — a row never has `user` from one side and
+  // `senderId` from the other. The fallback chains below assume that invariant.
   authorId: raw.userId ?? raw.senderId ?? null,
   authorName: raw.user?.name ?? raw.sender?.name ?? raw.aiMeta?.senderName ?? null,
   authorImage: raw.user?.image ?? raw.sender?.image ?? null,

--- a/apps/web/src/lib/channels/__tests__/agent-mention-responder.test.ts
+++ b/apps/web/src/lib/channels/__tests__/agent-mention-responder.test.ts
@@ -407,6 +407,25 @@ describe('agent-mention-responder', () => {
     expect(mockSendChannelExecute).not.toHaveBeenCalled();
     expect(mockBroadcastInboxEvent).not.toHaveBeenCalled();
   });
+
+  it('given askAgentExecute returns a result with a wrong-typed success field, persists nothing and skips', async () => {
+    mockPagesFindMany.mockResolvedValue([
+      { id: 'agent-1', title: 'Budget Agent', enabledTools: ['send_channel_message'] },
+    ]);
+    // Predicate must reject `success: 'true'` (string) — locks in the strict-type
+    // checks end-to-end, not just at the unit level.
+    mockAskAgentExecute.mockResolvedValueOnce({ success: 'true', response: 'ok' });
+
+    await triggerMentionedAgentResponses({
+      ...baseParams,
+      parentId: 'parent-thread',
+      content: 'Reply @[Budget Agent](agent-1:page)',
+    });
+
+    expect(mockInsertChannelThreadReply).not.toHaveBeenCalled();
+    expect(mockSendChannelExecute).not.toHaveBeenCalled();
+    expect(mockBroadcastInboxEvent).not.toHaveBeenCalled();
+  });
 });
 
 describe('isAskAgentResult', () => {

--- a/apps/web/src/lib/channels/__tests__/agent-mention-responder.test.ts
+++ b/apps/web/src/lib/channels/__tests__/agent-mention-responder.test.ts
@@ -81,6 +81,7 @@ import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
 import { agentCommunicationTools } from '@/lib/ai/tools/agent-communication-tools';
 import { channelTools } from '@/lib/ai/tools/channel-tools';
 import {
+  isAskAgentResult,
   triggerMentionedAgentResponses,
   type TriggerMentionedAgentResponsesParams,
 } from '../agent-mention-responder';
@@ -387,5 +388,65 @@ describe('agent-mention-responder', () => {
 
     expect(mockInsertChannelThreadReply).not.toHaveBeenCalled();
     expect(mockSendChannelExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it('given askAgentExecute returns a malformed value, persists nothing and skips the agent reply', async () => {
+    mockPagesFindMany.mockResolvedValue([
+      { id: 'agent-1', title: 'Budget Agent', enabledTools: ['send_channel_message'] },
+    ]);
+    // Boundary mock: simulate a future tool-shape change that no longer matches AskAgentResult.
+    mockAskAgentExecute.mockResolvedValueOnce({ unexpected: 'shape' });
+
+    await triggerMentionedAgentResponses({
+      ...baseParams,
+      parentId: 'parent-thread',
+      content: 'Reply @[Budget Agent](agent-1:page)',
+    });
+
+    expect(mockInsertChannelThreadReply).not.toHaveBeenCalled();
+    expect(mockSendChannelExecute).not.toHaveBeenCalled();
+    expect(mockBroadcastInboxEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe('isAskAgentResult', () => {
+  it('accepts the canonical success shape', () => {
+    expect(
+      isAskAgentResult({ success: true, response: 'hi', error: undefined })
+    ).toBe(true);
+  });
+
+  it('accepts a partial shape where only success is present', () => {
+    expect(isAskAgentResult({ success: false })).toBe(true);
+  });
+
+  it('accepts a partial shape where only error is present', () => {
+    expect(isAskAgentResult({ error: 'boom' })).toBe(true);
+  });
+
+  it('rejects an empty object — no recognizable AskAgentResult fields', () => {
+    expect(isAskAgentResult({})).toBe(false);
+  });
+
+  it('rejects null', () => {
+    expect(isAskAgentResult(null)).toBe(false);
+  });
+
+  it('rejects non-object primitives', () => {
+    expect(isAskAgentResult('ok')).toBe(false);
+    expect(isAskAgentResult(42)).toBe(false);
+    expect(isAskAgentResult(undefined)).toBe(false);
+  });
+
+  it('rejects when success is present but not boolean', () => {
+    expect(isAskAgentResult({ success: 'true' })).toBe(false);
+  });
+
+  it('rejects when response is present but not string', () => {
+    expect(isAskAgentResult({ success: true, response: 42 })).toBe(false);
+  });
+
+  it('rejects when error is present but not string', () => {
+    expect(isAskAgentResult({ success: false, error: { msg: 'x' } })).toBe(false);
   });
 });

--- a/apps/web/src/lib/channels/agent-mention-responder.ts
+++ b/apps/web/src/lib/channels/agent-mention-responder.ts
@@ -52,11 +52,13 @@ interface AskAgentResult {
 }
 
 // Recognizes the AskAgentResult contract — a non-null object that has at least
-// one of the three declared keys, each of which (if present) carries the right
-// primitive type. The downstream `!success || !response` gate handles the
-// shape-valid-but-empty case (e.g. `{ success: true }` with no response); this
-// predicate's job is solely to reject foreign shapes the cast would have
-// accepted blindly.
+// one of the three declared keys. Each key's value is checked against its
+// declared primitive type ONLY when the value is not `undefined`; an explicit
+// `undefined` value (with the key present) is treated the same as the key
+// being absent, matching the optional `?` semantics of the interface. The
+// downstream `!success || !response` gate handles the shape-valid-but-empty
+// case (e.g. `{ success: true }` with no response); this predicate's job is
+// solely to reject foreign shapes the cast would have accepted blindly.
 export function isAskAgentResult(value: unknown): value is AskAgentResult {
   if (typeof value !== 'object' || value === null) {
     return false;

--- a/apps/web/src/lib/channels/agent-mention-responder.ts
+++ b/apps/web/src/lib/channels/agent-mention-responder.ts
@@ -51,13 +51,17 @@ interface AskAgentResult {
   error?: string;
 }
 
+// Recognizes the AskAgentResult contract — a non-null object that has at least
+// one of the three declared keys, each of which (if present) carries the right
+// primitive type. The downstream `!success || !response` gate handles the
+// shape-valid-but-empty case (e.g. `{ success: true }` with no response); this
+// predicate's job is solely to reject foreign shapes the cast would have
+// accepted blindly.
 export function isAskAgentResult(value: unknown): value is AskAgentResult {
   if (typeof value !== 'object' || value === null) {
     return false;
   }
   const candidate = value as Record<string, unknown>;
-  // Each declared field is optional, so undefined is allowed; any other
-  // non-matching type rejects the shape.
   if (candidate.success !== undefined && typeof candidate.success !== 'boolean') {
     return false;
   }

--- a/apps/web/src/lib/channels/agent-mention-responder.ts
+++ b/apps/web/src/lib/channels/agent-mention-responder.ts
@@ -51,6 +51,25 @@ interface AskAgentResult {
   error?: string;
 }
 
+export function isAskAgentResult(value: unknown): value is AskAgentResult {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  // Each declared field is optional, so undefined is allowed; any other
+  // non-matching type rejects the shape.
+  if (candidate.success !== undefined && typeof candidate.success !== 'boolean') {
+    return false;
+  }
+  if (candidate.response !== undefined && typeof candidate.response !== 'string') {
+    return false;
+  }
+  if (candidate.error !== undefined && typeof candidate.error !== 'string') {
+    return false;
+  }
+  return 'success' in candidate || 'response' in candidate || 'error' in candidate;
+}
+
 function convertMentionsToDisplayText(content: string): string {
   return content.replace(
     /@\[([^\]]{1,500})\]\(([^:)]{1,200}):([^)]{1,200})\)/g,
@@ -347,7 +366,7 @@ export async function triggerMentionedAgentResponses(
     for (const agent of eligibleAgents) {
       try {
         const mentionConversationId = `channel:${params.channelId}:agent:${agent.id}`;
-        const askResult = (await askAgentExecute(
+        const rawAskResult: unknown = await askAgentExecute(
           {
             agentPath: `/${agent.title}`,
             agentId: agent.id,
@@ -372,7 +391,16 @@ export async function triggerMentionedAgentResponses(
               agentCallDepth: 0,
             } as ToolExecutionContext,
           }
-        )) as AskAgentResult;
+        );
+
+        if (!isAskAgentResult(rawAskResult)) {
+          channelMentionLogger.warn('Mentioned agent returned a malformed result; skipping', {
+            channelId: params.channelId,
+            agentId: agent.id,
+          });
+          continue;
+        }
+        const askResult = rawAskResult;
 
         if (!askResult.success || !askResult.response || !askResult.response.trim()) {
           channelMentionLogger.warn('Mentioned agent returned no response', {

--- a/apps/web/src/lib/channels/agent-mention-responder.ts
+++ b/apps/web/src/lib/channels/agent-mention-responder.ts
@@ -394,9 +394,14 @@ export async function triggerMentionedAgentResponses(
         );
 
         if (!isAskAgentResult(rawAskResult)) {
-          channelMentionLogger.warn('Mentioned agent returned a malformed result; skipping', {
+          channelMentionLogger.error('Mentioned agent returned a malformed result; skipping', {
             channelId: params.channelId,
             agentId: agent.id,
+            receivedType: typeof rawAskResult,
+            receivedKeys:
+              rawAskResult && typeof rawAskResult === 'object'
+                ? Object.keys(rawAskResult as Record<string, unknown>)
+                : null,
           });
           continue;
         }

--- a/packages/lib/src/services/__tests__/dm-message-repository.test.ts
+++ b/packages/lib/src/services/__tests__/dm-message-repository.test.ts
@@ -619,25 +619,28 @@ describe('dmMessageRepository.listActiveMessages [reactions parity]', () => {
     });
   });
 
-  it('hydrates sender and file alongside reactions (channel-parity dmMessageWith)', async () => {
+  it('hydrates sender, file, and reactions.user with the same column whitelist as channel-parity dmMessageWith', async () => {
     await dmMessageRepository.listActiveMessages({ conversationId: 'conv-1', limit: 50 });
 
     const call = mockDirectMessagesFindMany.mock.calls[0]?.[0] as {
       with: {
         sender: { columns: Record<string, true> };
         file: { columns: Record<string, true> };
+        reactions: { with: { user: { columns: Record<string, true> } } };
       };
     };
     assert({
       given: 'a DM list fetch',
-      should: 'request sender and file with the same column whitelist as the channel repo',
+      should: 'request sender, file, and reactions.user with the same column whitelist as the channel repo',
       actual: {
         senderCols: call.with.sender.columns,
         fileCols: call.with.file.columns,
+        reactionUserCols: call.with.reactions.with.user.columns,
       },
       expected: {
         senderCols: { id: true, name: true, image: true },
         fileCols: { id: true, mimeType: true, sizeBytes: true },
+        reactionUserCols: { id: true, name: true },
       },
     });
   });

--- a/packages/lib/src/services/__tests__/dm-message-repository.test.ts
+++ b/packages/lib/src/services/__tests__/dm-message-repository.test.ts
@@ -618,6 +618,29 @@ describe('dmMessageRepository.listActiveMessages [reactions parity]', () => {
       },
     });
   });
+
+  it('hydrates sender and file alongside reactions (channel-parity dmMessageWith)', async () => {
+    await dmMessageRepository.listActiveMessages({ conversationId: 'conv-1', limit: 50 });
+
+    const call = mockDirectMessagesFindMany.mock.calls[0]?.[0] as {
+      with: {
+        sender: { columns: Record<string, true> };
+        file: { columns: Record<string, true> };
+      };
+    };
+    assert({
+      given: 'a DM list fetch',
+      should: 'request sender and file with the same column whitelist as the channel repo',
+      actual: {
+        senderCols: call.with.sender.columns,
+        fileCols: call.with.file.columns,
+      },
+      expected: {
+        senderCols: { id: true, name: true, image: true },
+        fileCols: { id: true, mimeType: true, sizeBytes: true },
+      },
+    });
+  });
 });
 
 describe('dmMessageRepository.listActiveMessages [thread-isolation]', () => {
@@ -646,12 +669,7 @@ describe('dmMessageRepository.listActiveMessages [thread-isolation]', () => {
 describe('dmMessageRepository.listDmThreadReplies', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // db.select().from().where().orderBy().limit() chain
-    const limitMock = vi.fn().mockResolvedValue([]);
-    const orderByMock = vi.fn(() => ({ limit: limitMock }));
-    const whereMock = vi.fn(() => ({ orderBy: orderByMock }));
-    mockSelectFrom.mockReturnValue({ where: whereMock });
-    vi.mocked(db.select).mockReturnValue({ from: mockSelectFrom } as never);
+    mockDirectMessagesFindMany.mockResolvedValue([]);
   });
 
   it('filters by parentId AND isActive=true and orders ascending by (createdAt, id)', async () => {
@@ -693,6 +711,32 @@ describe('dmMessageRepository.listDmThreadReplies', () => {
         id: gtCalls.some(([field, value]) => field === directMessages.id && value === after.id),
       },
       expected: { createdAt: true, id: true },
+    });
+  });
+
+  it('hydrates sender, file, and reactions relations so the thread panel renders parity with channel replies', async () => {
+    await dmMessageRepository.listDmThreadReplies({ rootId: 'parent-1', limit: 50 });
+
+    const call = mockDirectMessagesFindMany.mock.calls[0]?.[0] as {
+      with: {
+        sender: { columns: Record<string, true> };
+        file: { columns: Record<string, true> };
+        reactions: { with: { user: { columns: Record<string, true> } } };
+      };
+    };
+    assert({
+      given: 'a DM thread reply fetch',
+      should: 'request sender, file, and reactions.user with the same column whitelist as the channel repo',
+      actual: {
+        senderCols: call.with.sender.columns,
+        fileCols: call.with.file.columns,
+        reactionUserCols: call.with.reactions.with.user.columns,
+      },
+      expected: {
+        senderCols: { id: true, name: true, image: true },
+        fileCols: { id: true, mimeType: true, sizeBytes: true },
+        reactionUserCols: { id: true, name: true },
+      },
     });
   });
 });

--- a/packages/lib/src/services/dm-message-repository.ts
+++ b/packages/lib/src/services/dm-message-repository.ts
@@ -12,6 +12,33 @@ import { and, asc, desc, eq, gt, isNotNull, isNull, lt, or, sql, type InferSelec
 import { dmConversations, directMessages, dmMessageReactions, dmThreadFollowers } from '@pagespace/db/schema/social';
 import { fileConversations, files, type AttachmentMeta } from '@pagespace/db/schema/storage';
 
+const dmMessageWith = {
+  sender: {
+    columns: {
+      id: true,
+      name: true,
+      image: true,
+    },
+  },
+  file: {
+    columns: {
+      id: true,
+      mimeType: true,
+      sizeBytes: true,
+    },
+  },
+  reactions: {
+    with: {
+      user: {
+        columns: {
+          id: true,
+          name: true,
+        },
+      },
+    },
+  },
+} as const;
+
 export interface DmConversationParticipants {
   id: string;
   participant1Id: string;
@@ -342,13 +369,7 @@ async function listActiveMessages(input: ListActiveMessagesInput) {
 
   return db.query.directMessages.findMany({
     where: and(...baseFilters),
-    with: {
-      reactions: {
-        with: {
-          user: { columns: { id: true, name: true } },
-        },
-      },
-    },
+    with: dmMessageWith,
     orderBy: [desc(directMessages.createdAt)],
     limit: input.limit,
   });
@@ -529,7 +550,7 @@ export interface ListDmThreadRepliesInput {
 
 async function listDmThreadReplies(
   input: ListDmThreadRepliesInput
-): Promise<DmMessageRow[]> {
+) {
   const conditions = [
     eq(directMessages.parentId, input.rootId),
     eq(directMessages.isActive, true),
@@ -547,12 +568,12 @@ async function listDmThreadReplies(
     );
   }
 
-  return db
-    .select()
-    .from(directMessages)
-    .where(and(...conditions))
-    .orderBy(asc(directMessages.createdAt), asc(directMessages.id))
-    .limit(input.limit);
+  return db.query.directMessages.findMany({
+    where: and(...conditions),
+    with: dmMessageWith,
+    orderBy: [asc(directMessages.createdAt), asc(directMessages.id)],
+    limit: input.limit,
+  });
 }
 
 async function addDmThreadFollower(

--- a/packages/lib/src/services/dm-message-repository.ts
+++ b/packages/lib/src/services/dm-message-repository.ts
@@ -12,6 +12,10 @@ import { and, asc, desc, eq, gt, isNotNull, isNull, lt, or, sql, type InferSelec
 import { dmConversations, directMessages, dmMessageReactions, dmThreadFollowers } from '@pagespace/db/schema/social';
 import { fileConversations, files, type AttachmentMeta } from '@pagespace/db/schema/storage';
 
+// Mirrors `messageWith` in channel-message-repository.ts. Kept duplicated
+// because the author relation is named differently (`sender` here vs `user`
+// there) and the column lists are short enough that a shared helper would
+// only obscure the intent.
 const dmMessageWith = {
   sender: {
     columns: {

--- a/packages/lib/src/services/dm-message-repository.ts
+++ b/packages/lib/src/services/dm-message-repository.ts
@@ -548,6 +548,8 @@ export interface ListDmThreadRepliesInput {
   after?: { createdAt: Date; id: string };
 }
 
+export type DmMessageWithRelations = Awaited<ReturnType<typeof listDmThreadReplies>>[number];
+
 async function listDmThreadReplies(
   input: ListDmThreadRepliesInput
 ) {


### PR DESCRIPTION
## Summary
- DM repository hydrates `sender`/`reactions`/`file` relations on `listDmThreadReplies` and `listActiveMessages` (channel parity via a new `dmMessageWith` const)
- `isAskAgentResult` type predicate replaces an unjustified cast in the channel mention responder; malformed agent results now log + skip rather than crashing the broadcast (logged at `.error` with received type/keys for diagnosability)
- Follow POST (channel + DM) returns the structured error code `parent_not_top_level` for non-root targets; DELETE stays permissive (idempotent unfollow)
- Route tests now assert the `thread_updated` recipient list explicitly (sorted-copy comparison), pin `broadcastThreadReplyCountUpdated` args, and cover the zero-followers edge case
- New exported `DmMessageWithRelations` type pins the inferred shape of `listDmThreadReplies` so the public contract no longer drifts silently

## Out of scope (per the plan)
- The "stop mutating ORM result" audit finding does not apply: `fanOutChannelInboxUpdate` on master already builds a Set with the explicit "Build a local member set so we never mutate the ORM-returned array" comment, and there are no `.push()` calls into ORM-returned arrays in either route.
- Repository-test discipline (PR 6b) and UI/store edge-case tests (PR 6c) are sibling PRs touching disjoint files.

## Follow-up (out of scope for 6a)
- The thread-reply-creation routes (`channels/[pageId]/messages/route.ts`, `messages/[conversationId]/route.ts`) still return freeform error strings for `kind: 'parent_not_top_level'` while the follow POST now returns the structured `parent_not_top_level` code. Aligning those is a small follow-up — kept out of this PR to avoid scope creep.

Part of the threads hardening epic. Plan: `/Users/jono/.claude/plans/channels-and-dm-s-need-imperative-bird.md`

## Test plan
- [x] `pnpm --filter @pagespace/lib test` — 3953/3953 passing
- [x] Targeted route + responder tests — 99/99 passing across the touched files
- [x] `pnpm typecheck` (recursive across 12 workspaces) — clean
- [x] `pnpm lint` — clean (only a pre-existing unrelated `react-hooks/exhaustive-deps` warning in QuickCreatePalette)
- [x] Unit Tests CI — green
- [x] Lint & TypeScript Check CI — green
- [x] Security Test Suite, Dependency Audit, Secret Scanning, Static Security Analysis, CodeQL — green
- [ ] Manual smoke: DM thread reply renders sender name + avatar in the panel
- [ ] Manual smoke: POST against a thread-reply id returns 400 `{ "error": "parent_not_top_level" }`
- [ ] Manual smoke: malformed agent result skips reply without persisting

🤖 Generated with [Claude Code](https://claude.com/claude-code)