### PR TITLE
fix(auth): allow unauthenticated access to share link routes

### DIFF
--- a/apps/web/src/middleware/security-headers.ts
+++ b/apps/web/src/middleware/security-headers.ts
@@ -138,7 +138,8 @@ export const isPublicPageRoute = (pathname: string): boolean =>
   pathname === '/auth' ||
   pathname.startsWith('/auth/') ||
   pathname === '/invite' ||
-  pathname.startsWith('/invite/');
+  pathname.startsWith('/invite/') ||
+  pathname.startsWith('/s/');
 
 export const shouldDisableCOEP = (pathname: string): boolean =>
   pathname.startsWith('/settings/plan') ||


### PR DESCRIPTION
## Summary
- `/s/*` routes were missing from `isPublicPageRoute` in `security-headers.ts`, causing middleware to redirect logged-out users to `/auth/signin` instead of the share/invite landing page
- Added `pathname.startsWith('/s/')` to the allowlist — one line change
- The `/s/[token]` page already handles unauthenticated users correctly via `AuthShell`

## Test plan
- [ ] Open an incognito window and visit a `/s/ps_share_...` URL — should show the invite landing page, not redirect to sign-in
- [ ] Confirm `/invite/` and `/auth/` routes still work normally
- [ ] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Routes starting with `/s/` are now recognized as publicly accessible.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1340)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->