### PR TITLE
[web] Limit calendar sidebar badge to upcoming pending invites

### DIFF
--- a/apps/web/src/app/api/sidebar/badges/route.ts
+++ b/apps/web/src/app/api/sidebar/badges/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { db } from '@pagespace/db/db';
-import { eq, ne, and, or, count, isNull } from '@pagespace/db/operators';
+import { eq, ne, and, or, count, isNull, gte } from '@pagespace/db/operators';
 import { directMessages, dmConversations } from '@pagespace/db/schema/social';
 import { notifications } from '@pagespace/db/schema/notifications';
 import { pages } from '@pagespace/db/schema/core';
@@ -77,7 +77,7 @@ export async function GET(req: Request) {
             )
           ),
 
-        // Pending calendar invites where user is not the organizer
+        // Pending RSVP invites for upcoming events where user is not the organizer
         db
           .select({ count: count() })
           .from(eventAttendees)
@@ -87,7 +87,8 @@ export async function GET(req: Request) {
               eq(eventAttendees.userId, userId),
               eq(eventAttendees.status, 'PENDING'),
               eq(eventAttendees.isOrganizer, false),
-              eq(calendarEvents.isTrashed, false)
+              eq(calendarEvents.isTrashed, false),
+              gte(calendarEvents.startAt, new Date())
             )
           ),
       ]);


### PR DESCRIPTION
### Motivation
- The left-sidebar Calendar badge was being inflated by historical pending attendee rows; it should only indicate actionable pending RSVP invites for future events.

### Description
- Updated `apps/web/src/app/api/sidebar/badges/route.ts` to import `gte` from `@pagespace/db/operators` and add `gte(calendarEvents.startAt, new Date())` to the calendar query so the badge counts only non-organizer, non-trashed pending RSVP invites for upcoming events.

### Testing
- Ran `pnpm --filter web lint`, which completed successfully (reported unrelated existing hook-dependency warnings in other files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe7b7f16f88320869faf5fad47c3ac)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the pending RSVP invites badge to only count upcoming events for improved accuracy and relevance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->