### PR TITLE
fix(share): remove client-side auth redirect from share accept components

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -136,11 +136,7 @@ export async function middleware(req: NextRequest) {
         return createSecureErrorResponse('Authentication required', 401, isProduction);
       }
 
-      const signinUrl = new URL('/auth/signin', req.url);
-      if (pathname.startsWith('/s/')) {
-        signinUrl.searchParams.set('next', pathname);
-      }
-      return NextResponse.redirect(signinUrl);
+      return NextResponse.redirect(new URL('/auth/signin', req.url));
     }
 
     // Session cookie exists - let request through

--- a/apps/web/src/app/s/[token]/DriveShareAccept.tsx
+++ b/apps/web/src/app/s/[token]/DriveShareAccept.tsx
@@ -79,7 +79,7 @@ export function DriveShareAccept({ token, info }: DriveShareAcceptProps) {
       <Button
         className="w-full"
         onClick={handleJoin}
-        disabled={isPending || (isAuthenticated && !csrfToken)}
+        disabled={isPending || authLoading || (isAuthenticated && !csrfToken)}
       >
         {isPending ? 'Joining…' : `Join ${info.driveName ?? 'workspace'}`}
       </Button>

--- a/apps/web/src/app/s/[token]/DriveShareAccept.tsx
+++ b/apps/web/src/app/s/[token]/DriveShareAccept.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
@@ -21,13 +21,11 @@ export function DriveShareAccept({ token, info }: DriveShareAcceptProps) {
   const [isPending, setIsPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!authLoading && !isAuthenticated) {
-      router.push(`/auth/signin?next=/s/${token}`);
-    }
-  }, [authLoading, isAuthenticated, router, token]);
-
   async function handleJoin() {
+    if (!isAuthenticated) {
+      router.push(`/auth/signin?next=/s/${token}`);
+      return;
+    }
     if (!csrfToken) return;
     setIsPending(true);
     setError(null);

--- a/apps/web/src/app/s/[token]/DriveShareAccept.tsx
+++ b/apps/web/src/app/s/[token]/DriveShareAccept.tsx
@@ -79,7 +79,7 @@ export function DriveShareAccept({ token, info }: DriveShareAcceptProps) {
       <Button
         className="w-full"
         onClick={handleJoin}
-        disabled={isPending || !csrfToken}
+        disabled={isPending || (isAuthenticated && !csrfToken)}
       >
         {isPending ? 'Joining…' : `Join ${info.driveName ?? 'workspace'}`}
       </Button>

--- a/apps/web/src/app/s/[token]/PageShareAccept.tsx
+++ b/apps/web/src/app/s/[token]/PageShareAccept.tsx
@@ -20,12 +20,6 @@ export function PageShareAccept({ token, info }: PageShareAcceptProps) {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!authLoading && !isAuthenticated) {
-      router.push(`/auth/signin?next=/s/${token}`);
-    }
-  }, [authLoading, isAuthenticated, router, token]);
-
-  useEffect(() => {
     if (!isAuthenticated || !csrfToken) return;
 
     const controller = new AbortController();
@@ -56,6 +50,28 @@ export function PageShareAccept({ token, info }: PageShareAcceptProps) {
     accept();
     return () => controller.abort();
   }, [isAuthenticated, csrfToken, token, router]);
+
+  if (!authLoading && !isAuthenticated) {
+    return (
+      <div className="space-y-6 text-center">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+            You&apos;re invited
+          </h1>
+          <p className="mt-3 text-sm text-muted-foreground">
+            Sign in to open{' '}
+            <span className="font-medium text-gray-900 dark:text-gray-100">
+              {info.pageTitle ?? 'this page'}
+            </span>
+            .
+          </p>
+        </div>
+        <Button className="w-full" onClick={() => router.push(`/auth/signin?next=/s/${token}`)}>
+          Sign in to continue
+        </Button>
+      </div>
+    );
+  }
 
   if (error) {
     return (

--- a/apps/web/src/app/s/[token]/__tests__/DriveShareAccept.test.tsx
+++ b/apps/web/src/app/s/[token]/__tests__/DriveShareAccept.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, act } from '@testing-library/react';
+import { render, act, screen, fireEvent } from '@testing-library/react';
 
 const pushMock = vi.fn();
 
@@ -34,20 +34,32 @@ describe('DriveShareAccept', () => {
     vi.mocked(useCSRFToken).mockReturnValue(csrfBase);
   });
 
-  it('Given auth is loading, should not redirect', () => {
+  it('Given auth is loading, should not redirect and disable the button', () => {
     vi.mocked(useAuth).mockReturnValue({ isAuthenticated: false, isLoading: true } as ReturnType<typeof useAuth>);
 
     render(<DriveShareAccept token="tok" info={INFO} />);
 
     expect(pushMock).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /join/i })).toBeDisabled();
   });
 
-  it('Given unauthenticated user after auth loads, should redirect to signin', async () => {
+  it('Given unauthenticated user after auth loads, should show invite landing page without redirecting', async () => {
     vi.mocked(useAuth).mockReturnValue({ isAuthenticated: false, isLoading: false } as ReturnType<typeof useAuth>);
 
     render(<DriveShareAccept token="tok-abc" info={INFO} />);
 
     await act(async () => {});
+
+    expect(pushMock).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /join/i })).toBeEnabled();
+  });
+
+  it('Given unauthenticated user clicks Join, should redirect to signin with next param', async () => {
+    vi.mocked(useAuth).mockReturnValue({ isAuthenticated: false, isLoading: false } as ReturnType<typeof useAuth>);
+
+    render(<DriveShareAccept token="tok-abc" info={INFO} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /join/i }));
 
     expect(pushMock).toHaveBeenCalledWith('/auth/signin?next=/s/tok-abc');
   });

--- a/apps/web/src/app/s/[token]/__tests__/PageShareAccept.test.tsx
+++ b/apps/web/src/app/s/[token]/__tests__/PageShareAccept.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { render, act } from '@testing-library/react';
+import { render, act, screen, fireEvent } from '@testing-library/react';
 
 const pushMock = vi.fn();
 
@@ -51,13 +51,26 @@ describe('PageShareAccept', () => {
     expect(pushMock).not.toHaveBeenCalledWith(expect.stringContaining('signin'));
   });
 
-  it('Given unauthenticated user after auth loads, should redirect to signin', async () => {
+  it('Given unauthenticated user after auth loads, should render sign-in prompt without redirecting', async () => {
     vi.mocked(useAuth).mockReturnValue({ isAuthenticated: false, isLoading: false } as ReturnType<typeof useAuth>);
     vi.mocked(useCSRFToken).mockReturnValue(csrfBase);
 
     render(<PageShareAccept token="tok-xyz" info={INFO} />);
 
     await act(async () => {});
+
+    expect(pushMock).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /sign in to continue/i })).toBeInTheDocument();
+    expect(screen.getByText(/you're invited/i)).toBeInTheDocument();
+  });
+
+  it('Given unauthenticated user clicks Sign in to continue, should redirect to signin with next param', async () => {
+    vi.mocked(useAuth).mockReturnValue({ isAuthenticated: false, isLoading: false } as ReturnType<typeof useAuth>);
+    vi.mocked(useCSRFToken).mockReturnValue(csrfBase);
+
+    render(<PageShareAccept token="tok-xyz" info={INFO} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /sign in to continue/i }));
 
     expect(pushMock).toHaveBeenCalledWith('/auth/signin?next=/s/tok-xyz');
   });

--- a/apps/web/src/middleware/security-headers.ts
+++ b/apps/web/src/middleware/security-headers.ts
@@ -138,7 +138,8 @@ export const isPublicPageRoute = (pathname: string): boolean =>
   pathname === '/auth' ||
   pathname.startsWith('/auth/') ||
   pathname === '/invite' ||
-  pathname.startsWith('/invite/');
+  pathname.startsWith('/invite/') ||
+  pathname.startsWith('/s/');
 
 export const shouldDisableCOEP = (pathname: string): boolean =>
   pathname.startsWith('/settings/plan') ||


### PR DESCRIPTION
## Summary

Both \`DriveShareAccept\` and \`PageShareAccept\` had a \`useEffect\` that immediately redirected unauthenticated users to \`/auth/signin\`, firing after hydration even though the middleware (fixed in #1340) now allows \`/s/*\` through without a session.

**Changes:**
- Removed the redirect \`useEffect\` from both components
- \`DriveShareAccept\`: signin redirect moved into \`handleJoin\` — anonymous visitors see the invite landing page and are redirected to sign-in only when they click Join. Button \`disabled\` condition updated to \`isPending || authLoading || (isAuthenticated && !csrfToken)\` so CSRF gating only applies when authenticated, and an auth-loading race is prevented.
- \`PageShareAccept\`: added explicit "You're invited — sign in to continue" UI for unauthenticated visitors; after sign-in with \`?next=/s/...\` they return to the share page and the existing auto-accept effect fires.
- \`middleware.ts\`: removed dead \`/s/\` branch from the signin redirect (unreachable since #1340 added \`/s/\` to \`isPublicPageRoute\`)
- Updated existing unit tests to assert the new invite-landing behavior for unauthenticated users instead of auto-redirect

## Test plan
- [ ] Incognito → drive invite link → see "Join [workspace]" landing page (no redirect)
- [ ] Click Join → redirected to \`/auth/signin?next=/s/...\`
- [ ] Sign in → return to share page → Join enabled → join succeeds → redirected to dashboard
- [ ] Incognito → page invite link → see "You're invited — sign in to continue" (no redirect)
- [ ] Click "Sign in to continue" → sign in → auto-accepts → redirected to the page
- [ ] Both flows work normally when already signed in (no regression)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)