### PR TITLE
feat(auth): magic-link signup with ToS gate

### DIFF
--- a/apps/web/src/app/api/auth/magic-link/__tests__/round-trip.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/__tests__/round-trip.test.ts
@@ -189,13 +189,14 @@ describe('magic-link round-trip — next honoured end-to-end', () => {
   });
 
   it('safe next on send body, but tampered to unsafe in the email link, is rejected at verify', async () => {
-    await sendPost(
+    const sendResp = await sendPost(
       buildSendRequest({
         email: 'user@example.com',
         next: '/dashboard/drive_abc',
         tosAccepted: true,
       }),
     );
+    expect(sendResp.status).toBe(200);
     extractUrlFromEmailCall();
 
     // Simulate a tampered email link — attacker swaps next= for an open

--- a/apps/web/src/app/api/auth/magic-link/__tests__/round-trip.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/__tests__/round-trip.test.ts
@@ -149,7 +149,11 @@ describe('magic-link round-trip — next honoured end-to-end', () => {
 
   it('safe next on send body lands the user on that path after verify', async () => {
     const sendResp = await sendPost(
-      buildSendRequest({ email: 'user@example.com', next: '/dashboard/drive_abc' }),
+      buildSendRequest({
+        email: 'user@example.com',
+        next: '/dashboard/drive_abc',
+        tosAccepted: true,
+      }),
     );
     expect(sendResp.status).toBe(200);
 
@@ -166,7 +170,11 @@ describe('magic-link round-trip — next honoured end-to-end', () => {
 
   it('unsafe next on send body is stripped at the boundary; verify URL has no next', async () => {
     const sendResp = await sendPost(
-      buildSendRequest({ email: 'user@example.com', next: '//evil.com/phish' }),
+      buildSendRequest({
+        email: 'user@example.com',
+        next: '//evil.com/phish',
+        tosAccepted: true,
+      }),
     );
     expect(sendResp.status).toBe(200);
 
@@ -182,7 +190,11 @@ describe('magic-link round-trip — next honoured end-to-end', () => {
 
   it('safe next on send body, but tampered to unsafe in the email link, is rejected at verify', async () => {
     await sendPost(
-      buildSendRequest({ email: 'user@example.com', next: '/dashboard/drive_abc' }),
+      buildSendRequest({
+        email: 'user@example.com',
+        next: '/dashboard/drive_abc',
+        tosAccepted: true,
+      }),
     );
     extractUrlFromEmailCall();
 

--- a/apps/web/src/app/api/auth/magic-link/send/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/send/__tests__/route.test.ts
@@ -74,7 +74,7 @@ import { validateLoginCSRFToken, getClientIP } from '@/lib/auth';
 import { parse } from 'cookie';
 
 const createMagicLinkRequest = (
-  body: Record<string, unknown> | string = { email: 'test@example.com' },
+  body: Record<string, unknown> | string = { email: 'test@example.com', tosAccepted: true },
   headers: Record<string, string> = {}
 ) => {
   const defaultHeaders: Record<string, string> = {
@@ -84,7 +84,15 @@ const createMagicLinkRequest = (
     ...headers,
   };
 
-  const bodyStr = typeof body === 'string' ? body : JSON.stringify(body);
+  // Auto-add tosAccepted:true to inline-object bodies that omit it, so the
+  // legacy tests (CSRF, rate limit, validation) keep passing the schema. Tests
+  // that specifically exercise the ToS gate set tosAccepted explicitly.
+  const bodyObj =
+    typeof body === 'object' && body !== null && !('tosAccepted' in body)
+      ? { ...body, tosAccepted: true }
+      : body;
+
+  const bodyStr = typeof bodyObj === 'string' ? bodyObj : JSON.stringify(bodyObj);
 
   return new Request('http://localhost/api/auth/magic-link/send', {
     method: 'POST',
@@ -233,6 +241,48 @@ describe('POST /api/auth/magic-link/send', () => {
     });
   });
 
+  describe('ToS acceptance gate', () => {
+    it('returns 400 tos_required when tosAccepted is false (server-side defense; never call the pipe)', async () => {
+      const request = createMagicLinkRequest({
+        email: 'test@example.com',
+        tosAccepted: false,
+      });
+      const response = await POST(request);
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body).toEqual({
+        code: 'tos_required',
+        error: 'Terms of Service must be accepted',
+      });
+      expect(pipeInner).not.toHaveBeenCalled();
+      expect(auditRequest).toHaveBeenCalledWith(
+        request,
+        expect.objectContaining({
+          eventType: 'security.suspicious.activity',
+          details: expect.objectContaining({ reason: 'magic_link_tos_not_accepted' }),
+        }),
+      );
+    });
+
+    it('returns 400 (zod schema) when tosAccepted is omitted entirely from the body', async () => {
+      // Bypass the helper's auto-add by passing a JSON string directly.
+      const request = new Request('http://localhost/api/auth/magic-link/send', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Login-CSRF-Token': 'valid-csrf-token',
+          'Cookie': 'login_csrf=valid-csrf-token',
+        },
+        body: JSON.stringify({ email: 'test@example.com' }),
+      });
+
+      const response = await POST(request);
+      expect(response.status).toBe(400);
+      expect(pipeInner).not.toHaveBeenCalled();
+    });
+  });
+
   describe('rate limiting', () => {
     it('returns 429 when IP rate limit exceeded', async () => {
       vi.mocked(checkDistributedRateLimit)
@@ -332,21 +382,22 @@ describe('POST /api/auth/magic-link/send', () => {
       );
     });
 
-    it('given the pipe returns NO_ACCOUNT_FOUND, returns 404 + the structured no_account payload (signup CTA)', async () => {
-      pipeInner.mockResolvedValue({ ok: false, error: 'NO_ACCOUNT_FOUND' });
+    it('given the pipe is invoked for an unknown email + tosAccepted=true, returns 200 (auto-create path lives inside the pipe; the route just sees ok)', async () => {
+      pipeInner.mockResolvedValue({ ok: true });
 
-      const request = createMagicLinkRequest({ email: 'unknown@example.com' });
+      const request = createMagicLinkRequest({
+        email: 'unknown@example.com',
+        tosAccepted: true,
+      });
       const response = await POST(request);
       const body = await response.json();
 
-      expect(response.status).toBe(404);
-      expect(body).toEqual({ code: 'no_account', email: 'unknown@example.com' });
-      expect(auditRequest).toHaveBeenCalledWith(
-        request,
+      expect(response.status).toBe(200);
+      expect(body.message).toContain('If an account exists');
+      expect(pipeInner).toHaveBeenCalledWith(
         expect.objectContaining({
-          eventType: 'auth.login.failure',
-          details: expect.objectContaining({ reason: 'magic_link_no_account_found' }),
-          riskScore: 0.2,
+          email: 'unknown@example.com',
+          tosAccepted: true,
         }),
       );
     });

--- a/apps/web/src/app/api/auth/magic-link/send/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/send/route.ts
@@ -19,6 +19,7 @@ const sendMagicLinkSchema = z.object({
   deviceId: z.string().optional(),
   deviceName: z.string().optional(),
   next: z.string().min(1).max(2048).optional(),
+  tosAccepted: z.boolean(),
 }).refine(
   (data) => data.platform !== 'desktop' || (data.deviceId && data.deviceName),
   { message: 'deviceId and deviceName are required for desktop platform' }
@@ -101,8 +102,24 @@ export async function POST(req: Request) {
       );
     }
 
-    const { email, platform, deviceId, deviceName, next } = validation.data;
+    const { email, platform, deviceId, deviceName, next, tosAccepted } = validation.data;
     const normalizedEmail = email.toLowerCase().trim();
+
+    // Defense in depth: the form's submit button is gated on the checkbox,
+    // but a tampered POST body must not bypass affirmative consent. Without
+    // tosAccepted we won't auto-create, and refusing here keeps the failure
+    // mode loud + auditable instead of silently sending a link.
+    if (tosAccepted !== true) {
+      auditRequest(req, {
+        eventType: 'security.suspicious.activity',
+        riskScore: 0.3,
+        details: { reason: 'magic_link_tos_not_accepted' },
+      });
+      return Response.json(
+        { code: 'tos_required', error: 'Terms of Service must be accepted' },
+        { status: 400 },
+      );
+    }
 
     // Re-validate next against the same allowlist the signin page uses. Defense
     // in depth: form already validated, but never trust the client across a
@@ -162,14 +179,16 @@ export async function POST(req: Request) {
       );
     }
 
-    // requestMagicLink pipe owns the full flow: load user → validate (no-auto-
-    // create / not-suspended) → mint token → send email. On any failure mode
-    // the pipe never minted a token nor sent an email.
+    // requestMagicLink pipe owns the full flow: load user → auto-create on
+    // unknown email (gated on tosAccepted) → mint token → send email. Magic-
+    // link is a unified signin/signup flow: the click on the link in the
+    // inbox proves email control and the ToS checkbox supplies legal consent.
     let result;
     try {
       result = await requestMagicLink(buildMagicLinkPorts())({
         email: normalizedEmail,
         now: new Date(),
+        tosAccepted,
         ...(platform && { platform }),
         ...(deviceId && { deviceId }),
         ...(deviceName && { deviceName }),
@@ -201,26 +220,10 @@ export async function POST(req: Request) {
         });
       }
 
-      // NO_ACCOUNT_FOUND is surfaced explicitly (trade enumeration-resistance
-      // for a clearer signup path). MagicLinkForm consumes the structured
-      // payload and renders the "Sign up instead" CTA pre-filled with the
-      // entered email.
-      if (result.error === 'NO_ACCOUNT_FOUND') {
-        auditRequest(req, {
-          eventType: 'auth.login.failure',
-          riskScore: 0.2,
-          details: { reason: 'magic_link_no_account_found' },
-        });
-        return Response.json(
-          { code: 'no_account', email: normalizedEmail },
-          { status: 404 },
-        );
-      }
-
-      // VALIDATION_FAILED from the pipe shouldn't reach here — we zod-
-      // validated upstream — but stay defensive. Wrap the string code in an
-      // Error so the entry.error structured field populates the same way the
-      // earlier error log on this handler does.
+      // TOS_REQUIRED from the pipe shouldn't reach here — the schema-level
+      // guard above already rejected tosAccepted=false — but stay defensive.
+      // Surface as a generic 200 to keep enumeration resistance intact.
+      // VALIDATION_FAILED is similarly upstream-impossible.
       loggers.auth.error(
         'Magic link pipe returned unexpected error',
         new Error(`MagicLinkErrorCode: ${result.error}`),

--- a/apps/web/src/app/api/auth/magic-link/send/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/send/route.ts
@@ -179,10 +179,6 @@ export async function POST(req: Request) {
       );
     }
 
-    // requestMagicLink pipe owns the full flow: load user → auto-create on
-    // unknown email (gated on tosAccepted) → mint token → send email. Magic-
-    // link is a unified signin/signup flow: the click on the link in the
-    // inbox proves email control and the ToS checkbox supplies legal consent.
     let result;
     try {
       result = await requestMagicLink(buildMagicLinkPorts())({
@@ -220,10 +216,9 @@ export async function POST(req: Request) {
         });
       }
 
-      // TOS_REQUIRED from the pipe shouldn't reach here — the schema-level
-      // guard above already rejected tosAccepted=false — but stay defensive.
-      // Surface as a generic 200 to keep enumeration resistance intact.
-      // VALIDATION_FAILED is similarly upstream-impossible.
+      // TOS_REQUIRED and VALIDATION_FAILED are upstream-impossible (the schema
+      // and the explicit tosAccepted guard above catch them first); surface as
+      // a generic 200 to preserve enumeration resistance.
       loggers.auth.error(
         'Magic link pipe returned unexpected error',
         new Error(`MagicLinkErrorCode: ${result.error}`),

--- a/apps/web/src/app/auth/signup/SignUpClient.tsx
+++ b/apps/web/src/app/auth/signup/SignUpClient.tsx
@@ -148,12 +148,14 @@ export function SignUpClient({ inviteToken, inviteContext }: SignUpClientProps) 
         transition={{ delay: 0.45, duration: 0.3 }}
       >
         {showMagicLink ? (
-          <div className="mt-2">
+          <div id="magic-link-form" className="mt-2">
             <MagicLinkForm {...(magicLinkNextPath && { nextPath: magicLinkNextPath })} />
           </div>
         ) : (
           <button
             type="button"
+            aria-expanded={showMagicLink}
+            aria-controls="magic-link-form"
             className="flex w-full items-center justify-center gap-2 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
             onClick={() => setShowMagicLink(true)}
           >

--- a/apps/web/src/app/auth/signup/SignUpClient.tsx
+++ b/apps/web/src/app/auth/signup/SignUpClient.tsx
@@ -11,6 +11,7 @@ import {
   OAuthButtons,
   GoogleOneTap,
   PasskeySignupButton,
+  MagicLinkForm,
   ExternalAuthWaiting,
 } from '@/components/auth';
 import { useAuthCSRF } from '@/hooks/useAuthCSRF';
@@ -24,9 +25,15 @@ interface SignUpClientProps {
 
 export function SignUpClient({ inviteToken, inviteContext }: SignUpClientProps) {
   const [error, setError] = useState<string | null>(null);
+  const [showMagicLink, setShowMagicLink] = useState(false);
   const router = useRouter();
   const { csrfToken, refreshToken } = useAuthCSRF();
   const [passkeyLoading, setPasskeyLoading] = useState(false);
+  // Invited users coming through magic-link should land on the invite-accept
+  // route after verify so the existing acceptInviteForExistingUser pipe
+  // consumes the token. Non-invite signups go to /dashboard via the verify
+  // route's default redirect.
+  const magicLinkNextPath = inviteToken ? `/invite/${inviteToken}/accept` : undefined;
   const {
     handleGoogleSignIn,
     handleAppleSignIn,
@@ -135,18 +142,25 @@ export function SignUpClient({ inviteToken, inviteContext }: SignUpClientProps) 
       )}
 
       <motion.div
-        className="mt-4 text-center"
+        className="mt-4"
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ delay: 0.45, duration: 0.3 }}
       >
-        <Link
-          href="/auth/magic-link"
-          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
-        >
-          <Mail className="h-3.5 w-3.5" />
-          Or sign up with email link
-        </Link>
+        {showMagicLink ? (
+          <div className="mt-2">
+            <MagicLinkForm {...(magicLinkNextPath && { nextPath: magicLinkNextPath })} />
+          </div>
+        ) : (
+          <button
+            type="button"
+            className="flex w-full items-center justify-center gap-2 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+            onClick={() => setShowMagicLink(true)}
+          >
+            <Mail className="h-4 w-4" />
+            Or sign up with email link
+          </button>
+        )}
       </motion.div>
 
       <motion.div

--- a/apps/web/src/components/auth/MagicLinkForm.tsx
+++ b/apps/web/src/components/auth/MagicLinkForm.tsx
@@ -69,6 +69,14 @@ export function MagicLinkForm({ nextPath }: MagicLinkFormProps = {}) {
 
     if (formState === 'sending') return;
     if (cooldownSeconds > 0) return;
+    // Submit-time guard: the button is disabled until acceptedTos, but a
+    // programmatic / Enter-key submit could still fire. Refuse to send a
+    // payload that would record consent without an actual checkbox tick.
+    if (!acceptedTos) {
+      setFormState('error');
+      setError('Please accept the Terms and Privacy Policy to continue.');
+      return;
+    }
 
     setFormState('sending');
     setError(null);
@@ -97,7 +105,7 @@ export function MagicLinkForm({ nextPath }: MagicLinkFormProps = {}) {
         credentials: 'include',
         body: JSON.stringify({
           email: email.trim(),
-          tosAccepted: true,
+          tosAccepted: acceptedTos,
           ...platformFields,
           ...(nextPath && { next: nextPath }),
         }),
@@ -137,7 +145,7 @@ export function MagicLinkForm({ nextPath }: MagicLinkFormProps = {}) {
       setFormState('error');
       setError('Network error. Please check your connection and try again.');
     }
-  }, [email, formState, cooldownSeconds, nextPath]);
+  }, [email, formState, cooldownSeconds, nextPath, acceptedTos]);
 
   const handleResend = useCallback(async () => {
     if (cooldownSeconds > 0) return;

--- a/apps/web/src/components/auth/MagicLinkForm.tsx
+++ b/apps/web/src/components/auth/MagicLinkForm.tsx
@@ -6,10 +6,11 @@ import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Mail, ArrowLeft, ArrowRight, Loader2, CheckCircle, UserPlus } from 'lucide-react';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Mail, ArrowLeft, Loader2, CheckCircle } from 'lucide-react';
 import { getDevicePlatformFields } from '@/lib/desktop-auth';
 
-type FormState = 'input' | 'sending' | 'sent' | 'error' | 'no-account';
+type FormState = 'input' | 'sending' | 'sent' | 'error';
 
 export interface MagicLinkFormProps {
   // Same-origin redirect target the user originally aimed at. Caller
@@ -21,6 +22,7 @@ export interface MagicLinkFormProps {
 export function MagicLinkForm({ nextPath }: MagicLinkFormProps = {}) {
   const formRef = useRef<HTMLFormElement>(null);
   const [email, setEmail] = useState('');
+  const [acceptedTos, setAcceptedTos] = useState(false);
   const [formState, setFormState] = useState<FormState>('input');
   const [error, setError] = useState<string | null>(null);
   const [cooldownSeconds, setCooldownSeconds] = useState(0);
@@ -95,6 +97,7 @@ export function MagicLinkForm({ nextPath }: MagicLinkFormProps = {}) {
         credentials: 'include',
         body: JSON.stringify({
           email: email.trim(),
+          tosAccepted: true,
           ...platformFields,
           ...(nextPath && { next: nextPath }),
         }),
@@ -116,14 +119,6 @@ export function MagicLinkForm({ nextPath }: MagicLinkFormProps = {}) {
         setFormState('error');
         setError(data.details || 'Security verification failed. Please refresh the page.');
         return;
-      }
-
-      if (response.status === 404) {
-        const data = (await response.json()) as { code?: string };
-        if (data.code === 'no_account') {
-          setFormState('no-account');
-          return;
-        }
       }
 
       if (!response.ok) {
@@ -159,46 +154,10 @@ export function MagicLinkForm({ nextPath }: MagicLinkFormProps = {}) {
     setFormState('input');
     setError(null);
     setEmail('');
+    setAcceptedTos(false);
     setCooldownSeconds(0);
     setRetryAfterSeconds(0);
   }, []);
-
-  // No-account state — surface NO_ACCOUNT_FOUND with a sign-up CTA. We
-  // deliberately disclose that no account exists for the entered email
-  // (trade enumeration-resistance for a clearer onboarding path).
-  if (formState === 'no-account') {
-    const signupParams = new URLSearchParams({ email });
-    if (nextPath) signupParams.set('next', nextPath);
-    const signupHref = `/auth/signup?${signupParams.toString()}`;
-    return (
-      <div className="space-y-4">
-        <div className="flex flex-col items-center gap-3 py-4">
-          <div className="rounded-full bg-blue-100 dark:bg-blue-900/30 p-3">
-            <UserPlus className="h-6 w-6 text-blue-600 dark:text-blue-400" />
-          </div>
-          <div className="text-center">
-            <h3 className="font-medium text-lg">No PageSpace account for that email</h3>
-            <p className="text-muted-foreground text-sm mt-1">
-              <span className="font-medium text-foreground">{email}</span> isn&apos;t signed up yet. Create an account to continue.
-            </p>
-          </div>
-        </div>
-
-        <div className="flex flex-col gap-2">
-          <Button asChild className="w-full">
-            <Link href={signupHref}>
-              Sign up
-              <ArrowRight className="ml-2 h-4 w-4" />
-            </Link>
-          </Button>
-          <Button type="button" variant="ghost" className="w-full" onClick={handleReset}>
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            Try a different email
-          </Button>
-        </div>
-      </div>
-    );
-  }
 
   // Sent state - show confirmation
   if (formState === 'sent') {
@@ -271,6 +230,30 @@ export function MagicLinkForm({ nextPath }: MagicLinkFormProps = {}) {
         </div>
       </div>
 
+      <div className="flex items-start gap-2">
+        <Checkbox
+          id="magic-link-tos"
+          checked={acceptedTos}
+          onCheckedChange={(checked) => setAcceptedTos(checked === true)}
+          disabled={formState === 'sending'}
+          className="mt-0.5"
+        />
+        <Label
+          htmlFor="magic-link-tos"
+          className="text-xs font-normal leading-snug text-muted-foreground"
+        >
+          I agree to PageSpace&apos;s{' '}
+          <Link href="/terms" className="underline hover:text-foreground">
+            Terms
+          </Link>
+          {' '}and{' '}
+          <Link href="/privacy" className="underline hover:text-foreground">
+            Privacy Policy
+          </Link>
+          .
+        </Label>
+      </div>
+
       {error && (
         <div className="text-sm text-red-500 dark:text-red-400">
           {error}
@@ -285,7 +268,7 @@ export function MagicLinkForm({ nextPath }: MagicLinkFormProps = {}) {
       <Button
         type="submit"
         className="w-full"
-        disabled={formState === 'sending' || retryAfterSeconds > 0}
+        disabled={formState === 'sending' || retryAfterSeconds > 0 || !acceptedTos}
       >
         {formState === 'sending' ? (
           <div className="flex items-center gap-2">

--- a/apps/web/src/components/auth/__tests__/MagicLinkForm.test.tsx
+++ b/apps/web/src/components/auth/__tests__/MagicLinkForm.test.tsx
@@ -1,15 +1,25 @@
 /**
- * Contract tests for MagicLinkForm next= forwarding.
+ * Contract tests for MagicLinkForm.
  *
- * The form is the source of truth for the user's intended destination at
- * the start of the round-trip. The signin page validates and supplies the
- * `nextPath` prop; the form forwards it verbatim into the POST body. The
- * send route re-validates — defense in depth, never trust across boundaries.
+ * The form is the unified signin/signup entry point: typing an email + ticking
+ * the ToS checkbox + clicking submit triggers a magic-link email. Auto-create
+ * for unknown emails happens server-side; the form's contract is just to
+ * collect (email, tosAccepted) and forward `next` from the signin page.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+
+// Radix UI Checkbox renders an indicator that calls into @radix-ui/react-use-size,
+// which constructs a ResizeObserver. jsdom doesn't implement it, so stub a no-op.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+(globalThis as { ResizeObserver?: typeof ResizeObserver }).ResizeObserver =
+  ResizeObserverStub as unknown as typeof ResizeObserver;
 
 vi.mock('sonner', () => ({
   toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
@@ -43,72 +53,76 @@ const setupFetchMock = () => {
   return fetchSpy;
 };
 
-describe('MagicLinkForm — next= forwarding', () => {
+describe('MagicLinkForm', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('given a nextPath prop, forwards it as `next` in the send-route POST body', async () => {
-    const fetchSpy = setupFetchMock();
-    render(<MagicLinkForm nextPath="/dashboard/drive_abc" />);
+  describe('ToS gate', () => {
+    it('disables the submit button until the ToS checkbox is ticked', async () => {
+      setupFetchMock();
+      render(<MagicLinkForm />);
 
-    await userEvent.type(screen.getByLabelText(/email/i), 'user@example.com');
-    await userEvent.click(screen.getByRole('button', { name: /sign-in link/i }));
+      await userEvent.type(screen.getByLabelText(/email/i), 'user@example.com');
+      const submit = screen.getByRole('button', { name: /sign-in link/i });
+      expect(submit).toBeDisabled();
 
-    const sendCall = fetchSpy.mock.calls.find(([url]) =>
-      typeof url === 'string' && url.includes('/api/auth/magic-link/send'),
-    );
-    expect(sendCall).toBeDefined();
-    const init = sendCall![1] as RequestInit;
-    const body = JSON.parse(init.body as string) as Record<string, unknown>;
-    expect(body.next).toBe('/dashboard/drive_abc');
-    expect(body.email).toBe('user@example.com');
-  });
-
-  it('given no nextPath prop, omits `next` from the send-route POST body', async () => {
-    const fetchSpy = setupFetchMock();
-    render(<MagicLinkForm />);
-
-    await userEvent.type(screen.getByLabelText(/email/i), 'user@example.com');
-    await userEvent.click(screen.getByRole('button', { name: /sign-in link/i }));
-
-    const sendCall = fetchSpy.mock.calls.find(([url]) =>
-      typeof url === 'string' && url.includes('/api/auth/magic-link/send'),
-    );
-    expect(sendCall).toBeDefined();
-    const init = sendCall![1] as RequestInit;
-    const body = JSON.parse(init.body as string) as Record<string, unknown>;
-    expect(body).not.toHaveProperty('next');
-  });
-
-  it('given a nextPath and a no-account response, preserves next on the signup CTA href', async () => {
-    const fetchSpy = vi.fn(async (url: string | URL | Request, _init?: RequestInit) => {
-      void _init;
-      const u = typeof url === 'string' ? url : url instanceof URL ? url.toString() : url.url;
-      if (u.includes('/api/auth/login-csrf')) {
-        return new Response(JSON.stringify({ csrfToken: 'csrf-token' }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        });
-      }
-      if (u.includes('/api/auth/magic-link/send')) {
-        return new Response(JSON.stringify({ code: 'no_account' }), {
-          status: 404,
-          headers: { 'Content-Type': 'application/json' },
-        });
-      }
-      throw new Error(`Unexpected fetch: ${u}`);
+      await userEvent.click(screen.getByLabelText(/i agree/i));
+      expect(submit).toBeEnabled();
     });
-    global.fetch = fetchSpy as unknown as typeof fetch;
 
-    render(<MagicLinkForm nextPath="/dashboard/drive_abc" />);
+    it('sends tosAccepted: true in the POST body once the checkbox is ticked', async () => {
+      const fetchSpy = setupFetchMock();
+      render(<MagicLinkForm />);
 
-    await userEvent.type(screen.getByLabelText(/email/i), 'unknown@example.com');
-    await userEvent.click(screen.getByRole('button', { name: /sign-in link/i }));
+      await userEvent.type(screen.getByLabelText(/email/i), 'user@example.com');
+      await userEvent.click(screen.getByLabelText(/i agree/i));
+      await userEvent.click(screen.getByRole('button', { name: /sign-in link/i }));
 
-    const signupLink = await screen.findByRole('link', { name: /sign up/i });
-    const href = signupLink.getAttribute('href');
-    expect(href).toContain('email=unknown%40example.com');
-    expect(href).toContain('next=%2Fdashboard%2Fdrive_abc');
+      const sendCall = fetchSpy.mock.calls.find(([url]) =>
+        typeof url === 'string' && url.includes('/api/auth/magic-link/send'),
+      );
+      expect(sendCall).toBeDefined();
+      const body = JSON.parse((sendCall![1] as RequestInit).body as string) as Record<string, unknown>;
+      expect(body.tosAccepted).toBe(true);
+      expect(body.email).toBe('user@example.com');
+    });
+  });
+
+  describe('next= forwarding', () => {
+    it('given a nextPath prop, forwards it as `next` in the send-route POST body', async () => {
+      const fetchSpy = setupFetchMock();
+      render(<MagicLinkForm nextPath="/dashboard/drive_abc" />);
+
+      await userEvent.type(screen.getByLabelText(/email/i), 'user@example.com');
+      await userEvent.click(screen.getByLabelText(/i agree/i));
+      await userEvent.click(screen.getByRole('button', { name: /sign-in link/i }));
+
+      const sendCall = fetchSpy.mock.calls.find(([url]) =>
+        typeof url === 'string' && url.includes('/api/auth/magic-link/send'),
+      );
+      expect(sendCall).toBeDefined();
+      const init = sendCall![1] as RequestInit;
+      const body = JSON.parse(init.body as string) as Record<string, unknown>;
+      expect(body.next).toBe('/dashboard/drive_abc');
+      expect(body.email).toBe('user@example.com');
+    });
+
+    it('given no nextPath prop, omits `next` from the send-route POST body', async () => {
+      const fetchSpy = setupFetchMock();
+      render(<MagicLinkForm />);
+
+      await userEvent.type(screen.getByLabelText(/email/i), 'user@example.com');
+      await userEvent.click(screen.getByLabelText(/i agree/i));
+      await userEvent.click(screen.getByRole('button', { name: /sign-in link/i }));
+
+      const sendCall = fetchSpy.mock.calls.find(([url]) =>
+        typeof url === 'string' && url.includes('/api/auth/magic-link/send'),
+      );
+      expect(sendCall).toBeDefined();
+      const init = sendCall![1] as RequestInit;
+      const body = JSON.parse(init.body as string) as Record<string, unknown>;
+      expect(body).not.toHaveProperty('next');
+    });
   });
 });

--- a/apps/web/src/components/auth/__tests__/MagicLinkForm.test.tsx
+++ b/apps/web/src/components/auth/__tests__/MagicLinkForm.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 // Radix UI Checkbox renders an indicator that calls into @radix-ui/react-use-size,
@@ -86,6 +86,31 @@ describe('MagicLinkForm', () => {
       const body = JSON.parse((sendCall![1] as RequestInit).body as string) as Record<string, unknown>;
       expect(body.tosAccepted).toBe(true);
       expect(body.email).toBe('user@example.com');
+    });
+
+    it('refuses to POST if a programmatic submit fires while the checkbox is unchecked (defense-in-depth: payload binds to state, not literal true)', async () => {
+      const fetchSpy = setupFetchMock();
+      render(<MagicLinkForm />);
+
+      // Type a valid email but DO NOT tick the ToS checkbox.
+      const input = screen.getByLabelText(/email/i) as HTMLInputElement;
+      await userEvent.type(input, 'user@example.com');
+
+      // Bypass the disabled submit button by triggering a programmatic submit
+      // on the form element itself (simulates Enter / scripted submit).
+      const form = input.closest('form')!;
+      await act(async () => {
+        form.dispatchEvent(new Event('submit', { cancelable: true, bubbles: true }));
+      });
+
+      // The handler must short-circuit BEFORE the send-route POST is issued.
+      // waitFor lets any queued promise microtasks settle without flake.
+      await waitFor(() => {
+        const sendCalls = fetchSpy.mock.calls.filter(([url]) =>
+          typeof url === 'string' && url.includes('/api/auth/magic-link/send'),
+        );
+        expect(sendCalls).toHaveLength(0);
+      });
     });
   });
 

--- a/apps/web/src/lib/auth/__tests__/magic-link-adapters.test.ts
+++ b/apps/web/src/lib/auth/__tests__/magic-link-adapters.test.ts
@@ -162,9 +162,10 @@ describe('buildMagicLinkPorts.createUserAccount', () => {
   });
 
   it('given a unique-constraint race (concurrent magic-link request landed first), re-loads the surviving id and returns it', async () => {
-    returningMock.mockRejectedValueOnce(
-      new Error('duplicate key value violates unique constraint "users_email_unique"'),
-    );
+    // SQLSTATE 23505 (unique_violation) — the standard Postgres code carried
+    // through node-postgres and Drizzle. Detection is by code, not message.
+    const pgUniqueViolation = Object.assign(new Error('duplicate key value violates unique constraint "users_email_unique"'), { code: '23505' });
+    returningMock.mockRejectedValueOnce(pgUniqueViolation);
     selectWhereMock.mockResolvedValueOnce([{ id: 'user_existing_456' }]);
 
     const ports = buildMagicLinkPorts();
@@ -177,7 +178,7 @@ describe('buildMagicLinkPorts.createUserAccount', () => {
     expect(dbSelectMock).toHaveBeenCalledOnce();
   });
 
-  it('given a non-constraint error, propagates it (caller sees the failure rather than a silent no-op)', async () => {
+  it('given a non-constraint error (no 23505 code), propagates it without attempting the post-race re-load', async () => {
     const dbDown = new Error('connection refused');
     returningMock.mockRejectedValueOnce(dbDown);
 
@@ -188,8 +189,22 @@ describe('buildMagicLinkPorts.createUserAccount', () => {
     expect(dbSelectMock).not.toHaveBeenCalled();
   });
 
-  it('given a constraint error but the post-race lookup finds no row (storage anomaly), rethrows the original error', async () => {
-    const constraintErr = new Error('unique constraint violation');
+  it('given an error whose message looks like a unique violation but lacks code 23505, propagates it (no string-match false-positive)', async () => {
+    // Defensive: a stale/test error whose message contains "unique constraint"
+    // but isn't a real pg unique-violation must NOT trigger the race-recovery
+    // path — that would mask real bugs.
+    const fakey = new Error('something something unique constraint blah');
+    returningMock.mockRejectedValueOnce(fakey);
+
+    const ports = buildMagicLinkPorts();
+    await expect(
+      ports.createUserAccount({ email: 'u@example.com', tosAcceptedAt: new Date() }),
+    ).rejects.toThrow(fakey);
+    expect(dbSelectMock).not.toHaveBeenCalled();
+  });
+
+  it('given code 23505 but the post-race lookup finds no row (storage anomaly), rethrows the original error', async () => {
+    const constraintErr = Object.assign(new Error('unique violation'), { code: '23505' });
     returningMock.mockRejectedValueOnce(constraintErr);
     selectWhereMock.mockResolvedValueOnce([]);
 

--- a/apps/web/src/lib/auth/__tests__/magic-link-adapters.test.ts
+++ b/apps/web/src/lib/auth/__tests__/magic-link-adapters.test.ts
@@ -16,9 +16,22 @@
 
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 
-const { sendEmailMock } = vi.hoisted(() => ({
-  sendEmailMock: vi.fn().mockResolvedValue(undefined),
-}));
+const { sendEmailMock, dbInsertMock, dbSelectMock, returningMock, selectWhereMock } =
+  vi.hoisted(() => {
+    const returning = vi.fn();
+    const insertValues = vi.fn(() => ({ returning }));
+    const insert = vi.fn(() => ({ values: insertValues }));
+    const where = vi.fn();
+    const from = vi.fn(() => ({ where }));
+    const select = vi.fn(() => ({ from }));
+    return {
+      sendEmailMock: vi.fn().mockResolvedValue(undefined),
+      dbInsertMock: insert,
+      dbSelectMock: select,
+      returningMock: returning,
+      selectWhereMock: where,
+    };
+  });
 
 vi.mock('@pagespace/lib/services/email-service', () => ({
   sendEmail: sendEmailMock,
@@ -29,11 +42,16 @@ vi.mock('@pagespace/lib/email-templates/MagicLinkEmail', () => ({
 }));
 
 vi.mock('@pagespace/db/db', () => ({
-  db: { insert: vi.fn(() => ({ values: vi.fn().mockResolvedValue(undefined) })) },
+  db: { insert: dbInsertMock, select: dbSelectMock },
 }));
 
 vi.mock('@pagespace/db/schema/auth', () => ({
   verificationTokens: {},
+  users: { id: 'users.id', email: 'users.email' },
+}));
+
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((col: unknown, val: unknown) => ({ col, val })),
 }));
 
 vi.mock('@pagespace/lib/auth/token-utils', () => ({
@@ -107,5 +125,91 @@ describe('buildMagicLinkPorts.sendMagicLinkEmail', () => {
     const url = args.react.props.magicLinkUrl;
     expect(url).toContain('token=tok');
     expect(url).toContain('next=%2Fdashboard%3Fwelcome%3D1%23top');
+  });
+});
+
+describe('buildMagicLinkPorts.createUserAccount', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('given a fresh email, inserts a users row with tosAcceptedAt and returns the new id', async () => {
+    returningMock.mockResolvedValueOnce([{ id: 'user_new_123' }]);
+    const tosAcceptedAt = new Date('2026-05-07T22:00:00.000Z');
+
+    const ports = buildMagicLinkPorts();
+    const result = await ports.createUserAccount({
+      email: 'fresh@example.com',
+      tosAcceptedAt,
+    });
+
+    expect(result).toEqual({ id: 'user_new_123' });
+    expect(dbInsertMock).toHaveBeenCalledOnce();
+
+    const valuesCall = dbInsertMock.mock.results[0].value.values as ReturnType<typeof vi.fn>;
+    expect(valuesCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'fresh@example.com',
+        provider: 'email',
+        role: 'user',
+        tokenVersion: 1,
+        tosAcceptedAt,
+        // Default name derives from the local part of the email so empty
+        // 'name' (which is notNull in the schema) never blocks creation.
+        name: 'fresh',
+      }),
+    );
+  });
+
+  it('given a unique-constraint race (concurrent magic-link request landed first), re-loads the surviving id and returns it', async () => {
+    returningMock.mockRejectedValueOnce(
+      new Error('duplicate key value violates unique constraint "users_email_unique"'),
+    );
+    selectWhereMock.mockResolvedValueOnce([{ id: 'user_existing_456' }]);
+
+    const ports = buildMagicLinkPorts();
+    const result = await ports.createUserAccount({
+      email: 'racey@example.com',
+      tosAcceptedAt: new Date(),
+    });
+
+    expect(result).toEqual({ id: 'user_existing_456' });
+    expect(dbSelectMock).toHaveBeenCalledOnce();
+  });
+
+  it('given a non-constraint error, propagates it (caller sees the failure rather than a silent no-op)', async () => {
+    const dbDown = new Error('connection refused');
+    returningMock.mockRejectedValueOnce(dbDown);
+
+    const ports = buildMagicLinkPorts();
+    await expect(
+      ports.createUserAccount({ email: 'u@example.com', tosAcceptedAt: new Date() }),
+    ).rejects.toThrow(/connection refused/);
+    expect(dbSelectMock).not.toHaveBeenCalled();
+  });
+
+  it('given a constraint error but the post-race lookup finds no row (storage anomaly), rethrows the original error', async () => {
+    const constraintErr = new Error('unique constraint violation');
+    returningMock.mockRejectedValueOnce(constraintErr);
+    selectWhereMock.mockResolvedValueOnce([]);
+
+    const ports = buildMagicLinkPorts();
+    await expect(
+      ports.createUserAccount({ email: 'u@example.com', tosAcceptedAt: new Date() }),
+    ).rejects.toThrow(constraintErr);
+  });
+
+  it('given an email with no local part (defensive — schema rejects upstream, but adapter must not crash), falls back to a non-empty name', async () => {
+    returningMock.mockResolvedValueOnce([{ id: 'user_x' }]);
+
+    const ports = buildMagicLinkPorts();
+    await ports.createUserAccount({
+      email: '@example.com',
+      tosAcceptedAt: new Date(),
+    });
+
+    const valuesCall = dbInsertMock.mock.results[0].value.values as ReturnType<typeof vi.fn>;
+    const inserted = valuesCall.mock.calls[0][0] as { name: string };
+    expect(inserted.name).toBeTruthy();
   });
 });

--- a/apps/web/src/lib/auth/magic-link-adapters.ts
+++ b/apps/web/src/lib/auth/magic-link-adapters.ts
@@ -10,9 +10,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import type { MagicLinkPorts } from '@pagespace/lib/services/invites';
 import { driveInviteRepository } from '@/lib/repositories/drive-invite-repository';
 
-// Postgres SQLSTATE 23505 (unique_violation). Mirrors the inline pattern used
-// in reactions/route.ts and drive-invite-repository.ts; matches the helper in
-// google-calendar/sync-service.ts.
+// Postgres SQLSTATE 23505 (unique_violation).
 const isUniqueConstraintError = (err: unknown): boolean =>
   err instanceof Error && 'code' in err && (err as { code: string }).code === '23505';
 
@@ -42,12 +40,10 @@ export const buildMagicLinkPorts = (): MagicLinkPorts => ({
         .returning({ id: users.id });
       return { id: created.id };
     } catch (error: unknown) {
-      // Concurrent magic-link request for the same email won the insert race.
-      // Re-load and return the surviving id. The losing pipe path still mints
+      // Concurrent magic-link request for the same email won the insert race;
+      // re-load and return the surviving id. The losing pipe path still mints
       // a token + sends an email, which is correct — the email is what we
-      // wanted to send anyway. Detect the race via Postgres SQLSTATE 23505
-      // (unique_violation) — message-string matching is brittle across pg
-      // driver/version upgrades.
+      // wanted to send anyway.
       if (!isUniqueConstraintError(error)) throw error;
 
       const [existing] = await db

--- a/apps/web/src/lib/auth/magic-link-adapters.ts
+++ b/apps/web/src/lib/auth/magic-link-adapters.ts
@@ -17,11 +17,16 @@ export const buildMagicLinkPorts = (): MagicLinkPorts => ({
   createUserAccount: async ({ email, tosAcceptedAt }) => {
     const id = createId();
     try {
+      // `name` is NOT NULL in the schema. Email zod-validates upstream so the
+      // local part is normally non-empty, but an empty local part would split
+      // to '' and `??` only catches null/undefined — fall back with `||` so a
+      // pathological email never produces a NOT NULL violation.
+      const localPart = email.split('@')[0];
       const [created] = await db
         .insert(users)
         .values({
           id,
-          name: email.split('@')[0] ?? 'New User',
+          name: localPart || 'New User',
           email,
           provider: 'email',
           role: 'user',

--- a/apps/web/src/lib/auth/magic-link-adapters.ts
+++ b/apps/web/src/lib/auth/magic-link-adapters.ts
@@ -10,6 +10,12 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import type { MagicLinkPorts } from '@pagespace/lib/services/invites';
 import { driveInviteRepository } from '@/lib/repositories/drive-invite-repository';
 
+// Postgres SQLSTATE 23505 (unique_violation). Mirrors the inline pattern used
+// in reactions/route.ts and drive-invite-repository.ts; matches the helper in
+// google-calendar/sync-service.ts.
+const isUniqueConstraintError = (err: unknown): boolean =>
+  err instanceof Error && 'code' in err && (err as { code: string }).code === '23505';
+
 export const buildMagicLinkPorts = (): MagicLinkPorts => ({
   loadUserByEmail: async ({ email }) =>
     driveInviteRepository.loadUserAccountByEmail(email),
@@ -39,13 +45,10 @@ export const buildMagicLinkPorts = (): MagicLinkPorts => ({
       // Concurrent magic-link request for the same email won the insert race.
       // Re-load and return the surviving id. The losing pipe path still mints
       // a token + sends an email, which is correct — the email is what we
-      // wanted to send anyway.
-      const isConstraintViolation =
-        error instanceof Error &&
-        (error.message.includes('unique constraint') ||
-          error.message.includes('duplicate key') ||
-          error.message.includes('UNIQUE constraint'));
-      if (!isConstraintViolation) throw error;
+      // wanted to send anyway. Detect the race via Postgres SQLSTATE 23505
+      // (unique_violation) — message-string matching is brittle across pg
+      // driver/version upgrades.
+      if (!isUniqueConstraintError(error)) throw error;
 
       const [existing] = await db
         .select({ id: users.id })

--- a/apps/web/src/lib/auth/magic-link-adapters.ts
+++ b/apps/web/src/lib/auth/magic-link-adapters.ts
@@ -1,7 +1,8 @@
 import { createId } from '@paralleldrive/cuid2';
 import React from 'react';
 import { db } from '@pagespace/db/db';
-import { verificationTokens } from '@pagespace/db/schema/auth';
+import { eq } from '@pagespace/db/operators';
+import { users, verificationTokens } from '@pagespace/db/schema/auth';
 import { generateToken } from '@pagespace/lib/auth/token-utils';
 import { sendEmail } from '@pagespace/lib/services/email-service';
 import { MagicLinkEmail } from '@pagespace/lib/email-templates/MagicLinkEmail';
@@ -12,6 +13,43 @@ import { driveInviteRepository } from '@/lib/repositories/drive-invite-repositor
 export const buildMagicLinkPorts = (): MagicLinkPorts => ({
   loadUserByEmail: async ({ email }) =>
     driveInviteRepository.loadUserAccountByEmail(email),
+
+  createUserAccount: async ({ email, tosAcceptedAt }) => {
+    const id = createId();
+    try {
+      const [created] = await db
+        .insert(users)
+        .values({
+          id,
+          name: email.split('@')[0] ?? 'New User',
+          email,
+          provider: 'email',
+          role: 'user',
+          tokenVersion: 1,
+          tosAcceptedAt,
+        })
+        .returning({ id: users.id });
+      return { id: created.id };
+    } catch (error: unknown) {
+      // Concurrent magic-link request for the same email won the insert race.
+      // Re-load and return the surviving id. The losing pipe path still mints
+      // a token + sends an email, which is correct — the email is what we
+      // wanted to send anyway.
+      const isConstraintViolation =
+        error instanceof Error &&
+        (error.message.includes('unique constraint') ||
+          error.message.includes('duplicate key') ||
+          error.message.includes('UNIQUE constraint'));
+      if (!isConstraintViolation) throw error;
+
+      const [existing] = await db
+        .select({ id: users.id })
+        .from(users)
+        .where(eq(users.email, email));
+      if (!existing) throw error;
+      return { id: existing.id };
+    }
+  },
 
   createTokenAndPersist: async ({ userId, expiresAt, platform, deviceId, deviceName }) => {
     const { token, hash, tokenPrefix } = generateToken('ps_magic');

--- a/packages/lib/src/services/invites/__tests__/pipes.test.ts
+++ b/packages/lib/src/services/invites/__tests__/pipes.test.ts
@@ -383,6 +383,7 @@ const baseMagicLinkInput = (
   email: 'user@example.com',
   now: new Date('2026-05-06T12:00:00.000Z'),
   expiryMinutes: 5,
+  tosAccepted: true,
   ...overrides,
 });
 
@@ -390,20 +391,54 @@ const buildMagicLinkPorts = (
   overrides: Partial<MagicLinkPorts> = {},
 ): MagicLinkPorts => ({
   loadUserByEmail: vi.fn().mockResolvedValue({ id: 'u_1', suspendedAt: null }),
+  createUserAccount: vi.fn().mockResolvedValue({ id: 'u_new' }),
   createTokenAndPersist: vi.fn().mockResolvedValue({ token: 'ps_magic_xyz' }),
   sendMagicLinkEmail: vi.fn().mockResolvedValue(undefined),
   ...overrides,
 });
 
 describe('requestMagicLink', () => {
-  it('given the email is unknown, should return NO_ACCOUNT_FOUND and never create a token or send email', async () => {
+  it('given an unknown email + tosAccepted, should auto-create the user, mint a token against the new id, and send the email', async () => {
     const ports = buildMagicLinkPorts({
       loadUserByEmail: vi.fn().mockResolvedValue(null),
     });
-    const result = await requestMagicLink(ports)(baseMagicLinkInput());
-    expect(result).toEqual({ ok: false, error: 'NO_ACCOUNT_FOUND' });
+    const now = new Date('2026-05-06T12:00:00.000Z');
+    const result = await requestMagicLink(ports)(
+      baseMagicLinkInput({ now, tosAccepted: true }),
+    );
+
+    expect(result).toEqual({ ok: true, data: undefined });
+    expect(ports.createUserAccount).toHaveBeenCalledOnce();
+    expect(ports.createUserAccount).toHaveBeenCalledWith({
+      email: 'user@example.com',
+      tosAcceptedAt: now,
+    });
+    expect(ports.createTokenAndPersist).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'u_new' }),
+    );
+    expect(ports.sendMagicLinkEmail).toHaveBeenCalledOnce();
+  });
+
+  it('given an unknown email + tosAccepted=false, should return TOS_REQUIRED and never create user/token/email', async () => {
+    const ports = buildMagicLinkPorts({
+      loadUserByEmail: vi.fn().mockResolvedValue(null),
+    });
+    const result = await requestMagicLink(ports)(
+      baseMagicLinkInput({ tosAccepted: false }),
+    );
+    expect(result).toEqual({ ok: false, error: 'TOS_REQUIRED' });
+    expect(ports.createUserAccount).not.toHaveBeenCalled();
     expect(ports.createTokenAndPersist).not.toHaveBeenCalled();
     expect(ports.sendMagicLinkEmail).not.toHaveBeenCalled();
+  });
+
+  it('given an existing user, should NOT call createUserAccount (tosAccepted is irrelevant for existing accounts)', async () => {
+    const ports = buildMagicLinkPorts();
+    await requestMagicLink(ports)(baseMagicLinkInput({ tosAccepted: true }));
+    expect(ports.createUserAccount).not.toHaveBeenCalled();
+    expect(ports.createTokenAndPersist).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'u_1' }),
+    );
   });
 
   it('given the user is suspended, should return ACCOUNT_SUSPENDED', async () => {
@@ -414,6 +449,7 @@ describe('requestMagicLink', () => {
     });
     const result = await requestMagicLink(ports)(baseMagicLinkInput());
     expect(result).toEqual({ ok: false, error: 'ACCOUNT_SUSPENDED' });
+    expect(ports.createUserAccount).not.toHaveBeenCalled();
     expect(ports.createTokenAndPersist).not.toHaveBeenCalled();
     expect(ports.sendMagicLinkEmail).not.toHaveBeenCalled();
   });

--- a/packages/lib/src/services/invites/__tests__/validators.test.ts
+++ b/packages/lib/src/services/invites/__tests__/validators.test.ts
@@ -90,10 +90,10 @@ describe('validateInviteForUser', () => {
 });
 
 describe('validateMagicLinkRequest', () => {
-  it('given user is null, should return NO_ACCOUNT_FOUND', () => {
+  it('given user is null (unknown email), should return ok with null data so the pipe can branch into auto-create', () => {
     expect(validateMagicLinkRequest({ user: null })).toEqual({
-      ok: false,
-      error: 'NO_ACCOUNT_FOUND',
+      ok: true,
+      data: null,
     });
   });
 

--- a/packages/lib/src/services/invites/pipes.ts
+++ b/packages/lib/src/services/invites/pipes.ts
@@ -141,11 +141,30 @@ export const requestMagicLink =
     const validated = validateMagicLinkRequest({ user });
     if (!validated.ok) return validated;
 
+    // Auto-create on unknown email is what makes magic-link a unified
+    // signin/signup flow. The click on the link in the inbox proves email
+    // control; the ToS checkbox at form-submit time is the legal consent.
+    // Together they're the full zero-trust chain — refuse to create the row
+    // without affirmative ToS acceptance.
+    let userId: string;
+    if (validated.data === null) {
+      if (!input.tosAccepted) {
+        return { ok: false, error: 'TOS_REQUIRED' };
+      }
+      const created = await ports.createUserAccount({
+        email: input.email,
+        tosAcceptedAt: input.now,
+      });
+      userId = created.id;
+    } else {
+      userId = validated.data.id;
+    }
+
     const expiryMinutes = input.expiryMinutes ?? MAGIC_LINK_EXPIRY_MINUTES;
     const expiresAt = new Date(input.now.getTime() + expiryMinutes * 60_000);
 
     const { token } = await ports.createTokenAndPersist({
-      userId: validated.data.id,
+      userId,
       expiresAt,
       ...(input.platform !== undefined && { platform: input.platform }),
       ...(input.deviceId !== undefined && { deviceId: input.deviceId }),

--- a/packages/lib/src/services/invites/ports.ts
+++ b/packages/lib/src/services/invites/ports.ts
@@ -49,6 +49,14 @@ export interface AcceptancePorts {
 
 export interface MagicLinkPorts {
   loadUserByEmail: (input: { email: string }) => Promise<UserAccount | null>;
+  // Creates a new user row when the typed email has no account. Adapter must
+  // handle unique-constraint races (two concurrent magic-link requests for
+  // the same email) by re-loading and returning the surviving id. Stores
+  // tosAcceptedAt to record affirmative consent at form-submit time.
+  createUserAccount: (input: {
+    email: string;
+    tosAcceptedAt: Date;
+  }) => Promise<{ id: string }>;
   createTokenAndPersist: (input: {
     userId: string;
     expiresAt: Date;

--- a/packages/lib/src/services/invites/types.ts
+++ b/packages/lib/src/services/invites/types.ts
@@ -75,10 +75,14 @@ export interface RequestMagicLinkInput {
   // have already validated against an allowlist; the pipe forwards verbatim
   // to the email-send port and never inspects it.
   next?: string;
+  // Affirmative ToS acceptance from the inline form. Required to auto-create
+  // the user when no account exists for `email`. Must be true for unknown
+  // emails or the pipe returns TOS_REQUIRED. Existing users are unaffected.
+  tosAccepted: boolean;
 }
 
 export type MagicLinkErrorCode =
-  | 'NO_ACCOUNT_FOUND'
+  | 'TOS_REQUIRED'
   | 'ACCOUNT_SUSPENDED'
   | 'VALIDATION_FAILED';
 

--- a/packages/lib/src/services/invites/validators.ts
+++ b/packages/lib/src/services/invites/validators.ts
@@ -44,11 +44,8 @@ export const validateMagicLinkRequest = ({
   user,
 }: {
   user: UserAccount | null;
-}): Result<UserAccount, MagicLinkErrorCode> => {
-  if (user === null) {
-    return { ok: false, error: 'NO_ACCOUNT_FOUND' };
-  }
-  if (isAccountSuspended({ suspendedAt: user.suspendedAt })) {
+}): Result<UserAccount | null, MagicLinkErrorCode> => {
+  if (user && isAccountSuspended({ suspendedAt: user.suspendedAt })) {
     return { ok: false, error: 'ACCOUNT_SUSPENDED' };
   }
   return { ok: true, data: user };


### PR DESCRIPTION
## Summary

- Magic-link is a unified signin/signup flow again. Typing an unknown email + ticking the inline ToS checkbox + clicking submit auto-creates the user with `tosAcceptedAt` set; the click on the link in the inbox proves email control.
- Reverts the existing-account-only kill from `a1d3577a8`. The original GDPR concern was narrower than the commit message framed: invite emails and magic-link emails were structurally indistinguishable, so a recipient couldn't tell whether a sign-in email was inviter-triggered or self-triggered. Templates and routes are now fully separated (invite → `/invite/<token>`, magic-link → `/api/auth/magic-link/verify`), so the consent question is settled by who triggered the email — auto-create is safe.
- `/auth/signup` gains the same inline magic-link dropdown the signin page already had, replacing the dead `Link href="/auth/magic-link"` (which 404'd).

## Behavior changes

- `POST /api/auth/magic-link/send` now requires `tosAccepted: boolean` in the body. 400 `tos_required` if absent or false (server-side defense, not just UI). Drops the 404 `no_account` branch.
- `requestMagicLink` pipe gains a `createUserAccount` port and an auto-create branch when the email is unknown and `tosAccepted=true`. Returns `TOS_REQUIRED` otherwise. `NO_ACCOUNT_FOUND` is removed from `MagicLinkErrorCode`.
- `MagicLinkForm` renders an inline ToS checkbox (mirrors `PasskeySignupButton`). The submit button is disabled until ticked AND the handler short-circuits on `!acceptedTos` (defense-in-depth — programmatic / Enter-key submit can't bypass the gate). The POST payload's `tosAccepted` is bound to the checkbox state, not literal `true`.
- Adapter detects unique-violation race via Postgres SQLSTATE `23505` (consistent with the existing inline pattern in `reactions/route.ts` and `drive-invite-repository.ts`, and the helper in `google-calendar/sync-service.ts`).
- Invited signups via magic-link thread `nextPath=/invite/<token>/accept` so the existing `acceptInviteForExistingUser` pipe consumes the token after verify (the auto-created user is now an existing user).
- Magic-link toggle on `/auth/signup` exposes its disclosure state via `aria-expanded` + `aria-controls`.

## Review feedback addressed (commit 56b78974)

| Reviewer | File | Concern | Fix |
|---|---|---|---|
| CodeRabbit (Major) / Codex (P2) | `MagicLinkForm.tsx` | Payload hardcoded `tosAccepted: true` regardless of checkbox; programmatic submit could record consent the user never gave | Bound payload to `acceptedTos` state; added `!acceptedTos` submit guard; added regression test that fires a synthetic submit while unchecked and asserts no POST is issued |
| CodeRabbit | `magic-link-adapters.ts` | Brittle `error.message.includes('unique constraint')` for race detection | Switched to `error.code === '23505'` (Postgres `unique_violation`); added regression test that string-only-match errors do NOT trigger the race-recovery path |
| CodeRabbit | `SignUpClient.tsx` | Disclosure toggle missing ARIA attributes for screen readers | Added `aria-expanded` + `aria-controls` to the button; matching `id` on the panel |
| CodeRabbit | `round-trip.test.ts` | Tamper-path test didn't assert /send response status | Captured `sendResp` and added `expect(sendResp.status).toBe(200)` before extracting the email URL |

## Test plan

- [x] `pnpm --filter @pagespace/lib test src/services/invites/__tests__/{pipes,validators}.test.ts src/auth/__tests__/magic-link-service.test.ts` — 79 tests pass
- [x] `pnpm --filter web test src/app/api/auth/magic-link/ src/components/auth/__tests__/MagicLinkForm.test.tsx src/lib/auth/__tests__/magic-link-adapters.test.ts` — 84 tests pass (includes the new consent-guard regression + 23505 regression)
- [x] `pnpm --filter @pagespace/lib typecheck && pnpm --filter web typecheck` — clean
- [x] `pnpm --filter @pagespace/lib lint && pnpm --filter web lint` — clean (one pre-existing unrelated warning in `QuickCreatePalette.tsx`)
- [ ] Manual: `/auth/signin` → unused email + ToS + submit → verify link → land on `/dashboard/<gettingStartedId>` with `users.tosAcceptedAt` and `emailVerified` set, Getting Started drive provisioned
- [ ] Manual: `/auth/signup` → "Or sign up with email link" → inline form drops down → same flow as above
- [ ] Manual invited signup: `/auth/signup?invite=<token>` → magic-link → after verify lands on `/dashboard/<inviteDriveId>?welcome=true`, `drive_members` row created, invite consumed
- [ ] Manual negative: tamper POST body to omit `tosAccepted` → server returns 400 `tos_required`

🤖 Generated with [Claude Code](https://claude.com/claude-code)