### PR TITLE
fix(ai): always mark pagespace provider as available

### DIFF
--- a/apps/web/src/app/api/ai/settings/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/settings/__tests__/route.test.ts
@@ -113,9 +113,11 @@ describe('AI settings route', () => {
 
       expect(response.status).toBe(200);
       expect(body.providers.anthropic.isAvailable).toBe(false);
-      expect(body.providers.pagespace.isAvailable).toBe(false);
+      // pagespace is always available — it is PageSpace's own hosted backend
+      expect(body.providers.pagespace.isAvailable).toBe(true);
       expect(body.providers.openai.isAvailable).toBe(false);
-      expect(body.isAnyProviderConfigured).toBe(false);
+      // pagespace always available means isAnyProviderConfigured is always true
+      expect(body.isAnyProviderConfigured).toBe(true);
     });
 
     it('reports isAnyProviderConfigured true when at least one provider has an env key', async () => {

--- a/apps/web/src/lib/ai/core/ai-utils.ts
+++ b/apps/web/src/lib/ai/core/ai-utils.ts
@@ -124,7 +124,9 @@ export function isProviderAvailable(
     return false;
   }
   if (provider === 'pagespace') {
-    return true;
+    // Cloud: pagespace is always available as the hosted backend.
+    // On-prem: still requires explicit backend credential config.
+    return !options.isOnPrem || getDefaultPageSpaceSettings() !== null;
   }
   return getManagedProviderKey(provider) !== null;
 }

--- a/apps/web/src/lib/ai/core/ai-utils.ts
+++ b/apps/web/src/lib/ai/core/ai-utils.ts
@@ -124,7 +124,7 @@ export function isProviderAvailable(
     return false;
   }
   if (provider === 'pagespace') {
-    return getDefaultPageSpaceSettings() !== null;
+    return true;
   }
   return getManagedProviderKey(provider) !== null;
 }


### PR DESCRIPTION
## Summary

- `isProviderAvailable('pagespace', ...)` was gated behind `getDefaultPageSpaceSettings() !== null`, which checks for backend env vars (`GLM_DEFAULT_API_KEY`, `GOOGLE_AI_DEFAULT_API_KEY`, `OPENROUTER_DEFAULT_API_KEY`)
- In cloud deployments none of these may be set as explicit env vars, causing the provider to be reported as unavailable — triggering "(Setup Required)" in the agent AI settings tab even when the endpoint works
- Fix: pagespace now returns `!options.isOnPrem || getDefaultPageSpaceSettings() !== null` — always available in cloud/SaaS mode, still env-var-gated on on-prem where backend credentials must be explicitly configured

## Test plan

- [ ] Open an agent page in a cloud deployment, go to AI settings tab — pagespace provider shows no "(Setup Required)" label and is not disabled in the dropdown
- [ ] On-prem deployment without backend keys: pagespace still shows "(Setup Required)" (preserving existing behavior)
- [ ] Other providers without deployment keys (e.g. `openai` without `OPENAI_DEFAULT_API_KEY`) still show "(Setup Required)"
- [ ] Chat with a pagespace-backed agent still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pagespace provider is now consistently available in cloud environments, improving access and reliability while on-premise availability remains governed by local settings.

* **Tests**
  * API contract tests updated to reflect pagespace availability and that a provider is considered configured even when no external API keys are set.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1312)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->