### PR TITLE
[codex] Fix avatar persistence and chat display

### DIFF
--- a/apps/web/src/app/api/inbox/__tests__/route.test.ts
+++ b/apps/web/src/app/api/inbox/__tests__/route.test.ts
@@ -61,6 +61,7 @@ const dmRow = {
   other_user_name: 'Alice',
   other_user_display_name: 'Alice',
   other_user_avatar_url: null,
+  other_user_image: '/api/avatar/alice/avatar.png?t=1',
   unread_count: '0',
 };
 
@@ -121,6 +122,14 @@ describe('GET /api/inbox ?type filter', () => {
     expect(vi.mocked(db.execute)).toHaveBeenCalledTimes(1);
     const sqlArg = vi.mocked(db.execute).mock.calls[0][0];
     expect(isDmQuery(sqlArg)).toBe(true);
+  });
+
+  it('uses users.image as the DM avatar when the profile avatar is blank', async () => {
+    const res = await GET(new Request('http://localhost/api/inbox?type=dm&limit=20'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.items[0].avatarUrl).toBe('/api/avatar/alice/avatar.png?t=1');
   });
 
   it('returns only channels when type=channel', async () => {

--- a/apps/web/src/app/api/inbox/route.ts
+++ b/apps/web/src/app/api/inbox/route.ts
@@ -188,6 +188,7 @@ export async function GET(request: Request) {
             dd."lastMessageAt" as last_message_at,
             dd."lastMessagePreview" as last_message,
             u.name as other_user_name,
+            u.image as other_user_image,
             up."displayName" as other_user_display_name,
             up."avatarUrl" as other_user_avatar_url,
             COALESCE(uc.unread_count, 0) as unread_count
@@ -209,7 +210,7 @@ export async function GET(request: Request) {
             id: row.id,
             type: 'dm',
             name: row.other_user_display_name || row.other_user_name,
-            avatarUrl: row.other_user_avatar_url,
+            avatarUrl: row.other_user_image || row.other_user_avatar_url,
             lastMessageAt: toISOTimestamp(row.last_message_at),
             lastMessagePreview: row.last_message,
             lastMessageSender: null,

--- a/apps/web/src/app/dashboard/channels/[pageId]/page.tsx
+++ b/apps/web/src/app/dashboard/channels/[pageId]/page.tsx
@@ -284,7 +284,7 @@ export default function InboxChannelPage() {
       user: {
         id: user.id,
         name: user.name || 'You',
-        image: null,
+        image: user.image ?? null,
       },
       fileId: attachment?.id || null,
       attachmentMeta,
@@ -577,7 +577,7 @@ export default function InboxChannelPage() {
       return { name: fromList.user.name, image: fromList.user.image };
     }
     if (authorId === user?.id) {
-      return { name: user?.name ?? 'You', image: null };
+      return { name: user?.name ?? 'You', image: user?.image ?? null };
     }
     return { name: fallbackName ?? 'Member', image: null };
   };

--- a/apps/web/src/app/dashboard/dms/[conversationId]/__tests__/page.test.tsx
+++ b/apps/web/src/app/dashboard/dms/[conversationId]/__tests__/page.test.tsx
@@ -11,10 +11,30 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
 }));
 
-const mockUser = { id: 'user-me', name: 'Me', email: 'me@x.test', image: null };
+const mockUser = {
+  id: 'user-me',
+  name: 'Me',
+  email: 'me@x.test',
+  image: '/api/avatar/user-me/avatar.png?t=1',
+};
 vi.mock('@/hooks/useAuth', () => ({
   useAuth: () => ({ user: mockUser }),
 }));
+
+vi.mock('@/components/ui/avatar', async () => {
+  const React = await vi.importActual<typeof import('react')>('react');
+
+  return {
+    Avatar: ({ children, className }: React.ComponentProps<'div'>) => (
+      <div data-slot="avatar" className={className}>{children}</div>
+    ),
+    AvatarImage: ({ src }: React.ComponentProps<'img'>) =>
+      src ? React.createElement('img', { 'data-slot': 'avatar-image', src, alt: '' }) : null,
+    AvatarFallback: ({ children, className }: React.ComponentProps<'div'>) => (
+      <div data-slot="avatar-fallback" className={className}>{children}</div>
+    ),
+  };
+});
 
 // Controllable socket mock
 type Handler = (...args: unknown[]) => void;
@@ -218,6 +238,33 @@ describe('InboxDMPage — attachments', () => {
     expect(body).toMatchObject({ content: 'hello' });
     expect(body.fileId).toBeUndefined();
     expect(body.attachmentMeta).toBeUndefined();
+  });
+
+  it('renders the current user avatar for own DM messages', async () => {
+    swrMessages = {
+      messages: [
+        {
+          id: 'msg-own',
+          conversationId: 'conv-1',
+          senderId: 'user-me',
+          content: 'hello from me',
+          isRead: false,
+          readAt: null,
+          isEdited: false,
+          editedAt: null,
+          createdAt: '2026-05-06T12:00:00.000Z',
+          parentId: null,
+          reactions: [],
+        },
+      ],
+    };
+
+    await act(async () => {
+      render(<InboxDMPage />);
+    });
+
+    const avatarImage = document.querySelector('[data-slot="avatar-image"]');
+    expect(avatarImage).toHaveAttribute('src', mockUser.image);
   });
 
   it('renderMessage_withFileId_rendersMessageAttachment', async () => {

--- a/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
@@ -349,7 +349,7 @@ export default function InboxDMPage() {
     const authorName = isOwn
       ? user?.name ?? 'You'
       : conversation?.otherUser?.displayName ?? conversation?.otherUser?.name ?? 'Member';
-    const authorImage = isOwn ? null : conversation?.otherUser?.image ?? conversation?.otherUser?.avatarUrl ?? null;
+    const authorImage = isOwn ? user?.image ?? null : conversation?.otherUser?.image ?? conversation?.otherUser?.avatarUrl ?? null;
     setQuotedMessageId(m.id);
     setActiveQuotedSnapshot({
       id: m.id,
@@ -471,11 +471,12 @@ export default function InboxDMPage() {
     const m = threadParent;
     const isOwn = m.senderId === user?.id;
     const name = isOwn ? user?.name ?? 'You' : displayName;
+    const image = isOwn ? user?.image ?? null : otherUser.image || otherUser.avatarUrl;
     const initial = (name?.charAt(0) ?? '?').toUpperCase();
     return (
       <div className="flex items-start gap-3">
         <Avatar className="h-8 w-8 shrink-0">
-          {!isOwn && <AvatarImage src={otherUser.image || otherUser.avatarUrl || ''} />}
+          {image && <AvatarImage src={image} />}
           <AvatarFallback>{initial}</AvatarFallback>
         </Avatar>
         <div className="min-w-0 flex-1">
@@ -498,7 +499,7 @@ export default function InboxDMPage() {
 
   const resolveThreadAuthor = (authorId: string | null | undefined, fallbackName?: string | null) => {
     if (authorId === user?.id) {
-      return { name: user?.name ?? 'You', image: null };
+      return { name: user?.name ?? 'You', image: user?.image ?? null };
     }
     if (authorId === otherUser.id) {
       return { name: displayName, image: otherUser.image || otherUser.avatarUrl };
@@ -572,9 +573,12 @@ export default function InboxDMPage() {
                   {isFirst ? (
                     <Avatar className="h-10 w-10 flex-shrink-0">
                       {isOwnMessage ? (
-                        <AvatarFallback className="bg-primary text-primary-foreground">
-                          {senderAvatar?.charAt(0).toUpperCase()}
-                        </AvatarFallback>
+                        <>
+                          {user?.image && <AvatarImage src={user.image} />}
+                          <AvatarFallback className="bg-primary text-primary-foreground">
+                            {senderAvatar?.charAt(0).toUpperCase()}
+                          </AvatarFallback>
+                        </>
                       ) : (
                         <>
                           <AvatarImage src={otherUser.image || otherUser.avatarUrl || ''} />

--- a/apps/web/src/app/dashboard/dms/new/page.tsx
+++ b/apps/web/src/app/dashboard/dms/new/page.tsx
@@ -155,7 +155,7 @@ export default function NewConversationPage() {
                     }`}
                   >
                     <Avatar className="h-10 w-10">
-                      <AvatarImage src={u.avatarUrl || u.image || ''} />
+                      <AvatarImage src={u.image || u.avatarUrl || ''} />
                       <AvatarFallback>
                         {displayName.charAt(0).toUpperCase()}
                       </AvatarFallback>

--- a/apps/web/src/app/settings/account/__tests__/page.test.tsx
+++ b/apps/web/src/app/settings/account/__tests__/page.test.tsx
@@ -1,0 +1,184 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AccountPage from '../page';
+
+const mocks = vi.hoisted(() => ({
+  useAuth: vi.fn(),
+  useDevices: vi.fn(),
+  fetchWithAuth: vi.fn(),
+  patch: vi.fn(),
+  post: vi.fn(),
+  del: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: mocks.useAuth,
+}));
+
+vi.mock('@/hooks/useDevices', () => ({
+  useDevices: mocks.useDevices,
+}));
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: mocks.fetchWithAuth,
+  patch: mocks.patch,
+  post: mocks.post,
+  del: mocks.del,
+}));
+
+vi.mock('swr', () => ({
+  default: vi.fn(() => ({
+    data: { emailVerified: new Date('2026-01-01T00:00:00.000Z') },
+    error: null,
+    isLoading: false,
+  })),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mocks.toastError,
+    success: mocks.toastSuccess,
+  },
+}));
+
+vi.mock('@/components/settings/PasskeyManager', () => ({
+  PasskeyManager: () => <div data-testid="passkey-manager" />,
+}));
+
+vi.mock('@/components/devices/DeviceList', () => ({
+  DeviceList: () => <div data-testid="device-list" />,
+}));
+
+vi.mock('@/components/devices/RevokeAllDevicesDialog', () => ({
+  RevokeAllDevicesDialog: () => null,
+}));
+
+vi.mock('@/components/dialogs/DeleteAccountDialog', () => ({
+  DeleteAccountDialog: () => null,
+}));
+
+vi.mock('@/components/dialogs/DriveOwnershipDialog', () => ({
+  DriveOwnershipDialog: () => null,
+}));
+
+vi.mock('@/components/dialogs/ImageCropperDialog', async () => {
+  const React = await vi.importActual<typeof import('react')>('react');
+
+  type ImageCropperDialogProps = {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    onCropComplete: (croppedBlob: Blob) => void;
+  };
+
+  return {
+    ImageCropperDialog: ({ open, onOpenChange, onCropComplete }: ImageCropperDialogProps) => {
+      const hasCroppedRef = React.useRef(false);
+
+      React.useEffect(() => {
+        if (!open || hasCroppedRef.current) {
+          return;
+        }
+
+        hasCroppedRef.current = true;
+        onCropComplete(new Blob(['avatar'], { type: 'image/png' }));
+        onOpenChange(false);
+      }, [open, onCropComplete, onOpenChange]);
+
+      return null;
+    },
+  };
+});
+
+class MockFileReader {
+  result = 'data:image/png;base64,avatar';
+  onloadend: (() => void) | null = null;
+
+  readAsDataURL(): void {
+    this.onloadend?.();
+  }
+}
+
+describe('AccountPage', () => {
+  const mutate = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.useAuth.mockReturnValue({
+      user: {
+        id: 'user-1',
+        name: 'Test User',
+        email: 'test@example.com',
+        image: null,
+      },
+      isLoading: false,
+      isAuthenticated: true,
+      isRefreshing: false,
+      sessionDuration: 0,
+      actions: {
+        logout: vi.fn(),
+        refreshAuth: vi.fn(),
+        checkAuth: vi.fn(),
+      },
+      mutate,
+    });
+
+    mocks.useDevices.mockReturnValue({
+      devices: [],
+      refetch: vi.fn(),
+    });
+
+    mocks.patch.mockResolvedValue({
+      id: 'user-1',
+      name: 'Test User',
+      email: 'test@example.com',
+      image: null,
+    });
+
+    mocks.fetchWithAuth.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ avatarUrl: '/api/avatar/user-1/avatar.png?t=1' }),
+    });
+
+    mutate.mockResolvedValue(undefined);
+    vi.stubGlobal('FileReader', MockFileReader);
+    Object.defineProperty(URL, 'createObjectURL', {
+      configurable: true,
+      value: vi.fn(() => 'blob:avatar-preview'),
+    });
+  });
+
+  it('given a pending cropped avatar, should upload it when saving account changes', async () => {
+    const user = userEvent.setup();
+
+    render(<AccountPage />);
+
+    fireEvent.change(screen.getByLabelText(/Choose File/i), {
+      target: {
+        files: [new File(['avatar'], 'avatar.png', { type: 'image/png' })],
+      },
+    });
+
+    await screen.findByText('Selected: avatar.png');
+
+    await user.click(screen.getByRole('button', { name: /Save Changes/i }));
+
+    await waitFor(() => {
+      expect(mocks.fetchWithAuth).toHaveBeenCalledWith(
+        '/api/account/avatar',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.any(FormData),
+        }),
+      );
+    });
+    expect(mocks.patch).toHaveBeenCalledWith('/api/account', {
+      name: 'Test User',
+      email: 'test@example.com',
+    });
+    expect(mutate).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/settings/account/page.tsx
+++ b/apps/web/src/app/settings/account/page.tsx
@@ -153,9 +153,7 @@ export default function AccountPage() {
       console.error("Profile update error:", error);
       toast.error(error instanceof Error ? error.message : "Failed to update profile");
     } finally {
-      if (mutate) {
-        await mutate().catch(() => {});
-      }
+      mutate?.();
       setIsUploadingAvatar(false);
       setIsSavingProfile(false);
     }

--- a/apps/web/src/app/settings/account/page.tsx
+++ b/apps/web/src/app/settings/account/page.tsx
@@ -85,6 +85,37 @@ export default function AccountPage() {
   const { devices, refetch: refetchDevices } = useDevices();
   const [isRevokeAllDialogOpen, setIsRevokeAllDialogOpen] = useState(false);
 
+  const uploadAvatarFile = async (file: File): Promise<void> => {
+    const formData = new FormData();
+    formData.append('file', file);
+
+    // Use fetchWithAuth directly - post() helper sets Content-Type: application/json
+    // which breaks FormData uploads. fetchWithAuth lets browser set correct boundary.
+    const response = await fetchWithAuth('/api/account/avatar', {
+      method: 'POST',
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const data: unknown = await response.json().catch(() => ({}));
+      const errorMessage =
+        data && typeof data === 'object' && 'error' in data && typeof data.error === 'string'
+          ? data.error
+          : 'Failed to upload avatar';
+      throw new Error(errorMessage);
+    }
+
+    const data: unknown = await response.json().catch(() => ({}));
+    const avatarUrl =
+      data && typeof data === 'object' && 'avatarUrl' in data && typeof data.avatarUrl === 'string'
+        ? data.avatarUrl
+        : null;
+
+    if (avatarUrl) {
+      setAvatarPreview(avatarUrl);
+    }
+  };
+
   // Load user data into form
   useEffect(() => {
     if (user) {
@@ -105,10 +136,19 @@ export default function AccountPage() {
 
   const handleProfileUpdate = async (e: React.FormEvent) => {
     e.preventDefault();
+    const pendingAvatarFile = avatarFile;
     setIsSavingProfile(true);
+    if (pendingAvatarFile) {
+      setIsUploadingAvatar(true);
+    }
 
     try {
       await patch("/api/account", { name, email });
+
+      if (pendingAvatarFile) {
+        await uploadAvatarFile(pendingAvatarFile);
+        setAvatarFile(null);
+      }
 
       if (mutate) {
         await mutate(); // Refresh user data
@@ -117,6 +157,7 @@ export default function AccountPage() {
       console.error("Profile update error:", error);
       toast.error(error instanceof Error ? error.message : "Failed to update profile");
     } finally {
+      setIsUploadingAvatar(false);
       setIsSavingProfile(false);
     }
   };
@@ -163,22 +204,9 @@ export default function AccountPage() {
     if (!avatarFile) return;
 
     setIsUploadingAvatar(true);
-    const formData = new FormData();
-    formData.append('file', avatarFile);
 
     try {
-      // Use fetchWithAuth directly - post() helper sets Content-Type: application/json
-      // which breaks FormData uploads. fetchWithAuth lets browser set correct boundary.
-      const response = await fetchWithAuth('/api/account/avatar', {
-        method: 'POST',
-        body: formData,
-      });
-
-      if (!response.ok) {
-        const data = await response.json().catch(() => ({}));
-        throw new Error(data.error || 'Failed to upload avatar');
-      }
-
+      await uploadAvatarFile(avatarFile);
       setAvatarFile(null);
 
       // Refresh user data to get new avatar URL
@@ -370,6 +398,7 @@ export default function AccountPage() {
                 </Avatar>
                 {avatarPreview && (
                   <Button
+                    type="button"
                     size="icon"
                     variant="destructive"
                     className="absolute -top-2 -right-2 h-6 w-6 rounded-full"
@@ -402,6 +431,7 @@ export default function AccountPage() {
                   </Label>
                   {avatarFile && (
                     <Button
+                      type="button"
                       size="sm"
                       onClick={handleAvatarUpload}
                       disabled={isUploadingAvatar}

--- a/apps/web/src/app/settings/account/page.tsx
+++ b/apps/web/src/app/settings/account/page.tsx
@@ -149,14 +149,13 @@ export default function AccountPage() {
         await uploadAvatarFile(pendingAvatarFile);
         setAvatarFile(null);
       }
-
-      if (mutate) {
-        await mutate(); // Refresh user data
-      }
     } catch (error) {
       console.error("Profile update error:", error);
       toast.error(error instanceof Error ? error.message : "Failed to update profile");
     } finally {
+      if (mutate) {
+        await mutate().catch(() => {});
+      }
       setIsUploadingAvatar(false);
       setIsSavingProfile(false);
     }

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -232,7 +232,7 @@ function ChannelView({ page }: ChannelViewProps) {
       user: {
         id: user.id,
         name: user.name || 'You',
-        image: null,
+        image: user.image ?? null,
       },
       // Include attachment info in optimistic message
       fileId: attachment?.id || null,
@@ -544,7 +544,7 @@ function ChannelView({ page }: ChannelViewProps) {
       return { name: fromList.user.name ?? fallbackName ?? 'Member', image: fromList.user.image };
     }
     if (authorId === user?.id) {
-      return { name: user?.name ?? 'You', image: null };
+      return { name: user?.name ?? 'You', image: user?.image ?? null };
     }
     return { name: fallbackName ?? 'Member', image: null };
   };

--- a/apps/web/src/types/messaging.ts
+++ b/apps/web/src/types/messaging.ts
@@ -57,6 +57,7 @@ export interface DMRow extends Record<string, unknown> {
   last_message: string | null;
   other_user_name: string;
   other_user_display_name: string | null;
+  other_user_image: string | null;
   other_user_avatar_url: string | null;
   unread_count: string;
 }

--- a/tasks/avatar-upload-persistence-epic.md
+++ b/tasks/avatar-upload-persistence-epic.md
@@ -1,0 +1,6 @@
+# Avatar Upload Persistence Epic
+
+## Requirements
+
+- Given a user selects and crops a new profile avatar, should persist the pending avatar when the user saves account changes.
+- Given a user has a persisted profile avatar, should show that avatar consistently in DM and channel chat surfaces.


### PR DESCRIPTION
## Summary
- Upload pending cropped avatar files when saving account changes, so the previewed avatar actually persists.
- Prefer the canonical \`users.image\` avatar in DM inbox rows and DM user picking.
- Preserve the current user's avatar in DM/channel optimistic messages, message rows, and thread author resolution instead of forcing blank fallbacks.
- Always refresh auth state after profile save (move \`mutate()\` to \`finally\` block) so stale UI state is avoided even when avatar upload fails.

## Root Cause
Avatar upload persisted to \`users.image\`, but several chat and inbox paths either read only \`user_profiles.avatarUrl\` or explicitly set the current user's image to \`null\`. The account settings save flow also PATCHed profile fields without uploading the pending cropped avatar. Additionally, \`mutate()\` was only called on full success, leaving auth state stale when avatar upload failed after a successful profile patch.

## Validation
- \`pnpm --filter web test src/app/settings/account/__tests__/page.test.tsx\`
- \`pnpm --filter web test src/app/api/account/avatar/__tests__/route.test.ts\`
- \`pnpm --filter web test src/app/api/inbox/__tests__/route.test.ts\`
- \`pnpm --filter web test 'src/app/dashboard/dms/[conversationId]/__tests__/page.test.tsx'\`
- \`pnpm --filter web typecheck\`
- \`pnpm --filter web lint\` (passes with existing \`QuickCreatePalette.tsx\` hook dependency warning)