### PR TITLE
feat(tasks): notify assignees on task creation

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
@@ -13,6 +13,7 @@ import { broadcastTaskEvent, broadcastPageEvent, createPageEventPayload } from '
 import { getDefaultContent } from '@pagespace/lib/content/page-types.config'
 import { PageType } from '@pagespace/lib/utils/enums';
 import { getActorInfo, logPageActivity } from '@pagespace/lib/monitoring/activity-logger';
+import { createTaskAssignedNotification } from '@pagespace/lib/notifications/notifications';
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
@@ -479,6 +480,20 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
   });
 
   const createdTitle = result.page.title;
+
+  // Notify newly assigned users (self-assign guard is inside createTaskAssignedNotification)
+  const assignedUserIds = (taskWithRelations?.assignees ?? [])
+    .map(a => a.userId)
+    .filter((id): id is string => !!id);
+  for (const assignedUserId of assignedUserIds) {
+    void createTaskAssignedNotification(
+      assignedUserId,
+      result.task.id,
+      createdTitle,
+      pageId,
+      userId
+    );
+  }
 
   // Broadcast events
   await Promise.all([


### PR DESCRIPTION
## Summary

- Task creation (`POST /api/pages/[pageId]/tasks`) was not firing assignment notifications when assignees were included — only the PATCH (update) path did
- Added `createTaskAssignedNotification()` call after task creation, mirroring the existing PATCH pattern
- The helper's self-assign guard (`targetUserId === triggeredByUserId`) prevents spurious notifications

## Test plan

- [ ] Create a task with another user as assignee → their notification bell increments and the notification appears
- [ ] Create a task assigned to yourself → no notification fires
- [ ] PATCH an existing task to add a new assignee → still notifies (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)