### PR TITLE
test(threads): hardening — boundary mocks + missing edge cases (PR 6b)

### DIFF
--- a/packages/lib/src/services/__tests__/channel-message-repository.test.ts
+++ b/packages/lib/src/services/__tests__/channel-message-repository.test.ts
@@ -1,6 +1,33 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Riteway-style assert helper (matches packages/lib/src/auth/magic-link-service.test.ts).
+// Boundary-level test double: see test-doubles/db.ts for the design rationale
+// (no thenable Drizzle chain mocks; assertions read observable state, not the
+// order of intermediate builder method calls).
+import { testDb, testDbState } from './test-doubles/db';
+
+vi.mock('@pagespace/db/db', async () => {
+  const m = await import('./test-doubles/db');
+  return { db: m.testDb };
+});
+vi.mock('@pagespace/db/operators', async () => {
+  const m = await import('./test-doubles/db');
+  return m.operators;
+});
+vi.mock('@pagespace/db/schema/chat', async () => {
+  const m = await import('./test-doubles/db');
+  return m.chatSchema;
+});
+vi.mock('@pagespace/db/schema/social', async () => {
+  const m = await import('./test-doubles/db');
+  return m.socialSchema;
+});
+vi.mock('@pagespace/db/schema/storage', async () => {
+  const m = await import('./test-doubles/db');
+  return m.storageSchema;
+});
+
+import { channelMessageRepository } from '../channel-message-repository';
+
 interface AssertParams {
   given: string;
   should: string;
@@ -9,270 +36,122 @@ interface AssertParams {
 }
 
 const assert = ({ given, should, actual, expected }: AssertParams): void => {
-  const message = `Given ${given}, should ${should}`;
-  expect(actual, message).toEqual(expected);
+  expect(actual, `Given ${given}, should ${should}`).toEqual(expected);
 };
 
-const {
-  mockChannelMessagesFindMany,
-  mockChannelMessagesFindFirst,
-  mockReactionsFindFirst,
-  mockFilesFindFirst,
-  mockFollowersWhere,
-  mockSelectFrom,
-  mockInsertValues,
-  mockInsertReturning,
-  mockInsertOnConflictDoUpdate,
-  mockInsertOnConflictDoNothing,
-  mockUpdateSet,
-  mockUpdateWhere,
-  mockUpdateReturning,
-  mockDeleteWhere,
-  mockDeleteReturning,
-  mockTransaction,
-} = vi.hoisted(() => ({
-  mockChannelMessagesFindMany: vi.fn(),
-  mockChannelMessagesFindFirst: vi.fn(),
-  mockReactionsFindFirst: vi.fn(),
-  mockFilesFindFirst: vi.fn(),
-  mockFollowersWhere: vi.fn(),
-  mockSelectFrom: vi.fn(),
-  mockInsertValues: vi.fn(),
-  mockInsertReturning: vi.fn(),
-  mockInsertOnConflictDoUpdate: vi.fn(),
-  mockInsertOnConflictDoNothing: vi.fn(),
-  mockUpdateSet: vi.fn(),
-  mockUpdateWhere: vi.fn(),
-  mockUpdateReturning: vi.fn(),
-  mockDeleteWhere: vi.fn(),
-  mockDeleteReturning: vi.fn(),
-  mockTransaction: vi.fn(),
-}));
-
-vi.mock('@pagespace/db/db', () => ({
-  db: {
-    query: {
-      channelMessages: {
-        findMany: mockChannelMessagesFindMany,
-        findFirst: mockChannelMessagesFindFirst,
-      },
-      channelMessageReactions: { findFirst: mockReactionsFindFirst },
-      files: { findFirst: mockFilesFindFirst },
-    },
-    insert: vi.fn(() => ({ values: mockInsertValues })),
-    update: vi.fn(() => ({ set: mockUpdateSet })),
-    delete: vi.fn(() => ({ where: mockDeleteWhere })),
-    select: vi.fn(() => ({ from: mockSelectFrom })),
-    transaction: mockTransaction,
-  },
-}));
-
-vi.mock('@pagespace/db/operators', () => {
-  const sqlFn = Object.assign(
-    vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values })),
-    {
-      join: vi.fn((items: unknown[], separator: unknown) => ({ items, separator })),
-    }
-  );
-  return {
-    and: vi.fn((...conditions: unknown[]) => ({ op: 'and', conditions })),
-    asc: vi.fn((field: unknown) => ({ op: 'asc', field })),
-    desc: vi.fn((field: unknown) => ({ op: 'desc', field })),
-    eq: vi.fn((field: unknown, value: unknown) => ({ op: 'eq', field, value })),
-    gt: vi.fn((field: unknown, value: unknown) => ({ op: 'gt', field, value })),
-    isNull: vi.fn((field: unknown) => ({ op: 'isNull', field })),
-    lt: vi.fn((field: unknown, value: unknown) => ({ op: 'lt', field, value })),
-    or: vi.fn((...conditions: unknown[]) => ({ op: 'or', conditions })),
-    sql: sqlFn,
-  };
-});
-
-vi.mock('@pagespace/db/schema/chat', () => ({
-  channelMessages: {
-    id: 'channel_messages.id',
-    pageId: 'channel_messages.pageId',
-    userId: 'channel_messages.userId',
-    content: 'channel_messages.content',
-    fileId: 'channel_messages.fileId',
-    attachmentMeta: 'channel_messages.attachmentMeta',
-    isActive: 'channel_messages.isActive',
-    editedAt: 'channel_messages.editedAt',
-    createdAt: 'channel_messages.createdAt',
-    parentId: 'channel_messages.parentId',
-    replyCount: 'channel_messages.replyCount',
-    lastReplyAt: 'channel_messages.lastReplyAt',
-    mirroredFromId: 'channel_messages.mirroredFromId',
-  },
-  channelMessageReactions: {
-    id: 'channel_message_reactions.id',
-    messageId: 'channel_message_reactions.messageId',
-    userId: 'channel_message_reactions.userId',
-    emoji: 'channel_message_reactions.emoji',
-  },
-  channelReadStatus: {
-    userId: 'channel_read_status.userId',
-    channelId: 'channel_read_status.channelId',
-    lastReadAt: 'channel_read_status.lastReadAt',
-  },
-  channelThreadFollowers: {
-    rootMessageId: 'channel_thread_followers.rootMessageId',
-    userId: 'channel_thread_followers.userId',
-  },
-}));
-
-vi.mock('@pagespace/db/schema/storage', () => ({
-  files: {
-    id: 'files.id',
-  },
-}));
-
-import { db } from '@pagespace/db/db';
-import {
-  channelMessages,
-  channelMessageReactions,
-  channelReadStatus,
-  channelThreadFollowers,
-} from '@pagespace/db/schema/chat';
-import { and, asc, eq, gt, isNull, lt, or } from '@pagespace/db/operators';
-import { channelMessageRepository } from '../channel-message-repository';
-
 beforeEach(() => {
-  vi.clearAllMocks();
-
-  // Insert pipeline
-  mockInsertOnConflictDoUpdate.mockResolvedValue(undefined);
-  mockInsertOnConflictDoNothing.mockResolvedValue(undefined);
-  mockInsertReturning.mockResolvedValue([{ id: 'msg-1' }]);
-  mockInsertValues.mockReturnValue({
-    returning: mockInsertReturning,
-    onConflictDoUpdate: mockInsertOnConflictDoUpdate,
-    onConflictDoNothing: mockInsertOnConflictDoNothing,
-  });
-  vi.mocked(db.insert).mockReturnValue({ values: mockInsertValues } as never);
-
-  // Update pipeline (resolves to a chainable .returning() too, for soft-delete tx)
-  mockUpdateReturning.mockResolvedValue([{ parentId: null }]);
-  mockUpdateWhere.mockReturnValue({
-    returning: mockUpdateReturning,
-    then: (resolve: (v: unknown) => unknown) => resolve(undefined),
-  });
-  mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
-  vi.mocked(db.update).mockReturnValue({ set: mockUpdateSet } as never);
-
-  // Delete pipeline
-  mockDeleteReturning.mockResolvedValue([{ id: 'reaction-1' }]);
-  mockDeleteWhere.mockReturnValue({
-    returning: mockDeleteReturning,
-    then: (resolve: (v: unknown) => unknown) => resolve(undefined),
-  });
-  vi.mocked(db.delete).mockReturnValue({ where: mockDeleteWhere } as never);
-
-  // Select pipeline. Two callers exist:
-  //  1) listChannelThreadFollowers — db.select(cols).from(table).where(...) → rows
-  //  2) insertChannelThreadReply — tx.select(cols).from(table).where(...).for('update') → rows
-  // The default chain handles both: where() returns an object that is itself
-  // thenable (so listFollowers awaits the rows directly) AND has .for() that
-  // returns a promise (so insertChannelThreadReply awaits the locked rows).
-  const defaultLockedRows: unknown[] = [];
-  const defaultRows: unknown[] = [];
-  mockSelectFrom.mockReturnValue({
-    where: vi.fn(() => ({
-      then: (resolve: (v: unknown) => unknown) => resolve(defaultRows),
-      for: vi.fn().mockResolvedValue(defaultLockedRows),
-    })),
-  });
-  vi.mocked(db.select).mockReturnValue({ from: mockSelectFrom } as never);
-
-  // Transaction passes db itself as the tx so all chain mocks above apply
-  // unchanged inside the callback.
-  mockTransaction.mockImplementation(
-    async (cb: (tx: unknown) => Promise<unknown>) => cb(db)
-  );
+  testDbState.reset();
 });
 
 describe('channelMessageRepository.listChannelMessages', () => {
   it('filters out replies by requiring parentId IS NULL', async () => {
-    mockChannelMessagesFindMany.mockResolvedValue([]);
+    testDbState.seed('channelMessages', [
+      { id: 'top-a', pageId: 'page-1', userId: 'u-1', content: 'a', isActive: true, parentId: null, createdAt: new Date('2026-05-01T00:00:00Z') },
+      { id: 'reply-a', pageId: 'page-1', userId: 'u-1', content: 'reply', isActive: true, parentId: 'top-a', createdAt: new Date('2026-05-01T00:01:00Z') },
+      { id: 'top-b', pageId: 'page-1', userId: 'u-1', content: 'b', isActive: true, parentId: null, createdAt: new Date('2026-05-01T00:02:00Z') },
+    ]);
 
-    await channelMessageRepository.listChannelMessages({ pageId: 'page-1', limit: 10 });
+    const rows = await channelMessageRepository.listChannelMessages({ pageId: 'page-1', limit: 10 });
 
     assert({
-      given: 'a top-level message fetch',
-      should: 'add a parentId IS NULL filter so thread replies do not leak into the main stream',
-      actual: vi.mocked(isNull).mock.calls.some(
-        ([field]) => field === channelMessages.parentId
-      ),
-      expected: true,
+      given: 'a top-level message fetch on a page that has both top-level rows and a thread reply',
+      should: 'omit the reply — only top-level rows leak into the main stream',
+      actual: rows.map((r) => r.id).sort(),
+      expected: ['top-a', 'top-b'],
     });
   });
 
   it('omits the cursor branch when no cursor is supplied', async () => {
-    mockChannelMessagesFindMany.mockResolvedValue([]);
+    const earliest = new Date('2026-05-01T00:00:00Z');
+    const middle = new Date('2026-05-01T00:01:00Z');
+    const latest = new Date('2026-05-01T00:02:00Z');
+    testDbState.seed('channelMessages', [
+      { id: 'a', pageId: 'page-1', isActive: true, parentId: null, createdAt: earliest },
+      { id: 'b', pageId: 'page-1', isActive: true, parentId: null, createdAt: middle },
+      { id: 'c', pageId: 'page-1', isActive: true, parentId: null, createdAt: latest },
+    ]);
 
-    await channelMessageRepository.listChannelMessages({ pageId: 'page-1', limit: 10 });
+    const rows = await channelMessageRepository.listChannelMessages({ pageId: 'page-1', limit: 10 });
 
     assert({
       given: 'a list call without a cursor',
-      should: 'not build any (createdAt, id) cursor disjunction',
-      actual: vi.mocked(or).mock.calls.length,
-      expected: 0,
+      should: 'return every active top-level row newest-first — no cursor exclusion is applied',
+      actual: rows.map((r) => r.id),
+      expected: ['c', 'b', 'a'],
     });
   });
 
   it('builds a composite cursor disjunction when cursor is supplied', async () => {
-    mockChannelMessagesFindMany.mockResolvedValue([]);
-    const cursor = { createdAt: new Date('2026-01-01T00:00:00Z'), id: 'msg-cursor' };
+    const t = new Date('2026-05-01T12:00:00Z');
+    const tBefore = new Date('2026-05-01T11:59:00Z');
+    const tAfter = new Date('2026-05-01T12:01:00Z');
+    testDbState.seed('channelMessages', [
+      // Same createdAt as the cursor row — id ordering is the tiebreaker.
+      { id: 'tie-before', pageId: 'page-1', isActive: true, parentId: null, createdAt: t },
+      { id: 'tie-cursor', pageId: 'page-1', isActive: true, parentId: null, createdAt: t },
+      { id: 'tie-zafter', pageId: 'page-1', isActive: true, parentId: null, createdAt: t },
+      // Strictly older row — should be returned by the cursor.
+      { id: 'older', pageId: 'page-1', isActive: true, parentId: null, createdAt: tBefore },
+      // Strictly newer row — should be excluded.
+      { id: 'newer', pageId: 'page-1', isActive: true, parentId: null, createdAt: tAfter },
+    ]);
 
-    await channelMessageRepository.listChannelMessages({
+    const rows = await channelMessageRepository.listChannelMessages({
       pageId: 'page-1',
       limit: 10,
-      cursor,
+      cursor: { createdAt: t, id: 'tie-cursor' },
     });
 
-    const ltCalls = vi.mocked(lt).mock.calls;
     assert({
-      given: 'a composite cursor (createdAt, id)',
-      should: 'use lt() against both createdAt and id so pagination is stable across ties',
-      actual: {
-        createdAt: ltCalls.some(([field, value]) => field === channelMessages.createdAt && value === cursor.createdAt),
-        id: ltCalls.some(([field, value]) => field === channelMessages.id && value === cursor.id),
-      },
-      expected: { createdAt: true, id: true },
+      given: 'a composite cursor (createdAt, id) at the tie row',
+      should: 'return rows strictly older by createdAt OR same-createdAt with strictly smaller id — never the cursor row, never anything newer',
+      actual: rows.map((r) => r.id).sort(),
+      expected: ['older', 'tie-before'],
     });
   });
 
   it('passes the supplied limit through unchanged so the route can fetch limit+1 for hasMore', async () => {
-    mockChannelMessagesFindMany.mockResolvedValue([]);
+    const rows = Array.from({ length: 10 }, (_, i) => ({
+      id: `m-${i}`,
+      pageId: 'page-1',
+      isActive: true,
+      parentId: null,
+      createdAt: new Date(2026, 4, 1, 12, i),
+    }));
+    testDbState.seed('channelMessages', rows);
 
-    await channelMessageRepository.listChannelMessages({ pageId: 'page-1', limit: 51 });
+    const result = await channelMessageRepository.listChannelMessages({ pageId: 'page-1', limit: 3 });
 
-    const call = mockChannelMessagesFindMany.mock.calls[0]?.[0] as { limit: number };
     assert({
       given: 'a limit value chosen by the route',
-      should: 'forward it verbatim — the repository does not own pagination semantics',
-      actual: call.limit,
-      expected: 51,
+      should: 'forward it verbatim — return at most that many rows',
+      actual: result.length,
+      expected: 3,
     });
   });
 });
 
 describe('channelMessageRepository.findChannelMessageInPage', () => {
   it('scopes the lookup to a single page', async () => {
-    mockChannelMessagesFindFirst.mockResolvedValueOnce({ id: 'msg-1', pageId: 'page-1' });
+    testDbState.seed('channelMessages', [
+      { id: 'msg-1', pageId: 'page-1', isActive: true, content: 'hi' },
+      { id: 'msg-1-other', pageId: 'page-other', isActive: true, content: 'leak' },
+    ]);
 
-    await channelMessageRepository.findChannelMessageInPage({ messageId: 'msg-1', pageId: 'page-1' });
+    const result = await channelMessageRepository.findChannelMessageInPage({ messageId: 'msg-1', pageId: 'page-1' });
 
-    const eqCalls = vi.mocked(eq).mock.calls;
     assert({
       given: 'a (messageId, pageId) tuple',
-      should: 'add an eq predicate on pageId so a stolen message id from another channel cannot hit',
-      actual: eqCalls.some(([field, value]) => field === channelMessages.pageId && value === 'page-1'),
-      expected: true,
+      should: 'return the row from the requested page only — never the other page row, even with the same id',
+      actual: result?.pageId,
+      expected: 'page-1',
     });
   });
 
   it('returns null when the message belongs to a different page', async () => {
-    mockChannelMessagesFindFirst.mockResolvedValueOnce(undefined);
+    testDbState.seed('channelMessages', [
+      { id: 'msg-1', pageId: 'page-1', isActive: true, content: 'hi' },
+    ]);
 
     const result = await channelMessageRepository.findChannelMessageInPage({
       messageId: 'msg-1',
@@ -290,29 +169,38 @@ describe('channelMessageRepository.findChannelMessageInPage', () => {
 
 describe('channelMessageRepository.loadChannelMessageWithRelations', () => {
   it('asks for user, file, and reactions-with-user relations so the route response stays rich', async () => {
-    mockChannelMessagesFindFirst.mockResolvedValueOnce({ id: 'msg-1' });
+    testDbState.seed('users', [
+      { id: 'u-1', name: 'Alice', image: '/avatar.png' },
+      { id: 'u-2', name: 'Bob' },
+    ]);
+    testDbState.seed('files', [
+      { id: 'file-1', mimeType: 'image/png', sizeBytes: 1024 },
+    ]);
+    testDbState.seed('channelMessages', [
+      { id: 'msg-1', pageId: 'page-1', userId: 'u-1', fileId: 'file-1', isActive: true, content: 'hi' },
+    ]);
+    testDbState.seed('channelMessageReactions', [
+      { id: 'rx-1', messageId: 'msg-1', userId: 'u-2', emoji: '👍' },
+    ]);
 
-    await channelMessageRepository.loadChannelMessageWithRelations('msg-1');
+    const result = await channelMessageRepository.loadChannelMessageWithRelations('msg-1');
 
-    const call = mockChannelMessagesFindFirst.mock.calls[0]?.[0] as {
-      with: { user: unknown; file: unknown; reactions: { with: { user: unknown } } };
-    };
     assert({
-      given: 'a freshly created message id',
-      should: 'load all three relations so the broadcast payload matches the route shape',
+      given: 'a freshly created message id with linked user/file/reactor',
+      should: 'load all three relations so the broadcast payload renders without a re-fetch',
       actual: {
-        hasUser: !!call.with.user,
-        hasFile: !!call.with.file,
-        hasReactionUser: !!call.with.reactions.with.user,
+        userId: (result?.user as { id: string } | null)?.id,
+        fileId: (result?.file as { id: string } | null)?.id,
+        reactionUser: (result?.reactions as Array<{ user: { name: string } }> | undefined)?.[0]?.user?.name,
       },
-      expected: { hasUser: true, hasFile: true, hasReactionUser: true },
+      expected: { userId: 'u-1', fileId: 'file-1', reactionUser: 'Bob' },
     });
   });
 });
 
 describe('channelMessageRepository.fileExists', () => {
   it('returns true when the file row is present', async () => {
-    mockFilesFindFirst.mockResolvedValueOnce({ id: 'file-1' });
+    testDbState.seed('files', [{ id: 'file-1', mimeType: 'image/png' }]);
 
     const result = await channelMessageRepository.fileExists('file-1');
 
@@ -325,8 +213,6 @@ describe('channelMessageRepository.fileExists', () => {
   });
 
   it('returns false when the file row is missing', async () => {
-    mockFilesFindFirst.mockResolvedValueOnce(undefined);
-
     const result = await channelMessageRepository.fileExists('missing-file');
 
     assert({
@@ -340,8 +226,6 @@ describe('channelMessageRepository.fileExists', () => {
 
 describe('channelMessageRepository.insertChannelMessage', () => {
   it('writes pageId, userId, content, fileId, and attachmentMeta verbatim', async () => {
-    mockInsertReturning.mockResolvedValueOnce([{ id: 'msg-1' }]);
-
     await channelMessageRepository.insertChannelMessage({
       pageId: 'page-1',
       userId: 'user-1',
@@ -350,11 +234,17 @@ describe('channelMessageRepository.insertChannelMessage', () => {
       attachmentMeta: { kind: 'image' } as never,
     });
 
-    const values = mockInsertValues.mock.calls[0]?.[0] as Record<string, unknown>;
+    const inserted = testDbState.rows('channelMessages')[0];
     assert({
       given: 'an insert request with all fields populated',
-      should: 'forward each field unchanged — the repository does not normalize input',
-      actual: values,
+      should: 'persist each field unchanged — the repository does not normalize input',
+      actual: {
+        pageId: inserted.pageId,
+        userId: inserted.userId,
+        content: inserted.content,
+        fileId: inserted.fileId,
+        attachmentMeta: inserted.attachmentMeta,
+      },
       expected: {
         pageId: 'page-1',
         userId: 'user-1',
@@ -366,8 +256,6 @@ describe('channelMessageRepository.insertChannelMessage', () => {
   });
 
   it('persists null fileId and null attachmentMeta when there is no attachment', async () => {
-    mockInsertReturning.mockResolvedValueOnce([{ id: 'msg-2' }]);
-
     await channelMessageRepository.insertChannelMessage({
       pageId: 'page-1',
       userId: 'user-1',
@@ -376,11 +264,11 @@ describe('channelMessageRepository.insertChannelMessage', () => {
       attachmentMeta: null,
     });
 
-    const values = mockInsertValues.mock.calls[0]?.[0] as Record<string, unknown>;
+    const inserted = testDbState.rows('channelMessages')[0];
     assert({
       given: 'a text-only message',
       should: 'insert NULL into fileId and attachmentMeta rather than dropping the columns',
-      actual: { fileId: values.fileId, attachmentMeta: values.attachmentMeta },
+      actual: { fileId: inserted.fileId, attachmentMeta: inserted.attachmentMeta },
       expected: { fileId: null, attachmentMeta: null },
     });
   });
@@ -388,29 +276,26 @@ describe('channelMessageRepository.insertChannelMessage', () => {
 
 describe('channelMessageRepository.upsertChannelReadStatus', () => {
   it('upserts on (userId, channelId) so a sender-reads-own-message write is idempotent', async () => {
-    const readAt = new Date('2026-05-04T12:00:00Z');
+    const earlier = new Date('2026-05-04T11:00:00Z');
+    const later = new Date('2026-05-04T12:00:00Z');
 
     await channelMessageRepository.upsertChannelReadStatus({
       userId: 'user-1',
       channelId: 'page-1',
-      readAt,
+      readAt: earlier,
+    });
+    await channelMessageRepository.upsertChannelReadStatus({
+      userId: 'user-1',
+      channelId: 'page-1',
+      readAt: later,
     });
 
-    const conflict = mockInsertOnConflictDoUpdate.mock.calls[0]?.[0] as {
-      target: unknown[];
-      set: { lastReadAt: Date };
-    };
+    const rows = testDbState.rows('channelReadStatus');
     assert({
-      given: 'a sender posting in their own channel',
-      should: 'target the (userId, channelId) composite and update lastReadAt',
-      actual: {
-        target: conflict.target,
-        lastReadAt: conflict.set.lastReadAt,
-      },
-      expected: {
-        target: [channelReadStatus.userId, channelReadStatus.channelId],
-        lastReadAt: readAt,
-      },
+      given: 'two read-status writes for the same (userId, channelId)',
+      should: 'collapse to one row, with lastReadAt updated to the later timestamp',
+      actual: { rowCount: rows.length, lastReadAt: rows[0]?.lastReadAt },
+      expected: { rowCount: 1, lastReadAt: later },
     });
   });
 });
@@ -418,6 +303,10 @@ describe('channelMessageRepository.upsertChannelReadStatus', () => {
 describe('channelMessageRepository.updateChannelMessageContent', () => {
   it('writes content + editedAt and scopes the update to the message id', async () => {
     const editedAt = new Date('2026-05-04T13:00:00Z');
+    testDbState.seed('channelMessages', [
+      { id: 'msg-1', pageId: 'page-1', userId: 'u-1', content: 'orig', isActive: true, editedAt: null },
+      { id: 'msg-2', pageId: 'page-1', userId: 'u-1', content: 'untouched', isActive: true, editedAt: null },
+    ]);
 
     await channelMessageRepository.updateChannelMessageContent({
       messageId: 'msg-1',
@@ -425,18 +314,17 @@ describe('channelMessageRepository.updateChannelMessageContent', () => {
       editedAt,
     });
 
-    const set = mockUpdateSet.mock.calls[0]?.[0] as Record<string, unknown>;
-    const eqCalls = vi.mocked(eq).mock.calls;
+    const rows = testDbState.rows('channelMessages');
     assert({
       given: 'an edit request',
-      should: 'set both content and editedAt and target the matching message id',
+      should: 'set both content and editedAt on the targeted row only — the other row is untouched',
       actual: {
-        set,
-        whereOnId: eqCalls.some(([field, value]) => field === channelMessages.id && value === 'msg-1'),
+        target: rows.find((r) => r.id === 'msg-1'),
+        other: rows.find((r) => r.id === 'msg-2'),
       },
       expected: {
-        set: { content: 'edited', editedAt },
-        whereOnId: true,
+        target: expect.objectContaining({ content: 'edited', editedAt }),
+        other: expect.objectContaining({ content: 'untouched', editedAt: null }),
       },
     });
   });
@@ -444,152 +332,131 @@ describe('channelMessageRepository.updateChannelMessageContent', () => {
 
 describe('channelMessageRepository.softDeleteChannelMessage', () => {
   it('flips isActive=false and returns 1 row affected for a fresh delete', async () => {
-    mockUpdateReturning.mockResolvedValueOnce([{ parentId: null }]);
+    testDbState.seed('channelMessages', [
+      { id: 'msg-1', pageId: 'page-1', isActive: true, parentId: null, replyCount: 0 },
+    ]);
 
     const count = await channelMessageRepository.softDeleteChannelMessage('msg-1');
 
-    const set = mockUpdateSet.mock.calls[0]?.[0] as Record<string, unknown>;
+    const rows = testDbState.rows('channelMessages');
     assert({
       given: 'a delete request for a top-level message',
-      should: 'set isActive=false and return 1 row affected so the route can audit + broadcast',
-      actual: { set, count },
-      expected: { set: { isActive: false }, count: 1 },
+      should: 'set isActive=false on the targeted row and return 1 row affected so the route can audit + broadcast',
+      actual: { isActive: rows[0].isActive, count },
+      expected: { isActive: false, count: 1 },
     });
   });
 
   it('returns 0 affected rows on a double soft-delete (idempotency guard for routes)', async () => {
-    // The where(isActive=true) filter makes a second delete a no-op; the route
-    // must use the returned count to skip duplicate audit + broadcast.
-    mockUpdateReturning.mockResolvedValueOnce([]);
+    testDbState.seed('channelMessages', [
+      { id: 'msg-1', pageId: 'page-1', isActive: false, parentId: null, replyCount: 0 },
+    ]);
 
-    const count = await channelMessageRepository.softDeleteChannelMessage('already-deleted');
+    const count = await channelMessageRepository.softDeleteChannelMessage('msg-1');
 
     assert({
       given: 'a soft-delete of an already-inactive message',
       should: 'return 0 so the route can 404 instead of re-broadcasting message_deleted',
-      actual: { count, secondUpdateIssued: mockUpdateSet.mock.calls.length },
-      expected: { count: 0, secondUpdateIssued: 1 },
+      actual: count,
+      expected: 0,
     });
   });
 
   it('decrements the parent replyCount when the soft-deleted row is a thread reply, scoped to the returned parentId', async () => {
-    mockUpdateReturning.mockResolvedValueOnce([{ parentId: 'parent-1' }]);
+    testDbState.seed('channelMessages', [
+      { id: 'parent-1', pageId: 'page-1', isActive: true, parentId: null, replyCount: 3 },
+      { id: 'sibling-parent', pageId: 'page-1', isActive: true, parentId: null, replyCount: 5 },
+      { id: 'reply-1', pageId: 'page-1', isActive: true, parentId: 'parent-1', replyCount: 0 },
+    ]);
 
     await channelMessageRepository.softDeleteChannelMessage('reply-1');
 
-    // Two update calls: 1) flip isActive=false on the reply,
-    // 2) replyCount = GREATEST(replyCount - 1, 0) on the parent.
-    const setCalls = mockUpdateSet.mock.calls.map((c) => c[0] as Record<string, unknown>);
-    // Verify the SECOND update's WHERE actually targets the parentId returned
-    // by the first UPDATE — this guards against a future refactor that
-    // accidentally decrements the wrong row.
-    const eqCalls = vi.mocked(eq).mock.calls;
-    const targetsParentId = eqCalls.some(
-      ([field, value]) => field === channelMessages.id && value === 'parent-1'
-    );
+    const rows = testDbState.rows('channelMessages');
     assert({
       given: 'a soft-delete of a thread reply',
-      should: 'issue two updates inside the same tx (flip isActive + decrement parent.replyCount) and target the returned parentId',
+      should: 'decrement the targeted parent.replyCount by exactly 1, never touch sibling parents, and tombstone the reply',
       actual: {
-        firstSet: setCalls[0],
-        secondHasReplyCount: 'replyCount' in (setCalls[1] ?? {}),
-        targetsParentId,
+        parent: rows.find((r) => r.id === 'parent-1')?.replyCount,
+        sibling: rows.find((r) => r.id === 'sibling-parent')?.replyCount,
+        replyActive: rows.find((r) => r.id === 'reply-1')?.isActive,
       },
-      expected: {
-        firstSet: { isActive: false },
-        secondHasReplyCount: true,
-        targetsParentId: true,
-      },
+      expected: { parent: 2, sibling: 5, replyActive: false },
     });
   });
 
   it('does NOT issue a parent-counter update when the row is top-level (parentId is null)', async () => {
-    mockUpdateReturning.mockResolvedValueOnce([{ parentId: null }]);
+    testDbState.seed('channelMessages', [
+      { id: 'top-1', pageId: 'page-1', isActive: true, parentId: null, replyCount: 7 },
+    ]);
 
     await channelMessageRepository.softDeleteChannelMessage('top-1');
 
+    const rows = testDbState.rows('channelMessages');
     assert({
       given: 'a soft-delete of a top-level message (parentId IS NULL)',
-      should: 'only run the isActive flip — never touch a parent counter',
-      actual: mockUpdateSet.mock.calls.length,
-      expected: 1,
+      should: 'flip isActive but never touch its own replyCount or any other row',
+      actual: { isActive: rows[0].isActive, replyCount: rows[0].replyCount, count: rows.length },
+      expected: { isActive: false, replyCount: 7, count: 1 },
     });
   });
 });
 
 describe('channelMessageRepository.restoreChannelMessage', () => {
   it('flips isActive=true when restoring a row and returns 1 row affected', async () => {
-    mockUpdateReturning.mockResolvedValueOnce([{ parentId: null }]);
+    testDbState.seed('channelMessages', [
+      { id: 'msg-1', pageId: 'page-1', isActive: false, parentId: null, replyCount: 0 },
+    ]);
 
     const count = await channelMessageRepository.restoreChannelMessage('msg-1');
 
-    const set = mockUpdateSet.mock.calls[0]?.[0] as Record<string, unknown>;
+    const rows = testDbState.rows('channelMessages');
     assert({
-      given: 'a restore request for a top-level row',
+      given: 'a restore request for a tombstoned top-level row',
       should: 'flip isActive back to true on the targeted row and return 1',
-      actual: { set, count },
-      expected: { set: { isActive: true }, count: 1 },
+      actual: { isActive: rows[0].isActive, count },
+      expected: { isActive: true, count: 1 },
     });
   });
 
-  // Helper for restore tests: stub the parent re-read inside the tx.
-  // restoreChannelMessage uses `tx.select().from().where().for('update')` for
-  // the parent isActive check (mirrors the insert-side lock).
-  const stubParentSelectForUpdate = (parent: Record<string, unknown> | null) => {
-    const forFn = vi.fn().mockResolvedValue(parent ? [parent] : []);
-    const whereFn = vi.fn(() => ({ for: forFn }));
-    const fromFn = vi.fn(() => ({ where: whereFn }));
-    vi.mocked(db.select).mockReturnValueOnce({ from: fromFn } as never);
-    return { forFn };
-  };
-
   it('increments the parent replyCount when the restored row is a thread reply AND the parent is still active', async () => {
-    mockUpdateReturning.mockResolvedValueOnce([{ parentId: 'parent-1' }]);
-    stubParentSelectForUpdate({ id: 'parent-1', isActive: true });
+    testDbState.seed('channelMessages', [
+      { id: 'parent-1', pageId: 'page-1', isActive: true, parentId: null, replyCount: 1 },
+      { id: 'reply-1', pageId: 'page-1', isActive: false, parentId: 'parent-1', replyCount: 0 },
+    ]);
 
     const count = await channelMessageRepository.restoreChannelMessage('reply-1');
 
+    const rows = testDbState.rows('channelMessages');
     assert({
       given: 'a restore of a thread reply whose parent is still active',
-      should: 'return 1 row restored AND run two updates (isActive flip + parent.replyCount bump)',
+      should: 'restore the reply and bump the active parent.replyCount by 1',
       actual: {
         count,
-        updateCount: mockUpdateSet.mock.calls.length,
-        secondHasReplyCount: 'replyCount' in (mockUpdateSet.mock.calls[1]?.[0] as Record<string, unknown> ?? {}),
+        replyActive: rows.find((r) => r.id === 'reply-1')?.isActive,
+        parentReplyCount: rows.find((r) => r.id === 'parent-1')?.replyCount,
       },
-      expected: { count: 1, updateCount: 2, secondHasReplyCount: true },
+      expected: { count: 1, replyActive: true, parentReplyCount: 2 },
     });
   });
 
   it('does NOT increment the parent counter when the parent has been soft-deleted in the meantime, but still returns 1 row restored', async () => {
-    // Race scenario: reply was soft-deleted, parent was then soft-deleted, now
-    // an admin restores the reply. Bumping a tombstoned parent's replyCount
-    // would corrupt the counter the moment a future restore brings the parent
-    // back. Skip the bump — but the reply IS restored, so return 1.
-    mockUpdateReturning.mockResolvedValueOnce([{ parentId: 'parent-1' }]);
-    stubParentSelectForUpdate({ id: 'parent-1', isActive: false });
+    testDbState.seed('channelMessages', [
+      { id: 'parent-1', pageId: 'page-1', isActive: false, parentId: null, replyCount: 5 },
+      { id: 'reply-1', pageId: 'page-1', isActive: false, parentId: 'parent-1', replyCount: 0 },
+    ]);
 
     const count = await channelMessageRepository.restoreChannelMessage('reply-1');
 
+    const rows = testDbState.rows('channelMessages');
     assert({
       given: 'a restore of a thread reply whose parent is itself soft-deleted',
-      should: 'flip isActive=true on the reply, skip the parent bump, AND still return 1',
-      actual: { count, updateCount: mockUpdateSet.mock.calls.length },
-      expected: { count: 1, updateCount: 1 },
-    });
-  });
-
-  it('locks the parent row for the restore tx (SELECT ... FOR UPDATE) so a concurrent soft-delete cannot race the bump', async () => {
-    mockUpdateReturning.mockResolvedValueOnce([{ parentId: 'parent-1' }]);
-    const { forFn } = stubParentSelectForUpdate({ id: 'parent-1', isActive: true });
-
-    await channelMessageRepository.restoreChannelMessage('reply-1');
-
-    assert({
-      given: 'a restore parent re-read inside the tx',
-      should: 'invoke .for("update") so a concurrent softDelete blocks until the restore commits',
-      actual: forFn.mock.calls[0]?.[0],
-      expected: 'update',
+      should: 'restore the reply but leave the tombstoned parent counter untouched (so a future parent restore does not over-count)',
+      actual: {
+        count,
+        replyActive: rows.find((r) => r.id === 'reply-1')?.isActive,
+        parentReplyCount: rows.find((r) => r.id === 'parent-1')?.replyCount,
+      },
+      expected: { count: 1, replyActive: true, parentReplyCount: 5 },
     });
   });
 });
@@ -604,331 +471,394 @@ describe('channelMessageRepository.insertChannelThreadReply', () => {
     attachmentMeta: null,
   };
 
-  // The helper validates the parent with `tx.select(...).from(...).where(...).for('update')`.
-  // This helper stubs the FOR UPDATE chain to return the supplied parent row
-  // (or no row, when null is passed).
-  const stubParentForUpdate = (parent: Record<string, unknown> | null) => {
-    const forFn = vi.fn().mockResolvedValue(parent ? [parent] : []);
-    const whereFn = vi.fn(() => ({ for: forFn }));
-    const fromFn = vi.fn(() => ({ where: whereFn }));
-    vi.mocked(db.select).mockReturnValueOnce({ from: fromFn } as never);
-    return { forFn, whereFn, fromFn };
+  const seedActiveParent = (overrides: Partial<Record<string, unknown>> = {}) => {
+    testDbState.seed('channelMessages', [
+      {
+        id: 'parent-1',
+        pageId: 'page-1',
+        userId: 'user-parent',
+        parentId: null,
+        isActive: true,
+        replyCount: 0,
+        ...overrides,
+      },
+    ]);
   };
 
-  it('locks the parent row for the duration of the tx (SELECT ... FOR UPDATE) so a concurrent soft-delete cannot orphan the reply', async () => {
-    const { forFn } = stubParentForUpdate({
-      id: 'parent-1',
-      pageId: 'page-1',
-      parentId: null,
-      userId: 'user-parent',
-      isActive: true,
-    });
-    mockInsertReturning.mockResolvedValueOnce([
-      { id: 'reply-1', createdAt: new Date(), parentId: 'parent-1' },
-    ]);
-    mockUpdateReturning.mockResolvedValueOnce([
-      { replyCount: 1, lastReplyAt: new Date() },
-    ]);
-
-    await channelMessageRepository.insertChannelThreadReply(baseInput);
-
-    assert({
-      given: 'a parent validation read inside the insert tx',
-      should: 'invoke .for("update") so a concurrent softDelete blocks until this tx commits',
-      actual: forFn.mock.calls[0]?.[0],
-      expected: 'update',
-    });
-  });
-
-  it('rejects with parent_not_found when the parent row is missing or inactive', async () => {
-    stubParentForUpdate(null);
-
+  it('rejects with parent_not_found when the parent row is missing', async () => {
     const result = await channelMessageRepository.insertChannelThreadReply(baseInput);
 
     assert({
-      given: 'a parent id that does not resolve to an active row',
+      given: 'a parent id that does not resolve to any row',
       should: 'return parent_not_found WITHOUT inserting a reply or follower row',
-      actual: { kind: result.kind, insertCount: mockInsertValues.mock.calls.length },
-      expected: { kind: 'parent_not_found', insertCount: 0 },
+      actual: {
+        kind: result.kind,
+        replyCount: testDbState.count('channelMessages'),
+        followerCount: testDbState.count('channelThreadFollowers'),
+      },
+      expected: { kind: 'parent_not_found', replyCount: 0, followerCount: 0 },
     });
   });
 
   it('rejects with parent_not_found when the parent row exists but is soft-deleted (isActive=false)', async () => {
-    stubParentForUpdate({
-      id: 'parent-1',
-      pageId: 'page-1',
-      parentId: null,
-      userId: 'parent-author',
-      isActive: false,
-    });
+    seedActiveParent({ isActive: false });
 
     const result = await channelMessageRepository.insertChannelThreadReply(baseInput);
 
     assert({
       given: 'a parent that has been soft-deleted',
       should: 'return parent_not_found — clients cannot reply into a tombstoned thread',
-      actual: { kind: result.kind, insertCount: mockInsertValues.mock.calls.length },
-      expected: { kind: 'parent_not_found', insertCount: 0 },
+      actual: {
+        kind: result.kind,
+        // The seeded parent stays the only row — no reply was added.
+        rowCount: testDbState.count('channelMessages'),
+      },
+      expected: { kind: 'parent_not_found', rowCount: 1 },
     });
   });
 
   it('rejects with parent_wrong_page when the parent belongs to a different channel', async () => {
-    stubParentForUpdate({
-      id: 'parent-1',
-      pageId: 'other-page',
-      parentId: null,
-      userId: 'parent-author',
-      isActive: true,
-    });
+    seedActiveParent({ pageId: 'other-page' });
 
     const result = await channelMessageRepository.insertChannelThreadReply(baseInput);
 
     assert({
       given: 'a parent id whose pageId differs from the request page',
       should: 'return parent_wrong_page so the route can 400 — never insert a reply scoped to the wrong channel',
-      actual: { kind: result.kind, insertCount: mockInsertValues.mock.calls.length },
-      expected: { kind: 'parent_wrong_page', insertCount: 0 },
+      actual: { kind: result.kind, rowCount: testDbState.count('channelMessages') },
+      expected: { kind: 'parent_wrong_page', rowCount: 1 },
     });
   });
 
   it('rejects with parent_not_top_level when the parent itself has parentId set (depth-2 attempt)', async () => {
-    stubParentForUpdate({
-      id: 'parent-1',
-      pageId: 'page-1',
-      parentId: 'grandparent',
-      userId: 'parent-author',
-      isActive: true,
-    });
+    seedActiveParent({ parentId: 'grandparent' });
 
     const result = await channelMessageRepository.insertChannelThreadReply(baseInput);
 
     assert({
       given: 'a parent that is itself a thread reply',
       should: 'return parent_not_top_level — threads are exactly one level deep',
-      actual: { kind: result.kind, insertCount: mockInsertValues.mock.calls.length },
-      expected: { kind: 'parent_not_top_level', insertCount: 0 },
+      actual: { kind: result.kind, rowCount: testDbState.count('channelMessages') },
+      expected: { kind: 'parent_not_top_level', rowCount: 1 },
     });
   });
 
   it('inserts the reply with parentId set, bumps replyCount + lastReplyAt, and upserts both followers', async () => {
-    stubParentForUpdate({
-      id: 'parent-1',
-      pageId: 'page-1',
-      parentId: null,
-      userId: 'user-parent',
-      isActive: true,
-    });
-    const replyCreatedAt = new Date('2026-05-04T12:00:00Z');
-    mockInsertReturning
-      .mockResolvedValueOnce([
-        { id: 'reply-1', createdAt: replyCreatedAt, parentId: 'parent-1' },
-      ]);
-    mockUpdateReturning.mockResolvedValueOnce([
-      { replyCount: 1, lastReplyAt: replyCreatedAt },
-    ]);
+    seedActiveParent();
 
     const result = await channelMessageRepository.insertChannelThreadReply(baseInput);
 
-    const replyValues = mockInsertValues.mock.calls[0]?.[0] as Record<string, unknown>;
-    const followerValues = mockInsertValues.mock.calls[1]?.[0] as Array<Record<string, unknown>>;
-    const updateSet = mockUpdateSet.mock.calls[0]?.[0] as Record<string, unknown>;
+    const messages = testDbState.rows('channelMessages');
+    const followers = testDbState.rows('channelThreadFollowers');
+    const reply = messages.find((r) => r.parentId === 'parent-1');
+    const parent = messages.find((r) => r.id === 'parent-1');
     assert({
       given: 'a happy-path thread reply with a distinct replier and parent author',
-      should: 'insert the reply with parentId, set lastReplyAt, and upsert followers for parent author + replier',
+      should: 'insert the reply with parentId=parent, bump parent.replyCount, set lastReplyAt, and add a follower row for both the parent author and the replier',
       actual: {
         kind: result.kind,
-        replyParent: replyValues.parentId,
-        updateHasReplyCount: 'replyCount' in updateSet,
-        updateLastReplyAt: updateSet.lastReplyAt,
-        followerUserIds: followerValues.map((r) => r.userId).sort(),
-        usedOnConflictDoNothing: mockInsertOnConflictDoNothing.mock.calls.length,
+        replyParentId: reply?.parentId,
+        parentReplyCount: parent?.replyCount,
+        parentLastReplyAt: parent?.lastReplyAt,
+        followerUserIds: followers.map((f) => f.userId).sort(),
       },
       expected: {
         kind: 'ok',
-        replyParent: 'parent-1',
-        updateHasReplyCount: true,
-        updateLastReplyAt: replyCreatedAt,
+        replyParentId: 'parent-1',
+        parentReplyCount: 1,
+        parentLastReplyAt: reply?.createdAt,
         followerUserIds: ['user-parent', 'user-replier'],
-        usedOnConflictDoNothing: 1,
       },
-    });
-  });
-
-  it('dedupes followers when the parent author replies to their own thread (one follower row, not two)', async () => {
-    stubParentForUpdate({
-      id: 'parent-1',
-      pageId: 'page-1',
-      parentId: null,
-      userId: 'user-self',
-      isActive: true,
-    });
-    mockInsertReturning.mockResolvedValueOnce([
-      { id: 'reply-1', createdAt: new Date(), parentId: 'parent-1' },
-    ]);
-    mockUpdateReturning.mockResolvedValueOnce([
-      { replyCount: 1, lastReplyAt: new Date() },
-    ]);
-
-    await channelMessageRepository.insertChannelThreadReply({
-      ...baseInput,
-      userId: 'user-self',
-    });
-
-    const followerValues = mockInsertValues.mock.calls[1]?.[0] as Array<Record<string, unknown>>;
-    assert({
-      given: 'a reply where the parent author and replier are the same user',
-      should: 'send a single follower row to onConflictDoNothing — Postgres rejects duplicate rows in one INSERT even with ON CONFLICT',
-      actual: followerValues,
-      expected: [{ rootMessageId: 'parent-1', userId: 'user-self' }],
     });
   });
 
   it('writes a second top-level row with mirroredFromId set when alsoSendToParent is true', async () => {
-    stubParentForUpdate({
-      id: 'parent-1',
-      pageId: 'page-1',
-      parentId: null,
-      userId: 'user-parent',
-      isActive: true,
-    });
-    mockInsertReturning
-      .mockResolvedValueOnce([
-        { id: 'reply-1', createdAt: new Date('2026-05-04T12:00:00Z'), parentId: 'parent-1' },
-      ])
-      .mockResolvedValueOnce([
-        { id: 'mirror-1', createdAt: new Date('2026-05-04T12:00:01Z'), mirroredFromId: 'reply-1' },
-      ]);
-    mockUpdateReturning.mockResolvedValueOnce([
-      { replyCount: 1, lastReplyAt: new Date('2026-05-04T12:00:00Z') },
-    ]);
+    seedActiveParent();
 
     const result = await channelMessageRepository.insertChannelThreadReply({
       ...baseInput,
       alsoSendToParent: true,
     });
 
-    // Three insert pipelines: 1) reply, 2) followers, 3) mirror top-level row.
-    const insertCount = mockInsertValues.mock.calls.length;
-    const mirrorValues = mockInsertValues.mock.calls[2]?.[0] as Record<string, unknown>;
+    const messages = testDbState.rows('channelMessages');
+    const reply = messages.find((r) => r.parentId === 'parent-1');
+    const mirror = messages.find((r) => r.mirroredFromId === reply?.id);
     assert({
       given: 'an alsoSendToParent thread reply',
-      should: 'write a second top-level row with mirroredFromId pointing at the reply id',
+      should: 'write a second top-level row (parentId IS NULL) with mirroredFromId pointing at the reply',
       actual: {
         kind: result.kind,
-        insertCount,
-        mirrorParentId: mirrorValues?.parentId ?? null,
-        mirrorMirroredFromId: mirrorValues?.mirroredFromId,
+        // Parent + reply + mirror.
+        rowCount: messages.length,
+        mirrorParentId: mirror?.parentId,
+        mirrorMirroredFromId: mirror?.mirroredFromId,
         resultMirrorId: result.kind === 'ok' ? result.mirror?.id : null,
       },
       expected: {
         kind: 'ok',
-        insertCount: 3,
+        rowCount: 3,
         mirrorParentId: null,
-        mirrorMirroredFromId: 'reply-1',
-        resultMirrorId: 'mirror-1',
+        mirrorMirroredFromId: reply?.id,
+        resultMirrorId: mirror?.id,
       },
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Edge cases (PR 6b — added per audit findings)
+  // -------------------------------------------------------------------------
+
+  it('upserts exactly two follower rows for a reply with distinct parent author and replier', async () => {
+    seedActiveParent();
+
+    await channelMessageRepository.insertChannelThreadReply(baseInput);
+
+    const followers = testDbState.rows('channelThreadFollowers');
+    assert({
+      given: 'a thread reply where the parent author and the replier are different users',
+      should: 'leave exactly two rows in channelThreadFollowers, one for each — and both keyed to the root',
+      actual: {
+        rowCount: followers.length,
+        rows: followers
+          .map((f) => ({ rootMessageId: f.rootMessageId, userId: f.userId }))
+          .sort((a, b) => String(a.userId).localeCompare(String(b.userId))),
+      },
+      expected: {
+        rowCount: 2,
+        rows: [
+          { rootMessageId: 'parent-1', userId: 'user-parent' },
+          { rootMessageId: 'parent-1', userId: 'user-replier' },
+        ],
+      },
+    });
+  });
+
+  it('upserts exactly one follower row when the parent author replies to their own thread (self-reply dedup)', async () => {
+    seedActiveParent({ userId: 'user-self' });
+
+    await channelMessageRepository.insertChannelThreadReply({
+      ...baseInput,
+      userId: 'user-self',
+    });
+
+    const followers = testDbState.rows('channelThreadFollowers');
+    assert({
+      given: 'a thread reply where the parent author and the replier are the same user',
+      should: 'collapse to a single follower row — the impl dedupes before INSERT to avoid Postgres rejecting two identical rows under onConflictDoNothing',
+      actual: followers.map((f) => ({ rootMessageId: f.rootMessageId, userId: f.userId })),
+      expected: [{ rootMessageId: 'parent-1', userId: 'user-self' }],
+    });
+  });
+
+  it('rolls the entire transaction back when the follower upsert step throws — no reply, no follower, parent counter unchanged', async () => {
+    const seededLastReplyAt = new Date('2026-04-01T00:00:00Z');
+    seedActiveParent({ replyCount: 7, lastReplyAt: seededLastReplyAt });
+    testDbState.failBefore('insert', 'channelThreadFollowers');
+
+    await expect(
+      channelMessageRepository.insertChannelThreadReply(baseInput)
+    ).rejects.toThrow();
+
+    const messages = testDbState.rows('channelMessages');
+    const followers = testDbState.rows('channelThreadFollowers');
+    const parent = messages.find((r) => r.id === 'parent-1');
+    assert({
+      given: 'an insertChannelThreadReply call where the follower upsert step fails inside the transaction',
+      should: 'roll back the reply insert AND the parent.replyCount + lastReplyAt bumps — only the seeded parent remains, every counter as-seeded, no followers',
+      actual: {
+        rowCount: messages.length,
+        parentReplyCount: parent?.replyCount,
+        parentLastReplyAt: parent?.lastReplyAt,
+        followerCount: followers.length,
+      },
+      expected: {
+        rowCount: 1,
+        parentReplyCount: 7,
+        parentLastReplyAt: seededLastReplyAt,
+        followerCount: 0,
+      },
+    });
+  });
+
+  it('rolls the entire transaction back when alsoSendToParent mirror-insert throws — reply rolled back, no mirror, parent counter unchanged', async () => {
+    seedActiveParent({ replyCount: 4 });
+    // The reply is the first channelMessages insert; the mirror is the second
+    // (after the followers insert hits channelThreadFollowers). Skip the first
+    // and fail the second so we exercise the rollback after a successful reply
+    // write.
+    testDbState.failBefore('insert', 'channelMessages', { skip: 1 });
+
+    await expect(
+      channelMessageRepository.insertChannelThreadReply({
+        ...baseInput,
+        alsoSendToParent: true,
+      })
+    ).rejects.toThrow();
+
+    const messages = testDbState.rows('channelMessages');
+    const followers = testDbState.rows('channelThreadFollowers');
+    const parent = messages.find((r) => r.id === 'parent-1');
+    assert({
+      given: 'an alsoSendToParent reply where the mirror insert step throws inside the transaction',
+      should: 'roll back EVERY write — no thread reply, no mirror, no follower rows, parent counter exactly as seeded',
+      actual: {
+        rowCount: messages.length,
+        parentReplyCount: parent?.replyCount,
+        followerCount: followers.length,
+      },
+      expected: { rowCount: 1, parentReplyCount: 4, followerCount: 0 },
+    });
+  });
+
+  it('soft-deleting a reply decrements parent.replyCount; restoring it (parent still active) increments it back', async () => {
+    seedActiveParent({ replyCount: 3 });
+    testDbState.seed('channelMessages', [
+      { id: 'reply-1', pageId: 'page-1', userId: 'user-replier', parentId: 'parent-1', isActive: true, replyCount: 0 },
+    ]);
+
+    await channelMessageRepository.softDeleteChannelMessage('reply-1');
+    const afterDelete = testDbState.rows('channelMessages').find((r) => r.id === 'parent-1')?.replyCount;
+    await channelMessageRepository.restoreChannelMessage('reply-1');
+    const afterRestore = testDbState.rows('channelMessages').find((r) => r.id === 'parent-1')?.replyCount;
+
+    assert({
+      given: 'a parent with replyCount=3 and an active reply, then a soft-delete followed by a restore',
+      should: 'decrement parent.replyCount to 2 on delete, then increment back to 3 on restore (parent stays active)',
+      actual: { afterDelete, afterRestore },
+      expected: { afterDelete: 2, afterRestore: 3 },
+    });
+  });
+
+  it('restoring a reply when the parent itself has been soft-deleted in the meantime does NOT bump the tombstoned parent counter', async () => {
+    // Parent active with 3 replies. Soft-delete a reply (parent → 2). Then
+    // soft-delete the parent (parent stays at 2 internally, but tombstoned).
+    // Restoring the reply should NOT bump the tombstoned parent's counter
+    // back to 3 — see channel-message-repository.ts:213-247 for the FOR UPDATE
+    // rationale.
+    testDbState.seed('channelMessages', [
+      { id: 'parent-1', pageId: 'page-1', userId: 'user-parent', parentId: null, isActive: true, replyCount: 2 },
+      { id: 'reply-1', pageId: 'page-1', userId: 'user-replier', parentId: 'parent-1', isActive: false, replyCount: 0 },
+    ]);
+    // Now soft-delete the parent so it is itself tombstoned.
+    await channelMessageRepository.softDeleteChannelMessage('parent-1');
+    const parentBeforeRestore = testDbState.rows('channelMessages').find((r) => r.id === 'parent-1');
+    expect(parentBeforeRestore?.isActive).toBe(false);
+
+    await channelMessageRepository.restoreChannelMessage('reply-1');
+
+    const rows = testDbState.rows('channelMessages');
+    const parent = rows.find((r) => r.id === 'parent-1');
+    const reply = rows.find((r) => r.id === 'reply-1');
+    assert({
+      given: 'a restore of a reply whose parent has been soft-deleted in the meantime',
+      should: 'restore the reply (isActive=true) but leave the tombstoned parent.replyCount exactly where it was',
+      actual: {
+        replyActive: reply?.isActive,
+        parentActive: parent?.isActive,
+        parentReplyCount: parent?.replyCount,
+      },
+      expected: { replyActive: true, parentActive: false, parentReplyCount: 2 },
     });
   });
 });
 
 describe('channelMessageRepository.listChannelThreadReplies', () => {
-  it('filters by parentId and asks for ascending order', async () => {
-    mockChannelMessagesFindMany.mockResolvedValueOnce([]);
+  it('filters by parentId and isActive=true and returns rows ascending by (createdAt, id)', async () => {
+    const t0 = new Date('2026-05-04T12:00:00Z');
+    const t1 = new Date('2026-05-04T12:01:00Z');
+    const t2 = new Date('2026-05-04T12:02:00Z');
+    testDbState.seed('channelMessages', [
+      { id: 'parent-1', pageId: 'page-1', isActive: true, parentId: null },
+      { id: 'r-3', pageId: 'page-1', isActive: true, parentId: 'parent-1', createdAt: t2 },
+      { id: 'r-1', pageId: 'page-1', isActive: true, parentId: 'parent-1', createdAt: t0 },
+      { id: 'r-2', pageId: 'page-1', isActive: true, parentId: 'parent-1', createdAt: t1 },
+      { id: 'r-deleted', pageId: 'page-1', isActive: false, parentId: 'parent-1', createdAt: t1 },
+      { id: 'other-parent-reply', pageId: 'page-1', isActive: true, parentId: 'other', createdAt: t1 },
+    ]);
 
-    await channelMessageRepository.listChannelThreadReplies({
-      rootId: 'parent-1',
-      limit: 50,
-    });
+    const result = await channelMessageRepository.listChannelThreadReplies({ rootId: 'parent-1', limit: 50 });
 
-    const eqCalls = vi.mocked(eq).mock.calls;
-    const ascCalls = vi.mocked(asc).mock.calls;
     assert({
-      given: 'a list-replies request for a thread root',
-      should: 'WHERE parentId = root AND order ascending by (createdAt, id)',
-      actual: {
-        scopedToParent: eqCalls.some(
-          ([field, value]) => field === channelMessages.parentId && value === 'parent-1'
-        ),
-        ascCount: ascCalls.length,
-      },
-      expected: { scopedToParent: true, ascCount: 2 },
+      given: 'a list-replies request for a thread root with active+deleted replies and an unrelated reply on another parent',
+      should: 'return only the parent-1 active replies, ordered ascending by (createdAt, id)',
+      actual: result.map((r) => r.id),
+      expected: ['r-1', 'r-2', 'r-3'],
     });
   });
 
   it('builds a strictly-greater-than composite cursor when after is supplied', async () => {
-    mockChannelMessagesFindMany.mockResolvedValueOnce([]);
-    const after = { createdAt: new Date('2026-05-04T12:00:00Z'), id: 'reply-cursor' };
+    const t0 = new Date('2026-05-04T12:00:00Z');
+    const t1 = new Date('2026-05-04T12:01:00Z');
+    testDbState.seed('channelMessages', [
+      { id: 'r-1', pageId: 'page-1', isActive: true, parentId: 'parent-1', createdAt: t0 },
+      { id: 'r-2-cursor', pageId: 'page-1', isActive: true, parentId: 'parent-1', createdAt: t1 },
+      { id: 'r-3', pageId: 'page-1', isActive: true, parentId: 'parent-1', createdAt: t1 },
+      { id: 'r-4', pageId: 'page-1', isActive: true, parentId: 'parent-1', createdAt: new Date('2026-05-04T12:02:00Z') },
+    ]);
 
-    await channelMessageRepository.listChannelThreadReplies({
+    const result = await channelMessageRepository.listChannelThreadReplies({
       rootId: 'parent-1',
       limit: 50,
-      after,
+      after: { createdAt: t1, id: 'r-2-cursor' },
     });
 
-    const gtCalls = vi.mocked(gt).mock.calls;
     assert({
-      given: 'an ascending-cursor pagination request',
-      should: 'use gt() against both createdAt and id so the next page never re-emits the cursor row',
-      actual: {
-        createdAt: gtCalls.some(([field, value]) => field === channelMessages.createdAt && value === after.createdAt),
-        id: gtCalls.some(([field, value]) => field === channelMessages.id && value === after.id),
-      },
-      expected: { createdAt: true, id: true },
+      given: 'an ascending-cursor pagination request at (t1, r-2-cursor)',
+      should: 'return rows strictly newer by createdAt OR same-createdAt with strictly larger id — never the cursor row, never anything older',
+      actual: result.map((r) => r.id).sort(),
+      expected: ['r-3', 'r-4'],
     });
   });
 });
 
 describe('channelMessageRepository thread follower helpers', () => {
-  it('addChannelThreadFollower inserts (rootId, userId) and uses onConflictDoNothing for idempotency', async () => {
+  it('addChannelThreadFollower inserts (rootId, userId) and is idempotent under a re-add', async () => {
+    await channelMessageRepository.addChannelThreadFollower('root-1', 'user-1');
     await channelMessageRepository.addChannelThreadFollower('root-1', 'user-1');
 
-    const values = mockInsertValues.mock.calls[0]?.[0] as Record<string, unknown>;
+    const rows = testDbState.rows('channelThreadFollowers');
     assert({
-      given: 'an explicit follower add',
-      should: 'insert the (rootMessageId, userId) pair with onConflictDoNothing so a re-add is a no-op',
-      actual: {
-        values,
-        usedOnConflictDoNothing: mockInsertOnConflictDoNothing.mock.calls.length,
-      },
-      expected: {
-        values: { rootMessageId: 'root-1', userId: 'user-1' },
-        usedOnConflictDoNothing: 1,
-      },
+      given: 'two adds of the same (rootId, userId)',
+      should: 'persist exactly one row — onConflictDoNothing makes the second add a no-op',
+      actual: rows.map((r) => ({ rootMessageId: r.rootMessageId, userId: r.userId })),
+      expected: [{ rootMessageId: 'root-1', userId: 'user-1' }],
     });
   });
 
   it('removeChannelThreadFollower deletes scoped to (rootId, userId) — never another user', async () => {
+    testDbState.seed('channelThreadFollowers', [
+      { rootMessageId: 'root-1', userId: 'user-1' },
+      { rootMessageId: 'root-1', userId: 'user-other' },
+      { rootMessageId: 'root-other', userId: 'user-1' },
+    ]);
+
     await channelMessageRepository.removeChannelThreadFollower('root-1', 'user-1');
 
-    const eqCalls = vi.mocked(eq).mock.calls;
+    const remaining = testDbState
+      .rows('channelThreadFollowers')
+      .map((r) => `${r.rootMessageId}:${r.userId}`)
+      .sort();
     assert({
-      given: 'an explicit follower remove',
-      should: 'WHERE on both rootMessageId AND userId so we never delete another user\'s follow row',
-      actual: {
-        scopedRoot: eqCalls.some(
-          ([field, value]) => field === channelThreadFollowers.rootMessageId && value === 'root-1'
-        ),
-        scopedUser: eqCalls.some(
-          ([field, value]) => field === channelThreadFollowers.userId && value === 'user-1'
-        ),
-      },
-      expected: { scopedRoot: true, scopedUser: true },
+      given: 'a remove of (root-1, user-1) when other follower rows exist',
+      should: 'delete only the matching tuple — leave (root-1, user-other) and (root-other, user-1) intact',
+      actual: remaining,
+      expected: ['root-1:user-other', 'root-other:user-1'],
     });
   });
 
   it('listChannelThreadFollowers returns a flat array of user ids — needed by inbox fanout', async () => {
-    const fromWhere = vi.fn().mockResolvedValueOnce([
-      { userId: 'user-a' },
-      { userId: 'user-b' },
+    testDbState.seed('channelThreadFollowers', [
+      { rootMessageId: 'root-1', userId: 'user-a' },
+      { rootMessageId: 'root-1', userId: 'user-b' },
+      { rootMessageId: 'root-other', userId: 'user-c' },
     ]);
-    mockSelectFrom.mockReturnValueOnce({ where: fromWhere });
 
     const result = await channelMessageRepository.listChannelThreadFollowers('root-1');
 
     assert({
-      given: 'a thread root with two followers',
-      should: 'return a flat string[] of user ids — callers fan out inbox events without re-shaping',
-      actual: result,
+      given: 'a thread root with two followers and an unrelated follower on another root',
+      should: 'return a flat string[] of user ids scoped to the requested root only',
+      actual: result.sort(),
       expected: ['user-a', 'user-b'],
     });
   });
@@ -936,22 +866,25 @@ describe('channelMessageRepository thread follower helpers', () => {
 
 describe('channelMessageRepository.addChannelReaction', () => {
   it('writes (messageId, userId, emoji) verbatim and returns the inserted row', async () => {
-    mockInsertReturning.mockResolvedValueOnce([{ id: 'reaction-1' }]);
-
     const result = await channelMessageRepository.addChannelReaction({
       messageId: 'msg-1',
       userId: 'user-1',
       emoji: '👍',
     });
 
-    const values = mockInsertValues.mock.calls[0]?.[0] as Record<string, unknown>;
+    const rows = testDbState.rows('channelMessageReactions');
     assert({
       given: 'a reaction add request',
-      should: 'persist the triple (messageId, userId, emoji) and return the new row id',
-      actual: { values, result },
+      should: 'persist the triple (messageId, userId, emoji) and return the inserted row',
+      actual: {
+        rowCount: rows.length,
+        persisted: { messageId: rows[0].messageId, userId: rows[0].userId, emoji: rows[0].emoji },
+        returned: { messageId: result.messageId, userId: result.userId, emoji: result.emoji },
+      },
       expected: {
-        values: { messageId: 'msg-1', userId: 'user-1', emoji: '👍' },
-        result: { id: 'reaction-1' },
+        rowCount: 1,
+        persisted: { messageId: 'msg-1', userId: 'user-1', emoji: '👍' },
+        returned: { messageId: 'msg-1', userId: 'user-1', emoji: '👍' },
       },
     });
   });
@@ -959,26 +892,24 @@ describe('channelMessageRepository.addChannelReaction', () => {
 
 describe('channelMessageRepository.loadChannelReactionWithUser', () => {
   it('fetches the reaction with the user relation so broadcasts include name+id', async () => {
-    mockReactionsFindFirst.mockResolvedValueOnce({ id: 'reaction-1', user: { id: 'u', name: 'n' } });
+    testDbState.seed('users', [{ id: 'u-1', name: 'Alice' }]);
+    testDbState.seed('channelMessageReactions', [
+      { id: 'rx-1', messageId: 'msg-1', userId: 'u-1', emoji: '👍' },
+    ]);
 
-    await channelMessageRepository.loadChannelReactionWithUser('reaction-1');
+    const result = await channelMessageRepository.loadChannelReactionWithUser('rx-1');
 
-    const call = mockReactionsFindFirst.mock.calls[0]?.[0] as {
-      with: { user: { columns: Record<string, true> } };
-    };
     assert({
       given: 'a freshly added reaction',
       should: 'load the user relation so the broadcast payload renders the actor without a re-fetch',
-      actual: call.with.user.columns,
-      expected: { id: true, name: true },
+      actual: (result?.user as { id: string; name: string } | null),
+      expected: { id: 'u-1', name: 'Alice' },
     });
   });
 });
 
 describe('channelMessageRepository.removeChannelReaction', () => {
   it('returns the count of rows actually removed so the route can 404 on no-op', async () => {
-    mockDeleteReturning.mockResolvedValueOnce([]);
-
     const removed = await channelMessageRepository.removeChannelReaction({
       messageId: 'msg-1',
       userId: 'user-1',
@@ -986,7 +917,7 @@ describe('channelMessageRepository.removeChannelReaction', () => {
     });
 
     assert({
-      given: 'a delete that matched no rows',
+      given: 'a delete that matched no rows (table is empty)',
       should: 'return 0 so the route can return 404 instead of pretending success',
       actual: removed,
       expected: 0,
@@ -994,29 +925,28 @@ describe('channelMessageRepository.removeChannelReaction', () => {
   });
 
   it('scopes the delete to (messageId, userId, emoji) — never deletes another user\'s reaction', async () => {
-    mockDeleteReturning.mockResolvedValueOnce([{ id: 'reaction-1' }]);
+    testDbState.seed('channelMessageReactions', [
+      { id: 'rx-mine', messageId: 'msg-1', userId: 'user-1', emoji: '👍' },
+      { id: 'rx-other-user', messageId: 'msg-1', userId: 'user-other', emoji: '👍' },
+      { id: 'rx-other-msg', messageId: 'msg-other', userId: 'user-1', emoji: '👍' },
+      { id: 'rx-other-emoji', messageId: 'msg-1', userId: 'user-1', emoji: '🎉' },
+    ]);
 
-    await channelMessageRepository.removeChannelReaction({
+    const removed = await channelMessageRepository.removeChannelReaction({
       messageId: 'msg-1',
       userId: 'user-1',
       emoji: '👍',
     });
 
-    const eqCalls = vi.mocked(eq).mock.calls;
-    const hasUserId = eqCalls.some(
-      ([field, value]) => field === channelMessageReactions.userId && value === 'user-1'
-    );
-    const hasMessageId = eqCalls.some(
-      ([field, value]) => field === channelMessageReactions.messageId && value === 'msg-1'
-    );
-    const hasEmoji = eqCalls.some(
-      ([field, value]) => field === channelMessageReactions.emoji && value === '👍'
-    );
+    const remaining = testDbState
+      .rows('channelMessageReactions')
+      .map((r) => r.id)
+      .sort();
     assert({
-      given: 'a reaction-removal request',
-      should: 'WHERE on all three of messageId, userId, and emoji so we only remove the requester\'s own reaction',
-      actual: { hasMessageId, hasUserId, hasEmoji },
-      expected: { hasMessageId: true, hasUserId: true, hasEmoji: true },
+      given: 'a reaction-removal request when reactions for other users / messages / emojis exist',
+      should: 'delete only the (msg-1, user-1, 👍) row, return 1, and leave the three unrelated rows intact',
+      actual: { removed, remaining },
+      expected: { removed: 1, remaining: ['rx-other-emoji', 'rx-other-msg', 'rx-other-user'] },
     });
   });
 });
@@ -1047,38 +977,6 @@ describe('channelMessageRepository surface', () => {
         'updateChannelMessageContent',
         'upsertChannelReadStatus',
       ],
-    });
-  });
-});
-
-// Anchor: locks the parentId IS NULL semantics into the test suite even if the
-// route refactor diverges in shape later. PR 3 will remove this filter only by
-// changing the call signature to accept parentId — at which point this test
-// must be deliberately updated.
-describe('channelMessageRepository.listChannelMessages [thread-prep invariant]', () => {
-  it('uses isNull(channelMessages.parentId) — not a different field — to scope to top-level', async () => {
-    mockChannelMessagesFindMany.mockResolvedValue([]);
-
-    await channelMessageRepository.listChannelMessages({ pageId: 'page-1', limit: 10 });
-
-    assert({
-      given: 'a top-level fetch (PR 1 semantics)',
-      should: 'pass channelMessages.parentId to isNull — accidentally passing isActive or pageId would silently break thread isolation later',
-      actual: vi.mocked(isNull).mock.calls.flat(),
-      expected: [channelMessages.parentId],
-    });
-  });
-
-  it('combines page filters with the parentId filter via and()', async () => {
-    mockChannelMessagesFindMany.mockResolvedValue([]);
-
-    await channelMessageRepository.listChannelMessages({ pageId: 'page-1', limit: 10 });
-
-    assert({
-      given: 'three top-level filters (pageId, isActive, parentId IS NULL)',
-      should: 'compose them with and() — never with or()',
-      actual: vi.mocked(and).mock.calls.length > 0,
-      expected: true,
     });
   });
 });

--- a/packages/lib/src/services/__tests__/channel-message-repository.test.ts
+++ b/packages/lib/src/services/__tests__/channel-message-repository.test.ts
@@ -459,6 +459,22 @@ describe('channelMessageRepository.restoreChannelMessage', () => {
       expected: { count: 1, replyActive: true, parentReplyCount: 5 },
     });
   });
+
+  it('locks the parent row for the duration of the restore tx (SELECT ... FOR UPDATE) so a concurrent soft-delete cannot race the bump', async () => {
+    testDbState.seed('channelMessages', [
+      { id: 'parent-1', pageId: 'page-1', isActive: true, parentId: null, replyCount: 1 },
+      { id: 'reply-1', pageId: 'page-1', isActive: false, parentId: 'parent-1', replyCount: 0 },
+    ]);
+
+    await channelMessageRepository.restoreChannelMessage('reply-1');
+
+    assert({
+      given: 'a restore of a thread reply whose parent must be re-validated under lock',
+      should: 'invoke .for("update") against channelMessages exactly once — the lock blocks a concurrent softDelete until the bump commits',
+      actual: testDbState.selectsForUpdate('channelMessages').length,
+      expected: 1,
+    });
+  });
 });
 
 describe('channelMessageRepository.insertChannelThreadReply', () => {
@@ -484,6 +500,19 @@ describe('channelMessageRepository.insertChannelThreadReply', () => {
       },
     ]);
   };
+
+  it('locks the parent row for the duration of the tx (SELECT ... FOR UPDATE) so a concurrent soft-delete cannot orphan the reply', async () => {
+    seedActiveParent();
+
+    await channelMessageRepository.insertChannelThreadReply(baseInput);
+
+    assert({
+      given: 'a parent validation read inside the insert tx',
+      should: 'invoke .for("update") against channelMessages exactly once — the lock blocks a concurrent softDelete until this tx commits',
+      actual: testDbState.selectsForUpdate('channelMessages').length,
+      expected: 1,
+    });
+  });
 
   it('rejects with parent_not_found when the parent row is missing', async () => {
     const result = await channelMessageRepository.insertChannelThreadReply(baseInput);

--- a/packages/lib/src/services/__tests__/channel-message-repository.test.ts
+++ b/packages/lib/src/services/__tests__/channel-message-repository.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Boundary-level test double: see test-doubles/db.ts for the design rationale
 // (no thenable Drizzle chain mocks; assertions read observable state, not the
 // order of intermediate builder method calls).
-import { testDb, testDbState } from './test-doubles/db';
+import { testDbState } from './test-doubles/db';
 
 vi.mock('@pagespace/db/db', async () => {
   const m = await import('./test-doubles/db');

--- a/packages/lib/src/services/__tests__/dm-message-repository.test.ts
+++ b/packages/lib/src/services/__tests__/dm-message-repository.test.ts
@@ -1,5 +1,31 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+// Boundary-level test double: see test-doubles/db.ts for the design rationale.
+import { testDb, testDbState } from './test-doubles/db';
+
+vi.mock('@pagespace/db/db', async () => {
+  const m = await import('./test-doubles/db');
+  return { db: m.testDb };
+});
+vi.mock('@pagespace/db/operators', async () => {
+  const m = await import('./test-doubles/db');
+  return m.operators;
+});
+vi.mock('@pagespace/db/schema/chat', async () => {
+  const m = await import('./test-doubles/db');
+  return m.chatSchema;
+});
+vi.mock('@pagespace/db/schema/social', async () => {
+  const m = await import('./test-doubles/db');
+  return m.socialSchema;
+});
+vi.mock('@pagespace/db/schema/storage', async () => {
+  const m = await import('./test-doubles/db');
+  return m.storageSchema;
+});
+
+import { dmMessageRepository } from '../dm-message-repository';
+
 interface AssertParams {
   given: string;
   should: string;
@@ -8,227 +34,84 @@ interface AssertParams {
 }
 
 const assert = ({ given, should, actual, expected }: AssertParams): void => {
-  const message = `Given ${given}, should ${should}`;
-  expect(actual, message).toEqual(expected);
+  expect(actual, `Given ${given}, should ${should}`).toEqual(expected);
 };
 
-const {
-  mockUpdateSet,
-  mockUpdateWhere,
-  mockUpdateReturning,
-  mockDeleteWhere,
-  mockDeleteReturning,
-  mockExecute,
-  mockTransaction,
-  mockInsertValues,
-  mockInsertReturning,
-  mockInsertOnConflictDoNothing,
-  mockDirectMessagesFindFirst,
-  mockDirectMessagesFindMany,
-  mockReactionsFindFirst,
-  mockSelectFrom,
-} = vi.hoisted(() => ({
-  mockUpdateSet: vi.fn(),
-  mockUpdateWhere: vi.fn(),
-  mockUpdateReturning: vi.fn(),
-  mockDeleteWhere: vi.fn(),
-  mockDeleteReturning: vi.fn(),
-  mockExecute: vi.fn(),
-  mockTransaction: vi.fn(),
-  mockInsertValues: vi.fn(),
-  mockInsertReturning: vi.fn(),
-  mockInsertOnConflictDoNothing: vi.fn(),
-  mockDirectMessagesFindFirst: vi.fn(),
-  mockDirectMessagesFindMany: vi.fn(),
-  mockReactionsFindFirst: vi.fn(),
-  mockSelectFrom: vi.fn(),
-}));
-
-vi.mock('@pagespace/db/db', () => ({
-  db: {
-    query: {
-      dmConversations: { findFirst: vi.fn() },
-      files: { findFirst: vi.fn() },
-      fileConversations: { findFirst: vi.fn() },
-      directMessages: {
-        findFirst: mockDirectMessagesFindFirst,
-        findMany: mockDirectMessagesFindMany,
-      },
-      dmMessageReactions: { findFirst: mockReactionsFindFirst },
-    },
-    insert: vi.fn(() => ({ values: mockInsertValues })),
-    update: vi.fn(() => ({ set: mockUpdateSet })),
-    delete: vi.fn(() => ({ where: mockDeleteWhere })),
-    select: vi.fn(() => ({ from: mockSelectFrom })),
-    execute: mockExecute,
-    transaction: mockTransaction,
-  },
-}));
-
-vi.mock('@pagespace/db/operators', () => {
-  const sql = Object.assign(
-    vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values })),
-    {
-      join: vi.fn((items: unknown[], separator: unknown) => ({ items, separator })),
-    }
-  );
-
-  return {
-    and: vi.fn((...conditions: unknown[]) => ({ op: 'and', conditions })),
-    asc: vi.fn((field: unknown) => ({ op: 'asc', field })),
-    desc: vi.fn((field: unknown) => ({ op: 'desc', field })),
-    eq: vi.fn((field: unknown, value: unknown) => ({ op: 'eq', field, value })),
-    gt: vi.fn((field: unknown, value: unknown) => ({ op: 'gt', field, value })),
-    isNotNull: vi.fn((field: unknown) => ({ op: 'isNotNull', field })),
-    isNull: vi.fn((field: unknown) => ({ op: 'isNull', field })),
-    lt: vi.fn((field: unknown, value: unknown) => ({ op: 'lt', field, value })),
-    or: vi.fn((...conditions: unknown[]) => ({ op: 'or', conditions })),
-    sql,
-  };
+beforeEach(() => {
+  testDbState.reset();
 });
 
-vi.mock('@pagespace/db/schema/social', () => ({
-  dmConversations: {
-    id: 'dm_conversations.id',
-    participant1Id: 'dm_conversations.participant1Id',
-    participant2Id: 'dm_conversations.participant2Id',
-    lastMessageAt: 'dm_conversations.lastMessageAt',
-  },
-  directMessages: {
-    id: 'direct_messages.id',
-    conversationId: 'direct_messages.conversationId',
-    senderId: 'direct_messages.senderId',
-    content: 'direct_messages.content',
-    fileId: 'direct_messages.fileId',
-    attachmentMeta: 'direct_messages.attachmentMeta',
-    isRead: 'direct_messages.isRead',
-    readAt: 'direct_messages.readAt',
-    isActive: 'direct_messages.isActive',
-    deletedAt: 'direct_messages.deletedAt',
-    createdAt: 'direct_messages.createdAt',
-    parentId: 'direct_messages.parentId',
-    replyCount: 'direct_messages.replyCount',
-    lastReplyAt: 'direct_messages.lastReplyAt',
-    mirroredFromId: 'direct_messages.mirroredFromId',
-  },
-  dmThreadFollowers: {
-    rootMessageId: 'dm_thread_followers.rootMessageId',
-    userId: 'dm_thread_followers.userId',
-  },
-  dmMessageReactions: {
-    id: 'dm_message_reactions.id',
-    messageId: 'dm_message_reactions.messageId',
-    userId: 'dm_message_reactions.userId',
-    emoji: 'dm_message_reactions.emoji',
-  },
-}));
-
-vi.mock('@pagespace/db/schema/storage', () => ({
-  files: {
-    id: 'files.id',
-    createdBy: 'files.createdBy',
-  },
-  fileConversations: {
-    fileId: 'file_conversations.fileId',
-    conversationId: 'file_conversations.conversationId',
-  },
-}));
-
-import { db } from '@pagespace/db/db';
-import { directMessages, dmMessageReactions, dmThreadFollowers } from '@pagespace/db/schema/social';
-import { asc, eq, gt, isNotNull, isNull, lt } from '@pagespace/db/operators';
-import { dmMessageRepository } from '../dm-message-repository';
-
-describe('dmMessageRepository lifecycle', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-
-    mockUpdateReturning.mockResolvedValue([{ id: 'msg-1', parentId: null }]);
-    mockUpdateWhere.mockReturnValue({
-      returning: mockUpdateReturning,
-      then: (resolve: (v: unknown) => unknown) => resolve(undefined),
-    });
-    mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
-    vi.mocked(db.update).mockReturnValue({ set: mockUpdateSet } as never);
-
-    mockInsertReturning.mockResolvedValue([{ id: 'msg-1' }]);
-    mockInsertOnConflictDoNothing.mockResolvedValue(undefined);
-    mockInsertValues.mockReturnValue({
-      returning: mockInsertReturning,
-      onConflictDoNothing: mockInsertOnConflictDoNothing,
-    });
-    vi.mocked(db.insert).mockReturnValue({ values: mockInsertValues } as never);
-
-    mockDeleteReturning.mockResolvedValue([
-      { id: 'msg-1', conversationId: 'conv-1', fileId: 'file-1' },
+describe('dmMessageRepository.softDeleteMessage', () => {
+  it('records deletedAt without falsifying the read receipt', async () => {
+    testDbState.seed('directMessages', [
+      { id: 'msg-1', conversationId: 'conv-1', senderId: 'u-1', isActive: true, isRead: true, readAt: new Date('2026-05-01T10:00:00Z'), parentId: null, replyCount: 0 },
     ]);
-    mockDeleteWhere.mockReturnValue({
-      returning: mockDeleteReturning,
-      then: (resolve: (v: unknown) => unknown) => resolve(undefined),
-    });
-    vi.mocked(db.delete).mockReturnValue({ where: mockDeleteWhere } as never);
-
-    mockSelectFrom.mockReturnValue({
-      where: vi.fn().mockResolvedValue([]),
-    });
-    vi.mocked(db.select).mockReturnValue({ from: mockSelectFrom } as never);
-
-    mockExecute.mockResolvedValue({ rows: [] });
-    // Default: pass db itself as the tx so all chain mocks above apply unchanged.
-    mockTransaction.mockImplementation(
-      async (callback: (tx: unknown) => Promise<unknown>) => callback(db)
-    );
-  });
-
-  it('given_softDelete_recordsDeletedAtWithoutFalsifyingReadReceipt', async () => {
-    mockUpdateReturning.mockResolvedValueOnce([{ id: 'msg-1', parentId: null }]);
 
     const count = await dmMessageRepository.softDeleteMessage('msg-1');
 
-    expect(count).toBe(1);
-    const updatePayload = mockUpdateSet.mock.calls[0]?.[0] as Record<string, unknown>;
-    expect(updatePayload.isActive).toBe(false);
-    expect(updatePayload.deletedAt).toBeInstanceOf(Date);
-    expect(updatePayload).not.toHaveProperty('isRead');
-    expect(updatePayload).not.toHaveProperty('readAt');
+    const row = testDbState.rows('directMessages')[0];
+    assert({
+      given: 'a soft-delete of an active DM with a prior read receipt',
+      should: 'flip isActive=false and stamp deletedAt — the read flags must remain truthful evidence the recipient saw it',
+      actual: {
+        count,
+        isActive: row.isActive,
+        deletedAtIsDate: row.deletedAt instanceof Date,
+        isRead: row.isRead,
+        readAt: row.readAt,
+      },
+      expected: {
+        count: 1,
+        isActive: false,
+        deletedAtIsDate: true,
+        isRead: true,
+        readAt: new Date('2026-05-01T10:00:00Z'),
+      },
+    });
   });
 
-  it('given_softDeleteOfThreadReply_decrementsParentReplyCount', async () => {
-    mockUpdateReturning.mockResolvedValueOnce([{ id: 'reply-1', parentId: 'parent-1' }]);
+  it('decrements parent replyCount when the soft-deleted row is a thread reply', async () => {
+    testDbState.seed('directMessages', [
+      { id: 'parent-1', conversationId: 'conv-1', senderId: 'u-parent', isActive: true, parentId: null, replyCount: 3 },
+      { id: 'reply-1', conversationId: 'conv-1', senderId: 'u-replier', isActive: true, parentId: 'parent-1', replyCount: 0 },
+    ]);
 
     await dmMessageRepository.softDeleteMessage('reply-1');
 
-    const setCalls = mockUpdateSet.mock.calls.map((c) => c[0] as Record<string, unknown>);
+    const rows = testDbState.rows('directMessages');
     assert({
-      given: 'a soft-delete of a DM thread reply',
-      should: 'issue two updates inside the same tx — one to flip isActive, one to decrement parent.replyCount',
+      given: 'a soft-delete of a DM thread reply with parent.replyCount=3',
+      should: 'decrement the parent counter to 2 in the same transaction as the reply tombstone',
       actual: {
-        firstSetIsActive: setCalls[0]?.isActive,
-        secondHasReplyCount: 'replyCount' in (setCalls[1] ?? {}),
+        replyActive: rows.find((r) => r.id === 'reply-1')?.isActive,
+        parentReplyCount: rows.find((r) => r.id === 'parent-1')?.replyCount,
       },
-      expected: { firstSetIsActive: false, secondHasReplyCount: true },
+      expected: { replyActive: false, parentReplyCount: 2 },
     });
   });
 
-  it('given_softDeleteOfTopLevelDm_doesNotIssueParentCounterUpdate', async () => {
-    mockUpdateReturning.mockResolvedValueOnce([{ id: 'top-1', parentId: null }]);
+  it('does not issue a parent-counter update when the row is top-level (parentId is null)', async () => {
+    testDbState.seed('directMessages', [
+      { id: 'top-1', conversationId: 'conv-1', senderId: 'u-1', isActive: true, parentId: null, replyCount: 9 },
+    ]);
 
     await dmMessageRepository.softDeleteMessage('top-1');
 
+    const row = testDbState.rows('directMessages')[0];
     assert({
       given: 'a soft-delete of a top-level DM (parentId IS NULL)',
-      should: 'only run the isActive flip — never touch a parent counter',
-      actual: mockUpdateSet.mock.calls.length,
-      expected: 1,
+      should: 'flip isActive but never touch its own replyCount',
+      actual: { isActive: row.isActive, replyCount: row.replyCount },
+      expected: { isActive: false, replyCount: 9 },
     });
   });
 
-  it('given_softDelete_returnsZero_whenAlreadyInactive', async () => {
-    // The where(isActive=true) filter makes a second delete a no-op; the route
-    // must use the returned count to skip duplicate audit + broadcast.
-    mockUpdateReturning.mockResolvedValueOnce([]);
+  it('returns 0 when the message is already inactive', async () => {
+    testDbState.seed('directMessages', [
+      { id: 'msg-1', conversationId: 'conv-1', senderId: 'u-1', isActive: false, parentId: null, replyCount: 0 },
+    ]);
 
-    const count = await dmMessageRepository.softDeleteMessage('already-deleted');
+    const count = await dmMessageRepository.softDeleteMessage('msg-1');
 
     assert({
       given: 'a soft-delete of an already-inactive DM',
@@ -237,99 +120,79 @@ describe('dmMessageRepository lifecycle', () => {
       expected: 0,
     });
   });
+});
 
-  // Helper for restore tests: stub the parent re-read inside the tx.
-  // restoreDmMessage uses `tx.select().from().where().for('update')`.
-  const stubRestoreParent = (parent: Record<string, unknown> | null) => {
-    const forFn = vi.fn().mockResolvedValue(parent ? [parent] : []);
-    const whereFn = vi.fn(() => ({ for: forFn }));
-    const fromFn = vi.fn(() => ({ where: whereFn }));
-    vi.mocked(db.select).mockReturnValueOnce({ from: fromFn } as never);
-    return { forFn };
-  };
-
-  it('given_restoreOfThreadReply_incrementsParentReplyCount_whenParentStillActive', async () => {
-    mockUpdateReturning.mockResolvedValueOnce([{ id: 'reply-1', parentId: 'parent-1' }]);
-    stubRestoreParent({ id: 'parent-1', isActive: true });
+describe('dmMessageRepository.restoreDmMessage', () => {
+  it('flips isActive=true and resets deletedAt; bumps parent.replyCount when the parent is still active', async () => {
+    testDbState.seed('directMessages', [
+      { id: 'parent-1', conversationId: 'conv-1', senderId: 'u-parent', isActive: true, parentId: null, replyCount: 1 },
+      { id: 'reply-1', conversationId: 'conv-1', senderId: 'u-replier', isActive: false, deletedAt: new Date('2026-04-01T00:00:00Z'), parentId: 'parent-1', replyCount: 0 },
+    ]);
 
     const count = await dmMessageRepository.restoreDmMessage('reply-1');
 
-    expect(count).toBe(1);
-    const setCalls = mockUpdateSet.mock.calls.map((c) => c[0] as Record<string, unknown>);
+    const rows = testDbState.rows('directMessages');
+    const reply = rows.find((r) => r.id === 'reply-1');
+    const parent = rows.find((r) => r.id === 'parent-1');
     assert({
       given: 'a restore of a DM thread reply whose parent is still active',
-      should: 'flip isActive=true, reset deletedAt, and increment parent.replyCount in the same tx',
+      should: 'flip the reply isActive=true, NULL deletedAt, and bump parent.replyCount to 2 in the same tx',
       actual: {
-        firstSetIsActive: setCalls[0]?.isActive,
+        count,
+        replyActive: reply?.isActive,
         // deletedAt MUST be reset on restore — otherwise the retention purge
         // (filters by deletedAt < olderThan) could either skip the row forever
         // or purge it unexpectedly when re-soft-deleted.
-        firstSetDeletedAt: setCalls[0]?.deletedAt,
-        secondHasReplyCount: 'replyCount' in (setCalls[1] ?? {}),
+        replyDeletedAt: reply?.deletedAt,
+        parentReplyCount: parent?.replyCount,
       },
-      expected: {
-        firstSetIsActive: true,
-        firstSetDeletedAt: null,
-        secondHasReplyCount: true,
-      },
+      expected: { count: 1, replyActive: true, replyDeletedAt: null, parentReplyCount: 2 },
     });
   });
 
-  it('given_restoreOfThreadReply_skipsParentBump_whenParentSoftDeleted_butStillReturns1', async () => {
-    mockUpdateReturning.mockResolvedValueOnce([{ id: 'reply-1', parentId: 'parent-1' }]);
-    stubRestoreParent({ id: 'parent-1', isActive: false });
+  it('does NOT bump the parent counter when the parent has been soft-deleted in the meantime, but still returns 1', async () => {
+    testDbState.seed('directMessages', [
+      { id: 'parent-1', conversationId: 'conv-1', senderId: 'u-parent', isActive: false, parentId: null, replyCount: 5 },
+      { id: 'reply-1', conversationId: 'conv-1', senderId: 'u-replier', isActive: false, parentId: 'parent-1', replyCount: 0 },
+    ]);
 
     const count = await dmMessageRepository.restoreDmMessage('reply-1');
 
+    const parent = testDbState.rows('directMessages').find((r) => r.id === 'parent-1');
     assert({
       given: 'a restore of a DM thread reply whose parent is itself soft-deleted',
-      should: 'flip isActive=true on the reply, skip the parent bump, AND still return 1',
-      actual: { count, updateCount: mockUpdateSet.mock.calls.length },
-      expected: { count: 1, updateCount: 1 },
+      should: 'restore the reply but leave the tombstoned parent counter exactly where it was',
+      actual: { count, parentReplyCount: parent?.replyCount },
+      expected: { count: 1, parentReplyCount: 5 },
     });
-  });
-
-  it('given_restoreOfThreadReply_locksParentRow_FOR_UPDATE', async () => {
-    mockUpdateReturning.mockResolvedValueOnce([{ id: 'reply-1', parentId: 'parent-1' }]);
-    const { forFn } = stubRestoreParent({ id: 'parent-1', isActive: true });
-
-    await dmMessageRepository.restoreDmMessage('reply-1');
-
-    assert({
-      given: 'a DM restore parent re-read inside the tx',
-      should: 'invoke .for("update") so a concurrent softDelete blocks until the restore commits',
-      actual: forFn.mock.calls[0]?.[0],
-      expected: 'update',
-    });
-  });
-
-  it('given_inactiveDmsPastRetention_purgesByDeletedAtAndReleasesConversationFileLinks', async () => {
-    // The purge tx callback uses tx.delete + tx.execute; mock transaction with
-    // exactly that surface so we don't fall through to the db pass-through used
-    // by the soft-delete tests above.
-    mockTransaction.mockImplementationOnce(async (callback: (tx: unknown) => Promise<unknown>) =>
-      callback({ delete: vi.mocked(db.delete), execute: mockExecute })
-    );
-
-    const cutoff = new Date('2026-04-01T00:00:00.000Z');
-
-    const count = await dmMessageRepository.purgeInactiveMessages(cutoff);
-
-    expect(count).toBe(1);
-    expect(isNotNull).toHaveBeenCalledWith(directMessages.deletedAt);
-    expect(lt).toHaveBeenCalledWith(directMessages.deletedAt, cutoff);
-    expect(mockDeleteReturning).toHaveBeenCalledWith({
-      id: directMessages.id,
-      conversationId: directMessages.conversationId,
-      fileId: directMessages.fileId,
-    });
-    expect(mockExecute).toHaveBeenCalledTimes(1);
   });
 });
 
-// =============================================================================
-// Thread reply functions
-// =============================================================================
+describe('dmMessageRepository.purgeInactiveMessages', () => {
+  it('purges only DMs older than the cutoff and returns the row count', async () => {
+    const cutoff = new Date('2026-04-01T00:00:00Z');
+    const old = new Date('2026-03-01T00:00:00Z');
+    const recent = new Date('2026-05-01T00:00:00Z');
+    testDbState.seed('directMessages', [
+      { id: 'old-purge-me', conversationId: 'conv-1', senderId: 'u-1', isActive: false, deletedAt: old, parentId: null, fileId: 'file-1' },
+      { id: 'recent-keep', conversationId: 'conv-1', senderId: 'u-1', isActive: false, deletedAt: recent, parentId: null, fileId: null },
+      { id: 'active-keep', conversationId: 'conv-1', senderId: 'u-1', isActive: true, deletedAt: null, parentId: null, fileId: null },
+    ]);
+
+    const count = await dmMessageRepository.purgeInactiveMessages(cutoff);
+
+    const remaining = testDbState
+      .rows('directMessages')
+      .map((r) => r.id)
+      .sort();
+    assert({
+      given: 'one stale tombstone, one fresh tombstone, and one active DM',
+      should: 'hard-delete only the stale tombstone (count 1) and leave both other rows in place',
+      actual: { count, remaining },
+      expected: { count: 1, remaining: ['active-keep', 'recent-keep'] },
+    });
+  });
+});
 
 describe('dmMessageRepository.insertDmThreadReply', () => {
   const baseInput = {
@@ -341,547 +204,562 @@ describe('dmMessageRepository.insertDmThreadReply', () => {
     attachmentMeta: null,
   };
 
-  // The helper validates the parent with `tx.select(...).from(...).where(...).for('update')`.
-  // This stubs the FOR UPDATE chain to return the supplied parent row.
-  const stubParentForUpdate = (parent: Record<string, unknown> | null) => {
-    const forFn = vi.fn().mockResolvedValue(parent ? [parent] : []);
-    const whereFn = vi.fn(() => ({ for: forFn }));
-    const fromFn = vi.fn(() => ({ where: whereFn }));
-    vi.mocked(db.select).mockReturnValueOnce({ from: fromFn } as never);
-    return { forFn, whereFn, fromFn };
+  const seedActiveParent = (overrides: Partial<Record<string, unknown>> = {}) => {
+    testDbState.seed('directMessages', [
+      {
+        id: 'parent-1',
+        conversationId: 'conv-1',
+        senderId: 'user-parent',
+        parentId: null,
+        isActive: true,
+        replyCount: 0,
+        lastReplyAt: null,
+        ...overrides,
+      },
+    ]);
   };
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-
-    mockUpdateReturning.mockResolvedValue([{ replyCount: 1, lastReplyAt: new Date() }]);
-    mockUpdateWhere.mockReturnValue({
-      returning: mockUpdateReturning,
-      then: (resolve: (v: unknown) => unknown) => resolve(undefined),
-    });
-    mockUpdateSet.mockReturnValue({ where: mockUpdateWhere });
-    vi.mocked(db.update).mockReturnValue({ set: mockUpdateSet } as never);
-
-    mockInsertReturning.mockResolvedValue([{ id: 'reply-1', createdAt: new Date(), parentId: 'parent-1' }]);
-    mockInsertOnConflictDoNothing.mockResolvedValue(undefined);
-    mockInsertValues.mockReturnValue({
-      returning: mockInsertReturning,
-      onConflictDoNothing: mockInsertOnConflictDoNothing,
-    });
-    vi.mocked(db.insert).mockReturnValue({ values: mockInsertValues } as never);
-
-    mockTransaction.mockImplementation(
-      async (callback: (tx: unknown) => Promise<unknown>) => callback(db)
-    );
-  });
-
-  it('locks the parent row for the duration of the tx (SELECT ... FOR UPDATE) so a concurrent soft-delete cannot orphan the reply', async () => {
-    const { forFn } = stubParentForUpdate({
-      id: 'parent-1',
-      conversationId: 'conv-1',
-      parentId: null,
-      senderId: 'user-parent',
-      isActive: true,
-    });
-    mockInsertReturning.mockResolvedValueOnce([
-      { id: 'reply-1', createdAt: new Date(), parentId: 'parent-1' },
-    ]);
-    mockUpdateReturning.mockResolvedValueOnce([
-      { replyCount: 1, lastReplyAt: new Date() },
-    ]);
-
-    await dmMessageRepository.insertDmThreadReply(baseInput);
-
-    assert({
-      given: 'a DM parent validation read inside the insert tx',
-      should: 'invoke .for("update") so a concurrent softDelete blocks until this tx commits',
-      actual: forFn.mock.calls[0]?.[0],
-      expected: 'update',
-    });
-  });
-
-  it('rejects with parent_not_found when the parent is missing or inactive', async () => {
-    stubParentForUpdate(null);
-
+  it('rejects with parent_not_found when the parent is missing', async () => {
     const result = await dmMessageRepository.insertDmThreadReply(baseInput);
 
     assert({
-      given: 'a parent id that does not resolve to an active DM row',
+      given: 'a parent id that does not resolve to any row',
       should: 'return parent_not_found WITHOUT inserting a reply or follower row',
-      actual: { kind: result.kind, insertCount: mockInsertValues.mock.calls.length },
-      expected: { kind: 'parent_not_found', insertCount: 0 },
+      actual: {
+        kind: result.kind,
+        rowCount: testDbState.count('directMessages'),
+        followerCount: testDbState.count('dmThreadFollowers'),
+      },
+      expected: { kind: 'parent_not_found', rowCount: 0, followerCount: 0 },
     });
   });
 
   it('rejects with parent_not_found when the parent row exists but is soft-deleted (isActive=false)', async () => {
-    stubParentForUpdate({
-      id: 'parent-1',
-      conversationId: 'conv-1',
-      parentId: null,
-      senderId: 'user-parent',
-      isActive: false,
-    });
+    seedActiveParent({ isActive: false });
 
     const result = await dmMessageRepository.insertDmThreadReply(baseInput);
 
     assert({
       given: 'a DM parent that has been soft-deleted',
       should: 'return parent_not_found — clients cannot reply into a tombstoned thread',
-      actual: { kind: result.kind, insertCount: mockInsertValues.mock.calls.length },
-      expected: { kind: 'parent_not_found', insertCount: 0 },
+      actual: { kind: result.kind, rowCount: testDbState.count('directMessages') },
+      expected: { kind: 'parent_not_found', rowCount: 1 },
     });
   });
 
   it('rejects with parent_wrong_conversation when the parent belongs to a different conversation', async () => {
-    stubParentForUpdate({
-      id: 'parent-1',
-      conversationId: 'other-conv',
-      parentId: null,
-      senderId: 'user-parent',
-      isActive: true,
-    });
+    seedActiveParent({ conversationId: 'other-conv' });
 
     const result = await dmMessageRepository.insertDmThreadReply(baseInput);
 
     assert({
       given: 'a parent id whose conversationId differs from the request conversation',
       should: 'return parent_wrong_conversation so the route can 400',
-      actual: { kind: result.kind, insertCount: mockInsertValues.mock.calls.length },
-      expected: { kind: 'parent_wrong_conversation', insertCount: 0 },
+      actual: { kind: result.kind, rowCount: testDbState.count('directMessages') },
+      expected: { kind: 'parent_wrong_conversation', rowCount: 1 },
     });
   });
 
   it('rejects with parent_not_top_level when the parent itself has parentId set (depth-2 attempt)', async () => {
-    stubParentForUpdate({
-      id: 'parent-1',
-      conversationId: 'conv-1',
-      parentId: 'grandparent',
-      senderId: 'user-parent',
-      isActive: true,
-    });
+    seedActiveParent({ parentId: 'grandparent' });
 
     const result = await dmMessageRepository.insertDmThreadReply(baseInput);
 
     assert({
       given: 'a DM parent that is itself a thread reply',
       should: 'return parent_not_top_level — DM threads are exactly one level deep',
-      actual: { kind: result.kind, insertCount: mockInsertValues.mock.calls.length },
-      expected: { kind: 'parent_not_top_level', insertCount: 0 },
+      actual: { kind: result.kind, rowCount: testDbState.count('directMessages') },
+      expected: { kind: 'parent_not_top_level', rowCount: 1 },
     });
   });
 
   it('inserts the reply with parentId set, bumps replyCount + lastReplyAt, and upserts both followers', async () => {
-    stubParentForUpdate({
-      id: 'parent-1',
-      conversationId: 'conv-1',
-      parentId: null,
-      senderId: 'user-parent',
-      isActive: true,
-    });
-    const replyCreatedAt = new Date('2026-05-04T12:00:00Z');
-    mockInsertReturning.mockResolvedValueOnce([
-      { id: 'reply-1', createdAt: replyCreatedAt, parentId: 'parent-1' },
-    ]);
-    mockUpdateReturning.mockResolvedValueOnce([
-      { replyCount: 1, lastReplyAt: replyCreatedAt },
-    ]);
+    seedActiveParent();
 
     const result = await dmMessageRepository.insertDmThreadReply(baseInput);
 
-    const replyValues = mockInsertValues.mock.calls[0]?.[0] as Record<string, unknown>;
-    const followerValues = mockInsertValues.mock.calls[1]?.[0] as Array<Record<string, unknown>>;
-    const updateSet = mockUpdateSet.mock.calls[0]?.[0] as Record<string, unknown>;
+    const messages = testDbState.rows('directMessages');
+    const followers = testDbState.rows('dmThreadFollowers');
+    const reply = messages.find((r) => r.parentId === 'parent-1');
+    const parent = messages.find((r) => r.id === 'parent-1');
     assert({
       given: 'a happy-path DM thread reply with a distinct replier and parent author',
-      should: 'insert the reply with parentId, set lastReplyAt, and upsert followers for parent author + replier',
+      should: 'insert the reply with parentId, bump parent.replyCount, set lastReplyAt, and add follower rows for parent author + replier',
       actual: {
         kind: result.kind,
-        replyParent: replyValues.parentId,
-        updateHasReplyCount: 'replyCount' in updateSet,
-        updateLastReplyAt: updateSet.lastReplyAt,
-        followerUserIds: followerValues.map((r) => r.userId).sort(),
-        usedOnConflictDoNothing: mockInsertOnConflictDoNothing.mock.calls.length,
+        replyParentId: reply?.parentId,
+        parentReplyCount: parent?.replyCount,
+        parentLastReplyAt: parent?.lastReplyAt,
+        followerUserIds: followers.map((f) => f.userId).sort(),
       },
       expected: {
         kind: 'ok',
-        replyParent: 'parent-1',
-        updateHasReplyCount: true,
-        updateLastReplyAt: replyCreatedAt,
+        replyParentId: 'parent-1',
+        parentReplyCount: 1,
+        parentLastReplyAt: reply?.createdAt,
         followerUserIds: ['user-parent', 'user-replier'],
-        usedOnConflictDoNothing: 1,
       },
-    });
-  });
-
-  it('dedupes followers when the parent author replies to their own DM thread', async () => {
-    stubParentForUpdate({
-      id: 'parent-1',
-      conversationId: 'conv-1',
-      parentId: null,
-      senderId: 'user-self',
-      isActive: true,
-    });
-    mockInsertReturning.mockResolvedValueOnce([
-      { id: 'reply-1', createdAt: new Date(), parentId: 'parent-1' },
-    ]);
-    mockUpdateReturning.mockResolvedValueOnce([
-      { replyCount: 1, lastReplyAt: new Date() },
-    ]);
-
-    await dmMessageRepository.insertDmThreadReply({
-      ...baseInput,
-      senderId: 'user-self',
-    });
-
-    const followerValues = mockInsertValues.mock.calls[1]?.[0] as Array<Record<string, unknown>>;
-    assert({
-      given: 'a DM reply where parent author and replier are the same user',
-      should: 'send a single follower row to onConflictDoNothing — Postgres rejects duplicates within one INSERT',
-      actual: followerValues,
-      expected: [{ rootMessageId: 'parent-1', userId: 'user-self' }],
     });
   });
 
   it('writes a second top-level row with mirroredFromId set when alsoSendToParent is true', async () => {
-    stubParentForUpdate({
-      id: 'parent-1',
-      conversationId: 'conv-1',
-      parentId: null,
-      senderId: 'user-parent',
-      isActive: true,
-    });
-    mockInsertReturning
-      .mockResolvedValueOnce([
-        { id: 'reply-1', createdAt: new Date('2026-05-04T12:00:00Z'), parentId: 'parent-1' },
-      ])
-      .mockResolvedValueOnce([
-        { id: 'mirror-1', createdAt: new Date('2026-05-04T12:00:01Z'), mirroredFromId: 'reply-1' },
-      ]);
-    mockUpdateReturning.mockResolvedValueOnce([
-      { replyCount: 1, lastReplyAt: new Date('2026-05-04T12:00:00Z') },
-    ]);
+    seedActiveParent();
 
     const result = await dmMessageRepository.insertDmThreadReply({
       ...baseInput,
       alsoSendToParent: true,
     });
 
-    const insertCount = mockInsertValues.mock.calls.length;
-    const mirrorValues = mockInsertValues.mock.calls[2]?.[0] as Record<string, unknown>;
+    const messages = testDbState.rows('directMessages');
+    const reply = messages.find((r) => r.parentId === 'parent-1');
+    const mirror = messages.find((r) => r.mirroredFromId === reply?.id);
     assert({
       given: 'an alsoSendToParent DM thread reply',
-      should: 'write a second top-level row with mirroredFromId pointing at the reply id',
+      should: 'write a second top-level row (parentId IS NULL) with mirroredFromId pointing at the reply',
       actual: {
         kind: result.kind,
-        insertCount,
-        mirrorParentId: mirrorValues?.parentId ?? null,
-        mirrorMirroredFromId: mirrorValues?.mirroredFromId,
+        rowCount: messages.length,
+        mirrorParentId: mirror?.parentId,
+        mirrorMirroredFromId: mirror?.mirroredFromId,
         resultMirrorId: result.kind === 'ok' ? result.mirror?.id : null,
       },
       expected: {
         kind: 'ok',
-        insertCount: 3,
+        rowCount: 3,
         mirrorParentId: null,
-        mirrorMirroredFromId: 'reply-1',
-        resultMirrorId: 'mirror-1',
+        mirrorMirroredFromId: reply?.id,
+        resultMirrorId: mirror?.id,
       },
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Edge cases (PR 6b — added per audit findings)
+  // -------------------------------------------------------------------------
+
+  it('upserts exactly two follower rows for a reply with distinct parent author and replier', async () => {
+    seedActiveParent();
+
+    await dmMessageRepository.insertDmThreadReply(baseInput);
+
+    const followers = testDbState.rows('dmThreadFollowers');
+    assert({
+      given: 'a DM thread reply where the parent author and the replier are different users',
+      should: 'leave exactly two rows in dmThreadFollowers, one for each — and both keyed to the root',
+      actual: {
+        rowCount: followers.length,
+        rows: followers
+          .map((f) => ({ rootMessageId: f.rootMessageId, userId: f.userId }))
+          .sort((a, b) => String(a.userId).localeCompare(String(b.userId))),
+      },
+      expected: {
+        rowCount: 2,
+        rows: [
+          { rootMessageId: 'parent-1', userId: 'user-parent' },
+          { rootMessageId: 'parent-1', userId: 'user-replier' },
+        ],
+      },
+    });
+  });
+
+  it('upserts exactly one follower row when the parent author replies to their own DM thread (self-reply dedup)', async () => {
+    seedActiveParent({ senderId: 'user-self' });
+
+    await dmMessageRepository.insertDmThreadReply({
+      ...baseInput,
+      senderId: 'user-self',
+    });
+
+    const followers = testDbState.rows('dmThreadFollowers');
+    assert({
+      given: 'a DM reply where the parent author and the replier are the same user',
+      should: 'collapse to a single follower row — Postgres rejects two identical rows in the same INSERT, even with onConflictDoNothing',
+      actual: followers.map((f) => ({ rootMessageId: f.rootMessageId, userId: f.userId })),
+      expected: [{ rootMessageId: 'parent-1', userId: 'user-self' }],
+    });
+  });
+
+  it('rolls the entire transaction back when the follower upsert step throws — no reply, no follower, parent counter unchanged', async () => {
+    const seededLastReplyAt = new Date('2026-04-01T00:00:00Z');
+    seedActiveParent({ replyCount: 7, lastReplyAt: seededLastReplyAt });
+    testDbState.failBefore('insert', 'dmThreadFollowers');
+
+    await expect(
+      dmMessageRepository.insertDmThreadReply(baseInput)
+    ).rejects.toThrow();
+
+    const messages = testDbState.rows('directMessages');
+    const followers = testDbState.rows('dmThreadFollowers');
+    const parent = messages.find((r) => r.id === 'parent-1');
+    assert({
+      given: 'an insertDmThreadReply call where the follower upsert step fails inside the transaction',
+      should: 'roll back every write — only the seeded parent remains, replyCount + lastReplyAt as-seeded, no followers',
+      actual: {
+        rowCount: messages.length,
+        parentReplyCount: parent?.replyCount,
+        parentLastReplyAt: parent?.lastReplyAt,
+        followerCount: followers.length,
+      },
+      expected: {
+        rowCount: 1,
+        parentReplyCount: 7,
+        parentLastReplyAt: seededLastReplyAt,
+        followerCount: 0,
+      },
+    });
+  });
+
+  it('rolls the entire transaction back when alsoSendToParent mirror-insert throws — no reply, no mirror, parent counter unchanged', async () => {
+    seedActiveParent({ replyCount: 4 });
+    // The reply is the first directMessages insert; the mirror is the second
+    // (the followers insert hits dmThreadFollowers). Skip the first and fail
+    // the second so we exercise rollback after a successful reply write.
+    testDbState.failBefore('insert', 'directMessages', { skip: 1 });
+
+    await expect(
+      dmMessageRepository.insertDmThreadReply({
+        ...baseInput,
+        alsoSendToParent: true,
+      })
+    ).rejects.toThrow();
+
+    const messages = testDbState.rows('directMessages');
+    const followers = testDbState.rows('dmThreadFollowers');
+    const parent = messages.find((r) => r.id === 'parent-1');
+    assert({
+      given: 'an alsoSendToParent DM reply where the mirror insert step throws inside the transaction',
+      should: 'roll back EVERY write — no thread reply, no mirror, no follower rows, parent counter exactly as seeded',
+      actual: {
+        rowCount: messages.length,
+        parentReplyCount: parent?.replyCount,
+        followerCount: followers.length,
+      },
+      expected: { rowCount: 1, parentReplyCount: 4, followerCount: 0 },
+    });
+  });
+
+  it('soft-deleting a DM reply decrements parent.replyCount; restoring it (parent still active) increments it back', async () => {
+    seedActiveParent({ replyCount: 3 });
+    testDbState.seed('directMessages', [
+      { id: 'reply-1', conversationId: 'conv-1', senderId: 'user-replier', parentId: 'parent-1', isActive: true, replyCount: 0 },
+    ]);
+
+    await dmMessageRepository.softDeleteMessage('reply-1');
+    const afterDelete = testDbState.rows('directMessages').find((r) => r.id === 'parent-1')?.replyCount;
+    await dmMessageRepository.restoreDmMessage('reply-1');
+    const afterRestore = testDbState.rows('directMessages').find((r) => r.id === 'parent-1')?.replyCount;
+
+    assert({
+      given: 'a parent with replyCount=3 and an active DM reply, then a soft-delete followed by a restore',
+      should: 'decrement parent.replyCount to 2 on delete, then increment back to 3 on restore (parent stays active)',
+      actual: { afterDelete, afterRestore },
+      expected: { afterDelete: 2, afterRestore: 3 },
+    });
+  });
+
+  it('restoring a DM reply when the parent itself has been soft-deleted in the meantime does NOT bump the tombstoned parent counter', async () => {
+    testDbState.seed('directMessages', [
+      { id: 'parent-1', conversationId: 'conv-1', senderId: 'user-parent', parentId: null, isActive: true, replyCount: 2 },
+      { id: 'reply-1', conversationId: 'conv-1', senderId: 'user-replier', parentId: 'parent-1', isActive: false, replyCount: 0 },
+    ]);
+    await dmMessageRepository.softDeleteMessage('parent-1');
+    const parentBeforeRestore = testDbState.rows('directMessages').find((r) => r.id === 'parent-1');
+    expect(parentBeforeRestore?.isActive).toBe(false);
+
+    await dmMessageRepository.restoreDmMessage('reply-1');
+
+    const rows = testDbState.rows('directMessages');
+    const parent = rows.find((r) => r.id === 'parent-1');
+    const reply = rows.find((r) => r.id === 'reply-1');
+    assert({
+      given: 'a restore of a DM reply whose parent has been soft-deleted in the meantime',
+      should: 'restore the reply (isActive=true) but leave the tombstoned parent.replyCount exactly where it was',
+      actual: {
+        replyActive: reply?.isActive,
+        parentActive: parent?.isActive,
+        parentReplyCount: parent?.replyCount,
+      },
+      expected: { replyActive: true, parentActive: false, parentReplyCount: 2 },
     });
   });
 });
 
-// ---------------------------------------------------------------------------
-// Reactions parity (PR 2 of 5)
-// ---------------------------------------------------------------------------
-
 describe('dmMessageRepository.listActiveMessages [reactions parity]', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockDirectMessagesFindMany.mockResolvedValue([]);
-  });
-
   it('joins the reactions relation with the user columns the broadcast payload needs', async () => {
-    await dmMessageRepository.listActiveMessages({ conversationId: 'conv-1', limit: 50 });
+    testDbState.seed('users', [{ id: 'u-1', name: 'Alice' }]);
+    testDbState.seed('directMessages', [
+      { id: 'msg-1', conversationId: 'conv-1', senderId: 'u-1', isActive: true, parentId: null, createdAt: new Date('2026-05-04T12:00:00Z') },
+    ]);
+    testDbState.seed('dmMessageReactions', [
+      { id: 'rx-1', messageId: 'msg-1', userId: 'u-1', emoji: '👍' },
+    ]);
 
-    const call = mockDirectMessagesFindMany.mock.calls[0]?.[0] as {
-      with: { reactions: { with: { user: { columns: Record<string, true> } } } };
-    };
+    const rows = await dmMessageRepository.listActiveMessages({ conversationId: 'conv-1', limit: 50 });
+
+    const msg = rows[0] as { reactions: Array<{ user: { id: string; name: string } | null }> };
     assert({
-      given: 'a DM list fetch',
-      should: 'request reactions with user.id and user.name so the DM page renders the same chip + tooltip shape as channels',
+      given: 'a DM list fetch on a conversation with a reaction',
+      should: 'return reactions joined with user.id and user.name so the DM page renders chips identically to channels',
       actual: {
-        hasReactions: !!call.with.reactions,
-        userColumns: call.with.reactions.with.user.columns,
+        reactionCount: msg.reactions?.length,
+        user: msg.reactions?.[0]?.user,
       },
-      expected: {
-        hasReactions: true,
-        userColumns: { id: true, name: true },
-      },
+      expected: { reactionCount: 1, user: { id: 'u-1', name: 'Alice' } },
     });
   });
 
-  it('hydrates sender, file, and reactions.user with the same column whitelist as channel-parity dmMessageWith', async () => {
-    await dmMessageRepository.listActiveMessages({ conversationId: 'conv-1', limit: 50 });
+  it('hydrates sender, file, and reactions.user on each row — the dmMessageWith parity contract with channels', async () => {
+    testDbState.seed('users', [
+      { id: 'u-sender', name: 'Author', image: '/avatar.png' },
+      { id: 'u-reactor', name: 'Reactor', image: null },
+    ]);
+    testDbState.seed('files', [
+      { id: 'file-1', mimeType: 'image/png', sizeBytes: 2048 },
+    ]);
+    testDbState.seed('directMessages', [
+      {
+        id: 'msg-1', conversationId: 'conv-1', senderId: 'u-sender',
+        isActive: true, parentId: null, fileId: 'file-1',
+        createdAt: new Date('2026-05-04T12:00:00Z'),
+      },
+    ]);
+    testDbState.seed('dmMessageReactions', [
+      { id: 'rx-1', messageId: 'msg-1', userId: 'u-reactor', emoji: '🎉' },
+    ]);
 
-    const call = mockDirectMessagesFindMany.mock.calls[0]?.[0] as {
-      with: {
-        sender: { columns: Record<string, true> };
-        file: { columns: Record<string, true> };
-        reactions: { with: { user: { columns: Record<string, true> } } };
-      };
+    const rows = await dmMessageRepository.listActiveMessages({ conversationId: 'conv-1', limit: 50 });
+
+    const msg = rows[0] as {
+      sender: { id: string; name: string; image: string | null } | null;
+      file: { id: string; mimeType: string; sizeBytes: number } | null;
+      reactions: Array<{ user: { id: string; name: string } | null }>;
     };
     assert({
-      given: 'a DM list fetch',
-      should: 'request sender, file, and reactions.user with the same column whitelist as the channel repo',
+      given: 'a DM list fetch where the message has both an attachment and a reaction by another user',
+      should: 'hydrate sender (id, name, image), file (id, mimeType, sizeBytes), and reactions.user (id, name) — the same column whitelist channel-message-repository.messageWith uses, so the DM panel renders parity with channels without a re-fetch',
       actual: {
-        senderCols: call.with.sender.columns,
-        fileCols: call.with.file.columns,
-        reactionUserCols: call.with.reactions.with.user.columns,
+        sender: msg.sender,
+        file: msg.file,
+        reactionUser: msg.reactions[0]?.user,
       },
       expected: {
-        senderCols: { id: true, name: true, image: true },
-        fileCols: { id: true, mimeType: true, sizeBytes: true },
-        reactionUserCols: { id: true, name: true },
+        sender: { id: 'u-sender', name: 'Author', image: '/avatar.png' },
+        file: { id: 'file-1', mimeType: 'image/png', sizeBytes: 2048 },
+        reactionUser: { id: 'u-reactor', name: 'Reactor' },
       },
     });
   });
 });
 
 describe('dmMessageRepository.listActiveMessages [thread-isolation]', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockDirectMessagesFindMany.mockResolvedValue([]);
-  });
-
   it('filters out replies by requiring parentId IS NULL — thread replies must NEVER leak into the main DM stream', async () => {
-    await dmMessageRepository.listActiveMessages({
-      conversationId: 'conv-1',
-      limit: 50,
-    });
+    testDbState.seed('directMessages', [
+      { id: 'top-a', conversationId: 'conv-1', senderId: 'u-1', isActive: true, parentId: null, createdAt: new Date('2026-05-01T00:00:00Z') },
+      { id: 'reply-leak', conversationId: 'conv-1', senderId: 'u-1', isActive: true, parentId: 'top-a', createdAt: new Date('2026-05-01T00:01:00Z') },
+      { id: 'top-b', conversationId: 'conv-1', senderId: 'u-2', isActive: true, parentId: null, createdAt: new Date('2026-05-01T00:02:00Z') },
+    ]);
+
+    const rows = await dmMessageRepository.listActiveMessages({ conversationId: 'conv-1', limit: 50 });
 
     assert({
-      given: 'a top-level DM messages fetch',
-      should: 'add an isNull(parentId) filter so thread replies do not leak into the main stream',
-      actual: vi.mocked(isNull).mock.calls.some(
-        ([field]) => field === directMessages.parentId
-      ),
-      expected: true,
+      given: 'a top-level DM messages fetch where a thread reply also exists',
+      should: 'omit the reply — only top-level rows leak into the main stream',
+      actual: rows.map((r) => r.id).sort(),
+      expected: ['top-a', 'top-b'],
     });
   });
 });
 
 describe('dmMessageRepository.listDmThreadReplies', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockDirectMessagesFindMany.mockResolvedValue([]);
-  });
-
   it('filters by parentId AND isActive=true and orders ascending by (createdAt, id)', async () => {
-    await dmMessageRepository.listDmThreadReplies({ rootId: 'parent-1', limit: 50 });
+    const t0 = new Date('2026-05-04T12:00:00Z');
+    const t1 = new Date('2026-05-04T12:01:00Z');
+    const t2 = new Date('2026-05-04T12:02:00Z');
+    testDbState.seed('directMessages', [
+      { id: 'parent-1', conversationId: 'conv-1', senderId: 'u-1', isActive: true, parentId: null },
+      { id: 'r-3', conversationId: 'conv-1', senderId: 'u-1', isActive: true, parentId: 'parent-1', createdAt: t2 },
+      { id: 'r-1', conversationId: 'conv-1', senderId: 'u-1', isActive: true, parentId: 'parent-1', createdAt: t0 },
+      { id: 'r-2', conversationId: 'conv-1', senderId: 'u-1', isActive: true, parentId: 'parent-1', createdAt: t1 },
+      { id: 'r-deleted', conversationId: 'conv-1', senderId: 'u-1', isActive: false, parentId: 'parent-1', createdAt: t1 },
+      { id: 'other-parent-reply', conversationId: 'conv-1', senderId: 'u-1', isActive: true, parentId: 'other', createdAt: t1 },
+    ]);
 
-    const eqCalls = vi.mocked(eq).mock.calls;
-    const ascCalls = vi.mocked(asc).mock.calls;
+    const result = await dmMessageRepository.listDmThreadReplies({ rootId: 'parent-1', limit: 50 });
+
     assert({
-      given: 'a DM thread list-replies request',
-      should: 'WHERE parentId = root AND isActive = true; ORDER BY createdAt asc, id asc',
-      actual: {
-        scopedToParent: eqCalls.some(
-          ([field, value]) => field === directMessages.parentId && value === 'parent-1'
-        ),
-        scopedActive: eqCalls.some(
-          ([field, value]) => field === directMessages.isActive && value === true
-        ),
-        ascCount: ascCalls.length,
-      },
-      expected: { scopedToParent: true, scopedActive: true, ascCount: 2 },
+      given: 'a DM list-replies request for a thread root with active+deleted replies and an unrelated reply on another parent',
+      should: 'return only the parent-1 active replies, ordered ascending by (createdAt, id)',
+      actual: result.map((r) => r.id),
+      expected: ['r-1', 'r-2', 'r-3'],
     });
   });
 
   it('builds a strictly-greater-than composite cursor when after is supplied', async () => {
-    const after = { createdAt: new Date('2026-05-04T12:00:00Z'), id: 'reply-cursor' };
+    const t0 = new Date('2026-05-04T12:00:00Z');
+    const t1 = new Date('2026-05-04T12:01:00Z');
+    testDbState.seed('directMessages', [
+      { id: 'r-1', conversationId: 'conv-1', senderId: 'u-1', isActive: true, parentId: 'parent-1', createdAt: t0 },
+      { id: 'r-2-cursor', conversationId: 'conv-1', senderId: 'u-1', isActive: true, parentId: 'parent-1', createdAt: t1 },
+      { id: 'r-3', conversationId: 'conv-1', senderId: 'u-1', isActive: true, parentId: 'parent-1', createdAt: t1 },
+      { id: 'r-4', conversationId: 'conv-1', senderId: 'u-1', isActive: true, parentId: 'parent-1', createdAt: new Date('2026-05-04T12:02:00Z') },
+    ]);
 
-    await dmMessageRepository.listDmThreadReplies({
+    const result = await dmMessageRepository.listDmThreadReplies({
       rootId: 'parent-1',
       limit: 50,
-      after,
+      after: { createdAt: t1, id: 'r-2-cursor' },
     });
 
-    const gtCalls = vi.mocked(gt).mock.calls;
     assert({
-      given: 'an ascending-cursor DM pagination request',
-      should: 'use gt() against both createdAt and id so the next page never re-emits the cursor row',
-      actual: {
-        createdAt: gtCalls.some(([field, value]) => field === directMessages.createdAt && value === after.createdAt),
-        id: gtCalls.some(([field, value]) => field === directMessages.id && value === after.id),
-      },
-      expected: { createdAt: true, id: true },
+      given: 'an ascending-cursor DM pagination request at (t1, r-2-cursor)',
+      should: 'return rows strictly newer by createdAt OR same-createdAt with strictly larger id — never the cursor row, never anything older',
+      actual: result.map((r) => r.id).sort(),
+      expected: ['r-3', 'r-4'],
     });
   });
 
-  it('hydrates sender, file, and reactions relations so the thread panel renders parity with channel replies', async () => {
-    await dmMessageRepository.listDmThreadReplies({ rootId: 'parent-1', limit: 50 });
+  it('hydrates sender, file, and reactions on each thread reply — the parity contract with channel replies', async () => {
+    testDbState.seed('users', [
+      { id: 'u-replier', name: 'Replier', image: '/r.png' },
+      { id: 'u-reactor', name: 'Reactor', image: null },
+    ]);
+    testDbState.seed('files', [
+      { id: 'file-att', mimeType: 'application/pdf', sizeBytes: 9001 },
+    ]);
+    testDbState.seed('directMessages', [
+      {
+        id: 'reply-1', conversationId: 'conv-1', senderId: 'u-replier',
+        isActive: true, parentId: 'parent-1', fileId: 'file-att',
+        createdAt: new Date('2026-05-04T12:00:00Z'),
+      },
+    ]);
+    testDbState.seed('dmMessageReactions', [
+      { id: 'rx-1', messageId: 'reply-1', userId: 'u-reactor', emoji: '👀' },
+    ]);
 
-    const call = mockDirectMessagesFindMany.mock.calls[0]?.[0] as {
-      with: {
-        sender: { columns: Record<string, true> };
-        file: { columns: Record<string, true> };
-        reactions: { with: { user: { columns: Record<string, true> } } };
-      };
+    const rows = await dmMessageRepository.listDmThreadReplies({ rootId: 'parent-1', limit: 50 });
+
+    const reply = rows[0] as unknown as {
+      sender: { id: string; name: string; image: string | null } | null;
+      file: { id: string; mimeType: string; sizeBytes: number } | null;
+      reactions: Array<{ user: { id: string; name: string } | null }>;
     };
     assert({
-      given: 'a DM thread reply fetch',
-      should: 'request sender, file, and reactions.user with the same column whitelist as the channel repo',
+      given: 'a DM thread reply with an attachment and a reaction by a different user',
+      should: 'return the reply with sender, file, and reactions.user hydrated using the same column whitelist as the channel side, so the thread panel renders without a follow-up fetch',
       actual: {
-        senderCols: call.with.sender.columns,
-        fileCols: call.with.file.columns,
-        reactionUserCols: call.with.reactions.with.user.columns,
+        sender: reply.sender,
+        file: reply.file,
+        reactionUser: reply.reactions[0]?.user,
       },
       expected: {
-        senderCols: { id: true, name: true, image: true },
-        fileCols: { id: true, mimeType: true, sizeBytes: true },
-        reactionUserCols: { id: true, name: true },
+        sender: { id: 'u-replier', name: 'Replier', image: '/r.png' },
+        file: { id: 'file-att', mimeType: 'application/pdf', sizeBytes: 9001 },
+        reactionUser: { id: 'u-reactor', name: 'Reactor' },
       },
     });
   });
 });
 
 describe('dmMessageRepository thread follower helpers', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-
-    mockInsertOnConflictDoNothing.mockResolvedValue(undefined);
-    mockInsertValues.mockReturnValue({
-      returning: vi.fn().mockResolvedValue([]),
-      onConflictDoNothing: mockInsertOnConflictDoNothing,
-    });
-    vi.mocked(db.insert).mockReturnValue({ values: mockInsertValues } as never);
-
-    mockDeleteWhere.mockResolvedValue(undefined);
-    vi.mocked(db.delete).mockReturnValue({ where: mockDeleteWhere } as never);
-
-    mockSelectFrom.mockReturnValue({
-      where: vi.fn().mockResolvedValue([]),
-    });
-    vi.mocked(db.select).mockReturnValue({ from: mockSelectFrom } as never);
-  });
-
-  it('addDmThreadFollower inserts (rootId, userId) and uses onConflictDoNothing for idempotency', async () => {
+  it('addDmThreadFollower inserts (rootId, userId) and is idempotent under a re-add', async () => {
+    await dmMessageRepository.addDmThreadFollower('root-1', 'user-1');
     await dmMessageRepository.addDmThreadFollower('root-1', 'user-1');
 
-    const values = mockInsertValues.mock.calls[0]?.[0] as Record<string, unknown>;
+    const rows = testDbState.rows('dmThreadFollowers');
     assert({
-      given: 'an explicit DM follower add',
-      should: 'insert the (rootMessageId, userId) pair with onConflictDoNothing',
-      actual: {
-        values,
-        usedOnConflictDoNothing: mockInsertOnConflictDoNothing.mock.calls.length,
-      },
-      expected: {
-        values: { rootMessageId: 'root-1', userId: 'user-1' },
-        usedOnConflictDoNothing: 1,
-      },
+      given: 'two DM follower adds for the same (rootId, userId)',
+      should: 'persist exactly one row — onConflictDoNothing makes the second add a no-op',
+      actual: rows.map((r) => ({ rootMessageId: r.rootMessageId, userId: r.userId })),
+      expected: [{ rootMessageId: 'root-1', userId: 'user-1' }],
     });
   });
 
   it('removeDmThreadFollower deletes scoped to (rootId, userId) — never another user', async () => {
+    testDbState.seed('dmThreadFollowers', [
+      { rootMessageId: 'root-1', userId: 'user-1' },
+      { rootMessageId: 'root-1', userId: 'user-other' },
+      { rootMessageId: 'root-other', userId: 'user-1' },
+    ]);
+
     await dmMessageRepository.removeDmThreadFollower('root-1', 'user-1');
 
-    const eqCalls = vi.mocked(eq).mock.calls;
+    const remaining = testDbState
+      .rows('dmThreadFollowers')
+      .map((r) => `${r.rootMessageId}:${r.userId}`)
+      .sort();
     assert({
-      given: 'an explicit DM follower remove',
-      should: 'WHERE on both rootMessageId AND userId so we never delete another user\'s follow row',
-      actual: {
-        scopedRoot: eqCalls.some(
-          ([field, value]) => field === dmThreadFollowers.rootMessageId && value === 'root-1'
-        ),
-        scopedUser: eqCalls.some(
-          ([field, value]) => field === dmThreadFollowers.userId && value === 'user-1'
-        ),
-      },
-      expected: { scopedRoot: true, scopedUser: true },
+      given: 'a remove of (root-1, user-1) when other follower rows exist',
+      should: 'delete only the matching tuple — leave (root-1, user-other) and (root-other, user-1) intact',
+      actual: remaining,
+      expected: ['root-1:user-other', 'root-other:user-1'],
     });
   });
 
   it('listDmThreadFollowers returns a flat array of user ids', async () => {
-    const fromWhere = vi.fn().mockResolvedValueOnce([
-      { userId: 'user-a' },
-      { userId: 'user-b' },
+    testDbState.seed('dmThreadFollowers', [
+      { rootMessageId: 'root-1', userId: 'user-a' },
+      { rootMessageId: 'root-1', userId: 'user-b' },
+      { rootMessageId: 'root-other', userId: 'user-c' },
     ]);
-    mockSelectFrom.mockReturnValueOnce({ where: fromWhere });
 
     const result = await dmMessageRepository.listDmThreadFollowers('root-1');
 
     assert({
-      given: 'a DM thread root with two followers',
-      should: 'return a flat string[] of user ids',
-      actual: result,
+      given: 'a DM thread root with two followers and an unrelated follower on another root',
+      should: 'return a flat string[] of user ids scoped to the requested root only',
+      actual: result.sort(),
       expected: ['user-a', 'user-b'],
     });
   });
 });
 
 describe('dmMessageRepository.addDmReaction', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockInsertReturning.mockResolvedValue([{ id: 'reaction-1' }]);
-    mockInsertValues.mockReturnValue({ returning: mockInsertReturning });
-    vi.mocked(db.insert).mockReturnValue({ values: mockInsertValues } as never);
-  });
-
   it('writes (messageId, userId, emoji) verbatim and returns the inserted row', async () => {
-    mockInsertReturning.mockResolvedValueOnce([{ id: 'reaction-1' }]);
-
     const result = await dmMessageRepository.addDmReaction({
       messageId: 'msg-1',
       userId: 'user-1',
       emoji: '👍',
     });
 
-    const values = mockInsertValues.mock.calls[0]?.[0] as Record<string, unknown>;
+    const rows = testDbState.rows('dmMessageReactions');
     assert({
       given: 'a DM reaction add request',
-      should: 'persist the triple (messageId, userId, emoji) and return the new row id (the unique index enforces no-dup at the DB layer)',
-      actual: { values, result },
+      should: 'persist the triple (messageId, userId, emoji) and return the inserted row',
+      actual: {
+        rowCount: rows.length,
+        persisted: { messageId: rows[0].messageId, userId: rows[0].userId, emoji: rows[0].emoji },
+        returned: { messageId: result.messageId, userId: result.userId, emoji: result.emoji },
+      },
       expected: {
-        values: { messageId: 'msg-1', userId: 'user-1', emoji: '👍' },
-        result: { id: 'reaction-1' },
+        rowCount: 1,
+        persisted: { messageId: 'msg-1', userId: 'user-1', emoji: '👍' },
+        returned: { messageId: 'msg-1', userId: 'user-1', emoji: '👍' },
       },
     });
   });
 });
 
 describe('dmMessageRepository.loadDmReactionWithUser', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it('fetches the reaction with the user relation so broadcasts include name+id without a re-fetch', async () => {
-    mockReactionsFindFirst.mockResolvedValueOnce({ id: 'reaction-1', user: { id: 'u', name: 'n' } });
+    testDbState.seed('users', [{ id: 'u-1', name: 'Alice' }]);
+    testDbState.seed('dmMessageReactions', [
+      { id: 'rx-1', messageId: 'msg-1', userId: 'u-1', emoji: '👍' },
+    ]);
 
-    await dmMessageRepository.loadDmReactionWithUser('reaction-1');
+    const result = await dmMessageRepository.loadDmReactionWithUser('rx-1');
 
-    const call = mockReactionsFindFirst.mock.calls[0]?.[0] as {
-      with: { user: { columns: Record<string, true> } };
-    };
     assert({
       given: 'a freshly added DM reaction',
       should: 'load the user relation (id, name) so the broadcast payload renders the actor without an extra round-trip',
-      actual: call.with.user.columns,
-      expected: { id: true, name: true },
+      actual: (result?.user as { id: string; name: string } | null),
+      expected: { id: 'u-1', name: 'Alice' },
     });
   });
 });
 
 describe('dmMessageRepository.removeDmReaction', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockDeleteReturning.mockResolvedValue([{ id: 'reaction-1' }]);
-    mockDeleteWhere.mockReturnValue({ returning: mockDeleteReturning });
-    vi.mocked(db.delete).mockReturnValue({ where: mockDeleteWhere } as never);
-  });
-
   it('returns 0 when the delete matched no rows so the route can 404 on no-op', async () => {
-    mockDeleteReturning.mockResolvedValueOnce([]);
-
     const removed = await dmMessageRepository.removeDmReaction({
       messageId: 'msg-1',
       userId: 'user-1',
@@ -897,36 +775,33 @@ describe('dmMessageRepository.removeDmReaction', () => {
   });
 
   it('scopes the delete to (messageId, userId, emoji) — never deletes another participant\'s reaction', async () => {
-    mockDeleteReturning.mockResolvedValueOnce([{ id: 'reaction-1' }]);
+    testDbState.seed('dmMessageReactions', [
+      { id: 'rx-mine', messageId: 'msg-1', userId: 'user-1', emoji: '👍' },
+      { id: 'rx-other-user', messageId: 'msg-1', userId: 'user-other', emoji: '👍' },
+      { id: 'rx-other-msg', messageId: 'msg-other', userId: 'user-1', emoji: '👍' },
+      { id: 'rx-other-emoji', messageId: 'msg-1', userId: 'user-1', emoji: '🎉' },
+    ]);
 
-    await dmMessageRepository.removeDmReaction({
+    const removed = await dmMessageRepository.removeDmReaction({
       messageId: 'msg-1',
       userId: 'user-1',
       emoji: '👍',
     });
 
-    const eqCalls = vi.mocked(eq).mock.calls;
-    const hasMessageId = eqCalls.some(
-      ([field, value]) => field === dmMessageReactions.messageId && value === 'msg-1'
-    );
-    const hasUserId = eqCalls.some(
-      ([field, value]) => field === dmMessageReactions.userId && value === 'user-1'
-    );
-    const hasEmoji = eqCalls.some(
-      ([field, value]) => field === dmMessageReactions.emoji && value === '👍'
-    );
+    const remaining = testDbState
+      .rows('dmMessageReactions')
+      .map((r) => r.id)
+      .sort();
     assert({
-      given: 'a reaction-removal request',
-      should: 'WHERE on all three of messageId, userId, and emoji so we only remove the requester\'s own reaction',
-      actual: { hasMessageId, hasUserId, hasEmoji },
-      expected: { hasMessageId: true, hasUserId: true, hasEmoji: true },
+      given: 'a reaction-removal request when reactions for other users / messages / emojis exist',
+      should: 'delete only the (msg-1, user-1, 👍) row, return 1, and leave the three unrelated rows intact',
+      actual: { removed, remaining },
+      expected: { removed: 1, remaining: ['rx-other-emoji', 'rx-other-msg', 'rx-other-user'] },
     });
   });
 });
 
 // Surface guard: keep the public API shape stable so consumers don't break.
-// Note: the route uses the existing `findActiveMessage` for the existence check
-// (active-only, by design — soft-deleted DMs cannot accept reactions).
 describe('dmMessageRepository surface', () => {
   it('exports the reaction functions the DM routes need at parity with channels', () => {
     const keys = Object.keys(dmMessageRepository);

--- a/packages/lib/src/services/__tests__/dm-message-repository.test.ts
+++ b/packages/lib/src/services/__tests__/dm-message-repository.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Boundary-level test double: see test-doubles/db.ts for the design rationale.
-import { testDb, testDbState } from './test-doubles/db';
+import { testDbState } from './test-doubles/db';
 
 vi.mock('@pagespace/db/db', async () => {
   const m = await import('./test-doubles/db');

--- a/packages/lib/src/services/__tests__/dm-message-repository.test.ts
+++ b/packages/lib/src/services/__tests__/dm-message-repository.test.ts
@@ -166,6 +166,22 @@ describe('dmMessageRepository.restoreDmMessage', () => {
       expected: { count: 1, parentReplyCount: 5 },
     });
   });
+
+  it('locks the parent row for the duration of the restore tx (SELECT ... FOR UPDATE) so a concurrent soft-delete cannot race the bump', async () => {
+    testDbState.seed('directMessages', [
+      { id: 'parent-1', conversationId: 'conv-1', senderId: 'u-parent', isActive: true, parentId: null, replyCount: 1 },
+      { id: 'reply-1', conversationId: 'conv-1', senderId: 'u-replier', isActive: false, parentId: 'parent-1', replyCount: 0 },
+    ]);
+
+    await dmMessageRepository.restoreDmMessage('reply-1');
+
+    assert({
+      given: 'a DM restore parent re-read inside the tx',
+      should: 'invoke .for("update") against directMessages exactly once — the lock blocks a concurrent softDelete until the bump commits',
+      actual: testDbState.selectsForUpdate('directMessages').length,
+      expected: 1,
+    });
+  });
 });
 
 describe('dmMessageRepository.purgeInactiveMessages', () => {
@@ -190,6 +206,47 @@ describe('dmMessageRepository.purgeInactiveMessages', () => {
       should: 'hard-delete only the stale tombstone (count 1) and leave both other rows in place',
       actual: { count, remaining },
       expected: { count: 1, remaining: ['active-keep', 'recent-keep'] },
+    });
+  });
+
+  it('cleans up orphaned file_conversations links AFTER the message rows are purged — but ONLY when no surviving DM still references the (fileId, conversationId) pair', async () => {
+    const cutoff = new Date('2026-04-01T00:00:00Z');
+    const old = new Date('2026-03-01T00:00:00Z');
+    testDbState.seed('directMessages', [
+      // Two stale tombstones in conv-1 attaching the same file. Both purge,
+      // and no other DM references (file-shared, conv-1) — the link must go.
+      { id: 'stale-a', conversationId: 'conv-1', senderId: 'u-1', isActive: false, deletedAt: old, parentId: null, fileId: 'file-shared' },
+      { id: 'stale-b', conversationId: 'conv-1', senderId: 'u-1', isActive: false, deletedAt: old, parentId: null, fileId: 'file-shared' },
+      // Stale tombstone in conv-2 attaching file-still-used. The link must
+      // STAY because an active DM in the same conv still references it.
+      { id: 'stale-c', conversationId: 'conv-2', senderId: 'u-1', isActive: false, deletedAt: old, parentId: null, fileId: 'file-still-used' },
+      { id: 'active-keeper', conversationId: 'conv-2', senderId: 'u-1', isActive: true, deletedAt: null, parentId: null, fileId: 'file-still-used' },
+      // Stale tombstone with no fileId — should NOT contribute to the
+      // orphan-link cleanup at all.
+      { id: 'stale-text-only', conversationId: 'conv-1', senderId: 'u-1', isActive: false, deletedAt: old, parentId: null, fileId: null },
+    ]);
+    testDbState.seed('fileConversations', [
+      { fileId: 'file-shared', conversationId: 'conv-1' },
+      { fileId: 'file-still-used', conversationId: 'conv-2' },
+      // Untouched link in a third conversation — no purge candidate references
+      // it, so the cleanup query must not see it as a candidate at all.
+      { fileId: 'file-other', conversationId: 'conv-3' },
+    ]);
+
+    const count = await dmMessageRepository.purgeInactiveMessages(cutoff);
+
+    const remainingLinks = testDbState
+      .rows('fileConversations')
+      .map((l) => `${l.fileId}:${l.conversationId}`)
+      .sort();
+    assert({
+      given: 'four stale rows (two sharing an orphaned file link, one whose file is still referenced by an active DM, one text-only) plus an unrelated active DM',
+      should: 'purge all four stale rows, drop the (file-shared, conv-1) link (no surviving reference), AND keep both (file-still-used, conv-2) and the unrelated (file-other, conv-3) links intact',
+      actual: { count, remainingLinks },
+      expected: {
+        count: 4,
+        remainingLinks: ['file-other:conv-3', 'file-still-used:conv-2'],
+      },
     });
   });
 });
@@ -218,6 +275,19 @@ describe('dmMessageRepository.insertDmThreadReply', () => {
       },
     ]);
   };
+
+  it('locks the parent row for the duration of the tx (SELECT ... FOR UPDATE) so a concurrent soft-delete cannot orphan the reply', async () => {
+    seedActiveParent();
+
+    await dmMessageRepository.insertDmThreadReply(baseInput);
+
+    assert({
+      given: 'a DM parent validation read inside the insert tx',
+      should: 'invoke .for("update") against directMessages exactly once — the lock blocks a concurrent softDelete until this tx commits',
+      actual: testDbState.selectsForUpdate('directMessages').length,
+      expected: 1,
+    });
+  });
 
   it('rejects with parent_not_found when the parent is missing', async () => {
     const result = await dmMessageRepository.insertDmThreadReply(baseInput);

--- a/packages/lib/src/services/__tests__/test-doubles/db.ts
+++ b/packages/lib/src/services/__tests__/test-doubles/db.ts
@@ -1,0 +1,761 @@
+/**
+ * Boundary-level test double for the channel + DM message repositories.
+ *
+ * The repositories were previously tested by mocking Drizzle's chained methods
+ * with `.then`-able stubs (`mockUpdateWhere.mockReturnValue({ returning, then })`)
+ * and asserting on the order of intermediate builder calls. That coupling meant
+ * any internal refactor — e.g. flipping the order of `where(eq(a), eq(b))`
+ * conjuncts, swapping `select().from().where()` for a relations query, or
+ * inlining a step — broke tests without changing observable behavior.
+ *
+ * This module replaces those tests' boundary with an in-memory db that:
+ *
+ *  - Holds rows for each table (`channelMessages`, `directMessages`, …) and
+ *    exposes them via `state.rows(name)` for assertions.
+ *  - Implements the chained API the repositories actually call
+ *    (`db.insert(t).values(r).returning()`, `db.update(t).set(p).where(pred).returning(cols)`,
+ *    `db.select(cols).from(t).where(pred).for('update')`, `db.transaction(cb)`,
+ *    `db.query.X.findFirst/findMany`, etc.) backed by real state mutation.
+ *  - Wraps `db.transaction(cb)` with a snapshot/restore so a thrown callback
+ *    rolls back ALL writes in that tx — the rollback edge cases test this.
+ *  - Exposes a `failBefore` hook so a test can inject a throw at any
+ *    `insert|update|delete` against any table without poking internals.
+ *
+ * Operators (`eq`, `and`, `or`, `lt`, `gt`, `isNull`, `isNotNull`) are mocked
+ * to return row predicate functions instead of opaque marker objects, so the
+ * `where(...)` step receives a function the double can call directly. This
+ * means tests survive any refactor that re-orders or rebalances the predicate
+ * tree — only the row-set the predicate selects matters.
+ *
+ * The `sql` tag is interpreted only for the two patterns the impl uses today:
+ * `${col} + 1` (increment) and `GREATEST(${col} - 1, 0)` (clamped decrement).
+ * Any other shape throws — so a future SQL fragment in the impl forces an
+ * explicit decision in this file rather than silently returning the wrong
+ * value.
+ *
+ * Fallback note: if a future test needs to mock a higher level (e.g., the
+ * repository module itself, in route tests), do that — don't leak Drizzle
+ * shape into yet more files.
+ */
+
+// ---------------------------------------------------------------------------
+// Schema column + table markers
+// ---------------------------------------------------------------------------
+
+export interface ColumnRef {
+  __col: true;
+  table: string;
+  name: string;
+}
+
+export interface TableRef {
+  __table: true;
+  __name: string;
+  [columnName: string]: ColumnRef | string | true;
+}
+
+export function makeColumn(table: string, name: string): ColumnRef {
+  return { __col: true, table, name };
+}
+
+export function makeTable(name: string, columns: readonly string[]): TableRef {
+  const t: Record<string, ColumnRef | string | true> = {
+    __table: true,
+    __name: name,
+  };
+  for (const c of columns) t[c] = makeColumn(name, c);
+  return t as TableRef;
+}
+
+const isColumn = (v: unknown): v is ColumnRef =>
+  typeof v === 'object' && v !== null && (v as { __col?: true }).__col === true;
+
+// ---------------------------------------------------------------------------
+// Operators
+// ---------------------------------------------------------------------------
+
+export type RowPredicate = (row: Record<string, unknown>) => boolean;
+
+export interface OrderSpec {
+  __order: 'asc' | 'desc';
+  col: ColumnRef;
+}
+
+export interface SqlMarker {
+  __sql: true;
+  strings: readonly string[];
+  values: readonly unknown[];
+}
+
+const compare = (a: unknown, b: unknown): number => {
+  if (a instanceof Date && b instanceof Date) return a.getTime() - b.getTime();
+  if (typeof a === 'number' && typeof b === 'number') return a - b;
+  if (typeof a === 'string' && typeof b === 'string') return a < b ? -1 : a > b ? 1 : 0;
+  // Fallback: string-coerce.
+  return String(a) < String(b) ? -1 : String(a) > String(b) ? 1 : 0;
+};
+
+export const operators = {
+  eq: (col: ColumnRef, value: unknown): RowPredicate =>
+    (row) => row[col.name] === value,
+  and: (...preds: Array<RowPredicate | undefined>): RowPredicate => {
+    const cs = preds.filter((p): p is RowPredicate => typeof p === 'function');
+    return (row) => cs.every((p) => p(row));
+  },
+  or: (...preds: Array<RowPredicate | undefined>): RowPredicate => {
+    const cs = preds.filter((p): p is RowPredicate => typeof p === 'function');
+    return (row) => cs.some((p) => p(row));
+  },
+  lt: (col: ColumnRef, value: unknown): RowPredicate =>
+    (row) => compare(row[col.name], value) < 0,
+  gt: (col: ColumnRef, value: unknown): RowPredicate =>
+    (row) => compare(row[col.name], value) > 0,
+  isNull: (col: ColumnRef): RowPredicate =>
+    (row) => row[col.name] === null || row[col.name] === undefined,
+  isNotNull: (col: ColumnRef): RowPredicate =>
+    (row) => row[col.name] !== null && row[col.name] !== undefined,
+  asc: (col: ColumnRef): OrderSpec => ({ __order: 'asc', col }),
+  desc: (col: ColumnRef): OrderSpec => ({ __order: 'desc', col }),
+  sql: Object.assign(
+    (strings: TemplateStringsArray, ...values: unknown[]): SqlMarker => ({
+      __sql: true,
+      strings: [...strings],
+      values,
+    }),
+    {
+      join: (items: unknown[], separator: unknown) => ({ __sqlJoin: true, items, separator }),
+    }
+  ),
+};
+
+const isSqlMarker = (v: unknown): v is SqlMarker =>
+  typeof v === 'object' && v !== null && (v as { __sql?: true }).__sql === true;
+
+// Interpret the two `sql` shapes the impl uses today. Any other shape is a
+// bug — fail loudly instead of silently writing garbage.
+function applySqlMarker(marker: SqlMarker, row: Record<string, unknown>): unknown {
+  if (marker.values.length === 1 && isColumn(marker.values[0])) {
+    const col = marker.values[0] as ColumnRef;
+    const joined = marker.strings.join('@COL@');
+    if (/^GREATEST\(@COL@\s*-\s*1,\s*0\)$/.test(joined)) {
+      return Math.max(((row[col.name] as number) ?? 0) - 1, 0);
+    }
+    if (/^@COL@\s*\+\s*1$/.test(joined)) {
+      return ((row[col.name] as number) ?? 0) + 1;
+    }
+  }
+  throw new Error(
+    `db double: unrecognized sql marker — strings=${JSON.stringify(marker.strings)}, values=${JSON.stringify(
+      marker.values.map((v) => (isColumn(v) ? `${v.table}.${v.name}` : v))
+    )}`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// In-memory state
+// ---------------------------------------------------------------------------
+
+type Row = Record<string, unknown>;
+type HookKind = 'insert' | 'update' | 'delete' | 'select';
+
+interface HookEvent {
+  kind: HookKind;
+  table: string;
+}
+
+type Hook = (e: HookEvent) => void;
+
+let nextAutoId = 0;
+const autoId = () => `auto-${++nextAutoId}`;
+
+const messageDefaults = (): Row => ({
+  isActive: true,
+  replyCount: 0,
+  lastReplyAt: null,
+  parentId: null,
+  mirroredFromId: null,
+  aiMeta: null,
+  fileId: null,
+  attachmentMeta: null,
+  editedAt: null,
+  isEdited: false,
+  isRead: false,
+  readAt: null,
+  deletedAt: null,
+});
+
+function applyDefaults(table: string, row: Row): Row {
+  const out: Row = { ...row };
+  if (table === 'channelMessages' || table === 'directMessages') {
+    const defaults = messageDefaults();
+    for (const [k, v] of Object.entries(defaults)) {
+      if (!(k in out)) out[k] = v;
+    }
+    if (!out.id) out.id = autoId();
+    if (!('createdAt' in out)) out.createdAt = new Date();
+  }
+  if (
+    table === 'channelMessageReactions' ||
+    table === 'dmMessageReactions' ||
+    table === 'channelThreadFollowers' ||
+    table === 'dmThreadFollowers'
+  ) {
+    if (!out.id && (table === 'channelMessageReactions' || table === 'dmMessageReactions')) {
+      out.id = autoId();
+    }
+    if (!('createdAt' in out)) out.createdAt = new Date();
+  }
+  return out;
+}
+
+export class DbState {
+  private tables = new Map<string, Row[]>();
+  private hooks = new Map<string, Hook[]>();
+  private executeCalls: SqlMarker[] = [];
+
+  seed(table: string, rows: Row[]): void {
+    const cur = this.tables.get(table) ?? [];
+    cur.push(...rows.map((r) => ({ ...r })));
+    this.tables.set(table, cur);
+  }
+
+  rows(table: string): Row[] {
+    return (this.tables.get(table) ?? []).map((r) => ({ ...r }));
+  }
+
+  rowsRef(table: string): Row[] {
+    if (!this.tables.has(table)) this.tables.set(table, []);
+    return this.tables.get(table) as Row[];
+  }
+
+  count(table: string): number {
+    return (this.tables.get(table) ?? []).length;
+  }
+
+  executes(): readonly SqlMarker[] {
+    return [...this.executeCalls];
+  }
+
+  recordExecute(marker: SqlMarker): void {
+    this.executeCalls.push(marker);
+  }
+
+  /**
+   * Inject a one-shot pre-op throw at the named table.
+   * Use to simulate a follower-upsert failure or mirror-insert failure inside
+   * a transaction — the wrapping `transaction(cb)` then rolls all writes back.
+   *
+   * `skip` lets the first N matching ops succeed before the throw fires —
+   * useful when the impl performs multiple inserts against the same table in a
+   * single tx and only the Nth one should fail (e.g. the mirror insert is the
+   * second `channelMessages` insert in `insertChannelThreadReply`).
+   */
+  failBefore(
+    kind: HookKind,
+    table: string,
+    options: { skip?: number; error?: Error } = {}
+  ): void {
+    const key = `${kind}:${table}`;
+    const skipCount = options.skip ?? 0;
+    const error = options.error ?? new Error(`${kind} ${table} failed`);
+    let seen = 0;
+    let fired = false;
+    const hook: Hook = () => {
+      if (fired) return;
+      if (seen < skipCount) {
+        seen += 1;
+        return;
+      }
+      fired = true;
+      throw error;
+    };
+    const arr = this.hooks.get(key) ?? [];
+    arr.push(hook);
+    this.hooks.set(key, arr);
+  }
+
+  runHooks(e: HookEvent): void {
+    const key = `${e.kind}:${e.table}`;
+    for (const h of this.hooks.get(key) ?? []) h(e);
+  }
+
+  snapshot(): Map<string, Row[]> {
+    return new Map([...this.tables].map(([k, v]) => [k, v.map((r) => ({ ...r }))]));
+  }
+
+  restore(snap: Map<string, Row[]>): void {
+    this.tables = new Map([...snap].map(([k, v]) => [k, v.map((r) => ({ ...r }))]));
+  }
+
+  reset(): void {
+    this.tables.clear();
+    this.hooks.clear();
+    this.executeCalls.length = 0;
+  }
+}
+
+function applySetPatch(patch: Record<string, unknown>, row: Row): Row {
+  const next: Row = { ...row };
+  for (const [field, value] of Object.entries(patch)) {
+    if (isSqlMarker(value)) {
+      next[field] = applySqlMarker(value, row);
+    } else {
+      next[field] = value;
+    }
+  }
+  return next;
+}
+
+// ---------------------------------------------------------------------------
+// Relations join — only what the repositories ask for today.
+// ---------------------------------------------------------------------------
+
+interface RelationCfg {
+  columns?: Record<string, true>;
+  with?: Record<string, RelationCfg>;
+}
+
+function projectColumns(row: Row | null | undefined, cols?: Record<string, true>): Row | null {
+  if (!row) return null;
+  if (!cols) return { ...row };
+  const out: Row = {};
+  for (const [k, v] of Object.entries(cols)) {
+    if (v) out[k] = row[k];
+  }
+  return out;
+}
+
+function joinRelations(
+  state: DbState,
+  table: string,
+  row: Row,
+  withSpec: Record<string, RelationCfg> | undefined
+): Row {
+  if (!withSpec) return { ...row };
+  const result: Row = { ...row };
+  for (const [relName, relCfg] of Object.entries(withSpec)) {
+    if (relName === 'user') {
+      const fk = (table === 'directMessages' || table === 'dmMessageReactions')
+        ? 'senderId'
+        : 'userId';
+      const userId = row[fk] ?? row.userId;
+      const user = state.rowsRef('users').find((u) => u.id === userId);
+      result.user = projectColumns(user, relCfg.columns);
+    } else if (relName === 'sender') {
+      const sender = state.rowsRef('users').find((u) => u.id === row.senderId);
+      result.sender = projectColumns(sender, relCfg.columns);
+    } else if (relName === 'file') {
+      const file = state.rowsRef('files').find((f) => f.id === row.fileId);
+      result.file = projectColumns(file, relCfg.columns);
+    } else if (relName === 'reactions') {
+      const reactionsTable =
+        table === 'channelMessages' ? 'channelMessageReactions' : 'dmMessageReactions';
+      const reactions = state.rowsRef(reactionsTable).filter((r) => r.messageId === row.id);
+      result.reactions = reactions.map((rxn) =>
+        joinRelations(state, reactionsTable, rxn, relCfg.with)
+      );
+    }
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// db proxy
+// ---------------------------------------------------------------------------
+
+interface QueryFindFirstCfg {
+  where?: RowPredicate;
+  with?: Record<string, RelationCfg>;
+  columns?: Record<string, true>;
+  orderBy?: OrderSpec[];
+}
+
+interface QueryFindManyCfg extends QueryFindFirstCfg {
+  limit?: number;
+}
+
+function sortRows(rows: Row[], orderBy: OrderSpec[]): Row[] {
+  const sorted = [...rows];
+  sorted.sort((a, b) => {
+    for (const o of orderBy) {
+      const cmp = compare(a[o.col.name], b[o.col.name]);
+      if (cmp !== 0) return o.__order === 'asc' ? cmp : -cmp;
+    }
+    return 0;
+  });
+  return sorted;
+}
+
+export interface TestDb {
+  state: DbState;
+  insert: (table: TableRef) => InsertBuilder;
+  update: (table: TableRef) => UpdateBuilder;
+  delete: (table: TableRef) => DeleteBuilder;
+  select: (cols?: Record<string, ColumnRef>) => SelectBuilder;
+  query: Record<string, QueryApi>;
+  transaction: <T>(cb: (tx: TestDb) => Promise<T>) => Promise<T>;
+  execute: (marker: SqlMarker) => Promise<{ rows: Row[] }>;
+}
+
+type Thenable<T> = {
+  then<T1 = T, T2 = never>(
+    onFulfilled?: ((value: T) => T1 | PromiseLike<T1>) | null,
+    onRejected?: ((reason: unknown) => T2 | PromiseLike<T2>) | null
+  ): Promise<T1 | T2>;
+};
+
+interface InsertBuilder {
+  values: (rowOrRows: Row | Row[]) => InsertChain;
+}
+
+interface InsertChain extends Thenable<Row[]> {
+  returning: () => Promise<Row[]>;
+  onConflictDoNothing: () => Promise<Row[]>;
+  onConflictDoUpdate: (cfg: { target: ColumnRef[]; set: Record<string, unknown> }) => Promise<Row[]>;
+}
+
+interface UpdateBuilder {
+  set: (patch: Record<string, unknown>) => UpdateSet;
+}
+
+interface UpdateSet {
+  where: (pred: RowPredicate) => UpdateChain;
+}
+
+interface UpdateChain extends Thenable<Row[]> {
+  returning: (cols?: Record<string, ColumnRef>) => Promise<Row[]>;
+}
+
+interface DeleteBuilder {
+  where: (pred: RowPredicate) => DeleteChain;
+}
+
+interface DeleteChain extends Thenable<Row[]> {
+  returning: (cols?: Record<string, ColumnRef>) => Promise<Row[]>;
+}
+
+interface SelectBuilder {
+  from: (table: TableRef) => SelectFrom;
+}
+
+interface SelectFrom {
+  where: (pred: RowPredicate) => SelectWhere;
+}
+
+interface SelectWhere extends Thenable<Row[]> {
+  for: (mode: string) => Promise<Row[]>;
+  orderBy: (...orders: OrderSpec[]) => SelectOrdered;
+}
+
+interface SelectOrdered {
+  limit: (n: number) => Promise<Row[]>;
+}
+
+const makeThen = <T>(produce: () => T) =>
+  <T1 = T, T2 = never>(
+    onFulfilled?: ((value: T) => T1 | PromiseLike<T1>) | null,
+    onRejected?: ((reason: unknown) => T2 | PromiseLike<T2>) | null
+  ): Promise<T1 | T2> =>
+    new Promise<T>((resolve, reject) => {
+      try {
+        resolve(produce());
+      } catch (e) {
+        reject(e);
+      }
+    }).then(onFulfilled ?? undefined, onRejected ?? undefined);
+
+interface QueryApi {
+  findFirst: (cfg?: QueryFindFirstCfg) => Promise<Row | undefined>;
+  findMany: (cfg?: QueryFindManyCfg) => Promise<Row[]>;
+}
+
+const QUERY_TABLES = [
+  'channelMessages',
+  'channelMessageReactions',
+  'directMessages',
+  'dmMessageReactions',
+  'dmConversations',
+  'files',
+  'fileConversations',
+  'users',
+  'pages',
+] as const;
+
+export function makeDb(state: DbState): TestDb {
+  const db: TestDb = {
+    state,
+    insert: (table) => makeInsertBuilder(state, table),
+    update: (table) => makeUpdateBuilder(state, table),
+    delete: (table) => makeDeleteBuilder(state, table),
+    select: (cols) => makeSelectBuilder(state, cols),
+    query: Object.fromEntries(
+      QUERY_TABLES.map((t) => [t, makeQueryApi(state, t)])
+    ) as Record<string, QueryApi>,
+    transaction: async <T>(cb: (tx: TestDb) => Promise<T>): Promise<T> => {
+      const snap = state.snapshot();
+      try {
+        return await cb(db);
+      } catch (err) {
+        state.restore(snap);
+        throw err;
+      }
+    },
+    execute: async (marker) => {
+      state.recordExecute(marker);
+      return { rows: [] };
+    },
+  };
+  return db;
+}
+
+function makeInsertBuilder(state: DbState, table: TableRef): InsertBuilder {
+  return {
+    values: (rowOrRows) => {
+      const rows = Array.isArray(rowOrRows) ? rowOrRows : [rowOrRows];
+      let mode: 'plain' | 'doNothing' | 'doUpdate' = 'plain';
+      let conflictTarget: ColumnRef[] | null = null;
+      let conflictSet: Record<string, unknown> | null = null;
+      const finalize = (): Row[] => {
+        state.runHooks({ kind: 'insert', table: table.__name });
+        const tableRows = state.rowsRef(table.__name);
+        const inserted: Row[] = [];
+        for (const r of rows) {
+          const withDefaults = applyDefaults(table.__name, r);
+          const target = conflictTarget;
+          const dupIdx =
+            target !== null
+              ? tableRows.findIndex((existing) =>
+                  target.every((c) => existing[c.name] === withDefaults[c.name])
+                )
+              : -1;
+          if (mode !== 'plain' && dupIdx >= 0) {
+            if (mode === 'doUpdate' && conflictSet) {
+              tableRows[dupIdx] = applySetPatch(conflictSet, tableRows[dupIdx]);
+            }
+            // doNothing: skip silently
+          } else {
+            tableRows.push(withDefaults);
+            inserted.push({ ...withDefaults });
+          }
+        }
+        return inserted;
+      };
+      const chain: InsertChain = {
+        returning: async () => finalize(),
+        onConflictDoNothing: async () => {
+          mode = 'doNothing';
+          // For onConflictDoNothing without an explicit target, the impl relies
+          // on a unique index. The PRs use either a composite pk on the
+          // followers table (rootMessageId, userId) or the reactions table
+          // unique constraint. Synthesize a reasonable default per-table.
+          conflictTarget = defaultConflictTarget(table.__name);
+          return finalize();
+        },
+        onConflictDoUpdate: async (cfg) => {
+          mode = 'doUpdate';
+          conflictTarget = cfg.target;
+          conflictSet = cfg.set;
+          return finalize();
+        },
+        then: makeThen<Row[]>(() => finalize()),
+      };
+      return chain;
+    },
+  };
+}
+
+function defaultConflictTarget(tableName: string): ColumnRef[] {
+  switch (tableName) {
+    case 'channelThreadFollowers':
+    case 'dmThreadFollowers':
+      return [makeColumn(tableName, 'rootMessageId'), makeColumn(tableName, 'userId')];
+    case 'channelMessageReactions':
+    case 'dmMessageReactions':
+      return [
+        makeColumn(tableName, 'messageId'),
+        makeColumn(tableName, 'userId'),
+        makeColumn(tableName, 'emoji'),
+      ];
+    default:
+      return [makeColumn(tableName, 'id')];
+  }
+}
+
+function makeUpdateBuilder(state: DbState, table: TableRef): UpdateBuilder {
+  return {
+    set: (patch) => ({
+      where: (pred) => {
+        const finalize = (cols?: Record<string, ColumnRef>): Row[] => {
+          state.runHooks({ kind: 'update', table: table.__name });
+          const tableRows = state.rowsRef(table.__name);
+          const updated: Row[] = [];
+          for (let i = 0; i < tableRows.length; i++) {
+            if (pred(tableRows[i])) {
+              tableRows[i] = applySetPatch(patch, tableRows[i]);
+              updated.push({ ...tableRows[i] });
+            }
+          }
+          if (cols) {
+            return updated.map((r) =>
+              Object.fromEntries(
+                Object.entries(cols).map(([alias, col]) => [alias, r[col.name]])
+              )
+            );
+          }
+          return updated;
+        };
+        const chain: UpdateChain = {
+          returning: async (cols) => finalize(cols),
+          then: makeThen<Row[]>(() => finalize()),
+        };
+        return chain;
+      },
+    }),
+  };
+}
+
+function makeDeleteBuilder(state: DbState, table: TableRef): DeleteBuilder {
+  return {
+    where: (pred) => {
+      const finalize = (cols?: Record<string, ColumnRef>): Row[] => {
+        state.runHooks({ kind: 'delete', table: table.__name });
+        const tableRows = state.rowsRef(table.__name);
+        const removed: Row[] = [];
+        for (let i = tableRows.length - 1; i >= 0; i--) {
+          if (pred(tableRows[i])) {
+            removed.unshift({ ...tableRows[i] });
+            tableRows.splice(i, 1);
+          }
+        }
+        if (cols) {
+          return removed.map((r) =>
+            Object.fromEntries(
+              Object.entries(cols).map(([alias, col]) => [alias, r[col.name]])
+            )
+          );
+        }
+        return removed;
+      };
+      const chain: DeleteChain = {
+        returning: async (cols) => finalize(cols),
+        then: makeThen<Row[]>(() => finalize()),
+      };
+      return chain;
+    },
+  };
+}
+
+function makeSelectBuilder(state: DbState, cols?: Record<string, ColumnRef>): SelectBuilder {
+  return {
+    from: (table) => ({
+      where: (pred) => {
+        const buildResult = (rows: Row[]): Row[] => {
+          if (cols) {
+            return rows.map((r) =>
+              Object.fromEntries(
+                Object.entries(cols).map(([alias, col]) => [alias, r[col.name]])
+              )
+            );
+          }
+          return rows.map((r) => ({ ...r }));
+        };
+        const filter = (): Row[] => {
+          state.runHooks({ kind: 'select', table: table.__name });
+          return state.rowsRef(table.__name).filter(pred);
+        };
+        const chain: SelectWhere = {
+          for: async (_mode) => buildResult(filter()),
+          orderBy: (...orders) => ({
+            limit: async (n) => buildResult(sortRows(filter(), orders).slice(0, n)),
+          }),
+          then: makeThen<Row[]>(() => buildResult(filter())),
+        };
+        return chain;
+      },
+    }),
+  };
+}
+
+function makeQueryApi(state: DbState, table: string): QueryApi {
+  return {
+    findFirst: async (cfg = {}) => {
+      let rows = state.rowsRef(table).filter(cfg.where ?? (() => true));
+      if (cfg.orderBy) rows = sortRows(rows, cfg.orderBy);
+      const first = rows[0];
+      if (!first) return undefined;
+      const joined = joinRelations(state, table, first, cfg.with);
+      if (cfg.columns) {
+        const projected = projectColumns(joined, cfg.columns);
+        return projected ?? undefined;
+      }
+      return joined;
+    },
+    findMany: async (cfg = {}) => {
+      let rows = state.rowsRef(table).filter(cfg.where ?? (() => true));
+      if (cfg.orderBy) rows = sortRows(rows, cfg.orderBy);
+      if (cfg.limit !== undefined) rows = rows.slice(0, cfg.limit);
+      return rows.map((r) => {
+        const joined = joinRelations(state, table, r, cfg.with);
+        if (cfg.columns) return projectColumns(joined, cfg.columns) ?? joined;
+        return joined;
+      });
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// vi.mock factories — tests import these from their vi.mock(...) calls.
+// ---------------------------------------------------------------------------
+
+export const chatSchema = {
+  channelMessages: makeTable('channelMessages', [
+    'id', 'pageId', 'userId', 'content', 'fileId', 'attachmentMeta',
+    'isActive', 'editedAt', 'createdAt', 'parentId', 'replyCount',
+    'lastReplyAt', 'mirroredFromId', 'aiMeta',
+  ]),
+  channelMessageReactions: makeTable('channelMessageReactions', [
+    'id', 'messageId', 'userId', 'emoji', 'createdAt',
+  ]),
+  channelReadStatus: makeTable('channelReadStatus', [
+    'userId', 'channelId', 'lastReadAt',
+  ]),
+  channelThreadFollowers: makeTable('channelThreadFollowers', [
+    'rootMessageId', 'userId', 'createdAt',
+  ]),
+};
+
+export const socialSchema = {
+  dmConversations: makeTable('dmConversations', [
+    'id', 'participant1Id', 'participant2Id', 'lastMessageAt',
+    'lastMessagePreview', 'participant1LastRead', 'participant2LastRead',
+  ]),
+  directMessages: makeTable('directMessages', [
+    'id', 'conversationId', 'senderId', 'content', 'fileId',
+    'attachmentMeta', 'isRead', 'readAt', 'isActive', 'isEdited',
+    'editedAt', 'deletedAt', 'createdAt', 'parentId', 'replyCount',
+    'lastReplyAt', 'mirroredFromId',
+  ]),
+  dmThreadFollowers: makeTable('dmThreadFollowers', [
+    'rootMessageId', 'userId', 'createdAt',
+  ]),
+  dmMessageReactions: makeTable('dmMessageReactions', [
+    'id', 'messageId', 'userId', 'emoji', 'createdAt',
+  ]),
+};
+
+export const storageSchema = {
+  files: makeTable('files', ['id', 'mimeType', 'sizeBytes', 'createdBy']),
+  fileConversations: makeTable('fileConversations', ['fileId', 'conversationId']),
+};
+
+// File-scope singletons — Vitest workers run each test file in its own VM
+// context, so these don't leak across files. Tests reset them between cases
+// with `state.reset()`.
+export const testDbState = new DbState();
+export const testDb = makeDb(testDbState);
+
+// Convenience pre-bound mock factories so tests can write
+//   vi.mock('@pagespace/db/db', () => testDbDbMock);
+// in a single line. We can't expose these as plain functions because vi.mock
+// factories are hoisted above any imports — instead each call site uses
+// `() => import('./test-doubles/db').then(m => ...)` (see channel-message-repository.test.ts).

--- a/packages/lib/src/services/__tests__/test-doubles/db.ts
+++ b/packages/lib/src/services/__tests__/test-doubles/db.ts
@@ -208,10 +208,16 @@ function applyDefaults(table: string, row: Row): Row {
   return out;
 }
 
+interface ForCall {
+  table: string;
+  mode: string;
+}
+
 export class DbState {
   private tables = new Map<string, Row[]>();
   private hooks = new Map<string, Hook[]>();
   private executeCalls: SqlMarker[] = [];
+  private forCalls: ForCall[] = [];
 
   seed(table: string, rows: Row[]): void {
     const cur = this.tables.get(table) ?? [];
@@ -238,6 +244,23 @@ export class DbState {
 
   recordExecute(marker: SqlMarker): void {
     this.executeCalls.push(marker);
+  }
+
+  /**
+   * Every `select(...).from(table).where(...).for(mode)` call lands here.
+   * Tests assert these to lock down `SELECT ... FOR UPDATE` against the
+   * impl — the lock prevents concurrent soft-delete from racing the
+   * insert/restore reply-count update, and silently dropping it would
+   * reintroduce the race the FOR UPDATE clause exists to close.
+   */
+  selectsForUpdate(table?: string): readonly ForCall[] {
+    const calls = this.forCalls.filter((c) => c.mode === 'update');
+    if (table) return calls.filter((c) => c.table === table);
+    return calls;
+  }
+
+  recordFor(table: string, mode: string): void {
+    this.forCalls.push({ table, mode });
   }
 
   /**
@@ -291,6 +314,7 @@ export class DbState {
     this.tables.clear();
     this.hooks.clear();
     this.executeCalls.length = 0;
+    this.forCalls.length = 0;
   }
 }
 
@@ -502,10 +526,70 @@ export function makeDb(state: DbState): TestDb {
     },
     execute: async (marker) => {
       state.recordExecute(marker);
+      applyExecuteSideEffects(state, marker);
       return { rows: [] };
     },
   };
   return db;
+}
+
+interface SqlJoinMarker {
+  __sqlJoin: true;
+  items: readonly unknown[];
+  separator: unknown;
+}
+
+const isSqlJoin = (v: unknown): v is SqlJoinMarker =>
+  typeof v === 'object' && v !== null && (v as { __sqlJoin?: true }).__sqlJoin === true;
+
+/**
+ * Side-effect interpreter for `tx.execute(sql\`...\`)`. Today the impl uses
+ * `execute` only for the `purgeInactiveMessages` orphan-link cleanup:
+ *
+ *   DELETE FROM file_conversations fc
+ *   USING (VALUES (fileId, conversationId), …) AS purged_pairs
+ *   WHERE fc.fileId = pp.fileId AND fc.conversationId = pp.conversationId
+ *     AND NOT EXISTS (SELECT 1 FROM direct_messages dm
+ *                     WHERE dm.fileId = fc.fileId
+ *                       AND dm.conversationId = fc.conversationId)
+ *
+ * Tests must observe that the orphan-link delete actually runs — without
+ * this branch, dropping the entire `tx.execute` call from the impl would
+ * leave attachment-link rows stranded and tests would still pass. So we
+ * recognize this specific pattern and apply the delete to in-memory state.
+ *
+ * Any other `execute` shape is left as record-only (caller knows). If a
+ * future impl introduces another raw SQL effect, add a branch here.
+ */
+function applyExecuteSideEffects(state: DbState, marker: SqlMarker): void {
+  const joined = marker.strings.join(' ');
+  if (!/DELETE\s+FROM\s+file_conversations/i.test(joined)) return;
+
+  const join = marker.values.find(isSqlJoin);
+  if (!join) return;
+
+  const pairs: Array<{ fileId: unknown; conversationId: unknown }> = [];
+  for (const item of join.items) {
+    if (!isSqlMarker(item)) continue;
+    const [fileId, conversationId] = item.values;
+    pairs.push({ fileId, conversationId });
+  }
+  if (pairs.length === 0) return;
+
+  const fileConversations = state.rowsRef('fileConversations');
+  const directMessages = state.rowsRef('directMessages');
+
+  for (let i = fileConversations.length - 1; i >= 0; i--) {
+    const link = fileConversations[i];
+    const matchedPair = pairs.some(
+      (p) => p.fileId === link.fileId && p.conversationId === link.conversationId
+    );
+    if (!matchedPair) continue;
+    const stillReferenced = directMessages.some(
+      (dm) => dm.fileId === link.fileId && dm.conversationId === link.conversationId
+    );
+    if (!stillReferenced) fileConversations.splice(i, 1);
+  }
 }
 
 function makeInsertBuilder(state: DbState, table: TableRef): InsertBuilder {
@@ -664,7 +748,10 @@ function makeSelectBuilder(state: DbState, cols?: Record<string, ColumnRef>): Se
           return state.rowsRef(table.__name).filter(pred);
         };
         const chain: SelectWhere = {
-          for: async (_mode) => buildResult(filter()),
+          for: async (mode) => {
+            state.recordFor(table.__name, mode);
+            return buildResult(filter());
+          },
           orderBy: (...orders) => ({
             limit: async (n) => buildResult(sortRows(filter(), orders).slice(0, n)),
           }),
@@ -753,9 +840,3 @@ export const storageSchema = {
 // with `state.reset()`.
 export const testDbState = new DbState();
 export const testDb = makeDb(testDbState);
-
-// Convenience pre-bound mock factories so tests can write
-//   vi.mock('@pagespace/db/db', () => testDbDbMock);
-// in a single line. We can't expose these as plain functions because vi.mock
-// factories are hoisted above any imports — instead each call site uses
-// `() => import('./test-doubles/db').then(m => ...)` (see channel-message-repository.test.ts).


### PR DESCRIPTION
## Summary
- New `test-doubles/db.ts`: in-memory db double the repository tests now run against
- `channel-message-repository.test.ts` and `dm-message-repository.test.ts` rewritten — no thenable ORM chain mocks remain
- New: follower upsert verification (both rows; collapses to one row on self-reply)
- New: transaction rollback on follower-upsert failure (both repos)
- New: transaction rollback on alsoSendToParent mirror-insert failure (both repos)
- New: soft-delete decrement + restore increment (both repos), including the tombstoned-parent edge
- New (post-Codex): `SELECT … FOR UPDATE` lock observable via `state.selectsForUpdate(table)`; both repos assert the lock fires on the parent re-read inside insert + restore transactions
- New (post-Codex): `tx.execute` now interprets the `purgeInactiveMessages` orphan-link DELETE and mutates state; new test seeds shared/non-shared `file_conversations` links and asserts only the truly orphaned one is dropped
- Rebased onto current master (post-PR 6a + 6c). PR 6a's two new DM relation-hydration tests (`listActiveMessages` + `listDmThreadReplies`) are re-cast against the boundary double — they now seed `users`/`files`/`dmMessageReactions` and assert the joined relations come through on the returned rows, instead of asserting on chain-mock call shape

`agent-mention-responder.test.ts` is unchanged by this PR: PR 5 already added the `aiMeta` assertion, and PR 6a (now on master) added the `isAskAgentResult` predicate tests + malformed-shape skip test. All 21 tests in that file pass against the merged impl.

Part of the threads hardening epic. Sibling PRs 6a (#1252) and 6c (#1251) merged. The two repository implementations are not modified by this PR.

## Mutation-test verification (zero-trust, re-run post-rebase against the merged master impl)
Each item below was applied as a one-shot impl mutation, the test suite was run, the mutation was reverted, and the suite re-confirmed green.

- [x] **Removed follower upsert from `insertChannelThreadReply`** → 4 channel tests failed
- [x] **Removed follower upsert from `insertDmThreadReply`** → 4 DM tests failed
- [x] **Removed parent counter decrement from `softDeleteChannelMessage`** → 2 channel tests failed
- [x] **Removed tombstone-parent guard from `restoreChannelMessage` (unconditional bump)** → 2 channel tests failed
- [x] **Moved parent counter bump OUTSIDE `db.transaction(...)` in `insertChannelThreadReply`** → both rollback tests failed
- [x] **Stripped `aiMeta` from `agent-mention-responder.ts:postAgentThreadReply`** → existing thread-routing test failed
- [x] **Stripped `.for('update')` from `insertChannelThreadReply` parent re-read** → lock-observability test failed
- [x] **Dropped the entire `tx.execute(...)` orphan-link DELETE block from `purgeInactiveMessages`** → orphan-link test failed
- [x] **Dropped `with: dmMessageWith` from `listDmThreadReplies`** → DM thread-reply relation-hydration test failed
- [x] **Dropped `with: dmMessageWith` from `listActiveMessages`** → DM list-active relation-hydration test failed

## Test plan
- [x] `pnpm --filter @pagespace/lib test` — 157 files / 3963 tests passed
- [x] `pnpm typecheck` (12 workspaces) — clean
- [x] `pnpm lint` — clean (only pre-existing `react-hooks/exhaustive-deps` warning in QuickCreatePalette, unrelated)
- [x] `apps/web` agent-mention-responder.test.ts — 21/21 pass (includes PR 6a's predicate + malformed-shape tests)
- [x] Branch rebased cleanly onto current `origin/master` — no remaining merge conflicts
- [x] No mocks on `.then` or chained Drizzle methods remain in either repository test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure with in-memory database state testing for improved test coverage and reliability of repository functionality.
  * Strengthened transactional behavior validation and concurrency semantics testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->