### PR TITLE
fix(drives): keep search input focus on typing

### DIFF
--- a/apps/web/src/components/layout/navbar/DriveSwitcher.tsx
+++ b/apps/web/src/components/layout/navbar/DriveSwitcher.tsx
@@ -155,6 +155,13 @@ export default function DriveSwitcher() {
                 placeholder="Search drives..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
+                onKeyDown={(e) => {
+                  // Radix DropdownMenu typeahead steals focus on printable keys —
+                  // swallow them so the input keeps focus while typing.
+                  if (!["Escape", "Tab", "ArrowDown", "ArrowUp"].includes(e.key)) {
+                    e.stopPropagation();
+                  }
+                }}
                 className="h-8 pl-8"
                 autoFocus
               />


### PR DESCRIPTION
## Summary
- Radix `DropdownMenu` typeahead was intercepting printable keys in the navbar drive switcher's search box, jumping focus to a matching drive item after the first letter and preventing the user from typing more to narrow results.
- Stop `keydown` propagation on the search `Input` for printable keys. Let `Escape`, `Tab`, `ArrowDown`, `ArrowUp` still bubble so dismissal and keyboard navigation into the filtered list keep working.
- Single-file change: `apps/web/src/components/layout/navbar/DriveSwitcher.tsx`.

## Test plan
- [ ] Open the navbar drive switcher.
- [ ] Type several letters in "Search drives..." → input keeps focus, query keeps growing, list filters live.
- [ ] Test with multiple drives sharing a leading letter (worst case for the prior typeahead behavior).
- [ ] `Escape` from the input still closes the dropdown.
- [ ] `ArrowDown` from the input still moves focus into the filtered list.
- [ ] Selecting a drive still navigates and resets the search query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)