### PR TITLE
feat(invite): show URL in share/invite link UI

### DIFF
--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/PageShareLinkSection.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/PageShareLinkSection.tsx
@@ -34,9 +34,11 @@ export function PageShareLinkSection({ pageId }: { pageId: string }) {
         <div className="space-y-2">
           <div className="flex items-center gap-2">
             <input
+              type="text"
               readOnly
               value={shareUrl ?? ''}
-              className="flex-1 h-8 min-w-0 px-2 text-xs font-mono bg-muted rounded border border-input truncate focus:outline-none cursor-text"
+              aria-label="Share link URL"
+              className="flex-1 h-8 min-w-0 px-2 text-xs font-mono bg-muted rounded border border-input truncate focus:ring-2 focus:ring-ring cursor-text"
               onClick={(e) => (e.target as HTMLInputElement).select()}
             />
             <Button

--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/PageShareLinkSection.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/PageShareLinkSection.tsx
@@ -33,34 +33,40 @@ export function PageShareLinkSection({ pageId }: { pageId: string }) {
       ) : activeLink ? (
         <div className="space-y-2">
           <div className="flex items-center gap-2">
+            <input
+              readOnly
+              value={shareUrl ?? ''}
+              className="flex-1 h-8 min-w-0 px-2 text-xs font-mono bg-muted rounded border border-input truncate focus:outline-none cursor-text"
+              onClick={(e) => (e.target as HTMLInputElement).select()}
+            />
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 px-2 shrink-0"
+              onClick={handleCopy}
+              disabled={!shareUrl}
+              aria-label="Copy share link"
+            >
+              <Copy className="h-3.5 w-3.5" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 px-2 shrink-0 text-destructive hover:text-destructive"
+              onClick={handleRevoke}
+              disabled={isRevoking}
+              aria-label="Revoke share link"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </Button>
+          </div>
+          <div className="flex items-center gap-2">
             <Badge variant="secondary" className="text-xs">
               {activeLink.permissions.includes('EDIT') ? 'View + Edit' : 'View only'}
             </Badge>
             <span className="text-xs text-muted-foreground">
               Used {activeLink.useCount} {activeLink.useCount === 1 ? 'time' : 'times'}
             </span>
-          </div>
-          <div className="flex gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              className="flex-1"
-              onClick={handleCopy}
-              disabled={!shareUrl}
-            >
-              <Copy className="mr-1.5 h-3.5 w-3.5" />
-              Copy link
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={handleRevoke}
-              disabled={isRevoking}
-              className="text-destructive hover:text-destructive"
-              aria-label="Revoke share link"
-            >
-              <Trash2 className="h-3.5 w-3.5" />
-            </Button>
           </div>
         </div>
       ) : (

--- a/apps/web/src/components/members/DriveShareLinkSection.tsx
+++ b/apps/web/src/components/members/DriveShareLinkSection.tsx
@@ -24,29 +24,37 @@ export function DriveShareLinkSection({ driveId }: { driveId: string }) {
           {links.length > 0 && (
             <div className="space-y-2">
               {links.map((link: DriveLink) => (
-                <div key={link.id} className="flex items-center gap-2">
-                  <Badge variant="secondary" className="text-xs capitalize shrink-0">{link.role.toLowerCase()}</Badge>
-                  <span className="text-xs text-muted-foreground flex-1">{link.useCount} {link.useCount === 1 ? 'use' : 'uses'}</span>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-7 px-2"
-                    onClick={() => handleCopy(link)}
-                    disabled={!link.shareUrl}
-                    aria-label={`Copy ${link.role.toLowerCase()} invite link`}
-                  >
-                    <Copy className="h-3.5 w-3.5" />
-                  </Button>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-7 px-2 text-destructive hover:text-destructive"
-                    onClick={() => handleRevoke(link.id)}
-                    disabled={revokingId === link.id}
-                    aria-label="Revoke invite link"
-                  >
-                    <Trash2 className="h-3.5 w-3.5" />
-                  </Button>
+                <div key={link.id} className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <Badge variant="secondary" className="text-xs capitalize shrink-0">{link.role.toLowerCase()}</Badge>
+                    <input
+                      readOnly
+                      value={link.shareUrl ?? ''}
+                      className="flex-1 h-7 min-w-0 px-2 text-xs font-mono bg-muted rounded border border-input truncate focus:outline-none cursor-text"
+                      onClick={(e) => (e.target as HTMLInputElement).select()}
+                    />
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 px-2 shrink-0"
+                      onClick={() => handleCopy(link)}
+                      disabled={!link.shareUrl}
+                      aria-label={`Copy ${link.role.toLowerCase()} invite link`}
+                    >
+                      <Copy className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 px-2 shrink-0 text-destructive hover:text-destructive"
+                      onClick={() => handleRevoke(link.id)}
+                      disabled={revokingId === link.id}
+                      aria-label="Revoke invite link"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                  <p className="text-xs text-muted-foreground pl-1">{link.useCount} {link.useCount === 1 ? 'use' : 'uses'}</p>
                 </div>
               ))}
             </div>

--- a/apps/web/src/components/members/DriveShareLinkSection.tsx
+++ b/apps/web/src/components/members/DriveShareLinkSection.tsx
@@ -28,9 +28,11 @@ export function DriveShareLinkSection({ driveId }: { driveId: string }) {
                   <div className="flex items-center gap-2">
                     <Badge variant="secondary" className="text-xs capitalize shrink-0">{link.role.toLowerCase()}</Badge>
                     <input
+                      type="text"
                       readOnly
                       value={link.shareUrl ?? ''}
-                      className="flex-1 h-7 min-w-0 px-2 text-xs font-mono bg-muted rounded border border-input truncate focus:outline-none cursor-text"
+                      aria-label={`${link.role.toLowerCase()} invite link URL`}
+                      className="flex-1 h-7 min-w-0 px-2 text-xs font-mono bg-muted rounded border border-input truncate focus:ring-2 focus:ring-ring cursor-text"
                       onClick={(e) => (e.target as HTMLInputElement).select()}
                     />
                     <Button


### PR DESCRIPTION
## Summary

- Drive invite links and page share links now display the full URL in a visible read-only monospace input field
- Users can click the input to select-all and copy manually, or still use the copy icon button
- Badge and use-count move below the URL row; no behaviour or API changes

## Test plan

- [ ] Open drive members panel → generate or view an invite link → URL is visible in the input
- [ ] Click the URL input → text selects; can manually copy
- [ ] Click the copy icon → toast confirms copy still works
- [ ] Open a page share dialog → generate or view a share link → URL is visible
- [ ] Revoke a link → row disappears as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Share URLs now display in read-only input fields with text auto-selecting on click
  * Simplified share link action buttons to icon-only format
  * Reorganized layout structure in share sections for improved organization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1339)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->