### PR TITLE
feat(dm): allow DM via shared drive membership

### DIFF
--- a/apps/web/src/app/api/messages/conversations/__tests__/route.test.ts
+++ b/apps/web/src/app/api/messages/conversations/__tests__/route.test.ts
@@ -107,7 +107,7 @@ describe('POST /api/messages/conversations DM eligibility', () => {
   it('allows DM when an accepted connection exists', async () => {
     vi.mocked(usersShareDrive).mockResolvedValue(false);
     vi.mocked(db.select)
-      .mockReturnValueOnce(selectChain([{ id: 'conn_1' }]))
+      .mockReturnValueOnce(selectChain([{ status: 'ACCEPTED' }]))
       .mockReturnValueOnce(selectChain([]));
     vi.mocked(db.insert).mockReturnValueOnce(
       insertChain([{ id: 'conv_1', participant1Id: userId, participant2Id: recipientId }])
@@ -145,6 +145,17 @@ describe('POST /api/messages/conversations DM eligibility', () => {
     const response = await POST(makeRequest({ recipientId }));
 
     expect(response.status).toBe(403);
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when the relationship is BLOCKED, even if users share a drive', async () => {
+    vi.mocked(usersShareDrive).mockResolvedValue(true);
+    vi.mocked(db.select).mockReturnValueOnce(selectChain([{ status: 'BLOCKED' }]));
+
+    const response = await POST(makeRequest({ recipientId }));
+
+    expect(response.status).toBe(403);
+    expect(usersShareDrive).not.toHaveBeenCalled();
     expect(db.insert).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/app/api/messages/conversations/__tests__/route.test.ts
+++ b/apps/web/src/app/api/messages/conversations/__tests__/route.test.ts
@@ -1,0 +1,164 @@
+/**
+ * DM eligibility tests for POST /api/messages/conversations.
+ * The route should allow conversation creation when the users have an
+ * ACCEPTED connection OR share a drive (owner or accepted member).
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn((result: unknown) => result && typeof result === 'object' && 'error' in result),
+}));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn(),
+  and: vi.fn(),
+  or: vi.fn(),
+  sql: Object.assign(vi.fn(), { raw: vi.fn() }),
+}));
+vi.mock('@pagespace/db/schema/social', () => ({
+  dmConversations: {},
+  connections: {},
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+    security: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  },
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: vi.fn(),
+}));
+vi.mock('@pagespace/lib/auth/verification-utils', () => ({
+  isEmailVerified: vi.fn().mockResolvedValue(true),
+}));
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  usersShareDrive: vi.fn(),
+}));
+
+vi.mock('@/lib/utils/query-params', () => ({
+  parseBoundedIntParam: vi.fn(() => 20),
+}));
+vi.mock('@/lib/utils/timestamp', () => ({
+  toISOTimestamp: vi.fn((v: unknown) => (v instanceof Date ? v.toISOString() : v)),
+}));
+
+import { POST } from '../route';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+import { db } from '@pagespace/db/db';
+import { usersShareDrive } from '@pagespace/lib/permissions/permissions';
+import { isEmailVerified } from '@pagespace/lib/auth/verification-utils';
+
+const userId = 'user_self';
+const recipientId = 'user_other';
+
+const mockAuth = () => {
+  vi.mocked(authenticateRequestWithOptions).mockResolvedValue({
+    userId,
+    tokenVersion: 0,
+    tokenType: 'session' as const,
+    sessionId: 'test-session',
+    role: 'user' as const,
+    adminRoleVersion: 0,
+  });
+};
+
+function selectChain(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  } as unknown as ReturnType<typeof db.select>;
+}
+
+function insertChain(rows: unknown[]) {
+  return {
+    values: vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue(rows),
+    }),
+  } as unknown as ReturnType<typeof db.insert>;
+}
+
+function makeRequest(body: Record<string, unknown>): Request {
+  return new Request('http://localhost/api/messages/conversations', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/messages/conversations DM eligibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth();
+    vi.mocked(isEmailVerified).mockResolvedValue(true);
+  });
+
+  it('allows DM when an accepted connection exists', async () => {
+    vi.mocked(usersShareDrive).mockResolvedValue(false);
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectChain([{ id: 'conn_1' }]))
+      .mockReturnValueOnce(selectChain([]));
+    vi.mocked(db.insert).mockReturnValueOnce(
+      insertChain([{ id: 'conv_1', participant1Id: userId, participant2Id: recipientId }])
+    );
+
+    const response = await POST(makeRequest({ recipientId }));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.conversation.id).toBe('conv_1');
+    expect(usersShareDrive).not.toHaveBeenCalled();
+  });
+
+  it('allows DM via shared drive even when no connection exists', async () => {
+    vi.mocked(usersShareDrive).mockResolvedValue(true);
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectChain([]))
+      .mockReturnValueOnce(selectChain([]));
+    vi.mocked(db.insert).mockReturnValueOnce(
+      insertChain([{ id: 'conv_2', participant1Id: userId, participant2Id: recipientId }])
+    );
+
+    const response = await POST(makeRequest({ recipientId }));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.conversation.id).toBe('conv_2');
+    expect(usersShareDrive).toHaveBeenCalledWith(userId, recipientId);
+  });
+
+  it('returns 403 when neither a connection nor a shared drive exists', async () => {
+    vi.mocked(usersShareDrive).mockResolvedValue(false);
+    vi.mocked(db.select).mockReturnValueOnce(selectChain([]));
+
+    const response = await POST(makeRequest({ recipientId }));
+
+    expect(response.status).toBe(403);
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('returns existing conversation without insert when one already exists', async () => {
+    vi.mocked(usersShareDrive).mockResolvedValue(true);
+    vi.mocked(db.select)
+      .mockReturnValueOnce(selectChain([])) // no connection
+      .mockReturnValueOnce(selectChain([{ id: 'existing_conv' }]));
+
+    const response = await POST(makeRequest({ recipientId }));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.conversation.id).toBe('existing_conv');
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/messages/conversations/route.ts
+++ b/apps/web/src/app/api/messages/conversations/route.ts
@@ -6,6 +6,7 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { isEmailVerified } from '@pagespace/lib/auth/verification-utils';
+import { usersShareDrive } from '@pagespace/lib/permissions/permissions';
 import { parseBoundedIntParam } from '@/lib/utils/query-params';
 import { toISOTimestamp } from '@/lib/utils/timestamp';
 import type { ConversationRow } from '@/types/messaging';
@@ -179,7 +180,7 @@ export async function POST(request: Request) {
       );
     }
 
-    // Check if users are connected
+    // DM eligibility: accepted connection OR shared drive membership
     const [connection] = await db
       .select()
       .from(connections)
@@ -200,9 +201,11 @@ export async function POST(request: Request) {
       )
       .limit(1);
 
-    if (!connection) {
+    const isEligible = !!connection || (await usersShareDrive(userId, recipientId));
+
+    if (!isEligible) {
       return NextResponse.json(
-        { error: 'You must be connected to start a conversation' },
+        { error: 'You can\'t message this user' },
         { status: 403 }
       );
     }

--- a/apps/web/src/app/api/messages/conversations/route.ts
+++ b/apps/web/src/app/api/messages/conversations/route.ts
@@ -180,9 +180,11 @@ export async function POST(request: Request) {
       );
     }
 
-    // DM eligibility: accepted connection OR shared drive membership
-    const [connection] = await db
-      .select()
+    // Block precedence: a BLOCKED relationship denies DMs even when the users
+    // share a drive. Otherwise, eligibility = accepted connection OR shared
+    // drive membership.
+    const [relationship] = await db
+      .select({ status: connections.status })
       .from(connections)
       .where(
         and(
@@ -196,12 +198,24 @@ export async function POST(request: Request) {
               eq(connections.user2Id, userId)
             )
           ),
-          eq(connections.status, 'ACCEPTED')
+          or(
+            eq(connections.status, 'ACCEPTED'),
+            eq(connections.status, 'BLOCKED')
+          )
         )
       )
       .limit(1);
 
-    const isEligible = !!connection || (await usersShareDrive(userId, recipientId));
+    if (relationship?.status === 'BLOCKED') {
+      return NextResponse.json(
+        { error: 'You can\'t message this user' },
+        { status: 403 }
+      );
+    }
+
+    const isEligible =
+      relationship?.status === 'ACCEPTED' ||
+      (await usersShareDrive(userId, recipientId));
 
     if (!isEligible) {
       return NextResponse.json(

--- a/apps/web/src/app/api/users/messageable/__tests__/route.test.ts
+++ b/apps/web/src/app/api/users/messageable/__tests__/route.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for GET /api/users/messageable.
+ * Returns the union of accepted connections and drive co-members,
+ * deduplicated. When a user appears in both, source = 'connection'.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn((result: unknown) => result && typeof result === 'object' && 'error' in result),
+}));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: { select: vi.fn() },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn(),
+  and: vi.fn(),
+  or: vi.fn(),
+  ne: vi.fn(),
+  isNotNull: vi.fn(),
+  inArray: vi.fn(),
+}));
+vi.mock('@pagespace/db/schema/auth', () => ({ users: {} }));
+vi.mock('@pagespace/db/schema/members', () => ({
+  driveMembers: {},
+  userProfiles: {},
+}));
+vi.mock('@pagespace/db/schema/core', () => ({
+  drives: {},
+}));
+vi.mock('@pagespace/db/schema/social', () => ({
+  connections: {},
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: vi.fn(),
+}));
+
+import { GET } from '../route';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+import { db } from '@pagespace/db/db';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+
+const userId = 'user_self';
+
+const mockAuth = () => {
+  vi.mocked(authenticateRequestWithOptions).mockResolvedValue({
+    userId,
+    tokenVersion: 0,
+    tokenType: 'session' as const,
+    sessionId: 'test-session',
+    role: 'user' as const,
+    adminRoleVersion: 0,
+  });
+};
+
+function fromWhere(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(rows),
+    }),
+  } as unknown as ReturnType<typeof db.select>;
+}
+
+function fromLeftJoinWhere(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      leftJoin: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  } as unknown as ReturnType<typeof db.select>;
+}
+
+function userRow(id: string, displayName: string) {
+  return {
+    id,
+    name: displayName,
+    email: `${id}@example.com`,
+    image: null,
+    username: id,
+    displayName,
+    bio: null,
+    avatarUrl: null,
+  };
+}
+
+describe('GET /api/users/messageable', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth();
+  });
+
+  it('returns empty users array when user has no drives or connections', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(fromWhere([])) // owned drives
+      .mockReturnValueOnce(fromWhere([])) // member drives
+      .mockReturnValueOnce(fromWhere([])); // connections
+
+    const response = await GET(new Request('http://localhost/api/users/messageable'));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.users).toEqual([]);
+    expect(auditRequest).toHaveBeenCalledWith(
+      expect.any(Request),
+      expect.objectContaining({ eventType: 'data.read', resourceType: 'messageable_users' })
+    );
+  });
+
+  it('returns drive co-members with source=drive and a sharedDriveCount', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(fromWhere([{ id: 'drive_1' }])) // owned drives
+      .mockReturnValueOnce(fromWhere([])) // member drives
+      .mockReturnValueOnce(fromWhere([])) // other owners on those drives
+      .mockReturnValueOnce(
+        fromWhere([
+          { userId: 'user_alice', driveId: 'drive_1' },
+          { userId: 'user_bob', driveId: 'drive_1' },
+        ])
+      ) // other accepted members
+      .mockReturnValueOnce(fromWhere([])) // connections (none)
+      .mockReturnValueOnce(
+        fromLeftJoinWhere([userRow('user_alice', 'Alice'), userRow('user_bob', 'Bob')])
+      );
+
+    const response = await GET(new Request('http://localhost/api/users/messageable'));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.users).toHaveLength(2);
+    const alice = body.users.find((u: { id: string }) => u.id === 'user_alice');
+    expect(alice).toMatchObject({
+      source: 'drive',
+      sharedDriveCount: 1,
+      displayName: 'Alice',
+    });
+  });
+
+  it('prefers source=connection when user is both a connection and a drive co-member', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(fromWhere([{ id: 'drive_1' }])) // owned drives
+      .mockReturnValueOnce(fromWhere([])) // member drives
+      .mockReturnValueOnce(fromWhere([])) // other owners
+      .mockReturnValueOnce(fromWhere([{ userId: 'user_alice', driveId: 'drive_1' }])) // co-member
+      .mockReturnValueOnce(
+        fromWhere([{ user1Id: userId, user2Id: 'user_alice' }])
+      ) // connections include alice
+      .mockReturnValueOnce(fromLeftJoinWhere([userRow('user_alice', 'Alice')]));
+
+    const response = await GET(new Request('http://localhost/api/users/messageable'));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.users).toHaveLength(1);
+    expect(body.users[0]).toMatchObject({
+      id: 'user_alice',
+      source: 'connection',
+      sharedDriveCount: 1,
+    });
+  });
+
+  it('counts membership across multiple shared drives correctly', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(fromWhere([{ id: 'drive_1' }, { id: 'drive_2' }])) // owns 2 drives
+      .mockReturnValueOnce(fromWhere([])) // no member drives
+      .mockReturnValueOnce(fromWhere([])) // other owners
+      .mockReturnValueOnce(
+        fromWhere([
+          { userId: 'user_alice', driveId: 'drive_1' },
+          { userId: 'user_alice', driveId: 'drive_2' },
+        ])
+      ) // alice is member of both
+      .mockReturnValueOnce(fromWhere([])) // connections
+      .mockReturnValueOnce(fromLeftJoinWhere([userRow('user_alice', 'Alice')]));
+
+    const response = await GET(new Request('http://localhost/api/users/messageable'));
+
+    const body = await response.json();
+    expect(body.users[0].sharedDriveCount).toBe(2);
+  });
+});

--- a/apps/web/src/app/api/users/messageable/__tests__/route.test.ts
+++ b/apps/web/src/app/api/users/messageable/__tests__/route.test.ts
@@ -125,7 +125,7 @@ describe('GET /api/users/messageable', () => {
           { userId: 'user_bob', driveId: 'drive_1' },
         ])
       ) // other accepted members
-      .mockReturnValueOnce(fromWhere([])) // connections (none)
+      .mockReturnValueOnce(fromWhere([])) // relationships (no connections, no blocks)
       .mockReturnValueOnce(
         fromLeftJoinWhere([userRow('user_alice', 'Alice'), userRow('user_bob', 'Bob')])
       );
@@ -150,8 +150,8 @@ describe('GET /api/users/messageable', () => {
       .mockReturnValueOnce(fromWhere([])) // other owners
       .mockReturnValueOnce(fromWhere([{ userId: 'user_alice', driveId: 'drive_1' }])) // co-member
       .mockReturnValueOnce(
-        fromWhere([{ user1Id: userId, user2Id: 'user_alice' }])
-      ) // connections include alice
+        fromWhere([{ user1Id: userId, user2Id: 'user_alice', status: 'ACCEPTED' }])
+      ) // accepted connection with alice
       .mockReturnValueOnce(fromLeftJoinWhere([userRow('user_alice', 'Alice')]));
 
     const response = await GET(new Request('http://localhost/api/users/messageable'));
@@ -166,6 +166,30 @@ describe('GET /api/users/messageable', () => {
     });
   });
 
+  it('excludes BLOCKED relationships even when the users share a drive', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(fromWhere([{ id: 'drive_1' }])) // owned drives
+      .mockReturnValueOnce(fromWhere([])) // member drives
+      .mockReturnValueOnce(fromWhere([])) // other owners
+      .mockReturnValueOnce(
+        fromWhere([
+          { userId: 'user_alice', driveId: 'drive_1' },
+          { userId: 'user_bob', driveId: 'drive_1' },
+        ])
+      ) // alice and bob co-members
+      .mockReturnValueOnce(
+        fromWhere([{ user1Id: userId, user2Id: 'user_alice', status: 'BLOCKED' }])
+      ) // alice is blocked
+      .mockReturnValueOnce(fromLeftJoinWhere([userRow('user_bob', 'Bob')]));
+
+    const response = await GET(new Request('http://localhost/api/users/messageable'));
+
+    const body = await response.json();
+    const ids = body.users.map((u: { id: string }) => u.id);
+    expect(ids).toEqual(['user_bob']);
+    expect(ids).not.toContain('user_alice');
+  });
+
   it('counts membership across multiple shared drives correctly', async () => {
     vi.mocked(db.select)
       .mockReturnValueOnce(fromWhere([{ id: 'drive_1' }, { id: 'drive_2' }])) // owns 2 drives
@@ -177,7 +201,7 @@ describe('GET /api/users/messageable', () => {
           { userId: 'user_alice', driveId: 'drive_2' },
         ])
       ) // alice is member of both
-      .mockReturnValueOnce(fromWhere([])) // connections
+      .mockReturnValueOnce(fromWhere([])) // relationships (none)
       .mockReturnValueOnce(fromLeftJoinWhere([userRow('user_alice', 'Alice')]));
 
     const response = await GET(new Request('http://localhost/api/users/messageable'));

--- a/apps/web/src/app/api/users/messageable/route.ts
+++ b/apps/web/src/app/api/users/messageable/route.ts
@@ -1,0 +1,171 @@
+import { NextResponse } from 'next/server';
+import { db } from '@pagespace/db/db';
+import { eq, and, or, ne, isNotNull, inArray } from '@pagespace/db/operators';
+import { users } from '@pagespace/db/schema/auth';
+import { driveMembers, userProfiles } from '@pagespace/db/schema/members';
+import { drives } from '@pagespace/db/schema/core';
+import { connections } from '@pagespace/db/schema/social';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+
+const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
+
+export type MessageableSource = 'connection' | 'drive';
+
+export interface MessageableUser {
+  id: string;
+  name: string | null;
+  email: string;
+  image: string | null;
+  username: string | null;
+  displayName: string | null;
+  bio: string | null;
+  avatarUrl: string | null;
+  source: MessageableSource;
+  sharedDriveCount: number;
+}
+
+// GET /api/users/messageable - Users the current user can DM (accepted
+// connections ∪ drive co-members), deduplicated. When a user appears in both,
+// `source` is reported as 'connection'.
+export async function GET(request: Request) {
+  try {
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
+    if (isAuthError(auth)) return auth.error;
+    const userId = auth.userId;
+
+    auditRequest(request, {
+      eventType: 'data.read',
+      userId,
+      resourceType: 'messageable_users',
+      resourceId: 'self',
+    });
+
+    const ownedDrives = await db
+      .select({ id: drives.id })
+      .from(drives)
+      .where(eq(drives.ownerId, userId));
+
+    const memberDrives = await db
+      .select({ driveId: driveMembers.driveId })
+      .from(driveMembers)
+      .where(
+        and(
+          eq(driveMembers.userId, userId),
+          isNotNull(driveMembers.acceptedAt)
+        )
+      );
+
+    const myDriveIds = Array.from(
+      new Set<string>([
+        ...ownedDrives.map((d) => d.id),
+        ...memberDrives.map((m) => m.driveId),
+      ])
+    );
+
+    const driveCountByUserId = new Map<string, number>();
+    if (myDriveIds.length > 0) {
+      const otherOwners = await db
+        .select({ userId: drives.ownerId, driveId: drives.id })
+        .from(drives)
+        .where(and(inArray(drives.id, myDriveIds), ne(drives.ownerId, userId)));
+
+      const otherMembers = await db
+        .select({ userId: driveMembers.userId, driveId: driveMembers.driveId })
+        .from(driveMembers)
+        .where(
+          and(
+            inArray(driveMembers.driveId, myDriveIds),
+            ne(driveMembers.userId, userId),
+            isNotNull(driveMembers.acceptedAt)
+          )
+        );
+
+      const seen = new Set<string>();
+      const bump = (uid: string, driveId: string) => {
+        const key = `${uid}:${driveId}`;
+        if (seen.has(key)) return;
+        seen.add(key);
+        driveCountByUserId.set(uid, (driveCountByUserId.get(uid) ?? 0) + 1);
+      };
+      for (const o of otherOwners) bump(o.userId, o.driveId);
+      for (const m of otherMembers) bump(m.userId, m.driveId);
+    }
+
+    const userConnections = await db
+      .select({
+        user1Id: connections.user1Id,
+        user2Id: connections.user2Id,
+      })
+      .from(connections)
+      .where(
+        and(
+          or(
+            eq(connections.user1Id, userId),
+            eq(connections.user2Id, userId)
+          ),
+          eq(connections.status, 'ACCEPTED')
+        )
+      );
+
+    const connectionUserIds = new Set<string>();
+    for (const c of userConnections) {
+      const other = c.user1Id === userId ? c.user2Id : c.user1Id;
+      if (other) connectionUserIds.add(other);
+    }
+
+    const allUserIds = Array.from(
+      new Set<string>([
+        ...connectionUserIds,
+        ...driveCountByUserId.keys(),
+      ])
+    );
+
+    if (allUserIds.length === 0) {
+      return NextResponse.json({ users: [] });
+    }
+
+    const userRows = await db
+      .select({
+        id: users.id,
+        name: users.name,
+        email: users.email,
+        image: users.image,
+        username: userProfiles.username,
+        displayName: userProfiles.displayName,
+        bio: userProfiles.bio,
+        avatarUrl: userProfiles.avatarUrl,
+      })
+      .from(users)
+      .leftJoin(userProfiles, eq(users.id, userProfiles.userId))
+      .where(inArray(users.id, allUserIds));
+
+    const messageable: MessageableUser[] = userRows.map((u) => ({
+      id: u.id,
+      name: u.name,
+      email: u.email,
+      image: u.image,
+      username: u.username,
+      displayName: u.displayName,
+      bio: u.bio,
+      avatarUrl: u.avatarUrl,
+      source: connectionUserIds.has(u.id) ? 'connection' : 'drive',
+      sharedDriveCount: driveCountByUserId.get(u.id) ?? 0,
+    }));
+
+    messageable.sort((a, b) => {
+      const an = (a.displayName || a.name || '').toLowerCase();
+      const bn = (b.displayName || b.name || '').toLowerCase();
+      return an.localeCompare(bn);
+    });
+
+    return NextResponse.json({ users: messageable });
+  } catch (error) {
+    loggers.api.error('Error fetching messageable users:', error as Error);
+    return NextResponse.json(
+      { error: 'Failed to fetch messageable users' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/src/app/api/users/messageable/route.ts
+++ b/apps/web/src/app/api/users/messageable/route.ts
@@ -93,10 +93,11 @@ export async function GET(request: Request) {
       for (const m of otherMembers) bump(m.userId, m.driveId);
     }
 
-    const userConnections = await db
+    const relationshipRows = await db
       .select({
         user1Id: connections.user1Id,
         user2Id: connections.user2Id,
+        status: connections.status,
       })
       .from(connections)
       .where(
@@ -105,14 +106,25 @@ export async function GET(request: Request) {
             eq(connections.user1Id, userId),
             eq(connections.user2Id, userId)
           ),
-          eq(connections.status, 'ACCEPTED')
+          or(
+            eq(connections.status, 'ACCEPTED'),
+            eq(connections.status, 'BLOCKED')
+          )
         )
       );
 
     const connectionUserIds = new Set<string>();
-    for (const c of userConnections) {
+    const blockedUserIds = new Set<string>();
+    for (const c of relationshipRows) {
       const other = c.user1Id === userId ? c.user2Id : c.user1Id;
-      if (other) connectionUserIds.add(other);
+      if (!other) continue;
+      if (c.status === 'BLOCKED') blockedUserIds.add(other);
+      else if (c.status === 'ACCEPTED') connectionUserIds.add(other);
+    }
+
+    for (const blockedId of blockedUserIds) {
+      driveCountByUserId.delete(blockedId);
+      connectionUserIds.delete(blockedId);
     }
 
     const allUserIds = Array.from(

--- a/apps/web/src/app/dashboard/dms/new/page.tsx
+++ b/apps/web/src/app/dashboard/dms/new/page.tsx
@@ -21,18 +21,17 @@ const fetcher = async (url: string) => {
   return response.json();
 };
 
-interface Connection {
+interface MessageableUser {
   id: string;
-  status: string;
-  user: {
-    id: string;
-    name: string;
-    email: string;
-    username: string | null;
-    displayName: string | null;
-    bio: string | null;
-    avatarUrl: string | null;
-  };
+  name: string | null;
+  email: string;
+  image: string | null;
+  username: string | null;
+  displayName: string | null;
+  bio: string | null;
+  avatarUrl: string | null;
+  source: 'connection' | 'drive';
+  sharedDriveCount: number;
 }
 
 export default function NewConversationPage() {
@@ -42,16 +41,14 @@ export default function NewConversationPage() {
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState(false);
 
-  // Fetch user's connections
-  const { data: connectionsData } = useSWR<{ connections: Connection[] }>(
-    '/api/connections?status=ACCEPTED',
+  const { data: messageableData } = useSWR<{ users: MessageableUser[] }>(
+    '/api/users/messageable',
     fetcher
   );
 
-  // Filter connections based on search
-  const filteredConnections = connectionsData?.connections?.filter((conn) => {
-    const displayName = conn.user.displayName || conn.user.name;
-    const username = conn.user.username || '';
+  const filteredUsers = messageableData?.users?.filter((u) => {
+    const displayName = u.displayName || u.name || '';
+    const username = u.username || '';
     return (
       displayName.toLowerCase().includes(searchQuery.toLowerCase()) ||
       username.toLowerCase().includes(searchQuery.toLowerCase())
@@ -67,12 +64,10 @@ export default function NewConversationPage() {
     setIsCreating(true);
 
     try {
-      // Create or get existing conversation
       const { conversation } = await post<{ conversation: { id: string } }>('/api/messages/conversations', {
         recipientId: selectedUserId,
       });
 
-      // Navigate to the conversation
       router.push(`/dashboard/dms/${conversation.id}`);
     } catch (error) {
       toast.error((error as Error).message || 'Failed to start conversation');
@@ -86,7 +81,6 @@ export default function NewConversationPage() {
 
   return (
     <div className="flex-1 flex flex-col">
-      {/* Header */}
       <div className="border-b border-border p-4">
         <div className="flex items-center gap-4">
           <Button
@@ -100,18 +94,17 @@ export default function NewConversationPage() {
         </div>
       </div>
 
-      {/* Content */}
       <div className="flex-1 p-6">
         <div className="max-w-2xl mx-auto">
           <div className="mb-6">
             <Label htmlFor="search" className="mb-2 block">
-              Select a connection to message
+              Select someone to message
             </Label>
             <div className="relative">
               <Search className="absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
               <Input
                 id="search"
-                placeholder="Search your connections..."
+                placeholder="Search connections and drive members..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 className="pl-9"
@@ -119,14 +112,13 @@ export default function NewConversationPage() {
             </div>
           </div>
 
-          {/* Connections List */}
           <ScrollArea className="h-[400px] border rounded-lg">
             <div className="p-4">
-              {filteredConnections.length === 0 && !searchQuery && (
+              {filteredUsers.length === 0 && !searchQuery && (
                 <div className="text-center py-8">
                   <UserPlus className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
                   <p className="text-muted-foreground mb-4">
-                    You need to connect with users before you can message them
+                    Connect with someone or join a shared drive to start messaging
                   </p>
                   <Button onClick={handleConnectionsClick} variant="outline">
                     Manage Connections
@@ -134,22 +126,28 @@ export default function NewConversationPage() {
                 </div>
               )}
 
-              {filteredConnections.length === 0 && searchQuery && (
+              {filteredUsers.length === 0 && searchQuery && (
                 <div className="text-center py-8">
                   <p className="text-muted-foreground">
-                    No connections found matching &quot;{searchQuery}&quot;
+                    No matches for &quot;{searchQuery}&quot;
                   </p>
                 </div>
               )}
 
-              {filteredConnections.map((connection) => {
-                const displayName = connection.user.displayName || connection.user.name;
-                const isSelected = selectedUserId === connection.user.id;
+              {filteredUsers.map((u) => {
+                const displayName = u.displayName || u.name || u.email;
+                const isSelected = selectedUserId === u.id;
+                const sourceLabel =
+                  u.source === 'connection'
+                    ? 'Connection'
+                    : u.sharedDriveCount > 1
+                      ? `Shares ${u.sharedDriveCount} drives`
+                      : 'Shared drive';
 
                 return (
                   <div
-                    key={connection.id}
-                    onClick={() => setSelectedUserId(connection.user.id)}
+                    key={u.id}
+                    onClick={() => setSelectedUserId(u.id)}
                     className={`flex items-center gap-3 p-3 rounded-lg cursor-pointer transition-colors ${
                       isSelected
                         ? 'bg-accent border-2 border-primary'
@@ -157,22 +155,27 @@ export default function NewConversationPage() {
                     }`}
                   >
                     <Avatar className="h-10 w-10">
-                      <AvatarImage src={connection.user.avatarUrl || ''} />
+                      <AvatarImage src={u.avatarUrl || u.image || ''} />
                       <AvatarFallback>
                         {displayName.charAt(0).toUpperCase()}
                       </AvatarFallback>
                     </Avatar>
 
-                    <div className="flex-1">
-                      <p className="font-medium">{displayName}</p>
-                      {connection.user.username && (
-                        <p className="text-sm text-muted-foreground">
-                          @{connection.user.username}
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <p className="font-medium truncate">{displayName}</p>
+                        <span className="text-xs text-muted-foreground shrink-0">
+                          · {sourceLabel}
+                        </span>
+                      </div>
+                      {u.username && (
+                        <p className="text-sm text-muted-foreground truncate">
+                          @{u.username}
                         </p>
                       )}
-                      {connection.user.bio && (
+                      {u.bio && (
                         <p className="text-sm text-muted-foreground line-clamp-1">
-                          {connection.user.bio}
+                          {u.bio}
                         </p>
                       )}
                     </div>
@@ -198,7 +201,6 @@ export default function NewConversationPage() {
             </div>
           </ScrollArea>
 
-          {/* Action Buttons */}
           <div className="flex justify-end gap-3 mt-6">
             <Button
               variant="outline"

--- a/packages/lib/src/permissions/__tests__/users-share-drive.test.ts
+++ b/packages/lib/src/permissions/__tests__/users-share-drive.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@pagespace/db/db', () => ({
+  db: { select: vi.fn() },
+}));
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'id', driveId: 'driveId' },
+  drives: { id: 'id', ownerId: 'ownerId' },
+}));
+vi.mock('@pagespace/db/schema/members', () => ({
+  driveMembers: {
+    id: 'id',
+    driveId: 'driveId',
+    userId: 'userId',
+    role: 'role',
+    acceptedAt: 'acceptedAt',
+  },
+  pagePermissions: {
+    id: 'id',
+    pageId: 'pageId',
+    userId: 'userId',
+    canView: 'canView',
+    expiresAt: 'expiresAt',
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn(),
+  and: vi.fn((...args: unknown[]) => ({ and: args })),
+  or: vi.fn((...args: unknown[]) => ({ or: args })),
+  isNull: vi.fn(),
+  isNotNull: vi.fn((a: unknown) => ({ isNotNull: a })),
+  gt: vi.fn(),
+  inArray: vi.fn((a: unknown, b: unknown) => ({ inArray: { a, b } })),
+}));
+
+vi.mock('../../logging/logger-config', () => ({
+  loggers: {
+    api: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+  },
+}));
+
+vi.mock('../../validators', () => ({
+  parseUserId: vi.fn(),
+  parsePageId: vi.fn(),
+}));
+
+import { usersShareDrive } from '../permissions';
+import { db } from '@pagespace/db/db';
+import { loggers } from '../../logging/logger-config';
+
+const A = 'user_a';
+const B = 'user_b';
+
+function stubFromWhere(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(rows),
+    }),
+  } as unknown as ReturnType<typeof db.select>;
+}
+
+function stubFromWhereLimit(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  } as unknown as ReturnType<typeof db.select>;
+}
+
+describe('usersShareDrive', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns false when both ids are the same user', async () => {
+    expect(await usersShareDrive(A, A)).toBe(false);
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('returns false when user A has neither owned nor accepted-member drives', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubFromWhere([])) // owned by A
+      .mockReturnValueOnce(stubFromWhere([])); // member rows for A
+
+    expect(await usersShareDrive(A, B)).toBe(false);
+    expect(db.select).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns true when both users are accepted members of the same drive', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubFromWhere([])) // A owns nothing
+      .mockReturnValueOnce(stubFromWhere([{ driveId: 'drive_1' }])) // A is member
+      .mockReturnValueOnce(stubFromWhereLimit([])) // B does not own a drive in A's set
+      .mockReturnValueOnce(stubFromWhereLimit([{ id: 'mem_b' }])); // B is accepted member
+
+    expect(await usersShareDrive(A, B)).toBe(true);
+  });
+
+  it('returns true when A owns a drive that B is an accepted member of', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubFromWhere([{ id: 'drive_1' }])) // A owns drive_1
+      .mockReturnValueOnce(stubFromWhere([])) // A has no member rows
+      .mockReturnValueOnce(stubFromWhereLimit([])) // B is not owner of drive_1
+      .mockReturnValueOnce(stubFromWhereLimit([{ id: 'mem_b' }])); // B is member of drive_1
+
+    expect(await usersShareDrive(A, B)).toBe(true);
+  });
+
+  it('returns true when B owns a drive that A is an accepted member of', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubFromWhere([])) // A owns nothing
+      .mockReturnValueOnce(stubFromWhere([{ driveId: 'drive_1' }])) // A is member of drive_1
+      .mockReturnValueOnce(stubFromWhereLimit([{ id: 'drive_1' }])); // B is owner of drive_1 — short-circuits
+
+    expect(await usersShareDrive(A, B)).toBe(true);
+  });
+
+  it('returns false when A has drives but B has no overlap (neither owner nor member)', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubFromWhere([{ id: 'drive_a' }])) // A owns drive_a
+      .mockReturnValueOnce(stubFromWhere([])) // no A member rows
+      .mockReturnValueOnce(stubFromWhereLimit([])) // B not owner
+      .mockReturnValueOnce(stubFromWhereLimit([])); // B not member
+
+    expect(await usersShareDrive(A, B)).toBe(false);
+  });
+
+  it('fails closed and logs on a DB error', async () => {
+    vi.mocked(db.select).mockImplementationOnce(() => {
+      throw new Error('DB down');
+    });
+
+    expect(await usersShareDrive(A, B)).toBe(false);
+    expect(loggers.api.error).toHaveBeenCalledWith(
+      '[USERS_SHARE_DRIVE] Error checking shared drive membership',
+      expect.objectContaining({ userIdA: A, userIdB: B })
+    );
+  });
+});

--- a/packages/lib/src/permissions/permissions.ts
+++ b/packages/lib/src/permissions/permissions.ts
@@ -657,6 +657,77 @@ export async function getUserDrivePermissions(
 }
 
 /**
+ * Check whether two users share at least one drive, where "share" means each
+ * is either the drive owner (`drives.ownerId`) or an accepted drive member
+ * (`drive_members` with `acceptedAt IS NOT NULL`). Page-level collaborators
+ * (page_permissions only) do NOT count — matches the drive-membership boundary
+ * used by `getUserDrivePermissions`.
+ *
+ * Used to gate DM eligibility: drive co-members can DM each other without
+ * needing a connections-level relationship.
+ *
+ * Fail-closed on error.
+ */
+export async function usersShareDrive(
+  userIdA: string,
+  userIdB: string
+): Promise<boolean> {
+  if (userIdA === userIdB) return false;
+
+  try {
+    const aDriveIds = new Set<string>();
+
+    const aOwned = await db
+      .select({ id: drives.id })
+      .from(drives)
+      .where(eq(drives.ownerId, userIdA));
+    for (const d of aOwned) aDriveIds.add(d.id);
+
+    const aMember = await db
+      .select({ driveId: driveMembers.driveId })
+      .from(driveMembers)
+      .where(
+        and(
+          eq(driveMembers.userId, userIdA),
+          isNotNull(driveMembers.acceptedAt)
+        )
+      );
+    for (const m of aMember) aDriveIds.add(m.driveId);
+
+    if (aDriveIds.size === 0) return false;
+    const aIds = Array.from(aDriveIds);
+
+    const bOwned = await db
+      .select({ id: drives.id })
+      .from(drives)
+      .where(and(inArray(drives.id, aIds), eq(drives.ownerId, userIdB)))
+      .limit(1);
+    if (bOwned.length > 0) return true;
+
+    const bMember = await db
+      .select({ id: driveMembers.id })
+      .from(driveMembers)
+      .where(
+        and(
+          inArray(driveMembers.driveId, aIds),
+          eq(driveMembers.userId, userIdB),
+          isNotNull(driveMembers.acceptedAt)
+        )
+      )
+      .limit(1);
+
+    return bMember.length > 0;
+  } catch (error) {
+    loggers.api.error('[USERS_SHARE_DRIVE] Error checking shared drive membership', {
+      userIdA,
+      userIdB,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}
+
+/**
  * Batch permission lookup for multiple pages in a single DB round-trip.
  *
  * One SQL statement joins `pages`, `drives`, `drive_members` (for ADMIN role,


### PR DESCRIPTION
## Summary
- **Drive co-membership is now sufficient to DM** — alongside the existing accepted-connection rule. Working in the same drive no longer requires sending a connection request first.
- New `usersShareDrive(a, b)` permission helper in `packages/lib/src/permissions/permissions.ts` (fail-closed; counts owners and accepted members; ignores page-only collaborators).
- New `GET /api/users/messageable` returns the union of accepted connections and drive co-members, deduped, with `source` (`connection` | `drive`) and `sharedDriveCount`. When a user is in both, source is reported as `connection`.
- `POST /api/messages/conversations` gate updated: `connection || usersShareDrive(...)`. Error message generalized to "You can't message this user" so we don't leak drive membership.
- DM new-conversation picker (`/dashboard/dms/new`) switches to `/api/users/messageable` and shows a small source badge per row.

Page-level collaborators (users with only `pagePermissions` access, no drive membership) intentionally still need a connection — matches the existing drive-membership boundary used elsewhere in `permissions.ts`.

## Test plan
- [x] `usersShareDrive` unit tests (7): same-user, no drives, mutual member, owner+member combos, no overlap, fail-closed on DB error
- [x] `POST /api/messages/conversations` route tests (4): connection allows; drive co-member allows without connection; neither = 403; existing conversation reused without insert
- [x] `GET /api/users/messageable` route tests (4): empty case; drive labeling + sharedDriveCount; connection-preferred dedup; multi-drive count
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (only pre-existing unrelated warning in `QuickCreatePalette.tsx`)
- [ ] Manual end-to-end: invite a second user to a drive, accept; visit `/dashboard/dms/new` as the inviter — recipient appears with "Shared drive" badge; start DM; confirm a third user with no shared drive and no connection still 403s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now message others they share a drive with, extending beyond accepted connections.
  * Unified messageable users list now combines both connection contacts and shared drive members in the new conversation interface.

* **Bug Fixes**
  * Improved error messaging when attempting to message ineligible users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->