### PR TITLE
fix(dm): drop acceptedAt gate for drive co-member surfacing

### DIFF
--- a/apps/web/src/app/api/__tests__/drive-member-gate-coverage.test.ts
+++ b/apps/web/src/app/api/__tests__/drive-member-gate-coverage.test.ts
@@ -46,6 +46,10 @@ const ACCEPTED_AT_GATE_EXEMPT = new Map<string, string>([
     'channels/[pageId]/messages',
     'Followup #4: pending admins should not receive @mention broadcast — tracked in followup-4.',
   ],
+  [
+    'users/messageable',
+    'DM-eligibility surfacing intentionally drops the gate so co-members whose driveMembers.acceptedAt is NULL (legacy rows missed by migrate-pending-invites, or transient invite states) still appear in the New Conversation picker. DM eligibility is softer than drive access; the gate is preserved everywhere a NULL row could exercise authority (page reads, member listings, broadcasts).',
+  ],
 ]);
 
 /**

--- a/apps/web/src/app/api/users/messageable/route.ts
+++ b/apps/web/src/app/api/users/messageable/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { db } from '@pagespace/db/db';
-import { eq, and, or, ne, isNotNull, inArray } from '@pagespace/db/operators';
+import { eq, and, or, ne, inArray } from '@pagespace/db/operators';
 import { users } from '@pagespace/db/schema/auth';
 import { driveMembers, userProfiles } from '@pagespace/db/schema/members';
 import { drives } from '@pagespace/db/schema/core';
@@ -47,15 +47,15 @@ export async function GET(request: Request) {
       .from(drives)
       .where(eq(drives.ownerId, userId));
 
+    // Note: no acceptedAt gate. DM eligibility is intentionally softer than
+    // drive-access checks elsewhere in the permissions layer; a co-member with
+    // a `driveMembers` row predating the new invite flow (or otherwise missing
+    // acceptedAt) should still appear in the picker rather than be silently
+    // hidden.
     const memberDrives = await db
       .select({ driveId: driveMembers.driveId })
       .from(driveMembers)
-      .where(
-        and(
-          eq(driveMembers.userId, userId),
-          isNotNull(driveMembers.acceptedAt)
-        )
-      );
+      .where(eq(driveMembers.userId, userId));
 
     const myDriveIds = Array.from(
       new Set<string>([
@@ -77,8 +77,7 @@ export async function GET(request: Request) {
         .where(
           and(
             inArray(driveMembers.driveId, myDriveIds),
-            ne(driveMembers.userId, userId),
-            isNotNull(driveMembers.acceptedAt)
+            ne(driveMembers.userId, userId)
           )
         );
 

--- a/apps/web/src/components/inbox/DMCenterList.tsx
+++ b/apps/web/src/components/inbox/DMCenterList.tsx
@@ -117,7 +117,7 @@ export default function DMCenterList() {
             </div>
             <div>
               <h1 className="text-xl font-semibold">Direct Messages</h1>
-              <p className="text-sm text-muted-foreground">Conversations with your connections</p>
+              <p className="text-sm text-muted-foreground">Direct messages with your connections and drive co-members</p>
             </div>
           </div>
           <Button asChild size="sm">

--- a/packages/lib/src/permissions/__tests__/users-share-drive.test.ts
+++ b/packages/lib/src/permissions/__tests__/users-share-drive.test.ts
@@ -79,7 +79,7 @@ describe('usersShareDrive', () => {
     expect(db.select).not.toHaveBeenCalled();
   });
 
-  it('returns false when user A has neither owned nor accepted-member drives', async () => {
+  it('returns false when user A has neither owned nor any-member drives', async () => {
     vi.mocked(db.select)
       .mockReturnValueOnce(stubFromWhere([])) // owned by A
       .mockReturnValueOnce(stubFromWhere([])); // member rows for A
@@ -88,17 +88,17 @@ describe('usersShareDrive', () => {
     expect(db.select).toHaveBeenCalledTimes(2);
   });
 
-  it('returns true when both users are accepted members of the same drive', async () => {
+  it('returns true when both users are members of the same drive', async () => {
     vi.mocked(db.select)
       .mockReturnValueOnce(stubFromWhere([])) // A owns nothing
       .mockReturnValueOnce(stubFromWhere([{ driveId: 'drive_1' }])) // A is member
       .mockReturnValueOnce(stubFromWhereLimit([])) // B does not own a drive in A's set
-      .mockReturnValueOnce(stubFromWhereLimit([{ id: 'mem_b' }])); // B is accepted member
+      .mockReturnValueOnce(stubFromWhereLimit([{ id: 'mem_b' }])); // B is member
 
     expect(await usersShareDrive(A, B)).toBe(true);
   });
 
-  it('returns true when A owns a drive that B is an accepted member of', async () => {
+  it('returns true when A owns a drive that B is a member of', async () => {
     vi.mocked(db.select)
       .mockReturnValueOnce(stubFromWhere([{ id: 'drive_1' }])) // A owns drive_1
       .mockReturnValueOnce(stubFromWhere([])) // A has no member rows
@@ -108,11 +108,24 @@ describe('usersShareDrive', () => {
     expect(await usersShareDrive(A, B)).toBe(true);
   });
 
-  it('returns true when B owns a drive that A is an accepted member of', async () => {
+  it('returns true when B owns a drive that A is a member of', async () => {
     vi.mocked(db.select)
       .mockReturnValueOnce(stubFromWhere([])) // A owns nothing
       .mockReturnValueOnce(stubFromWhere([{ driveId: 'drive_1' }])) // A is member of drive_1
       .mockReturnValueOnce(stubFromWhereLimit([{ id: 'drive_1' }])); // B is owner of drive_1 — short-circuits
+
+    expect(await usersShareDrive(A, B)).toBe(true);
+  });
+
+  it('returns true even when membership rows lack acceptedAt (legacy data)', async () => {
+    // Defensive: a driveMembers row whose acceptedAt is NULL (e.g., a legacy
+    // pending row not yet cleaned up by migrate-pending-invites) still counts
+    // as drive co-membership for DM purposes.
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubFromWhere([])) // A owns nothing
+      .mockReturnValueOnce(stubFromWhere([{ driveId: 'drive_1' }])) // A row exists, acceptedAt may be NULL
+      .mockReturnValueOnce(stubFromWhereLimit([])) // B not owner
+      .mockReturnValueOnce(stubFromWhereLimit([{ id: 'mem_b' }])); // B row exists, acceptedAt may be NULL
 
     expect(await usersShareDrive(A, B)).toBe(true);
   });

--- a/packages/lib/src/permissions/permissions.ts
+++ b/packages/lib/src/permissions/permissions.ts
@@ -658,10 +658,14 @@ export async function getUserDrivePermissions(
 
 /**
  * Check whether two users share at least one drive, where "share" means each
- * is either the drive owner (`drives.ownerId`) or an accepted drive member
- * (`drive_members` with `acceptedAt IS NOT NULL`). Page-level collaborators
- * (page_permissions only) do NOT count — matches the drive-membership boundary
- * used by `getUserDrivePermissions`.
+ * is either the drive owner (`drives.ownerId`) or has a `drive_members` row
+ * for that drive. Unlike `getUserDriveAccess` and `isUserDriveMember`, the
+ * `acceptedAt IS NOT NULL` gate is *not* applied here — DM eligibility is a
+ * softer permission than drive access, and surfacing co-members whose
+ * acceptance state is in flux (or whose row predates the post-rebuild
+ * `migrate-pending-invites` cleanup) is preferable to silently hiding them
+ * from the picker. Page-level collaborators (page_permissions only) still
+ * do NOT count.
  *
  * Used to gate DM eligibility: drive co-members can DM each other without
  * needing a connections-level relationship.
@@ -686,12 +690,7 @@ export async function usersShareDrive(
     const aMember = await db
       .select({ driveId: driveMembers.driveId })
       .from(driveMembers)
-      .where(
-        and(
-          eq(driveMembers.userId, userIdA),
-          isNotNull(driveMembers.acceptedAt)
-        )
-      );
+      .where(eq(driveMembers.userId, userIdA));
     for (const m of aMember) aDriveIds.add(m.driveId);
 
     if (aDriveIds.size === 0) return false;
@@ -710,8 +709,7 @@ export async function usersShareDrive(
       .where(
         and(
           inArray(driveMembers.driveId, aIds),
-          eq(driveMembers.userId, userIdB),
-          isNotNull(driveMembers.acceptedAt)
+          eq(driveMembers.userId, userIdB)
         )
       )
       .limit(1);


### PR DESCRIPTION
Follow-up to #1276. The merged change made drive co-membership a sufficient condition for DM eligibility, but both `usersShareDrive` (`packages/lib/src/permissions/permissions.ts`) and `/api/users/messageable` required `driveMembers.acceptedAt IS NOT NULL` — the same gate `getUserDriveAccess` uses for actual drive *access*. Any `drive_members` row whose `acceptedAt` happened to be NULL (legacy rows that slipped past `migrate-pending-invites`, or a future write-path bug) was silently hidden, so users reported drive co-members missing from the New Conversation picker.

## Summary
- **`usersShareDrive`** (`packages/lib/src/permissions/permissions.ts`): drop `isNotNull(acceptedAt)` from both A's and B's member checks. Owner detection via `drives.ownerId` is unchanged. Updated docstring explains the rationale (DM eligibility is intentionally softer than drive access).
- **`/api/users/messageable`** (`apps/web/src/app/api/users/messageable/route.ts`): drop `isNotNull(acceptedAt)` from `memberDrives` and `otherMembers` queries. Inline comment notes the divergence from access-checking helpers.
- **DMCenterList subtitle** (`apps/web/src/components/inbox/DMCenterList.tsx:120`): "Conversations with your connections" → "Direct messages with your connections and drive co-members" so the inbox copy matches the new eligibility model.
- **Tests**: rename two tests from "accepted member" → "member" wording, add a defensive regression test (`returns true even when membership rows lack acceptedAt`) so the loosened semantic is pinned.

## Test plan
- [x] `pnpm exec vitest run packages/lib/src/permissions/__tests__/users-share-drive.test.ts` — 8/8 pass (was 7/7)
- [x] `pnpm exec vitest run apps/web/src/app/api/users/messageable apps/web/src/app/api/messages/conversations` — 10/10 pass
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (only pre-existing warning in QuickCreatePalette.tsx)
- [ ] Manual: log in as a user who is a member of someone else's drive; visit `/dashboard/dms/new`; confirm the drive owner + other members appear with "Shared drive" labels regardless of whether their `acceptedAt` is populated; start a DM end-to-end

## Notes for reviewers
- Security boundary: this only loosens the DM-eligibility surface. Drive *access* (page reads/writes, member listings, broadcast recipients) still goes through `getUserDriveAccess` / `isUserDriveMember` / `getDriveMemberUserIds`, all of which keep `acceptedAt IS NOT NULL`. A NULL-acceptedAt user can DM, but cannot read drive content.
- The BLOCKED relationship gate added in #1276 still takes precedence over drive co-membership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)