### PR TITLE
fix(db): backfill task_items.pageId before NOT NULL in 0120

### DIFF
--- a/packages/db/drizzle/0120_bent_texas_twister.sql
+++ b/packages/db/drizzle/0120_bent_texas_twister.sql
@@ -1,2 +1,10 @@
+UPDATE "task_items" SET "pageId" = tl."pageId"
+FROM "task_lists" tl
+WHERE "task_items"."taskListId" = tl."id"
+  AND "task_items"."pageId" IS NULL
+  AND tl."pageId" IS NOT NULL;
+--> statement-breakpoint
+DELETE FROM "task_items" WHERE "pageId" IS NULL;
+--> statement-breakpoint
 ALTER TABLE "task_items" ALTER COLUMN "pageId" SET NOT NULL;--> statement-breakpoint
 ALTER TABLE "task_items" DROP COLUMN IF EXISTS "title";


### PR DESCRIPTION
## Summary
- Production migrate is failing on `0120_bent_texas_twister.sql` (from #1254). It tries to set `task_items.pageId` NOT NULL, but legacy rows have NULL `pageId`. Tx rolls back, `migrate` service exits non-zero, and `web`/`realtime`/`processor` won't start (all `depends_on: migrate`).
- Add backfill + orphan cleanup ahead of the NOT NULL alter, in the same migration / same tx.
- Edit-in-place is safe: `packages/db/src/migrate.ts:42` skips by `folderMillis`, not hash. Dev DBs that already migrated past 0120 won't re-run; prod (never recorded as applied because the tx rolled back) picks up the new SQL.

## What the migration now does
1. `UPDATE task_items` — pull `pageId` from parent `task_lists` where the list has one (covers historical rows inserted without pageId against a page-backed list).
2. `DELETE FROM task_items WHERE "pageId" IS NULL` — drop AI ephemeral / conversation-only orphans. The new design (#1254) requires every task to have a linked page, so these rows are no longer valid.
3. `ALTER COLUMN "pageId" SET NOT NULL` — original op.
4. `DROP COLUMN IF EXISTS "title"` — original op.

## Why hand-edit a generated SQL file
`pnpm db:generate` only emits DDL from schema diffs, not data ops. Schema (`packages/db/src/schema/tasks.ts`) and snapshot (`0120_snapshot.json`) are unchanged: end state is identical to what #1254 declared.

## Test plan
- [ ] Pre-flight (optional): `docker exec pagespace-deploy-postgres-1 psql -U user -d pagespace -c 'SELECT COUNT(*) FROM task_items WHERE "pageId" IS NULL;'` to know blast radius.
- [ ] Merge → CI rebuilds `pagespace-migrate:latest`.
- [ ] On prod box: `docker compose pull migrate && docker compose up -d migrate`.
- [ ] Verify logs show `Applying: 5e29a63c... (1778013731460)` succeeds, then 0121 (`1778018613162`), then `Migrations finished.`
- [ ] Post: `SELECT COUNT(*) FROM task_items WHERE "pageId" IS NULL;` → 0.
- [ ] Post: `\d task_items` → `pageId NOT NULL`, no `title` column.
- [ ] UI smoke: open a task list, create a task, rename a task → page title sync still works (the drift fix from #1254).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Database Updates**
  * Improved data consistency by auto-populating missing page references in task items.
  * Page references in task items are now a required field.
  * Removed the title field from task items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->