### PR TITLE
fix(invites): correct unique-index name in connection-invite conflict handler

### DIFF
--- a/apps/web/src/app/api/connections/invite/route.ts
+++ b/apps/web/src/app/api/connections/invite/route.ts
@@ -225,7 +225,7 @@ export async function POST(request: Request) {
     } catch (insertError) {
       const msg = insertError instanceof Error ? insertError.message : String(insertError);
       const isUniqueViolation =
-        msg.includes('pending_connection_invites_active_owner_email_idx') ||
+        msg.includes('pending_connection_invites_active_inviter_email_idx') ||
         msg.includes('pending_connection_invites_token_hash_unique') ||
         msg.includes('duplicate key');
       if (isUniqueViolation) {


### PR DESCRIPTION
## Summary
The unique-violation handler in `POST /api/connections/invite` was matching against `pending_connection_invites_active_owner_email_idx`, but the actual schema-defined index name is `pending_connection_invites_active_inviter_email_idx` (see `packages/db/src/schema/pending-connection-invites.ts:19`).

The generic `'duplicate key'` fallback caught the constraint in practice, so user-visible behavior was correct, but the specific check was dead code that would never fire.

## Test plan
- [x] Existing route tests still pass — the `'duplicate key'` fallback path covered the same cases the misnamed check claimed to.
- [ ] No new test needed; this is a one-token correction in dead-code-equivalent guard. If we wanted to assert the specific match, we'd need to inject a Postgres error with the precise index name in the message — out of scope for the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)