### PR TITLE
feat(dashboard): dynamic copy for drive vs root view

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -892,11 +892,15 @@ const GlobalAssistantView: React.FC = () => {
         welcomeTitle={
           selectedAgent
             ? `Chat with ${selectedAgent.title}`
+            : locationContext?.currentDrive
+            ? locationContext.currentDrive.name
             : 'How can I help you today?'
         }
         welcomeSubtitle={
           selectedAgent
             ? 'Ask me anything!'
+            : locationContext?.currentDrive
+            ? 'Ask about pages in this drive, or tell me what you\'re working on.'
             : 'Tell me what you\'re thinking about or working on.'
         }
         onEdit={handleEdit}


### PR DESCRIPTION
## Summary

- `GlobalAssistantView` welcome title/subtitle now change based on location
- Inside a drive: shows the drive name as the title and a drive-scoped subtitle
- Root dashboard: unchanged ("How can I help you today?")
- Agent selected: unchanged ("Chat with [Agent]")

Fixes the UX confusion where users without the sidebar open couldn't tell if they'd navigated into a drive or were still on the root dashboard.

## Test plan

- [ ] Open app with sidebar collapsed
- [ ] Visit `/dashboard` — confirm root copy ("How can I help you today?")
- [ ] Navigate into a drive — confirm drive name appears as title and drive subtitle shows
- [ ] Select an agent — confirm agent copy is unaffected
- [ ] Navigate back to root dashboard — confirm copy resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)