### PR TITLE
fix(avatars): avatar blank after upload in local dev

### DIFF
--- a/apps/processor/src/api/avatar.ts
+++ b/apps/processor/src/api/avatar.ts
@@ -36,7 +36,7 @@ const upload = multer({
   },
 });
 
-const STORAGE_ROOT = path.resolve(process.env.FILE_STORAGE_PATH || '/data/files');
+const STORAGE_ROOT = path.resolve(process.env.FILE_STORAGE_PATH || path.join(process.cwd(), '../../storage'));
 const AVATAR_ROOT = resolvePathWithin(STORAGE_ROOT, 'avatars');
 
 /* c8 ignore next 3 -- startup guard, module throws before any handler runs */

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,6 +1,15 @@
 # Database Configuration
 DATABASE_URL=postgresql://user:password@localhost:5432/pagespace
 
+# File storage — must match the processor's FILE_STORAGE_PATH so avatar files can be served.
+# In Docker both apps use /app/storage (set via docker-compose.yml). For local dev (pnpm dev),
+# both apps default to <monorepo-root>/storage if this var is unset, so you only need to
+# set it when running the processor separately or in a non-standard layout.
+# FILE_STORAGE_PATH=../../storage
+
+# Processor service URL (local dev). In Docker this is set to http://processor:3003.
+PROCESSOR_URL=http://localhost:3003
+
 # CSRF Protection
 CSRF_SECRET=generate_another_secure_64_character_hex_string_here
 

--- a/apps/web/src/app/api/account/avatar/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/avatar/__tests__/route.test.ts
@@ -365,6 +365,53 @@ describe('POST /api/account/avatar', () => {
     });
   });
 
+  describe('processor filename validation', () => {
+    it('given processor returns no filename, should return 500 without storing a bad URL', async () => {
+      mockSelectChain([{ image: null }]);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ success: true }), // no filename field
+      });
+
+      const file = createMockFile('image/png', 1024);
+      const response = await POST(createUploadRequest(file));
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(body.error).toBe('Failed to upload avatar');
+    });
+
+    it('given processor returns empty-string filename, should return 500', async () => {
+      mockSelectChain([{ image: null }]);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ filename: '' }),
+      });
+
+      const file = createMockFile('image/png', 1024);
+      const response = await POST(createUploadRequest(file));
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(body.error).toBe('Failed to upload avatar');
+    });
+
+    it('given processor returns non-string filename, should return 500', async () => {
+      mockSelectChain([{ image: null }]);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ filename: 42 }),
+      });
+
+      const file = createMockFile('image/png', 1024);
+      const response = await POST(createUploadRequest(file));
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(body.error).toBe('Failed to upload avatar');
+    });
+  });
+
   describe('successful upload', () => {
     it('updates user record and returns avatar URL', async () => {
       mockSelectChain([{ image: null }]);

--- a/apps/web/src/app/api/account/avatar/route.ts
+++ b/apps/web/src/app/api/account/avatar/route.ts
@@ -122,8 +122,11 @@ export async function POST(request: NextRequest) {
     const processorResult = await processorResponse.json();
     const { filename } = processorResult;
 
-    // Update user record with API URL for the avatar
-    const avatarUrl = `/api/avatar/${userId}/${filename}?t=${Date.now()}`; // Add timestamp for cache busting
+    if (!filename || typeof filename !== 'string') {
+      throw new Error('Processor returned invalid avatar response');
+    }
+
+    const avatarUrl = `/api/avatar/${userId}/${filename}?t=${Date.now()}`;
     await db.update(users)
       .set({ image: avatarUrl })
       .where(eq(users.id, userId));

--- a/apps/web/src/app/api/avatar/[userId]/[filename]/route.ts
+++ b/apps/web/src/app/api/avatar/[userId]/[filename]/route.ts
@@ -22,7 +22,7 @@ export async function GET(
     const { userId, filename } = await context.params;
 
     // Use the configured storage path that matches processor's storage
-    const storageBasePath = process.env.FILE_STORAGE_PATH || join(process.cwd(), 'storage');
+    const storageBasePath = process.env.FILE_STORAGE_PATH || resolve(process.cwd(), '../../storage');
 
     // Safely resolve the avatar path with traversal protection
     const pathResult = resolveAvatarPath(storageBasePath, userId, filename);

--- a/apps/web/src/app/api/avatar/[userId]/[filename]/route.ts
+++ b/apps/web/src/app/api/avatar/[userId]/[filename]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { readFile } from 'fs/promises';
-import { join, resolve } from 'path';
+import { resolve } from 'path';
 import { resolveAvatarPath, verifyPathWithinBase } from '@/lib/security/safe-path';
 
 /**

--- a/apps/web/src/app/settings/account/page.tsx
+++ b/apps/web/src/app/settings/account/page.tsx
@@ -179,9 +179,13 @@ export default function AccountPage() {
         throw new Error(data.error || 'Failed to upload avatar');
       }
 
+      const data = await response.json().catch(() => ({}));
       setAvatarFile(null);
+      if (data.avatarUrl) {
+        setAvatarPreview(data.avatarUrl);
+      }
+      toast.success('Avatar updated');
 
-      // Refresh user data to get new avatar URL
       if (mutate) {
         await mutate();
       }


### PR DESCRIPTION
## Problem

After a successful avatar upload the avatar immediately reverts to blank with no visible error. The upload API returns 200, the DB gets updated, but the image can't be served — so `AvatarImage` silently falls back to `AvatarFallback`.

### Root cause

Storage path mismatch between the processor (saves) and the web app (serves):

| App | Default when `FILE_STORAGE_PATH` is unset |
|-----|---|
| `apps/processor` | `/data/files` |
| `apps/web` serving route | `join(process.cwd(), 'storage')` → `apps/web/storage` |

In Docker both containers explicitly set `FILE_STORAGE_PATH` and mount the same named volume at different paths — that's intentional and still works. In local dev (`pnpm dev`), neither app has `FILE_STORAGE_PATH` set, so they fall back to different directories. The processor saves the file, the web app can't find it, returns 404, and `AvatarImage` shows the blank fallback with no user-visible error.

## Changes

- **`apps/processor/src/api/avatar.ts`** — change default `STORAGE_ROOT` from `/data/files` to `path.join(process.cwd(), '../../storage')`, which resolves to the monorepo root `storage/` when Turbo runs the processor from `apps/processor/`
- **`apps/web/src/app/api/avatar/.../route.ts`** — change default `storageBasePath` from `join(process.cwd(), 'storage')` to `resolve(process.cwd(), '../../storage')` — same monorepo-root `storage/` from `apps/web/`
- **`apps/web/src/app/api/account/avatar/route.ts`** — validate `filename` from processor response before building and storing the URL; prevents `/api/avatar/{userId}/undefined?t=…` from ever being written to the DB
- **`apps/web/src/app/settings/account/page.tsx`** — read `avatarUrl` from the upload response and set the preview immediately; add a success toast so the user knows the upload worked
- **`apps/web/.env.example`** — document `FILE_STORAGE_PATH` and `PROCESSOR_URL` for local dev

## Test plan

- [ ] 3 new unit tests added for `filename` validation in `POST /api/account/avatar` (all red → green)
- [ ] All 94 avatar-related tests pass (route, security, safe-path, google-avatar)
- [ ] `pnpm dev` local: upload avatar → avatar persists after save and page reload
- [ ] Docker (`docker compose up`): avatar upload/display unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Avatar uploads now display an immediate success notification upon completion, providing instant user feedback.

* **Bug Fixes**
  * Enhanced validation and error handling for avatar upload responses to properly detect and report failures.

* **Chores**
  * Updated configuration documentation for avatar file storage path settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->