### PR TITLE
fix(invites): resolve page invites in consent screen

### DIFF
--- a/apps/web/src/app/invite/[token]/page.tsx
+++ b/apps/web/src/app/invite/[token]/page.tsx
@@ -40,6 +40,50 @@ export default async function InvitePage({ params }: InvitePageProps) {
   const { data } = resolution;
   const encodedToken = encodeURIComponent(token);
 
+  if (data.kind === 'page') {
+    const ctaHref = data.isExistingUser
+      ? `/auth/signin?invite=${encodedToken}`
+      : `/auth/signup?invite=${encodedToken}`;
+    const ctaLabel = data.isExistingUser ? 'Sign in to access' : 'Create account & access';
+
+    return (
+      <AuthShell>
+        <div className="space-y-6">
+          <div className="text-center">
+            <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+              <span className="text-blue-600 dark:text-blue-400">{data.inviterName}</span>
+              {' '}has shared a page with you
+            </h1>
+            <p className="mt-3 text-sm text-muted-foreground">
+              <span className="font-medium text-gray-900 dark:text-gray-100">&ldquo;{data.pageTitle}&rdquo;</span>
+              {' '}in{' '}
+              <span className="font-medium text-gray-900 dark:text-gray-100">{data.driveName}</span>
+              {' '}was shared with{' '}
+              <span className="font-medium text-gray-900 dark:text-gray-100">{data.email}</span>.
+            </p>
+          </div>
+
+          <div className="rounded-lg border border-gray-200 bg-white/60 p-4 text-sm text-gray-700 dark:border-gray-700 dark:bg-gray-800/40 dark:text-gray-300">
+            <p>
+              By continuing, you agree to PageSpace&apos;s{' '}
+              <Link href="/terms" className="underline hover:text-foreground">Terms</Link>
+              {' '}and{' '}
+              <Link href="/privacy" className="underline hover:text-foreground">Privacy Policy</Link>.
+            </p>
+          </div>
+
+          <Link href={ctaHref}>
+            <Button className="w-full">{ctaLabel}</Button>
+          </Link>
+
+          <p className="text-center text-xs text-muted-foreground/70">
+            Not {data.email}? Sign out of any other account first, then return to this link.
+          </p>
+        </div>
+      </AuthShell>
+    );
+  }
+
   if (data.kind === 'connection') {
     const ctaHref = data.isExistingUser
       ? `/auth/signin?invite=${encodedToken}`

--- a/apps/web/src/lib/auth/__tests__/invite-resolver.test.ts
+++ b/apps/web/src/lib/auth/__tests__/invite-resolver.test.ts
@@ -13,6 +13,12 @@ vi.mock('@/lib/repositories/connection-invite-repository', () => ({
   },
 }));
 
+vi.mock('@/lib/repositories/page-invite-repository', () => ({
+  pageInviteRepository: {
+    findPendingInviteByTokenHash: vi.fn(),
+  },
+}));
+
 vi.mock('@pagespace/lib/auth/token-utils', () => ({
   hashToken: vi.fn((t: string) => `hash(${t})`),
 }));
@@ -20,6 +26,7 @@ vi.mock('@pagespace/lib/auth/token-utils', () => ({
 import { resolveInviteContext } from '../invite-resolver';
 import { driveInviteRepository } from '@/lib/repositories/drive-invite-repository';
 import { connectionInviteRepository } from '@/lib/repositories/connection-invite-repository';
+import { pageInviteRepository } from '@/lib/repositories/page-invite-repository';
 
 const now = new Date('2026-05-06T12:00:00.000Z');
 
@@ -45,10 +52,25 @@ const baseConnectionInvite = {
   consumedAt: null as Date | null,
 };
 
+const basePageInvite = {
+  id: 'pg_inv_1',
+  email: 'invitee@example.com',
+  pageId: 'page_1',
+  pageTitle: 'Q3 Plan',
+  driveId: 'drive_1',
+  driveName: 'Acme',
+  permissions: ['VIEW' as const],
+  invitedBy: 'inviter_1',
+  inviterName: 'Jane',
+  expiresAt: new Date('2026-05-08T12:00:00.000Z'),
+  consumedAt: null as Date | null,
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
-  // Default: both repos return null (no invite found)
+  // Default: all repos return null (no invite found)
   vi.mocked(driveInviteRepository.findPendingInviteByTokenHash).mockResolvedValue(null);
+  vi.mocked(pageInviteRepository.findPendingInviteByTokenHash).mockResolvedValue(null);
   vi.mocked(connectionInviteRepository.findPendingInviteByTokenHash).mockResolvedValue(null);
 });
 
@@ -134,15 +156,77 @@ describe('resolveInviteContext', () => {
     });
   });
 
-  it('given a token, looks up by SHA3 hash (never plaintext)', async () => {
+  it('given a token, looks up by SHA3 hash across all three repos (never plaintext)', async () => {
     await resolveInviteContext({ token: 'ps_invite_abc', now });
 
     expect(driveInviteRepository.findPendingInviteByTokenHash).toHaveBeenCalledWith(
       'hash(ps_invite_abc)'
     );
+    expect(pageInviteRepository.findPendingInviteByTokenHash).toHaveBeenCalledWith(
+      'hash(ps_invite_abc)'
+    );
     expect(connectionInviteRepository.findPendingInviteByTokenHash).toHaveBeenCalledWith(
       'hash(ps_invite_abc)'
     );
+  });
+
+  describe('page invite tokens', () => {
+    it('given an active page row + no existing user, returns ok page context with isExistingUser=false', async () => {
+      vi.mocked(pageInviteRepository.findPendingInviteByTokenHash).mockResolvedValue(basePageInvite);
+      vi.mocked(driveInviteRepository.loadUserAccountByEmail).mockResolvedValue(null);
+
+      const result = await resolveInviteContext({ token: 'tok', now });
+
+      expect(result).toEqual({
+        ok: true,
+        data: {
+          kind: 'page',
+          pageTitle: 'Q3 Plan',
+          driveName: 'Acme',
+          inviterName: 'Jane',
+          permissions: ['VIEW'],
+          email: 'invitee@example.com',
+          isExistingUser: false,
+        },
+      });
+    });
+
+    it('given an active page row + existing user, returns ok page context with isExistingUser=true', async () => {
+      vi.mocked(pageInviteRepository.findPendingInviteByTokenHash).mockResolvedValue(basePageInvite);
+      vi.mocked(driveInviteRepository.loadUserAccountByEmail).mockResolvedValue({
+        id: 'user_1',
+        suspendedAt: null,
+      });
+
+      const result = await resolveInviteContext({ token: 'tok', now });
+
+      expect(result).toEqual({
+        ok: true,
+        data: expect.objectContaining({ kind: 'page', isExistingUser: true }),
+      });
+    });
+
+    it('given a page row whose consumedAt is set, returns CONSUMED', async () => {
+      vi.mocked(pageInviteRepository.findPendingInviteByTokenHash).mockResolvedValue({
+        ...basePageInvite,
+        consumedAt: new Date('2026-05-06T11:00:00.000Z'),
+      });
+
+      const result = await resolveInviteContext({ token: 'tok', now });
+
+      expect(result).toEqual({ ok: false, error: 'CONSUMED' });
+    });
+
+    it('given a page row whose expiresAt is in the past, returns EXPIRED', async () => {
+      vi.mocked(pageInviteRepository.findPendingInviteByTokenHash).mockResolvedValue({
+        ...basePageInvite,
+        expiresAt: new Date('2026-05-06T11:00:00.000Z'),
+      });
+
+      const result = await resolveInviteContext({ token: 'tok', now });
+
+      expect(result).toEqual({ ok: false, error: 'EXPIRED' });
+    });
   });
 
   describe('connection invite tokens', () => {

--- a/apps/web/src/lib/auth/__tests__/native-invite-acceptance.test.ts
+++ b/apps/web/src/lib/auth/__tests__/native-invite-acceptance.test.ts
@@ -95,6 +95,7 @@ const pageRow = (overrides = {}) => ({
   driveName: 'Acme',
   permissions: ['VIEW' as const],
   invitedBy: 'user_inviter',
+  inviterName: 'Jane',
   expiresAt: new Date('2099-01-01'),
   consumedAt: null,
   ...overrides,

--- a/apps/web/src/lib/auth/invite-resolver.ts
+++ b/apps/web/src/lib/auth/invite-resolver.ts
@@ -2,6 +2,8 @@ import { hashToken } from '@pagespace/lib/auth/token-utils';
 import { isInviteExpired, isInviteConsumed } from '@pagespace/lib/services/invites';
 import { driveInviteRepository } from '@/lib/repositories/drive-invite-repository';
 import { connectionInviteRepository } from '@/lib/repositories/connection-invite-repository';
+import { pageInviteRepository } from '@/lib/repositories/page-invite-repository';
+import type { PendingPagePermission } from '@pagespace/db/schema/pending-page-invites';
 
 export type InviteResolutionError = 'NOT_FOUND' | 'EXPIRED' | 'CONSUMED';
 
@@ -11,6 +13,15 @@ export type InviteContextData =
       driveName: string;
       inviterName: string;
       role: 'OWNER' | 'ADMIN' | 'MEMBER';
+      email: string;
+      isExistingUser: boolean;
+    }
+  | {
+      kind: 'page';
+      pageTitle: string;
+      driveName: string;
+      inviterName: string;
+      permissions: PendingPagePermission[];
       email: string;
       isExistingUser: boolean;
     }
@@ -47,12 +58,13 @@ export const resolveInviteContext = async ({
 }): Promise<InviteResolution> => {
   const tokenHash = hashToken(token);
 
-  const [driveRow, connectionRow] = await Promise.all([
+  const [driveRow, pageRow, connectionRow] = await Promise.all([
     driveInviteRepository.findPendingInviteByTokenHash(tokenHash),
+    pageInviteRepository.findPendingInviteByTokenHash(tokenHash),
     connectionInviteRepository.findPendingInviteByTokenHash(tokenHash),
   ]);
 
-  const row = driveRow ?? connectionRow;
+  const row = driveRow ?? pageRow ?? connectionRow;
   if (!row) {
     return { ok: false, error: 'NOT_FOUND' };
   }
@@ -78,6 +90,21 @@ export const resolveInviteContext = async ({
         inviterName: driveRow.inviterName,
         role: driveRow.role,
         email: driveRow.email,
+        isExistingUser,
+      },
+    };
+  }
+
+  if (pageRow) {
+    return {
+      ok: true,
+      data: {
+        kind: 'page',
+        pageTitle: pageRow.pageTitle,
+        driveName: pageRow.driveName,
+        inviterName: pageRow.inviterName,
+        permissions: pageRow.permissions,
+        email: pageRow.email,
         isExistingUser,
       },
     };

--- a/apps/web/src/lib/repositories/page-invite-repository.ts
+++ b/apps/web/src/lib/repositories/page-invite-repository.ts
@@ -38,6 +38,7 @@ export const pageInviteRepository = {
     driveName: string;
     permissions: PendingPagePermission[];
     invitedBy: string;
+    inviterName: string;
     expiresAt: Date;
     consumedAt: Date | null;
   } | null> {
@@ -51,12 +52,14 @@ export const pageInviteRepository = {
         driveName: drives.name,
         permissions: pendingPageInvites.permissions,
         invitedBy: pendingPageInvites.invitedBy,
+        inviterName: users.name,
         expiresAt: pendingPageInvites.expiresAt,
         consumedAt: pendingPageInvites.consumedAt,
       })
       .from(pendingPageInvites)
       .innerJoin(pages, eq(pages.id, pendingPageInvites.pageId))
       .innerJoin(drives, eq(drives.id, pages.driveId))
+      .innerJoin(users, eq(users.id, pendingPageInvites.invitedBy))
       .where(eq(pendingPageInvites.tokenHash, tokenHash))
       .limit(1);
     return results.at(0) ?? null;


### PR DESCRIPTION
## Summary

- `resolveInviteContext()` only queried drive and connection invite tables — page invite tokens stored in `pending_page_invites` were never looked up, so clicking a page share email link always showed the "expired or invalid" error card
- Added `pageInviteRepository` to the 3-way `Promise.all` lookup in `invite-resolver.ts`
- Added `kind: 'page'` arm to the `InviteContextData` union and dispatch
- Joined `users` in `pageInviteRepository.findPendingInviteByTokenHash` to return `inviterName` (mirrors drive-invite-repository)
- Added the page invite consent screen branch in `invite/[token]/page.tsx`

## Affected files

- `apps/web/src/lib/auth/invite-resolver.ts`
- `apps/web/src/lib/repositories/page-invite-repository.ts`
- `apps/web/src/app/invite/[token]/page.tsx`

## Test plan

- [ ] Share a page by email → click the emailed link → consent screen shows page title, drive name, and inviter name (not the "expired" card)
- [ ] Sign in / create account from the consent screen → land on the page with correct permissions
- [ ] Drive member invite links still work (no regression)
- [ ] Collaborator/connection invite links still work (no regression)
- [ ] Full build + typecheck passes (`pnpm typecheck` — 12/12 tasks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Users can now receive and accept page sharing invitations, with details displayed about the shared page, associated drive, and inviter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->