### PR TITLE
feat(mentions): add @everyone and @role group mentions

### DIFF
--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -364,17 +364,24 @@ export async function POST(request: Request) {
           conversationId,
         } });
 
-        // Fire mention notifications for @user, @everyone, @role mentions in AI chat pages
+        // Fire mention notifications for @user, @everyone, @role mentions in AI chat pages.
+        // Gate each recipient on view permission to prevent leaking page metadata.
         if (page?.driveId) {
           expandMentionsToUserIds(messageContent, page.driveId)
-            .then((notifyIds) => {
-              const filtered = notifyIds.filter((id) => id !== userId);
-              return Promise.allSettled(
-                filtered.map((id) =>
-                  createMentionNotification(id, chatId!, userId!).catch((err) =>
-                    loggers.ai.error('AI Chat: Failed to send mention notification', err as Error)
+            .then(async (notifyIds) => {
+              const candidates = notifyIds.filter((id) => id !== userId);
+              if (candidates.length === 0) return;
+              const viewChecks = await Promise.all(
+                candidates.map(async (id) => ({ id, canView: await canUserViewPage(id, chatId!) }))
+              );
+              await Promise.allSettled(
+                viewChecks
+                  .filter((e) => e.canView)
+                  .map((e) =>
+                    createMentionNotification(e.id, chatId!, userId!).catch((err) =>
+                      loggers.ai.error('AI Chat: Failed to send mention notification', err as Error)
+                    )
                   )
-                )
               );
             })
             .catch((err) => loggers.ai.error('AI Chat: Failed to expand mentions', err as Error));

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -68,6 +68,8 @@ import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 import type { MCPTool } from '@/types/mcp';
 import { getMCPBridge } from '@/lib/mcp';
 import { applyPageMutation, PageRevisionMismatchError } from '@/services/api/page-mutation-service';
+import { expandMentionsToUserIds } from '@/lib/channels/expand-group-mentions';
+import { createMentionNotification } from '@pagespace/lib/notifications/notifications';
 import {
   createStreamAbortController,
   removeStream,
@@ -361,6 +363,22 @@ export async function POST(request: Request) {
           action: 'chat_message',
           conversationId,
         } });
+
+        // Fire mention notifications for @user, @everyone, @role mentions in AI chat pages
+        if (page?.driveId) {
+          expandMentionsToUserIds(messageContent, page.driveId)
+            .then((notifyIds) => {
+              const filtered = notifyIds.filter((id) => id !== userId);
+              return Promise.allSettled(
+                filtered.map((id) =>
+                  createMentionNotification(id, chatId!, userId!).catch((err) =>
+                    loggers.ai.error('AI Chat: Failed to send mention notification', err as Error)
+                  )
+                )
+              );
+            })
+            .catch((err) => loggers.ai.error('AI Chat: Failed to expand mentions', err as Error));
+        }
       } catch (error) {
         loggers.ai.error('AI Chat API: Failed to save user message', error as Error);
         return NextResponse.json({

--- a/apps/web/src/app/api/channels/[pageId]/messages/route.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/route.ts
@@ -10,7 +10,6 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { createSignedBroadcastHeaders } from '@pagespace/lib/auth/broadcast-auth';
 import { broadcastInboxEvent, broadcastThreadReplyCountUpdated } from '@/lib/websocket/socket-utils';
 import { channelMessageRepository } from '@pagespace/lib/services/channel-message-repository';
-import { extractMentionedUserIds } from '@/lib/channels/extract-user-mentions';
 import { expandMentionsToUserIds } from '@/lib/channels/expand-group-mentions';
 import { buildThreadPreview } from '@pagespace/lib/services/preview';
 import { attachQuotedMessages } from '@pagespace/lib/services/quote-enrichment';

--- a/apps/web/src/app/api/channels/[pageId]/messages/route.ts
+++ b/apps/web/src/app/api/channels/[pageId]/messages/route.ts
@@ -11,6 +11,7 @@ import { createSignedBroadcastHeaders } from '@pagespace/lib/auth/broadcast-auth
 import { broadcastInboxEvent, broadcastThreadReplyCountUpdated } from '@/lib/websocket/socket-utils';
 import { channelMessageRepository } from '@pagespace/lib/services/channel-message-repository';
 import { extractMentionedUserIds } from '@/lib/channels/extract-user-mentions';
+import { expandMentionsToUserIds } from '@/lib/channels/expand-group-mentions';
 import { buildThreadPreview } from '@pagespace/lib/services/preview';
 import { attachQuotedMessages } from '@pagespace/lib/services/quote-enrichment';
 import { createMentionNotification } from '@pagespace/lib/notifications/notifications';
@@ -447,7 +448,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
       // event, inflating the recipient's unread count by 2 instead of 1.
       const isThreadOnlyReply = !mirrorWithRelations;
       if (isThreadOnlyReply && replyContent.trim().length > 0 && channel?.driveId) {
-        const mentionedUserIds = extractMentionedUserIds(replyContent);
+        const mentionedUserIds = await expandMentionsToUserIds(replyContent, channel.driveId);
         // Non-followers need channel_updated so the thread surfaces in their unread.
         // Followers already receive thread_updated above — sending channel_updated
         // too would double-count their unread.
@@ -645,7 +646,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
       });
 
       try {
-        const mentionedIds = extractMentionedUserIds(messageContent);
+        const mentionedIds = await expandMentionsToUserIds(messageContent, channel.driveId);
         const candidates = mentionedIds.filter((id) => id !== userId);
         if (candidates.length > 0) {
           const viewChecks = await Promise.all(

--- a/apps/web/src/app/api/mentions/search/route.ts
+++ b/apps/web/src/app/api/mentions/search/route.ts
@@ -220,10 +220,23 @@ export async function GET(request: Request) {
       return NextResponse.json([]);
     }
 
-    // Group mentions (@everyone, @role) — within-drive only, appear first
+    // For within-drive searches, pre-fetch member list once so both the group-mention
+    // gate and the user-suggestion block can reuse it without a double query.
+    let withinDriveMemberIds: string[] | null = null;
+    if (!crossDrive && driveId) {
+      const ids = await getDriveRecipientUserIds(driveId);
+      withinDriveMemberIds = ids;
+      if (ids.length === 0) {
+        return NextResponse.json({ error: 'Drive not found' }, { status: 404 });
+      }
+    }
+
+    // Group mentions (@everyone, @role) — within-drive only, visible to members/owners only.
+    // Users with only page-level access must not see role membership metadata.
     const wantsGroups =
       !crossDrive &&
       driveId &&
+      withinDriveMemberIds?.includes(userId) &&
       (requestedTypes.includes('user') ||
         requestedTypes.includes('everyone' as MentionType) ||
         requestedTypes.includes('role' as MentionType));
@@ -357,14 +370,9 @@ export async function GET(request: Request) {
           }
         }
       } else {
-        // Within-drive: surface members only to other drive members/owners
-        const memberIds = await getDriveRecipientUserIds(driveId!);
-        if (memberIds.length === 0) {
-          return NextResponse.json(
-            { error: 'Drive not found' },
-            { status: 404 }
-          );
-        }
+        // Within-drive: surface members only to other drive members/owners.
+        // Reuse the already-fetched withinDriveMemberIds to avoid a second DB query.
+        const memberIds = withinDriveMemberIds ?? [];
         if (memberIds.includes(userId)) {
           for (const id of memberIds) {
             authorizedUserIds.add(id);

--- a/apps/web/src/app/api/mentions/search/route.ts
+++ b/apps/web/src/app/api/mentions/search/route.ts
@@ -8,6 +8,7 @@ import { db } from '@pagespace/db/db'
 import { and, eq, ilike, inArray, desc, SQL } from '@pagespace/db/operators'
 import { users } from '@pagespace/db/schema/auth'
 import { pages, drives } from '@pagespace/db/schema/core';
+import { driveRoles } from '@pagespace/db/schema/members';
 import { MentionSuggestion, MentionType } from '@/types/mentions';
 import { z } from 'zod';
 
@@ -219,6 +220,66 @@ export async function GET(request: Request) {
       return NextResponse.json([]);
     }
 
+    // Group mentions (@everyone, @role) — within-drive only, appear first
+    const wantsGroups =
+      !crossDrive &&
+      driveId &&
+      (requestedTypes.includes('user') ||
+        requestedTypes.includes('everyone' as MentionType) ||
+        requestedTypes.includes('role' as MentionType));
+
+    if (wantsGroups) {
+      const q = query.trim().toLowerCase();
+
+      // @everyone
+      if (!q || 'everyone'.startsWith(q)) {
+        suggestions.push({
+          id: 'everyone',
+          label: 'everyone',
+          type: 'everyone',
+          data: { driveId: driveId! },
+          description: 'Notify all drive members',
+        });
+      }
+
+      // Standard roles
+      const standardRoles: { id: 'OWNER' | 'ADMIN' | 'MEMBER'; label: string }[] = [
+        { id: 'OWNER', label: 'Owner' },
+        { id: 'ADMIN', label: 'Admin' },
+        { id: 'MEMBER', label: 'Member' },
+      ];
+      for (const { id, label } of standardRoles) {
+        if (!q || label.toLowerCase().startsWith(q) || id.toLowerCase().startsWith(q)) {
+          suggestions.push({
+            id,
+            label,
+            type: 'role',
+            data: { driveId: driveId!, roleId: id },
+            description: `Notify all ${label.toLowerCase()}s`,
+          });
+        }
+      }
+
+      // Custom drive roles
+      const customRoles = await db
+        .select({ id: driveRoles.id, name: driveRoles.name, color: driveRoles.color })
+        .from(driveRoles)
+        .where(eq(driveRoles.driveId, driveId!))
+        .orderBy(driveRoles.position);
+
+      for (const cr of customRoles) {
+        if (!q || cr.name.toLowerCase().includes(q)) {
+          suggestions.push({
+            id: cr.id,
+            label: cr.name,
+            type: 'role',
+            data: { driveId: driveId!, roleId: cr.id, color: cr.color ?? undefined },
+            description: `Notify all ${cr.name} members`,
+          });
+        }
+      }
+    }
+
     // Search pages (all page types)
     if (requestedTypes.includes('page')) {
       const searchCondition = buildMultiWordSearchCondition(query);
@@ -350,21 +411,20 @@ export async function GET(request: Request) {
     }
 
 
-    // Sort by relevance when there's a query; preserve DB order (updatedAt) when empty
+    // Keep group mentions (everyone/role) at the top; sort page/user by relevance
+    const groupSuggestions = suggestions.filter(s => s.type === 'everyone' || s.type === 'role');
+    const otherSuggestions = suggestions.filter(s => s.type !== 'everyone' && s.type !== 'role');
+
     if (query.trim()) {
-      suggestions.sort((a, b) => {
+      otherSuggestions.sort((a, b) => {
         const aScore = calculateRelevanceScore(a.label, query);
         const bScore = calculateRelevanceScore(b.label, query);
-
-        if (aScore !== bScore) {
-          return bScore - aScore;
-        }
-
+        if (aScore !== bScore) return bScore - aScore;
         return a.label.localeCompare(b.label);
       });
     }
 
-    const finalSuggestions = suggestions.slice(0, 10);
+    const finalSuggestions = [...groupSuggestions, ...otherSuggestions].slice(0, 10);
     loggers.api.debug('[API] Returning suggestions', { count: finalSuggestions.length, suggestions: finalSuggestions });
 
     auditRequest(request, { eventType: 'data.read', userId, resourceType: 'search', resourceId: driveId ?? '*', details: { source: 'mentions', resultCount: finalSuggestions.length } });

--- a/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
@@ -11,7 +11,7 @@ import { canUserViewPage, canUserEditPage } from '@pagespace/lib/permissions/per
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { broadcastTaskEvent, broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { createMentionNotification } from '@pagespace/lib/notifications/notifications';
-import { extractMentionedUserIds } from '@/lib/channels/extract-user-mentions';
+import { expandMentionsToUserIds } from '@/lib/channels/expand-group-mentions';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { getDefaultContent } from '@pagespace/lib/content/page-types.config'
 import { PageType } from '@pagespace/lib/utils/enums';
@@ -523,7 +523,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
 
   if (description) {
     try {
-      const mentionedIds = extractMentionedUserIds(description);
+      const mentionedIds = await expandMentionsToUserIds(description, taskListPage.driveId!);
       const candidates = mentionedIds.filter((id) => id !== userId);
       if (candidates.length > 0) {
         const taskPageId = result.page.id;

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -494,6 +494,12 @@ svg.lucide {
   @apply dark:hover:bg-green-900/30 dark:hover:border-green-600;
 }
 
+/* Group mention styles (@everyone, @role) */
+.mention--group {
+  @apply inline-block font-semibold rounded px-1 py-0.5 cursor-default;
+  @apply bg-indigo-100 text-indigo-700 border border-indigo-200;
+  @apply dark:bg-indigo-900/30 dark:text-indigo-300 dark:border-indigo-700;
+}
 
 /* Loading state */
 .mention-pill.is-loading {

--- a/apps/web/src/components/mentions/SuggestionPopup.tsx
+++ b/apps/web/src/components/mentions/SuggestionPopup.tsx
@@ -87,6 +87,7 @@ export default function SuggestionPopup({
         `}
       >
         {items.map((suggestion, index) => {
+          const isGroup = suggestion.type === 'everyone' || suggestion.type === 'role';
           return (
             <li
               key={`${suggestion.id}-${index}`}
@@ -103,10 +104,15 @@ export default function SuggestionPopup({
               onMouseEnter={() => onSelectionChange(index)}
             >
               <div className="flex items-center gap-2">
-                <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                {isGroup && (
+                  <span className="text-xs font-bold text-white bg-indigo-500 rounded px-1 py-0.5 shrink-0">
+                    @
+                  </span>
+                )}
+                <span className={`text-sm font-medium ${isGroup ? 'text-indigo-600 dark:text-indigo-400' : 'text-gray-900 dark:text-gray-100'}`}>
                   {suggestion.label}
                 </span>
-                {suggestion.type && (
+                {!isGroup && suggestion.type && (
                   <span className="text-xs text-gray-500 ml-auto">
                     {suggestion.type}
                   </span>

--- a/apps/web/src/hooks/useSuggestion.ts
+++ b/apps/web/src/hooks/useSuggestion.ts
@@ -48,7 +48,7 @@ export function useSuggestion({
   inputRef,
   onValueChange,
   trigger = '@',
-  allowedTypes = ['page', 'user'],
+  allowedTypes = ['page', 'user', 'everyone', 'role'] as MentionType[],
   driveId,
   crossDrive = false,
   mentionFormat = 'label',

--- a/apps/web/src/lib/channels/expand-group-mentions.ts
+++ b/apps/web/src/lib/channels/expand-group-mentions.ts
@@ -1,0 +1,97 @@
+import {
+  getDriveRecipientUserIds,
+  getDriveMemberUserIdsByStandardRole,
+  getDriveMemberUserIdsByCustomRole,
+} from '@pagespace/lib/services/drive-member-service';
+import { extractMentionedUserIds } from './extract-user-mentions';
+
+const STANDARD_ROLES = new Set(['OWNER', 'ADMIN', 'MEMBER'] as const);
+type StandardRole = 'OWNER' | 'ADMIN' | 'MEMBER';
+
+function isStandardRole(id: string): id is StandardRole {
+  return STANDARD_ROLES.has(id as StandardRole);
+}
+
+/**
+ * Extract raw group mention tokens from content without expanding to user IDs.
+ * Returns `{ type: 'everyone' }` entries and `{ type: 'role', roleId }` entries.
+ */
+export function extractGroupMentions(
+  content: string,
+): Array<{ type: 'everyone' } | { type: 'role'; roleId: string }> {
+  if (!content || content.length === 0) return [];
+
+  const results: Array<{ type: 'everyone' } | { type: 'role'; roleId: string }> = [];
+  const seen = new Set<string>();
+
+  const re = /@\[[^\]]{1,500}\]\(([^:)]{1,200}):(everyone|role)\)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(content)) !== null) {
+    const id = m[1];
+    const type = m[2] as 'everyone' | 'role';
+    const key = `${type}:${id}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    if (type === 'everyone') {
+      results.push({ type: 'everyone' });
+    } else {
+      results.push({ type: 'role', roleId: id });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Expand all user, @everyone, and @role mentions in content to a deduplicated
+ * list of user IDs. Group mentions are resolved via DB queries against the
+ * given driveId.
+ */
+export async function expandMentionsToUserIds(
+  content: string,
+  driveId: string,
+): Promise<string[]> {
+  const seen = new Set<string>();
+  const out: string[] = [];
+
+  const addIds = (ids: string[]) => {
+    for (const id of ids) {
+      if (!seen.has(id)) {
+        seen.add(id);
+        out.push(id);
+      }
+    }
+  };
+
+  // Individual user mentions
+  addIds(extractMentionedUserIds(content));
+
+  const groupMentions = extractGroupMentions(content);
+  if (groupMentions.length === 0) return out;
+
+  let hasEveryone = false;
+  const roleIds: string[] = [];
+
+  for (const gm of groupMentions) {
+    if (gm.type === 'everyone') {
+      hasEveryone = true;
+    } else {
+      roleIds.push(gm.roleId);
+    }
+  }
+
+  // @everyone — owner + all accepted members
+  if (hasEveryone) {
+    addIds(await getDriveRecipientUserIds(driveId));
+  }
+
+  // @role mentions — expand each unique role
+  for (const roleId of roleIds) {
+    const ids = isStandardRole(roleId)
+      ? await getDriveMemberUserIdsByStandardRole(driveId, roleId)
+      : await getDriveMemberUserIdsByCustomRole(driveId, roleId);
+    addIds(ids);
+  }
+
+  return out;
+}

--- a/apps/web/src/lib/editor/tiptap-mention-config.tsx
+++ b/apps/web/src/lib/editor/tiptap-mention-config.tsx
@@ -95,29 +95,39 @@ const TiptapSuggestionList = forwardRef<SuggestionListRef, TiptapSuggestionListP
     <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-md shadow-lg min-w-48 max-w-sm">
       {props.items.length ? (
         <ul className="max-h-60 overflow-y-auto">
-          {props.items.map((item, index) => (
-            <li
-              key={item.id}
-              className={`px-3 py-2 cursor-pointer transition-colors duration-150 ease-in-out hover:bg-gray-100 hover:dark:bg-gray-700 ${
-                index === selectedIndex ? 'bg-gray-100 dark:bg-gray-700 border-l-2 border-blue-500' : ''
-              }`}
-              onClick={() => selectItem(index)}
-            >
-              <div className="flex items-center gap-2">
-                <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                  {item.label}
-                </span>
-                <span className="text-xs text-gray-500 ml-auto">
-                  {item.type}
-                </span>
-              </div>
-              {item.description && (
-                <div className="text-xs text-gray-500 mt-1 truncate">
-                  {item.description}
+          {props.items.map((item, index) => {
+            const isGroup = item.type === 'everyone' || item.type === 'role';
+            return (
+              <li
+                key={`${item.id}-${index}`}
+                className={`px-3 py-2 cursor-pointer transition-colors duration-150 ease-in-out hover:bg-gray-100 hover:dark:bg-gray-700 ${
+                  index === selectedIndex ? 'bg-gray-100 dark:bg-gray-700 border-l-2 border-blue-500' : ''
+                }`}
+                onClick={() => selectItem(index)}
+              >
+                <div className="flex items-center gap-2">
+                  {isGroup && (
+                    <span className="text-xs font-bold text-white bg-indigo-500 rounded px-1 py-0.5 shrink-0">
+                      @
+                    </span>
+                  )}
+                  <span className={`text-sm font-medium ${isGroup ? 'text-indigo-600 dark:text-indigo-400' : 'text-gray-900 dark:text-gray-100'}`}>
+                    {item.label}
+                  </span>
+                  {!isGroup && (
+                    <span className="text-xs text-gray-500 ml-auto">
+                      {item.type}
+                    </span>
+                  )}
                 </div>
-              )}
-            </li>
-          ))}
+                {item.description && (
+                  <div className="text-xs text-gray-500 mt-1 truncate">
+                    {item.description}
+                  </div>
+                )}
+              </li>
+            );
+          })}
         </ul>
       ) : (
         <div className="p-3 text-sm text-gray-500">No results found</div>
@@ -152,45 +162,48 @@ const PageMentionNode = Mention.extend({
       label: { default: null },
       driveId: { default: null },
       driveSlug: { default: null },
+      // 'page' | 'user' | 'everyone' | 'role'
+      mentionType: { default: 'page' },
     };
   },
 
   addNodeView() {
-    return ({ node }: { node: { attrs: { id: string; label: string; driveId: string; driveSlug: string } } }) => {
-      const dom = document.createElement('a');
-      const href = node.attrs.driveId
-        ? `/dashboard/${node.attrs.driveId}/${node.attrs.id}`
-        : `/dashboard/`;
+    return ({ node }: { node: { attrs: { id: string; label: string; driveId: string; driveSlug: string; mentionType: string } } }) => {
+      const { mentionType, id, label, driveId } = node.attrs;
+      const isGroup = mentionType === 'everyone' || mentionType === 'role';
 
-      // Set up link attributes - NO target="_blank" to stay in WebView on Capacitor
+      if (isGroup) {
+        const dom = document.createElement('span');
+        dom.className = 'mention mention--group';
+        dom.contentEditable = 'false';
+        dom.setAttribute('data-mention-type', mentionType);
+        if (mentionType === 'role') dom.setAttribute('data-role-id', id);
+        if (driveId) dom.setAttribute('data-drive-id', driveId);
+        dom.textContent = `@${label}`;
+        dom.addEventListener('mousedown', (event) => { event.preventDefault(); });
+        return { dom, contentDOM: null };
+      }
+
+      const dom = document.createElement('a');
+      const href = driveId ? `/dashboard/${driveId}/${id}` : `/dashboard/`;
+
+      // NO target="_blank" - stays in WebView on Capacitor
       dom.href = href;
       dom.rel = 'noopener noreferrer nofollow';
       dom.className = 'mention';
       dom.contentEditable = 'false';
       dom.setAttribute('data-mention-type', 'page');
-      dom.setAttribute('data-page-id', node.attrs.id);
+      dom.setAttribute('data-page-id', id);
+      dom.textContent = `@${label}`;
 
-      // Set content
-      dom.textContent = `@${node.attrs.label}`;
-
-      // Handle click events - dispatch navigation event for React router handling
-      // Falls back to window.location for non-React contexts
       dom.addEventListener('click', (event) => {
         event.preventDefault();
         event.stopPropagation();
-        // Dispatch event for parent component to handle with router.push()
         dispatchInternalNavigation(href);
       });
+      dom.addEventListener('mousedown', (event) => { event.preventDefault(); });
 
-      // Prevent selection on click
-      dom.addEventListener('mousedown', (event) => {
-        event.preventDefault();
-      });
-
-      return {
-        dom,
-        contentDOM: null, // No content DOM since this is atomic
-      };
+      return { dom, contentDOM: null };
     };
   },
 });
@@ -201,21 +214,48 @@ export const PageMention = PageMentionNode.configure({
     contenteditable: 'false',
   },
   renderHTML({ options, node }) {
-    const href = node.attrs.driveId
-      ? `/dashboard/${node.attrs.driveId}/${node.attrs.id}`
-      : `/dashboard/`;
+    const { mentionType, id, label, driveId } = node.attrs;
+
+    if (mentionType === 'everyone') {
+      return [
+        'span',
+        {
+          ...options.HTMLAttributes,
+          'data-mention-type': 'everyone',
+          'data-drive-id': driveId ?? '',
+          contenteditable: 'false',
+        },
+        `@${label}`,
+      ];
+    }
+
+    if (mentionType === 'role') {
+      return [
+        'span',
+        {
+          ...options.HTMLAttributes,
+          'data-mention-type': 'role',
+          'data-role-id': id,
+          'data-drive-id': driveId ?? '',
+          contenteditable: 'false',
+        },
+        `@${label}`,
+      ];
+    }
+
+    const href = driveId ? `/dashboard/${driveId}/${id}` : `/dashboard/`;
     return [
       'a',
       {
         ...options.HTMLAttributes,
-        href: href,
+        href,
         // NO target="_blank" - stays in WebView on Capacitor iOS
         rel: 'noopener noreferrer nofollow',
         'data-mention-type': 'page',
-        'data-page-id': node.attrs.id,
+        'data-page-id': id,
         contenteditable: 'false',
       },
-      `@${node.attrs.label}`,
+      `@${label}`,
     ];
   },
   suggestion: {
@@ -230,7 +270,7 @@ export const PageMention = PageMentionNode.configure({
         return [];
       }
 
-      const types = ['page', 'user'].join(',');
+      const types = ['page', 'user', 'everyone', 'role'].join(',');
       const url = `/api/mentions/search?q=${encodeURIComponent(query)}&driveId=${encodeURIComponent(currentDriveId)}&types=${types}`;
       console.log('[TipTap] Fetching suggestions from:', url);
 
@@ -255,8 +295,12 @@ export const PageMention = PageMentionNode.configure({
               command: (item: MentionSuggestion) => {
                 console.log('[TipTap] command called with item:', item);
                 const { drives } = useDriveStore.getState();
-                const drive = drives.find(d => d.id === (item.data as PageMentionData).driveId);
-                
+                const isGroup = item.type === 'everyone' || item.type === 'role';
+                const itemDriveId = isGroup
+                  ? (item.data as { driveId: string }).driveId
+                  : (item.data as PageMentionData).driveId;
+                const drive = drives.find(d => d.id === itemDriveId);
+
                 console.log('[TipTap] Executing mention insertion command');
                 const { editor, range } = props;
                 editor
@@ -269,17 +313,18 @@ export const PageMention = PageMentionNode.configure({
                       attrs: {
                         id: item.id,
                         label: item.label,
-                        driveId: (item.data as PageMentionData).driveId,
+                        driveId: itemDriveId,
                         driveSlug: drive?.slug || '',
+                        mentionType: item.type,
                       },
                     },
                     {
                       type: 'text',
-                      text: '\u00A0', // Add a non-breaking space right after
+                      text: '\u00A0', // Non-breaking space after mention
                     },
                   ])
                   .run();
-                
+
                 console.log('[TipTap] Mention insertion command completed');
               },
             },
@@ -316,8 +361,12 @@ export const PageMention = PageMentionNode.configure({
             items: props.items,
             command: (item: MentionSuggestion) => {
               const { drives } = useDriveStore.getState();
-              const drive = drives.find(d => d.id === (item.data as PageMentionData).driveId);
-              
+              const isGroup = item.type === 'everyone' || item.type === 'role';
+              const itemDriveId = isGroup
+                ? (item.data as { driveId: string }).driveId
+                : (item.data as PageMentionData).driveId;
+              const drive = drives.find(d => d.id === itemDriveId);
+
               const { editor, range } = props;
               editor
                 .chain()
@@ -329,13 +378,14 @@ export const PageMention = PageMentionNode.configure({
                     attrs: {
                       id: item.id,
                       label: item.label,
-                      driveId: (item.data as PageMentionData).driveId,
+                      driveId: itemDriveId,
                       driveSlug: drive?.slug || '',
+                      mentionType: item.type,
                     },
                   },
                   {
                     type: 'text',
-                    text: '\u00A0', // Add a non-breaking space right after
+                    text: '\u00A0', // Non-breaking space after mention
                   },
                 ])
                 .run();

--- a/apps/web/src/services/api/page-mention-service.ts
+++ b/apps/web/src/services/api/page-mention-service.ts
@@ -3,38 +3,75 @@ import { db } from '@pagespace/db/db'
 import { eq, and, inArray } from '@pagespace/db/operators'
 import { mentions, userMentions } from '@pagespace/db/schema/core';
 import { loggers } from '@pagespace/lib/logging/logger-config';
+import {
+  getDriveRecipientUserIds,
+  getDriveMemberUserIdsByStandardRole,
+  getDriveMemberUserIdsByCustomRole,
+} from '@pagespace/lib/services/drive-member-service';
 
 type TransactionType = Parameters<Parameters<typeof db.transaction>[0]>[0];
 type DatabaseType = typeof db;
 
+interface GroupMention {
+  type: 'everyone' | 'role';
+  roleId?: string;
+  driveId?: string;
+}
+
 interface MentionIds {
   pageIds: string[];
   userIds: string[];
+  groupMentions: GroupMention[];
 }
+
+const STANDARD_ROLES = new Set(['OWNER', 'ADMIN', 'MEMBER']);
 
 function findMentionNodes(content: unknown): MentionIds {
   const pageIds: string[] = [];
   const userIds: string[] = [];
+  const groupMentions: GroupMention[] = [];
+  const seenGroups = new Set<string>();
   const contentStr = Array.isArray(content) ? content.join('\n') : String(content);
 
-  const shouldParseHtml = contentStr.includes('<') && contentStr.includes('data-page-id');
+  const shouldParseHtml = contentStr.includes('<') && (
+    contentStr.includes('data-page-id') ||
+    contentStr.includes('data-mention-type="everyone"') ||
+    contentStr.includes('data-mention-type="role"')
+  );
 
   let parseFailed = false;
   if (shouldParseHtml) {
     try {
       const $ = cheerio.load(contentStr);
-      // Parse page mentions from HTML
       $('a[data-page-id]').each((_, element) => {
         const pageId = $(element).attr('data-page-id');
-        if (pageId) {
-          pageIds.push(pageId);
-        }
+        if (pageId) pageIds.push(pageId);
       });
-      // Parse user mentions from HTML
       $('a[data-user-id]').each((_, element) => {
         const userId = $(element).attr('data-user-id');
-        if (userId) {
-          userIds.push(userId);
+        if (userId) userIds.push(userId);
+      });
+      $('span[data-mention-type="everyone"]').each((_, element) => {
+        const key = 'everyone';
+        if (!seenGroups.has(key)) {
+          seenGroups.add(key);
+          groupMentions.push({
+            type: 'everyone',
+            driveId: $(element).attr('data-drive-id'),
+          });
+        }
+      });
+      $('span[data-mention-type="role"]').each((_, element) => {
+        const roleId = $(element).attr('data-role-id');
+        if (!roleId) return;
+        const key = `role:${roleId}`;
+        if (!seenGroups.has(key)) {
+          seenGroups.add(key);
+          groupMentions.push({
+            type: 'role',
+            roleId,
+            driveId: $(element).attr('data-drive-id'),
+          });
         }
       });
     } catch (error) {
@@ -45,13 +82,25 @@ function findMentionNodes(content: unknown): MentionIds {
 
   if (!shouldParseHtml || parseFailed) {
     // Parse markdown-style mentions: @[Label](id:type)
-    const regex = /@\[([^\]]*)\]\(([^:)]+):?([^)]*)\)/g;
+    const regex = /@\[([^\]]{1,500})\]\(([^:)]{1,200}):?([^)]{0,200})\)/g;
     let match;
     while ((match = regex.exec(contentStr)) !== null) {
       const id = match[2];
-      const type = match[3] || 'page'; // Default to page if no type specified
+      const type = match[3] || 'page';
       if (type === 'user') {
         userIds.push(id);
+      } else if (type === 'everyone') {
+        const key = 'everyone';
+        if (!seenGroups.has(key)) {
+          seenGroups.add(key);
+          groupMentions.push({ type: 'everyone' });
+        }
+      } else if (type === 'role') {
+        const key = `role:${id}`;
+        if (!seenGroups.has(key)) {
+          seenGroups.add(key);
+          groupMentions.push({ type: 'role', roleId: id });
+        }
       } else {
         pageIds.push(id);
       }
@@ -61,11 +110,40 @@ function findMentionNodes(content: unknown): MentionIds {
   return {
     pageIds: Array.from(new Set(pageIds)),
     userIds: Array.from(new Set(userIds)),
+    groupMentions,
   };
+}
+
+async function expandGroupMentions(
+  groupMentions: GroupMention[],
+  driveId: string,
+): Promise<string[]> {
+  const seen = new Set<string>();
+  const out: string[] = [];
+
+  const addIds = (ids: string[]) => {
+    for (const id of ids) {
+      if (!seen.has(id)) { seen.add(id); out.push(id); }
+    }
+  };
+
+  for (const gm of groupMentions) {
+    if (gm.type === 'everyone') {
+      addIds(await getDriveRecipientUserIds(driveId));
+    } else if (gm.type === 'role' && gm.roleId) {
+      const ids = STANDARD_ROLES.has(gm.roleId)
+        ? await getDriveMemberUserIdsByStandardRole(driveId, gm.roleId as 'OWNER' | 'ADMIN' | 'MEMBER')
+        : await getDriveMemberUserIdsByCustomRole(driveId, gm.roleId);
+      addIds(ids);
+    }
+  }
+
+  return out;
 }
 
 export interface SyncMentionsOptions {
   mentionedByUserId?: string;
+  driveId?: string;
 }
 
 export interface SyncMentionsResult {
@@ -80,7 +158,17 @@ export async function syncMentions(
   tx: TransactionType | DatabaseType,
   options?: SyncMentionsOptions
 ): Promise<SyncMentionsResult> {
-  const { pageIds: mentionedPageIds, userIds: mentionedUserIds } = findMentionNodes(content);
+  const { pageIds: mentionedPageIds, userIds: directUserIds, groupMentions } = findMentionNodes(content);
+
+  // Expand group mentions (@everyone, @role) to individual user IDs
+  let expandedUserIds: string[] = [];
+  if (groupMentions.length > 0 && options?.driveId) {
+    expandedUserIds = await expandGroupMentions(groupMentions, options.driveId);
+  }
+
+  // Merge direct and group-expanded user IDs, preserving uniqueness
+  const allUserIdSet = new Set([...directUserIds, ...expandedUserIds]);
+  const mentionedUserIds = Array.from(allUserIdSet);
 
   // Sync page mentions
   await syncPageMentions(sourcePageId, mentionedPageIds, tx);

--- a/apps/web/src/services/api/page-mutation-service.ts
+++ b/apps/web/src/services/api/page-mutation-service.ts
@@ -213,7 +213,10 @@ export async function applyPageMutation({
     }
 
     if (updates.content !== undefined) {
-      mentionsResult = await syncMentions(pageId, nextContent, transaction, { mentionedByUserId: context.userId });
+      mentionsResult = await syncMentions(pageId, nextContent, transaction, {
+        mentionedByUserId: context.userId,
+        driveId: currentPage.driveId,
+      });
     }
 
     // Create page version BEFORE acquiring the activity chain lock,

--- a/apps/web/src/types/mentions.ts
+++ b/apps/web/src/types/mentions.ts
@@ -1,6 +1,6 @@
 // Enhanced mention types for the flexible mention system
 
-export type MentionType = 'page' | 'user';
+export type MentionType = 'page' | 'user' | 'everyone' | 'role';
 
 export interface BaseMention {
   id: string;
@@ -17,9 +17,21 @@ export interface PageMentionData {
 // The label (user name) is sufficient
 export type UserMentionData = Record<string, never>;
 
-export type MentionData = 
-  | PageMentionData 
-  | UserMentionData;
+export interface EveryoneMentionData {
+  driveId: string;
+}
+
+export interface RoleMentionData {
+  driveId: string;
+  roleId: string;
+  color?: string;
+}
+
+export type MentionData =
+  | PageMentionData
+  | UserMentionData
+  | EveryoneMentionData
+  | RoleMentionData;
 
 export interface EnhancedMention extends BaseMention {
   data: MentionData;
@@ -36,10 +48,22 @@ export interface UserMention extends BaseMention {
   data: UserMentionData;
 }
 
+export interface EveryoneMention extends BaseMention {
+  type: 'everyone';
+  data: EveryoneMentionData;
+}
+
+export interface RoleMention extends BaseMention {
+  type: 'role';
+  data: RoleMentionData;
+}
+
 // Union type for all specific mention types
-export type TypedMention = 
-  | PageMention 
-  | UserMention;
+export type TypedMention =
+  | PageMention
+  | UserMention
+  | EveryoneMention
+  | RoleMention;
 
 // For search results and suggestions
 export interface MentionSuggestion {

--- a/packages/lib/src/services/drive-member-service.ts
+++ b/packages/lib/src/services/drive-member-service.ts
@@ -155,6 +155,53 @@ export async function getDriveRecipientUserIds(driveId: string): Promise<string[
 }
 
 /**
+ * Get user IDs of drive members with a specific standard role.
+ * OWNER is stored in drives.ownerId, not in the driveMembers table.
+ */
+export async function getDriveMemberUserIdsByStandardRole(
+  driveId: string,
+  role: 'OWNER' | 'ADMIN' | 'MEMBER',
+): Promise<string[]> {
+  if (role === 'OWNER') {
+    const drive = await db.query.drives.findFirst({
+      where: eq(drives.id, driveId),
+      columns: { ownerId: true },
+    });
+    return drive ? [drive.ownerId] : [];
+  }
+
+  const members = await db
+    .select({ userId: driveMembers.userId })
+    .from(driveMembers)
+    .where(and(
+      eq(driveMembers.driveId, driveId),
+      eq(driveMembers.role, role),
+      isNotNull(driveMembers.acceptedAt),
+    ));
+
+  return members.map((m) => m.userId);
+}
+
+/**
+ * Get user IDs of drive members assigned a specific custom role.
+ */
+export async function getDriveMemberUserIdsByCustomRole(
+  driveId: string,
+  customRoleId: string,
+): Promise<string[]> {
+  const members = await db
+    .select({ userId: driveMembers.userId })
+    .from(driveMembers)
+    .where(and(
+      eq(driveMembers.driveId, driveId),
+      eq(driveMembers.customRoleId, customRoleId),
+      isNotNull(driveMembers.acceptedAt),
+    ));
+
+  return members.map((m) => m.userId);
+}
+
+/**
  * List all members of a drive with their details and permission counts
  */
 export async function listDriveMembers(driveId: string): Promise<MemberWithDetails[]> {


### PR DESCRIPTION
## Summary

- **@everyone** — mentions all accepted drive members + owner; works in channels, documents, AI chat pages, and task descriptions
- **@role** — mentions all members with a standard role (Owner/Admin/Member) or a custom drive role; same surfaces
- **AI chat notifications** — AI chat pages now fire user mention notifications on message send (previously missing entirely)

## How it works

Group mentions are stored as `@[everyone](everyone:everyone)` or `@[Admin](ADMIN:role)` in markdown (same typed format as existing mentions). Server-side expansion resolves them to individual user IDs at notification time — no new DB tables needed.

### Files changed

| Area | Change |
|------|--------|
| `types/mentions.ts` | Added `'everyone'` and `'role'` to `MentionType` |
| `drive-member-service.ts` | Added `getDriveMemberUserIdsByStandardRole` and `getDriveMemberUserIdsByCustomRole` |
| `expand-group-mentions.ts` (new) | Async utility: expands `:everyone`/`:role` mentions to user ID lists |
| `mentions/search/route.ts` | Returns group suggestions (everyone + roles) at top of dropdown |
| `tiptap-mention-config.tsx` | `mentionType` attr; group mentions render as indigo `<span>`, not links |
| `SuggestionPopup.tsx` + `TiptapSuggestionList` | Indigo `@` badge for group items |
| `useSuggestion.ts` | Default `allowedTypes` includes `'everyone'` and `'role'` |
| `page-mention-service.ts` | Detects group mention HTML/markdown; expands on sync |
| `page-mutation-service.ts` | Passes `driveId` to `syncMentions` |
| `channels/messages/route.ts` | Uses `expandMentionsToUserIds` for both thread and top-level messages |
| `tasks/route.ts` | Same group mention expansion |
| `ai/chat/route.ts` | Fires mention notifications; expands group mentions |
| `globals.css` | `.mention--group` indigo styling |

## Test plan

- [ ] Type `@` in a channel — `@everyone`, `@Owner`, `@Admin`, `@Member`, and custom roles appear at top of dropdown
- [ ] Send `@everyone` in a channel — all other drive members get MENTION notifications (socket + email + push)
- [ ] Send `@Admin` — only Admin-role members notified
- [ ] Send a custom `@[Role Name]` — only members with that custom role notified
- [ ] Mention yourself via `@everyone` — no self-notification (existing guard)
- [ ] Add `@everyone` to a TipTap document and save — notifications fire
- [ ] `@everyone` in an AI chat page — users notified; AI context unaffected
- [ ] `@everyone` in a task description — notifications fire on task creation
- [ ] Group mention chips render in indigo with `@` badge in dropdowns

🤖 Generated with [Claude Code](https://claude.com/claude-code)