### PR TITLE
fix(realtime): broadcast missing socket mutations

### DIFF
--- a/apps/web/src/app/api/messages/[conversationId]/[messageId]/route.ts
+++ b/apps/web/src/app/api/messages/[conversationId]/[messageId]/route.ts
@@ -2,8 +2,25 @@ import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { dmMessageRepository } from '@pagespace/lib/services/dm-message-repository';
+import { createSignedBroadcastHeaders } from '@pagespace/lib/auth/broadcast-auth';
+import { loggers } from '@pagespace/lib/logging/logger-config';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
+
+const BROADCAST_TIMEOUT_MS = 1500;
+
+async function broadcastDmEvent(requestBody: string): Promise<void> {
+  if (!process.env.INTERNAL_REALTIME_URL) return;
+  const response = await fetch(`${process.env.INTERNAL_REALTIME_URL}/api/broadcast`, {
+    method: 'POST',
+    headers: createSignedBroadcastHeaders(requestBody),
+    body: requestBody,
+    signal: AbortSignal.timeout(BROADCAST_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new Error(`Broadcast failed with status ${response.status}`);
+  }
+}
 
 type RouteParams = { params: Promise<{ conversationId: string; messageId: string }> };
 
@@ -57,6 +74,16 @@ export async function PATCH(req: Request, { params }: RouteParams) {
   // caller would see if the soft-delete had landed first.
   if (edited === 0) {
     return NextResponse.json({ error: 'Message not found' }, { status: 404 });
+  }
+
+  try {
+    await broadcastDmEvent(JSON.stringify({
+      channelId: `dm:${conversationId}`,
+      event: 'message_edited',
+      payload: { messageId, content: content.trim(), editedAt: editedAt.toISOString() },
+    }));
+  } catch (error) {
+    loggers.realtime.error('Failed to broadcast DM message_edited:', error as Error);
   }
 
   auditRequest(req, {
@@ -115,6 +142,16 @@ export async function DELETE(req: Request, { params }: RouteParams) {
   // rows. Surface the same 404 the second-DELETE caller would see.
   if (deleted === 0) {
     return NextResponse.json({ error: 'Message not found' }, { status: 404 });
+  }
+
+  try {
+    await broadcastDmEvent(JSON.stringify({
+      channelId: `dm:${conversationId}`,
+      event: 'message_deleted',
+      payload: { messageId },
+    }));
+  } catch (error) {
+    loggers.realtime.error('Failed to broadcast DM message_deleted:', error as Error);
   }
 
   auditRequest(req, {

--- a/apps/web/src/app/api/pages/[pageId]/agent-config/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/agent-config/route.ts
@@ -9,6 +9,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import { applyPageMutation, PageRevisionMismatchError } from '@/services/api/page-mutation-service';
+import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
@@ -244,6 +245,12 @@ export async function PATCH(
         userId,
         updatedFields: Object.keys(updateData),
       });
+
+      await broadcastPageEvent(
+        createPageEventPayload(page.driveId, pageId, 'updated', {
+          updatedFields: Object.keys(updateData),
+        }),
+      );
     }
 
     auditRequest(request, { eventType: 'data.write', userId, resourceType: 'agent_config', resourceId: pageId, details: { action: 'update_agent_config', updatedFields: Object.keys(updateData) } });

--- a/apps/web/src/app/api/pages/[pageId]/agent-config/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/agent-config/route.ts
@@ -247,9 +247,7 @@ export async function PATCH(
       });
 
       await broadcastPageEvent(
-        createPageEventPayload(page.driveId, pageId, 'updated', {
-          updatedFields: Object.keys(updateData),
-        }),
+        createPageEventPayload(page.driveId, pageId, 'updated'),
       );
     }
 

--- a/apps/web/src/app/api/pages/[pageId]/agent-config/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/agent-config/route.ts
@@ -247,7 +247,7 @@ export async function PATCH(
       });
 
       await broadcastPageEvent(
-        createPageEventPayload(page.driveId, pageId, 'updated'),
+        createPageEventPayload(responsePage.driveId, pageId, 'updated'),
       );
     }
 

--- a/apps/web/src/app/api/pages/[pageId]/agent-config/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/agent-config/route.ts
@@ -246,9 +246,13 @@ export async function PATCH(
         updatedFields: Object.keys(updateData),
       });
 
-      await broadcastPageEvent(
-        createPageEventPayload(responsePage.driveId, pageId, 'updated'),
-      );
+      try {
+        await broadcastPageEvent(
+          createPageEventPayload(responsePage.driveId, pageId, 'updated'),
+        );
+      } catch (broadcastError) {
+        loggers.api.error('Failed to broadcast agent config update', broadcastError as Error);
+      }
     }
 
     auditRequest(request, { eventType: 'data.write', userId, resourceType: 'agent_config', resourceId: pageId, details: { action: 'update_agent_config', updatedFields: Object.keys(updateData) } });

--- a/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
@@ -233,16 +233,32 @@ export default function InboxDMPage() {
       );
     };
 
+    const handleMessageEdited = (data: { messageId: string; content: string; editedAt: string }) => {
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === data.messageId ? { ...m, content: data.content, isEdited: true, editedAt: data.editedAt } : m
+        )
+      );
+    };
+
+    const handleMessageDeleted = (data: { messageId: string }) => {
+      setMessages((prev) => prev.filter((m) => m.id !== data.messageId));
+    };
+
     socket.on('new_dm_message', handleNewMessage);
     socket.on('reaction_added', handleReactionAdded);
     socket.on('reaction_removed', handleReactionRemoved);
     socket.on('thread_reply_count_updated', handleThreadCountUpdated);
+    socket.on('message_edited', handleMessageEdited);
+    socket.on('message_deleted', handleMessageDeleted);
 
     return () => {
       socket.off('new_dm_message', handleNewMessage);
       socket.off('reaction_added', handleReactionAdded);
       socket.off('reaction_removed', handleReactionRemoved);
       socket.off('thread_reply_count_updated', handleThreadCountUpdated);
+      socket.off('message_edited', handleMessageEdited);
+      socket.off('message_deleted', handleMessageDeleted);
       socket.emit('leave_dm_conversation', conversationId);
     };
   }, [conversationId, user, socket]);


### PR DESCRIPTION
## Summary

- **Agent config PATCH** (\`/api/pages/[pageId]/agent-config\`) — was mutating \`systemPrompt\`, \`enabledTools\`, \`aiProvider\`, \`aiModel\`, etc. via \`applyPageMutation\` but never calling \`broadcastPageEvent\`. Collaborators viewing the same agent page saw stale config until refresh. Broadcast now uses the post-mutation \`responsePage.driveId\` so the event goes to the correct room even if the page was moved.
- **DM message edit/delete** (\`/api/messages/[conversationId]/[messageId]\`) — PATCH and DELETE had no real-time broadcast. The channel equivalent already broadcast correctly; DM reactions already used \`broadcastDmEvent\`. Added the same pattern for \`message_edited\` and \`message_deleted\` on \`dm:{conversationId}\`.
- **DM conversation view** (\`/app/dashboard/dms/[conversationId]/page.tsx\`) — subscribed to reactions and new messages but not \`message_edited\` or \`message_deleted\`. Added \`handleMessageEdited\` (updates content/editedAt in state) and \`handleMessageDeleted\` (filters message out) inside the existing socket \`useEffect\`.

## Test plan

- [ ] Open the same agent page as two users → change AI model/system prompt as User A → User B sees the agent config panel reflect the change without refreshing
- [ ] Open a DM conversation as two users → User A edits a message → User B sees the updated content in real time
- [ ] User A deletes a DM message → User B sees the message disappear without refreshing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Direct messages now update in real time when messages are edited or deleted, keeping all connected clients in sync without manual refresh.
  * Updates to a page’s agent configuration are now broadcast in real time so changes appear immediately across connected clients.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1329)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->