### PR TITLE
refactor(invite): unify permissions matrix for email and link sharing

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/share-links/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/share-links/route.ts
@@ -84,7 +84,7 @@ export async function POST(
     }
     if (result.error === 'INVALID_PERMISSIONS') {
       return NextResponse.json(
-        { error: 'EDIT permission requires VIEW permission' },
+        { error: 'VIEW permission is required' },
         { status: 400 }
       );
     }

--- a/apps/web/src/app/api/pages/[pageId]/share-links/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/share-links/route.ts
@@ -11,7 +11,7 @@ import { z } from 'zod/v4';
 const AUTH_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_WRITE = { allow: ['session'] as const, requireCSRF: true };
 
-const PermissionEnum = z.enum(['VIEW', 'EDIT']);
+const PermissionEnum = z.enum(['VIEW', 'EDIT', 'SHARE', 'DELETE']);
 
 const CreateBodySchema = z.object({
   permissions: z.array(PermissionEnum).optional(),

--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/PageShareLinkSection.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/PageShareLinkSection.tsx
@@ -2,17 +2,28 @@
 
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Switch } from '@/components/ui/switch';
-import { Label } from '@/components/ui/label';
 import { Link2, Copy, Trash2 } from 'lucide-react';
-import { usePageShareLink } from '@/hooks/usePageShareLink';
+import { usePageShareLink, type ShareLinkPermissions } from '@/hooks/usePageShareLink';
 
-export function PageShareLinkSection({ pageId }: { pageId: string }) {
+function permissionLabel(permissions: string[]): string {
+  const labels: string[] = [];
+  if (permissions.includes('VIEW'))   labels.push('View');
+  if (permissions.includes('EDIT'))   labels.push('Edit');
+  if (permissions.includes('SHARE'))  labels.push('Share');
+  if (permissions.includes('DELETE')) labels.push('Delete');
+  if (labels.length === 1) return 'View only';
+  return labels.join(', ');
+}
+
+interface PageShareLinkSectionProps {
+  pageId: string;
+  permissions: ShareLinkPermissions;
+}
+
+export function PageShareLinkSection({ pageId, permissions }: PageShareLinkSectionProps) {
   const {
     activeLink,
     shareUrl,
-    includeEdit,
-    setIncludeEdit,
     isLoading,
     isGenerating,
     isRevoking,
@@ -64,7 +75,7 @@ export function PageShareLinkSection({ pageId }: { pageId: string }) {
           </div>
           <div className="flex items-center gap-2">
             <Badge variant="secondary" className="text-xs">
-              {activeLink.permissions.includes('EDIT') ? 'View + Edit' : 'View only'}
+              {permissionLabel(activeLink.permissions)}
             </Badge>
             <span className="text-xs text-muted-foreground">
               Used {activeLink.useCount} {activeLink.useCount === 1 ? 'time' : 'times'}
@@ -72,28 +83,16 @@ export function PageShareLinkSection({ pageId }: { pageId: string }) {
           </div>
         </div>
       ) : (
-        <div className="space-y-3">
-          <div className="flex items-center gap-3">
-            <Switch
-              id="share-link-edit"
-              checked={includeEdit}
-              onCheckedChange={setIncludeEdit}
-            />
-            <Label htmlFor="share-link-edit" className="text-sm cursor-pointer">
-              Allow editing
-            </Label>
-          </div>
-          <Button
-            variant="outline"
-            size="sm"
-            className="w-full"
-            onClick={handleGenerate}
-            disabled={isGenerating}
-          >
-            <Link2 className="mr-1.5 h-3.5 w-3.5" />
-            {isGenerating ? 'Generating…' : 'Generate link'}
-          </Button>
-        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full"
+          onClick={() => handleGenerate(permissions)}
+          disabled={isGenerating}
+        >
+          <Link2 className="mr-1.5 h-3.5 w-3.5" />
+          {isGenerating ? 'Generating…' : 'Generate link'}
+        </Button>
       )}
     </div>
   );

--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/PageShareLinkSection.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/PageShareLinkSection.tsx
@@ -88,7 +88,8 @@ export function PageShareLinkSection({ pageId, permissions }: PageShareLinkSecti
           size="sm"
           className="w-full"
           onClick={() => handleGenerate(permissions)}
-          disabled={isGenerating}
+          disabled={isGenerating || !permissions.canView}
+          title={!permissions.canView ? 'Select at least View permission to generate a link' : undefined}
         >
           <Link2 className="mr-1.5 h-3.5 w-3.5" />
           {isGenerating ? 'Generating…' : 'Generate link'}

--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/ShareDialog.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/ShareDialog.tsx
@@ -373,7 +373,10 @@ export function ShareDialog({ pageId: propPageId }: { pageId?: string | null } =
               )}
 
               <div className="border-t pt-4">
-                <PageShareLinkSection pageId={page.id} />
+                <PageShareLinkSection
+                  pageId={page.id}
+                  permissions={{ canEdit: permissions.canEdit, canShare: permissions.canShare, canDelete: permissions.canDelete }}
+                />
               </div>
             </TabsContent>
             <TabsContent value="permissions" className="mt-4">

--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/ShareDialog.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/ShareDialog.tsx
@@ -375,7 +375,12 @@ export function ShareDialog({ pageId: propPageId }: { pageId?: string | null } =
               <div className="border-t pt-4">
                 <PageShareLinkSection
                   pageId={page.id}
-                  permissions={{ canEdit: permissions.canEdit, canShare: permissions.canShare, canDelete: permissions.canDelete }}
+                  permissions={{
+                    canView: permissions.canView,
+                    canEdit: permissions.canEdit,
+                    canShare: permissions.canShare,
+                    canDelete: offPlatformEmail ? false : permissions.canDelete,
+                  }}
                 />
               </div>
             </TabsContent>

--- a/apps/web/src/hooks/__tests__/usePageShareLink.test.ts
+++ b/apps/web/src/hooks/__tests__/usePageShareLink.test.ts
@@ -95,7 +95,7 @@ describe('usePageShareLink', () => {
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
       await act(async () => {
-        await result.current.handleGenerate({ canEdit: false, canShare: false, canDelete: false });
+        await result.current.handleGenerate({ canView: true, canEdit: false, canShare: false, canDelete: false });
       });
 
       expect(result.current.shareUrl).toBe(SHARE_URL);
@@ -115,7 +115,7 @@ describe('usePageShareLink', () => {
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
       await act(async () => {
-        await result.current.handleGenerate({ canEdit: true, canShare: false, canDelete: false });
+        await result.current.handleGenerate({ canView: true, canEdit: true, canShare: false, canDelete: false });
       });
 
       expect(vi.mocked(post)).toHaveBeenCalledWith(
@@ -133,7 +133,7 @@ describe('usePageShareLink', () => {
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
       await act(async () => {
-        await result.current.handleGenerate({ canEdit: false, canShare: true, canDelete: true });
+        await result.current.handleGenerate({ canView: true, canEdit: false, canShare: true, canDelete: true });
       });
 
       expect(vi.mocked(post)).toHaveBeenCalledWith(
@@ -151,7 +151,7 @@ describe('usePageShareLink', () => {
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
       await act(async () => {
-        await result.current.handleGenerate({ canEdit: true, canShare: true, canDelete: true });
+        await result.current.handleGenerate({ canView: true, canEdit: true, canShare: true, canDelete: true });
       });
 
       expect(vi.mocked(post)).toHaveBeenCalledWith(

--- a/apps/web/src/hooks/__tests__/usePageShareLink.test.ts
+++ b/apps/web/src/hooks/__tests__/usePageShareLink.test.ts
@@ -82,28 +82,31 @@ describe('usePageShareLink', () => {
   });
 
   describe('generating a link', () => {
-    it('Given POST succeeds with VIEW permissions, should update shareUrl and activeLink', async () => {
+    it('Given VIEW-only permissions, should POST with only VIEW in permissions array', async () => {
       mockFetchResolve({ links: [] });
       vi.mocked(post).mockResolvedValueOnce({
         id: LINK_ID,
         rawToken: 'ps_share_abc',
         shareUrl: SHARE_URL,
       });
+      Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
 
       const { result } = renderHook(() => usePageShareLink(PAGE_ID));
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-      Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
-
       await act(async () => {
-        await result.current.handleGenerate();
+        await result.current.handleGenerate({ canEdit: false, canShare: false, canDelete: false });
       });
 
       expect(result.current.shareUrl).toBe(SHARE_URL);
       expect(result.current.activeLink?.permissions).toEqual(['VIEW']);
+      expect(vi.mocked(post)).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ permissions: ['VIEW'] })
+      );
     });
 
-    it('Given includeEdit is true before generate, should include EDIT in permissions body', async () => {
+    it('Given canEdit is true, should include EDIT in permissions body', async () => {
       mockFetchResolve({ links: [] });
       vi.mocked(post).mockResolvedValueOnce({ id: LINK_ID, rawToken: 'tok', shareUrl: SHARE_URL });
       Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
@@ -111,15 +114,49 @@ describe('usePageShareLink', () => {
       const { result } = renderHook(() => usePageShareLink(PAGE_ID));
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-      act(() => { result.current.setIncludeEdit(true); });
-
       await act(async () => {
-        await result.current.handleGenerate();
+        await result.current.handleGenerate({ canEdit: true, canShare: false, canDelete: false });
       });
 
       expect(vi.mocked(post)).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({ permissions: ['VIEW', 'EDIT'] })
+      );
+    });
+
+    it('Given canShare and canDelete are true, should include SHARE and DELETE in permissions body', async () => {
+      mockFetchResolve({ links: [] });
+      vi.mocked(post).mockResolvedValueOnce({ id: LINK_ID, rawToken: 'tok', shareUrl: SHARE_URL });
+      Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
+
+      const { result } = renderHook(() => usePageShareLink(PAGE_ID));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.handleGenerate({ canEdit: false, canShare: true, canDelete: true });
+      });
+
+      expect(vi.mocked(post)).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ permissions: ['VIEW', 'SHARE', 'DELETE'] })
+      );
+    });
+
+    it('Given all permissions true, should include all four in permissions body', async () => {
+      mockFetchResolve({ links: [] });
+      vi.mocked(post).mockResolvedValueOnce({ id: LINK_ID, rawToken: 'tok', shareUrl: SHARE_URL });
+      Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
+
+      const { result } = renderHook(() => usePageShareLink(PAGE_ID));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.handleGenerate({ canEdit: true, canShare: true, canDelete: true });
+      });
+
+      expect(vi.mocked(post)).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ permissions: ['VIEW', 'EDIT', 'SHARE', 'DELETE'] })
       );
     });
   });
@@ -159,17 +196,6 @@ describe('usePageShareLink', () => {
 
       expect(result.current.activeLink).toBeNull();
       expect(result.current.shareUrl).toBeNull();
-    });
-  });
-
-  describe('includeEdit state', () => {
-    it('should default includeEdit to false', async () => {
-      mockFetchResolve({ links: [] });
-
-      const { result } = renderHook(() => usePageShareLink(PAGE_ID));
-      await waitFor(() => expect(result.current.isLoading).toBe(false));
-
-      expect(result.current.includeEdit).toBe(false);
     });
   });
 });

--- a/apps/web/src/hooks/usePageShareLink.ts
+++ b/apps/web/src/hooks/usePageShareLink.ts
@@ -19,6 +19,7 @@ const PageListResponseSchema = z.object({
 type PageLink = z.infer<typeof PageLinkSchema>;
 
 export interface ShareLinkPermissions {
+  canView: boolean;
   canEdit: boolean;
   canShare: boolean;
   canDelete: boolean;

--- a/apps/web/src/hooks/usePageShareLink.ts
+++ b/apps/web/src/hooks/usePageShareLink.ts
@@ -7,7 +7,7 @@ import { toast } from 'sonner';
 
 const PageLinkSchema = z.object({
   id: z.string(),
-  permissions: z.array(z.enum(['VIEW', 'EDIT'])),
+  permissions: z.array(z.enum(['VIEW', 'EDIT', 'SHARE', 'DELETE'])),
   useCount: z.number(),
   shareUrl: z.string().nullable(),
 });
@@ -18,10 +18,15 @@ const PageListResponseSchema = z.object({
 
 type PageLink = z.infer<typeof PageLinkSchema>;
 
+export interface ShareLinkPermissions {
+  canEdit: boolean;
+  canShare: boolean;
+  canDelete: boolean;
+}
+
 export function usePageShareLink(pageId: string) {
   const [activeLink, setActiveLink] = useState<PageLink | null>(null);
   const [shareUrl, setShareUrl] = useState<string | null>(null);
-  const [includeEdit, setIncludeEdit] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [isGenerating, setIsGenerating] = useState(false);
   const [isRevoking, setIsRevoking] = useState(false);
@@ -53,9 +58,12 @@ export function usePageShareLink(pageId: string) {
     return () => { cancelled = true; };
   }, [pageId]);
 
-  async function handleGenerate() {
+  async function handleGenerate(perms: ShareLinkPermissions) {
     setIsGenerating(true);
-    const permissions: Array<'VIEW' | 'EDIT'> = includeEdit ? ['VIEW', 'EDIT'] : ['VIEW'];
+    const permissions: Array<'VIEW' | 'EDIT' | 'SHARE' | 'DELETE'> = ['VIEW'];
+    if (perms.canEdit)   permissions.push('EDIT');
+    if (perms.canShare)  permissions.push('SHARE');
+    if (perms.canDelete) permissions.push('DELETE');
     try {
       const data = await post<{ id: string; rawToken: string; shareUrl: string }>(
         `/api/pages/${pageId}/share-links`,
@@ -94,5 +102,5 @@ export function usePageShareLink(pageId: string) {
     }
   }
 
-  return { activeLink, shareUrl, includeEdit, setIncludeEdit, isLoading, isGenerating, isRevoking, handleGenerate, handleCopy, handleRevoke };
+  return { activeLink, shareUrl, isLoading, isGenerating, isRevoking, handleGenerate, handleCopy, handleRevoke };
 }

--- a/packages/db/src/schema/share-links.ts
+++ b/packages/db/src/schema/share-links.ts
@@ -5,7 +5,7 @@ import { users } from './auth';
 import { drives, pages } from './core';
 import { memberRole } from './members';
 
-export type ShareLinkPermission = 'VIEW' | 'EDIT';
+export type ShareLinkPermission = 'VIEW' | 'EDIT' | 'SHARE' | 'DELETE';
 
 export const driveShareLinks = pgTable('drive_share_links', {
   id: text('id').primaryKey().$defaultFn(() => createId()),

--- a/packages/lib/src/permissions/__tests__/share-link-service.test.ts
+++ b/packages/lib/src/permissions/__tests__/share-link-service.test.ts
@@ -497,6 +497,94 @@ describe('redeemPageShareLink', () => {
     expect(mockDb.insert).toHaveBeenCalledTimes(2);
   });
 
+  it('maps SHARE and DELETE permissions from link into pagePermissions insert', async () => {
+    let callCount = 0;
+    mockDb.select.mockImplementation(() => ({
+      from: vi.fn().mockReturnThis(),
+      innerJoin: vi.fn().mockReturnThis(),
+      leftJoin: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve([{
+            id: LINK_ID, pageId: PAGE_ID, driveId: DRIVE_ID,
+            permissions: ['VIEW', 'SHARE', 'DELETE'], isActive: true, expiresAt: null,
+          }]);
+        }
+        return Promise.resolve([]);
+      }),
+    }));
+    const valuesCapture = vi.fn().mockReturnThis();
+    mockDb.insert.mockReturnValue({
+      values: valuesCapture,
+      returning: vi.fn().mockResolvedValue([{ id: 'new-pp-id' }]),
+      onConflictDoNothing: vi.fn().mockResolvedValue(undefined),
+      onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+    });
+    makeUpdateChain();
+
+    await redeemPageShareLink(makeCtx(), 'valid-token');
+
+    // Second insert call is pagePermissions — check its values contain canShare and canDelete
+    const allCalls = valuesCapture.mock.calls;
+    const pagePermCall = allCalls.find((args) => {
+      const v = args[0];
+      return typeof v === 'object' && v !== null && 'canView' in v;
+    });
+    expect(pagePermCall).toBeDefined();
+    expect(pagePermCall![0]).toMatchObject({
+      canView: true,
+      canShare: true,
+      canDelete: true,
+    });
+  });
+
+  it('does not grant SHARE or DELETE when link only has VIEW+EDIT', async () => {
+    let callCount = 0;
+    mockDb.select.mockImplementation(() => ({
+      from: vi.fn().mockReturnThis(),
+      innerJoin: vi.fn().mockReturnThis(),
+      leftJoin: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve([{
+            id: LINK_ID, pageId: PAGE_ID, driveId: DRIVE_ID,
+            permissions: ['VIEW', 'EDIT'], isActive: true, expiresAt: null,
+          }]);
+        }
+        return Promise.resolve([]);
+      }),
+    }));
+    const valuesCapture = vi.fn().mockReturnThis();
+    mockDb.insert.mockReturnValue({
+      values: valuesCapture,
+      returning: vi.fn().mockResolvedValue([{ id: 'new-pp-id' }]),
+      onConflictDoNothing: vi.fn().mockResolvedValue(undefined),
+      onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+    });
+    makeUpdateChain();
+
+    await redeemPageShareLink(makeCtx(), 'valid-token');
+
+    const allCalls = valuesCapture.mock.calls;
+    const pagePermCall = allCalls.find((args) => {
+      const v = args[0];
+      return typeof v === 'object' && v !== null && 'canView' in v;
+    });
+    expect(pagePermCall).toBeDefined();
+    expect(pagePermCall![0]).toMatchObject({
+      canView: true,
+      canEdit: true,
+      canShare: false,
+      canDelete: false,
+    });
+  });
+
   it('skips useCount increment when user already has canView access', async () => {
     let callCount = 0;
     mockDb.select.mockImplementation(() => ({

--- a/packages/lib/src/permissions/share-link-service.ts
+++ b/packages/lib/src/permissions/share-link-service.ts
@@ -355,8 +355,10 @@ export async function redeemPageShareLink(
     set: { acceptedAt: new Date() },
   });
 
-  const canView = link.permissions.includes('VIEW');
-  const canEdit = link.permissions.includes('EDIT');
+  const canView   = link.permissions.includes('VIEW');
+  const canEdit   = link.permissions.includes('EDIT');
+  const canShare  = link.permissions.includes('SHARE');
+  const canDelete = link.permissions.includes('DELETE');
 
   await db
     .insert(pagePermissions)
@@ -366,16 +368,18 @@ export async function redeemPageShareLink(
       userId: ctx.userId,
       canView,
       canEdit,
-      canShare: false,
-      canDelete: false,
+      canShare,
+      canDelete,
       grantedBy: null,
       grantedAt: new Date(),
     })
     .onConflictDoUpdate({
       target: [pagePermissions.pageId, pagePermissions.userId],
       set: {
-        canView: sql`${pagePermissions.canView} OR EXCLUDED."canView"`,
-        canEdit: sql`${pagePermissions.canEdit} OR EXCLUDED."canEdit"`,
+        canView:   sql`${pagePermissions.canView}   OR EXCLUDED."canView"`,
+        canEdit:   sql`${pagePermissions.canEdit}   OR EXCLUDED."canEdit"`,
+        canShare:  sql`${pagePermissions.canShare}  OR EXCLUDED."canShare"`,
+        canDelete: sql`${pagePermissions.canDelete} OR EXCLUDED."canDelete"`,
         grantedAt: new Date(),
       },
     });


### PR DESCRIPTION
## Summary

- Removes the standalone "Allow editing" toggle from the share link section — it no longer has its own permission control
- The existing View/Edit/Share/Delete matrix (already used for email invites) now controls both delivery methods — set permissions once, then share via email or generate a link
- Extends \`ShareLinkPermission\` to include \`SHARE\` and \`DELETE\` so link-based invites can grant the full permission set on redemption
- Updates \`redeemPageShareLink\` to map all four permissions (with OR-merge conflict logic for existing users)
- Generate link button is disabled when View is unchecked, preventing links from granting broader access than the selected permissions state
- When in off-platform email mode, \`canDelete\` is explicitly excluded from link generation (matching the visual state where Delete shows as disabled)

## Test plan

- [ ] Open Share dialog on any page → Share tab
- [ ] Confirm no separate "Allow editing" toggle exists in the link section
- [ ] Check "Edit" in the matrix → Generate link → redeem as another user → confirm \`canEdit: true\`
- [ ] Check "Share" → Generate link → redeem → confirm \`canShare: true\`
- [ ] Uncheck "View" → confirm Generate link button is disabled
- [ ] Enter off-platform email → check that Delete is visually off → Generate link → confirm link does NOT grant Delete
- [ ] Existing VIEW-only links still show "View only" badge; VIEW+EDIT shows "View, Edit"
- [ ] Off-platform email invite still works (Delete excluded from off-platform path — unchanged)
- [ ] \`pnpm test:unit\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)