### PR TITLE
feat(channels): show thread-origin badge on mirrored messages

### DIFF
--- a/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
@@ -24,6 +24,7 @@ import { useSocket } from '@/hooks/useSocket';
 import { post, patch, del, fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { Check, X } from 'lucide-react';
 import MessageQuoteBlock from '@/components/messages/MessageQuoteBlock';
+import { ThreadOriginBadge } from '@/components/messages/ThreadOriginBadge';
 import type { QuotedMessageSnapshot } from '@pagespace/lib/services/quote-enrichment';
 import { buildThreadPreview } from '@pagespace/lib/services/preview';
 import { useThreadPanelStore } from '@/stores/useThreadPanelStore';
@@ -59,6 +60,8 @@ interface Message {
   lastReplyAt?: string | null;
   quotedMessageId?: string | null;
   quotedMessage?: QuotedMessageSnapshot | null;
+  mirroredFromId?: string | null;
+  mirroredFrom?: { parentId: string | null } | null;
 }
 
 interface DmConversation {
@@ -649,6 +652,13 @@ export default function InboxDMPage() {
                       </div>
                     ) : (
                       <>
+                        {message.mirroredFromId && (
+                          <ThreadOriginBadge
+                            onOpenThread={message.mirroredFrom?.parentId
+                              ? () => openThread({ source: 'dm', contextId: conversationId, parentId: message.mirroredFrom!.parentId! })
+                              : undefined}
+                          />
+                        )}
                         {(message.quotedMessage || message.quotedMessageId) && (
                           <MessageQuoteBlock quoted={message.quotedMessage ?? null} />
                         )}

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -21,6 +21,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Lock, Check, X } from 'lucide-react';
 import { MessageAttachment } from '@/components/shared/MessageAttachment';
 import MessageQuoteBlock from '@/components/messages/MessageQuoteBlock';
+import { ThreadOriginBadge } from '@/components/messages/ThreadOriginBadge';
 import type { QuotedMessageSnapshot } from '@pagespace/lib/services/quote-enrichment';
 import { buildThreadPreview } from '@pagespace/lib/services/preview';
 import { post, del, patch, fetchWithAuth } from '@/lib/auth/auth-fetch';
@@ -59,6 +60,8 @@ interface MessageWithReactions extends MessageWithUser {
   quotedMessage?: QuotedMessageSnapshot | null;
   replyCount?: number;
   lastReplyAt?: string | null;
+  mirroredFromId?: string | null;
+  mirroredFrom?: { parentId: string | null } | null;
 }
 
 function ChannelView({ page }: ChannelViewProps) {
@@ -675,6 +678,13 @@ function ChannelView({ page }: ChannelViewProps) {
                                   </div>
                                 ) : (
                                   <>
+                                    {m.mirroredFromId && (
+                                      <ThreadOriginBadge
+                                        onOpenThread={m.mirroredFrom?.parentId
+                                          ? () => openThread({ source: 'channel', contextId: page.id, parentId: m.mirroredFrom!.parentId! })
+                                          : undefined}
+                                      />
+                                    )}
                                     {(m.quotedMessage || m.quotedMessageId) && (
                                       <MessageQuoteBlock quoted={m.quotedMessage ?? null} />
                                     )}

--- a/apps/web/src/components/messages/ThreadOriginBadge.tsx
+++ b/apps/web/src/components/messages/ThreadOriginBadge.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { MessageSquareReply } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface ThreadOriginBadgeProps {
+  onOpenThread?: () => void;
+  className?: string;
+}
+
+export function ThreadOriginBadge({ onOpenThread, className }: ThreadOriginBadgeProps) {
+  const base = cn(
+    'border-l-2 border-muted pl-3 py-0.5 mb-1 text-xs text-muted-foreground flex items-center gap-1.5',
+    className,
+  );
+
+  if (onOpenThread) {
+    return (
+      <button
+        type="button"
+        onClick={onOpenThread}
+        className={cn(base, 'hover:text-foreground hover:border-primary/60 transition-colors')}
+      >
+        <MessageSquareReply size={11} />
+        Also sent from thread
+      </button>
+    );
+  }
+
+  return (
+    <div className={base}>
+      <MessageSquareReply size={11} />
+      Also sent from thread
+    </div>
+  );
+}

--- a/packages/db/src/schema/chat.ts
+++ b/packages/db/src/schema/chat.ts
@@ -59,6 +59,11 @@ export const channelMessagesRelations = relations(channelMessages, ({ one, many 
         references: [files.id],
     }),
     reactions: many(channelMessageReactions),
+    mirroredFrom: one(channelMessages, {
+        fields: [channelMessages.mirroredFromId],
+        references: [channelMessages.id],
+        relationName: 'mirroredFrom',
+    }),
 }));
 
 /**

--- a/packages/db/src/schema/social.ts
+++ b/packages/db/src/schema/social.ts
@@ -188,6 +188,11 @@ export const directMessagesRelations = relations(directMessages, ({ one, many })
     references: [files.id],
   }),
   reactions: many(dmMessageReactions),
+  mirroredFrom: one(directMessages, {
+    fields: [directMessages.mirroredFromId],
+    references: [directMessages.id],
+    relationName: 'mirroredFrom',
+  }),
 }));
 
 export const dmMessageReactionsRelations = relations(dmMessageReactions, ({ one }) => ({

--- a/packages/lib/src/services/channel-message-repository.ts
+++ b/packages/lib/src/services/channel-message-repository.ts
@@ -47,6 +47,9 @@ const messageWith = {
       },
     },
   },
+  mirroredFrom: {
+    columns: { parentId: true },
+  },
 } as const;
 
 export interface ListChannelMessagesInput {

--- a/packages/lib/src/services/dm-message-repository.ts
+++ b/packages/lib/src/services/dm-message-repository.ts
@@ -41,6 +41,9 @@ const dmMessageWith = {
       },
     },
   },
+  mirroredFrom: {
+    columns: { parentId: true },
+  },
 } as const;
 
 export interface DmConversationParticipants {


### PR DESCRIPTION
## Summary

- Thread replies sent with "Also send to channel/DM" now display a **"Also sent from thread"** badge above the message body in the main feed, making it clear the message originated from a thread rather than appearing as a random top-level post
- Badge reuses the `MessageQuoteBlock` left-border visual language (muted border, small icon, `text-xs text-muted-foreground`)
- Clicking the badge opens the thread panel directly — achieved via a `mirroredFrom` self-join added to the Drizzle relations for `channelMessages` and `directMessages`, so the thread root ID arrives with the message payload rather than requiring an extra round-trip

## Changes

- `packages/db/src/schema/chat.ts` / `social.ts` — self-referential `mirroredFrom` `one` relation on both message tables
- `packages/lib/src/services/channel-message-repository.ts` / `dm-message-repository.ts` — include `mirroredFrom.parentId` in `messageWith` / `dmMessageWith`
- `apps/web/src/components/messages/ThreadOriginBadge.tsx` *(new)* — reusable badge component
- `ChannelView.tsx` / DM `page.tsx` — render badge for messages where `mirroredFromId` is set

## Test plan

- [ ] Reply in a channel thread with "Also send to channel" checked — mirror message in the main feed shows the badge
- [ ] Click the badge — thread panel opens to the correct thread
- [ ] Reply in a DM thread with "Also send to DM" checked — same badge appears in the DM feed
- [ ] Regular (non-mirrored) messages show no badge
- [ ] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)