### PR TITLE
feat(channels): bring channel views to DM parity

### DIFF
--- a/apps/web/src/app/dashboard/channels/[pageId]/page.tsx
+++ b/apps/web/src/app/dashboard/channels/[pageId]/page.tsx
@@ -17,7 +17,7 @@ import {
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { renderMessageParts, convertToMessageParts } from '@/components/messages/MessagePartRenderer';
+import { StreamingMarkdown } from '@/components/ai/shared/chat/StreamingMarkdown';
 import { type ChannelInputRef, type FileAttachment } from '@/components/layout/middle-content/page-views/channel/ChannelInput';
 import { MessageInput } from '@/components/shared/MessageInput';
 import { MessageDropZone } from '@/components/layout/middle-content/page-views/channel/MessageDropZone';
@@ -561,7 +561,7 @@ export default function InboxChannelPage() {
           </div>
           {m.content && (
             <div className="prose prose-sm dark:prose-invert max-w-none">
-              {renderMessageParts(convertToMessageParts(m.content))}
+              <StreamingMarkdown content={m.content} isStreaming={false} />
             </div>
           )}
           <MessageAttachment message={m} />
@@ -713,7 +713,7 @@ export default function InboxChannelPage() {
                         )}
                         {m.content ? (
                           <div className="prose prose-sm dark:prose-invert max-w-none break-words [overflow-wrap:anywhere] min-w-0">
-                            {renderMessageParts(convertToMessageParts(m.content))}
+                            <StreamingMarkdown content={m.content} isStreaming={false} />
                           </div>
                         ) : null}
                       </>

--- a/apps/web/src/app/dashboard/channels/[pageId]/page.tsx
+++ b/apps/web/src/app/dashboard/channels/[pageId]/page.tsx
@@ -9,17 +9,23 @@ import { Hash, ExternalLink, Lock, Check, X } from 'lucide-react';
 import { MessageAttachment } from '@/components/shared/MessageAttachment';
 import { useAuth } from '@/hooks/useAuth';
 import { usePermissions, getPermissionErrorMessage } from '@/hooks/usePermissions';
-import { ScrollArea } from '@/components/ui/scroll-area';
+import {
+  Conversation,
+  ConversationContent,
+  ConversationScrollButton,
+} from '@/components/ai/ui/conversation';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { StreamingMarkdown } from '@/components/ai/shared/chat/StreamingMarkdown';
+import { renderMessageParts, convertToMessageParts } from '@/components/messages/MessagePartRenderer';
 import { type ChannelInputRef, type FileAttachment } from '@/components/layout/middle-content/page-views/channel/ChannelInput';
 import { MessageInput } from '@/components/shared/MessageInput';
 import { MessageDropZone } from '@/components/layout/middle-content/page-views/channel/MessageDropZone';
 import { MessageReactions, type Reaction } from '@/components/shared/MessageReactions';
 import { MessageHoverToolbar } from '@/components/shared/MessageHoverToolbar';
-import { PullToRefresh } from '@/components/ui/pull-to-refresh';
+import MessageQuoteBlock from '@/components/messages/MessageQuoteBlock';
+import type { QuotedMessageSnapshot } from '@pagespace/lib/services/quote-enrichment';
+import { buildThreadPreview } from '@pagespace/lib/services/preview';
 import { post, del, patch, fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useSocketStore } from '@/stores/useSocketStore';
 import {
@@ -67,6 +73,8 @@ interface MessageWithUser {
   parentId?: string | null;
   replyCount?: number;
   lastReplyAt?: string | null;
+  quotedMessageId?: string | null;
+  quotedMessage?: QuotedMessageSnapshot | null;
 }
 
 interface Page {
@@ -86,11 +94,17 @@ export default function InboxChannelPage() {
   const [hasMore, setHasMore] = useState(false);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [loadingOlder, setLoadingOlder] = useState(false);
-  const scrollAreaRef = useRef<HTMLDivElement>(null);
   const channelInputRef = useRef<ChannelInputRef>(null);
-  const skipAutoScrollRef = useRef(false);
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
   const [editContent, setEditContent] = useState('');
+  // Active inline quote-reply target. The snapshot is captured at quote-start
+  // time so the optimistic insert can render the embed immediately, before
+  // the server's enriched payload arrives.
+  const [quotedMessageId, setQuotedMessageId] = useState<string | null>(null);
+  const [activeQuotedSnapshot, setActiveQuotedSnapshot] = useState<QuotedMessageSnapshot | null>(null);
+  const quotedPreview = activeQuotedSnapshot
+    ? { authorName: activeQuotedSnapshot.authorName ?? 'Member', snippet: activeQuotedSnapshot.contentSnippet }
+    : null;
 
   const socket = useSocketStore((state) => state.socket);
   const connectionStatus = useSocketStore((state) => state.connectionStatus);
@@ -112,6 +126,10 @@ export default function InboxChannelPage() {
   // a panel against an unrelated message list otherwise.
   useEffect(() => {
     closeThread();
+    // Also drop any active quote so a chip composed against a previous
+    // channel cannot leak its messageId into the next channel's POST.
+    setQuotedMessageId(null);
+    setActiveQuotedSnapshot(null);
     // Only fire on context switch.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pageId]);
@@ -204,16 +222,25 @@ export default function InboxChannelPage() {
     };
   }, [socket, connectionStatus, pageId]);
 
-  // Auto-scroll (skip when loading older messages)
-  useEffect(() => {
-    if (skipAutoScrollRef.current) {
-      skipAutoScrollRef.current = false;
-      return;
-    }
-    if (scrollAreaRef.current) {
-      scrollAreaRef.current.scrollTop = scrollAreaRef.current.scrollHeight;
-    }
-  }, [messages]);
+  const handleStartQuote = useCallback((m: MessageWithUser) => {
+    if (m.id.startsWith('temp-')) return;
+    setQuotedMessageId(m.id);
+    setActiveQuotedSnapshot({
+      id: m.id,
+      authorId: m.user?.id ?? m.userId ?? null,
+      authorName: m.aiMeta?.senderName || m.user?.name || 'Member',
+      authorImage: m.user?.image ?? null,
+      contentSnippet: buildThreadPreview(m.content),
+      createdAt: m.createdAt instanceof Date ? m.createdAt : new Date(m.createdAt),
+      isActive: true,
+    });
+    channelInputRef.current?.focus();
+  }, []);
+
+  const clearQuote = useCallback(() => {
+    setQuotedMessageId(null);
+    setActiveQuotedSnapshot(null);
+  }, []);
 
   const handleTopLevelSubmit = async ({
     content,
@@ -227,6 +254,21 @@ export default function InboxChannelPage() {
       toast.error(getPermissionErrorMessage('send', 'channel'));
       return;
     }
+
+    const activeQuoteId = quotedMessageId;
+    const activeQuoteSnapshot = activeQuotedSnapshot;
+    setInputValue('');
+    channelInputRef.current?.clear();
+    clearQuote();
+
+    const attachmentMeta: AttachmentMeta | null = attachment
+      ? {
+          originalName: attachment.originalName,
+          size: attachment.size,
+          mimeType: attachment.mimeType,
+          contentHash: attachment.contentHash,
+        }
+      : null;
 
     const tempId = `temp-${Date.now()}`;
     const optimisticMessage: MessageWithUser = {
@@ -244,53 +286,38 @@ export default function InboxChannelPage() {
         image: null,
       },
       fileId: attachment?.id || null,
-      attachmentMeta: attachment
-        ? {
-            originalName: attachment.originalName,
-            size: attachment.size,
-            mimeType: attachment.mimeType,
-            contentHash: attachment.contentHash,
-          }
-        : null,
+      attachmentMeta,
+      quotedMessageId: activeQuoteId,
+      quotedMessage: activeQuoteSnapshot ?? null,
     };
 
     setMessages((prev) => [...prev, optimisticMessage]);
-    setInputValue('');
-    channelInputRef.current?.clear();
 
     try {
-      await post(`/api/channels/${pageId}/messages`, {
+      const body: { content: string; fileId?: string; attachmentMeta?: AttachmentMeta; quotedMessageId?: string } = {
         content,
-        fileId: attachment?.id,
-        attachmentMeta: attachment
-          ? {
-              originalName: attachment.originalName,
-              size: attachment.size,
-              mimeType: attachment.mimeType,
-              contentHash: attachment.contentHash,
-            }
-          : undefined,
-      });
+      };
+      if (attachment) {
+        body.fileId = attachment.id;
+        body.attachmentMeta = attachmentMeta!;
+      }
+      if (activeQuoteId) {
+        body.quotedMessageId = activeQuoteId;
+      }
+      await post(`/api/channels/${pageId}/messages`, body);
     } catch (error) {
       setMessages((prev) => prev.filter((m) => m.id !== tempId));
       console.error('Error sending message:', error);
+      toast.error('Failed to send message');
+      setInputValue(content);
+      // Restore the quote chip so the user's retry still carries the quote
+      // they originally selected.
+      if (activeQuoteId) {
+        setQuotedMessageId(activeQuoteId);
+        setActiveQuotedSnapshot(activeQuoteSnapshot);
+      }
     }
   };
-
-  const handleRefresh = useCallback(async () => {
-    try {
-      const res = await fetchWithAuth(`/api/channels/${pageId}/messages`);
-      if (!res.ok) {
-        throw new Error(`Failed to fetch messages: ${res.status}`);
-      }
-      const data = await res.json();
-      setMessages(data.messages ?? data);
-      setHasMore(data.hasMore ?? false);
-      setNextCursor(data.nextCursor ?? null);
-    } catch (error) {
-      console.error('Failed to refresh messages:', error);
-    }
-  }, [pageId]);
 
   const handleLoadOlder = useCallback(async () => {
     if (!nextCursor || loadingOlder) return;
@@ -300,7 +327,6 @@ export default function InboxChannelPage() {
       if (!res.ok) throw new Error(`Failed to fetch older messages: ${res.status}`);
       const data = await res.json();
       const olderMessages: MessageWithUser[] = data.messages ?? data;
-      skipAutoScrollRef.current = true;
       setMessages((prev) => [...olderMessages, ...prev]);
       setHasMore(data.hasMore ?? false);
       setNextCursor(data.nextCursor ?? null);
@@ -535,7 +561,7 @@ export default function InboxChannelPage() {
           </div>
           {m.content && (
             <div className="prose prose-sm dark:prose-invert max-w-none">
-              <StreamingMarkdown content={m.content} isStreaming={false} />
+              {renderMessageParts(convertToMessageParts(m.content))}
             </div>
           )}
           <MessageAttachment message={m} />
@@ -593,10 +619,10 @@ export default function InboxChannelPage() {
       </div>
 
       {/* Messages */}
-      <div className="flex-grow overflow-hidden">
-        <PullToRefresh direction="top" onRefresh={handleRefresh}>
-          <ScrollArea className="h-full" ref={scrollAreaRef}>
-            <div className="p-4 space-y-4 max-w-4xl mx-auto">
+      <div className="flex-grow overflow-hidden relative">
+        <Conversation className="h-full">
+          <ConversationContent className="max-w-4xl mx-auto p-4">
+            <div className="space-y-4">
               {hasMore && (
                 <div className="flex justify-center py-2">
                   <Button
@@ -680,14 +706,18 @@ export default function InboxChannelPage() {
                           <span className="opacity-60">Enter to save · Esc to cancel</span>
                         </div>
                       </div>
-                    ) : m.content ? (
-                      <div className="prose prose-sm dark:prose-invert max-w-none">
-                        <StreamingMarkdown
-                          content={m.content}
-                          isStreaming={false}
-                        />
-                      </div>
-                    ) : null}
+                    ) : (
+                      <>
+                        {(m.quotedMessage || m.quotedMessageId) && (
+                          <MessageQuoteBlock quoted={m.quotedMessage ?? null} />
+                        )}
+                        {m.content ? (
+                          <div className="prose prose-sm dark:prose-invert max-w-none break-words [overflow-wrap:anywhere] min-w-0">
+                            {renderMessageParts(convertToMessageParts(m.content))}
+                          </div>
+                        ) : null}
+                      </>
+                    )}
                     <MessageAttachment message={m} />
                     {replyCount > 0 && (
                       <button
@@ -718,12 +748,13 @@ export default function InboxChannelPage() {
                         canReact={permissions?.canView || false}
                         canEdit={isOwnMessage}
                         canDelete={isOwnMessage}
-                        canReplyInThread={!isAi}
-                        canQuoteReply={false}
+                        canReplyInThread={!m.id.startsWith('temp-')}
+                        canQuoteReply={true}
                         reactions={m.reactions}
                         currentUserId={user?.id}
                         onAddReaction={(emoji) => handleAddReaction(m.id, emoji)}
                         onRemoveReaction={(emoji) => handleRemoveReaction(m.id, emoji)}
+                        onQuoteReply={() => handleStartQuote(m)}
                         onEdit={() => { setEditingMessageId(m.id); setEditContent(m.content); }}
                         onDelete={() => handleDeleteMessage(m.id)}
                         onReplyInThread={() =>
@@ -736,8 +767,9 @@ export default function InboxChannelPage() {
                 );
               })}
             </div>
-          </ScrollArea>
-        </PullToRefresh>
+          </ConversationContent>
+          <ConversationScrollButton className="z-20 bottom-6" />
+        </Conversation>
       </div>
 
       {/* Input */}
@@ -753,6 +785,8 @@ export default function InboxChannelPage() {
               onSubmit={handleTopLevelSubmit}
               driveId={page.driveId}
               attachmentsEnabled
+              quotedPreview={quotedPreview}
+              onClearQuote={clearQuote}
             />
           ) : (
             <Alert className="border-yellow-200 dark:border-yellow-800 bg-yellow-50 dark:bg-yellow-900/20">

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -6,13 +6,14 @@ import { useAuth } from '@/hooks/useAuth';
 import { usePermissions, getPermissionErrorMessage } from '@/hooks/usePermissions';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { TreePage, MessageWithUser } from '@/hooks/usePageTree';
-import { StreamingMarkdown } from '@/components/ai/shared/chat/StreamingMarkdown';
+import { renderMessageParts, convertToMessageParts } from '@/components/messages/MessagePartRenderer';
 import {
   Conversation,
   ConversationContent,
   ConversationScrollButton,
 } from '@/components/ai/ui/conversation';
-import { ChannelInput, type ChannelInputRef, type FileAttachment } from './ChannelInput';
+import { type ChannelInputRef, type FileAttachment } from './ChannelInput';
+import { MessageInput } from '@/components/shared/MessageInput';
 import { MessageDropZone } from './MessageDropZone';
 import { MessageReactions, type Reaction } from '@/components/shared/MessageReactions';
 import { MessageHoverToolbar } from '@/components/shared/MessageHoverToolbar';
@@ -25,6 +26,9 @@ import { buildThreadPreview } from '@pagespace/lib/services/preview';
 import { post, del, patch, fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useSocketStore } from '@/stores/useSocketStore';
 import { useThreadPanelStore } from '@/stores/useThreadPanelStore';
+import { ThreadPanel } from '@/components/layout/middle-content/page-views/thread/ThreadPanel';
+import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
+import { useMobile } from '@/hooks/useMobile';
 import {
   type AttachmentMeta,
   type FileRelation,
@@ -67,7 +71,19 @@ function ChannelView({ page }: ChannelViewProps) {
   const socket = useSocketStore((state) => state.socket);
   const connectionStatus = useSocketStore((state) => state.connectionStatus);
   const connect = useSocketStore((state) => state.connect);
+  const threadPanelOpen = useThreadPanelStore((state) => state.open);
+  const threadPanelSource = useThreadPanelStore((state) => state.source);
+  const threadPanelContextId = useThreadPanelStore((state) => state.contextId);
+  const threadPanelParentId = useThreadPanelStore((state) => state.parentId);
   const openThread = useThreadPanelStore((state) => state.openThread);
+  const closeThread = useThreadPanelStore((state) => state.close);
+  const isMobile = useMobile();
+
+  const isThreadVisible =
+    threadPanelOpen &&
+    threadPanelSource === 'channel' &&
+    threadPanelContextId === page.id &&
+    !!threadPanelParentId;
 
   // Use the centralized permissions hook
   const { permissions } = usePermissions(page.id);
@@ -253,17 +269,24 @@ function ChannelView({ page }: ChannelViewProps) {
     }
   };
 
-  const handleSendMessage = (attachment?: FileAttachment) => {
-    // Allow sending if there's text or an attachment
-    if (!inputValue.trim() && !attachment) return;
+  const handleTopLevelSubmit = ({
+    content,
+    attachment,
+  }: {
+    content: string;
+    attachment?: FileAttachment;
+  }) => {
+    if (!content.trim() && !attachment) return;
     if (!canEdit) {
       toast.error(getPermissionErrorMessage('send', 'channel'));
       return;
     }
-    handleSubmit(inputValue, attachment, quotedMessageId, activeQuotedSnapshot);
-    channelInputRef.current?.clear();
+    const activeQuoteId = quotedMessageId;
+    const activeQuoteSnapshot = activeQuotedSnapshot;
     setInputValue('');
+    channelInputRef.current?.clear();
     clearQuote();
+    handleSubmit(content, attachment, activeQuoteId, activeQuoteSnapshot);
   };
 
   // Load older messages when scrolling to top
@@ -460,8 +483,77 @@ function ChannelView({ page }: ChannelViewProps) {
     }
   }, [page.id]);
 
+  const threadParent = isThreadVisible
+    ? messages.find((mm) => mm.id === threadPanelParentId) ?? null
+    : null;
+
+  const renderParentSlot = () => {
+    if (!threadParent) {
+      return (
+        <div className="text-sm text-muted-foreground italic">
+          Original message unavailable
+        </div>
+      );
+    }
+    const m = threadParent;
+    const isAi = !!m.aiMeta;
+    const displayName = isAi ? m.aiMeta!.senderName : m.user?.name;
+    const avatarFallback = isAi
+      ? m.aiMeta!.senderType === 'agent'
+        ? 'A'
+        : m.aiMeta!.senderName?.[0]
+      : m.user?.name?.[0];
+    return (
+      <div className="flex items-start gap-3">
+        <Avatar className="shrink-0">
+          {!isAi && <AvatarImage src={m.user?.image || ''} />}
+          <AvatarFallback>{avatarFallback}</AvatarFallback>
+        </Avatar>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="font-semibold text-sm">{displayName}</span>
+            <span className="text-xs text-muted-foreground">
+              {new Date(m.createdAt).toLocaleTimeString()}
+            </span>
+          </div>
+          {m.content && (
+            <div className="prose prose-sm dark:prose-invert max-w-none">
+              {renderMessageParts(convertToMessageParts(m.content))}
+            </div>
+          )}
+          <MessageAttachment message={m} />
+        </div>
+      </div>
+    );
+  };
+
+  const resolveThreadAuthor = (authorId: string | null | undefined, fallbackName?: string | null) => {
+    const fromList = messages.find((mm) => mm.userId === authorId);
+    if (fromList?.user) {
+      return { name: fromList.user.name ?? fallbackName ?? 'Member', image: fromList.user.image };
+    }
+    if (authorId === user?.id) {
+      return { name: user?.name ?? 'You', image: null };
+    }
+    return { name: fallbackName ?? 'Member', image: null };
+  };
+
+  const threadPanel = isThreadVisible && threadPanelParentId ? (
+    <ThreadPanel
+      source="channel"
+      contextId={page.id}
+      parentId={threadPanelParentId}
+      currentUserId={user?.id ?? null}
+      parentSlot={renderParentSlot()}
+      resolveAuthor={resolveThreadAuthor}
+      replyCountHint={threadParent?.replyCount}
+      onClose={closeThread}
+    />
+  ) : null;
+
   return (
-    <MessageDropZone inputRef={channelInputRef} enabled={canEdit} className="flex flex-col h-full">
+    <div className="flex h-full w-full">
+    <MessageDropZone inputRef={channelInputRef} enabled={canEdit} className="flex flex-col h-full flex-1 min-w-0">
         <div className="flex-grow overflow-hidden relative">
           <Conversation className="h-full">
             <ConversationContent className="max-w-4xl mx-auto p-4">
@@ -576,11 +668,8 @@ function ChannelView({ page }: ChannelViewProps) {
                                       <MessageQuoteBlock quoted={m.quotedMessage ?? null} />
                                     )}
                                     {m.content && (
-                                      <div className="prose prose-sm dark:prose-invert max-w-none">
-                                        <StreamingMarkdown
-                                          content={m.content}
-                                          isStreaming={false}
-                                        />
+                                      <div className="prose prose-sm dark:prose-invert max-w-none break-words [overflow-wrap:anywhere] min-w-0">
+                                        {renderMessageParts(convertToMessageParts(m.content))}
                                       </div>
                                     )}
                                     {!isFirst && m.editedAt && (
@@ -618,7 +707,7 @@ function ChannelView({ page }: ChannelViewProps) {
                                     canReact={permissions?.canView || false}
                                     canEdit={showOwnerActions}
                                     canDelete={showOwnerActions}
-                                    canReplyInThread={!isAi && !m.id.startsWith('temp-')}
+                                    canReplyInThread={!m.id.startsWith('temp-')}
                                     canQuoteReply={true}
                                     reactions={m.reactions}
                                     currentUserId={user?.id}
@@ -644,14 +733,15 @@ function ChannelView({ page }: ChannelViewProps) {
         <div className="flex-shrink-0 border-t border-border p-4">
           <div className="max-w-4xl mx-auto">
             {canEdit ? (
-              <ChannelInput
+              <MessageInput
                 ref={channelInputRef}
+                source="channel"
+                contextId={page.id}
                 value={inputValue}
                 onChange={setInputValue}
-                onSend={handleSendMessage}
+                onSubmit={handleTopLevelSubmit}
                 placeholder="Type a message... (use @ to mention, supports **markdown**)"
                 driveId={page.driveId}
-                channelId={page.id}
                 attachmentsEnabled
                 quotedPreview={quotedPreview}
                 onClearQuote={clearQuote}
@@ -667,6 +757,20 @@ function ChannelView({ page }: ChannelViewProps) {
           </div>
         </div>
     </MessageDropZone>
+    {threadPanel && !isMobile && (
+      <div className="hidden md:flex w-[420px] shrink-0 h-full">
+        {threadPanel}
+      </div>
+    )}
+    {threadPanel && isMobile && (
+      <Sheet open onOpenChange={(o) => { if (!o) closeThread(); }}>
+        <SheetContent side="right" className="w-full sm:max-w-full p-0">
+          <SheetTitle className="sr-only">Thread</SheetTitle>
+          {threadPanel}
+        </SheetContent>
+      </Sheet>
+    )}
+    </div>
   );
 }
 

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -6,7 +6,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { usePermissions, getPermissionErrorMessage } from '@/hooks/usePermissions';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { TreePage, MessageWithUser } from '@/hooks/usePageTree';
-import { renderMessageParts, convertToMessageParts } from '@/components/messages/MessagePartRenderer';
+import { StreamingMarkdown } from '@/components/ai/shared/chat/StreamingMarkdown';
 import {
   Conversation,
   ConversationContent,
@@ -102,6 +102,16 @@ function ChannelView({ page }: ChannelViewProps) {
   const quotedPreview = activeQuotedSnapshot
     ? { authorName: activeQuotedSnapshot.authorName ?? 'Member', snippet: activeQuotedSnapshot.contentSnippet }
     : null;
+
+  // Close any open thread when navigating between channels — `useThreadPanelStore`
+  // is global, so a stale parentId from a previous page would otherwise reappear
+  // when CenterPanel reuses ChannelView without a per-page key.
+  useEffect(() => {
+    closeThread();
+    setQuotedMessageId(null);
+    setActiveQuotedSnapshot(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page.id]);
 
   useEffect(() => {
     const fetchMessages = async () => {
@@ -518,7 +528,7 @@ function ChannelView({ page }: ChannelViewProps) {
           </div>
           {m.content && (
             <div className="prose prose-sm dark:prose-invert max-w-none">
-              {renderMessageParts(convertToMessageParts(m.content))}
+              <StreamingMarkdown content={m.content} isStreaming={false} />
             </div>
           )}
           <MessageAttachment message={m} />
@@ -669,7 +679,7 @@ function ChannelView({ page }: ChannelViewProps) {
                                     )}
                                     {m.content && (
                                       <div className="prose prose-sm dark:prose-invert max-w-none break-words [overflow-wrap:anywhere] min-w-0">
-                                        {renderMessageParts(convertToMessageParts(m.content))}
+                                        <StreamingMarkdown content={m.content} isStreaming={false} />
                                       </div>
                                     )}
                                     {!isFirst && m.editedAt && (


### PR DESCRIPTION
## Summary

- **Hover toolbar parity** across both channel surfaces: every real message now shows Quote + Reply-in-thread + Emoji + (own-message overflow). Drops the `!isAi` gate so agent/global-assistant messages can be threaded — matches DM behavior.
- **Reply-in-thread now actually opens the thread in drives.** `ChannelView` was firing `openThread()` but never rendering `<ThreadPanel>`, so clicks were silently no-op. Now wires the full store subscription and renders the panel as a desktop side-panel + mobile Sheet, mirroring the DM page layout. Also adds a `useEffect` on `page.id` that closes the thread + clears the quote chip when navigating between channels (the store is global and `CenterPanel` reuses `ChannelView` without a per-page key).
- **Quote end-to-end on the dashboard channel page**: state, `handleStartQuote`/`clearQuote`, `quotedMessageId` in the POST body, inline `MessageQuoteBlock` display, and `quotedPreview`/`onClearQuote` wired through `MessageInput`. Type extension on `MessageWithUser` for the new fields.
- **Modern primitives**: dashboard channel switches from `ScrollArea` + `PullToRefresh` to `Conversation` / `ConversationContent` / `ConversationScrollButton` (auto-scroll-to-bottom now native; `scrollAreaRef`/`skipAutoScrollRef` and `handleRefresh` removed). `ChannelView` moves from the bare `ChannelInput` to the source-aware `MessageInput` wrapper. Markdown rendering stays on `StreamingMarkdown` (Streamdown) — the wrapper that actually parses `**bold**`/code blocks and resolves `@[Label](id:type)` mentions.

## Test plan

- [ ] **In-drive channel** — open a Channel page inside a drive
  - [ ] Hover a **human** message: Quote, Reply-in-thread, Emoji, plus overflow on own messages
  - [ ] Hover an **AI/agent** message: Quote, Reply-in-thread, Emoji all present (this was the original bug)
  - [ ] Click Quote → input chip appears → submit → message renders with inline quote block
  - [ ] Click Reply-in-thread → ThreadPanel opens beside the messages on desktop and as a Sheet on mobile (resize to test)
  - [ ] Reply in the thread → root message updates its "N replies" footer
  - [ ] Navigate between two channels with a thread open in the first → second channel does not show stale thread
- [ ] **Dashboard channel** (/dashboard/channels/[pageId]) — same suite as above, including the AI-message hover check
  - [ ] `Conversation` scroll-to-bottom button appears on long lists
  - [ ] No `PullToRefresh` regression on mobile
- [ ] **Markdown** — send a message containing `**bold**`, an `\`inline code\`` snippet, and a fenced code block; confirm formatting renders (not raw syntax)
- [ ] **DM regression** — Quote, Reply-in-thread, Emoji, Edit, Delete still work
- [ ] `pnpm --filter web typecheck` clean ✓
- [ ] `pnpm --filter web lint` clean ✓
- [ ] Channel/message-related unit tests pass (ChannelInput, ThreadPanel, MessageQuoteBlock, useThreadPanelStore, channel routes) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)