### PR TITLE
fix(ai): unwrap execute_tool in chat renderers

### DIFF
--- a/apps/web/src/components/ai/shared/chat/tool-calls/CompactToolCallRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/CompactToolCallRenderer.tsx
@@ -837,6 +837,8 @@ export const CompactToolCallRenderer: React.FC<CompactToolCallRendererProps> = m
     }
   }
 
+  if (toolName === 'tool_search') return null;
+
   if (toolName === 'update_task') return <TaskRenderer part={resolvedPart} />;
   return <CompactToolCallRendererInternal part={resolvedPart} toolName={toolName} />;
 });

--- a/apps/web/src/components/ai/shared/chat/tool-calls/CompactToolCallRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/CompactToolCallRenderer.tsx
@@ -823,12 +823,20 @@ const CompactToolCallRendererInternal: React.FC<{ part: ToolPart; toolName: stri
 });
 
 export const CompactToolCallRenderer: React.FC<CompactToolCallRendererProps> = memo(function CompactToolCallRenderer({ part }) {
-  const toolName = part.toolName || part.type?.replace('tool-', '') || '';
+  let toolName = part.toolName || part.type?.replace('tool-', '') || '';
+  let resolvedPart = part;
 
-  // Task management tools - render with TaskRenderer
-  if (toolName === 'update_task') {
-    return <TaskRenderer part={part} />;
+  if (toolName === 'tool_search') return null;
+
+  if (toolName === 'execute_tool') {
+    const raw = safeJsonParse(part.input);
+    const innerName = typeof raw?.tool_name === 'string' ? raw.tool_name : null;
+    if (innerName) {
+      toolName = innerName;
+      resolvedPart = { ...part, input: raw?.parameters ?? {} };
+    }
   }
 
-  return <CompactToolCallRendererInternal part={part} toolName={toolName} />;
+  if (toolName === 'update_task') return <TaskRenderer part={resolvedPart} />;
+  return <CompactToolCallRendererInternal part={resolvedPart} toolName={toolName} />;
 });

--- a/apps/web/src/components/ai/shared/chat/tool-calls/ToolCallRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/ToolCallRenderer.tsx
@@ -815,17 +815,21 @@ const ToolCallRendererInternal: React.FC<{ part: ToolPart; toolName: string }> =
 });
 
 export const ToolCallRenderer: React.FC<ToolCallRendererProps> = memo(function ToolCallRenderer({ part }) {
-  const toolName = part.toolName || part.type?.replace('tool-', '') || 'unknown_tool';
+  let toolName = part.toolName || part.type?.replace('tool-', '') || 'unknown_tool';
+  let resolvedPart = part;
 
-  // Task management - has its own dedicated renderer
-  if (toolName === 'update_task') {
-    return <TaskRenderer part={part} />;
+  if (toolName === 'tool_search') return null;
+
+  if (toolName === 'execute_tool') {
+    const raw = safeJsonParse(part.input);
+    const innerName = typeof raw?.tool_name === 'string' ? raw.tool_name : null;
+    if (innerName) {
+      toolName = innerName;
+      resolvedPart = { ...part, input: raw?.parameters ?? {} };
+    }
   }
 
-  // Ask Agent - has its own conversation UI
-  if (toolName === 'ask_agent') {
-    return <PageAgentConversationRenderer part={part} />;
-  }
-
-  return <ToolCallRendererInternal part={part} toolName={toolName} />;
+  if (toolName === 'update_task') return <TaskRenderer part={resolvedPart} />;
+  if (toolName === 'ask_agent') return <PageAgentConversationRenderer part={resolvedPart} />;
+  return <ToolCallRendererInternal part={resolvedPart} toolName={toolName} />;
 });

--- a/apps/web/src/components/ai/shared/chat/tool-calls/ToolCallRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/ToolCallRenderer.tsx
@@ -829,6 +829,8 @@ export const ToolCallRenderer: React.FC<ToolCallRendererProps> = memo(function T
     }
   }
 
+  if (toolName === 'tool_search') return null;
+
   if (toolName === 'update_task') return <TaskRenderer part={resolvedPart} />;
   if (toolName === 'ask_agent') return <PageAgentConversationRenderer part={resolvedPart} />;
   return <ToolCallRendererInternal part={resolvedPart} toolName={toolName} />;


### PR DESCRIPTION
## Summary

- `execute_tool` dispatcher calls are now transparently unwrapped in both `ToolCallRenderer` and `CompactToolCallRenderer` — the UI shows the actual underlying tool (e.g. "Create Page", "Web Search") instead of "Execute Tool"
- `tool_search` calls are hidden entirely — schema discovery is an implementation detail users don't need to see
- Special-case routing (`update_task` → `TaskRenderer`, `ask_agent` → `PageAgentConversationRenderer`) still applies correctly after unwrap

## Test plan

- [ ] Trigger a non-core tool via global AI chat (e.g. "create a new workspace") — card should show "Create Workspace" not "Execute Tool"
- [ ] Trigger a flow that requires `tool_search` — nothing should render in the UI for it
- [ ] Trigger `update_task` via `execute_tool` — `TaskRenderer` should still fire
- [ ] Trigger a core tool directly (e.g. `list_pages`) — existing rendering unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of nested tool calls in the AI chat so inner tool names and parameters are correctly detected and used.
  * Skips rendering unsupported search tool calls to avoid spurious UI output.
  * Ensures task updates and agent interactions are routed and displayed consistently after resolving the actual tool and payload.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1314)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->