### PR TITLE
feat(calendar): RSVP accept/maybe/decline in event modal

### DIFF
--- a/apps/web/src/components/calendar/CalendarView.tsx
+++ b/apps/web/src/components/calendar/CalendarView.tsx
@@ -273,7 +273,7 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
 
   const handleRsvp = useCallback(async (status: AttendeeStatus) => {
     if (!selectedEvent) return;
-    await updateRsvp(selectedEvent.id, status);
+    const previousEvent = selectedEvent;
     setSelectedEvent((prev) =>
       prev
         ? {
@@ -286,6 +286,12 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
           }
         : null,
     );
+    try {
+      await updateRsvp(selectedEvent.id, status);
+    } catch {
+      setSelectedEvent(previousEvent);
+      throw new Error('Failed to update RSVP');
+    }
   }, [selectedEvent, updateRsvp, currentUserId]);
 
   // Get header title based on view mode

--- a/apps/web/src/components/calendar/CalendarView.tsx
+++ b/apps/web/src/components/calendar/CalendarView.tsx
@@ -27,12 +27,14 @@ import { MobileCalendarView } from './MobileCalendarView';
 import { EventModal } from './EventModal';
 import { CalendarSidebar } from './CalendarSidebar';
 import {
+  AttendeeStatus,
   CalendarViewMode,
   CalendarEvent,
   CalendarHandlers,
   EventColorConfig,
   getDriveCalendarColor,
 } from './calendar-types';
+import { useAuthStore } from '@/stores/useAuthStore';
 
 interface CalendarViewProps {
   context: 'user' | 'drive';
@@ -70,6 +72,8 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
     allDay: boolean;
   } | null>(null);
 
+  const currentUserId = useAuthStore((s) => s.user?.id);
+
   const {
     events,
     tasks,
@@ -78,6 +82,7 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
     createEvent,
     updateEvent,
     deleteEvent,
+    updateRsvp,
     refresh: _refresh,
   } = useCalendarData({
     context,
@@ -266,6 +271,23 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
     setIsEventModalOpen(false);
   };
 
+  const handleRsvp = useCallback(async (status: AttendeeStatus) => {
+    if (!selectedEvent) return;
+    await updateRsvp(selectedEvent.id, status);
+    setSelectedEvent((prev) =>
+      prev
+        ? {
+            ...prev,
+            attendees: prev.attendees.map((a) =>
+              a.userId === currentUserId
+                ? { ...a, status, respondedAt: new Date().toISOString() }
+                : a,
+            ),
+          }
+        : null,
+    );
+  }, [selectedEvent, updateRsvp, currentUserId]);
+
   // Get header title based on view mode
   const getHeaderTitle = () => {
     switch (viewMode) {
@@ -316,6 +338,7 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
           defaultValues={newEventDefaults}
           onSave={handleEventSave}
           onDelete={selectedEvent ? async () => { await handlers.onEventDelete(selectedEvent.id); } : undefined}
+          onRsvp={handleRsvp}
           driveId={driveId}
           context={context}
         />
@@ -576,6 +599,7 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
         defaultValues={newEventDefaults}
         onSave={handleEventSave}
         onDelete={selectedEvent ? async () => { await handlers.onEventDelete(selectedEvent.id); } : undefined}
+        onRsvp={handleRsvp}
         driveId={driveId}
         context={context}
       />

--- a/apps/web/src/components/calendar/EventModal.tsx
+++ b/apps/web/src/components/calendar/EventModal.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useMemo } from 'react';
 import { format } from 'date-fns';
-import { AlertCircle, Bot, CalendarIcon, ChevronRight, Clock, MapPin, Trash2, Zap } from 'lucide-react';
+import { AlertCircle, Bot, CalendarIcon, Check, ChevronRight, CircleHelp, Clock, MapPin, Trash2, X, Zap } from 'lucide-react';
 import { toast } from 'sonner';
 import useSWR from 'swr';
 import {
@@ -40,7 +40,8 @@ import { cn } from '@/lib/utils';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useEditingStore } from '@/stores/useEditingStore';
 import { useEditingSession } from '@/stores/useEditingSession';
-import { CalendarEvent, EVENT_COLORS } from './calendar-types';
+import { useAuthStore } from '@/stores/useAuthStore';
+import { AttendeeStatus, CalendarEvent, EVENT_COLORS } from './calendar-types';
 import { TriggerPagePicker } from '@/components/layout/middle-content/page-views/task-list/TriggerPagePicker';
 import {
   AgentTriggerSection,
@@ -77,6 +78,7 @@ interface EventModalProps {
     agentTrigger?: AgentTriggerSavePayload | null;
   }) => Promise<void>;
   onDelete?: () => Promise<void>;
+  onRsvp?: (status: AttendeeStatus) => Promise<void>;
   driveId?: string;
   context: 'user' | 'drive';
 }
@@ -138,6 +140,7 @@ export function EventModal({
   defaultValues,
   onSave,
   onDelete,
+  onRsvp,
   driveId,
   context,
 }: EventModalProps) {
@@ -160,6 +163,25 @@ export function EventModal({
   const [allDay, setAllDay] = useState(false);
   const [color, setColor] = useState<keyof typeof EVENT_COLORS>('default');
   const [isSaving, setIsSaving] = useState(false);
+  const [rsvpLoading, setRsvpLoading] = useState(false);
+
+  const currentUserId = useAuthStore((s) => s.user?.id);
+  const myAttendee = useMemo(
+    () => event?.attendees.find((a) => a.userId === currentUserId) ?? null,
+    [event, currentUserId],
+  );
+
+  const handleRsvp = async (status: AttendeeStatus) => {
+    if (!onRsvp) return;
+    setRsvpLoading(true);
+    try {
+      await onRsvp(status);
+    } catch {
+      toast.error('Failed to update RSVP');
+    } finally {
+      setRsvpLoading(false);
+    }
+  };
 
   // Agent trigger state
   const [agentEnabled, setAgentEnabled] = useState(false);
@@ -412,7 +434,7 @@ export function EventModal({
           </DialogDescription>
         </DialogHeader>
 
-        <fieldset disabled={isSaving}>
+        <fieldset disabled={isSaving || rsvpLoading}>
           <div className="space-y-4 py-4">
             {/* Title */}
             <div className="space-y-2">
@@ -425,6 +447,45 @@ export function EventModal({
                 autoFocus
               />
             </div>
+
+          {/* RSVP section — only shown when the current user is an attendee */}
+          {myAttendee && onRsvp && (
+            <div className="space-y-2 rounded-md border p-3">
+              <Label className="text-sm font-medium">Your RSVP</Label>
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={myAttendee.status === 'ACCEPTED' ? 'default' : 'outline'}
+                  onClick={() => handleRsvp('ACCEPTED')}
+                  disabled={rsvpLoading}
+                >
+                  <Check className="h-3.5 w-3.5 mr-1.5" />
+                  Accept
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={myAttendee.status === 'TENTATIVE' ? 'secondary' : 'outline'}
+                  onClick={() => handleRsvp('TENTATIVE')}
+                  disabled={rsvpLoading}
+                >
+                  <CircleHelp className="h-3.5 w-3.5 mr-1.5" />
+                  Maybe
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={myAttendee.status === 'DECLINED' ? 'destructive' : 'outline'}
+                  onClick={() => handleRsvp('DECLINED')}
+                  disabled={rsvpLoading}
+                >
+                  <X className="h-3.5 w-3.5 mr-1.5" />
+                  Decline
+                </Button>
+              </div>
+            </div>
+          )}
 
           {/* All-day toggle */}
           <div className="flex items-center justify-between">

--- a/apps/web/src/components/calendar/EventModal.tsx
+++ b/apps/web/src/components/calendar/EventModal.tsx
@@ -449,7 +449,6 @@ export function EventModal({
               />
             </div>
 
-            {/* RSVP section — only shown when the current user is a non-organizer attendee */}
             {myAttendee && onRsvp && (
               <div className="space-y-2 rounded-md border p-3">
                 <Label className="text-sm font-medium">Your RSVP</Label>

--- a/apps/web/src/components/calendar/EventModal.tsx
+++ b/apps/web/src/components/calendar/EventModal.tsx
@@ -167,7 +167,7 @@ export function EventModal({
 
   const currentUserId = useAuthStore((s) => s.user?.id);
   const myAttendee = useMemo(
-    () => event?.attendees.find((a) => a.userId === currentUserId) ?? null,
+    () => event?.attendees.find((a) => a.userId === currentUserId && !a.isOrganizer) ?? null,
     [event, currentUserId],
   );
 
@@ -176,6 +176,7 @@ export function EventModal({
     setRsvpLoading(true);
     try {
       await onRsvp(status);
+      toast.success('RSVP updated');
     } catch {
       toast.error('Failed to update RSVP');
     } finally {
@@ -448,44 +449,41 @@ export function EventModal({
               />
             </div>
 
-          {/* RSVP section — only shown when the current user is an attendee */}
-          {myAttendee && onRsvp && (
-            <div className="space-y-2 rounded-md border p-3">
-              <Label className="text-sm font-medium">Your RSVP</Label>
-              <div className="flex gap-2">
-                <Button
-                  type="button"
-                  size="sm"
-                  variant={myAttendee.status === 'ACCEPTED' ? 'default' : 'outline'}
-                  onClick={() => handleRsvp('ACCEPTED')}
-                  disabled={rsvpLoading}
-                >
-                  <Check className="h-3.5 w-3.5 mr-1.5" />
-                  Accept
-                </Button>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant={myAttendee.status === 'TENTATIVE' ? 'secondary' : 'outline'}
-                  onClick={() => handleRsvp('TENTATIVE')}
-                  disabled={rsvpLoading}
-                >
-                  <CircleHelp className="h-3.5 w-3.5 mr-1.5" />
-                  Maybe
-                </Button>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant={myAttendee.status === 'DECLINED' ? 'destructive' : 'outline'}
-                  onClick={() => handleRsvp('DECLINED')}
-                  disabled={rsvpLoading}
-                >
-                  <X className="h-3.5 w-3.5 mr-1.5" />
-                  Decline
-                </Button>
+            {/* RSVP section — only shown when the current user is a non-organizer attendee */}
+            {myAttendee && onRsvp && (
+              <div className="space-y-2 rounded-md border p-3">
+                <Label className="text-sm font-medium">Your RSVP</Label>
+                <div className="flex gap-2">
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant={myAttendee.status === 'ACCEPTED' ? 'default' : 'outline'}
+                    onClick={() => handleRsvp('ACCEPTED')}
+                  >
+                    <Check className="h-3.5 w-3.5 mr-1.5" />
+                    Accept
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant={myAttendee.status === 'TENTATIVE' ? 'secondary' : 'outline'}
+                    onClick={() => handleRsvp('TENTATIVE')}
+                  >
+                    <CircleHelp className="h-3.5 w-3.5 mr-1.5" />
+                    Maybe
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant={myAttendee.status === 'DECLINED' ? 'destructive' : 'outline'}
+                    onClick={() => handleRsvp('DECLINED')}
+                  >
+                    <X className="h-3.5 w-3.5 mr-1.5" />
+                    Decline
+                  </Button>
+                </div>
               </div>
-            </div>
-          )}
+            )}
 
           {/* All-day toggle */}
           <div className="flex items-center justify-between">

--- a/apps/web/src/components/calendar/__tests__/EventModal.test.tsx
+++ b/apps/web/src/components/calendar/__tests__/EventModal.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { SWRConfig, mutate as globalMutate } from 'swr';
 import { assert } from '@/stores/__tests__/riteway';
 import { useEditingStore } from '@/stores/useEditingStore';
-import { CalendarEvent } from '../calendar-types';
+import { CalendarEvent, CalendarEventAttendee } from '../calendar-types';
 
 vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
@@ -28,6 +28,7 @@ vi.mock(
 );
 
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import * as authStoreModule from '@/stores/useAuthStore';
 import { EventModal } from '../EventModal';
 
 const DRIVE_ID = 'drive-1';
@@ -359,6 +360,185 @@ describe('EventModal — agent trigger disclosure', () => {
       should: 'preserve the in-progress prompt rather than clobbering it with the refetched value',
       actual: promptInput.value,
       expected: 'in-flight typing',
+    });
+  });
+});
+
+const attendeeFixture = (overrides: Partial<CalendarEventAttendee> = {}): CalendarEventAttendee => ({
+  id: 'att-1',
+  eventId: EVENT_ID,
+  userId: 'user-2',
+  status: 'PENDING',
+  responseNote: null,
+  isOrganizer: false,
+  isOptional: false,
+  invitedAt: '2026-05-04T00:00:00Z',
+  respondedAt: null,
+  user: { id: 'user-2', name: 'Attendee', image: null },
+  ...overrides,
+});
+
+const mockUseAuthStore = (userId: string) => {
+  vi.spyOn(authStoreModule, 'useAuthStore').mockImplementation((selector: unknown) => {
+    const state = { user: { id: userId } };
+    return typeof selector === 'function' ? (selector as (s: typeof state) => unknown)(state) : state;
+  });
+};
+
+describe('EventModal — RSVP section', () => {
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useEditingStore.getState().clearAllSessions();
+    mockUseAuthStore('user-2');
+    cannedFetch({ trigger: null });
+  });
+
+  const renderWithRsvp = (
+    attendees: CalendarEvent['attendees'],
+    onRsvp = vi.fn<(status: string) => Promise<void>>(async () => undefined),
+  ) =>
+    render(
+      <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+        <EventModal
+          isOpen
+          onClose={() => {}}
+          event={baseEvent({ attendees })}
+          defaultValues={null}
+          onSave={async () => undefined}
+          onRsvp={onRsvp}
+          driveId={DRIVE_ID}
+          context="drive"
+        />
+      </SWRConfig>,
+    );
+
+  test('shows RSVP section when current user is a non-organizer attendee', async () => {
+    renderWithRsvp([attendeeFixture({ userId: 'user-2', isOrganizer: false })]);
+
+    const section = await screen.findByText('Your RSVP');
+
+    assert({
+      given: 'an event where the current user is a non-organizer attendee',
+      should: 'render the RSVP section',
+      actual: !!section,
+      expected: true,
+    });
+
+    assert({
+      given: 'the RSVP section is visible',
+      should: 'render Accept, Maybe, and Decline buttons',
+      actual: [
+        !!screen.queryByRole('button', { name: /Accept/i }),
+        !!screen.queryByRole('button', { name: /Maybe/i }),
+        !!screen.queryByRole('button', { name: /Decline/i }),
+      ],
+      expected: [true, true, true],
+    });
+  });
+
+  test('hides RSVP section when current user is the organizer', async () => {
+    mockUseAuthStore('user-1');
+    renderWithRsvp([attendeeFixture({ userId: 'user-1', isOrganizer: true })]);
+
+    await screen.findByText('Edit Event');
+
+    assert({
+      given: 'an event where the current user is the organizer',
+      should: 'not render the RSVP section',
+      actual: screen.queryByText('Your RSVP'),
+      expected: null,
+    });
+  });
+
+  test('hides RSVP section when user is not an attendee', async () => {
+    renderWithRsvp([]);
+
+    await screen.findByText('Edit Event');
+
+    assert({
+      given: 'an event where the current user is not an attendee',
+      should: 'not render the RSVP section',
+      actual: screen.queryByText('Your RSVP'),
+      expected: null,
+    });
+  });
+
+  test('clicking Accept calls onRsvp with ACCEPTED', async () => {
+    const onRsvp = vi.fn<(status: string) => Promise<void>>(async () => undefined);
+    renderWithRsvp([attendeeFixture({ userId: 'user-2', status: 'PENDING' })], onRsvp);
+
+    await userEvent.click(await screen.findByRole('button', { name: /Accept/i }));
+
+    assert({
+      given: 'clicking the Accept button',
+      should: 'call onRsvp with ACCEPTED',
+      actual: onRsvp.mock.calls[0]?.[0],
+      expected: 'ACCEPTED',
+    });
+  });
+
+  test('clicking Maybe calls onRsvp with TENTATIVE', async () => {
+    const onRsvp = vi.fn<(status: string) => Promise<void>>(async () => undefined);
+    renderWithRsvp([attendeeFixture({ userId: 'user-2', status: 'PENDING' })], onRsvp);
+
+    await userEvent.click(await screen.findByRole('button', { name: /Maybe/i }));
+
+    assert({
+      given: 'clicking the Maybe button',
+      should: 'call onRsvp with TENTATIVE',
+      actual: onRsvp.mock.calls[0]?.[0],
+      expected: 'TENTATIVE',
+    });
+  });
+
+  test('clicking Decline calls onRsvp with DECLINED', async () => {
+    const onRsvp = vi.fn<(status: string) => Promise<void>>(async () => undefined);
+    renderWithRsvp([attendeeFixture({ userId: 'user-2', status: 'PENDING' })], onRsvp);
+
+    await userEvent.click(await screen.findByRole('button', { name: /Decline/i }));
+
+    assert({
+      given: 'clicking the Decline button',
+      should: 'call onRsvp with DECLINED',
+      actual: onRsvp.mock.calls[0]?.[0],
+      expected: 'DECLINED',
+    });
+  });
+
+  test('shows success toast after RSVP update', async () => {
+    const { toast } = await import('sonner');
+    const onRsvp = vi.fn<(status: string) => Promise<void>>(async () => undefined);
+    renderWithRsvp([attendeeFixture({ userId: 'user-2' })], onRsvp);
+
+    await userEvent.click(await screen.findByRole('button', { name: /Accept/i }));
+
+    await waitFor(() => {
+      assert({
+        given: 'a successful RSVP update',
+        should: 'show a success toast',
+        actual: vi.mocked(toast.success).mock.calls.some((c) => String(c[0]).includes('RSVP')),
+        expected: true,
+      });
+    });
+  });
+
+  test('shows error toast when onRsvp throws', async () => {
+    const { toast } = await import('sonner');
+    const onRsvp = vi.fn<(status: string) => Promise<void>>(async () => {
+      throw new Error('network error');
+    });
+    renderWithRsvp([attendeeFixture({ userId: 'user-2' })], onRsvp);
+
+    await userEvent.click(await screen.findByRole('button', { name: /Accept/i }));
+
+    await waitFor(() => {
+      assert({
+        given: 'onRsvp throws an error',
+        should: 'show an error toast',
+        actual: vi.mocked(toast.error).mock.calls.some((c) => String(c[0]).includes('RSVP')),
+        expected: true,
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds an **Accept / Maybe / Decline** RSVP section to the EventModal that appears only when the current user is a non-organizer attendee of the event
- Active status button is visually highlighted (Accept = filled/default, Maybe = secondary, Decline = destructive)
- Truly optimistic update on \`selectedEvent\` in CalendarView: local state updates immediately, network call follows, rollback on failure — needed because \`useEditingSession\` pauses SWR re-fetches while the modal is open
- Wired to the pre-existing \`updateRsvp\` hook in \`useCalendarData\` and backend \`PATCH /api/calendar/events/[eventId]/attendees\`

## What was already in place

The entire backend was implemented but nothing called it from the UI:
- \`event_attendees\` table with \`status: PENDING | ACCEPTED | DECLINED | TENTATIVE\`
- \`PATCH /api/calendar/events/[eventId]/attendees\` API route
- \`updateRsvp\` hook in \`useCalendarData\`
- \`rsvp_calendar_event\` MCP tool

## Changes

| File | Change |
|------|--------|
| \`apps/web/src/components/calendar/EventModal.tsx\` | Add \`onRsvp\` prop, derive \`myAttendee\` (excludes organizer), render RSVP button group |
| \`apps/web/src/components/calendar/CalendarView.tsx\` | Destructure \`updateRsvp\`, add \`handleRsvp\` with optimistic update + rollback, pass to both modal instances |
| \`apps/web/src/components/calendar/__tests__/EventModal.test.tsx\` | Add 8 tests covering: show/hide for attendee/organizer/non-attendee, Accept/Maybe/Decline calls, success and error toasts |

## Test plan

- [ ] As an invitee (non-organizer), open an event — RSVP section appears with Accept / Maybe / Decline
- [ ] Click each button — active button highlights immediately (optimistic), success toast appears
- [ ] Reload page — status persists
- [ ] As the event creator (organizer), open the same event — no RSVP section shown
- [ ] As a non-attendee, open the event — no RSVP section shown
- [ ] Verify mobile EventModal also shows RSVP section correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can respond to calendar event invitations directly from the event modal with Accept, Maybe, or Decline; responses save automatically and show success/error notifications.
  * RSVP actions update the displayed event immediately for faster feedback.

* **Tests**
  * Added coverage verifying RSVP UI visibility, button behavior, and success/error notifications.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1311)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->