### PR TITLE
fix(channels): render numbered lists with visible markers

### DIFF
--- a/apps/web/src/components/ai/shared/chat/StreamingMarkdown.tsx
+++ b/apps/web/src/components/ai/shared/chat/StreamingMarkdown.tsx
@@ -202,7 +202,7 @@ function CustomTable({ children, ...props }: TableHTMLAttributes<HTMLTableElemen
 // Custom list item component with smart word breaking and hyphenation
 function CustomListItem({ children, className, ...props }: HTMLAttributes<HTMLLIElement> & { children?: ReactNode }) {
   return (
-    <li className={cn("min-w-0 max-w-full [overflow-wrap:break-word] [hyphens:auto] [text-wrap:pretty] [&>p]:inline", className)} {...props}>
+    <li className={cn("min-w-0 max-w-full [overflow-wrap:break-word] [hyphens:auto] [text-wrap:pretty]", className)} {...props}>
       {children}
     </li>
   );

--- a/apps/web/src/components/ai/shared/chat/StreamingMarkdown.tsx
+++ b/apps/web/src/components/ai/shared/chat/StreamingMarkdown.tsx
@@ -200,11 +200,29 @@ function CustomTable({ children, ...props }: TableHTMLAttributes<HTMLTableElemen
 }
 
 // Custom list item component with smart word breaking and hyphenation
-function CustomListItem({ children, ...props }: HTMLAttributes<HTMLLIElement> & { children?: ReactNode }) {
+function CustomListItem({ children, className, ...props }: HTMLAttributes<HTMLLIElement> & { children?: ReactNode }) {
   return (
-    <li className="min-w-0 max-w-full [overflow-wrap:break-word] [hyphens:auto] [text-wrap:pretty]" {...props}>
+    <li className={cn("min-w-0 max-w-full [overflow-wrap:break-word] [hyphens:auto] [text-wrap:pretty] [&>p]:inline", className)} {...props}>
       {children}
     </li>
+  );
+}
+
+// Custom ordered list — list-outside with padding keeps markers inside the padded area,
+// safe from overflow:hidden on ancestor containers (Streamdown's list-inside can be clipped).
+function CustomOrderedList({ children, className, ...props }: HTMLAttributes<HTMLOListElement> & { children?: ReactNode }) {
+  return (
+    <ol className={cn("list-decimal list-outside pl-6 my-2", className)} {...props}>
+      {children}
+    </ol>
+  );
+}
+
+function CustomUnorderedList({ children, className, ...props }: HTMLAttributes<HTMLUListElement> & { children?: ReactNode }) {
+  return (
+    <ul className={cn("list-disc list-outside pl-6 my-2", className)} {...props}>
+      {children}
+    </ul>
   );
 }
 
@@ -298,6 +316,8 @@ function createStreamdownComponents(router: RouterLike) {
     pre: CustomPre,
     p: CustomParagraph,
     table: CustomTable,
+    ol: CustomOrderedList,
+    ul: CustomUnorderedList,
     li: CustomListItem,
     span: CustomSpan,
   };


### PR DESCRIPTION
## Summary

- Add `CustomOrderedList` and `CustomUnorderedList` to `StreamingMarkdown` using `list-outside` + `pl-6`, replacing Streamdown's `list-inside` default which was clipped by the `overflow:hidden` ancestor on the message list container
- Fix `CustomListItem` to destructure `className` and merge via `cn()`, and add `[&>p]:inline` for loose-list content

## Root Cause

Channel messages render via `StreamingMarkdown` → `Streamdown`. The default `MarkdownOl`/`MarkdownUl` apply `list-inside` (marker inside the content box, no padding). The message list is wrapped in `<div className="flex-grow overflow-hidden relative">` — `overflow: hidden` clips markers in the overflow area. `list-outside` + `pl-6` keeps markers inside the padded box where they're never clipped.

## Test plan

- [ ] Channel message with numbered list → numbers visible
- [ ] Channel message with bullet list → bullets visible
- [ ] Thread panel lists render correctly
- [ ] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)