### PR TITLE
fix(share): revoke 204 bug + multi share links for pages

### DIFF
--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/PageShareLinkSection.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/PageShareLinkSection.tsx
@@ -3,7 +3,7 @@
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Link2, Copy, Trash2 } from 'lucide-react';
-import { usePageShareLink, type ShareLinkPermissions } from '@/hooks/usePageShareLink';
+import { usePageShareLink, type PageLink, type ShareLinkPermissions } from '@/hooks/usePageShareLink';
 
 function permissionLabel(permissions: string[]): string {
   const labels: string[] = [];
@@ -21,79 +21,79 @@ interface PageShareLinkSectionProps {
 }
 
 export function PageShareLinkSection({ pageId, permissions }: PageShareLinkSectionProps) {
-  const {
-    activeLink,
-    shareUrl,
-    isLoading,
-    isGenerating,
-    isRevoking,
-    handleGenerate,
-    handleCopy,
-    handleRevoke,
-  } = usePageShareLink(pageId);
+  const { links, isLoading, isGenerating, revokingId, handleGenerate, handleCopy, handleRevoke } =
+    usePageShareLink(pageId);
 
   return (
     <div className="space-y-3">
       <h4 className="text-sm font-medium flex items-center gap-2">
         <Link2 className="h-4 w-4" />
-        Share link
+        Share links
       </h4>
 
       {isLoading ? (
         <div className="h-8 w-full animate-pulse rounded bg-muted" />
-      ) : activeLink ? (
-        <div className="space-y-2">
-          <div className="flex items-center gap-2">
-            <input
-              type="text"
-              readOnly
-              value={shareUrl ?? ''}
-              aria-label="Share link URL"
-              className="flex-1 h-8 min-w-0 px-2 text-xs font-mono bg-muted rounded border border-input truncate focus:ring-2 focus:ring-ring cursor-text"
-              onClick={(e) => (e.target as HTMLInputElement).select()}
-            />
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-8 px-2 shrink-0"
-              onClick={handleCopy}
-              disabled={!shareUrl}
-              aria-label="Copy share link"
-            >
-              <Copy className="h-3.5 w-3.5" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-8 px-2 shrink-0 text-destructive hover:text-destructive"
-              onClick={handleRevoke}
-              disabled={isRevoking}
-              aria-label="Revoke share link"
-            >
-              <Trash2 className="h-3.5 w-3.5" />
-            </Button>
-          </div>
-          <div className="flex items-center gap-2">
-            <Badge variant="secondary" className="text-xs">
-              {permissionLabel(activeLink.permissions)}
-            </Badge>
-            <span className="text-xs text-muted-foreground">
-              Used {activeLink.useCount} {activeLink.useCount === 1 ? 'time' : 'times'}
-            </span>
-          </div>
-        </div>
       ) : (
-        <Button
-          variant="outline"
-          size="sm"
-          className="w-full"
-          onClick={() => handleGenerate(permissions)}
-          disabled={isGenerating || !permissions.canView}
-          title={!permissions.canView ? 'Select at least View permission to generate a link' : undefined}
-        >
-          <Link2 className="mr-1.5 h-3.5 w-3.5" />
-          {isGenerating ? 'Generating…' : 'Generate link'}
-        </Button>
+        <>
+          {links.length > 0 && (
+            <div className="space-y-2">
+              {links.map((link: PageLink) => (
+                <div key={link.id} className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <Badge variant="secondary" className="text-xs shrink-0">
+                      {permissionLabel(link.permissions)}
+                    </Badge>
+                    <input
+                      type="text"
+                      readOnly
+                      value={link.shareUrl ?? ''}
+                      aria-label="Share link URL"
+                      className="flex-1 h-7 min-w-0 px-2 text-xs font-mono bg-muted rounded border border-input truncate focus:ring-2 focus:ring-ring cursor-text"
+                      onClick={(e) => (e.target as HTMLInputElement).select()}
+                    />
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 px-2 shrink-0"
+                      onClick={() => handleCopy(link)}
+                      disabled={!link.shareUrl}
+                      aria-label="Copy share link"
+                    >
+                      <Copy className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-7 px-2 shrink-0 text-destructive hover:text-destructive"
+                      onClick={() => handleRevoke(link.id)}
+                      disabled={revokingId === link.id}
+                      aria-label="Revoke share link"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                  <p className="text-xs text-muted-foreground pl-1">
+                    {link.useCount} {link.useCount === 1 ? 'use' : 'uses'}
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div className={links.length > 0 ? 'border-t border-gray-200 dark:border-gray-700 pt-3' : ''}>
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full"
+              onClick={() => handleGenerate(permissions)}
+              disabled={isGenerating || !permissions.canView}
+              title={!permissions.canView ? 'Select at least View permission to generate a link' : undefined}
+            >
+              <Link2 className="mr-1.5 h-3.5 w-3.5" />
+              {isGenerating ? 'Generating…' : 'New share link'}
+            </Button>
+          </div>
+        </>
       )}
     </div>
   );

--- a/apps/web/src/hooks/__tests__/usePageShareLink.test.ts
+++ b/apps/web/src/hooks/__tests__/usePageShareLink.test.ts
@@ -37,47 +37,62 @@ describe('usePageShareLink', () => {
     vi.restoreAllMocks();
   });
 
-  describe('loading existing link', () => {
-    it('Given GET returns a link with shareUrl, should populate activeLink and shareUrl', async () => {
+  describe('loading existing links', () => {
+    it('Given GET returns a link with shareUrl, should populate links array', async () => {
       mockFetchResolve({
-        links: [{ id: LINK_ID, permissions: ['VIEW'], useCount: 5, shareUrl: SHARE_URL, expiresAt: null, createdAt: new Date().toISOString() }],
+        links: [{ id: LINK_ID, permissions: ['VIEW'], useCount: 5, shareUrl: SHARE_URL }],
       });
 
       const { result } = renderHook(() => usePageShareLink(PAGE_ID));
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-      expect(result.current.activeLink?.id).toBe(LINK_ID);
-      expect(result.current.activeLink?.permissions).toEqual(['VIEW']);
-      expect(result.current.shareUrl).toBe(SHARE_URL);
+      expect(result.current.links).toHaveLength(1);
+      expect(result.current.links[0].id).toBe(LINK_ID);
+      expect(result.current.links[0].permissions).toEqual(['VIEW']);
+      expect(result.current.links[0].shareUrl).toBe(SHARE_URL);
+    });
+
+    it('Given GET returns multiple links, should populate all of them', async () => {
+      mockFetchResolve({
+        links: [
+          { id: 'link-1', permissions: ['VIEW'], useCount: 0, shareUrl: SHARE_URL },
+          { id: 'link-2', permissions: ['VIEW', 'EDIT'], useCount: 2, shareUrl: 'https://app.pagespace.ai/s/ps_share_def' },
+        ],
+      });
+
+      const { result } = renderHook(() => usePageShareLink(PAGE_ID));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.links).toHaveLength(2);
     });
 
     it('Given GET returns a VIEW+EDIT link, should expose permissions correctly', async () => {
       mockFetchResolve({
-        links: [{ id: LINK_ID, permissions: ['VIEW', 'EDIT'], useCount: 0, shareUrl: SHARE_URL, expiresAt: null, createdAt: new Date().toISOString() }],
+        links: [{ id: LINK_ID, permissions: ['VIEW', 'EDIT'], useCount: 0, shareUrl: SHARE_URL }],
       });
 
       const { result } = renderHook(() => usePageShareLink(PAGE_ID));
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-      expect(result.current.activeLink?.permissions).toEqual(['VIEW', 'EDIT']);
+      expect(result.current.links[0].permissions).toEqual(['VIEW', 'EDIT']);
     });
 
-    it('Given GET returns malformed data (permissions is not an array), should treat as no active link', async () => {
+    it('Given GET returns malformed data (permissions is not an array), should have empty links', async () => {
       mockFetchResolve({ links: [{ id: LINK_ID, permissions: 'VIEW', useCount: 0 }] });
 
       const { result } = renderHook(() => usePageShareLink(PAGE_ID));
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-      expect(result.current.activeLink).toBeNull();
+      expect(result.current.links).toHaveLength(0);
     });
 
-    it('Given GET fails, should finish loading with no active link', async () => {
+    it('Given GET fails, should finish loading with empty links', async () => {
       mockFetchReject();
 
       const { result } = renderHook(() => usePageShareLink(PAGE_ID));
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-      expect(result.current.activeLink).toBeNull();
+      expect(result.current.links).toHaveLength(0);
     });
   });
 
@@ -98,8 +113,8 @@ describe('usePageShareLink', () => {
         await result.current.handleGenerate({ canView: true, canEdit: false, canShare: false, canDelete: false });
       });
 
-      expect(result.current.shareUrl).toBe(SHARE_URL);
-      expect(result.current.activeLink?.permissions).toEqual(['VIEW']);
+      expect(result.current.links).toHaveLength(1);
+      expect(result.current.links[0].permissions).toEqual(['VIEW']);
       expect(vi.mocked(post)).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({ permissions: ['VIEW'] })
@@ -159,12 +174,29 @@ describe('usePageShareLink', () => {
         expect.objectContaining({ permissions: ['VIEW', 'EDIT', 'SHARE', 'DELETE'] })
       );
     });
+
+    it('Given existing links, generating a new link should append to the list', async () => {
+      mockFetchResolve({
+        links: [{ id: 'link-1', permissions: ['VIEW'], useCount: 0, shareUrl: SHARE_URL }],
+      });
+      vi.mocked(post).mockResolvedValueOnce({ id: 'link-2', rawToken: 'tok2', shareUrl: 'https://app.pagespace.ai/s/tok2' });
+      Object.assign(navigator, { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } });
+
+      const { result } = renderHook(() => usePageShareLink(PAGE_ID));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.handleGenerate({ canView: true, canEdit: false, canShare: false, canDelete: false });
+      });
+
+      expect(result.current.links).toHaveLength(2);
+    });
   });
 
   describe('copying a link', () => {
-    it('Given shareUrl is set, handleCopy should write shareUrl to clipboard', async () => {
+    it('Given a link with shareUrl, handleCopy should write shareUrl to clipboard', async () => {
       mockFetchResolve({
-        links: [{ id: LINK_ID, permissions: ['VIEW'], useCount: 0, shareUrl: SHARE_URL, expiresAt: null, createdAt: new Date().toISOString() }],
+        links: [{ id: LINK_ID, permissions: ['VIEW'], useCount: 0, shareUrl: SHARE_URL }],
       });
       const writeText = vi.fn().mockResolvedValue(undefined);
       Object.assign(navigator, { clipboard: { writeText } });
@@ -173,7 +205,7 @@ describe('usePageShareLink', () => {
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
       await act(async () => {
-        await result.current.handleCopy();
+        await result.current.handleCopy(result.current.links[0]);
       });
 
       expect(writeText).toHaveBeenCalledWith(SHARE_URL);
@@ -181,9 +213,9 @@ describe('usePageShareLink', () => {
   });
 
   describe('revoking a link', () => {
-    it('Given DELETE succeeds, should clear activeLink and shareUrl', async () => {
+    it('Given DELETE succeeds, should remove the link from the list', async () => {
       mockFetchResolve({
-        links: [{ id: LINK_ID, permissions: ['VIEW'], useCount: 1, shareUrl: SHARE_URL, expiresAt: null, createdAt: new Date().toISOString() }],
+        links: [{ id: LINK_ID, permissions: ['VIEW'], useCount: 1, shareUrl: SHARE_URL }],
       });
       vi.mocked(del).mockResolvedValueOnce(undefined);
 
@@ -191,11 +223,46 @@ describe('usePageShareLink', () => {
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
       await act(async () => {
-        await result.current.handleRevoke();
+        await result.current.handleRevoke(LINK_ID);
       });
 
-      expect(result.current.activeLink).toBeNull();
-      expect(result.current.shareUrl).toBeNull();
+      expect(result.current.links).toHaveLength(0);
+    });
+
+    it('Given two links, revoking one should leave the other intact', async () => {
+      mockFetchResolve({
+        links: [
+          { id: 'link-1', permissions: ['VIEW'], useCount: 0, shareUrl: SHARE_URL },
+          { id: 'link-2', permissions: ['VIEW', 'EDIT'], useCount: 0, shareUrl: 'https://other.url' },
+        ],
+      });
+      vi.mocked(del).mockResolvedValueOnce(undefined);
+
+      const { result } = renderHook(() => usePageShareLink(PAGE_ID));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.handleRevoke('link-1');
+      });
+
+      expect(result.current.links).toHaveLength(1);
+      expect(result.current.links[0].id).toBe('link-2');
+    });
+
+    it('Given DELETE fails, should keep the link in the list', async () => {
+      mockFetchResolve({
+        links: [{ id: LINK_ID, permissions: ['VIEW'], useCount: 1, shareUrl: SHARE_URL }],
+      });
+      vi.mocked(del).mockRejectedValueOnce(new Error('server error'));
+
+      const { result } = renderHook(() => usePageShareLink(PAGE_ID));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.handleRevoke(LINK_ID);
+      });
+
+      expect(result.current.links).toHaveLength(1);
     });
   });
 });

--- a/apps/web/src/hooks/usePageShareLink.ts
+++ b/apps/web/src/hooks/usePageShareLink.ts
@@ -16,7 +16,7 @@ const PageListResponseSchema = z.object({
   links: z.array(PageLinkSchema),
 });
 
-type PageLink = z.infer<typeof PageLinkSchema>;
+export type PageLink = z.infer<typeof PageLinkSchema>;
 
 export interface ShareLinkPermissions {
   canView: boolean;
@@ -26,17 +26,15 @@ export interface ShareLinkPermissions {
 }
 
 export function usePageShareLink(pageId: string) {
-  const [activeLink, setActiveLink] = useState<PageLink | null>(null);
-  const [shareUrl, setShareUrl] = useState<string | null>(null);
+  const [links, setLinks] = useState<PageLink[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isGenerating, setIsGenerating] = useState(false);
-  const [isRevoking, setIsRevoking] = useState(false);
+  const [revokingId, setRevokingId] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
     setIsLoading(true);
-    setActiveLink(null);
-    setShareUrl(null);
+    setLinks([]);
 
     async function loadExisting() {
       try {
@@ -44,10 +42,8 @@ export function usePageShareLink(pageId: string) {
         if (!res.ok || cancelled) return;
         const raw = await res.json();
         const parsed = PageListResponseSchema.safeParse(raw);
-        if (cancelled || !parsed.success || parsed.data.links.length === 0) return;
-        const link = parsed.data.links[0];
-        setActiveLink(link);
-        setShareUrl(link.shareUrl);
+        if (cancelled || !parsed.success) return;
+        setLinks(parsed.data.links);
       } catch {
         // silently fail — user can still generate a new link
       } finally {
@@ -70,8 +66,8 @@ export function usePageShareLink(pageId: string) {
         `/api/pages/${pageId}/share-links`,
         { permissions }
       );
-      setShareUrl(data.shareUrl);
-      setActiveLink({ id: data.id, permissions, useCount: 0, shareUrl: data.shareUrl });
+      const newLink: PageLink = { id: data.id, permissions, useCount: 0, shareUrl: data.shareUrl };
+      setLinks(prev => [...prev, newLink]);
       const copied = await navigator.clipboard.writeText(data.shareUrl).then(() => true).catch(() => false);
       toast.success(copied ? 'Link created and copied to clipboard' : 'Link created');
     } catch {
@@ -81,27 +77,25 @@ export function usePageShareLink(pageId: string) {
     }
   }
 
-  async function handleCopy() {
-    if (!shareUrl) return;
-    const copied = await navigator.clipboard.writeText(shareUrl).then(() => true).catch(() => false);
+  async function handleCopy(link: PageLink) {
+    if (!link.shareUrl) return;
+    const copied = await navigator.clipboard.writeText(link.shareUrl).then(() => true).catch(() => false);
     if (copied) toast.success('Link copied to clipboard');
     else toast.error('Could not copy link to clipboard');
   }
 
-  async function handleRevoke() {
-    if (!activeLink) return;
-    setIsRevoking(true);
+  async function handleRevoke(linkId: string) {
+    setRevokingId(linkId);
     try {
-      await del(`/api/pages/${pageId}/share-links/${activeLink.id}`);
-      setActiveLink(null);
-      setShareUrl(null);
+      await del(`/api/pages/${pageId}/share-links/${linkId}`);
+      setLinks(prev => prev.filter(l => l.id !== linkId));
       toast.success('Link revoked');
     } catch {
       toast.error('Failed to revoke link');
     } finally {
-      setIsRevoking(false);
+      setRevokingId(prev => (prev === linkId ? null : prev));
     }
   }
 
-  return { activeLink, shareUrl, isLoading, isGenerating, isRevoking, handleGenerate, handleCopy, handleRevoke };
+  return { links, isLoading, isGenerating, revokingId, handleGenerate, handleCopy, handleRevoke };
 }

--- a/apps/web/src/lib/auth/auth-fetch.ts
+++ b/apps/web/src/lib/auth/auth-fetch.ts
@@ -1083,6 +1083,7 @@ class AuthFetch {
       }
     }
 
+    if (response.status === 204) return undefined as T;
     return response.json();
   }
 


### PR DESCRIPTION
## Summary

- **Fix "Failed to revoke URL"** — `fetchJSON` in `auth-fetch.ts` was calling `response.json()` on `204 No Content` responses, throwing a `SyntaxError` that surfaced as "Failed to revoke link" toast. Both page and drive DELETE routes return 204 — one-line guard fixes both.
- **Multiple share links for pages** — `usePageShareLink` and `PageShareLinkSection` rewritten to match the existing `useDriveShareLink` / `DriveShareLinkSection` pattern. The schema and API already supported multiple links; the UI was discarding all but `links[0]`. Users can now create, copy, and revoke multiple page share links independently.

## Changes

| File | What changed |
|------|-------------|
| `apps/web/src/lib/auth/auth-fetch.ts` | Add `204` guard in `fetchJSON` before `response.json()` |
| `apps/web/src/hooks/usePageShareLink.ts` | Rewrite: `links[]` array, per-link `revokingId`, args-based copy/revoke |
| `apps/web/src/components/.../PageShareLinkSection.tsx` | Rewrite: render all links, always-visible generate button |
| `apps/web/src/hooks/__tests__/usePageShareLink.test.ts` | Updated + new tests for multi-link behaviour |

## Test plan

- [ ] Open a page share dialog → generate a link → click revoke → should show "Link revoked" (no error)
- [ ] Open drive settings → revoke a share link → same, no error
- [ ] On a page, generate a link, then generate a second → both appear as rows, each independently copyable and revocable
- [ ] Revoking one link from a two-link list removes only that row

🤖 Generated with [Claude Code](https://claude.com/claude-code)