### PR TITLE
fix(account): show correct drive count in ownership dialog

### DIFF
--- a/apps/web/src/app/settings/account/page.tsx
+++ b/apps/web/src/app/settings/account/page.tsx
@@ -716,12 +716,14 @@ export default function AccountPage() {
       </Card>
 
       {/* Drive Ownership Dialog */}
-      <DriveOwnershipDialog
-        isOpen={isOwnershipDialogOpen}
-        onClose={() => setIsOwnershipDialogOpen(false)}
-        onAllDrivesHandled={handleAllDrivesHandled}
-        multiMemberDrives={multiMemberDrives}
-      />
+      {isOwnershipDialogOpen && (
+        <DriveOwnershipDialog
+          isOpen={isOwnershipDialogOpen}
+          onClose={() => setIsOwnershipDialogOpen(false)}
+          onAllDrivesHandled={handleAllDrivesHandled}
+          multiMemberDrives={multiMemberDrives}
+        />
+      )}
 
       {/* Delete Account Dialog */}
       <DeleteAccountDialog


### PR DESCRIPTION
## Summary

- `DriveOwnershipDialog` was always mounted in the DOM, causing `useState(initialDrives)` to capture the empty `[]` on first mount before `multiMemberDrives` state was populated
- When the dialog later opened with actual drives in the prop, React's `useState` correctly ignores changed props — so the count stayed at 0 and the list was empty
- Wrapping with `{isOwnershipDialogOpen && ...}` forces a fresh mount each time the dialog opens, so the drive count and list display correctly

## Test plan

- [ ] Own a drive with at least one other member
- [ ] Go to Settings → Account → Delete Account
- [ ] Verify the ownership dialog opens and shows the correct drive count (e.g. "You own 1 drive with other members")
- [ ] Verify the drive name and member count appear in the list
- [ ] Transfer or delete the drive and confirm the flow proceeds to account deletion confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)