### PR TITLE
fix(ai): allow drive members to create root-level pages

### DIFF
--- a/apps/web/src/app/api/pages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/__tests__/route.test.ts
@@ -254,10 +254,10 @@ describe('POST /api/pages', () => {
       expect(body.error).toMatch(/not found/i);
     });
 
-    it('returns 403 when user is not owner or admin', async () => {
+    it('returns 403 when user is not a drive member', async () => {
       vi.mocked(pageService.createPage).mockResolvedValue({
         success: false,
-        error: 'Only drive owners and admins can create pages',
+        error: 'You must be a drive member to create pages',
         status: 403,
       });
 
@@ -269,7 +269,7 @@ describe('POST /api/pages', () => {
       const body = await response.json();
 
       expect(response.status).toBe(403);
-      expect(body.error).toMatch(/owner|admin/i);
+      expect(body.error).toMatch(/member/i);
     });
   });
 

--- a/apps/web/src/app/api/pages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/__tests__/route.test.ts
@@ -254,7 +254,7 @@ describe('POST /api/pages', () => {
       expect(body.error).toMatch(/not found/i);
     });
 
-    it('returns 403 when user is not a drive member', async () => {
+    it('returns 403 when user is not a drive member (root level)', async () => {
       vi.mocked(pageService.createPage).mockResolvedValue({
         success: false,
         error: 'You must be a drive member to create pages',
@@ -270,6 +270,25 @@ describe('POST /api/pages', () => {
 
       expect(response.status).toBe(403);
       expect(body.error).toMatch(/member/i);
+    });
+
+    it('returns 403 when user lacks edit permission on parent page', async () => {
+      vi.mocked(pageService.createPage).mockResolvedValue({
+        success: false,
+        error: 'Insufficient permissions to create pages in this folder',
+        status: 403,
+      });
+
+      const response = await POST(createRequest({
+        title: 'Test Page',
+        type: 'DOCUMENT',
+        driveId: mockDriveId,
+        parentId: 'parent_456',
+      }));
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.error).toMatch(/permission/i);
     });
   });
 

--- a/apps/web/src/app/api/pages/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/__tests__/route.test.ts
@@ -290,6 +290,25 @@ describe('POST /api/pages', () => {
       expect(response.status).toBe(403);
       expect(body.error).toMatch(/permission/i);
     });
+
+    it('returns 400 when parent page belongs to a different drive', async () => {
+      vi.mocked(pageService.createPage).mockResolvedValue({
+        success: false,
+        error: 'Parent page not found in this drive',
+        status: 400,
+      });
+
+      const response = await POST(createRequest({
+        title: 'Test Page',
+        type: 'DOCUMENT',
+        driveId: mockDriveId,
+        parentId: 'parent_other_drive',
+      }));
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toMatch(/not found/i);
+    });
   });
 
   describe('service delegation', () => {

--- a/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
@@ -370,11 +370,12 @@ describe('page-write-tools', () => {
       expect(mockDriveRepo.findByIdBasic).toHaveBeenCalledWith('non-existent');
     });
 
-    it('creates page successfully at root level', async () => {
-      // Arrange
+    it('creates page successfully at root level for non-owner member', async () => {
+      // Arrange — actor is a member, NOT the drive owner, to verify the new
+      // membership check (not the old owner-only guard) is what grants access.
       mockDriveRepo.findByIdBasic.mockResolvedValue({
         id: 'drive-1',
-        ownerId: 'user-123',
+        ownerId: 'owner-999',
       });
       mockIsUserDriveMember.mockResolvedValue(true);
       mockPageRepo.getNextPosition.mockResolvedValue(1);
@@ -402,6 +403,9 @@ describe('page-write-tools', () => {
       expect(success.id).toBe('new-page-1');
       expect(success.title).toBe('New Page');
 
+      // Verify membership check was used, not the old owner-only guard
+      expect(mockIsUserDriveMember).toHaveBeenCalledWith('user-123', 'drive-1');
+
       // Verify repository was called with correct payload
       expect(mockPageRepo.create).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -414,8 +418,6 @@ describe('page-write-tools', () => {
           isTrashed: false,
         })
       );
-
-      // Activity logging is handled by mutation logging.
     });
   });
 

--- a/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
@@ -14,6 +14,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
     canUserEditPage: vi.fn(),
     canUserDeletePage: vi.fn(),
+    isUserDriveMember: vi.fn(),
 }));
 vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
     logPageActivity: vi.fn(),
@@ -111,13 +112,14 @@ vi.mock('@/lib/logging/mask', () => ({
 }));
 
 import { pageWriteTools } from '../page-write-tools';
-import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
+import { canUserEditPage, isUserDriveMember } from '@pagespace/lib/permissions/permissions';
 import { pageRepository } from '@pagespace/lib/repositories/page-repository';
 import { driveRepository } from '@pagespace/lib/repositories/drive-repository';
 import { applyPageMutation } from '@/services/api/page-mutation-service';
 import type { ToolExecutionContext } from '../../core';
 
 const mockCanUserEditPage = vi.mocked(canUserEditPage);
+const mockIsUserDriveMember = vi.mocked(isUserDriveMember);
 const mockPageRepo = vi.mocked(pageRepository);
 const mockDriveRepo = vi.mocked(driveRepository);
 const mockApplyPageMutation = vi.mocked(applyPageMutation);
@@ -374,6 +376,7 @@ describe('page-write-tools', () => {
         id: 'drive-1',
         ownerId: 'user-123',
       });
+      mockIsUserDriveMember.mockResolvedValue(true);
       mockPageRepo.getNextPosition.mockResolvedValue(1);
       mockPageRepo.create.mockResolvedValue({
         id: 'new-page-1',

--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -1,6 +1,6 @@
 import { tool } from 'ai';
 import { z } from 'zod';
-import { canUserEditPage, canUserDeletePage } from '@pagespace/lib/permissions/permissions';
+import { canUserEditPage, canUserDeletePage, isUserDriveMember } from '@pagespace/lib/permissions/permissions';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { isAIChatPage, isDocumentPage, isCodePage, getDefaultContent, getCreatablePageTypes } from '@pagespace/lib/content/page-types.config';
 import { parseSheetContent, serializeSheetContent, updateSheetCells, isValidCellAddress, isSheetType } from '@pagespace/lib/sheets/sheet';
@@ -559,9 +559,10 @@ export const pageWriteTools = {
             throw new Error('Insufficient permissions to create pages in this folder');
           }
         } else {
-          // Creating at root level - check if user owns the drive
-          if (drive.ownerId !== userId) {
-            throw new Error('Only drive owners can create pages at the root level');
+          // Creating at root level - any drive member can create
+          const isMember = await isUserDriveMember(userId, driveId);
+          if (!isMember) {
+            throw new Error('You must be a drive member to create pages at the root level');
           }
         }
 

--- a/apps/web/src/services/api/page-service.ts
+++ b/apps/web/src/services/api/page-service.ts
@@ -608,6 +608,13 @@ export const pageService = {
     // Check authorization — mirror the AI tool's split: nested pages require
     // edit permission on the parent; root-level pages require drive membership.
     if (params.parentId) {
+      const parentPage = await db.query.pages.findFirst({
+        where: and(eq(pages.id, params.parentId), eq(pages.driveId, params.driveId)),
+        columns: { id: true },
+      });
+      if (!parentPage) {
+        return { success: false, error: 'Parent page not found in this drive', status: 400 };
+      }
       const canEdit = await canUserEditPage(userId, params.parentId);
       if (!canEdit) {
         return { success: false, error: 'Insufficient permissions to create pages in this folder', status: 403 };

--- a/apps/web/src/services/api/page-service.ts
+++ b/apps/web/src/services/api/page-service.ts
@@ -605,10 +605,18 @@ export const pageService = {
       return { success: false, error: 'Drive not found', status: 404 };
     }
 
-    // Check authorization
-    const hasPermission = await isUserDriveMember(userId, params.driveId);
-    if (!hasPermission) {
-      return { success: false, error: 'You must be a drive member to create pages', status: 403 };
+    // Check authorization — mirror the AI tool's split: nested pages require
+    // edit permission on the parent; root-level pages require drive membership.
+    if (params.parentId) {
+      const canEdit = await canUserEditPage(userId, params.parentId);
+      if (!canEdit) {
+        return { success: false, error: 'Insufficient permissions to create pages in this folder', status: 403 };
+      }
+    } else {
+      const isMember = await isUserDriveMember(userId, params.driveId);
+      if (!isMember) {
+        return { success: false, error: 'You must be a drive member to create pages', status: 403 };
+      }
     }
 
     // Calculate position - use isNull when parentId is null/undefined

--- a/apps/web/src/services/api/page-service.ts
+++ b/apps/web/src/services/api/page-service.ts
@@ -11,7 +11,7 @@ import { validatePageMove } from '@pagespace/lib/pages/circular-reference-guard'
 import { validatePageCreation, validateAIChatTools } from '@pagespace/lib/content/page-type-validators'
 import { getDefaultContent, isAIChatPage } from '@pagespace/lib/content/page-types.config'
 import { PageType as PageTypeEnum } from '@pagespace/lib/utils/enums'
-import { isDriveOwnerOrAdmin } from '@pagespace/lib/permissions/permissions';
+import { isDriveOwnerOrAdmin, isUserDriveMember } from '@pagespace/lib/permissions/permissions';
 import { createChangeGroupId, inferChangeGroupType } from '@pagespace/lib/monitoring/change-group';
 import { logActivityWithTx, type DeferredWorkflowTrigger } from '@pagespace/lib/monitoring/activity-logger';
 import { createId } from '@paralleldrive/cuid2';
@@ -606,9 +606,9 @@ export const pageService = {
     }
 
     // Check authorization
-    const hasPermission = await isDriveOwnerOrAdmin(userId, params.driveId);
+    const hasPermission = await isUserDriveMember(userId, params.driveId);
     if (!hasPermission) {
-      return { success: false, error: 'Only drive owners and admins can create pages', status: 403 };
+      return { success: false, error: 'You must be a drive member to create pages', status: 403 };
     }
 
     // Calculate position - use isNull when parentId is null/undefined


### PR DESCRIPTION
## Summary

- \`create_page\` AI SDK tool blocked non-owner users from creating pages at the drive root — it checked \`drive.ownerId !== userId\` instead of drive membership
- \`pageService.createPage\` (REST API) had the same issue and additionally had a flat \`isDriveOwnerOrAdmin\` check that didn't distinguish root from nested creation
- Both now use the correct permission split (mirrors existing AI tool logic):
  - **Root-level** (\`parentId\` absent): \`isUserDriveMember\` — any accepted drive member can create
  - **Nested** (\`parentId\` present): \`canUserEditPage\` on the parent — prevents view-only members from writing under arbitrary parent pages
- REST API now also validates that a supplied \`parentId\` belongs to the target \`driveId\` before checking edit permission, preventing cross-drive linking (the AI tool already had \`pageRepository.existsInDrive\` for this)

## Root cause

The owner-only guard on root-level creation (\`drive.ownerId !== userId\`) was written in at Open Beta Init (Aug 21, 2025) and has always been wrong. It surfaced when an AI agent ran in a shared drive where the user is a member but not the owner.

The flat \`isDriveOwnerOrAdmin\` in \`pageService.createPage\` was a secondary issue: it also blocked all MEMBER-role users from the REST API path and didn't distinguish root vs. nested creation.

## Test plan

- [x] \`pnpm --filter web test -- page-write-tools\` — green
- [x] \`pnpm --filter web test -- pages/route\` — green (+ new contract tests for nested-403 and cross-drive-400 paths)
- [ ] AI agent in a shared drive (member, not owner) can create a page with no \`parentId\`
- [ ] View-only member cannot create pages under an arbitrary \`parentId\` (still blocked by \`canUserEditPage\`)
- [ ] Cross-drive \`parentId\` rejected with 400 before permission check
- [ ] Drive owners and admins unaffected (both pass \`isUserDriveMember\` and \`canUserEditPage\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)