### PR TITLE
fix(calendar): show attendee names after invite

### DIFF
--- a/apps/web/src/components/calendar/CalendarView.tsx
+++ b/apps/web/src/components/calendar/CalendarView.tsx
@@ -323,7 +323,10 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
           : null
       );
       try {
-        await addAttendees(selectedEvent.id, [userId]);
+        const updatedAttendees = await addAttendees(selectedEvent.id, [userId]);
+        if (updatedAttendees.length > 0) {
+          setSelectedEvent((prev) => prev ? { ...prev, attendees: updatedAttendees } : null);
+        }
       } catch {
         setSelectedEvent(prevEvent);
         throw new Error('Failed to add attendee');

--- a/apps/web/src/components/calendar/CalendarView.tsx
+++ b/apps/web/src/components/calendar/CalendarView.tsx
@@ -331,7 +331,9 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
           );
         }
       } catch {
-        setSelectedEvent(prevEvent);
+        setSelectedEvent((prev) =>
+          prev && prev.id === targetEventId ? prevEvent : prev
+        );
         throw new Error('Failed to add attendee');
       }
     },

--- a/apps/web/src/components/calendar/CalendarView.tsx
+++ b/apps/web/src/components/calendar/CalendarView.tsx
@@ -322,10 +322,13 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
             }
           : null
       );
+      const targetEventId = selectedEvent.id;
       try {
-        const updatedAttendees = await addAttendees(selectedEvent.id, [userId]);
+        const updatedAttendees = await addAttendees(targetEventId, [userId]);
         if (updatedAttendees.length > 0) {
-          setSelectedEvent((prev) => prev ? { ...prev, attendees: updatedAttendees } : null);
+          setSelectedEvent((prev) =>
+            prev && prev.id === targetEventId ? { ...prev, attendees: updatedAttendees } : prev
+          );
         }
       } catch {
         setSelectedEvent(prevEvent);

--- a/apps/web/src/components/calendar/useCalendarData.ts
+++ b/apps/web/src/components/calendar/useCalendarData.ts
@@ -5,7 +5,7 @@ import useSWR, { mutate } from 'swr';
 import { fetchWithAuth, post, patch, del } from '@/lib/auth/auth-fetch';
 import { useCalendarSocket } from '@/hooks/useCalendarSocket';
 import { useEditingStore } from '@/stores/useEditingStore';
-import { CalendarEvent, TaskWithDueDate } from './calendar-types';
+import { CalendarEvent, CalendarEventAttendee, TaskWithDueDate } from './calendar-types';
 import {
   startOfMonth,
   endOfMonth,
@@ -206,8 +206,7 @@ export function useCalendarData({
 
   const addAttendees = useCallback(
     async (eventId: string, userIds: string[], isOptional = false) => {
-      const result = await post(`/api/calendar/events/${eventId}/attendees`, { userIds, isOptional });
-      const data = await result.json() as { attendees?: import('./calendar-types').CalendarEventAttendee[] };
+      const data = await post<{ attendees?: CalendarEventAttendee[] }>(`/api/calendar/events/${eventId}/attendees`, { userIds, isOptional });
       mutate(eventsUrl);
       return data.attendees ?? [];
     },

--- a/apps/web/src/components/calendar/useCalendarData.ts
+++ b/apps/web/src/components/calendar/useCalendarData.ts
@@ -206,8 +206,10 @@ export function useCalendarData({
 
   const addAttendees = useCallback(
     async (eventId: string, userIds: string[], isOptional = false) => {
-      await post(`/api/calendar/events/${eventId}/attendees`, { userIds, isOptional });
+      const result = await post(`/api/calendar/events/${eventId}/attendees`, { userIds, isOptional });
+      const data = await result.json() as { attendees?: import('./calendar-types').CalendarEventAttendee[] };
       mutate(eventsUrl);
+      return data.attendees ?? [];
     },
     [eventsUrl]
   );


### PR DESCRIPTION
## Summary

- After inviting a drive member to a calendar event, the attendee list was displaying raw user IDs instead of names
- Optimistic update in `handleAddAttendee` used `user: { name: null }`, causing the `a.user.name ?? a.userId` fallback to show the ID
- `addAttendees` discarded the API response which contained full user objects with names/images

## Changes

- `useCalendarData.ts`: `addAttendees` now parses and returns the attendees array from the POST response
- `CalendarView.tsx`: after a successful invite, `selectedEvent` is patched with the server's attendee list (with correct names and avatars)

## Test plan

- [ ] Open a drive calendar event, invite a drive member — attendee list should show their name immediately after invite
- [ ] Confirm the "Pending" badge still appears correctly alongside the name
- [ ] Confirm remove attendee still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Event modal now syncs attendee list with the server after adding attendees, ensuring the modal shows the actual backend results.
  * Optimistic UI updates are preserved only while the modal still shows the same event; on failure the original attendee list is restored.
  * Attendee additions now trigger data revalidation so the calendar consistently reflects updated rosters.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1320)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->