### PR TITLE
feat(channels): auto-link bare URLs in channel and DM messages

### DIFF
--- a/apps/web/src/components/ai/shared/__tests__/StreamingMarkdown.test.tsx
+++ b/apps/web/src/components/ai/shared/__tests__/StreamingMarkdown.test.tsx
@@ -170,6 +170,68 @@ describe('preprocessMentions', () => {
   });
 });
 
+describe('autoLinkUrls', () => {
+  it('should convert bare URL to markdown link', () => {
+    render(<StreamingMarkdown content="check out https://example.com today" />);
+    expect(screen.getByTestId('streamdown').textContent).toBe(
+      'check out [https://example.com](https://example.com) today'
+    );
+  });
+
+  it('should strip trailing punctuation from URL', () => {
+    render(<StreamingMarkdown content="see https://example.com." />);
+    expect(screen.getByTestId('streamdown').textContent).toBe(
+      'see [https://example.com](https://example.com).'
+    );
+  });
+
+  it('should not double-wrap URLs already inside markdown links', () => {
+    render(<StreamingMarkdown content="[click here](https://example.com)" />);
+    expect(screen.getByTestId('streamdown').textContent).toBe(
+      '[click here](https://example.com)'
+    );
+  });
+
+  it('should not double-wrap URLs used as markdown link labels', () => {
+    render(<StreamingMarkdown content="[https://example.com](https://example.com)" />);
+    expect(screen.getByTestId('streamdown').textContent).toBe(
+      '[https://example.com](https://example.com)'
+    );
+  });
+
+  it('should auto-link alongside mentions', () => {
+    render(
+      <StreamingMarkdown content="@[User](id:user) see https://example.com" />
+    );
+    expect(screen.getByTestId('streamdown').textContent).toBe(
+      '[mention:User](mention://id/user) see [https://example.com](https://example.com)'
+    );
+  });
+
+  it('should handle http:// URLs', () => {
+    render(<StreamingMarkdown content="visit http://example.com" />);
+    expect(screen.getByTestId('streamdown').textContent).toBe(
+      'visit [http://example.com](http://example.com)'
+    );
+  });
+
+  it('should preserve balanced parens in URL paths (Wikipedia-style)', () => {
+    render(
+      <StreamingMarkdown content="see https://en.wikipedia.org/wiki/Foo_(bar) for details" />
+    );
+    expect(screen.getByTestId('streamdown').textContent).toBe(
+      'see [https://en.wikipedia.org/wiki/Foo_(bar)](https://en.wikipedia.org/wiki/Foo_(bar)) for details'
+    );
+  });
+
+  it('should strip unbalanced trailing ) from URL', () => {
+    render(<StreamingMarkdown content="(see https://example.com)" />);
+    expect(screen.getByTestId('streamdown').textContent).toBe(
+      '(see [https://example.com](https://example.com))'
+    );
+  });
+});
+
 describe('raw HTML rendering', () => {
   it('should keep raw user markdown source intact while installing an HTML-to-text remark plugin', () => {
     render(

--- a/apps/web/src/components/ai/shared/chat/StreamingMarkdown.tsx
+++ b/apps/web/src/components/ai/shared/chat/StreamingMarkdown.tsx
@@ -37,13 +37,31 @@ function preprocessMentions(content: string): string {
 
 /**
  * Convert bare http(s):// URLs to markdown [url](url) links so Streamdown renders them
- * as clickable anchors. Skips URLs already inside markdown link syntax `(url)`.
- * Trailing punctuation is stripped from the URL and preserved as literal text.
+ * as clickable anchors. Skips URLs already inside markdown link syntax `[...](...)`
+ * via negative lookbehinds. Trailing punctuation is stripped and preserved as literal
+ * text; unbalanced closing parens are also stripped (balanced parens in paths are kept,
+ * so Wikipedia-style URLs like .../Foo_(bar) work correctly).
  */
 function autoLinkUrls(content: string): string {
-  return content.replace(/(?<!\()(https?:\/\/[^\s<>"')\]]+)/g, (rawUrl) => {
-    const url = rawUrl.replace(/[.,;:!?'")\]>]+$/, '');
-    const trailing = rawUrl.slice(url.length);
+  // Allow ) in URL body — handled via post-match paren balancing below
+  return content.replace(/(?<!\[)(?<!\()(https?:\/\/[^\s<>"'\]]+)/g, (rawUrl) => {
+    // Strip trailing plain punctuation
+    let url = rawUrl.replace(/[.,;:!?'">\]]+$/, '');
+    let trailing = rawUrl.slice(url.length);
+
+    // Strip unbalanced trailing ) so "https://example.com)" doesn't include the )
+    // but "https://en.wikipedia.org/wiki/Foo_(bar)" keeps its balanced )
+    while (url.endsWith(')')) {
+      const opens = (url.match(/\(/g) ?? []).length;
+      const closes = (url.match(/\)/g) ?? []).length;
+      if (closes > opens) {
+        trailing = ')' + trailing;
+        url = url.slice(0, -1);
+      } else {
+        break;
+      }
+    }
+
     return `[${url}](${url})${trailing}`;
   });
 }

--- a/apps/web/src/components/ai/shared/chat/StreamingMarkdown.tsx
+++ b/apps/web/src/components/ai/shared/chat/StreamingMarkdown.tsx
@@ -35,6 +35,19 @@ function preprocessMentions(content: string): string {
   });
 }
 
+/**
+ * Convert bare http(s):// URLs to markdown [url](url) links so Streamdown renders them
+ * as clickable anchors. Skips URLs already inside markdown link syntax `(url)`.
+ * Trailing punctuation is stripped from the URL and preserved as literal text.
+ */
+function autoLinkUrls(content: string): string {
+  return content.replace(/(?<!\()(https?:\/\/[^\s<>"')\]]+)/g, (rawUrl) => {
+    const url = rawUrl.replace(/[.,;:!?'")\]>]+$/, '');
+    const trailing = rawUrl.slice(url.length);
+    return `[${url}](${url})${trailing}`;
+  });
+}
+
 /** Converts single \n to CommonMark hard line breaks (two trailing spaces + \n).
  * Leaves \n\n paragraph breaks untouched. Use for user-typed content only —
  * not AI-generated markdown where \n has structural meaning (lists, code blocks). */
@@ -354,8 +367,8 @@ export const StreamingMarkdown = memo(
   ({ content, isStreaming = false, renderHtmlAsText = false, className }: StreamingMarkdownProps) => {
     const router = useRouter();
 
-    // Pre-process mentions before rendering
-    const processedContent = useMemo(() => preprocessMentions(content), [content]);
+    // Pre-process mentions and auto-link bare URLs before rendering
+    const processedContent = useMemo(() => autoLinkUrls(preprocessMentions(content)), [content]);
 
     // Create components with router for mobile-aware navigation
     // Memoize to avoid recreating on every render

--- a/apps/web/src/components/messages/MessagePartRenderer.tsx
+++ b/apps/web/src/components/messages/MessagePartRenderer.tsx
@@ -22,9 +22,6 @@ interface MessagePartRendererProps {
   context?: 'message';
 }
 
-// Matches either a @mention or a bare http(s) URL, in document order
-const CONTENT_REGEX = /@\[([^\]]+)\]\(([^:]+):([^)]+)\)|(https?:\/\/[^\s<>"')\]]+)/g;
-
 function parseTextIntoNodes(
   text: string,
   baseKey: string,
@@ -35,10 +32,11 @@ function parseTextIntoNodes(
   let lastIndex = 0;
   let match: RegExpExecArray | null;
 
-  // Reset stateful regex before use
-  CONTENT_REGEX.lastIndex = 0;
+  // Local regex instance — avoids shared lastIndex state across concurrent renders
+  // URL part allows ) in paths; unbalanced trailing ) handled in post-processing below
+  const contentRegex = /@\[([^\]]+)\]\(([^:]+):([^)]+)\)|(https?:\/\/[^\s<>"'\]]+)/g;
 
-  while ((match = CONTENT_REGEX.exec(text)) !== null) {
+  while ((match = contentRegex.exec(text)) !== null) {
     const preceding = text.slice(lastIndex, match.index);
     if (preceding) {
       elements.push(<span key={`${baseKey}-t-${lastIndex}`}>{preceding}</span>);
@@ -72,8 +70,21 @@ function parseTextIntoNodes(
     } else {
       // Bare URL: group 4
       const rawUrl = match[4];
-      const url = rawUrl.replace(/[.,;:!?'")\]>]+$/, '');
-      const trailing = rawUrl.slice(url.length);
+      let url = rawUrl.replace(/[.,;:!?'">\]]+$/, '');
+      let trailing = rawUrl.slice(url.length);
+
+      // Strip unbalanced trailing ) — keeps balanced parens in paths (e.g. Wikipedia URLs)
+      while (url.endsWith(')')) {
+        const opens = (url.match(/\(/g) ?? []).length;
+        const closes = (url.match(/\)/g) ?? []).length;
+        if (closes > opens) {
+          trailing = ')' + trailing;
+          url = url.slice(0, -1);
+        } else {
+          break;
+        }
+      }
+
       elements.push(
         <a
           key={`${baseKey}-u-${match.index}`}

--- a/apps/web/src/components/messages/MessagePartRenderer.tsx
+++ b/apps/web/src/components/messages/MessagePartRenderer.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import React, { MouseEvent } from 'react';
+import { useRouter } from 'next/navigation';
 import { usePageNavigation } from '@/hooks/usePageNavigation';
+import { openExternalUrl, isInternalUrl } from '@/lib/navigation/app-navigation';
 
 // Define the structure for message parts
 export interface MessagePart {
@@ -20,116 +22,122 @@ interface MessagePartRendererProps {
   context?: 'message';
 }
 
+// Matches either a @mention or a bare http(s) URL, in document order
+const CONTENT_REGEX = /@\[([^\]]+)\]\(([^:]+):([^)]+)\)|(https?:\/\/[^\s<>"')\]]+)/g;
+
+function parseTextIntoNodes(
+  text: string,
+  baseKey: string,
+  onMentionClick: (e: MouseEvent<HTMLAnchorElement>, pageId: string) => void,
+  onUrlClick: (e: MouseEvent<HTMLAnchorElement>, url: string) => void,
+): React.ReactNode[] {
+  const elements: React.ReactNode[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  // Reset stateful regex before use
+  CONTENT_REGEX.lastIndex = 0;
+
+  while ((match = CONTENT_REGEX.exec(text)) !== null) {
+    const preceding = text.slice(lastIndex, match.index);
+    if (preceding) {
+      elements.push(<span key={`${baseKey}-t-${lastIndex}`}>{preceding}</span>);
+    }
+
+    if (match[1] !== undefined) {
+      // @mention: groups 1=label, 2=id, 3=type
+      const [, label, id, type] = match;
+      if (type === 'page') {
+        elements.push(
+          <a
+            key={`${baseKey}-m-${match.index}`}
+            href={`/p/${id}`}
+            onClick={(e) => onMentionClick(e, id)}
+            className="bg-primary/10 text-primary dark:bg-primary/20 dark:text-primary px-1 rounded hover:bg-primary/20 dark:hover:bg-primary/30 transition-colors no-underline"
+          >
+            @{label}
+          </a>
+        );
+      } else {
+        elements.push(
+          <span
+            key={`${baseKey}-m-${match.index}`}
+            className="bg-primary/10 text-primary dark:bg-primary/20 dark:text-primary px-1 rounded"
+          >
+            @{label}
+          </span>
+        );
+      }
+      lastIndex = match.index + match[0].length;
+    } else {
+      // Bare URL: group 4
+      const rawUrl = match[4];
+      const url = rawUrl.replace(/[.,;:!?'")\]>]+$/, '');
+      const trailing = rawUrl.slice(url.length);
+      elements.push(
+        <a
+          key={`${baseKey}-u-${match.index}`}
+          href={url}
+          onClick={(e) => onUrlClick(e, url)}
+          className="text-primary underline break-all [overflow-wrap:anywhere]"
+        >
+          {url}
+        </a>
+      );
+      if (trailing) {
+        elements.push(<span key={`${baseKey}-u-trail-${match.index}`}>{trailing}</span>);
+      }
+      lastIndex = match.index + match[0].length;
+    }
+  }
+
+  const remaining = text.slice(lastIndex);
+  if (remaining) {
+    elements.push(<span key={`${baseKey}-t-${lastIndex}`}>{remaining}</span>);
+  }
+
+  return elements;
+}
+
 const MessagePartRenderer: React.FC<MessagePartRendererProps> = ({ part, index }) => {
+  const router = useRouter();
   const { navigateToPage } = usePageNavigation();
 
-  // Handle mention link clicks - use navigateToPage to stay in WebView on Capacitor/Electron
   const handleMentionClick = (e: MouseEvent<HTMLAnchorElement>, pageId: string) => {
     e.preventDefault();
     navigateToPage(pageId);
   };
 
+  const handleUrlClick = async (e: MouseEvent<HTMLAnchorElement>, url: string) => {
+    e.preventDefault();
+    if (isInternalUrl(url)) {
+      router.push(url);
+    } else {
+      await openExternalUrl(url);
+    }
+  };
+
   switch (part.type) {
-    case 'text':
-      // Check if text contains mentions in markdown-typed format
+    case 'text': {
       const text = part.text || '';
-      const textMentionRegex = /@\[([^\]]+)\]\(([^:]+):([^)]+)\)/g;
-      const textElements = [];
-      let textLastIndex = 0;
-      let textMatch;
+      const nodes = parseTextIntoNodes(text, `${index}`, handleMentionClick, handleUrlClick);
 
-      while ((textMatch = textMentionRegex.exec(text)) !== null) {
-        const [fullMatch, label, id, type] = textMatch;
-        const precedingText = text.slice(textLastIndex, textMatch.index);
-        if (precedingText) {
-          textElements.push(<span key={`${index}-text-${textLastIndex}`}>{precedingText}</span>);
-        }
-        // Only page mentions should be clickable links
-        if (type === 'page') {
-          textElements.push(
-            <a
-              key={`${index}-mention-${textMatch.index}`}
-              href={`/p/${id}`}
-              onClick={(e) => handleMentionClick(e, id)}
-              className="bg-primary/10 text-primary dark:bg-primary/20 dark:text-primary px-1 rounded hover:bg-primary/20 dark:hover:bg-primary/30 transition-colors no-underline"
-            >
-              @{label}
-            </a>
-          );
-        } else {
-          // Non-page mentions (user, agent, etc.) render as styled badges without links
-          textElements.push(
-            <span
-              key={`${index}-mention-${textMatch.index}`}
-              className="bg-primary/10 text-primary dark:bg-primary/20 dark:text-primary px-1 rounded"
-            >
-              @{label}
-            </span>
-          );
-        }
-        textLastIndex = textMatch.index + fullMatch.length;
-      }
-
-      const remainingTextContent = text.slice(textLastIndex);
-      if (remainingTextContent) {
-        textElements.push(<span key={`${index}-text-${textLastIndex}`}>{remainingTextContent}</span>);
-      }
-
-      // If no mentions found, just return the plain text
-      if (textElements.length === 0) {
+      if (nodes.length === 0) {
         return <span key={index} className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{text}</span>;
       }
 
-      return <span key={index} className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{textElements}</span>;
+      return <span key={index} className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{nodes}</span>;
+    }
 
-    case 'rich-text':
+    case 'rich-text': {
       const textContent = typeof part.content === 'string'
         ? part.content
         : JSON.stringify(part.content, null, 2);
 
-      const mentionRegex = /@\[([^\]]+)\]\(([^:]+):([^)]+)\)/g;
-      const elements = [];
-      let lastIndex = 0;
-      let match;
+      const nodes = parseTextIntoNodes(textContent, `${index}`, handleMentionClick, handleUrlClick);
 
-      while ((match = mentionRegex.exec(textContent)) !== null) {
-        const [fullMatch, label, id, mentionType] = match;
-        const precedingText = textContent.slice(lastIndex, match.index);
-        if (precedingText) {
-          elements.push(<span key={`${index}-text-${lastIndex}`}>{precedingText}</span>);
-        }
-        // Only page mentions should be clickable links
-        if (mentionType === 'page') {
-          elements.push(
-            <a
-              key={`${index}-mention-${id}`}
-              href={`/p/${id}`}
-              onClick={(e) => handleMentionClick(e, id)}
-              className="bg-primary/10 text-primary dark:bg-primary/20 dark:text-primary px-1 rounded hover:bg-primary/20 dark:hover:bg-primary/30 transition-colors no-underline"
-            >
-              @{label}
-            </a>
-          );
-        } else {
-          // Non-page mentions (user, agent, etc.) render as styled badges without links
-          elements.push(
-            <span
-              key={`${index}-mention-${id}`}
-              className="bg-primary/10 text-primary dark:bg-primary/20 dark:text-primary px-1 rounded"
-            >
-              @{label}
-            </span>
-          );
-        }
-        lastIndex = match.index + fullMatch.length;
-      }
-
-      const remainingText = textContent.slice(lastIndex);
-      if (remainingText) {
-        elements.push(<span key={`${index}-text-${lastIndex}`}>{remainingText}</span>);
-      }
-
-      return <div key={index} className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{elements}</div>;
+      return <div key={index} className="whitespace-pre-wrap break-words [overflow-wrap:anywhere]">{nodes}</div>;
+    }
 
     case 'tool-invocation':
       return (

--- a/apps/web/src/components/messages/__tests__/MessagePartRenderer.test.tsx
+++ b/apps/web/src/components/messages/__tests__/MessagePartRenderer.test.tsx
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { convertToMessageParts, renderMessageParts } from '../MessagePartRenderer';
+import React from 'react';
+
+vi.mock('@/hooks/usePageNavigation', () => ({
+  usePageNavigation: () => ({ navigateToPage: vi.fn() }),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('@/lib/navigation/app-navigation', () => ({
+  isInternalUrl: (url: string) => url.startsWith('/'),
+  openExternalUrl: vi.fn(),
+}));
+
+interface AssertParams {
+  given: string;
+  should: string;
+  actual: unknown;
+  expected: unknown;
+}
+
+const assert = ({ given, should, actual, expected }: AssertParams): void => {
+  expect(actual, `Given ${given}, should ${should}`).toEqual(expected);
+};
+
+function renderText(content: string) {
+  const parts = convertToMessageParts(content);
+  return render(<div>{renderMessageParts(parts)}</div>);
+}
+
+describe('convertToMessageParts', () => {
+  it('converts plain string to text part', () => {
+    assert({
+      given: 'a plain string',
+      should: 'produce a single text part',
+      actual: convertToMessageParts('hello world'),
+      expected: [{ type: 'text', text: 'hello world' }],
+    });
+  });
+
+  it('converts JSON doc string to rich-text part', () => {
+    const doc = '{"type":"doc","content":[]}';
+    assert({
+      given: 'a JSON doc string',
+      should: 'produce a rich-text part',
+      actual: convertToMessageParts(doc),
+      expected: [{ type: 'rich-text', content: { type: 'doc', content: [] } }],
+    });
+  });
+});
+
+describe('URL auto-linking in text parts', () => {
+  it('renders a bare https URL as a clickable anchor', () => {
+    renderText('check out https://example.com today');
+
+    const link = screen.getByRole('link', { name: 'https://example.com' });
+    assert({
+      given: 'a bare https URL in text',
+      should: 'render as an anchor with correct href',
+      actual: link.getAttribute('href'),
+      expected: 'https://example.com',
+    });
+  });
+
+  it('renders a bare http URL as a clickable anchor', () => {
+    renderText('visit http://example.com now');
+
+    const link = screen.getByRole('link', { name: 'http://example.com' });
+    assert({
+      given: 'a bare http URL in text',
+      should: 'render as a clickable link',
+      actual: link.getAttribute('href'),
+      expected: 'http://example.com',
+    });
+  });
+
+  it('strips trailing period from URL', () => {
+    renderText('see https://example.com.');
+
+    const link = screen.getByRole('link', { name: 'https://example.com' });
+    assert({
+      given: 'a URL with trailing period',
+      should: 'exclude the period from the href',
+      actual: link.getAttribute('href'),
+      expected: 'https://example.com',
+    });
+
+    assert({
+      given: 'a URL with trailing period',
+      should: 'render the period as plain text after the link',
+      actual: link.nextSibling?.textContent,
+      expected: '.',
+    });
+  });
+
+  it('renders plain text before and after the URL correctly', () => {
+    renderText('before https://example.com after');
+
+    const link = screen.getByRole('link', { name: 'https://example.com' });
+    assert({
+      given: 'surrounding text',
+      should: 'preserve text before the link',
+      actual: link.previousSibling?.textContent,
+      expected: 'before ',
+    });
+    assert({
+      given: 'surrounding text',
+      should: 'preserve text after the link',
+      actual: link.nextSibling?.textContent,
+      expected: ' after',
+    });
+  });
+
+  it('renders multiple URLs in the same message', () => {
+    renderText('https://one.com and https://two.com');
+
+    const links = screen.getAllByRole('link');
+    assert({
+      given: 'two bare URLs',
+      should: 'render two anchors',
+      actual: links.length,
+      expected: 2,
+    });
+    assert({
+      given: 'first URL',
+      should: 'have correct href',
+      actual: links[0].getAttribute('href'),
+      expected: 'https://one.com',
+    });
+    assert({
+      given: 'second URL',
+      should: 'have correct href',
+      actual: links[1].getAttribute('href'),
+      expected: 'https://two.com',
+    });
+  });
+});
+
+describe('mentions and URLs together', () => {
+  it('renders both a mention badge and a URL link in the same message', () => {
+    renderText('@[Alice](alice123:user) shared https://example.com');
+
+    const link = screen.getByRole('link', { name: 'https://example.com' });
+    assert({
+      given: 'a mention followed by a URL',
+      should: 'render the URL as a link',
+      actual: link.getAttribute('href'),
+      expected: 'https://example.com',
+    });
+
+    const mention = screen.getByText('@Alice');
+    assert({
+      given: 'a user mention',
+      should: 'render as a badge span (not a link)',
+      actual: mention.tagName.toLowerCase(),
+      expected: 'span',
+    });
+  });
+
+  it('renders a page mention as a link and a URL as a link', () => {
+    renderText('@[Docs](docid:page) see https://external.com');
+
+    const links = screen.getAllByRole('link');
+    assert({
+      given: 'a page mention and a URL',
+      should: 'render two links',
+      actual: links.length,
+      expected: 2,
+    });
+  });
+});
+
+describe('plain text without URLs', () => {
+  it('renders plain text without modification', () => {
+    renderText('hello world');
+
+    assert({
+      given: 'plain text with no URLs or mentions',
+      should: 'render the text as-is',
+      actual: screen.getByText('hello world').textContent,
+      expected: 'hello world',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Bare `http(s)://` URLs typed in channel messages and DMs now automatically render as clickable hyperlinks
- **Channels**: Added `autoLinkUrls()` preprocessor in `StreamingMarkdown` that converts bare URLs to markdown `[url](url)` before Streamdown renders — reuses the existing `createCustomAnchor` handler for Capacitor-aware navigation
- **DMs**: Refactored `MessagePartRenderer` to use a single-pass combined regex that handles both `@mentions` and bare URLs, wiring up `openExternalUrl`/`isInternalUrl` for correct cross-platform behavior

## Test plan

- [ ] Send a channel message with a bare URL (`https://pagespace.ai`) — renders as a clickable link
- [ ] Send a DM with a bare URL — same result
- [ ] Existing markdown links `[text](url)` in AI responses still work (no double-wrapping)
- [ ] `@mentions` still work in both surfaces
- [ ] URL with trailing punctuation (`https://example.com.`) — punct is excluded from the link
- [ ] Typecheck passes (pre-existing errors in `drive-invite-repository.ts` / `share-link-service.ts` are unrelated to this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Bare URLs in chat messages are now automatically converted into clickable links
  * Improved message rendering with enhanced support for mentions and URLs
  * Links properly handle trailing punctuation and distinguish between internal and external navigation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1348)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->