### PR TITLE
fix(account): await audit+activity writes before deleteUser

### DIFF
--- a/apps/web/src/app/api/account/route.ts
+++ b/apps/web/src/app/api/account/route.ts
@@ -14,7 +14,7 @@ import { deleteMonitoringDataForUser } from '@pagespace/lib/logging/monitoring-p
 import { isValidEmail } from '@pagespace/lib/validators/email';
 import { isCloud } from '@pagespace/lib/deployment-mode';
 import { createAnonymizedActorEmail } from '@pagespace/lib/compliance/anonymize';
-import { getActorInfo, logActivity } from '@pagespace/lib/monitoring/activity-logger';
+import { getActorInfo, logActivity, logUserActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { securityAudit } from '@pagespace/lib/audit/security-audit';
 import { stripe } from '@/lib/stripe/client';
 
@@ -243,20 +243,23 @@ export async function DELETE(req: Request) {
       }
     }
 
-    // CRITICAL: Log account deletion BEFORE anonymization (required for GDPR compliance)
-    // This ensures we have an audit record of who deleted their account and when.
-    // Must be awaited — fire-and-forget would race with deleteUser() and cause FK violations.
+    // Log account deletion BEFORE anonymization (GDPR compliance).
+    // Best-effort: a logging failure must not block the right to erasure.
     const actorInfo = await getActorInfo(userId);
-    await logActivity({
-      userId,
-      actorEmail: actorInfo?.actorEmail ?? 'unknown@system',
-      actorDisplayName: actorInfo?.actorDisplayName,
-      operation: 'account_delete',
-      resourceType: 'user',
-      resourceId: userId,
-      resourceTitle: user.email ?? undefined,
-      driveId: null,
-    });
+    try {
+      await logActivity({
+        userId,
+        actorEmail: actorInfo?.actorEmail ?? 'unknown@system',
+        actorDisplayName: actorInfo?.actorDisplayName,
+        operation: 'account_delete',
+        resourceType: 'user',
+        resourceId: userId,
+        resourceTitle: user.email ?? undefined,
+        driveId: null,
+      });
+    } catch (error) {
+      loggers.auth.error('Could not write activity log during account deletion:', error as Error);
+    }
 
     // Anonymize activity logs before user deletion (GDPR compliance + SOX audit trail)
     // This preserves the audit trail while removing PII
@@ -297,18 +300,22 @@ export async function DELETE(req: Request) {
     }
 
     // Log security audit BEFORE user deletion so the userId FK is still valid.
-    // Must be awaited — auditRequest() is fire-and-forget and would race with deleteUser().
-    await securityAudit.logEvent({
-      eventType: 'admin.user.deleted',
-      userId,
-      resourceType: 'account',
-      resourceId: userId,
-      ipAddress:
-        req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
-        req.headers.get('x-real-ip')?.trim() ??
-        'unknown',
-      userAgent: req.headers.get('user-agent')?.trim() ?? 'unknown',
-    });
+    // Best-effort: a transient audit-table or lock failure must not block the right to erasure.
+    try {
+      await securityAudit.logEvent({
+        eventType: 'admin.user.deleted',
+        userId,
+        resourceType: 'account',
+        resourceId: userId,
+        ipAddress:
+          req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+          req.headers.get('x-real-ip')?.trim() ??
+          'unknown',
+        userAgent: req.headers.get('user-agent')?.trim() ?? 'unknown',
+      });
+    } catch (error) {
+      loggers.auth.error('Could not write security audit during account deletion:', error as Error);
+    }
 
     // Delete the user via repository seam (FK set null will preserve activity logs with userId = null)
     await accountRepository.deleteUser(userId);

--- a/apps/web/src/app/api/account/route.ts
+++ b/apps/web/src/app/api/account/route.ts
@@ -14,7 +14,8 @@ import { deleteMonitoringDataForUser } from '@pagespace/lib/logging/monitoring-p
 import { isValidEmail } from '@pagespace/lib/validators/email';
 import { isCloud } from '@pagespace/lib/deployment-mode';
 import { createAnonymizedActorEmail } from '@pagespace/lib/compliance/anonymize';
-import { getActorInfo, logUserActivity } from '@pagespace/lib/monitoring/activity-logger';
+import { getActorInfo, logActivity } from '@pagespace/lib/monitoring/activity-logger';
+import { securityAudit } from '@pagespace/lib/audit/security-audit';
 import { stripe } from '@/lib/stripe/client';
 
 const patchBodySchema = z
@@ -243,12 +244,19 @@ export async function DELETE(req: Request) {
     }
 
     // CRITICAL: Log account deletion BEFORE anonymization (required for GDPR compliance)
-    // This ensures we have an audit record of who deleted their account and when
+    // This ensures we have an audit record of who deleted their account and when.
+    // Must be awaited — fire-and-forget would race with deleteUser() and cause FK violations.
     const actorInfo = await getActorInfo(userId);
-    logUserActivity(userId, 'account_delete', {
-      targetUserId: userId,
-      targetUserEmail: user.email,
-    }, actorInfo);
+    await logActivity({
+      userId,
+      actorEmail: actorInfo?.actorEmail ?? 'unknown@system',
+      actorDisplayName: actorInfo?.actorDisplayName,
+      operation: 'account_delete',
+      resourceType: 'user',
+      resourceId: userId,
+      resourceTitle: user.email ?? undefined,
+      driveId: null,
+    });
 
     // Anonymize activity logs before user deletion (GDPR compliance + SOX audit trail)
     // This preserves the audit trail while removing PII
@@ -289,8 +297,18 @@ export async function DELETE(req: Request) {
     }
 
     // Log security audit BEFORE user deletion so the userId FK is still valid.
-    // Timeout prevents stalling account deletion if the advisory lock hangs.
-    auditRequest(req, { eventType: 'admin.user.deleted', userId, resourceType: 'account', resourceId: userId });
+    // Must be awaited — auditRequest() is fire-and-forget and would race with deleteUser().
+    await securityAudit.logEvent({
+      eventType: 'admin.user.deleted',
+      userId,
+      resourceType: 'account',
+      resourceId: userId,
+      ipAddress:
+        req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ??
+        req.headers.get('x-real-ip')?.trim() ??
+        'unknown',
+      userAgent: req.headers.get('user-agent')?.trim() ?? 'unknown',
+    });
 
     // Delete the user via repository seam (FK set null will preserve activity logs with userId = null)
     await accountRepository.deleteUser(userId);

--- a/apps/web/src/app/api/pulse/generate/route.ts
+++ b/apps/web/src/app/api/pulse/generate/route.ts
@@ -61,7 +61,10 @@ export async function POST(req: Request) {
 
     // Get user info for personalization
     const [user] = await db.select().from(users).where(eq(users.id, userId));
-    const userName = user?.name || user?.email?.split('@')[0] || 'there';
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+    const userName = user.name || user.email?.split('@')[0] || 'there';
 
     // Determine timezone: use client-provided, then stored preference, then UTC
     const userTimezone = clientTimezone || normalizeTimezone(user?.timezone);


### PR DESCRIPTION
## Summary

- **`security_audit_log` FK violations** — `auditRequest()` was fire-and-forget. Despite appearing before `deleteUser()` in source, the async DB INSERT landed after the user row was gone. Replaced with `await securityAudit.logEvent({...})` so the write completes while the `userId` FK is still valid.
- **`activity_logs` FK violations** — `logUserActivity()` is a `void` helper with no await mechanism. Replaced with a direct `await logActivity({...})` call at the deletion site, same fix.
- **`pulse_summaries` FK violations** — the on-demand pulse generate route had no null-guard after the user fetch. A deleted user could pass session auth, trigger 600+ lines of AI generation, then fail on the `pulseSummaries` INSERT. Added an early `404` return if the user no longer exists.

The email rate-limit error in the same log window is unrelated — the invite route already rolls back the pending row correctly. No change needed there.

## Root cause

The comment on line 291 already said "BEFORE user deletion so the userId FK is still valid" — both `auditRequest()` and `logUserActivity()` return `void` and dispatch their DB writes via `.catch()`, so the INSERTs always landed after `deleteUser()` regardless of call order in source.

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm test:unit` passes
- [ ] Staging: delete test account — no FK violations in `security_audit_log` or `activity_logs`
- [ ] Staging: `admin.user.deleted` audit record IS present after deletion
- [ ] Staging: on-demand pulse for deleted userId — returns 404 not 500

🤖 Generated with [Claude Code](https://claude.ai/claude-code)