### PR TITLE
feat(tasks): default task surfaces to active filter

### DIFF
--- a/apps/web/src/app/api/tasks/route.ts
+++ b/apps/web/src/app/api/tasks/route.ts
@@ -325,6 +325,21 @@ export async function GET(request: Request) {
       }
     }
 
+    // Serialize status configs once so we can return the same shape from both
+    // the empty fast-path and the regular response. The dashboard builds its
+    // status menus from this payload, so an empty {} would hide custom statuses
+    // even when the underlying task lists still have them.
+    const serializedStatusConfigsByTaskList: Record<string, Array<{
+      id: string; taskListId: string; name: string;
+      slug: string; color: string; group: TaskStatusGroup; position: number;
+    }>> = {};
+    for (const [taskListId, configs] of taskListStatusMap) {
+      serializedStatusConfigsByTaskList[taskListId] = configs.map(c => ({
+        id: c.id, taskListId: c.taskListId, name: c.name,
+        slug: c.slug, color: c.color, group: c.group, position: c.position,
+      }));
+    }
+
     // Group-level status filter. Convert the requested group into a per-task-list
     // set of allowed status slugs (custom configs first, defaults if none) and
     // build an OR over (taskListId, status IN (...)) tuples.
@@ -350,7 +365,7 @@ export async function GET(request: Request) {
       if (perTaskListConditions.length === 0) {
         return NextResponse.json({
           tasks: [],
-          statusConfigsByTaskList: {},
+          statusConfigsByTaskList: serializedStatusConfigsByTaskList,
           pagination: {
             total: 0,
             limit: params.limit,
@@ -440,24 +455,11 @@ export async function GET(request: Request) {
 
     const total = countResult?.total ?? 0;
 
-    // Serialize status configs so the frontend can build per-task dropdowns
-    type StatusGroup = 'todo' | 'in_progress' | 'done';
-    const statusConfigsByTaskList: Record<string, Array<{
-      id: string; taskListId: string; name: string;
-      slug: string; color: string; group: StatusGroup; position: number;
-    }>> = {};
-    for (const [taskListId, configs] of taskListStatusMap) {
-      statusConfigsByTaskList[taskListId] = configs.map(c => ({
-        id: c.id, taskListId: c.taskListId, name: c.name,
-        slug: c.slug, color: c.color, group: c.group, position: c.position,
-      }));
-    }
-
     auditRequest(request, { eventType: 'data.read', userId, resourceType: 'tasks', resourceId: userId, details: { context: params.context } });
 
     return NextResponse.json({
       tasks: enrichedTasks,
-      statusConfigsByTaskList,
+      statusConfigsByTaskList: serializedStatusConfigsByTaskList,
       pagination: {
         total,
         limit: params.limit,

--- a/apps/web/src/app/api/tasks/route.ts
+++ b/apps/web/src/app/api/tasks/route.ts
@@ -4,7 +4,7 @@ import { db } from '@pagespace/db/db'
 import { eq, and, desc, count, gte, lt, lte, inArray, or, isNull, not, sql } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core'
 import { taskItems, taskLists, taskStatusConfigs } from '@pagespace/db/schema/tasks';
-import { DEFAULT_STATUS_CONFIG } from '@/lib/task-status-config';
+import { DEFAULT_STATUS_CONFIG, type TaskStatusGroup } from '@/lib/task-status-config';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope, filterDrivesByMCPScope } from '@/lib/auth';
@@ -27,6 +27,10 @@ const querySchema = z.object({
   assigneeAgentId: z.string().optional(),
   showAllAssignees: z.enum(['true', 'false']).transform(v => v === 'true').optional(),
   dueDateFilter: z.enum(['overdue', 'today', 'this_week', 'upcoming']).optional(),
+  // Group-level status filter: 'active' = todo + in_progress, 'completed' = done.
+  // Custom per-task-list status configs are honoured; fall back to DEFAULT_STATUS_CONFIG
+  // when a task list has no entries.
+  statusGroup: z.enum(['all', 'active', 'completed']).optional(),
   // Pagination
   limit: z.coerce.number().int().min(1).max(100).default(50),
   offset: z.coerce.number().int().min(0).default(0),
@@ -73,6 +77,7 @@ export async function GET(request: Request) {
       assigneeAgentId: searchParams.get('assigneeAgentId') ?? undefined,
       showAllAssignees: searchParams.get('showAllAssignees') ?? undefined,
       dueDateFilter: searchParams.get('dueDateFilter') ?? undefined,
+      statusGroup: searchParams.get('statusGroup') ?? undefined,
       limit: searchParams.get('limit') ?? undefined,
       offset: searchParams.get('offset') ?? undefined,
     });
@@ -205,6 +210,19 @@ export async function GET(request: Request) {
       .where(and(eq(pages.isTrashed, true), inArray(pages.driveId, driveIds)));
     const trashedPageIds = trashedPages.map(p => p.id);
 
+    // Fetch status configs for all involved task lists. Done up-front so we can
+    // both (a) filter by status group and (b) enrich each task with metadata below.
+    const statusConfigRows = await db.query.taskStatusConfigs.findMany({
+      where: inArray(taskStatusConfigs.taskListId, taskListIds),
+    });
+
+    const taskListStatusMap = new Map<string, typeof statusConfigRows>();
+    for (const config of statusConfigRows) {
+      const existing = taskListStatusMap.get(config.taskListId) || [];
+      existing.push(config);
+      taskListStatusMap.set(config.taskListId, existing);
+    }
+
     // Build assignee filter condition
     // Default: tasks assigned to current user
     // If assigneeId or assigneeAgentId is provided, filter by that instead
@@ -307,20 +325,45 @@ export async function GET(request: Request) {
       }
     }
 
-    const whereCondition = and(...filterConditions);
+    // Group-level status filter. Convert the requested group into a per-task-list
+    // set of allowed status slugs (custom configs first, defaults if none) and
+    // build an OR over (taskListId, status IN (...)) tuples.
+    if (params.statusGroup && params.statusGroup !== 'all') {
+      const allowedGroups: TaskStatusGroup[] = params.statusGroup === 'active'
+        ? ['todo', 'in_progress']
+        : ['done'];
+      const allowedGroupSet = new Set<TaskStatusGroup>(allowedGroups);
 
-    // Fetch status configs for all involved task lists
-    const statusConfigRows = await db.query.taskStatusConfigs.findMany({
-      where: inArray(taskStatusConfigs.taskListId, taskListIds),
-    });
+      const defaultAllowedSlugs = Object.entries(DEFAULT_STATUS_CONFIG)
+        .filter(([, cfg]) => allowedGroupSet.has(cfg.group))
+        .map(([slug]) => slug);
 
-    // Build map: taskListId -> status configs
-    const taskListStatusMap = new Map<string, typeof statusConfigRows>();
-    for (const config of statusConfigRows) {
-      const existing = taskListStatusMap.get(config.taskListId) || [];
-      existing.push(config);
-      taskListStatusMap.set(config.taskListId, existing);
+      const perTaskListConditions = taskListIds.map((id) => {
+        const configs = taskListStatusMap.get(id);
+        const slugs = configs && configs.length > 0
+          ? configs.filter((c) => allowedGroupSet.has(c.group)).map((c) => c.slug)
+          : defaultAllowedSlugs;
+        if (slugs.length === 0) return undefined;
+        return and(eq(taskItems.taskListId, id), inArray(taskItems.status, slugs));
+      }).filter((c): c is NonNullable<typeof c> => c !== undefined);
+
+      if (perTaskListConditions.length === 0) {
+        return NextResponse.json({
+          tasks: [],
+          statusConfigsByTaskList: {},
+          pagination: {
+            total: 0,
+            limit: params.limit,
+            offset: params.offset,
+            hasMore: false,
+          },
+        });
+      }
+
+      filterConditions.push(or(...perTaskListConditions));
     }
+
+    const whereCondition = and(...filterConditions);
 
     // Fetch tasks with relations (including multi-assignees)
     const tasks = await db.query.taskItems.findMany({

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/useTaskListPageFilter.test.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/__tests__/useTaskListPageFilter.test.ts
@@ -19,10 +19,10 @@ describe('useTaskListPageFilter', () => {
     localStorage.clear();
   });
 
-  it('given no entry stored for the page, should default to "all"', () => {
+  it('given no entry stored for the page, should default to "active"', () => {
     const { result } = renderHook(() => useTaskListPageFilter('page-1'));
 
-    expect(result.current[0]).toBe('all');
+    expect(result.current[0]).toBe('active');
   });
 
   it('given the store has a filter for the page, should return that filter', () => {
@@ -55,6 +55,6 @@ describe('useTaskListPageFilter', () => {
 
     const { result } = renderHook(() => useTaskListPageFilter('page-1'));
 
-    expect(result.current[0]).toBe('all');
+    expect(result.current[0]).toBe('active');
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/useTaskListPageFilter.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/useTaskListPageFilter.ts
@@ -4,7 +4,7 @@ import { useLayoutStore, type TaskListPageFilter } from '@/stores/useLayoutStore
 export function useTaskListPageFilter(
   pageId: string,
 ): [TaskListPageFilter, (next: TaskListPageFilter) => void] {
-  const filter = useLayoutStore((s) => s.taskListPageFilters[pageId]) ?? 'all';
+  const filter = useLayoutStore((s) => s.taskListPageFilters[pageId]) ?? 'active';
   const setStored = useLayoutStore((s) => s.setTaskListPageFilter);
   const setFilter = useCallback(
     (next: TaskListPageFilter) => setStored(pageId, next),

--- a/apps/web/src/components/tasks/FilterComponents.tsx
+++ b/apps/web/src/components/tasks/FilterComponents.tsx
@@ -14,6 +14,7 @@ import type { Drive } from './types';
 
 export type DueDateFilter = 'all' | 'overdue' | 'today' | 'this_week' | 'upcoming';
 export type AssigneeFilter = 'mine' | 'all';
+export type StatusGroupFilter = 'all' | 'active' | 'completed';
 
 export interface FilterValues {
   status?: TaskStatus;
@@ -21,6 +22,7 @@ export interface FilterValues {
   driveId?: string;
   dueDateFilter?: DueDateFilter;
   assigneeFilter?: AssigneeFilter;
+  statusGroup?: StatusGroupFilter;
 }
 
 export interface FilterSelectProps {
@@ -259,6 +261,39 @@ export function AssigneeToggle({ value, onChange, variant = 'compact', className
         <Users className="h-3.5 w-3.5" />
         <span className="hidden sm:inline">All tasks</span>
       </button>
+    </div>
+  );
+}
+
+export interface StatusGroupToggleProps {
+  value: StatusGroupFilter;
+  onChange: (value: StatusGroupFilter) => void;
+  className?: string;
+}
+
+const STATUS_GROUP_OPTIONS: Array<{ value: StatusGroupFilter; label: string }> = [
+  { value: 'active', label: 'Active' },
+  { value: 'all', label: 'All' },
+  { value: 'completed', label: 'Completed' },
+];
+
+export function StatusGroupToggle({ value, onChange, className }: StatusGroupToggleProps) {
+  return (
+    <div className={cn('flex items-center bg-muted rounded-md p-0.5', className)}>
+      {STATUS_GROUP_OPTIONS.map((opt) => (
+        <button
+          key={opt.value}
+          onClick={() => onChange(opt.value)}
+          className={cn(
+            'px-3 py-1.5 text-sm font-medium rounded transition-colors flex-1 sm:flex-none',
+            value === opt.value
+              ? 'bg-background text-foreground shadow-sm'
+              : 'text-muted-foreground hover:text-foreground'
+          )}
+        >
+          {opt.label}
+        </button>
+      ))}
     </div>
   );
 }

--- a/apps/web/src/components/tasks/FilterComponents.tsx
+++ b/apps/web/src/components/tasks/FilterComponents.tsx
@@ -279,11 +279,17 @@ const STATUS_GROUP_OPTIONS: Array<{ value: StatusGroupFilter; label: string }> =
 
 export function StatusGroupToggle({ value, onChange, className }: StatusGroupToggleProps) {
   return (
-    <div className={cn('flex items-center bg-muted rounded-md p-0.5', className)}>
+    <div
+      role="group"
+      aria-label="Task completion filter"
+      className={cn('flex items-center bg-muted rounded-md p-0.5', className)}
+    >
       {STATUS_GROUP_OPTIONS.map((opt) => (
         <button
           key={opt.value}
+          type="button"
           onClick={() => onChange(opt.value)}
+          aria-pressed={value === opt.value}
           className={cn(
             'px-3 py-1.5 text-sm font-medium rounded transition-colors flex-1 sm:flex-none',
             value === opt.value

--- a/apps/web/src/components/tasks/FilterControls.tsx
+++ b/apps/web/src/components/tasks/FilterControls.tsx
@@ -7,15 +7,17 @@ import { aggregateStatuses } from './task-helpers';
 import {
   type DueDateFilter,
   type AssigneeFilter,
+  type StatusGroupFilter,
   type FilterValues,
   DriveSelect,
   StatusSelect,
   PrioritySelect,
   DueDateSelect,
   AssigneeToggle,
+  StatusGroupToggle,
 } from './FilterComponents';
 
-export type { DueDateFilter, AssigneeFilter, FilterValues };
+export type { DueDateFilter, AssigneeFilter, StatusGroupFilter, FilterValues };
 
 export interface FilterControlsProps {
   layout: 'mobile' | 'desktop';
@@ -51,6 +53,12 @@ export function FilterControls({
   if (isMobile) {
     return (
       <>
+        <StatusGroupToggle
+          value={filters.statusGroup || 'active'}
+          onChange={(g) => onFiltersChange({ statusGroup: g })}
+          className="w-full"
+        />
+
         <div
           className="-mx-3 overflow-x-auto px-3 pb-1"
           role="region"
@@ -107,6 +115,10 @@ export function FilterControls({
 
   return (
     <>
+      <StatusGroupToggle
+        value={filters.statusGroup || 'active'}
+        onChange={(g) => onFiltersChange({ statusGroup: g })}
+      />
       <DriveSelect
         context={context}
         drives={drives}

--- a/apps/web/src/components/tasks/TaskFilterSheet.tsx
+++ b/apps/web/src/components/tasks/TaskFilterSheet.tsx
@@ -15,15 +15,17 @@ import { aggregateStatuses } from './task-helpers';
 import {
   type DueDateFilter,
   type AssigneeFilter,
+  type StatusGroupFilter,
   type FilterValues,
   DriveSelect,
   StatusSelect,
   PrioritySelect,
   DueDateSelect,
   AssigneeToggle,
+  StatusGroupToggle,
 } from './FilterComponents';
 
-export type { DueDateFilter, AssigneeFilter, FilterValues };
+export type { DueDateFilter, AssigneeFilter, StatusGroupFilter, FilterValues };
 
 export interface TaskFilterSheetProps {
   open: boolean;
@@ -85,6 +87,15 @@ export function TaskFilterSheet({
         </SheetHeader>
 
         <div className="overflow-y-auto px-5 pb-4 space-y-5 mt-2">
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-muted-foreground">Completion</label>
+            <StatusGroupToggle
+              value={filters.statusGroup || 'active'}
+              onChange={(g) => onFiltersChange({ statusGroup: g })}
+              className="w-full"
+            />
+          </div>
+
           <div className="space-y-1.5">
             <label className="text-xs font-medium text-muted-foreground">Show tasks</label>
             <AssigneeToggle

--- a/apps/web/src/components/tasks/TasksDashboard.tsx
+++ b/apps/web/src/components/tasks/TasksDashboard.tsx
@@ -44,6 +44,7 @@ import {
   fromStoredOrDefaults,
   type DueDateFilter,
   type AssigneeFilter,
+  type StatusGroupFilter,
 } from './dashboardFiltersPersistence';
 import { useEditingStore } from '@/stores/useEditingStore';
 import { useMobile } from '@/hooks/useMobile';
@@ -76,6 +77,7 @@ interface ExtendedFilters extends TaskFilters {
   search?: string;
   dueDateFilter?: DueDateFilter;
   assigneeFilter?: AssigneeFilter;
+  statusGroup?: StatusGroupFilter;
 }
 
 export function TasksDashboard({ context, driveId: initialDriveId, driveName }: TasksDashboardProps) {
@@ -158,6 +160,9 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
     }
     if (newFilters.assigneeFilter && newFilters.assigneeFilter !== 'mine') {
       params.set('assigneeFilter', newFilters.assigneeFilter);
+    }
+    if (newFilters.statusGroup && newFilters.statusGroup !== 'active') {
+      params.set('statusGroup', newFilters.statusGroup);
     }
     // For user context, driveId is a filter (not in the URL path)
     if (newFilters.driveId && !newDriveId) {
@@ -244,6 +249,9 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
         // Handle assignee filter - 'all' shows all tasks, 'mine' (default) shows only user's tasks
         if (filters.assigneeFilter === 'all') {
           params.set('showAllAssignees', 'true');
+        }
+        if (filters.statusGroup && filters.statusGroup !== 'all') {
+          params.set('statusGroup', filters.statusGroup);
         }
 
         const response = await fetchWithAuth(`/api/tasks?${params.toString()}`);
@@ -571,20 +579,22 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
       ? `Your tasks in ${drives.find(d => d.id === filters.driveId)?.name || 'selected drive'}`
       : 'Your tasks across all drives';
 
-  // Note: assigneeFilter === 'all' is included because the default is 'mine',
-  // so viewing all tasks is a deviation from the default state that users may want to clear
+  // Note: assigneeFilter === 'all' and statusGroup !== 'active' are included because their
+  // defaults are 'mine' and 'active' respectively — deviations users may want to clear.
   const hasActiveFilters = Boolean(
     filters.search ||
     filters.status ||
     filters.priority ||
     (filters.dueDateFilter && filters.dueDateFilter !== 'all') ||
     (context === 'user' && filters.driveId) ||
-    filters.assigneeFilter === 'all'
+    filters.assigneeFilter === 'all' ||
+    (filters.statusGroup && filters.statusGroup !== 'active')
   );
 
   const clearFilters = () => {
     const nextFilters: ExtendedFilters = {
       assigneeFilter: 'mine',
+      statusGroup: 'active',
     };
 
     if (searchTimeoutRef.current) {
@@ -605,6 +615,7 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
     filters.dueDateFilter && filters.dueDateFilter !== 'all',
     context === 'user' && filters.driveId,
     filters.assigneeFilter === 'all',
+    filters.statusGroup && filters.statusGroup !== 'active',
   ].filter(Boolean).length;
 
   const handleOpenDetailSheet = (task: Task) => {

--- a/apps/web/src/components/tasks/__tests__/dashboardFiltersPersistence.test.ts
+++ b/apps/web/src/components/tasks/__tests__/dashboardFiltersPersistence.test.ts
@@ -36,6 +36,18 @@ describe('pickInitialFilters', () => {
 
     expect(result.status).toBe('in_progress');
     expect(result.assigneeFilter).toBe('mine');
+  });
+
+  it('given URL has explicit status slug but no statusGroup, should default statusGroup to "all" so the API does not AND both filters', () => {
+    const result = pickInitialFilters(params({ status: 'completed' }), undefined);
+
+    expect(result.status).toBe('completed');
+    expect(result.statusGroup).toBe('all');
+  });
+
+  it('given URL has any persistable param but no status, should still default statusGroup to "active"', () => {
+    const result = pickInitialFilters(params({ priority: 'high' }), undefined);
+
     expect(result.statusGroup).toBe('active');
   });
 
@@ -43,6 +55,12 @@ describe('pickInitialFilters', () => {
     const result = pickInitialFilters(params({ statusGroup: 'completed' }), undefined);
 
     expect(result.statusGroup).toBe('completed');
+  });
+
+  it('given URL has invalid statusGroup value, should ignore it and fall back to default', () => {
+    const result = pickInitialFilters(params({ statusGroup: 'bogus', priority: 'high' }), undefined);
+
+    expect(result.statusGroup).toBe('active');
   });
 
   it('given URL is bare and stored prefs exist, should use stored prefs', () => {

--- a/apps/web/src/components/tasks/__tests__/dashboardFiltersPersistence.test.ts
+++ b/apps/web/src/components/tasks/__tests__/dashboardFiltersPersistence.test.ts
@@ -36,6 +36,13 @@ describe('pickInitialFilters', () => {
 
     expect(result.status).toBe('in_progress');
     expect(result.assigneeFilter).toBe('mine');
+    expect(result.statusGroup).toBe('active');
+  });
+
+  it('given URL has statusGroup param, should reflect that statusGroup value', () => {
+    const result = pickInitialFilters(params({ statusGroup: 'completed' }), undefined);
+
+    expect(result.statusGroup).toBe('completed');
   });
 
   it('given URL is bare and stored prefs exist, should use stored prefs', () => {
@@ -86,6 +93,13 @@ describe('fromStoredOrDefaults', () => {
 
     expect(result.status).toBe('in_progress');
     expect(result.assigneeFilter).toBe('mine');
+    expect(result.statusGroup).toBe('active');
+  });
+
+  it('given stored prefs that override statusGroup, should respect the override', () => {
+    const result = fromStoredOrDefaults({ statusGroup: 'all' });
+
+    expect(result.statusGroup).toBe('all');
   });
 
   it('given stored prefs that override the default assignee, should respect the override', () => {
@@ -104,6 +118,7 @@ describe('toStoredDashboardFilters', () => {
       search: 'budget',
       dueDateFilter: 'overdue',
       assigneeFilter: 'all',
+      statusGroup: 'completed',
     });
 
     expect(result).toEqual({
@@ -112,6 +127,7 @@ describe('toStoredDashboardFilters', () => {
       search: 'budget',
       dueDateFilter: 'overdue',
       assigneeFilter: 'all',
+      statusGroup: 'completed',
     });
   });
 

--- a/apps/web/src/components/tasks/dashboardFiltersPersistence.ts
+++ b/apps/web/src/components/tasks/dashboardFiltersPersistence.ts
@@ -35,15 +35,33 @@ function urlHasAnyPersistableParam(searchParams: URLSearchParams): boolean {
   return URL_FILTER_KEYS.some((key) => searchParams.has(key));
 }
 
+const VALID_STATUS_GROUPS: ReadonlyArray<StatusGroupFilter> = ['all', 'active', 'completed'];
+
+function isValidStatusGroup(value: string | null): value is StatusGroupFilter {
+  return value !== null && (VALID_STATUS_GROUPS as readonly string[]).includes(value);
+}
+
 function readFromUrl(searchParams: URLSearchParams): PersistableFilters {
+  const status = searchParams.get('status') || undefined;
+  const rawStatusGroup = searchParams.get('statusGroup');
+
+  // Validate URL value; if absent and an explicit `status` slug is set,
+  // fall back to 'all' so the API doesn't conjunctively filter both
+  // (e.g. ?status=completed should not be silently ANDed with 'active').
+  const statusGroup: StatusGroupFilter = isValidStatusGroup(rawStatusGroup)
+    ? rawStatusGroup
+    : status
+      ? 'all'
+      : 'active';
+
   return {
-    status: searchParams.get('status') || undefined,
+    status,
     priority: (searchParams.get('priority') as TaskPriority) || undefined,
     driveId: searchParams.get('driveId') || undefined,
     search: searchParams.get('search') || undefined,
     dueDateFilter: (searchParams.get('dueDateFilter') as DueDateFilter) || undefined,
     assigneeFilter: (searchParams.get('assigneeFilter') as AssigneeFilter) || 'mine',
-    statusGroup: (searchParams.get('statusGroup') as StatusGroupFilter) || 'active',
+    statusGroup,
   };
 }
 

--- a/apps/web/src/components/tasks/dashboardFiltersPersistence.ts
+++ b/apps/web/src/components/tasks/dashboardFiltersPersistence.ts
@@ -3,6 +3,7 @@ import type { StoredDashboardFilters } from '@/stores/useLayoutStore';
 
 export type DueDateFilter = 'all' | 'overdue' | 'today' | 'this_week' | 'upcoming';
 export type AssigneeFilter = 'mine' | 'all';
+export type StatusGroupFilter = 'all' | 'active' | 'completed';
 
 export interface PersistableFilters {
   status?: string;
@@ -10,6 +11,7 @@ export interface PersistableFilters {
   search?: string;
   dueDateFilter?: DueDateFilter;
   assigneeFilter?: AssigneeFilter;
+  statusGroup?: StatusGroupFilter;
   driveId?: string;
 }
 
@@ -20,9 +22,10 @@ export const DEFAULT_DASHBOARD_FILTERS: PersistableFilters = {
   search: undefined,
   dueDateFilter: undefined,
   assigneeFilter: 'mine',
+  statusGroup: 'active',
 };
 
-const URL_FILTER_KEYS = ['status', 'priority', 'driveId', 'search', 'dueDateFilter', 'assigneeFilter'] as const;
+const URL_FILTER_KEYS = ['status', 'priority', 'driveId', 'search', 'dueDateFilter', 'assigneeFilter', 'statusGroup'] as const;
 
 export function scopeKeyFor(context: 'user' | 'drive', driveId: string | undefined): string {
   return context === 'user' ? 'user' : `drive:${driveId ?? ''}`;
@@ -40,6 +43,7 @@ function readFromUrl(searchParams: URLSearchParams): PersistableFilters {
     search: searchParams.get('search') || undefined,
     dueDateFilter: (searchParams.get('dueDateFilter') as DueDateFilter) || undefined,
     assigneeFilter: (searchParams.get('assigneeFilter') as AssigneeFilter) || 'mine',
+    statusGroup: (searchParams.get('statusGroup') as StatusGroupFilter) || 'active',
   };
 }
 
@@ -69,5 +73,6 @@ export function toStoredDashboardFilters(filters: PersistableFilters): StoredDas
   if (filters.search !== undefined) out.search = filters.search;
   if (filters.dueDateFilter !== undefined) out.dueDateFilter = filters.dueDateFilter;
   if (filters.assigneeFilter !== undefined) out.assigneeFilter = filters.assigneeFilter;
+  if (filters.statusGroup !== undefined) out.statusGroup = filters.statusGroup;
   return out;
 }

--- a/apps/web/src/stores/useLayoutStore.ts
+++ b/apps/web/src/stores/useLayoutStore.ts
@@ -10,6 +10,7 @@ export interface StoredDashboardFilters {
   search?: string;
   dueDateFilter?: 'all' | 'overdue' | 'today' | 'this_week' | 'upcoming';
   assigneeFilter?: 'mine' | 'all';
+  statusGroup?: 'all' | 'active' | 'completed';
 }
 
 interface LayoutState {


### PR DESCRIPTION
## Summary
- TaskList page (page-type), user `/dashboard/tasks`, and drive `/dashboard/[driveId]/tasks` now default to **Active** instead of **All**, so first-visit surfaces don't open onto a wall of completed tasks.
- New `active | all | completed` toggle on the dashboards (mirroring the existing TaskList page UI) backed by a server-side `statusGroup` query param on `/api/tasks` so pagination stays correct.
- TaskList page persistence is unchanged for existing users — the new default only kicks in when no value is already stored.

## Implementation notes
- `/api/tasks` resolves the requested group to per-task-list slugs using each task list's custom status configs first (`taskStatusConfigs.group`), falling back to `DEFAULT_STATUS_CONFIG`. Empty resolution short-circuits to an empty result page.
- `clearFilters` / `hasActiveFilters` / `activeFilterCount` on the dashboard treat `statusGroup !== 'active'` as a deviation, matching the existing `assigneeFilter !== 'mine'` handling.
- No DB migration; no schema change.

## Test plan
- [x] `pnpm --filter web typecheck` clean
- [x] `pnpm --filter web lint` clean (no new warnings)
- [x] `pnpm --filter web exec vitest run src/components/tasks src/components/layout/middle-content/page-views/task-list src/app/api/tasks` — 60/60 pass
- [ ] Open a fresh TaskList page → defaults to **Active**
- [ ] Open a TaskList page with a stored `'all'` filter → still **All**
- [ ] Visit `/dashboard/tasks` (cleared localStorage) → toggle on **Active**, no completed tasks shown, request includes `statusGroup=active`
- [ ] Toggle to **All** on dashboard → completed tasks reappear, URL drops `statusGroup`
- [ ] Visit `/dashboard/<driveId>/tasks` → same behaviour scoped to drive
- [ ] Custom-status task list (e.g. `triage` in todo, `shipped` in done) → `Active` includes triage, excludes shipped
- [ ] `/dashboard/tasks?statusGroup=completed` deep link → mounts on Completed
- [ ] Pagination > 50 tasks with `statusGroup=active` → "Load more" totals/`hasMore` reflect the filtered count

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added task status group filtering with three options: "All", "Active", and "Completed" throughout the dashboard and API.
  * Users can now filter tasks by completion status using the new toggle control in filter menus.

* **Tests**
  * Updated and added test coverage for the new status group filter persistence and default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->