### PR TITLE
fix(channel,dm): preserve line breaks in messages

### DIFF
--- a/apps/web/src/components/ai/shared/__tests__/StreamingMarkdown.test.tsx
+++ b/apps/web/src/components/ai/shared/__tests__/StreamingMarkdown.test.tsx
@@ -28,7 +28,7 @@ vi.mock('streamdown', () => ({
 }));
 
 // Import after mocking
-import { StreamingMarkdown } from '../chat/StreamingMarkdown';
+import { StreamingMarkdown, addHardLineBreaks } from '../chat/StreamingMarkdown';
 
 interface MarkdownNode {
   type: string;
@@ -261,6 +261,40 @@ describe('raw HTML rendering', () => {
       { type: 'text', value: ' ' },
       { type: 'text', value: '<style>' },
     ]);
+  });
+});
+
+describe('addHardLineBreaks', () => {
+  it('converts a single newline to a CommonMark hard line break', () => {
+    expect(addHardLineBreaks('line1\nline2')).toBe('line1  \nline2');
+  });
+
+  it('leaves paragraph breaks (double newline) untouched', () => {
+    expect(addHardLineBreaks('para1\n\npara2')).toBe('para1\n\npara2');
+  });
+
+  it('converts multiple single newlines independently', () => {
+    expect(addHardLineBreaks('a\nb\nc')).toBe('a  \nb  \nc');
+  });
+
+  it('handles mixed single and double newlines', () => {
+    expect(addHardLineBreaks('a\nb\n\nc')).toBe('a  \nb\n\nc');
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(addHardLineBreaks('')).toBe('');
+  });
+
+  it('returns a single-line string unchanged', () => {
+    expect(addHardLineBreaks('no newlines here')).toBe('no newlines here');
+  });
+
+  it('does not modify a leading newline', () => {
+    expect(addHardLineBreaks('\ntext')).toBe('\ntext');
+  });
+
+  it('does not modify a trailing newline', () => {
+    expect(addHardLineBreaks('text\n')).toBe('text\n');
   });
 });
 

--- a/apps/web/src/components/ai/shared/chat/StreamingMarkdown.tsx
+++ b/apps/web/src/components/ai/shared/chat/StreamingMarkdown.tsx
@@ -35,6 +35,13 @@ function preprocessMentions(content: string): string {
   });
 }
 
+/** Converts single \n to CommonMark hard line breaks (two trailing spaces + \n).
+ * Leaves \n\n paragraph breaks untouched. Use for user-typed content only —
+ * not AI-generated markdown where \n has structural meaning (lists, code blocks). */
+export function addHardLineBreaks(content: string): string {
+  return content.replace(/(?<=[^\n])\n(?=[^\n])/g, '  \n');
+}
+
 interface MarkdownNode {
   type: string;
   value?: string;

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -6,7 +6,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { usePermissions, getPermissionErrorMessage } from '@/hooks/usePermissions';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { TreePage, MessageWithUser } from '@/hooks/usePageTree';
-import { StreamingMarkdown } from '@/components/ai/shared/chat/StreamingMarkdown';
+import { StreamingMarkdown, addHardLineBreaks } from '@/components/ai/shared/chat/StreamingMarkdown';
 import {
   Conversation,
   ConversationContent,
@@ -529,7 +529,7 @@ function ChannelView({ page }: ChannelViewProps) {
           </div>
           {m.content && (
             <div className="prose prose-sm dark:prose-invert max-w-none">
-              <StreamingMarkdown content={m.content} isStreaming={false} />
+              <StreamingMarkdown content={addHardLineBreaks(m.content)} isStreaming={false} />
             </div>
           )}
           <MessageAttachment message={m} />
@@ -680,7 +680,7 @@ function ChannelView({ page }: ChannelViewProps) {
                                     )}
                                     {m.content && (
                                       <div className="prose prose-sm dark:prose-invert max-w-none break-words [overflow-wrap:anywhere] min-w-0">
-                                        <StreamingMarkdown content={m.content} isStreaming={false} />
+                                        <StreamingMarkdown content={addHardLineBreaks(m.content)} isStreaming={false} />
                                       </div>
                                     )}
                                     {!isFirst && m.editedAt && (

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -529,7 +529,7 @@ function ChannelView({ page }: ChannelViewProps) {
           </div>
           {m.content && (
             <div className="prose prose-sm dark:prose-invert max-w-none">
-              <StreamingMarkdown content={addHardLineBreaks(m.content)} isStreaming={false} />
+              <StreamingMarkdown content={isAi ? m.content : addHardLineBreaks(m.content)} isStreaming={false} />
             </div>
           )}
           <MessageAttachment message={m} />
@@ -680,7 +680,7 @@ function ChannelView({ page }: ChannelViewProps) {
                                     )}
                                     {m.content && (
                                       <div className="prose prose-sm dark:prose-invert max-w-none break-words [overflow-wrap:anywhere] min-w-0">
-                                        <StreamingMarkdown content={addHardLineBreaks(m.content)} isStreaming={false} />
+                                        <StreamingMarkdown content={isAi ? m.content : addHardLineBreaks(m.content)} isStreaming={false} />
                                       </div>
                                     )}
                                     {!isFirst && m.editedAt && (

--- a/apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx
@@ -27,7 +27,7 @@ import useSWR from 'swr';
 import { Bell, BellOff, X } from 'lucide-react';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
-import { StreamingMarkdown } from '@/components/ai/shared/chat/StreamingMarkdown';
+import { StreamingMarkdown, addHardLineBreaks } from '@/components/ai/shared/chat/StreamingMarkdown';
 import { MessageAttachment } from '@/components/shared/MessageAttachment';
 import { MessageInput } from '@/components/shared/MessageInput';
 import { fetchWithAuth, post } from '@/lib/auth/auth-fetch';
@@ -530,7 +530,7 @@ export function ThreadPanel({
                   {reply.content && (
                     <div className="prose prose-sm dark:prose-invert max-w-none break-words [overflow-wrap:anywhere]">
                       {source === 'channel' ? (
-                        <StreamingMarkdown content={reply.content} isStreaming={false} />
+                        <StreamingMarkdown content={addHardLineBreaks(reply.content)} isStreaming={false} />
                       ) : (
                         renderMessageParts(convertToMessageParts(reply.content))
                       )}

--- a/apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx
@@ -530,7 +530,7 @@ export function ThreadPanel({
                   {reply.content && (
                     <div className="prose prose-sm dark:prose-invert max-w-none break-words [overflow-wrap:anywhere]">
                       {source === 'channel' ? (
-                        <StreamingMarkdown content={addHardLineBreaks(reply.content)} isStreaming={false} />
+                        <StreamingMarkdown content={reply.aiSenderName ? reply.content : addHardLineBreaks(reply.content)} isStreaming={false} />
                       ) : (
                         renderMessageParts(convertToMessageParts(reply.content))
                       )}

--- a/apps/web/src/components/messages/MessagePartRenderer.tsx
+++ b/apps/web/src/components/messages/MessagePartRenderer.tsx
@@ -77,10 +77,10 @@ const MessagePartRenderer: React.FC<MessagePartRendererProps> = ({ part, index }
 
       // If no mentions found, just return the plain text
       if (textElements.length === 0) {
-        return <span key={index} className="break-words [overflow-wrap:anywhere]">{text}</span>;
+        return <span key={index} className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{text}</span>;
       }
 
-      return <span key={index} className="break-words [overflow-wrap:anywhere]">{textElements}</span>;
+      return <span key={index} className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{textElements}</span>;
 
     case 'rich-text':
       const textContent = typeof part.content === 'string'


### PR DESCRIPTION
## Summary

- Channel messages rendered via StreamingMarkdown/Streamdown collapsed `\n` to spaces per CommonMark soft-break rules — adds `addHardLineBreaks()` utility that converts single newlines to two-space hard breaks, applied at the channel and thread call sites only (not globally, so AI-generated markdown lists/code blocks are unaffected)
- DM messages rendered via `MessagePartRenderer` were missing `whitespace-pre-wrap` on the `text` case spans, causing the browser to collapse `\n` to spaces — adds the class to match the existing `rich-text` case

## Files changed

| File | Change |
|------|--------|
| `StreamingMarkdown.tsx` | Export `addHardLineBreaks()` utility |
| `ChannelView.tsx` | Apply preprocessing to both channel message render sites |
| `ThreadPanel.tsx` | Apply preprocessing for channel-source thread replies |
| `MessagePartRenderer.tsx` | Add `whitespace-pre-wrap` to `text` case spans |

## Test plan

- [ ] Send a channel message with Shift+Enter line breaks — verify they render as visible line breaks
- [ ] Send a DM with Shift+Enter line breaks — verify same
- [ ] Open a thread and reply with line breaks in both channel and DM contexts
- [ ] Verify AI responses in AI Chat are unaffected (no corruption of code blocks or lists)
- [ ] Verify `\n\n` paragraph spacing still works in channel markdown messages

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Convert single newlines in user-authored messages into visible hard line breaks for clearer formatting in channels, threads, and message views (AI-authored messages unchanged).

* **Bug Fixes**
  * Preserve whitespace and line-wrapping for plain-text message parts to retain intended spacing and improve readability.
  * Added tests covering newline-to-hard-break behavior across various input scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1309)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->