### PR TITLE
feat(notifications): @mention notifications for channels and tasks

### DIFF
--- a/apps/web/src/app/api/channels/[pageId]/messages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/__tests__/route.test.ts
@@ -112,6 +112,11 @@ vi.mock('@/lib/channels/agent-mention-responder', () => ({
   triggerMentionedAgentResponses: vi.fn(),
 }));
 
+const mockCreateMentionNotification = vi.fn();
+vi.mock('@pagespace/lib/notifications/notifications', () => ({
+  createMentionNotification: (...args: unknown[]) => mockCreateMentionNotification(...args),
+}));
+
 // --- Imports under test --------------------------------------------------------
 import { GET, POST } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
@@ -262,6 +267,7 @@ describe('POST /api/channels/[pageId]/messages (thread reply)', () => {
     mockBroadcastThreadReplyCountUpdated.mockResolvedValue(undefined);
     mockListChannelThreadFollowers.mockResolvedValue([]);
     mockBroadcastInboxEvent.mockResolvedValue(undefined);
+    mockCreateMentionNotification.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -638,6 +644,7 @@ describe('POST /api/channels/[pageId]/messages (top-level — existing path)', (
       createdAt: new Date('2026-05-04T12:00:00Z'),
       user: { id: USER_ID, name: 'Test', image: null },
     });
+    mockCreateMentionNotification.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -662,5 +669,160 @@ describe('POST /api/channels/[pageId]/messages (top-level — existing path)', (
 
     expect(res.status).toBe(401);
     expect(mockInsertChannelMessage).not.toHaveBeenCalled();
+  });
+});
+
+// --- Top-level POST: mention notifications ------------------------------------
+describe('POST /api/channels/[pageId]/messages (top-level — mention notifications)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  const originalRealtimeUrl = process.env.INTERNAL_REALTIME_URL;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    process.env.INTERNAL_REALTIME_URL = 'http://realtime.test';
+    fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(sessionAuth());
+    mockInsertChannelMessage.mockResolvedValue({ id: 'msg-1' });
+    mockUpsertChannelReadStatus.mockResolvedValue(undefined);
+    mockLoadChannelMessageWithRelations.mockResolvedValue({
+      id: 'msg-1',
+      content: '',
+      createdAt: new Date('2026-05-04T12:00:00Z'),
+      user: { id: USER_ID, name: 'Sender', image: null },
+    });
+    mockCreateMentionNotification.mockResolvedValue(undefined);
+    mockBroadcastInboxEvent.mockResolvedValue(undefined);
+    const { canUserViewPage } = await import('@pagespace/lib/permissions/permissions');
+    vi.mocked(canUserViewPage).mockResolvedValue(true);
+    const dbModule = (await import('@pagespace/db/db')) as unknown as {
+      db: { query: { pages: { findFirst: ReturnType<typeof vi.fn> } } };
+    };
+    dbModule.db.query.pages.findFirst.mockResolvedValue({
+      driveId: 'drive-1',
+      title: 'General',
+      drive: { ownerId: 'owner-1', name: 'Workspace', slug: 'workspace' },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (originalRealtimeUrl === undefined) {
+      delete process.env.INTERNAL_REALTIME_URL;
+    } else {
+      process.env.INTERNAL_REALTIME_URL = originalRealtimeUrl;
+    }
+  });
+
+  it('fires createMentionNotification for a @mentioned user who can view the channel', async () => {
+    const res = await callPost({ content: 'hello @[Alice](user-alice:user)' });
+
+    expect(res.status).toBe(201);
+    expect(mockCreateMentionNotification).toHaveBeenCalledWith('user-alice', PAGE_ID, USER_ID);
+  });
+
+  it('does not notify the sender even if they @mention themselves', async () => {
+    const res = await callPost({ content: `hello @[Me](${USER_ID}:user)` });
+
+    expect(res.status).toBe(201);
+    expect(mockCreateMentionNotification).not.toHaveBeenCalledWith(
+      USER_ID,
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it('does not notify a @mentioned user who cannot view the channel', async () => {
+    const { canUserViewPage } = await import('@pagespace/lib/permissions/permissions');
+    vi.mocked(canUserViewPage).mockResolvedValue(false);
+
+    const res = await callPost({ content: 'hello @[Outsider](user-outsider:user)' });
+
+    expect(res.status).toBe(201);
+    expect(mockCreateMentionNotification).not.toHaveBeenCalled();
+  });
+
+  it('returns 201 even when createMentionNotification throws', async () => {
+    mockCreateMentionNotification.mockRejectedValue(new Error('notification service down'));
+
+    const res = await callPost({ content: 'hello @[Alice](user-alice:user)' });
+
+    expect(res.status).toBe(201);
+  });
+});
+
+// --- Thread reply POST: mention notifications ---------------------------------
+describe('POST /api/channels/[pageId]/messages (thread reply — mention notifications)', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  const originalRealtimeUrl = process.env.INTERNAL_REALTIME_URL;
+
+  function makeThreadReplyScenario(content: string) {
+    const replyCreatedAt = new Date('2026-05-04T12:00:00Z');
+    mockInsertChannelThreadReply.mockResolvedValueOnce({
+      kind: 'ok',
+      reply: { id: 'reply-1', createdAt: replyCreatedAt },
+      mirror: null,
+      rootId: PARENT_ID,
+      replyCount: 1,
+      lastReplyAt: replyCreatedAt,
+    });
+    mockLoadChannelMessageWithRelations.mockResolvedValueOnce({
+      id: 'reply-1',
+      parentId: PARENT_ID,
+      pageId: PAGE_ID,
+      content,
+      createdAt: replyCreatedAt.toISOString(),
+      user: { id: USER_ID, name: 'Sender', image: null },
+    });
+    // USER_ID is a follower; other mentioned users are not
+    mockListChannelThreadFollowers.mockResolvedValueOnce([USER_ID]);
+    return replyCreatedAt;
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    process.env.INTERNAL_REALTIME_URL = 'http://realtime.test';
+    fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(sessionAuth());
+    mockBroadcastThreadReplyCountUpdated.mockResolvedValue(undefined);
+    mockBroadcastInboxEvent.mockResolvedValue(undefined);
+    mockCreateMentionNotification.mockResolvedValue(undefined);
+    const { canUserViewPage } = await import('@pagespace/lib/permissions/permissions');
+    vi.mocked(canUserViewPage).mockResolvedValue(true);
+    const dbModule = (await import('@pagespace/db/db')) as unknown as {
+      db: { query: { pages: { findFirst: ReturnType<typeof vi.fn> } } };
+    };
+    dbModule.db.query.pages.findFirst.mockResolvedValue({
+      driveId: 'drive-1',
+      title: 'General',
+      drive: { ownerId: 'owner-1', name: 'Workspace', slug: 'workspace' },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (originalRealtimeUrl === undefined) {
+      delete process.env.INTERNAL_REALTIME_URL;
+    } else {
+      process.env.INTERNAL_REALTIME_URL = originalRealtimeUrl;
+    }
+  });
+
+  it('fires createMentionNotification for a @mentioned non-follower who can view the channel', async () => {
+    makeThreadReplyScenario('hey @[Bob](user-bob:user)');
+
+    await callPost({ content: 'hey @[Bob](user-bob:user)', parentId: PARENT_ID });
+
+    expect(mockCreateMentionNotification).toHaveBeenCalledWith('user-bob', PAGE_ID, USER_ID);
+  });
+
+  it('returns 201 even when mention notification throws in a thread reply', async () => {
+    makeThreadReplyScenario('hey @[Bob](user-bob:user)');
+    mockCreateMentionNotification.mockRejectedValue(new Error('notification failed'));
+
+    const res = await callPost({ content: 'hey @[Bob](user-bob:user)', parentId: PARENT_ID });
+
+    expect(res.status).toBe(201);
   });
 });

--- a/apps/web/src/app/api/channels/[pageId]/messages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/__tests__/route.test.ts
@@ -819,6 +819,32 @@ describe('POST /api/channels/[pageId]/messages (thread reply — mention notific
     expect(mockCreateMentionNotification).toHaveBeenCalledWith('user-bob', PAGE_ID, USER_ID);
   });
 
+  it('fires createMentionNotification for a @mentioned user who is already a thread follower', async () => {
+    const replyCreatedAt = new Date('2026-05-04T12:00:00Z');
+    mockInsertChannelThreadReply.mockResolvedValueOnce({
+      kind: 'ok',
+      reply: { id: 'reply-1', createdAt: replyCreatedAt },
+      mirror: null,
+      rootId: PARENT_ID,
+      replyCount: 1,
+      lastReplyAt: replyCreatedAt,
+    });
+    mockLoadChannelMessageWithRelations.mockResolvedValueOnce({
+      id: 'reply-1',
+      parentId: PARENT_ID,
+      pageId: PAGE_ID,
+      content: 'hey @[Alice](user-alice:user)',
+      createdAt: replyCreatedAt.toISOString(),
+      user: { id: USER_ID, name: 'Sender', image: null },
+    });
+    // user-alice is already a thread follower — they should still get a MENTION notification
+    mockListChannelThreadFollowers.mockResolvedValueOnce([USER_ID, 'user-alice']);
+
+    await callPost({ content: 'hey @[Alice](user-alice:user)', parentId: PARENT_ID });
+
+    expect(mockCreateMentionNotification).toHaveBeenCalledWith('user-alice', PAGE_ID, USER_ID);
+  });
+
   it('returns 201 even when mention notification throws in a thread reply', async () => {
     makeThreadReplyScenario('hey @[Bob](user-bob:user)');
     mockCreateMentionNotification.mockRejectedValue(new Error('notification failed'));

--- a/apps/web/src/app/api/channels/[pageId]/messages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/__tests__/route.test.ts
@@ -580,6 +580,8 @@ describe('POST /api/channels/[pageId]/messages (thread reply)', () => {
       {}
     );
     expect(recipientCounts['user-bob'] ?? 0).toBeLessThanOrEqual(1);
+    // Mention notification also suppressed — broad fan-out already covers everyone
+    expect(mockCreateMentionNotification).not.toHaveBeenCalled();
   });
 
   it('does NOT emit channel_updated to a mentioned user who cannot view the channel', async () => {

--- a/apps/web/src/app/api/channels/[pageId]/messages/route.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/route.ts
@@ -482,14 +482,13 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
           )
         );
 
-        // Fire MENTION notifications for the view-checked targets
-        try {
-          await Promise.all(
-            mentionTargets.map((id: string) => createMentionNotification(id, pageId, userId))
-          );
-        } catch (mentionErr) {
-          loggers.realtime.error('Failed to send mention notifications for thread reply:', mentionErr as Error);
-        }
+        await Promise.all(
+          mentionTargets.map((id) =>
+            createMentionNotification(id, pageId, userId).catch((err) =>
+              loggers.realtime.error('Failed to send mention notification for thread reply', err as Error)
+            )
+          )
+        );
       }
 
       if (mirrorWithRelations && channel?.driveId) {
@@ -637,7 +636,6 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
         lastMessageSender: newMessage?.aiMeta?.senderName || newMessage?.user?.name || undefined,
       });
 
-      // Fire MENTION notifications for @mentioned viewable non-sender users
       try {
         const mentionedIds = extractMentionedUserIds(messageContent);
         const candidates = mentionedIds.filter((id) => id !== userId);
@@ -648,11 +646,15 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
           await Promise.all(
             viewChecks
               .filter((e) => e.canView)
-              .map((e) => createMentionNotification(e.id, pageId, userId))
+              .map((e) =>
+                createMentionNotification(e.id, pageId, userId).catch((err) =>
+                  loggers.realtime.error('Failed to send mention notification', err as Error)
+                )
+              )
           );
         }
       } catch (mentionErr) {
-        loggers.realtime.error('Failed to send mention notifications:', mentionErr as Error);
+        loggers.realtime.error('Failed to resolve mention targets', mentionErr as Error);
       }
 
       // Broadcast read status change to sender to update their unread count

--- a/apps/web/src/app/api/channels/[pageId]/messages/route.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/route.ts
@@ -13,6 +13,7 @@ import { channelMessageRepository } from '@pagespace/lib/services/channel-messag
 import { extractMentionedUserIds } from '@/lib/channels/extract-user-mentions';
 import { buildThreadPreview } from '@pagespace/lib/services/preview';
 import { attachQuotedMessages } from '@pagespace/lib/services/quote-enrichment';
+import { createMentionNotification } from '@pagespace/lib/notifications/notifications';
 import type { AttachmentMeta } from '@pagespace/lib/types';
 
 interface ChannelInboxFanoutInput {
@@ -480,6 +481,15 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
             })
           )
         );
+
+        // Fire MENTION notifications for the view-checked targets
+        try {
+          await Promise.all(
+            mentionTargets.map((id: string) => createMentionNotification(id, pageId, userId))
+          );
+        } catch (mentionErr) {
+          loggers.realtime.error('Failed to send mention notifications for thread reply:', mentionErr as Error);
+        }
       }
 
       if (mirrorWithRelations && channel?.driveId) {
@@ -626,6 +636,24 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
         lastMessagePreview: messagePreview,
         lastMessageSender: newMessage?.aiMeta?.senderName || newMessage?.user?.name || undefined,
       });
+
+      // Fire MENTION notifications for @mentioned viewable non-sender users
+      try {
+        const mentionedIds = extractMentionedUserIds(messageContent);
+        const candidates = mentionedIds.filter((id) => id !== userId);
+        if (candidates.length > 0) {
+          const viewChecks = await Promise.all(
+            candidates.map(async (id) => ({ id, canView: await canUserViewPage(id, pageId) }))
+          );
+          await Promise.all(
+            viewChecks
+              .filter((e) => e.canView)
+              .map((e) => createMentionNotification(e.id, pageId, userId))
+          );
+        }
+      } catch (mentionErr) {
+        loggers.realtime.error('Failed to send mention notifications:', mentionErr as Error);
+      }
 
       // Broadcast read status change to sender to update their unread count
       await broadcastInboxEvent(userId, {

--- a/apps/web/src/app/api/channels/[pageId]/messages/route.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/route.ts
@@ -448,18 +448,24 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
       const isThreadOnlyReply = !mirrorWithRelations;
       if (isThreadOnlyReply && replyContent.trim().length > 0 && channel?.driveId) {
         const mentionedUserIds = extractMentionedUserIds(replyContent);
-        const candidateTargets = mentionedUserIds.filter(
+        // Non-followers need channel_updated so the thread surfaces in their unread.
+        // Followers already receive thread_updated above — sending channel_updated
+        // too would double-count their unread.
+        const nonFollowerMentioned = mentionedUserIds.filter(
           (id: string) => id !== userId && !followerSet.has(id)
+        );
+        // Followers who are @mentioned have view access by definition (they're already
+        // subscribed), but they still need a durable MENTION notification.
+        const followerMentioned = mentionedUserIds.filter(
+          (id: string) => id !== userId && followerSet.has(id)
         );
 
         // Mention IDs come from message text, which is sender-controlled — so
         // before we broadcast a channel_updated payload (which leaks the channel
-        // id, drive id, preview, and sender name), every candidate must pass
-        // the channel's view-permission check. Without this gate a sender could
-        // craft mentions for arbitrary user IDs and surface this channel to
-        // users who have no access.
+        // id, drive id, preview, and sender name), every non-follower candidate
+        // must pass the channel's view-permission check.
         const viewabilityChecks = await Promise.all(
-          candidateTargets.map(async (id: string) => ({
+          nonFollowerMentioned.map(async (id: string) => ({
             id,
             canView: await canUserViewPage(id, pageId),
           }))
@@ -482,8 +488,10 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
           )
         );
 
+        // Fire MENTION notifications for all @mentioned users — both non-followers
+        // who passed the view check and followers (who already have access).
         await Promise.all(
-          mentionTargets.map((id) =>
+          [...mentionTargets, ...followerMentioned].map((id) =>
             createMentionNotification(id, pageId, userId).catch((err) =>
               loggers.realtime.error('Failed to send mention notification for thread reply', err as Error)
             )

--- a/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/__tests__/route.test.ts
@@ -1020,7 +1020,8 @@ describe('PATCH /api/pages/[pageId]/tasks/[taskId]', () => {
     );
 
     expect(response.status).toBe(200);
-    expect(createMentionNotification).toHaveBeenCalledWith('user-alice', mockPageId, mockUserId);
+    // Notification must link to the individual task page, not the task list page
+    expect(createMentionNotification).toHaveBeenCalledWith('user-alice', baseTask.pageId, mockUserId);
   });
 
   it('does not re-notify for @mentions already present in the previous description', async () => {
@@ -1044,8 +1045,8 @@ describe('PATCH /api/pages/[pageId]/tasks/[taskId]', () => {
     expect(response.status).toBe(200);
     // Alice was already in old description — no re-notification
     expect(createMentionNotification).not.toHaveBeenCalledWith('user-alice', expect.anything(), expect.anything());
-    // Bob is newly added — should be notified
-    expect(createMentionNotification).toHaveBeenCalledWith('user-bob', mockPageId, mockUserId);
+    // Bob is newly added — should be notified at the task's own page ID
+    expect(createMentionNotification).toHaveBeenCalledWith('user-bob', baseTask.pageId, mockUserId);
   });
 
   it('does not fire createMentionNotification when description is not part of the update', async () => {
@@ -1084,7 +1085,7 @@ describe('PATCH /api/pages/[pageId]/tasks/[taskId]', () => {
     );
   });
 
-  it('does not notify a @mentioned user who cannot view the task list page', async () => {
+  it('does not notify a @mentioned user who cannot view the task page', async () => {
     setupAuth();
     setupCanEdit(true);
     const newDesc = 'cc @[Outsider](user-outsider:user)';

--- a/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/__tests__/route.test.ts
@@ -10,7 +10,8 @@ vi.mock('@/lib/auth', () => ({
 }));
 
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
-    canUserEditPage: vi.fn(),
+  canUserEditPage: vi.fn(),
+  canUserViewPage: vi.fn().mockResolvedValue(false),
 }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
   loggers: {
@@ -50,6 +51,7 @@ vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
 
 vi.mock('@pagespace/lib/notifications/notifications', () => ({
   createTaskAssignedNotification: vi.fn().mockResolvedValue(undefined),
+  createMentionNotification: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('@/services/api/page-mutation-service', () => ({
@@ -141,11 +143,11 @@ vi.mock('@/lib/websocket', () => ({
 
 import { PATCH, DELETE } from '../route';
 import { authenticateRequestWithOptions, checkMCPPageScope } from '@/lib/auth';
-import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
+import { canUserEditPage, canUserViewPage } from '@pagespace/lib/permissions/permissions';
 import { db } from '@pagespace/db/db';
 import { broadcastTaskEvent, broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { applyPageMutation } from '@/services/api/page-mutation-service';
-import { createTaskAssignedNotification } from '@pagespace/lib/notifications/notifications';
+import { createTaskAssignedNotification, createMentionNotification } from '@pagespace/lib/notifications/notifications';
 
 // ---------- Helpers ----------
 
@@ -994,6 +996,123 @@ describe('PATCH /api/pages/[pageId]/tasks/[taskId]', () => {
 
     // Only changing assigneeAgentId, not assigneeId - legacy path should sync both
     const response = await PATCH(createPatchRequest({ assigneeAgentId: 'agent-1' }), context);
+    expect(response.status).toBe(200);
+  });
+
+  // --- mention notifications ---
+
+  it('fires createMentionNotification for newly added @mentions in description', async () => {
+    setupAuth();
+    setupCanEdit(true);
+    vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: mockTaskListId } as never);
+    // First call: existingTask (no mentions); Second call: taskWithRelations after update
+    vi.mocked(db.query.taskItems.findFirst)
+      .mockResolvedValueOnce({ ...baseTask, description: 'old text' } as never)
+      .mockResolvedValueOnce({
+        ...baseTask, description: 'review @[Alice](user-alice:user)',
+        assignee: null, assigneeAgent: null, user: null, assignees: [],
+      } as never);
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue({ driveId: 'drive-1' } as never);
+    vi.mocked(canUserViewPage).mockResolvedValue(true);
+    setupTransaction({ ...baseTask, description: 'review @[Alice](user-alice:user)' });
+
+    const response = await PATCH(
+      createPatchRequest({ description: 'review @[Alice](user-alice:user)' }),
+      context,
+    );
+
+    expect(response.status).toBe(200);
+    expect(createMentionNotification).toHaveBeenCalledWith('user-alice', mockPageId, mockUserId);
+  });
+
+  it('does not re-notify for @mentions already present in the previous description', async () => {
+    setupAuth();
+    setupCanEdit(true);
+    const newDesc = 'review @[Alice](user-alice:user) and @[Bob](user-bob:user)';
+    vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: mockTaskListId } as never);
+    // First call: existingTask (Alice already mentioned); Second call: taskWithRelations after update
+    vi.mocked(db.query.taskItems.findFirst)
+      .mockResolvedValueOnce({ ...baseTask, description: 'review @[Alice](user-alice:user)' } as never)
+      .mockResolvedValueOnce({
+        ...baseTask, description: newDesc,
+        assignee: null, assigneeAgent: null, user: null, assignees: [],
+      } as never);
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue({ driveId: 'drive-1' } as never);
+    vi.mocked(canUserViewPage).mockResolvedValue(true);
+    setupTransaction({ ...baseTask, description: newDesc });
+
+    const response = await PATCH(createPatchRequest({ description: newDesc }), context);
+
+    expect(response.status).toBe(200);
+    // Alice was already in old description — no re-notification
+    expect(createMentionNotification).not.toHaveBeenCalledWith('user-alice', expect.anything(), expect.anything());
+    // Bob is newly added — should be notified
+    expect(createMentionNotification).toHaveBeenCalledWith('user-bob', mockPageId, mockUserId);
+  });
+
+  it('does not fire createMentionNotification when description is not part of the update', async () => {
+    setupAuth();
+    setupCanEdit(true);
+    setupTaskLookup();
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue({ driveId: 'drive-1' } as never);
+    setupTransaction({ ...baseTask, priority: 'high' });
+    setupRelationsLookup({ ...baseTask, priority: 'high', assignee: null, assigneeAgent: null, user: null, assignees: [] });
+
+    const response = await PATCH(createPatchRequest({ priority: 'high' }), context);
+
+    expect(response.status).toBe(200);
+    expect(createMentionNotification).not.toHaveBeenCalled();
+  });
+
+  it('does not notify the updater even if they self-@mention in the new description', async () => {
+    setupAuth();
+    setupCanEdit(true);
+    setupTaskLookup({ id: mockTaskListId }, { ...baseTask, description: null });
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue({ driveId: 'drive-1' } as never);
+    vi.mocked(canUserViewPage).mockResolvedValue(true);
+    const selfMention = `ping @[Me](${mockUserId}:user)`;
+    setupTransaction({ ...baseTask, description: selfMention });
+    setupRelationsLookup({ ...baseTask, description: selfMention, assignee: null, assigneeAgent: null, user: null, assignees: [] });
+
+    const response = await PATCH(createPatchRequest({ description: selfMention }), context);
+
+    expect(response.status).toBe(200);
+    expect(createMentionNotification).not.toHaveBeenCalledWith(
+      mockUserId,
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it('does not notify a @mentioned user who cannot view the task list page', async () => {
+    setupAuth();
+    setupCanEdit(true);
+    setupTaskLookup({ id: mockTaskListId }, { ...baseTask, description: null });
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue({ driveId: 'drive-1' } as never);
+    vi.mocked(canUserViewPage).mockResolvedValue(false);
+    const newDesc = 'cc @[Outsider](user-outsider:user)';
+    setupTransaction({ ...baseTask, description: newDesc });
+    setupRelationsLookup({ ...baseTask, description: newDesc, assignee: null, assigneeAgent: null, user: null, assignees: [] });
+
+    const response = await PATCH(createPatchRequest({ description: newDesc }), context);
+
+    expect(response.status).toBe(200);
+    expect(createMentionNotification).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 even when createMentionNotification throws during task update', async () => {
+    setupAuth();
+    setupCanEdit(true);
+    setupTaskLookup({ id: mockTaskListId }, { ...baseTask, description: null });
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue({ driveId: 'drive-1' } as never);
+    vi.mocked(canUserViewPage).mockResolvedValue(true);
+    vi.mocked(createMentionNotification).mockRejectedValue(new Error('notification service down'));
+    const newDesc = 'cc @[Alice](user-alice:user)';
+    setupTransaction({ ...baseTask, description: newDesc });
+    setupRelationsLookup({ ...baseTask, description: newDesc, assignee: null, assigneeAgent: null, user: null, assignees: [] });
+
+    const response = await PATCH(createPatchRequest({ description: newDesc }), context);
+
     expect(response.status).toBe(200);
   });
 });

--- a/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/__tests__/route.test.ts
@@ -13,15 +13,13 @@ vi.mock('@pagespace/lib/permissions/permissions', () => ({
   canUserEditPage: vi.fn(),
   canUserViewPage: vi.fn().mockResolvedValue(false),
 }));
-vi.mock('@pagespace/lib/logging/logger-config', () => ({
-  loggers: {
-    api: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
-    ai: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
-  },
-  logger: {
-    child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })),
-  },
-}));
+vi.mock('@pagespace/lib/logging/logger-config', () => {
+  const mkLogger = () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn() });
+  return {
+    loggers: { api: mkLogger(), ai: mkLogger(), realtime: mkLogger() },
+    logger: mkLogger(),
+  };
+});
 vi.mock('@pagespace/lib/audit/audit-log', () => ({
     auditRequest: vi.fn(),
 }));
@@ -1067,12 +1065,14 @@ describe('PATCH /api/pages/[pageId]/tasks/[taskId]', () => {
   it('does not notify the updater even if they self-@mention in the new description', async () => {
     setupAuth();
     setupCanEdit(true);
-    setupTaskLookup({ id: mockTaskListId }, { ...baseTask, description: null });
+    const selfMention = `ping @[Me](${mockUserId}:user)`;
+    vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: mockTaskListId } as never);
+    vi.mocked(db.query.taskItems.findFirst)
+      .mockResolvedValueOnce({ ...baseTask, description: null } as never)
+      .mockResolvedValueOnce({ ...baseTask, description: selfMention, assignee: null, assigneeAgent: null, user: null, assignees: [] } as never);
     vi.mocked(db.query.pages.findFirst).mockResolvedValue({ driveId: 'drive-1' } as never);
     vi.mocked(canUserViewPage).mockResolvedValue(true);
-    const selfMention = `ping @[Me](${mockUserId}:user)`;
     setupTransaction({ ...baseTask, description: selfMention });
-    setupRelationsLookup({ ...baseTask, description: selfMention, assignee: null, assigneeAgent: null, user: null, assignees: [] });
 
     const response = await PATCH(createPatchRequest({ description: selfMention }), context);
 
@@ -1087,12 +1087,14 @@ describe('PATCH /api/pages/[pageId]/tasks/[taskId]', () => {
   it('does not notify a @mentioned user who cannot view the task list page', async () => {
     setupAuth();
     setupCanEdit(true);
-    setupTaskLookup({ id: mockTaskListId }, { ...baseTask, description: null });
+    const newDesc = 'cc @[Outsider](user-outsider:user)';
+    vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: mockTaskListId } as never);
+    vi.mocked(db.query.taskItems.findFirst)
+      .mockResolvedValueOnce({ ...baseTask, description: null } as never)
+      .mockResolvedValueOnce({ ...baseTask, description: newDesc, assignee: null, assigneeAgent: null, user: null, assignees: [] } as never);
     vi.mocked(db.query.pages.findFirst).mockResolvedValue({ driveId: 'drive-1' } as never);
     vi.mocked(canUserViewPage).mockResolvedValue(false);
-    const newDesc = 'cc @[Outsider](user-outsider:user)';
     setupTransaction({ ...baseTask, description: newDesc });
-    setupRelationsLookup({ ...baseTask, description: newDesc, assignee: null, assigneeAgent: null, user: null, assignees: [] });
 
     const response = await PATCH(createPatchRequest({ description: newDesc }), context);
 
@@ -1103,13 +1105,15 @@ describe('PATCH /api/pages/[pageId]/tasks/[taskId]', () => {
   it('returns 200 even when createMentionNotification throws during task update', async () => {
     setupAuth();
     setupCanEdit(true);
-    setupTaskLookup({ id: mockTaskListId }, { ...baseTask, description: null });
+    const newDesc = 'cc @[Alice](user-alice:user)';
+    vi.mocked(db.query.taskLists.findFirst).mockResolvedValue({ id: mockTaskListId } as never);
+    vi.mocked(db.query.taskItems.findFirst)
+      .mockResolvedValueOnce({ ...baseTask, description: null } as never)
+      .mockResolvedValueOnce({ ...baseTask, description: newDesc, assignee: null, assigneeAgent: null, user: null, assignees: [] } as never);
     vi.mocked(db.query.pages.findFirst).mockResolvedValue({ driveId: 'drive-1' } as never);
     vi.mocked(canUserViewPage).mockResolvedValue(true);
     vi.mocked(createMentionNotification).mockRejectedValue(new Error('notification service down'));
-    const newDesc = 'cc @[Alice](user-alice:user)';
     setupTransaction({ ...baseTask, description: newDesc });
-    setupRelationsLookup({ ...baseTask, description: newDesc, assignee: null, assigneeAgent: null, user: null, assignees: [] });
 
     const response = await PATCH(createPatchRequest({ description: newDesc }), context);
 

--- a/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/route.ts
@@ -392,14 +392,15 @@ export async function PATCH(
       const newMentionIds = extractMentionedUserIds(updates.description ?? '');
       const newlyAdded = newMentionIds.filter((id) => id !== userId && !oldMentionIds.has(id));
       if (newlyAdded.length > 0) {
+        const taskPageId = existingTask.pageId;
         const viewChecks = await Promise.all(
-          newlyAdded.map(async (id) => ({ id, canView: await canUserViewPage(id, pageId) }))
+          newlyAdded.map(async (id) => ({ id, canView: await canUserViewPage(id, taskPageId) }))
         );
         await Promise.all(
           viewChecks
             .filter((e) => e.canView)
             .map((e) =>
-              createMentionNotification(e.id, pageId, userId).catch((err) =>
+              createMentionNotification(e.id, taskPageId, userId).catch((err) =>
                 loggers.api.error('Failed to send mention notification', err as Error)
               )
             )

--- a/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/route.ts
@@ -4,13 +4,14 @@ import { eq, and } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core'
 import { taskItems, taskLists, taskStatusConfigs, taskAssignees } from '@pagespace/db/schema/tasks';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
-import { canUserEditPage } from '@pagespace/lib/permissions/permissions'
+import { canUserEditPage, canUserViewPage } from '@pagespace/lib/permissions/permissions'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { broadcastTaskEvent, broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import { applyPageMutation, PageRevisionMismatchError } from '@/services/api/page-mutation-service';
 import type { DeferredWorkflowTrigger } from '@pagespace/lib/monitoring/activity-logger';
-import { createTaskAssignedNotification } from '@pagespace/lib/notifications/notifications';
+import { createTaskAssignedNotification, createMentionNotification } from '@pagespace/lib/notifications/notifications';
+import { extractMentionedUserIds } from '@/lib/channels/extract-user-mentions';
 import { syncTaskDueDateTrigger, cancelTaskDueDateTrigger, fireCompletionTrigger, disableTaskTriggers } from '@/lib/workflows/task-trigger-helpers';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
@@ -381,6 +382,27 @@ export async function PATCH(
         pageId,
         userId
       );
+    }
+  }
+
+  // Fire MENTION notifications for newly added @mentions in the description
+  if (description !== undefined) {
+    try {
+      const oldMentionIds = new Set(extractMentionedUserIds(existingTask.description ?? ''));
+      const newMentionIds = extractMentionedUserIds(updates.description ?? '');
+      const newlyAdded = newMentionIds.filter((id) => id !== userId && !oldMentionIds.has(id));
+      if (newlyAdded.length > 0) {
+        const viewChecks = await Promise.all(
+          newlyAdded.map(async (id) => ({ id, canView: await canUserViewPage(id, pageId) }))
+        );
+        await Promise.all(
+          viewChecks
+            .filter((e) => e.canView)
+            .map((e) => createMentionNotification(e.id, pageId, userId))
+        );
+      }
+    } catch {
+      // intentional: notification failures must never fail a committed task update
     }
   }
 

--- a/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/route.ts
@@ -12,6 +12,7 @@ import { applyPageMutation, PageRevisionMismatchError } from '@/services/api/pag
 import type { DeferredWorkflowTrigger } from '@pagespace/lib/monitoring/activity-logger';
 import { createTaskAssignedNotification, createMentionNotification } from '@pagespace/lib/notifications/notifications';
 import { extractMentionedUserIds } from '@/lib/channels/extract-user-mentions';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { syncTaskDueDateTrigger, cancelTaskDueDateTrigger, fireCompletionTrigger, disableTaskTriggers } from '@/lib/workflows/task-trigger-helpers';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
@@ -385,7 +386,6 @@ export async function PATCH(
     }
   }
 
-  // Fire MENTION notifications for newly added @mentions in the description
   if (description !== undefined) {
     try {
       const oldMentionIds = new Set(extractMentionedUserIds(existingTask.description ?? ''));
@@ -398,11 +398,15 @@ export async function PATCH(
         await Promise.all(
           viewChecks
             .filter((e) => e.canView)
-            .map((e) => createMentionNotification(e.id, pageId, userId))
+            .map((e) =>
+              createMentionNotification(e.id, pageId, userId).catch((err) =>
+                loggers.api.error('Failed to send mention notification', err as Error)
+              )
+            )
         );
       }
-    } catch {
-      // intentional: notification failures must never fail a committed task update
+    } catch (err) {
+      loggers.api.error('Failed to resolve mention targets', err as Error);
     }
   }
 

--- a/apps/web/src/app/api/pages/[pageId]/tasks/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/__tests__/route.test.ts
@@ -157,6 +157,9 @@ describe('Task API Routes', () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
+    // vi.resetAllMocks() clears mockCreateMentionNotification's implementation,
+    // making .catch() throw TypeError and silently hide the success path.
+    mockCreateMentionNotification.mockResolvedValue(undefined);
     // Reset default mock for taskStatusConfigs.findMany
     vi.mocked(db.query.taskStatusConfigs.findMany).mockResolvedValue([] as never);
     vi.mocked(isAuthError).mockImplementation((result: unknown) => result != null && typeof result === 'object' && 'error' in result);

--- a/apps/web/src/app/api/pages/[pageId]/tasks/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/__tests__/route.test.ts
@@ -752,7 +752,8 @@ describe('Task API Routes', () => {
       );
 
       expect(response.status).toBe(201);
-      expect(mockCreateMentionNotification).toHaveBeenCalledWith('user-alice', mockPageId, mockUserId);
+      // Notification must link to the individual task page, not the task list page
+      expect(mockCreateMentionNotification).toHaveBeenCalledWith('user-alice', mockNewPage.id, mockUserId);
     });
 
     it('does not notify the task creator even when self-mentioned in description', async () => {
@@ -788,7 +789,7 @@ describe('Task API Routes', () => {
       );
     });
 
-    it('does not notify a @mentioned user who cannot view the task list page', async () => {
+    it('does not notify a @mentioned user who cannot view the task page', async () => {
       const mockTaskList = { id: mockTaskListId };
       const mockNewTask = { id: 'new-task', title: 'Task', status: 'pending', priority: 'medium', position: 0 };
       const mockNewPage = { id: 'new-page', title: 'Task', type: 'DOCUMENT' };

--- a/apps/web/src/app/api/pages/[pageId]/tasks/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/__tests__/route.test.ts
@@ -139,6 +139,11 @@ vi.mock('@/lib/websocket', () => ({
   createPageEventPayload: vi.fn(() => ({})),
 }));
 
+const mockCreateMentionNotification = vi.fn().mockResolvedValue(undefined);
+vi.mock('@pagespace/lib/notifications/notifications', () => ({
+  createMentionNotification: (...args: unknown[]) => mockCreateMentionNotification(...args),
+}));
+
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
 import { canUserViewPage, canUserEditPage } from '@pagespace/lib/permissions/permissions'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
@@ -714,6 +719,126 @@ describe('Task API Routes', () => {
         dueDate: '2024-12-31',
         assigneeId: 'user-456',
       }), { params: mockParams });
+
+      expect(response.status).toBe(201);
+    });
+
+    it('fires createMentionNotification for @mentioned users in task description', async () => {
+      const mockTaskList = { id: mockTaskListId };
+      const mockNewTask = { id: 'new-task', status: 'pending', priority: 'medium', position: 0 };
+      const mockNewPage = { id: 'new-page', title: 'Task', type: 'DOCUMENT' };
+
+      transactionPageResult = [mockNewPage];
+      transactionTaskResult = [mockNewTask];
+
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId: mockUserId } as never);
+      vi.mocked(canUserEditPage).mockResolvedValue(true);
+      vi.mocked(canUserViewPage).mockResolvedValue(true);
+      vi.mocked(db.query.pages.findFirst)
+        .mockResolvedValueOnce({ id: mockPageId, driveId: 'drive-123' } as never)
+        .mockResolvedValueOnce(null as never);
+      vi.mocked(db.query.taskLists.findFirst).mockResolvedValue(mockTaskList as never);
+      vi.mocked(db.query.taskStatusConfigs.findMany).mockResolvedValue([] as never);
+      vi.mocked(db.query.taskItems.findFirst)
+        .mockResolvedValueOnce(null as never)
+        .mockResolvedValueOnce({ ...mockNewTask, assignee: null, user: null, assignees: [] } as never);
+
+      const response = await POST(
+        createRequest({ title: 'Task', description: 'Needs review @[Alice](user-alice:user)' }),
+        { params: mockParams },
+      );
+
+      expect(response.status).toBe(201);
+      expect(mockCreateMentionNotification).toHaveBeenCalledWith('user-alice', mockPageId, mockUserId);
+    });
+
+    it('does not notify the task creator even when self-mentioned in description', async () => {
+      const mockTaskList = { id: mockTaskListId };
+      const mockNewTask = { id: 'new-task', status: 'pending', priority: 'medium', position: 0 };
+      const mockNewPage = { id: 'new-page', title: 'Task', type: 'DOCUMENT' };
+
+      transactionPageResult = [mockNewPage];
+      transactionTaskResult = [mockNewTask];
+
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId: mockUserId } as never);
+      vi.mocked(canUserEditPage).mockResolvedValue(true);
+      vi.mocked(canUserViewPage).mockResolvedValue(true);
+      vi.mocked(db.query.pages.findFirst)
+        .mockResolvedValueOnce({ id: mockPageId, driveId: 'drive-123' } as never)
+        .mockResolvedValueOnce(null as never);
+      vi.mocked(db.query.taskLists.findFirst).mockResolvedValue(mockTaskList as never);
+      vi.mocked(db.query.taskStatusConfigs.findMany).mockResolvedValue([] as never);
+      vi.mocked(db.query.taskItems.findFirst)
+        .mockResolvedValueOnce(null as never)
+        .mockResolvedValueOnce({ ...mockNewTask, assignee: null, user: null, assignees: [] } as never);
+
+      const response = await POST(
+        createRequest({ title: 'Task', description: `CC @[Me](${mockUserId}:user)` }),
+        { params: mockParams },
+      );
+
+      expect(response.status).toBe(201);
+      expect(mockCreateMentionNotification).not.toHaveBeenCalledWith(
+        mockUserId,
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it('does not notify a @mentioned user who cannot view the task list page', async () => {
+      const mockTaskList = { id: mockTaskListId };
+      const mockNewTask = { id: 'new-task', status: 'pending', priority: 'medium', position: 0 };
+      const mockNewPage = { id: 'new-page', title: 'Task', type: 'DOCUMENT' };
+
+      transactionPageResult = [mockNewPage];
+      transactionTaskResult = [mockNewTask];
+
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId: mockUserId } as never);
+      vi.mocked(canUserEditPage).mockResolvedValue(true);
+      vi.mocked(canUserViewPage).mockResolvedValue(false);
+      vi.mocked(db.query.pages.findFirst)
+        .mockResolvedValueOnce({ id: mockPageId, driveId: 'drive-123' } as never)
+        .mockResolvedValueOnce(null as never);
+      vi.mocked(db.query.taskLists.findFirst).mockResolvedValue(mockTaskList as never);
+      vi.mocked(db.query.taskStatusConfigs.findMany).mockResolvedValue([] as never);
+      vi.mocked(db.query.taskItems.findFirst)
+        .mockResolvedValueOnce(null as never)
+        .mockResolvedValueOnce({ ...mockNewTask, assignee: null, user: null, assignees: [] } as never);
+
+      const response = await POST(
+        createRequest({ title: 'Task', description: 'Hey @[Outsider](user-outsider:user)' }),
+        { params: mockParams },
+      );
+
+      expect(response.status).toBe(201);
+      expect(mockCreateMentionNotification).not.toHaveBeenCalled();
+    });
+
+    it('returns 201 even when createMentionNotification throws during task creation', async () => {
+      const mockTaskList = { id: mockTaskListId };
+      const mockNewTask = { id: 'new-task', status: 'pending', priority: 'medium', position: 0 };
+      const mockNewPage = { id: 'new-page', title: 'Task', type: 'DOCUMENT' };
+
+      transactionPageResult = [mockNewPage];
+      transactionTaskResult = [mockNewTask];
+
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId: mockUserId } as never);
+      vi.mocked(canUserEditPage).mockResolvedValue(true);
+      vi.mocked(canUserViewPage).mockResolvedValue(true);
+      vi.mocked(db.query.pages.findFirst)
+        .mockResolvedValueOnce({ id: mockPageId, driveId: 'drive-123' } as never)
+        .mockResolvedValueOnce(null as never);
+      vi.mocked(db.query.taskLists.findFirst).mockResolvedValue(mockTaskList as never);
+      vi.mocked(db.query.taskStatusConfigs.findMany).mockResolvedValue([] as never);
+      vi.mocked(db.query.taskItems.findFirst)
+        .mockResolvedValueOnce(null as never)
+        .mockResolvedValueOnce({ ...mockNewTask, assignee: null, user: null, assignees: [] } as never);
+      mockCreateMentionNotification.mockRejectedValue(new Error('notification service down'));
+
+      const response = await POST(
+        createRequest({ title: 'Task', description: 'Hey @[Alice](user-alice:user)' }),
+        { params: mockParams },
+      );
 
       expect(response.status).toBe(201);
     });

--- a/apps/web/src/app/api/pages/[pageId]/tasks/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/__tests__/route.test.ts
@@ -725,7 +725,7 @@ describe('Task API Routes', () => {
 
     it('fires createMentionNotification for @mentioned users in task description', async () => {
       const mockTaskList = { id: mockTaskListId };
-      const mockNewTask = { id: 'new-task', status: 'pending', priority: 'medium', position: 0 };
+      const mockNewTask = { id: 'new-task', title: 'Task', status: 'pending', priority: 'medium', position: 0 };
       const mockNewPage = { id: 'new-page', title: 'Task', type: 'DOCUMENT' };
 
       transactionPageResult = [mockNewPage];
@@ -754,7 +754,7 @@ describe('Task API Routes', () => {
 
     it('does not notify the task creator even when self-mentioned in description', async () => {
       const mockTaskList = { id: mockTaskListId };
-      const mockNewTask = { id: 'new-task', status: 'pending', priority: 'medium', position: 0 };
+      const mockNewTask = { id: 'new-task', title: 'Task', status: 'pending', priority: 'medium', position: 0 };
       const mockNewPage = { id: 'new-page', title: 'Task', type: 'DOCUMENT' };
 
       transactionPageResult = [mockNewPage];
@@ -787,7 +787,7 @@ describe('Task API Routes', () => {
 
     it('does not notify a @mentioned user who cannot view the task list page', async () => {
       const mockTaskList = { id: mockTaskListId };
-      const mockNewTask = { id: 'new-task', status: 'pending', priority: 'medium', position: 0 };
+      const mockNewTask = { id: 'new-task', title: 'Task', status: 'pending', priority: 'medium', position: 0 };
       const mockNewPage = { id: 'new-page', title: 'Task', type: 'DOCUMENT' };
 
       transactionPageResult = [mockNewPage];
@@ -816,7 +816,7 @@ describe('Task API Routes', () => {
 
     it('returns 201 even when createMentionNotification throws during task creation', async () => {
       const mockTaskList = { id: mockTaskListId };
-      const mockNewTask = { id: 'new-task', status: 'pending', priority: 'medium', position: 0 };
+      const mockNewTask = { id: 'new-task', title: 'Task', status: 'pending', priority: 'medium', position: 0 };
       const mockNewPage = { id: 'new-page', title: 'Task', type: 'DOCUMENT' };
 
       transactionPageResult = [mockNewPage];

--- a/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
@@ -12,6 +12,7 @@ import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { broadcastTaskEvent, broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { createMentionNotification } from '@pagespace/lib/notifications/notifications';
 import { extractMentionedUserIds } from '@/lib/channels/extract-user-mentions';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getDefaultContent } from '@pagespace/lib/content/page-types.config'
 import { PageType } from '@pagespace/lib/utils/enums';
 import { getActorInfo, logPageActivity } from '@pagespace/lib/monitoring/activity-logger';
@@ -505,10 +506,9 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
     ),
   ]);
 
-  // Fire MENTION notifications for @mentioned users in task description
-  try {
-    if (description && typeof description === 'string' && description.trim().length > 0) {
-      const mentionedIds = extractMentionedUserIds(description.trim());
+  if (description) {
+    try {
+      const mentionedIds = extractMentionedUserIds(description);
       const candidates = mentionedIds.filter((id) => id !== userId);
       if (candidates.length > 0) {
         const viewChecks = await Promise.all(
@@ -517,12 +517,16 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
         await Promise.all(
           viewChecks
             .filter((e) => e.canView)
-            .map((e) => createMentionNotification(e.id, pageId, userId))
+            .map((e) =>
+              createMentionNotification(e.id, pageId, userId).catch((err) =>
+                loggers.api.error('Failed to send mention notification', err as Error)
+              )
+            )
         );
       }
+    } catch (err) {
+      loggers.api.error('Failed to resolve mention targets', err as Error);
     }
-  } catch {
-    // intentional: notification failures must never fail a committed task insert
   }
 
   // Log task creation for compliance (fire-and-forget)

--- a/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
@@ -511,14 +511,15 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
       const mentionedIds = extractMentionedUserIds(description);
       const candidates = mentionedIds.filter((id) => id !== userId);
       if (candidates.length > 0) {
+        const taskPageId = result.page.id;
         const viewChecks = await Promise.all(
-          candidates.map(async (id) => ({ id, canView: await canUserViewPage(id, pageId) }))
+          candidates.map(async (id) => ({ id, canView: await canUserViewPage(id, taskPageId) }))
         );
         await Promise.all(
           viewChecks
             .filter((e) => e.canView)
             .map((e) =>
-              createMentionNotification(e.id, pageId, userId).catch((err) =>
+              createMentionNotification(e.id, taskPageId, userId).catch((err) =>
                 loggers.api.error('Failed to send mention notification', err as Error)
               )
             )

--- a/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
@@ -10,6 +10,8 @@ import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '
 import { canUserViewPage, canUserEditPage } from '@pagespace/lib/permissions/permissions'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { broadcastTaskEvent, broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
+import { createMentionNotification } from '@pagespace/lib/notifications/notifications';
+import { extractMentionedUserIds } from '@/lib/channels/extract-user-mentions';
 import { getDefaultContent } from '@pagespace/lib/content/page-types.config'
 import { PageType } from '@pagespace/lib/utils/enums';
 import { getActorInfo, logPageActivity } from '@pagespace/lib/monitoring/activity-logger';
@@ -502,6 +504,26 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
       }),
     ),
   ]);
+
+  // Fire MENTION notifications for @mentioned users in task description
+  try {
+    if (description && typeof description === 'string' && description.trim().length > 0) {
+      const mentionedIds = extractMentionedUserIds(description.trim());
+      const candidates = mentionedIds.filter((id) => id !== userId);
+      if (candidates.length > 0) {
+        const viewChecks = await Promise.all(
+          candidates.map(async (id) => ({ id, canView: await canUserViewPage(id, pageId) }))
+        );
+        await Promise.all(
+          viewChecks
+            .filter((e) => e.canView)
+            .map((e) => createMentionNotification(e.id, pageId, userId))
+        );
+      }
+    }
+  } catch {
+    // intentional: notification failures must never fail a committed task insert
+  }
 
   // Log task creation for compliance (fire-and-forget)
   const actorInfo = await getActorInfo(userId);


### PR DESCRIPTION
## Summary

- Channel messages (top-level and thread replies) now fire `createMentionNotification` for each @mentioned user who passes a `canUserViewPage` check
- Task creation fires mention notifications for @mentioned users in the description
- Task updates diff old vs new description mentions — only newly added mentions trigger notifications, preventing re-notification on edits
- All notification calls use per-call `.catch()` for best-effort delivery (one failure never blocks others)
- `loggers.api.error()` added to all task-route catch blocks for observability
- Security gate: `canUserViewPage` always checked before notifying — prevents crafted mentions from leaking channel/page existence to unauthorized users

## Test plan

- [ ] Channel top-level POST: `createMentionNotification` fires for viewable @mentioned non-senders; skipped for sender self-mentions and users who can't view the channel; errors don't fail the 201 response
- [ ] Channel thread reply POST: notification fires for view-checked `mentionTargets`; suppressed when `alsoSendToParent` is set (broad fan-out covers everyone); errors don't fail the 201
- [ ] Task create POST: notifications fire for @mentioned users in description; self-mentions and non-viewable users skipped; errors don't fail the 201
- [ ] Task update PATCH: only newly added @mentions notify (diff logic); self-mentions, non-viewable users, and already-mentioned users skipped; errors don't fail the 200
- [ ] All 6 task-update mention tests use explicit `mockResolvedValueOnce` chains — `canUserViewPage` gate and error isolation are actually exercised (not vacuous)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mention notifications for channel messages: users are now notified when mentioned in message posts, respecting visibility permissions.
  * Added mention notifications for task descriptions: users receive notifications when newly mentioned during task creation or updates, excluding self-mentions and respecting page visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->