### PR TITLE
feat(slack): add DM scopes + types default

### DIFF
--- a/packages/lib/src/integrations/execution/build-request.test.ts
+++ b/packages/lib/src/integrations/execution/build-request.test.ts
@@ -86,6 +86,34 @@ describe('resolveValue', () => {
 
     expect(resolveValue(ref, input)).toBeUndefined();
   });
+
+  it('given missing param with default, should return the default value', () => {
+    const ref = { $param: 'types', default: 'public_channel,im' };
+    const input = {};
+
+    expect(resolveValue(ref, input)).toBe('public_channel,im');
+  });
+
+  it('given input value present, should override the default', () => {
+    const ref = { $param: 'types', default: 'public_channel,im' };
+    const input = { types: 'private_channel' };
+
+    expect(resolveValue(ref, input)).toBe('private_channel');
+  });
+
+  it('given missing param with default and transform, should apply transform to default', () => {
+    const ref = { $param: 'limit', default: 50, transform: 'string' as const };
+    const input = {};
+
+    expect(resolveValue(ref, input)).toBe('50');
+  });
+
+  it('given default of null, should still treat missing input as having no value', () => {
+    const ref = { $param: 'optional', default: null };
+    const input = {};
+
+    expect(resolveValue(ref, input)).toBeNull();
+  });
 });
 
 describe('resolveBody', () => {

--- a/packages/lib/src/integrations/execution/build-request.ts
+++ b/packages/lib/src/integrations/execution/build-request.ts
@@ -33,7 +33,9 @@ export const resolveValue = (
   }
 
   if (typeof value === 'object' && '$param' in value) {
-    const rawValue = input[value.$param];
+    const rawValue = input[value.$param] !== undefined
+      ? input[value.$param]
+      : value.default;
 
     if (rawValue === undefined) {
       return undefined;

--- a/packages/lib/src/integrations/providers/slack.test.ts
+++ b/packages/lib/src/integrations/providers/slack.test.ts
@@ -173,6 +173,10 @@ describe('slackProvider', () => {
       expect(tool.outputTransform!.mapping).toHaveProperty('name');
       expect(tool.outputTransform!.maxLength).toBe(500);
     });
+
+    it('given an IM-shaped channel, should map the user field so DMs are identifiable', () => {
+      expect(tool.outputTransform!.mapping).toHaveProperty('user', 'user');
+    });
   });
 
   describe('send_message tool', () => {

--- a/packages/lib/src/integrations/providers/slack.test.ts
+++ b/packages/lib/src/integrations/providers/slack.test.ts
@@ -31,6 +31,15 @@ describe('slackProvider', () => {
       expect(authMethod.config.scopes).toContain('users:read.email');
     });
 
+    it('given the provider config, should request DM scopes for 1:1 and group DMs', () => {
+      const { authMethod } = slackProvider;
+      if (authMethod.type !== 'oauth2') throw new Error('unexpected auth type');
+      expect(authMethod.config.scopes).toContain('im:read');
+      expect(authMethod.config.scopes).toContain('im:history');
+      expect(authMethod.config.scopes).toContain('mpim:read');
+      expect(authMethod.config.scopes).toContain('mpim:history');
+    });
+
     it('given the provider config, should not require PKCE', () => {
       const { authMethod } = slackProvider;
       if (authMethod.type !== 'oauth2') throw new Error('unexpected auth type');
@@ -142,11 +151,19 @@ describe('slackProvider', () => {
       expect(result.body).toBeUndefined();
     });
 
-    it('given no params, should build request without query string params', () => {
+    it('given no params, should default types to all four conversation kinds so DMs surface alongside channels', () => {
       const config = (tool.execution as { config: HttpExecutionConfig }).config;
       const result = buildHttpRequest(config, {}, 'https://slack.com/api');
 
-      expect(result.url).toBe('https://slack.com/api/conversations.list');
+      expect(result.url).toContain('types=public_channel%2Cprivate_channel%2Cmpim%2Cim');
+    });
+
+    it('given an explicit types argument, should override the default rather than concatenate', () => {
+      const config = (tool.execution as { config: HttpExecutionConfig }).config;
+      const result = buildHttpRequest(config, { types: 'im,mpim' }, 'https://slack.com/api');
+
+      expect(result.url).toContain('types=im%2Cmpim');
+      expect(result.url).not.toContain('public_channel');
     });
 
     it('given the tool, should have output transform with mapping and maxLength', () => {

--- a/packages/lib/src/integrations/providers/slack.ts
+++ b/packages/lib/src/integrations/providers/slack.ts
@@ -28,6 +28,10 @@ export const slackProvider: IntegrationProviderConfig = {
         'channels:history',
         'groups:read',
         'groups:history',
+        'im:read',
+        'im:history',
+        'mpim:read',
+        'mpim:history',
         'chat:write',
         'users:read',
         'users:read.email',
@@ -78,7 +82,7 @@ export const slackProvider: IntegrationProviderConfig = {
           },
           types: {
             type: 'string',
-            description: 'Comma-separated channel types (public_channel, private_channel)',
+            description: 'Comma-separated conversation types (public_channel, private_channel, mpim, im). Defaults to all four so DMs surface alongside channels.',
           },
         },
         required: [],
@@ -91,7 +95,7 @@ export const slackProvider: IntegrationProviderConfig = {
           queryParams: {
             limit: { $param: 'limit', transform: 'string' },
             cursor: { $param: 'cursor' },
-            types: { $param: 'types' },
+            types: { $param: 'types', default: 'public_channel,private_channel,mpim,im' },
           },
         },
       },

--- a/packages/lib/src/integrations/providers/slack.ts
+++ b/packages/lib/src/integrations/providers/slack.ts
@@ -105,6 +105,7 @@ export const slackProvider: IntegrationProviderConfig = {
         mapping: {
           id: 'id',
           name: 'name',
+          user: 'user',
           topic: 'topic.value',
           purpose: 'purpose.value',
           num_members: 'num_members',

--- a/packages/lib/src/integrations/types.ts
+++ b/packages/lib/src/integrations/types.ts
@@ -62,6 +62,7 @@ export type BodyEncoding = 'json' | 'form' | 'multipart';
 export interface ParameterRef {
   $param: string;
   transform?: 'string' | 'number' | 'boolean' | 'json';
+  default?: unknown;
 }
 
 export interface HttpExecutionConfig {

--- a/plan.md
+++ b/plan.md
@@ -3,6 +3,7 @@
 ## Active Epics
 
 - [Inline Quote Replies](tasks/inline-quote-replies.md) — Slack/Twitter-style inline quote-reply embeds in channels and DMs via additive `quotedMessageId` self-FK + read-time enrichment helper; orthogonal to the just-shipped thread panel.
+- [Slack DM Support](tasks/slack-dm-support.md) — extend the Slack provider adapter with `im:*` + `mpim:*` scopes and default `conversations.list` to all conversation types so agents can read 1:1 and group DMs alongside channels.
 - [DM File Attachments](tasks/dm-file-attachments.md) — bring DM conversations to channel parity for file attachments via a `fileConversations` join table, nullable `files.driveId`, and shared upload/token/processor/composer/renderer infrastructure.
 - [Multiplayer AI Chat Streaming](tasks/multiplayer-ai-chat-streaming.md) — Socket-notified, HTTP-joined AI stream sharing: all page viewers see live ghost text and "X is waiting for AI response…" indicators in real-time.
 - [AI Chat Send Flash Fix](tasks/ai-chat-send-flash-fix.md) — eliminate stream-abort and flash on send; stabilise `chatConfig` deps and extend `invalidateTree` guard to cover all active states.

--- a/tasks/slack-dm-support.md
+++ b/tasks/slack-dm-support.md
@@ -1,0 +1,24 @@
+# Slack DM Support Epic
+
+**Status**: 📋 PLANNED
+**Goal**: Let agents read and send 1:1 and group DMs through the existing Slack provider adapter.
+
+## Overview
+
+The Slack provider adapter shipped with channel scopes only (`channels:*`, `groups:*`), so agents can list and read public/private channels but every DM in the workspace is invisible. This epic adds the four DM scopes and updates `list_channels` to default to all conversation types — `list_messages` and `send_message` already accept DM channel IDs unchanged. Existing connected users (none in production yet) must disconnect and reconnect to pick up the new scopes; that re-auth UX is out of scope for this epic and tracked as a follow-up.
+
+---
+
+## Add DM scopes and conversation type filter to Slack provider
+
+Extend `packages/lib/src/integrations/providers/slack.ts` scope array with `im:read`, `im:history`, `mpim:read`, `mpim:history`, and add `types=public_channel,private_channel,mpim,im` as the default `queryParams.types` on the `list_channels` tool so DMs surface alongside channels.
+
+**Requirements**:
+- Given a fresh Slack OAuth flow after this change, the consent screen should request all four DM scopes in addition to the existing seven.
+- Given an agent calling `list_channels` without arguments, the request should include `types=public_channel,private_channel,mpim,im` so 1:1 and group DMs appear in the result.
+- Given an agent calling `list_channels` with an explicit `types` argument, the agent's value should override the default rather than being concatenated to it.
+- Given an agent calling `list_messages` against an `im` or `mpim` channel ID, the existing `conversations.history` request should succeed without per-channel-type branching in the tool config.
+- Given a workspace with no DM history, `list_channels` should still return successfully with channel-only results rather than failing on missing DM scopes (Slack returns `ok:true` with a partial list).
+- Given a Slack token that lacks DM scopes (legacy connection), `list_channels` filtered to `im,mpim` should surface Slack's `missing_scope` error verbatim through the existing `$.error` validation path so the caller can see why DMs are empty.
+
+---


### PR DESCRIPTION
## Summary

- Adds `im:read`, `im:history`, `mpim:read`, `mpim:history` scopes to the Slack provider so agents can read 1:1 and group DMs alongside public/private channels.
- Defaults `conversations.list` `types` in the `list_channels` tool to `public_channel,private_channel,mpim,im` so DMs surface without per-call configuration; an explicit `types` argument still overrides.
- Extends `ParameterRef` with an optional `default` value applied when input is missing (before transform). Preserves existing null pass-through; no behavior change for providers that omit the field.

Epic: `tasks/slack-dm-support.md`. Existing connected users must disconnect + reconnect to pick up new scopes — re-auth UX is intentionally out of scope and tracked as a follow-up.

## Test plan

- [x] `pnpm --filter @pagespace/lib exec vitest run src/integrations/execution/build-request.test.ts src/integrations/providers/slack.test.ts` — 59/59 pass
- [x] `pnpm --filter @pagespace/lib exec vitest run src/integrations` — 517/517 actual tests pass (one pre-existing index.test.ts loader failure unrelated to this change)
- [x] `pnpm --filter @pagespace/lib exec tsc --noEmit` — clean
- [x] `pnpm --filter @pagespace/lib lint` — clean
- [ ] Manual: add the 4 DM scopes to the Slack app's Bot Token Scopes at api.slack.com/apps
- [ ] Manual: run `list_channels` from an agent against a real workspace; confirm DMs and mpims appear interleaved
- [ ] Manual: run `list_messages` against an `im` channel ID; confirm history returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Parameters can now specify default values when input is missing
  * Slack conversations list now includes direct messages (1:1 and group DMs) alongside channels

* **Tests**
  * Added test coverage for parameter default behavior and transformations
  * Added test coverage for Slack conversation types including DM support and override semantics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->