### PR TITLE
feat(messages): promote quote reply to top-level action

### DIFF
--- a/apps/web/src/components/shared/MessageHoverToolbar.tsx
+++ b/apps/web/src/components/shared/MessageHoverToolbar.tsx
@@ -59,9 +59,9 @@ export function MessageHoverToolbar({
   const showQuote = canQuoteReply && !!onQuoteReply;
   const showEdit = canEdit && !!onEdit;
   const showDelete = canDelete && !!onDelete;
-  const hasOverflow = showQuote || showEdit || showDelete;
+  const hasOverflow = showEdit || showDelete;
   const showReplyInThread = canReplyInThread && !!onReplyInThread;
-  const hasAny = canReact || showReplyInThread || hasOverflow;
+  const hasAny = canReact || showQuote || showReplyInThread || hasOverflow;
   if (!hasAny) return null;
 
   const handleEmojiSelect = (emoji: string) => {
@@ -108,6 +108,16 @@ export function MessageHoverToolbar({
           </button>
         </EmojiPickerPopover>
       )}
+      {showQuote && (
+        <button
+          type="button"
+          aria-label="Quote reply"
+          onClick={onQuoteReply}
+          className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <CornerUpLeft size={14} aria-hidden />
+        </button>
+      )}
       {showReplyInThread && (
         <button
           type="button"
@@ -130,22 +140,14 @@ export function MessageHoverToolbar({
             </button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            {showQuote && (
-              <DropdownMenuItem onClick={onQuoteReply}>
-                <CornerUpLeft className="mr-2 h-4 w-4" /> Quote reply
-              </DropdownMenuItem>
-            )}
             {showEdit && (
-              <>
-                {showQuote && <DropdownMenuSeparator />}
-                <DropdownMenuItem onClick={onEdit}>
-                  <Pencil className="mr-2 h-4 w-4" /> Edit
-                </DropdownMenuItem>
-              </>
+              <DropdownMenuItem onClick={onEdit}>
+                <Pencil className="mr-2 h-4 w-4" /> Edit
+              </DropdownMenuItem>
             )}
             {showDelete && (
               <>
-                {(showQuote || showEdit) && <DropdownMenuSeparator />}
+                {showEdit && <DropdownMenuSeparator />}
                 <DropdownMenuItem
                   onClick={onDelete}
                   className="text-destructive focus:text-destructive"


### PR DESCRIPTION
## Summary
- Moves **Quote reply** out of the 3-dot overflow menu and into the primary hover toolbar, alongside emoji and reply-in-thread.
- Overflow menu now only holds Edit/Delete, and is hidden entirely when neither is available.
- Quote remains a single-icon button (CornerUpLeft) with `aria-label="Quote reply"`.

## Why
Quote reply is a frequent action — burying it behind an extra click in the 3-dot menu was inconsistent with how reply/emoji are surfaced.

## Test plan
- [ ] Hover a channel message: emoji, quote, reply-in-thread visible inline; 3-dot only shows when Edit/Delete are available.
- [ ] Click the Quote button → inline quote-reply composer activates as before.
- [ ] DM messages: Quote button visible (canQuoteReply=true).
- [ ] Channel messages outside a thread: Quote button visible; threaded view (canQuoteReply=false): Quote button hidden.
- [ ] Touch / `@media(hover:none)` devices: toolbar still visible by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)