### PR TITLE
fix(invites): forward token in Google One Tap

### DIFF
--- a/apps/web/src/app/auth/signin/page.tsx
+++ b/apps/web/src/app/auth/signin/page.tsx
@@ -137,7 +137,12 @@ function SignInForm() {
 
   return (
     <AuthShell>
-      <GoogleOneTap autoSelect={true} cancelOnTapOutside={true} context="signin" />
+      <GoogleOneTap
+        autoSelect={true}
+        cancelOnTapOutside={true}
+        context="signin"
+        {...(inviteToken && { inviteToken })}
+      />
 
       {/* Heading */}
       <motion.div

--- a/apps/web/src/app/auth/signup/SignUpClient.tsx
+++ b/apps/web/src/app/auth/signup/SignUpClient.tsx
@@ -45,7 +45,12 @@ export function SignUpClient({ inviteToken, inviteContext }: SignUpClientProps) 
 
   return (
     <AuthShell>
-      <GoogleOneTap autoSelect={true} cancelOnTapOutside={true} context="signup" />
+      <GoogleOneTap
+        autoSelect={true}
+        cancelOnTapOutside={true}
+        context="signup"
+        {...(inviteToken && { inviteToken })}
+      />
 
       {inviteContext && (
         <motion.div

--- a/apps/web/src/components/auth/GoogleOneTap.tsx
+++ b/apps/web/src/components/auth/GoogleOneTap.tsx
@@ -19,6 +19,8 @@ interface GoogleOneTapProps {
   disabled?: boolean;
   /** Redirect URL after successful sign-in */
   redirectTo?: string;
+  /** Pending invite token to consume on successful sign-in */
+  inviteToken?: string;
 }
 
 const GOOGLE_GSI_SCRIPT_URL = 'https://accounts.google.com/gsi/client';
@@ -31,6 +33,7 @@ export function GoogleOneTap({
   context = 'signin',
   disabled = false,
   redirectTo,
+  inviteToken,
 }: GoogleOneTapProps) {
   const isLoadingRef = useRef(false);
   const initializedRef = useRef(false);
@@ -73,6 +76,7 @@ export function GoogleOneTap({
             platform: isDesktop ? 'desktop' : 'web',
             deviceId,
             deviceName,
+            ...(inviteToken && { inviteToken }),
           }),
         });
 
@@ -127,7 +131,7 @@ export function GoogleOneTap({
         isLoadingRef.current = false;
       }
     },
-    [onSuccess, onError, redirectTo]
+    [onSuccess, onError, redirectTo, inviteToken]
   );
 
   // Check if user already has an active session before showing One Tap

--- a/apps/web/src/components/auth/__tests__/GoogleOneTap.test.tsx
+++ b/apps/web/src/components/auth/__tests__/GoogleOneTap.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * Contract test for GoogleOneTap inviteToken forwarding.
+ *
+ * The signup/signin pages own the invite token (parsed from URL params or
+ * server-resolved). The component is the courier — it must forward the token
+ * verbatim into the POST body to /api/auth/google/one-tap so the route can
+ * consume the pending invite during the same request that creates the user.
+ *
+ * Without this guarantee, an invitee who taps the auto-prompt is authenticated
+ * but never added to the drive, and the inviter's pending list never clears.
+ * The route already accepts and consumes the token (see one-tap route tests);
+ * this test locks in that the client actually sends it.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import type { CredentialResponse, IdConfiguration } from '@/types/google-identity';
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock('@/lib/analytics', () => ({
+  getOrCreateDeviceId: () => 'device-id-mock',
+  getDeviceName: () => 'Test Device',
+}));
+
+import { GoogleOneTap } from '../GoogleOneTap';
+
+const GSI_SRC = 'https://accounts.google.com/gsi/client';
+
+interface OneTapMocks {
+  fetchSpy: ReturnType<typeof vi.fn>;
+  capturedCallback: { current: ((r: CredentialResponse) => void) | null };
+  hrefSetter: ReturnType<typeof vi.fn>;
+}
+
+const setupOneTapMocks = (): OneTapMocks => {
+  const capturedCallback: OneTapMocks['capturedCallback'] = { current: null };
+
+  const fetchSpy = vi.fn(async (url: string | URL | Request) => {
+    const u = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
+    if (u.includes('/api/auth/me')) {
+      return new Response(null, { status: 401 });
+    }
+    if (u.includes('/api/auth/google/one-tap')) {
+      return new Response(JSON.stringify({ success: false, error: 'short-circuit' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    throw new Error(`Unexpected fetch: ${u}`);
+  });
+  global.fetch = fetchSpy as unknown as typeof fetch;
+
+  const script = document.createElement('script');
+  script.src = GSI_SRC;
+  document.head.appendChild(script);
+
+  const win = window as unknown as {
+    google: {
+      accounts: {
+        id: {
+          initialize: (config: IdConfiguration) => void;
+          prompt: () => void;
+          cancel: () => void;
+        };
+      };
+    };
+  };
+  win.google = {
+    accounts: {
+      id: {
+        initialize: (config: IdConfiguration) => {
+          capturedCallback.current = config.callback ?? null;
+        },
+        prompt: vi.fn(),
+        cancel: vi.fn(),
+      },
+    },
+  };
+
+  const hrefSetter = vi.fn();
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: new Proxy(
+      { ...window.location, origin: 'http://localhost' },
+      {
+        set(target, prop, value) {
+          if (prop === 'href') {
+            hrefSetter(value);
+            return true;
+          }
+          (target as Record<string | symbol, unknown>)[prop] = value;
+          return true;
+        },
+        get(target, prop) {
+          return (target as Record<string | symbol, unknown>)[prop];
+        },
+      },
+    ),
+  });
+
+  return { fetchSpy, capturedCallback, hrefSetter };
+};
+
+const teardownOneTapMocks = () => {
+  document.querySelectorAll(`script[src="${GSI_SRC}"]`).forEach((s) => s.remove());
+  const win = window as unknown as { google?: unknown };
+  delete win.google;
+  vi.unstubAllEnvs();
+};
+
+const fireCredentialCallback = async (
+  capturedCallback: OneTapMocks['capturedCallback'],
+  fetchSpy: OneTapMocks['fetchSpy'],
+) => {
+  await waitFor(() => {
+    expect(capturedCallback.current).toBeTypeOf('function');
+  });
+  await capturedCallback.current!({ credential: 'mock-jwt', select_by: 'user' });
+  await waitFor(() => {
+    const oneTapCall = fetchSpy.mock.calls.find(
+      ([url]) => typeof url === 'string' && url.includes('/api/auth/google/one-tap'),
+    );
+    expect(oneTapCall).toBeDefined();
+  });
+};
+
+const readOneTapBody = (fetchSpy: OneTapMocks['fetchSpy']): Record<string, unknown> => {
+  const oneTapCall = fetchSpy.mock.calls.find(
+    ([url]) => typeof url === 'string' && url.includes('/api/auth/google/one-tap'),
+  );
+  const init = oneTapCall![1] as RequestInit;
+  return JSON.parse(init.body as string) as Record<string, unknown>;
+};
+
+describe('GoogleOneTap — inviteToken forwarding', () => {
+  beforeEach(() => {
+    vi.stubEnv('NEXT_PUBLIC_GOOGLE_OAUTH_CLIENT_ID', 'mock-client-id.apps.googleusercontent.com');
+  });
+
+  afterEach(() => {
+    teardownOneTapMocks();
+    vi.clearAllMocks();
+  });
+
+  it('forwards inviteToken in the one-tap POST body when the prop is set', async () => {
+    const { fetchSpy, capturedCallback } = setupOneTapMocks();
+    render(<GoogleOneTap inviteToken="ps_invite_xyz" />);
+
+    await fireCredentialCallback(capturedCallback, fetchSpy);
+
+    const body = readOneTapBody(fetchSpy);
+    expect(body.inviteToken).toBe('ps_invite_xyz');
+    expect(body.credential).toBe('mock-jwt');
+  });
+
+  it('omits inviteToken from the one-tap POST body when the prop is not set', async () => {
+    const { fetchSpy, capturedCallback } = setupOneTapMocks();
+    render(<GoogleOneTap />);
+
+    await fireCredentialCallback(capturedCallback, fetchSpy);
+
+    const body = readOneTapBody(fetchSpy);
+    expect(body).not.toHaveProperty('inviteToken');
+    expect(body.credential).toBe('mock-jwt');
+  });
+});


### PR DESCRIPTION
## Summary

- `<GoogleOneTap>` is rendered unconditionally on `/auth/signup` and `/auth/signin`. It auto-prompts via FedCM and POSTs to `/api/auth/google/one-tap`, but it was not forwarding the `inviteToken`. Users invited by email who tapped the One Tap prompt got authenticated **without** consuming the invite — they did not become drive members and the inviter still saw a pending invite.
- The server route already accepts and consumes `inviteToken` (and tests cover it); only the client was dropping it. The regular "Continue with Google" button via `useOAuthSignIn` was unaffected.
- Plumbed `inviteToken` from both auth pages into `<GoogleOneTap>` and on into the request body. Added a regression test that captures Google's credential callback and asserts the POST body forwards (or omits) the token.

Files touched:
- `apps/web/src/components/auth/GoogleOneTap.tsx` — added `inviteToken?: string` prop, forwarded in fetch body, added to `useCallback` deps
- `apps/web/src/app/auth/signup/SignUpClient.tsx` — passes `inviteToken` through
- `apps/web/src/app/auth/signin/page.tsx` — passes `inviteToken` through
- `apps/web/src/components/auth/__tests__/GoogleOneTap.test.tsx` — new wire-contract test

## Why a test for 3 lines of plumbing

The prop is optional. If a future refactor drops the JSX spread on either page, TS will not catch it and the bug returns silently for invitees who tap One Tap. The test mocks Google Identity Services, fires the credential callback, and asserts the POST body — same wire-contract pattern as `MagicLinkForm.test.tsx`.

## Test plan

- [ ] Invite a fresh email (no existing account) to a drive
- [ ] Open invite link in clean browser → lands on `/auth/signup?invite=<token>` with the drive name banner
- [ ] Wait for One Tap prompt, select matching Google account
- [ ] Verify redirect to `/dashboard/<driveId>?invited=1`
- [ ] Verify the user is a member of the drive and the inviter's pending list no longer shows the invite
- [ ] Network tab: `POST /api/auth/google/one-tap` body includes `inviteToken`
- [ ] Existing-user case: sign out, click invite link with an account that already exists, confirm One Tap path on `/auth/signin?invite=<token>` also accepts the invite
- [x] `pnpm --filter web typecheck`
- [x] `pnpm --filter web exec vitest run src/components/auth/__tests__` (47/47 pass, includes new GoogleOneTap test)
- [x] `pnpm --filter web exec vitest run src/app/api/auth/google` (existing route tests still pass)

## Out of scope

- The user already stuck in pending state from the original repro: easiest fix is to revoke + re-send the invite. Once authenticated, their next click will route through `/invite/<token>/accept` and the membership lands cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)