### PR TITLE
fix(channel): wire up emoji picker button

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInputFooter.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInputFooter.tsx
@@ -22,7 +22,7 @@ import {
   AtSign,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { EmojiPickerPopover } from '@/components/ui/emoji-picker';
+import { EmojiPicker } from '@/components/ui/emoji-picker';
 
 export interface ChannelInputFooterProps {
   /** Callback when formatting button clicked */
@@ -176,36 +176,42 @@ export function ChannelInputFooter({
         </Tooltip>
 
         {/* Emoji picker */}
-        <EmojiPickerPopover
-          open={emojiPickerOpen}
-          onOpenChange={setEmojiPickerOpen}
-          onEmojiSelect={(emoji) => {
-            onEmojiSelect?.(emoji);
-            setEmojiPickerOpen(false);
-          }}
-          side="top"
-          align="start"
-          showQuickReactions={false}
-        >
+        <Popover open={emojiPickerOpen} onOpenChange={setEmojiPickerOpen}>
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="sm"
-                disabled={disabled}
-                className={cn(
-                  'h-8 w-8 p-0',
-                  'text-muted-foreground hover:text-foreground',
-                  'hover:bg-muted/50'
-                )}
-              >
-                <Smile className="h-4 w-4" />
-                <span className="sr-only">Emoji</span>
-              </Button>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={disabled}
+                  className={cn(
+                    'h-8 w-8 p-0',
+                    'text-muted-foreground hover:text-foreground',
+                    'hover:bg-muted/50'
+                  )}
+                >
+                  <Smile className="h-4 w-4" />
+                  <span className="sr-only">Emoji</span>
+                </Button>
+              </PopoverTrigger>
             </TooltipTrigger>
             <TooltipContent side="top">Add emoji</TooltipContent>
           </Tooltip>
-        </EmojiPickerPopover>
+          <PopoverContent
+            side="top"
+            align="start"
+            className="w-auto p-0"
+            sideOffset={8}
+          >
+            <EmojiPicker
+              onEmojiSelect={(emoji) => {
+                onEmojiSelect?.(emoji);
+                setEmojiPickerOpen(false);
+              }}
+              showQuickReactions={false}
+            />
+          </PopoverContent>
+        </Popover>
       </div>
 
       {/* Right group - Attachments + thread also-send toggle */}


### PR DESCRIPTION
## Summary
- The Smile button in the channel/DM/thread/floating composer never opened the emoji picker. `<EmojiPickerPopover>` rendered `<PopoverTrigger asChild>{children}</PopoverTrigger>` and the `children` was a `<Tooltip>` Radix Root — a context-only provider that renders no DOM, so Slot had nothing to attach the open-toggle to.
- Restructured to the working pattern used by the formatting button right above it: `Popover → Tooltip → TooltipTrigger asChild → PopoverTrigger asChild → Button`, with the picker inlined via `<EmojiPicker>` inside `<PopoverContent>`. Single file (`apps/web/src/components/layout/middle-content/page-views/channel/ChannelInputFooter.tsx`); covers all four surfaces because they all share `MessageInput → ChannelInput → ChannelInputFooter`.
- `MessageHoverToolbar`'s reaction picker is unchanged (it passes a plain `<button>` as the `EmojiPickerPopover` child, which was already correct).

## Test plan
- [ ] Open a channel → click smile in composer → picker opens, click an emoji → emoji appended, picker closes, textarea refocused
- [ ] Open a DM → same behavior
- [ ] Open a thread panel from either → same behavior
- [ ] Hover-tooltip on the smile button still reads "Add emoji"
- [ ] Hover a message → reaction picker still opens (regression check on `MessageHoverToolbar`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)