### PR TITLE
fix(hotkeys): persist customized bindings across reloads

### DIFF
--- a/apps/web/src/app/settings/hotkeys/page.tsx
+++ b/apps/web/src/app/settings/hotkeys/page.tsx
@@ -7,13 +7,14 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useHotkeyPreferences, updateHotkeyPreference } from '@/hooks/useHotkeyPreferences';
 import { HOTKEY_REGISTRY, HOTKEY_CATEGORIES, getHotkeysByCategory, type HotkeyCategory } from '@/lib/hotkeys/registry';
-import { getEffectiveBinding } from '@/stores/useHotkeyStore';
+import { getEffectiveBinding, useHotkeyStore } from '@/stores/useHotkeyStore';
 import { HotkeyInput } from '@/components/settings/hotkeys/HotkeyInput';
 import { toast } from 'sonner';
 
 export default function HotkeysSettingsPage() {
   const router = useRouter();
   const { isLoading, mutate } = useHotkeyPreferences();
+  const userBindings = useHotkeyStore((s) => s.userBindings);
   const [editingId, setEditingId] = useState<string | null>(null);
 
   const hotkeysByCategory = getHotkeysByCategory();
@@ -97,7 +98,7 @@ export default function HotkeysSettingsPage() {
                 <CardContent>
                   <div className="space-y-4">
                     {hotkeys.map((hotkey) => {
-                      const effectiveBinding = getEffectiveBinding(hotkey.id);
+                      const effectiveBinding = userBindings.get(hotkey.id) ?? hotkey.defaultBinding;
                       const isEditing = editingId === hotkey.id;
                       const isCustomized = effectiveBinding !== hotkey.defaultBinding;
 


### PR DESCRIPTION
## Summary

- Custom hotkey bindings save successfully to the DB but the `/settings/hotkeys` page shows defaults after a reload.
- Root cause: `apps/web/src/app/settings/hotkeys/page.tsx` read each row via `getEffectiveBinding(hotkey.id)`, which calls `useHotkeyStore.getState()` non-reactively. On reload, SWR data resolves and `isLoading` flips before `useHotkeyPreferences`' hydration effect runs, so the first non-loading render reads the still-empty store and renders defaults; the post-effect `setUserBindings` never causes a re-render because nothing in the page subscribes.
- Fix: subscribe to `userBindings` via a Zustand selector in the settings page and read the binding from the selector in render. Imperative consumers (`detectConflict`, `TabBar`, `InlineSearch`, `QuickCreatePalette`) keep using `getEffectiveBinding` since they run inside event handlers, where `getState()` is correct.

## Test plan

- [ ] Open `/settings/hotkeys`, change `Tabs > Next Tab` to `Alt+Tab`, save.
- [ ] Hard reload (`Cmd+Shift+R`) — the row should still show `Alt+Tab` and the reset arrow should be visible.
- [ ] Reset to default — should disappear after reload too.
- [ ] Use the new shortcut on a multi-tab page to confirm `TabBar` still picks it up from the same store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the hotkeys settings page to accurately display which hotkey bindings have been customized versus using defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->