### PR TITLE
fix(ai): use conversationId in list_conversations renderer

### DIFF
--- a/apps/web/src/components/ai/shared/chat/tool-calls/CompactToolCallRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/CompactToolCallRenderer.tsx
@@ -417,14 +417,14 @@ const CompactToolCallRendererInternal: React.FC<{ part: ToolPart; toolName: stri
     }
 
     if (toolName === 'list_conversations' && result.conversations != null) {
-      const conversations = result.conversations as Array<{ id: string; title?: string }>;
+      const conversations = result.conversations as Array<{ conversationId: string; title?: string; firstMessagePreview?: string }>;
       return (
         <PageTreeRenderer
           tree={conversations.map(c => ({
-            path: c.id,
-            title: c.title || `Conversation ${c.id.slice(0, 8)}`,
+            path: c.conversationId,
+            title: c.title || c.firstMessagePreview?.slice(0, 40) || `Conversation ${c.conversationId?.slice(0, 8) ?? ''}`,
             type: 'AI_CHAT',
-            pageId: c.id,
+            pageId: c.conversationId,
             children: []
           }))}
           title="Conversations"

--- a/apps/web/src/components/ai/shared/chat/tool-calls/ToolCallRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/tool-calls/ToolCallRenderer.tsx
@@ -408,15 +408,14 @@ const ToolCallRendererInternal: React.FC<{ part: ToolPart; toolName: string }> =
     }
 
     if (toolName === 'list_conversations' && parsedOutput.conversations) {
-      // Display conversations as a simple list
-      const conversations = parsedOutput.conversations as Array<{ id: string; title?: string; messageCount?: number }>;
+      const conversations = parsedOutput.conversations as Array<{ conversationId: string; title?: string; firstMessagePreview?: string; messageCount?: number }>;
       return (
         <PageTreeRenderer
           tree={conversations.map(c => ({
-            path: c.id,
-            title: c.title || `Conversation ${c.id.slice(0, 8)}`,
+            path: c.conversationId,
+            title: c.title || c.firstMessagePreview?.slice(0, 40) || `Conversation ${c.conversationId?.slice(0, 8) ?? ''}`,
             type: 'AI_CHAT',
-            pageId: c.id,
+            pageId: c.conversationId,
             children: []
           }))}
           title="Conversations"


### PR DESCRIPTION
## Summary

- `list_conversations` returns `conversationId` but both chat renderers accessed `c.id`, which was always `undefined`
- `c.id.slice(0, 8)` threw **"cannot read properties of undefined (reading 'slice')"** during streaming
- Fixed in both `ToolCallRenderer` (page AI chat) and `CompactToolCallRenderer` (global assistant sidebar)
- Added `firstMessagePreview` as title fallback so conversations show meaningful labels instead of the raw ID prefix

## Test plan

- [ ] Trigger `list_conversations` in an AI Chat page — confirm conversations render without crashing
- [ ] Trigger the same via `execute_tool` wrapping `list_conversations` — confirm the unwrap path also works
- [ ] Open right-sidebar global assistant, repeat — confirm compact renderer also renders cleanly
- [ ] `pnpm test:unit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced conversation display in the list tool with improved title fallback logic and additional preview information.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1318)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->