### PR TITLE
fix(dms): show Read only on last read message

### DIFF
--- a/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
@@ -519,6 +519,15 @@ export default function InboxDMPage() {
     />
   ) : null;
 
+  let lastReadOwnIndex = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m.senderId === user?.id && m.isRead) {
+      lastReadOwnIndex = i;
+      break;
+    }
+  }
+
   return (
     <div className="flex h-full w-full">
     <MessageDropZone inputRef={chatInputRef} enabled className="flex flex-col h-full flex-1 min-w-0">
@@ -556,6 +565,7 @@ export default function InboxDMPage() {
               const showOwnerActions = isOwnMessage && isRealMessage;
               const replyCount = message.replyCount ?? 0;
               const showReplyInThread = !message.id.startsWith('temp-');
+              const isLastRead = i === lastReadOwnIndex;
 
               return (
                 <div key={message.id} className={`group/msg flex items-start gap-4 ${rowSpacing}`}>
@@ -593,7 +603,7 @@ export default function InboxDMPage() {
                         {message.isEdited && (
                           <span className="text-xs text-muted-foreground italic">(edited)</span>
                         )}
-                        {message.isRead && isOwnMessage && (
+                        {isLastRead && isOwnMessage && (
                           <span className="text-xs text-muted-foreground">Read</span>
                         )}
                       </div>
@@ -644,12 +654,12 @@ export default function InboxDMPage() {
                           </div>
                         )}
                         <MessageAttachment message={message} />
-                        {!isFirst && (message.isEdited || (message.isRead && isOwnMessage)) && (
+                        {!isFirst && (message.isEdited || (isLastRead && isOwnMessage)) && (
                           <div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
                             {message.isEdited && (
                               <span className="italic">(edited)</span>
                             )}
-                            {message.isRead && isOwnMessage && (
+                            {isLastRead && isOwnMessage && (
                               <span>Read</span>
                             )}
                           </div>


### PR DESCRIPTION
## Summary
- DM read receipts previously rendered on every own message with `isRead === true`, stacking multiple "Read" labels through a conversation (the recipient's mark-as-read sweep flips all prior messages at once).
- Compute the most recent own message that has been read, then gate the existing render sites on that index — so exactly one "Read" indicator renders per conversation.
- No backend, schema, or channel-view changes. Pure UI fix in `apps/web/src/app/dashboard/dms/[conversationId]/page.tsx`.

## Test plan
- [ ] Open a DM in two browser sessions. Send 3 messages from A in one group, open the DM as B, return to A — confirm exactly one "Read" label, on the last message.
- [ ] Group break: A sends, B replies, A sends two more, B opens. Confirm "Read" appears only on A's most recent message.
- [ ] Recipient view (B) shows no "Read" labels on incoming messages.
- [ ] Edit a non-first-in-group message that is not the last read — confirm `(edited)` still renders below it.
- [ ] `pnpm --filter web typecheck` and `pnpm --filter web lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)