### PR TITLE
fix(messages): correct quote icon + grouped overlap

### DIFF
--- a/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
@@ -688,6 +688,7 @@ export default function InboxDMPage() {
                         canQuoteReply={true}
                         reactions={message.reactions}
                         currentUserId={user?.id}
+                        className={!isFirst ? 'top-0' : undefined}
                         onAddReaction={(emoji) => handleAddReaction(message.id, emoji)}
                         onRemoveReaction={(emoji) => handleRemoveReaction(message.id, emoji)}
                         onQuoteReply={() => handleStartQuote(message)}

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -622,6 +622,7 @@ function ChannelView({ page }: ChannelViewProps) {
                                     canQuoteReply={true}
                                     reactions={m.reactions}
                                     currentUserId={user?.id}
+                                    className={!isFirst ? 'top-0' : undefined}
                                     onAddReaction={(emoji) => handleAddReaction(m.id, emoji)}
                                     onRemoveReaction={(emoji) => handleRemoveReaction(m.id, emoji)}
                                     onQuoteReply={() => handleStartQuote(m)}

--- a/apps/web/src/components/shared/MessageHoverToolbar.tsx
+++ b/apps/web/src/components/shared/MessageHoverToolbar.tsx
@@ -12,10 +12,10 @@ import {
 import { EmojiPickerPopover } from '@/components/ui/emoji-picker';
 import type { Reaction } from '@/components/shared/MessageReactions';
 import {
-  CornerUpLeft,
   MessageSquareReply,
   MoreHorizontal,
   Pencil,
+  Quote,
   Smile,
   Trash2,
 } from 'lucide-react';
@@ -115,7 +115,7 @@ export function MessageHoverToolbar({
           onClick={onQuoteReply}
           className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
         >
-          <CornerUpLeft size={14} aria-hidden />
+          <Quote size={14} aria-hidden />
         </button>
       )}
       {showReplyInThread && (


### PR DESCRIPTION
## Summary
- **Icon:** Quote button on the hover toolbar now uses lucide's `Quote` (quotation-mark) icon instead of `CornerUpLeft` (return-arrow), matching the action's intent.
- **Grouped-message overlap:** The toolbar's default `-top-3` floats it ~10px above the row. With grouped rows using `mt-0.5` (2px) of spacing, this overlapped the previous grouped message's last line. Call sites now pass `className={!isFirst ? 'top-0' : undefined}` so the toolbar tucks inside the current row's footprint when the message is a grouped continuation.

No `MessageHoverToolbar` API change — the existing `className` prop + `cn()` (tailwind-merge) handles the override.

## Files
- `apps/web/src/components/shared/MessageHoverToolbar.tsx` — icon swap.
- `apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx` — `className` override.
- `apps/web/src/app/dashboard/dms/[conversationId]/page.tsx` — `className` override.

Dashboard channels route (`apps/web/src/app/dashboard/channels/[pageId]/page.tsx`) doesn't group consecutive messages, so it's unchanged.

## Test plan
- [ ] Channel: send 3 messages from the same user within 5 min — confirm grouping.
- [ ] Hover the first (non-grouped) message: toolbar floats above with the new Quote icon.
- [ ] Hover a grouped message: toolbar sits at the top-right of the row, **not** floating up over the previous message.
- [ ] DM: same checks in `/dashboard/dms/{conversationId}`.
- [ ] Dashboard channels route: toolbar still floats above each message (no grouping there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined message hover toolbar positioning to enhance visual consistency and spacing in direct message threads and channel conversations, particularly for non-first messages in conversation groups
  * Updated the quote action button icon to provide clearer visual representation and improved interface consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->