### PR TITLE
feat(messages): unified hover toolbar; fix grouped-message overlap

### DIFF
--- a/apps/web/src/app/dashboard/channels/[pageId]/page.tsx
+++ b/apps/web/src/app/dashboard/channels/[pageId]/page.tsx
@@ -720,7 +720,10 @@ export default function InboxChannelPage() {
                         canDelete={isOwnMessage}
                         canReplyInThread={!isAi}
                         canQuoteReply={false}
+                        reactions={m.reactions}
+                        currentUserId={user?.id}
                         onAddReaction={(emoji) => handleAddReaction(m.id, emoji)}
+                        onRemoveReaction={(emoji) => handleRemoveReaction(m.id, emoji)}
                         onEdit={() => { setEditingMessageId(m.id); setEditContent(m.content); }}
                         onDelete={() => handleDeleteMessage(m.id)}
                         onReplyInThread={() =>

--- a/apps/web/src/app/dashboard/channels/[pageId]/page.tsx
+++ b/apps/web/src/app/dashboard/channels/[pageId]/page.tsx
@@ -5,7 +5,7 @@ import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import useSWR from 'swr';
 import { toast } from 'sonner';
-import { Hash, ExternalLink, Lock, Pencil, Trash2, Check, X, MoreHorizontal, MessageSquareReply } from 'lucide-react';
+import { Hash, ExternalLink, Lock, Check, X } from 'lucide-react';
 import { MessageAttachment } from '@/components/shared/MessageAttachment';
 import { useAuth } from '@/hooks/useAuth';
 import { usePermissions, getPermissionErrorMessage } from '@/hooks/usePermissions';
@@ -18,15 +18,9 @@ import { type ChannelInputRef, type FileAttachment } from '@/components/layout/m
 import { MessageInput } from '@/components/shared/MessageInput';
 import { MessageDropZone } from '@/components/layout/middle-content/page-views/channel/MessageDropZone';
 import { MessageReactions, type Reaction } from '@/components/shared/MessageReactions';
+import { MessageHoverToolbar } from '@/components/shared/MessageHoverToolbar';
 import { PullToRefresh } from '@/components/ui/pull-to-refresh';
 import { post, del, patch, fetchWithAuth } from '@/lib/auth/auth-fetch';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
 import { useSocketStore } from '@/stores/useSocketStore';
 import {
   type AttachmentMeta,
@@ -637,7 +631,7 @@ export default function InboxChannelPage() {
                     {!isAi && <AvatarImage src={m.user?.image || ''} />}
                     <AvatarFallback>{avatarFallback}</AvatarFallback>
                   </Avatar>
-                  <div className="flex flex-col min-w-0 flex-1">
+                  <div className="flex flex-col min-w-0 flex-1 relative">
                     <div className="flex items-center gap-2">
                       <span className="font-semibold text-sm">{displayName}</span>
                       {aiLabel && (
@@ -651,48 +645,6 @@ export default function InboxChannelPage() {
                       {m.editedAt && (
                         <span className="text-xs text-muted-foreground italic">(Edited)</span>
                       )}
-                      <div className="ml-auto flex items-center gap-1">
-                        {!isAi && !m.id.startsWith('temp-') && (
-                          <button
-                            type="button"
-                            aria-label="Reply in thread"
-                            data-testid={`reply-in-thread-${m.id}`}
-                            onClick={() =>
-                              openThread({ source: 'channel', contextId: pageId, parentId: m.id })
-                            }
-                            className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
-                          >
-                            <MessageSquareReply size={14} aria-hidden />
-                          </button>
-                        )}
-                      {isOwnMessage && !m.id.startsWith('temp-') && editingMessageId !== m.id && (
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <button
-                              aria-label="Message options"
-                              className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
-                              type="button"
-                            >
-                              <MoreHorizontal size={14} aria-hidden />
-                            </button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="end">
-                            <DropdownMenuItem
-                              onClick={() => { setEditingMessageId(m.id); setEditContent(m.content); }}
-                            >
-                              <Pencil className="mr-2 h-4 w-4" /> Edit
-                            </DropdownMenuItem>
-                            <DropdownMenuSeparator />
-                            <DropdownMenuItem
-                              onClick={() => handleDeleteMessage(m.id)}
-                              className="text-destructive focus:text-destructive"
-                            >
-                              <Trash2 className="mr-2 h-4 w-4" /> Delete
-                            </DropdownMenuItem>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      )}
-                      </div>
                     </div>
                     {editingMessageId === m.id ? (
                       <div className="mt-1 flex flex-col gap-2">
@@ -752,7 +704,6 @@ export default function InboxChannelPage() {
                           : ''}
                       </button>
                     )}
-                    {/* Reactions */}
                     {user && !m.id.startsWith('temp-') && (
                       <MessageReactions
                         reactions={m.reactions || []}
@@ -760,6 +711,21 @@ export default function InboxChannelPage() {
                         onAddReaction={(emoji) => handleAddReaction(m.id, emoji)}
                         onRemoveReaction={(emoji) => handleRemoveReaction(m.id, emoji)}
                         canReact={permissions?.canView || false}
+                      />
+                    )}
+                    {!m.id.startsWith('temp-') && editingMessageId !== m.id && (
+                      <MessageHoverToolbar
+                        canReact={permissions?.canView || false}
+                        canEdit={isOwnMessage}
+                        canDelete={isOwnMessage}
+                        canReplyInThread={!isAi}
+                        canQuoteReply={false}
+                        onAddReaction={(emoji) => handleAddReaction(m.id, emoji)}
+                        onEdit={() => { setEditingMessageId(m.id); setEditContent(m.content); }}
+                        onDelete={() => handleDeleteMessage(m.id)}
+                        onReplyInThread={() =>
+                          openThread({ source: 'channel', contextId: pageId, parentId: m.id })
+                        }
                       />
                     )}
                   </div>

--- a/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
@@ -686,7 +686,10 @@ export default function InboxDMPage() {
                         canDelete={showOwnerActions}
                         canReplyInThread={showReplyInThread}
                         canQuoteReply={true}
+                        reactions={message.reactions}
+                        currentUserId={user?.id}
                         onAddReaction={(emoji) => handleAddReaction(message.id, emoji)}
+                        onRemoveReaction={(emoji) => handleRemoveReaction(message.id, emoji)}
                         onQuoteReply={() => handleStartQuote(message)}
                         onEdit={() => { setEditingMessageId(message.id); setEditContent(message.content); }}
                         onDelete={() => handleDeleteMessage(message.id)}

--- a/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
@@ -15,13 +15,14 @@ import { MessageDropZone } from '@/components/layout/middle-content/page-views/c
 import type { FileAttachment } from '@/hooks/useAttachmentUpload';
 import { MessageAttachment } from '@/components/shared/MessageAttachment';
 import { MessageReactions, type Reaction } from '@/components/shared/MessageReactions';
+import { MessageHoverToolbar } from '@/components/shared/MessageHoverToolbar';
 import { renderMessageParts, convertToMessageParts } from '@/components/messages/MessagePartRenderer';
 import type { AttachmentMeta } from '@/lib/attachment-utils';
 import useSWR from 'swr';
 import { toast } from 'sonner';
 import { useSocket } from '@/hooks/useSocket';
 import { post, patch, del, fetchWithAuth } from '@/lib/auth/auth-fetch';
-import { Pencil, Trash2, Check, X, MoreHorizontal, MessageSquareReply, CornerUpLeft } from 'lucide-react';
+import { Check, X } from 'lucide-react';
 import MessageQuoteBlock from '@/components/messages/MessageQuoteBlock';
 import type { QuotedMessageSnapshot } from '@pagespace/lib/services/quote-enrichment';
 import { buildThreadPreview } from '@pagespace/lib/services/preview';
@@ -30,13 +31,6 @@ import { ThreadPanel } from '@/components/layout/middle-content/page-views/threa
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
 import { useMobile } from '@/hooks/useMobile';
 import { formatDistanceToNow } from 'date-fns';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
 import { isFirstInGroup } from '@/lib/messages/grouping';
 
 const fetcher = async (url: string) => {
@@ -559,8 +553,6 @@ export default function InboxDMPage() {
               );
               const rowSpacing = i === 0 ? '' : isFirst ? 'mt-4' : 'mt-0.5';
               const isRealMessage = !message.id.startsWith('temp-') && editingMessageId !== message.id;
-              // The menu opens for any real message (Quote reply is universal); Edit/Delete remain gated by ownership.
-              const showMenu = isRealMessage;
               const showOwnerActions = isOwnMessage && isRealMessage;
               const replyCount = message.replyCount ?? 0;
               const showReplyInThread = !message.id.startsWith('temp-');
@@ -604,56 +596,6 @@ export default function InboxDMPage() {
                         {message.isRead && isOwnMessage && (
                           <span className="text-xs text-muted-foreground">Read</span>
                         )}
-                        <div className="ml-auto flex items-center gap-1">
-                          {showReplyInThread && (
-                            <button
-                              type="button"
-                              aria-label="Reply in thread"
-                              data-testid={`reply-in-thread-${message.id}`}
-                              onClick={() =>
-                                openThread({ source: 'dm', contextId: conversationId, parentId: message.id })
-                              }
-                              className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
-                            >
-                              <MessageSquareReply size={14} aria-hidden />
-                            </button>
-                          )}
-                          {showMenu && (
-                          <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                              <button
-                                aria-label="Message options"
-                                className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
-                                type="button"
-                              >
-                                <MoreHorizontal size={14} aria-hidden />
-                              </button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end">
-                              <DropdownMenuItem onClick={() => handleStartQuote(message)}>
-                                <CornerUpLeft className="mr-2 h-4 w-4" /> Quote reply
-                              </DropdownMenuItem>
-                              {showOwnerActions && (
-                                <>
-                                  <DropdownMenuSeparator />
-                                  <DropdownMenuItem
-                                    onClick={() => { setEditingMessageId(message.id); setEditContent(message.content); }}
-                                  >
-                                    <Pencil className="mr-2 h-4 w-4" /> Edit
-                                  </DropdownMenuItem>
-                                  <DropdownMenuSeparator />
-                                  <DropdownMenuItem
-                                    onClick={() => handleDeleteMessage(message.id)}
-                                    className="text-destructive focus:text-destructive"
-                                  >
-                                    <Trash2 className="mr-2 h-4 w-4" /> Delete
-                                  </DropdownMenuItem>
-                                </>
-                              )}
-                            </DropdownMenuContent>
-                          </DropdownMenu>
-                          )}
-                        </div>
                       </div>
                     )}
 
@@ -692,21 +634,17 @@ export default function InboxDMPage() {
                         </div>
                       </div>
                     ) : (
-                      <div className={`p-3 rounded-lg max-w-full ${
-                        isOwnMessage
-                          ? 'bg-primary/5 dark:bg-primary/10 ml-8'
-                          : 'bg-gray-50 dark:bg-gray-800/50 mr-8'
-                      }`}>
+                      <>
                         {(message.quotedMessage || message.quotedMessageId) && (
                           <MessageQuoteBlock quoted={message.quotedMessage ?? null} />
                         )}
                         {message.content && (
-                          <div className="text-gray-900 dark:text-gray-100 break-words [overflow-wrap:anywhere] min-w-0">
+                          <div className="prose prose-sm dark:prose-invert max-w-none break-words [overflow-wrap:anywhere] min-w-0">
                             {renderMessageParts(convertToMessageParts(message.content))}
                           </div>
                         )}
                         <MessageAttachment message={message} />
-                        {!isFirst && (
+                        {!isFirst && (message.isEdited || (message.isRead && isOwnMessage)) && (
                           <div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
                             {message.isEdited && (
                               <span className="italic">(edited)</span>
@@ -716,59 +654,7 @@ export default function InboxDMPage() {
                             )}
                           </div>
                         )}
-                      </div>
-                    )}
-                    {!isFirst && (
-                      <div className="absolute top-0 right-0 flex items-center gap-1">
-                        {showReplyInThread && (
-                          <button
-                            type="button"
-                            aria-label="Reply in thread"
-                            data-testid={`reply-in-thread-${message.id}`}
-                            onClick={() =>
-                              openThread({ source: 'dm', contextId: conversationId, parentId: message.id })
-                            }
-                            className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
-                          >
-                            <MessageSquareReply size={14} aria-hidden />
-                          </button>
-                        )}
-                        {showMenu && (
-                          <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                              <button
-                                aria-label="Message options"
-                                className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
-                                type="button"
-                              >
-                                <MoreHorizontal size={14} aria-hidden />
-                              </button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end">
-                              <DropdownMenuItem onClick={() => handleStartQuote(message)}>
-                                <CornerUpLeft className="mr-2 h-4 w-4" /> Quote reply
-                              </DropdownMenuItem>
-                              {showOwnerActions && (
-                                <>
-                                  <DropdownMenuSeparator />
-                                  <DropdownMenuItem
-                                    onClick={() => { setEditingMessageId(message.id); setEditContent(message.content); }}
-                                  >
-                                    <Pencil className="mr-2 h-4 w-4" /> Edit
-                                  </DropdownMenuItem>
-                                  <DropdownMenuSeparator />
-                                  <DropdownMenuItem
-                                    onClick={() => handleDeleteMessage(message.id)}
-                                    className="text-destructive focus:text-destructive"
-                                  >
-                                    <Trash2 className="mr-2 h-4 w-4" /> Delete
-                                  </DropdownMenuItem>
-                                </>
-                              )}
-                            </DropdownMenuContent>
-                          </DropdownMenu>
-                        )}
-                      </div>
+                      </>
                     )}
                     {replyCount > 0 && (
                       <button
@@ -791,6 +677,22 @@ export default function InboxDMPage() {
                         currentUserId={user.id}
                         onAddReaction={(emoji) => handleAddReaction(message.id, emoji)}
                         onRemoveReaction={(emoji) => handleRemoveReaction(message.id, emoji)}
+                      />
+                    )}
+                    {isRealMessage && (
+                      <MessageHoverToolbar
+                        canReact={true}
+                        canEdit={showOwnerActions}
+                        canDelete={showOwnerActions}
+                        canReplyInThread={showReplyInThread}
+                        canQuoteReply={true}
+                        onAddReaction={(emoji) => handleAddReaction(message.id, emoji)}
+                        onQuoteReply={() => handleStartQuote(message)}
+                        onEdit={() => { setEditingMessageId(message.id); setEditContent(message.content); }}
+                        onDelete={() => handleDeleteMessage(message.id)}
+                        onReplyInThread={() =>
+                          openThread({ source: 'dm', contextId: conversationId, parentId: message.id })
+                        }
                       />
                     )}
                   </div>

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -604,7 +604,10 @@ function ChannelView({ page }: ChannelViewProps) {
                                     canDelete={showOwnerActions}
                                     canReplyInThread={!isAi && !m.id.startsWith('temp-')}
                                     canQuoteReply={true}
+                                    reactions={m.reactions}
+                                    currentUserId={user?.id}
                                     onAddReaction={(emoji) => handleAddReaction(m.id, emoji)}
+                                    onRemoveReaction={(emoji) => handleRemoveReaction(m.id, emoji)}
                                     onQuoteReply={() => handleStartQuote(m)}
                                     onEdit={() => { setEditingMessageId(m.id); setEditContent(m.content); }}
                                     onDelete={() => handleDeleteMessage(m.id)}

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -15,26 +15,22 @@ import {
 import { ChannelInput, type ChannelInputRef, type FileAttachment } from './ChannelInput';
 import { MessageDropZone } from './MessageDropZone';
 import { MessageReactions, type Reaction } from '@/components/shared/MessageReactions';
+import { MessageHoverToolbar } from '@/components/shared/MessageHoverToolbar';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Lock, Pencil, Trash2, Check, X, MoreHorizontal, CornerUpLeft } from 'lucide-react';
+import { Lock, Check, X } from 'lucide-react';
 import { MessageAttachment } from '@/components/shared/MessageAttachment';
 import MessageQuoteBlock from '@/components/messages/MessageQuoteBlock';
 import type { QuotedMessageSnapshot } from '@pagespace/lib/services/quote-enrichment';
 import { buildThreadPreview } from '@pagespace/lib/services/preview';
 import { post, del, patch, fetchWithAuth } from '@/lib/auth/auth-fetch';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
 import { useSocketStore } from '@/stores/useSocketStore';
+import { useThreadPanelStore } from '@/stores/useThreadPanelStore';
 import {
   type AttachmentMeta,
   type FileRelation,
 } from '@/lib/attachment-utils';
 import { isFirstInGroup } from '@/lib/messages/grouping';
+import { formatDistanceToNow } from 'date-fns';
 
 interface ChannelViewProps {
   page: TreePage;
@@ -57,6 +53,8 @@ interface MessageWithReactions extends MessageWithUser {
   editedAt?: string | null;
   quotedMessageId?: string | null;
   quotedMessage?: QuotedMessageSnapshot | null;
+  replyCount?: number;
+  lastReplyAt?: string | null;
 }
 
 function ChannelView({ page }: ChannelViewProps) {
@@ -69,6 +67,7 @@ function ChannelView({ page }: ChannelViewProps) {
   const socket = useSocketStore((state) => state.socket);
   const connectionStatus = useSocketStore((state) => state.connectionStatus);
   const connect = useSocketStore((state) => state.connect);
+  const openThread = useThreadPanelStore((state) => state.openThread);
 
   // Use the centralized permissions hook
   const { permissions } = usePermissions(page.id);
@@ -488,9 +487,8 @@ function ChannelView({ page }: ChannelViewProps) {
                         );
                         const rowSpacing = i === 0 ? '' : isFirst ? 'mt-4' : 'mt-0.5';
                         const isRealMessage = !m.id.startsWith('temp-') && editingMessageId !== m.id;
-                        // The menu opens for any real message (Quote reply is universal); Edit/Delete remain gated by ownership inside the menu.
-                        const showMenu = isRealMessage;
                         const showOwnerActions = isOwnMessage && isRealMessage;
+                        const replyCount = m.replyCount ?? 0;
                         return (
                         <div key={m.id} className={`group/msg flex items-start gap-4 ${rowSpacing}`}>
                             {isFirst ? (
@@ -519,41 +517,6 @@ function ChannelView({ page }: ChannelViewProps) {
                                       </span>
                                       {m.editedAt && (
                                         <span className="text-xs text-muted-foreground italic">(Edited)</span>
-                                      )}
-                                      {showMenu && (
-                                        <DropdownMenu>
-                                          <DropdownMenuTrigger asChild>
-                                            <button
-                                              aria-label="Message options"
-                                              className="ml-auto p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
-                                              type="button"
-                                            >
-                                              <MoreHorizontal size={14} aria-hidden />
-                                            </button>
-                                          </DropdownMenuTrigger>
-                                          <DropdownMenuContent align="end">
-                                            <DropdownMenuItem onClick={() => handleStartQuote(m)}>
-                                              <CornerUpLeft className="mr-2 h-4 w-4" /> Quote reply
-                                            </DropdownMenuItem>
-                                            {showOwnerActions && (
-                                              <>
-                                                <DropdownMenuSeparator />
-                                                <DropdownMenuItem
-                                                  onClick={() => { setEditingMessageId(m.id); setEditContent(m.content); }}
-                                                >
-                                                  <Pencil className="mr-2 h-4 w-4" /> Edit
-                                                </DropdownMenuItem>
-                                                <DropdownMenuSeparator />
-                                                <DropdownMenuItem
-                                                  onClick={() => handleDeleteMessage(m.id)}
-                                                  className="text-destructive focus:text-destructive"
-                                                >
-                                                  <Trash2 className="mr-2 h-4 w-4" /> Delete
-                                                </DropdownMenuItem>
-                                              </>
-                                            )}
-                                          </DropdownMenuContent>
-                                        </DropdownMenu>
                                       )}
                                   </div>
                                 )}
@@ -610,40 +573,20 @@ function ChannelView({ page }: ChannelViewProps) {
                                   </>
                                 )}
                                 <MessageAttachment message={m} />
-                                {!isFirst && showMenu && (
-                                  <DropdownMenu>
-                                    <DropdownMenuTrigger asChild>
-                                      <button
-                                        aria-label="Message options"
-                                        className="absolute top-0 right-0 p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
-                                        type="button"
-                                      >
-                                        <MoreHorizontal size={14} aria-hidden />
-                                      </button>
-                                    </DropdownMenuTrigger>
-                                    <DropdownMenuContent align="end">
-                                      <DropdownMenuItem onClick={() => handleStartQuote(m)}>
-                                        <CornerUpLeft className="mr-2 h-4 w-4" /> Quote reply
-                                      </DropdownMenuItem>
-                                      {showOwnerActions && (
-                                        <>
-                                          <DropdownMenuSeparator />
-                                          <DropdownMenuItem
-                                            onClick={() => { setEditingMessageId(m.id); setEditContent(m.content); }}
-                                          >
-                                            <Pencil className="mr-2 h-4 w-4" /> Edit
-                                          </DropdownMenuItem>
-                                          <DropdownMenuSeparator />
-                                          <DropdownMenuItem
-                                            onClick={() => handleDeleteMessage(m.id)}
-                                            className="text-destructive focus:text-destructive"
-                                          >
-                                            <Trash2 className="mr-2 h-4 w-4" /> Delete
-                                          </DropdownMenuItem>
-                                        </>
-                                      )}
-                                    </DropdownMenuContent>
-                                  </DropdownMenu>
+                                {replyCount > 0 && (
+                                  <button
+                                    type="button"
+                                    onClick={() =>
+                                      openThread({ source: 'channel', contextId: page.id, parentId: m.id })
+                                    }
+                                    data-testid={`thread-footer-${m.id}`}
+                                    className="mt-1 self-start text-xs text-muted-foreground hover:text-foreground hover:underline"
+                                  >
+                                    {replyCount} {replyCount === 1 ? 'reply' : 'replies'}
+                                    {m.lastReplyAt
+                                      ? ` · last reply ${formatDistanceToNow(new Date(m.lastReplyAt), { addSuffix: true })}`
+                                      : ''}
+                                  </button>
                                 )}
                                 {user && !m.id.startsWith('temp-') && (
                                   <MessageReactions
@@ -652,6 +595,22 @@ function ChannelView({ page }: ChannelViewProps) {
                                     onAddReaction={(emoji) => handleAddReaction(m.id, emoji)}
                                     onRemoveReaction={(emoji) => handleRemoveReaction(m.id, emoji)}
                                     canReact={permissions?.canView || false}
+                                  />
+                                )}
+                                {isRealMessage && (
+                                  <MessageHoverToolbar
+                                    canReact={permissions?.canView || false}
+                                    canEdit={showOwnerActions}
+                                    canDelete={showOwnerActions}
+                                    canReplyInThread={!isAi && !m.id.startsWith('temp-')}
+                                    canQuoteReply={true}
+                                    onAddReaction={(emoji) => handleAddReaction(m.id, emoji)}
+                                    onQuoteReply={() => handleStartQuote(m)}
+                                    onEdit={() => { setEditingMessageId(m.id); setEditContent(m.content); }}
+                                    onDelete={() => handleDeleteMessage(m.id)}
+                                    onReplyInThread={() =>
+                                      openThread({ source: 'channel', contextId: page.id, parentId: m.id })
+                                    }
                                   />
                                 )}
                             </div>

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -134,10 +134,26 @@ function ChannelView({ page }: ChannelViewProps) {
       });
     };
 
+    const handleThreadCountUpdated = (data: {
+      rootId: string;
+      replyCount: number;
+      lastReplyAt: string;
+    }) => {
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === data.rootId
+            ? { ...m, replyCount: data.replyCount, lastReplyAt: data.lastReplyAt }
+            : m,
+        ),
+      );
+    };
+
     socket.on('new_message', handleNewMessage);
+    socket.on('thread_reply_count_updated', handleThreadCountUpdated);
 
     return () => {
       socket.off('new_message', handleNewMessage);
+      socket.off('thread_reply_count_updated', handleThreadCountUpdated);
     };
   }, [socket, connectionStatus, page.id]);
 

--- a/apps/web/src/components/shared/MessageHoverToolbar.tsx
+++ b/apps/web/src/components/shared/MessageHoverToolbar.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useState } from 'react';
+import { cn } from '@/lib/utils';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { EmojiPickerPopover } from '@/components/ui/emoji-picker';
+import {
+  CornerUpLeft,
+  MessageSquareReply,
+  MoreHorizontal,
+  Pencil,
+  Smile,
+  Trash2,
+} from 'lucide-react';
+
+export interface MessageHoverToolbarProps {
+  canReact: boolean;
+  canEdit: boolean;
+  canDelete: boolean;
+  canReplyInThread: boolean;
+  canQuoteReply: boolean;
+  onAddReaction: (emoji: string) => void;
+  onQuoteReply?: () => void;
+  onEdit?: () => void;
+  onDelete?: () => void;
+  onReplyInThread?: () => void;
+  className?: string;
+}
+
+export function MessageHoverToolbar({
+  canReact,
+  canEdit,
+  canDelete,
+  canReplyInThread,
+  canQuoteReply,
+  onAddReaction,
+  onQuoteReply,
+  onEdit,
+  onDelete,
+  onReplyInThread,
+  className,
+}: MessageHoverToolbarProps) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const hasOverflow =
+    (canQuoteReply && !!onQuoteReply) ||
+    (canEdit && !!onEdit) ||
+    (canDelete && !!onDelete);
+
+  return (
+    <div
+      className={cn(
+        'absolute -top-3 right-2 z-10',
+        'flex items-center gap-0.5 p-0.5',
+        'rounded-md border border-border bg-popover shadow-sm',
+        'opacity-0 group-hover/msg:opacity-100 focus-within:opacity-100',
+        'transition-opacity',
+        pickerOpen && 'opacity-100',
+        className,
+      )}
+    >
+      {canReact && (
+        <EmojiPickerPopover
+          open={pickerOpen}
+          onOpenChange={setPickerOpen}
+          onEmojiSelect={(emoji) => {
+            onAddReaction(emoji);
+            setPickerOpen(false);
+          }}
+          side="top"
+          align="end"
+        >
+          <button
+            type="button"
+            aria-label="Add reaction"
+            className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <Smile size={14} aria-hidden />
+          </button>
+        </EmojiPickerPopover>
+      )}
+      {canReplyInThread && onReplyInThread && (
+        <button
+          type="button"
+          aria-label="Reply in thread"
+          onClick={onReplyInThread}
+          className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <MessageSquareReply size={14} aria-hidden />
+        </button>
+      )}
+      {hasOverflow && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              aria-label="Message options"
+              className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <MoreHorizontal size={14} aria-hidden />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {canQuoteReply && onQuoteReply && (
+              <DropdownMenuItem onClick={onQuoteReply}>
+                <CornerUpLeft className="mr-2 h-4 w-4" /> Quote reply
+              </DropdownMenuItem>
+            )}
+            {canEdit && onEdit && (
+              <>
+                {canQuoteReply && onQuoteReply && <DropdownMenuSeparator />}
+                <DropdownMenuItem onClick={onEdit}>
+                  <Pencil className="mr-2 h-4 w-4" /> Edit
+                </DropdownMenuItem>
+              </>
+            )}
+            {canDelete && onDelete && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  onClick={onDelete}
+                  className="text-destructive focus:text-destructive"
+                >
+                  <Trash2 className="mr-2 h-4 w-4" /> Delete
+                </DropdownMenuItem>
+              </>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+    </div>
+  );
+}
+
+export default MessageHoverToolbar;

--- a/apps/web/src/components/shared/MessageHoverToolbar.tsx
+++ b/apps/web/src/components/shared/MessageHoverToolbar.tsx
@@ -47,10 +47,13 @@ export function MessageHoverToolbar({
   className,
 }: MessageHoverToolbarProps) {
   const [pickerOpen, setPickerOpen] = useState(false);
-  const hasOverflow =
-    (canQuoteReply && !!onQuoteReply) ||
-    (canEdit && !!onEdit) ||
-    (canDelete && !!onDelete);
+  const showQuote = canQuoteReply && !!onQuoteReply;
+  const showEdit = canEdit && !!onEdit;
+  const showDelete = canDelete && !!onDelete;
+  const hasOverflow = showQuote || showEdit || showDelete;
+  const showReplyInThread = canReplyInThread && !!onReplyInThread;
+  const hasAny = canReact || showReplyInThread || hasOverflow;
+  if (!hasAny) return null;
 
   return (
     <div
@@ -84,7 +87,7 @@ export function MessageHoverToolbar({
           </button>
         </EmojiPickerPopover>
       )}
-      {canReplyInThread && onReplyInThread && (
+      {showReplyInThread && (
         <button
           type="button"
           aria-label="Reply in thread"
@@ -106,22 +109,22 @@ export function MessageHoverToolbar({
             </button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            {canQuoteReply && onQuoteReply && (
+            {showQuote && (
               <DropdownMenuItem onClick={onQuoteReply}>
                 <CornerUpLeft className="mr-2 h-4 w-4" /> Quote reply
               </DropdownMenuItem>
             )}
-            {canEdit && onEdit && (
+            {showEdit && (
               <>
-                {canQuoteReply && onQuoteReply && <DropdownMenuSeparator />}
+                {showQuote && <DropdownMenuSeparator />}
                 <DropdownMenuItem onClick={onEdit}>
                   <Pencil className="mr-2 h-4 w-4" /> Edit
                 </DropdownMenuItem>
               </>
             )}
-            {canDelete && onDelete && (
+            {showDelete && (
               <>
-                <DropdownMenuSeparator />
+                {(showQuote || showEdit) && <DropdownMenuSeparator />}
                 <DropdownMenuItem
                   onClick={onDelete}
                   className="text-destructive focus:text-destructive"

--- a/apps/web/src/components/shared/MessageHoverToolbar.tsx
+++ b/apps/web/src/components/shared/MessageHoverToolbar.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { EmojiPickerPopover } from '@/components/ui/emoji-picker';
+import type { Reaction } from '@/components/shared/MessageReactions';
 import {
   CornerUpLeft,
   MessageSquareReply,
@@ -25,7 +26,12 @@ export interface MessageHoverToolbarProps {
   canDelete: boolean;
   canReplyInThread: boolean;
   canQuoteReply: boolean;
+  /** Existing reactions on the message — used to make picker selection toggle. */
+  reactions?: Reaction[];
+  /** Current user id — used together with `reactions` for toggle behavior. */
+  currentUserId?: string;
   onAddReaction: (emoji: string) => void;
+  onRemoveReaction?: (emoji: string) => void;
   onQuoteReply?: () => void;
   onEdit?: () => void;
   onDelete?: () => void;
@@ -39,7 +45,10 @@ export function MessageHoverToolbar({
   canDelete,
   canReplyInThread,
   canQuoteReply,
+  reactions,
+  currentUserId,
   onAddReaction,
+  onRemoveReaction,
   onQuoteReply,
   onEdit,
   onDelete,
@@ -55,13 +64,28 @@ export function MessageHoverToolbar({
   const hasAny = canReact || showReplyInThread || hasOverflow;
   if (!hasAny) return null;
 
+  const handleEmojiSelect = (emoji: string) => {
+    const alreadyReacted =
+      !!currentUserId &&
+      !!reactions?.some((r) => r.emoji === emoji && r.userId === currentUserId);
+    if (alreadyReacted && onRemoveReaction) {
+      onRemoveReaction(emoji);
+    } else {
+      onAddReaction(emoji);
+    }
+    setPickerOpen(false);
+  };
+
   return (
     <div
       className={cn(
         'absolute -top-3 right-2 z-10',
         'flex items-center gap-0.5 p-0.5',
         'rounded-md border border-border bg-popover shadow-sm',
+        // Hover devices: hidden by default, shown on hover/focus or when picker is open.
+        // Touch / no-hover devices: always visible so message actions remain reachable.
         'opacity-0 group-hover/msg:opacity-100 focus-within:opacity-100',
+        '[@media(hover:none)]:opacity-100',
         'transition-opacity',
         pickerOpen && 'opacity-100',
         className,
@@ -71,10 +95,7 @@ export function MessageHoverToolbar({
         <EmojiPickerPopover
           open={pickerOpen}
           onOpenChange={setPickerOpen}
-          onEmojiSelect={(emoji) => {
-            onAddReaction(emoji);
-            setPickerOpen(false);
-          }}
+          onEmojiSelect={handleEmojiSelect}
           side="top"
           align="end"
         >

--- a/apps/web/src/components/shared/MessageReactions.tsx
+++ b/apps/web/src/components/shared/MessageReactions.tsx
@@ -1,15 +1,12 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { cn } from '@/lib/utils';
-import { Button } from '@/components/ui/button';
 import {
   Tooltip,
   TooltipTrigger,
   TooltipContent,
 } from '@/components/ui/tooltip';
-import { EmojiPickerPopover } from '@/components/ui/emoji-picker';
-import { Plus } from 'lucide-react';
 
 export interface Reaction {
   id: string;
@@ -22,17 +19,11 @@ export interface Reaction {
 }
 
 export interface MessageReactionsProps {
-  /** Reactions on this message */
   reactions: Reaction[];
-  /** Current user ID */
   currentUserId: string;
-  /** Called when adding a reaction */
-  onAddReaction: (emoji: string) => void;
-  /** Called when removing a reaction */
   onRemoveReaction: (emoji: string) => void;
-  /** Whether the user can add reactions */
+  onAddReaction: (emoji: string) => void;
   canReact?: boolean;
-  /** Additional class names */
   className?: string;
 }
 
@@ -43,26 +34,14 @@ interface GroupedReaction {
   hasReacted: boolean;
 }
 
-/**
- * MessageReactions - Display and manage reactions on a message
- *
- * Features:
- * - Grouped reaction chips with counts
- * - Hover tooltip showing who reacted
- * - Click to toggle own reaction
- * - Add reaction button with emoji picker
- */
 export function MessageReactions({
   reactions,
   currentUserId,
-  onAddReaction,
   onRemoveReaction,
+  onAddReaction,
   canReact = true,
   className,
 }: MessageReactionsProps) {
-  const [pickerOpen, setPickerOpen] = useState(false);
-
-  // Group reactions by emoji
   const groupedReactions = useMemo<GroupedReaction[]>(() => {
     const groups = new Map<string, GroupedReaction>();
 
@@ -84,17 +63,18 @@ export function MessageReactions({
       }
     }
 
-    // Sort by count descending, then by emoji
     return Array.from(groups.values()).sort((a, b) => {
       if (b.count !== a.count) return b.count - a.count;
       return a.emoji.localeCompare(b.emoji);
     });
   }, [reactions, currentUserId]);
 
-  // Handle clicking a reaction chip
+  if (groupedReactions.length === 0) {
+    return null;
+  }
+
   const handleReactionClick = (group: GroupedReaction) => {
     if (!canReact) return;
-
     if (group.hasReacted) {
       onRemoveReaction(group.emoji);
     } else {
@@ -102,21 +82,6 @@ export function MessageReactions({
     }
   };
 
-  // Handle selecting emoji from picker
-  const handleEmojiSelect = (emoji: string) => {
-    // Check if already reacted with this emoji
-    const existing = groupedReactions.find((g) => g.emoji === emoji);
-    if (existing?.hasReacted) {
-      // Already reacted, remove it
-      onRemoveReaction(emoji);
-    } else {
-      // Add new reaction
-      onAddReaction(emoji);
-    }
-    setPickerOpen(false);
-  };
-
-  // Format user names for tooltip
   const formatUserNames = (users: { id: string; name: string | null }[]) => {
     const names = users
       .map((u) => (u.id === currentUserId ? 'You' : u.name || 'Unknown'))
@@ -129,13 +94,8 @@ export function MessageReactions({
     return names.join(', ');
   };
 
-  if (groupedReactions.length === 0 && !canReact) {
-    return null;
-  }
-
   return (
     <div className={cn('flex flex-wrap items-center gap-1 mt-1', className)}>
-      {/* Reaction chips */}
       {groupedReactions.map((group) => (
         <Tooltip key={group.emoji}>
           <TooltipTrigger asChild>
@@ -161,30 +121,6 @@ export function MessageReactions({
           </TooltipContent>
         </Tooltip>
       ))}
-
-      {/* Add reaction button */}
-      {canReact && (
-        <EmojiPickerPopover
-          open={pickerOpen}
-          onOpenChange={setPickerOpen}
-          onEmojiSelect={handleEmojiSelect}
-          side="top"
-          align="start"
-        >
-          <Button
-            variant="ghost"
-            size="sm"
-            className={cn(
-              'h-6 w-6 p-0 rounded-full',
-              'text-muted-foreground hover:text-foreground',
-              'hover:bg-muted/50',
-            )}
-          >
-            <Plus className="h-3.5 w-3.5" />
-            <span className="sr-only">Add reaction</span>
-          </Button>
-        </EmojiPickerPopover>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Extracts `MessageHoverToolbar` (emoji-react · reply-in-thread · ⋯ overflow with Quote / Edit / Delete) and uses it in all three message surfaces (`ChannelView`, dashboard channels route, DM page) so the action surface is consistent.
- Fixes the bug where grouped messages had `MoreHorizontal` / reply icons absolutely positioned on top of the first line of message text — the toolbar now sits at the top of the message row outside the content area, identical for first-in-group and grouped rows.
- `ChannelView` now exposes reply-in-thread + reply-count footer (the thread store / API / panel were already wired; the UI just didn't surface them).
- DMs drop the bubble background (`bg-primary/5` / `bg-gray-50`) to match channel flat rendering.
- `MessageReactions` slims to chips-only — the `+` add-reaction moved into the unified toolbar.

## Behavior details

- **Touch / no-hover devices**: toolbar is always visible (`[@media(hover:none)]:opacity-100`). On hover-capable devices it fades in on row hover / focus-within / when the picker is open.
- **Reaction toggle**: selecting an emoji from the picker for which the current user has already reacted dispatches `onRemoveReaction` (toggle off) instead of `onAddReaction`, matching the previous `MessageReactions` picker behavior. Toolbar takes `reactions` + `currentUserId` to make this decision.

## Files

- **NEW** `apps/web/src/components/shared/MessageHoverToolbar.tsx`
- `apps/web/src/components/shared/MessageReactions.tsx` — chips only
- `apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx` — toolbar + reply-in-thread + reply-count footer
- `apps/web/src/app/dashboard/channels/[pageId]/page.tsx` — toolbar (Quote reply opt-out: this surface has no quote-reply infrastructure; tracked as follow-up)
- `apps/web/src/app/dashboard/dms/[conversationId]/page.tsx` — toolbar; bubble removed

## Test plan

- [ ] Open a Channel page (CenterPanel) — hover any message, including grouped ones; toolbar appears above the row, never overlaps text.
- [ ] Same for `/dashboard/channels/[pageId]` route.
- [ ] Open a DM with several back-to-back messages from one person within 5 minutes — confirm grouped messages no longer have icons over the first line; bubbles are gone; flat rendering matches channels.
- [ ] Click each toolbar action: emoji adds a reaction; Quote reply populates composer (channels + DMs); reply-in-thread opens `ThreadPanel`; Edit / Delete only on own messages.
- [ ] Reaction chips still render below messages; click toggles own reaction.
- [ ] Pick an emoji you've already reacted with from the toolbar picker — it should *remove* (toggle off), not add a duplicate.
- [ ] Mobile / touch device: toolbar is always visible above each message; tap to act.

## Out of scope (follow-ups)

- Add `isFirstInGroup` grouping to `dashboard/channels/[pageId]/page.tsx` (it doesn't currently group — separate parity gap).
- Wire quote-reply infrastructure (state + handler + composer integration + `MessageQuoteBlock` rendering) into `dashboard/channels/[pageId]/page.tsx`. Currently `canQuoteReply={false}` on that surface only.
- Extract a shared `MessageList` so the three surfaces stop reimplementing the same map+render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)