### PR TITLE
feat(invites): collaborator-by-email from connections UI

### DIFF
--- a/apps/web/src/app/api/auth/magic-link/__tests__/round-trip.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/__tests__/round-trip.test.ts
@@ -248,6 +248,7 @@ describe('magic-link round-trip — inviteToken metadata binding end-to-end', ()
     vi.mocked(resolveInviteContext).mockResolvedValueOnce({
       ok: true,
       data: {
+        kind: 'drive',
         driveName: 'Acme',
         inviterName: 'Jane',
         role: 'MEMBER',

--- a/apps/web/src/app/api/connections/invite/__tests__/route.test.ts
+++ b/apps/web/src/app/api/connections/invite/__tests__/route.test.ts
@@ -1,0 +1,314 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ============================================================================
+// Contract tests for POST /api/connections/invite
+//
+// Mocks the connectionInviteRepository seam, email service, rate limiter,
+// and notification helper. No ORM chain mocking — Drizzle is never poked.
+// ============================================================================
+
+vi.mock('@/lib/repositories/connection-invite-repository', () => ({
+  connectionInviteRepository: {
+    findInviterDisplay: vi.fn(),
+    findUserIdByEmail: vi.fn(),
+    findExistingConnection: vi.fn(),
+    findActivePendingInviteByOwnerAndEmail: vi.fn(),
+    createPendingInvite: vi.fn(),
+    deletePendingInvite: vi.fn(),
+    createDirectConnection: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn((result: unknown) => result && typeof result === 'object' && 'error' in result),
+}));
+
+vi.mock('@pagespace/lib/auth/verification-utils', () => ({
+  isEmailVerified: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('@pagespace/lib/auth/invite-token', () => ({
+  createInviteToken: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/services/notification-email-service', () => ({
+  sendPendingConnectionInvitationEmail: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+  checkDistributedRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
+  DISTRIBUTED_RATE_LIMITS: {
+    CONNECTION_INVITE: { maxAttempts: 3, windowMs: 900000 },
+  },
+}));
+
+vi.mock('@pagespace/lib/notifications/notifications', () => ({
+  createNotification: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  },
+}));
+
+import { POST } from '../route';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+import { isEmailVerified } from '@pagespace/lib/auth/verification-utils';
+import { connectionInviteRepository } from '@/lib/repositories/connection-invite-repository';
+import { createInviteToken } from '@pagespace/lib/auth/invite-token';
+import { sendPendingConnectionInvitationEmail } from '@pagespace/lib/services/notification-email-service';
+import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
+import { createNotification } from '@pagespace/lib/notifications/notifications';
+
+const INVITER_USER_ID = 'user_inviter';
+const TARGET_USER_ID = 'user_target';
+const INVITER_EMAIL = 'inviter@example.com';
+const TARGET_EMAIL = 'target@example.com';
+
+const mockAuthSuccess = () => {
+  vi.mocked(authenticateRequestWithOptions).mockResolvedValue({
+    userId: INVITER_USER_ID,
+    tokenVersion: 0,
+    tokenType: 'session' as const,
+    sessionId: 'test-session',
+    role: 'user' as const,
+    adminRoleVersion: 0,
+  });
+};
+
+const makeRequest = (body: unknown) =>
+  new Request('http://localhost/api/connections/invite', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+describe('POST /api/connections/invite', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthSuccess();
+
+    vi.mocked(isEmailVerified).mockResolvedValue(true);
+    vi.mocked(connectionInviteRepository.findInviterDisplay).mockResolvedValue({
+      name: 'Inviter User',
+      email: INVITER_EMAIL,
+    });
+    vi.mocked(checkDistributedRateLimit).mockResolvedValue({ allowed: true });
+    vi.mocked(connectionInviteRepository.findUserIdByEmail).mockResolvedValue(null);
+    vi.mocked(connectionInviteRepository.findActivePendingInviteByOwnerAndEmail).mockResolvedValue(null);
+    vi.mocked(createInviteToken).mockReturnValue({
+      token: 'ps_invite_abc123',
+      tokenHash: 'hash_abc123',
+      expiresAt: new Date(Date.now() + 48 * 60 * 60 * 1000),
+    });
+    vi.mocked(connectionInviteRepository.createPendingInvite).mockResolvedValue({
+      id: 'invite_123',
+      tokenHash: 'hash_abc123',
+      email: TARGET_EMAIL,
+      invitedBy: INVITER_USER_ID,
+      requestMessage: null,
+      expiresAt: new Date(),
+      consumedAt: null,
+      createdAt: new Date(),
+    });
+
+    process.env.NEXT_PUBLIC_APP_URL = 'https://app.pagespace.ai';
+  });
+
+  describe('happy path — new user', () => {
+    it('creates a pending invite row and sends an email', async () => {
+      const res = await POST(makeRequest({ email: TARGET_EMAIL }));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.kind).toBe('invited');
+      expect(body.inviteId).toBe('invite_123');
+      expect(connectionInviteRepository.createPendingInvite).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: TARGET_EMAIL,
+          invitedBy: INVITER_USER_ID,
+          requestMessage: null,
+        })
+      );
+      expect(sendPendingConnectionInvitationEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          recipientEmail: TARGET_EMAIL,
+          inviterName: 'Inviter User',
+        })
+      );
+    });
+
+    it('passes optional message through to both pending row and email', async () => {
+      await POST(makeRequest({ email: TARGET_EMAIL, message: 'Hello!' }));
+
+      expect(connectionInviteRepository.createPendingInvite).toHaveBeenCalledWith(
+        expect.objectContaining({ requestMessage: 'Hello!' })
+      );
+      expect(sendPendingConnectionInvitationEmail).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Hello!' })
+      );
+    });
+  });
+
+  describe('existing verified user — fast path (R1)', () => {
+    beforeEach(() => {
+      vi.mocked(connectionInviteRepository.findUserIdByEmail).mockResolvedValue({
+        id: TARGET_USER_ID,
+        emailVerified: new Date('2024-01-01'),
+        suspendedAt: null,
+      });
+      vi.mocked(connectionInviteRepository.findExistingConnection).mockResolvedValue(null);
+      vi.mocked(connectionInviteRepository.createDirectConnection).mockResolvedValue({
+        id: 'conn_abc',
+      });
+    });
+
+    it('creates a PENDING connection directly, skips pending invite table', async () => {
+      const res = await POST(makeRequest({ email: TARGET_EMAIL }));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.kind).toBe('requested');
+      expect(body.connectionId).toBe('conn_abc');
+      expect(connectionInviteRepository.createPendingInvite).not.toHaveBeenCalled();
+      expect(createNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: TARGET_USER_ID,
+          type: 'CONNECTION_REQUEST',
+        })
+      );
+    });
+  });
+
+  describe('inviter email not verified (R3)', () => {
+    it('returns 403 with requiresEmailVerification flag', async () => {
+      vi.mocked(isEmailVerified).mockResolvedValue(false);
+
+      const res = await POST(makeRequest({ email: TARGET_EMAIL }));
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.requiresEmailVerification).toBe(true);
+    });
+  });
+
+  describe('self-invite (R5)', () => {
+    it('returns 400 when inviting own email', async () => {
+      const res = await POST(makeRequest({ email: INVITER_EMAIL }));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe('Cannot connect with yourself');
+    });
+  });
+
+  describe('suspended target account', () => {
+    it('returns 403 when target account is suspended', async () => {
+      vi.mocked(connectionInviteRepository.findUserIdByEmail).mockResolvedValue({
+        id: TARGET_USER_ID,
+        emailVerified: new Date('2024-01-01'),
+        suspendedAt: new Date('2025-01-01'),
+      });
+
+      const res = await POST(makeRequest({ email: TARGET_EMAIL }));
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.error).toMatch(/suspended/i);
+    });
+  });
+
+  describe('already-pending invite', () => {
+    it('returns 409 when an active pending invite already exists', async () => {
+      vi.mocked(connectionInviteRepository.findActivePendingInviteByOwnerAndEmail).mockResolvedValue(
+        { id: 'existing_invite_123' }
+      );
+
+      const res = await POST(makeRequest({ email: TARGET_EMAIL }));
+      const body = await res.json();
+
+      expect(res.status).toBe(409);
+      expect(body.error).toMatch(/already pending/i);
+    });
+  });
+
+  describe('already-connected fast-path', () => {
+    it('returns 400 when a PENDING connection row exists', async () => {
+      vi.mocked(connectionInviteRepository.findUserIdByEmail).mockResolvedValue({
+        id: TARGET_USER_ID,
+        emailVerified: new Date('2024-01-01'),
+        suspendedAt: null,
+      });
+      vi.mocked(connectionInviteRepository.findExistingConnection).mockResolvedValue({
+        id: 'conn_123',
+        status: 'PENDING',
+      });
+
+      const res = await POST(makeRequest({ email: TARGET_EMAIL }));
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when an ACCEPTED connection row exists', async () => {
+      vi.mocked(connectionInviteRepository.findUserIdByEmail).mockResolvedValue({
+        id: TARGET_USER_ID,
+        emailVerified: new Date('2024-01-01'),
+        suspendedAt: null,
+      });
+      vi.mocked(connectionInviteRepository.findExistingConnection).mockResolvedValue({
+        id: 'conn_123',
+        status: 'ACCEPTED',
+      });
+
+      const res = await POST(makeRequest({ email: TARGET_EMAIL }));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toMatch(/already connected/i);
+    });
+  });
+
+  describe('rate limit exceeded', () => {
+    it('returns 429 when pair-scoped rate limit is exceeded', async () => {
+      vi.mocked(checkDistributedRateLimit).mockResolvedValueOnce({
+        allowed: false,
+        retryAfter: 900,
+      });
+
+      const res = await POST(makeRequest({ email: TARGET_EMAIL }));
+
+      expect(res.status).toBe(429);
+      expect(res.headers.get('Retry-After')).toBe('900');
+    });
+
+    it('returns 429 when global email rate limit is exceeded', async () => {
+      vi.mocked(checkDistributedRateLimit)
+        .mockResolvedValueOnce({ allowed: true }) // pair limit passes
+        .mockResolvedValueOnce({ allowed: false, retryAfter: 900 }); // email limit fails
+
+      const res = await POST(makeRequest({ email: TARGET_EMAIL }));
+
+      expect(res.status).toBe(429);
+    });
+  });
+
+  describe('SMTP rollback (R6)', () => {
+    it('deletes pending invite row when email send fails', async () => {
+      vi.mocked(sendPendingConnectionInvitationEmail).mockRejectedValue(
+        new Error('SMTP connection refused')
+      );
+
+      const res = await POST(makeRequest({ email: TARGET_EMAIL }));
+      const body = await res.json();
+
+      expect(res.status).toBe(502);
+      expect(connectionInviteRepository.deletePendingInvite).toHaveBeenCalledWith('invite_123');
+    });
+  });
+});

--- a/apps/web/src/app/api/connections/invite/__tests__/route.test.ts
+++ b/apps/web/src/app/api/connections/invite/__tests__/route.test.ts
@@ -305,7 +305,6 @@ describe('POST /api/connections/invite', () => {
       );
 
       const res = await POST(makeRequest({ email: TARGET_EMAIL }));
-      const body = await res.json();
 
       expect(res.status).toBe(502);
       expect(connectionInviteRepository.deletePendingInvite).toHaveBeenCalledWith('invite_123');

--- a/apps/web/src/app/api/connections/invite/route.ts
+++ b/apps/web/src/app/api/connections/invite/route.ts
@@ -130,11 +130,29 @@ export async function POST(request: Request) {
         }
       }
 
-      const newConn = await connectionInviteRepository.createDirectConnection({
-        inviterUserId,
-        targetUserId: targetUser.id,
-        requestMessage: message,
-      });
+      let newConn: { id: string };
+      try {
+        newConn = await connectionInviteRepository.createDirectConnection({
+          inviterUserId,
+          targetUserId: targetUser.id,
+          requestMessage: message,
+        });
+      } catch (insertError) {
+        // Two concurrent requests can both pass the existence check and race
+        // on the connections_user_pair_key unique constraint. Map this to a
+        // deterministic conflict response rather than a 500.
+        const msg = insertError instanceof Error ? insertError.message : String(insertError);
+        const isUniqueViolation =
+          msg.includes('connections_user_pair_key') ||
+          (msg.includes('duplicate key') && msg.includes('connections'));
+        if (isUniqueViolation) {
+          return NextResponse.json(
+            { error: 'Connection request already pending' },
+            { status: 400 }
+          );
+        }
+        throw insertError;
+      }
 
       const senderName = inviterDisplay?.name ?? 'Someone';
       await createNotification({

--- a/apps/web/src/app/api/connections/invite/route.ts
+++ b/apps/web/src/app/api/connections/invite/route.ts
@@ -1,0 +1,276 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod/v4';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { isEmailVerified } from '@pagespace/lib/auth/verification-utils';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { connectionInviteRepository } from '@/lib/repositories/connection-invite-repository';
+import { createInviteToken } from '@pagespace/lib/auth/invite-token';
+import { sendPendingConnectionInvitationEmail } from '@pagespace/lib/services/notification-email-service';
+import {
+  checkDistributedRateLimit,
+  DISTRIBUTED_RATE_LIMITS,
+} from '@pagespace/lib/security/distributed-rate-limit';
+import { createNotification } from '@pagespace/lib/notifications/notifications';
+
+const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
+
+const inviteBodySchema = z.object({
+  email: z.string().trim().toLowerCase().pipe(z.string().email().max(254)),
+  message: z.string().max(500).optional(),
+});
+
+function resolveAppUrl(): string | null {
+  const url = process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL;
+  if (!url) return null;
+  return url.replace(/\/+$/, '');
+}
+
+export async function POST(request: Request) {
+  try {
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
+    if (isAuthError(auth)) return auth.error;
+    const inviterUserId = auth.userId;
+
+    const emailVerified = await isEmailVerified(inviterUserId);
+    if (!emailVerified) {
+      return NextResponse.json(
+        {
+          error: 'Email verification required. Please verify your email to perform this action.',
+          requiresEmailVerification: true,
+        },
+        { status: 403 }
+      );
+    }
+
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    const parsed = inviteBodySchema.safeParse(rawBody);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Invalid request body', issues: parsed.error.issues },
+        { status: 400 }
+      );
+    }
+    const { email, message } = parsed.data;
+
+    // Fetch inviter info once — used for self-invite check + display name later.
+    const inviterDisplay = await connectionInviteRepository.findInviterDisplay(inviterUserId);
+
+    // Self-invite check (R5)
+    if (inviterDisplay?.email === email) {
+      return NextResponse.json(
+        { error: 'Cannot connect with yourself' },
+        { status: 400 }
+      );
+    }
+
+    // Pair-scoped rate limit: catches a single user spamming one address.
+    const pairRl = await checkDistributedRateLimit(
+      `connection_invite:inviter:${inviterUserId}:${email}`,
+      DISTRIBUTED_RATE_LIMITS.CONNECTION_INVITE
+    );
+    if (!pairRl.allowed) {
+      return NextResponse.json(
+        { error: 'Too many invitations to this address. Please try again later.' },
+        { status: 429, headers: { 'Retry-After': String(pairRl.retryAfter ?? 900) } }
+      );
+    }
+    // Global per-email limit: catches the same address being spammed across inviters.
+    const emailRl = await checkDistributedRateLimit(
+      `connection_invite:email:${email}`,
+      DISTRIBUTED_RATE_LIMITS.CONNECTION_INVITE
+    );
+    if (!emailRl.allowed) {
+      return NextResponse.json(
+        { error: 'Too many invitations to this address. Please try again later.' },
+        { status: 429, headers: { 'Retry-After': String(emailRl.retryAfter ?? 900) } }
+      );
+    }
+
+    const targetUser = await connectionInviteRepository.findUserIdByEmail(email);
+
+    // Suspended-account gate (mirror drive route line 348).
+    if (targetUser?.suspendedAt) {
+      return NextResponse.json(
+        { error: 'This account is suspended and cannot be invited.' },
+        { status: 403 }
+      );
+    }
+
+    // Existing verified user → fast path (R1): create PENDING connection directly.
+    if (targetUser && targetUser.emailVerified) {
+      const existingConn = await connectionInviteRepository.findExistingConnection(
+        inviterUserId,
+        targetUser.id
+      );
+      if (existingConn) {
+        if (existingConn.status === 'ACCEPTED') {
+          return NextResponse.json(
+            { error: 'Already connected with this user' },
+            { status: 400 }
+          );
+        }
+        if (existingConn.status === 'PENDING') {
+          return NextResponse.json(
+            { error: 'Connection request already pending' },
+            { status: 400 }
+          );
+        }
+        if (existingConn.status === 'BLOCKED') {
+          return NextResponse.json(
+            { error: 'Cannot send connection request' },
+            { status: 400 }
+          );
+        }
+      }
+
+      const newConn = await connectionInviteRepository.createDirectConnection({
+        inviterUserId,
+        targetUserId: targetUser.id,
+        requestMessage: message,
+      });
+
+      const senderName = inviterDisplay?.name ?? 'Someone';
+      await createNotification({
+        userId: targetUser.id,
+        type: 'CONNECTION_REQUEST',
+        title: 'New Connection Request',
+        message: `${senderName} wants to connect with you`,
+        metadata: {
+          connectionId: newConn.id,
+          senderId: inviterUserId,
+          requestMessage: message,
+          requesterName: senderName,
+        },
+        triggeredByUserId: inviterUserId,
+      });
+
+      auditRequest(request, {
+        eventType: 'data.write',
+        userId: inviterUserId,
+        resourceType: 'connection',
+        resourceId: newConn.id,
+        details: { targetUserId: targetUser.id, via: 'email-invite', email },
+      });
+
+      return NextResponse.json({
+        kind: 'requested',
+        connectionId: newConn.id,
+        message: `Connection request sent to ${email}`,
+      });
+    }
+
+    // New-user path (R2): create pending invite row + send email.
+    const now = new Date();
+
+    const existingPending = await connectionInviteRepository.findActivePendingInviteByOwnerAndEmail(
+      inviterUserId,
+      email,
+      now
+    );
+    if (existingPending) {
+      return NextResponse.json(
+        { error: 'An invitation is already pending for this email.' },
+        { status: 409 }
+      );
+    }
+
+    const appUrl = resolveAppUrl();
+    if (!appUrl) {
+      loggers.api.error(
+        'Connection invite email cannot be sent: WEB_APP_URL and NEXT_PUBLIC_APP_URL both unset'
+      );
+      return NextResponse.json(
+        { error: 'Email delivery is not configured on this deployment.' },
+        { status: 500 }
+      );
+    }
+
+    const { token, tokenHash, expiresAt } = createInviteToken({ now });
+
+    let pendingInvite: { id: string };
+    try {
+      pendingInvite = await connectionInviteRepository.createPendingInvite({
+        tokenHash,
+        email,
+        invitedBy: inviterUserId,
+        requestMessage: message ?? null,
+        expiresAt,
+        now,
+      });
+    } catch (insertError) {
+      const msg = insertError instanceof Error ? insertError.message : String(insertError);
+      const isUniqueViolation =
+        msg.includes('pending_connection_invites_active_owner_email_idx') ||
+        msg.includes('pending_connection_invites_token_hash_unique') ||
+        msg.includes('duplicate key');
+      if (isUniqueViolation) {
+        return NextResponse.json(
+          { error: 'An invitation is already pending for this email.' },
+          { status: 409 }
+        );
+      }
+      loggers.api.error(
+        'Failed to persist pending connection invite',
+        insertError instanceof Error ? insertError : new Error(String(insertError))
+      );
+      return NextResponse.json({ error: 'Failed to create invitation' }, { status: 500 });
+    }
+
+    // ps_invite_* tokens are URL-safe (cuid2 alnum); encodeURIComponent is defensive.
+    const inviteUrl = `${appUrl}/invite/${encodeURIComponent(token)}`;
+
+    // If email fails, compensating-delete the pending row (R6).
+    try {
+      await sendPendingConnectionInvitationEmail({
+        recipientEmail: email,
+        inviterName: inviterDisplay?.name ?? 'A teammate',
+        message,
+        inviteUrl,
+      });
+    } catch (emailError) {
+      loggers.api.error(
+        'Failed to send pending connection invitation email; rolling back pending invite row',
+        emailError instanceof Error ? emailError : new Error(String(emailError)),
+        { recipientEmail: email }
+      );
+      try {
+        await connectionInviteRepository.deletePendingInvite(pendingInvite.id);
+      } catch (rollbackError) {
+        loggers.api.error(
+          'Rollback of pending_connection_invites row failed after email send failure',
+          rollbackError instanceof Error ? rollbackError : new Error(String(rollbackError)),
+          { inviteId: pendingInvite.id }
+        );
+      }
+      return NextResponse.json(
+        { error: 'Failed to send invitation email. Please try again.' },
+        { status: 502 }
+      );
+    }
+
+    auditRequest(request, {
+      eventType: 'data.write',
+      userId: inviterUserId,
+      resourceType: 'connection',
+      resourceId: pendingInvite.id,
+      details: { targetEmail: email, operation: 'invite', pending: true },
+    });
+
+    return NextResponse.json({
+      kind: 'invited',
+      inviteId: pendingInvite.id,
+      email,
+      message: `Connection invite sent to ${email}`,
+    });
+  } catch (error) {
+    loggers.api.error('Error creating connection invite:', error as Error);
+    return NextResponse.json({ error: 'Failed to create connection invite' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/auth/signup/SignUpClient.tsx
+++ b/apps/web/src/app/auth/signup/SignUpClient.tsx
@@ -62,12 +62,21 @@ export function SignUpClient({ inviteToken, inviteContext }: SignUpClientProps) 
           transition={{ duration: 0.3 }}
         >
           <p className="text-gray-900 dark:text-gray-100">
-            You&apos;re joining{' '}
-            <span className="font-semibold text-blue-700 dark:text-blue-300">
-              {inviteContext.driveName}
-            </span>
-            , invited by{' '}
-            <span className="font-semibold">{inviteContext.inviterName}</span>.
+            {inviteContext.kind === 'connection' ? (
+              <>
+                <span className="font-semibold">{inviteContext.inviterName}</span>
+                {' '}wants to connect with you on PageSpace.
+              </>
+            ) : (
+              <>
+                You&apos;re joining{' '}
+                <span className="font-semibold text-blue-700 dark:text-blue-300">
+                  {inviteContext.driveName}
+                </span>
+                , invited by{' '}
+                <span className="font-semibold">{inviteContext.inviterName}</span>.
+              </>
+            )}
           </p>
         </motion.div>
       )}

--- a/apps/web/src/app/dashboard/connections/__tests__/page.test.tsx
+++ b/apps/web/src/app/dashboard/connections/__tests__/page.test.tsx
@@ -56,7 +56,7 @@ describe('ConnectionsPage — Add Connection tab invite branch', () => {
     return discoverTab;
   }
 
-  it('given user search returns no match, surfaces the invite-to-PageSpace CTA', async () => {
+  it('given user search returns "no user found", surfaces the invite-to-PageSpace CTA', async () => {
     const user = userEvent.setup();
 
     vi.mocked(fetchWithAuth).mockResolvedValueOnce(
@@ -84,7 +84,7 @@ describe('ConnectionsPage — Add Connection tab invite branch', () => {
     const user = userEvent.setup();
 
     vi.mocked(fetchWithAuth).mockResolvedValueOnce(
-      new Response(JSON.stringify({ user: null }), {
+      new Response(JSON.stringify({ user: null, error: 'No user found with this email address' }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       })
@@ -119,11 +119,34 @@ describe('ConnectionsPage — Add Connection tab invite branch', () => {
     });
   });
 
+  it('given user search returns "already connected", shows error toast (not invite CTA)', async () => {
+    const user = userEvent.setup();
+
+    vi.mocked(fetchWithAuth).mockResolvedValueOnce(
+      new Response(JSON.stringify({ user: null, error: 'Already connected with this user' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const discoverTab = renderAndGetTab();
+    await user.click(discoverTab);
+
+    const input = screen.getByPlaceholderText('Enter email address');
+    await user.type(input, 'existing@example.com');
+    await user.click(screen.getByRole('button', { name: /Find User/i }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Already connected with this user');
+      expect(screen.queryByRole('button', { name: /Invite to PageSpace/i })).not.toBeInTheDocument();
+    });
+  });
+
   it('given invite returns 409 (already pending), shows appropriate error toast', async () => {
     const user = userEvent.setup();
 
     vi.mocked(fetchWithAuth).mockResolvedValueOnce(
-      new Response(JSON.stringify({ user: null }), {
+      new Response(JSON.stringify({ user: null, error: 'No user found with this email address' }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       })

--- a/apps/web/src/app/dashboard/connections/__tests__/page.test.tsx
+++ b/apps/web/src/app/dashboard/connections/__tests__/page.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// ============================================================================
+// Smoke tests for the connections "Add Connection" tab invite branch.
+// Focuses on: user-not-found → invite CTA surface, and invite POST payload.
+// ============================================================================
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: vi.fn(() => ({ user: { id: 'user_123' } })),
+}));
+
+vi.mock('@/hooks/useSocket', () => ({
+  useSocket: vi.fn(() => null),
+}));
+
+vi.mock('@/stores/useNotificationStore', () => ({
+  useNotificationStore: {
+    getState: vi.fn(() => ({
+      notifications: [],
+      updateNotification: vi.fn(),
+    })),
+  },
+}));
+
+vi.mock('swr', () => ({
+  default: vi.fn(() => ({ data: { connections: [] }, error: null })),
+  mutate: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: vi.fn(),
+  post: vi.fn(),
+}));
+
+import ConnectionsPage from '../page';
+import { fetchWithAuth, post } from '@/lib/auth/auth-fetch';
+import { toast } from 'sonner';
+
+describe('ConnectionsPage — Add Connection tab invite branch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function renderAndGetTab() {
+    render(<ConnectionsPage />);
+    const discoverTab = screen.getByRole('tab', { name: /Add Connection/i });
+    return discoverTab;
+  }
+
+  it('given user search returns no match, surfaces the invite-to-PageSpace CTA', async () => {
+    const user = userEvent.setup();
+
+    vi.mocked(fetchWithAuth).mockResolvedValueOnce(
+      new Response(JSON.stringify({ user: null, error: 'No user found with this email address' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const discoverTab = renderAndGetTab();
+    await user.click(discoverTab);
+
+    const input = screen.getByPlaceholderText('Enter email address');
+    await user.type(input, 'unknown@example.com');
+    await user.click(screen.getByRole('button', { name: /Find User/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('User not found')).toBeInTheDocument();
+      expect(screen.getByText(/unknown@example.com is not on PageSpace yet/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Invite to PageSpace/i })).toBeInTheDocument();
+    });
+  });
+
+  it('given user clicks the invite CTA, POSTs to /api/connections/invite with correct email', async () => {
+    const user = userEvent.setup();
+
+    vi.mocked(fetchWithAuth).mockResolvedValueOnce(
+      new Response(JSON.stringify({ user: null }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    vi.mocked(post).mockResolvedValueOnce({
+      kind: 'invited',
+      inviteId: 'invite_abc',
+      email: 'unknown@example.com',
+      message: 'Connection invite sent to unknown@example.com',
+    });
+
+    const discoverTab = renderAndGetTab();
+    await user.click(discoverTab);
+
+    const input = screen.getByPlaceholderText('Enter email address');
+    await user.type(input, 'unknown@example.com');
+    await user.click(screen.getByRole('button', { name: /Find User/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Invite to PageSpace/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /Invite to PageSpace/i }));
+
+    await waitFor(() => {
+      expect(post).toHaveBeenCalledWith('/api/connections/invite', {
+        email: 'unknown@example.com',
+      });
+      expect(toast.success).toHaveBeenCalledWith(
+        expect.stringContaining('unknown@example.com')
+      );
+    });
+  });
+
+  it('given invite returns 409 (already pending), shows appropriate error toast', async () => {
+    const user = userEvent.setup();
+
+    vi.mocked(fetchWithAuth).mockResolvedValueOnce(
+      new Response(JSON.stringify({ user: null }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    vi.mocked(post).mockRejectedValueOnce(
+      new Error('An invitation is already pending for this email.')
+    );
+
+    const discoverTab = renderAndGetTab();
+    await user.click(discoverTab);
+
+    const input = screen.getByPlaceholderText('Enter email address');
+    await user.type(input, 'unknown@example.com');
+    await user.click(screen.getByRole('button', { name: /Find User/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Invite to PageSpace/i })).toBeInTheDocument()
+    );
+
+    await user.click(screen.getByRole('button', { name: /Invite to PageSpace/i }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        expect.stringContaining('already have a pending connection invite')
+      );
+    });
+  });
+});

--- a/apps/web/src/app/dashboard/connections/page.tsx
+++ b/apps/web/src/app/dashboard/connections/page.tsx
@@ -9,7 +9,7 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
-import { UserPlus, UserMinus, UserCheck, UserX, MessageSquare, MoreVertical, User } from 'lucide-react';
+import { UserPlus, UserMinus, UserCheck, UserX, MessageSquare, MoreVertical, User, Mail } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -57,6 +57,8 @@ export default function ConnectionsPage() {
   const socket = useSocket();
   const [email, setEmail] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isInviting, setIsInviting] = useState(false);
+  const [invitableEmail, setInvitableEmail] = useState<string | null>(null);
   const [showVerificationAlert, setShowVerificationAlert] = useState(false);
 
   // Fetch accepted connections
@@ -91,18 +93,20 @@ export default function ConnectionsPage() {
   }, [socket]);
 
   const handleSendConnectionRequest = async () => {
-    const trimmedEmail = email.trim();
+    const trimmedEmail = email.trim().toLowerCase();
     if (!trimmedEmail) return;
 
+    setInvitableEmail(null);
     setIsSubmitting(true);
     try {
       const response = await fetchWithAuth(`/api/connections/search?email=${encodeURIComponent(trimmedEmail)}`);
-      if (!response.ok) throw new Error('Failed to send connection request');
+      if (!response.ok) throw new Error('Failed to search for user');
 
       const data = await response.json();
 
       if (!data.user) {
-        toast.error(data.error || 'No user found with this email address');
+        // Surface the invite-to-PageSpace CTA for unknown emails.
+        setInvitableEmail(trimmedEmail);
         return;
       }
 
@@ -123,6 +127,29 @@ export default function ConnectionsPage() {
       toast.error(errorMessage || 'Failed to send connection request');
     } finally {
       setIsSubmitting(false);
+    }
+  };
+
+  const handleInviteToPageSpace = async () => {
+    if (!invitableEmail) return;
+
+    setIsInviting(true);
+    try {
+      await post('/api/connections/invite', { email: invitableEmail });
+      toast.success(`Connection invite sent to ${invitableEmail}`);
+      setEmail('');
+      setInvitableEmail(null);
+    } catch (error) {
+      const errorMessage = (error as Error).message;
+      if (errorMessage.includes('already pending')) {
+        toast.error(`You already have a pending connection invite for ${invitableEmail}`);
+      } else if (errorMessage.includes('requiresEmailVerification') || errorMessage.includes('verification')) {
+        setShowVerificationAlert(true);
+      } else {
+        toast.error(errorMessage || 'Failed to send invite');
+      }
+    } finally {
+      setIsInviting(false);
     }
   };
 
@@ -375,18 +402,40 @@ export default function ConnectionsPage() {
                     type="email"
                     placeholder="Enter email address"
                     value={email}
-                    onChange={(e) => setEmail(e.target.value)}
+                    onChange={(e) => {
+                      setEmail(e.target.value);
+                      if (invitableEmail) setInvitableEmail(null);
+                    }}
                     onKeyDown={(e) => e.key === 'Enter' && handleSendConnectionRequest()}
-                    disabled={isSubmitting}
+                    disabled={isSubmitting || isInviting}
                   />
                   <Button
                     onClick={handleSendConnectionRequest}
-                    disabled={isSubmitting || !email.trim()}
+                    disabled={isSubmitting || isInviting || !email.trim()}
                   >
                     <UserPlus className="h-4 w-4 mr-2" />
-                    {isSubmitting ? 'Sending...' : 'Send Request'}
+                    {isSubmitting ? 'Searching...' : 'Find User'}
                   </Button>
                 </div>
+                {invitableEmail && (
+                  <div className="flex items-start gap-3 rounded-lg border border-dashed p-4">
+                    <Mail className="h-5 w-5 text-muted-foreground mt-0.5 shrink-0" />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium">User not found</p>
+                      <p className="text-sm text-muted-foreground truncate">
+                        {invitableEmail} is not on PageSpace yet.
+                      </p>
+                    </div>
+                    <Button
+                      size="sm"
+                      onClick={handleInviteToPageSpace}
+                      disabled={isInviting}
+                    >
+                      <Mail className="h-4 w-4 mr-2" />
+                      {isInviting ? 'Sending...' : 'Invite to PageSpace'}
+                    </Button>
+                  </div>
+                )}
               </div>
             </CardContent>
           </Card>

--- a/apps/web/src/app/dashboard/connections/page.tsx
+++ b/apps/web/src/app/dashboard/connections/page.tsx
@@ -105,8 +105,15 @@ export default function ConnectionsPage() {
       const data = await response.json();
 
       if (!data.user) {
-        // Surface the invite-to-PageSpace CTA for unknown emails.
-        setInvitableEmail(trimmedEmail);
+        const errorMsg: string = data.error || '';
+        // Only surface the invite CTA for true "user not found" — not for
+        // self-search or existing PENDING/ACCEPTED/BLOCKED relationships,
+        // which also return user: null but with a specific reason.
+        if (errorMsg.toLowerCase().includes('no user found')) {
+          setInvitableEmail(trimmedEmail);
+        } else {
+          toast.error(errorMsg || 'No user found with this email address');
+        }
         return;
       }
 

--- a/apps/web/src/app/invite/[token]/page.tsx
+++ b/apps/web/src/app/invite/[token]/page.tsx
@@ -37,26 +37,75 @@ export default async function InvitePage({ params }: InvitePageProps) {
     );
   }
 
-  const { driveName, inviterName, role, email, isExistingUser } = resolution.data;
+  const { data } = resolution;
   const encodedToken = encodeURIComponent(token);
-  const ctaHref = isExistingUser
+
+  if (data.kind === 'connection') {
+    const ctaHref = data.isExistingUser
+      ? `/auth/signin?invite=${encodedToken}`
+      : `/auth/signup?invite=${encodedToken}`;
+    const ctaLabel = data.isExistingUser ? 'Sign in to connect' : 'Create account & connect';
+
+    return (
+      <AuthShell>
+        <div className="space-y-6">
+          <div className="text-center">
+            <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+              <span className="text-blue-600 dark:text-blue-400">{data.inviterName}</span>
+              {' '}wants to connect with you
+            </h1>
+            <p className="mt-3 text-sm text-muted-foreground">
+              This invitation was sent to{' '}
+              <span className="font-medium text-gray-900 dark:text-gray-100">{data.email}</span>.
+            </p>
+          </div>
+
+          {data.message && (
+            <div className="rounded-lg border border-gray-200 bg-white/60 p-4 text-sm text-gray-700 dark:border-gray-700 dark:bg-gray-800/40 dark:text-gray-300 italic">
+              &ldquo;{data.message}&rdquo;
+            </div>
+          )}
+
+          <div className="rounded-lg border border-gray-200 bg-white/60 p-4 text-sm text-gray-700 dark:border-gray-700 dark:bg-gray-800/40 dark:text-gray-300">
+            <p>
+              By continuing, you agree to PageSpace&apos;s{' '}
+              <Link href="/terms" className="underline hover:text-foreground">Terms</Link>
+              {' '}and{' '}
+              <Link href="/privacy" className="underline hover:text-foreground">Privacy Policy</Link>.
+            </p>
+          </div>
+
+          <Link href={ctaHref}>
+            <Button className="w-full">{ctaLabel}</Button>
+          </Link>
+
+          <p className="text-center text-xs text-muted-foreground/70">
+            Not {data.email}? Sign out of any other account first, then return to this link.
+          </p>
+        </div>
+      </AuthShell>
+    );
+  }
+
+  // kind === 'drive'
+  const ctaHref = data.isExistingUser
     ? `/auth/signin?invite=${encodedToken}`
     : `/auth/signup?invite=${encodedToken}`;
-  const ctaLabel = isExistingUser ? 'Sign in to join' : 'Create account & join';
+  const ctaLabel = data.isExistingUser ? 'Sign in to join' : 'Create account & join';
 
   return (
     <AuthShell>
       <div className="space-y-6">
         <div className="text-center">
           <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
-            You&apos;re invited to <span className="text-blue-600 dark:text-blue-400">{driveName}</span>
+            You&apos;re invited to <span className="text-blue-600 dark:text-blue-400">{data.driveName}</span>
           </h1>
           <p className="mt-3 text-sm text-muted-foreground">
-            <span className="font-medium text-gray-900 dark:text-gray-100">{inviterName}</span>
+            <span className="font-medium text-gray-900 dark:text-gray-100">{data.inviterName}</span>
             {' '}invited{' '}
-            <span className="font-medium text-gray-900 dark:text-gray-100">{email}</span>
+            <span className="font-medium text-gray-900 dark:text-gray-100">{data.email}</span>
             {' '}to join as a{' '}
-            <span className="font-medium text-gray-900 dark:text-gray-100">{role.toLowerCase()}</span>.
+            <span className="font-medium text-gray-900 dark:text-gray-100">{data.role.toLowerCase()}</span>.
           </p>
         </div>
 
@@ -74,7 +123,7 @@ export default async function InvitePage({ params }: InvitePageProps) {
         </Link>
 
         <p className="text-center text-xs text-muted-foreground/70">
-          Not {email}? Sign out of any other account first, then return to this link.
+          Not {data.email}? Sign out of any other account first, then return to this link.
         </p>
       </div>
     </AuthShell>

--- a/apps/web/src/lib/auth/__tests__/invite-resolver.test.ts
+++ b/apps/web/src/lib/auth/__tests__/invite-resolver.test.ts
@@ -7,16 +7,23 @@ vi.mock('@/lib/repositories/drive-invite-repository', () => ({
   },
 }));
 
+vi.mock('@/lib/repositories/connection-invite-repository', () => ({
+  connectionInviteRepository: {
+    findPendingInviteByTokenHash: vi.fn(),
+  },
+}));
+
 vi.mock('@pagespace/lib/auth/token-utils', () => ({
   hashToken: vi.fn((t: string) => `hash(${t})`),
 }));
 
 import { resolveInviteContext } from '../invite-resolver';
 import { driveInviteRepository } from '@/lib/repositories/drive-invite-repository';
+import { connectionInviteRepository } from '@/lib/repositories/connection-invite-repository';
 
 const now = new Date('2026-05-06T12:00:00.000Z');
 
-const baseInvite = {
+const baseDriveInvite = {
   id: 'inv_1',
   email: 'invitee@example.com',
   driveId: 'drive_1',
@@ -28,20 +35,33 @@ const baseInvite = {
   inviterName: 'Jane',
 };
 
-beforeEach(() => vi.clearAllMocks());
+const baseConnectionInvite = {
+  id: 'cinv_1',
+  email: 'invitee@example.com',
+  invitedBy: 'inviter_1',
+  inviterName: 'Bob',
+  requestMessage: null as string | null,
+  expiresAt: new Date('2026-05-08T12:00:00.000Z'),
+  consumedAt: null as Date | null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: both repos return null (no invite found)
+  vi.mocked(driveInviteRepository.findPendingInviteByTokenHash).mockResolvedValue(null);
+  vi.mocked(connectionInviteRepository.findPendingInviteByTokenHash).mockResolvedValue(null);
+});
 
 describe('resolveInviteContext', () => {
   it('given a token that does not match any pending row, returns NOT_FOUND', async () => {
-    vi.mocked(driveInviteRepository.findPendingInviteByTokenHash).mockResolvedValue(null);
-
     const result = await resolveInviteContext({ token: 'garbage', now });
 
     expect(result).toEqual({ ok: false, error: 'NOT_FOUND' });
   });
 
-  it('given a row whose consumedAt is set, returns CONSUMED', async () => {
+  it('given a drive row whose consumedAt is set, returns CONSUMED', async () => {
     vi.mocked(driveInviteRepository.findPendingInviteByTokenHash).mockResolvedValue({
-      ...baseInvite,
+      ...baseDriveInvite,
       consumedAt: new Date('2026-05-06T11:00:00.000Z'),
     });
 
@@ -50,9 +70,9 @@ describe('resolveInviteContext', () => {
     expect(result).toEqual({ ok: false, error: 'CONSUMED' });
   });
 
-  it('given a row whose expiresAt is in the past, returns EXPIRED', async () => {
+  it('given a drive row whose expiresAt is in the past, returns EXPIRED', async () => {
     vi.mocked(driveInviteRepository.findPendingInviteByTokenHash).mockResolvedValue({
-      ...baseInvite,
+      ...baseDriveInvite,
       expiresAt: new Date('2026-05-06T11:00:00.000Z'),
     });
 
@@ -61,8 +81,8 @@ describe('resolveInviteContext', () => {
     expect(result).toEqual({ ok: false, error: 'EXPIRED' });
   });
 
-  it('given an active row + a user with tosAcceptedAt set, returns ok with isExistingUser=true', async () => {
-    vi.mocked(driveInviteRepository.findPendingInviteByTokenHash).mockResolvedValue(baseInvite);
+  it('given an active drive row + existing user, returns ok drive context with isExistingUser=true', async () => {
+    vi.mocked(driveInviteRepository.findPendingInviteByTokenHash).mockResolvedValue(baseDriveInvite);
     vi.mocked(driveInviteRepository.loadUserAccountByEmail).mockResolvedValue({
       id: 'user_1',
       suspendedAt: null,
@@ -73,6 +93,7 @@ describe('resolveInviteContext', () => {
     expect(result).toEqual({
       ok: true,
       data: {
+        kind: 'drive',
         driveName: 'Alpha',
         inviterName: 'Jane',
         role: 'MEMBER',
@@ -82,8 +103,8 @@ describe('resolveInviteContext', () => {
     });
   });
 
-  it('given an active row + a user record exists with tosAcceptedAt null (OAuth / magic-link user), returns ok with isExistingUser=true', async () => {
-    vi.mocked(driveInviteRepository.findPendingInviteByTokenHash).mockResolvedValue(baseInvite);
+  it('given an active drive row + a user record exists with tosAcceptedAt null (OAuth / magic-link user), returns ok with isExistingUser=true', async () => {
+    vi.mocked(driveInviteRepository.findPendingInviteByTokenHash).mockResolvedValue(baseDriveInvite);
     vi.mocked(driveInviteRepository.loadUserAccountByEmail).mockResolvedValue({
       id: 'user_oauth',
       suspendedAt: null,
@@ -101,8 +122,8 @@ describe('resolveInviteContext', () => {
     });
   });
 
-  it('given an active row + no user mapped to that email, returns ok with isExistingUser=false', async () => {
-    vi.mocked(driveInviteRepository.findPendingInviteByTokenHash).mockResolvedValue(baseInvite);
+  it('given an active drive row + no user mapped to that email, returns ok with isExistingUser=false', async () => {
+    vi.mocked(driveInviteRepository.findPendingInviteByTokenHash).mockResolvedValue(baseDriveInvite);
     vi.mocked(driveInviteRepository.loadUserAccountByEmail).mockResolvedValue(null);
 
     const result = await resolveInviteContext({ token: 'tok', now });
@@ -114,12 +135,89 @@ describe('resolveInviteContext', () => {
   });
 
   it('given a token, looks up by SHA3 hash (never plaintext)', async () => {
-    vi.mocked(driveInviteRepository.findPendingInviteByTokenHash).mockResolvedValue(null);
-
     await resolveInviteContext({ token: 'ps_invite_abc', now });
 
     expect(driveInviteRepository.findPendingInviteByTokenHash).toHaveBeenCalledWith(
       'hash(ps_invite_abc)'
     );
+    expect(connectionInviteRepository.findPendingInviteByTokenHash).toHaveBeenCalledWith(
+      'hash(ps_invite_abc)'
+    );
+  });
+
+  describe('connection invite tokens', () => {
+    it('given an active connection row + no existing user, returns ok connection context with isExistingUser=false', async () => {
+      vi.mocked(connectionInviteRepository.findPendingInviteByTokenHash).mockResolvedValue(
+        baseConnectionInvite
+      );
+      vi.mocked(driveInviteRepository.loadUserAccountByEmail).mockResolvedValue(null);
+
+      const result = await resolveInviteContext({ token: 'tok', now });
+
+      expect(result).toEqual({
+        ok: true,
+        data: {
+          kind: 'connection',
+          inviterName: 'Bob',
+          email: 'invitee@example.com',
+          isExistingUser: false,
+          message: null,
+        },
+      });
+    });
+
+    it('given an active connection row + existing user, returns ok connection context with isExistingUser=true', async () => {
+      vi.mocked(connectionInviteRepository.findPendingInviteByTokenHash).mockResolvedValue(
+        baseConnectionInvite
+      );
+      vi.mocked(driveInviteRepository.loadUserAccountByEmail).mockResolvedValue({
+        id: 'user_1',
+        suspendedAt: null,
+      });
+
+      const result = await resolveInviteContext({ token: 'tok', now });
+
+      expect(result).toEqual({
+        ok: true,
+        data: expect.objectContaining({ kind: 'connection', isExistingUser: true }),
+      });
+    });
+
+    it('includes the optional requestMessage in connection context', async () => {
+      vi.mocked(connectionInviteRepository.findPendingInviteByTokenHash).mockResolvedValue({
+        ...baseConnectionInvite,
+        requestMessage: 'Hey, let\'s connect!',
+      });
+      vi.mocked(driveInviteRepository.loadUserAccountByEmail).mockResolvedValue(null);
+
+      const result = await resolveInviteContext({ token: 'tok', now });
+
+      expect(result).toEqual({
+        ok: true,
+        data: expect.objectContaining({ message: 'Hey, let\'s connect!' }),
+      });
+    });
+
+    it('given a connection row whose consumedAt is set, returns CONSUMED', async () => {
+      vi.mocked(connectionInviteRepository.findPendingInviteByTokenHash).mockResolvedValue({
+        ...baseConnectionInvite,
+        consumedAt: new Date('2026-05-06T11:00:00.000Z'),
+      });
+
+      const result = await resolveInviteContext({ token: 'tok', now });
+
+      expect(result).toEqual({ ok: false, error: 'CONSUMED' });
+    });
+
+    it('given a connection row whose expiresAt is in the past, returns EXPIRED', async () => {
+      vi.mocked(connectionInviteRepository.findPendingInviteByTokenHash).mockResolvedValue({
+        ...baseConnectionInvite,
+        expiresAt: new Date('2026-05-06T11:00:00.000Z'),
+      });
+
+      const result = await resolveInviteContext({ token: 'tok', now });
+
+      expect(result).toEqual({ ok: false, error: 'EXPIRED' });
+    });
   });
 });

--- a/apps/web/src/lib/auth/invite-resolver.ts
+++ b/apps/web/src/lib/auth/invite-resolver.ts
@@ -1,16 +1,26 @@
 import { hashToken } from '@pagespace/lib/auth/token-utils';
 import { isInviteExpired, isInviteConsumed } from '@pagespace/lib/services/invites';
 import { driveInviteRepository } from '@/lib/repositories/drive-invite-repository';
+import { connectionInviteRepository } from '@/lib/repositories/connection-invite-repository';
 
 export type InviteResolutionError = 'NOT_FOUND' | 'EXPIRED' | 'CONSUMED';
 
-export interface InviteContextData {
-  driveName: string;
-  inviterName: string;
-  role: 'OWNER' | 'ADMIN' | 'MEMBER';
-  email: string;
-  isExistingUser: boolean;
-}
+export type InviteContextData =
+  | {
+      kind: 'drive';
+      driveName: string;
+      inviterName: string;
+      role: 'OWNER' | 'ADMIN' | 'MEMBER';
+      email: string;
+      isExistingUser: boolean;
+    }
+  | {
+      kind: 'connection';
+      inviterName: string;
+      email: string;
+      isExistingUser: boolean;
+      message: string | null;
+    };
 
 export type InviteResolution =
   | { ok: true; data: InviteContextData }
@@ -23,6 +33,10 @@ export type InviteResolution =
  * resolve to discriminated errors so the page renders the same opaque "no
  * longer valid" card for all three failure modes — never disclosing which
  * specific reason caused the rejection (would leak token existence + state).
+ *
+ * Token hashes are universally unique across the drive and connection invite
+ * tables (same `ps_invite_*` generator, per-table UNIQUE indices), so at most
+ * one table will return a row.
  */
 export const resolveInviteContext = async ({
   token,
@@ -32,31 +46,51 @@ export const resolveInviteContext = async ({
   now: Date;
 }): Promise<InviteResolution> => {
   const tokenHash = hashToken(token);
-  const invite = await driveInviteRepository.findPendingInviteByTokenHash(tokenHash);
-  if (!invite) {
+
+  const [driveRow, connectionRow] = await Promise.all([
+    driveInviteRepository.findPendingInviteByTokenHash(tokenHash),
+    connectionInviteRepository.findPendingInviteByTokenHash(tokenHash),
+  ]);
+
+  const row = driveRow ?? connectionRow;
+  if (!row) {
     return { ok: false, error: 'NOT_FOUND' };
   }
-  if (isInviteConsumed({ consumedAt: invite.consumedAt })) {
+  if (isInviteConsumed({ consumedAt: row.consumedAt })) {
     return { ok: false, error: 'CONSUMED' };
   }
-  if (isInviteExpired({ expiresAt: invite.expiresAt, now })) {
+  if (isInviteExpired({ expiresAt: row.expiresAt, now })) {
     return { ok: false, error: 'EXPIRED' };
   }
 
   // Classify by ACCOUNT PRESENCE. OAuth/magic-link users are real existing
   // accounts even if their ToS state predates the consent column; the accept
   // gateway re-prompts for ToS separately when needed.
-  const account = await driveInviteRepository.loadUserAccountByEmail(invite.email);
+  const account = await driveInviteRepository.loadUserAccountByEmail(row.email);
   const isExistingUser = account !== null;
+
+  if (driveRow) {
+    return {
+      ok: true,
+      data: {
+        kind: 'drive',
+        driveName: driveRow.driveName,
+        inviterName: driveRow.inviterName,
+        role: driveRow.role,
+        email: driveRow.email,
+        isExistingUser,
+      },
+    };
+  }
 
   return {
     ok: true,
     data: {
-      driveName: invite.driveName,
-      inviterName: invite.inviterName,
-      role: invite.role,
-      email: invite.email,
+      kind: 'connection',
+      inviterName: connectionRow!.inviterName,
+      email: connectionRow!.email,
       isExistingUser,
+      message: connectionRow!.requestMessage,
     },
   };
 };

--- a/apps/web/src/lib/repositories/connection-invite-repository.ts
+++ b/apps/web/src/lib/repositories/connection-invite-repository.ts
@@ -210,6 +210,37 @@ export const connectionInviteRepository = {
     }
   },
 
+  async findUserIdByEmail(
+    email: string,
+  ): Promise<{ id: string; emailVerified: Date | null; suspendedAt: Date | null } | null> {
+    const user = await db.query.users.findFirst({
+      where: eq(users.email, email),
+      columns: { id: true, emailVerified: true, suspendedAt: true },
+    });
+    return user
+      ? { id: user.id, emailVerified: user.emailVerified ?? null, suspendedAt: user.suspendedAt ?? null }
+      : null;
+  },
+
+  async createDirectConnection(input: {
+    inviterUserId: string;
+    targetUserId: string;
+    requestMessage?: string;
+  }): Promise<{ id: string }> {
+    const [user1Id, user2Id] = sortedPair(input.inviterUserId, input.targetUserId);
+    const [row] = await db
+      .insert(connections)
+      .values({
+        user1Id,
+        user2Id,
+        status: 'PENDING',
+        requestedBy: input.inviterUserId,
+        requestMessage: input.requestMessage ?? null,
+      })
+      .returning({ id: connections.id });
+    return { id: row.id };
+  },
+
   async findInviterDisplay(userId: string): Promise<{ name: string; email: string } | null> {
     const user = await db.query.users.findFirst({
       where: eq(users.id, userId),

--- a/packages/lib/src/email-templates/ConnectionInvitationEmail.tsx
+++ b/packages/lib/src/email-templates/ConnectionInvitationEmail.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Link,
+  Section,
+  Text,
+} from '@react-email/components';
+import { emailStyles } from './shared-styles';
+
+interface ConnectionInvitationEmailProps {
+  recipientEmail: string;
+  inviterName: string;
+  message?: string;
+  acceptUrl: string;
+}
+
+export function ConnectionInvitationEmail({
+  recipientEmail,
+  inviterName,
+  message,
+  acceptUrl,
+}: ConnectionInvitationEmailProps) {
+  return (
+    <Html>
+      <Head />
+      <Body style={emailStyles.main}>
+        <Container style={emailStyles.container}>
+          <Section style={emailStyles.header}>
+            <Heading style={emailStyles.headerTitle}>PageSpace</Heading>
+          </Section>
+          <Section style={emailStyles.content}>
+            <Text style={emailStyles.contentHeading}>
+              {inviterName} wants to connect with you
+            </Text>
+            <Text style={emailStyles.paragraph}>
+              Hi {recipientEmail},
+            </Text>
+            <Text style={emailStyles.paragraph}>
+              <strong>{inviterName}</strong> would like to connect with you on PageSpace — a platform where people and AI agents collaborate in shared workspaces.
+            </Text>
+            {message && (
+              <Section style={emailStyles.messageBox}>
+                <Text style={emailStyles.messageText}>&ldquo;{message}&rdquo;</Text>
+              </Section>
+            )}
+            <Text style={emailStyles.paragraph}>
+              Create your account and accept the connection invite.
+            </Text>
+            <Section style={emailStyles.buttonContainer}>
+              <Button style={emailStyles.button} href={acceptUrl}>
+                Accept and Join PageSpace
+              </Button>
+            </Section>
+            <Text style={emailStyles.hint}>
+              Or copy and paste this link into your browser:
+              <br />
+              <Link href={acceptUrl} style={emailStyles.link}>
+                {acceptUrl}
+              </Link>
+            </Text>
+          </Section>
+          <Section style={emailStyles.footer}>
+            <Text style={emailStyles.footerText}>
+              You received this because {inviterName} sent you a connection invite on PageSpace.
+            </Text>
+          </Section>
+        </Container>
+      </Body>
+    </Html>
+  );
+}

--- a/packages/lib/src/security/distributed-rate-limit.ts
+++ b/packages/lib/src/security/distributed-rate-limit.ts
@@ -570,6 +570,12 @@ export const DISTRIBUTED_RATE_LIMITS = {
     blockDurationMs: 24 * 60 * 60 * 1000,
     progressiveDelay: false,
   },
+  CONNECTION_INVITE: {
+    maxAttempts: 3,
+    windowMs: 15 * 60 * 1000,
+    blockDurationMs: 15 * 60 * 1000,
+    progressiveDelay: false,
+  },
 } as const;
 
 // =============================================================================

--- a/packages/lib/src/services/notification-email-service.ts
+++ b/packages/lib/src/services/notification-email-service.ts
@@ -4,6 +4,7 @@ import { users, emailUnsubscribeTokens } from '@pagespace/db/schema/auth';
 import { emailNotificationPreferences, emailNotificationLog } from '@pagespace/db/schema/email-notifications';
 import { sendEmail } from './email-service';
 import { DriveInvitationEmail } from '../email-templates/DriveInvitationEmail';
+import { ConnectionInvitationEmail } from '../email-templates/ConnectionInvitationEmail';
 import { DirectMessageEmail } from '../email-templates/DirectMessageEmail';
 import { ConnectionRequestEmail } from '../email-templates/ConnectionRequestEmail';
 import { PageSharedEmail } from '../email-templates/PageSharedEmail';
@@ -298,6 +299,31 @@ export async function sendPendingDriveInvitationEmail(input: {
       userName: input.recipientEmail,
       inviterName: safeInviterName,
       driveName: safeDriveName,
+      acceptUrl: input.inviteUrl,
+    }),
+  });
+}
+
+/**
+ * Send a "someone wants to connect with you" invite email to a recipient who
+ * does not yet hold a PageSpace account. Errors propagate so the caller can
+ * compensating-delete the pending row on SMTP failure.
+ */
+export async function sendPendingConnectionInvitationEmail(input: {
+  recipientEmail: string;
+  inviterName: string;
+  message?: string;
+  inviteUrl: string;
+}): Promise<void> {
+  const safeInviterName = stripHeaderControls(input.inviterName) || 'Someone';
+
+  await sendEmail({
+    to: input.recipientEmail,
+    subject: `${safeInviterName} wants to connect on PageSpace`,
+    react: ConnectionInvitationEmail({
+      recipientEmail: input.recipientEmail,
+      inviterName: safeInviterName,
+      message: input.message,
       acceptUrl: input.inviteUrl,
     }),
   });


### PR DESCRIPTION
## Summary
- New \`POST /api/connections/invite\` route — mirrors drive-invite route shape (rate limit, verified-inviter gate, self-invite check, suspended-target gate, pending row + email + SMTP rollback)
- New \`sendPendingConnectionInvitationEmail\` template — personal "wants to connect" framing
- New \`ConnectionInvitationEmail.tsx\` email template component
- New \`CONNECTION_INVITE\` rate limit config in \`DISTRIBUTED_RATE_LIMITS\`
- New \`findUserIdByEmail\` and \`createDirectConnection\` methods on \`connectionInviteRepository\`
- Connections UI: user-search 404 now branches to an "Invite to PageSpace" CTA
- Existing-user fast path falls through to the current \`POST /api/connections\` flow (creates PENDING connection directly + sends in-app notification)
- \`resolveInviteContext\` extended to query connection invite table in parallel with drive invite table — \`InviteContextData\` is now a discriminated union (\`kind: 'drive' | 'connection'\`); \`/invite/[token]\` renders a "wants to connect" consent screen for connection tokens

This is Task 3 of 3 from the [Invite-by-Email Surfaces epic](../tasks/invite-by-email-surfaces.md). Task 1 (#1285) shipped the dispatcher, \`pendingConnectionInvites\` table, and the consume-on-signup helper that creates the \`connections\` row in PENDING. This PR is the user-facing surface. Task 2 (page-share) runs in parallel.

## Test plan
- [x] API route tests: happy + existing-user fast path + 403 (unverified inviter) + 400 (self-invite) + 403 (suspended target) + 409 (already pending) + 400 (already connected PENDING) + 400 (already connected ACCEPTED) + 429 (rate limit pair-scoped) + 429 (rate limit email-scoped) + SMTP rollback (12 tests, all passing)
- [x] Connections UI smoke: 404 branch surfaces invite CTA + invite POST called with correct payload + existing-connection 404 branch shows error toast + 409 shows appropriate toast (4 tests, all passing)
- [x] invite-resolver unit tests: drive token (6 cases) + connection token (5 cases, all passing)
- [ ] Manually invite an unknown email from the connections page → check pendingConnectionInvites row in Studio → click email link → confirm "wants to connect" consent screen → sign up → confirm a connections row appears in PENDING

🤖 Generated with [Claude Code](https://claude.com/claude-code)