### PR TITLE
fix(sidebar): + and Alt+N always create at root

### DIFF
--- a/apps/web/src/components/create/QuickCreatePalette.tsx
+++ b/apps/web/src/components/create/QuickCreatePalette.tsx
@@ -164,7 +164,7 @@ export default function QuickCreatePalette() {
       const binding = getEffectiveBinding('pages.quick-create');
       if (matchesKeyEvent(binding, e) && !isEditingActive() && driveId && !quickCreateOpen) {
         e.preventDefault();
-        openQuickCreate();
+        openQuickCreate(null);
       }
     };
     document.addEventListener('keydown', handler);

--- a/apps/web/src/components/layout/left-sidebar/index.tsx
+++ b/apps/web/src/components/layout/left-sidebar/index.tsx
@@ -94,7 +94,7 @@ export default function Sidebar({ className }: SidebarProps) {
                     variant="ghost"
                     size="icon"
                     className="h-8 w-8 shrink-0"
-                    onClick={() => openQuickCreate()}
+                    onClick={() => openQuickCreate(null)}
                   >
                     <Plus className="h-4 w-4" />
                   </Button>


### PR DESCRIPTION
## Summary
- The sidebar **+** button (next to the search input) and the **Alt+N** hotkey now always create the new page at the drive root, regardless of which page is currently open.
- Per-row **+** buttons in the page tree are unchanged — they still nest the new page under their row.
- Implementation: pass `null` as the parent override to `openQuickCreate()` from both call sites; the palette already supports `null` to mean "drive root" (vs. `undefined` which auto-detects).

## Why
Auto-detection from the open page (folder → child, page → sibling) made the global "create" affordances ambiguous. The per-row + already covers contextual nesting, so the sidebar + and Alt+N are better as unambiguous "new page at root" actions. The palette's context label will now correctly read **"Drive root"** for these entry points.

## Test plan
- [ ] Open a drive, navigate into a nested folder/page so the URL has a `pageId`.
- [ ] Click the sidebar **+** — palette shows context "Drive root"; new page lands at the top level of the tree.
- [ ] Press **Alt+N** with the same nested page open — same result.
- [ ] Hover any tree row, click its **+** — palette shows that row's title; new page nests under it (regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)