### PR TITLE
fix(email): point DM "View Message" link at /dashboard/dms

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -51,6 +51,7 @@ const nextConfig: NextConfig = {
     return [
       { source: '/dashboard/inbox/channel/:pageId', destination: '/dashboard/channels/:pageId', permanent: false },
       { source: '/dashboard/inbox/dm/:conversationId', destination: '/dashboard/dms/:conversationId', permanent: false },
+      { source: '/dashboard/messages/:conversationId', destination: '/dashboard/dms/:conversationId', permanent: false },
       { source: '/dashboard/inbox/new', destination: '/dashboard/dms/new', permanent: false },
       { source: '/dashboard/inbox', destination: '/dashboard/dms', permanent: false },
       { source: '/dashboard/:driveId/inbox', destination: '/dashboard/:driveId/channels', permanent: false },

--- a/packages/lib/src/services/__tests__/notification-email-service.test.ts
+++ b/packages/lib/src/services/__tests__/notification-email-service.test.ts
@@ -52,6 +52,7 @@ vi.mock('../../auth/token-utils', () => ({
 
 import { db } from '@pagespace/db/db';
 import { sendEmail } from '../email-service';
+import { DirectMessageEmail } from '../../email-templates/DirectMessageEmail';
 import { sendNotificationEmail, sendPendingDriveInvitationEmail } from '../notification-email-service';
 
 type MockFn = ReturnType<typeof vi.fn>;
@@ -130,6 +131,9 @@ describe('notification-email-service', () => {
 
     expect(sendEmail).toHaveBeenCalledWith(expect.objectContaining({
       subject: expect.stringContaining('Bob'),
+    }));
+    expect(DirectMessageEmail).toHaveBeenCalledWith(expect.objectContaining({
+      viewUrl: expect.stringContaining('/dashboard/dms/c1'),
     }));
   });
 

--- a/packages/lib/src/services/notification-email-service.ts
+++ b/packages/lib/src/services/notification-email-service.ts
@@ -133,7 +133,7 @@ function getEmailTemplate(data: NotificationEmailData, user: { name: string; ema
           userName: user.name,
           senderName: (data.metadata.senderName as string) || 'Someone',
           messagePreview: (data.metadata.messagePreview as string) || 'New message received',
-          viewUrl: `${appUrl}/dashboard/messages/${data.metadata.conversationId}`,
+          viewUrl: `${appUrl}/dashboard/dms/${data.metadata.conversationId}`,
           unsubscribeUrl,
         }),
       };


### PR DESCRIPTION
## Summary

- DM notification email built `/dashboard/messages/{conversationId}` — a route that never existed in this app. DMs live at `/dashboard/dms/[conversationId]` (introduced when inbox was split into Direct Messages + Channels). Clicking **View Message** 404'd.
- Fix the email link in `notification-email-service.ts` to point at `/dashboard/dms/{conversationId}`.
- Add a redirect for `/dashboard/messages/:conversationId` → `/dashboard/dms/:conversationId` so emails already in users' inboxes still resolve instead of crashing.
- Tighten the `NEW_DIRECT_MESSAGE` email-service test to assert `viewUrl` contains `/dashboard/dms/<id>`, locking the route shape against future moves.

Reported when an email about a new DM crashed on click — only `/dashboard/messages/` reference in the codebase, and the legacy `/dashboard/inbox/...` redirect map didn't cover it.

## Test plan

- [x] `pnpm --filter @pagespace/lib test notification-email-service` — 23/23 pass, including the new `viewUrl` assertion.
- [x] `pnpm --filter @pagespace/lib typecheck` — clean.
- [x] Web typecheck errors verified pre-existing (same on baseline before changes).
- [ ] Manual: trigger a DM notification email in dev, confirm the link is `/dashboard/dms/<id>`.
- [ ] Manual: visit `/dashboard/messages/<conversation-id>` in dev, confirm it 308-redirects to `/dashboard/dms/<id>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)