### PR TITLE
refactor(memory): tighten cron personalization signal

### DIFF
--- a/apps/web/src/app/api/memory/cron/route.ts
+++ b/apps/web/src/app/api/memory/cron/route.ts
@@ -155,7 +155,6 @@ async function processUserMemory(
 
   const totalInsights =
     insights.worldview.length +
-    insights.projects.length +
     insights.communication.length +
     insights.preferences.length;
 
@@ -188,7 +187,6 @@ async function processUserMemory(
     userId,
     insightCounts: {
       worldview: insights.worldview.length,
-      projects: insights.projects.length,
       communication: insights.communication.length,
       preferences: insights.preferences.length,
     },

--- a/apps/web/src/lib/memory/__tests__/discovery-service.test.ts
+++ b/apps/web/src/lib/memory/__tests__/discovery-service.test.ts
@@ -9,7 +9,7 @@ import { assert } from './riteway';
  *
  * Key behaviors to test:
  * 1. Returns empty results when insufficient conversation data
- * 2. Runs 4 focused passes (worldview, projects, communication, preferences)
+ * 2. Runs 3 focused passes (worldview, communication, preferences)
  * 3. Parses JSON array responses from LLM
  * 4. Handles LLM errors gracefully (returns empty arrays, doesn't throw)
  * 5. Gathers conversations from multiple sources
@@ -145,7 +145,7 @@ describe('discovery-service', () => {
       });
     });
 
-    it('should return DiscoveryResult with four arrays', async () => {
+    it('should return DiscoveryResult with three arrays', async () => {
       const { runDiscoveryPasses } = await import('../discovery-service');
 
       const result = await runDiscoveryPasses('user-123');
@@ -154,13 +154,6 @@ describe('discovery-service', () => {
         given: 'a userId',
         should: 'return result with worldview array',
         actual: Array.isArray(result.worldview),
-        expected: true,
-      });
-
-      assert({
-        given: 'a userId',
-        should: 'return result with projects array',
-        actual: Array.isArray(result.projects),
         expected: true,
       });
 
@@ -195,8 +188,8 @@ describe('discovery-service', () => {
 
       assert({
         given: 'a user with fewer than 3 conversations',
-        should: 'return empty projects array',
-        actual: result.projects,
+        should: 'return empty preferences array',
+        actual: result.preferences,
         expected: [],
       });
     });
@@ -204,13 +197,11 @@ describe('discovery-service', () => {
 
   describe('DiscoveryResult type', () => {
     it('should define DiscoveryResult interface', async () => {
-      // Type check - if this compiles, the type exists
       const { runDiscoveryPasses } = await import('../discovery-service');
       const result = await runDiscoveryPasses('test');
 
       // TypeScript will fail compilation if these properties don't exist
       const _worldview: string[] = result.worldview;
-      const _projects: string[] = result.projects;
       const _communication: string[] = result.communication;
       const _preferences: string[] = result.preferences;
 
@@ -228,11 +219,10 @@ describe('discovery-service', () => {
       vi.clearAllMocks();
     });
 
-    it('should run 4 LLM passes when sufficient conversations exist', async () => {
+    it('should run 3 LLM passes when sufficient conversations exist', async () => {
       setupDbWithMessages(10);
       setupAIProviderSuccess([
         '["Expert in TypeScript"]',
-        '["Working on memory system"]',
         '["Prefers concise responses"]',
         '["No emojis please"]',
       ]);
@@ -240,12 +230,11 @@ describe('discovery-service', () => {
       const { runDiscoveryPasses } = await import('../discovery-service');
       await runDiscoveryPasses('user-with-data');
 
-      // Should have called generateText 4 times (one per pass)
       assert({
         given: 'user with sufficient conversations',
-        should: 'call LLM 4 times for 4 discovery passes',
+        should: 'call LLM 3 times for worldview, communication, and preferences passes',
         actual: mockGenerateText.mock.calls.length,
-        expected: 4,
+        expected: 3,
       });
     });
 
@@ -253,7 +242,6 @@ describe('discovery-service', () => {
       setupDbWithMessages(10);
       setupAIProviderSuccess([
         '["Expert in TypeScript", "Values TDD"]',
-        '["Working on memory system"]',
         '["Prefers concise responses"]',
         '["No emojis please"]',
       ]);
@@ -273,7 +261,6 @@ describe('discovery-service', () => {
       setupDbWithMessages(10);
       setupAIProviderSuccess([
         '```json\n["Expert in TypeScript"]\n```',
-        '["Working on memory system"]',
         '["Prefers concise responses"]',
         '["No emojis"]',
       ]);
@@ -293,7 +280,6 @@ describe('discovery-service', () => {
       setupDbWithMessages(10);
       setupAIProviderSuccess([
         'I found some insights about this user',
-        '["Working on memory system"]',
         '["Prefers concise responses"]',
         '["No emojis"]',
       ]);

--- a/apps/web/src/lib/memory/compaction-service.ts
+++ b/apps/web/src/lib/memory/compaction-service.ts
@@ -22,16 +22,16 @@ const COMPACTION_TARGET_RATIO = 0.7;
 type PersonalizationField = 'bio' | 'writingStyle' | 'rules';
 
 const COMPACTION_PROMPTS: Record<PersonalizationField, string> = {
-  bio: `You are reorganizing a user's bio/background information that has grown too long.
+  bio: `You are reorganizing a user's bio and background information that has grown too long.
 
 Your job is to:
-1. Preserve all key facts about their background, expertise, and role
-2. Consolidate redundant or overlapping information
-3. Remove outdated or superseded information (keep most recent)
-4. Maintain the essential character and voice
+1. Preserve facts about their background, expertise, domain, and thinking style
+2. REMOVE any current task or project status — that's ephemeral and belongs in project context, not here
+3. Consolidate redundant or overlapping information
+4. Keep the most recent version when information has been superseded
 5. Organize into clear sections if appropriate
 
-Output the reorganized bio as clean prose or bullet points. Do NOT add commentary or explanations - just output the compacted content.`,
+Output only the compacted bio content as prose or bullet points. No commentary.`,
 
   writingStyle: `You are reorganizing a user's writing style preferences that have grown too long.
 
@@ -44,16 +44,16 @@ Your job is to:
 
 Output the reorganized writing style as clean prose or bullet points. Do NOT add commentary - just output the compacted content.`,
 
-  rules: `You are reorganizing a user's AI rules/instructions that have grown too long.
+  rules: `You are reorganizing a user's AI behavior rules that have grown too long.
 
 Your job is to:
-1. Preserve all explicit do's and don'ts
-2. Consolidate rules that say the same thing differently
-3. Remove rules that contradict newer rules (keep most recent)
-4. Organize by category if appropriate
-5. Keep the most specific/actionable rules
+1. Keep rules that describe how the user wants AI to behave in any context — universal preferences
+2. REMOVE rules that are project-specific decisions, technology choices for a particular product, or scope calls that belong in a project's own context
+3. Consolidate rules that say the same thing differently
+4. Remove rules that contradict newer rules (keep most recent)
+5. Keep the most specific and actionable guidance
 
-Output the reorganized rules as clean prose or bullet points. Do NOT add commentary - just output the compacted content.`,
+Output only the compacted rules content as prose or bullet points. No commentary.`,
 };
 
 /**

--- a/apps/web/src/lib/memory/discovery-service.ts
+++ b/apps/web/src/lib/memory/discovery-service.ts
@@ -18,7 +18,6 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 
 export interface DiscoveryResult {
   worldview: string[];
-  projects: string[];
   communication: string[];
   preferences: string[];
 }
@@ -40,15 +39,6 @@ Only report clear patterns, not speculation. Return a JSON array of strings, eac
 
 Example output: ["Values test-driven development", "Expert in React and TypeScript", "Has background in finance"]`;
 
-const PROJECTS_PROMPT = `Analyze these conversations to discover:
-- What is this person actively working on?
-- What projects or goals do they mention?
-- What problems are they trying to solve?
-
-Focus on current/recent work, not historical. Return a JSON array of strings, each string being a distinct insight about their current work. If nothing clear emerges, return an empty array.
-
-Example output: ["Working on a memory system for AI personalization", "Building a collaborative workspace app"]`;
-
 const COMMUNICATION_PROMPT = `Analyze these conversations to discover:
 - How does this person like to communicate?
 - Do they prefer brief or detailed responses?
@@ -59,14 +49,24 @@ Look for patterns in how they interact. Return a JSON array of strings, each str
 
 Example output: ["Prefers concise responses", "Uses technical language comfortably"]`;
 
-const PREFERENCES_PROMPT = `Analyze these conversations to discover:
-- What has this person explicitly asked for or against?
-- What frustrates them about AI responses?
-- What specific instructions have they given?
+const PREFERENCES_PROMPT = `Analyze these conversations to identify persistent preferences for how this person wants AI to interact with them.
 
-Only include explicit preferences, not inferred ones. Return a JSON array of strings, each string being a distinct preference or rule. If none found, return an empty array.
+ONLY capture preferences that pass the portability test: "Would this still apply if the user was working on a completely different project in a different workspace?" If no, skip it.
 
-Example output: ["Don't use emojis", "Always include TypeScript types"]`;
+DO capture:
+- Response format and length preferences
+- Tone and communication style they expect from AI
+- Persistent do's and don'ts about AI output (e.g., "don't use emojis", "always show TypeScript types")
+
+DO NOT capture:
+- Technology or tool choices for a specific project
+- Scope or prioritization decisions ("we're not doing X for this release")
+- One-off decisions explained by their conversational context
+- Project-specific constraints or workflow choices
+
+Return a JSON array of strings. If no clearly portable preferences emerge, return an empty array.
+
+Example output: ["Prefers responses without preamble or sign-off", "Always wants TypeScript types in code examples"]`;
 
 /**
  * Gather recent messages from all conversation sources for a user
@@ -289,10 +289,8 @@ export async function runDiscoveryPasses(userId: string): Promise<DiscoveryResul
 
   const fullContext = conversationContext + activityContext;
 
-  // Run all 4 passes in parallel
-  const [worldview, projects, communication, preferences] = await Promise.all([
+  const [worldview, communication, preferences] = await Promise.all([
     runDiscoveryPass(userId, 'worldview', WORLDVIEW_PROMPT, fullContext),
-    runDiscoveryPass(userId, 'projects', PROJECTS_PROMPT, fullContext),
     runDiscoveryPass(userId, 'communication', COMMUNICATION_PROMPT, fullContext),
     runDiscoveryPass(userId, 'preferences', PREFERENCES_PROMPT, fullContext),
   ]);
@@ -301,7 +299,6 @@ export async function runDiscoveryPasses(userId: string): Promise<DiscoveryResul
     userId,
     insightCounts: {
       worldview: worldview.length,
-      projects: projects.length,
       communication: communication.length,
       preferences: preferences.length,
     },
@@ -309,7 +306,6 @@ export async function runDiscoveryPasses(userId: string): Promise<DiscoveryResul
 
   return {
     worldview,
-    projects,
     communication,
     preferences,
   };

--- a/apps/web/src/lib/memory/discovery-service.ts
+++ b/apps/web/src/lib/memory/discovery-service.ts
@@ -269,7 +269,6 @@ export async function runDiscoveryPasses(userId: string): Promise<DiscoveryResul
     });
     return {
       worldview: [],
-      projects: [],
       communication: [],
       preferences: [],
     };

--- a/apps/web/src/lib/memory/integration-service.ts
+++ b/apps/web/src/lib/memory/integration-service.ts
@@ -36,24 +36,18 @@ export interface IntegrationDecision {
 // Signal strength threshold
 const MIN_INSIGHTS_FOR_UPDATE = 2;
 
-const EVALUATOR_SYSTEM_PROMPT = `You are evaluating discovered insights about a user to decide if they should be added to their personalization profile.
-
-Your job is to:
-1. Compare new insights against what's already in the profile
-2. Filter out redundant or already-captured information
-3. Identify genuinely new, significant insights worth recording
-4. Categorize approved insights into the correct field
+const EVALUATOR_SYSTEM_PROMPT = `You are deciding what to add to a user's personalization profile. The profile exists to make every AI conversation feel personal — like the AI already knows who this person is.
 
 FIELDS:
-- bio: Background, expertise, role, beliefs, worldview, mental models
-- writingStyle: Communication preferences, tone, formatting, interaction style
-- rules: Explicit instructions, preferences about AI behavior, do's and don'ts
+- bio: Who this person is — background, expertise, domain, thinking style, mental models. Describes the person, not their current tasks.
+- writingStyle: How they want AI to communicate — tone, verbosity, formatting, interaction patterns.
+- rules: Universal AI behavior preferences that apply in any workspace ("never use emojis", "always include TypeScript types"). Not project decisions, technology choices, or scope calls.
 
-QUALITY GATES:
-- Only approve insights that add meaningful new understanding
-- Skip if the insight is already captured (even if worded differently)
-- Skip if the insight is too vague or generic to be useful
-- Skip if the insight contradicts existing profile content
+QUALITY GATES (apply in order — fail any gate = skip):
+1. Portability: Would this still apply if the person was working on a completely different project? If no, skip.
+2. Personhood: Does this describe the person, or just a decision they made in a specific context? Project-scoped decisions don't belong here.
+3. Novelty: Is this already captured in the existing profile (even if worded differently)? If yes, skip.
+4. Signal: Is this a clear, repeatable pattern — not a single mention or one-off? If no, skip.
 
 For each field, decide:
 - "append" - Add new content to the end of this field
@@ -140,7 +134,6 @@ export async function evaluateAndIntegrate(
 
   const totalInsights =
     insights.worldview.length +
-    insights.projects.length +
     insights.communication.length +
     insights.preferences.length;
 
@@ -160,9 +153,6 @@ export async function evaluateAndIntegrate(
   const insightsText = `
 WORLDVIEW & EXPERTISE INSIGHTS:
 ${insights.worldview.length > 0 ? insights.worldview.map((i) => `- ${i}`).join('\n') : '(none discovered)'}
-
-PROJECTS & CURRENT WORK INSIGHTS:
-${insights.projects.length > 0 ? insights.projects.map((i) => `- ${i}`).join('\n') : '(none discovered)'}
 
 COMMUNICATION STYLE INSIGHTS:
 ${insights.communication.length > 0 ? insights.communication.map((i) => `- ${i}`).join('\n') : '(none discovered)'}

--- a/apps/web/src/lib/memory/integration-service.ts
+++ b/apps/web/src/lib/memory/integration-service.ts
@@ -47,7 +47,8 @@ QUALITY GATES (apply in order — fail any gate = skip):
 1. Portability: Would this still apply if the person was working on a completely different project? If no, skip.
 2. Personhood: Does this describe the person, or just a decision they made in a specific context? Project-scoped decisions don't belong here.
 3. Novelty: Is this already captured in the existing profile (even if worded differently)? If yes, skip.
-4. Signal: Is this a clear, repeatable pattern — not a single mention or one-off? If no, skip.
+4. Consistency: Does this contradict something already in the profile? If yes, skip — do not append conflicting statements.
+5. Signal: Is this a clear, repeatable pattern — not a single mention or one-off? If no, skip.
 
 For each field, decide:
 - "append" - Add new content to the end of this field


### PR DESCRIPTION
## Summary

- Removes the `projects` discovery pass — ephemeral task state is already held in drive context and doesn't make chat feel more personal
- Rewrites `PREFERENCES_PROMPT` with an explicit portability test: only preferences that would apply across *any* workspace get captured (blocks project-scoped decisions like tech choices or scope calls)
- Rewrites the integration evaluator with 4 ordered quality gates: portability → personhood → novelty → signal strength; project-specific decisions now fail gate 1
- Compaction prompts now actively prune project-specific content and stale task state instead of blindly preserving everything

## Test plan

- [x] All 10 discovery-service tests pass
- [ ] Verify next cron run logs `rulesAction: "skip"` for project-scoped conversation inputs
- [ ] Check existing `userPersonalization.rules` fields for any previously ingested project decisions (will be cleaned on next compaction trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)