### PR TITLE
feat(calendar): drive selection in root calendar

### DIFF
--- a/apps/web/src/components/calendar/CalendarSidebar.tsx
+++ b/apps/web/src/components/calendar/CalendarSidebar.tsx
@@ -20,6 +20,8 @@ interface CalendarSidebarProps {
   userEventsVisible: boolean;
   onToggleAgentEvents: () => void;
   onToggleUserEvents: () => void;
+  selectedKey?: string;
+  onSelectCalendar?: (key: string) => void;
   className?: string;
 }
 
@@ -32,6 +34,8 @@ export function CalendarSidebar({
   userEventsVisible,
   onToggleAgentEvents,
   onToggleUserEvents,
+  selectedKey,
+  onSelectCalendar,
   className,
 }: CalendarSidebarProps) {
   const hasCalendars = calendars.length > 0;
@@ -57,18 +61,21 @@ export function CalendarSidebar({
           key={cal.key}
           role="button"
           tabIndex={0}
-          onClick={() => onToggle(cal.key)}
-          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggle(cal.key); } }}
+          onClick={() => onSelectCalendar?.(cal.key)}
+          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelectCalendar?.(cal.key); } }}
           className={cn(
             'flex items-center gap-2 px-1.5 py-1 rounded cursor-pointer transition-colors',
             'hover:bg-muted/50',
-            !cal.visible && 'opacity-50'
+            !cal.visible && 'opacity-50',
+            cal.key === selectedKey && 'bg-accent/50'
           )}
         >
           <span
             role="checkbox"
             aria-checked={cal.visible}
             aria-label={`Toggle ${cal.name}`}
+            onClick={(e) => { e.stopPropagation(); onToggle(cal.key); }}
+            onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); e.stopPropagation(); onToggle(cal.key); } }}
             className={cn(
               'size-3.5 shrink-0 rounded-sm border transition-colors',
               cal.visible

--- a/apps/web/src/components/calendar/CalendarSidebar.tsx
+++ b/apps/web/src/components/calendar/CalendarSidebar.tsx
@@ -62,7 +62,7 @@ export function CalendarSidebar({
           role="button"
           tabIndex={0}
           onClick={() => onSelectCalendar ? onSelectCalendar(cal.key) : onToggle(cal.key)}
-          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelectCalendar ? onSelectCalendar(cal.key) : onToggle(cal.key); } }}
+          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); if (onSelectCalendar) { onSelectCalendar(cal.key); } else { onToggle(cal.key); } } }}
           className={cn(
             'flex items-center gap-2 px-1.5 py-1 rounded cursor-pointer transition-colors',
             'hover:bg-muted/50',

--- a/apps/web/src/components/calendar/CalendarSidebar.tsx
+++ b/apps/web/src/components/calendar/CalendarSidebar.tsx
@@ -61,8 +61,8 @@ export function CalendarSidebar({
           key={cal.key}
           role="button"
           tabIndex={0}
-          onClick={() => onSelectCalendar?.(cal.key)}
-          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelectCalendar?.(cal.key); } }}
+          onClick={() => onSelectCalendar ? onSelectCalendar(cal.key) : onToggle(cal.key)}
+          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelectCalendar ? onSelectCalendar(cal.key) : onToggle(cal.key); } }}
           className={cn(
             'flex items-center gap-2 px-1.5 py-1 rounded cursor-pointer transition-colors',
             'hover:bg-muted/50',
@@ -74,6 +74,7 @@ export function CalendarSidebar({
             role="checkbox"
             aria-checked={cal.visible}
             aria-label={`Toggle ${cal.name}`}
+            tabIndex={0}
             onClick={(e) => { e.stopPropagation(); onToggle(cal.key); }}
             onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); e.stopPropagation(); onToggle(cal.key); } }}
             className={cn(

--- a/apps/web/src/components/calendar/CalendarView.tsx
+++ b/apps/web/src/components/calendar/CalendarView.tsx
@@ -167,13 +167,16 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
   );
 
   // When user context: derive the effective driveId/context for the event modal.
-  // Editing an existing event: prefer the event's own driveId so drive features are
-  // always available regardless of which sidebar calendar is selected.
+  // Editing an existing event: use the event's own driveId. A null driveId means
+  // the event is personal — convert null→undefined so it isn't confused with "no
+  // event selected". Never inherit the selected calendar key when editing.
   // Creating a new event: use the selected calendar key.
   const creationDriveId = isUserContext && selectedCalendarKey !== 'personal'
     ? selectedCalendarKey
     : (isUserContext ? undefined : driveId);
-  const effectiveModalDriveId = selectedEvent?.driveId ?? creationDriveId;
+  const effectiveModalDriveId = selectedEvent
+    ? (selectedEvent.driveId ?? undefined)
+    : creationDriveId;
   const effectiveModalContext: 'user' | 'drive' = effectiveModalDriveId ? 'drive' : 'user';
 
   const { data: googleCalendarStatus } = useSWR<GoogleCalendarStatusResponse>(

--- a/apps/web/src/components/calendar/CalendarView.tsx
+++ b/apps/web/src/components/calendar/CalendarView.tsx
@@ -100,6 +100,7 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
   const { hiddenCalendars, toggleCalendar, showAll, hideAll, hiddenEventTypes, toggleEventType, isEventTypeVisible } =
     useCalendarFilterStore();
   const [sidebarOpen, setSidebarOpen] = useState(true);
+  const [selectedCalendarKey, setSelectedCalendarKey] = useState('personal');
 
   // Force-refresh drives on mount so the sidebar reflects current memberships
   const isUserContext = context === 'user';
@@ -164,6 +165,16 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
     () => calendarEntries.map((c) => c.key),
     [calendarEntries]
   );
+
+  // When user context: derive the effective driveId/context for the event modal.
+  // Editing an existing event: prefer the event's own driveId so drive features are
+  // always available regardless of which sidebar calendar is selected.
+  // Creating a new event: use the selected calendar key.
+  const creationDriveId = isUserContext && selectedCalendarKey !== 'personal'
+    ? selectedCalendarKey
+    : (isUserContext ? undefined : driveId);
+  const effectiveModalDriveId = selectedEvent?.driveId ?? creationDriveId;
+  const effectiveModalContext: 'user' | 'drive' = effectiveModalDriveId ? 'drive' : 'user';
 
   const { data: googleCalendarStatus } = useSWR<GoogleCalendarStatusResponse>(
     '/api/integrations/google-calendar/status',
@@ -265,10 +276,13 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
     } else {
       // POST schema doesn't accept null (only undefined no-op or object upsert)
       const { agentTrigger, ...rest } = eventData;
+      const driveOverride = isUserContext && selectedCalendarKey !== 'personal'
+        ? selectedCalendarKey
+        : undefined;
       await createEvent({
         ...rest,
         agentTrigger: agentTrigger ?? undefined,
-      });
+      }, driveOverride);
     }
     setIsEventModalOpen(false);
   };
@@ -410,8 +424,8 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
           onRsvp={handleRsvp}
           onAddAttendee={handleAddAttendee}
           onRemoveAttendee={handleRemoveAttendee}
-          driveId={driveId}
-          context={context}
+          driveId={effectiveModalDriveId}
+          context={effectiveModalContext}
         />
       </div>
     );
@@ -604,6 +618,8 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
               userEventsVisible={isEventTypeVisible('user')}
               onToggleAgentEvents={() => toggleEventType('agent')}
               onToggleUserEvents={() => toggleEventType('user')}
+              selectedKey={selectedCalendarKey}
+              onSelectCalendar={setSelectedCalendarKey}
             />
           </aside>
         )}
@@ -673,8 +689,8 @@ export function CalendarView({ context, driveId, driveName: _driveName, classNam
         onRsvp={handleRsvp}
         onAddAttendee={handleAddAttendee}
         onRemoveAttendee={handleRemoveAttendee}
-        driveId={driveId}
-        context={context}
+        driveId={effectiveModalDriveId}
+        context={effectiveModalContext}
       />
     </div>
   );

--- a/apps/web/src/components/calendar/useCalendarData.ts
+++ b/apps/web/src/components/calendar/useCalendarData.ts
@@ -130,9 +130,12 @@ export function useCalendarData({
         instructionPageId: string | null;
         contextPageIds: string[];
       };
-    }) => {
+    }, overrideDriveId?: string | null) => {
+      const targetDriveId = overrideDriveId !== undefined
+        ? overrideDriveId
+        : (context === 'drive' ? driveId : null);
       const result = await post<CalendarEvent>('/api/calendar/events', {
-        driveId: context === 'drive' ? driveId : null,
+        driveId: targetDriveId,
         ...eventData,
         startAt: eventData.startAt.toISOString(),
         endAt: eventData.endAt.toISOString(),


### PR DESCRIPTION
## Summary

- **Split sidebar click behavior**: the colored dot toggles a drive's visibility; clicking the row label selects it as the active creation context (highlighted with `bg-accent/50`)
- **Full modal parity from root calendar**: when a drive is selected, the New Event modal shows attendees, agent triggers, and linked-page sections — identical to the drive-level calendar
- **Correct event creation**: new events are posted with the selected drive's ID; opening existing drive events from root calendar also unlocks all drive features in the modal

## Changes

| File | What changed |
|------|-------------|
| `CalendarSidebar.tsx` | New `selectedKey` + `onSelectCalendar` props; split click targets; selection highlight |
| `CalendarView.tsx` | `selectedCalendarKey` state; derives `effectiveModalDriveId/Context`; wires both desktop + mobile `EventModal` and `createEvent` override |
| `useCalendarData.ts` | `createEvent` accepts optional `overrideDriveId` (backwards-compatible) |

## Test plan

- [ ] Open `/dashboard/calendar` — Personal is highlighted by default
- [ ] Click a drive name in the sidebar — row highlights; click New Event → modal shows Attendees, Agent trigger, Advanced sections
- [ ] Create the event → it appears under the correct drive calendar with the right color
- [ ] Switch back to Personal → New Event modal shows basic fields only, event is personal
- [ ] Click the colored dot on a drive → visibility toggles without changing selection
- [ ] Open an existing drive event from root calendar → all drive sections visible in modal
- [ ] Drive-level calendar (`/dashboard/[id]/calendar`) behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar rows are now selectable with keyboard support and a visual highlight for the selected calendar.
  * New events created from the sidebar respect the currently selected calendar, and the event editor receives the correct calendar context.

* **Bug Fixes**
  * Checkbox/toggle clicks (and Enter/Space on them) no longer trigger row selection or activation, preventing accidental selection when toggling visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1330)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->