### PR TITLE
feat(calendar): invite drive members to events from EventModal

### DIFF
--- a/apps/web/src/components/calendar/CalendarView.tsx
+++ b/apps/web/src/components/calendar/CalendarView.tsx
@@ -83,6 +83,8 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
     updateEvent,
     deleteEvent,
     updateRsvp,
+    addAttendees,
+    removeAttendee,
     refresh: _refresh,
   } = useCalendarData({
     context,
@@ -294,6 +296,59 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
     }
   }, [selectedEvent, updateRsvp, currentUserId]);
 
+  const handleAddAttendee = useCallback(
+    async (userId: string) => {
+      if (!selectedEvent) return;
+      const prevEvent = selectedEvent;
+      setSelectedEvent((prev) =>
+        prev
+          ? {
+              ...prev,
+              attendees: [
+                ...prev.attendees,
+                {
+                  id: userId,
+                  eventId: prev.id,
+                  userId,
+                  status: 'PENDING' as const,
+                  responseNote: null,
+                  isOrganizer: false,
+                  isOptional: false,
+                  invitedAt: new Date().toISOString(),
+                  respondedAt: null,
+                  user: { id: userId, name: null, image: null },
+                },
+              ],
+            }
+          : null
+      );
+      try {
+        await addAttendees(selectedEvent.id, [userId]);
+      } catch {
+        setSelectedEvent(prevEvent);
+        throw new Error('Failed to add attendee');
+      }
+    },
+    [selectedEvent, addAttendees]
+  );
+
+  const handleRemoveAttendee = useCallback(
+    async (userId: string) => {
+      if (!selectedEvent) return;
+      const prevEvent = selectedEvent;
+      setSelectedEvent((prev) =>
+        prev ? { ...prev, attendees: prev.attendees.filter((a) => a.userId !== userId) } : null
+      );
+      try {
+        await removeAttendee(selectedEvent.id, userId);
+      } catch {
+        setSelectedEvent(prevEvent);
+        throw new Error('Failed to remove attendee');
+      }
+    },
+    [selectedEvent, removeAttendee]
+  );
+
   // Get header title based on view mode
   const getHeaderTitle = () => {
     switch (viewMode) {
@@ -345,6 +400,8 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
           onSave={handleEventSave}
           onDelete={selectedEvent ? async () => { await handlers.onEventDelete(selectedEvent.id); } : undefined}
           onRsvp={handleRsvp}
+          onAddAttendee={handleAddAttendee}
+          onRemoveAttendee={handleRemoveAttendee}
           driveId={driveId}
           context={context}
         />
@@ -606,6 +663,8 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
         onSave={handleEventSave}
         onDelete={selectedEvent ? async () => { await handlers.onEventDelete(selectedEvent.id); } : undefined}
         onRsvp={handleRsvp}
+        onAddAttendee={handleAddAttendee}
+        onRemoveAttendee={handleRemoveAttendee}
         driveId={driveId}
         context={context}
       />

--- a/apps/web/src/components/calendar/EventModal.tsx
+++ b/apps/web/src/components/calendar/EventModal.tsx
@@ -309,8 +309,12 @@ export function EventModal({
   const agents = useMemo(() => agentsData?.agents ?? [], [agentsData]);
   const noAgents = !agentsLoading && agents.length === 0;
 
-  // Fetch drive members for the attendee picker (drive events only)
-  const assigneesKey = isOpen && isDriveContext && driveId ? `/api/drives/${driveId}/assignees` : null;
+  // Attendees make sense whenever the event has a drive association. Derive from the event
+  // itself when editing so the section works even in user-context CalendarView.
+  const effectiveDriveId = event?.driveId ?? driveId;
+  const showAttendeesSection = !!effectiveDriveId;
+
+  const assigneesKey = isOpen && showAttendeesSection ? `/api/drives/${effectiveDriveId}/assignees` : null;
   const { data: assigneesData } = useSWR<AssigneesResponse>(assigneesKey, assigneesFetcher, {
     revalidateOnFocus: false,
   });
@@ -416,7 +420,11 @@ export function EventModal({
 
   const handleAddAttendee = async (userId: string) => {
     if (event) {
-      await onAddAttendee?.(userId);
+      try {
+        await onAddAttendee?.(userId);
+      } catch {
+        toast.error('Failed to add attendee');
+      }
     } else {
       const member = driveUsers.find((u) => u.id === userId);
       setPendingAttendees((prev) => {
@@ -442,7 +450,11 @@ export function EventModal({
 
   const handleRemoveAttendee = async (userId: string) => {
     if (event) {
-      await onRemoveAttendee?.(userId);
+      try {
+        await onRemoveAttendee?.(userId);
+      } catch {
+        toast.error('Failed to remove attendee');
+      }
     } else {
       setPendingAttendees((prev) => prev.filter((a) => a.userId !== userId));
     }
@@ -763,8 +775,8 @@ export function EventModal({
             />
           </div>
 
-          {/* Attendees — drive events only */}
-          {isDriveContext && (
+          {/* Attendees — drive events only (gate on actual driveId, not view context) */}
+          {showAttendeesSection && (
             <div className="space-y-2 rounded-md border p-3">
               <Label className="text-sm font-medium">Attendees</Label>
               {shownAttendees.length > 0 && (
@@ -793,6 +805,7 @@ export function EventModal({
                             size="icon"
                             variant="ghost"
                             className="h-5 w-5"
+                            aria-label={`Remove ${a.user.name ?? a.userId}`}
                             onClick={() => handleRemoveAttendee(a.userId)}
                           >
                             <X className="h-3 w-3" />

--- a/apps/web/src/components/calendar/EventModal.tsx
+++ b/apps/web/src/components/calendar/EventModal.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useMemo } from 'react';
 import { format } from 'date-fns';
-import { AlertCircle, Bot, CalendarIcon, Check, ChevronRight, CircleHelp, Clock, MapPin, Trash2, X, Zap } from 'lucide-react';
+import { AlertCircle, Bot, CalendarIcon, Check, ChevronRight, CircleHelp, Clock, MapPin, Trash2, UserPlus, X, Zap } from 'lucide-react';
 import { toast } from 'sonner';
 import useSWR from 'swr';
 import {
@@ -41,7 +41,17 @@ import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useEditingStore } from '@/stores/useEditingStore';
 import { useEditingSession } from '@/stores/useEditingSession';
 import { useAuthStore } from '@/stores/useAuthStore';
-import { AttendeeStatus, CalendarEvent, EVENT_COLORS } from './calendar-types';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { AttendeeStatus, CalendarEvent, CalendarEventAttendee, ATTENDEE_STATUS_CONFIG, EVENT_COLORS } from './calendar-types';
 import { TriggerPagePicker } from '@/components/layout/middle-content/page-views/task-list/TriggerPagePicker';
 import {
   AgentTriggerSection,
@@ -55,6 +65,62 @@ export type AgentTriggerSavePayload = {
   instructionPageId: string | null;
   contextPageIds: string[];
 };
+
+interface AssigneesResponse {
+  assignees: Array<{ id: string; type: 'user' | 'agent'; name: string | null; image: string | null }>;
+}
+
+const assigneesFetcher = async (url: string): Promise<AssigneesResponse> => {
+  const res = await fetchWithAuth(url);
+  if (!res.ok) throw new Error('Failed to load assignees');
+  return res.json();
+};
+
+interface AttendeeComboboxProps {
+  users: Array<{ id: string; name: string | null; image: string | null }>;
+  onAdd: (userId: string) => void;
+}
+
+function AttendeeCombobox({ users, onAdd }: AttendeeComboboxProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button type="button" variant="outline" size="sm" className="w-full justify-start text-muted-foreground">
+          <UserPlus className="h-4 w-4 mr-2" />
+          Add attendee
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-64 p-0" align="start">
+        <Command>
+          <CommandInput placeholder="Search members…" />
+          <CommandList>
+            <CommandEmpty>No members found</CommandEmpty>
+            <CommandGroup>
+              {users.map((user) => (
+                <CommandItem
+                  key={user.id}
+                  value={user.name ?? user.id}
+                  onSelect={() => {
+                    onAdd(user.id);
+                    setOpen(false);
+                  }}
+                >
+                  <Avatar className="h-5 w-5 mr-2">
+                    {user.image && <AvatarImage src={user.image} />}
+                    <AvatarFallback className="text-xs">{(user.name ?? '?')[0].toUpperCase()}</AvatarFallback>
+                  </Avatar>
+                  {user.name ?? user.id}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
 
 interface EventModalProps {
   isOpen: boolean;
@@ -79,6 +145,8 @@ interface EventModalProps {
   }) => Promise<void>;
   onDelete?: () => Promise<void>;
   onRsvp?: (status: AttendeeStatus) => Promise<void>;
+  onAddAttendee?: (userId: string) => Promise<void>;
+  onRemoveAttendee?: (userId: string) => Promise<void>;
   driveId?: string;
   context: 'user' | 'drive';
 }
@@ -141,6 +209,8 @@ export function EventModal({
   onSave,
   onDelete,
   onRsvp,
+  onAddAttendee,
+  onRemoveAttendee,
   driveId,
   context,
 }: EventModalProps) {
@@ -183,6 +253,9 @@ export function EventModal({
       setRsvpLoading(false);
     }
   };
+
+  // Attendee state (pending list for new events)
+  const [pendingAttendees, setPendingAttendees] = useState<CalendarEventAttendee[]>([]);
 
   // Agent trigger state
   const [agentEnabled, setAgentEnabled] = useState(false);
@@ -235,6 +308,16 @@ export function EventModal({
 
   const agents = useMemo(() => agentsData?.agents ?? [], [agentsData]);
   const noAgents = !agentsLoading && agents.length === 0;
+
+  // Fetch drive members for the attendee picker (drive events only)
+  const assigneesKey = isOpen && isDriveContext && driveId ? `/api/drives/${driveId}/assignees` : null;
+  const { data: assigneesData } = useSWR<AssigneesResponse>(assigneesKey, assigneesFetcher, {
+    revalidateOnFocus: false,
+  });
+  const driveUsers = useMemo(
+    () => (assigneesData?.assignees ?? []).filter((a) => a.type === 'user'),
+    [assigneesData]
+  );
   const existingTrigger = triggerData?.trigger ?? null;
   const existingStatus: LastRunStatus | null = existingTrigger
     ? lastRunStatusFor(existingTrigger)
@@ -289,6 +372,7 @@ export function EventModal({
       }
       setAdvancedExpanded(false);
       setAgentExpanded(false);
+      setPendingAttendees([]);
     } else {
       triggerLoadedRef.current = false;
       agentsLoadedRef.current = false;
@@ -322,6 +406,47 @@ export function EventModal({
     const found = agents.find((a) => a.id === agentValue.agentPageId);
     return found?.title ?? null;
   }, [agentEnabled, agents, agentValue.agentPageId]);
+
+  const isCreator = !event || event.createdById === currentUserId;
+  const shownAttendees = (event?.attendees ?? pendingAttendees).filter((a) => !a.isOrganizer);
+  const existingAttendeeUserIds = event
+    ? event.attendees.map((a) => a.userId)
+    : pendingAttendees.map((a) => a.userId);
+  const availableUsers = driveUsers.filter((u) => !existingAttendeeUserIds.includes(u.id));
+
+  const handleAddAttendee = async (userId: string) => {
+    if (event) {
+      await onAddAttendee?.(userId);
+    } else {
+      const member = driveUsers.find((u) => u.id === userId);
+      setPendingAttendees((prev) => {
+        if (prev.some((a) => a.userId === userId)) return prev;
+        return [
+          ...prev,
+          {
+            id: userId,
+            eventId: '',
+            userId,
+            status: 'PENDING' as const,
+            responseNote: null,
+            isOrganizer: false,
+            isOptional: false,
+            invitedAt: new Date().toISOString(),
+            respondedAt: null,
+            user: { id: userId, name: member?.name ?? null, image: member?.image ?? null },
+          },
+        ];
+      });
+    }
+  };
+
+  const handleRemoveAttendee = async (userId: string) => {
+    if (event) {
+      await onRemoveAttendee?.(userId);
+    } else {
+      setPendingAttendees((prev) => prev.filter((a) => a.userId !== userId));
+    }
+  };
 
   const buildDateTime = (date: Date, time: string): Date => {
     const [hours, minutes] = time.split(':').map(Number);
@@ -391,6 +516,9 @@ export function EventModal({
         color,
         pageId: isDriveContext ? linkedPageId : undefined,
         agentTrigger,
+        attendeeIds: !event && pendingAttendees.length > 0
+          ? pendingAttendees.map((a) => a.userId)
+          : undefined,
       });
       toast.success(isEditing ? 'Event updated' : 'Event created');
       onClose();
@@ -634,6 +762,55 @@ export function EventModal({
               rows={3}
             />
           </div>
+
+          {/* Attendees — drive events only */}
+          {isDriveContext && (
+            <div className="space-y-2 rounded-md border p-3">
+              <Label className="text-sm font-medium">Attendees</Label>
+              {shownAttendees.length > 0 && (
+                <div className="space-y-1">
+                  {shownAttendees.map((a) => (
+                    <div key={a.userId} className="flex items-center justify-between gap-2 text-sm">
+                      <div className="flex items-center gap-2 min-w-0">
+                        <Avatar className="h-5 w-5 shrink-0">
+                          {a.user.image && <AvatarImage src={a.user.image} />}
+                          <AvatarFallback className="text-xs">
+                            {(a.user.name ?? '?')[0].toUpperCase()}
+                          </AvatarFallback>
+                        </Avatar>
+                        <span className="truncate">{a.user.name ?? a.userId}</span>
+                      </div>
+                      <div className="flex items-center gap-1 shrink-0">
+                        <Badge
+                          variant="outline"
+                          className={cn('text-xs', ATTENDEE_STATUS_CONFIG[a.status].color)}
+                        >
+                          {ATTENDEE_STATUS_CONFIG[a.status].label}
+                        </Badge>
+                        {isCreator && (
+                          <Button
+                            type="button"
+                            size="icon"
+                            variant="ghost"
+                            className="h-5 w-5"
+                            onClick={() => handleRemoveAttendee(a.userId)}
+                          >
+                            <X className="h-3 w-3" />
+                          </Button>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+              {isCreator && (
+                <AttendeeCombobox
+                  users={availableUsers}
+                  onAdd={handleAddAttendee}
+                />
+              )}
+            </div>
+          )}
 
           {/* Agent trigger — collapsed by default; only meaningful for drive events.
               Status text reflects whether a trigger is configured so the modal

--- a/apps/web/src/components/calendar/useCalendarData.ts
+++ b/apps/web/src/components/calendar/useCalendarData.ts
@@ -204,6 +204,22 @@ export function useCalendarData({
     [eventsUrl]
   );
 
+  const addAttendees = useCallback(
+    async (eventId: string, userIds: string[], isOptional = false) => {
+      await post(`/api/calendar/events/${eventId}/attendees`, { userIds, isOptional });
+      mutate(eventsUrl);
+    },
+    [eventsUrl]
+  );
+
+  const removeAttendee = useCallback(
+    async (eventId: string, userId: string) => {
+      await del(`/api/calendar/events/${eventId}/attendees?userId=${userId}`);
+      mutate(eventsUrl);
+    },
+    [eventsUrl]
+  );
+
   // Refresh data
   const refresh = useCallback(() => {
     mutate(eventsUrl);
@@ -231,6 +247,8 @@ export function useCalendarData({
     updateEvent,
     deleteEvent,
     updateRsvp,
+    addAttendees,
+    removeAttendee,
     refresh,
   };
 }


### PR DESCRIPTION
## Summary

Adds drive member invite management to the EventModal. Users can now add and remove attendees from drive events directly in the calendar event form.

- **useCalendarData**: `addAttendees(eventId, userIds, isOptional?)` and `removeAttendee(eventId, userId)` using existing `post`/`del` imports
- **EventModal**: attendee section (drive events — gated on `event?.driveId ?? driveId` so it works from both the drive and user-context calendars); inline `AttendeeCombobox` (Popover + Command) fetching drive members from `/api/drives/${effectiveDriveId}/assignees`; pending-attendee local state for new events; `attendeeIds` in `onSave` payload; RSVP status badges; accessible remove button
- **CalendarView**: `handleAddAttendee` / `handleRemoveAttendee` with optimistic updates and rollback, wired to both desktop and mobile EventModal instances alongside the existing `onRsvp` handler from #1311

## Acceptance criteria

- [x] Drive event, new: Attendees section appears with combobox to add drive members
- [x] Drive event, new: Selecting a member adds them to the list immediately (local state)
- [x] Drive event, new: Removing a pending attendee before save works
- [x] Drive event, new: Saving includes `attendeeIds` in the payload
- [x] Drive event, existing (as creator): Attendees section shows list with RSVP status badges
- [x] Drive event, existing (as creator): Can add a new drive member → appears immediately (optimistic)
- [x] Drive event, existing (as creator): Can remove an attendee → disappears immediately (optimistic)
- [x] Drive event, existing (as non-creator attendee): Attendees section is read-only
- [x] Personal event: No attendees section visible
- [x] Drive event opened from user-context calendar: Attendees section visible (gated on `event.driveId`, not view context)
- [x] `pnpm typecheck` passes with no new errors

## Test plan

- [ ] Create a drive event, add drive members in the combobox, save — reload and confirm attendees persist
- [ ] Open the same event as creator, remove an attendee — optimistic removal, confirmed on reload
- [ ] Open event as a non-creator attendee — confirm no add/remove buttons, RSVP buttons still visible
- [ ] Create a personal event — confirm no attendees section
- [ ] Open a drive event from `/dashboard/calendar` (user-context view) — confirm attendees section appears
- [ ] Verify RSVP buttons (from #1311) still work alongside the new attendee section

## Review changes

- **Drive context gate**: Changed from `isDriveContext` (view context prop) to `event?.driveId ?? driveId` so drive events opened from the user calendar also show attendee UI
- **Error handling**: `handleAddAttendee`/`handleRemoveAttendee` now wrap API calls in try/catch with `toast.error` feedback
- **Accessibility**: Remove-attendee button now has `aria-label="Remove {name}"` for screen readers

🤖 Generated with [Claude Code](https://claude.com/claude-code)