### PR TITLE
fix(share-links): broadcast member-added on share link redemption

### DIFF
--- a/apps/web/src/app/api/share/[token]/accept/route.ts
+++ b/apps/web/src/app/api/share/[token]/accept/route.ts
@@ -36,9 +36,9 @@ export async function POST(
       driveName: driveResult.data.driveName,
       role: driveResult.data.role,
       invitedUserId: auth.ctx.userId,
-      inviterUserId: auth.ctx.userId,
+      inviterUserId: driveResult.data.createdBy,
     };
-    await emitAcceptanceSideEffects(ports, acceptData, 0);
+    await emitAcceptanceSideEffects(ports, acceptData, 0).catch(() => undefined);
     return NextResponse.json({ type: 'drive', driveId: driveResult.data.driveId });
   }
 

--- a/apps/web/src/app/api/share/[token]/accept/route.ts
+++ b/apps/web/src/app/api/share/[token]/accept/route.ts
@@ -5,6 +5,9 @@ import {
   redeemPageShareLink,
 } from '@pagespace/lib/permissions/share-link-service';
 import { securityAudit } from '@pagespace/lib/audit/security-audit';
+import { buildAcceptancePorts } from '@/lib/auth/invite-acceptance-adapters';
+import { emitAcceptanceSideEffects } from '@pagespace/lib/services/invites';
+import type { AcceptedInviteData } from '@pagespace/lib/services/invites';
 
 const AUTH_WRITE = { allow: ['session'] as const, requireCSRF: true };
 
@@ -26,6 +29,16 @@ export async function POST(
       linkId: driveResult.data.linkId,
       ipAddress: clientIP,
     }).catch(() => undefined);
+    const ports = buildAcceptancePorts(request);
+    const acceptData: AcceptedInviteData = {
+      memberId: driveResult.data.memberId,
+      driveId: driveResult.data.driveId,
+      driveName: driveResult.data.driveName,
+      role: driveResult.data.role,
+      invitedUserId: auth.ctx.userId,
+      inviterUserId: auth.ctx.userId,
+    };
+    await emitAcceptanceSideEffects(ports, acceptData, 0);
     return NextResponse.json({ type: 'drive', driveId: driveResult.data.driveId });
   }
 

--- a/packages/lib/src/permissions/__tests__/share-link-service.test.ts
+++ b/packages/lib/src/permissions/__tests__/share-link-service.test.ts
@@ -116,6 +116,7 @@ function makeSelectChain(result: unknown[]) {
   const chain = {
     from: vi.fn().mockReturnThis(),
     leftJoin: vi.fn().mockReturnThis(),
+    innerJoin: vi.fn().mockReturnThis(),
     where: vi.fn().mockReturnValue(terminal),
     limit: vi.fn().mockResolvedValue(result),
     orderBy: vi.fn().mockReturnThis(),
@@ -276,11 +277,12 @@ describe('redeemDriveShareLink', () => {
   it('creates drive membership and increments useCount for valid token', async () => {
     mockDb.select.mockImplementation(() => ({
       from: vi.fn().mockReturnThis(),
-      leftJoin: vi.fn().mockReturnThis(),
+      innerJoin: vi.fn().mockReturnThis(),
       where: vi.fn().mockReturnThis(),
       limit: vi.fn().mockResolvedValue([{
         id: LINK_ID, driveId: DRIVE_ID, role: 'MEMBER',
         isActive: true, expiresAt: null, driveName: 'Test Drive',
+        createdBy: 'creator-user-id',
       }]),
     }));
     vi.mocked(isUserDriveMember).mockResolvedValue(false);
@@ -296,6 +298,7 @@ describe('redeemDriveShareLink', () => {
       expect(result.data.memberId).toBe('new-member-id');
       expect(result.data.driveName).toBe('Test Drive');
       expect(result.data.role).toBe('MEMBER');
+      expect(result.data.createdBy).toBe('creator-user-id');
     }
     expect(mockDb.insert).toHaveBeenCalled();
     expect(mockDb.update).toHaveBeenCalled();

--- a/packages/lib/src/permissions/__tests__/share-link-service.test.ts
+++ b/packages/lib/src/permissions/__tests__/share-link-service.test.ts
@@ -128,8 +128,8 @@ function makeInsertChain(result: unknown[] = []) {
   const chain = {
     values: vi.fn().mockReturnThis(),
     returning: vi.fn().mockResolvedValue(result),
-    onConflictDoNothing: vi.fn().mockResolvedValue(undefined),
-    onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+    onConflictDoNothing: vi.fn().mockReturnThis(),
+    onConflictDoUpdate: vi.fn().mockReturnThis(),
   };
   mockDb.insert.mockReturnValue(chain);
   return chain;
@@ -274,21 +274,17 @@ describe('redeemDriveShareLink', () => {
   });
 
   it('creates drive membership and increments useCount for valid token', async () => {
-    let callCount = 0;
     mockDb.select.mockImplementation(() => ({
       from: vi.fn().mockReturnThis(),
       leftJoin: vi.fn().mockReturnThis(),
       where: vi.fn().mockReturnThis(),
-      limit: vi.fn().mockImplementation(() => {
-        callCount++;
-        if (callCount === 1) {
-          return Promise.resolve([{ id: LINK_ID, driveId: DRIVE_ID, role: 'MEMBER', isActive: true, expiresAt: null }]);
-        }
-        return Promise.resolve([]);
-      }),
+      limit: vi.fn().mockResolvedValue([{
+        id: LINK_ID, driveId: DRIVE_ID, role: 'MEMBER',
+        isActive: true, expiresAt: null, driveName: 'Test Drive',
+      }]),
     }));
     vi.mocked(isUserDriveMember).mockResolvedValue(false);
-    makeInsertChain([]);
+    makeInsertChain([{ id: 'new-member-id' }]);
     makeUpdateChain();
 
     const result = await redeemDriveShareLink(makeCtx(), 'valid-token');
@@ -297,6 +293,9 @@ describe('redeemDriveShareLink', () => {
     if (result.ok) {
       expect(result.data.driveId).toBe(DRIVE_ID);
       expect(result.data.linkId).toBe(LINK_ID);
+      expect(result.data.memberId).toBe('new-member-id');
+      expect(result.data.driveName).toBe('Test Drive');
+      expect(result.data.role).toBe('MEMBER');
     }
     expect(mockDb.insert).toHaveBeenCalled();
     expect(mockDb.update).toHaveBeenCalled();

--- a/packages/lib/src/permissions/share-link-service.ts
+++ b/packages/lib/src/permissions/share-link-service.ts
@@ -151,7 +151,7 @@ export async function redeemDriveShareLink(
   ctx: EnforcedAuthContext,
   rawToken: string
 ): Promise<
-  | { ok: true; data: { driveId: string; linkId: string } }
+  | { ok: true; data: { driveId: string; linkId: string; memberId: string; driveName: string; role: DriveShareLink['role'] } }
   | { ok: false; error: 'ALREADY_MEMBER'; driveId: string }
   | { ok: false; error: 'NOT_FOUND' }
 > {
@@ -165,8 +165,10 @@ export async function redeemDriveShareLink(
       isActive: driveShareLinks.isActive,
       expiresAt: driveShareLinks.expiresAt,
       useCount: driveShareLinks.useCount,
+      driveName: drives.name,
     })
     .from(driveShareLinks)
+    .leftJoin(drives, eq(driveShareLinks.driveId, drives.id))
     .where(eq(driveShareLinks.tokenHash, tokenHash))
     .limit(1);
 
@@ -179,7 +181,7 @@ export async function redeemDriveShareLink(
   const alreadyMember = await isUserDriveMember(ctx.userId, link.driveId);
   if (alreadyMember) return { ok: false, error: 'ALREADY_MEMBER', driveId: link.driveId };
 
-  await db.insert(driveMembers).values({
+  const [inserted] = await db.insert(driveMembers).values({
     id: createId(),
     driveId: link.driveId,
     userId: ctx.userId,
@@ -192,14 +194,23 @@ export async function redeemDriveShareLink(
       // Preserve ADMIN role — never downgrade an existing ADMIN via a MEMBER share link
       role: sql`CASE WHEN ${driveMembers.role} = 'ADMIN' THEN ${driveMembers.role} ELSE EXCLUDED.role END`,
     },
-  });
+  }).returning({ id: driveMembers.id });
 
   await db
     .update(driveShareLinks)
     .set({ useCount: sql`${driveShareLinks.useCount} + 1` })
     .where(eq(driveShareLinks.id, link.id));
 
-  return { ok: true, data: { driveId: link.driveId, linkId: link.id } };
+  return {
+    ok: true,
+    data: {
+      driveId: link.driveId,
+      linkId: link.id,
+      memberId: inserted.id,
+      driveName: link.driveName ?? '',
+      role: link.role,
+    },
+  };
 }
 
 // ============================================================================

--- a/packages/lib/src/permissions/share-link-service.ts
+++ b/packages/lib/src/permissions/share-link-service.ts
@@ -40,6 +40,15 @@ export interface PageShareLinkView {
   createdAt: Date;
 }
 
+export interface DriveShareLinkRedemption {
+  driveId: string;
+  linkId: string;
+  memberId: string;
+  driveName: string;
+  role: DriveShareLink['role'];
+  createdBy: string;
+}
+
 export interface ShareTokenInfo {
   type: 'drive' | 'page';
   linkId: string;
@@ -151,7 +160,7 @@ export async function redeemDriveShareLink(
   ctx: EnforcedAuthContext,
   rawToken: string
 ): Promise<
-  | { ok: true; data: { driveId: string; linkId: string; memberId: string; driveName: string; role: DriveShareLink['role']; createdBy: string } }
+  | { ok: true; data: DriveShareLinkRedemption }
   | { ok: false; error: 'ALREADY_MEMBER'; driveId: string }
   | { ok: false; error: 'NOT_FOUND' }
 > {

--- a/packages/lib/src/permissions/share-link-service.ts
+++ b/packages/lib/src/permissions/share-link-service.ts
@@ -151,7 +151,7 @@ export async function redeemDriveShareLink(
   ctx: EnforcedAuthContext,
   rawToken: string
 ): Promise<
-  | { ok: true; data: { driveId: string; linkId: string; memberId: string; driveName: string; role: DriveShareLink['role'] } }
+  | { ok: true; data: { driveId: string; linkId: string; memberId: string; driveName: string; role: DriveShareLink['role']; createdBy: string } }
   | { ok: false; error: 'ALREADY_MEMBER'; driveId: string }
   | { ok: false; error: 'NOT_FOUND' }
 > {
@@ -165,10 +165,11 @@ export async function redeemDriveShareLink(
       isActive: driveShareLinks.isActive,
       expiresAt: driveShareLinks.expiresAt,
       useCount: driveShareLinks.useCount,
+      createdBy: driveShareLinks.createdBy,
       driveName: drives.name,
     })
     .from(driveShareLinks)
-    .leftJoin(drives, eq(driveShareLinks.driveId, drives.id))
+    .innerJoin(drives, eq(driveShareLinks.driveId, drives.id))
     .where(eq(driveShareLinks.tokenHash, tokenHash))
     .limit(1);
 
@@ -207,8 +208,9 @@ export async function redeemDriveShareLink(
       driveId: link.driveId,
       linkId: link.id,
       memberId: inserted.id,
-      driveName: link.driveName ?? '',
+      driveName: link.driveName,
       role: link.role,
+      createdBy: link.createdBy,
     },
   };
 }


### PR DESCRIPTION
## Summary

Fills the gap identified after #1305: when a user redeems a **drive share link**, the `member_added` websocket event was never fired. Other drive members would not see the new member appear in the members panel without a page refresh.

- `redeemDriveShareLink` now `innerJoin`s `drives` (enforces FK invariant; eliminated the `?? ''` fallback) and returns `DriveShareLinkRedemption` — a named interface containing `memberId`, `driveName`, `role`, and `createdBy` alongside the existing `driveId`/`linkId`
- `POST /api/share/[token]/accept` calls `buildAcceptancePorts` + `emitAcceptanceSideEffects` after a successful drive redemption, firing `member_added` to all drive members. `inviterUserId` is set to the share link `createdBy` (the link creator), not the redeemer. The call is `.catch()`-wrapped so a broadcast failure cannot reverse the committed membership row.
- `DriveShareLinkRedemption` extracted as a named exported interface, consistent with `DriveShareLinkView`/`ShareTokenInfo` patterns in the same file
- Test mock helpers updated: `onConflictDoUpdate → mockReturnThis()` (chainable for `.returning()`), `innerJoin` added to `makeSelectChain`; success test asserts all new fields including `createdBy`

## Test plan

- [x] `pnpm --filter @pagespace/lib build` — clean
- [x] `node_modules/.bin/vitest run packages/lib/src/permissions/__tests__/share-link-service.test.ts` — 29/29 pass
- [x] `pnpm --filter web typecheck` — clean
- [ ] Manual: redeem a drive share link while another member has the members panel open — new member appears without a page refresh
- [ ] Manual: audit log and activity feed show the link creator (not the redeemer) as the inviter

## Related

- #1305 — original public share links epic (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Accepting drive share links now reliably registers users as drive members and applies the correct access role.
* **New Features**
  * Share-link redemption returns more details: member ID, drive name, role, and link creator.
  * Acceptance emits downstream side-effects (e.g., notifications/audit flows) without disrupting the user flow if those emissions fail.
* **Tests**
  * Updated tests to cover expanded redemption behavior and returned fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1322)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->