### PR TITLE
fix(share): auto-join drive after OAuth sign-in/up

### DIFF
--- a/apps/web/src/app/api/auth/apple/callback/route.ts
+++ b/apps/web/src/app/api/auth/apple/callback/route.ts
@@ -182,7 +182,9 @@ export async function POST(req: Request) {
       const provisionedDrive = await provisionGettingStartedDriveIfNeeded(user.id);
       if (provisionedDrive.created) {
         isNewlyProvisioned = true;
-        returnUrl = `/dashboard/${provisionedDrive.driveId}`;
+        if (!returnUrl.startsWith('/s/')) {
+          returnUrl = `/dashboard/${provisionedDrive.driveId}`;
+        }
       }
     } catch (provisionError) {
       loggers.auth.error('Failed to provision Getting Started drive', provisionError as Error, {

--- a/apps/web/src/app/api/auth/apple/native/route.ts
+++ b/apps/web/src/app/api/auth/apple/native/route.ts
@@ -10,7 +10,7 @@ import { maskEmail } from '@pagespace/lib/audit/mask-email';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { z } from 'zod/v4';
 import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-started-drive';
-import { getClientIP } from '@/lib/auth';
+import { getClientIP, isSafeReturnUrl } from '@/lib/auth';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';
 import {
   checkDistributedRateLimit,
@@ -76,7 +76,6 @@ export async function POST(req: Request) {
     }
 
     const { idToken, platform, deviceId, deviceName, givenName, familyName, inviteToken, returnUrl: rawReturnUrl } = validation.data;
-    const { isSafeReturnUrl } = await import('@/lib/auth/auth-helpers');
     const returnUrl = rawReturnUrl && isSafeReturnUrl(rawReturnUrl) ? rawReturnUrl : undefined;
 
     // Validate required environment variables

--- a/apps/web/src/app/api/auth/apple/native/route.ts
+++ b/apps/web/src/app/api/auth/apple/native/route.ts
@@ -34,6 +34,7 @@ const nativeAuthSchema = z.object({
   givenName: z.string().optional(),
   familyName: z.string().optional(),
   inviteToken: z.string().min(1).max(INVITE_TOKEN_MAX_LENGTH).optional(),
+  returnUrl: z.string().max(2048).optional(),
 });
 
 /**
@@ -74,7 +75,9 @@ export async function POST(req: Request) {
       );
     }
 
-    const { idToken, platform, deviceId, deviceName, givenName, familyName, inviteToken } = validation.data;
+    const { idToken, platform, deviceId, deviceName, givenName, familyName, inviteToken, returnUrl: rawReturnUrl } = validation.data;
+    const { isSafeReturnUrl } = await import('@/lib/auth/auth-helpers');
+    const returnUrl = rawReturnUrl && isSafeReturnUrl(rawReturnUrl) ? rawReturnUrl : undefined;
 
     // Validate required environment variables
     if (!process.env.APPLE_CLIENT_ID) {
@@ -255,6 +258,7 @@ export async function POST(req: Request) {
       invitedPageId: inviteResult.invitedPageId,
       invitedConnectionId: inviteResult.connectionId,
       ...(inviteResult.inviteError && { inviteError: inviteResult.inviteError }),
+      ...(returnUrl && { returnUrl }),
       user: {
         id: user.id,
         name: user.name,

--- a/apps/web/src/app/api/auth/google/callback/route.ts
+++ b/apps/web/src/app/api/auth/google/callback/route.ts
@@ -196,7 +196,9 @@ export async function GET(req: Request) {
       const provisionedDrive = await provisionGettingStartedDriveIfNeeded(user.id);
       if (provisionedDrive.created) {
         isNewlyProvisioned = true;
-        returnUrl = `/dashboard/${provisionedDrive.driveId}`;
+        if (!returnUrl.startsWith('/s/')) {
+          returnUrl = `/dashboard/${provisionedDrive.driveId}`;
+        }
       }
     } catch (error) {
       loggers.auth.error('Failed to provision Getting Started drive', error as Error, {

--- a/apps/web/src/app/api/auth/google/native/route.ts
+++ b/apps/web/src/app/api/auth/google/native/route.ts
@@ -33,6 +33,7 @@ const nativeAuthSchema = z.object({
   deviceId: z.string().min(1, 'Device ID is required'),
   deviceName: z.string().optional(),
   inviteToken: z.string().min(1).max(INVITE_TOKEN_MAX_LENGTH).optional(),
+  returnUrl: z.string().max(2048).optional(),
 });
 
 /**
@@ -73,7 +74,9 @@ export async function POST(req: Request) {
       );
     }
 
-    const { idToken, platform, deviceId, deviceName, inviteToken } = validation.data;
+    const { idToken, platform, deviceId, deviceName, inviteToken, returnUrl: rawReturnUrl } = validation.data;
+    const { isSafeReturnUrl } = await import('@/lib/auth/auth-helpers');
+    const returnUrl = rawReturnUrl && isSafeReturnUrl(rawReturnUrl) ? rawReturnUrl : undefined;
 
     // Validate required environment variables
     if (!process.env.GOOGLE_OAUTH_CLIENT_ID || !process.env.GOOGLE_OAUTH_IOS_CLIENT_ID) {
@@ -278,6 +281,7 @@ export async function POST(req: Request) {
       invitedPageId: inviteResult.invitedPageId,
       invitedConnectionId: inviteResult.connectionId,
       ...(inviteResult.inviteError && { inviteError: inviteResult.inviteError }),
+      ...(returnUrl && { returnUrl }),
       user: {
         id: user.id,
         name: user.name,

--- a/apps/web/src/app/api/auth/google/native/route.ts
+++ b/apps/web/src/app/api/auth/google/native/route.ts
@@ -10,7 +10,7 @@ import { maskEmail } from '@pagespace/lib/audit/mask-email';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 import { z } from 'zod/v4';
 import { provisionGettingStartedDriveIfNeeded } from '@/lib/onboarding/getting-started-drive';
-import { getClientIP } from '@/lib/auth';
+import { getClientIP, isSafeReturnUrl } from '@/lib/auth';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';
 import { resolveGoogleAvatarImage } from '@/lib/auth/google-avatar';
 import {
@@ -75,7 +75,6 @@ export async function POST(req: Request) {
     }
 
     const { idToken, platform, deviceId, deviceName, inviteToken, returnUrl: rawReturnUrl } = validation.data;
-    const { isSafeReturnUrl } = await import('@/lib/auth/auth-helpers');
     const returnUrl = rawReturnUrl && isSafeReturnUrl(rawReturnUrl) ? rawReturnUrl : undefined;
 
     // Validate required environment variables

--- a/apps/web/src/app/auth/signin/page.tsx
+++ b/apps/web/src/app/auth/signin/page.tsx
@@ -38,7 +38,10 @@ function SignInForm() {
     isWaitingForExternalAuth,
     waitingProvider,
     cancelExternalAuth,
-  } = useOAuthSignIn(inviteToken ? { inviteToken } : {});
+  } = useOAuthSignIn({
+    ...(inviteToken && { inviteToken }),
+    ...(nextPath && { returnUrl: nextPath }),
+  });
   const onPrem = isOnPrem();
 
   useEffect(() => {
@@ -236,7 +239,7 @@ function SignInForm() {
         <p className="text-sm text-muted-foreground">
           Don&apos;t have an account?{" "}
           <Link
-            href="/auth/signup"
+            href={nextPath ? `/auth/signup?next=${encodeURIComponent(nextPath)}` : '/auth/signup'}
             className="font-medium text-blue-600 hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300"
           >
             Sign up

--- a/apps/web/src/app/auth/signup/SignUpClient.tsx
+++ b/apps/web/src/app/auth/signup/SignUpClient.tsx
@@ -21,9 +21,10 @@ import type { InviteContextData } from '@/lib/auth/invite-resolver';
 interface SignUpClientProps {
   inviteToken?: string;
   inviteContext?: InviteContextData;
+  returnUrl?: string;
 }
 
-export function SignUpClient({ inviteToken, inviteContext }: SignUpClientProps) {
+export function SignUpClient({ inviteToken, inviteContext, returnUrl }: SignUpClientProps) {
   const [error, setError] = useState<string | null>(null);
   const [showMagicLink, setShowMagicLink] = useState(false);
   const router = useRouter();
@@ -41,6 +42,7 @@ export function SignUpClient({ inviteToken, inviteContext }: SignUpClientProps) 
     onStart: () => setError(null),
     onError: (msg) => setError(msg),
     ...(inviteToken && { inviteToken }),
+    ...(returnUrl && { returnUrl }),
   });
 
   const isAnyLoading = isGoogleLoading || isAppleLoading || passkeyLoading;
@@ -153,7 +155,7 @@ export function SignUpClient({ inviteToken, inviteContext }: SignUpClientProps) 
       >
         {showMagicLink ? (
           <div id="magic-link-form" className="mt-2">
-            <MagicLinkForm {...(inviteToken && { inviteToken })} />
+            <MagicLinkForm {...(inviteToken && { inviteToken })} {...(returnUrl && { nextPath: returnUrl })} />
           </div>
         ) : (
           <button

--- a/apps/web/src/app/auth/signup/SignUpClient.tsx
+++ b/apps/web/src/app/auth/signup/SignUpClient.tsx
@@ -180,7 +180,7 @@ export function SignUpClient({ inviteToken, inviteContext, returnUrl }: SignUpCl
         <p className="text-sm text-muted-foreground">
           Already have an account?{' '}
           <Link
-            href="/auth/signin"
+            href={returnUrl ? `/auth/signin?next=${encodeURIComponent(returnUrl)}` : '/auth/signin'}
             className="font-medium text-blue-600 hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300"
           >
             Log in

--- a/apps/web/src/app/auth/signup/SignUpClient.tsx
+++ b/apps/web/src/app/auth/signup/SignUpClient.tsx
@@ -117,12 +117,13 @@ export function SignUpClient({ inviteToken, inviteContext, returnUrl }: SignUpCl
             csrfToken={csrfToken}
             refreshToken={refreshToken}
             onEmailExists={() => {
-              router.push('/auth/signin');
+              router.push(returnUrl ? `/auth/signin?next=${encodeURIComponent(returnUrl)}` : '/auth/signin');
             }}
             onLoadingChange={setPasskeyLoading}
             disabled={isAnyLoading}
             inviteToken={inviteToken}
             lockedEmail={inviteContext?.email}
+            {...(returnUrl && { nextPath: returnUrl })}
           />
         </motion.div>
       )}

--- a/apps/web/src/app/auth/signup/page.tsx
+++ b/apps/web/src/app/auth/signup/page.tsx
@@ -1,10 +1,11 @@
 import { redirect } from 'next/navigation';
 import { resolveInviteContext } from '@/lib/auth/invite-resolver';
 import { isOnPrem } from '@/lib/deployment-mode';
+import { isSafeNextPath, SIGNIN_NEXT_ALLOWED_PREFIXES } from '@/lib/auth/auth-helpers';
 import { SignUpClient } from './SignUpClient';
 
 interface SignUpPageProps {
-  searchParams: Promise<{ invite?: string }>;
+  searchParams: Promise<{ invite?: string; next?: string }>;
 }
 
 export default async function SignUp({ searchParams }: SignUpPageProps) {
@@ -13,10 +14,13 @@ export default async function SignUp({ searchParams }: SignUpPageProps) {
     redirect('/auth/signin?onprem=contact_admin');
   }
 
-  const { invite } = await searchParams;
+  const { invite, next } = await searchParams;
+  const safeNext = next && isSafeNextPath({ path: next, allowedPrefixes: SIGNIN_NEXT_ALLOWED_PREFIXES })
+    ? next
+    : undefined;
 
   if (!invite) {
-    return <SignUpClient />;
+    return <SignUpClient {...(safeNext && { returnUrl: safeNext })} />;
   }
 
   const resolution = await resolveInviteContext({ token: invite, now: new Date() });
@@ -27,5 +31,5 @@ export default async function SignUp({ searchParams }: SignUpPageProps) {
     redirect(`/invite/${encodeURIComponent(invite)}`);
   }
 
-  return <SignUpClient inviteToken={invite} inviteContext={resolution.data} />;
+  return <SignUpClient inviteToken={invite} inviteContext={resolution.data} {...(safeNext && { returnUrl: safeNext })} />;
 }

--- a/apps/web/src/app/s/[token]/DriveShareAccept.tsx
+++ b/apps/web/src/app/s/[token]/DriveShareAccept.tsx
@@ -17,7 +17,7 @@ interface DriveShareAcceptProps {
 export function DriveShareAccept({ token, info }: DriveShareAcceptProps) {
   const router = useRouter();
   const { isAuthenticated, isLoading: authLoading } = useAuth();
-  const { csrfToken } = useCSRFToken();
+  const { csrfToken, isLoading: csrfLoading, error: csrfError } = useCSRFToken();
   const [isPending, setIsPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -56,7 +56,7 @@ export function DriveShareAccept({ token, info }: DriveShareAcceptProps) {
     return () => controller.abort();
   }, [isAuthenticated, csrfToken, token, router]);
 
-  if (authLoading || (isAuthenticated && (!csrfToken || isPending) && !error)) {
+  if (authLoading || (isAuthenticated && (csrfLoading || isPending) && !error)) {
     return (
       <div className="text-center space-y-4">
         <p className="text-sm text-muted-foreground">
@@ -110,14 +110,16 @@ export function DriveShareAccept({ token, info }: DriveShareAcceptProps) {
     );
   }
 
-  if (error) {
+  if (csrfError || error) {
     return (
       <div className="text-center space-y-6">
         <div>
           <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
             Something went wrong
           </h1>
-          <p className="mt-3 text-sm text-muted-foreground">{error}</p>
+          <p className="mt-3 text-sm text-muted-foreground">
+            {error ?? 'Something went wrong. Please try again.'}
+          </p>
         </div>
         <Link href="/dashboard">
           <Button variant="outline" className="w-full">Go to dashboard</Button>

--- a/apps/web/src/app/s/[token]/DriveShareAccept.tsx
+++ b/apps/web/src/app/s/[token]/DriveShareAccept.tsx
@@ -94,7 +94,7 @@ export function DriveShareAccept({ token, info }: DriveShareAcceptProps) {
           </p>
         </div>
 
-        <Button className="w-full" onClick={() => router.push(`/auth/signin?next=/s/${token}`)}>
+        <Button className="w-full" onClick={() => router.push(`/auth/signin?next=${encodeURIComponent(`/s/${token}`)}`)}>
           Sign in to join
         </Button>
 

--- a/apps/web/src/app/s/[token]/DriveShareAccept.tsx
+++ b/apps/web/src/app/s/[token]/DriveShareAccept.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
@@ -21,77 +21,110 @@ export function DriveShareAccept({ token, info }: DriveShareAcceptProps) {
   const [isPending, setIsPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  async function handleJoin() {
-    if (!isAuthenticated) {
-      router.push(`/auth/signin?next=/s/${token}`);
-      return;
-    }
-    if (!csrfToken) return;
-    setIsPending(true);
-    setError(null);
+  useEffect(() => {
+    if (!isAuthenticated || !csrfToken) return;
 
-    try {
-      const res = await fetch(`/api/share/${token}/accept`, {
-        method: 'POST',
-        headers: { 'x-csrf-token': csrfToken },
-        credentials: 'include',
-      });
+    const controller = new AbortController();
 
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        setError((body as { error?: string }).error ?? 'Failed to join. Please try again.');
-        return;
+    async function accept() {
+      setIsPending(true);
+      try {
+        const res = await fetch(`/api/share/${token}/accept`, {
+          method: 'POST',
+          headers: { 'x-csrf-token': csrfToken! },
+          credentials: 'include',
+          signal: controller.signal,
+        });
+
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          setError((body as { error?: string }).error ?? 'Failed to join. Please try again.');
+          return;
+        }
+
+        const data = (await res.json()) as { type: string; driveId: string };
+        router.push(`/dashboard/${data.driveId}`);
+      } catch (err) {
+        if ((err as Error).name === 'AbortError') return;
+        setError('Something went wrong. Please try again.');
+      } finally {
+        setIsPending(false);
       }
-
-      const data = (await res.json()) as { type: string; driveId: string };
-      router.push(`/dashboard/${data.driveId}`);
-    } catch {
-      setError('Something went wrong. Please try again.');
-    } finally {
-      setIsPending(false);
     }
+
+    accept();
+    return () => controller.abort();
+  }, [isAuthenticated, csrfToken, token, router]);
+
+  if (authLoading || (isAuthenticated && isPending && !error)) {
+    return (
+      <div className="text-center space-y-4">
+        <p className="text-sm text-muted-foreground">
+          Joining{' '}
+          <span className="font-medium text-gray-900 dark:text-gray-100">
+            {info.driveName ?? 'workspace'}
+          </span>
+          …
+        </p>
+        <div className="flex justify-center">
+          <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+        </div>
+      </div>
+    );
   }
 
-  return (
-    <div className="space-y-6">
-      <div className="text-center">
-        <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
-          Join{' '}
-          <span className="text-blue-600 dark:text-blue-400">
-            {info.driveName ?? 'this workspace'}
-          </span>
-        </h1>
-        <p className="mt-3 text-sm text-muted-foreground">
-          <span className="font-medium text-gray-900 dark:text-gray-100">{info.creatorName}</span>
-          {' '}shared an invite link.{' '}
-          You&apos;ll join as a{' '}
-          <Badge variant="secondary" className="text-xs">
-            {info.role ?? 'Member'}
-          </Badge>
-          .
-        </p>
+  if (!isAuthenticated) {
+    return (
+      <div className="space-y-6">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+            Join{' '}
+            <span className="text-blue-600 dark:text-blue-400">
+              {info.driveName ?? 'this workspace'}
+            </span>
+          </h1>
+          <p className="mt-3 text-sm text-muted-foreground">
+            <span className="font-medium text-gray-900 dark:text-gray-100">{info.creatorName}</span>
+            {' '}shared an invite link.{' '}
+            You&apos;ll join as a{' '}
+            <Badge variant="secondary" className="text-xs">
+              {info.role ?? 'Member'}
+            </Badge>
+            .
+          </p>
+        </div>
+
+        <Button className="w-full" onClick={() => router.push(`/auth/signin?next=/s/${token}`)}>
+          Sign in to join
+        </Button>
+
+        <div className="text-center">
+          <Link
+            href="/dashboard"
+            className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Not now
+          </Link>
+        </div>
       </div>
+    );
+  }
 
-      {error && (
-        <p className="text-sm text-destructive text-center">{error}</p>
-      )}
-
-      <Button
-        className="w-full"
-        onClick={handleJoin}
-        disabled={isPending || authLoading || (isAuthenticated && !csrfToken)}
-      >
-        {isPending ? 'Joining…' : `Join ${info.driveName ?? 'workspace'}`}
-      </Button>
-
-      <div className="text-center">
-        <Link
-          href="/dashboard"
-          className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-        >
-          Not now
+  if (error) {
+    return (
+      <div className="text-center space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+            Something went wrong
+          </h1>
+          <p className="mt-3 text-sm text-muted-foreground">{error}</p>
+        </div>
+        <Link href="/dashboard">
+          <Button variant="outline" className="w-full">Go to dashboard</Button>
         </Link>
       </div>
-    </div>
-  );
+    );
+  }
+
+  return null;
 }

--- a/apps/web/src/app/s/[token]/DriveShareAccept.tsx
+++ b/apps/web/src/app/s/[token]/DriveShareAccept.tsx
@@ -56,7 +56,7 @@ export function DriveShareAccept({ token, info }: DriveShareAcceptProps) {
     return () => controller.abort();
   }, [isAuthenticated, csrfToken, token, router]);
 
-  if (authLoading || (isAuthenticated && isPending && !error)) {
+  if (authLoading || (isAuthenticated && (!csrfToken || isPending) && !error)) {
     return (
       <div className="text-center space-y-4">
         <p className="text-sm text-muted-foreground">

--- a/apps/web/src/app/s/[token]/__tests__/DriveShareAccept.test.tsx
+++ b/apps/web/src/app/s/[token]/__tests__/DriveShareAccept.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, act, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, act, screen, fireEvent, waitFor } from '@testing-library/react';
 
 const pushMock = vi.fn();
 
@@ -32,6 +32,14 @@ describe('DriveShareAccept', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(useCSRFToken).mockReturnValue(csrfBase);
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ type: 'drive', driveId: 'drive-fallback' }),
+    } as Response);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('Given auth is loading, should show spinner and not redirect', () => {
@@ -65,12 +73,56 @@ describe('DriveShareAccept', () => {
     expect(pushMock).toHaveBeenCalledWith('/auth/signin?next=%2Fs%2Ftok-abc');
   });
 
-  it('Given authenticated user, should not redirect even if csrfToken is null', () => {
+  it('Given authenticated user, when CSRF fails to load, should show error state not an infinite spinner', () => {
     vi.mocked(useAuth).mockReturnValue({ isAuthenticated: true, isLoading: false } as ReturnType<typeof useAuth>);
-    vi.mocked(useCSRFToken).mockReturnValue({ ...csrfBase, error: 'csrf error' });
+    vi.mocked(useCSRFToken).mockReturnValue({ ...csrfBase, isLoading: false, error: 'Failed to fetch CSRF token' });
 
     render(<DriveShareAccept token="tok" info={INFO} />);
 
+    expect(pushMock).not.toHaveBeenCalled();
+    expect(screen.queryByText(/joining/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /go to dashboard/i })).toBeInTheDocument();
+  });
+
+  it('Given authenticated user with CSRF token, should auto-POST accept and redirect to dashboard', async () => {
+    vi.mocked(useAuth).mockReturnValue({ isAuthenticated: true, isLoading: false } as ReturnType<typeof useAuth>);
+    vi.mocked(useCSRFToken).mockReturnValue({ ...csrfBase, csrfToken: 'csrf-tok' });
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ type: 'drive', driveId: 'drive-123' }),
+    } as Response);
+
+    render(<DriveShareAccept token="tok-abc" info={INFO} />);
+
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith('/dashboard/drive-123'));
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/share/tok-abc/accept',
+      expect.objectContaining({ method: 'POST', headers: { 'x-csrf-token': 'csrf-tok' } })
+    );
+  });
+
+  it('Given authenticated user with CSRF token, when accept returns non-ok, should show server error', async () => {
+    vi.mocked(useAuth).mockReturnValue({ isAuthenticated: true, isLoading: false } as ReturnType<typeof useAuth>);
+    vi.mocked(useCSRFToken).mockReturnValue({ ...csrfBase, csrfToken: 'csrf-tok' });
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: 'Invite link has expired' }),
+    } as Response);
+
+    render(<DriveShareAccept token="tok-abc" info={INFO} />);
+
+    await waitFor(() => expect(screen.getByText(/invite link has expired/i)).toBeInTheDocument());
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('Given authenticated user with CSRF token, when accept throws, should show generic error', async () => {
+    vi.mocked(useAuth).mockReturnValue({ isAuthenticated: true, isLoading: false } as ReturnType<typeof useAuth>);
+    vi.mocked(useCSRFToken).mockReturnValue({ ...csrfBase, csrfToken: 'csrf-tok' });
+    vi.spyOn(global, 'fetch').mockRejectedValue(new Error('Network error'));
+
+    render(<DriveShareAccept token="tok-abc" info={INFO} />);
+
+    await waitFor(() => expect(screen.getByRole('link', { name: /go to dashboard/i })).toBeInTheDocument());
     expect(pushMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/s/[token]/__tests__/DriveShareAccept.test.tsx
+++ b/apps/web/src/app/s/[token]/__tests__/DriveShareAccept.test.tsx
@@ -34,13 +34,14 @@ describe('DriveShareAccept', () => {
     vi.mocked(useCSRFToken).mockReturnValue(csrfBase);
   });
 
-  it('Given auth is loading, should not redirect and disable the button', () => {
+  it('Given auth is loading, should show spinner and not redirect', () => {
     vi.mocked(useAuth).mockReturnValue({ isAuthenticated: false, isLoading: true } as ReturnType<typeof useAuth>);
 
     render(<DriveShareAccept token="tok" info={INFO} />);
 
     expect(pushMock).not.toHaveBeenCalled();
-    expect(screen.getByRole('button', { name: /join/i })).toBeDisabled();
+    expect(screen.getByText(/joining/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /join/i })).not.toBeInTheDocument();
   });
 
   it('Given unauthenticated user after auth loads, should show invite landing page without redirecting', async () => {
@@ -61,7 +62,7 @@ describe('DriveShareAccept', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /join/i }));
 
-    expect(pushMock).toHaveBeenCalledWith('/auth/signin?next=/s/tok-abc');
+    expect(pushMock).toHaveBeenCalledWith('/auth/signin?next=%2Fs%2Ftok-abc');
   });
 
   it('Given authenticated user, should not redirect even if csrfToken is null', () => {

--- a/apps/web/src/components/auth/PasskeySignupButton.tsx
+++ b/apps/web/src/components/auth/PasskeySignupButton.tsx
@@ -28,6 +28,8 @@ interface PasskeySignupButtonProps {
   lockedEmail?: string;
   /** Forwarded to /api/auth/signup-passkey so the server can attach the new user to the invite. */
   inviteToken?: string;
+  /** If set, overrides the server redirect after successful registration (e.g. share link return). */
+  nextPath?: string;
 }
 
 export function PasskeySignupButton({
@@ -40,6 +42,7 @@ export function PasskeySignupButton({
   disabled = false,
   lockedEmail,
   inviteToken,
+  nextPath,
 }: PasskeySignupButtonProps) {
   const isSupported = useWebAuthnSupport();
   const [isRegistering, setIsRegistering] = useState(false);
@@ -156,9 +159,9 @@ export function PasskeySignupButton({
       toast.success('Account created successfully!');
 
       if (onSuccess) {
-        onSuccess(verifyData.redirectUrl);
+        onSuccess(nextPath ?? verifyData.redirectUrl);
       } else {
-        window.location.href = verifyData.redirectUrl;
+        window.location.href = nextPath ?? verifyData.redirectUrl;
       }
     } catch (err) {
       if (err instanceof Error) {
@@ -177,7 +180,7 @@ export function PasskeySignupButton({
     } finally {
       setIsRegistering(false);
     }
-  }, [csrfToken, refreshToken, email, name, acceptedTos, inviteToken, onSuccess, onEmailExists]);
+  }, [csrfToken, refreshToken, email, name, acceptedTos, inviteToken, nextPath, onSuccess, onEmailExists]);
 
   // Don't render if browser doesn't support WebAuthn
   if (isSupported === false) {

--- a/apps/web/src/hooks/__tests__/useOAuthSignIn.test.ts
+++ b/apps/web/src/hooks/__tests__/useOAuthSignIn.test.ts
@@ -43,6 +43,25 @@ describe('buildOAuthSigninBody', () => {
     });
     expect(body).not.toHaveProperty('inviteToken');
   });
+
+  it('includes returnUrl when provided', () => {
+    const body = buildOAuthSigninBody({
+      platform: 'web',
+      deviceId: 'dev-1',
+      deviceName: 'Browser',
+      returnUrl: '/s/tok-abc123',
+    });
+    expect(body.returnUrl).toBe('/s/tok-abc123');
+  });
+
+  it('omits returnUrl when undefined', () => {
+    const body = buildOAuthSigninBody({
+      platform: 'web',
+      deviceId: 'dev-1',
+      deviceName: 'Browser',
+    });
+    expect(body).not.toHaveProperty('returnUrl');
+  });
 });
 
 describe('buildPostNativeAuthRedirect', () => {
@@ -68,5 +87,18 @@ describe('buildPostNativeAuthRedirect', () => {
 
   it('treats null invitedDriveId as no-invite', () => {
     expect(buildPostNativeAuthRedirect({ invitedDriveId: null })).toBe('/dashboard');
+  });
+
+  it('uses returnUrl when no invite was consumed and user is not new', () => {
+    expect(buildPostNativeAuthRedirect({ returnUrl: '/s/tok-abc' })).toBe('/s/tok-abc');
+  });
+
+  it('uses returnUrl over welcome redirect when user is new but has no invite', () => {
+    expect(buildPostNativeAuthRedirect({ isNewUser: true, returnUrl: '/s/tok-abc' })).toBe('/s/tok-abc');
+  });
+
+  it('invite-consumed drive wins over returnUrl', () => {
+    expect(buildPostNativeAuthRedirect({ invitedDriveId: 'drive-123', returnUrl: '/s/tok-abc' }))
+      .toBe('/dashboard/drive-123?invited=1');
   });
 });

--- a/apps/web/src/hooks/useOAuthSignIn.ts
+++ b/apps/web/src/hooks/useOAuthSignIn.ts
@@ -14,6 +14,7 @@ export interface OAuthSigninBodyInput {
   deviceId: string;
   deviceName: string;
   inviteToken?: string;
+  returnUrl?: string;
 }
 
 export const buildOAuthSigninBody = ({
@@ -21,11 +22,13 @@ export const buildOAuthSigninBody = ({
   deviceId,
   deviceName,
   inviteToken,
+  returnUrl,
 }: OAuthSigninBodyInput): Record<string, string> => ({
   platform,
   deviceId,
   deviceName,
   ...(inviteToken && { inviteToken }),
+  ...(returnUrl && { returnUrl }),
 });
 
 export interface PostNativeAuthRedirectInput {
@@ -53,9 +56,10 @@ interface UseOAuthSignInOptions {
   onStart?: () => void;
   onError?: (message: string) => void;
   inviteToken?: string;
+  returnUrl?: string;
 }
 
-export function useOAuthSignIn({ onStart, onError, inviteToken }: UseOAuthSignInOptions = {}) {
+export function useOAuthSignIn({ onStart, onError, inviteToken, returnUrl }: UseOAuthSignInOptions = {}) {
   const [isGoogleLoading, setIsGoogleLoading] = useState(false);
   const [isAppleLoading, setIsAppleLoading] = useState(false);
   const [waitingProvider, setWaitingProvider] = useState<OAuthProvider | null>(null);
@@ -120,6 +124,7 @@ export function useOAuthSignIn({ onStart, onError, inviteToken }: UseOAuthSignIn
       deviceId,
       deviceName,
       inviteToken,
+      returnUrl,
     });
     const response = await fetch(endpoint, {
       method: 'POST',

--- a/apps/web/src/hooks/useOAuthSignIn.ts
+++ b/apps/web/src/hooks/useOAuthSignIn.ts
@@ -34,20 +34,23 @@ export const buildOAuthSigninBody = ({
 export interface PostNativeAuthRedirectInput {
   isNewUser?: boolean;
   invitedDriveId?: string | null;
+  returnUrl?: string;
 }
 
 /**
  * Decide where to land a user after a successful native (iOS) OAuth flow.
  *
- * Precedence: invite-consumed drive > new-user welcome > /dashboard.
+ * Precedence: invite-consumed drive > returnUrl > new-user welcome > /dashboard.
  * Pure function — extracted so the redirect logic can be tested without
  * rendering the hook.
  */
 export const buildPostNativeAuthRedirect = ({
   isNewUser,
   invitedDriveId,
+  returnUrl,
 }: PostNativeAuthRedirectInput): string => {
   if (invitedDriveId) return `/dashboard/${invitedDriveId}?invited=1`;
+  if (returnUrl) return returnUrl;
   if (isNewUser) return '/dashboard?welcome=true';
   return '/dashboard';
 };
@@ -94,6 +97,7 @@ export function useOAuthSignIn({ onStart, onError, inviteToken, returnUrl }: Use
   const handleNativeSuccess = async (result: {
     isNewUser?: boolean;
     invitedDriveId?: string | null;
+    returnUrl?: string;
     user?: { id: string; name: string | null; email: string | null; image?: string | null };
   }) => {
     const { useAuthStore } = await import('@/stores/useAuthStore');
@@ -104,6 +108,7 @@ export function useOAuthSignIn({ onStart, onError, inviteToken, returnUrl }: Use
     router.replace(buildPostNativeAuthRedirect({
       isNewUser: result.isNewUser,
       invitedDriveId: result.invitedDriveId,
+      returnUrl: result.returnUrl,
     }));
   };
 
@@ -179,7 +184,10 @@ export function useOAuthSignIn({ onStart, onError, inviteToken, returnUrl }: Use
         await import('@/lib/ios-google-auth');
 
       if (isNativeGoogleAuthAvailable()) {
-        const result = await nativeSignIn(inviteToken ? { inviteToken } : {});
+        const result = await nativeSignIn({
+          ...(inviteToken && { inviteToken }),
+          ...(returnUrl && { returnUrl }),
+        });
         if (result.success) {
           await handleNativeSuccess(result);
         } else if (result.error !== 'Sign-in cancelled') {
@@ -207,7 +215,10 @@ export function useOAuthSignIn({ onStart, onError, inviteToken, returnUrl }: Use
         await import('@/lib/ios-apple-auth');
 
       if (isNativeAppleAuthAvailable()) {
-        const result = await nativeSignIn(inviteToken ? { inviteToken } : {});
+        const result = await nativeSignIn({
+          ...(inviteToken && { inviteToken }),
+          ...(returnUrl && { returnUrl }),
+        });
         if (result.success) {
           await handleNativeSuccess(result);
         } else if (result.error !== 'Sign-in cancelled') {

--- a/apps/web/src/lib/ios-apple-auth.ts
+++ b/apps/web/src/lib/ios-apple-auth.ts
@@ -15,6 +15,7 @@ export interface AppleAuthResult {
   isNewUser?: boolean;
   invitedDriveId?: string | null;
   inviteError?: string;
+  returnUrl?: string;
   user?: {
     id: string;
     name: string | null;
@@ -30,6 +31,7 @@ type AppleNativeAuthResponse = {
   isNewUser?: boolean;
   invitedDriveId?: string | null;
   inviteError?: string;
+  returnUrl?: string;
   user?: AppleAuthResult['user'];
 };
 
@@ -39,7 +41,7 @@ const APPLE_CLIENT_ID = 'ai.pagespace.ios';
  * Perform native Apple Sign-In and exchange tokens with backend.
  * Only works when running in the iOS Capacitor app.
  */
-export async function signInWithApple(options: { inviteToken?: string } = {}): Promise<AppleAuthResult> {
+export async function signInWithApple(options: { inviteToken?: string; returnUrl?: string } = {}): Promise<AppleAuthResult> {
   // Guard: only run on iOS native app
   if (!isCapacitorApp() || getPlatform() !== 'ios') {
     return { success: false, error: 'Not in iOS app' };
@@ -99,6 +101,7 @@ export async function signInWithApple(options: { inviteToken?: string } = {}): P
         givenName,
         familyName,
         ...(options.inviteToken && { inviteToken: options.inviteToken }),
+        ...(options.returnUrl && { returnUrl: options.returnUrl }),
       }),
     });
 
@@ -108,7 +111,7 @@ export async function signInWithApple(options: { inviteToken?: string } = {}): P
       throw new Error(errorData.error || 'Authentication failed');
     }
 
-    const { sessionToken, csrfToken, deviceToken, isNewUser, invitedDriveId, inviteError, user } =
+    const { sessionToken, csrfToken, deviceToken, isNewUser, invitedDriveId, inviteError, returnUrl, user } =
       (await response.json()) as AppleNativeAuthResponse;
 
     if (!sessionToken) {
@@ -134,6 +137,7 @@ export async function signInWithApple(options: { inviteToken?: string } = {}): P
       user,
       ...(invitedDriveId !== undefined && { invitedDriveId }),
       ...(inviteError && { inviteError }),
+      ...(returnUrl && { returnUrl }),
     };
   } catch (error) {
     console.error('[iOS Apple Auth] Sign-in failed:', error);

--- a/apps/web/src/lib/ios-google-auth.ts
+++ b/apps/web/src/lib/ios-google-auth.ts
@@ -15,6 +15,7 @@ export interface GoogleAuthResult {
   isNewUser?: boolean;
   invitedDriveId?: string | null;
   inviteError?: string;
+  returnUrl?: string;
   user?: {
     id: string;
     name: string | null;
@@ -30,6 +31,7 @@ type GoogleNativeAuthResponse = {
   isNewUser?: boolean;
   invitedDriveId?: string | null;
   inviteError?: string;
+  returnUrl?: string;
   user?: GoogleAuthResult['user'];
 };
 
@@ -46,7 +48,7 @@ const IOS_CLIENT_ID = process.env.NEXT_PUBLIC_GOOGLE_OAUTH_IOS_CLIENT_ID;
  * Perform native Google Sign-In and exchange tokens with backend.
  * Only works when running in the iOS Capacitor app.
  */
-export async function signInWithGoogle(options: { inviteToken?: string } = {}): Promise<GoogleAuthResult> {
+export async function signInWithGoogle(options: { inviteToken?: string; returnUrl?: string } = {}): Promise<GoogleAuthResult> {
   // Guard: only run on iOS native app
   if (!isCapacitorApp() || getPlatform() !== 'ios') {
     return { success: false, error: 'Not in iOS app' };
@@ -105,6 +107,7 @@ export async function signInWithGoogle(options: { inviteToken?: string } = {}): 
         deviceId,
         deviceName: 'iOS App',
         ...(options.inviteToken && { inviteToken: options.inviteToken }),
+        ...(options.returnUrl && { returnUrl: options.returnUrl }),
       }),
     });
 
@@ -114,7 +117,7 @@ export async function signInWithGoogle(options: { inviteToken?: string } = {}): 
       throw new Error(errorData.error || 'Authentication failed');
     }
 
-    const { sessionToken, csrfToken, deviceToken, isNewUser, invitedDriveId, inviteError, user } =
+    const { sessionToken, csrfToken, deviceToken, isNewUser, invitedDriveId, inviteError, returnUrl, user } =
       (await response.json()) as GoogleNativeAuthResponse;
 
     if (!sessionToken) {
@@ -140,6 +143,7 @@ export async function signInWithGoogle(options: { inviteToken?: string } = {}): 
       user,
       ...(invitedDriveId !== undefined && { invitedDriveId }),
       ...(inviteError && { inviteError }),
+      ...(returnUrl && { returnUrl }),
     };
   } catch (error) {
     console.error('[iOS Google Auth] Sign-in failed:', error);


### PR DESCRIPTION
## Summary

- **Root cause 1**: \`useOAuthSignIn\` never passed a \`returnUrl\` to the OAuth state, so after Google/Apple sign-in the user always landed on \`/dashboard\` instead of back on \`/s/[token]\` — they never saw the share accept page again.
- **Root cause 2**: New-user getting-started drive provisioning in the Google and Apple OAuth callbacks overwrote \`returnUrl\`, sending brand-new sign-ups to their fresh drive rather than back to the share link.
- **Root cause 3**: \`DriveShareAccept\` required a manual button click to join. \`PageShareAccept\` already auto-accepts via \`useEffect\` — drive shares now match that behaviour.
- **Root cause 4**: \`DriveShareAccept\` only destructured \`csrfToken\` from \`useCSRFToken\`, so a CSRF fetch failure left the component in an infinite spinner with no escape.

**Changes:**
- \`useOAuthSignIn\` — adds \`returnUrl\` option, threads it into \`buildOAuthSigninBody\` (both Google and Apple signin routes already accept it); also threads \`returnUrl\` through native iOS sign-in calls
- \`signin/page.tsx\` — passes \`nextPath\` as \`returnUrl\` to \`useOAuthSignIn\`; "Sign up" link preserves \`?next=\` param
- \`signup/page.tsx\` + \`SignUpClient.tsx\` — reads and validates \`?next=\`, forwards it through to \`useOAuthSignIn\` and \`MagicLinkForm\`; "Log in" link preserves \`?next=\` param
- \`google/callback/route.ts\` + \`apple/callback/route.ts\` — skips getting-started drive redirect when \`returnUrl\` is a share link (\`/s/…\`)
- \`DriveShareAccept.tsx\` — rewired to auto-accept on auth via \`useEffect\`; CSRF loading state uses \`csrfLoading\` (not \`!csrfToken\`) so a CSRF failure shows error UI rather than an infinite spinner
- \`ios-google-auth.ts\` + \`ios-apple-auth.ts\` — accept \`returnUrl\` in options, pass it to backend, surface it in result
- \`api/auth/google/native\` + \`api/auth/apple/native\` — accept \`returnUrl\` in Zod schema, validate with \`isSafeReturnUrl\`, echo back in response
- \`buildPostNativeAuthRedirect\` — \`returnUrl\` takes precedence over new-user welcome (invite-consumed drive still wins)
- \`PasskeySignupButton\` — threads \`nextPath\` so passkey registration also returns to the share link

## Test plan

- [ ] Sign out, visit a drive share link → click "Sign in to join" → sign in with Google → lands back on \`/s/[token]\` → auto-joins → redirected to drive
- [ ] Same flow with Apple sign-in
- [ ] Same flow with magic link
- [ ] Same flow with passkey (sign in + sign up)
- [ ] Brand-new account via Google OAuth from a share link → getting-started drive is created but user still ends up in the invited drive
- [ ] "Sign up" link on signin page with \`?next=/s/[token]\` preserves the next param through to signup
- [ ] "Log in" link on signup page with \`returnUrl\` set preserves it back to signin
- [ ] Already-authenticated user visiting a share link is immediately auto-joined (no button click)
- [ ] Authenticated user with CSRF failure sees error state and "Go to dashboard" link, not an infinite spinner
- [ ] Page share links (\`PageShareAccept\`) still work (no regression)
- [ ] Email invite flow unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)