### PR TITLE
feat(invites): page-share-by-email from Share dialog

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/share-invite/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/share-invite/__tests__/route.test.ts
@@ -1,0 +1,404 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+import type { SessionAuthResult, AuthError } from '@/lib/auth';
+
+// ============================================================================
+// Contract Tests for POST /api/pages/[pageId]/share-invite
+//
+// Mocks the pageInviteRepository seam, the email helper, the rate limiter,
+// the permission check, and the auth layer. No ORM chain mocking.
+// ============================================================================
+
+vi.mock('@/lib/repositories/page-invite-repository', () => ({
+  pageInviteRepository: {
+    findPageById: vi.fn(),
+    findUserIdByEmail: vi.fn(),
+    findActivePendingInviteByPageAndEmail: vi.fn(),
+    findInviterDisplay: vi.fn(),
+    createPendingInvite: vi.fn(),
+    deletePendingInvite: vi.fn(),
+    createDirectPagePermission: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/auth/verification-utils', () => ({
+  isEmailVerified: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  canUserSharePage: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  },
+  logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  audit: vi.fn(),
+  auditRequest: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
+  trackPageOperation: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/auth/invite-token', () => ({
+  createInviteToken: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/services/notification-email-service', () => ({
+  sendPendingPageShareInvitationEmail: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
+  checkDistributedRateLimit: vi.fn().mockResolvedValue({ allowed: true }),
+  DISTRIBUTED_RATE_LIMITS: { PAGE_SHARE_INVITE: { maxAttempts: 3, windowMs: 900000 } },
+}));
+
+import { POST } from '../route';
+import { pageInviteRepository } from '@/lib/repositories/page-invite-repository';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { isEmailVerified } from '@pagespace/lib/auth/verification-utils';
+import { canUserSharePage } from '@pagespace/lib/permissions/permissions';
+import { createInviteToken } from '@pagespace/lib/auth/invite-token';
+import { sendPendingPageShareInvitationEmail } from '@pagespace/lib/services/notification-email-service';
+import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
+
+const mockWebAuth = (userId: string): SessionAuthResult => ({
+  userId,
+  tokenVersion: 0,
+  tokenType: 'session',
+  sessionId: 'test-session-id',
+  role: 'user',
+  adminRoleVersion: 0,
+});
+
+const mockAuthErrorResponse = (status = 401): AuthError => ({
+  error: NextResponse.json({ error: 'Unauthorized' }, { status }),
+});
+
+const createContext = (pageId: string) => ({
+  params: Promise.resolve({ pageId }),
+});
+
+const buildPost = (pageId: string, body: unknown) =>
+  new Request(`https://example.com/api/pages/${pageId}/share-invite`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+
+const ORIGINAL_ENV = { ...process.env };
+
+const mockUserId = 'user_123';
+const mockPageId = 'page_abc';
+const mockPage = {
+  id: mockPageId,
+  title: 'My Test Page',
+  driveId: 'drive_xyz',
+  driveName: 'Test Drive',
+};
+
+const validBody = {
+  email: 'new@example.com',
+  permissions: ['VIEW'],
+};
+
+describe('POST /api/pages/[pageId]/share-invite', () => {
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.WEB_APP_URL = 'https://app.example.com';
+    delete process.env.NEXT_PUBLIC_APP_URL;
+
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockWebAuth(mockUserId));
+    vi.mocked(isAuthError).mockReturnValue(false);
+    vi.mocked(isEmailVerified).mockResolvedValue(true);
+    vi.mocked(canUserSharePage).mockResolvedValue(true);
+
+    vi.mocked(pageInviteRepository.findPageById).mockResolvedValue(mockPage);
+    vi.mocked(pageInviteRepository.findUserIdByEmail).mockResolvedValue(null);
+    vi.mocked(pageInviteRepository.findActivePendingInviteByPageAndEmail).mockResolvedValue(null);
+    vi.mocked(pageInviteRepository.findInviterDisplay).mockResolvedValue({
+      name: 'Inviter Name',
+      email: 'inviter@example.com',
+    });
+    vi.mocked(pageInviteRepository.createPendingInvite).mockResolvedValue({ id: 'inv_pending' } as never);
+    vi.mocked(pageInviteRepository.deletePendingInvite).mockResolvedValue(undefined);
+    vi.mocked(pageInviteRepository.createDirectPagePermission).mockResolvedValue({ id: 'perm_new' });
+
+    vi.mocked(checkDistributedRateLimit).mockResolvedValue({ allowed: true });
+    vi.mocked(createInviteToken).mockReturnValue({
+      token: 'ps_invite_xyz',
+      tokenHash: 'hash_xyz',
+      expiresAt: new Date('2026-05-10T12:00:00.000Z'),
+    });
+    vi.mocked(sendPendingPageShareInvitationEmail).mockResolvedValue(undefined);
+  });
+
+  // ==========================================================================
+  // Auth + authorization
+  // ==========================================================================
+
+  describe('auth + authorization', () => {
+    it('returns 401 when not authenticated', async () => {
+      vi.mocked(isAuthError).mockReturnValue(true);
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthErrorResponse(401));
+
+      const response = await POST(buildPost(mockPageId, validBody), createContext(mockPageId));
+      expect(response.status).toBe(401);
+    });
+
+    it('returns 403 when inviter lacks canShare on the page', async () => {
+      vi.mocked(canUserSharePage).mockResolvedValue(false);
+
+      const response = await POST(buildPost(mockPageId, validBody), createContext(mockPageId));
+      const json = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(json.error).toMatch(/permission/i);
+    });
+
+    it('does not write any row when canShare check fails (R3)', async () => {
+      vi.mocked(canUserSharePage).mockResolvedValue(false);
+
+      await POST(buildPost(mockPageId, validBody), createContext(mockPageId));
+
+      expect(pageInviteRepository.createPendingInvite).not.toHaveBeenCalled();
+      expect(pageInviteRepository.createDirectPagePermission).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 with requiresEmailVerification when inviter email unverified', async () => {
+      vi.mocked(isEmailVerified).mockResolvedValue(false);
+
+      const response = await POST(buildPost(mockPageId, validBody), createContext(mockPageId));
+      const json = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(json.requiresEmailVerification).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // Input validation
+  // ==========================================================================
+
+  describe('input validation', () => {
+    it('returns 400 for invalid JSON', async () => {
+      const response = await POST(buildPost(mockPageId, '{not json'), createContext(mockPageId));
+      expect(response.status).toBe(400);
+    });
+
+    it('returns 400 when email is missing', async () => {
+      const response = await POST(
+        buildPost(mockPageId, { permissions: ['VIEW'] }),
+        createContext(mockPageId),
+      );
+      expect(response.status).toBe(400);
+    });
+
+    it('returns 400 when email is malformed', async () => {
+      const response = await POST(
+        buildPost(mockPageId, { email: 'not-an-email', permissions: ['VIEW'] }),
+        createContext(mockPageId),
+      );
+      expect(response.status).toBe(400);
+    });
+
+    it('returns 400 when permissions contains DELETE (R5)', async () => {
+      const response = await POST(
+        buildPost(mockPageId, { email: 'new@example.com', permissions: ['VIEW', 'DELETE'] }),
+        createContext(mockPageId),
+      );
+      expect(response.status).toBe(400);
+    });
+
+    it('returns 400 when permissions is empty (min 1)', async () => {
+      const response = await POST(
+        buildPost(mockPageId, { email: 'new@example.com', permissions: [] }),
+        createContext(mockPageId),
+      );
+      expect(response.status).toBe(400);
+    });
+  });
+
+  // ==========================================================================
+  // Suspended target
+  // ==========================================================================
+
+  describe('suspended target account', () => {
+    it('returns 403 when target email belongs to suspended user', async () => {
+      vi.mocked(pageInviteRepository.findUserIdByEmail).mockResolvedValue({
+        id: 'user_suspended',
+        emailVerified: new Date('2026-01-01'),
+        suspendedAt: new Date('2026-03-01'),
+      });
+
+      const response = await POST(buildPost(mockPageId, validBody), createContext(mockPageId));
+      const json = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(json.error).toMatch(/suspended/i);
+    });
+  });
+
+  // ==========================================================================
+  // Existing-user fast path (R1)
+  // ==========================================================================
+
+  describe('existing verified user fast path (R1)', () => {
+    it('grants page permission directly without creating a pending invite row', async () => {
+      vi.mocked(pageInviteRepository.findUserIdByEmail).mockResolvedValue({
+        id: 'user_existing',
+        emailVerified: new Date('2026-01-01'),
+        suspendedAt: null,
+      });
+
+      const response = await POST(
+        buildPost(mockPageId, { email: 'existing@example.com', permissions: ['VIEW', 'EDIT'] }),
+        createContext(mockPageId),
+      );
+      const json = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(json.kind).toBe('granted');
+      expect(pageInviteRepository.createDirectPagePermission).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pageId: mockPageId,
+          userId: 'user_existing',
+          canView: true,
+          canEdit: true,
+          canShare: false,
+          grantedBy: mockUserId,
+        }),
+      );
+      expect(pageInviteRepository.createPendingInvite).not.toHaveBeenCalled();
+      expect(sendPendingPageShareInvitationEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  // ==========================================================================
+  // New-user happy path (R2)
+  // ==========================================================================
+
+  describe('new user invite happy path (R2)', () => {
+    it('creates pending invite, sends email, returns kind: invited', async () => {
+      const response = await POST(buildPost(mockPageId, validBody), createContext(mockPageId));
+      const json = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(json.kind).toBe('invited');
+      expect(json.email).toBe('new@example.com');
+      expect(pageInviteRepository.createPendingInvite).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: 'new@example.com',
+          pageId: mockPageId,
+          permissions: ['VIEW'],
+          invitedBy: mockUserId,
+        }),
+      );
+      expect(sendPendingPageShareInvitationEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          recipientEmail: 'new@example.com',
+          pageTitle: 'My Test Page',
+          driveName: 'Test Drive',
+        }),
+      );
+    });
+
+    it('passes correct inviteUrl using WEB_APP_URL', async () => {
+      await POST(buildPost(mockPageId, validBody), createContext(mockPageId));
+
+      expect(sendPendingPageShareInvitationEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          inviteUrl: 'https://app.example.com/invite/ps_invite_xyz',
+        }),
+      );
+    });
+  });
+
+  // ==========================================================================
+  // Already-pending (409)
+  // ==========================================================================
+
+  describe('already pending invite (409)', () => {
+    it('returns 409 when an active pending invite already exists', async () => {
+      vi.mocked(pageInviteRepository.findActivePendingInviteByPageAndEmail).mockResolvedValue({
+        id: 'inv_existing',
+      });
+
+      const response = await POST(buildPost(mockPageId, validBody), createContext(mockPageId));
+      const json = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(json.error).toMatch(/already pending/i);
+    });
+  });
+
+  // ==========================================================================
+  // Rate limiting (429)
+  // ==========================================================================
+
+  describe('rate limiting (429)', () => {
+    it('returns 429 when inviter+email rate limit is exceeded', async () => {
+      vi.mocked(checkDistributedRateLimit).mockResolvedValueOnce({
+        allowed: false,
+        retryAfter: 900,
+      });
+
+      const response = await POST(buildPost(mockPageId, validBody), createContext(mockPageId));
+      expect(response.status).toBe(429);
+    });
+
+    it('returns 429 when global email rate limit is exceeded', async () => {
+      vi.mocked(checkDistributedRateLimit)
+        .mockResolvedValueOnce({ allowed: true })
+        .mockResolvedValueOnce({ allowed: false, retryAfter: 900 });
+
+      const response = await POST(buildPost(mockPageId, validBody), createContext(mockPageId));
+      expect(response.status).toBe(429);
+    });
+  });
+
+  // ==========================================================================
+  // SMTP failure → compensating delete (R6)
+  // ==========================================================================
+
+  describe('SMTP failure rollback (R6)', () => {
+    it('deletes the pending invite row when email send fails', async () => {
+      vi.mocked(sendPendingPageShareInvitationEmail).mockRejectedValue(
+        new Error('SMTP connection refused'),
+      );
+
+      const response = await POST(buildPost(mockPageId, validBody), createContext(mockPageId));
+      const json = await response.json();
+
+      expect(response.status).toBe(502);
+      expect(json.error).toMatch(/invitation email/i);
+      expect(pageInviteRepository.deletePendingInvite).toHaveBeenCalledWith('inv_pending');
+    });
+
+    it('still returns 502 even if rollback itself fails (logs the error)', async () => {
+      vi.mocked(sendPendingPageShareInvitationEmail).mockRejectedValue(
+        new Error('SMTP failure'),
+      );
+      vi.mocked(pageInviteRepository.deletePendingInvite).mockRejectedValue(
+        new Error('DB error'),
+      );
+
+      const response = await POST(buildPost(mockPageId, validBody), createContext(mockPageId));
+      expect(response.status).toBe(502);
+    });
+  });
+});

--- a/apps/web/src/app/api/pages/[pageId]/share-invite/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/share-invite/__tests__/route.test.ts
@@ -231,6 +231,22 @@ describe('POST /api/pages/[pageId]/share-invite', () => {
       );
       expect(response.status).toBe(400);
     });
+
+    it('returns 400 when EDIT is requested without VIEW', async () => {
+      const response = await POST(
+        buildPost(mockPageId, { email: 'new@example.com', permissions: ['EDIT'] }),
+        createContext(mockPageId),
+      );
+      expect(response.status).toBe(400);
+    });
+
+    it('returns 400 when SHARE is requested without VIEW', async () => {
+      const response = await POST(
+        buildPost(mockPageId, { email: 'new@example.com', permissions: ['SHARE'] }),
+        createContext(mockPageId),
+      );
+      expect(response.status).toBe(400);
+    });
   });
 
   // ==========================================================================

--- a/apps/web/src/app/api/pages/[pageId]/share-invite/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/share-invite/route.ts
@@ -16,12 +16,25 @@ import { canUserSharePage } from '@pagespace/lib/permissions/permissions';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 
-const shareInviteBodySchema = z.object({
-  email: z.string().trim().toLowerCase().pipe(z.string().email().max(254)),
-  permissions: z
-    .array(z.enum(['VIEW', 'EDIT', 'SHARE']))
-    .min(1, 'At least VIEW permission is required'),
-});
+const shareInviteBodySchema = z
+  .object({
+    email: z.string().trim().toLowerCase().pipe(z.string().email().max(254)),
+    permissions: z
+      .array(z.enum(['VIEW', 'EDIT', 'SHARE']))
+      .min(1, 'At least VIEW permission is required'),
+  })
+  .superRefine(({ permissions }, ctx) => {
+    if (
+      (permissions.includes('EDIT') || permissions.includes('SHARE')) &&
+      !permissions.includes('VIEW')
+    ) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['permissions'],
+        message: 'VIEW is required when EDIT or SHARE is granted',
+      });
+    }
+  });
 
 function resolveAppUrl(): string | null {
   const url = process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL;

--- a/apps/web/src/app/api/pages/[pageId]/share-invite/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/share-invite/route.ts
@@ -83,7 +83,7 @@ export async function POST(
     const parsed = shareInviteBodySchema.safeParse(rawBody);
     if (!parsed.success) {
       return NextResponse.json(
-        { error: 'Invalid request body', issues: parsed.error.issues },
+        { error: 'Invalid request body', details: parsed.error.flatten().fieldErrors },
         { status: 400 },
       );
     }

--- a/apps/web/src/app/api/pages/[pageId]/share-invite/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/share-invite/route.ts
@@ -1,0 +1,265 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod/v4';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { isEmailVerified } from '@pagespace/lib/auth/verification-utils';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { pageInviteRepository } from '@/lib/repositories/page-invite-repository';
+import { trackPageOperation } from '@pagespace/lib/monitoring/activity-tracker';
+import { createInviteToken } from '@pagespace/lib/auth/invite-token';
+import { sendPendingPageShareInvitationEmail } from '@pagespace/lib/services/notification-email-service';
+import {
+  checkDistributedRateLimit,
+  DISTRIBUTED_RATE_LIMITS,
+} from '@pagespace/lib/security/distributed-rate-limit';
+import { canUserSharePage } from '@pagespace/lib/permissions/permissions';
+
+const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
+
+const shareInviteBodySchema = z.object({
+  email: z.string().trim().toLowerCase().pipe(z.string().email().max(254)),
+  permissions: z
+    .array(z.enum(['VIEW', 'EDIT', 'SHARE']))
+    .min(1, 'At least VIEW permission is required'),
+});
+
+function resolveAppUrl(): string | null {
+  const url = process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL;
+  if (!url) return null;
+  return url.replace(/\/+$/, '');
+}
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ pageId: string }> },
+) {
+  try {
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
+    if (isAuthError(auth)) return auth.error;
+    const inviterUserId = auth.userId;
+
+    const { pageId } = await context.params;
+
+    // R3: canShare check BEFORE any row is written
+    const hasSharePermission = await canUserSharePage(inviterUserId, pageId);
+    if (!hasSharePermission) {
+      return NextResponse.json(
+        { error: 'You do not have permission to share this page.' },
+        { status: 403 },
+      );
+    }
+
+    const emailVerified = await isEmailVerified(inviterUserId);
+    if (!emailVerified) {
+      return NextResponse.json(
+        {
+          error: 'Email verification required. Please verify your email to perform this action.',
+          requiresEmailVerification: true,
+        },
+        { status: 403 },
+      );
+    }
+
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+
+    const parsed = shareInviteBodySchema.safeParse(rawBody);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Invalid request body', issues: parsed.error.issues },
+        { status: 400 },
+      );
+    }
+    const { email, permissions } = parsed.data;
+
+    // R5: DELETE is blocked at the zod layer above; this is a belt-and-suspenders guard
+    // (the zod enum only allows VIEW | EDIT | SHARE, so DELETE can never reach here)
+
+    const page = await pageInviteRepository.findPageById(pageId);
+    if (!page) {
+      return NextResponse.json({ error: 'Page not found' }, { status: 404 });
+    }
+
+    // Pair-scoped rate limit (inviter + email)
+    const inviterRl = await checkDistributedRateLimit(
+      `page_share_invite:inviter:${inviterUserId}:${email}`,
+      DISTRIBUTED_RATE_LIMITS.PAGE_SHARE_INVITE,
+    );
+    if (!inviterRl.allowed) {
+      return NextResponse.json(
+        { error: 'Too many invitations to this address. Please try again later.' },
+        { status: 429, headers: { 'Retry-After': String(inviterRl.retryAfter ?? 900) } },
+      );
+    }
+
+    // Global per-email rate limit
+    const emailRl = await checkDistributedRateLimit(
+      `page_share_invite:email:${email}`,
+      DISTRIBUTED_RATE_LIMITS.PAGE_SHARE_INVITE,
+    );
+    if (!emailRl.allowed) {
+      return NextResponse.json(
+        { error: 'Too many invitations to this address. Please try again later.' },
+        { status: 429, headers: { 'Retry-After': String(emailRl.retryAfter ?? 900) } },
+      );
+    }
+
+    const existingUser = await pageInviteRepository.findUserIdByEmail(email);
+
+    // Suspended users cannot be invited regardless of verification status
+    if (existingUser?.suspendedAt) {
+      return NextResponse.json(
+        { error: 'This account is suspended and cannot be invited.' },
+        { status: 403 },
+      );
+    }
+
+    // R1: Existing verified user — direct grant, no pendingPageInvites row
+    if (existingUser && existingUser.emailVerified) {
+      const permissionRow = await pageInviteRepository.createDirectPagePermission({
+        pageId,
+        userId: existingUser.id,
+        canView: permissions.includes('VIEW'),
+        canEdit: permissions.includes('EDIT'),
+        canShare: permissions.includes('SHARE'),
+        grantedBy: inviterUserId,
+      });
+
+      auditRequest(request, {
+        eventType: 'authz.permission.granted',
+        userId: inviterUserId,
+        resourceType: 'page',
+        resourceId: pageId,
+        details: { targetUserId: existingUser.id, permissions, operation: 'share_invite_direct' },
+      });
+
+      return NextResponse.json({
+        kind: 'granted',
+        permissionId: permissionRow.id,
+        message: `Permissions granted to ${email}`,
+      });
+    }
+
+    // R2: Non-existing user (or unverified existing user) — create pending invite
+
+    const now = new Date();
+
+    const activePending = await pageInviteRepository.findActivePendingInviteByPageAndEmail(
+      pageId,
+      email,
+      now,
+    );
+    if (activePending) {
+      return NextResponse.json(
+        { error: 'An invitation is already pending for this email.', existingInviteId: activePending.id },
+        { status: 409 },
+      );
+    }
+
+    const appUrl = resolveAppUrl();
+    if (!appUrl) {
+      loggers.api.error(
+        'Page share invite email cannot be sent: WEB_APP_URL and NEXT_PUBLIC_APP_URL both unset',
+      );
+      return NextResponse.json(
+        { error: 'Email delivery is not configured on this deployment.' },
+        { status: 500 },
+      );
+    }
+
+    const { token, tokenHash, expiresAt } = createInviteToken({ now });
+
+    let pendingInvite: { id: string };
+    try {
+      pendingInvite = await pageInviteRepository.createPendingInvite({
+        tokenHash,
+        email,
+        pageId,
+        permissions,
+        invitedBy: inviterUserId,
+        expiresAt,
+        now,
+      });
+    } catch (insertError) {
+      const message = insertError instanceof Error ? insertError.message : String(insertError);
+      const isUniqueViolation =
+        message.includes('pending_page_invites_active_page_email_idx') ||
+        message.includes('pending_page_invites_token_hash_unique') ||
+        message.includes('duplicate key');
+      if (isUniqueViolation) {
+        return NextResponse.json(
+          { error: 'An invitation is already pending for this email.' },
+          { status: 409 },
+        );
+      }
+      loggers.api.error(
+        'Failed to persist pending page invite',
+        insertError instanceof Error ? insertError : new Error(String(insertError)),
+        { pageId },
+      );
+      return NextResponse.json({ error: 'Failed to send invite' }, { status: 500 });
+    }
+
+    const inviter = await pageInviteRepository.findInviterDisplay(inviterUserId);
+    const inviteUrl = `${appUrl}/invite/${encodeURIComponent(token)}`;
+
+    // R6: SMTP failure → compensating delete so the partial unique index stays clean
+    try {
+      await sendPendingPageShareInvitationEmail({
+        recipientEmail: email,
+        inviterName: inviter?.name ?? 'A teammate',
+        pageTitle: page.title,
+        driveName: page.driveName,
+        permissions: permissions.map((p) => p.toLowerCase()),
+        inviteUrl,
+      });
+    } catch (emailError) {
+      loggers.api.error(
+        'Failed to send pending page share invitation email; rolling back pending invite row',
+        emailError instanceof Error ? emailError : new Error(String(emailError)),
+        { pageId, recipientEmail: email },
+      );
+      try {
+        await pageInviteRepository.deletePendingInvite(pendingInvite.id);
+      } catch (rollbackError) {
+        loggers.api.error(
+          'Rollback of pending_page_invites row failed after email send failure',
+          rollbackError instanceof Error ? rollbackError : new Error(String(rollbackError)),
+          { inviteId: pendingInvite.id, pageId },
+        );
+      }
+      return NextResponse.json(
+        { error: 'Failed to send invitation email. Please try again.' },
+        { status: 502 },
+      );
+    }
+
+    trackPageOperation(inviterUserId, 'share', pageId, {
+      invitedEmail: email,
+      permissions,
+      pending: true,
+    });
+
+    auditRequest(request, {
+      eventType: 'authz.permission.granted',
+      userId: inviterUserId,
+      resourceType: 'page',
+      resourceId: pageId,
+      details: { targetEmail: email, permissions, operation: 'share_invite', pending: true },
+    });
+
+    return NextResponse.json({
+      kind: 'invited',
+      inviteId: pendingInvite.id,
+      email,
+      message: `Invitation sent to ${email}`,
+    });
+  } catch (error) {
+    loggers.api.error('Error in page share invite:', error as Error);
+    return NextResponse.json({ error: 'Failed to send invite' }, { status: 500 });
+  }
+}

--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/ShareDialog.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/ShareDialog.tsx
@@ -48,6 +48,7 @@ export function ShareDialog({ pageId: propPageId }: { pageId?: string | null } =
   const [isOpen, setIsOpen] = useState(false);
   const [email, setEmail] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [offPlatformEmail, setOffPlatformEmail] = useState<string | null>(null);
   const [permissions, setPermissions] = useState({
     canView: true,
     canEdit: false,
@@ -84,6 +85,13 @@ export function ShareDialog({ pageId: propPageId }: { pageId?: string | null } =
     setPermissions(newPerms);
   };
 
+  const resetForm = () => {
+    setEmail('');
+    setOffPlatformEmail(null);
+    setPermissions({ canView: true, canEdit: false, canShare: false, canDelete: false });
+    setPermissionsVersion(v => v + 1);
+  };
+
   const handleInvite = async () => {
     if (!email) {
       toast.error('Please enter an email address.');
@@ -94,6 +102,11 @@ export function ShareDialog({ pageId: propPageId }: { pageId?: string | null } =
       // 1. Find the user by email
       const userResponse = await fetchWithAuth(`/api/users/find?email=${encodeURIComponent(email)}`);
       if (!userResponse.ok) {
+        if (userResponse.status === 404) {
+          // User not found — switch to off-platform invite mode
+          setOffPlatformEmail(email);
+          return;
+        }
         const { error } = await userResponse.json();
         throw new Error(error || 'User not found.');
       }
@@ -106,16 +119,43 @@ export function ShareDialog({ pageId: propPageId }: { pageId?: string | null } =
       });
 
       toast.success(`Permission granted to ${email}`);
-      setEmail('');
-      // Reset permissions to default
-      setPermissions({
-        canView: true,
-        canEdit: false,
-        canShare: false,
-        canDelete: false,
+      resetForm();
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred.';
+      toast.error(errorMessage);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleOffPlatformInvite = async () => {
+    if (!offPlatformEmail) return;
+    setIsSubmitting(true);
+    try {
+      // Translate checkbox state → VIEW/EDIT/SHARE array (DELETE excluded for off-platform)
+      const permissionsArray: Array<'VIEW' | 'EDIT' | 'SHARE'> = ['VIEW'];
+      if (permissions.canEdit) permissionsArray.push('EDIT');
+      if (permissions.canShare) permissionsArray.push('SHARE');
+
+      const response = await fetchWithAuth(`/api/pages/${page.id}/share-invite`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: offPlatformEmail, permissions: permissionsArray }),
       });
-      // Increment version to trigger re-render of PermissionsList
-      setPermissionsVersion(v => v + 1);
+
+      if (response.status === 409) {
+        toast.info(`An invite is already pending for ${offPlatformEmail}`);
+        resetForm();
+        return;
+      }
+
+      if (!response.ok) {
+        const json = await response.json().catch(() => ({}));
+        throw new Error((json as { error?: string }).error || 'Failed to send invite.');
+      }
+
+      toast.success(`Invite sent to ${offPlatformEmail}`);
+      resetForm();
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred.';
       toast.error(errorMessage);
@@ -178,15 +218,38 @@ export function ShareDialog({ pageId: propPageId }: { pageId?: string | null } =
               </TabsTrigger>
             </TabsList>
             <TabsContent value="share" className="mt-4 space-y-4">
+              {offPlatformEmail ? (
+                <Alert>
+                  <AlertDescription>
+                    <strong>{offPlatformEmail}</strong> is not yet on PageSpace. They will receive an
+                    email invitation to create an account and access this page.
+                  </AlertDescription>
+                </Alert>
+              ) : null}
               <div className="flex space-x-2">
                 <Input
                   type="email"
                   placeholder="Add people by email..."
                   className="flex-1"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  disabled={isSubmitting || !canShare}
+                  value={offPlatformEmail ?? email}
+                  onChange={(e) => {
+                    if (offPlatformEmail) {
+                      setOffPlatformEmail(null);
+                    }
+                    setEmail(e.target.value);
+                  }}
+                  disabled={isSubmitting || !canShare || !!offPlatformEmail}
                 />
+                {offPlatformEmail && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setOffPlatformEmail(null)}
+                    disabled={isSubmitting}
+                  >
+                    Cancel
+                  </Button>
+                )}
               </div>
 
               {/* Permission Checkboxes */}
@@ -231,24 +294,51 @@ export function ShareDialog({ pageId: propPageId }: { pageId?: string | null } =
                     </Label>
                   </div>
 
-                  <div className="flex items-center space-x-2">
-                    <Checkbox
-                      id="canDelete"
-                      checked={permissions.canDelete}
-                      disabled={!permissions.canView}
-                      onCheckedChange={(checked) => handlePermissionChange('canDelete', !!checked)}
-                    />
-                    <Label htmlFor="canDelete" className="text-sm">
-                      Delete
-                      <span className="text-xs text-gray-500 block">Can delete this page</span>
-                    </Label>
-                  </div>
+                  {offPlatformEmail ? (
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <div className="flex items-center space-x-2 opacity-50">
+                            <Checkbox id="canDelete" checked={false} disabled />
+                            <Label htmlFor="canDelete" className="text-sm cursor-not-allowed">
+                              Delete
+                              <span className="text-xs text-gray-500 block">Can delete this page</span>
+                            </Label>
+                          </div>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>Delete cannot be granted to off-platform invites</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  ) : (
+                    <div className="flex items-center space-x-2">
+                      <Checkbox
+                        id="canDelete"
+                        checked={permissions.canDelete}
+                        disabled={!permissions.canView}
+                        onCheckedChange={(checked) => handlePermissionChange('canDelete', !!checked)}
+                      />
+                      <Label htmlFor="canDelete" className="text-sm">
+                        Delete
+                        <span className="text-xs text-gray-500 block">Can delete this page</span>
+                      </Label>
+                    </div>
+                  )}
                 </div>
               </div>
 
-              <Button onClick={handleInvite} disabled={isSubmitting} className="w-full">
-                {isSubmitting ? 'Granting Access...' : 'Grant Access'}
-              </Button>
+              {offPlatformEmail ? (
+                <Button onClick={handleOffPlatformInvite} disabled={isSubmitting} className="w-full">
+                  {isSubmitting
+                    ? 'Sending Invite...'
+                    : `Invite ${offPlatformEmail} to PageSpace and share this page`}
+                </Button>
+              ) : (
+                <Button onClick={handleInvite} disabled={isSubmitting} className="w-full">
+                  {isSubmitting ? 'Granting Access...' : 'Grant Access'}
+                </Button>
+              )}
             </TabsContent>
             <TabsContent value="permissions" className="mt-4">
               <PermissionsList key={permissionsVersion} />

--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/ShareDialog.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/ShareDialog.tsx
@@ -149,12 +149,16 @@ export function ShareDialog({ pageId: propPageId }: { pageId?: string | null } =
         return;
       }
 
+      const json = await response.json().catch(() => ({})) as { kind?: string; error?: string };
       if (!response.ok) {
-        const json = await response.json().catch(() => ({}));
-        throw new Error((json as { error?: string }).error || 'Failed to send invite.');
+        throw new Error(json.error || 'Failed to send invite.');
       }
 
-      toast.success(`Invite sent to ${offPlatformEmail}`);
+      if (json.kind === 'granted') {
+        toast.success(`Access granted to ${offPlatformEmail}`);
+      } else {
+        toast.success(`Invite sent to ${offPlatformEmail}`);
+      }
       resetForm();
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred.';

--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/__tests__/ShareDialog.test.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/__tests__/ShareDialog.test.tsx
@@ -87,7 +87,6 @@ vi.mock(
 );
 
 import { fetchWithAuth, post } from '@/lib/auth/auth-fetch';
-import { toast } from 'sonner';
 import { ShareDialog } from '../ShareDialog';
 
 const make404Response = () =>

--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/__tests__/ShareDialog.test.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/__tests__/ShareDialog.test.tsx
@@ -1,0 +1,267 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { assert } from '@/stores/__tests__/riteway';
+
+// ============================================================================
+// Smoke tests for the ShareDialog off-platform invite branch.
+//
+// Validates that:
+//   1. A 404 from /api/users/find surfaces the invite-CTA button label.
+//   2. Clicking the invite CTA POSTs to /share-invite with the right payload.
+//   3. DELETE is excluded from the share-invite payload on the off-platform path.
+// ============================================================================
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: vi.fn(),
+  post: vi.fn(),
+}));
+
+vi.mock('@/hooks/usePage', () => ({
+  usePageStore: vi.fn((selector: (s: { pageId: string }) => string) =>
+    selector({ pageId: 'page_abc' })
+  ),
+}));
+
+vi.mock('@/hooks/usePageTree', () => ({
+  usePageTree: vi.fn(() => ({
+    tree: [
+      {
+        id: 'page_abc',
+        title: 'Test Page',
+        children: [],
+        type: 'document',
+        driveId: 'drive_xyz',
+        isTrashed: false,
+        order: 0,
+        parentId: null,
+      },
+    ],
+  })),
+}));
+
+vi.mock('@/lib/tree/tree-utils', () => ({
+  findNodeAndParent: vi.fn(() => ({
+    node: {
+      id: 'page_abc',
+      title: 'Test Page',
+      children: [],
+      type: 'document',
+      driveId: 'drive_xyz',
+      isTrashed: false,
+      order: 0,
+      parentId: null,
+    },
+    parent: null,
+  })),
+}));
+
+vi.mock('next/navigation', () => ({
+  useParams: vi.fn(() => ({ driveId: 'drive_xyz' })),
+}));
+
+vi.mock('@/hooks/usePermissions', () => ({
+  usePermissions: vi.fn(() => ({
+    permissions: { canView: true, canEdit: true, canShare: true, canDelete: true },
+  })),
+  getPermissionErrorMessage: vi.fn(() => 'You need share permission'),
+}));
+
+vi.mock('@/hooks/useMobile', () => ({
+  useMobile: vi.fn(() => false),
+}));
+
+vi.mock(
+  '@/components/layout/middle-content/content-header/page-settings/PermissionsList',
+  () => ({
+    PermissionsList: () => <div data-testid="permissions-list" />,
+  }),
+);
+
+import { fetchWithAuth, post } from '@/lib/auth/auth-fetch';
+import { toast } from 'sonner';
+import { ShareDialog } from '../ShareDialog';
+
+const make404Response = () =>
+  new Response(JSON.stringify({ error: 'User not found' }), {
+    status: 404,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+const make200UserResponse = () =>
+  new Response(JSON.stringify({ id: 'user_existing' }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+const makeInviteSuccess = () =>
+  new Response(JSON.stringify({ kind: 'invited', email: 'new@example.com' }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+describe('ShareDialog — off-platform invite branch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const openDialogAndFillEmail = async (
+    user: ReturnType<typeof userEvent.setup>,
+    email: string,
+  ) => {
+    const shareButton = screen.getByRole('button', { name: /share/i });
+    await user.click(shareButton);
+    const emailInput = screen.getByPlaceholderText(/add people by email/i);
+    await user.clear(emailInput);
+    await user.type(emailInput, email);
+  };
+
+  it('given /api/users/find returns 404, renders the invite-to-PageSpace CTA button', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValue(make404Response());
+
+    const user = userEvent.setup();
+    render(<ShareDialog />);
+
+    await openDialogAndFillEmail(user, 'new@example.com');
+
+    const grantButton = screen.getByRole('button', { name: /grant access/i });
+    await user.click(grantButton);
+
+    await waitFor(() => {
+      const inviteButton = screen.getByRole('button', {
+        name: /invite.*pagespace.*share this page/i,
+      });
+      assert({
+        given: 'a 404 from /api/users/find',
+        should: 'show invite-to-PageSpace CTA button',
+        actual: inviteButton !== null,
+        expected: true,
+      });
+    });
+  });
+
+  it('given user clicks invite CTA, POSTs to /share-invite with VIEW permission', async () => {
+    vi.mocked(fetchWithAuth)
+      .mockResolvedValueOnce(make404Response())   // /api/users/find
+      .mockResolvedValueOnce(makeInviteSuccess()); // /share-invite
+
+    const user = userEvent.setup();
+    render(<ShareDialog />);
+
+    await openDialogAndFillEmail(user, 'new@example.com');
+    const grantButton = screen.getByRole('button', { name: /grant access/i });
+    await user.click(grantButton);
+
+    await waitFor(() => {
+      screen.getByRole('button', { name: /invite.*pagespace.*share this page/i });
+    });
+
+    const inviteButton = screen.getByRole('button', { name: /invite.*pagespace.*share this page/i });
+    await user.click(inviteButton);
+
+    await waitFor(() => {
+      const calls = vi.mocked(fetchWithAuth).mock.calls;
+      const shareInviteCall = calls.find(([url]) =>
+        typeof url === 'string' && url.includes('/share-invite'),
+      );
+      assert({
+        given: 'user clicks the invite CTA',
+        should: 'POST to /share-invite',
+        actual: shareInviteCall !== undefined,
+        expected: true,
+      });
+
+      if (shareInviteCall) {
+        const options = shareInviteCall[1] as RequestInit;
+        const body = JSON.parse(options.body as string) as {
+          email: string;
+          permissions: string[];
+        };
+        assert({
+          given: 'only VIEW is selected',
+          should: 'send permissions: ["VIEW"]',
+          actual: body.permissions,
+          expected: ['VIEW'],
+        });
+      }
+    });
+  });
+
+  it('given DELETE is checked before 404, the share-invite payload does NOT include DELETE', async () => {
+    vi.mocked(fetchWithAuth)
+      .mockResolvedValueOnce(make404Response())
+      .mockResolvedValueOnce(makeInviteSuccess());
+
+    const user = userEvent.setup();
+    render(<ShareDialog />);
+
+    await openDialogAndFillEmail(user, 'new@example.com');
+
+    // Check the Delete checkbox before looking up the user
+    const deleteCheckbox = screen.getByRole('checkbox', { name: /delete/i });
+    await user.click(deleteCheckbox);
+
+    const grantButton = screen.getByRole('button', { name: /grant access/i });
+    await user.click(grantButton);
+
+    await waitFor(() => {
+      screen.getByRole('button', { name: /invite.*pagespace.*share this page/i });
+    });
+
+    const inviteButton = screen.getByRole('button', { name: /invite.*pagespace.*share this page/i });
+    await user.click(inviteButton);
+
+    await waitFor(() => {
+      const calls = vi.mocked(fetchWithAuth).mock.calls;
+      const shareInviteCall = calls.find(([url]) =>
+        typeof url === 'string' && url.includes('/share-invite'),
+      );
+      if (shareInviteCall) {
+        const options = shareInviteCall[1] as RequestInit;
+        const body = JSON.parse(options.body as string) as { permissions: string[] };
+        assert({
+          given: 'DELETE was checked before the 404',
+          should: 'not include DELETE in the share-invite payload',
+          actual: body.permissions.includes('DELETE'),
+          expected: false,
+        });
+      }
+    });
+  });
+
+  it('given /api/users/find returns 200, uses the direct grant path (not share-invite)', async () => {
+    vi.mocked(fetchWithAuth).mockResolvedValueOnce(make200UserResponse());
+    vi.mocked(post).mockResolvedValueOnce({ id: 'perm_1' });
+
+    const user = userEvent.setup();
+    render(<ShareDialog />);
+
+    await openDialogAndFillEmail(user, 'existing@example.com');
+    const grantButton = screen.getByRole('button', { name: /grant access/i });
+    await user.click(grantButton);
+
+    await waitFor(() => {
+      const shareInviteCall = vi.mocked(fetchWithAuth).mock.calls.find(([url]) =>
+        typeof url === 'string' && url.includes('/share-invite'),
+      );
+      assert({
+        given: '/api/users/find returns 200',
+        should: 'not call /share-invite',
+        actual: shareInviteCall,
+        expected: undefined,
+      });
+      expect(post).toHaveBeenCalledWith(
+        expect.stringContaining('/permissions'),
+        expect.objectContaining({ userId: 'user_existing' }),
+      );
+    });
+  });
+});

--- a/apps/web/src/lib/repositories/page-invite-repository.ts
+++ b/apps/web/src/lib/repositories/page-invite-repository.ts
@@ -14,6 +14,7 @@ import { eq, and, gt, lte, isNull } from '@pagespace/db/operators'
 import { users } from '@pagespace/db/schema/auth'
 import { drives, pages } from '@pagespace/db/schema/core'
 import { driveMembers, pagePermissions } from '@pagespace/db/schema/members';
+import { createId } from '@paralleldrive/cuid2';
 import {
   pendingPageInvites,
   type PendingPagePermission,
@@ -272,6 +273,55 @@ export const pageInviteRepository = {
       columns: { name: true, email: true },
     });
     return user ? { name: user.name, email: user.email } : null;
+  },
+
+  async findUserIdByEmail(
+    email: string,
+  ): Promise<{ id: string; emailVerified: Date | null; suspendedAt: Date | null } | null> {
+    const user = await db.query.users.findFirst({
+      where: eq(users.email, email),
+      columns: { id: true, emailVerified: true, suspendedAt: true },
+    });
+    return user
+      ? { id: user.id, emailVerified: user.emailVerified, suspendedAt: user.suspendedAt }
+      : null;
+  },
+
+  async findPageById(pageId: string): Promise<{
+    id: string;
+    title: string;
+    driveId: string;
+    driveName: string;
+  } | null> {
+    const results = await db
+      .select({
+        id: pages.id,
+        title: pages.title,
+        driveId: pages.driveId,
+        driveName: drives.name,
+      })
+      .from(pages)
+      .innerJoin(drives, eq(drives.id, pages.driveId))
+      .where(eq(pages.id, pageId))
+      .limit(1);
+    return results.at(0) ?? null;
+  },
+
+  async createDirectPagePermission(data: {
+    pageId: string;
+    userId: string;
+    canView: boolean;
+    canEdit: boolean;
+    canShare: boolean;
+    grantedBy: string;
+  }): Promise<{ id: string }> {
+    const id = createId();
+    const [row] = await db
+      .insert(pagePermissions)
+      .values({ id, ...data, canDelete: false })
+      .onConflictDoNothing({ target: [pagePermissions.pageId, pagePermissions.userId] })
+      .returning({ id: pagePermissions.id });
+    return row ?? { id };
   },
 };
 

--- a/apps/web/src/lib/repositories/page-invite-repository.ts
+++ b/apps/web/src/lib/repositories/page-invite-repository.ts
@@ -315,13 +315,29 @@ export const pageInviteRepository = {
     canShare: boolean;
     grantedBy: string;
   }): Promise<{ id: string }> {
-    const id = createId();
     const [row] = await db
       .insert(pagePermissions)
-      .values({ id, ...data, canDelete: false })
+      .values({ id: createId(), ...data, canDelete: false })
       .onConflictDoNothing({ target: [pagePermissions.pageId, pagePermissions.userId] })
       .returning({ id: pagePermissions.id });
-    return row ?? { id };
+    if (row) return row;
+
+    // Conflict: permission already exists — return the real row id
+    const [existing] = await db
+      .select({ id: pagePermissions.id })
+      .from(pagePermissions)
+      .where(
+        and(
+          eq(pagePermissions.pageId, data.pageId),
+          eq(pagePermissions.userId, data.userId),
+        ),
+      )
+      .limit(1);
+
+    if (!existing) {
+      throw new Error('Failed to create or read existing page permission');
+    }
+    return existing;
   },
 };
 

--- a/packages/lib/src/email-templates/PageShareInvitationEmail.tsx
+++ b/packages/lib/src/email-templates/PageShareInvitationEmail.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Link,
+  Section,
+  Text,
+} from '@react-email/components';
+import { emailStyles } from './shared-styles';
+
+interface PageShareInvitationEmailProps {
+  inviterName: string;
+  pageTitle: string;
+  driveName: string;
+  permissions: string[];
+  acceptUrl: string;
+}
+
+export function PageShareInvitationEmail({
+  inviterName,
+  pageTitle,
+  driveName,
+  permissions,
+  acceptUrl,
+}: PageShareInvitationEmailProps) {
+  const permissionList = permissions.join(', ');
+
+  return (
+    <Html>
+      <Head />
+      <Body style={emailStyles.main}>
+        <Container style={emailStyles.container}>
+          <Section style={emailStyles.header}>
+            <Heading style={emailStyles.headerTitle}>PageSpace</Heading>
+          </Section>
+          <Section style={emailStyles.content}>
+            <Text style={emailStyles.contentHeading}>
+              You&apos;ve been invited to view a document
+            </Text>
+            <Text style={emailStyles.paragraph}>
+              <strong>{inviterName}</strong> shared the document{' '}
+              <strong>&quot;{pageTitle}&quot;</strong> with you on PageSpace.
+            </Text>
+            <Text style={emailStyles.paragraph}>
+              You have been granted the following permissions:{' '}
+              <strong>{permissionList}</strong>.
+            </Text>
+            <Text style={emailStyles.paragraph}>
+              This document is part of the <strong>{driveName}</strong> workspace.
+              Create a free account to access it.
+            </Text>
+            <Section style={emailStyles.buttonContainer}>
+              <Button style={emailStyles.button} href={acceptUrl}>
+                Accept &amp; View Document
+              </Button>
+            </Section>
+            <Text style={emailStyles.hint}>
+              Or copy and paste this link into your browser:
+              <br />
+              <Link href={acceptUrl} style={emailStyles.link}>
+                {acceptUrl}
+              </Link>
+            </Text>
+          </Section>
+          <Section style={emailStyles.footer}>
+            <Text style={emailStyles.footerText}>
+              You&apos;re receiving this email because someone shared a PageSpace document with you.
+              If you did not expect this, you can safely ignore it.
+            </Text>
+          </Section>
+        </Container>
+      </Body>
+    </Html>
+  );
+}

--- a/packages/lib/src/security/distributed-rate-limit.ts
+++ b/packages/lib/src/security/distributed-rate-limit.ts
@@ -570,6 +570,12 @@ export const DISTRIBUTED_RATE_LIMITS = {
     blockDurationMs: 24 * 60 * 60 * 1000,
     progressiveDelay: false,
   },
+  PAGE_SHARE_INVITE: {
+    maxAttempts: 3,
+    windowMs: 15 * 60 * 1000,
+    blockDurationMs: 15 * 60 * 1000,
+    progressiveDelay: false,
+  },
 } as const;
 
 // =============================================================================

--- a/packages/lib/src/services/notification-email-service.ts
+++ b/packages/lib/src/services/notification-email-service.ts
@@ -4,6 +4,7 @@ import { users, emailUnsubscribeTokens } from '@pagespace/db/schema/auth';
 import { emailNotificationPreferences, emailNotificationLog } from '@pagespace/db/schema/email-notifications';
 import { sendEmail } from './email-service';
 import { DriveInvitationEmail } from '../email-templates/DriveInvitationEmail';
+import { PageShareInvitationEmail } from '../email-templates/PageShareInvitationEmail';
 import { DirectMessageEmail } from '../email-templates/DirectMessageEmail';
 import { ConnectionRequestEmail } from '../email-templates/ConnectionRequestEmail';
 import { PageSharedEmail } from '../email-templates/PageSharedEmail';
@@ -298,6 +299,36 @@ export async function sendPendingDriveInvitationEmail(input: {
       userName: input.recipientEmail,
       inviterName: safeInviterName,
       driveName: safeDriveName,
+      acceptUrl: input.inviteUrl,
+    }),
+  });
+}
+
+/**
+ * Send a "you've been invited to view a page" email to a recipient who does not
+ * yet hold an active session. Errors propagate so the caller can compensating-delete
+ * the pending row on failure.
+ */
+export async function sendPendingPageShareInvitationEmail(input: {
+  recipientEmail: string;
+  inviterName: string;
+  pageTitle: string;
+  driveName: string;
+  permissions: string[];
+  inviteUrl: string;
+}): Promise<void> {
+  const safeInviterName = stripHeaderControls(input.inviterName) || 'Someone';
+  const safePageTitle = stripHeaderControls(input.pageTitle) || 'a document';
+  const safeDriveName = stripHeaderControls(input.driveName) || 'a workspace';
+
+  await sendEmail({
+    to: input.recipientEmail,
+    subject: `${safeInviterName} shared "${safePageTitle}" with you on PageSpace`,
+    react: PageShareInvitationEmail({
+      inviterName: safeInviterName,
+      pageTitle: safePageTitle,
+      driveName: safeDriveName,
+      permissions: input.permissions,
       acceptUrl: input.inviteUrl,
     }),
   });


### PR DESCRIPTION
## Summary
- New `POST /api/pages/[pageId]/share-invite` route — mirrors drive-invite route shape (rate limit, suspended/verified gates, canShare check, pending row + email + SMTP rollback)
- New `sendPendingPageShareInvitationEmail` template — separate framing emphasizing the specific page ("view this document")
- ShareDialog: `/api/users/find` 404 now branches to an "Invite [email] to PageSpace and share this page" CTA; `canDelete` suppressed with tooltip on off-platform path
- DELETE permission rejected at zod layer (schema only allows VIEW | EDIT | SHARE); VIEW enforced as prerequisite when EDIT or SHARE is requested
- `PAGE_SHARE_INVITE` rate limit constant added to `DISTRIBUTED_RATE_LIMITS`
- `pageInviteRepository` extended: `findUserIdByEmail`, `findPageById`, `createDirectPagePermission` (reads back real row ID on conflict)
- ShareDialog handles `kind: 'granted'` response for race where invitee registers mid-flight

This is Task 2 of 3 from the Invite-by-Email Surfaces epic. Task 1 (#1285) shipped the dispatcher and `pendingPageInvites` table; this PR is the user-facing surface. Task 3 (collaborator) runs in parallel.

## Requirements coverage
- **R1** Existing verified user → direct `pagePermissions` write via `createDirectPagePermission`, no pending row created ✅
- **R2** Non-existing user → `pendingPageInvites` row + email via `sendPendingPageShareInvitationEmail` ✅
- **R3** `canUserSharePage` check is the first gate, before any row or email ✅
- **R4** Acceptance via Task 1's dispatcher (unchanged) ✅
- **R5** `DELETE` blocked at zod enum; `VIEW` enforced when `EDIT` or `SHARE` requested ✅
- **R6** SMTP failure → `pageInviteRepository.deletePendingInvite` compensating delete ✅

## Review fixes applied
- Added `.superRefine` to reject `['EDIT']`/`['SHARE']` without `VIEW` (would persist `canView=false`)
- `createDirectPagePermission` now reads back the real existing row ID on conflict instead of fabricating one
- ShareDialog `handleOffPlatformInvite` now parses response `kind` before toasting (handles `kind: 'granted'` race path)
- Validation errors now use `details: flatten().fieldErrors` format to match repo convention

## Test plan
- [x] ShareDialog smoke tests (4/4 pass): 404 branch surfaces invite CTA, DELETE excluded from payload, existing-user path unchanged
- [x] API route tests (20 tests): happy path, 403 (no canShare), 403 (unverified inviter), 403 (suspended target), 400 (DELETE in payload), 400 (no permissions), 400 (EDIT without VIEW), 400 (SHARE without VIEW), 409 (already pending), 429 (rate limit × 2), SMTP rollback
- [x] lib notification-email-service tests: 23/23 pass (existing tests unaffected)
- [ ] Manual: Share dialog → unknown email → invite CTA → check pendingPageInvites row in Studio

## Notes
The `@pagespace/lib` build is broken in this worktree (pre-existing: same issue affects drive-invite route tests). Route tests are mocked at the seam layer and run correctly; ShareDialog smoke tests (pure frontend) pass cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)