### PR TITLE
fix(dm): enable cross-drive @ mention search

### DIFF
--- a/apps/web/src/components/shared/MessageInput.tsx
+++ b/apps/web/src/components/shared/MessageInput.tsx
@@ -113,6 +113,7 @@ export const MessageInput = forwardRef<ChannelInputRef, MessageInputProps>(
           placeholder ?? 'Type a message... (use @ to mention, supports **markdown**)'
         }
         driveId={source === 'channel' ? driveId : undefined}
+        crossDrive={source === 'dm'}
         channelId={source === 'channel' ? contextId : undefined}
         conversationId={source === 'dm' ? contextId : undefined}
         attachmentsEnabled={attachmentsEnabled}

--- a/apps/web/src/components/shared/__tests__/MessageInput.test.tsx
+++ b/apps/web/src/components/shared/__tests__/MessageInput.test.tsx
@@ -50,6 +50,8 @@ vi.mock('@/components/ai/chat/input/ChatTextarea', () => {
     placeholder?: string;
     canSendEmpty?: boolean;
     disabled?: boolean;
+    driveId?: string;
+    crossDrive?: boolean;
   }
   const MockChatTextarea = React.forwardRef<
     { focus: () => void; clear: () => void },
@@ -59,6 +61,8 @@ vi.mock('@/components/ai/chat/input/ChatTextarea', () => {
     return (
       <textarea
         data-testid="chat-textarea"
+        data-drive-id={props.driveId ?? ''}
+        data-cross-drive={props.crossDrive ? 'true' : 'false'}
         value={props.value}
         placeholder={props.placeholder}
         disabled={props.disabled}
@@ -99,6 +103,7 @@ const Harness = ({
   contextId,
   parentId,
   showAlsoSendToParent,
+  driveId,
   onSubmit,
 }: {
   initialValue?: string;
@@ -106,6 +111,7 @@ const Harness = ({
   contextId: string;
   parentId?: string;
   showAlsoSendToParent?: boolean;
+  driveId?: string;
   onSubmit: (info: MessageInputSubmit) => void;
 }) => {
   const [value, setValue] = React.useState(initialValue);
@@ -118,6 +124,7 @@ const Harness = ({
       onSubmit={onSubmit}
       parentId={parentId}
       showAlsoSendToParent={showAlsoSendToParent}
+      driveId={driveId}
     />
   );
 };
@@ -217,6 +224,48 @@ describe('MessageInput', () => {
       should: 'submit with alsoSendToParent=false',
       actual: false,
       expected: false,
+    });
+  });
+
+  it('given a DM source, should forward crossDrive=true and no driveId so mention search runs cross-drive', () => {
+    const onSubmit = vi.fn();
+    render(<Harness source="dm" contextId="conv-1" driveId="drive-x" onSubmit={onSubmit} />);
+
+    const textarea = screen.getByTestId('chat-textarea');
+    expect({
+      given: 'a DM compose (DMs are not scoped to a single drive)',
+      should: 'forward crossDrive=true and no driveId to the mention-aware textarea',
+      actual: {
+        crossDrive: textarea.getAttribute('data-cross-drive'),
+        driveId: textarea.getAttribute('data-drive-id'),
+      },
+      expected: { crossDrive: 'true', driveId: '' },
+    }).toEqual({
+      given: 'a DM compose (DMs are not scoped to a single drive)',
+      should: 'forward crossDrive=true and no driveId to the mention-aware textarea',
+      actual: { crossDrive: 'true', driveId: '' },
+      expected: { crossDrive: 'true', driveId: '' },
+    });
+  });
+
+  it('given a channel source, should forward driveId and crossDrive=false so mention search stays within-drive', () => {
+    const onSubmit = vi.fn();
+    render(<Harness source="channel" contextId="page-1" driveId="drive-x" onSubmit={onSubmit} />);
+
+    const textarea = screen.getByTestId('chat-textarea');
+    expect({
+      given: 'a channel compose with a known drive',
+      should: 'forward driveId and crossDrive=false to the mention-aware textarea',
+      actual: {
+        crossDrive: textarea.getAttribute('data-cross-drive'),
+        driveId: textarea.getAttribute('data-drive-id'),
+      },
+      expected: { crossDrive: 'false', driveId: 'drive-x' },
+    }).toEqual({
+      given: 'a channel compose with a known drive',
+      should: 'forward driveId and crossDrive=false to the mention-aware textarea',
+      actual: { crossDrive: 'false', driveId: 'drive-x' },
+      expected: { crossDrive: 'false', driveId: 'drive-x' },
     });
   });
 


### PR DESCRIPTION
## Summary

- DM composers were calling `/api/mentions/search` with no `driveId` and `crossDrive=false`, which trips the within-drive guard in `useSuggestionCore` (and the matching guard server-side) and surfaces the error **"Drive ID is required for within-drive search"** — so the `@` popup never opens in DMs.
- Fix: in `apps/web/src/components/shared/MessageInput.tsx`, pass `crossDrive={source === 'dm'}` to `ChannelInput`. DMs aren't scoped to a single drive, and the API already supports `crossDrive=true` (searches every drive the requester has access to and only enumerates members of drives the requester belongs to). All downstream plumbing — `ChannelInput` → `ChatTextarea` → `useSuggestion` → `useSuggestionCore` — was already wired for `crossDrive`. Channels are unchanged.
- Also fixes the DM thread composer (same `MessageInput`).

## Test plan

- [ ] `pnpm --filter web test -- MessageInput` (new tests pin DM → `crossDrive=true`/no `driveId`, channel → `driveId`/`crossDrive=false`)
- [ ] Open a DM, type `@foo` — popup loads results; network tab shows `GET /api/mentions/search?q=foo&crossDrive=true`
- [ ] Open a DM thread reply, type `@` — popup loads results
- [ ] Open a channel, type `@` — popup still scoped to the channel's drive (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Direct messages now support cross-drive mention search, allowing users to discover mentions across all available drives. Channel conversations maintain drive-specific mention search for contextually relevant results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->