### PR TITLE
fix(realtime): broadcast drive role mutations and wire RolesManager socket listener

### DIFF
--- a/apps/web/src/app/api/drives/[driveId]/roles/[roleId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/roles/[roleId]/route.ts
@@ -3,6 +3,8 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log'
 import { checkDriveAccessForRoles, getRoleById, updateDriveRole, deleteDriveRole, validateRolePermissions } from '@pagespace/lib/services/drive-role-service';
 import { getActorInfo, logRoleActivity } from '@pagespace/lib/monitoring/activity-logger';
+import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
+import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
@@ -113,6 +115,10 @@ export async function PATCH(
       permissions,
     });
 
+    // Broadcast role change so other admins see it live
+    const recipientUserIds = await getDriveRecipientUserIds(driveId);
+    await broadcastDriveEvent(createDriveEventPayload(driveId, 'updated', {}), recipientUserIds);
+
     // Log activity for audit trail
     const actorInfo = await getActorInfo(userId);
     logRoleActivity(userId, 'update', {
@@ -166,6 +172,10 @@ export async function DELETE(
     }
 
     await deleteDriveRole(driveId, roleId);
+
+    // Broadcast role change so other admins see it live
+    const recipientUserIdsForDelete = await getDriveRecipientUserIds(driveId);
+    await broadcastDriveEvent(createDriveEventPayload(driveId, 'updated', {}), recipientUserIdsForDelete);
 
     // Log activity for audit trail
     const actorInfo = await getActorInfo(userId);

--- a/apps/web/src/app/api/drives/[driveId]/roles/[roleId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/roles/[roleId]/route.ts
@@ -115,9 +115,13 @@ export async function PATCH(
       permissions,
     });
 
-    // Broadcast role change so other admins see it live
-    const recipientUserIds = await getDriveRecipientUserIds(driveId);
-    await broadcastDriveEvent(createDriveEventPayload(driveId, 'updated', {}), recipientUserIds);
+    // Broadcast role change so other admins see it live (best-effort — don't fail the request if it errors)
+    try {
+      const recipientUserIds = await getDriveRecipientUserIds(driveId);
+      await broadcastDriveEvent(createDriveEventPayload(driveId, 'updated', {}), recipientUserIds);
+    } catch (broadcastError) {
+      console.error('Failed to broadcast role update event for drive', driveId, broadcastError);
+    }
 
     // Log activity for audit trail
     const actorInfo = await getActorInfo(userId);
@@ -173,9 +177,13 @@ export async function DELETE(
 
     await deleteDriveRole(driveId, roleId);
 
-    // Broadcast role change so other admins see it live
-    const recipientUserIdsForDelete = await getDriveRecipientUserIds(driveId);
-    await broadcastDriveEvent(createDriveEventPayload(driveId, 'updated', {}), recipientUserIdsForDelete);
+    // Broadcast role change so other admins see it live (best-effort — don't fail the request if it errors)
+    try {
+      const recipientUserIdsForDelete = await getDriveRecipientUserIds(driveId);
+      await broadcastDriveEvent(createDriveEventPayload(driveId, 'updated', {}), recipientUserIdsForDelete);
+    } catch (broadcastError) {
+      console.error('Failed to broadcast role delete event for drive', driveId, broadcastError);
+    }
 
     // Log activity for audit trail
     const actorInfo = await getActorInfo(userId);

--- a/apps/web/src/app/api/drives/[driveId]/roles/reorder/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/roles/reorder/route.ts
@@ -6,6 +6,8 @@ import { db } from '@pagespace/db/db'
 import { eq, asc } from '@pagespace/db/operators'
 import { driveRoles } from '@pagespace/db/schema/members';
 import { getActorInfo, logRoleActivity } from '@pagespace/lib/monitoring/activity-logger';
+import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
+import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 
@@ -48,6 +50,10 @@ export async function PATCH(
     const previousOrder = previousRoles.map(r => r.id);
 
     await reorderDriveRoles(driveId, roleIds);
+
+    // Broadcast role change so other admins see it live
+    const recipientUserIds = await getDriveRecipientUserIds(driveId);
+    await broadcastDriveEvent(createDriveEventPayload(driveId, 'updated', {}), recipientUserIds);
 
     // Log activity for audit trail
     const actorInfo = await getActorInfo(userId);

--- a/apps/web/src/app/api/drives/[driveId]/roles/reorder/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/roles/reorder/route.ts
@@ -51,9 +51,13 @@ export async function PATCH(
 
     await reorderDriveRoles(driveId, roleIds);
 
-    // Broadcast role change so other admins see it live
-    const recipientUserIds = await getDriveRecipientUserIds(driveId);
-    await broadcastDriveEvent(createDriveEventPayload(driveId, 'updated', {}), recipientUserIds);
+    // Broadcast role change so other admins see it live (best-effort — don't fail the request if it errors)
+    try {
+      const recipientUserIds = await getDriveRecipientUserIds(driveId);
+      await broadcastDriveEvent(createDriveEventPayload(driveId, 'updated', {}), recipientUserIds);
+    } catch (broadcastError) {
+      console.error('Failed to broadcast role reorder event for drive', driveId, broadcastError);
+    }
 
     // Log activity for audit trail
     const actorInfo = await getActorInfo(userId);

--- a/apps/web/src/app/api/drives/[driveId]/roles/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/roles/route.ts
@@ -89,9 +89,13 @@ export async function POST(
       permissions,
     });
 
-    // Broadcast role change so other admins see it live
-    const recipientUserIds = await getDriveRecipientUserIds(driveId);
-    await broadcastDriveEvent(createDriveEventPayload(driveId, 'updated', {}), recipientUserIds);
+    // Broadcast role change so other admins see it live (best-effort — don't fail the request if it errors)
+    try {
+      const recipientUserIds = await getDriveRecipientUserIds(driveId);
+      await broadcastDriveEvent(createDriveEventPayload(driveId, 'updated', {}), recipientUserIds);
+    } catch (broadcastError) {
+      console.error('Failed to broadcast role create event for drive', driveId, broadcastError);
+    }
 
     // Log activity for audit trail
     const actorInfo = await getActorInfo(userId);

--- a/apps/web/src/app/api/drives/[driveId]/roles/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/roles/route.ts
@@ -3,6 +3,8 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log'
 import { checkDriveAccessForRoles, listDriveRoles, createDriveRole, validateRolePermissions } from '@pagespace/lib/services/drive-role-service';
 import { getActorInfo, logRoleActivity } from '@pagespace/lib/monitoring/activity-logger';
+import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
+import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
@@ -86,6 +88,10 @@ export async function POST(
       isDefault,
       permissions,
     });
+
+    // Broadcast role change so other admins see it live
+    const recipientUserIds = await getDriveRecipientUserIds(driveId);
+    await broadcastDriveEvent(createDriveEventPayload(driveId, 'updated', {}), recipientUserIds);
 
     // Log activity for audit trail
     const actorInfo = await getActorInfo(userId);

--- a/apps/web/src/components/settings/RolesManager.tsx
+++ b/apps/web/src/components/settings/RolesManager.tsx
@@ -7,7 +7,7 @@ import { Badge } from '@/components/ui/badge';
 import { Plus, Pencil, Trash2, GripVertical, Star, Shield } from 'lucide-react';
 import { useToast } from '@/hooks/useToast';
 import { useSocket } from '@/hooks/useSocket';
-import { DriveEventPayload } from '@/lib/websocket';
+import type { DriveEventPayload } from '@/lib/websocket';
 import { fetchWithAuth, del } from '@/lib/auth/auth-fetch';
 import { getRoleColorClasses } from '@/lib/utils';
 import { RoleEditor } from './RoleEditor';

--- a/apps/web/src/components/settings/RolesManager.tsx
+++ b/apps/web/src/components/settings/RolesManager.tsx
@@ -1,11 +1,13 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Plus, Pencil, Trash2, GripVertical, Star, Shield } from 'lucide-react';
 import { useToast } from '@/hooks/useToast';
+import { useSocket } from '@/hooks/useSocket';
+import { DriveEventPayload } from '@/lib/websocket';
 import { fetchWithAuth, del } from '@/lib/auth/auth-fetch';
 import { getRoleColorClasses } from '@/lib/utils';
 import { RoleEditor } from './RoleEditor';
@@ -41,6 +43,7 @@ export function RolesManager({ driveId }: RolesManagerProps) {
   const [isCreating, setIsCreating] = useState(false);
   const [deletingRoleId, setDeletingRoleId] = useState<string | null>(null);
   const { toast } = useToast();
+  const socket = useSocket();
 
   const fetchRoles = async () => {
     try {
@@ -64,6 +67,21 @@ export function RolesManager({ driveId }: RolesManagerProps) {
     fetchRoles();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [driveId]);
+
+  const handleDriveUpdated = useCallback((event: DriveEventPayload) => {
+    if (event.driveId === driveId) {
+      fetchRoles();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [driveId]);
+
+  useEffect(() => {
+    if (!socket) return;
+    socket.on('drive:updated', handleDriveUpdated);
+    return () => {
+      socket.off('drive:updated', handleDriveUpdated);
+    };
+  }, [socket, handleDriveUpdated]);
 
   const handleDeleteRole = async (roleId: string) => {
     try {


### PR DESCRIPTION
## Summary

- Add `broadcastDriveEvent` calls to all four drive role mutation routes (create, update, delete, reorder) so peer admins receive a `drive:updated` socket event immediately
- Wire a `drive:updated` socket listener in `RolesManager.tsx` that calls `fetchRoles()` when an event arrives for the current drive, keeping the roles list live for all admins viewing the panel simultaneously

## Test plan

- [ ] Open Roles settings panel as two admin users in the same drive
- [ ] Admin A creates a role — Admin B's list updates without refresh
- [ ] Admin A edits a role — Admin B sees the updated name/color/permissions
- [ ] Admin A deletes a role — Admin B's list removes it live
- [ ] Admin A reorders roles — Admin B sees the new order
- [ ] Verify socket listener is cleaned up on component unmount (no listener leak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Role management (create, edit, reorder, delete) now broadcasts updates via realtime events so changes propagate instantly to drive members.
  * Settings UI now listens for drive update events and refreshes role lists automatically when the current drive is affected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1328)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->