### PR TITLE
fix(invite): fix redirect bug and multi-link UI

### DIFF
--- a/apps/web/src/components/members/DriveShareLinkSection.tsx
+++ b/apps/web/src/components/members/DriveShareLinkSection.tsx
@@ -4,34 +4,54 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Link2, Copy, Trash2 } from 'lucide-react';
-import { useDriveShareLink, type DriveRole } from '@/hooks/useDriveShareLink';
+import { useDriveShareLink, type DriveLink, type DriveRole } from '@/hooks/useDriveShareLink';
 
 export function DriveShareLinkSection({ driveId }: { driveId: string }) {
-  const { activeLink, shareUrl, role, setRole, isLoading, isGenerating, isRevoking, handleGenerate, handleCopy, handleRevoke } =
+  const { links, role, setRole, isLoading, isGenerating, revokingId, handleGenerate, handleCopy, handleRevoke } =
     useDriveShareLink(driveId);
+
   return (
     <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 space-y-3">
       <div>
-        <h3 className="text-sm font-medium flex items-center gap-2"><Link2 className="h-4 w-4" />Invite link</h3>
-        <p className="text-xs text-muted-foreground mt-0.5">Anyone with this link can join the drive (must be signed in).</p>
+        <h3 className="text-sm font-medium flex items-center gap-2"><Link2 className="h-4 w-4" />Invite links</h3>
+        <p className="text-xs text-muted-foreground mt-0.5">Anyone with a link can join the drive (must be signed in).</p>
       </div>
+
       {isLoading ? (
         <div className="h-8 w-full animate-pulse rounded bg-muted" />
-      ) : activeLink ? (
-        <div className="space-y-2">
-          <div className="flex items-center gap-2">
-            <Badge variant="secondary" className="text-xs capitalize">{activeLink.role.toLowerCase()}</Badge>
-            <span className="text-xs text-muted-foreground">Used {activeLink.useCount} {activeLink.useCount === 1 ? 'time' : 'times'}</span>
-          </div>
-          <div className="flex gap-2">
-            <Button variant="outline" size="sm" className="flex-1" onClick={handleCopy} disabled={!shareUrl}><Copy className="mr-1.5 h-3.5 w-3.5" />Copy link</Button>
-            <Button variant="ghost" size="sm" onClick={handleRevoke} disabled={isRevoking} className="text-destructive hover:text-destructive" aria-label="Revoke invite link"><Trash2 className="h-3.5 w-3.5" /></Button>
-          </div>
-        </div>
       ) : (
-        <div className="space-y-3">
-          <div className="flex items-center gap-3">
-            <span className="text-sm">Role</span>
+        <>
+          {links.length > 0 && (
+            <div className="space-y-2">
+              {links.map((link: DriveLink) => (
+                <div key={link.id} className="flex items-center gap-2">
+                  <Badge variant="secondary" className="text-xs capitalize shrink-0">{link.role.toLowerCase()}</Badge>
+                  <span className="text-xs text-muted-foreground flex-1">{link.useCount} {link.useCount === 1 ? 'use' : 'uses'}</span>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 px-2"
+                    onClick={() => handleCopy(link)}
+                    disabled={!link.shareUrl}
+                  >
+                    <Copy className="h-3.5 w-3.5" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 px-2 text-destructive hover:text-destructive"
+                    onClick={() => handleRevoke(link.id)}
+                    disabled={revokingId === link.id}
+                    aria-label="Revoke invite link"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div className={links.length > 0 ? 'flex items-center gap-2 border-t border-gray-200 dark:border-gray-700 pt-3' : 'flex items-center gap-2'}>
             <Select value={role} onValueChange={(v) => setRole(v as DriveRole)}>
               <SelectTrigger className="w-32 h-8"><SelectValue /></SelectTrigger>
               <SelectContent>
@@ -39,11 +59,11 @@ export function DriveShareLinkSection({ driveId }: { driveId: string }) {
                 <SelectItem value="ADMIN">Admin</SelectItem>
               </SelectContent>
             </Select>
+            <Button variant="outline" size="sm" onClick={handleGenerate} disabled={isGenerating} className="flex-1">
+              <Link2 className="mr-1.5 h-3.5 w-3.5" />{isGenerating ? 'Generating…' : 'New invite link'}
+            </Button>
           </div>
-          <Button variant="outline" size="sm" className="w-full" onClick={handleGenerate} disabled={isGenerating}>
-            <Link2 className="mr-1.5 h-3.5 w-3.5" />{isGenerating ? 'Generating…' : 'Generate invite link'}
-          </Button>
-        </div>
+        </>
       )}
     </div>
   );

--- a/apps/web/src/components/members/DriveShareLinkSection.tsx
+++ b/apps/web/src/components/members/DriveShareLinkSection.tsx
@@ -33,6 +33,7 @@ export function DriveShareLinkSection({ driveId }: { driveId: string }) {
                     className="h-7 px-2"
                     onClick={() => handleCopy(link)}
                     disabled={!link.shareUrl}
+                    aria-label={`Copy ${link.role.toLowerCase()} invite link`}
                   >
                     <Copy className="h-3.5 w-3.5" />
                   </Button>

--- a/apps/web/src/hooks/__tests__/useDriveShareLink.test.ts
+++ b/apps/web/src/hooks/__tests__/useDriveShareLink.test.ts
@@ -12,11 +12,16 @@ vi.mock('sonner', () => ({
 
 import { post, del } from '@/lib/auth/auth-fetch';
 import { toast } from 'sonner';
-import { useDriveShareLink } from '../useDriveShareLink';
+import { useDriveShareLink, type DriveLink } from '../useDriveShareLink';
 
 const DRIVE_ID = 'drive-abc';
 const LINK_ID = 'link-123';
+const LINK_ID_2 = 'link-456';
 const SHARE_URL = 'https://app.pagespace.ai/s/ps_share_xyz';
+const SHARE_URL_2 = 'https://app.pagespace.ai/s/ps_share_abc';
+
+const MEMBER_LINK: DriveLink = { id: LINK_ID, role: 'MEMBER', useCount: 3, shareUrl: SHARE_URL };
+const ADMIN_LINK: DriveLink = { id: LINK_ID_2, role: 'ADMIN', useCount: 1, shareUrl: SHARE_URL_2 };
 
 function mockFetchResolve(data: unknown) {
   vi.spyOn(global, 'fetch').mockResolvedValueOnce({
@@ -38,11 +43,9 @@ describe('useDriveShareLink', () => {
     vi.restoreAllMocks();
   });
 
-  describe('loading existing link', () => {
-    it('Given GET returns a link with shareUrl, should populate activeLink and shareUrl', async () => {
-      mockFetchResolve({
-        links: [{ id: LINK_ID, role: 'MEMBER', useCount: 3, shareUrl: SHARE_URL, expiresAt: null, createdAt: new Date().toISOString() }],
-      });
+  describe('loading existing links', () => {
+    it('Given GET returns links, should populate links list', async () => {
+      mockFetchResolve({ links: [MEMBER_LINK] });
 
       const { result } = renderHook(() => useDriveShareLink(DRIVE_ID));
 
@@ -50,54 +53,65 @@ describe('useDriveShareLink', () => {
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-      expect(result.current.activeLink?.id).toBe(LINK_ID);
-      expect(result.current.activeLink?.role).toBe('MEMBER');
-      expect(result.current.shareUrl).toBe(SHARE_URL);
+      expect(result.current.links).toHaveLength(1);
+      expect(result.current.links[0].id).toBe(LINK_ID);
+      expect(result.current.links[0].role).toBe('MEMBER');
+      expect(result.current.links[0].shareUrl).toBe(SHARE_URL);
     });
 
-    it('Given GET returns an empty list, should have no activeLink', async () => {
+    it('Given GET returns multiple links, should populate all in list', async () => {
+      mockFetchResolve({ links: [MEMBER_LINK, ADMIN_LINK] });
+
+      const { result } = renderHook(() => useDriveShareLink(DRIVE_ID));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.links).toHaveLength(2);
+      expect(result.current.links[0].id).toBe(LINK_ID);
+      expect(result.current.links[1].id).toBe(LINK_ID_2);
+    });
+
+    it('Given GET returns an empty list, should have empty links array', async () => {
       mockFetchResolve({ links: [] });
 
       const { result } = renderHook(() => useDriveShareLink(DRIVE_ID));
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-      expect(result.current.activeLink).toBeNull();
-      expect(result.current.shareUrl).toBeNull();
+      expect(result.current.links).toHaveLength(0);
     });
 
-    it('Given GET returns a link with null shareUrl (legacy row), should set shareUrl to null', async () => {
+    it('Given GET returns a link with null shareUrl, should include it in list', async () => {
       mockFetchResolve({
-        links: [{ id: LINK_ID, role: 'ADMIN', useCount: 0, shareUrl: null, expiresAt: null, createdAt: new Date().toISOString() }],
+        links: [{ id: LINK_ID, role: 'ADMIN', useCount: 0, shareUrl: null }],
       });
 
       const { result } = renderHook(() => useDriveShareLink(DRIVE_ID));
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-      expect(result.current.activeLink?.id).toBe(LINK_ID);
-      expect(result.current.shareUrl).toBeNull();
+      expect(result.current.links).toHaveLength(1);
+      expect(result.current.links[0].shareUrl).toBeNull();
     });
 
-    it('Given GET returns malformed data (missing id), should treat as no active link', async () => {
+    it('Given GET returns malformed data (missing id), should leave links empty', async () => {
       mockFetchResolve({ links: [{ role: 'MEMBER', useCount: 0 }] });
 
       const { result } = renderHook(() => useDriveShareLink(DRIVE_ID));
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-      expect(result.current.activeLink).toBeNull();
+      expect(result.current.links).toHaveLength(0);
     });
 
-    it('Given GET fails with network error, should finish loading with no active link', async () => {
+    it('Given GET fails with network error, should finish loading with empty links', async () => {
       mockFetchReject();
 
       const { result } = renderHook(() => useDriveShareLink(DRIVE_ID));
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-      expect(result.current.activeLink).toBeNull();
+      expect(result.current.links).toHaveLength(0);
     });
   });
 
   describe('generating a link', () => {
-    it('Given POST succeeds, should update shareUrl and activeLink from response', async () => {
+    it('Given POST succeeds, should append new link to list', async () => {
       mockFetchResolve({ links: [] });
       vi.mocked(post).mockResolvedValueOnce({
         id: LINK_ID,
@@ -114,12 +128,37 @@ describe('useDriveShareLink', () => {
         await result.current.handleGenerate();
       });
 
-      expect(result.current.shareUrl).toBe(SHARE_URL);
-      expect(result.current.activeLink?.id).toBe(LINK_ID);
-      expect(result.current.activeLink?.role).toBe('MEMBER');
+      expect(result.current.links).toHaveLength(1);
+      expect(result.current.links[0].id).toBe(LINK_ID);
+      expect(result.current.links[0].role).toBe('MEMBER');
+      expect(result.current.links[0].shareUrl).toBe(SHARE_URL);
     });
 
-    it('Given POST fails, should not update activeLink', async () => {
+    it('Given existing links, POST should append without removing existing', async () => {
+      mockFetchResolve({ links: [MEMBER_LINK] });
+      vi.mocked(post).mockResolvedValueOnce({
+        id: LINK_ID_2,
+        rawToken: 'ps_share_abc',
+        shareUrl: SHARE_URL_2,
+      });
+
+      const { result } = renderHook(() => useDriveShareLink(DRIVE_ID));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
+
+      act(() => { result.current.setRole('ADMIN'); });
+
+      await act(async () => {
+        await result.current.handleGenerate();
+      });
+
+      expect(result.current.links).toHaveLength(2);
+      expect(result.current.links[1].id).toBe(LINK_ID_2);
+      expect(result.current.links[1].role).toBe('ADMIN');
+    });
+
+    it('Given POST fails, should not update links list', async () => {
       mockFetchResolve({ links: [] });
       vi.mocked(post).mockRejectedValueOnce(new Error('server error'));
 
@@ -130,16 +169,14 @@ describe('useDriveShareLink', () => {
         await result.current.handleGenerate();
       });
 
-      expect(result.current.activeLink).toBeNull();
+      expect(result.current.links).toHaveLength(0);
       expect(toast.error).toHaveBeenCalled();
     });
   });
 
   describe('copying a link', () => {
-    it('Given shareUrl is set, handleCopy should write shareUrl to clipboard', async () => {
-      mockFetchResolve({
-        links: [{ id: LINK_ID, role: 'MEMBER', useCount: 1, shareUrl: SHARE_URL, expiresAt: null, createdAt: new Date().toISOString() }],
-      });
+    it('Given a link with shareUrl, handleCopy should write that shareUrl to clipboard', async () => {
+      mockFetchResolve({ links: [MEMBER_LINK] });
       const writeText = vi.fn().mockResolvedValue(undefined);
       Object.assign(navigator, { clipboard: { writeText } });
 
@@ -147,15 +184,16 @@ describe('useDriveShareLink', () => {
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
       await act(async () => {
-        await result.current.handleCopy();
+        await result.current.handleCopy(result.current.links[0]);
       });
 
       expect(writeText).toHaveBeenCalledWith(SHARE_URL);
       expect(toast.success).toHaveBeenCalled();
     });
 
-    it('Given shareUrl is null, handleCopy should do nothing', async () => {
-      mockFetchResolve({ links: [] });
+    it('Given a link with null shareUrl, handleCopy should do nothing', async () => {
+      const nullUrlLink: DriveLink = { id: LINK_ID, role: 'MEMBER', useCount: 0, shareUrl: null };
+      mockFetchResolve({ links: [nullUrlLink] });
       const writeText = vi.fn();
       Object.assign(navigator, { clipboard: { writeText } });
 
@@ -163,30 +201,87 @@ describe('useDriveShareLink', () => {
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
       await act(async () => {
-        await result.current.handleCopy();
+        await result.current.handleCopy(result.current.links[0]);
       });
 
       expect(writeText).not.toHaveBeenCalled();
     });
+
+    it('Given multiple links, handleCopy copies only the specified link URL', async () => {
+      mockFetchResolve({ links: [MEMBER_LINK, ADMIN_LINK] });
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.assign(navigator, { clipboard: { writeText } });
+
+      const { result } = renderHook(() => useDriveShareLink(DRIVE_ID));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.handleCopy(result.current.links[1]);
+      });
+
+      expect(writeText).toHaveBeenCalledWith(SHARE_URL_2);
+    });
   });
 
   describe('revoking a link', () => {
-    it('Given DELETE succeeds, should clear activeLink and shareUrl', async () => {
-      mockFetchResolve({
-        links: [{ id: LINK_ID, role: 'MEMBER', useCount: 2, shareUrl: SHARE_URL, expiresAt: null, createdAt: new Date().toISOString() }],
-      });
+    it('Given DELETE succeeds, should remove revoked link from list', async () => {
+      mockFetchResolve({ links: [MEMBER_LINK] });
       vi.mocked(del).mockResolvedValueOnce(undefined);
 
       const { result } = renderHook(() => useDriveShareLink(DRIVE_ID));
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
       await act(async () => {
-        await result.current.handleRevoke();
+        await result.current.handleRevoke(LINK_ID);
       });
 
-      expect(result.current.activeLink).toBeNull();
-      expect(result.current.shareUrl).toBeNull();
+      expect(result.current.links).toHaveLength(0);
       expect(toast.success).toHaveBeenCalled();
+    });
+
+    it('Given multiple links, revoking one should leave the other', async () => {
+      mockFetchResolve({ links: [MEMBER_LINK, ADMIN_LINK] });
+      vi.mocked(del).mockResolvedValueOnce(undefined);
+
+      const { result } = renderHook(() => useDriveShareLink(DRIVE_ID));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.handleRevoke(LINK_ID);
+      });
+
+      expect(result.current.links).toHaveLength(1);
+      expect(result.current.links[0].id).toBe(LINK_ID_2);
+    });
+
+    it('Given DELETE fails, should keep link in list and show error', async () => {
+      mockFetchResolve({ links: [MEMBER_LINK] });
+      vi.mocked(del).mockRejectedValueOnce(new Error('server error'));
+
+      const { result } = renderHook(() => useDriveShareLink(DRIVE_ID));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.handleRevoke(LINK_ID);
+      });
+
+      expect(result.current.links).toHaveLength(1);
+      expect(toast.error).toHaveBeenCalled();
+    });
+
+    it('revokingId should be set during DELETE and cleared after', async () => {
+      mockFetchResolve({ links: [MEMBER_LINK] });
+      let resolveDelete!: () => void;
+      vi.mocked(del).mockReturnValueOnce(new Promise<void>(res => { resolveDelete = res; }));
+
+      const { result } = renderHook(() => useDriveShareLink(DRIVE_ID));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      act(() => { result.current.handleRevoke(LINK_ID); });
+      expect(result.current.revokingId).toBe(LINK_ID);
+
+      await act(async () => { resolveDelete(); });
+      expect(result.current.revokingId).toBeNull();
     });
   });
 

--- a/apps/web/src/hooks/useDriveShareLink.ts
+++ b/apps/web/src/hooks/useDriveShareLink.ts
@@ -84,7 +84,7 @@ export function useDriveShareLink(driveId: string) {
     } catch {
       toast.error('Failed to revoke invite link');
     } finally {
-      setRevokingId(null);
+      setRevokingId(prev => (prev === linkId ? null : prev));
     }
   }
 

--- a/apps/web/src/hooks/useDriveShareLink.ts
+++ b/apps/web/src/hooks/useDriveShareLink.ts
@@ -16,22 +16,20 @@ const DriveListResponseSchema = z.object({
   links: z.array(DriveLinkSchema),
 });
 
-type DriveLink = z.infer<typeof DriveLinkSchema>;
+export type DriveLink = z.infer<typeof DriveLinkSchema>;
 export type DriveRole = 'MEMBER' | 'ADMIN';
 
 export function useDriveShareLink(driveId: string) {
-  const [activeLink, setActiveLink] = useState<DriveLink | null>(null);
-  const [shareUrl, setShareUrl] = useState<string | null>(null);
+  const [links, setLinks] = useState<DriveLink[]>([]);
   const [role, setRole] = useState<DriveRole>('MEMBER');
   const [isLoading, setIsLoading] = useState(true);
   const [isGenerating, setIsGenerating] = useState(false);
-  const [isRevoking, setIsRevoking] = useState(false);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     setIsLoading(true);
-    setActiveLink(null);
-    setShareUrl(null);
+    setLinks([]);
 
     async function loadExisting() {
       try {
@@ -39,10 +37,8 @@ export function useDriveShareLink(driveId: string) {
         if (!res.ok || cancelled) return;
         const raw = await res.json();
         const parsed = DriveListResponseSchema.safeParse(raw);
-        if (cancelled || !parsed.success || parsed.data.links.length === 0) return;
-        const link = parsed.data.links[0];
-        setActiveLink(link);
-        setShareUrl(link.shareUrl);
+        if (cancelled || !parsed.success) return;
+        setLinks(parsed.data.links);
       } catch {
         // silently fail — user can still generate a new link
       } finally {
@@ -61,8 +57,8 @@ export function useDriveShareLink(driveId: string) {
         `/api/drives/${driveId}/share-links`,
         { role }
       );
-      setShareUrl(data.shareUrl);
-      setActiveLink({ id: data.id, role, useCount: 0, shareUrl: data.shareUrl });
+      const newLink: DriveLink = { id: data.id, role, useCount: 0, shareUrl: data.shareUrl };
+      setLinks(prev => [...prev, newLink]);
       const copied = await navigator.clipboard.writeText(data.shareUrl).then(() => true).catch(() => false);
       toast.success(copied ? 'Invite link created and copied to clipboard' : 'Invite link created');
     } catch {
@@ -72,27 +68,25 @@ export function useDriveShareLink(driveId: string) {
     }
   }
 
-  async function handleCopy() {
-    if (!shareUrl) return;
-    const copied = await navigator.clipboard.writeText(shareUrl).then(() => true).catch(() => false);
+  async function handleCopy(link: DriveLink) {
+    if (!link.shareUrl) return;
+    const copied = await navigator.clipboard.writeText(link.shareUrl).then(() => true).catch(() => false);
     if (copied) toast.success('Invite link copied to clipboard');
     else toast.error('Could not copy link to clipboard');
   }
 
-  async function handleRevoke() {
-    if (!activeLink) return;
-    setIsRevoking(true);
+  async function handleRevoke(linkId: string) {
+    setRevokingId(linkId);
     try {
-      await del(`/api/drives/${driveId}/share-links/${activeLink.id}`);
-      setActiveLink(null);
-      setShareUrl(null);
+      await del(`/api/drives/${driveId}/share-links/${linkId}`);
+      setLinks(prev => prev.filter(l => l.id !== linkId));
       toast.success('Invite link revoked');
     } catch {
       toast.error('Failed to revoke invite link');
     } finally {
-      setIsRevoking(false);
+      setRevokingId(null);
     }
   }
 
-  return { activeLink, shareUrl, role, setRole, isLoading, isGenerating, isRevoking, handleGenerate, handleCopy, handleRevoke };
+  return { links, role, setRole, isLoading, isGenerating, revokingId, handleGenerate, handleCopy, handleRevoke };
 }

--- a/apps/web/src/middleware/security-headers.ts
+++ b/apps/web/src/middleware/security-headers.ts
@@ -136,7 +136,9 @@ export const applySecurityHeaders = (
 
 export const isPublicPageRoute = (pathname: string): boolean =>
   pathname === '/auth' ||
-  pathname.startsWith('/auth/');
+  pathname.startsWith('/auth/') ||
+  pathname === '/invite' ||
+  pathname.startsWith('/invite/');
 
 export const shouldDisableCOEP = (pathname: string): boolean =>
   pathname.startsWith('/settings/plan') ||


### PR DESCRIPTION
## Summary

- **Redirect bug**: `/invite/[token]` was not in the middleware public-route allowlist, so unauthenticated visitors (new users) were immediately redirected to `/auth/signin` with no invite context. Adding the path to `isPublicPageRoute()` lets the server component render the consent page, which already handles the "Create account & join" / "Sign in to join" flow correctly.
- **Multi-link UI**: The drive invite link section only displayed `links[0]` and toggled between a "no link" form and a "link exists" view — making it impossible to have a Member link and an Admin link active simultaneously. The hook and component are now refactored to show all active links as a list, with an always-visible role selector + create button below.

## Changes

- `apps/web/src/middleware/security-headers.ts` — add `/invite` and `/invite/*` to `isPublicPageRoute()`
- `apps/web/src/hooks/useDriveShareLink.ts` — replace `activeLink: DriveLink | null` with `links: DriveLink[]`; `handleCopy(link)` and `handleRevoke(id)` are now per-link; generate appends to the list
- `apps/web/src/components/members/DriveShareLinkSection.tsx` — render all active links as rows with Copy/Revoke per link; always-visible create form at the bottom

## Test plan

- [ ] Log out, visit `/invite/[valid-token]` — should see invite consent page, not the signin page
- [ ] Create a Member invite link → appears in list; create an Admin link → both appear
- [ ] Copy each link individually; both share URLs work when redeemed
- [ ] Revoke one link → the other remains active and usable
- [ ] With no links, only the create form is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Drive share links now support managing multiple simultaneous invite links instead of a single link
- Each link displays its assigned role and usage count with individual copy and revoke actions
- Improved invite workflow with role selection and new link generation controls

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1337)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->