### PR TITLE
feat(channels): media preview modal on click

### DIFF
--- a/apps/web/src/components/shared/MessageAttachment.tsx
+++ b/apps/web/src/components/shared/MessageAttachment.tsx
@@ -1,7 +1,16 @@
-import { FileIcon, FileText, Download } from 'lucide-react';
+'use client';
+
+import { useState } from 'react';
+import { FileIcon, FileText, Download, Video } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import {
   type MessageWithAttachment,
   isImageAttachment,
+  isVideoAttachment,
   getFileId,
   getAttachmentName,
   getAttachmentMimeType,
@@ -15,6 +24,8 @@ interface MessageAttachmentProps {
 }
 
 export function MessageAttachment({ message }: MessageAttachmentProps) {
+  const [previewOpen, setPreviewOpen] = useState(false);
+
   if (!hasAttachment(message)) return null;
 
   const fileId = getFileId(message);
@@ -25,11 +36,10 @@ export function MessageAttachment({ message }: MessageAttachmentProps) {
   if (isImageAttachment(message)) {
     return (
       <div className="mt-2">
-        <a
-          href={`/api/files/${fileId}/view?filename=${encodeURIComponent(name)}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="block max-w-sm"
+        <button
+          type="button"
+          onClick={() => setPreviewOpen(true)}
+          className="block max-w-sm cursor-zoom-in"
         >
           {/* eslint-disable-next-line @next/next/no-img-element -- auth-gated API route; processor already optimizes on upload */}
           <img
@@ -37,7 +47,54 @@ export function MessageAttachment({ message }: MessageAttachmentProps) {
             alt={name}
             className="rounded-lg max-h-64 object-contain border border-border/50"
           />
-        </a>
+        </button>
+
+        <Dialog open={previewOpen} onOpenChange={setPreviewOpen}>
+          <DialogContent className="max-w-[90vw] max-h-[90vh] p-2">
+            <DialogTitle className="sr-only">Image preview</DialogTitle>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={`/api/files/${fileId}/view`}
+              alt={name}
+              className="max-w-full max-h-[85vh] object-contain mx-auto"
+            />
+          </DialogContent>
+        </Dialog>
+      </div>
+    );
+  }
+
+  if (isVideoAttachment(message)) {
+    return (
+      <div className="mt-2">
+        <button
+          type="button"
+          onClick={() => setPreviewOpen(true)}
+          className="flex items-center gap-3 p-3 bg-muted/50 hover:bg-muted rounded-lg border border-border/50 max-w-sm transition-colors cursor-pointer"
+        >
+          <div className="w-10 h-10 rounded bg-muted flex items-center justify-center shrink-0">
+            <Video className="h-5 w-5 text-muted-foreground" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium truncate">{name}</p>
+            {size != null && (
+              <p className="text-xs text-muted-foreground">{formatFileSize(size)}</p>
+            )}
+          </div>
+        </button>
+
+        <Dialog open={previewOpen} onOpenChange={setPreviewOpen}>
+          <DialogContent className="max-w-[90vw] max-h-[90vh] p-2">
+            <DialogTitle className="sr-only">Video preview</DialogTitle>
+            {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+            <video
+              src={`/api/files/${fileId}/view`}
+              controls
+              autoPlay
+              className="max-w-full max-h-[85vh] mx-auto"
+            />
+          </DialogContent>
+        </Dialog>
       </div>
     );
   }

--- a/apps/web/src/components/shared/MessageAttachment.tsx
+++ b/apps/web/src/components/shared/MessageAttachment.tsx
@@ -90,7 +90,6 @@ export function MessageAttachment({ message }: MessageAttachmentProps) {
             <video
               src={`/api/files/${fileId}/view`}
               controls
-              autoPlay
               className="max-w-full max-h-[85vh] mx-auto"
             />
           </DialogContent>

--- a/apps/web/src/lib/attachment-utils.ts
+++ b/apps/web/src/lib/attachment-utils.ts
@@ -24,6 +24,12 @@ export function isImageAttachment(m: MessageWithAttachment): boolean {
   return false;
 }
 
+export function isVideoAttachment(m: MessageWithAttachment): boolean {
+  if (m.attachmentMeta?.mimeType?.startsWith('video/')) return true;
+  if (m.file?.mimeType?.startsWith('video/')) return true;
+  return false;
+}
+
 export function getFileId(m: MessageWithAttachment): string | null {
   return m.fileId || m.file?.id || null;
 }


### PR DESCRIPTION
## Summary

- Images in channel/DM messages now open a full-size lightbox Dialog on click instead of a new browser tab
- Videos in channel/DM messages show a file card with a Video icon; clicking opens an in-app `<video controls autoPlay>` modal
- Non-media attachments (PDF, docs, etc.) retain the existing download-link behaviour
- Adds `isVideoAttachment` utility to `attachment-utils.ts` mirroring the existing `isImageAttachment`

## Test plan

- [ ] Send an image in a channel → click thumbnail → lightbox modal opens, no new tab
- [ ] Press Escape / click outside lightbox → modal closes
- [ ] Send a video in a channel → Video icon card renders → click → video player modal opens and autoplays
- [ ] Send a PDF/doc in a channel → download card unchanged
- [ ] Repeat image + video steps in a DM
- [ ] AI chat image previews unaffected (`ImageMessageContent.tsx` is separate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-place previews for image and video attachments: tap a preview button to open media in a modal within the chat.
  * Non-media attachments continue to offer a direct download link and metadata display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1332)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->