### PR TITLE
fix(ai): move tool discovery to global assistant + enforce page agent enabledTools

### DIFF
--- a/apps/web/src/app/api/ai/chat/__tests__/mcp-scope.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/mcp-scope.test.ts
@@ -118,7 +118,6 @@ vi.mock('@/lib/ai/core', () => ({
   getUserLMStudioSettings: vi.fn(),
   getUserGLMSettings: vi.fn(),
   pageSpaceTools: {},
-  pageSpaceToolsStubbed: {},
   extractMessageContent: vi.fn().mockReturnValue('test content'),
   extractToolCalls: vi.fn().mockReturnValue([]),
   extractToolResults: vi.fn().mockReturnValue([]),
@@ -192,10 +191,6 @@ vi.mock('@/lib/ai/core/validate-image-parts', () => ({
 
 vi.mock('@/lib/ai/core/model-capabilities', () => ({
   hasVisionCapability: vi.fn().mockReturnValue(true),
-}));
-
-vi.mock('@/lib/ai/tools/tool-search-tool', () => ({
-  createToolSearchTool: vi.fn().mockReturnValue({}),
 }));
 
 import { authenticateRequestWithOptions, checkMCPPageScope } from '@/lib/auth';

--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -133,7 +133,6 @@ vi.mock('@/lib/ai/core', () => ({
   getUserLMStudioSettings: vi.fn(),
   getUserGLMSettings: vi.fn(),
   pageSpaceTools: {},
-  pageSpaceToolsStubbed: {},
   extractMessageContent: vi.fn().mockReturnValue('test content'),
   extractToolCalls: vi.fn().mockReturnValue([]),
   extractToolResults: vi.fn().mockReturnValue([]),
@@ -224,10 +223,6 @@ vi.mock('@/lib/ai/core/tool-utils', () => ({
 vi.mock('@/lib/ai/tools/finish-tool', () => ({
   finishTool: {},
   FINISH_TOOL_NAME: 'finish',
-}));
-
-vi.mock('@/lib/ai/tools/tool-search-tool', () => ({
-  createToolSearchTool: vi.fn().mockReturnValue({}),
 }));
 
 vi.mock('@/lib/ai/core/stream-pipe-utils', () => ({

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -275,10 +275,11 @@ export async function POST(request: Request) {
     }
 
     // Extract custom agent configuration from page.
-    // Note: page.enabledTools is intentionally NOT consulted here. It seeds the
-    // composer's tool toggles on the client; the toggles in the request body
-    // are the source of truth at runtime so the UI doesn't lie about what the
-    // model can actually do.
+    // page.enabledTools seeds the composer's tool toggles on the client.
+    // Request-body toggles (isReadOnly, webSearchEnabled) are applied first via
+    // buildPageAITools, then the per-agent allowlist is enforced server-side
+    // (see agentEnabledTools filter below) so the client UI and server agree on
+    // which tools the model can actually use.
     const customSystemPrompt = page.systemPrompt;
 
     // Fetch drive prompt if page has includeDrivePrompt enabled

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -35,7 +35,6 @@ import {
   type ProviderRequest,
   buildProviderAvailabilityMap,
   pageSpaceTools,
-  pageSpaceToolsStubbed,
   extractMessageContent,
   extractToolCalls,
   extractToolResults,
@@ -68,7 +67,6 @@ import { trackFeature } from '@pagespace/lib/monitoring/activity-tracker';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 import type { MCPTool } from '@/types/mcp';
 import { getMCPBridge } from '@/lib/mcp';
-import { createToolSearchTool } from '@/lib/ai/tools/tool-search-tool';
 import { applyPageMutation, PageRevisionMismatchError } from '@/services/api/page-mutation-service';
 import {
   createStreamAbortController,
@@ -509,32 +507,30 @@ export async function POST(request: Request) {
     const webSearchMode = webSearchEnabled === true;
     loggers.ai.debug('AI Page Chat API: Tool modes', { isReadOnly: readOnlyMode, webSearchEnabled: webSearchMode });
 
-    // Build tools: non-core tools use passthrough stub schemas to reduce context window usage.
-    // The AI calls tool_search to get full parameter schemas before using non-core tools.
-    // See stub-tools.ts for the core tool set definition.
-    let filteredTools: ToolSet = buildPageAITools(pageSpaceToolsStubbed, {
+    // Build tools filtered by runtime toggles, then enforce the per-agent allowlist.
+    let filteredTools: ToolSet = buildPageAITools(pageSpaceTools, {
       isReadOnly: readOnlyMode,
       webSearchEnabled: webSearchMode,
     });
 
-    // Inject tool_search scoped to the enabled tool set (with full schemas).
-    // Using the filtered key set prevents tool_search from advertising tools that are
-    // unavailable in this request (e.g. write tools in read-only, web_search when disabled).
-    const enabledFullSchemaTools = Object.fromEntries(
-      Object.keys(filteredTools)
-        .filter((name) => name in pageSpaceTools)
-        .map((name) => [name, pageSpaceTools[name as keyof typeof pageSpaceTools]])
-    ) as ToolSet;
-    filteredTools = {
-      ...filteredTools,
-      tool_search: createToolSearchTool(enabledFullSchemaTools),
-    } as ToolSet;
+    // Enforce per-agent tool allowlist. When enabledTools is a non-empty array,
+    // only tools explicitly listed are made available to the agent. This is a
+    // server-side security boundary — the client toggles (isReadOnly, webSearchEnabled)
+    // are still applied first so read-only mode always wins.
+    // null/undefined = no per-tool restriction (backwards compat for unconfigured pages).
+    const agentEnabledTools = page.enabledTools as string[] | null;
+    if (agentEnabledTools && agentEnabledTools.length > 0) {
+      filteredTools = Object.fromEntries(
+        Object.entries(filteredTools).filter(([name]) => agentEnabledTools.includes(name))
+      ) as ToolSet;
+    }
 
     loggers.ai.debug('AI Page Chat API: Tools built from baseline + runtime toggles', {
-      totalTools: Object.keys(pageSpaceToolsStubbed).length,
+      totalTools: Object.keys(pageSpaceTools).length,
       filteredTools: Object.keys(filteredTools).length,
       isReadOnly: readOnlyMode,
-      webSearchEnabled: webSearchMode
+      webSearchEnabled: webSearchMode,
+      enabledToolsAllowlist: agentEnabledTools?.length ?? 'unrestricted',
     });
 
     // INTEGRATION TOOLS: Resolve and merge integration tools for this agent

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
@@ -155,6 +155,7 @@ vi.mock('@/lib/ai/core', () => ({
   createProviderErrorResponse: vi.fn(),
   isProviderError: vi.fn().mockReturnValue(false),
   pageSpaceTools: {},
+  pageSpaceToolsStubbed: {},
   extractMessageContent: vi.fn().mockReturnValue('test content'),
   extractToolCalls: vi.fn().mockReturnValue([]),
   extractToolResults: vi.fn().mockReturnValue([]),
@@ -263,6 +264,10 @@ vi.mock('@/lib/ai/core/tool-utils', () => ({
 vi.mock('@/lib/ai/tools/finish-tool', () => ({
   finishTool: {},
   FINISH_TOOL_NAME: 'finish',
+}));
+
+vi.mock('@/lib/ai/tools/tool-search-tool', () => ({
+  createToolSearchTool: vi.fn().mockReturnValue({}),
 }));
 
 import { POST } from '../route';

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/stream-socket-events.test.ts
@@ -156,6 +156,7 @@ vi.mock('@/lib/ai/core', () => ({
   isProviderError: vi.fn().mockReturnValue(false),
   pageSpaceTools: {},
   pageSpaceToolsStubbed: {},
+  TOOL_DISCOVERY_PROMPT: 'TOOLS: mock',
   extractMessageContent: vi.fn().mockReturnValue('test content'),
   extractToolCalls: vi.fn().mockReturnValue([]),
   extractToolResults: vi.fn().mockReturnValue([]),

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -29,6 +29,7 @@ import {
   buildMentionSystemPrompt,
   buildTimestampSystemPrompt,
   buildSystemPrompt,
+  TOOL_DISCOVERY_PROMPT,
   buildAgentAwarenessPrompt,
   filterToolsForReadOnly,
   filterToolsForWebSearch,
@@ -591,8 +592,8 @@ export async function POST(
       }
     }
 
-    // Add global assistant specific instructions
-    const systemPrompt = baseSystemPrompt + mentionSystemPrompt + timestampSystemPrompt + `
+    // Add global assistant specific instructions (including tool discovery — only this route has tool_search)
+    const systemPrompt = baseSystemPrompt + '\n\n' + TOOL_DISCOVERY_PROMPT + mentionSystemPrompt + timestampSystemPrompt + `
 
 You are the Global Assistant for PageSpace - accessible from both the dashboard and sidebar.
 

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -18,6 +18,7 @@ import {
   isProviderError,
   type ProviderRequest,
   pageSpaceTools,
+  pageSpaceToolsStubbed,
   extractMessageContent,
   extractToolCalls,
   extractToolResults,
@@ -64,6 +65,7 @@ import {
 import { pipeUIMessageStreamStrippingStart } from '@/lib/ai/core/stream-pipe-utils';
 import { validateUserMessageFileParts, hasFileParts } from '@/lib/ai/core/validate-image-parts';
 import { hasVisionCapability } from '@/lib/ai/core/model-capabilities';
+import { createToolSearchTool } from '@/lib/ai/tools/tool-search-tool';
 
 // Allow streaming responses up to 5 minutes
 export const maxDuration = 300;
@@ -690,10 +692,25 @@ MENTION PROCESSING:
       + (agentAwarenessPrompt ? '\n\n' + agentAwarenessPrompt : '')
       + pageTreePrompt;
 
-    // Filter tools based on read-only mode and web search toggle
-    const postReadOnlyTools = filterToolsForReadOnly(pageSpaceTools, readOnlyMode);
+    // Filter tools based on read-only mode and web search toggle.
+    // Non-core tools use passthrough stub schemas to reduce context window usage (~7–16k tokens/request).
+    // The AI calls tool_search to get full parameter schemas before using non-core tools.
+    const postReadOnlyTools = filterToolsForReadOnly(pageSpaceToolsStubbed, readOnlyMode);
     // Apply web search filtering (exclude web_search if disabled)
     let finalTools: ToolSet = filterToolsForWebSearch(postReadOnlyTools, webSearchMode) as ToolSet;
+
+    // Inject tool_search scoped to the currently-enabled PageSpace tools (full schemas).
+    // Using the filtered key set prevents tool_search from advertising tools that are
+    // unavailable in this request (e.g. write tools in read-only, web_search when disabled).
+    const enabledFullSchemaTools = Object.fromEntries(
+      Object.keys(finalTools)
+        .filter((name) => name in pageSpaceTools)
+        .map((name) => [name, pageSpaceTools[name as keyof typeof pageSpaceTools]])
+    ) as ToolSet;
+    finalTools = {
+      ...finalTools,
+      tool_search: createToolSearchTool(enabledFullSchemaTools),
+    } as ToolSet;
 
     loggers.api.debug('Global Assistant Chat API: Tool modes', {
       isReadOnly: readOnlyMode,

--- a/apps/web/src/lib/ai/core/system-prompt.ts
+++ b/apps/web/src/lib/ai/core/system-prompt.ts
@@ -36,7 +36,7 @@ STYLE:
 • Be concise but conversational - like a knowledgeable colleague
 • Match user energy - conversational when exploring, efficient when executing`;
 
-const TOOL_DISCOVERY_PROMPT = `TOOLS:
+export const TOOL_DISCOVERY_PROMPT = `TOOLS:
 • Core tools are always ready: list/read drives and pages, search, create, edit content
 • For other tools (calendar, agents, channels, tasks, etc.): call tool_search("keyword") or tool_search("select:tool_name") first to get the full parameter schema`;
 
@@ -131,7 +131,6 @@ export function buildSystemPrompt(
     personalizationPrompt,
     contextPrompt,
     BEHAVIOR_PROMPT,
-    TOOL_DISCOVERY_PROMPT,
     isReadOnly ? READ_ONLY_CONSTRAINT : null,
   ].filter(Boolean);
 


### PR DESCRIPTION
## Summary

- **Moves** stub schemas + \`tool_search\` from the page AI chat route to the global assistant route — the correct target (receives all 37 tools on every request, ~7–16k tokens/turn saved)
- **Reverts** the stub/tool_search pattern from \`/api/ai/chat/route.ts\` (page agents are selectively configured per-agent, not appropriate for global discovery)
- **Closes a security gap**: adds server-side enforcement of \`page.enabledTools\` in the page AI chat route. Previously, the allowlist was only used to seed client-side toggles; the server never restricted execution. Agents could reach tools outside their configured allowlist. Now, when \`enabledTools\` is a non-empty array, only those tools are made available to the model (still intersected with \`isReadOnly\`/\`webSearchEnabled\` filters so read-only mode always wins)
- **Scopes \`TOOL_DISCOVERY_PROMPT\`** to the global assistant only. The shared \`buildSystemPrompt\` no longer includes tool-discovery instructions; the global assistant appends them explicitly after \`baseSystemPrompt\`. This prevents page agents from being instructed to call \`tool_search\`, which is not registered in their tool set

## What changed

| File | Change |
|------|--------|
| \`apps/web/src/app/api/ai/global/[id]/messages/route.ts\` | Use \`pageSpaceToolsStubbed\`, inject \`tool_search\`, append \`TOOL_DISCOVERY_PROMPT\` |
| \`apps/web/src/app/api/ai/chat/route.ts\` | Revert to \`pageSpaceTools\`; add \`page.enabledTools\` allowlist enforcement |
| \`apps/web/src/lib/ai/core/system-prompt.ts\` | Export \`TOOL_DISCOVERY_PROMPT\`; remove it from shared \`buildSystemPrompt\` sections |
| \`chat/__tests__/mcp-scope.test.ts\` | Remove stubs/tool_search mocks |
| \`chat/__tests__/stream-socket-events.test.ts\` | Remove stubs/tool_search mocks |
| \`global/[id]/messages/__tests__/stream-socket-events.test.ts\` | Add \`pageSpaceToolsStubbed\` + \`createToolSearchTool\` mocks |

## Infrastructure

All underlying infrastructure (\`stub-tools.ts\`, \`tool-search-tool.ts\`, \`pageSpaceToolsStubbed\`) landed in #1301 and is unchanged.

## Test plan

- [x] \`src/app/api/ai/chat/__tests__\` — 20 tests pass
- [x] \`src/app/api/ai/global/**/__tests__\` — 91 tests pass
- [x] \`src/lib/ai/**/__tests__\` — 733 tests pass (includes system-prompt.test.ts)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured AI tool management system for improved filtering and per-page access controls.
  * Updated tool discovery mechanism in AI chat and messaging routes.
  * Refactored system prompt composition for better tool discovery handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1306)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->