### PR TITLE
feat(sidebar): unread badges on primary nav

### DIFF
--- a/apps/web/src/app/api/sidebar/badges/route.ts
+++ b/apps/web/src/app/api/sidebar/badges/route.ts
@@ -6,6 +6,7 @@ import { notifications } from '@pagespace/db/schema/notifications';
 import { pages } from '@pagespace/db/schema/core';
 import { calendarEvents, eventAttendees } from '@pagespace/db/schema/calendar';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
@@ -90,6 +91,8 @@ export async function GET(req: Request) {
             )
           ),
       ]);
+
+    auditRequest(req, { eventType: 'data.read', userId, resourceType: 'badge', resourceId: 'self' });
 
     return NextResponse.json({
       dms: Number(dmResult[0]?.count ?? 0),

--- a/apps/web/src/app/api/sidebar/badges/route.ts
+++ b/apps/web/src/app/api/sidebar/badges/route.ts
@@ -1,0 +1,105 @@
+import { NextResponse } from 'next/server';
+import { db } from '@pagespace/db/db';
+import { eq, ne, and, or, count, isNull } from '@pagespace/db/operators';
+import { directMessages, dmConversations } from '@pagespace/db/schema/social';
+import { notifications } from '@pagespace/db/schema/notifications';
+import { pages } from '@pagespace/db/schema/core';
+import { calendarEvents, eventAttendees } from '@pagespace/db/schema/calendar';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+
+const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
+
+export async function GET(req: Request) {
+  const auth = await authenticateRequestWithOptions(req, AUTH_OPTIONS);
+  if (isAuthError(auth)) return auth.error;
+  const { userId } = auth;
+
+  try {
+    const [dmResult, channelMentionResult, fileMentionResult, taskResult, calendarResult] =
+      await Promise.all([
+        // Unread DMs from other participants (top-level messages only)
+        db
+          .select({ count: count() })
+          .from(directMessages)
+          .innerJoin(dmConversations, eq(directMessages.conversationId, dmConversations.id))
+          .where(
+            and(
+              or(
+                eq(dmConversations.participant1Id, userId),
+                eq(dmConversations.participant2Id, userId)
+              ),
+              ne(directMessages.senderId, userId),
+              eq(directMessages.isRead, false),
+              eq(directMessages.isActive, true),
+              isNull(directMessages.parentId)
+            )
+          ),
+
+        // Unread @mention notifications in channel pages
+        db
+          .select({ count: count() })
+          .from(notifications)
+          .innerJoin(pages, eq(notifications.pageId, pages.id))
+          .where(
+            and(
+              eq(notifications.userId, userId),
+              eq(notifications.isRead, false),
+              eq(notifications.type, 'MENTION'),
+              eq(pages.type, 'CHANNEL')
+            )
+          ),
+
+        // Unread @mention notifications in non-channel pages (docs, files, etc.)
+        db
+          .select({ count: count() })
+          .from(notifications)
+          .innerJoin(pages, eq(notifications.pageId, pages.id))
+          .where(
+            and(
+              eq(notifications.userId, userId),
+              eq(notifications.isRead, false),
+              eq(notifications.type, 'MENTION'),
+              ne(pages.type, 'CHANNEL')
+            )
+          ),
+
+        // Unread task assignment notifications
+        db
+          .select({ count: count() })
+          .from(notifications)
+          .where(
+            and(
+              eq(notifications.userId, userId),
+              eq(notifications.isRead, false),
+              eq(notifications.type, 'TASK_ASSIGNED')
+            )
+          ),
+
+        // Pending calendar invites where user is not the organizer
+        db
+          .select({ count: count() })
+          .from(eventAttendees)
+          .innerJoin(calendarEvents, eq(eventAttendees.eventId, calendarEvents.id))
+          .where(
+            and(
+              eq(eventAttendees.userId, userId),
+              eq(eventAttendees.status, 'PENDING'),
+              eq(eventAttendees.isOrganizer, false),
+              eq(calendarEvents.isTrashed, false)
+            )
+          ),
+      ]);
+
+    return NextResponse.json({
+      dms: Number(dmResult[0]?.count ?? 0),
+      channels: Number(channelMentionResult[0]?.count ?? 0),
+      files: Number(fileMentionResult[0]?.count ?? 0),
+      tasks: Number(taskResult[0]?.count ?? 0),
+      calendar: Number(calendarResult[0]?.count ?? 0),
+    });
+  } catch (error) {
+    loggers.api.error('Error fetching sidebar badges:', error as Error);
+    return NextResponse.json({ error: 'Failed to fetch sidebar badges' }, { status: 500 });
+  }
+}

--- a/apps/web/src/components/layout/left-sidebar/PrimaryNavigation.tsx
+++ b/apps/web/src/components/layout/left-sidebar/PrimaryNavigation.tsx
@@ -7,6 +7,7 @@ import { Calendar, CheckSquare, Folder, Hash, Home, MessageSquare } from "lucide
 import { cn } from "@/lib/utils";
 import { useLayoutStore } from "@/stores/useLayoutStore";
 import { useBreakpoint } from "@/hooks/useBreakpoint";
+import { useSidebarBadges } from "@/hooks/useSidebarBadges";
 
 interface PrimaryNavigationProps {
     driveId?: string;
@@ -16,6 +17,7 @@ export default function PrimaryNavigation({ driveId }: PrimaryNavigationProps) {
     const pathname = usePathname();
     const isSheetBreakpoint = useBreakpoint("(max-width: 1023px)");
     const setLeftSheetOpen = useLayoutStore((state) => state.setLeftSheetOpen);
+    const badges = useSidebarBadges();
 
     const navigation = [
         {
@@ -23,6 +25,7 @@ export default function PrimaryNavigation({ driveId }: PrimaryNavigationProps) {
             href: driveId ? `/dashboard/${driveId}` : "/dashboard",
             icon: Home,
             exact: true,
+            badge: 0,
         },
         // DMs are user-scoped — same href in drive nav so they're always one click away.
         {
@@ -30,30 +33,35 @@ export default function PrimaryNavigation({ driveId }: PrimaryNavigationProps) {
             href: "/dashboard/dms",
             icon: MessageSquare,
             exact: false,
+            badge: badges.dms,
         },
         {
             name: "Channels",
             href: driveId ? `/dashboard/${driveId}/channels` : "/dashboard/channels",
             icon: Hash,
             exact: false,
+            badge: badges.channels,
         },
         {
             name: "Files",
             href: driveId ? `/dashboard/${driveId}/files` : "/dashboard/drives",
             icon: Folder,
             exact: false,
+            badge: badges.files,
         },
         {
             name: "Tasks",
             href: driveId ? `/dashboard/${driveId}/tasks` : "/dashboard/tasks",
             icon: CheckSquare,
             exact: false,
+            badge: badges.tasks,
         },
         {
             name: "Calendar",
             href: driveId ? `/dashboard/${driveId}/calendar` : "/dashboard/calendar",
             icon: Calendar,
             exact: false,
+            badge: badges.calendar,
         },
     ];
 
@@ -82,8 +90,13 @@ export default function PrimaryNavigation({ driveId }: PrimaryNavigationProps) {
                                 : "text-sidebar-foreground hover:bg-accent hover:text-accent-foreground"
                         )}
                     >
-                        <item.icon className="h-4 w-4" />
+                        <item.icon className="h-4 w-4 shrink-0" />
                         {item.name}
+                        {item.badge > 0 && (
+                            <span className="ml-auto inline-flex items-center justify-center h-4 min-w-[16px] px-1 rounded-full bg-primary text-primary-foreground text-[10px] font-medium tabular-nums">
+                                {item.badge > 99 ? "99+" : item.badge}
+                            </span>
+                        )}
                     </Link>
                 );
             })}

--- a/apps/web/src/hooks/useSidebarBadges.ts
+++ b/apps/web/src/hooks/useSidebarBadges.ts
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import useSWR from 'swr';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useSocket } from './useSocket';
+import { useNotificationStore } from '@/stores/useNotificationStore';
 
 export type SidebarBadges = {
   dms: number;
@@ -25,6 +26,7 @@ export function useSidebarBadges(): SidebarBadges {
   const socket = useSocket();
   const { data, mutate } = useSWR<SidebarBadges>('/api/sidebar/badges', fetcher);
 
+  // Revalidate when socket events arrive (new notifications, DM updates)
   useEffect(() => {
     if (!socket) return;
     const revalidate = () => void mutate();
@@ -37,6 +39,14 @@ export function useSidebarBadges(): SidebarBadges {
       socket.off('inbox:read_status_changed', revalidate);
     };
   }, [socket, mutate]);
+
+  // Revalidate when the user marks notifications as read in the current tab.
+  // handleNotificationRead / handleMarkAllAsRead update Zustand state only —
+  // no socket event fires — so we watch unreadCount directly as the trigger.
+  const notificationUnreadCount = useNotificationStore((state) => state.unreadCount);
+  useEffect(() => {
+    void mutate();
+  }, [notificationUnreadCount, mutate]);
 
   return data ?? EMPTY;
 }

--- a/apps/web/src/hooks/useSidebarBadges.ts
+++ b/apps/web/src/hooks/useSidebarBadges.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect } from 'react';
+import useSWR from 'swr';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { useSocket } from './useSocket';
+
+export type SidebarBadges = {
+  dms: number;
+  channels: number;
+  files: number;
+  tasks: number;
+  calendar: number;
+};
+
+const fetcher = async (url: string): Promise<SidebarBadges> => {
+  const res = await fetchWithAuth(url);
+  if (!res.ok) throw new Error('Failed to fetch sidebar badges');
+  return res.json() as Promise<SidebarBadges>;
+};
+
+const EMPTY: SidebarBadges = { dms: 0, channels: 0, files: 0, tasks: 0, calendar: 0 };
+
+export function useSidebarBadges(): SidebarBadges {
+  const socket = useSocket();
+  const { data, mutate } = useSWR<SidebarBadges>('/api/sidebar/badges', fetcher);
+
+  useEffect(() => {
+    if (!socket) return;
+    const revalidate = () => void mutate();
+    socket.on('notification:new', revalidate);
+    socket.on('inbox:dm_updated', revalidate);
+    socket.on('inbox:read_status_changed', revalidate);
+    return () => {
+      socket.off('notification:new', revalidate);
+      socket.off('inbox:dm_updated', revalidate);
+      socket.off('inbox:read_status_changed', revalidate);
+    };
+  }, [socket, mutate]);
+
+  return data ?? EMPTY;
+}


### PR DESCRIPTION
## Summary

- Adds a `GET /api/sidebar/badges` endpoint that runs five parallel Drizzle queries to count actionable unread items per nav section
- Adds `useSidebarBadges` hook that fetches badge counts and revalidates on `notification:new`, `inbox:dm_updated`, and `inbox:read_status_changed` socket events
- Renders a primary-colored pill badge on each nav item in `PrimaryNavigation` when count > 0, capped at `99+`

## Badge semantics

| Nav item | What it counts | How it clears |
|---|---|---|
| DMs | Unread direct messages (top-level, not sent by you) | Reading the conversation |
| Channels | Unread `MENTION` notifications in channel pages | Marking notification read |
| Files | Unread `MENTION` notifications in non-channel pages | Marking notification read |
| Tasks | Unread `TASK_ASSIGNED` notifications | Marking notification read |
| Calendar | Pending invites (`status = PENDING`, not organizer) | Accepting or declining |

## Test plan

- [ ] Receive a DM → DMs badge appears; open conversation → clears
- [ ] Get @mentioned in a channel → Channels badge appears; mark notification read → clears
- [ ] Get @mentioned in a document → Files badge appears; mark notification read → clears
- [ ] Get assigned a task → Tasks badge appears; mark notification read → clears
- [ ] Receive a calendar invite → Calendar badge appears; accept/decline → clears
- [ ] Fresh account with no activity → all badges show nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)