### PR TITLE
fix(realtime): broadcast agent grant and conversation mutations

### DIFF
--- a/apps/web/src/app/api/agents/[agentId]/integrations/[grantId]/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/integrations/[grantId]/route.ts
@@ -6,6 +6,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { getGrantById, updateGrant, deleteGrant } from '@pagespace/lib/integrations/repositories/grant-repository';
+import { broadcastAgentGrantChanged } from '@/lib/websocket/socket-utils';
 
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
 
@@ -51,6 +52,9 @@ export async function PUT(
     }
 
     const updated = await updateGrant(db, grantId, validation.data);
+
+    void broadcastAgentGrantChanged({ agentId, triggeredBy: { userId: auth.userId } });
+
     return NextResponse.json({ grant: updated });
   } catch (error) {
     loggers.api.error('Error updating agent integration grant:', error as Error);
@@ -84,6 +88,8 @@ export async function DELETE(
     await deleteGrant(db, grantId);
 
     auditRequest(request, { eventType: 'data.delete', userId: auth.userId, resourceType: 'agent_grant', resourceId: grantId });
+
+    void broadcastAgentGrantChanged({ agentId, triggeredBy: { userId: auth.userId } });
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/apps/web/src/app/api/agents/[agentId]/integrations/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/integrations/route.ts
@@ -9,6 +9,7 @@ import { getDriveAccess } from '@pagespace/lib/services/drive-service';
 import { listGrantsByAgent, createGrant, findGrant } from '@pagespace/lib/integrations/repositories/grant-repository';
 import { getConnectionById } from '@pagespace/lib/integrations/repositories/connection-repository';
 import type { ToolDefinition } from '@pagespace/lib/integrations/types';
+import { broadcastAgentGrantChanged } from '@/lib/websocket/socket-utils';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
@@ -168,6 +169,8 @@ export async function POST(
     });
 
     auditRequest(request, { eventType: 'data.write', userId: auth.userId, resourceType: 'agent_grant', resourceId: agentId });
+
+    void broadcastAgentGrantChanged({ agentId, triggeredBy: { userId: auth.userId } });
 
     return NextResponse.json({ grant }, { status: 201 });
   } catch (error) {

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/conversations/[conversationId]/route.ts
@@ -4,6 +4,9 @@ import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { conversationRepository } from '@/lib/repositories/conversation-repository';
+import { broadcastAiConversationRenamed, broadcastAiConversationDeleted } from '@/lib/websocket/socket-utils';
+import { resolveTriggeredBy } from '@/lib/websocket/broadcast-triggered-by';
+import { maskIdentifier } from '@/lib/logging/mask';
 
 // Auth options: PATCH and DELETE are write operations requiring CSRF protection
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
@@ -94,6 +97,18 @@ export async function PATCH(
       action: 'update_conversation',
       agentId,
     } });
+
+    void (async () => {
+      try {
+        const triggeredBy = await resolveTriggeredBy(auth.userId, request);
+        await broadcastAiConversationRenamed({ agentId, conversationId, title, triggeredBy });
+      } catch (broadcastError) {
+        loggers.ai.error('Failed to broadcast chat conversation-renamed', broadcastError as Error, {
+          agentId: maskIdentifier(agentId),
+          conversationId: maskIdentifier(conversationId),
+        });
+      }
+    })();
 
     return NextResponse.json({
       success: true,
@@ -189,6 +204,18 @@ export async function DELETE(
       action: 'delete_conversation',
       agentId,
     } });
+
+    void (async () => {
+      try {
+        const triggeredBy = await resolveTriggeredBy(auth.userId, request);
+        await broadcastAiConversationDeleted({ agentId, conversationId, triggeredBy });
+      } catch (broadcastError) {
+        loggers.ai.error('Failed to broadcast chat conversation-deleted', broadcastError as Error, {
+          agentId: maskIdentifier(agentId),
+          conversationId: maskIdentifier(conversationId),
+        });
+      }
+    })();
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/components/ai/page-agents/AgentIntegrationsPanel.tsx
+++ b/apps/web/src/components/ai/page-agents/AgentIntegrationsPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
@@ -14,6 +14,8 @@ import { useAgentGrants, useUserConnections, useDriveConnections } from '@/hooks
 import { IntegrationStatusBadge } from '@/components/integrations/IntegrationStatusBadge';
 import { post, put, del } from '@/lib/auth/auth-fetch';
 import type { SafeConnection, SafeGrant } from '@/components/integrations/types';
+import { useSocket } from '@/hooks/useSocket';
+import type { AgentGrantChangedPayload } from '@/lib/websocket/socket-utils';
 
 interface AgentIntegrationsPanelProps {
   pageId: string;
@@ -38,9 +40,22 @@ export function AgentIntegrationsPanel({ pageId, driveId }: AgentIntegrationsPan
   const { grants, isLoading: loadingGrants, error: grantsError, mutate: mutateGrants } = useAgentGrants(pageId);
   const { connections: userConnections, isLoading: loadingUser, error: userError } = useUserConnections();
   const { connections: driveConnections, isLoading: loadingDrive, error: driveError } = useDriveConnections(driveId);
+  const socket = useSocket();
 
   const [toggling, setToggling] = useState<string | null>(null);
   const [updatingGrant, setUpdatingGrant] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!socket) return;
+    const handleGrantChanged = (payload: AgentGrantChangedPayload) => {
+      if (payload.agentId !== pageId) return;
+      mutateGrants();
+    };
+    socket.on('agent:grant_changed', handleGrantChanged);
+    return () => {
+      socket.off('agent:grant_changed', handleGrantChanged);
+    };
+  }, [socket, pageId, mutateGrants]);
 
   const isLoading = loadingGrants || loadingUser || loadingDrive;
   const error = grantsError || userError || driveError;

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -157,6 +157,7 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
     createConversation,
     deleteConversation,
     prependConversationOptimistic,
+    refreshConversations,
   } = useConversations({
     agentId: page.id,
     currentConversationId,
@@ -379,6 +380,12 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
     onConversationAdded: (payload) => {
       if (!shouldPrependConversation(payload, getBrowserSessionId(), conversations)) return;
       prependConversationOptimistic(payload.conversation);
+    },
+    onConversationRenamed: () => {
+      refreshConversations();
+    },
+    onConversationDeleted: () => {
+      refreshConversations();
     },
     onStreamComplete: (messageId) => {
       const stream = usePendingStreamsStore.getState().streams.get(messageId);

--- a/apps/web/src/hooks/useChannelStreamSocket.ts
+++ b/apps/web/src/hooks/useChannelStreamSocket.ts
@@ -14,6 +14,8 @@ import type {
   ChatMessageDeletedPayload,
   ChatUndoAppliedPayload,
   ChatConversationAddedPayload,
+  ChatConversationRenamedPayload,
+  ChatConversationDeletedPayload,
 } from '@/lib/websocket/socket-utils';
 import type { UIMessage } from 'ai';
 
@@ -74,6 +76,18 @@ export interface UseChannelStreamSocketOptions {
    * conversation to their history list, gated by `shouldPrependConversation`.
    */
   onConversationAdded?: (payload: ChatConversationAddedPayload) => void;
+  /**
+   * Fires when a remote tab renames a conversation in this agent room.
+   * Same stale-room (`agentId !== channelId`) + own-tab dedup as
+   * `onConversationAdded`.
+   */
+  onConversationRenamed?: (payload: ChatConversationRenamedPayload) => void;
+  /**
+   * Fires when a remote tab deletes a conversation in this agent room.
+   * Same stale-room (`agentId !== channelId`) + own-tab dedup as
+   * `onConversationAdded`.
+   */
+  onConversationDeleted?: (payload: ChatConversationDeletedPayload) => void;
 }
 
 /** Subscribes a component to a channel's AI streaming lifecycle: DB-replay on mount, live socket events, SSE join, store cleanup on unmount. Pass `undefined` channelId to no-op. */
@@ -91,6 +105,8 @@ export function useChannelStreamSocket(
   const onMessageDeletedRef = useRef(options?.onMessageDeleted);
   const onUndoAppliedRef = useRef(options?.onUndoApplied);
   const onConversationAddedRef = useRef(options?.onConversationAdded);
+  const onConversationRenamedRef = useRef(options?.onConversationRenamed);
+  const onConversationDeletedRef = useRef(options?.onConversationDeleted);
   onStreamCompleteRef.current = options?.onStreamComplete;
   onOwnStreamBootstrapRef.current = options?.onOwnStreamBootstrap;
   onOwnStreamFinalizeRef.current = options?.onOwnStreamFinalize;
@@ -99,6 +115,8 @@ export function useChannelStreamSocket(
   onMessageDeletedRef.current = options?.onMessageDeleted;
   onUndoAppliedRef.current = options?.onUndoApplied;
   onConversationAddedRef.current = options?.onConversationAdded;
+  onConversationRenamedRef.current = options?.onConversationRenamed;
+  onConversationDeletedRef.current = options?.onConversationDeleted;
 
   useEffect(() => {
     if (!socket || !channelId) return;
@@ -258,6 +276,18 @@ export function useChannelStreamSocket(
       onConversationAddedRef.current?.(payload);
     };
 
+    const handleConversationRenamed = (payload: ChatConversationRenamedPayload) => {
+      if (payload.agentId !== channelId) return;
+      if (isOwnStream(payload.triggeredBy, localBrowserSessionId)) return;
+      onConversationRenamedRef.current?.(payload);
+    };
+
+    const handleConversationDeleted = (payload: ChatConversationDeletedPayload) => {
+      if (payload.agentId !== channelId) return;
+      if (isOwnStream(payload.triggeredBy, localBrowserSessionId)) return;
+      onConversationDeletedRef.current?.(payload);
+    };
+
     socket.on('chat:stream_start', handleStreamStart);
     socket.on('chat:stream_complete', handleStreamComplete);
     socket.on('chat:user_message', handleUserMessage);
@@ -265,6 +295,8 @@ export function useChannelStreamSocket(
     socket.on('chat:message_deleted', handleMessageDeleted);
     socket.on('chat:undo_applied', handleUndoApplied);
     socket.on('chat:conversation_added', handleConversationAdded);
+    socket.on('chat:conversation_renamed', handleConversationRenamed);
+    socket.on('chat:conversation_deleted', handleConversationDeleted);
 
     return () => {
       cancelled = true;
@@ -275,6 +307,8 @@ export function useChannelStreamSocket(
       socket.off('chat:message_deleted', handleMessageDeleted);
       socket.off('chat:undo_applied', handleUndoApplied);
       socket.off('chat:conversation_added', handleConversationAdded);
+      socket.off('chat:conversation_renamed', handleConversationRenamed);
+      socket.off('chat:conversation_deleted', handleConversationDeleted);
       for (const controller of controllers.values()) {
         controller.abort();
       }

--- a/apps/web/src/lib/websocket/socket-utils.ts
+++ b/apps/web/src/lib/websocket/socket-utils.ts
@@ -712,6 +712,24 @@ export interface ChatConversationAddedPayload {
   triggeredBy: { userId: string; displayName: string; browserSessionId: string };
 }
 
+export interface ChatConversationRenamedPayload {
+  agentId: string;
+  conversationId: string;
+  title: string;
+  triggeredBy: { userId: string; displayName: string; browserSessionId: string };
+}
+
+export interface ChatConversationDeletedPayload {
+  agentId: string;
+  conversationId: string;
+  triggeredBy: { userId: string; displayName: string; browserSessionId: string };
+}
+
+export interface AgentGrantChangedPayload {
+  agentId: string;
+  triggeredBy: { userId: string };
+}
+
 export async function broadcastAiStreamStart(payload: AiStreamStartPayload): Promise<void> {
   const realtimeUrl = getEnvVar('INTERNAL_REALTIME_URL');
   if (!realtimeUrl) {
@@ -944,6 +962,108 @@ export async function broadcastAiConversationAdded(payload: ChatConversationAdde
       error instanceof Error ? error : undefined,
       {
         event: 'chat:conversation_added',
+        channel: maskIdentifier(payload.agentId),
+      }
+    );
+  }
+}
+
+export async function broadcastAiConversationRenamed(payload: ChatConversationRenamedPayload): Promise<void> {
+  const realtimeUrl = getEnvVar('INTERNAL_REALTIME_URL');
+  if (!realtimeUrl) {
+    realtimeLogger.warn('Realtime URL not configured, skipping chat conversation-renamed broadcast', {
+      event: 'chat:conversation_renamed',
+    });
+    return;
+  }
+
+  try {
+    const requestBody = JSON.stringify({
+      channelId: payload.agentId,
+      event: 'chat:conversation_renamed',
+      payload,
+    });
+
+    await fetch(`${realtimeUrl}/api/broadcast`, {
+      method: 'POST',
+      headers: createSignedBroadcastHeaders(requestBody),
+      body: requestBody,
+      signal: AbortSignal.timeout(5000),
+    });
+  } catch (error) {
+    realtimeLogger.error(
+      'Failed to broadcast chat conversation-renamed',
+      error instanceof Error ? error : undefined,
+      {
+        event: 'chat:conversation_renamed',
+        channel: maskIdentifier(payload.agentId),
+      }
+    );
+  }
+}
+
+export async function broadcastAiConversationDeleted(payload: ChatConversationDeletedPayload): Promise<void> {
+  const realtimeUrl = getEnvVar('INTERNAL_REALTIME_URL');
+  if (!realtimeUrl) {
+    realtimeLogger.warn('Realtime URL not configured, skipping chat conversation-deleted broadcast', {
+      event: 'chat:conversation_deleted',
+    });
+    return;
+  }
+
+  try {
+    const requestBody = JSON.stringify({
+      channelId: payload.agentId,
+      event: 'chat:conversation_deleted',
+      payload,
+    });
+
+    await fetch(`${realtimeUrl}/api/broadcast`, {
+      method: 'POST',
+      headers: createSignedBroadcastHeaders(requestBody),
+      body: requestBody,
+      signal: AbortSignal.timeout(5000),
+    });
+  } catch (error) {
+    realtimeLogger.error(
+      'Failed to broadcast chat conversation-deleted',
+      error instanceof Error ? error : undefined,
+      {
+        event: 'chat:conversation_deleted',
+        channel: maskIdentifier(payload.agentId),
+      }
+    );
+  }
+}
+
+export async function broadcastAgentGrantChanged(payload: AgentGrantChangedPayload): Promise<void> {
+  const realtimeUrl = getEnvVar('INTERNAL_REALTIME_URL');
+  if (!realtimeUrl) {
+    realtimeLogger.warn('Realtime URL not configured, skipping agent grant-changed broadcast', {
+      event: 'agent:grant_changed',
+    });
+    return;
+  }
+
+  try {
+    const requestBody = JSON.stringify({
+      channelId: payload.agentId,
+      event: 'agent:grant_changed',
+      payload,
+    });
+
+    await fetch(`${realtimeUrl}/api/broadcast`, {
+      method: 'POST',
+      headers: createSignedBroadcastHeaders(requestBody),
+      body: requestBody,
+      signal: AbortSignal.timeout(5000),
+    });
+  } catch (error) {
+    realtimeLogger.error(
+      'Failed to broadcast agent grant-changed',
+      error instanceof Error ? error : undefined,
+      {
+        event: 'agent:grant_changed',
         channel: maskIdentifier(payload.agentId),
       }
     );

--- a/apps/web/src/lib/websocket/socket-utils.ts
+++ b/apps/web/src/lib/websocket/socket-utils.ts
@@ -984,12 +984,15 @@ export async function broadcastAiConversationRenamed(payload: ChatConversationRe
       payload,
     });
 
-    await fetch(`${realtimeUrl}/api/broadcast`, {
+    const response = await fetch(`${realtimeUrl}/api/broadcast`, {
       method: 'POST',
       headers: createSignedBroadcastHeaders(requestBody),
       body: requestBody,
       signal: AbortSignal.timeout(5000),
     });
+    if (!response.ok) {
+      throw new Error(`Broadcast HTTP ${response.status}`);
+    }
   } catch (error) {
     realtimeLogger.error(
       'Failed to broadcast chat conversation-renamed',
@@ -1018,12 +1021,15 @@ export async function broadcastAiConversationDeleted(payload: ChatConversationDe
       payload,
     });
 
-    await fetch(`${realtimeUrl}/api/broadcast`, {
+    const response = await fetch(`${realtimeUrl}/api/broadcast`, {
       method: 'POST',
       headers: createSignedBroadcastHeaders(requestBody),
       body: requestBody,
       signal: AbortSignal.timeout(5000),
     });
+    if (!response.ok) {
+      throw new Error(`Broadcast HTTP ${response.status}`);
+    }
   } catch (error) {
     realtimeLogger.error(
       'Failed to broadcast chat conversation-deleted',
@@ -1052,12 +1058,15 @@ export async function broadcastAgentGrantChanged(payload: AgentGrantChangedPaylo
       payload,
     });
 
-    await fetch(`${realtimeUrl}/api/broadcast`, {
+    const response = await fetch(`${realtimeUrl}/api/broadcast`, {
       method: 'POST',
       headers: createSignedBroadcastHeaders(requestBody),
       body: requestBody,
       signal: AbortSignal.timeout(5000),
     });
+    if (!response.ok) {
+      throw new Error(`Broadcast HTTP ${response.status}`);
+    }
   } catch (error) {
     realtimeLogger.error(
       'Failed to broadcast agent grant-changed',


### PR DESCRIPTION
## Summary

- Adds `agent:grant_changed` Socket.IO broadcast to all three integration grant mutation routes (POST create, PUT update, DELETE remove) — `AgentIntegrationsPanel` subscribes and calls `mutateGrants()` so co-editors see the up-to-date tool list without a manual refresh
- Adds `chat:conversation_renamed` broadcast to the conversation PATCH route and `chat:conversation_deleted` to the DELETE route, following the same fire-and-forget + `resolveTriggeredBy` pattern as `chat:conversation_added`
- Extends `useChannelStreamSocket` with `onConversationRenamed` and `onConversationDeleted` callback options (stable-ref pattern, own-tab dedup, agentId guard) matching the existing `onConversationAdded` shape

## Test plan

- [ ] Open the same agent's Integrations panel in two browser tabs; toggle an integration in tab A — tab B should refresh automatically
- [ ] Open the same agent's conversation list in two tabs; rename a conversation in tab A — tab B should reflect the new title
- [ ] Delete a conversation in tab A — tab B's list should remove it
- [ ] Verify no broadcast errors appear in server logs when `INTERNAL_REALTIME_URL` is unset (warn + return, no throw)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent integration create, update, and delete now sync in real-time across active sessions.
  * AI conversation rename and delete events are broadcast in real-time.
  * UI panels automatically refresh when integrations or conversations change.
  * Conversation lists and chat views now update immediately on remote changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1327)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->