### PR TITLE
fix(drives): clear stale state on logout & socket reconnect

### DIFF
--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -113,6 +113,13 @@ export function useAuth(): {
         // Non-critical — tabs will just show dashboard on next login
       }
 
+      try {
+        const { useDriveStore } = await import('@/hooks/useDrive');
+        useDriveStore.getState().reset();
+      } catch {
+        // Non-critical
+      }
+
       endSession();
       router.push('/auth/signin');
     }

--- a/apps/web/src/hooks/useDrive.ts
+++ b/apps/web/src/hooks/useDrive.ts
@@ -14,6 +14,7 @@ interface DriveState {
   removeDrive: (driveId: string) => void;
   updateDrive: (driveId: string, updates: Partial<Drive>) => void;
   setCurrentDrive: (driveId: string | null) => void;
+  reset: () => void;
 }
 
 const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
@@ -61,6 +62,7 @@ export const useDriveStore = create<DriveState>()(
         lastFetched: Date.now()
       })),
       setCurrentDrive: (driveId: string | null) => set({ currentDriveId: driveId }),
+      reset: () => set({ drives: [], lastFetched: 0, currentDriveId: null }),
     }),
     {
       name: 'drive-storage',

--- a/apps/web/src/hooks/useDrive.ts
+++ b/apps/web/src/hooks/useDrive.ts
@@ -62,7 +62,7 @@ export const useDriveStore = create<DriveState>()(
         lastFetched: Date.now()
       })),
       setCurrentDrive: (driveId: string | null) => set({ currentDriveId: driveId }),
-      reset: () => set({ drives: [], lastFetched: 0, currentDriveId: null }),
+      reset: () => set({ drives: [], lastFetched: 0, currentDriveId: null, isLoading: false }),
     }),
     {
       name: 'drive-storage',

--- a/apps/web/src/hooks/useGlobalDriveSocket.ts
+++ b/apps/web/src/hooks/useGlobalDriveSocket.ts
@@ -71,6 +71,8 @@ export function useGlobalDriveSocket() {
       hasJoinedRef.current = true;
       joinedUserIdRef.current = user.id;
       console.log(`🌍 Joined user:${user.id}:drives channel`);
+      // Catch any member_added events that fired while the socket was disconnected
+      fetchDrives(false, true);
     }
 
     // Listen for drive events on user-specific channel

--- a/apps/web/src/hooks/useGlobalDriveSocket.ts
+++ b/apps/web/src/hooks/useGlobalDriveSocket.ts
@@ -71,8 +71,10 @@ export function useGlobalDriveSocket() {
       hasJoinedRef.current = true;
       joinedUserIdRef.current = user.id;
       console.log(`🌍 Joined user:${user.id}:drives channel`);
-      // Catch any member_added events that fired while the socket was disconnected
-      fetchDrives(false, true);
+      // Catch any member_added events that fired while the socket was disconnected.
+      // Use includeTrash=true to match the debounced handler and avoid overwriting
+      // a trash-inclusive list with a narrower response.
+      fetchDrives(true, true);
     }
 
     // Listen for drive events on user-specific channel


### PR DESCRIPTION
## Summary

- Adds `reset()` action to `useDriveStore` — zeroes `drives`, `lastFetched`, and `currentDriveId` in-memory state
- Calls `useDriveStore.getState().reset()` on logout (alongside the existing tabs store clear), preventing the previous user's drives from bleeding into the next session when a different account logs in on the same browser
- Calls `fetchDrives(false, true)` immediately after joining `user:${userId}:drives` in `useGlobalDriveSocket`, so any `drive:member_added` events that fired while the socket was disconnected (e.g. invite accepted before app load) are recovered on reconnect

## Root causes fixed

**Cross-user bleed**: `clearStoresIfUserChanged` cleared localStorage on next login but left the Zustand in-memory store populated. The 5-min cache guard (`drives.length > 0 && age < CACHE_DURATION`) then skipped the API call, leaving User B seeing User A's drives until cache expiry.

**Shared drive delay**: The socket-based `drive:member_added` handler already triggers a force-refresh — but if the recipient's socket hadn't joined the room yet when the event fired, it was lost with no replay. The force-refresh on room join closes that gap.

## Test plan

- [ ] Log in as User A, confirm drives load
- [ ] Log out, log in as User B — User A's drives should be gone immediately (no flash)
- [ ] Share a drive with User B from another session — should appear within ~500ms
- [ ] Reload page as User B — drives still correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced logout process to properly clear drive-related state and ensure clean session termination.
  * Improved real-time synchronization to catch and recover drive updates that may have occurred during socket reconnections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->