### PR TITLE
fix(realtime): broadcast drivePrompt, permissions, and share-invite mutations

### DIFF
--- a/apps/web/src/app/api/drives/[driveId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/__tests__/route.test.ts
@@ -528,11 +528,12 @@ describe('PATCH /api/drives/[driveId]', () => {
       );
     });
 
-    it('should NOT broadcast event when only drivePrompt changes', async () => {
+    it('should broadcast drive updated event when only drivePrompt changes', async () => {
       const drive = createRawDriveFixture({ id: mockDriveId, name: 'Test' });
+      const updatedDrive = { ...drive, drivePrompt: 'New prompt' };
       vi.mocked(getDriveById).mockResolvedValue(drive);
       vi.mocked(getDriveAccess).mockResolvedValue(createAccessFixture({ isOwner: true }));
-      vi.mocked(updateDrive).mockResolvedValue({ ...drive, drivePrompt: 'New prompt' });
+      vi.mocked(updateDrive).mockResolvedValue(updatedDrive);
 
       const request = new Request(`https://example.com/api/drives/${mockDriveId}`, {
         method: 'PATCH',
@@ -540,7 +541,7 @@ describe('PATCH /api/drives/[driveId]', () => {
       });
       await PATCH(request, createContext(mockDriveId));
 
-      expect(broadcastDriveEvent).not.toHaveBeenCalled();
+      expect(broadcastDriveEvent).toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/drives/[driveId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/__tests__/route.test.ts
@@ -541,7 +541,15 @@ describe('PATCH /api/drives/[driveId]', () => {
       });
       await PATCH(request, createContext(mockDriveId));
 
-      expect(broadcastDriveEvent).toHaveBeenCalled();
+      expect(createDriveEventPayload).toHaveBeenCalledWith(
+        mockDriveId,
+        'updated',
+        { name: 'Test', slug: 'test' }
+      );
+      expect(broadcastDriveEvent).toHaveBeenCalledWith(
+        { driveId: mockDriveId, event: 'updated', data: { name: 'Test', slug: 'test' } },
+        ['user-123', 'user-456']
+      );
     });
   });
 

--- a/apps/web/src/app/api/drives/[driveId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/route.ts
@@ -103,8 +103,8 @@ export async function PATCH(
       drivePrompt: validatedBody.drivePrompt,
     });
 
-    // Broadcast drive update event if name changed
-    if (validatedBody.name && updatedDrive) {
+    // Broadcast drive update event if name or drivePrompt changed
+    if (updatedDrive && (validatedBody.name || validatedBody.drivePrompt !== undefined)) {
       const recipientUserIds = await getDriveRecipientUserIds(driveId);
       await broadcastDriveEvent(
         createDriveEventPayload(drive.id, 'updated', {

--- a/apps/web/src/app/api/pages/[pageId]/permissions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/permissions/__tests__/route.test.ts
@@ -75,10 +75,12 @@ vi.mock('@pagespace/db/schema/core', () => ({
   pages: { id: 'id' },
 }));
 
-// Mock websocket utilities for real-time permission revocation
+// Mock websocket utilities for real-time permission revocation and broadcast
 vi.mock('@/lib/websocket', () => ({
   kickUserFromPage: vi.fn().mockResolvedValue({ success: true, kickedCount: 0, rooms: [] }),
   kickUserFromPageActivity: vi.fn().mockResolvedValue({ success: true, kickedCount: 0, rooms: [] }),
+  broadcastPageEvent: vi.fn().mockResolvedValue(undefined),
+  createPageEventPayload: vi.fn((driveId, pageId, operation) => ({ driveId, pageId, operation })),
 }));
 
 import { permissionManagementService } from '@/services/api';

--- a/apps/web/src/app/api/pages/[pageId]/permissions/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/permissions/route.ts
@@ -14,7 +14,7 @@ import { permissionManagementService } from '@/services/api';
 import { db } from '@pagespace/db/db'
 import { eq } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core';
-import { kickUserFromPage, kickUserFromPageActivity } from '@/lib/websocket';
+import { kickUserFromPage, kickUserFromPageActivity, broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
@@ -126,6 +126,12 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
       where: eq(pages.id, pageId),
       columns: { driveId: true },
     });
+
+    if (page?.driveId) {
+      await broadcastPageEvent(
+        createPageEventPayload(page.driveId, pageId, 'updated')
+      );
+    }
 
     return NextResponse.json({
       id: result.data.permissionId,

--- a/apps/web/src/app/api/pages/[pageId]/permissions/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/permissions/route.ts
@@ -128,9 +128,11 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
     });
 
     if (page?.driveId) {
-      await broadcastPageEvent(
+      broadcastPageEvent(
         createPageEventPayload(page.driveId, pageId, 'updated')
-      );
+      ).catch((err: Error) => {
+        loggers.api.error('Failed to broadcast page permission event:', err);
+      });
     }
 
     return NextResponse.json({

--- a/apps/web/src/app/api/pages/[pageId]/share-invite/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/share-invite/__tests__/route.test.ts
@@ -63,6 +63,11 @@ vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
   DISTRIBUTED_RATE_LIMITS: { PAGE_SHARE_INVITE: { maxAttempts: 3, windowMs: 900000 } },
 }));
 
+vi.mock('@/lib/websocket', () => ({
+  broadcastPageEvent: vi.fn().mockResolvedValue(undefined),
+  createPageEventPayload: vi.fn((driveId, pageId, operation) => ({ driveId, pageId, operation })),
+}));
+
 import { POST } from '../route';
 import { pageInviteRepository } from '@/lib/repositories/page-invite-repository';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';

--- a/apps/web/src/app/api/pages/[pageId]/share-invite/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/share-invite/route.ts
@@ -13,6 +13,7 @@ import {
   DISTRIBUTED_RATE_LIMITS,
 } from '@pagespace/lib/security/distributed-rate-limit';
 import { canUserSharePage } from '@pagespace/lib/permissions/permissions';
+import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 
@@ -150,6 +151,10 @@ export async function POST(
         resourceId: pageId,
         details: { targetUserId: existingUser.id, permissions, operation: 'share_invite_direct' },
       });
+
+      await broadcastPageEvent(
+        createPageEventPayload(page.driveId, pageId, 'updated')
+      );
 
       return NextResponse.json({
         kind: 'granted',

--- a/apps/web/src/app/api/pages/[pageId]/share-invite/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/share-invite/route.ts
@@ -152,9 +152,13 @@ export async function POST(
         details: { targetUserId: existingUser.id, permissions, operation: 'share_invite_direct' },
       });
 
-      await broadcastPageEvent(
-        createPageEventPayload(page.driveId, pageId, 'updated')
-      );
+      if (page.driveId) {
+        broadcastPageEvent(
+          createPageEventPayload(page.driveId, pageId, 'updated')
+        ).catch((err: Error) => {
+          loggers.api.error('Failed to broadcast share-invite page event:', err);
+        });
+      }
 
       return NextResponse.json({
         kind: 'granted',


### PR DESCRIPTION
## Summary

- **Drive PATCH**: broadcast was gated on `name` change only — widened to also fire when `drivePrompt` is updated, so collaborators see drive context changes live
- **Page permissions POST**: added `broadcastPageEvent` after permission grant so other users in the drive get a live `page:updated` signal
- **Share invite POST**: added `broadcastPageEvent` in the direct-grant path (R1: existing verified user) — pending invites (R2) intentionally excluded since no access is granted yet

## Test plan

- [ ] Update a drive's AI prompt (drivePrompt only, no name change) — confirm other connected clients receive a drive update event
- [ ] Grant a page permission via the permissions panel — confirm other clients in the same drive see the page update without refreshing
- [ ] Share a page to an existing verified user via email invite — confirm `page:updated` broadcast fires and other clients reflect the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drive prompts can be updated alongside drive names; updates now broadcast to connected sessions when either field is changed.
  * Real-time page events are broadcast when permissions are granted or share invites are accepted so collaborators see changes immediately.

* **Tests**
  * Tests updated to expect broadcasts for prompt-only drive updates and added websocket mocks/stubs for page permission and share-invite flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1326)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->