### PR TITLE
feat(calendar): agent triggers on recurring events

### DIFF
--- a/apps/web/src/app/api/calendar/events/[eventId]/__tests__/patch-agent-trigger.test.ts
+++ b/apps/web/src/app/api/calendar/events/[eventId]/__tests__/patch-agent-trigger.test.ts
@@ -49,6 +49,7 @@ vi.mock('@/lib/workflows/calendar-trigger-helpers', () => ({
   upsertCalendarTriggerWorkflowInTx: vi.fn().mockResolvedValue({ workflowId: 'wf-1', triggerId: 'trg-1' }),
   removeCalendarTrigger: vi.fn().mockResolvedValue(undefined),
   validateCalendarAgentTrigger: vi.fn().mockResolvedValue({ agentPageId: 'agent-1' }),
+  resyncCalendarTriggerTimings: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('../../../../../../lib/ai/core/timestamp-utils', () => ({
@@ -92,6 +93,7 @@ import {
   upsertCalendarTriggerWorkflowInTx,
   removeCalendarTrigger,
   validateCalendarAgentTrigger,
+  resyncCalendarTriggerTimings,
 } from '@/lib/workflows/calendar-trigger-helpers';
 
 const USER_ID = 'user_creator';
@@ -276,6 +278,38 @@ describe('PATCH /api/calendar/events/[eventId] agentTrigger', () => {
         recurrenceRule: { frequency: 'WEEKLY', interval: 1 },
         recurrenceExceptions: [],
       }),
+    );
+  });
+
+  it('calls resyncCalendarTriggerTimings — not upsertCalendarTriggerWorkflowInTx — when only startAt changes on a recurring event', async () => {
+    // Regression: the old code updated all unfired trigger rows to the same
+    // adjustedStartAt, collapsing all occurrences onto one timestamp. Now the
+    // route delegates timing re-sync to resyncCalendarTriggerTimings which
+    // does a proper occurrence re-expansion for recurring events.
+    const recurringEvent = {
+      ...baseEvent,
+      recurrenceRule: { frequency: 'WEEKLY', interval: 1 },
+      recurrenceExceptions: [] as string[],
+    };
+    setupSuccessfulPatch();
+    (db.query.calendarEvents.findFirst as Mock).mockReset();
+    (db.query.calendarEvents.findFirst as Mock)
+      .mockResolvedValueOnce(recurringEvent)
+      .mockResolvedValueOnce(recurringEvent);
+
+    const res = await PATCH(makeRequest({
+      startAt: '2026-06-01T10:00:00Z',
+      endAt: '2026-06-01T11:00:00Z',
+    }), ctx());
+
+    expect(res.status).toBe(200);
+    expect(upsertCalendarTriggerWorkflowInTx).not.toHaveBeenCalled();
+    expect(resyncCalendarTriggerTimings).toHaveBeenCalledWith(
+      expect.anything(),
+      EVENT_ID,
+      expect.any(Date),
+      expect.objectContaining({ frequency: 'WEEKLY' }),
+      [],
     );
   });
 });

--- a/apps/web/src/app/api/calendar/events/[eventId]/__tests__/patch-agent-trigger.test.ts
+++ b/apps/web/src/app/api/calendar/events/[eventId]/__tests__/patch-agent-trigger.test.ts
@@ -249,8 +249,17 @@ describe('PATCH /api/calendar/events/[eventId] agentTrigger', () => {
     expect(upsertCalendarTriggerWorkflowInTx).not.toHaveBeenCalled();
   });
 
-  it('rejects an agent-trigger upsert on a recurring event', async () => {
-    const recurringEvent = { ...baseEvent, recurrenceRule: { frequency: 'WEEKLY', interval: 1 } };
+  it('allows an agent-trigger upsert on a recurring event and passes recurrenceRule to the helper', async () => {
+    // Recurring events now support agent triggers — the recurrence rule is
+    // expanded into individual trigger rows by the helper. The PATCH route
+    // must pass recurrenceRule (and recurrenceExceptions) to the helper so
+    // it can do the expansion.
+    const recurringEvent = {
+      ...baseEvent,
+      recurrenceRule: { frequency: 'WEEKLY', interval: 1 },
+      recurrenceExceptions: [] as string[],
+    };
+    setupSuccessfulPatch();
     (db.query.calendarEvents.findFirst as Mock).mockReset();
     (db.query.calendarEvents.findFirst as Mock)
       .mockResolvedValueOnce(recurringEvent)
@@ -260,8 +269,13 @@ describe('PATCH /api/calendar/events/[eventId] agentTrigger', () => {
       agentTrigger: { agentPageId: 'agent-1', prompt: 'p' },
     }), ctx());
 
-    expect(res.status).toBe(400);
-    expect((await res.json()).error).toMatch(/recur/i);
-    expect(upsertCalendarTriggerWorkflowInTx).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect(upsertCalendarTriggerWorkflowInTx).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        recurrenceRule: { frequency: 'WEEKLY', interval: 1 },
+        recurrenceExceptions: [],
+      }),
+    );
   });
 });

--- a/apps/web/src/app/api/calendar/events/[eventId]/route.ts
+++ b/apps/web/src/app/api/calendar/events/[eventId]/route.ts
@@ -1,10 +1,8 @@
 import { NextResponse, after } from 'next/server';
 import { z } from 'zod';
 import { db } from '@pagespace/db/db'
-import { eq, and, sql } from '@pagespace/db/operators'
+import { eq, and } from '@pagespace/db/operators'
 import { calendarEvents, eventAttendees } from '@pagespace/db/schema/calendar';
-import { calendarTriggers } from '@pagespace/db/schema/calendar-triggers';
-import { workflowRuns } from '@pagespace/db/schema/workflow-runs';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope } from '@/lib/auth';
@@ -14,6 +12,7 @@ import { pushEventUpdateToGoogle, pushEventDeleteToGoogle } from '@/lib/integrat
 import { isNaiveISODatetime, parseNaiveDatetimeInTimezone } from '@/lib/ai/core/timestamp-utils';
 import {
   removeCalendarTrigger,
+  resyncCalendarTriggerTimings,
   upsertCalendarTriggerWorkflowInTx,
   validateCalendarAgentTrigger,
 } from '@/lib/workflows/calendar-trigger-helpers';
@@ -291,34 +290,16 @@ export async function PATCH(
         .where(eq(calendarEvents.id, eventId))
         .returning();
 
-      if (adjustedStartAt && data.agentTrigger === undefined) {
-        // Caller didn't touch the trigger payload — keep the existing
-        // re-aim semantics: only triggers that haven't been processed yet
-        // get their triggerAt bumped. If the caller IS upserting the
-        // trigger this tick, the upsert below will set triggerAt itself
-        // and there's no point doing the re-aim sweep.
-        await tx
-          .update(calendarTriggers)
-          .set({ triggerAt: adjustedStartAt })
-          .where(and(
-            eq(calendarTriggers.calendarEventId, eventId),
-            sql`NOT EXISTS (
-              SELECT 1 FROM ${workflowRuns}
-              WHERE ${workflowRuns.sourceTable} = 'calendarTriggers'
-                AND ${workflowRuns.sourceId} = ${calendarTriggers.id}
-            )`,
-          ));
-      }
+      // Effective recurrence rule after the update (undefined = unchanged).
+      const effectiveRecurrenceRule = data.recurrenceRule !== undefined
+        ? data.recurrenceRule
+        : event.recurrenceRule;
 
       // Apply agentTrigger changes inside the same tx so partial writes
       // can't leave the event mutated but the trigger out of sync.
       if (data.agentTrigger === null) {
         await removeCalendarTrigger(tx, eventId);
       } else if (data.agentTrigger && event.driveId) {
-        // Effective recurrence rule after the update (data.recurrenceRule=undefined means unchanged)
-        const effectiveRecurrenceRule = data.recurrenceRule !== undefined
-          ? data.recurrenceRule
-          : event.recurrenceRule;
         await upsertCalendarTriggerWorkflowInTx(tx, {
           driveId: event.driveId,
           scheduledById: userId,
@@ -329,6 +310,17 @@ export async function PATCH(
           recurrenceRule: effectiveRecurrenceRule,
           recurrenceExceptions: event.recurrenceExceptions ?? [],
         });
+      } else if (data.agentTrigger === undefined && (adjustedStartAt || data.recurrenceRule !== undefined)) {
+        // Caller didn't touch agentTrigger but timing/recurrence changed.
+        // For recurring events: re-expand the full occurrence series.
+        // For one-shot events: re-aim the single pending trigger row.
+        await resyncCalendarTriggerTimings(
+          tx,
+          eventId,
+          newStartAt,
+          effectiveRecurrenceRule,
+          event.recurrenceExceptions ?? [],
+        );
       }
 
       return result;

--- a/apps/web/src/app/api/calendar/events/[eventId]/route.ts
+++ b/apps/web/src/app/api/calendar/events/[eventId]/route.ts
@@ -250,18 +250,6 @@ export async function PATCH(
       );
     }
 
-    // Reject agent-trigger upserts on recurring events. The cron poller
-    // fires one-shot occurrences, so attaching one trigger to a recurring
-    // event would silently misfire on every occurrence past the first.
-    // Mirrors the POST /events and PUT /triggers guards.
-    const willBeRecurring = data.recurrenceRule !== undefined ? data.recurrenceRule !== null : event.recurrenceRule !== null;
-    if (data.agentTrigger && willBeRecurring) {
-      return NextResponse.json(
-        { error: 'Agent triggers are not supported for recurring events' },
-        { status: 400 }
-      );
-    }
-
     // Pre-validate agent trigger before opening the event update tx so a bad
     // payload (off-drive agent / context page, missing prompt-or-instruction)
     // returns 400 without dirtying event state.
@@ -327,6 +315,10 @@ export async function PATCH(
       if (data.agentTrigger === null) {
         await removeCalendarTrigger(tx, eventId);
       } else if (data.agentTrigger && event.driveId) {
+        // Effective recurrence rule after the update (data.recurrenceRule=undefined means unchanged)
+        const effectiveRecurrenceRule = data.recurrenceRule !== undefined
+          ? data.recurrenceRule
+          : event.recurrenceRule;
         await upsertCalendarTriggerWorkflowInTx(tx, {
           driveId: event.driveId,
           scheduledById: userId,
@@ -334,6 +326,8 @@ export async function PATCH(
           triggerAt: newStartAt,
           timezone: data.timezone ?? event.timezone ?? 'UTC',
           agentTrigger: data.agentTrigger,
+          recurrenceRule: effectiveRecurrenceRule,
+          recurrenceExceptions: event.recurrenceExceptions ?? [],
         });
       }
 

--- a/apps/web/src/app/api/calendar/events/[eventId]/triggers/__tests__/route.test.ts
+++ b/apps/web/src/app/api/calendar/events/[eventId]/triggers/__tests__/route.test.ts
@@ -231,15 +231,22 @@ describe('PUT /api/calendar/events/[eventId]/triggers', () => {
     expect(upsertCalendarTriggerWorkflow).not.toHaveBeenCalled();
   });
 
-  it('rejects an upsert on a recurring event', async () => {
+  it('accepts an upsert on a recurring event and passes recurrenceRule to the helper', async () => {
+    // Recurring events now support agent triggers — this PR adds that capability.
     (db.query.calendarEvents.findFirst as Mock).mockResolvedValue({
       ...baseEvent,
       recurrenceRule: { frequency: 'WEEKLY', interval: 1 },
+      recurrenceExceptions: [],
     });
     const res = await PUT(mkRequest('PUT', { agentPageId: 'agent-1', prompt: 'p' }), ctx());
-    expect(res.status).toBe(400);
-    expect((await res.json()).error).toMatch(/recur/i);
-    expect(upsertCalendarTriggerWorkflow).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect(upsertCalendarTriggerWorkflow).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        recurrenceRule: { frequency: 'WEEKLY', interval: 1 },
+        recurrenceExceptions: [],
+      }),
+    );
   });
 
   it('returns 403 when an outsider asks', async () => {

--- a/apps/web/src/app/api/calendar/events/[eventId]/triggers/route.ts
+++ b/apps/web/src/app/api/calendar/events/[eventId]/triggers/route.ts
@@ -172,16 +172,6 @@ export async function PUT(request: Request, context: { params: Promise<{ eventId
     );
   }
 
-  // Reject recurring events. The cron poller fires one-shot occurrences, so
-  // attaching one trigger to a recurring event would silently misfire on
-  // every occurrence past the first. Mirrors the POST /events guard.
-  if (event.recurrenceRule) {
-    return NextResponse.json(
-      { error: 'Agent triggers are not supported for recurring events' },
-      { status: 400 }
-    );
-  }
-
   const canManage = await canManageEventTrigger(userId, event);
   if (!canManage) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
@@ -195,6 +185,8 @@ export async function PUT(request: Request, context: { params: Promise<{ eventId
       triggerAt: event.startAt,
       timezone: event.timezone ?? 'UTC',
       agentTrigger: parsed.data,
+      recurrenceRule: event.recurrenceRule,
+      recurrenceExceptions: event.recurrenceExceptions ?? [],
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Failed to save trigger';

--- a/apps/web/src/app/api/calendar/events/__tests__/post-agent-trigger.test.ts
+++ b/apps/web/src/app/api/calendar/events/__tests__/post-agent-trigger.test.ts
@@ -70,7 +70,9 @@ vi.mock('@pagespace/db/schema/workflows', () => ({ workflows: { id: 'id' } }));
 vi.mock('@pagespace/db/schema/workflow-runs', () => ({ workflowRuns: { id: 'id', sourceTable: 'sourceTable', sourceId: 'sourceId' } }));
 
 vi.mock('@/lib/workflows/calendar-trigger-helpers', () => ({
-  createCalendarTriggerWorkflow: vi.fn().mockResolvedValue({ workflowId: 'wf-1', triggerId: 'trg-1' }),
+  // POST route uses upsertCalendarTriggerWorkflowInTx (not createCalendarTriggerWorkflow)
+  // since recurring and one-shot events share the same upsert path in this branch.
+  upsertCalendarTriggerWorkflowInTx: vi.fn().mockResolvedValue({ workflowId: 'wf-1', triggerId: 'trg-1' }),
   validateCalendarAgentTrigger: vi.fn().mockResolvedValue({ agentPageId: 'agent-1' }),
 }));
 
@@ -124,7 +126,7 @@ import { POST } from '../route';
 import { db } from '@pagespace/db/db';
 import { authenticateRequestWithOptions } from '@/lib/auth';
 import {
-  createCalendarTriggerWorkflow,
+  upsertCalendarTriggerWorkflowInTx,
   validateCalendarAgentTrigger,
 } from '@/lib/workflows/calendar-trigger-helpers';
 
@@ -177,7 +179,7 @@ describe('POST /api/calendar/events — agent trigger context', () => {
     });
   });
 
-  it('forwards agentTrigger.instructionPageId and contextPageIds to createCalendarTriggerWorkflow', async () => {
+  it('forwards agentTrigger.instructionPageId and contextPageIds to upsertCalendarTriggerWorkflowInTx', async () => {
     const res = await POST(makeRequest({
       driveId: DRIVE_ID,
       title: 'Standup with prep',
@@ -206,7 +208,8 @@ describe('POST /api/calendar/events — agent trigger context', () => {
       }),
     );
 
-    expect(createCalendarTriggerWorkflow).toHaveBeenCalledWith(
+    expect(upsertCalendarTriggerWorkflowInTx).toHaveBeenCalledWith(
+      expect.anything(),
       expect.objectContaining({
         driveId: DRIVE_ID,
         agentTrigger: expect.objectContaining({

--- a/apps/web/src/app/api/calendar/events/route.ts
+++ b/apps/web/src/app/api/calendar/events/route.ts
@@ -7,7 +7,7 @@ import { calendarTriggers } from '@pagespace/db/schema/calendar-triggers'
 import { workflows } from '@pagespace/db/schema/workflows';
 import { workflowRuns } from '@pagespace/db/schema/workflow-runs';
 import { desc } from '@pagespace/db/operators';
-import { createCalendarTriggerWorkflow, validateCalendarAgentTrigger } from '@/lib/workflows/calendar-trigger-helpers';
+import { upsertCalendarTriggerWorkflowInTx, validateCalendarAgentTrigger } from '@/lib/workflows/calendar-trigger-helpers';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getDriveMemberUserIds } from '@pagespace/lib/services/drive-member-service';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
@@ -490,13 +490,6 @@ export async function POST(request: Request) {
           { status: 400 }
         );
       }
-      if (data.recurrenceRule) {
-        return NextResponse.json(
-          { error: 'Agent triggers are not supported for recurring events' },
-          { status: 400 }
-        );
-      }
-
       try {
         const validated = await validateCalendarAgentTrigger(db, {
           driveId: data.driveId,
@@ -588,8 +581,7 @@ export async function POST(request: Request) {
       }
 
       if (data.agentTrigger && agentPageId && data.driveId) {
-        await createCalendarTriggerWorkflow({
-          tx,
+        await upsertCalendarTriggerWorkflowInTx(tx, {
           driveId: data.driveId,
           scheduledById: userId,
           calendarEventId: created.id,
@@ -601,6 +593,8 @@ export async function POST(request: Request) {
             instructionPageId: data.agentTrigger.instructionPageId ?? null,
             contextPageIds: data.agentTrigger.contextPageIds ?? [],
           },
+          recurrenceRule: data.recurrenceRule ?? null,
+          recurrenceExceptions: [],
         });
       }
 

--- a/apps/web/src/app/api/cron/calendar-triggers/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/calendar-triggers/__tests__/route.test.ts
@@ -167,6 +167,18 @@ describe('POST /api/cron/calendar-triggers', () => {
     mockSelectWhere.mockReturnValue({ orderBy: mockSelectOrderBy });
     mockSelectOrderBy.mockReturnValue({ limit: mockSelectLimit });
     mockSelectLimit.mockResolvedValue([]);
+
+    // Default: refillRecurringTriggers (selectDistinct chain) finds nothing to refill.
+    // Must be re-set after vi.resetAllMocks() clears the vi.hoisted factory.
+    mockSelectDistinct.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        innerJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            limit: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      }),
+    });
   });
 
   it('returns auth error when cron request is invalid', async () => {

--- a/apps/web/src/app/api/cron/calendar-triggers/__tests__/route.test.ts
+++ b/apps/web/src/app/api/cron/calendar-triggers/__tests__/route.test.ts
@@ -18,6 +18,7 @@ const {
   mockInsert,
   mockInsertValues,
   mockOnConflictDoNothing,
+  mockSelectDistinct,
 } = vi.hoisted(() => ({
   mockUpdateWhere: vi.fn(),
   mockUpdateSet: vi.fn(),
@@ -31,6 +32,16 @@ const {
   mockInsert: vi.fn(),
   mockInsertValues: vi.fn(),
   mockOnConflictDoNothing: vi.fn(),
+  // selectDistinct is used by refillRecurringTriggers — resolves to [] so refill is a no-op in tests
+  mockSelectDistinct: vi.fn(() => ({
+    from: vi.fn(() => ({
+      innerJoin: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn().mockResolvedValue([]),
+        })),
+      })),
+    })),
+  })),
 }));
 
 vi.mock('@/lib/auth/cron-auth', () => ({
@@ -60,6 +71,7 @@ vi.mock('@pagespace/lib/audit/audit-log', () => ({
 vi.mock('@pagespace/db/db', () => ({
   db: {
     select: mockSelect,
+    selectDistinct: mockSelectDistinct,
     update: mockUpdate,
     insert: mockInsert,
   },
@@ -71,10 +83,17 @@ vi.mock('@pagespace/db/operators', () => ({
   inArray: vi.fn(),
   asc: vi.fn(),
   sql: vi.fn(),
+  isNotNull: vi.fn(),
+  gt: vi.fn(),
 }));
 vi.mock('@pagespace/db/schema/calendar', () => ({
   calendarEvents: {
     id: 'id',
+    isTrashed: 'isTrashed',
+    recurrenceRule: 'recurrenceRule',
+    driveId: 'driveId',
+    startAt: 'startAt',
+    recurrenceExceptions: 'recurrenceExceptions',
   },
 }));
 vi.mock('@pagespace/db/schema/calendar-triggers', () => ({
@@ -82,6 +101,9 @@ vi.mock('@pagespace/db/schema/calendar-triggers', () => ({
     id: 'id',
     triggerAt: 'triggerAt',
     calendarEventId: 'calendarEventId',
+    workflowId: 'workflowId',
+    scheduledById: 'scheduledById',
+    driveId: 'driveId',
   },
 }));
 vi.mock('@pagespace/db/schema/workflow-runs', () => ({

--- a/apps/web/src/app/api/cron/calendar-triggers/route.ts
+++ b/apps/web/src/app/api/cron/calendar-triggers/route.ts
@@ -1,11 +1,13 @@
 import { NextResponse } from 'next/server';
 import { db } from '@pagespace/db/db'
-import { eq, and, lte, inArray, asc, sql } from '@pagespace/db/operators'
+import { eq, and, lte, inArray, asc, sql, isNotNull, gt } from '@pagespace/db/operators'
 import { calendarEvents } from '@pagespace/db/schema/calendar'
 import { calendarTriggers } from '@pagespace/db/schema/calendar-triggers';
 import { workflowRuns } from '@pagespace/db/schema/workflow-runs';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
 import { executeCalendarTrigger } from '@/lib/workflows/calendar-trigger-executor';
+import { bulkCreateOccurrenceTriggerRows } from '@/lib/workflows/calendar-trigger-helpers';
+import { expandOccurrences } from '@/lib/workflows/recurrence-utils';
 import type { WorkflowExecutionResult } from '@/lib/workflows/workflow-executor';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { audit } from '@pagespace/lib/audit/audit-log';
@@ -13,6 +15,9 @@ import { audit } from '@pagespace/lib/audit/audit-log';
 const STUCK_RUN_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 const MAX_CONCURRENT_TRIGGERS = 5;
 const MAX_DUE_TRIGGERS = 50;
+const REFILL_MAX_EVENTS = 20;
+const REFILL_LOOKAHEAD_DAYS = 30;
+const REFILL_HORIZON_DAYS = 180;
 
 const logger = loggers.api.child({ module: 'cron-calendar-triggers' });
 
@@ -151,6 +156,12 @@ export async function POST(req: Request) {
 
     logger.info(`Calendar trigger cron: Complete. Executed ${executed}/${totalAttempted}`);
 
+    // 4. Look-ahead refill: recurring events whose future trigger queue is running
+    //    dry get a fresh batch of occurrence rows. Uses the same pure expansion
+    //    function as the upsert path — ON CONFLICT DO NOTHING makes it safe to
+    //    call every tick without duplicates.
+    await refillRecurringTriggers(now);
+
     audit({ eventType: 'data.write', resourceType: 'cron_job', resourceId: 'calendar_triggers', details: { executed, failed: errors.length } });
 
     return NextResponse.json({
@@ -163,4 +174,64 @@ export async function POST(req: Request) {
     logger.error('Calendar trigger cron error:', error as Error);
     return NextResponse.json({ error: 'Calendar trigger cron failed' }, { status: 500 });
   }
+}
+
+async function refillRecurringTriggers(now: Date): Promise<void> {
+  const lookaheadCutoff = new Date(now.getTime() + REFILL_LOOKAHEAD_DAYS * 86_400_000);
+
+  // Find recurring events whose trigger queue has no rows beyond the lookahead
+  // window — these need a fresh batch of future occurrence rows.
+  const needsRefill = await db
+    .selectDistinct({
+      calendarEventId: calendarTriggers.calendarEventId,
+      workflowId: calendarTriggers.workflowId,
+      driveId: calendarTriggers.driveId,
+      scheduledById: calendarTriggers.scheduledById,
+    })
+    .from(calendarTriggers)
+    .innerJoin(calendarEvents, eq(calendarTriggers.calendarEventId, calendarEvents.id))
+    .where(and(
+      isNotNull(calendarEvents.recurrenceRule),
+      eq(calendarEvents.isTrashed, false),
+      sql`NOT EXISTS (
+        SELECT 1 FROM ${calendarTriggers} ct2
+        WHERE ct2."calendarEventId" = ${calendarTriggers.calendarEventId}
+          AND ct2."triggerAt" > ${lookaheadCutoff}
+      )`,
+    ))
+    .limit(REFILL_MAX_EVENTS);
+
+  if (needsRefill.length === 0) return;
+
+  const eventIds = needsRefill.map((r) => r.calendarEventId);
+  const events = await db
+    .select()
+    .from(calendarEvents)
+    .where(inArray(calendarEvents.id, eventIds));
+
+  const eventMap = new Map(events.map((e) => [e.id, e]));
+  const horizon = new Date(now.getTime() + REFILL_HORIZON_DAYS * 86_400_000);
+
+  await Promise.allSettled(
+    needsRefill.map(async (row) => {
+      const event = eventMap.get(row.calendarEventId);
+      if (!event?.recurrenceRule) return;
+
+      const occurrences = expandOccurrences(
+        event.recurrenceRule,
+        event.startAt,
+        now,
+        horizon,
+        event.recurrenceExceptions ?? [],
+      );
+
+      await bulkCreateOccurrenceTriggerRows(db, {
+        workflowId: row.workflowId,
+        calendarEventId: row.calendarEventId,
+        driveId: row.driveId,
+        scheduledById: row.scheduledById,
+        occurrences,
+      });
+    }),
+  );
 }

--- a/apps/web/src/app/api/cron/calendar-triggers/route.ts
+++ b/apps/web/src/app/api/cron/calendar-triggers/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { db } from '@pagespace/db/db'
-import { eq, and, lte, inArray, asc, sql, isNotNull, gt } from '@pagespace/db/operators'
+import { eq, and, lte, inArray, asc, sql, isNotNull } from '@pagespace/db/operators'
 import { calendarEvents } from '@pagespace/db/schema/calendar'
 import { calendarTriggers } from '@pagespace/db/schema/calendar-triggers';
 import { workflowRuns } from '@pagespace/db/schema/workflow-runs';
@@ -81,6 +81,7 @@ export async function POST(req: Request) {
       .limit(MAX_DUE_TRIGGERS);
 
     if (dueTriggers.length === 0) {
+      await refillRecurringTriggers(now);
       audit({ eventType: 'data.write', resourceType: 'cron_job', resourceId: 'calendar_triggers', details: { executed: 0, failed: 0 } });
       return NextResponse.json({ message: 'No calendar triggers due', executed: 0 });
     }
@@ -180,22 +181,24 @@ async function refillRecurringTriggers(now: Date): Promise<void> {
   const lookaheadCutoff = new Date(now.getTime() + REFILL_LOOKAHEAD_DAYS * 86_400_000);
 
   // Find recurring events whose trigger queue has no rows beyond the lookahead
-  // window — these need a fresh batch of future occurrence rows.
+  // window — these need a fresh batch of future occurrence rows. Driving from
+  // calendarEvents (not calendarTriggers) means events whose all trigger rows
+  // were fired and none remain are still found correctly.
   const needsRefill = await db
     .selectDistinct({
-      calendarEventId: calendarTriggers.calendarEventId,
+      calendarEventId: calendarEvents.id,
       workflowId: calendarTriggers.workflowId,
-      driveId: calendarTriggers.driveId,
+      driveId: calendarEvents.driveId,
       scheduledById: calendarTriggers.scheduledById,
     })
-    .from(calendarTriggers)
-    .innerJoin(calendarEvents, eq(calendarTriggers.calendarEventId, calendarEvents.id))
+    .from(calendarEvents)
+    .innerJoin(calendarTriggers, eq(calendarTriggers.calendarEventId, calendarEvents.id))
     .where(and(
       isNotNull(calendarEvents.recurrenceRule),
       eq(calendarEvents.isTrashed, false),
       sql`NOT EXISTS (
         SELECT 1 FROM ${calendarTriggers} ct2
-        WHERE ct2."calendarEventId" = ${calendarTriggers.calendarEventId}
+        WHERE ct2."calendarEventId" = ${calendarEvents.id}
           AND ct2."triggerAt" > ${lookaheadCutoff}
       )`,
     ))

--- a/apps/web/src/app/api/cron/calendar-triggers/route.ts
+++ b/apps/web/src/app/api/cron/calendar-triggers/route.ts
@@ -188,7 +188,7 @@ async function refillRecurringTriggers(now: Date): Promise<void> {
     .selectDistinct({
       calendarEventId: calendarEvents.id,
       workflowId: calendarTriggers.workflowId,
-      driveId: calendarEvents.driveId,
+      driveId: calendarTriggers.driveId,
       scheduledById: calendarTriggers.scheduledById,
     })
     .from(calendarEvents)

--- a/apps/web/src/components/calendar/EventModal.tsx
+++ b/apps/web/src/components/calendar/EventModal.tsx
@@ -143,7 +143,6 @@ export function EventModal({
 }: EventModalProps) {
   const isEditing = !!event;
   const isDriveContext = context === 'drive' && !!driveId;
-  const isRecurring = !!event?.recurrenceRule;
   // Agent triggers attach to drive events only — the executor needs a drive
   // context to resolve agent / instruction / context pages.
   const showAgentSection = isDriveContext;
@@ -278,7 +277,7 @@ export function EventModal({
   // means save sends agentTrigger=null and removes any defensive stale row.
   useEffect(() => {
     if (!isOpen) return;
-    if (existingTrigger && !isRecurring) {
+    if (existingTrigger) {
       setAgentEnabled(true);
       setAgentValue({
         agentPageId: existingTrigger.agentPageId,
@@ -287,12 +286,11 @@ export function EventModal({
         contextPageIds: existingTrigger.contextPageIds ?? [],
       });
     } else if (!triggerKey || (!triggerLoading && triggerData)) {
-      // No fetch (new event) OR fetch landed with no trigger row (or with one
-      // we're ignoring on a recurring event) → reset to empty.
+      // No fetch (new event) OR fetch landed with no trigger row → reset to empty.
       setAgentEnabled(false);
       setAgentValue(EMPTY_AGENT_VALUE);
     }
-  }, [isOpen, existingTrigger, isRecurring, triggerKey, triggerLoading, triggerData]);
+  }, [isOpen, existingTrigger, triggerKey, triggerLoading, triggerData]);
 
   const selectedAgentName = useMemo(() => {
     if (!agentEnabled) return null;
@@ -328,10 +326,6 @@ export function EventModal({
     let agentTrigger: AgentTriggerSavePayload | null | undefined;
     if (showAgentSection) {
       if (agentEnabled) {
-        if (isRecurring) {
-          toast.error('Recurring events can’t have agent triggers');
-          return;
-        }
         if (!agentValue.agentPageId) {
           toast.error('Pick an agent for the trigger');
           return;
@@ -346,11 +340,8 @@ export function EventModal({
           instructionPageId: agentValue.instructionPageId,
           contextPageIds: agentValue.contextPageIds,
         };
-      } else if (existingTrigger && !isRecurring) {
-        // Was enabled, user turned it off → remove. Skip on recurring events:
-        // the trigger row shouldn't exist there anyway, but if a stale one is
-        // present we leave it alone rather than silently deleting it on every
-        // edit. The user never saw an Off→On affordance for it.
+      } else if (existingTrigger) {
+        // Was enabled, user turned it off → remove.
         agentTrigger = null;
       }
       // else: undefined → no-op (no trigger before, none now)
@@ -599,12 +590,7 @@ export function EventModal({
                 </Button>
               </CollapsibleTrigger>
               <CollapsibleContent className="space-y-3 pt-2">
-                {isRecurring ? (
-                  <p className="text-xs text-muted-foreground rounded-md border border-dashed p-3">
-                    Recurring events can&apos;t have agent triggers. The cron poller fires one-shot occurrences only.
-                  </p>
-                ) : (
-                  <div className="space-y-3 rounded-md border p-3">
+                <div className="space-y-3 rounded-md border p-3">
                     <div className="flex items-center justify-between gap-2">
                       <div className="flex items-center gap-2 min-w-0">
                         <Bot className="h-4 w-4 text-muted-foreground shrink-0" />
@@ -654,7 +640,6 @@ export function EventModal({
                       </>
                     )}
                   </div>
-                )}
               </CollapsibleContent>
             </Collapsible>
           )}

--- a/apps/web/src/components/calendar/__tests__/EventModal.test.tsx
+++ b/apps/web/src/components/calendar/__tests__/EventModal.test.tsx
@@ -180,7 +180,7 @@ describe('EventModal — agent trigger disclosure', () => {
     });
   });
 
-  test('shows recurring-event note instead of the form when event is recurring', async () => {
+  test('shows the agent form (not a disabled note) when event is recurring', async () => {
     cannedFetch({ trigger: null });
 
     renderModal({
@@ -192,14 +192,17 @@ describe('EventModal — agent trigger disclosure', () => {
     const triggerHeader = await screen.findByRole('button', { name: /Agent trigger/i });
     await userEvent.click(triggerHeader);
 
-    await waitFor(() => {
-      screen.getByText(/Recurring events can.+t have agent triggers/i);
+    assert({
+      given: 'a recurring drive event with the Agent trigger disclosure expanded',
+      should: 'show the "Run agent at event start" toggle (not a disabled note)',
+      actual: !!screen.queryByText(/Run agent at event start/i),
+      expected: true,
     });
 
     assert({
       given: 'a recurring drive event with the Agent trigger disclosure expanded',
-      should: 'show the "can\'t have agent triggers" note instead of the form',
-      actual: screen.queryByText(/Run agent at event start/i),
+      should: 'not show the old "can\'t have agent triggers" disabled message',
+      actual: screen.queryByText(/Recurring events can.+t have agent triggers/i),
       expected: null,
     });
   });
@@ -276,12 +279,10 @@ describe('EventModal — agent trigger disclosure', () => {
     });
   });
 
-  test('a recurring event with a stale trigger row leaves it alone on save (agentTrigger=undefined)', async () => {
-    // Defensive case: the API rejects upserting triggers on recurring events,
-    // so a recurring row with a trigger should never exist. If one does, the
-    // modal must not surface it as enabled (would trap the user behind a
-    // recurring-validation error) and must not silently send agentTrigger=null
-    // either (that would delete the row without user intent).
+  test('a recurring event with an existing trigger row hydrates and saves the trigger', async () => {
+    // Recurring events now fully support agent triggers. When the modal opens
+    // for a recurring event that has a trigger, it should hydrate the form and
+    // allow saving the trigger payload unchanged (idempotent upsert).
     const onSave = vi.fn<(data: unknown) => Promise<void>>(async () => undefined);
 
     renderModal({
@@ -291,19 +292,23 @@ describe('EventModal — agent trigger disclosure', () => {
       onSave,
     });
 
-    // Disclosure header should read 'Off' even though a trigger row exists,
-    // because hydration skips recurring events.
-    await screen.findByRole('button', { name: /Agent trigger\s*Off/i });
+    // Disclosure header should read the agent name (trigger is hydrated from the canned fetch).
+    await screen.findByRole('button', { name: /Triage Bot at start/i });
 
     await userEvent.click(screen.getByRole('button', { name: /^Update$/i }));
 
     const payload = await firstSavePayload(onSave);
 
     assert({
-      given: 'a recurring event with a stale trigger row',
-      should: 'send agentTrigger=undefined (no-op) so the broken row is left alone, not deleted',
+      given: 'a recurring event with an existing trigger row',
+      should: 'hydrate and forward the trigger payload to onSave (not undefined/null)',
       actual: payload.agentTrigger,
-      expected: undefined,
+      expected: {
+        agentPageId: 'agent-1',
+        prompt: 'remote-prompt',
+        instructionPageId: null,
+        contextPageIds: [],
+      },
     });
   });
 

--- a/apps/web/src/lib/ai/tools/__tests__/calendar-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/calendar-write-tools.test.ts
@@ -458,7 +458,7 @@ describe('calendar-write-tools', () => {
     });
 
     describe('agentTrigger', () => {
-      it('returns error when agentTrigger combined with recurrence', async () => {
+      it('does NOT reject agentTrigger combined with recurrence (recurring triggers are now supported)', async () => {
         mockIsUserDriveMember.mockResolvedValue(true);
 
         const input = {
@@ -478,18 +478,15 @@ describe('calendar-write-tools', () => {
           createAuthContext()
         );
 
+        // The old guard returned { success: false, error: '...recurring...' }.
+        // Now it must NOT return that specific recurrence error — the feature is
+        // enabled. The result may succeed or fail for unrelated mock reasons, but
+        // the recurrence guard itself must be gone.
         assert({
           given: 'agentTrigger with recurrence',
-          should: 'return error',
-          actual: (result as { success: boolean }).success,
+          should: 'not reject with a recurring-specific error message',
+          actual: (result as { error?: string }).error?.toLowerCase().includes('recur') ?? false,
           expected: false,
-        });
-
-        assert({
-          given: 'agentTrigger with recurrence',
-          should: 'mention recurring in error',
-          actual: (result as { error?: string }).error?.toLowerCase().includes('recur'),
-          expected: true,
         });
       });
 

--- a/apps/web/src/lib/ai/tools/__tests__/calendar-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/calendar-write-tools.test.ts
@@ -168,6 +168,7 @@ import { db } from '@pagespace/db/db'
 import { isUserDriveMember } from '@pagespace/lib/permissions/permissions';
 import { getDriveMemberUserIds } from '@pagespace/lib/services/drive-member-service';
 import { broadcastCalendarEvent } from '@/lib/websocket/calendar-events';
+import { upsertCalendarTriggerWorkflowInTx } from '@/lib/workflows/calendar-trigger-helpers';
 import type { ToolExecutionContext } from '../../core';
 
 const mockDb = vi.mocked(db);
@@ -458,8 +459,24 @@ describe('calendar-write-tools', () => {
     });
 
     describe('agentTrigger', () => {
-      it('does NOT reject agentTrigger combined with recurrence (recurring triggers are now supported)', async () => {
+      it('passes recurrenceRule to upsertCalendarTriggerWorkflowInTx when agentTrigger + recurrence are combined', async () => {
         mockIsUserDriveMember.mockResolvedValue(true);
+
+        // Return a valid AI_CHAT agent page for the agent-page lookup
+        (mockDb.where as ReturnType<typeof vi.fn>).mockResolvedValueOnce([{
+          id: 'agent-1',
+          type: 'AI_CHAT',
+          title: 'Test Agent',
+          isTrashed: false,
+          driveId: 'drive-1',
+        }]);
+
+        const newEvent = createMockEvent({ recurrenceRule: { frequency: 'WEEKLY', interval: 1 } });
+        (mockDb.insert as ReturnType<typeof vi.fn>).mockReturnValue({
+          values: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([newEvent]),
+          }),
+        });
 
         const input = {
           title: 'Recurring Agent Task',
@@ -473,20 +490,16 @@ describe('calendar-write-tools', () => {
           },
         };
 
-        const result = await calendarWriteTools.create_calendar_event.execute!(
-          input,
-          createAuthContext()
-        );
+        await calendarWriteTools.create_calendar_event.execute!(input, createAuthContext());
 
-        // The old guard returned { success: false, error: '...recurring...' }.
-        // Now it must NOT return that specific recurrence error — the feature is
-        // enabled. The result may succeed or fail for unrelated mock reasons, but
-        // the recurrence guard itself must be gone.
+        const upsertCalls = vi.mocked(upsertCalendarTriggerWorkflowInTx).mock.calls;
         assert({
           given: 'agentTrigger with recurrence',
-          should: 'not reject with a recurring-specific error message',
-          actual: (result as { error?: string }).error?.toLowerCase().includes('recur') ?? false,
-          expected: false,
+          should: 'call upsertCalendarTriggerWorkflowInTx with the recurrence rule',
+          actual: upsertCalls.some(
+            ([, params]) => (params as { recurrenceRule?: { frequency: string } }).recurrenceRule?.frequency === 'WEEKLY',
+          ),
+          expected: true,
         });
       });
 

--- a/apps/web/src/lib/ai/tools/__tests__/calendar-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/calendar-write-tools.test.ts
@@ -462,14 +462,19 @@ describe('calendar-write-tools', () => {
       it('passes recurrenceRule to upsertCalendarTriggerWorkflowInTx when agentTrigger + recurrence are combined', async () => {
         mockIsUserDriveMember.mockResolvedValue(true);
 
-        // Return a valid AI_CHAT agent page for the agent-page lookup
-        (mockDb.where as ReturnType<typeof vi.fn>).mockResolvedValueOnce([{
-          id: 'agent-1',
-          type: 'AI_CHAT',
-          title: 'Test Agent',
-          isTrashed: false,
-          driveId: 'drive-1',
-        }]);
+        // Return a valid AI_CHAT agent page for the agent-page lookup via
+        // db.select({...}).from(pages).where(...)
+        (mockDb.select as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValueOnce([{
+              id: 'agent-1',
+              type: 'AI_CHAT',
+              title: 'Test Agent',
+              isTrashed: false,
+              driveId: 'drive-1',
+            }]),
+          }),
+        });
 
         const newEvent = createMockEvent({ recurrenceRule: { frequency: 'WEEKLY', interval: 1 } });
         (mockDb.insert as ReturnType<typeof vi.fn>).mockReturnValue({

--- a/apps/web/src/lib/ai/tools/calendar-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/calendar-write-tools.ts
@@ -8,7 +8,6 @@ import { calendarTriggers } from '@pagespace/db/schema/calendar-triggers';
 import { workflowRuns } from '@pagespace/db/schema/workflow-runs';
 import type { CalendarTriggerMetadata } from '@pagespace/db/schema/calendar-triggers';
 import {
-  createCalendarTriggerWorkflow,
   removeCalendarTrigger,
   upsertCalendarTriggerWorkflowInTx,
   validateCalendarAgentTrigger,
@@ -173,9 +172,6 @@ export const calendarWriteTools = {
           if (!driveId) {
             return { success: false, error: 'Agent triggers require a drive event (driveId must be provided).' };
           }
-          if (recurrence) {
-            return { success: false, error: 'Agent triggers are not yet supported on recurring events. Create a one-time event instead.' };
-          }
           if (!agentTrigger.prompt && !agentTrigger.instructionPageId) {
             return { success: false, error: 'Agent trigger needs either a prompt or instructionPageId.' };
           }
@@ -315,8 +311,7 @@ export const calendarWriteTools = {
 
           let createdTriggerIdLocal: string | null = null;
           if (agentTrigger && driveId && validatedAgent) {
-            const { triggerId: newTriggerId } = await createCalendarTriggerWorkflow({
-              tx,
+            const { triggerId: newTriggerId } = await upsertCalendarTriggerWorkflowInTx(tx, {
               driveId,
               scheduledById: userId,
               calendarEventId: createdEvent.id,
@@ -328,6 +323,8 @@ export const calendarWriteTools = {
                 instructionPageId: agentTrigger.instructionPageId ?? null,
                 contextPageIds: agentTrigger.contextPageIds ?? [],
               },
+              recurrenceRule: recurrence ?? null,
+              recurrenceExceptions: [],
             });
 
             await tx
@@ -516,18 +513,6 @@ export const calendarWriteTools = {
           };
         }
 
-        // Reject agentTrigger upserts on recurring events. The cron poller
-        // fires triggers as one-shot occurrences, so attaching one to a
-        // recurring event would silently misfire on every occurrence after
-        // the first. Mirrors the create_calendar_event guard.
-        const willBeRecurring = recurrence !== undefined ? recurrence !== null : event.recurrenceRule !== null;
-        if (agentTrigger && willBeRecurring) {
-          return {
-            success: false,
-            error: 'Agent triggers are not supported for recurring events.',
-          };
-        }
-
         // Pre-validate agentTrigger BEFORE opening the tx so a bad payload
         // (off-drive agent / context page, missing prompt-or-instruction)
         // doesn't briefly hold row locks during the event update.
@@ -588,6 +573,7 @@ export const calendarWriteTools = {
           if (agentTrigger === null) {
             await removeCalendarTrigger(tx, eventId);
           } else if (agentTrigger && event.driveId) {
+            const effectiveRecurrenceRule = recurrence !== undefined ? recurrence : event.recurrenceRule;
             await upsertCalendarTriggerWorkflowInTx(tx, {
               driveId: event.driveId,
               scheduledById: userId,
@@ -595,6 +581,8 @@ export const calendarWriteTools = {
               triggerAt: updated.startAt,
               timezone: updated.timezone ?? 'UTC',
               agentTrigger,
+              recurrenceRule: effectiveRecurrenceRule,
+              recurrenceExceptions: event.recurrenceExceptions ?? [],
             });
           }
 

--- a/apps/web/src/lib/workflows/__tests__/calendar-trigger-helpers.test.ts
+++ b/apps/web/src/lib/workflows/__tests__/calendar-trigger-helpers.test.ts
@@ -39,6 +39,9 @@ vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((field, value) => ({ op: 'eq', field, value })),
   and: vi.fn((...conds) => ({ op: 'and', conds })),
   inArray: vi.fn((field, values) => ({ op: 'inArray', field, values })),
+  ne: vi.fn((field, value) => ({ op: 'ne', field, value })),
+  gt: vi.fn((field, value) => ({ op: 'gt', field, value })),
+  sql: vi.fn(() => ({})),
 }));
 vi.mock('@pagespace/db/schema/core', () => ({
   pages: { id: 'id', type: 'type', isTrashed: 'isTrashed', driveId: 'driveId' },
@@ -47,7 +50,10 @@ vi.mock('@pagespace/db/schema/workflows', () => ({
   workflows: { id: 'id' },
 }));
 vi.mock('@pagespace/db/schema/calendar-triggers', () => ({
-  calendarTriggers: { id: 'id', workflowId: 'workflowId', calendarEventId: 'calendarEventId' },
+  calendarTriggers: { id: 'id', workflowId: 'workflowId', calendarEventId: 'calendarEventId', driveId: 'driveId', scheduledById: 'scheduledById' },
+}));
+vi.mock('@pagespace/db/schema/workflow-runs', () => ({
+  workflowRuns: { sourceTable: 'sourceTable', sourceId: 'sourceId' },
 }));
 
 import {
@@ -314,6 +320,7 @@ describe('upsertCalendarTriggerWorkflow', () => {
       select: mockSelect,
       update: mockUpdate,
       insert: vi.fn(),
+      delete: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
     }));
   });
 
@@ -335,7 +342,7 @@ describe('upsertCalendarTriggerWorkflow', () => {
     // Validation calls
     mockQueryPages.findFirst.mockResolvedValueOnce({ id: 'agent-1', driveId: 'drive-1' });
     // Existing trigger lookup inside the tx
-    mockSelectWhere.mockResolvedValueOnce([{ workflowId: 'wf-existing' }]);
+    mockSelectWhere.mockResolvedValueOnce([{ id: 'trg-existing', workflowId: 'wf-existing' }]);
 
     await upsertCalendarTriggerWorkflow(db, baseParams);
 

--- a/apps/web/src/lib/workflows/__tests__/calendar-trigger-helpers.test.ts
+++ b/apps/web/src/lib/workflows/__tests__/calendar-trigger-helpers.test.ts
@@ -341,8 +341,10 @@ describe('upsertCalendarTriggerWorkflow', () => {
   it('updates the existing workflow row when a trigger already exists for the event', async () => {
     // Validation calls
     mockQueryPages.findFirst.mockResolvedValueOnce({ id: 'agent-1', driveId: 'drive-1' });
-    // Existing trigger lookup inside the tx
+    // 1st select: existing trigger lookup (for workflowId)
     mockSelectWhere.mockResolvedValueOnce([{ id: 'trg-existing', workflowId: 'wf-existing' }]);
+    // 2nd select: pending (unfired) trigger lookup
+    mockSelectWhere.mockResolvedValueOnce([{ id: 'trg-existing' }]);
 
     await upsertCalendarTriggerWorkflow(db, baseParams);
 

--- a/apps/web/src/lib/workflows/__tests__/recurrence-utils.test.ts
+++ b/apps/web/src/lib/workflows/__tests__/recurrence-utils.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from 'vitest';
+import { expandOccurrences, type RecurrenceRule } from '../recurrence-utils';
+
+const iso = (d: Date) => d.toISOString().slice(0, 10);
+const dates = (arr: Date[]) => arr.map(iso);
+
+// 9 AM UTC on 2026-06-01 (Monday)
+const BASE = new Date('2026-06-01T09:00:00Z');
+const FROM = new Date('2026-06-01T00:00:00Z');
+
+describe('expandOccurrences — DAILY', () => {
+  it('returns one occurrence per day for interval=1', () => {
+    const rule: RecurrenceRule = { frequency: 'DAILY', interval: 1, count: 5 };
+    const result = dates(expandOccurrences(rule, BASE, FROM, new Date('2026-12-31'), []));
+    expect(result).toEqual(['2026-06-01', '2026-06-02', '2026-06-03', '2026-06-04', '2026-06-05']);
+  });
+
+  it('skips every other day for interval=2', () => {
+    const rule: RecurrenceRule = { frequency: 'DAILY', interval: 2, count: 3 };
+    const result = dates(expandOccurrences(rule, BASE, FROM, new Date('2026-12-31'), []));
+    expect(result).toEqual(['2026-06-01', '2026-06-03', '2026-06-05']);
+  });
+
+  it('preserves time-of-day across all occurrences', () => {
+    const rule: RecurrenceRule = { frequency: 'DAILY', interval: 1, count: 3 };
+    const result = expandOccurrences(rule, BASE, FROM, new Date('2026-12-31'), []);
+    for (const d of result) {
+      expect(d.getUTCHours()).toBe(9);
+      expect(d.getUTCMinutes()).toBe(0);
+    }
+  });
+
+  it('respects the to boundary', () => {
+    const rule: RecurrenceRule = { frequency: 'DAILY', interval: 1 };
+    const to = new Date('2026-06-03T23:59:59Z');
+    const result = dates(expandOccurrences(rule, BASE, FROM, to, []));
+    expect(result).toEqual(['2026-06-01', '2026-06-02', '2026-06-03']);
+  });
+
+  it('skips exception dates', () => {
+    const rule: RecurrenceRule = { frequency: 'DAILY', interval: 1, count: 5 };
+    const result = dates(expandOccurrences(rule, BASE, FROM, new Date('2026-12-31'), ['2026-06-02', '2026-06-04']));
+    expect(result).toEqual(['2026-06-01', '2026-06-03', '2026-06-05']);
+  });
+
+  it('stops at rule.until before to', () => {
+    const rule: RecurrenceRule = { frequency: 'DAILY', interval: 1, until: '2026-06-03T23:59:59Z' };
+    const result = dates(expandOccurrences(rule, BASE, FROM, new Date('2026-12-31'), []));
+    expect(result).toEqual(['2026-06-01', '2026-06-02', '2026-06-03']);
+  });
+
+  it('respects count and does not exceed it', () => {
+    const rule: RecurrenceRule = { frequency: 'DAILY', interval: 1, count: 2 };
+    const result = expandOccurrences(rule, BASE, FROM, new Date('2026-12-31'), []);
+    expect(result).toHaveLength(2);
+  });
+
+  it('returns [] when from > to', () => {
+    const rule: RecurrenceRule = { frequency: 'DAILY', interval: 1 };
+    const result = expandOccurrences(rule, BASE, new Date('2026-12-31'), new Date('2026-06-01'), []);
+    expect(result).toEqual([]);
+  });
+
+  it('excludes occurrences before from', () => {
+    const rule: RecurrenceRule = { frequency: 'DAILY', interval: 1, count: 5 };
+    const from = new Date('2026-06-03T00:00:00Z');
+    const result = dates(expandOccurrences(rule, BASE, from, new Date('2026-12-31'), []));
+    // COUNT still counts from series start; 5 total = Jun 1,2,3,4,5; only Jun 3-5 are in [from,to]
+    expect(result).toEqual(['2026-06-03', '2026-06-04', '2026-06-05']);
+  });
+
+  it('count counts from series start, not from window start', () => {
+    const rule: RecurrenceRule = { frequency: 'DAILY', interval: 1, count: 2 };
+    const from = new Date('2026-06-03T00:00:00Z');
+    // Only 2 occurrences total (Jun 1 + Jun 2); both before from — result is empty
+    const result = expandOccurrences(rule, BASE, from, new Date('2026-12-31'), []);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('expandOccurrences — WEEKLY', () => {
+  // BASE is 2026-06-01 (Monday)
+
+  it('returns weekly occurrences on same day-of-week when no byDay', () => {
+    const rule: RecurrenceRule = { frequency: 'WEEKLY', interval: 1, count: 3 };
+    const result = dates(expandOccurrences(rule, BASE, FROM, new Date('2026-12-31'), []));
+    expect(result).toEqual(['2026-06-01', '2026-06-08', '2026-06-15']);
+  });
+
+  it('byDay emits multiple weekdays per week', () => {
+    // MO + WE + FR from a Monday base
+    const rule: RecurrenceRule = { frequency: 'WEEKLY', interval: 1, byDay: ['MO', 'WE', 'FR'], count: 6 };
+    const result = dates(expandOccurrences(rule, BASE, FROM, new Date('2026-12-31'), []));
+    // Week 1: Jun 1 (Mon), Jun 3 (Wed), Jun 5 (Fri); Week 2: Jun 8, Jun 10, Jun 12
+    expect(result).toEqual(['2026-06-01', '2026-06-03', '2026-06-05', '2026-06-08', '2026-06-10', '2026-06-12']);
+  });
+
+  it('biweekly (interval=2) skips alternate weeks', () => {
+    const rule: RecurrenceRule = { frequency: 'WEEKLY', interval: 2, count: 3 };
+    const result = dates(expandOccurrences(rule, BASE, FROM, new Date('2026-12-31'), []));
+    expect(result).toEqual(['2026-06-01', '2026-06-15', '2026-06-29']);
+  });
+
+  it('preserves time-of-day', () => {
+    const rule: RecurrenceRule = { frequency: 'WEEKLY', interval: 1, count: 2 };
+    const result = expandOccurrences(rule, BASE, FROM, new Date('2026-12-31'), []);
+    for (const d of result) {
+      expect(d.getUTCHours()).toBe(9);
+    }
+  });
+
+  it('skips exception dates', () => {
+    const rule: RecurrenceRule = { frequency: 'WEEKLY', interval: 1, count: 4 };
+    const result = dates(expandOccurrences(rule, BASE, FROM, new Date('2026-12-31'), ['2026-06-08']));
+    expect(result).toEqual(['2026-06-01', '2026-06-15', '2026-06-22']);
+  });
+
+  it('respects until', () => {
+    const rule: RecurrenceRule = { frequency: 'WEEKLY', interval: 1, until: '2026-06-15T23:59:59Z' };
+    const result = dates(expandOccurrences(rule, BASE, FROM, new Date('2026-12-31'), []));
+    expect(result).toEqual(['2026-06-01', '2026-06-08', '2026-06-15']);
+  });
+});
+
+describe('expandOccurrences — MONTHLY', () => {
+  it('returns same day-of-month each month', () => {
+    const rule: RecurrenceRule = { frequency: 'MONTHLY', interval: 1, count: 4 };
+    const result = dates(expandOccurrences(rule, BASE, FROM, new Date('2026-12-31'), []));
+    expect(result).toEqual(['2026-06-01', '2026-07-01', '2026-08-01', '2026-09-01']);
+  });
+
+  it('interval=3 gives quarterly occurrences', () => {
+    const rule: RecurrenceRule = { frequency: 'MONTHLY', interval: 3, count: 4 };
+    const result = dates(expandOccurrences(rule, BASE, FROM, new Date('2027-12-31'), []));
+    expect(result).toEqual(['2026-06-01', '2026-09-01', '2026-12-01', '2027-03-01']);
+  });
+
+  it('byMonthDay overrides the base day', () => {
+    const rule: RecurrenceRule = { frequency: 'MONTHLY', interval: 1, byMonthDay: [15], count: 3 };
+    const result = dates(expandOccurrences(rule, BASE, FROM, new Date('2026-12-31'), []));
+    expect(result).toEqual(['2026-06-15', '2026-07-15', '2026-08-15']);
+  });
+
+  it('preserves time-of-day', () => {
+    const rule: RecurrenceRule = { frequency: 'MONTHLY', interval: 1, count: 2 };
+    const result = expandOccurrences(rule, BASE, FROM, new Date('2026-12-31'), []);
+    for (const d of result) {
+      expect(d.getUTCHours()).toBe(9);
+    }
+  });
+
+  it('skips exception dates', () => {
+    const rule: RecurrenceRule = { frequency: 'MONTHLY', interval: 1, count: 4 };
+    const result = dates(expandOccurrences(rule, BASE, FROM, new Date('2026-12-31'), ['2026-07-01']));
+    expect(result).toEqual(['2026-06-01', '2026-08-01', '2026-09-01']);
+  });
+
+  it('crosses year boundary correctly', () => {
+    const base = new Date('2026-11-01T09:00:00Z');
+    const rule: RecurrenceRule = { frequency: 'MONTHLY', interval: 1, count: 4 };
+    const result = dates(expandOccurrences(rule, base, base, new Date('2027-12-31'), []));
+    expect(result).toEqual(['2026-11-01', '2026-12-01', '2027-01-01', '2027-02-01']);
+  });
+});
+
+describe('expandOccurrences — YEARLY', () => {
+  it('returns same date each year', () => {
+    const rule: RecurrenceRule = { frequency: 'YEARLY', interval: 1, count: 4 };
+    const result = dates(expandOccurrences(rule, BASE, FROM, new Date('2030-12-31'), []));
+    expect(result).toEqual(['2026-06-01', '2027-06-01', '2028-06-01', '2029-06-01']);
+  });
+
+  it('interval=2 gives biennial occurrences', () => {
+    const rule: RecurrenceRule = { frequency: 'YEARLY', interval: 2, count: 3 };
+    const result = dates(expandOccurrences(rule, BASE, FROM, new Date('2035-12-31'), []));
+    expect(result).toEqual(['2026-06-01', '2028-06-01', '2030-06-01']);
+  });
+
+  it('respects until', () => {
+    const rule: RecurrenceRule = { frequency: 'YEARLY', interval: 1, until: '2028-06-01T23:59:59Z' };
+    const result = dates(expandOccurrences(rule, BASE, FROM, new Date('2035-12-31'), []));
+    expect(result).toEqual(['2026-06-01', '2027-06-01', '2028-06-01']);
+  });
+
+  it('preserves time-of-day', () => {
+    const rule: RecurrenceRule = { frequency: 'YEARLY', interval: 1, count: 2 };
+    const result = expandOccurrences(rule, BASE, FROM, new Date('2030-12-31'), []);
+    for (const d of result) {
+      expect(d.getUTCHours()).toBe(9);
+    }
+  });
+});
+
+describe('expandOccurrences — exception edge cases', () => {
+  it('accepts full ISO exception strings and matches on date part', () => {
+    const rule: RecurrenceRule = { frequency: 'DAILY', interval: 1, count: 3 };
+    // Pass a full ISO string as an exception — should still match by date prefix
+    const result = dates(expandOccurrences(rule, BASE, FROM, new Date('2026-12-31'), ['2026-06-02T09:00:00.000Z']));
+    expect(result).toEqual(['2026-06-01', '2026-06-03']);
+  });
+
+  it('returns [] for a series fully exhausted by count before the window', () => {
+    const rule: RecurrenceRule = { frequency: 'DAILY', interval: 1, count: 1 };
+    const from = new Date('2026-06-05T00:00:00Z');
+    const result = expandOccurrences(rule, BASE, from, new Date('2026-12-31'), []);
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/workflows/calendar-trigger-helpers.ts
+++ b/apps/web/src/lib/workflows/calendar-trigger-helpers.ts
@@ -1,15 +1,14 @@
 import type { db as DbType } from '@pagespace/db/db';
-import { eq, and, inArray } from '@pagespace/db/operators';
+import { eq, and, inArray, gt, sql } from '@pagespace/db/operators';
 import { pages } from '@pagespace/db/schema/core';
 import { workflows } from '@pagespace/db/schema/workflows';
 import { calendarTriggers } from '@pagespace/db/schema/calendar-triggers';
+import { workflowRuns } from '@pagespace/db/schema/workflow-runs';
+import { expandOccurrences, type RecurrenceRule } from './recurrence-utils';
 
 const MAX_CONTEXT_PAGES = 10;
+const TRIGGER_HORIZON_DAYS = 180;
 
-// Drizzle tx exposes the same insert/select/update/delete chain shape as the
-// top-level db, so helpers that don't open their own transaction can take
-// either. Call sites that are already inside an outer tx pass the tx; call
-// sites that aren't pass `db`.
 type DbOrTx = typeof DbType | Parameters<Parameters<typeof DbType.transaction>[0]>[0];
 
 export interface CalendarAgentTriggerInput {
@@ -25,20 +24,22 @@ export interface CreateCalendarTriggerWorkflowParams {
   scheduledById: string;
   calendarEventId: string;
   triggerAt: Date;
+  occurrenceDate?: Date;
   timezone: string;
   agentTrigger: CalendarAgentTriggerInput;
 }
 
 /**
- * Atomically write the workflows row (execution payload) and the
- * calendar_triggers row (the "when") inside a caller-supplied transaction.
- * Validation of the agent / instruction / context pages is the caller's
- * responsibility — by this point those checks must have passed.
+ * Atomically write the workflows row (execution payload) and a single
+ * calendar_triggers row inside a caller-supplied transaction. Used for
+ * one-shot (non-recurring) events. Pass occurrenceDate when creating an
+ * individual occurrence row for a recurring event (e.g. the refill path).
+ * Validation is the caller's responsibility.
  */
 export async function createCalendarTriggerWorkflow(
   params: CreateCalendarTriggerWorkflowParams,
 ): Promise<{ workflowId: string; triggerId: string }> {
-  const { tx, driveId, scheduledById, calendarEventId, triggerAt, timezone, agentTrigger } = params;
+  const { tx, driveId, scheduledById, calendarEventId, triggerAt, occurrenceDate, timezone, agentTrigger } = params;
   const triggerPrompt = agentTrigger.prompt || 'Execute instructions from linked page.';
 
   const [createdWorkflow] = await tx.insert(workflows).values({
@@ -60,9 +61,43 @@ export async function createCalendarTriggerWorkflow(
     driveId,
     scheduledById,
     triggerAt,
+    ...(occurrenceDate ? { occurrenceDate } : {}),
   }).returning({ id: calendarTriggers.id });
 
   return { workflowId: createdWorkflow.id, triggerId: createdTrigger.id };
+}
+
+/**
+ * Batch-insert one calendar_triggers row per occurrence date. All rows share
+ * the same workflowId (the workflows row is already written by the caller).
+ * Uses ON CONFLICT DO NOTHING — safe to call repeatedly for the same event;
+ * already-fired occurrences are not re-inserted.
+ */
+export async function bulkCreateOccurrenceTriggerRows(
+  database: DbOrTx,
+  params: {
+    workflowId: string;
+    calendarEventId: string;
+    driveId: string;
+    scheduledById: string;
+    occurrences: Date[];
+  },
+): Promise<void> {
+  if (params.occurrences.length === 0) return;
+
+  await database
+    .insert(calendarTriggers)
+    .values(
+      params.occurrences.map((date) => ({
+        workflowId: params.workflowId,
+        calendarEventId: params.calendarEventId,
+        driveId: params.driveId,
+        scheduledById: params.scheduledById,
+        triggerAt: date,
+        occurrenceDate: date,
+      })),
+    )
+    .onConflictDoNothing();
 }
 
 export interface ValidateCalendarAgentTriggerParams {
@@ -131,10 +166,6 @@ export async function validateCalendarAgentTrigger(
  * Remove the agent trigger from a calendar event. Deletes the linked workflows
  * row(s); FK cascade drops the calendar_triggers rows. Treats a no-op
  * (no triggers exist) as success so callers don't need a pre-check.
- *
- * Accepts either `db` or a transaction handle so callers that are already in
- * an outer tx (e.g. PATCH /events/[id]) can keep event + trigger writes
- * atomic.
  */
 export async function removeCalendarTrigger(
   database: DbOrTx,
@@ -147,7 +178,7 @@ export async function removeCalendarTrigger(
 
   if (triggerRows.length === 0) return;
 
-  const workflowIds = triggerRows.map((r) => r.workflowId);
+  const workflowIds = [...new Set(triggerRows.map((r) => r.workflowId))];
   await database.delete(workflows).where(inArray(workflows.id, workflowIds));
 }
 
@@ -158,15 +189,22 @@ export interface UpsertCalendarTriggerWorkflowParams {
   triggerAt: Date;
   timezone: string;
   agentTrigger: CalendarAgentTriggerInput;
+  recurrenceRule?: RecurrenceRule | null;
+  recurrenceExceptions?: string[];
 }
 
 /**
- * In-tx version of upsertCalendarTriggerWorkflow. Caller is responsible for
- * pre-validating via validateCalendarAgentTrigger. Used by event PATCH /
- * AI update_calendar_event so the event update and the trigger upsert commit
- * (or roll back) together — protects against partial-write states where a
- * non-trigger validation failure (e.g. db blip mid-upsert) leaves the event
- * mutated but the trigger out of sync.
+ * In-tx upsert. Caller must pre-validate via validateCalendarAgentTrigger.
+ *
+ * For recurring events (recurrenceRule non-null):
+ *   - Upserts the single workflows row (stable workflowId preserves history).
+ *   - Deletes all unfired future trigger rows (so recurrence-rule or time-of-day
+ *     changes take effect cleanly).
+ *   - Bulk-inserts occurrence rows for the next 180 days via
+ *     bulkCreateOccurrenceTriggerRows (ON CONFLICT DO NOTHING = idempotent).
+ *
+ * For one-shot events (recurrenceRule null/absent):
+ *   - Updates the existing trigger row's triggerAt, or creates one if absent.
  */
 export async function upsertCalendarTriggerWorkflowInTx(
   tx: Parameters<Parameters<typeof DbType.transaction>[0]>[0],
@@ -178,11 +216,13 @@ export async function upsertCalendarTriggerWorkflowInTx(
   const existing = await tx
     .select({ id: calendarTriggers.id, workflowId: calendarTriggers.workflowId })
     .from(calendarTriggers)
-    .where(eq(calendarTriggers.calendarEventId, params.calendarEventId));
+    .where(eq(calendarTriggers.calendarEventId, params.calendarEventId))
+    .limit(1);
+
+  let workflowId: string;
 
   if (existing.length > 0) {
-    const { id: triggerId, workflowId } = existing[0];
-
+    workflowId = existing[0].workflowId;
     await tx.update(workflows).set({
       agentPageId: params.agentTrigger.agentPageId,
       prompt: triggerPrompt,
@@ -191,33 +231,80 @@ export async function upsertCalendarTriggerWorkflowInTx(
       timezone: params.timezone,
       isEnabled: true,
     }).where(eq(workflows.id, workflowId));
-
-    await tx.update(calendarTriggers).set({
-      triggerAt: params.triggerAt,
-    }).where(eq(calendarTriggers.id, triggerId));
-
-    return { workflowId, triggerId };
+  } else {
+    const [created] = await tx.insert(workflows).values({
+      driveId: params.driveId,
+      createdBy: params.scheduledById,
+      name: `calendar-trigger-${params.calendarEventId}`,
+      agentPageId: params.agentTrigger.agentPageId,
+      prompt: triggerPrompt,
+      instructionPageId: params.agentTrigger.instructionPageId ?? null,
+      contextPageIds,
+      triggerType: 'cron',
+      timezone: params.timezone,
+      isEnabled: true,
+    }).returning({ id: workflows.id });
+    workflowId = created.id;
   }
 
-  return createCalendarTriggerWorkflow({
-    tx,
+  if (params.recurrenceRule) {
+    // Clean up unfired future occurrence rows before recreating — ensures that
+    // recurrence-rule changes (e.g. weekly → daily) or time-of-day changes
+    // take effect immediately rather than leaving stale rows in the queue.
+    const now = new Date();
+    await tx.delete(calendarTriggers).where(
+      and(
+        eq(calendarTriggers.calendarEventId, params.calendarEventId),
+        gt(calendarTriggers.triggerAt, now),
+        sql`NOT EXISTS (
+          SELECT 1 FROM ${workflowRuns}
+          WHERE ${workflowRuns.sourceTable} = 'calendarTriggers'
+            AND ${workflowRuns.sourceId} = ${calendarTriggers.id}
+        )`,
+      ),
+    );
+
+    const horizon = new Date(now.getTime() + TRIGGER_HORIZON_DAYS * 86_400_000);
+    const occurrences = expandOccurrences(
+      params.recurrenceRule,
+      params.triggerAt,
+      now,
+      horizon,
+      params.recurrenceExceptions ?? [],
+    );
+
+    await bulkCreateOccurrenceTriggerRows(tx, {
+      workflowId,
+      calendarEventId: params.calendarEventId,
+      driveId: params.driveId,
+      scheduledById: params.scheduledById,
+      occurrences,
+    });
+
+    return { workflowId, triggerId: '' };
+  }
+
+  // One-shot path: update existing trigger row's triggerAt, or create one.
+  if (existing.length > 0) {
+    await tx.update(calendarTriggers).set({
+      triggerAt: params.triggerAt,
+    }).where(eq(calendarTriggers.id, existing[0].id));
+    return { workflowId, triggerId: existing[0].id };
+  }
+
+  const [created] = await tx.insert(calendarTriggers).values({
+    workflowId,
+    calendarEventId: params.calendarEventId,
     driveId: params.driveId,
     scheduledById: params.scheduledById,
-    calendarEventId: params.calendarEventId,
     triggerAt: params.triggerAt,
-    timezone: params.timezone,
-    agentTrigger: params.agentTrigger,
-  });
+  }).returning({ id: calendarTriggers.id });
+
+  return { workflowId, triggerId: created.id };
 }
 
 /**
- * Upsert an event's agent trigger.
- *
- * If a trigger row already exists for this event, updates the linked workflows
- * row in place (agent / prompt / instruction / context pages) and re-aims
- * triggerAt — the workflowId stays stable so any historical workflow_runs
- * stays cleanly linked. If no trigger exists yet, falls through to
- * createCalendarTriggerWorkflow inside the same transaction.
+ * Upsert an event's agent trigger (standalone, outside an existing transaction).
  *
  * Validation runs before the transaction so a bad agent or off-drive context
  * page doesn't briefly hold a row lock. Used by the standalone PUT /triggers

--- a/apps/web/src/lib/workflows/calendar-trigger-helpers.ts
+++ b/apps/web/src/lib/workflows/calendar-trigger-helpers.ts
@@ -216,8 +216,7 @@ export async function upsertCalendarTriggerWorkflowInTx(
   const existing = await tx
     .select({ id: calendarTriggers.id, workflowId: calendarTriggers.workflowId })
     .from(calendarTriggers)
-    .where(eq(calendarTriggers.calendarEventId, params.calendarEventId))
-    .limit(1);
+    .where(eq(calendarTriggers.calendarEventId, params.calendarEventId));
 
   let workflowId: string;
 
@@ -364,8 +363,7 @@ export async function resyncCalendarTriggerTimings(
         scheduledById: calendarTriggers.scheduledById,
       })
       .from(calendarTriggers)
-      .where(eq(calendarTriggers.calendarEventId, calendarEventId))
-      .limit(1);
+      .where(eq(calendarTriggers.calendarEventId, calendarEventId));
 
     if (existingTrigger.length === 0) return;
 

--- a/apps/web/src/lib/workflows/calendar-trigger-helpers.ts
+++ b/apps/web/src/lib/workflows/calendar-trigger-helpers.ts
@@ -285,24 +285,42 @@ export async function upsertCalendarTriggerWorkflowInTx(
 
   // One-shot path: clean up any leftover occurrence rows (from a previous
   // recurring configuration), then update or create the single trigger row.
+  // Query for an *unfired* trigger row separately — `existing` may include
+  // already-fired occurrence rows and we must not retarget historical data.
   if (existing.length > 0) {
-    // Delete all unfired rows for this event except the one we'll update.
-    // This removes stale occurrence rows when a recurring event becomes one-shot.
-    await tx.delete(calendarTriggers).where(
-      and(
-        eq(calendarTriggers.calendarEventId, params.calendarEventId),
-        ne(calendarTriggers.id, existing[0].id),
-        sql`NOT EXISTS (
-          SELECT 1 FROM ${workflowRuns}
-          WHERE ${workflowRuns.sourceTable} = 'calendarTriggers'
-            AND ${workflowRuns.sourceId} = ${calendarTriggers.id}
-        )`,
-      ),
-    );
-    await tx.update(calendarTriggers).set({
-      triggerAt: params.triggerAt,
-    }).where(eq(calendarTriggers.id, existing[0].id));
-    return { workflowId, triggerId: existing[0].id };
+    const [pendingTrigger] = await tx
+      .select({ id: calendarTriggers.id })
+      .from(calendarTriggers)
+      .where(
+        and(
+          eq(calendarTriggers.calendarEventId, params.calendarEventId),
+          sql`NOT EXISTS (
+            SELECT 1 FROM ${workflowRuns}
+            WHERE ${workflowRuns.sourceTable} = 'calendarTriggers'
+              AND ${workflowRuns.sourceId} = ${calendarTriggers.id}
+          )`,
+        ),
+      );
+
+    if (pendingTrigger) {
+      // Delete every unfired row except the one we'll reuse.
+      await tx.delete(calendarTriggers).where(
+        and(
+          eq(calendarTriggers.calendarEventId, params.calendarEventId),
+          ne(calendarTriggers.id, pendingTrigger.id),
+          sql`NOT EXISTS (
+            SELECT 1 FROM ${workflowRuns}
+            WHERE ${workflowRuns.sourceTable} = 'calendarTriggers'
+              AND ${workflowRuns.sourceId} = ${calendarTriggers.id}
+          )`,
+        ),
+      );
+      await tx.update(calendarTriggers).set({
+        triggerAt: params.triggerAt,
+      }).where(eq(calendarTriggers.id, pendingTrigger.id));
+      return { workflowId, triggerId: pendingTrigger.id };
+    }
+    // All trigger rows were already fired — fall through to insert a fresh row.
   }
 
   const [created] = await tx.insert(calendarTriggers).values({

--- a/apps/web/src/lib/workflows/calendar-trigger-helpers.ts
+++ b/apps/web/src/lib/workflows/calendar-trigger-helpers.ts
@@ -1,5 +1,5 @@
 import type { db as DbType } from '@pagespace/db/db';
-import { eq, and, inArray, gt, sql } from '@pagespace/db/operators';
+import { eq, and, inArray, ne, gt, sql } from '@pagespace/db/operators';
 import { pages } from '@pagespace/db/schema/core';
 import { workflows } from '@pagespace/db/schema/workflows';
 import { calendarTriggers } from '@pagespace/db/schema/calendar-triggers';
@@ -284,8 +284,22 @@ export async function upsertCalendarTriggerWorkflowInTx(
     return { workflowId, triggerId: '' };
   }
 
-  // One-shot path: update existing trigger row's triggerAt, or create one.
+  // One-shot path: clean up any leftover occurrence rows (from a previous
+  // recurring configuration), then update or create the single trigger row.
   if (existing.length > 0) {
+    // Delete all unfired rows for this event except the one we'll update.
+    // This removes stale occurrence rows when a recurring event becomes one-shot.
+    await tx.delete(calendarTriggers).where(
+      and(
+        eq(calendarTriggers.calendarEventId, params.calendarEventId),
+        ne(calendarTriggers.id, existing[0].id),
+        sql`NOT EXISTS (
+          SELECT 1 FROM ${workflowRuns}
+          WHERE ${workflowRuns.sourceTable} = 'calendarTriggers'
+            AND ${workflowRuns.sourceId} = ${calendarTriggers.id}
+        )`,
+      ),
+    );
     await tx.update(calendarTriggers).set({
       triggerAt: params.triggerAt,
     }).where(eq(calendarTriggers.id, existing[0].id));
@@ -321,4 +335,81 @@ export async function upsertCalendarTriggerWorkflow(
   });
 
   return database.transaction((tx) => upsertCalendarTriggerWorkflowInTx(tx, params));
+}
+
+/**
+ * Re-synchronise trigger rows when the event's timing or recurrence rule changes
+ * but the caller did NOT explicitly supply a new agentTrigger payload.
+ *
+ * For recurring events: deletes unfired future rows and re-expands the series
+ * from newBaseAt using the caller-supplied recurrenceRule, preserving the
+ * existing workflowId so history stays linked.
+ *
+ * For one-shot events: re-aims the single pending trigger row to newBaseAt.
+ *
+ * No-op if the event has no trigger rows at all.
+ */
+export async function resyncCalendarTriggerTimings(
+  tx: Parameters<Parameters<typeof DbType.transaction>[0]>[0],
+  calendarEventId: string,
+  newBaseAt: Date,
+  effectiveRecurrenceRule: RecurrenceRule | null | undefined,
+  exceptions: string[],
+): Promise<void> {
+  if (effectiveRecurrenceRule) {
+    const existingTrigger = await tx
+      .select({
+        workflowId: calendarTriggers.workflowId,
+        driveId: calendarTriggers.driveId,
+        scheduledById: calendarTriggers.scheduledById,
+      })
+      .from(calendarTriggers)
+      .where(eq(calendarTriggers.calendarEventId, calendarEventId))
+      .limit(1);
+
+    if (existingTrigger.length === 0) return;
+
+    const { workflowId, driveId, scheduledById } = existingTrigger[0];
+    const now = new Date();
+    await tx.delete(calendarTriggers).where(
+      and(
+        eq(calendarTriggers.calendarEventId, calendarEventId),
+        gt(calendarTriggers.triggerAt, now),
+        sql`NOT EXISTS (
+          SELECT 1 FROM ${workflowRuns}
+          WHERE ${workflowRuns.sourceTable} = 'calendarTriggers'
+            AND ${workflowRuns.sourceId} = ${calendarTriggers.id}
+        )`,
+      ),
+    );
+
+    const horizon = new Date(now.getTime() + TRIGGER_HORIZON_DAYS * 86_400_000);
+    const occurrences = expandOccurrences(
+      effectiveRecurrenceRule,
+      newBaseAt,
+      now,
+      horizon,
+      exceptions,
+    );
+
+    await bulkCreateOccurrenceTriggerRows(tx, {
+      workflowId,
+      calendarEventId,
+      driveId,
+      scheduledById,
+      occurrences,
+    });
+  } else {
+    await tx
+      .update(calendarTriggers)
+      .set({ triggerAt: newBaseAt })
+      .where(and(
+        eq(calendarTriggers.calendarEventId, calendarEventId),
+        sql`NOT EXISTS (
+          SELECT 1 FROM ${workflowRuns}
+          WHERE ${workflowRuns.sourceTable} = 'calendarTriggers'
+            AND ${workflowRuns.sourceId} = ${calendarTriggers.id}
+        )`,
+      ));
+  }
 }

--- a/apps/web/src/lib/workflows/recurrence-utils.ts
+++ b/apps/web/src/lib/workflows/recurrence-utils.ts
@@ -105,16 +105,20 @@ export function expandOccurrences(
     }
 
     case 'MONTHLY': {
-      const targetDay = rule.byMonthDay?.[0] ?? baseStartAt.getUTCDate();
+      const targetDays = rule.byMonthDay ?? [baseStartAt.getUTCDate()];
       let y = baseStartAt.getUTCFullYear();
       let m = baseStartAt.getUTCMonth();
 
-      while (true) {
-        const candidate = new Date(Date.UTC(
-          y, m, targetDay,
-          baseStartAt.getUTCHours(), baseStartAt.getUTCMinutes(), baseStartAt.getUTCSeconds(), 0,
-        ));
-        if (!collect(candidate)) break;
+      outer: while (true) {
+        const maxDay = new Date(Date.UTC(y, m + 1, 0)).getUTCDate();
+        for (const targetDay of targetDays) {
+          if (targetDay > maxDay) continue; // skip days that don't exist in this month
+          const candidate = new Date(Date.UTC(
+            y, m, targetDay,
+            baseStartAt.getUTCHours(), baseStartAt.getUTCMinutes(), baseStartAt.getUTCSeconds(), 0,
+          ));
+          if (!collect(candidate)) break outer;
+        }
         m += rule.interval;
         if (m >= 12) { y += Math.floor(m / 12); m %= 12; }
       }
@@ -123,13 +127,22 @@ export function expandOccurrences(
 
     case 'YEARLY': {
       let y = baseStartAt.getUTCFullYear();
+      // byMonth uses 1-indexed month numbers; convert to 0-indexed for Date.UTC
+      const months = rule.byMonth?.map((mo) => mo - 1) ?? [baseStartAt.getUTCMonth()];
+      const days = rule.byMonthDay ?? [baseStartAt.getUTCDate()];
 
-      while (true) {
-        const candidate = new Date(Date.UTC(
-          y, baseStartAt.getUTCMonth(), baseStartAt.getUTCDate(),
-          baseStartAt.getUTCHours(), baseStartAt.getUTCMinutes(), baseStartAt.getUTCSeconds(), 0,
-        ));
-        if (!collect(candidate)) break;
+      outer: while (true) {
+        for (const mo of months) {
+          const maxDay = new Date(Date.UTC(y, mo + 1, 0)).getUTCDate();
+          for (const d of days) {
+            if (d > maxDay) continue; // skip days that don't exist in this month
+            const candidate = new Date(Date.UTC(
+              y, mo, d,
+              baseStartAt.getUTCHours(), baseStartAt.getUTCMinutes(), baseStartAt.getUTCSeconds(), 0,
+            ));
+            if (!collect(candidate)) break outer;
+          }
+        }
         y += rule.interval;
       }
       break;

--- a/apps/web/src/lib/workflows/recurrence-utils.ts
+++ b/apps/web/src/lib/workflows/recurrence-utils.ts
@@ -1,0 +1,140 @@
+type Weekday = 'MO' | 'TU' | 'WE' | 'TH' | 'FR' | 'SA' | 'SU';
+
+export interface RecurrenceRule {
+  frequency: 'DAILY' | 'WEEKLY' | 'MONTHLY' | 'YEARLY';
+  interval: number;
+  byDay?: Weekday[];
+  byMonthDay?: number[];
+  byMonth?: number[];
+  count?: number;
+  until?: string;
+}
+
+const WEEKDAY_INDEX: Record<Weekday, number> = {
+  SU: 0, MO: 1, TU: 2, WE: 3, TH: 4, FR: 5, SA: 6,
+};
+
+const MS_PER_DAY = 86_400_000;
+
+function utcMidnight(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+}
+
+function addDays(d: Date, n: number): Date {
+  return new Date(d.getTime() + n * MS_PER_DAY);
+}
+
+function withBaseTime(d: Date, base: Date): Date {
+  return new Date(Date.UTC(
+    d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(),
+    base.getUTCHours(), base.getUTCMinutes(), base.getUTCSeconds(), 0,
+  ));
+}
+
+/**
+ * Expand a recurrence rule into concrete UTC timestamps within [from, to].
+ *
+ * Pure function — no I/O, no side effects. Safe to call in tests and in the
+ * cron poller's refill step with identical inputs and expect identical output.
+ *
+ * Params:
+ *   rule         — the recurrence rule (frequency, interval, byDay, etc.)
+ *   baseStartAt  — the parent event's startAt; preserves time-of-day for all occurrences
+ *   from         — lower bound (inclusive); occurrences before this are skipped
+ *   to           — upper bound (inclusive); expansion stops here
+ *   exceptions   — ISO date strings (YYYY-MM-DD or full ISO) to skip
+ *
+ * COUNT semantics: all occurrences from baseStartAt count toward rule.count,
+ * including those before `from`. If the series is exhausted before `from`,
+ * returns [].
+ */
+export function expandOccurrences(
+  rule: RecurrenceRule,
+  baseStartAt: Date,
+  from: Date,
+  to: Date,
+  exceptions: string[],
+): Date[] {
+  const effectiveTo = rule.until
+    ? new Date(Math.min(new Date(rule.until).getTime(), to.getTime()))
+    : to;
+
+  const excluded = new Set(exceptions.map((e) => e.slice(0, 10)));
+  const limit = rule.count ?? Infinity;
+  const results: Date[] = [];
+  let totalSeen = 0; // counts all occurrences from series start, including pre-from
+
+  function collect(candidate: Date): boolean {
+    if (candidate < baseStartAt) return true; // before series start — skip, don't count
+    totalSeen++;
+    if (totalSeen > limit) return false; // COUNT exhausted — stop
+    if (candidate > effectiveTo) return false; // past window — stop
+    if (candidate >= from && !excluded.has(candidate.toISOString().slice(0, 10))) {
+      results.push(candidate);
+    }
+    return true; // continue
+  }
+
+  switch (rule.frequency) {
+    case 'DAILY': {
+      let cursor = new Date(baseStartAt);
+      while (cursor <= effectiveTo) {
+        if (!collect(cursor)) break;
+        cursor = addDays(cursor, rule.interval);
+      }
+      break;
+    }
+
+    case 'WEEKLY': {
+      const targetDays = (
+        rule.byDay?.map((d) => WEEKDAY_INDEX[d]) ?? [baseStartAt.getUTCDay()]
+      ).sort((a, b) => a - b);
+
+      // Sunday UTC of the week containing baseStartAt
+      const offsetToSunday = baseStartAt.getUTCDay();
+      let weekSunday = utcMidnight(addDays(baseStartAt, -offsetToSunday));
+
+      outer: while (weekSunday <= effectiveTo) {
+        for (const wd of targetDays) {
+          const candidate = withBaseTime(addDays(weekSunday, wd), baseStartAt);
+          if (!collect(candidate)) break outer;
+        }
+        weekSunday = addDays(weekSunday, 7 * rule.interval);
+      }
+      break;
+    }
+
+    case 'MONTHLY': {
+      const targetDay = rule.byMonthDay?.[0] ?? baseStartAt.getUTCDate();
+      let y = baseStartAt.getUTCFullYear();
+      let m = baseStartAt.getUTCMonth();
+
+      while (true) {
+        const candidate = new Date(Date.UTC(
+          y, m, targetDay,
+          baseStartAt.getUTCHours(), baseStartAt.getUTCMinutes(), baseStartAt.getUTCSeconds(), 0,
+        ));
+        if (!collect(candidate)) break;
+        m += rule.interval;
+        if (m >= 12) { y += Math.floor(m / 12); m %= 12; }
+      }
+      break;
+    }
+
+    case 'YEARLY': {
+      let y = baseStartAt.getUTCFullYear();
+
+      while (true) {
+        const candidate = new Date(Date.UTC(
+          y, baseStartAt.getUTCMonth(), baseStartAt.getUTCDate(),
+          baseStartAt.getUTCHours(), baseStartAt.getUTCMinutes(), baseStartAt.getUTCSeconds(), 0,
+        ));
+        if (!collect(candidate)) break;
+        y += rule.interval;
+      }
+      break;
+    }
+  }
+
+  return results;
+}


### PR DESCRIPTION
## Summary

- **New pure function** \`expandOccurrences()\` in \`recurrence-utils.ts\` — maps an iCalendar-style recurrence rule (DAILY/WEEKLY/MONTHLY/YEARLY, \`byDay\`, \`byMonthDay\`, \`byMonth\`, \`count\`, \`until\`, exceptions) to concrete UTC timestamps; no I/O, fully unit-testable
- **MONTHLY/YEARLY bug fixes** — MONTHLY now iterates all \`byMonthDay\` entries and skips invalid month-days (e.g. Feb 31) instead of Date-rolling into the next month; YEARLY now honors \`byMonth\`+\`byMonthDay\` so a rule like \`{byMonth:[12],byMonthDay:[25]}\` correctly fires Dec 25
- **Recurring occurrence rows** — \`upsertCalendarTriggerWorkflowInTx\` expands 180 days of \`calendar_triggers\` rows when \`recurrenceRule\` is present; unfired future rows are deleted first; \`ON CONFLICT DO NOTHING\` makes it idempotent
- **One-shot path safety** — when a recurring→one-shot transition happens, the cleanup query now uses a separate \`pendingTrigger\` query with \`NOT EXISTS\` guard so only unfired rows are retargeted (never historical fired rows)
- **\`resyncCalendarTriggerTimings\`** — new function called from the PATCH route when \`agentTrigger\` is unchanged but \`startAt\` or \`recurrenceRule\` changes; re-expands the occurrence series for recurring events, re-aims the single pending row for one-shot events
- **Cron look-ahead refill** — \`refillRecurringTriggers()\` step added; tops up recurring events whose trigger queue has fewer than 30 days of future rows (max 20 events/tick, refills to 180 days); now called on every tick including quiet ticks (no due triggers)
- **Refill discovery fix** — \`needsRefill\` query now drives from \`calendarEvents\` (not \`calendarTriggers\`) so events whose entire queue was fired and no rows remain are still rediscovered
- **All five guards removed** — UI (\`EventModal\`), API (\`POST /events\`, \`PATCH /events/[id]\`, \`PUT /events/[id]/triggers\`), and AI tools no longer block recurring events from having agent triggers

## How it works

The existing schema had \`occurrenceDate\` and a \`(calendarEventId, occurrenceDate)\` unique constraint already designed for this. The cron poller fires rows when \`triggerAt <= now\`, so pre-populating the queue with one row per future occurrence is all that was needed.

## Test plan

- [ ] Create a weekly recurring event → agent trigger picker appears (no disabled message)
- [ ] Save with trigger → \`calendar_triggers\` has ~26 rows with distinct \`occurrenceDate\` values; all share one \`workflowId\`; \`triggerAt\` preserves correct time-of-day
- [ ] Backdate one row's \`triggerAt\` → POST \`/api/cron/calendar-triggers\` → fires; \`workflow_runs\` success row appears; cron picks up next batch
- [ ] Delete trigger → all \`calendar_triggers\` rows cascade-deleted, \`workflows\` row deleted
- [ ] Set \`recurrenceRule.until\` → no rows inserted past that date
- [ ] Delete all future rows manually → POST cron → refill step re-adds them
- [ ] Change \`startAt\` on a recurring event with trigger → \`resyncCalendarTriggerTimings\` re-expands series
- [ ] \`pnpm test:unit\` — 28 \`recurrence-utils\` unit tests + 5 new PATCH/cron/trigger contract tests pass; no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)