### PR TITLE
refactor(share-links): extract useShareLink hook to deduplicate UI components

### DIFF
--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/PageShareLinkSection.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/PageShareLinkSection.tsx
@@ -1,163 +1,59 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { Link2, Copy, Trash2 } from 'lucide-react';
-import { post, del } from '@/lib/auth/auth-fetch';
-import { toast } from 'sonner';
+import { useShareLink } from '@/hooks/useShareLink';
 
-interface ActiveLink {
-  id: string;
-  permissions: Array<'VIEW' | 'EDIT'>;
-  useCount: number;
-}
+type PagePerms = Array<'VIEW' | 'EDIT'>;
+interface PageLink { id: string; permissions: PagePerms; useCount: number; }
+const MSGS = {
+  created: 'Link created',
+  createdAndCopied: 'Link created and copied to clipboard',
+  copied: 'Link copied to clipboard',
+  copyFailed: 'Could not copy link to clipboard',
+  revoked: 'Link revoked',
+  createFailed: 'Failed to create link',
+  revokeFailed: 'Failed to revoke link',
+};
 
-interface PageShareLinkSectionProps {
-  pageId: string;
-}
-
-const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? '';
-
-export function PageShareLinkSection({ pageId }: PageShareLinkSectionProps) {
-  const [activeLink, setActiveLink] = useState<ActiveLink | null>(null);
-  const [rawToken, setRawToken] = useState<string | null>(null);
+export function PageShareLinkSection({ pageId }: { pageId: string }) {
   const [includeEdit, setIncludeEdit] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isGenerating, setIsGenerating] = useState(false);
-  const [isRevoking, setIsRevoking] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-    async function loadExisting() {
-      try {
-        const res = await fetch(`/api/pages/${pageId}/share-links`, {
-          credentials: 'include',
-        });
-        if (!res.ok || cancelled) return;
-        const data = await res.json() as {
-          links: Array<{ id: string; permissions: Array<'VIEW' | 'EDIT'>; useCount: number }>;
-        };
-        if (!cancelled && data.links.length > 0) {
-          const first = data.links[0];
-          setActiveLink({ id: first.id, permissions: first.permissions, useCount: first.useCount });
-        }
-      } catch {
-        // silently fail — user can still generate a new link
-      } finally {
-        if (!cancelled) setIsLoading(false);
-      }
-    }
-    loadExisting();
-    return () => { cancelled = true; };
-  }, [pageId]);
-
-  async function handleGenerate() {
-    setIsGenerating(true);
-    try {
-      const permissions: Array<'VIEW' | 'EDIT'> = includeEdit ? ['VIEW', 'EDIT'] : ['VIEW'];
-      const data = await post<{ id: string; rawToken: string; shareUrl: string }>(
-        `/api/pages/${pageId}/share-links`,
-        { permissions }
-      );
-      setRawToken(data.rawToken);
-      const link: ActiveLink = {
-        id: data.id,
-        permissions,
-        useCount: 0,
-      };
-      setActiveLink(link);
-      const copied = await navigator.clipboard.writeText(data.shareUrl).then(() => true).catch(() => false);
-      toast.success(copied ? 'Link created and copied to clipboard' : 'Link created');
-    } catch {
-      toast.error('Failed to create link');
-    } finally {
-      setIsGenerating(false);
-    }
-  }
-
-  async function handleCopy() {
-    if (!rawToken) return;
-    const shareUrl = new URL(`/s/${rawToken}`, APP_URL || window.location.origin).toString();
-    const copied = await navigator.clipboard.writeText(shareUrl).then(() => true).catch(() => false);
-    if (copied) toast.success('Link copied to clipboard');
-    else toast.error('Could not copy link to clipboard');
-  }
-
-  async function handleRevoke() {
-    if (!activeLink) return;
-    setIsRevoking(true);
-    try {
-      await del(`/api/pages/${pageId}/share-links/${activeLink.id}`);
-      setActiveLink(null);
-      setRawToken(null);
-      toast.success('Link revoked');
-    } catch {
-      toast.error('Failed to revoke link');
-    } finally {
-      setIsRevoking(false);
-    }
-  }
-
+  const { activeLink, rawToken, isLoading, isGenerating, isRevoking, handleGenerate, handleCopy, handleRevoke } =
+    useShareLink<PageLink>({
+      apiBase: `/api/pages/${pageId}/share-links`,
+      extractLink: (i) => ({ id: i.id as string, permissions: i.permissions as PagePerms, useCount: i.useCount as number }),
+      getGenerateBody: () => ({ permissions: includeEdit ? ['VIEW', 'EDIT'] : ['VIEW'] }),
+      buildNewLink: (id) => ({ id, permissions: includeEdit ? ['VIEW', 'EDIT'] : ['VIEW'], useCount: 0 }),
+      messages: MSGS,
+    });
   return (
     <div className="space-y-3">
-      <h4 className="text-sm font-medium flex items-center gap-2">
-        <Link2 className="h-4 w-4" />
-        Share link
-      </h4>
-
+      <h4 className="text-sm font-medium flex items-center gap-2"><Link2 className="h-4 w-4" />Share link</h4>
       {isLoading ? (
         <div className="h-8 w-full animate-pulse rounded bg-muted" />
       ) : activeLink ? (
         <div className="space-y-2">
           <div className="flex items-center gap-2">
-            <Badge variant="secondary" className="text-xs">
-              {activeLink.permissions.includes('EDIT') ? 'View + Edit' : 'View only'}
-            </Badge>
-            <span className="text-xs text-muted-foreground">
-              Used {activeLink.useCount} {activeLink.useCount === 1 ? 'time' : 'times'}
-            </span>
+            <Badge variant="secondary" className="text-xs">{activeLink.permissions.includes('EDIT') ? 'View + Edit' : 'View only'}</Badge>
+            <span className="text-xs text-muted-foreground">Used {activeLink.useCount} {activeLink.useCount === 1 ? 'time' : 'times'}</span>
           </div>
           <div className="flex gap-2">
-            <Button variant="outline" size="sm" className="flex-1" onClick={handleCopy} disabled={!rawToken}>
-              <Copy className="mr-1.5 h-3.5 w-3.5" />
-              Copy link
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={handleRevoke}
-              disabled={isRevoking}
-              className="text-destructive hover:text-destructive"
-              aria-label="Revoke share link"
-            >
-              <Trash2 className="h-3.5 w-3.5" />
-            </Button>
+            <Button variant="outline" size="sm" className="flex-1" onClick={handleCopy} disabled={!rawToken}><Copy className="mr-1.5 h-3.5 w-3.5" />Copy link</Button>
+            <Button variant="ghost" size="sm" onClick={handleRevoke} disabled={isRevoking} className="text-destructive hover:text-destructive" aria-label="Revoke share link"><Trash2 className="h-3.5 w-3.5" /></Button>
           </div>
         </div>
       ) : (
         <div className="space-y-3">
           <div className="flex items-center gap-3">
-            <Switch
-              id="share-link-edit"
-              checked={includeEdit}
-              onCheckedChange={setIncludeEdit}
-            />
-            <Label htmlFor="share-link-edit" className="text-sm cursor-pointer">
-              Allow editing
-            </Label>
+            <Switch id="share-link-edit" checked={includeEdit} onCheckedChange={setIncludeEdit} />
+            <Label htmlFor="share-link-edit" className="text-sm cursor-pointer">Allow editing</Label>
           </div>
-          <Button
-            variant="outline"
-            size="sm"
-            className="w-full"
-            onClick={handleGenerate}
-            disabled={isGenerating}
-          >
-            <Link2 className="mr-1.5 h-3.5 w-3.5" />
-            {isGenerating ? 'Generating…' : 'Generate link'}
+          <Button variant="outline" size="sm" className="w-full" onClick={handleGenerate} disabled={isGenerating}>
+            <Link2 className="mr-1.5 h-3.5 w-3.5" />{isGenerating ? 'Generating…' : 'Generate link'}
           </Button>
         </div>
       )}

--- a/apps/web/src/components/members/DriveShareLinkSection.tsx
+++ b/apps/web/src/components/members/DriveShareLinkSection.tsx
@@ -1,169 +1,67 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Link2, Copy, Trash2 } from 'lucide-react';
-import { post, del } from '@/lib/auth/auth-fetch';
-import { toast } from 'sonner';
+import { useShareLink } from '@/hooks/useShareLink';
 
-interface ActiveLink {
-  id: string;
-  role: 'MEMBER' | 'ADMIN';
-  useCount: number;
-}
+type DriveRole = 'MEMBER' | 'ADMIN';
+interface DriveLink { id: string; role: DriveRole; useCount: number; }
+const MSGS = {
+  created: 'Invite link created',
+  createdAndCopied: 'Invite link created and copied to clipboard',
+  copied: 'Invite link copied to clipboard',
+  copyFailed: 'Could not copy link to clipboard',
+  revoked: 'Invite link revoked',
+  createFailed: 'Failed to create invite link',
+  revokeFailed: 'Failed to revoke invite link',
+};
 
-interface DriveShareLinkSectionProps {
-  driveId: string;
-}
-
-const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? '';
-
-export function DriveShareLinkSection({ driveId }: DriveShareLinkSectionProps) {
-  const [activeLink, setActiveLink] = useState<ActiveLink | null>(null);
-  const [rawToken, setRawToken] = useState<string | null>(null);
-  const [role, setRole] = useState<'MEMBER' | 'ADMIN'>('MEMBER');
-  const [isLoading, setIsLoading] = useState(true);
-  const [isGenerating, setIsGenerating] = useState(false);
-  const [isRevoking, setIsRevoking] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-    async function loadExisting() {
-      try {
-        const res = await fetch(`/api/drives/${driveId}/share-links`, {
-          credentials: 'include',
-        });
-        if (!res.ok || cancelled) return;
-        const data = await res.json() as {
-          links: Array<{ id: string; role: 'MEMBER' | 'ADMIN'; useCount: number }>;
-        };
-        if (!cancelled && data.links.length > 0) {
-          const first = data.links[0];
-          setActiveLink({ id: first.id, role: first.role, useCount: first.useCount });
-        }
-      } catch {
-        // silently fail — user can still generate a new link
-      } finally {
-        if (!cancelled) setIsLoading(false);
-      }
-    }
-    loadExisting();
-    return () => { cancelled = true; };
-  }, [driveId]);
-
-  async function handleGenerate() {
-    setIsGenerating(true);
-    try {
-      const data = await post<{ id: string; rawToken: string; shareUrl: string }>(
-        `/api/drives/${driveId}/share-links`,
-        { role }
-      );
-      setRawToken(data.rawToken);
-      setActiveLink({ id: data.id, role, useCount: 0 });
-      const copied = await navigator.clipboard.writeText(data.shareUrl).then(() => true).catch(() => false);
-      toast.success(copied ? 'Invite link created and copied to clipboard' : 'Invite link created');
-    } catch {
-      toast.error('Failed to create invite link');
-    } finally {
-      setIsGenerating(false);
-    }
-  }
-
-  async function handleCopy() {
-    if (!rawToken) return;
-    const inviteUrl = new URL(`/s/${rawToken}`, APP_URL || window.location.origin).toString();
-    const copied = await navigator.clipboard.writeText(inviteUrl).then(() => true).catch(() => false);
-    if (copied) toast.success('Invite link copied to clipboard');
-    else toast.error('Could not copy link to clipboard');
-  }
-
-  async function handleRevoke() {
-    if (!activeLink) return;
-    setIsRevoking(true);
-    try {
-      await del(`/api/drives/${driveId}/share-links/${activeLink.id}`);
-      setActiveLink(null);
-      setRawToken(null);
-      toast.success('Invite link revoked');
-    } catch {
-      toast.error('Failed to revoke invite link');
-    } finally {
-      setIsRevoking(false);
-    }
-  }
-
+export function DriveShareLinkSection({ driveId }: { driveId: string }) {
+  const [role, setRole] = useState<DriveRole>('MEMBER');
+  const { activeLink, rawToken, isLoading, isGenerating, isRevoking, handleGenerate, handleCopy, handleRevoke } =
+    useShareLink<DriveLink>({
+      apiBase: `/api/drives/${driveId}/share-links`,
+      extractLink: (i) => ({ id: i.id as string, role: i.role as DriveRole, useCount: i.useCount as number }),
+      getGenerateBody: () => ({ role }),
+      buildNewLink: (id) => ({ id, role, useCount: 0 }),
+      messages: MSGS,
+    });
   return (
     <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 space-y-3">
       <div>
-        <h3 className="text-sm font-medium flex items-center gap-2">
-          <Link2 className="h-4 w-4" />
-          Invite link
-        </h3>
-        <p className="text-xs text-muted-foreground mt-0.5">
-          Anyone with this link can join the drive (must be signed in).
-        </p>
+        <h3 className="text-sm font-medium flex items-center gap-2"><Link2 className="h-4 w-4" />Invite link</h3>
+        <p className="text-xs text-muted-foreground mt-0.5">Anyone with this link can join the drive (must be signed in).</p>
       </div>
-
       {isLoading ? (
         <div className="h-8 w-full animate-pulse rounded bg-muted" />
       ) : activeLink ? (
         <div className="space-y-2">
           <div className="flex items-center gap-2">
-            <Badge variant="secondary" className="text-xs capitalize">
-              {activeLink.role.toLowerCase()}
-            </Badge>
-            <span className="text-xs text-muted-foreground">
-              Used {activeLink.useCount} {activeLink.useCount === 1 ? 'time' : 'times'}
-            </span>
+            <Badge variant="secondary" className="text-xs capitalize">{activeLink.role.toLowerCase()}</Badge>
+            <span className="text-xs text-muted-foreground">Used {activeLink.useCount} {activeLink.useCount === 1 ? 'time' : 'times'}</span>
           </div>
           <div className="flex gap-2">
-            <Button variant="outline" size="sm" className="flex-1" onClick={handleCopy} disabled={!rawToken}>
-              <Copy className="mr-1.5 h-3.5 w-3.5" />
-              Copy link
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={handleRevoke}
-              disabled={isRevoking}
-              className="text-destructive hover:text-destructive"
-              aria-label="Revoke invite link"
-            >
-              <Trash2 className="h-3.5 w-3.5" />
-            </Button>
+            <Button variant="outline" size="sm" className="flex-1" onClick={handleCopy} disabled={!rawToken}><Copy className="mr-1.5 h-3.5 w-3.5" />Copy link</Button>
+            <Button variant="ghost" size="sm" onClick={handleRevoke} disabled={isRevoking} className="text-destructive hover:text-destructive" aria-label="Revoke invite link"><Trash2 className="h-3.5 w-3.5" /></Button>
           </div>
         </div>
       ) : (
         <div className="space-y-3">
           <div className="flex items-center gap-3">
             <span className="text-sm">Role</span>
-            <Select value={role} onValueChange={(v) => setRole(v as 'MEMBER' | 'ADMIN')}>
-              <SelectTrigger className="w-32 h-8">
-                <SelectValue />
-              </SelectTrigger>
+            <Select value={role} onValueChange={(v) => setRole(v as DriveRole)}>
+              <SelectTrigger className="w-32 h-8"><SelectValue /></SelectTrigger>
               <SelectContent>
                 <SelectItem value="MEMBER">Member</SelectItem>
                 <SelectItem value="ADMIN">Admin</SelectItem>
               </SelectContent>
             </Select>
           </div>
-          <Button
-            variant="outline"
-            size="sm"
-            className="w-full"
-            onClick={handleGenerate}
-            disabled={isGenerating}
-          >
-            <Link2 className="mr-1.5 h-3.5 w-3.5" />
-            {isGenerating ? 'Generating…' : 'Generate invite link'}
+          <Button variant="outline" size="sm" className="w-full" onClick={handleGenerate} disabled={isGenerating}>
+            <Link2 className="mr-1.5 h-3.5 w-3.5" />{isGenerating ? 'Generating…' : 'Generate invite link'}
           </Button>
         </div>
       )}

--- a/apps/web/src/hooks/useShareLink.ts
+++ b/apps/web/src/hooks/useShareLink.ts
@@ -1,0 +1,111 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { post, del } from '@/lib/auth/auth-fetch';
+import { toast } from 'sonner';
+
+const APP_URL = process.env.NEXT_PUBLIC_APP_URL ?? '';
+
+interface UseShareLinkMessages {
+  created: string;
+  createdAndCopied: string;
+  copied: string;
+  copyFailed: string;
+  revoked: string;
+  createFailed: string;
+  revokeFailed: string;
+}
+
+interface UseShareLinkConfig<TLink extends { id: string; useCount: number }> {
+  apiBase: string;
+  extractLink: (item: Record<string, unknown>) => TLink;
+  getGenerateBody: () => Record<string, unknown>;
+  buildNewLink: (id: string) => TLink;
+  messages: UseShareLinkMessages;
+}
+
+export function useShareLink<TLink extends { id: string; useCount: number }>({
+  apiBase,
+  extractLink,
+  getGenerateBody,
+  buildNewLink,
+  messages,
+}: UseShareLinkConfig<TLink>) {
+  const [activeLink, setActiveLink] = useState<TLink | null>(null);
+  const [rawToken, setRawToken] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [isRevoking, setIsRevoking] = useState(false);
+
+  const extractLinkRef = useRef(extractLink);
+  extractLinkRef.current = extractLink;
+  const getGenerateBodyRef = useRef(getGenerateBody);
+  getGenerateBodyRef.current = getGenerateBody;
+  const buildNewLinkRef = useRef(buildNewLink);
+  buildNewLinkRef.current = buildNewLink;
+  const messagesRef = useRef(messages);
+  messagesRef.current = messages;
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadExisting() {
+      try {
+        const res = await fetch(apiBase, { credentials: 'include' });
+        if (!res.ok || cancelled) return;
+        const data = await res.json() as { links: Array<Record<string, unknown>> };
+        if (!cancelled && data.links.length > 0) {
+          setActiveLink(extractLinkRef.current(data.links[0]));
+        }
+      } catch {
+        // silently fail — user can still generate a new link
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+    loadExisting();
+    return () => { cancelled = true; };
+  }, [apiBase]);
+
+  async function handleGenerate() {
+    setIsGenerating(true);
+    try {
+      const data = await post<{ id: string; rawToken: string; shareUrl: string }>(
+        apiBase,
+        getGenerateBodyRef.current()
+      );
+      setRawToken(data.rawToken);
+      setActiveLink(buildNewLinkRef.current(data.id));
+      const copied = await navigator.clipboard.writeText(data.shareUrl).then(() => true).catch(() => false);
+      toast.success(copied ? messagesRef.current.createdAndCopied : messagesRef.current.created);
+    } catch {
+      toast.error(messagesRef.current.createFailed);
+    } finally {
+      setIsGenerating(false);
+    }
+  }
+
+  async function handleCopy() {
+    if (!rawToken) return;
+    const shareUrl = new URL(`/s/${rawToken}`, APP_URL || window.location.origin).toString();
+    const copied = await navigator.clipboard.writeText(shareUrl).then(() => true).catch(() => false);
+    if (copied) toast.success(messagesRef.current.copied);
+    else toast.error(messagesRef.current.copyFailed);
+  }
+
+  async function handleRevoke() {
+    if (!activeLink) return;
+    setIsRevoking(true);
+    try {
+      await del(`${apiBase}/${activeLink.id}`);
+      setActiveLink(null);
+      setRawToken(null);
+      toast.success(messagesRef.current.revoked);
+    } catch {
+      toast.error(messagesRef.current.revokeFailed);
+    } finally {
+      setIsRevoking(false);
+    }
+  }
+
+  return { activeLink, rawToken, isLoading, isGenerating, isRevoking, handleGenerate, handleCopy, handleRevoke };
+}

--- a/apps/web/src/hooks/useShareLink.ts
+++ b/apps/web/src/hooks/useShareLink.ts
@@ -48,14 +48,16 @@ export function useShareLink<TLink extends { id: string; useCount: number }>({
 
   useEffect(() => {
     let cancelled = false;
+    setIsLoading(true);
+    setActiveLink(null);
+    setRawToken(null);
     async function loadExisting() {
       try {
         const res = await fetch(apiBase, { credentials: 'include' });
         if (!res.ok || cancelled) return;
         const data = await res.json() as { links: Array<Record<string, unknown>> };
-        if (!cancelled && data.links.length > 0) {
-          setActiveLink(extractLinkRef.current(data.links[0]));
-        }
+        if (cancelled) return;
+        setActiveLink(data.links.length > 0 ? extractLinkRef.current(data.links[0]) : null);
       } catch {
         // silently fail — user can still generate a new link
       } finally {
@@ -68,13 +70,17 @@ export function useShareLink<TLink extends { id: string; useCount: number }>({
 
   async function handleGenerate() {
     setIsGenerating(true);
+    // Snapshot callbacks before the await so UI changes mid-flight don't corrupt
+    // the activeLink that gets set — the server received `body`, not the new state.
+    const body = getGenerateBodyRef.current();
+    const buildLink = buildNewLinkRef.current;
     try {
       const data = await post<{ id: string; rawToken: string; shareUrl: string }>(
         apiBase,
-        getGenerateBodyRef.current()
+        body
       );
       setRawToken(data.rawToken);
-      setActiveLink(buildNewLinkRef.current(data.id));
+      setActiveLink(buildLink(data.id));
       const copied = await navigator.clipboard.writeText(data.shareUrl).then(() => true).catch(() => false);
       toast.success(copied ? messagesRef.current.createdAndCopied : messagesRef.current.created);
     } catch {

--- a/apps/web/src/hooks/useShareLink.ts
+++ b/apps/web/src/hooks/useShareLink.ts
@@ -70,8 +70,7 @@ export function useShareLink<TLink extends { id: string; useCount: number }>({
 
   async function handleGenerate() {
     setIsGenerating(true);
-    // Snapshot callbacks before the await so UI changes mid-flight don't corrupt
-    // the activeLink that gets set — the server received `body`, not the new state.
+    // Snapshot before await — role/permissions changed mid-flight must not corrupt the stored link.
     const body = getGenerateBodyRef.current();
     const buildLink = buildNewLinkRef.current;
     try {


### PR DESCRIPTION
## Summary

- Extracted shared state machine from `DriveShareLinkSection` and `PageShareLinkSection` into a generic `useShareLink<TLink>` hook at `apps/web/src/hooks/useShareLink.ts`
- `DriveShareLinkSection`: 172 → 70 lines (pure JSX + config, no logic)
- `PageShareLinkSection`: 166 → 62 lines (pure JSX + config, no logic)
- Zero behavior change — identical state machine, same toasts, same API calls

## Design notes

The hook accepts a typed config: `apiBase`, `extractLink`, `getGenerateBody`, `buildNewLink`, and `messages`. Callbacks are stored in refs internally so closures (e.g. `role`, `includeEdit`) always capture the latest render's values without causing stale-closure bugs or spurious `useEffect` re-runs.

## Test plan

- [ ] `pnpm --filter web typecheck` passes (0 errors ✅)
- [ ] Drive share link panel: generate, copy, and revoke still work
- [ ] Page share link panel: generate (view-only and view+edit), copy, and revoke still work
- [ ] No regressions in DriveMembers or ShareDialog (unchanged callers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Share-link behavior consolidated into a reusable hook and applied across share-link UIs; user-facing flows (generate, copy, revoke, and “Allow editing” toggle) remain the same but now behave more consistently and reliably across pages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1323)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->