### PR TITLE
fix(permissions): treat drive as root parent node for page creation access

### DIFF
--- a/apps/web/src/app/api/drives/[driveId]/permissions-tree/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/permissions-tree/__tests__/route.test.ts
@@ -85,12 +85,16 @@ vi.mock('@pagespace/lib/logging/logger-config', () => ({
 
   logger: { child: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() })) },
 }));
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  getUserAccessLevel: vi.fn(),
+}));
 
 // ---------- imports (after mocks) ----------
 
 import { GET } from '../route';
 import { verifyAuth } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config';
+import { getUserAccessLevel } from '@pagespace/lib/permissions/permissions';
 
 // ---------- helpers ----------
 
@@ -146,6 +150,9 @@ describe('GET /api/drives/[driveId]/permissions-tree', () => {
 
     // Default: no permissions
     mockPermResults.value = [];
+
+    // Default: getUserAccessLevel returns null (overridden in specific tests)
+    vi.mocked(getUserAccessLevel).mockResolvedValue(null);
   });
 
   // ---------- Authentication ----------
@@ -403,13 +410,16 @@ describe('GET /api/drives/[driveId]/permissions-tree', () => {
     });
 
     it('drive root node has currentPermissions when userId query param provided (owner case)', async () => {
+      vi.mocked(getUserAccessLevel).mockResolvedValue({
+        canView: true, canEdit: true, canShare: true, canDelete: true,
+      });
+
       const response = await GET(
         createRequest(mockDriveId, `?userId=${mockUserId}`),
         createContext(mockDriveId)
       );
       const body = await response.json();
 
-      // Drive owner gets full edit access on the drive root node
       expect(body.pages[0].currentPermissions).toEqual({
         canView: true,
         canEdit: true,

--- a/apps/web/src/app/api/drives/[driveId]/permissions-tree/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/permissions-tree/__tests__/route.test.ts
@@ -231,7 +231,9 @@ describe('GET /api/drives/[driveId]/permissions-tree', () => {
         slug: 'test-drive',
         ownerId: mockUserId,
       });
-      expect(body.pages).toEqual([]);
+      // pages[0] is always the drive root node; no page nodes beyond that
+      expect(body.pages).toHaveLength(1);
+      expect(body.pages[0].type).toBe('DRIVE');
       expect(body.totalPages).toBe(0);
     });
 
@@ -246,13 +248,14 @@ describe('GET /api/drives/[driveId]/permissions-tree', () => {
 
       expect(response.status).toBe(200);
       expect(body.totalPages).toBe(2);
-      expect(body.pages).toHaveLength(1);
-      expect(body.pages[0].id).toBe('p1');
-      expect(body.pages[0].title).toBe('Root');
-      expect(body.pages[0].children).toHaveLength(1);
-      expect(body.pages[0].children[0].id).toBe('p2');
-      expect(body.pages[0].children[0].title).toBe('Child');
-      expect(body.pages[0].children[0].children).toEqual([]);
+      // pages[0] = drive root, pages[1] = p1 (with p2 as child)
+      expect(body.pages).toHaveLength(2);
+      expect(body.pages[1].id).toBe('p1');
+      expect(body.pages[1].title).toBe('Root');
+      expect(body.pages[1].children).toHaveLength(1);
+      expect(body.pages[1].children[0].id).toBe('p2');
+      expect(body.pages[1].children[0].title).toBe('Child');
+      expect(body.pages[1].children[0].children).toEqual([]);
     });
 
     it('should sort children by position', async () => {
@@ -265,8 +268,8 @@ describe('GET /api/drives/[driveId]/permissions-tree', () => {
       const response = await GET(createRequest(), createContext(mockDriveId));
       const body = await response.json();
 
-      expect(body.pages[0].children[0].title).toBe('First');
-      expect(body.pages[0].children[1].title).toBe('Second');
+      expect(body.pages[1].children[0].title).toBe('First');
+      expect(body.pages[1].children[1].title).toBe('Second');
     });
 
     it('should include type and position fields in page nodes', async () => {
@@ -277,8 +280,8 @@ describe('GET /api/drives/[driveId]/permissions-tree', () => {
       const response = await GET(createRequest(), createContext(mockDriveId));
       const body = await response.json();
 
-      expect(body.pages[0].type).toBe('document');
-      expect(body.pages[0].position).toBe(5);
+      expect(body.pages[1].type).toBe('document');
+      expect(body.pages[1].position).toBe(5);
     });
   });
 
@@ -300,7 +303,7 @@ describe('GET /api/drives/[driveId]/permissions-tree', () => {
       const body = await response.json();
 
       expect(response.status).toBe(200);
-      expect(body.pages[0].currentPermissions).toEqual({
+      expect(body.pages[1].currentPermissions).toEqual({
         canView: true,
         canEdit: true,
         canShare: false,
@@ -319,14 +322,14 @@ describe('GET /api/drives/[driveId]/permissions-tree', () => {
       );
       const body = await response.json();
 
-      expect(body.pages[0].currentPermissions).toEqual({
+      expect(body.pages[1].currentPermissions).toEqual({
         canView: false,
         canEdit: false,
         canShare: false,
       });
     });
 
-    it('should return default permissions when no targetUserId is provided', async () => {
+    it('should return no currentPermissions on page nodes when no targetUserId is provided', async () => {
       mockPagesResults.value = [
         { id: 'p1', title: 'Root', type: 'page', parentId: null, position: 0, isTrashed: false },
       ];
@@ -334,7 +337,8 @@ describe('GET /api/drives/[driveId]/permissions-tree', () => {
       const response = await GET(createRequest(), createContext(mockDriveId));
       const body = await response.json();
 
-      expect(body.pages[0].currentPermissions).toEqual({
+      // Without userId the route still attaches default false permissions on page nodes
+      expect(body.pages[1].currentPermissions).toEqual({
         canView: false,
         canEdit: false,
         canShare: false,
@@ -356,18 +360,68 @@ describe('GET /api/drives/[driveId]/permissions-tree', () => {
       );
       const body = await response.json();
 
+      // pages[0] = drive root, pages[1] = p1, pages[2] = p2
       // p1 has no permissions
-      expect(body.pages[0].currentPermissions).toEqual({
+      expect(body.pages[1].currentPermissions).toEqual({
         canView: false,
         canEdit: false,
         canShare: false,
       });
       // p2 has specific permissions
-      expect(body.pages[1].currentPermissions).toEqual({
+      expect(body.pages[2].currentPermissions).toEqual({
         canView: true,
         canEdit: false,
         canShare: true,
       });
+    });
+  });
+
+  // ---------- Drive root node ----------
+
+  describe('drive root node', () => {
+    it('includes drive as first node in pages array with type DRIVE', async () => {
+      const response = await GET(createRequest(), createContext(mockDriveId));
+      const body = await response.json();
+
+      expect(body.pages[0]).toMatchObject({
+        id: mockDriveId,
+        title: mockDrive.name,
+        type: 'DRIVE',
+      });
+    });
+
+    it('drive root node appears before page nodes', async () => {
+      mockPagesResults.value = [
+        { id: 'p1', title: 'Page 1', type: 'DOCUMENT', parentId: null, position: 1, isTrashed: false },
+      ];
+
+      const response = await GET(createRequest(), createContext(mockDriveId));
+      const body = await response.json();
+
+      expect(body.pages[0].type).toBe('DRIVE');
+      expect(body.pages[1].id).toBe('p1');
+    });
+
+    it('drive root node has currentPermissions when userId query param provided (owner case)', async () => {
+      const response = await GET(
+        createRequest(mockDriveId, `?userId=${mockUserId}`),
+        createContext(mockDriveId)
+      );
+      const body = await response.json();
+
+      // Drive owner gets full edit access on the drive root node
+      expect(body.pages[0].currentPermissions).toEqual({
+        canView: true,
+        canEdit: true,
+        canShare: true,
+      });
+    });
+
+    it('drive root node has no currentPermissions when no userId param', async () => {
+      const response = await GET(createRequest(), createContext(mockDriveId));
+      const body = await response.json();
+
+      expect(body.pages[0].currentPermissions).toBeUndefined();
     });
   });
 

--- a/apps/web/src/app/api/drives/[driveId]/permissions-tree/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/permissions-tree/route.ts
@@ -20,6 +20,7 @@ interface PageNode {
   };
 }
 
+
 export async function GET(
   request: Request,
   context: { params: Promise<{ driveId: string }> }
@@ -119,7 +120,6 @@ export async function GET(
 
     const tree = buildTree(null);
 
-    // Also return drive info
     const driveInfo = {
       id: drive[0].id,
       name: drive[0].name,
@@ -127,11 +127,52 @@ export async function GET(
       ownerId: drive[0].ownerId,
     };
 
+    // Drive-as-root-node: prepend a synthetic drive root node so the UI
+    // permission matrix can display and edit drive-level access (which gates
+    // root-level page creation) using the same code path as page nodes.
+    let driveRootPermissions: { canView: boolean; canEdit: boolean; canShare: boolean } | undefined;
+    if (targetUserId) {
+      if (targetUserId === drive[0].ownerId) {
+        driveRootPermissions = { canView: true, canEdit: true, canShare: true };
+      } else {
+        // Check for an explicit drive-level entry in the permissions map
+        // (used by agent custom roles which store the driveId as a key)
+        const explicit = existingPermissions.get(driveId);
+        if (explicit) {
+          driveRootPermissions = explicit;
+        } else {
+          // Check drive membership role to determine default access
+          const membership = await db.select({ role: driveMembers.role })
+            .from(driveMembers)
+            .where(and(
+              eq(driveMembers.driveId, driveId),
+              eq(driveMembers.userId, targetUserId),
+              isNotNull(driveMembers.acceptedAt)
+            ))
+            .limit(1);
+          if (membership.length > 0) {
+            driveRootPermissions = { canView: true, canEdit: true, canShare: true };
+          } else {
+            driveRootPermissions = { canView: false, canEdit: false, canShare: false };
+          }
+        }
+      }
+    }
+
+    const driveRootNode: PageNode = {
+      id: driveInfo.id,
+      title: driveInfo.name,
+      type: 'DRIVE',
+      position: -1,
+      children: [],
+      ...(driveRootPermissions !== undefined ? { currentPermissions: driveRootPermissions } : {}),
+    };
+
     auditRequest(request, { eventType: 'data.read', userId: user.id, resourceType: 'drive_permissions', resourceId: driveId, details: { action: 'view_permissions_tree', pageCount: allPages.length } });
 
     return NextResponse.json({
       drive: driveInfo,
-      pages: tree,
+      pages: [driveRootNode, ...tree],
       totalPages: allPages.length,
     });
   } catch (error) {

--- a/apps/web/src/app/api/drives/[driveId]/permissions-tree/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/permissions-tree/route.ts
@@ -6,6 +6,7 @@ import { pagePermissions, driveMembers } from '@pagespace/db/schema/members';
 import { verifyAuth } from '@/lib/auth';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { getUserAccessLevel } from '@pagespace/lib/permissions/permissions';
 
 interface PageNode {
   id: string;
@@ -132,30 +133,16 @@ export async function GET(
     // root-level page creation) using the same code path as page nodes.
     let driveRootPermissions: { canView: boolean; canEdit: boolean; canShare: boolean } | undefined;
     if (targetUserId) {
-      if (targetUserId === drive[0].ownerId) {
-        driveRootPermissions = { canView: true, canEdit: true, canShare: true };
+      // Explicit drive-level entry in the permissions map takes precedence
+      // (used by agent custom roles which store the driveId as a key).
+      const explicit = existingPermissions.get(driveId);
+      if (explicit) {
+        driveRootPermissions = explicit;
       } else {
-        // Check for an explicit drive-level entry in the permissions map
-        // (used by agent custom roles which store the driveId as a key)
-        const explicit = existingPermissions.get(driveId);
-        if (explicit) {
-          driveRootPermissions = explicit;
-        } else {
-          // Check drive membership role to determine default access
-          const membership = await db.select({ role: driveMembers.role })
-            .from(driveMembers)
-            .where(and(
-              eq(driveMembers.driveId, driveId),
-              eq(driveMembers.userId, targetUserId),
-              isNotNull(driveMembers.acceptedAt)
-            ))
-            .limit(1);
-          if (membership.length > 0) {
-            driveRootPermissions = { canView: true, canEdit: true, canShare: true };
-          } else {
-            driveRootPermissions = { canView: false, canEdit: false, canShare: false };
-          }
-        }
+        const access = await getUserAccessLevel(targetUserId, driveId);
+        driveRootPermissions = access
+          ? { canView: access.canView, canEdit: access.canEdit, canShare: access.canShare }
+          : { canView: false, canEdit: false, canShare: false };
       }
     }
 

--- a/apps/web/src/app/dashboard/[driveId]/members/[userId]/page.tsx
+++ b/apps/web/src/app/dashboard/[driveId]/members/[userId]/page.tsx
@@ -437,6 +437,7 @@ export default function MemberSettingsPage() {
                 userId={userId}
                 permissions={permissions}
                 onChange={handlePermissionChange}
+                readOnlyDriveRoot
               />
             </CardContent>
           </Card>

--- a/apps/web/src/app/dashboard/[driveId]/members/invite/page.tsx
+++ b/apps/web/src/app/dashboard/[driveId]/members/invite/page.tsx
@@ -451,6 +451,7 @@ export default function InviteMemberPage() {
                     driveId={driveId}
                     permissions={permissions}
                     onChange={handlePermissionChange}
+                    readOnlyDriveRoot
                   />
                 </CardContent>
               </Card>

--- a/apps/web/src/components/members/PermissionsGrid.tsx
+++ b/apps/web/src/components/members/PermissionsGrid.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef, forwardRef, useImperativeHandle, useCallback } from 'react';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Button } from '@/components/ui/button';
-import { ChevronRight, ChevronDown } from 'lucide-react';
+import { ChevronRight, ChevronDown, HardDrive } from 'lucide-react';
 import { PageTypeIcon } from '@/components/common/PageTypeIcon';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
@@ -203,7 +203,44 @@ export const PermissionsGrid = forwardRef<PermissionsGridRef, PermissionsGridPro
     clearAll(pages);
   };
 
+  const renderDriveRootRow = (page: PageNode) => {
+    const perms = permissions.get(page.id) || { canView: false, canEdit: false, canShare: false };
+    return (
+      <div key={page.id} className="flex items-center p-2 bg-blue-50 dark:bg-blue-900/20 border-b-2 border-blue-200 dark:border-blue-700">
+        <div className="flex-1 flex items-center space-x-2">
+          <HardDrive className="w-4 h-4 text-blue-600 dark:text-blue-400 shrink-0" />
+          <span className="font-semibold truncate">{page.title}</span>
+          <span className="text-xs text-gray-500 dark:text-gray-400 shrink-0">(drive root — controls root-level page creation)</span>
+        </div>
+        <div className="w-[100px] flex justify-center">
+          <Checkbox
+            checked={perms.canView}
+            onCheckedChange={(checked) => handlePermissionChange(page.id, 'canView', !!checked)}
+          />
+        </div>
+        <div className="w-[100px] flex justify-center">
+          <Checkbox
+            checked={perms.canEdit}
+            disabled={!perms.canView}
+            onCheckedChange={(checked) => handlePermissionChange(page.id, 'canEdit', !!checked)}
+          />
+        </div>
+        <div className="w-[100px] flex justify-center">
+          <Checkbox
+            checked={perms.canShare}
+            disabled={!perms.canView}
+            onCheckedChange={(checked) => handlePermissionChange(page.id, 'canShare', !!checked)}
+          />
+        </div>
+      </div>
+    );
+  };
+
   const renderPageRow = (page: PageNode, depth: number = 0) => {
+    if (page.type === 'DRIVE') {
+      return renderDriveRootRow(page);
+    }
+
     const perms = permissions.get(page.id) || { canView: false, canEdit: false, canShare: false };
     const hasChildren = page.children && page.children.length > 0;
     const isExpanded = expandedNodes.has(page.id);
@@ -212,7 +249,7 @@ export const PermissionsGrid = forwardRef<PermissionsGridRef, PermissionsGridPro
       <div key={page.id}>
         <div className="flex items-center p-2 bg-gray-50 dark:bg-gray-800/50 hover:bg-gray-100 dark:hover:bg-gray-700/50 border-b border-gray-200 dark:border-gray-700">
           {/* Page Name with Indentation */}
-          <div 
+          <div
             className="flex-1 flex items-center cursor-pointer"
             style={{ paddingLeft: `${depth * 20}px` }}
             onClick={() => hasChildren && toggleExpanded(page.id)}
@@ -238,30 +275,30 @@ export const PermissionsGrid = forwardRef<PermissionsGridRef, PermissionsGridPro
               </button>
             )}
           </div>
-          
+
           {/* Permission Checkboxes */}
           <div className="w-[100px] flex justify-center">
-            <Checkbox 
+            <Checkbox
               checked={perms.canView}
               onCheckedChange={(checked) => handlePermissionChange(page.id, 'canView', !!checked)}
             />
           </div>
           <div className="w-[100px] flex justify-center">
-            <Checkbox 
+            <Checkbox
               checked={perms.canEdit}
               disabled={!perms.canView}
               onCheckedChange={(checked) => handlePermissionChange(page.id, 'canEdit', !!checked)}
             />
           </div>
           <div className="w-[100px] flex justify-center">
-            <Checkbox 
+            <Checkbox
               checked={perms.canShare}
               disabled={!perms.canView}
               onCheckedChange={(checked) => handlePermissionChange(page.id, 'canShare', !!checked)}
             />
           </div>
         </div>
-        
+
         {/* Render Children */}
         {hasChildren && isExpanded && (
           <div>

--- a/apps/web/src/components/members/PermissionsGrid.tsx
+++ b/apps/web/src/components/members/PermissionsGrid.tsx
@@ -25,6 +25,10 @@ interface PermissionsGridProps {
   userId?: string;
   permissions: Map<string, { canView: boolean; canEdit: boolean; canShare: boolean }>;
   onChange: (pageId: string, perms: { canView: boolean; canEdit: boolean; canShare: boolean }) => void;
+  /** When true, the drive root row is shown as informational only (checkboxes disabled).
+   *  Use in member management context where drive-level access is derived from membership role,
+   *  not from the permissions JSONB. */
+  readOnlyDriveRoot?: boolean;
 }
 
 export interface PermissionsGridRef {
@@ -32,7 +36,7 @@ export interface PermissionsGridRef {
 }
 
 export const PermissionsGrid = forwardRef<PermissionsGridRef, PermissionsGridProps>(function PermissionsGrid(
-  { driveId, userId, permissions, onChange },
+  { driveId, userId, permissions, onChange, readOnlyDriveRoot = false },
   ref
 ) {
   const [pages, setPages] = useState<PageNode[]>([]);
@@ -210,25 +214,30 @@ export const PermissionsGrid = forwardRef<PermissionsGridRef, PermissionsGridPro
         <div className="flex-1 flex items-center space-x-2">
           <HardDrive className="w-4 h-4 text-blue-600 dark:text-blue-400 shrink-0" />
           <span className="font-semibold truncate">{page.title}</span>
-          <span className="text-xs text-gray-500 dark:text-gray-400 shrink-0">(drive root — controls root-level page creation)</span>
+          <span className="text-xs text-gray-500 dark:text-gray-400 shrink-0">
+            {readOnlyDriveRoot
+              ? '(drive root — access derived from membership role)'
+              : '(drive root — controls root-level page creation)'}
+          </span>
         </div>
         <div className="w-[100px] flex justify-center">
           <Checkbox
             checked={perms.canView}
+            disabled={readOnlyDriveRoot}
             onCheckedChange={(checked) => handlePermissionChange(page.id, 'canView', !!checked)}
           />
         </div>
         <div className="w-[100px] flex justify-center">
           <Checkbox
             checked={perms.canEdit}
-            disabled={!perms.canView}
+            disabled={readOnlyDriveRoot || !perms.canView}
             onCheckedChange={(checked) => handlePermissionChange(page.id, 'canEdit', !!checked)}
           />
         </div>
         <div className="w-[100px] flex justify-center">
           <Checkbox
             checked={perms.canShare}
-            disabled={!perms.canView}
+            disabled={readOnlyDriveRoot || !perms.canView}
             onCheckedChange={(checked) => handlePermissionChange(page.id, 'canShare', !!checked)}
           />
         </div>

--- a/apps/web/src/components/members/PermissionsGrid.tsx
+++ b/apps/web/src/components/members/PermissionsGrid.tsx
@@ -53,13 +53,14 @@ export const PermissionsGrid = forwardRef<PermissionsGridRef, PermissionsGridPro
   const applyPermissionsToTree = useCallback((rolePerms: Record<string, { canView: boolean; canEdit: boolean; canShare: boolean }>, nodes: PageNode[]) => {
     const applyRecursive = (permsMap: typeof rolePerms, nodeList: PageNode[]) => {
       nodeList.forEach(node => {
+        if (node.type === 'DRIVE' && readOnlyDriveRoot) return;
         const perms = permsMap[node.id];
         onChange(node.id, perms || { canView: false, canEdit: false, canShare: false });
         if (node.children) applyRecursive(permsMap, node.children);
       });
     };
     applyRecursive(rolePerms, nodes);
-  }, [onChange]);
+  }, [onChange, readOnlyDriveRoot]);
 
   // Expose applyRolePermissions to parent via ref
   useImperativeHandle(ref, () => ({
@@ -180,6 +181,7 @@ export const PermissionsGrid = forwardRef<PermissionsGridRef, PermissionsGridPro
   const selectAll = () => {
     const applyToAll = (nodes: PageNode[]) => {
       nodes.forEach(node => {
+        if (node.type === 'DRIVE' && readOnlyDriveRoot) return;
         onChange(node.id, { canView: true, canEdit: false, canShare: false });
         if (node.children) applyToAll(node.children);
       });
@@ -190,6 +192,7 @@ export const PermissionsGrid = forwardRef<PermissionsGridRef, PermissionsGridPro
   const selectAllPermissions = () => {
     const applyToAll = (nodes: PageNode[]) => {
       nodes.forEach(node => {
+        if (node.type === 'DRIVE' && readOnlyDriveRoot) return;
         onChange(node.id, { canView: true, canEdit: true, canShare: true });
         if (node.children) applyToAll(node.children);
       });
@@ -200,6 +203,7 @@ export const PermissionsGrid = forwardRef<PermissionsGridRef, PermissionsGridPro
   const selectNone = () => {
     const clearAll = (nodes: PageNode[]) => {
       nodes.forEach(node => {
+        if (node.type === 'DRIVE' && readOnlyDriveRoot) return;
         onChange(node.id, { canView: false, canEdit: false, canShare: false });
         if (node.children) clearAll(node.children);
       });

--- a/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
@@ -14,7 +14,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
     canUserEditPage: vi.fn(),
     canUserDeletePage: vi.fn(),
-    isUserDriveMember: vi.fn(),
+}));
+vi.mock('@pagespace/lib/permissions/agent-permissions', () => ({
+    getAgentAccessLevel: vi.fn(),
+    hasAgentDriveMembership: vi.fn(),
+    getAgentAccessiblePagesInDrive: vi.fn(),
 }));
 vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
     logPageActivity: vi.fn(),
@@ -112,14 +116,15 @@ vi.mock('@/lib/logging/mask', () => ({
 }));
 
 import { pageWriteTools } from '../page-write-tools';
-import { canUserEditPage, isUserDriveMember } from '@pagespace/lib/permissions/permissions';
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
+import { getAgentAccessLevel } from '@pagespace/lib/permissions/agent-permissions';
 import { pageRepository } from '@pagespace/lib/repositories/page-repository';
 import { driveRepository } from '@pagespace/lib/repositories/drive-repository';
 import { applyPageMutation } from '@/services/api/page-mutation-service';
 import type { ToolExecutionContext } from '../../core';
 
 const mockCanUserEditPage = vi.mocked(canUserEditPage);
-const mockIsUserDriveMember = vi.mocked(isUserDriveMember);
+const mockGetAgentAccessLevel = vi.mocked(getAgentAccessLevel);
 const mockPageRepo = vi.mocked(pageRepository);
 const mockDriveRepo = vi.mocked(driveRepository);
 const mockApplyPageMutation = vi.mocked(applyPageMutation);
@@ -370,14 +375,9 @@ describe('page-write-tools', () => {
       expect(mockDriveRepo.findByIdBasic).toHaveBeenCalledWith('non-existent');
     });
 
-    it('creates page successfully at root level for non-owner member', async () => {
-      // Arrange — actor is a member, NOT the drive owner, to verify the new
-      // membership check (not the old owner-only guard) is what grants access.
-      mockDriveRepo.findByIdBasic.mockResolvedValue({
-        id: 'drive-1',
-        ownerId: 'owner-999',
-      });
-      mockIsUserDriveMember.mockResolvedValue(true);
+    it('creates page successfully at root level for a drive member (user)', async () => {
+      mockDriveRepo.findByIdBasic.mockResolvedValue({ id: 'drive-1', ownerId: 'owner-999' });
+      mockCanUserEditPage.mockResolvedValue(true);
       mockPageRepo.getNextPosition.mockResolvedValue(1);
       mockPageRepo.create.mockResolvedValue({
         id: 'new-page-1',
@@ -390,34 +390,83 @@ describe('page-write-tools', () => {
         experimental_context: { userId: 'user-123' } as ToolExecutionContext,
       };
 
-      // Act
       const result = await pageWriteTools.create_page.execute!(
         { driveId: 'drive-1', title: 'New Page', type: 'DOCUMENT' },
         context
       );
 
-      // Assert: observable outcomes
-      if ('error' in result) throw new Error(`Expected success but got error`);
+      if ('error' in result) throw new Error('Expected success');
       const success = result as { success: boolean; id: string; title: string };
       expect(success.success).toBe(true);
       expect(success.id).toBe('new-page-1');
-      expect(success.title).toBe('New Page');
-
-      // Verify membership check was used, not the old owner-only guard
-      expect(mockIsUserDriveMember).toHaveBeenCalledWith('user-123', 'drive-1');
-
-      // Verify repository was called with correct payload
+      // drive treated as root parent: canUserEditPage called with driveId
+      expect(mockCanUserEditPage).toHaveBeenCalledWith('user-123', 'drive-1');
       expect(mockPageRepo.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          title: 'New Page',
-          type: 'DOCUMENT',
-          content: '',
-          position: 1,
-          driveId: 'drive-1',
-          parentId: null,
-          isTrashed: false,
-        })
+        expect.objectContaining({ title: 'New Page', type: 'DOCUMENT', driveId: 'drive-1', parentId: null })
       );
+    });
+
+    it('blocks root-level creation when user lacks drive edit access', async () => {
+      mockDriveRepo.findByIdBasic.mockResolvedValue({ id: 'drive-1', ownerId: 'owner-999' });
+      mockCanUserEditPage.mockResolvedValue(false);
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      await expect(
+        pageWriteTools.create_page.execute!(
+          { driveId: 'drive-1', title: 'New Page', type: 'DOCUMENT' },
+          context
+        )
+      ).rejects.toThrow('Insufficient permissions to create pages in this drive');
+    });
+
+    it('allows ADMIN agent to create root-level pages', async () => {
+      mockDriveRepo.findByIdBasic.mockResolvedValue({ id: 'drive-1', ownerId: 'owner-999' });
+      mockGetAgentAccessLevel.mockResolvedValue({ canView: true, canEdit: true, canShare: true, canDelete: true });
+      mockPageRepo.getNextPosition.mockResolvedValue(1);
+      mockPageRepo.create.mockResolvedValue({ id: 'new-page-1', title: 'New Page', type: 'DOCUMENT' });
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: {
+          userId: 'user-123',
+          chatSource: { type: 'page', agentPageId: 'agent-page-1' },
+        } as unknown as ToolExecutionContext,
+      };
+
+      const result = await pageWriteTools.create_page.execute!(
+        { driveId: 'drive-1', title: 'New Page', type: 'DOCUMENT' },
+        context
+      );
+
+      if ('error' in result) throw new Error('Expected success');
+      const success = result as { success: boolean; id: string };
+      expect(success.success).toBe(true);
+      // agent permission checked with drive ID as the node
+      expect(mockGetAgentAccessLevel).toHaveBeenCalledWith('agent-page-1', 'drive-1');
+    });
+
+    it('blocks MEMBER agent (no custom role) from root-level page creation', async () => {
+      mockDriveRepo.findByIdBasic.mockResolvedValue({ id: 'drive-1', ownerId: 'owner-999' });
+      mockGetAgentAccessLevel.mockResolvedValue({ canView: true, canEdit: false, canShare: false, canDelete: false });
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: {
+          userId: 'user-123',
+          chatSource: { type: 'page', agentPageId: 'agent-page-1' },
+        } as unknown as ToolExecutionContext,
+      };
+
+      await expect(
+        pageWriteTools.create_page.execute!(
+          { driveId: 'drive-1', title: 'New Page', type: 'DOCUMENT' },
+          context
+        )
+      ).rejects.toThrow('Insufficient permissions to create pages in this drive');
     });
   });
 

--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -1,6 +1,5 @@
 import { tool } from 'ai';
 import { z } from 'zod';
-import { isUserDriveMember } from '@pagespace/lib/permissions/permissions';
 import { canActorEditPage, canActorDeletePage } from './actor-permissions';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { isAIChatPage, isDocumentPage, isCodePage, getDefaultContent, getCreatablePageTypes } from '@pagespace/lib/content/page-types.config';
@@ -552,18 +551,18 @@ export const pageWriteTools = {
           }
         }
 
-        // Check permissions for page creation
+        // Check permissions for page creation.
+        // The drive is the root parent node: creating a child anywhere requires
+        // canEdit on the parent. For root-level pages the drive is the parent.
         if (parentId) {
-          // Creating in a folder - check permissions on parent page
-          const canEdit = await canActorEditPage(context as ToolExecutionContext,parentId);
+          const canEdit = await canActorEditPage(context as ToolExecutionContext, parentId);
           if (!canEdit) {
             throw new Error('Insufficient permissions to create pages in this folder');
           }
         } else {
-          // Creating at root level - any drive member can create
-          const isMember = await isUserDriveMember(userId, driveId);
-          if (!isMember) {
-            throw new Error('You must be a drive member to create pages at the root level');
+          const canEdit = await canActorEditPage(context as ToolExecutionContext, driveId);
+          if (!canEdit) {
+            throw new Error('Insufficient permissions to create pages in this drive');
           }
         }
 

--- a/apps/web/src/services/api/page-service.ts
+++ b/apps/web/src/services/api/page-service.ts
@@ -605,8 +605,8 @@ export const pageService = {
       return { success: false, error: 'Drive not found', status: 404 };
     }
 
-    // Check authorization — mirror the AI tool's split: nested pages require
-    // edit permission on the parent; root-level pages require drive membership.
+    // Check authorization — nested pages require edit permission on the parent;
+    // root-level pages treat the drive as the root parent and require canEdit on the drive.
     if (params.parentId) {
       const parentPage = await db.query.pages.findFirst({
         where: and(eq(pages.id, params.parentId), eq(pages.driveId, params.driveId)),

--- a/apps/web/src/services/api/page-service.ts
+++ b/apps/web/src/services/api/page-service.ts
@@ -11,7 +11,7 @@ import { validatePageMove } from '@pagespace/lib/pages/circular-reference-guard'
 import { validatePageCreation, validateAIChatTools } from '@pagespace/lib/content/page-type-validators'
 import { getDefaultContent, isAIChatPage } from '@pagespace/lib/content/page-types.config'
 import { PageType as PageTypeEnum } from '@pagespace/lib/utils/enums'
-import { isDriveOwnerOrAdmin, isUserDriveMember } from '@pagespace/lib/permissions/permissions';
+import { isDriveOwnerOrAdmin } from '@pagespace/lib/permissions/permissions';
 import { createChangeGroupId, inferChangeGroupType } from '@pagespace/lib/monitoring/change-group';
 import { logActivityWithTx, type DeferredWorkflowTrigger } from '@pagespace/lib/monitoring/activity-logger';
 import { createId } from '@paralleldrive/cuid2';
@@ -620,9 +620,9 @@ export const pageService = {
         return { success: false, error: 'Insufficient permissions to create pages in this folder', status: 403 };
       }
     } else {
-      const isMember = await isUserDriveMember(userId, params.driveId);
-      if (!isMember) {
-        return { success: false, error: 'You must be a drive member to create pages', status: 403 };
+      const canEdit = await canUserEditPage(userId, params.driveId);
+      if (!canEdit) {
+        return { success: false, error: 'Insufficient permissions to create pages in this drive', status: 403 };
       }
     }
 

--- a/packages/lib/src/permissions/__tests__/agent-permissions.test.ts
+++ b/packages/lib/src/permissions/__tests__/agent-permissions.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@pagespace/db/db', () => ({
+  db: { select: vi.fn() },
+}));
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'id', driveId: 'driveId' },
+  drives: { id: 'id', ownerId: 'ownerId' },
+}));
+vi.mock('@pagespace/db/schema/members', () => ({
+  driveAgentMembers: {
+    id: 'id',
+    agentPageId: 'agentPageId',
+    driveId: 'driveId',
+    role: 'role',
+    customRoleId: 'customRoleId',
+  },
+  driveRoles: {
+    id: 'id',
+    permissions: 'permissions',
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((_a: unknown, _b: unknown) => 'eq'),
+  and: vi.fn((...args: unknown[]) => ({ and: args })),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import { getAgentAccessLevel, hasAgentDriveMembership } from '../agent-permissions';
+import { db } from '@pagespace/db/db';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const AGENT_PAGE_ID = 'agent_aaaaaaaaaaaaaaaaaaaaaa';
+const TARGET_PAGE_ID = 'page_bbbbbbbbbbbbbbbbbbbbbbb';
+const DRIVE_ID = 'drive_cccccccccccccccccccccc';
+const CUSTOM_ROLE_ID = 'role_dddddddddddddddddddddd';
+
+function stubSelect(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  } as unknown as ReturnType<typeof db.select>;
+}
+
+// ---------------------------------------------------------------------------
+// getAgentAccessLevel — existing page-level behaviour
+// ---------------------------------------------------------------------------
+
+describe('getAgentAccessLevel — page targets', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns null when agent has no membership in the drive', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect([{ driveId: DRIVE_ID }]))   // page lookup
+      .mockReturnValueOnce(stubSelect([]));                         // membership lookup
+
+    const result = await getAgentAccessLevel(AGENT_PAGE_ID, TARGET_PAGE_ID);
+    expect(result).toBeNull();
+  });
+
+  it('returns full access for ADMIN role agent', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect([{ driveId: DRIVE_ID }]))
+      .mockReturnValueOnce(stubSelect([{ role: 'ADMIN', customRoleId: null }]));
+
+    const result = await getAgentAccessLevel(AGENT_PAGE_ID, TARGET_PAGE_ID);
+    expect(result).toEqual({ canView: true, canEdit: true, canShare: true, canDelete: true });
+  });
+
+  it('returns view-only for MEMBER agent with no custom role', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect([{ driveId: DRIVE_ID }]))
+      .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: null }]));
+
+    const result = await getAgentAccessLevel(AGENT_PAGE_ID, TARGET_PAGE_ID);
+    expect(result).toEqual({ canView: true, canEdit: false, canShare: false, canDelete: false });
+  });
+
+  it('returns custom role permissions for MEMBER agent with custom role', async () => {
+    const perms = { [TARGET_PAGE_ID]: { canView: true, canEdit: true, canShare: false } };
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect([{ driveId: DRIVE_ID }]))
+      .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: CUSTOM_ROLE_ID }]))
+      .mockReturnValueOnce(stubSelect([{ permissions: perms }]));
+
+    const result = await getAgentAccessLevel(AGENT_PAGE_ID, TARGET_PAGE_ID);
+    expect(result).toEqual({ canView: true, canEdit: true, canShare: false, canDelete: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAgentAccessLevel — drive-as-root-node
+// ---------------------------------------------------------------------------
+
+describe('getAgentAccessLevel — drive targets (drive-as-root-node)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns null when agent has no membership in the drive', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect([]))   // page lookup → not a page
+      .mockReturnValueOnce(stubSelect([]));  // membership lookup → none
+
+    const result = await getAgentAccessLevel(AGENT_PAGE_ID, DRIVE_ID);
+    expect(result).toBeNull();
+  });
+
+  it('returns full access for ADMIN role agent on a drive ID', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect([]))                                        // page lookup → not a page
+      .mockReturnValueOnce(stubSelect([{ role: 'ADMIN', customRoleId: null }])); // membership
+
+    const result = await getAgentAccessLevel(AGENT_PAGE_ID, DRIVE_ID);
+    expect(result).toEqual({ canView: true, canEdit: true, canShare: true, canDelete: true });
+  });
+
+  it('returns view-only for MEMBER agent with no custom role on a drive ID', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect([]))
+      .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: null }]));
+
+    const result = await getAgentAccessLevel(AGENT_PAGE_ID, DRIVE_ID);
+    expect(result).toEqual({ canView: true, canEdit: false, canShare: false, canDelete: false });
+  });
+
+  it('returns canEdit: true when MEMBER agent custom role grants drive-level canEdit', async () => {
+    const perms = { [DRIVE_ID]: { canView: true, canEdit: true, canShare: false } };
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect([]))
+      .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: CUSTOM_ROLE_ID }]))
+      .mockReturnValueOnce(stubSelect([{ permissions: perms }]));
+
+    const result = await getAgentAccessLevel(AGENT_PAGE_ID, DRIVE_ID);
+    expect(result).toEqual({ canView: true, canEdit: true, canShare: false, canDelete: false });
+  });
+
+  it('returns canEdit: false when MEMBER agent custom role denies drive-level canEdit', async () => {
+    const perms = { [DRIVE_ID]: { canView: true, canEdit: false, canShare: false } };
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect([]))
+      .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: CUSTOM_ROLE_ID }]))
+      .mockReturnValueOnce(stubSelect([{ permissions: perms }]));
+
+    const result = await getAgentAccessLevel(AGENT_PAGE_ID, DRIVE_ID);
+    expect(result).toEqual({ canView: true, canEdit: false, canShare: false, canDelete: false });
+  });
+
+  it('returns all-false when MEMBER agent custom role has no drive-level entry', async () => {
+    const perms = { 'some-other-page': { canView: true, canEdit: true, canShare: false } };
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect([]))
+      .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: CUSTOM_ROLE_ID }]))
+      .mockReturnValueOnce(stubSelect([{ permissions: perms }]));
+
+    const result = await getAgentAccessLevel(AGENT_PAGE_ID, DRIVE_ID);
+    expect(result).toEqual({ canView: false, canEdit: false, canShare: false, canDelete: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasAgentDriveMembership
+// ---------------------------------------------------------------------------
+
+describe('hasAgentDriveMembership', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns true when membership row exists', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(stubSelect([{ id: 'member-1' }]));
+    expect(await hasAgentDriveMembership(AGENT_PAGE_ID, DRIVE_ID)).toBe(true);
+  });
+
+  it('returns false when no membership row', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(stubSelect([]));
+    expect(await hasAgentDriveMembership(AGENT_PAGE_ID, DRIVE_ID)).toBe(false);
+  });
+});

--- a/packages/lib/src/permissions/__tests__/permissions.test.ts
+++ b/packages/lib/src/permissions/__tests__/permissions.test.ts
@@ -536,7 +536,7 @@ describe('getUserAccessLevel', () => {
       } as unknown as ReturnType<typeof db.select>);
 
     const result = await getUserAccessLevel(VALID_USER, VALID_DRIVE);
-    expect(result).toEqual({ canView: true, canEdit: true, canShare: true, canDelete: false });
+    expect(result).toEqual({ canView: true, canEdit: true, canShare: false, canDelete: false });
   });
 
   it('returns null when nodeId is a drive and user has no membership', async () => {

--- a/packages/lib/src/permissions/__tests__/permissions.test.ts
+++ b/packages/lib/src/permissions/__tests__/permissions.test.ts
@@ -206,25 +206,43 @@ describe('getUserAccessLevel', () => {
     expect(loggers.api.debug).toHaveBeenCalled();
   });
 
-  it('returns null when page not found', async () => {
+  it('returns null when page not found and not a drive id either', async () => {
     mockValidators(true, true);
-    const limitFn = vi.fn().mockResolvedValue([]);
-    const whereFn = vi.fn().mockReturnValue({ limit: limitFn });
-    const leftJoinFn = vi.fn().mockReturnValue({ where: whereFn });
-    const fromFn = vi.fn().mockReturnValue({ leftJoin: leftJoinFn });
-    vi.mocked(db.select).mockReturnValue({ from: fromFn } as unknown as ReturnType<typeof db.select>);
+    vi.mocked(db.select)
+      // page lookup → not found
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          leftJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+          }),
+        }),
+      } as unknown as ReturnType<typeof db.select>)
+      // drive fallback → not found
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+        }),
+      } as unknown as ReturnType<typeof db.select>);
 
     const result = await getUserAccessLevel(VALID_USER, VALID_PAGE);
     expect(result).toBeNull();
   });
 
-  it('logs page not found debug when silent=false', async () => {
+  it('logs page not found debug when silent=false and id is not a drive', async () => {
     mockValidators(true, true);
-    const limitFn = vi.fn().mockResolvedValue([]);
-    const whereFn = vi.fn().mockReturnValue({ limit: limitFn });
-    const leftJoinFn = vi.fn().mockReturnValue({ where: whereFn });
-    const fromFn = vi.fn().mockReturnValue({ leftJoin: leftJoinFn });
-    vi.mocked(db.select).mockReturnValue({ from: fromFn } as unknown as ReturnType<typeof db.select>);
+    vi.mocked(db.select)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          leftJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+          }),
+        }),
+      } as unknown as ReturnType<typeof db.select>)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+        }),
+      } as unknown as ReturnType<typeof db.select>);
 
     await getUserAccessLevel(VALID_USER, VALID_PAGE, { silent: false });
     expect(loggers.api.debug).toHaveBeenCalled();
@@ -437,6 +455,116 @@ describe('getUserAccessLevel', () => {
 
     await getUserAccessLevel(VALID_USER, VALID_PAGE, { silent: false });
     expect(loggers.api.debug).toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Drive-as-root-node: nodeId is a drive ID
+  // -------------------------------------------------------------------------
+
+  it('returns full access when nodeId is a drive and user is the drive owner', async () => {
+    mockValidators(true, true);
+    vi.mocked(db.select)
+      // page lookup → not found
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          leftJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+          }),
+        }),
+      } as unknown as ReturnType<typeof db.select>)
+      // drive fallback → owner
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ id: VALID_DRIVE, ownerId: VALID_USER }]) }),
+        }),
+      } as unknown as ReturnType<typeof db.select>);
+
+    const result = await getUserAccessLevel(VALID_USER, VALID_DRIVE);
+    expect(result).toEqual({ canView: true, canEdit: true, canShare: true, canDelete: true });
+  });
+
+  it('returns full access when nodeId is a drive and user is an ADMIN member', async () => {
+    mockValidators(true, true);
+    vi.mocked(db.select)
+      // page lookup → not found
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          leftJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+          }),
+        }),
+      } as unknown as ReturnType<typeof db.select>)
+      // drive fallback → found, different owner
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ id: VALID_DRIVE, ownerId: 'other-owner' }]) }),
+        }),
+      } as unknown as ReturnType<typeof db.select>)
+      // membership lookup → ADMIN
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ role: 'ADMIN' }]) }),
+        }),
+      } as unknown as ReturnType<typeof db.select>);
+
+    const result = await getUserAccessLevel(VALID_USER, VALID_DRIVE);
+    expect(result).toEqual({ canView: true, canEdit: true, canShare: true, canDelete: true });
+  });
+
+  it('returns member access (canEdit: true, canDelete: false) when nodeId is a drive and user is a MEMBER', async () => {
+    mockValidators(true, true);
+    vi.mocked(db.select)
+      // page lookup → not found
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          leftJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+          }),
+        }),
+      } as unknown as ReturnType<typeof db.select>)
+      // drive fallback → found, different owner
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ id: VALID_DRIVE, ownerId: 'other-owner' }]) }),
+        }),
+      } as unknown as ReturnType<typeof db.select>)
+      // membership lookup → MEMBER
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ role: 'MEMBER' }]) }),
+        }),
+      } as unknown as ReturnType<typeof db.select>);
+
+    const result = await getUserAccessLevel(VALID_USER, VALID_DRIVE);
+    expect(result).toEqual({ canView: true, canEdit: true, canShare: true, canDelete: false });
+  });
+
+  it('returns null when nodeId is a drive and user has no membership', async () => {
+    mockValidators(true, true);
+    vi.mocked(db.select)
+      // page lookup → not found
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          leftJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+          }),
+        }),
+      } as unknown as ReturnType<typeof db.select>)
+      // drive fallback → found
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ id: VALID_DRIVE, ownerId: 'other-owner' }]) }),
+        }),
+      } as unknown as ReturnType<typeof db.select>)
+      // membership lookup → none
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+        }),
+      } as unknown as ReturnType<typeof db.select>);
+
+    const result = await getUserAccessLevel(VALID_USER, VALID_DRIVE);
+    expect(result).toBeNull();
   });
 });
 

--- a/packages/lib/src/permissions/agent-permissions.ts
+++ b/packages/lib/src/permissions/agent-permissions.ts
@@ -14,8 +14,8 @@ export async function getAgentAccessLevel(
     .where(eq(pages.id, targetPageId))
     .limit(1);
 
-  if (page.length === 0) return null;
-  const { driveId } = page[0];
+  // When no page matches, treat targetPageId as a drive ID (drive-as-root-node)
+  const driveId = page.length > 0 ? page[0].driveId : targetPageId;
 
   const membership = await db
     .select()

--- a/packages/lib/src/permissions/permissions.ts
+++ b/packages/lib/src/permissions/permissions.ts
@@ -75,10 +75,15 @@ export async function getDriveIdsForUser(userId: string): Promise<string[]> {
 }
 
 /**
- * Get user access level for a page.
+ * Get user access level for a page or drive (drive-as-root-node).
+ *
+ * If `pageId` does not resolve to a page, it is treated as a drive ID.
+ * Drive owners and ADMIN members get full access; non-admin members get
+ * canView/canEdit with canDelete=false. canShare follows the same owner/admin
+ * gate as drive-level sharing (non-admin members cannot share the drive root).
  *
  * @param userId - User ID to check permissions for (validated as CUID2)
- * @param pageId - Page ID to check permissions on (validated as CUID2)
+ * @param pageId - Page or drive ID to check permissions on (validated as CUID2)
  * @param options.silent - If false, log debug messages (default: true)
  * @returns Permission object or null if no access / invalid input
  */
@@ -155,7 +160,7 @@ export async function getUserAccessLevel(
         return {
           canView: true,
           canEdit: true,
-          canShare: true,
+          canShare: isAdmin,
           canDelete: isAdmin,
         };
       }

--- a/packages/lib/src/permissions/permissions.ts
+++ b/packages/lib/src/permissions/permissions.ts
@@ -124,9 +124,42 @@ export async function getUserAccessLevel(
     .limit(1);
 
     if (page.length === 0) {
-      if (!silent) {
-        loggers.api.debug(`[PERMISSIONS] Page not found: ${validPageId}`);
+      // Fall back to treating the ID as a drive (drive-as-root-node model)
+      const drive = await db.select({ id: drives.id, ownerId: drives.ownerId })
+        .from(drives)
+        .where(eq(drives.id, validPageId))
+        .limit(1);
+
+      if (drive.length === 0) {
+        if (!silent) {
+          loggers.api.debug(`[PERMISSIONS] Page not found: ${validPageId}`);
+        }
+        return null;
       }
+
+      if (drive[0].ownerId === validUserId) {
+        return { canView: true, canEdit: true, canShare: true, canDelete: true };
+      }
+
+      const membership = await db.select({ role: driveMembers.role })
+        .from(driveMembers)
+        .where(and(
+          eq(driveMembers.driveId, drive[0].id),
+          eq(driveMembers.userId, validUserId),
+          isNotNull(driveMembers.acceptedAt),
+        ))
+        .limit(1);
+
+      if (membership.length > 0) {
+        const isAdmin = membership[0].role === 'ADMIN';
+        return {
+          canView: true,
+          canEdit: true,
+          canShare: true,
+          canDelete: isAdmin,
+        };
+      }
+
       return null;
     }
 


### PR DESCRIPTION
## Summary

- Members and agents with no edit permissions could create root-level pages because the old check (`isUserDriveMember`) was binary and completely bypassed agent RBAC. This PR fixes it by treating the drive as the topmost parent node — `canEdit` on the drive gates root-level creation, the same rule as any other parent.
- Extends `getUserAccessLevel` and `getAgentAccessLevel` to accept drive IDs as targets, so the existing `canUserEditPage`/`canActorEditPage` stack handles drive-level checks without new API surface.
- Adds the drive as a synthetic root node (`type: 'DRIVE'`) in the permissions-tree response and renders it as the first row in `PermissionsGrid`, so drive-level access is visible and editable in the permission matrix UI.

## Changes

| File | Change |
|------|--------|
| `packages/lib/src/permissions/permissions.ts` | `getUserAccessLevel` falls through to drive lookup when page not found |
| `packages/lib/src/permissions/agent-permissions.ts` | `getAgentAccessLevel` uses `targetPageId` as `driveId` when page not found |
| `packages/lib/src/permissions/__tests__/agent-permissions.test.ts` | New — 12 tests covering ADMIN/MEMBER/custom-role/no-membership for both page and drive targets |
| `packages/lib/src/permissions/__tests__/permissions.test.ts` | Drive-as-root test cases + fix existing tests for the drive fallback path |
| `apps/web/src/services/api/page-service.ts` | Root create: `isUserDriveMember` → `canUserEditPage(userId, driveId)` |
| `apps/web/src/lib/ai/tools/page-write-tools.ts` | Root create: `isUserDriveMember` → `canActorEditPage(context, driveId)` |
| `apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts` | Tests for blocked MEMBER agent, allowed ADMIN agent, blocked non-member |
| `apps/web/src/app/api/drives/[driveId]/permissions-tree/route.ts` | Drive root node prepended as `pages[0]` with correct `currentPermissions` |
| `apps/web/src/app/api/drives/[driveId]/permissions-tree/__tests__/route.test.ts` | Drive root node tests + updated existing tests for new array layout |
| `apps/web/src/components/members/PermissionsGrid.tsx` | Drive root row rendered first with blue styling, HardDrive icon, descriptive label |

## Test plan

- [x] `packages/lib` unit tests — 285 passing (all permission test files)
- [x] `apps/web` drives API + page-write-tools — 602 passing (27 files)
- [x] Full unit suite — 7549 passing (491 files); 27 pre-existing failures in gift-subscription DB test unrelated to this PR
- [x] Typecheck — clean across monorepo
- [ ] Manual: agent with MEMBER role (no custom role) should get 403 on root-level page creation
- [ ] Manual: agent with ADMIN role should succeed at root-level creation
- [ ] Manual: permission matrix shows drive root row at top; toggling canEdit persists drive ID key in role JSONB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Drive root node now displays in the permissions tree with dedicated permission controls
  * Reorganized permissions interface with structured checkboxes for view, edit, and share access levels
  * Enhanced authorization system for more consistent permission handling across drives and pages

* **Bug Fixes**
  * Improved permission resolution to correctly handle drive-level access scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1343)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->