### PR TITLE
fix(ai): use actorEmail for isYou in get_activity

### DIFF
--- a/apps/web/src/lib/ai/tools/activity-tools.ts
+++ b/apps/web/src/lib/ai/tools/activity-tools.ts
@@ -4,6 +4,7 @@ import { db } from '@pagespace/db/db'
 import { eq, and, or, desc, gte, ne, isNull, isNotNull, inArray } from '@pagespace/db/operators'
 import { sessions } from '@pagespace/db/schema/sessions'
 import { drives } from '@pagespace/db/schema/core'
+import { users } from '@pagespace/db/schema/auth'
 import { activityLogs } from '@pagespace/db/schema/monitoring'
 import { driveMembers } from '@pagespace/db/schema/members';
 import { isUserDriveMember, getBatchPagePermissions, isDriveOwnerOrAdmin } from '@pagespace/lib/permissions/permissions';
@@ -313,6 +314,14 @@ When summarizing multiple changes, group them thematically and describe the over
       }
 
       try {
+        // Look up current user's email — actorEmail is the authoritative actor
+        // identifier (used by the UI), so isYou must compare against it, not userId.
+        const [currentUserRow] = await db
+          .select({ email: users.email })
+          .from(users)
+          .where(eq(users.id, userId))
+          .limit(1);
+        const currentUserEmail = currentUserRow?.email ?? null;
         // Get last visit time if needed
         let lastVisitTime: Date | undefined;
         if (since === 'last_visit') {
@@ -471,7 +480,7 @@ When summarizing multiple changes, group them thematically and describe the over
             const actor: CompactActor = {
               email,
               name: activity.actorDisplayName || activity.user?.name || null,
-              isYou: activity.userId === userId,
+              isYou: currentUserEmail !== null && activity.actorEmail === currentUserEmail,
               count: 0,
             };
             entry = { idx: actorsList.length, actor };

--- a/apps/web/src/lib/ai/tools/activity-tools.ts
+++ b/apps/web/src/lib/ai/tools/activity-tools.ts
@@ -314,8 +314,11 @@ When summarizing multiple changes, group them thematically and describe the over
       }
 
       try {
-        // Look up current user's email — actorEmail is the authoritative actor
-        // identifier (used by the UI), so isYou must compare against it, not userId.
+        // Fetch current user's email for isYou determination on AI-generated activities.
+        // For human activities we use userId (stable across email changes).
+        // For AI-generated activities we use actorEmail because the agent logs under
+        // a distinct email even when running in the user's session (userId would
+        // incorrectly match the session owner and say "you" for agent actions).
         const [currentUserRow] = await db
           .select({ email: users.email })
           .from(users)
@@ -480,7 +483,9 @@ When summarizing multiple changes, group them thematically and describe the over
             const actor: CompactActor = {
               email,
               name: activity.actorDisplayName || activity.user?.name || null,
-              isYou: currentUserEmail !== null && activity.actorEmail === currentUserEmail,
+              isYou: activity.isAiGenerated
+                ? currentUserEmail !== null && activity.actorEmail === currentUserEmail
+                : activity.userId === userId,
               count: 0,
             };
             entry = { idx: actorsList.length, actor };


### PR DESCRIPTION
## Summary

- `get_activity` was setting `isYou: true` based on `activity.userId === userId`, but `userId` (the session owner FK) and `actorEmail` (the denormalized actor snapshot) can diverge — most notably when an AI agent runs in the user's session under their `userId` but with a distinct `actorEmail`
- This caused the LLM to say "you trashed X" when a collaborator (or agent with its own identity) actually did it; the UI activity log showed the correct actor because it reads `actorEmail` directly
- Fix: look up the current user's email at tool execution time and compare `activity.actorEmail === currentUserEmail`, consistent with how the UI identifies actors

## Test plan

- [ ] Ask AI for a workspace update in a shared drive where a collaborator recently made changes — confirm it no longer attributes their actions to "you"
- [ ] Verify your own recent activities still say "you" correctly
- [ ] Run `pnpm test:unit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved accuracy of activity tracking by identifying the current user via email for AI-generated activities; human (non-AI) activity attribution remains based on user ID.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1324)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1324)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->