### PR TITLE
feat(invites): OAuth + members UI + revoke + next=

### DIFF
--- a/apps/web/src/app/api/__tests__/drive-member-gate-coverage.test.ts
+++ b/apps/web/src/app/api/__tests__/drive-member-gate-coverage.test.ts
@@ -60,6 +60,10 @@ const LIB_ACCEPTED_AT_GATE_EXEMPT = new Map<string, string>([
     'repositories/drive-invite-repository.ts',
     'Repository seam — each query carries its own gate (findAdminMembership filters IS NOT NULL; findActivePendingMemberByEmail intentionally filters IS NULL to surface pending rows; createDriveMember/findExistingMember/updateDriveMemberRole operate by composite key or memberId and do not branch on acceptedAt).',
   ],
+  [
+    'auth/revoke-adapters.ts',
+    'findActorMembership returns raw {role, acceptedAt} so the strict "accepted OWNER/ADMIN" gate lives once in validateRevokeRequest (pure-core). Filtering acceptedAt at the SQL layer would silently NOT_FOUND a request that should FORBIDDEN, masking a wrong-role attempt.',
+  ],
 ]);
 
 const DRIVE_MEMBERS_REFERENCE = /\bdriveMembers\b/;

--- a/apps/web/src/app/api/auth/__tests__/google-callback-redirect.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/google-callback-redirect.test.ts
@@ -79,19 +79,22 @@ vi.mock('@/lib/auth/cookie-config', () => ({
   createDeviceTokenHandoffCookie: vi.fn().mockReturnValue('ps_device_token=mock; Path=/; Max-Age=60'),
 }));
 
-vi.mock('@pagespace/lib/logging/logger-config', () => ({
-  loggers: {
-      auth: {
-        error: vi.fn(),
-        info: vi.fn(),
-        warn: vi.fn(),
-        debug: vi.fn(),
-      },
-      security: {
-        warn: vi.fn(),
-      },
+vi.mock('@pagespace/lib/logging/logger-config', () => {
+  const childLogger = {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(() => childLogger),
+  };
+  return {
+    logger: childLogger,
+    loggers: {
+      auth: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+      security: { warn: vi.fn() },
     },
-}));
+  };
+});
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
   auditRequest: vi.fn(),
 }));

--- a/apps/web/src/app/api/auth/apple/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/apple/callback/__tests__/route.test.ts
@@ -127,6 +127,18 @@ vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
   },
 }));
 
+vi.mock('@/lib/auth/invite-acceptance-adapters', () => ({
+  buildAcceptancePorts: vi.fn(() => ({})),
+}));
+
+const acceptInviteForNewUserPipe = vi.fn();
+const acceptInviteForExistingUserPipe = vi.fn();
+
+vi.mock('@pagespace/lib/services/invites', () => ({
+  acceptInviteForNewUser: vi.fn(() => acceptInviteForNewUserPipe),
+  acceptInviteForExistingUser: vi.fn(() => acceptInviteForExistingUserPipe),
+}));
+
 import { POST } from '../route';
 import { authRepository } from '@/lib/repositories/auth-repository';
 import { sessionService } from '@pagespace/lib/auth/session-service';
@@ -139,6 +151,8 @@ import { validateOrCreateDeviceToken } from '@pagespace/lib/auth/device-auth-uti
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-started-drive';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';
+import { acceptInviteForNewUser, acceptInviteForExistingUser } from '@pagespace/lib/services/invites';
+import { buildAcceptancePorts } from '@/lib/auth/invite-acceptance-adapters';
 
 // Helper to create signed state
 function createSignedState(
@@ -1140,6 +1154,169 @@ describe('POST /api/auth/apple/callback', () => {
       expect(errCall).toBeDefined();
       const meta = errCall?.[1] as { email?: string };
       expect(meta.email).toBe('te***@example.com');
+    });
+  });
+
+  describe('invite acceptance via OAuth', () => {
+    const mockExistingUser = {
+      id: 'existing-user-id',
+      name: 'Existing User',
+      email: 'test@example.com',
+      appleId: 'apple-sub-123',
+      tokenVersion: 1,
+      role: 'user',
+      provider: 'apple',
+      image: null,
+      emailVerified: new Date(),
+    };
+
+    beforeEach(() => {
+      acceptInviteForNewUserPipe.mockReset();
+      acceptInviteForExistingUserPipe.mockReset();
+      vi.mocked(acceptInviteForNewUser).mockImplementation(() => acceptInviteForNewUserPipe);
+      vi.mocked(acceptInviteForExistingUser).mockImplementation(() => acceptInviteForExistingUserPipe);
+      vi.mocked(buildAcceptancePorts).mockReturnValue({} as never);
+    });
+
+    it('calls acceptInviteForNewUser for new users when inviteToken is in state', async () => {
+      acceptInviteForNewUserPipe.mockResolvedValueOnce({
+        ok: true,
+        data: {
+          inviteId: 'invite-1',
+          inviteEmail: 'test@example.com',
+          memberId: 'member-1',
+          driveId: 'drive-apple-789',
+          driveName: 'Shared Drive',
+          role: 'MEMBER',
+          invitedUserId: 'new-user-id',
+          inviterUserId: 'inviter-1',
+        },
+      });
+      const state = createSignedState({
+        returnUrl: '/dashboard',
+        platform: 'web',
+        inviteToken: 'ps_invite_apple_abc',
+      });
+      const request = createCallbackRequest({ id_token: 'valid-token', state });
+      const response = await POST(request);
+
+      expect(acceptInviteForNewUser).toHaveBeenCalled();
+      expect(acceptInviteForNewUserPipe).toHaveBeenCalledWith(
+        expect.objectContaining({
+          token: 'ps_invite_apple_abc',
+          userEmail: 'test@example.com',
+          suspendedAt: null,
+        }),
+      );
+      const location = response.headers.get('Location')!;
+      expect(location).toContain('/dashboard/drive-apple-789');
+      expect(location).toContain('invited=1');
+    });
+
+    it('calls acceptInviteForExistingUser for existing users when inviteToken is in state', async () => {
+      vi.mocked(authRepository.findUserByAppleIdOrEmail).mockResolvedValue(mockExistingUser as never);
+      vi.mocked(authRepository.findUserById).mockResolvedValue(mockExistingUser as never);
+
+      acceptInviteForExistingUserPipe.mockResolvedValueOnce({
+        ok: true,
+        data: {
+          inviteId: 'invite-2',
+          inviteEmail: 'test@example.com',
+          memberId: 'member-2',
+          driveId: 'drive-existing-apple',
+          driveName: 'Other Drive',
+          role: 'ADMIN',
+          invitedUserId: 'existing-user-id',
+          inviterUserId: 'inviter-2',
+        },
+      });
+      const state = createSignedState({
+        returnUrl: '/dashboard',
+        platform: 'web',
+        inviteToken: 'ps_invite_existing',
+      });
+      const request = createCallbackRequest({ id_token: 'valid-token', state });
+      const response = await POST(request);
+
+      expect(acceptInviteForExistingUser).toHaveBeenCalled();
+      expect(acceptInviteForNewUser).not.toHaveBeenCalled();
+      const location = response.headers.get('Location')!;
+      expect(location).toContain('/dashboard/drive-existing-apple');
+      expect(location).toContain('invited=1');
+    });
+
+    it('does not call any acceptance pipe when inviteToken is absent from state', async () => {
+      const state = createSignedState({ returnUrl: '/dashboard', platform: 'web' });
+      const request = createCallbackRequest({ id_token: 'valid-token', state });
+      await POST(request);
+
+      expect(acceptInviteForNewUser).not.toHaveBeenCalled();
+      expect(acceptInviteForExistingUser).not.toHaveBeenCalled();
+    });
+
+    // Apple private-relay regression guard: if the user signed up at the
+    // invite consent screen with their personal email but Apple returns a
+    // private-relay address, the pipe MUST surface EMAIL_MISMATCH and not
+    // silently join them to the drive.
+    it('appends inviteError=EMAIL_MISMATCH when Apple returns private-relay email mismatch', async () => {
+      vi.mocked(verifyAppleIdToken).mockResolvedValueOnce({
+        success: true,
+        // @ts-expect-error - partial mock data
+        userInfo: {
+          providerId: 'apple-sub-123',
+          email: 'abc123@privaterelay.appleid.com',
+          emailVerified: true,
+        },
+      });
+      acceptInviteForNewUserPipe.mockResolvedValueOnce({ ok: false, error: 'EMAIL_MISMATCH' });
+
+      const state = createSignedState({
+        returnUrl: '/dashboard',
+        platform: 'web',
+        inviteToken: 'ps_invite_relay',
+      });
+      const request = createCallbackRequest({ id_token: 'valid-token', state });
+      const response = await POST(request);
+
+      expect(response.status).toBe(307);
+      const location = response.headers.get('Location')!;
+      expect(location).toContain('inviteError=EMAIL_MISMATCH');
+      expect(location).toContain('auth=success');
+    });
+
+    it('appends inviteError to returnUrl on TOKEN_CONSUMED', async () => {
+      acceptInviteForNewUserPipe.mockResolvedValueOnce({ ok: false, error: 'TOKEN_CONSUMED' });
+
+      const state = createSignedState({
+        returnUrl: '/dashboard',
+        platform: 'web',
+        inviteToken: 'ps_invite_consumed',
+      });
+      const request = createCallbackRequest({ id_token: 'valid-token', state });
+      const response = await POST(request);
+
+      const location = response.headers.get('Location')!;
+      expect(location).toContain('inviteError=TOKEN_CONSUMED');
+    });
+
+    it('does not bounce auth when invite acceptance pipe throws', async () => {
+      acceptInviteForNewUserPipe.mockRejectedValueOnce(new Error('apple pipe blew up'));
+
+      const state = createSignedState({
+        returnUrl: '/dashboard',
+        platform: 'web',
+        inviteToken: 'ps_invite_throw',
+      });
+      const request = createCallbackRequest({ id_token: 'valid-token', state });
+      const response = await POST(request);
+
+      expect(response.status).toBe(307);
+      const location = response.headers.get('Location')!;
+      expect(location).toContain('auth=success');
+      expect(loggers.auth.error).toHaveBeenCalledWith(
+        'Invite acceptance pipe threw',
+        expect.any(Error),
+      );
     });
   });
 

--- a/apps/web/src/app/api/auth/apple/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/apple/callback/__tests__/route.test.ts
@@ -1322,6 +1322,67 @@ describe('POST /api/auth/apple/callback', () => {
         expect.any(Error),
       );
     });
+
+    it('attaches invitedDriveId to desktop deep link when invite is consumed', async () => {
+      acceptInviteForNewUserPipe.mockResolvedValueOnce({
+        ok: true,
+        data: {
+          inviteId: 'invite-d1',
+          inviteEmail: 'test@example.com',
+          memberId: 'member-d1',
+          driveId: 'drive-desktop-apple',
+          driveName: 'Desktop Drive',
+          role: 'MEMBER',
+          invitedUserId: 'user-d1',
+          inviterUserId: 'inviter-d1',
+        },
+      });
+
+      const state = createSignedState({
+        returnUrl: '/dashboard',
+        platform: 'desktop',
+        deviceId: 'desktop-dev-123',
+        deviceName: 'My Mac',
+        inviteToken: 'ps_invite_apple_desktop',
+      });
+      const request = createCallbackRequest({ id_token: 'valid-token', state });
+      const response = await POST(request);
+
+      expect(response.status).toBe(200);
+      const body = await response.text();
+      expect(body).toContain('invitedDriveId=drive-desktop-apple');
+    });
+
+    it('attaches invitedDriveId to iOS deep link when invite is consumed', async () => {
+      acceptInviteForNewUserPipe.mockResolvedValueOnce({
+        ok: true,
+        data: {
+          inviteId: 'invite-i1',
+          inviteEmail: 'test@example.com',
+          memberId: 'member-i1',
+          driveId: 'drive-ios-apple',
+          driveName: 'iOS Drive',
+          role: 'MEMBER',
+          invitedUserId: 'user-i1',
+          inviterUserId: 'inviter-i1',
+        },
+      });
+
+      const state = createSignedState({
+        returnUrl: '/dashboard',
+        platform: 'ios',
+        deviceId: 'ios-dev-123',
+        deviceName: 'iPhone',
+        inviteToken: 'ps_invite_apple_ios',
+      });
+      const request = createCallbackRequest({ id_token: 'valid-token', state });
+      const response = await POST(request);
+
+      expect(response.status).toBe(307);
+      const location = response.headers.get('Location')!;
+      expect(location).toContain('pagespace://auth-exchange');
+      expect(location).toContain('invitedDriveId=drive-ios-apple');
+    });
   });
 
 });

--- a/apps/web/src/app/api/auth/apple/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/apple/callback/__tests__/route.test.ts
@@ -131,8 +131,12 @@ vi.mock('@/lib/auth/invite-acceptance-adapters', () => ({
   buildAcceptancePorts: vi.fn(() => ({})),
 }));
 
-const acceptInviteForNewUserPipe = vi.fn();
-const acceptInviteForExistingUserPipe = vi.fn();
+// vi.hoisted ensures the pipes exist before vi.mock factories run, even though
+// they're only called from inside lazily-evaluated factory closures.
+const { acceptInviteForNewUserPipe, acceptInviteForExistingUserPipe } = vi.hoisted(() => ({
+  acceptInviteForNewUserPipe: vi.fn(),
+  acceptInviteForExistingUserPipe: vi.fn(),
+}));
 
 vi.mock('@pagespace/lib/services/invites', () => ({
   acceptInviteForNewUser: vi.fn(() => acceptInviteForNewUserPipe),

--- a/apps/web/src/app/api/auth/apple/callback/route.ts
+++ b/apps/web/src/app/api/auth/apple/callback/route.ts
@@ -23,11 +23,7 @@ import { verifyOAuthState } from '@/lib/auth/oauth-state';
 import { appendSessionCookie, createDeviceTokenHandoffCookie } from '@/lib/auth/cookie-config';
 import { authRepository } from '@/lib/repositories/auth-repository';
 import { buildHandoffBridgeResponse } from '@/app/api/auth/_shared/handoffBridgeResponse';
-import {
-  acceptInviteForExistingUser,
-  acceptInviteForNewUser,
-} from '@pagespace/lib/services/invites';
-import { buildAcceptancePorts } from '@/lib/auth/invite-acceptance-adapters';
+import { consumeInviteIfPresent } from '@/lib/auth/native-invite-acceptance';
 
 // Apple sends name info as JSON in the 'user' field (only on first authorization)
 const appleUserSchema = z.object({
@@ -234,6 +230,19 @@ export async function POST(req: Request) {
       userAgent: req.headers.get('user-agent')
     });
 
+    // Invite consumption runs BEFORE platform branching so desktop/iOS users
+    // who arrived with `?invite=<token>` don't have their invite silently
+    // dropped at the deep-link handoff. The invite is fully consumed (the
+    // membership row is created) regardless of platform; deep-link clients
+    // get `invitedDriveId` as a query param for forward-compatible routing.
+    const oauthInviteResult = await consumeInviteIfPresent({
+      request: req,
+      inviteToken: verifiedState.inviteToken,
+      user: { id: user.id, suspendedAt: user.suspendedAt },
+      isNewUser: wasNewUser,
+      email,
+    });
+
     // DESKTOP PLATFORM: Redirect with tokens encoded via exchange code
     if (platform === 'desktop') {
       if (!deviceId) {
@@ -270,11 +279,15 @@ export async function POST(req: Request) {
       if (isNewlyProvisioned) {
         deepLinkUrl.searchParams.set('isNewUser', 'true');
       }
+      if (oauthInviteResult.invitedDriveId) {
+        deepLinkUrl.searchParams.set('invitedDriveId', oauthInviteResult.invitedDriveId);
+      }
 
       loggers.auth.info('Desktop Apple OAuth deep link bridge', {
         userId: user.id,
         provider: 'apple',
         hasNewUserFlag: isNewlyProvisioned,
+        invitedDriveId: oauthInviteResult.invitedDriveId ?? null,
       });
 
       return buildHandoffBridgeResponse(deepLinkUrl.toString(), "You're signed in");
@@ -310,11 +323,15 @@ export async function POST(req: Request) {
       if (isNewlyProvisioned) {
         deepLinkUrl.searchParams.set('isNewUser', 'true');
       }
+      if (oauthInviteResult.invitedDriveId) {
+        deepLinkUrl.searchParams.set('invitedDriveId', oauthInviteResult.invitedDriveId);
+      }
 
       loggers.auth.info('iOS Apple OAuth deep link redirect', {
         userId: user.id,
         provider: 'apple',
         hasNewUserFlag: isNewlyProvisioned,
+        invitedDriveId: oauthInviteResult.invitedDriveId ?? null,
       });
 
       return NextResponse.redirect(deepLinkUrl.toString());
@@ -336,30 +353,11 @@ export async function POST(req: Request) {
       }
     }
 
-    const inviteToken = verifiedState.inviteToken;
-    if (inviteToken) {
-      try {
-        const ports = buildAcceptancePorts(req);
-        const acceptInput = {
-          token: inviteToken,
-          userId: user.id,
-          userEmail: email.toLowerCase(),
-          suspendedAt: wasNewUser ? null : (user.suspendedAt ?? null),
-          now: new Date(),
-        };
-        const result = wasNewUser
-          ? await acceptInviteForNewUser(ports)(acceptInput)
-          : await acceptInviteForExistingUser(ports)(acceptInput);
-
-        if (result.ok) {
-          returnUrl = `/dashboard/${result.data.driveId}?invited=1`;
-        } else {
-          const sep = returnUrl.includes('?') ? '&' : '?';
-          returnUrl = `${returnUrl}${sep}inviteError=${result.error}`;
-        }
-      } catch (error) {
-        loggers.auth.error('Invite acceptance pipe threw', error as Error);
-      }
+    if (oauthInviteResult.invitedDriveId) {
+      returnUrl = `/dashboard/${oauthInviteResult.invitedDriveId}?invited=1`;
+    } else if (oauthInviteResult.inviteError) {
+      const sep = returnUrl.includes('?') ? '&' : '?';
+      returnUrl = `${returnUrl}${sep}inviteError=${oauthInviteResult.inviteError}`;
     }
 
     const redirectUrl = new URL(returnUrl, baseUrl);

--- a/apps/web/src/app/api/auth/apple/callback/route.ts
+++ b/apps/web/src/app/api/auth/apple/callback/route.ts
@@ -23,6 +23,11 @@ import { verifyOAuthState } from '@/lib/auth/oauth-state';
 import { appendSessionCookie, createDeviceTokenHandoffCookie } from '@/lib/auth/cookie-config';
 import { authRepository } from '@/lib/repositories/auth-repository';
 import { buildHandoffBridgeResponse } from '@/app/api/auth/_shared/handoffBridgeResponse';
+import {
+  acceptInviteForExistingUser,
+  acceptInviteForNewUser,
+} from '@pagespace/lib/services/invites';
+import { buildAcceptancePorts } from '@/lib/auth/invite-acceptance-adapters';
 
 // Apple sends name info as JSON in the 'user' field (only on first authorization)
 const appleUserSchema = z.object({
@@ -137,6 +142,7 @@ export async function POST(req: Request) {
 
     // Find or create user
     let user = await authRepository.findUserByAppleIdOrEmail(appleId, email);
+    const wasNewUser = !user;
 
     if (user) {
       // Update existing user if needed
@@ -327,6 +333,32 @@ export async function POST(req: Request) {
         loggers.auth.warn('Failed to create device token', {
           userId: user.id, error: error instanceof Error ? error.message : String(error),
         });
+      }
+    }
+
+    const inviteToken = verifiedState.inviteToken;
+    if (inviteToken) {
+      try {
+        const ports = buildAcceptancePorts(req);
+        const acceptInput = {
+          token: inviteToken,
+          userId: user.id,
+          userEmail: email.toLowerCase(),
+          suspendedAt: wasNewUser ? null : (user.suspendedAt ?? null),
+          now: new Date(),
+        };
+        const result = wasNewUser
+          ? await acceptInviteForNewUser(ports)(acceptInput)
+          : await acceptInviteForExistingUser(ports)(acceptInput);
+
+        if (result.ok) {
+          returnUrl = `/dashboard/${result.data.driveId}?invited=1`;
+        } else {
+          const sep = returnUrl.includes('?') ? '&' : '?';
+          returnUrl = `${returnUrl}${sep}inviteError=${result.error}`;
+        }
+      } catch (error) {
+        loggers.auth.error('Invite acceptance pipe threw', error as Error);
       }
     }
 

--- a/apps/web/src/app/api/auth/apple/native/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/apple/native/__tests__/route.test.ts
@@ -118,7 +118,12 @@ vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
   },
 }));
 
+vi.mock('@/lib/auth/native-invite-acceptance', () => ({
+  consumeInviteIfPresent: vi.fn().mockResolvedValue({ invitedDriveId: null }),
+}));
+
 import { POST } from '../route';
+import { consumeInviteIfPresent } from '@/lib/auth/native-invite-acceptance';
 import { authRepository } from '@/lib/repositories/auth-repository';
 import { sessionService } from '@pagespace/lib/auth/session-service';
 import { verifyAppleIdToken } from '@pagespace/lib/auth/oauth-utils';
@@ -725,6 +730,41 @@ describe('POST /api/auth/apple/native', () => {
       expect(call).toBeDefined();
       const meta = call?.[1] as { email?: string };
       expect(meta.email).toBe('te***@example.com');
+    });
+  });
+
+  describe('invite acceptance', () => {
+    it('forwards inviteToken to consumeInviteIfPresent and includes invitedDriveId in response', async () => {
+      vi.mocked(consumeInviteIfPresent).mockResolvedValueOnce({ invitedDriveId: 'drive-from-invite' });
+
+      const response = await POST(createNativeRequest({ ...validPayload, inviteToken: 'ps_invite_xyz' }));
+      const body = await response.json();
+
+      expect(consumeInviteIfPresent).toHaveBeenCalledWith(
+        expect.objectContaining({ inviteToken: 'ps_invite_xyz', isNewUser: true }),
+      );
+      expect(body.invitedDriveId).toBe('drive-from-invite');
+    });
+
+    it('passes inviteError through when pipe rejects', async () => {
+      vi.mocked(consumeInviteIfPresent).mockResolvedValueOnce({
+        invitedDriveId: null,
+        inviteError: 'TOKEN_CONSUMED',
+      });
+
+      const response = await POST(createNativeRequest({ ...validPayload, inviteToken: 'ps_invite_xyz' }));
+      const body = await response.json();
+
+      expect(body.invitedDriveId).toBeNull();
+      expect(body.inviteError).toBe('TOKEN_CONSUMED');
+    });
+
+    it('returns invitedDriveId: null and no inviteError when no inviteToken provided', async () => {
+      const response = await POST(createNativeRequest(validPayload));
+      const body = await response.json();
+
+      expect(body.invitedDriveId).toBeNull();
+      expect(body.inviteError).toBeUndefined();
     });
   });
 

--- a/apps/web/src/app/api/auth/apple/native/route.ts
+++ b/apps/web/src/app/api/auth/apple/native/route.ts
@@ -18,6 +18,8 @@ import {
   DISTRIBUTED_RATE_LIMITS,
 } from '@pagespace/lib/security/distributed-rate-limit';
 import { authRepository } from '@/lib/repositories/auth-repository';
+import { INVITE_TOKEN_MAX_LENGTH } from '@/lib/auth/oauth-state';
+import { consumeInviteIfPresent } from '@/lib/auth/native-invite-acceptance';
 
 const nativeAuthSchema = z.object({
   idToken: z.string().min(1, 'ID token is required'),
@@ -28,6 +30,7 @@ const nativeAuthSchema = z.object({
   // The client must pass it if available
   givenName: z.string().optional(),
   familyName: z.string().optional(),
+  inviteToken: z.string().min(1).max(INVITE_TOKEN_MAX_LENGTH).optional(),
 });
 
 /**
@@ -68,7 +71,7 @@ export async function POST(req: Request) {
       );
     }
 
-    const { idToken, platform, deviceId, deviceName, givenName, familyName } = validation.data;
+    const { idToken, platform, deviceId, deviceName, givenName, familyName, inviteToken } = validation.data;
 
     // Validate required environment variables
     if (!process.env.APPLE_CLIENT_ID) {
@@ -218,6 +221,14 @@ export async function POST(req: Request) {
       isNewUser,
     });
 
+    const { invitedDriveId, inviteError } = await consumeInviteIfPresent({
+      request: req,
+      inviteToken,
+      user,
+      isNewUser,
+      email,
+    });
+
     // Set session cookie so middleware recognizes the authenticated session
     const headers = new Headers();
     appendSessionCookie(headers, sessionToken);
@@ -227,6 +238,8 @@ export async function POST(req: Request) {
       csrfToken,
       deviceToken,
       isNewUser,
+      invitedDriveId,
+      ...(inviteError && { inviteError }),
       user: {
         id: user.id,
         name: user.name,

--- a/apps/web/src/app/api/auth/apple/signin/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/apple/signin/__tests__/route.test.ts
@@ -191,6 +191,24 @@ describe('POST /api/auth/apple/signin', () => {
       expect(response.status).toBe(400);
       expect(body.errors.deviceName).toBeDefined();
     });
+
+    it('returns 400 for inviteToken longer than 128 chars', async () => {
+      const request = createPostRequest({ inviteToken: 'ps_invite_' + 'x'.repeat(120) });
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.errors.inviteToken).toBeDefined();
+    });
+
+    it('returns 400 for empty inviteToken', async () => {
+      const request = createPostRequest({ inviteToken: '' });
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.errors.inviteToken).toBeDefined();
+    });
   });
 
   describe('return URL safety', () => {
@@ -337,6 +355,47 @@ describe('POST /api/auth/apple/signin', () => {
       expect(decoded.data.deviceId).toBeUndefined();
       expect(decoded.data.deviceName).toBeUndefined();
     });
+
+    it('forwards inviteToken into state when provided', async () => {
+      const inviteToken = 'ps_invite_abc123def456ghi789';
+      const request = createPostRequest({ inviteToken });
+      const response = await POST(request);
+      const body = await response.json();
+      const url = new URL(body.url);
+
+      const stateParam = url.searchParams.get('state')!;
+      const decoded = JSON.parse(Buffer.from(stateParam, 'base64').toString('utf-8'));
+      expect(decoded.data.inviteToken).toBe(inviteToken);
+    });
+
+    it('omits inviteToken from state when not provided', async () => {
+      const request = createPostRequest({});
+      const response = await POST(request);
+      const body = await response.json();
+      const url = new URL(body.url);
+
+      const stateParam = url.searchParams.get('state')!;
+      const decoded = JSON.parse(Buffer.from(stateParam, 'base64').toString('utf-8'));
+      expect(decoded.data.inviteToken).toBeUndefined();
+    });
+
+    // Regression guard for the createSignedState migration: the helper
+    // auto-attaches a `timestamp` field that verifyOAuthState requires.
+    // Without this, callbacks would reject the state as malformed.
+    it('includes timestamp in state', async () => {
+      const before = Date.now();
+      const request = createPostRequest({});
+      const response = await POST(request);
+      const body = await response.json();
+      const url = new URL(body.url);
+      const after = Date.now();
+
+      const stateParam = url.searchParams.get('state')!;
+      const decoded = JSON.parse(Buffer.from(stateParam, 'base64').toString('utf-8'));
+      expect(typeof decoded.data.timestamp).toBe('number');
+      expect(decoded.data.timestamp).toBeGreaterThanOrEqual(before);
+      expect(decoded.data.timestamp).toBeLessThanOrEqual(after);
+    });
   });
 
   describe('error handling', () => {
@@ -474,6 +533,7 @@ describe('GET /api/auth/apple/signin', () => {
 
       expect(decoded.data.returnUrl).toBe('/dashboard');
       expect(decoded.data.platform).toBe('web');
+      expect(typeof decoded.data.timestamp).toBe('number');
       expect(typeof decoded.sig).toBe('string');
       expect(decoded.sig.length).toBeGreaterThan(0);
     });

--- a/apps/web/src/app/api/auth/apple/signin/route.ts
+++ b/apps/web/src/app/api/auth/apple/signin/route.ts
@@ -6,6 +6,7 @@ import {
 } from '@pagespace/lib/security/distributed-rate-limit';
 import { createSignedState } from '@pagespace/lib/integrations/oauth/oauth-state';
 import { getClientIP, isSafeReturnUrl } from '@/lib/auth';
+import { INVITE_TOKEN_MAX_LENGTH } from '@/lib/auth/oauth-state';
 
 // Length bounds must match verifyOAuthState's oauthStateDataSchema — otherwise
 // the server can mint a signed state it will later reject at the callback,
@@ -15,7 +16,7 @@ const appleSigninSchema = z.object({
   platform: z.enum(['web', 'desktop', 'ios']).optional(),
   deviceId: z.string().min(1).max(128).optional(),
   deviceName: z.string().max(255).optional(),
-  inviteToken: z.string().min(1).max(128).optional(),
+  inviteToken: z.string().min(1).max(INVITE_TOKEN_MAX_LENGTH).optional(),
 });
 
 export async function POST(req: Request) {

--- a/apps/web/src/app/api/auth/apple/signin/route.ts
+++ b/apps/web/src/app/api/auth/apple/signin/route.ts
@@ -4,7 +4,7 @@ import {
   checkDistributedRateLimit,
   DISTRIBUTED_RATE_LIMITS,
 } from '@pagespace/lib/security/distributed-rate-limit';
-import crypto from 'crypto';
+import { createSignedState } from '@pagespace/lib/integrations/oauth/oauth-state';
 import { getClientIP, isSafeReturnUrl } from '@/lib/auth';
 
 // Length bounds must match verifyOAuthState's oauthStateDataSchema — otherwise
@@ -15,6 +15,7 @@ const appleSigninSchema = z.object({
   platform: z.enum(['web', 'desktop', 'ios']).optional(),
   deviceId: z.string().min(1).max(128).optional(),
   deviceName: z.string().max(255).optional(),
+  inviteToken: z.string().min(1).max(128).optional(),
 });
 
 export async function POST(req: Request) {
@@ -43,7 +44,7 @@ export async function POST(req: Request) {
       return Response.json({ errors: validation.error.flatten().fieldErrors }, { status: 400 });
     }
 
-    const { returnUrl, platform, deviceId, deviceName } = validation.data;
+    const { returnUrl, platform, deviceId, deviceName, inviteToken } = validation.data;
 
     // SECURITY: Validate returnUrl to prevent open redirect attacks
     if (!isSafeReturnUrl(returnUrl)) {
@@ -81,27 +82,19 @@ export async function POST(req: Request) {
       );
     }
 
-    // Create state object to preserve platform and deviceId through OAuth redirect
-    const stateData = {
-      returnUrl: returnUrl || '/dashboard',
-      platform: platform || 'web',
-      ...(deviceId && { deviceId }),
-      ...(deviceName && { deviceName }),
-    };
-
-    // Sign state parameter with HMAC-SHA256 to prevent tampering
-    const statePayload = JSON.stringify(stateData);
-    const signature = crypto
-      .createHmac('sha256', process.env.OAUTH_STATE_SECRET!)
-      .update(statePayload)
-      .digest('hex');
-
-    const stateWithSignature = JSON.stringify({
-      data: stateData,
-      sig: signature,
-    });
-
-    const stateParam = Buffer.from(stateWithSignature).toString('base64');
+    // Sign state with HMAC-SHA256 + auto-attached timestamp via the shared
+    // helper (matches Google signin); verifyOAuthState requires timestamp to
+    // accept the state at the callback.
+    const stateParam = createSignedState(
+      {
+        returnUrl: returnUrl || '/dashboard',
+        platform: platform || 'web',
+        ...(deviceId && { deviceId }),
+        ...(deviceName && { deviceName }),
+        ...(inviteToken && { inviteToken }),
+      },
+      process.env.OAUTH_STATE_SECRET!
+    );
 
     // Generate Apple OAuth URL
     // Note: Apple uses response_mode=form_post which POSTs the authorization response
@@ -153,24 +146,12 @@ export async function GET(req: Request) {
       return Response.redirect(new URL('/auth/signin?error=rate_limit', baseUrl).toString());
     }
 
-    // SECURITY: Create signed state parameter to prevent CSRF attacks
-    const stateData = {
-      returnUrl: '/dashboard',
-      platform: 'web',
-    };
-
-    const statePayload = JSON.stringify(stateData);
-    const signature = crypto
-      .createHmac('sha256', process.env.OAUTH_STATE_SECRET!)
-      .update(statePayload)
-      .digest('hex');
-
-    const stateWithSignature = JSON.stringify({
-      data: stateData,
-      sig: signature,
-    });
-
-    const stateParam = Buffer.from(stateWithSignature).toString('base64');
+    // SECURITY: Create signed state parameter to prevent CSRF attacks.
+    // Auto-attaches timestamp required by verifyOAuthState at the callback.
+    const stateParam = createSignedState(
+      { returnUrl: '/dashboard', platform: 'web' },
+      process.env.OAUTH_STATE_SECRET!
+    );
 
     // Generate OAuth URL for direct link access
     const params = new URLSearchParams({

--- a/apps/web/src/app/api/auth/google/__tests__/google-callback-redirect.test.ts
+++ b/apps/web/src/app/api/auth/google/__tests__/google-callback-redirect.test.ts
@@ -74,19 +74,22 @@ vi.mock('@/lib/auth/cookie-config', () => ({
   createDeviceTokenHandoffCookie: vi.fn().mockReturnValue('ps_device_token=mock; Path=/; Max-Age=60'),
 }));
 
-vi.mock('@pagespace/lib/logging/logger-config', () => ({
-  loggers: {
-      auth: {
-        error: vi.fn(),
-        info: vi.fn(),
-        warn: vi.fn(),
-        debug: vi.fn(),
-      },
-      security: {
-        warn: vi.fn(),
-      },
+vi.mock('@pagespace/lib/logging/logger-config', () => {
+  const childLogger = {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(() => childLogger),
+  };
+  return {
+    logger: childLogger,
+    loggers: {
+      auth: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+      security: { warn: vi.fn() },
     },
-}));
+  };
+});
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
   auditRequest: vi.fn(),
 }));

--- a/apps/web/src/app/api/auth/google/__tests__/one-tap.test.ts
+++ b/apps/web/src/app/api/auth/google/__tests__/one-tap.test.ts
@@ -68,19 +68,22 @@ vi.mock('@/lib/auth/cookie-config', () => ({
   getSessionFromCookies: vi.fn().mockReturnValue('ps_sess_mock_session_token'),
 }));
 
-vi.mock('@pagespace/lib/logging/logger-config', () => ({
-  loggers: {
-      auth: {
-        error: vi.fn(),
-        info: vi.fn(),
-        warn: vi.fn(),
-        debug: vi.fn(),
-      },
-      security: {
-        warn: vi.fn(),
-      },
+vi.mock('@pagespace/lib/logging/logger-config', () => {
+  const childLogger = {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(() => childLogger),
+  };
+  return {
+    logger: childLogger,
+    loggers: {
+      auth: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+      security: { warn: vi.fn() },
     },
-}));
+  };
+});
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
   auditRequest: vi.fn(),
 }));

--- a/apps/web/src/app/api/auth/google/__tests__/open-redirect-protection.test.ts
+++ b/apps/web/src/app/api/auth/google/__tests__/open-redirect-protection.test.ts
@@ -10,19 +10,22 @@ import { POST } from '../signin/route';
 import { GET } from '../callback/route';
 
 // Mock dependencies for signin
-vi.mock('@pagespace/lib/logging/logger-config', () => ({
-  loggers: {
-      auth: {
-        error: vi.fn(),
-        info: vi.fn(),
-        warn: vi.fn(),
-        debug: vi.fn(),
-      },
-      security: {
-        warn: vi.fn(),
-      },
+vi.mock('@pagespace/lib/logging/logger-config', () => {
+  const childLogger = {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(() => childLogger),
+  };
+  return {
+    logger: childLogger,
+    loggers: {
+      auth: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+      security: { warn: vi.fn() },
     },
-}));
+  };
+});
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
   auditRequest: vi.fn(),
 }));

--- a/apps/web/src/app/api/auth/google/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/callback/__tests__/route.test.ts
@@ -149,6 +149,18 @@ vi.mock('@/lib/auth/cookie-config', () => ({
   createDeviceTokenHandoffCookie: vi.fn().mockReturnValue('ps_device_token=mock; Path=/; Max-Age=60'),
 }));
 
+vi.mock('@/lib/auth/invite-acceptance-adapters', () => ({
+  buildAcceptancePorts: vi.fn(() => ({})),
+}));
+
+const acceptInviteForNewUserPipe = vi.fn();
+const acceptInviteForExistingUserPipe = vi.fn();
+
+vi.mock('@pagespace/lib/services/invites', () => ({
+  acceptInviteForNewUser: vi.fn(() => acceptInviteForNewUserPipe),
+  acceptInviteForExistingUser: vi.fn(() => acceptInviteForExistingUserPipe),
+}));
+
 vi.mock('@/lib/auth/google-avatar', () => ({
   resolveGoogleAvatarImage: vi.fn().mockResolvedValue(null),
 }));
@@ -168,6 +180,8 @@ import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-s
 import { getClientIP, isSafeReturnUrl } from '@/lib/auth';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';
 import { resolveGoogleAvatarImage } from '@/lib/auth/google-avatar';
+import { acceptInviteForNewUser, acceptInviteForExistingUser } from '@pagespace/lib/services/invites';
+import { buildAcceptancePorts } from '@/lib/auth/invite-acceptance-adapters';
 
 // Helper to create signed state
 function createSignedState(
@@ -1274,6 +1288,137 @@ describe('GET /api/auth/google/callback', () => {
       const response = await GET(request);
 
       expect(response.status).toBe(500);
+    });
+  });
+
+  describe('invite acceptance via OAuth', () => {
+    const stateWithInvite = createSignedState({
+      returnUrl: '/dashboard',
+      platform: 'web',
+      inviteToken: 'ps_invite_abc123def456',
+    });
+
+    beforeEach(() => {
+      acceptInviteForNewUserPipe.mockReset();
+      acceptInviteForExistingUserPipe.mockReset();
+      // Outer beforeEach calls vi.resetAllMocks() which wipes the curried
+      // factory implementations. Re-establish them so the route can keep
+      // calling `acceptInviteForXxx(ports)(input)` and reach the inner mock.
+      vi.mocked(acceptInviteForNewUser).mockImplementation(() => acceptInviteForNewUserPipe);
+      vi.mocked(acceptInviteForExistingUser).mockImplementation(() => acceptInviteForExistingUserPipe);
+      vi.mocked(buildAcceptancePorts).mockReturnValue({} as never);
+    });
+
+    it('calls acceptInviteForNewUser for new users when inviteToken is in state', async () => {
+      acceptInviteForNewUserPipe.mockResolvedValueOnce({
+        ok: true,
+        data: {
+          inviteId: 'invite-1',
+          inviteEmail: 'test@example.com',
+          memberId: 'member-1',
+          driveId: 'drive-789',
+          driveName: 'Shared Drive',
+          role: 'MEMBER',
+          invitedUserId: 'user-123',
+          inviterUserId: 'inviter-1',
+        },
+      });
+
+      const request = createCallbackRequest({ code: 'valid-code', state: stateWithInvite });
+      const response = await GET(request);
+
+      expect(acceptInviteForNewUser).toHaveBeenCalled();
+      expect(acceptInviteForNewUserPipe).toHaveBeenCalledWith(
+        expect.objectContaining({
+          token: 'ps_invite_abc123def456',
+          userEmail: 'test@example.com',
+          suspendedAt: null,
+        }),
+      );
+
+      const location = response.headers.get('Location')!;
+      expect(location).toContain('/dashboard/drive-789');
+      expect(location).toContain('invited=1');
+    });
+
+    it('calls acceptInviteForExistingUser for existing users when inviteToken is in state', async () => {
+      vi.mocked(authRepository.findUserByGoogleIdOrEmail).mockResolvedValue(mockExistingUser as never);
+      vi.mocked(authRepository.findUserById).mockResolvedValue(mockExistingUser as never);
+
+      acceptInviteForExistingUserPipe.mockResolvedValueOnce({
+        ok: true,
+        data: {
+          inviteId: 'invite-2',
+          inviteEmail: 'test@example.com',
+          memberId: 'member-2',
+          driveId: 'drive-existing',
+          driveName: 'Other Drive',
+          role: 'ADMIN',
+          invitedUserId: 'existing-user-456',
+          inviterUserId: 'inviter-2',
+        },
+      });
+
+      const request = createCallbackRequest({ code: 'valid-code', state: stateWithInvite });
+      const response = await GET(request);
+
+      expect(acceptInviteForExistingUser).toHaveBeenCalled();
+      expect(acceptInviteForNewUser).not.toHaveBeenCalled();
+      const location = response.headers.get('Location')!;
+      expect(location).toContain('/dashboard/drive-existing');
+      expect(location).toContain('invited=1');
+    });
+
+    it('does not call any acceptance pipe when inviteToken is absent from state', async () => {
+      const stateNoInvite = createSignedState({ returnUrl: '/dashboard', platform: 'web' });
+      const request = createCallbackRequest({ code: 'valid-code', state: stateNoInvite });
+      await GET(request);
+
+      expect(acceptInviteForNewUser).not.toHaveBeenCalled();
+      expect(acceptInviteForExistingUser).not.toHaveBeenCalled();
+    });
+
+    it('appends inviteError to returnUrl on EMAIL_MISMATCH (auth still succeeds)', async () => {
+      acceptInviteForNewUserPipe.mockResolvedValueOnce({
+        ok: false,
+        error: 'EMAIL_MISMATCH',
+      });
+
+      const request = createCallbackRequest({ code: 'valid-code', state: stateWithInvite });
+      const response = await GET(request);
+
+      expect(response.status).toBe(307);
+      const location = response.headers.get('Location')!;
+      expect(location).toContain('inviteError=EMAIL_MISMATCH');
+      expect(location).toContain('auth=success');
+    });
+
+    it('appends inviteError to returnUrl on TOKEN_CONSUMED', async () => {
+      acceptInviteForNewUserPipe.mockResolvedValueOnce({
+        ok: false,
+        error: 'TOKEN_CONSUMED',
+      });
+
+      const request = createCallbackRequest({ code: 'valid-code', state: stateWithInvite });
+      const response = await GET(request);
+
+      const location = response.headers.get('Location')!;
+      expect(location).toContain('inviteError=TOKEN_CONSUMED');
+    });
+
+    it('does not bounce auth when invite acceptance pipe throws', async () => {
+      acceptInviteForNewUserPipe.mockRejectedValueOnce(new Error('pipe blew up'));
+
+      const request = createCallbackRequest({ code: 'valid-code', state: stateWithInvite });
+      const response = await GET(request);
+
+      expect(response.status).toBe(307);
+      const location = response.headers.get('Location')!;
+      expect(location).toContain('auth=success');
+      expect(loggers.auth.error).toHaveBeenCalledWith(
+        'Invite acceptance pipe threw',
+        expect.any(Error),
+      );
     });
   });
 

--- a/apps/web/src/app/api/auth/google/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/callback/__tests__/route.test.ts
@@ -153,8 +153,12 @@ vi.mock('@/lib/auth/invite-acceptance-adapters', () => ({
   buildAcceptancePorts: vi.fn(() => ({})),
 }));
 
-const acceptInviteForNewUserPipe = vi.fn();
-const acceptInviteForExistingUserPipe = vi.fn();
+// vi.hoisted ensures the pipes exist before vi.mock factories run, even though
+// they're only called from inside lazily-evaluated factory closures.
+const { acceptInviteForNewUserPipe, acceptInviteForExistingUserPipe } = vi.hoisted(() => ({
+  acceptInviteForNewUserPipe: vi.fn(),
+  acceptInviteForExistingUserPipe: vi.fn(),
+}));
 
 vi.mock('@pagespace/lib/services/invites', () => ({
   acceptInviteForNewUser: vi.fn(() => acceptInviteForNewUserPipe),
@@ -1292,11 +1296,14 @@ describe('GET /api/auth/google/callback', () => {
   });
 
   describe('invite acceptance via OAuth', () => {
-    const stateWithInvite = createSignedState({
-      returnUrl: '/dashboard',
-      platform: 'web',
-      inviteToken: 'ps_invite_abc123def456',
-    });
+    // Per-test factory: a single module-level signed state would embed a fixed
+    // timestamp and could expire mid-suite, causing flaky failures.
+    const stateWithInvite = () =>
+      createSignedState({
+        returnUrl: '/dashboard',
+        platform: 'web',
+        inviteToken: 'ps_invite_abc123def456',
+      });
 
     beforeEach(() => {
       acceptInviteForNewUserPipe.mockReset();
@@ -1324,7 +1331,7 @@ describe('GET /api/auth/google/callback', () => {
         },
       });
 
-      const request = createCallbackRequest({ code: 'valid-code', state: stateWithInvite });
+      const request = createCallbackRequest({ code: 'valid-code', state: stateWithInvite() });
       const response = await GET(request);
 
       expect(acceptInviteForNewUser).toHaveBeenCalled();
@@ -1359,7 +1366,7 @@ describe('GET /api/auth/google/callback', () => {
         },
       });
 
-      const request = createCallbackRequest({ code: 'valid-code', state: stateWithInvite });
+      const request = createCallbackRequest({ code: 'valid-code', state: stateWithInvite() });
       const response = await GET(request);
 
       expect(acceptInviteForExistingUser).toHaveBeenCalled();
@@ -1384,7 +1391,7 @@ describe('GET /api/auth/google/callback', () => {
         error: 'EMAIL_MISMATCH',
       });
 
-      const request = createCallbackRequest({ code: 'valid-code', state: stateWithInvite });
+      const request = createCallbackRequest({ code: 'valid-code', state: stateWithInvite() });
       const response = await GET(request);
 
       expect(response.status).toBe(307);
@@ -1399,7 +1406,7 @@ describe('GET /api/auth/google/callback', () => {
         error: 'TOKEN_CONSUMED',
       });
 
-      const request = createCallbackRequest({ code: 'valid-code', state: stateWithInvite });
+      const request = createCallbackRequest({ code: 'valid-code', state: stateWithInvite() });
       const response = await GET(request);
 
       const location = response.headers.get('Location')!;
@@ -1409,7 +1416,7 @@ describe('GET /api/auth/google/callback', () => {
     it('does not bounce auth when invite acceptance pipe throws', async () => {
       acceptInviteForNewUserPipe.mockRejectedValueOnce(new Error('pipe blew up'));
 
-      const request = createCallbackRequest({ code: 'valid-code', state: stateWithInvite });
+      const request = createCallbackRequest({ code: 'valid-code', state: stateWithInvite() });
       const response = await GET(request);
 
       expect(response.status).toBe(307);

--- a/apps/web/src/app/api/auth/google/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/callback/__tests__/route.test.ts
@@ -1427,6 +1427,69 @@ describe('GET /api/auth/google/callback', () => {
         expect.any(Error),
       );
     });
+
+    it('attaches invitedDriveId to desktop deep link when invite is consumed', async () => {
+      acceptInviteForNewUserPipe.mockResolvedValueOnce({
+        ok: true,
+        data: {
+          inviteId: 'invite-d1',
+          inviteEmail: 'test@example.com',
+          memberId: 'member-d1',
+          driveId: 'drive-desktop-1',
+          driveName: 'Desktop Drive',
+          role: 'MEMBER',
+          invitedUserId: 'user-d1',
+          inviterUserId: 'inviter-d1',
+        },
+      });
+
+      const state = createSignedState({
+        returnUrl: '/dashboard',
+        platform: 'desktop',
+        deviceId: 'desktop-dev-123',
+        deviceName: 'My Mac',
+        inviteToken: 'ps_invite_abc123def456',
+      });
+
+      const request = createCallbackRequest({ code: 'valid-code', state });
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const body = await response.text();
+      expect(body).toContain('invitedDriveId=drive-desktop-1');
+    });
+
+    it('attaches invitedDriveId to iOS deep link when invite is consumed', async () => {
+      acceptInviteForNewUserPipe.mockResolvedValueOnce({
+        ok: true,
+        data: {
+          inviteId: 'invite-i1',
+          inviteEmail: 'test@example.com',
+          memberId: 'member-i1',
+          driveId: 'drive-ios-1',
+          driveName: 'iOS Drive',
+          role: 'MEMBER',
+          invitedUserId: 'user-i1',
+          inviterUserId: 'inviter-i1',
+        },
+      });
+
+      const state = createSignedState({
+        returnUrl: '/dashboard',
+        platform: 'ios',
+        deviceId: 'ios-dev-123',
+        deviceName: 'iPhone',
+        inviteToken: 'ps_invite_abc123def456',
+      });
+
+      const request = createCallbackRequest({ code: 'valid-code', state });
+      const response = await GET(request);
+
+      expect(response.status).toBe(307);
+      const location = response.headers.get('Location')!;
+      expect(location).toContain('pagespace://auth-exchange');
+      expect(location).toContain('invitedDriveId=drive-ios-1');
+    });
   });
 
 });

--- a/apps/web/src/app/api/auth/google/callback/route.ts
+++ b/apps/web/src/app/api/auth/google/callback/route.ts
@@ -24,11 +24,7 @@ import { resolveGoogleAvatarImage } from '@/lib/auth/google-avatar';
 import { consumePKCEVerifier } from '@pagespace/lib/auth/pkce';
 import { authRepository } from '@/lib/repositories/auth-repository';
 import { buildHandoffBridgeResponse } from '@/app/api/auth/_shared/handoffBridgeResponse';
-import {
-  acceptInviteForExistingUser,
-  acceptInviteForNewUser,
-} from '@pagespace/lib/services/invites';
-import { buildAcceptancePorts } from '@/lib/auth/invite-acceptance-adapters';
+import { consumeInviteIfPresent } from '@/lib/auth/native-invite-acceptance';
 
 const client = new OAuth2Client(
   process.env.GOOGLE_OAUTH_CLIENT_ID,
@@ -248,6 +244,19 @@ export async function GET(req: Request) {
       userAgent: req.headers.get('user-agent')
     });
 
+    // Invite consumption runs BEFORE platform branching so desktop/iOS users
+    // who arrived with `?invite=<token>` don't have their invite silently
+    // dropped at the deep-link handoff. The invite is fully consumed (the
+    // membership row is created) regardless of platform; deep-link clients
+    // get `invitedDriveId` as a query param for forward-compatible routing.
+    const oauthInviteResult = await consumeInviteIfPresent({
+      request: req,
+      inviteToken: verifiedState.inviteToken,
+      user: { id: user.id, suspendedAt: user.suspendedAt },
+      isNewUser: wasNewUser,
+      email,
+    });
+
     // DESKTOP PLATFORM: Redirect with tokens encoded in URL
     // OAuth callbacks happen via browser redirect from Google, so we can't return JSON
     // The desktop app (Electron) intercepts the redirect URL and extracts the tokens
@@ -307,11 +316,15 @@ export async function GET(req: Request) {
       if (isNewlyProvisioned) {
         deepLinkUrl.searchParams.set('isNewUser', 'true');
       }
+      if (oauthInviteResult.invitedDriveId) {
+        deepLinkUrl.searchParams.set('invitedDriveId', oauthInviteResult.invitedDriveId);
+      }
 
       loggers.auth.info('Desktop OAuth deep link bridge', {
         userId: user.id,
         provider: 'google',
         hasNewUserFlag: isNewlyProvisioned,
+        invitedDriveId: oauthInviteResult.invitedDriveId ?? null,
       });
 
       return buildHandoffBridgeResponse(deepLinkUrl.toString(), "You're signed in");
@@ -367,11 +380,15 @@ export async function GET(req: Request) {
       if (isNewlyProvisioned) {
         deepLinkUrl.searchParams.set('isNewUser', 'true');
       }
+      if (oauthInviteResult.invitedDriveId) {
+        deepLinkUrl.searchParams.set('invitedDriveId', oauthInviteResult.invitedDriveId);
+      }
 
       loggers.auth.info('iOS OAuth deep link redirect', {
         userId: user.id,
         provider: 'google',
         hasNewUserFlag: isNewlyProvisioned,
+        invitedDriveId: oauthInviteResult.invitedDriveId ?? null,
       });
 
       return NextResponse.redirect(deepLinkUrl.toString());
@@ -393,30 +410,11 @@ export async function GET(req: Request) {
       }
     }
 
-    const inviteToken = verifiedState.inviteToken;
-    if (inviteToken) {
-      try {
-        const ports = buildAcceptancePorts(req);
-        const acceptInput = {
-          token: inviteToken,
-          userId: user.id,
-          userEmail: email.toLowerCase(),
-          suspendedAt: wasNewUser ? null : (user.suspendedAt ?? null),
-          now: new Date(),
-        };
-        const result = wasNewUser
-          ? await acceptInviteForNewUser(ports)(acceptInput)
-          : await acceptInviteForExistingUser(ports)(acceptInput);
-
-        if (result.ok) {
-          returnUrl = `/dashboard/${result.data.driveId}?invited=1`;
-        } else {
-          const sep = returnUrl.includes('?') ? '&' : '?';
-          returnUrl = `${returnUrl}${sep}inviteError=${result.error}`;
-        }
-      } catch (error) {
-        loggers.auth.error('Invite acceptance pipe threw', error as Error);
-      }
+    if (oauthInviteResult.invitedDriveId) {
+      returnUrl = `/dashboard/${oauthInviteResult.invitedDriveId}?invited=1`;
+    } else if (oauthInviteResult.inviteError) {
+      const sep = returnUrl.includes('?') ? '&' : '?';
+      returnUrl = `${returnUrl}${sep}inviteError=${oauthInviteResult.inviteError}`;
     }
 
     const redirectUrl = new URL(returnUrl, baseUrl);

--- a/apps/web/src/app/api/auth/google/callback/route.ts
+++ b/apps/web/src/app/api/auth/google/callback/route.ts
@@ -24,6 +24,11 @@ import { resolveGoogleAvatarImage } from '@/lib/auth/google-avatar';
 import { consumePKCEVerifier } from '@pagespace/lib/auth/pkce';
 import { authRepository } from '@/lib/repositories/auth-repository';
 import { buildHandoffBridgeResponse } from '@/app/api/auth/_shared/handoffBridgeResponse';
+import {
+  acceptInviteForExistingUser,
+  acceptInviteForNewUser,
+} from '@pagespace/lib/services/invites';
+import { buildAcceptancePorts } from '@/lib/auth/invite-acceptance-adapters';
 
 const client = new OAuth2Client(
   process.env.GOOGLE_OAUTH_CLIENT_ID,
@@ -130,6 +135,7 @@ export async function GET(req: Request) {
     const userName = name || email.split('@')[0] || 'User';
 
     let user = await authRepository.findUserByGoogleIdOrEmail(googleId!, email);
+    const wasNewUser = !user;
 
     if (user) {
       const resolvedImage = await resolveGoogleAvatarImage({
@@ -384,6 +390,32 @@ export async function GET(req: Request) {
         loggers.auth.warn('Failed to create device token', {
           userId: user.id, error: error instanceof Error ? error.message : String(error),
         });
+      }
+    }
+
+    const inviteToken = verifiedState.inviteToken;
+    if (inviteToken) {
+      try {
+        const ports = buildAcceptancePorts(req);
+        const acceptInput = {
+          token: inviteToken,
+          userId: user.id,
+          userEmail: email.toLowerCase(),
+          suspendedAt: wasNewUser ? null : (user.suspendedAt ?? null),
+          now: new Date(),
+        };
+        const result = wasNewUser
+          ? await acceptInviteForNewUser(ports)(acceptInput)
+          : await acceptInviteForExistingUser(ports)(acceptInput);
+
+        if (result.ok) {
+          returnUrl = `/dashboard/${result.data.driveId}?invited=1`;
+        } else {
+          const sep = returnUrl.includes('?') ? '&' : '?';
+          returnUrl = `${returnUrl}${sep}inviteError=${result.error}`;
+        }
+      } catch (error) {
+        loggers.auth.error('Invite acceptance pipe threw', error as Error);
       }
     }
 

--- a/apps/web/src/app/api/auth/google/native/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/native/__tests__/route.test.ts
@@ -34,7 +34,12 @@ vi.mock('google-auth-library', () => ({
   })),
 }));
 
+vi.mock('@/lib/auth/native-invite-acceptance', () => ({
+  consumeInviteIfPresent: vi.fn().mockResolvedValue({ invitedDriveId: null }),
+}));
+
 import { POST } from '../route';
+import { consumeInviteIfPresent } from '@/lib/auth/native-invite-acceptance';
 
 vi.mock('@/lib/repositories/auth-repository', () => ({
   authRepository: {
@@ -211,6 +216,7 @@ describe('POST /api/auth/google/native', () => {
     // Default mocks for successful flow
     vi.mocked(checkDistributedRateLimit).mockResolvedValue({ allowed: true, attemptsRemaining: 5 });
     vi.mocked(resetDistributedRateLimit).mockResolvedValue(undefined);
+    vi.mocked(consumeInviteIfPresent).mockResolvedValue({ invitedDriveId: null });
 
     // Default session mocks
     vi.mocked(sessionService.createSession).mockResolvedValue('ps_sess_mock_session_token');
@@ -762,6 +768,45 @@ describe('POST /api/auth/google/native', () => {
       expect(call).toBeDefined();
       const meta = call?.[1] as { email?: string };
       expect(meta.email).toBe('te***@example.com');
+    });
+  });
+
+  describe('invite acceptance', () => {
+    it('forwards inviteToken to consumeInviteIfPresent and includes invitedDriveId in response', async () => {
+      vi.mocked(consumeInviteIfPresent).mockResolvedValueOnce({ invitedDriveId: 'drive-from-invite' });
+
+      const request = createNativeRequest({ ...validNativePayload, inviteToken: 'ps_invite_xyz' });
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(consumeInviteIfPresent).toHaveBeenCalledWith(
+        expect.objectContaining({ inviteToken: 'ps_invite_xyz', isNewUser: true }),
+      );
+      expect(body.invitedDriveId).toBe('drive-from-invite');
+      expect(body.inviteError).toBeUndefined();
+    });
+
+    it('passes inviteError through when pipe rejects with EMAIL_MISMATCH', async () => {
+      vi.mocked(consumeInviteIfPresent).mockResolvedValueOnce({
+        invitedDriveId: null,
+        inviteError: 'EMAIL_MISMATCH',
+      });
+
+      const request = createNativeRequest({ ...validNativePayload, inviteToken: 'ps_invite_xyz' });
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(body.invitedDriveId).toBeNull();
+      expect(body.inviteError).toBe('EMAIL_MISMATCH');
+    });
+
+    it('returns invitedDriveId: null and no inviteError when no inviteToken provided', async () => {
+      const request = createNativeRequest(validNativePayload);
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(body.invitedDriveId).toBeNull();
+      expect(body.inviteError).toBeUndefined();
     });
   });
 

--- a/apps/web/src/app/api/auth/google/native/route.ts
+++ b/apps/web/src/app/api/auth/google/native/route.ts
@@ -19,6 +19,8 @@ import {
   DISTRIBUTED_RATE_LIMITS,
 } from '@pagespace/lib/security/distributed-rate-limit';
 import { authRepository } from '@/lib/repositories/auth-repository';
+import { INVITE_TOKEN_MAX_LENGTH } from '@/lib/auth/oauth-state';
+import { consumeInviteIfPresent } from '@/lib/auth/native-invite-acceptance';
 
 const client = new OAuth2Client();
 
@@ -27,6 +29,7 @@ const nativeAuthSchema = z.object({
   platform: z.enum(['ios', 'android']),
   deviceId: z.string().min(1, 'Device ID is required'),
   deviceName: z.string().optional(),
+  inviteToken: z.string().min(1).max(INVITE_TOKEN_MAX_LENGTH).optional(),
 });
 
 /**
@@ -67,7 +70,7 @@ export async function POST(req: Request) {
       );
     }
 
-    const { idToken, platform, deviceId, deviceName } = validation.data;
+    const { idToken, platform, deviceId, deviceName, inviteToken } = validation.data;
 
     // Validate required environment variables
     if (!process.env.GOOGLE_OAUTH_CLIENT_ID || !process.env.GOOGLE_OAUTH_IOS_CLIENT_ID) {
@@ -241,6 +244,14 @@ export async function POST(req: Request) {
       isNewUser,
     });
 
+    const { invitedDriveId, inviteError } = await consumeInviteIfPresent({
+      request: req,
+      inviteToken,
+      user,
+      isNewUser,
+      email,
+    });
+
     // Set session cookie so middleware recognizes the authenticated session
     const headers = new Headers();
     appendSessionCookie(headers, sessionToken);
@@ -250,6 +261,8 @@ export async function POST(req: Request) {
       csrfToken,
       deviceToken,
       isNewUser,
+      invitedDriveId,
+      ...(inviteError && { inviteError }),
       user: {
         id: user.id,
         name: user.name,

--- a/apps/web/src/app/api/auth/google/one-tap/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/one-tap/__tests__/route.test.ts
@@ -127,7 +127,12 @@ vi.mock('@/lib/auth/google-avatar', () => ({
   resolveGoogleAvatarImage: vi.fn().mockResolvedValue(null),
 }));
 
+vi.mock('@/lib/auth/native-invite-acceptance', () => ({
+  consumeInviteIfPresent: vi.fn().mockResolvedValue({ invitedDriveId: null }),
+}));
+
 import { POST } from '../route';
+import { consumeInviteIfPresent } from '@/lib/auth/native-invite-acceptance';
 import { authRepository } from '@/lib/repositories/auth-repository';
 import { sessionService } from '@pagespace/lib/auth/session-service';
 import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
@@ -208,6 +213,7 @@ describe('POST /api/auth/google/one-tap', () => {
     // Default mocks
     vi.mocked(checkDistributedRateLimit).mockResolvedValue({ allowed: true, attemptsRemaining: 5 });
     vi.mocked(resetDistributedRateLimit).mockResolvedValue(undefined);
+    vi.mocked(consumeInviteIfPresent).mockResolvedValue({ invitedDriveId: null });
 
     vi.mocked(sessionService.createSession).mockResolvedValue('ps_sess_mock_session_token');
     vi.mocked(sessionService.validateSession).mockResolvedValue({
@@ -748,6 +754,46 @@ describe('POST /api/auth/google/one-tap', () => {
       const meta = call?.[1] as Record<string, unknown>;
       expect(meta).not.toHaveProperty('name');
       expect(meta).toHaveProperty('userId');
+    });
+  });
+
+  describe('invite acceptance', () => {
+    it('forwards inviteToken and overrides redirectTo when invite consumed', async () => {
+      vi.mocked(consumeInviteIfPresent).mockResolvedValueOnce({ invitedDriveId: 'drive-from-invite' });
+
+      const request = createOneTapRequest({ ...validOneTapPayload, inviteToken: 'ps_invite_xyz' });
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(consumeInviteIfPresent).toHaveBeenCalledWith(
+        expect.objectContaining({ inviteToken: 'ps_invite_xyz' }),
+      );
+      expect(body.invitedDriveId).toBe('drive-from-invite');
+      expect(body.redirectTo).toBe('/dashboard/drive-from-invite?invited=1');
+    });
+
+    it('keeps original redirectTo and surfaces inviteError when pipe rejects', async () => {
+      vi.mocked(consumeInviteIfPresent).mockResolvedValueOnce({
+        invitedDriveId: null,
+        inviteError: 'EMAIL_MISMATCH',
+      });
+
+      const request = createOneTapRequest({ ...validOneTapPayload, inviteToken: 'ps_invite_xyz' });
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(body.invitedDriveId).toBeNull();
+      expect(body.inviteError).toBe('EMAIL_MISMATCH');
+      expect(body.redirectTo).toBe('/dashboard');
+    });
+
+    it('returns invitedDriveId: null when no inviteToken provided', async () => {
+      const request = createOneTapRequest(validOneTapPayload);
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(body.invitedDriveId).toBeNull();
+      expect(body.inviteError).toBeUndefined();
     });
   });
 

--- a/apps/web/src/app/api/auth/google/one-tap/route.ts
+++ b/apps/web/src/app/api/auth/google/one-tap/route.ts
@@ -20,12 +20,15 @@ import { getClientIP } from '@/lib/auth';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';
 import { resolveGoogleAvatarImage } from '@/lib/auth/google-avatar';
 import { authRepository } from '@/lib/repositories/auth-repository';
+import { INVITE_TOKEN_MAX_LENGTH } from '@/lib/auth/oauth-state';
+import { consumeInviteIfPresent } from '@/lib/auth/native-invite-acceptance';
 
 const oneTapSchema = z.object({
   credential: z.string().min(1, 'Credential is required'),
   platform: z.enum(['web', 'desktop']).optional().default('web'),
   deviceId: z.string().optional(),
   deviceName: z.string().optional(),
+  inviteToken: z.string().min(1).max(INVITE_TOKEN_MAX_LENGTH).optional(),
 });
 
 const client = new OAuth2Client(process.env.GOOGLE_OAUTH_CLIENT_ID);
@@ -52,7 +55,7 @@ export async function POST(req: Request) {
       );
     }
 
-    const { credential, platform, deviceId, deviceName } = validation.data;
+    const { credential, platform, deviceId, deviceName, inviteToken } = validation.data;
 
     // Rate limiting by IP address
     const clientIP = getClientIP(req);
@@ -201,7 +204,7 @@ export async function POST(req: Request) {
       });
     }
 
-    const redirectTo = provisionedDrive?.created ? `/dashboard/${provisionedDrive.driveId}` : '/dashboard';
+    let redirectTo = provisionedDrive?.created ? `/dashboard/${provisionedDrive.driveId}` : '/dashboard';
 
     await revokeSessionsForLogin(user.id, deviceId, 'new_login', 'Google One Tap');
 
@@ -267,6 +270,17 @@ export async function POST(req: Request) {
       }
     }
 
+    const { invitedDriveId, inviteError } = await consumeInviteIfPresent({
+      request: req,
+      inviteToken,
+      user,
+      isNewUser,
+      email,
+    });
+    if (invitedDriveId) {
+      redirectTo = `/dashboard/${invitedDriveId}?invited=1`;
+    }
+
     const headers = new Headers();
     appendSessionCookie(headers, sessionToken);
 
@@ -284,6 +298,8 @@ export async function POST(req: Request) {
         ...(deviceTokenValue && { deviceToken: deviceTokenValue }),
         redirectTo,
         isNewUser,
+        invitedDriveId,
+        ...(inviteError && { inviteError }),
       },
       { headers }
     );

--- a/apps/web/src/app/api/auth/google/signin/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/signin/__tests__/route.test.ts
@@ -212,6 +212,24 @@ describe('/api/auth/google/signin', () => {
         expect(response.status).toBe(400);
         expect(body.errors.deviceName).toBeDefined();
       });
+
+      it('returns 400 for inviteToken longer than 128 chars', async () => {
+        const request = createPostRequest({ inviteToken: 'ps_invite_' + 'x'.repeat(120) });
+        const response = await POST(request);
+        const body = await response.json();
+
+        expect(response.status).toBe(400);
+        expect(body.errors.inviteToken).toBeDefined();
+      });
+
+      it('returns 400 for empty inviteToken', async () => {
+        const request = createPostRequest({ inviteToken: '' });
+        const response = await POST(request);
+        const body = await response.json();
+
+        expect(response.status).toBe(400);
+        expect(body.errors.inviteToken).toBeDefined();
+      });
     });
 
     describe('unsafe returnUrl rejection', () => {
@@ -335,6 +353,29 @@ describe('/api/auth/google/signin', () => {
         const stateParam = url.searchParams.get('state');
         const decoded = JSON.parse(Buffer.from(stateParam!, 'base64').toString('utf-8'));
         expect(decoded.data.deviceId).toBeUndefined();
+      });
+
+      it('forwards inviteToken into state when provided', async () => {
+        const inviteToken = 'ps_invite_abc123def456ghi789';
+        const request = createPostRequest({ inviteToken });
+        const response = await POST(request);
+        const body = await response.json();
+
+        const url = new URL(body.url);
+        const stateParam = url.searchParams.get('state');
+        const decoded = JSON.parse(Buffer.from(stateParam!, 'base64').toString('utf-8'));
+        expect(decoded.data.inviteToken).toBe(inviteToken);
+      });
+
+      it('omits inviteToken from state when not provided', async () => {
+        const request = createPostRequest({});
+        const response = await POST(request);
+        const body = await response.json();
+
+        const url = new URL(body.url);
+        const stateParam = url.searchParams.get('state');
+        const decoded = JSON.parse(Buffer.from(stateParam!, 'base64').toString('utf-8'));
+        expect(decoded.data.inviteToken).toBeUndefined();
       });
 
       it('defaults returnUrl to /dashboard and platform to web', async () => {

--- a/apps/web/src/app/api/auth/google/signin/route.ts
+++ b/apps/web/src/app/api/auth/google/signin/route.ts
@@ -16,6 +16,7 @@ const googleSigninSchema = z.object({
   platform: z.enum(['web', 'desktop', 'ios']).optional(),
   deviceId: z.string().min(1).max(128).optional(),
   deviceName: z.string().max(255).optional(),
+  inviteToken: z.string().min(1).max(128).optional(),
 });
 
 export async function POST(req: Request) {
@@ -40,7 +41,7 @@ export async function POST(req: Request) {
       return Response.json({ errors: validation.error.flatten().fieldErrors }, { status: 400 });
     }
 
-    const { returnUrl, platform, deviceId, deviceName } = validation.data;
+    const { returnUrl, platform, deviceId, deviceName, inviteToken } = validation.data;
 
     // SECURITY: Validate returnUrl to prevent open redirect attacks
     // An attacker could set returnUrl to an external domain and capture the deviceToken
@@ -86,6 +87,7 @@ export async function POST(req: Request) {
         platform: platform || 'web',
         ...(deviceId && { deviceId }),
         ...(deviceName && { deviceName }),
+        ...(inviteToken && { inviteToken }),
       },
       process.env.OAUTH_STATE_SECRET!
     );

--- a/apps/web/src/app/api/auth/google/signin/route.ts
+++ b/apps/web/src/app/api/auth/google/signin/route.ts
@@ -6,6 +6,7 @@ import {
 } from '@pagespace/lib/security/distributed-rate-limit';
 import { createSignedState } from '@pagespace/lib/integrations/oauth/oauth-state';
 import { getClientIP, isSafeReturnUrl } from '@/lib/auth';
+import { INVITE_TOKEN_MAX_LENGTH } from '@/lib/auth/oauth-state';
 import { generatePKCE } from '@pagespace/lib/auth/pkce';
 
 // Length bounds must match verifyOAuthState's oauthStateDataSchema — otherwise
@@ -16,7 +17,7 @@ const googleSigninSchema = z.object({
   platform: z.enum(['web', 'desktop', 'ios']).optional(),
   deviceId: z.string().min(1).max(128).optional(),
   deviceName: z.string().max(255).optional(),
-  inviteToken: z.string().min(1).max(128).optional(),
+  inviteToken: z.string().min(1).max(INVITE_TOKEN_MAX_LENGTH).optional(),
 });
 
 export async function POST(req: Request) {

--- a/apps/web/src/app/api/drives/[driveId]/members/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/__tests__/route.test.ts
@@ -16,6 +16,12 @@ vi.mock('@pagespace/lib/services/drive-member-service', () => ({
   listDriveMembers: vi.fn(),
 }));
 
+vi.mock('@/lib/repositories/drive-invite-repository', () => ({
+  driveInviteRepository: {
+    findUnconsumedInvitesByDrive: vi.fn().mockResolvedValue([]),
+  },
+}));
+
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
   loggers: {
     api: {
@@ -37,6 +43,7 @@ import { GET } from '../route';
 import { checkDriveAccess, listDriveMembers } from '@pagespace/lib/services/drive-member-service';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { driveInviteRepository } from '@/lib/repositories/drive-invite-repository';
 
 // ============================================================================
 // Test Fixtures
@@ -125,6 +132,7 @@ describe('GET /api/drives/[driveId]/members', () => {
     vi.resetAllMocks();
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockWebAuth(mockUserId));
     vi.mocked(isAuthError).mockReturnValue(false);
+    vi.mocked(driveInviteRepository.findUnconsumedInvitesByDrive).mockResolvedValue([]);
   });
 
   describe('authentication', () => {
@@ -318,6 +326,87 @@ describe('GET /api/drives/[driveId]/members', () => {
 
       expect(response.status).toBe(200);
       expect(body.members).toEqual([]);
+    });
+  });
+
+  describe('pendingInvites field', () => {
+    const samplePending = [{
+      id: 'inv_1',
+      email: 'invitee@example.com',
+      role: 'MEMBER' as const,
+      driveId: 'drive_abc',
+      invitedByName: 'Alice',
+      createdAt: new Date('2024-02-01'),
+      expiresAt: new Date('2024-02-03'),
+    }];
+
+    it('returns populated pendingInvites for OWNER', async () => {
+      vi.mocked(checkDriveAccess).mockResolvedValue(createAccessFixture({
+        isOwner: true, isMember: true,
+        drive: createDriveFixture({ id: mockDriveId, name: 'Test', ownerId: mockUserId }),
+      }));
+      vi.mocked(listDriveMembers).mockResolvedValue([]);
+      vi.mocked(driveInviteRepository.findUnconsumedInvitesByDrive).mockResolvedValue(samplePending);
+
+      const request = new Request(`https://example.com/api/drives/${mockDriveId}/members`);
+      const response = await GET(request, createContext(mockDriveId));
+      const body = await response.json();
+
+      expect(driveInviteRepository.findUnconsumedInvitesByDrive).toHaveBeenCalledWith(mockDriveId);
+      expect(body.pendingInvites).toHaveLength(1);
+      expect(body.pendingInvites[0]).toMatchObject({
+        id: 'inv_1',
+        email: 'invitee@example.com',
+        role: 'MEMBER',
+        invitedByName: 'Alice',
+      });
+    });
+
+    it('returns populated pendingInvites for ADMIN', async () => {
+      vi.mocked(checkDriveAccess).mockResolvedValue(createAccessFixture({
+        isOwner: false, isAdmin: true, isMember: true,
+        drive: createDriveFixture({ id: mockDriveId, name: 'Test' }),
+      }));
+      vi.mocked(listDriveMembers).mockResolvedValue([]);
+      vi.mocked(driveInviteRepository.findUnconsumedInvitesByDrive).mockResolvedValue(samplePending);
+
+      const request = new Request(`https://example.com/api/drives/${mockDriveId}/members`);
+      const response = await GET(request, createContext(mockDriveId));
+      const body = await response.json();
+
+      expect(body.pendingInvites).toHaveLength(1);
+    });
+
+    it('returns empty pendingInvites for regular MEMBER (no leak)', async () => {
+      vi.mocked(checkDriveAccess).mockResolvedValue(createAccessFixture({
+        isOwner: false, isAdmin: false, isMember: true,
+        drive: createDriveFixture({ id: mockDriveId, name: 'Test' }),
+      }));
+      vi.mocked(listDriveMembers).mockResolvedValue([]);
+      vi.mocked(driveInviteRepository.findUnconsumedInvitesByDrive).mockResolvedValue(samplePending);
+
+      const request = new Request(`https://example.com/api/drives/${mockDriveId}/members`);
+      const response = await GET(request, createContext(mockDriveId));
+      const body = await response.json();
+
+      // Field present (stable shape across roles) but empty for MEMBER
+      expect(body.pendingInvites).toEqual([]);
+      // Repo should not even be queried for non-OWNER/ADMIN
+      expect(driveInviteRepository.findUnconsumedInvitesByDrive).not.toHaveBeenCalled();
+    });
+
+    it('field is always an array (never undefined) when authorized', async () => {
+      vi.mocked(checkDriveAccess).mockResolvedValue(createAccessFixture({
+        isOwner: false, isAdmin: false, isMember: true,
+        drive: createDriveFixture({ id: mockDriveId, name: 'Test' }),
+      }));
+      vi.mocked(listDriveMembers).mockResolvedValue([]);
+
+      const request = new Request(`https://example.com/api/drives/${mockDriveId}/members`);
+      const response = await GET(request, createContext(mockDriveId));
+      const body = await response.json();
+
+      expect(Array.isArray(body.pendingInvites)).toBe(true);
     });
   });
 

--- a/apps/web/src/app/api/drives/[driveId]/members/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { checkDriveAccess, listDriveMembers } from '@pagespace/lib/services/drive-member-service';
+import { driveInviteRepository } from '@/lib/repositories/drive-invite-repository';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 
@@ -30,8 +31,18 @@ export async function GET(
     // Get all members with their profiles and permission counts
     const members = await listDriveMembers(driveId);
 
+    // Pending invites are visible to OWNER/ADMIN only. The field is always an
+    // array (never undefined) so client-side SWR cache shape stays stable as
+    // a viewer's role changes — avoids "field present for some users, missing
+    // for others" type ambiguity in the UI.
+    const canSeePending = access.isOwner || access.isAdmin;
+    const pendingInvites = canSeePending
+      ? await driveInviteRepository.findUnconsumedInvitesByDrive(driveId)
+      : [];
+
     return NextResponse.json({
       members,
+      pendingInvites,
       currentUserRole: access.isOwner ? 'OWNER' : (access.isAdmin ? 'ADMIN' : 'MEMBER')
     });
   } catch (error) {

--- a/apps/web/src/app/api/drives/[driveId]/pending-invites/[inviteId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/pending-invites/[inviteId]/__tests__/route.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+import type { SessionAuthResult, AuthError } from '@/lib/auth';
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  },
+}));
+
+vi.mock('@/lib/auth/revoke-adapters', () => ({
+  buildRevokePorts: vi.fn(() => ({})),
+}));
+
+const revokePipe = vi.fn();
+vi.mock('@pagespace/lib/services/invites', () => ({
+  revokePendingInvite: vi.fn(() => revokePipe),
+}));
+
+import { DELETE } from '../route';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { revokePendingInvite } from '@pagespace/lib/services/invites';
+import { buildRevokePorts } from '@/lib/auth/revoke-adapters';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+
+const mockWebAuth = (userId: string): SessionAuthResult => ({
+  userId,
+  tokenVersion: 0,
+  tokenType: 'session',
+  sessionId: 'test-session-id',
+  role: 'user',
+  adminRoleVersion: 0,
+});
+const mockAuthError = (status = 401): AuthError => ({
+  error: NextResponse.json({ error: 'Unauthorized' }, { status }),
+});
+
+const createContext = (driveId: string, inviteId: string) => ({
+  params: Promise.resolve({ driveId, inviteId }),
+});
+
+const createDeleteRequest = () =>
+  new Request('https://example.com/api/drives/d1/pending-invites/inv1', {
+    method: 'DELETE',
+  });
+
+describe('DELETE /api/drives/[driveId]/pending-invites/[inviteId]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    revokePipe.mockReset();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockWebAuth('user-1'));
+    vi.mocked(isAuthError).mockReturnValue(false);
+    vi.mocked(revokePendingInvite).mockImplementation(() => revokePipe);
+    vi.mocked(buildRevokePorts).mockReturnValue({} as never);
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    vi.mocked(isAuthError).mockReturnValue(true);
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthError(401));
+
+    const response = await DELETE(createDeleteRequest(), createContext('d1', 'inv1'));
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 200 with inviteId + driveId on successful revoke', async () => {
+    revokePipe.mockResolvedValueOnce({
+      ok: true,
+      data: { inviteId: 'inv1', driveId: 'd1', email: 't@example.com', role: 'MEMBER' },
+    });
+
+    const response = await DELETE(createDeleteRequest(), createContext('d1', 'inv1'));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ inviteId: 'inv1', driveId: 'd1' });
+    expect(revokePipe).toHaveBeenCalledWith({
+      inviteId: 'inv1',
+      driveId: 'd1',
+      actorId: 'user-1',
+    });
+  });
+
+  it('returns 404 on NOT_FOUND (invite missing or wrong-drive)', async () => {
+    revokePipe.mockResolvedValueOnce({ ok: false, error: 'NOT_FOUND' });
+
+    const response = await DELETE(createDeleteRequest(), createContext('d1', 'inv1'));
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.error).toBe('Invite not found');
+  });
+
+  // Security guard: a wrong-drive request must NOT distinguish from a
+  // never-existed invite — both 404. Otherwise an attacker could enumerate
+  // invite IDs across drives.
+  it('returns 404 (not 403) when driveId mismatches existing invite', async () => {
+    revokePipe.mockResolvedValueOnce({ ok: false, error: 'NOT_FOUND' });
+
+    const response = await DELETE(createDeleteRequest(), createContext('other-drive', 'inv1'));
+    expect(response.status).toBe(404);
+  });
+
+  it('returns 403 when actor is not an accepted OWNER/ADMIN', async () => {
+    revokePipe.mockResolvedValueOnce({ ok: false, error: 'FORBIDDEN' });
+
+    const response = await DELETE(createDeleteRequest(), createContext('d1', 'inv1'));
+    const body = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(body.error).toBe('Forbidden');
+  });
+
+  it('returns 500 when pipe throws', async () => {
+    revokePipe.mockRejectedValueOnce(new Error('database explosion'));
+
+    const response = await DELETE(createDeleteRequest(), createContext('d1', 'inv1'));
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error).toBe('Failed to revoke invite');
+    expect(loggers.api.error).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/drives/[driveId]/pending-invites/[inviteId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/pending-invites/[inviteId]/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { revokePendingInvite } from '@pagespace/lib/services/invites';
+import { buildRevokePorts } from '@/lib/auth/revoke-adapters';
+
+const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
+
+/**
+ * Revoke a pending drive invite. Authorization (accepted OWNER/ADMIN of the
+ * drive) lives in the pure-core `validateRevokeRequest`; this handler just
+ * builds adapter ports and maps result codes to HTTP.
+ *
+ * NOT_FOUND is returned when the invite does not exist OR exists on a
+ * different drive — never disclose the cross-drive existence to a wrong-drive
+ * admin (that would let a non-OWNER/ADMIN of any drive enumerate invite IDs).
+ */
+export async function DELETE(
+  request: Request,
+  context: { params: Promise<{ driveId: string; inviteId: string }> },
+) {
+  try {
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
+    if (isAuthError(auth)) return auth.error;
+
+    const { driveId, inviteId } = await context.params;
+
+    const result = await revokePendingInvite(buildRevokePorts(request))({
+      inviteId,
+      driveId,
+      actorId: auth.userId,
+    });
+
+    if (!result.ok) {
+      if (result.error === 'NOT_FOUND') {
+        return NextResponse.json({ error: 'Invite not found' }, { status: 404 });
+      }
+      // FORBIDDEN — actor is not an accepted OWNER/ADMIN of this drive
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    return NextResponse.json({
+      inviteId: result.data.inviteId,
+      driveId: result.data.driveId,
+    });
+  } catch (error) {
+    loggers.api.error('Error revoking pending invite:', error as Error);
+    return NextResponse.json(
+      { error: 'Failed to revoke invite' },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/api/drives/[driveId]/pending-invites/[inviteId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/pending-invites/[inviteId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { revokePendingInvite } from '@pagespace/lib/services/invites';
 import { buildRevokePorts } from '@/lib/auth/revoke-adapters';
 
@@ -35,10 +36,23 @@ export async function DELETE(
       if (result.error === 'NOT_FOUND') {
         return NextResponse.json({ error: 'Invite not found' }, { status: 404 });
       }
-      // FORBIDDEN — actor is not an accepted OWNER/ADMIN of this drive
+      // FORBIDDEN — actor is not an accepted OWNER/ADMIN of this drive.
+      // Adapter's auditPermissionRevoked fires only on success; audit the
+      // denied attempt explicitly here so a malicious enumeration leaves a
+      // trail.
+      auditRequest(request, {
+        eventType: 'authz.access.denied',
+        userId: auth.userId,
+        riskScore: 0.4,
+        resourceType: 'drive',
+        resourceId: driveId,
+        details: { operation: 'revoke_invite', inviteId },
+      });
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 
+    // Success-side audit (authz.permission.revoked) is emitted by the
+    // adapter's auditPermissionRevoked port inside the pipe.
     return NextResponse.json({
       inviteId: result.data.inviteId,
       driveId: result.data.driveId,

--- a/apps/web/src/app/auth/signin/page.tsx
+++ b/apps/web/src/app/auth/signin/page.tsx
@@ -18,12 +18,20 @@ import {
 import { useAuthCSRF } from "@/hooks/useAuthCSRF";
 import { useOAuthSignIn } from "@/hooks/useOAuthSignIn";
 import { isOnPrem } from "@/lib/deployment-mode";
+import { isSafeNextPath } from "@/lib/auth/auth-helpers";
+
+const SIGNIN_NEXT_ALLOWED_PREFIXES = ['/dashboard', '/invite/', '/account'];
 
 function SignInForm() {
   const [showMagicLink, setShowMagicLink] = useState(false);
   const searchParams = useSearchParams();
   const { csrfToken, refreshToken } = useAuthCSRF();
   const inviteToken = searchParams.get('invite') ?? undefined;
+  const rawNext = searchParams.get('next');
+  const nextPath = rawNext && isSafeNextPath({
+    path: rawNext,
+    allowedPrefixes: SIGNIN_NEXT_ALLOWED_PREFIXES,
+  }) ? rawNext : undefined;
   const {
     handleGoogleSignIn,
     handleAppleSignIn,
@@ -117,6 +125,7 @@ function SignInForm() {
             <PasskeyLoginButton
               csrfToken={csrfToken}
               refreshToken={refreshToken}
+              {...(nextPath && { nextPath })}
             />
           </motion.div>
         )}

--- a/apps/web/src/app/auth/signin/page.tsx
+++ b/apps/web/src/app/auth/signin/page.tsx
@@ -23,6 +23,7 @@ function SignInForm() {
   const [showMagicLink, setShowMagicLink] = useState(false);
   const searchParams = useSearchParams();
   const { csrfToken, refreshToken } = useAuthCSRF();
+  const inviteToken = searchParams.get('invite') ?? undefined;
   const {
     handleGoogleSignIn,
     handleAppleSignIn,
@@ -31,7 +32,7 @@ function SignInForm() {
     isWaitingForExternalAuth,
     waitingProvider,
     cancelExternalAuth,
-  } = useOAuthSignIn();
+  } = useOAuthSignIn(inviteToken ? { inviteToken } : {});
   const onPrem = isOnPrem();
 
   useEffect(() => {

--- a/apps/web/src/app/auth/signin/page.tsx
+++ b/apps/web/src/app/auth/signin/page.tsx
@@ -166,6 +166,7 @@ function SignInForm() {
           <PasskeyLoginButton
             csrfToken={csrfToken}
             refreshToken={refreshToken}
+            {...(nextPath && { nextPath })}
           />
         </motion.div>
       )}

--- a/apps/web/src/app/auth/signup/SignUpClient.tsx
+++ b/apps/web/src/app/auth/signup/SignUpClient.tsx
@@ -38,6 +38,7 @@ export function SignUpClient({ inviteToken, inviteContext }: SignUpClientProps) 
   } = useOAuthSignIn({
     onStart: () => setError(null),
     onError: (msg) => setError(msg),
+    ...(inviteToken && { inviteToken }),
   });
 
   const isAnyLoading = isGoogleLoading || isAppleLoading || passkeyLoading;

--- a/apps/web/src/components/auth/PasskeyLoginButton.tsx
+++ b/apps/web/src/components/auth/PasskeyLoginButton.tsx
@@ -21,6 +21,13 @@ interface PasskeyLoginButtonProps {
   refreshToken?: () => Promise<string | null>;
   email?: string;
   onSuccess?: (redirectUrl: string) => void;
+  /**
+   * Pre-validated relative path to redirect to on success. Caller is
+   * responsible for safety-checking this (e.g. via `isSafeNextPath`) before
+   * passing it in. When present, takes precedence over the server's
+   * `verifyData.redirectUrl`.
+   */
+  nextPath?: string;
   className?: string;
   variant?: 'default' | 'outline' | 'secondary';
 }
@@ -30,6 +37,7 @@ export function PasskeyLoginButton({
   refreshToken,
   email,
   onSuccess,
+  nextPath,
   className,
   variant = 'default',
 }: PasskeyLoginButtonProps) {
@@ -154,10 +162,15 @@ export function PasskeyLoginButton({
 
       if (await handleDesktopAuthResponse(verifyData)) return;
 
+      // Pre-validated nextPath wins over the server's default redirect so the
+      // user lands where they were trying to go (e.g. an /invite/[token] page
+      // they were forced to sign in from).
+      const targetUrl = nextPath ?? verifyData.redirectUrl;
+
       if (onSuccess) {
-        onSuccess(verifyData.redirectUrl);
+        onSuccess(targetUrl);
       } else {
-        window.location.href = verifyData.redirectUrl;
+        window.location.href = targetUrl;
       }
     } catch (err) {
       if (err instanceof Error) {
@@ -174,7 +187,7 @@ export function PasskeyLoginButton({
     } finally {
       setIsAuthenticating(false);
     }
-  }, [csrfToken, refreshToken, email, onSuccess]);
+  }, [csrfToken, refreshToken, email, onSuccess, nextPath]);
 
   // Don't render if browser doesn't support WebAuthn
   if (isSupported === false) {

--- a/apps/web/src/components/members/DriveMembers.tsx
+++ b/apps/web/src/components/members/DriveMembers.tsx
@@ -136,6 +136,24 @@ export function DriveMembers({ driveId }: DriveMembersProps) {
     }
   };
 
+  const handleRevokeInvite = async (inviteId: string) => {
+    try {
+      await del(`/api/drives/${driveId}/pending-invites/${inviteId}`);
+      setPendingInvites((prev) => prev.filter((inv) => inv.id !== inviteId));
+      toast({
+        title: 'Invitation revoked',
+        description: 'The invitation link no longer works.',
+      });
+    } catch (error) {
+      console.error('Error revoking invite:', error);
+      toast({
+        title: 'Error',
+        description: 'Failed to revoke invitation',
+        variant: 'destructive',
+      });
+    }
+  };
+
   if (loading) {
     return (
       <div className="flex justify-center py-8">
@@ -182,6 +200,7 @@ export function DriveMembers({ driveId }: DriveMembersProps) {
       <PendingInvitesSection
         invites={pendingInvites}
         currentUserRole={currentUserRole}
+        onRevoke={handleRevokeInvite}
       />
     </div>
   );

--- a/apps/web/src/components/members/DriveMembers.tsx
+++ b/apps/web/src/components/members/DriveMembers.tsx
@@ -5,6 +5,8 @@ import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { UserPlus } from 'lucide-react';
 import { MemberRow } from './MemberRow';
+import { PendingInvitesSection } from './PendingInvitesSection';
+import type { PendingInvite } from './PendingInviteRow';
 import { useToast } from '@/hooks/useToast';
 import { useSocket } from '@/hooks/useSocket';
 import { del, fetchWithAuth } from '@/lib/auth/auth-fetch';
@@ -55,6 +57,7 @@ const DRIVE_MEMBER_EVENTS = [
 
 export function DriveMembers({ driveId }: DriveMembersProps) {
   const [members, setMembers] = useState<DriveMember[]>([]);
+  const [pendingInvites, setPendingInvites] = useState<PendingInvite[]>([]);
   const [currentUserRole, setCurrentUserRole] = useState<'OWNER' | 'ADMIN' | 'MEMBER'>('MEMBER');
   const [loading, setLoading] = useState(true);
   const router = useRouter();
@@ -73,6 +76,7 @@ export function DriveMembers({ driveId }: DriveMembersProps) {
       const data = await response.json();
       if (currentSeq !== requestSeqRef.current) return;
       setMembers(data.members);
+      setPendingInvites(data.pendingInvites ?? []);
       setCurrentUserRole(data.currentUserRole || 'MEMBER');
     } catch (error) {
       if (currentSeq !== requestSeqRef.current) return;
@@ -110,11 +114,8 @@ export function DriveMembers({ driveId }: DriveMembersProps) {
     };
   }, [socket, driveId, fetchMembers]);
 
-  const handleRemoveMember = async (userId: string, isPending: boolean) => {
-    const message = isPending
-      ? 'Are you sure you want to revoke this invitation?'
-      : 'Are you sure you want to remove this member?';
-    if (!confirm(message)) return;
+  const handleRemoveMember = async (userId: string) => {
+    if (!confirm('Are you sure you want to remove this member?')) return;
 
     try {
       await del(`/api/drives/${driveId}/members/${userId}`);
@@ -123,13 +124,13 @@ export function DriveMembers({ driveId }: DriveMembersProps) {
 
       toast({
         title: 'Success',
-        description: isPending ? 'Invitation revoked' : 'Member removed successfully',
+        description: 'Member removed successfully',
       });
     } catch (error) {
       console.error('Error removing member:', error);
       toast({
         title: 'Error',
-        description: isPending ? 'Failed to revoke invitation' : 'Failed to remove member',
+        description: 'Failed to remove member',
         variant: 'destructive',
       });
     }
@@ -143,23 +144,11 @@ export function DriveMembers({ driveId }: DriveMembersProps) {
     );
   }
 
-  // Strict null check: undefined from a malformed payload must not classify as pending.
-  // Post the GDPR + zero-trust invite migration, drive_members rows are only
-  // created at acceptance time (acceptedAt is always set on insert), so
-  // pendingMembers will normally be empty here. Pending invitations now live
-  // in the pending_invites table and are not surfaced through the members API
-  // — that's an intentional follow-up (see tasks/drive-invite-gdpr-zero-trust.md
-  // "Out of scope: Members-UI pending-invites list"). The block below remains
-  // so that any legacy acceptedAt=null row that survives the migration cutover
-  // is still surfaced rather than silently hidden.
-  const acceptedMembers = members.filter((m) => m.acceptedAt != null);
-  const pendingMembers = members.filter((m) => m.acceptedAt === null);
-
   return (
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <div>
-          <h2 className="text-lg font-semibold">Members ({acceptedMembers.length})</h2>
+          <h2 className="text-lg font-semibold">Members ({members.length})</h2>
           <p className="text-sm text-gray-600 dark:text-gray-400">
             People with access to this drive
           </p>
@@ -173,44 +162,27 @@ export function DriveMembers({ driveId }: DriveMembersProps) {
       </div>
 
       <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 divide-y divide-gray-200 dark:divide-gray-700">
-        {acceptedMembers.length === 0 ? (
+        {members.length === 0 ? (
           <div className="p-8 text-center text-gray-500 dark:text-gray-400">
             No members yet. Invite someone to collaborate!
           </div>
         ) : (
-          acceptedMembers.map((member) => (
+          members.map((member) => (
             <MemberRow
               key={member.id}
               member={member}
               driveId={driveId}
               currentUserRole={currentUserRole}
-              onRemove={() => handleRemoveMember(member.userId, false)}
+              onRemove={() => handleRemoveMember(member.userId)}
             />
           ))
         )}
       </div>
 
-      {pendingMembers.length > 0 && (
-        <div>
-          <div className="mb-3">
-            <h2 className="text-lg font-semibold">Pending invitations ({pendingMembers.length})</h2>
-            <p className="text-sm text-gray-600 dark:text-gray-400">
-              People invited but not yet joined
-            </p>
-          </div>
-          <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 divide-y divide-gray-200 dark:divide-gray-700">
-            {pendingMembers.map((member) => (
-              <MemberRow
-                key={member.id}
-                member={member}
-                driveId={driveId}
-                currentUserRole={currentUserRole}
-                onRemove={() => handleRemoveMember(member.userId, true)}
-              />
-            ))}
-          </div>
-        </div>
-      )}
+      <PendingInvitesSection
+        invites={pendingInvites}
+        currentUserRole={currentUserRole}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/members/MemberRow.tsx
+++ b/apps/web/src/components/members/MemberRow.tsx
@@ -40,7 +40,6 @@ interface MemberRowProps {
 }
 
 export function MemberRow({ member, driveId, currentUserRole, onRemove }: MemberRowProps) {
-  const isPending = member.acceptedAt === null;
   const canManage = currentUserRole === 'OWNER' || currentUserRole === 'ADMIN';
   const displayName = member.profile?.displayName || member.user.name || member.user.email || 'Unknown User';
   const initials = displayName
@@ -117,44 +116,34 @@ export function MemberRow({ member, driveId, currentUserRole, onRemove }: Member
               <span className="text-sm text-gray-500 dark:text-gray-400">@{member.profile.username}</span>
             )}
             {getRoleBadge()}
-            {isPending && (
-              <Badge
-                variant="outline"
-                className="border-yellow-500/50 bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300"
-              >
-                Pending
-              </Badge>
-            )}
           </div>
           <p className="text-sm text-gray-600 dark:text-gray-400">{member.user.email}</p>
 
-          {!isPending && (
-            <div className="flex items-center space-x-4 mt-1">
-              {member.permissionCounts.view > 0 && (
-                <div className="flex items-center space-x-1 text-xs text-gray-500 dark:text-gray-400">
-                  <Eye className="w-3 h-3" />
-                  <span>{member.permissionCounts.view} pages</span>
-                </div>
-              )}
-              {member.permissionCounts.edit > 0 && (
-                <div className="flex items-center space-x-1 text-xs text-gray-500 dark:text-gray-400">
-                  <Edit className="w-3 h-3" />
-                  <span>{member.permissionCounts.edit} pages</span>
-                </div>
-              )}
-              {member.permissionCounts.share > 0 && (
-                <div className="flex items-center space-x-1 text-xs text-gray-500 dark:text-gray-400">
-                  <Share className="w-3 h-3" />
-                  <span>{member.permissionCounts.share} pages</span>
-                </div>
-              )}
-            </div>
-          )}
+          <div className="flex items-center space-x-4 mt-1">
+            {member.permissionCounts.view > 0 && (
+              <div className="flex items-center space-x-1 text-xs text-gray-500 dark:text-gray-400">
+                <Eye className="w-3 h-3" />
+                <span>{member.permissionCounts.view} pages</span>
+              </div>
+            )}
+            {member.permissionCounts.edit > 0 && (
+              <div className="flex items-center space-x-1 text-xs text-gray-500 dark:text-gray-400">
+                <Edit className="w-3 h-3" />
+                <span>{member.permissionCounts.edit} pages</span>
+              </div>
+            )}
+            {member.permissionCounts.share > 0 && (
+              <div className="flex items-center space-x-1 text-xs text-gray-500 dark:text-gray-400">
+                <Share className="w-3 h-3" />
+                <span>{member.permissionCounts.share} pages</span>
+              </div>
+            )}
+          </div>
         </div>
       </div>
 
       <div className="flex items-center space-x-2">
-        {canManage && !isPending && (
+        {canManage && (
           <Link href={`/dashboard/${driveId}/members/${member.userId}`}>
             <Button
               variant="ghost"
@@ -171,7 +160,7 @@ export function MemberRow({ member, driveId, currentUserRole, onRemove }: Member
             size="sm"
             onClick={onRemove}
             className="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
-            title={isPending ? 'Revoke Invitation' : 'Remove Member'}
+            title="Remove Member"
           >
             <Trash2 className="w-4 h-4" />
           </Button>

--- a/apps/web/src/components/members/PendingInviteRow.tsx
+++ b/apps/web/src/components/members/PendingInviteRow.tsx
@@ -1,7 +1,20 @@
 'use client';
 
-import { Mail } from 'lucide-react';
+import { Mail, Trash2 } from 'lucide-react';
+import { useState } from 'react';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
 
 export interface PendingInvite {
   id: string;
@@ -14,9 +27,23 @@ export interface PendingInvite {
 
 interface PendingInviteRowProps {
   invite: PendingInvite;
+  canRevoke?: boolean;
+  onRevoke?: (inviteId: string) => void | Promise<void>;
 }
 
-export function PendingInviteRow({ invite }: PendingInviteRowProps) {
+export function PendingInviteRow({ invite, canRevoke = false, onRevoke }: PendingInviteRowProps) {
+  const [isRevoking, setIsRevoking] = useState(false);
+
+  const handleConfirmRevoke = async () => {
+    if (!onRevoke) return;
+    setIsRevoking(true);
+    try {
+      await onRevoke(invite.id);
+    } finally {
+      setIsRevoking(false);
+    }
+  };
+
   const roleBadge =
     invite.role === 'ADMIN'
       ? (
@@ -69,6 +96,35 @@ export function PendingInviteRow({ invite }: PendingInviteRowProps) {
           </p>
         </div>
       </div>
+
+      {canRevoke && onRevoke && (
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+              title="Revoke Invitation"
+              disabled={isRevoking}
+            >
+              <Trash2 className="w-4 h-4" />
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Revoke this invitation?</AlertDialogTitle>
+              <AlertDialogDescription>
+                The invitation to <span className="font-medium">{invite.email}</span> will be deleted.
+                The recipient&apos;s link will stop working immediately. This cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={handleConfirmRevoke}>Revoke</AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/members/PendingInviteRow.tsx
+++ b/apps/web/src/components/members/PendingInviteRow.tsx
@@ -105,6 +105,7 @@ export function PendingInviteRow({ invite, canRevoke = false, onRevoke }: Pendin
               size="sm"
               className="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
               title="Revoke Invitation"
+              aria-label={`Revoke invitation for ${invite.email}`}
               disabled={isRevoking}
             >
               <Trash2 className="w-4 h-4" />

--- a/apps/web/src/components/members/PendingInviteRow.tsx
+++ b/apps/web/src/components/members/PendingInviteRow.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { Mail } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+
+export interface PendingInvite {
+  id: string;
+  email: string;
+  role: 'OWNER' | 'ADMIN' | 'MEMBER';
+  invitedByName: string;
+  createdAt: string;
+  expiresAt: string;
+}
+
+interface PendingInviteRowProps {
+  invite: PendingInvite;
+}
+
+export function PendingInviteRow({ invite }: PendingInviteRowProps) {
+  const roleBadge =
+    invite.role === 'ADMIN'
+      ? (
+          <Badge className="bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
+            Admin
+          </Badge>
+        )
+      : invite.role === 'OWNER'
+      ? (
+          <Badge className="bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300">
+            Owner
+          </Badge>
+        )
+      : (
+          <Badge className="bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300">
+            Member
+          </Badge>
+        );
+
+  const expiresAt = new Date(invite.expiresAt);
+  const isExpired = expiresAt.getTime() < Date.now();
+
+  return (
+    <div
+      className="p-4 flex items-center justify-between hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors"
+      data-testid="pending-invite-row"
+      data-invite-id={invite.id}
+    >
+      <div className="flex items-center space-x-4">
+        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-300">
+          <Mail className="h-5 w-5" />
+        </div>
+        <div>
+          <div className="flex items-center space-x-2">
+            <p className="font-medium">{invite.email}</p>
+            {roleBadge}
+            <Badge
+              variant="outline"
+              className={
+                isExpired
+                  ? 'border-red-500/50 bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300'
+                  : 'border-yellow-500/50 bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300'
+              }
+            >
+              {isExpired ? 'Expired' : 'Pending'}
+            </Badge>
+          </div>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            Invited by {invite.invitedByName}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/members/PendingInvitesSection.tsx
+++ b/apps/web/src/components/members/PendingInvitesSection.tsx
@@ -5,6 +5,7 @@ import { PendingInviteRow, type PendingInvite } from './PendingInviteRow';
 interface PendingInvitesSectionProps {
   invites: PendingInvite[];
   currentUserRole: 'OWNER' | 'ADMIN' | 'MEMBER';
+  onRevoke?: (inviteId: string) => void | Promise<void>;
 }
 
 /**
@@ -12,9 +13,9 @@ interface PendingInvitesSectionProps {
  * regular members or when the array is empty — keeps the members page
  * uncluttered for viewers without the management surface.
  */
-export function PendingInvitesSection({ invites, currentUserRole }: PendingInvitesSectionProps) {
-  const canSee = currentUserRole === 'OWNER' || currentUserRole === 'ADMIN';
-  if (!canSee || invites.length === 0) return null;
+export function PendingInvitesSection({ invites, currentUserRole, onRevoke }: PendingInvitesSectionProps) {
+  const canManage = currentUserRole === 'OWNER' || currentUserRole === 'ADMIN';
+  if (!canManage || invites.length === 0) return null;
 
   return (
     <div className="mt-6 bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
@@ -25,7 +26,12 @@ export function PendingInvitesSection({ invites, currentUserRole }: PendingInvit
       </div>
       <div className="divide-y divide-gray-200 dark:divide-gray-700">
         {invites.map((invite) => (
-          <PendingInviteRow key={invite.id} invite={invite} />
+          <PendingInviteRow
+            key={invite.id}
+            invite={invite}
+            canRevoke={canManage}
+            {...(onRevoke && { onRevoke })}
+          />
         ))}
       </div>
     </div>

--- a/apps/web/src/components/members/PendingInvitesSection.tsx
+++ b/apps/web/src/components/members/PendingInvitesSection.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { PendingInviteRow, type PendingInvite } from './PendingInviteRow';
+
+interface PendingInvitesSectionProps {
+  invites: PendingInvite[];
+  currentUserRole: 'OWNER' | 'ADMIN' | 'MEMBER';
+}
+
+/**
+ * Owner/Admin-only list of pending drive invites. Renders nothing for
+ * regular members or when the array is empty — keeps the members page
+ * uncluttered for viewers without the management surface.
+ */
+export function PendingInvitesSection({ invites, currentUserRole }: PendingInvitesSectionProps) {
+  const canSee = currentUserRole === 'OWNER' || currentUserRole === 'ADMIN';
+  if (!canSee || invites.length === 0) return null;
+
+  return (
+    <div className="mt-6 bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+      <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+        <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300">
+          Pending invitations ({invites.length})
+        </h3>
+      </div>
+      <div className="divide-y divide-gray-200 dark:divide-gray-700">
+        {invites.map((invite) => (
+          <PendingInviteRow key={invite.id} invite={invite} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/members/__tests__/DriveMembers.test.tsx
+++ b/apps/web/src/components/members/__tests__/DriveMembers.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { DriveMembers } from '../DriveMembers';
 
 const mockFetchWithAuth = vi.fn();

--- a/apps/web/src/components/members/__tests__/DriveMembers.test.tsx
+++ b/apps/web/src/components/members/__tests__/DriveMembers.test.tsx
@@ -49,10 +49,23 @@ const member = (overrides: { userId?: string; acceptedAt?: string | null } = {})
   permissionCounts: { view: 0, edit: 0, share: 0 },
 });
 
-const okMembers = (members: ReturnType<typeof member>[], currentUserRole = 'OWNER') =>
+type PendingInviteFixture = {
+  id: string;
+  email: string;
+  role: 'OWNER' | 'ADMIN' | 'MEMBER';
+  invitedByName: string;
+  createdAt: string;
+  expiresAt: string;
+};
+
+const okMembers = (
+  members: ReturnType<typeof member>[],
+  currentUserRole = 'OWNER',
+  pendingInvites: PendingInviteFixture[] = [],
+) =>
   Promise.resolve({
     ok: true,
-    json: () => Promise.resolve({ currentUserRole, members }),
+    json: () => Promise.resolve({ currentUserRole, members, pendingInvites }),
   });
 
 const EVENTS = ['drive:member_added', 'drive:member_removed', 'drive:member_role_changed'] as const;
@@ -70,56 +83,35 @@ describe('DriveMembers', () => {
     window.confirm = originalConfirm;
   });
 
-  it('Given a mix of pending + accepted, renders two distinct sections with correct counts', async () => {
+  const samplePending = (overrides: Partial<PendingInviteFixture> = {}): PendingInviteFixture => ({
+    id: 'inv_1',
+    email: 'invitee@example.com',
+    role: 'MEMBER',
+    invitedByName: 'Alice',
+    createdAt: '2026-05-01T00:00:00Z',
+    expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+    ...overrides,
+  });
+
+  it('Given accepted members and pending invites, renders both sections with correct counts', async () => {
     mockFetchWithAuth.mockImplementation(() =>
-      okMembers([
-        member({ userId: 'a1' }),
-        member({ userId: 'a2' }),
-        member({ userId: 'p1', acceptedAt: null }),
-      ])
+      okMembers(
+        [member({ userId: 'a1' }), member({ userId: 'a2' })],
+        'OWNER',
+        [samplePending(), samplePending({ id: 'inv_2', email: 'b@example.com' })],
+      )
     );
     render(<DriveMembers driveId="drive-1" />);
 
     expect(await screen.findByText('Members (2)')).toBeInTheDocument();
-    expect(screen.getByText('Pending invitations (1)')).toBeInTheDocument();
-    expect(screen.getByText('Pending')).toBeInTheDocument();
+    expect(screen.getByText('Pending invitations (2)')).toBeInTheDocument();
   });
 
-  it('Strict null check: acceptedAt undefined must NOT classify as pending', async () => {
-    mockFetchWithAuth.mockImplementation(() =>
-      Promise.resolve({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            currentUserRole: 'OWNER',
-            members: [{ ...member({ userId: 'm1' }), acceptedAt: undefined }],
-          }),
-      })
-    );
+  it('Renders no pending section when API returns an empty pendingInvites array', async () => {
+    mockFetchWithAuth.mockImplementation(() => okMembers([member({ userId: 'm1' })]));
     render(<DriveMembers driveId="drive-1" />);
     await screen.findByText(/members \(/i);
     expect(screen.queryByText(/pending invitations/i)).not.toBeInTheDocument();
-  });
-
-  it('Given Revoke succeeds on a pending row, removes it from local state without a refetch', async () => {
-    mockFetchWithAuth.mockImplementation(() =>
-      okMembers([
-        member({ userId: 'a1' }),
-        member({ userId: 'p1', acceptedAt: null }),
-      ])
-    );
-    mockDel.mockResolvedValue(undefined);
-
-    render(<DriveMembers driveId="drive-1" />);
-    await screen.findByText('Pending invitations (1)');
-    expect(mockFetchWithAuth).toHaveBeenCalledTimes(1);
-
-    await userEvent.setup().click(screen.getByRole('button', { name: /revoke invitation/i }));
-    await waitFor(() =>
-      expect(screen.queryByText(/pending invitations/i)).not.toBeInTheDocument()
-    );
-    expect(mockDel).toHaveBeenCalledWith('/api/drives/drive-1/members/p1');
-    expect(mockFetchWithAuth).toHaveBeenCalledTimes(1);
   });
 
   it('Given the component mounts, subscribes to all three drive member events', async () => {
@@ -160,14 +152,4 @@ describe('DriveMembers', () => {
     EVENTS.forEach((e) => expect(socket.__count(e)).toBe(0));
   });
 
-  it('Given a pending row, no Resend button is rendered (resend was retired with the broad-sweep cutover)', async () => {
-    mockFetchWithAuth.mockImplementation(() =>
-      okMembers([member({ userId: 'p1', acceptedAt: null })])
-    );
-
-    render(<DriveMembers driveId="drive-1" />);
-    await screen.findByText('Pending invitations (1)');
-
-    expect(screen.queryByRole('button', { name: /resend invitation/i })).not.toBeInTheDocument();
-  });
 });

--- a/apps/web/src/components/members/__tests__/MemberRow.test.tsx
+++ b/apps/web/src/components/members/__tests__/MemberRow.test.tsx
@@ -35,51 +35,27 @@ const renderRow = (
 describe('MemberRow', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  describe('Given a pending member row (acceptedAt === null)', () => {
-    it('renders a Pending badge', () => {
-      renderRow(null);
-      expect(screen.getByText('Pending')).toBeInTheDocument();
-    });
-
-    it('hides the Member Settings button', () => {
-      renderRow(null);
-      expect(screen.queryByRole('button', { name: /member settings/i })).not.toBeInTheDocument();
-    });
-
-    it.each([['OWNER' as const], ['ADMIN' as const]])(
-      'exposes a Revoke button to %s and fires onRemove on click',
-      async (role) => {
-        const onRemove = vi.fn();
-        renderRow(null, { currentUserRole: role, onRemove });
-        await userEvent.setup().click(screen.getByRole('button', { name: /revoke invitation/i }));
-        expect(onRemove).toHaveBeenCalledOnce();
-      }
-    );
-
-    it('does NOT expose a Revoke button to MEMBER', () => {
-      renderRow(null, { currentUserRole: 'MEMBER' });
-      expect(screen.queryByRole('button', { name: /revoke invitation/i })).not.toBeInTheDocument();
-    });
-
-    it('does NOT render a Resend button (resend was retired with the broad-sweep cutover)', () => {
-      renderRow(null);
-      expect(screen.queryByRole('button', { name: /resend invitation/i })).not.toBeInTheDocument();
-    });
+  it('shows Member Settings + Remove for OWNER on a regular row', async () => {
+    const onRemove = vi.fn();
+    renderRow('2026-05-02T00:00:00Z', { onRemove });
+    expect(screen.queryByText('Pending')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /member settings/i })).toBeInTheDocument();
+    await userEvent.setup().click(screen.getByRole('button', { name: /remove member/i }));
+    expect(onRemove).toHaveBeenCalledOnce();
   });
 
-  describe('Given an accepted member row (acceptedAt !== null)', () => {
-    it('does NOT render a Pending badge and shows Member Settings + Remove for OWNER', async () => {
-      const onRemove = vi.fn();
-      renderRow('2026-05-02T00:00:00Z', { onRemove });
-      expect(screen.queryByText('Pending')).not.toBeInTheDocument();
-      expect(screen.getByRole('button', { name: /member settings/i })).toBeInTheDocument();
-      await userEvent.setup().click(screen.getByRole('button', { name: /remove member/i }));
-      expect(onRemove).toHaveBeenCalledOnce();
-    });
-
-    it('does NOT render a Remove button for OWNER role', () => {
-      renderRow('2026-05-02T00:00:00Z', { role: 'OWNER' });
-      expect(screen.queryByRole('button', { name: /remove member/i })).not.toBeInTheDocument();
-    });
+  it('does not render a Remove button for OWNER role member', () => {
+    renderRow('2026-05-02T00:00:00Z', { role: 'OWNER' });
+    expect(screen.queryByRole('button', { name: /remove member/i })).not.toBeInTheDocument();
   });
+
+  it('hides Member Settings + Remove for non-managers', () => {
+    renderRow('2026-05-02T00:00:00Z', { currentUserRole: 'MEMBER' });
+    expect(screen.queryByRole('button', { name: /member settings/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /remove member/i })).not.toBeInTheDocument();
+  });
+
+  // Pending invites no longer share this component — they live in
+  // PendingInviteRow + PendingInvitesSection, fed by a separate API field.
+  // drive_members rows always have acceptedAt set post-cutover.
 });

--- a/apps/web/src/components/members/__tests__/PendingInviteRow.test.tsx
+++ b/apps/web/src/components/members/__tests__/PendingInviteRow.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PendingInviteRow, type PendingInvite } from '../PendingInviteRow';
+
+const buildInvite = (overrides: Partial<PendingInvite> = {}): PendingInvite => ({
+  id: 'inv_1',
+  email: 'invitee@example.com',
+  role: 'MEMBER',
+  invitedByName: 'Alice',
+  createdAt: '2026-05-01T00:00:00Z',
+  expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+  ...overrides,
+});
+
+describe('PendingInviteRow', () => {
+  it('renders invitee email and inviter name', () => {
+    render(<PendingInviteRow invite={buildInvite()} />);
+    expect(screen.getByText('invitee@example.com')).toBeInTheDocument();
+    expect(screen.getByText(/Invited by Alice/)).toBeInTheDocument();
+  });
+
+  it('shows Pending badge for non-expired invites', () => {
+    render(<PendingInviteRow invite={buildInvite()} />);
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+    expect(screen.queryByText('Expired')).not.toBeInTheDocument();
+  });
+
+  it('shows Expired badge for past-expiry invites', () => {
+    const expiresAt = new Date(Date.now() - 1000).toISOString();
+    render(<PendingInviteRow invite={buildInvite({ expiresAt })} />);
+    expect(screen.getByText('Expired')).toBeInTheDocument();
+    expect(screen.queryByText('Pending')).not.toBeInTheDocument();
+  });
+
+  it('renders role-specific badge: Member', () => {
+    render(<PendingInviteRow invite={buildInvite({ role: 'MEMBER' })} />);
+    expect(screen.getByText('Member')).toBeInTheDocument();
+  });
+
+  it('renders role-specific badge: Admin', () => {
+    render(<PendingInviteRow invite={buildInvite({ role: 'ADMIN' })} />);
+    expect(screen.getByText('Admin')).toBeInTheDocument();
+  });
+
+  it('attaches data-invite-id for downstream interaction (e.g. revoke in T9)', () => {
+    const { container } = render(<PendingInviteRow invite={buildInvite({ id: 'inv_xyz' })} />);
+    const row = container.querySelector('[data-testid="pending-invite-row"]');
+    expect(row).toBeInTheDocument();
+    expect(row?.getAttribute('data-invite-id')).toBe('inv_xyz');
+  });
+});

--- a/apps/web/src/components/members/__tests__/PendingInviteRow.test.tsx
+++ b/apps/web/src/components/members/__tests__/PendingInviteRow.test.tsx
@@ -43,6 +43,11 @@ describe('PendingInviteRow', () => {
     expect(screen.getByText('Admin')).toBeInTheDocument();
   });
 
+  it('renders role-specific badge: Owner', () => {
+    render(<PendingInviteRow invite={buildInvite({ role: 'OWNER' })} />);
+    expect(screen.getByText('Owner')).toBeInTheDocument();
+  });
+
   it('attaches data-invite-id for downstream interaction', () => {
     const { container } = render(<PendingInviteRow invite={buildInvite({ id: 'inv_xyz' })} />);
     const row = container.querySelector('[data-testid="pending-invite-row"]');

--- a/apps/web/src/components/members/__tests__/PendingInviteRow.test.tsx
+++ b/apps/web/src/components/members/__tests__/PendingInviteRow.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { PendingInviteRow, type PendingInvite } from '../PendingInviteRow';
 
 const buildInvite = (overrides: Partial<PendingInvite> = {}): PendingInvite => ({
@@ -42,10 +43,47 @@ describe('PendingInviteRow', () => {
     expect(screen.getByText('Admin')).toBeInTheDocument();
   });
 
-  it('attaches data-invite-id for downstream interaction (e.g. revoke in T9)', () => {
+  it('attaches data-invite-id for downstream interaction', () => {
     const { container } = render(<PendingInviteRow invite={buildInvite({ id: 'inv_xyz' })} />);
     const row = container.querySelector('[data-testid="pending-invite-row"]');
     expect(row).toBeInTheDocument();
     expect(row?.getAttribute('data-invite-id')).toBe('inv_xyz');
+  });
+
+  it('does not render a revoke button when canRevoke is false', () => {
+    render(<PendingInviteRow invite={buildInvite()} onRevoke={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: /revoke invitation/i })).not.toBeInTheDocument();
+  });
+
+  it('does not render a revoke button when onRevoke is missing', () => {
+    render(<PendingInviteRow invite={buildInvite()} canRevoke />);
+    expect(screen.queryByRole('button', { name: /revoke invitation/i })).not.toBeInTheDocument();
+  });
+
+  it('renders a revoke button when canRevoke + onRevoke are both provided', () => {
+    render(<PendingInviteRow invite={buildInvite()} canRevoke onRevoke={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /revoke invitation/i })).toBeInTheDocument();
+  });
+
+  it('opens confirmation dialog and calls onRevoke with the invite id on confirm', async () => {
+    const onRevoke = vi.fn().mockResolvedValue(undefined);
+    render(<PendingInviteRow invite={buildInvite({ id: 'inv_42' })} canRevoke onRevoke={onRevoke} />);
+
+    await userEvent.setup().click(screen.getByRole('button', { name: /revoke invitation/i }));
+
+    expect(screen.getByText(/revoke this invitation/i)).toBeInTheDocument();
+    await userEvent.setup().click(screen.getByRole('button', { name: /^revoke$/i }));
+
+    expect(onRevoke).toHaveBeenCalledWith('inv_42');
+  });
+
+  it('does not call onRevoke when user cancels the dialog', async () => {
+    const onRevoke = vi.fn();
+    render(<PendingInviteRow invite={buildInvite()} canRevoke onRevoke={onRevoke} />);
+
+    await userEvent.setup().click(screen.getByRole('button', { name: /revoke invitation/i }));
+    await userEvent.setup().click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(onRevoke).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/members/__tests__/PendingInvitesSection.test.tsx
+++ b/apps/web/src/components/members/__tests__/PendingInvitesSection.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PendingInvitesSection } from '../PendingInvitesSection';
+import type { PendingInvite } from '../PendingInviteRow';
+
+const sample: PendingInvite[] = [
+  {
+    id: 'inv_1',
+    email: 'a@example.com',
+    role: 'MEMBER',
+    invitedByName: 'Alice',
+    createdAt: '2026-05-01T00:00:00Z',
+    expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+  },
+  {
+    id: 'inv_2',
+    email: 'b@example.com',
+    role: 'ADMIN',
+    invitedByName: 'Alice',
+    createdAt: '2026-05-01T00:00:00Z',
+    expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+  },
+];
+
+describe('PendingInvitesSection', () => {
+  it('renders both rows for OWNER', () => {
+    render(<PendingInvitesSection invites={sample} currentUserRole="OWNER" />);
+    expect(screen.getByText('a@example.com')).toBeInTheDocument();
+    expect(screen.getByText('b@example.com')).toBeInTheDocument();
+  });
+
+  it('renders rows for ADMIN', () => {
+    render(<PendingInvitesSection invites={sample} currentUserRole="ADMIN" />);
+    expect(screen.getByText('a@example.com')).toBeInTheDocument();
+  });
+
+  it('renders nothing for regular MEMBER', () => {
+    const { container } = render(
+      <PendingInvitesSection invites={sample} currentUserRole="MEMBER" />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when invites array is empty', () => {
+    const { container } = render(
+      <PendingInvitesSection invites={[]} currentUserRole="OWNER" />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows the count in the section heading', () => {
+    render(<PendingInvitesSection invites={sample} currentUserRole="OWNER" />);
+    expect(screen.getByText(/Pending invitations \(2\)/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/hooks/__tests__/useOAuthSignIn.test.ts
+++ b/apps/web/src/hooks/__tests__/useOAuthSignIn.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { buildOAuthSigninBody } from '../useOAuthSignIn';
+
+describe('buildOAuthSigninBody', () => {
+  it('serializes web device info without inviteToken', () => {
+    const body = buildOAuthSigninBody({
+      platform: 'web',
+      deviceId: 'dev-123',
+      deviceName: 'Chrome on macOS',
+    });
+    expect(body).toEqual({
+      platform: 'web',
+      deviceId: 'dev-123',
+      deviceName: 'Chrome on macOS',
+    });
+  });
+
+  it('includes inviteToken when provided', () => {
+    const body = buildOAuthSigninBody({
+      platform: 'web',
+      deviceId: 'dev-123',
+      deviceName: 'Chrome',
+      inviteToken: 'ps_invite_abc123def456',
+    });
+    expect(body.inviteToken).toBe('ps_invite_abc123def456');
+  });
+
+  it('omits inviteToken when undefined', () => {
+    const body = buildOAuthSigninBody({
+      platform: 'desktop',
+      deviceId: 'dev-1',
+      deviceName: 'My Mac',
+    });
+    expect(body).not.toHaveProperty('inviteToken');
+  });
+
+  it('omits inviteToken when empty string', () => {
+    const body = buildOAuthSigninBody({
+      platform: 'web',
+      deviceId: 'dev-1',
+      deviceName: 'Browser',
+      inviteToken: '',
+    });
+    expect(body).not.toHaveProperty('inviteToken');
+  });
+});

--- a/apps/web/src/hooks/__tests__/useOAuthSignIn.test.ts
+++ b/apps/web/src/hooks/__tests__/useOAuthSignIn.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildOAuthSigninBody } from '../useOAuthSignIn';
+import { buildOAuthSigninBody, buildPostNativeAuthRedirect } from '../useOAuthSignIn';
 
 describe('buildOAuthSigninBody', () => {
   it('serializes web device info without inviteToken', () => {
@@ -42,5 +42,31 @@ describe('buildOAuthSigninBody', () => {
       inviteToken: '',
     });
     expect(body).not.toHaveProperty('inviteToken');
+  });
+});
+
+describe('buildPostNativeAuthRedirect', () => {
+  it('routes to drive-specific dashboard when an invite was consumed', () => {
+    expect(buildPostNativeAuthRedirect({ invitedDriveId: 'drive-123' }))
+      .toBe('/dashboard/drive-123?invited=1');
+  });
+
+  it('invite-consumed wins over isNewUser welcome', () => {
+    expect(buildPostNativeAuthRedirect({ isNewUser: true, invitedDriveId: 'drive-123' }))
+      .toBe('/dashboard/drive-123?invited=1');
+  });
+
+  it('routes new users to welcome when no invite', () => {
+    expect(buildPostNativeAuthRedirect({ isNewUser: true }))
+      .toBe('/dashboard?welcome=true');
+  });
+
+  it('falls back to /dashboard for existing users without invites', () => {
+    expect(buildPostNativeAuthRedirect({})).toBe('/dashboard');
+    expect(buildPostNativeAuthRedirect({ isNewUser: false })).toBe('/dashboard');
+  });
+
+  it('treats null invitedDriveId as no-invite', () => {
+    expect(buildPostNativeAuthRedirect({ invitedDriveId: null })).toBe('/dashboard');
   });
 });

--- a/apps/web/src/hooks/useOAuthSignIn.ts
+++ b/apps/web/src/hooks/useOAuthSignIn.ts
@@ -94,7 +94,7 @@ export function useOAuthSignIn({ onStart, onError, inviteToken }: UseOAuthSignIn
       platform,
       deviceId,
       deviceName,
-      ...(inviteToken && { inviteToken }),
+      inviteToken,
     });
     const response = await fetch(endpoint, {
       method: 'POST',

--- a/apps/web/src/hooks/useOAuthSignIn.ts
+++ b/apps/web/src/hooks/useOAuthSignIn.ts
@@ -9,12 +9,32 @@ const EXTERNAL_AUTH_TIMEOUT_MS = 5 * 60 * 1000;
 
 type OAuthProvider = 'google' | 'apple';
 
+export interface OAuthSigninBodyInput {
+  platform: 'web' | 'desktop';
+  deviceId: string;
+  deviceName: string;
+  inviteToken?: string;
+}
+
+export const buildOAuthSigninBody = ({
+  platform,
+  deviceId,
+  deviceName,
+  inviteToken,
+}: OAuthSigninBodyInput): Record<string, string> => ({
+  platform,
+  deviceId,
+  deviceName,
+  ...(inviteToken && { inviteToken }),
+});
+
 interface UseOAuthSignInOptions {
   onStart?: () => void;
   onError?: (message: string) => void;
+  inviteToken?: string;
 }
 
-export function useOAuthSignIn({ onStart, onError }: UseOAuthSignInOptions = {}) {
+export function useOAuthSignIn({ onStart, onError, inviteToken }: UseOAuthSignInOptions = {}) {
   const [isGoogleLoading, setIsGoogleLoading] = useState(false);
   const [isAppleLoading, setIsAppleLoading] = useState(false);
   const [waitingProvider, setWaitingProvider] = useState<OAuthProvider | null>(null);
@@ -70,10 +90,16 @@ export function useOAuthSignIn({ onStart, onError }: UseOAuthSignInOptions = {})
 
   const initiateWebOAuth = async (endpoint: string, provider: OAuthProvider) => {
     const { platform, deviceId, deviceName } = await getDeviceInfo();
+    const body = buildOAuthSigninBody({
+      platform,
+      deviceId,
+      deviceName,
+      ...(inviteToken && { inviteToken }),
+    });
     const response = await fetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ platform, deviceId, deviceName }),
+      body: JSON.stringify(body),
     });
 
     if (response.ok) {

--- a/apps/web/src/hooks/useOAuthSignIn.ts
+++ b/apps/web/src/hooks/useOAuthSignIn.ts
@@ -28,6 +28,27 @@ export const buildOAuthSigninBody = ({
   ...(inviteToken && { inviteToken }),
 });
 
+export interface PostNativeAuthRedirectInput {
+  isNewUser?: boolean;
+  invitedDriveId?: string | null;
+}
+
+/**
+ * Decide where to land a user after a successful native (iOS) OAuth flow.
+ *
+ * Precedence: invite-consumed drive > new-user welcome > /dashboard.
+ * Pure function — extracted so the redirect logic can be tested without
+ * rendering the hook.
+ */
+export const buildPostNativeAuthRedirect = ({
+  isNewUser,
+  invitedDriveId,
+}: PostNativeAuthRedirectInput): string => {
+  if (invitedDriveId) return `/dashboard/${invitedDriveId}?invited=1`;
+  if (isNewUser) return '/dashboard?welcome=true';
+  return '/dashboard';
+};
+
 interface UseOAuthSignInOptions {
   onStart?: () => void;
   onError?: (message: string) => void;
@@ -68,6 +89,7 @@ export function useOAuthSignIn({ onStart, onError, inviteToken }: UseOAuthSignIn
 
   const handleNativeSuccess = async (result: {
     isNewUser?: boolean;
+    invitedDriveId?: string | null;
     user?: { id: string; name: string | null; email: string | null; image?: string | null };
   }) => {
     const { useAuthStore } = await import('@/stores/useAuthStore');
@@ -75,7 +97,10 @@ export function useOAuthSignIn({ onStart, onError, inviteToken }: UseOAuthSignIn
     if (result.user) {
       useAuthStore.getState().setUser(result.user);
     }
-    router.replace(result.isNewUser ? '/dashboard?welcome=true' : '/dashboard');
+    router.replace(buildPostNativeAuthRedirect({
+      isNewUser: result.isNewUser,
+      invitedDriveId: result.invitedDriveId,
+    }));
   };
 
   const getDeviceInfo = async () => {
@@ -149,7 +174,7 @@ export function useOAuthSignIn({ onStart, onError, inviteToken }: UseOAuthSignIn
         await import('@/lib/ios-google-auth');
 
       if (isNativeGoogleAuthAvailable()) {
-        const result = await nativeSignIn();
+        const result = await nativeSignIn(inviteToken ? { inviteToken } : {});
         if (result.success) {
           await handleNativeSuccess(result);
         } else if (result.error !== 'Sign-in cancelled') {
@@ -177,7 +202,7 @@ export function useOAuthSignIn({ onStart, onError, inviteToken }: UseOAuthSignIn
         await import('@/lib/ios-apple-auth');
 
       if (isNativeAppleAuthAvailable()) {
-        const result = await nativeSignIn();
+        const result = await nativeSignIn(inviteToken ? { inviteToken } : {});
         if (result.success) {
           await handleNativeSuccess(result);
         } else if (result.error !== 'Sign-in cancelled') {

--- a/apps/web/src/lib/auth/__tests__/native-invite-acceptance.test.ts
+++ b/apps/web/src/lib/auth/__tests__/native-invite-acceptance.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    auth: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  },
+}));
+
+vi.mock('@/lib/auth/invite-acceptance-adapters', () => ({
+  buildAcceptancePorts: vi.fn(() => ({})),
+}));
+
+const acceptForNewPipe = vi.fn();
+const acceptForExistingPipe = vi.fn();
+
+vi.mock('@pagespace/lib/services/invites', () => ({
+  acceptInviteForNewUser: vi.fn(() => acceptForNewPipe),
+  acceptInviteForExistingUser: vi.fn(() => acceptForExistingPipe),
+}));
+
+import { consumeInviteIfPresent } from '../native-invite-acceptance';
+import { acceptInviteForNewUser, acceptInviteForExistingUser } from '@pagespace/lib/services/invites';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+
+const dummyRequest = new Request('http://localhost/test', { method: 'POST' });
+const dummyUser = { id: 'user-1', suspendedAt: null };
+
+describe('consumeInviteIfPresent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    acceptForNewPipe.mockReset();
+    acceptForExistingPipe.mockReset();
+    vi.mocked(acceptInviteForNewUser).mockImplementation(() => acceptForNewPipe);
+    vi.mocked(acceptInviteForExistingUser).mockImplementation(() => acceptForExistingPipe);
+  });
+
+  it('returns invitedDriveId: null and skips pipes when no inviteToken', async () => {
+    const result = await consumeInviteIfPresent({
+      request: dummyRequest,
+      inviteToken: undefined,
+      user: dummyUser,
+      isNewUser: false,
+      email: 'a@b.com',
+    });
+    expect(result).toEqual({ invitedDriveId: null });
+    expect(acceptInviteForNewUser).not.toHaveBeenCalled();
+    expect(acceptInviteForExistingUser).not.toHaveBeenCalled();
+  });
+
+  it('routes new users through acceptInviteForNewUser with suspendedAt: null', async () => {
+    acceptForNewPipe.mockResolvedValueOnce({
+      ok: true,
+      data: { driveId: 'drive-new', memberId: 'm', driveName: 'D', role: 'MEMBER', invitedUserId: 'user-1', inviterUserId: 'i' },
+    });
+
+    const result = await consumeInviteIfPresent({
+      request: dummyRequest,
+      inviteToken: 'ps_invite_t',
+      user: { id: 'user-1', suspendedAt: new Date() },
+      isNewUser: true,
+      email: 'A@B.COM',
+    });
+
+    expect(acceptForNewPipe).toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: 'ps_invite_t',
+        userId: 'user-1',
+        userEmail: 'a@b.com',
+        suspendedAt: null,
+      }),
+    );
+    expect(result.invitedDriveId).toBe('drive-new');
+  });
+
+  it('routes existing users through acceptInviteForExistingUser with their suspendedAt', async () => {
+    const suspendedAt = new Date('2024-01-01');
+    acceptForExistingPipe.mockResolvedValueOnce({
+      ok: true,
+      data: { driveId: 'drive-exist', memberId: 'm', driveName: 'D', role: 'ADMIN', invitedUserId: 'user-1', inviterUserId: 'i' },
+    });
+
+    const result = await consumeInviteIfPresent({
+      request: dummyRequest,
+      inviteToken: 'ps_invite_t',
+      user: { id: 'user-1', suspendedAt },
+      isNewUser: false,
+      email: 'a@b.com',
+    });
+
+    expect(acceptForExistingPipe).toHaveBeenCalledWith(
+      expect.objectContaining({ suspendedAt }),
+    );
+    expect(result.invitedDriveId).toBe('drive-exist');
+  });
+
+  it('surfaces inviteError on EMAIL_MISMATCH without throwing', async () => {
+    acceptForNewPipe.mockResolvedValueOnce({ ok: false, error: 'EMAIL_MISMATCH' });
+
+    const result = await consumeInviteIfPresent({
+      request: dummyRequest,
+      inviteToken: 'ps_invite_t',
+      user: dummyUser,
+      isNewUser: true,
+      email: 'a@b.com',
+    });
+
+    expect(result).toEqual({ invitedDriveId: null, inviteError: 'EMAIL_MISMATCH' });
+  });
+
+  it('returns invitedDriveId: null and logs when pipe throws', async () => {
+    acceptForNewPipe.mockRejectedValueOnce(new Error('pipe blew up'));
+
+    const result = await consumeInviteIfPresent({
+      request: dummyRequest,
+      inviteToken: 'ps_invite_t',
+      user: dummyUser,
+      isNewUser: true,
+      email: 'a@b.com',
+    });
+
+    expect(result).toEqual({ invitedDriveId: null });
+    expect(loggers.auth.error).toHaveBeenCalledWith(
+      'Invite acceptance pipe threw',
+      expect.any(Error),
+    );
+  });
+
+  it('lowercases userEmail before passing to pipe', async () => {
+    acceptForNewPipe.mockResolvedValueOnce({
+      ok: true,
+      data: { driveId: 'd', memberId: 'm', driveName: 'D', role: 'MEMBER', invitedUserId: 'u', inviterUserId: 'i' },
+    });
+
+    await consumeInviteIfPresent({
+      request: dummyRequest,
+      inviteToken: 'ps_invite_t',
+      user: dummyUser,
+      isNewUser: true,
+      email: 'MiXeD@CaSe.COM',
+    });
+
+    expect(acceptForNewPipe).toHaveBeenCalledWith(
+      expect.objectContaining({ userEmail: 'mixed@case.com' }),
+    );
+  });
+});

--- a/apps/web/src/lib/auth/__tests__/oauth-state.test.ts
+++ b/apps/web/src/lib/auth/__tests__/oauth-state.test.ts
@@ -132,6 +132,48 @@ describe('verifyOAuthState', () => {
     expect(result.status).toBe('malformed');
   });
 
+  it('round-trips inviteToken when present', () => {
+    const now = Date.now();
+    const state = createState({
+      returnUrl: '/dashboard',
+      platform: 'web',
+      inviteToken: 'ps_invite_abc123def456ghi789jklm',
+      timestamp: now,
+    });
+    const result = verifyOAuthState(state);
+    expect(result).toEqual({
+      status: 'valid',
+      data: {
+        returnUrl: '/dashboard',
+        platform: 'web',
+        inviteToken: 'ps_invite_abc123def456ghi789jklm',
+        timestamp: now,
+      },
+    });
+  });
+
+  it('returns malformed for inviteToken longer than 128 chars', () => {
+    const state = createState({
+      returnUrl: '/dashboard',
+      platform: 'web',
+      inviteToken: 'ps_invite_' + 'x'.repeat(120),
+      timestamp: Date.now(),
+    });
+    const result = verifyOAuthState(state);
+    expect(result.status).toBe('malformed');
+  });
+
+  it('returns malformed for empty inviteToken string', () => {
+    const state = createState({
+      returnUrl: '/dashboard',
+      platform: 'web',
+      inviteToken: '',
+      timestamp: Date.now(),
+    });
+    const result = verifyOAuthState(state);
+    expect(result.status).toBe('malformed');
+  });
+
   it('extracts data fields from valid state', () => {
     const now = Date.now();
     const state = createState({

--- a/apps/web/src/lib/auth/native-invite-acceptance.ts
+++ b/apps/web/src/lib/auth/native-invite-acceptance.ts
@@ -1,0 +1,60 @@
+/**
+ * Shared invite-acceptance helper for native auth routes
+ * (google/native, google/one-tap, apple/native).
+ *
+ * Web callbacks (google/callback, apple/callback) handle this inline because
+ * they need to override `returnUrl` rather than emit a JSON field; native
+ * routes return JSON, so the hook layer reads `invitedDriveId` and routes
+ * to `/dashboard/<id>?invited=1` from there.
+ */
+
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import {
+  acceptInviteForExistingUser,
+  acceptInviteForNewUser,
+  type InviteAcceptanceErrorCode,
+} from '@pagespace/lib/services/invites';
+import { buildAcceptancePorts } from './invite-acceptance-adapters';
+
+export interface NativeInviteAcceptanceInput {
+  request: Request;
+  inviteToken: string | undefined;
+  user: { id: string; suspendedAt?: Date | null };
+  isNewUser: boolean;
+  email: string;
+}
+
+export interface NativeInviteAcceptanceResult {
+  invitedDriveId: string | null;
+  inviteError?: InviteAcceptanceErrorCode;
+}
+
+export const consumeInviteIfPresent = async ({
+  request,
+  inviteToken,
+  user,
+  isNewUser,
+  email,
+}: NativeInviteAcceptanceInput): Promise<NativeInviteAcceptanceResult> => {
+  if (!inviteToken) return { invitedDriveId: null };
+
+  try {
+    const ports = buildAcceptancePorts(request);
+    const acceptInput = {
+      token: inviteToken,
+      userId: user.id,
+      userEmail: email.toLowerCase(),
+      suspendedAt: isNewUser ? null : (user.suspendedAt ?? null),
+      now: new Date(),
+    };
+    const result = isNewUser
+      ? await acceptInviteForNewUser(ports)(acceptInput)
+      : await acceptInviteForExistingUser(ports)(acceptInput);
+
+    if (result.ok) return { invitedDriveId: result.data.driveId };
+    return { invitedDriveId: null, inviteError: result.error };
+  } catch (error) {
+    loggers.auth.error('Invite acceptance pipe threw', error as Error);
+    return { invitedDriveId: null };
+  }
+};

--- a/apps/web/src/lib/auth/native-invite-acceptance.ts
+++ b/apps/web/src/lib/auth/native-invite-acceptance.ts
@@ -19,7 +19,7 @@ import { buildAcceptancePorts } from './invite-acceptance-adapters';
 export interface NativeInviteAcceptanceInput {
   request: Request;
   inviteToken: string | undefined;
-  user: { id: string; suspendedAt?: Date | null };
+  user: { id: string; suspendedAt: Date | null };
   isNewUser: boolean;
   email: string;
 }
@@ -44,7 +44,7 @@ export const consumeInviteIfPresent = async ({
       token: inviteToken,
       userId: user.id,
       userEmail: email.toLowerCase(),
-      suspendedAt: isNewUser ? null : (user.suspendedAt ?? null),
+      suspendedAt: isNewUser ? null : user.suspendedAt,
       now: new Date(),
     };
     const result = isNewUser

--- a/apps/web/src/lib/auth/oauth-state.ts
+++ b/apps/web/src/lib/auth/oauth-state.ts
@@ -5,13 +5,21 @@ import { secureCompare } from '@pagespace/lib/auth/secure-compare';
 // State expires after 10 minutes — prevents replay attacks
 const STATE_MAX_AGE_MS = 10 * 60 * 1000;
 
+// Bound matches the request-body validators in google/signin & apple/signin.
+// Real tokens are `ps_invite_<cuid2>` (~33 chars) — 128 leaves headroom while
+// keeping the signed+base64 state well under provider redirect-URL limits.
+const INVITE_TOKEN_MAX_LENGTH = 128;
+
 const oauthStateDataSchema = z.object({
   returnUrl: z.string().max(2048).optional(),
   platform: z.enum(['web', 'desktop', 'ios']).optional(),
   deviceId: z.string().min(1).max(128).optional(),
   deviceName: z.string().max(255).optional(),
+  inviteToken: z.string().min(1).max(INVITE_TOKEN_MAX_LENGTH).optional(),
   timestamp: z.number().finite(),
 });
+
+export { INVITE_TOKEN_MAX_LENGTH };
 
 export type OAuthStateData = z.infer<typeof oauthStateDataSchema>;
 

--- a/apps/web/src/lib/auth/revoke-adapters.ts
+++ b/apps/web/src/lib/auth/revoke-adapters.ts
@@ -1,0 +1,66 @@
+/**
+ * Concrete IO implementation of RevokePorts for the
+ * `revokePendingInvite` pipe (DELETE /api/drives/[driveId]/pending-invites/[inviteId]).
+ *
+ * Per the port contract in `@pagespace/lib/services/invites/ports.ts`:
+ * - `loadPendingInviteForDrive` and `findActorMembership` are pre-commit ports
+ *   and MAY throw — the route catches and surfaces a 5xx so the user can retry.
+ * - `deletePendingInviteForDrive` is the commit and MAY throw.
+ * - `auditPermissionRevoked` is a post-commit side-effect port and MUST NOT
+ *   throw — wraps its own try/catch + log so a flaky audit pipeline cannot
+ *   reverse the delete.
+ *
+ * `findActorMembership` deliberately reads `driveMembers` WITHOUT
+ * `isNotNull(acceptedAt)` and returns the raw `acceptedAt` so the strict
+ * "accepted OWNER/ADMIN" gate lives in `validateRevokeRequest` (one source of
+ * truth, easier to audit). The drive-member-gate-coverage test exempts this
+ * file with that rationale.
+ */
+
+import { eq, and } from '@pagespace/db/operators';
+import { db } from '@pagespace/db/db';
+import { driveMembers } from '@pagespace/db/schema/members';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import type { RevokePorts } from '@pagespace/lib/services/invites';
+import { driveInviteRepository } from '@/lib/repositories/drive-invite-repository';
+
+export const buildRevokePorts = (request: Request): RevokePorts => ({
+  loadPendingInviteForDrive: async ({ inviteId, driveId }) =>
+    driveInviteRepository.findUnconsumedInviteForDrive({ inviteId, driveId }),
+
+  findActorMembership: async ({ driveId, actorId }) => {
+    const rows = await db
+      .select({ role: driveMembers.role, acceptedAt: driveMembers.acceptedAt })
+      .from(driveMembers)
+      .where(and(eq(driveMembers.driveId, driveId), eq(driveMembers.userId, actorId)))
+      .limit(1);
+    return rows.at(0) ?? null;
+  },
+
+  deletePendingInviteForDrive: async ({ inviteId, driveId }) =>
+    driveInviteRepository.deletePendingInviteForDrive({ inviteId, driveId }),
+
+  auditPermissionRevoked: ({ inviteId, driveId, actorId, targetEmail, role }) => {
+    try {
+      auditRequest(request, {
+        eventType: 'authz.permission.revoked',
+        userId: actorId,
+        resourceType: 'drive',
+        resourceId: driveId,
+        details: {
+          inviteId,
+          targetEmail,
+          role,
+          operation: 'revoke_invite',
+        },
+      });
+    } catch (error) {
+      loggers.api.warn('Failed to audit authz.permission.revoked on revoke', {
+        driveId,
+        inviteId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  },
+});

--- a/apps/web/src/lib/ios-apple-auth.ts
+++ b/apps/web/src/lib/ios-apple-auth.ts
@@ -13,6 +13,8 @@ export interface AppleAuthResult {
   success: boolean;
   error?: string;
   isNewUser?: boolean;
+  invitedDriveId?: string | null;
+  inviteError?: string;
   user?: {
     id: string;
     name: string | null;
@@ -26,6 +28,8 @@ type AppleNativeAuthResponse = {
   csrfToken?: string | null;
   deviceToken?: string;
   isNewUser?: boolean;
+  invitedDriveId?: string | null;
+  inviteError?: string;
   user?: AppleAuthResult['user'];
 };
 
@@ -35,7 +39,7 @@ const APPLE_CLIENT_ID = 'ai.pagespace.ios';
  * Perform native Apple Sign-In and exchange tokens with backend.
  * Only works when running in the iOS Capacitor app.
  */
-export async function signInWithApple(): Promise<AppleAuthResult> {
+export async function signInWithApple(options: { inviteToken?: string } = {}): Promise<AppleAuthResult> {
   // Guard: only run on iOS native app
   if (!isCapacitorApp() || getPlatform() !== 'ios') {
     return { success: false, error: 'Not in iOS app' };
@@ -94,6 +98,7 @@ export async function signInWithApple(): Promise<AppleAuthResult> {
         deviceName: 'iOS App',
         givenName,
         familyName,
+        ...(options.inviteToken && { inviteToken: options.inviteToken }),
       }),
     });
 
@@ -103,7 +108,7 @@ export async function signInWithApple(): Promise<AppleAuthResult> {
       throw new Error(errorData.error || 'Authentication failed');
     }
 
-    const { sessionToken, csrfToken, deviceToken, isNewUser, user } =
+    const { sessionToken, csrfToken, deviceToken, isNewUser, invitedDriveId, inviteError, user } =
       (await response.json()) as AppleNativeAuthResponse;
 
     if (!sessionToken) {
@@ -123,7 +128,13 @@ export async function signInWithApple(): Promise<AppleAuthResult> {
 
     console.log('[iOS Apple Auth] Sign-in successful, tokens stored');
 
-    return { success: true, isNewUser, user };
+    return {
+      success: true,
+      isNewUser,
+      user,
+      ...(invitedDriveId !== undefined && { invitedDriveId }),
+      ...(inviteError && { inviteError }),
+    };
   } catch (error) {
     console.error('[iOS Apple Auth] Sign-in failed:', error);
 

--- a/apps/web/src/lib/ios-google-auth.ts
+++ b/apps/web/src/lib/ios-google-auth.ts
@@ -13,6 +13,8 @@ export interface GoogleAuthResult {
   success: boolean;
   error?: string;
   isNewUser?: boolean;
+  invitedDriveId?: string | null;
+  inviteError?: string;
   user?: {
     id: string;
     name: string | null;
@@ -26,6 +28,8 @@ type GoogleNativeAuthResponse = {
   csrfToken?: string | null;
   deviceToken?: string;
   isNewUser?: boolean;
+  invitedDriveId?: string | null;
+  inviteError?: string;
   user?: GoogleAuthResult['user'];
 };
 
@@ -42,7 +46,7 @@ const IOS_CLIENT_ID = process.env.NEXT_PUBLIC_GOOGLE_OAUTH_IOS_CLIENT_ID;
  * Perform native Google Sign-In and exchange tokens with backend.
  * Only works when running in the iOS Capacitor app.
  */
-export async function signInWithGoogle(): Promise<GoogleAuthResult> {
+export async function signInWithGoogle(options: { inviteToken?: string } = {}): Promise<GoogleAuthResult> {
   // Guard: only run on iOS native app
   if (!isCapacitorApp() || getPlatform() !== 'ios') {
     return { success: false, error: 'Not in iOS app' };
@@ -100,6 +104,7 @@ export async function signInWithGoogle(): Promise<GoogleAuthResult> {
         platform: 'ios',
         deviceId,
         deviceName: 'iOS App',
+        ...(options.inviteToken && { inviteToken: options.inviteToken }),
       }),
     });
 
@@ -109,7 +114,7 @@ export async function signInWithGoogle(): Promise<GoogleAuthResult> {
       throw new Error(errorData.error || 'Authentication failed');
     }
 
-    const { sessionToken, csrfToken, deviceToken, isNewUser, user } =
+    const { sessionToken, csrfToken, deviceToken, isNewUser, invitedDriveId, inviteError, user } =
       (await response.json()) as GoogleNativeAuthResponse;
 
     if (!sessionToken) {
@@ -129,7 +134,13 @@ export async function signInWithGoogle(): Promise<GoogleAuthResult> {
 
     console.log('[iOS Google Auth] Sign-in successful, tokens stored');
 
-    return { success: true, isNewUser, user };
+    return {
+      success: true,
+      isNewUser,
+      user,
+      ...(invitedDriveId !== undefined && { invitedDriveId }),
+      ...(inviteError && { inviteError }),
+    };
   } catch (error) {
     console.error('[iOS Google Auth] Sign-in failed:', error);
 


### PR DESCRIPTION
## Summary

Closes the four items deferred from PR #1267 (the from-scratch invite architecture rebuild):

- **OAuth invite consumption** (Google + Apple, web + native + one-tap + **desktop + iOS**): `inviteToken` now plumbs through `oauthStateDataSchema`, both signin schemas, the `useOAuthSignIn` hook, and the iOS auth modules. Web callbacks consume invites inline and override `returnUrl` to `/dashboard/<driveId>?invited=1`. Native + one-tap routes share a `consumeInviteIfPresent` helper and return `invitedDriveId` + `inviteError` in the response payload. Desktop and iOS web-callback paths run the SAME helper before deep-link handoff, attaching `invitedDriveId=<id>` to the `pagespace://auth-exchange` URL as a forward-compat query param so the user is correctly added to the drive regardless of platform.
- **Members API + UI**: `GET /api/drives/[driveId]/members` returns `{ members, currentUserRole, pendingInvites }`; new `PendingInvitesSection` + `PendingInviteRow` components render the OWNER/ADMIN-only pending list. The legacy `MemberRow.isPending` branch and `pendingMembers` filter (which were dead post-cutover) are removed.
- **Revoke endpoint**: `DELETE /api/drives/[driveId]/pending-invites/[inviteId]` calls the existing `revokePendingInvite` pipe via a new `buildRevokePorts` adapter. Maps validator codes to HTTP: NOT_FOUND→404 (covers cross-drive enumeration), FORBIDDEN→403, ok→200. UI gets an AlertDialog-confirmed revoke button on each pending row.
- **`next=` honoring on passkey signin**: SignInForm reads `?next=` from the URL, validates via `isSafeNextPath` against `['/dashboard', '/invite/', '/account']`, and threads the safe value to **both** the cloud and on-prem `PasskeyLoginButton` instances. Magic-link signin honoring `next` is a separate follow-up — that path requires the email link itself to carry the param through the send + verify backend.

### Bonus fix (silent)

The Apple POST signin route was building OAuth state inline with `crypto.createHmac`, omitting the `timestamp` field that `verifyOAuthState` requires. Apple POST signin would have failed with `oauth_error` for every user on master. T1's migration to the shared `createSignedState` helper auto-attaches the timestamp, so this PR silently fixes that pre-existing bug. Test: `apps/web/src/app/api/auth/apple/signin/__tests__/route.test.ts` "includes timestamp in state".

## Architecture notes

- **Pure-core untouched.** All business logic lives in `packages/lib/src/services/invites/` (pipes, validators, predicates) and was not modified by this PR. New IO sits in adapters (`apps/web/src/lib/auth/{invite-acceptance-adapters,revoke-adapters,native-invite-acceptance}.ts`).
- **`emitAcceptanceSideEffects` invariant maintained.** Every drive-membership write goes through one of the pipes, which in turn fires the four side-effect ports.
- **Drive-member gate coverage**: the new `auth/revoke-adapters.ts` is added to `LIB_ACCEPTED_AT_GATE_EXEMPT` with the rationale that `findActorMembership` deliberately returns raw `{role, acceptedAt}` so the strict "accepted OWNER/ADMIN" gate lives once in the pure-core validator.
- **Hard-cutover discipline**: no nullable bridges, no compat re-exports, no shim code.
- **Single OAuth invite acceptance code path**: the `consumeInviteIfPresent` helper is now called from native (google/native, apple/native, google/one-tap) AND web callbacks (google/callback web/desktop/iOS branches, apple/callback web/desktop/iOS branches). One acceptance contract, six call sites.

## Reviews already done

- Codex sanity-check after T1 (OAuth state architecture): clean.
- Codex sanity-check after T9 (revoke authz model): clean.
- Adversarial security fan-out at T1: confirmed no current vulnerability; called out the pre-existing Apple bug.
- Adversarial security fan-out at T9: clean. One non-exploitable low-severity finding (duplicate audit events on concurrent revoke — log noise, not a security hole) intentionally deferred.
- Codex whole-diff sanity before PR: clean — no blockers.
- CodeRabbit review: 4 inline + 2 outside-diff findings addressed (test flakiness, a11y, type tightening, cloud passkey nextPath, desktop/iOS invite gap, vi.hoisted nit). Permission-helper suggestion declined with rationale (page-perm helpers are wrong domain for drive-management role checks; pattern matches MemberRow / DriveMembers).

## Test plan

- [x] `pnpm typecheck` clean monorepo-wide
- [x] `pnpm lint` clean
- [x] `pnpm test:unit` — 7236+ pass; remaining failures are pre-existing local-DB integration tests (`role "test" does not exist`) and 4 pre-existing import-resolution test files unchanged from master
- [x] `drive-member-gate-coverage` 8/8 (with new revoke-adapters.ts allow-list entry)
- [x] `security-audit-coverage` green (revoke route emits `authz.access.denied` on FORBIDDEN, `authz.permission.revoked` on success via adapter)
- [x] Apple + Google callback test suites: 130/130 pass including new desktop + iOS deep-link `invitedDriveId` propagation tests
- [ ] Manual smoke: invite known user → see in pending list → revoke → row gone → invite again → accept via `/invite/[token]/accept`
- [ ] Manual smoke: OAuth Google + Apple sign-in with `?invite=<token>` consumes correctly (web)
- [ ] Manual smoke: signin with `?next=/dashboard/<driveId>` honored; `?next=//evil.com` ignored

## References

- Architecture base: PR #1267 (from-scratch invite architecture)
- Plan: `~/.claude/plans/async-churning-waterfall.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)