### PR TITLE
feat(ai): stub non-core tool schemas + tool_search to reduce context window usage

### DIFF
--- a/apps/web/ai-evals/tool-discovery/core-tools-no-search.sudo
+++ b/apps/web/ai-evals/tool-discovery/core-tools-no-search.sudo
@@ -1,0 +1,12 @@
+import 'apps/web/ai-evals/tool-discovery/spec.mdc'
+
+userPrompt = """
+Based on the tool discovery spec, a user asks: "Show me all my workspaces."
+
+Available tools: list_drives (core), tool_search.
+
+Describe the correct first tool call to fulfill this request. Should you call tool_search first or list_drives directly?
+"""
+
+- Given a user request to list workspaces, should call list_drives as the first tool
+- Given list_drives is a core tool with a full schema, should not call tool_search before list_drives

--- a/apps/web/ai-evals/tool-discovery/non-core-requires-search.sudo
+++ b/apps/web/ai-evals/tool-discovery/non-core-requires-search.sudo
@@ -1,0 +1,13 @@
+import 'apps/web/ai-evals/tool-discovery/spec.mdc'
+
+userPrompt = """
+Based on the tool discovery spec, a user asks: "Add a 30-minute standup meeting for tomorrow at 9am."
+
+Available tools: list_drives (core), create_calendar_event (extended/stub), tool_search.
+
+Describe the correct sequence of tool calls to fulfill this request. Start with the first tool you would call.
+"""
+
+- Given a user request to create a calendar event, should call tool_search before create_calendar_event
+- Given create_calendar_event is an extended tool, should not call create_calendar_event as the first step
+- Given the spec says extended tools need tool_search first, should query tool_search with "calendar" or "select:create_calendar_event"

--- a/apps/web/ai-evals/tool-discovery/spec.mdc
+++ b/apps/web/ai-evals/tool-discovery/spec.mdc
@@ -1,0 +1,28 @@
+# PageSpace Tool Discovery Spec
+
+## System prompt rule
+
+The AI receives this instruction in every request:
+
+> Core tools are always ready: list/read drives and pages, search, create, edit content
+> For other tools (calendar, agents, channels, tasks, etc.): call tool_search("keyword") or
+> tool_search("select:tool_name") first to get the full parameter schema
+
+## Core tools (full schemas — call directly)
+
+list_drives, list_pages, read_page, get_page_details, create_page, replace_lines,
+regex_search, multi_drive_search
+
+## Extended tools (stub schemas — must call tool_search first)
+
+All other tools including: list_calendar_events, create_calendar_event,
+update_calendar_event, delete_calendar_event, update_task, list_agents,
+send_channel_message, get_activity, and others.
+
+## tool_search
+
+Always available. Query formats:
+- `tool_search("select:tool_name")` — get exact tool by name
+- `tool_search("calendar")` — find all calendar-related tools by keyword
+
+Returns: full parameter schemas for the matched tools.

--- a/apps/web/src/app/api/ai/chat/__tests__/mcp-scope.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/mcp-scope.test.ts
@@ -118,6 +118,7 @@ vi.mock('@/lib/ai/core', () => ({
   getUserLMStudioSettings: vi.fn(),
   getUserGLMSettings: vi.fn(),
   pageSpaceTools: {},
+  pageSpaceToolsStubbed: {},
   extractMessageContent: vi.fn().mockReturnValue('test content'),
   extractToolCalls: vi.fn().mockReturnValue([]),
   extractToolResults: vi.fn().mockReturnValue([]),
@@ -191,6 +192,10 @@ vi.mock('@/lib/ai/core/validate-image-parts', () => ({
 
 vi.mock('@/lib/ai/core/model-capabilities', () => ({
   hasVisionCapability: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('@/lib/ai/tools/tool-search-tool', () => ({
+  createToolSearchTool: vi.fn().mockReturnValue({}),
 }));
 
 import { authenticateRequestWithOptions, checkMCPPageScope } from '@/lib/auth';

--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -133,6 +133,7 @@ vi.mock('@/lib/ai/core', () => ({
   getUserLMStudioSettings: vi.fn(),
   getUserGLMSettings: vi.fn(),
   pageSpaceTools: {},
+  pageSpaceToolsStubbed: {},
   extractMessageContent: vi.fn().mockReturnValue('test content'),
   extractToolCalls: vi.fn().mockReturnValue([]),
   extractToolResults: vi.fn().mockReturnValue([]),
@@ -223,6 +224,10 @@ vi.mock('@/lib/ai/core/tool-utils', () => ({
 vi.mock('@/lib/ai/tools/finish-tool', () => ({
   finishTool: {},
   FINISH_TOOL_NAME: 'finish',
+}));
+
+vi.mock('@/lib/ai/tools/tool-search-tool', () => ({
+  createToolSearchTool: vi.fn().mockReturnValue({}),
 }));
 
 vi.mock('@/lib/ai/core/stream-pipe-utils', () => ({

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -35,6 +35,7 @@ import {
   type ProviderRequest,
   buildProviderAvailabilityMap,
   pageSpaceTools,
+  pageSpaceToolsStubbed,
   extractMessageContent,
   extractToolCalls,
   extractToolResults,
@@ -67,6 +68,7 @@ import { trackFeature } from '@pagespace/lib/monitoring/activity-tracker';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 import type { MCPTool } from '@/types/mcp';
 import { getMCPBridge } from '@/lib/mcp';
+import { createToolSearchTool } from '@/lib/ai/tools/tool-search-tool';
 import { applyPageMutation, PageRevisionMismatchError } from '@/services/api/page-mutation-service';
 import {
   createStreamAbortController,
@@ -507,13 +509,20 @@ export async function POST(request: Request) {
     const webSearchMode = webSearchEnabled === true;
     loggers.ai.debug('AI Page Chat API: Tool modes', { isReadOnly: readOnlyMode, webSearchEnabled: webSearchMode });
 
-    // Build tools from the full PageSpace baseline, modulated by the composer's
-    // runtime toggles (read-only + web search). This makes the popover the
-    // single source of truth — see comment near customSystemPrompt above.
-    let filteredTools: ToolSet = buildPageAITools(pageSpaceTools, {
+    // Build tools: non-core tools use passthrough stub schemas to reduce context window usage.
+    // The AI calls tool_search to get full parameter schemas before using non-core tools.
+    // See stub-tools.ts for the core tool set definition.
+    let filteredTools: ToolSet = buildPageAITools(pageSpaceToolsStubbed, {
       isReadOnly: readOnlyMode,
       webSearchEnabled: webSearchMode,
     });
+
+    // Inject tool_search with a reference to the full (non-stubbed) registry so it can
+    // return complete parameter schemas on demand.
+    filteredTools = {
+      ...filteredTools,
+      tool_search: createToolSearchTool(pageSpaceTools),
+    } as ToolSet;
 
     loggers.ai.debug('AI Page Chat API: Tools built from baseline + runtime toggles', {
       totalTools: Object.keys(pageSpaceTools).length,

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -524,7 +524,7 @@ export async function POST(request: Request) {
       Object.keys(filteredTools)
         .filter((name) => name in pageSpaceTools)
         .map((name) => [name, pageSpaceTools[name as keyof typeof pageSpaceTools]])
-    );
+    ) as ToolSet;
     filteredTools = {
       ...filteredTools,
       tool_search: createToolSearchTool(enabledFullSchemaTools),

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -517,15 +517,21 @@ export async function POST(request: Request) {
       webSearchEnabled: webSearchMode,
     });
 
-    // Inject tool_search with a reference to the full (non-stubbed) registry so it can
-    // return complete parameter schemas on demand.
+    // Inject tool_search scoped to the enabled tool set (with full schemas).
+    // Using the filtered key set prevents tool_search from advertising tools that are
+    // unavailable in this request (e.g. write tools in read-only, web_search when disabled).
+    const enabledFullSchemaTools = Object.fromEntries(
+      Object.keys(filteredTools)
+        .filter((name) => name in pageSpaceTools)
+        .map((name) => [name, pageSpaceTools[name as keyof typeof pageSpaceTools]])
+    );
     filteredTools = {
       ...filteredTools,
-      tool_search: createToolSearchTool(pageSpaceTools),
+      tool_search: createToolSearchTool(enabledFullSchemaTools),
     } as ToolSet;
 
     loggers.ai.debug('AI Page Chat API: Tools built from baseline + runtime toggles', {
-      totalTools: Object.keys(pageSpaceTools).length,
+      totalTools: Object.keys(pageSpaceToolsStubbed).length,
       filteredTools: Object.keys(filteredTools).length,
       isReadOnly: readOnlyMode,
       webSearchEnabled: webSearchMode

--- a/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
@@ -98,7 +98,7 @@ vi.mock('../../tools/channel-tools', () => ({
   },
 }));
 
-import { pageSpaceTools } from '../ai-tools';
+import { pageSpaceTools, pageSpaceToolsStubbed } from '../ai-tools';
 import { driveTools } from '../../tools/drive-tools';
 import { pageReadTools } from '../../tools/page-read-tools';
 import { pageWriteTools } from '../../tools/page-write-tools';
@@ -176,6 +176,28 @@ describe('ai-tools', () => {
           throw new Error(`Tool "${name}" is ${tool}`);
         }
       }
+    });
+  });
+
+  describe('pageSpaceToolsStubbed', () => {
+    it('is exported and defined', () => {
+      expect(pageSpaceToolsStubbed).toBeDefined();
+    });
+
+    it('has the same keys as pageSpaceTools', () => {
+      expect(Object.keys(pageSpaceToolsStubbed).sort()).toEqual(
+        Object.keys(pageSpaceTools).sort()
+      );
+    });
+
+    it('keeps core tools as the same object reference', () => {
+      expect(pageSpaceToolsStubbed.list_drives).toBe(pageSpaceTools.list_drives);
+      expect(pageSpaceToolsStubbed.read_page).toBe(pageSpaceTools.read_page);
+    });
+
+    it('replaces non-core tools with distinct stub objects', () => {
+      expect(pageSpaceToolsStubbed.list_calendar_events).not.toBe(pageSpaceTools.list_calendar_events);
+      expect(pageSpaceToolsStubbed.update_task).not.toBe(pageSpaceTools.update_task);
     });
   });
 });

--- a/apps/web/src/lib/ai/core/__tests__/stub-tools.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stub-tools.test.ts
@@ -1,0 +1,118 @@
+import { describe, it } from 'vitest';
+import { z } from 'zod';
+import type { Tool } from 'ai';
+import { assert } from './riteway';
+import { CORE_TOOL_NAMES, buildStubbedTools } from '../stub-tools';
+
+const fakeCore: Tool = {
+  description: 'A core tool',
+  inputSchema: z.object({ id: z.string() }),
+  execute: async ({ id }: { id: string }) => ({ result: id }),
+};
+
+const fakeExtended: Tool = {
+  description: 'A non-core tool',
+  inputSchema: z.object({ name: z.string(), date: z.string() }),
+  execute: async ({ name }: { name: string }) => ({ result: name }),
+};
+
+const registry = {
+  list_drives: fakeCore,
+  list_calendar_events: fakeExtended,
+};
+
+describe('CORE_TOOL_NAMES', () => {
+  it('contains exactly the 8 designated core tools', () => {
+    assert({
+      given: 'the CORE_TOOL_NAMES set',
+      should: 'list exactly the 8 core tools',
+      actual: [...CORE_TOOL_NAMES].sort(),
+      expected: [
+        'create_page',
+        'get_page_details',
+        'list_drives',
+        'list_pages',
+        'multi_drive_search',
+        'read_page',
+        'regex_search',
+        'replace_lines',
+      ],
+    });
+  });
+});
+
+describe('buildStubbedTools', () => {
+  it('passes core tools through unchanged', () => {
+    const stubbed = buildStubbedTools(registry);
+    assert({
+      given: 'a core tool (list_drives)',
+      should: 'be the same object reference as the original',
+      actual: stubbed.list_drives === registry.list_drives,
+      expected: true,
+    });
+  });
+
+  it('replaces non-core inputSchema with a passthrough that accepts any object', () => {
+    const stubbed = buildStubbedTools(registry);
+    const schema = stubbed.list_calendar_events.inputSchema as z.ZodType;
+    assert({
+      given: 'a non-core stub schema',
+      should: 'accept any object',
+      actual: schema.safeParse({ anything: true }).success,
+      expected: true,
+    });
+    assert({
+      given: 'a non-core stub schema',
+      should: 'accept an empty object',
+      actual: schema.safeParse({}).success,
+      expected: true,
+    });
+  });
+
+  it('preserves the description on non-core stubs', () => {
+    const stubbed = buildStubbedTools(registry);
+    assert({
+      given: 'a non-core stub tool',
+      should: 'keep its original description',
+      actual: stubbed.list_calendar_events.description,
+      expected: fakeExtended.description,
+    });
+  });
+
+  it('stub execute delegates to real impl when args are valid', async () => {
+    const stubbed = buildStubbedTools(registry);
+    const result = await stubbed.list_calendar_events.execute!(
+      { name: 'test', date: '2025-01-01' },
+      {} as never
+    );
+    assert({
+      given: 'valid args passed to a stub execute',
+      should: 'delegate to the real execute function',
+      actual: result,
+      expected: { result: 'test' },
+    });
+  });
+
+  it('stub execute returns a tool_search error for invalid args', async () => {
+    const stubbed = buildStubbedTools(registry);
+    const result = await stubbed.list_calendar_events.execute!(
+      {},
+      {} as never
+    );
+    assert({
+      given: 'invalid args (missing required fields)',
+      should: 'return an error that mentions tool_search',
+      actual: (result as { error: string }).error.includes('tool_search'),
+      expected: true,
+    });
+  });
+
+  it('returns an empty object for an empty input registry', () => {
+    assert({
+      given: 'an empty tool registry',
+      should: 'produce an empty stubbed registry',
+      actual: buildStubbedTools({}),
+      expected: {},
+    });
+  });
+});

--- a/apps/web/src/lib/ai/core/ai-tools.ts
+++ b/apps/web/src/lib/ai/core/ai-tools.ts
@@ -10,6 +10,7 @@ import { activityTools } from '../tools/activity-tools';
 import { calendarReadTools } from '../tools/calendar-read-tools';
 import { calendarWriteTools } from '../tools/calendar-write-tools';
 import { channelTools } from '../tools/channel-tools';
+import { buildStubbedTools } from './stub-tools';
 
 /**
  * PageSpace AI Tools - Internal AI SDK tool implementations
@@ -32,3 +33,5 @@ export const pageSpaceTools = {
 };
 
 export type PageSpaceTools = typeof pageSpaceTools;
+
+export const pageSpaceToolsStubbed = buildStubbedTools(pageSpaceTools);

--- a/apps/web/src/lib/ai/core/stub-tools.ts
+++ b/apps/web/src/lib/ai/core/stub-tools.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+import type { Tool } from 'ai';
+
+export const CORE_TOOL_NAMES = new Set([
+  'list_drives',
+  'list_pages',
+  'read_page',
+  'get_page_details',
+  'create_page',
+  'replace_lines',
+  'regex_search',
+  'multi_drive_search',
+]);
+
+function wrapWithStub(name: string, t: Tool): Tool {
+  const realSchema = t.inputSchema as z.ZodType;
+  return {
+    ...t,
+    inputSchema: z.object({}).passthrough(),
+    execute: async (rawArgs: unknown, options: unknown) => {
+      const parsed = realSchema.safeParse(rawArgs);
+      if (!parsed.success) {
+        return {
+          error: `Invalid arguments for ${name}. Call tool_search("${name}") to get the correct parameter schema.`,
+        };
+      }
+      return (t.execute as (args: unknown, opts: unknown) => unknown)(parsed.data, options);
+    },
+  };
+}
+
+export function buildStubbedTools<T extends Record<string, Tool>>(tools: T): T {
+  return Object.fromEntries(
+    Object.entries(tools).map(([name, t]) => [
+      name,
+      CORE_TOOL_NAMES.has(name) ? t : wrapWithStub(name, t),
+    ])
+  ) as T;
+}

--- a/apps/web/src/lib/ai/core/system-prompt.ts
+++ b/apps/web/src/lib/ai/core/system-prompt.ts
@@ -36,6 +36,10 @@ STYLE:
 • Be concise but conversational - like a knowledgeable colleague
 • Match user energy - conversational when exploring, efficient when executing`;
 
+const TOOL_DISCOVERY_PROMPT = `TOOLS:
+• Core tools are always ready: list/read drives and pages, search, create, edit content
+• For other tools (calendar, agents, channels, tasks, etc.): call tool_search("keyword") or tool_search("select:tool_name") first to get the full parameter schema`;
+
 const READ_ONLY_CONSTRAINT = `READ-ONLY MODE:
 • You cannot modify, create, or delete any content
 • Focus on exploring, analyzing, and planning
@@ -127,6 +131,7 @@ export function buildSystemPrompt(
     personalizationPrompt,
     contextPrompt,
     BEHAVIOR_PROMPT,
+    TOOL_DISCOVERY_PROMPT,
     isReadOnly ? READ_ONLY_CONSTRAINT : null,
   ].filter(Boolean);
 

--- a/apps/web/src/lib/ai/tools/__tests__/tool-search-tool.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/tool-search-tool.test.ts
@@ -1,0 +1,136 @@
+import { describe, it } from 'vitest';
+import { z } from 'zod';
+import type { Tool } from 'ai';
+import { assert } from './riteway';
+import { createToolSearchTool } from '../tool-search-tool';
+
+const calendarTool: Tool = {
+  description: 'List calendar events for a date range',
+  inputSchema: z.object({ startDate: z.string(), endDate: z.string() }),
+  execute: async () => ({ events: [] }),
+};
+
+const taskTool: Tool = {
+  description: 'Update a task item',
+  inputSchema: z.object({ taskId: z.string(), status: z.string() }),
+  execute: async () => ({ success: true }),
+};
+
+const registry = {
+  list_calendar_events: calendarTool,
+  update_task: taskTool,
+};
+
+type ToolSearchResult = {
+  tools: Array<{ name: string; description: string; inputSchema: { type: string } }>;
+};
+
+describe('createToolSearchTool', () => {
+  it('returns a tool with a string description', () => {
+    const t = createToolSearchTool(registry);
+    assert({
+      given: 'a tool registry',
+      should: 'produce a tool_search tool with a string description',
+      actual: typeof t.description,
+      expected: 'string',
+    });
+  });
+
+  it('select: query returns exactly the named tool', async () => {
+    const t = createToolSearchTool(registry);
+    const { tools } = (await t.execute!(
+      { query: 'select:list_calendar_events' },
+      {} as never
+    )) as ToolSearchResult;
+    assert({
+      given: 'select:list_calendar_events',
+      should: 'return one tool named list_calendar_events',
+      actual: tools.map((x) => x.name),
+      expected: ['list_calendar_events'],
+    });
+  });
+
+  it('select: with two names returns both tools', async () => {
+    const t = createToolSearchTool(registry);
+    const { tools } = (await t.execute!(
+      { query: 'select:list_calendar_events,update_task' },
+      {} as never
+    )) as ToolSearchResult;
+    assert({
+      given: 'select: with two valid names',
+      should: 'return both tools',
+      actual: tools.map((x) => x.name).sort(),
+      expected: ['list_calendar_events', 'update_task'],
+    });
+  });
+
+  it('select: with unknown name returns empty array', async () => {
+    const t = createToolSearchTool(registry);
+    const { tools } = (await t.execute!(
+      { query: 'select:does_not_exist' },
+      {} as never
+    )) as ToolSearchResult;
+    assert({
+      given: 'select: with an unknown tool name',
+      should: 'return no tools',
+      actual: tools.length,
+      expected: 0,
+    });
+  });
+
+  it('keyword query matches on tool name', async () => {
+    const t = createToolSearchTool(registry);
+    const { tools } = (await t.execute!(
+      { query: 'calendar' },
+      {} as never
+    )) as ToolSearchResult;
+    assert({
+      given: '"calendar" keyword',
+      should: 'return the calendar event tool',
+      actual: tools.map((x) => x.name),
+      expected: ['list_calendar_events'],
+    });
+  });
+
+  it('keyword query matches on description text', async () => {
+    const t = createToolSearchTool(registry);
+    const { tools } = (await t.execute!(
+      { query: 'task item' },
+      {} as never
+    )) as ToolSearchResult;
+    assert({
+      given: '"task item" matching description',
+      should: 'return update_task',
+      actual: tools.map((x) => x.name),
+      expected: ['update_task'],
+    });
+  });
+
+  it('returned inputSchema has JSON Schema type:object', async () => {
+    const t = createToolSearchTool(registry);
+    const { tools } = (await t.execute!(
+      { query: 'select:list_calendar_events' },
+      {} as never
+    )) as ToolSearchResult;
+    assert({
+      given: 'a tool with a Zod object schema',
+      should: 'return a JSON Schema with type "object"',
+      actual: tools[0].inputSchema.type,
+      expected: 'object',
+    });
+  });
+
+  it('unmatched keyword returns empty tools array', async () => {
+    const t = createToolSearchTool(registry);
+    const { tools } = (await t.execute!(
+      { query: 'xyznonexistent123' },
+      {} as never
+    )) as ToolSearchResult;
+    assert({
+      given: 'a keyword matching nothing',
+      should: 'return an empty tools array',
+      actual: tools.length,
+      expected: 0,
+    });
+  });
+});

--- a/apps/web/src/lib/ai/tools/tool-search-tool.ts
+++ b/apps/web/src/lib/ai/tools/tool-search-tool.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
-import type { Tool } from 'ai';
+import type { Tool, ToolSet } from 'ai';
 
-export function createToolSearchTool(fullTools: Record<string, Tool>): Tool {
+export function createToolSearchTool(fullTools: ToolSet): Tool {
   return {
     description:
       'Get full parameter schemas for any PageSpace tool before calling it. Use "select:name1,name2" for specific tools by name, or a keyword like "calendar", "agent", "task", "channel", "drive" to find all tools in that area.',
@@ -22,7 +22,7 @@ export function createToolSearchTool(fullTools: Record<string, Tool>): Tool {
   };
 }
 
-function resolveMatches(tools: Record<string, Tool>, query: string): Record<string, Tool> {
+function resolveMatches(tools: ToolSet, query: string): ToolSet {
   if (query.startsWith('select:')) {
     const names = query.slice(7).split(',').map((s) => s.trim());
     return Object.fromEntries(names.filter((n) => tools[n]).map((n) => [n, tools[n]]));

--- a/apps/web/src/lib/ai/tools/tool-search-tool.ts
+++ b/apps/web/src/lib/ai/tools/tool-search-tool.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+import type { Tool } from 'ai';
+
+export function createToolSearchTool(fullTools: Record<string, Tool>): Tool {
+  return {
+    description:
+      'Get full parameter schemas for any PageSpace tool before calling it. Use "select:name1,name2" for specific tools by name, or a keyword like "calendar", "agent", "task", "channel", "drive" to find all tools in that area.',
+    inputSchema: z.object({
+      query: z.string().describe(
+        'Either "select:name1,name2" for specific tools or a search keyword'
+      ),
+    }),
+    execute: async ({ query }: { query: string }) => {
+      const matches = resolveMatches(fullTools, query);
+      const result = Object.entries(matches).map(([name, t]) => ({
+        name,
+        description: t.description,
+        inputSchema: z.toJSONSchema(t.inputSchema as z.ZodType),
+      }));
+      return { tools: result };
+    },
+  };
+}
+
+function resolveMatches(tools: Record<string, Tool>, query: string): Record<string, Tool> {
+  if (query.startsWith('select:')) {
+    const names = query.slice(7).split(',').map((s) => s.trim());
+    return Object.fromEntries(names.filter((n) => tools[n]).map((n) => [n, tools[n]]));
+  }
+  const kw = query.toLowerCase();
+  return Object.fromEntries(
+    Object.entries(tools).filter(
+      ([name, t]) => name.includes(kw) || (t.description ?? '').toLowerCase().includes(kw)
+    )
+  );
+}


### PR DESCRIPTION
## Summary

- Sending all 37 full Zod schemas to Claude every request costs ~7–18k tokens per turn in tool overhead
- Non-core tools (29 of 37) now use \`z.object({}).passthrough()\` stub schemas; the AI calls \`tool_search\` to fetch full parameter schemas on demand before using them — same pattern as Claude Code's own deferred tools / ToolSearch
- Core 8 tools (\`list_drives\`, \`list_pages\`, \`read_page\`, \`get_page_details\`, \`create_page\`, \`replace_lines\`, \`regex_search\`, \`multi_drive_search\`) keep full schemas since they're used in almost every session
- \`tool_search\` is scoped to the **enabled** tool set: in read-only mode write tools are absent; when web search is off \`web_search\` is absent — so the AI can never discover unavailable tools
- Estimated saving: ~7,000–16,000 tokens per request

## Changes

**New files:**
- \`stub-tools.ts\` — wraps non-core tools with passthrough stubs; real \`safeParse\` validation inside \`execute\` returns a helpful \`tool_search\` error on invalid args
- \`tool-search-tool.ts\` — introspects the live registry via \`z.toJSONSchema\`; supports \`select:name1,name2\` and keyword queries; accepts a \`ToolSet\` so it can be scoped at call time
- \`ai-evals/tool-discovery/\` — \`riteway ai\` prompt evals for behavioral testing (run with \`riteway ai 'apps/web/ai-evals/tool-discovery/*.sudo'\`)

**Modified files:**
- \`chat/route.ts\` — uses \`pageSpaceToolsStubbed\` + builds \`enabledFullSchemaTools\` (intersection of \`filteredTools\` keys and full-schema \`pageSpaceTools\`) + injects \`tool_search\` from that scoped set
- \`system-prompt.ts\` — adds \`TOOL_DISCOVERY_PROMPT\` section teaching the AI which tools are core and how to use \`tool_search\`
- \`ai-tools.ts\` — exports \`pageSpaceToolsStubbed\`

## Test plan

- [x] 23 unit tests passing: \`stub-tools.test.ts\` (7), \`tool-search-tool.test.ts\` (8), \`ai-tools.test.ts\` (4 new + 4 existing)
- [x] Fixed mocks in \`stream-socket-events.test.ts\` and \`mcp-scope.test.ts\` (both tests mock \`@/lib/ai/core\` — added \`pageSpaceToolsStubbed: {}\` and mocked \`tool-search-tool\` module)
- [ ] Run prompt evals: \`riteway ai 'apps/web/ai-evals/tool-discovery/*.sudo'\`
- [ ] Smoke test AI chat in the UI — verify calendar/task/agent tools still work (AI should call \`tool_search\` first, then the tool with correct params)

🤖 Generated with [Claude Code](https://claude.com/claude-code)