### PR TITLE
feat(ai): allow AI to read and edit CODE pages via replace_lines

### DIFF
--- a/apps/web/src/lib/ai/core/inline-instructions.ts
+++ b/apps/web/src/lib/ai/core/inline-instructions.ts
@@ -47,6 +47,7 @@ CONTEXT:
 PAGE TYPES:
 • FOLDER: Container with list/icon view of children. Accepts file uploads via drag-drop.
 • DOCUMENT: Rich text stored as HTML. Use replace_lines for content changes.
+• CODE: Plain-text source code with syntax highlighting. Use replace_lines for edits (raw text, no HTML processing).
 • SHEET: Spreadsheet stored as TOML. Use edit_sheet_cells for cell-level edits.
 • CANVAS: Raw HTML/CSS rendered in an isolated sandbox. body/html/:root styles auto-remap to the sandbox root. Edit as HTML.
 • TASK_LIST: Task manager where each task auto-creates a linked child DOCUMENT page.
@@ -97,6 +98,7 @@ CONTEXT:
 PAGE TYPES:
 • FOLDER: Container with list/icon view of children. Accepts file uploads via drag-drop.
 • DOCUMENT: Rich text stored as HTML. Use replace_lines for content changes.
+• CODE: Plain-text source code with syntax highlighting. Use replace_lines for edits (raw text, no HTML processing).
 • SHEET: Spreadsheet stored as TOML. Use edit_sheet_cells for cell-level edits.
 • CANVAS: Raw HTML/CSS rendered in an isolated sandbox. body/html/:root styles auto-remap to the sandbox root. Edit as HTML.
 • TASK_LIST: Task manager where each task auto-creates a linked child DOCUMENT page.

--- a/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
@@ -76,6 +76,7 @@ vi.mock('@pagespace/lib/permissions/permissions', () => ({
 vi.mock('@pagespace/lib/content/page-types.config', () => ({
     getPageTypeEmoji: vi.fn((_type: string) => '📄'),
     isFolderPage: vi.fn((type: string) => type === 'FOLDER'),
+    isCodePage: vi.fn((type: string) => type === 'CODE'),
     getCreatablePageTypes: vi.fn(() => []),
 }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({

--- a/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
@@ -49,6 +49,7 @@ vi.mock('@pagespace/lib/content/page-types.config', () => ({
     getCreatablePageTypes: vi.fn(() => ['FOLDER', 'DOCUMENT', 'CHANNEL', 'AI_CHAT', 'CANVAS', 'SHEET', 'TASK_LIST', 'CODE']),
     isAIChatPage: vi.fn((type) => type === 'AI_CHAT'),
     isDocumentPage: vi.fn((type) => type === 'DOCUMENT'),
+    isCodePage: vi.fn((type) => type === 'CODE'),
 }));
 vi.mock('@pagespace/lib/sheets/sheet', () => ({
     parseSheetContent: vi.fn(() => ({ rowCount: 10, columnCount: 5 })),
@@ -283,6 +284,47 @@ describe('page-write-tools', () => {
           updates: { content: 'Line 1\nNew Line 2\nLine 3' },
           updatedFields: ['content'],
           context: expect.objectContaining({ userId: 'user-123', isAiGenerated: true }),
+        })
+      );
+    });
+
+    it('replaces lines in CODE page without HTML mangling', async () => {
+      // CODE pages may contain raw HTML/XML source. addLineBreaksForAI must NOT
+      // run on them, so the saved content should preserve angle brackets verbatim.
+      mockPageRepo.findById.mockResolvedValue({
+        id: 'page-1',
+        title: 'index.html',
+        type: 'CODE',
+        content: '<div>old</div>\n<p>keep</p>',
+        contentMode: 'html' as const,
+        driveId: 'drive-1',
+        parentId: null,
+        position: 1,
+        isTrashed: false,
+        trashedAt: null,
+        revision: 1,
+        stateHash: null,
+      });
+      mockCanUserEditPage.mockResolvedValue(true);
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      const result = await pageWriteTools.replace_lines.execute!(
+        { title: 'index.html', pageId: 'page-1', startLine: 1, content: '<div>new</div>' },
+        context
+      );
+
+      if ('error' in result) throw new Error(`Expected success but got error: ${result.error}`);
+      const success = result as { success: boolean };
+      expect(success.success).toBe(true);
+      expect(mockApplyPageMutation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pageId: 'page-1',
+          operation: 'update',
+          updates: { content: '<div>new</div>\n<p>keep</p>' },
         })
       );
     });

--- a/apps/web/src/lib/ai/tools/page-read-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-read-tools.ts
@@ -7,7 +7,7 @@ import { taskItems, taskLists, taskStatusConfigs, DEFAULT_TASK_STATUSES } from '
 import { channelMessages } from '@pagespace/db/schema/chat';
 import { buildTree } from '@pagespace/lib/content/tree-utils';
 import { getUserAccessLevel, getUserDriveAccess, getUserAccessiblePagesInDriveWithDetails } from '@pagespace/lib/permissions/permissions';
-import { getPageTypeEmoji, isFolderPage } from '@pagespace/lib/content/page-types.config';
+import { getPageTypeEmoji, isFolderPage, isCodePage } from '@pagespace/lib/content/page-types.config';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { type ToolExecutionContext, getSuggestedVisionModels } from '../core';
 import { addLineBreaksForAI } from '@/lib/editor/line-breaks';
@@ -543,10 +543,11 @@ export const pageReadTools = {
           };
         }
 
-        // Format content for AI line-based editing, then split into lines
-        // Markdown pages already have natural line structure; HTML pages need addLineBreaksForAI
-        const isMarkdown = page.contentMode === 'markdown';
-        const formattedContent = isMarkdown
+        // Format content for AI line-based editing, then split into lines.
+        // CODE and markdown pages have natural line structure (and CODE may contain
+        // raw HTML/XML that addLineBreaksForAI would mangle); HTML documents need it.
+        const isRawText = page.contentMode === 'markdown' || isCodePage(page.type as PageType);
+        const formattedContent = isRawText
           ? (page.content || '')
           : addLineBreaksForAI(page.content || '');
         const allLines = formattedContent.split('\n');

--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -2,7 +2,7 @@ import { tool } from 'ai';
 import { z } from 'zod';
 import { canUserEditPage, canUserDeletePage } from '@pagespace/lib/permissions/permissions';
 import { PageType } from '@pagespace/lib/utils/enums';
-import { isAIChatPage, isDocumentPage, getDefaultContent, getCreatablePageTypes } from '@pagespace/lib/content/page-types.config';
+import { isAIChatPage, isDocumentPage, isCodePage, getDefaultContent, getCreatablePageTypes } from '@pagespace/lib/content/page-types.config';
 import { parseSheetContent, serializeSheetContent, updateSheetCells, isValidCellAddress, isSheetType } from '@pagespace/lib/sheets/sheet';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { logPageActivity, logDriveActivity, getActorInfo, type ActivityOperation } from '@pagespace/lib/monitoring/activity-logger';
@@ -372,7 +372,7 @@ export const pageWriteTools = {
    * Replace specific line(s) in a document
    */
   replace_lines: tool({
-    description: 'Replace one or more lines in a document with new content. Specify start and end line numbers (1-based indexing).',
+    description: 'Replace one or more lines in a document or code page with new content. Specify start and end line numbers (1-based indexing).',
     inputSchema: z.object({
       title: z.string().describe('The document title for display context'),
       pageId: z.string().describe('The unique ID of the page to edit'),
@@ -431,10 +431,11 @@ export const pageWriteTools = {
           throw new Error('Insufficient permissions to edit this document');
         }
 
-        // Format content for AI line-based editing, then split into lines
-        // Markdown pages already have natural line structure; HTML pages need addLineBreaksForAI
-        const isMarkdown = page.contentMode === 'markdown';
-        const formattedContent = isMarkdown
+        // Format content for AI line-based editing, then split into lines.
+        // CODE and markdown pages have natural line structure (and CODE may contain
+        // raw HTML/XML that addLineBreaksForAI would mangle); HTML documents need it.
+        const isRawText = page.contentMode === 'markdown' || isCodePage(page.type as PageType);
+        const formattedContent = isRawText
           ? (page.content || '')
           : addLineBreaksForAI(page.content || '');
         const lines = formattedContent.split('\n');

--- a/packages/lib/src/content/page-types.config.ts
+++ b/packages/lib/src/content/page-types.config.ts
@@ -180,7 +180,7 @@ export const PAGE_TYPE_CONFIGS: Record<PageType, PageTypeConfig> = {
       canBeConverted: false,
       supportsRealtime: true,
       supportsVersioning: true,
-      supportsAI: false,
+      supportsAI: true,
     },
     defaultContent: () => '',
     uiComponent: 'CodePageView',


### PR DESCRIPTION
CODE pages now have supportsAI: true. read_page and replace_lines
treat CODE content as raw text (skip addLineBreaksForAI) so HTML/XML
source isn't mangled by the block-tag formatter. Tool descriptions
and inline AI instructions updated to mention CODE.