### PR TITLE
feat(reactions): rich hover/long-press tooltip

### DIFF
--- a/apps/web/src/components/shared/MessageReactions.tsx
+++ b/apps/web/src/components/shared/MessageReactions.tsx
@@ -83,15 +83,20 @@ function ReactionPill({
     }, 500);
   };
 
-  const cancelLongPress = () => {
+  const onTouchEnd = (e: React.TouchEvent) => {
+    if (longPressTimer.current) clearTimeout(longPressTimer.current);
+    if (suppressNextClick.current) {
+      // Prevent the synthetic click that mobile browsers fire after touchend
+      e.preventDefault();
+      suppressNextClick.current = false;
+    }
+  };
+
+  const onTouchMove = () => {
     if (longPressTimer.current) clearTimeout(longPressTimer.current);
   };
 
   const handleClick = () => {
-    if (suppressNextClick.current) {
-      suppressNextClick.current = false;
-      return;
-    }
     onReactionClick(group);
   };
 
@@ -103,8 +108,8 @@ function ReactionPill({
           onMouseEnter={scheduleOpen}
           onMouseLeave={scheduleClose}
           onTouchStart={onTouchStart}
-          onTouchEnd={cancelLongPress}
-          onTouchMove={cancelLongPress}
+          onTouchEnd={onTouchEnd}
+          onTouchMove={onTouchMove}
           disabled={!canReact}
           className={cn(
             'inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-xs',

--- a/apps/web/src/components/shared/MessageReactions.tsx
+++ b/apps/web/src/components/shared/MessageReactions.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useMemo } from 'react';
+import { useState, useRef, useMemo, useEffect } from 'react';
 import { cn } from '@/lib/utils';
 import {
   Popover,
@@ -48,33 +48,60 @@ function ReactionPill({
   onReactionClick,
 }: ReactionPillProps) {
   const [open, setOpen] = useState(false);
-  const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Prevent synthetic click from firing after a long press on mobile
+  const suppressNextClick = useRef(false);
 
-  const onMouseEnter = () => {
-    hoverTimer.current = setTimeout(() => setOpen(true), 300);
+  useEffect(() => {
+    return () => {
+      if (openTimer.current) clearTimeout(openTimer.current);
+      if (closeTimer.current) clearTimeout(closeTimer.current);
+      if (longPressTimer.current) clearTimeout(longPressTimer.current);
+    };
+  }, []);
+
+  const scheduleOpen = () => {
+    if (closeTimer.current) clearTimeout(closeTimer.current);
+    openTimer.current = setTimeout(() => setOpen(true), 300);
   };
 
-  const onMouseLeave = () => {
-    if (hoverTimer.current) clearTimeout(hoverTimer.current);
-    setOpen(false);
+  const scheduleClose = () => {
+    if (openTimer.current) clearTimeout(openTimer.current);
+    closeTimer.current = setTimeout(() => setOpen(false), 150);
+  };
+
+  const cancelClose = () => {
+    if (closeTimer.current) clearTimeout(closeTimer.current);
   };
 
   const onTouchStart = () => {
-    longPressTimer.current = setTimeout(() => setOpen(true), 500);
+    longPressTimer.current = setTimeout(() => {
+      suppressNextClick.current = true;
+      setOpen(true);
+    }, 500);
   };
 
   const cancelLongPress = () => {
     if (longPressTimer.current) clearTimeout(longPressTimer.current);
   };
 
+  const handleClick = () => {
+    if (suppressNextClick.current) {
+      suppressNextClick.current = false;
+      return;
+    }
+    onReactionClick(group);
+  };
+
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <button
-          onClick={() => onReactionClick(group)}
-          onMouseEnter={onMouseEnter}
-          onMouseLeave={onMouseLeave}
+          onClick={handleClick}
+          onMouseEnter={scheduleOpen}
+          onMouseLeave={scheduleClose}
           onTouchStart={onTouchStart}
           onTouchEnd={cancelLongPress}
           onTouchMove={cancelLongPress}
@@ -96,10 +123,8 @@ function ReactionPill({
       <PopoverContent
         side="top"
         className="w-auto min-w-[120px] max-w-[200px] p-3 space-y-2"
-        onMouseEnter={() => {
-          if (hoverTimer.current) clearTimeout(hoverTimer.current);
-        }}
-        onMouseLeave={onMouseLeave}
+        onMouseEnter={cancelClose}
+        onMouseLeave={scheduleClose}
       >
         <div className="flex items-center gap-2 text-sm font-medium">
           <span className="text-lg leading-none">{group.emoji}</span>

--- a/apps/web/src/components/shared/MessageReactions.tsx
+++ b/apps/web/src/components/shared/MessageReactions.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useState, useRef, useMemo } from 'react';
 import { cn } from '@/lib/utils';
 import {
-  Tooltip,
-  TooltipTrigger,
-  TooltipContent,
-} from '@/components/ui/tooltip';
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
 
 export interface Reaction {
   id: string;
@@ -32,6 +32,96 @@ interface GroupedReaction {
   count: number;
   users: { id: string; name: string | null }[];
   hasReacted: boolean;
+}
+
+interface ReactionPillProps {
+  group: GroupedReaction;
+  currentUserId: string;
+  canReact: boolean;
+  onReactionClick: (group: GroupedReaction) => void;
+}
+
+function ReactionPill({
+  group,
+  currentUserId,
+  canReact,
+  onReactionClick,
+}: ReactionPillProps) {
+  const [open, setOpen] = useState(false);
+  const hoverTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const onMouseEnter = () => {
+    hoverTimer.current = setTimeout(() => setOpen(true), 300);
+  };
+
+  const onMouseLeave = () => {
+    if (hoverTimer.current) clearTimeout(hoverTimer.current);
+    setOpen(false);
+  };
+
+  const onTouchStart = () => {
+    longPressTimer.current = setTimeout(() => setOpen(true), 500);
+  };
+
+  const cancelLongPress = () => {
+    if (longPressTimer.current) clearTimeout(longPressTimer.current);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          onClick={() => onReactionClick(group)}
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
+          onTouchStart={onTouchStart}
+          onTouchEnd={cancelLongPress}
+          onTouchMove={cancelLongPress}
+          disabled={!canReact}
+          className={cn(
+            'inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-xs',
+            'transition-all duration-150',
+            'border',
+            group.hasReacted
+              ? 'bg-primary/10 border-primary/30 text-primary hover:bg-primary/20'
+              : 'bg-muted/50 border-border/50 text-muted-foreground hover:bg-muted',
+            !canReact && 'cursor-default opacity-80'
+          )}
+        >
+          <span className="text-sm">{group.emoji}</span>
+          <span className="font-medium">{group.count}</span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        side="top"
+        className="w-auto min-w-[120px] max-w-[200px] p-3 space-y-2"
+        onMouseEnter={() => {
+          if (hoverTimer.current) clearTimeout(hoverTimer.current);
+        }}
+        onMouseLeave={onMouseLeave}
+      >
+        <div className="flex items-center gap-2 text-sm font-medium">
+          <span className="text-lg leading-none">{group.emoji}</span>
+          <span className="text-foreground">
+            {group.count} {group.count === 1 ? 'reaction' : 'reactions'}
+          </span>
+        </div>
+        <div className="border-t pt-2 space-y-1">
+          {group.users.slice(0, 10).map((u) => (
+            <div key={u.id} className="text-sm text-muted-foreground">
+              {u.id === currentUserId ? 'You' : (u.name ?? 'Unknown')}
+            </div>
+          ))}
+          {group.users.length > 10 && (
+            <div className="text-xs text-muted-foreground">
+              and {group.users.length - 10} more
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
 }
 
 export function MessageReactions({
@@ -82,44 +172,16 @@ export function MessageReactions({
     }
   };
 
-  const formatUserNames = (users: { id: string; name: string | null }[]) => {
-    const names = users
-      .map((u) => (u.id === currentUserId ? 'You' : u.name || 'Unknown'))
-      .slice(0, 10);
-
-    if (users.length > 10) {
-      names.push(`and ${users.length - 10} more`);
-    }
-
-    return names.join(', ');
-  };
-
   return (
     <div className={cn('flex flex-wrap items-center gap-1 mt-1', className)}>
       {groupedReactions.map((group) => (
-        <Tooltip key={group.emoji}>
-          <TooltipTrigger asChild>
-            <button
-              onClick={() => handleReactionClick(group)}
-              disabled={!canReact}
-              className={cn(
-                'inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-xs',
-                'transition-all duration-150',
-                'border',
-                group.hasReacted
-                  ? 'bg-primary/10 border-primary/30 text-primary hover:bg-primary/20'
-                  : 'bg-muted/50 border-border/50 text-muted-foreground hover:bg-muted',
-                !canReact && 'cursor-default opacity-80'
-              )}
-            >
-              <span className="text-sm">{group.emoji}</span>
-              <span className="font-medium">{group.count}</span>
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="top" className="max-w-xs">
-            <p className="text-sm">{formatUserNames(group.users)}</p>
-          </TooltipContent>
-        </Tooltip>
+        <ReactionPill
+          key={group.emoji}
+          group={group}
+          currentUserId={currentUserId}
+          canReact={canReact}
+          onReactionClick={handleReactionClick}
+        />
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary

- Replaces the plain comma-separated \`Tooltip\` on emoji reaction pills with a controlled \`Popover\` showing a rich card (emoji, count, named reactor list) — matching Discord/Slack behaviour
- Desktop: popover opens after a 300ms hover delay; moving mouse into the card cancels the scheduled close so the card stays open; leaving the card restarts the 150ms close delay
- Mobile: popover opens after a 500ms long-press; short taps still toggle the reaction; dragging cancels the long-press; \`e.preventDefault()\` in \`onTouchEnd\` blocks the synthetic click that mobile browsers fire after a long-press, preventing accidental reaction toggles
- All three timers (\`openTimer\`, \`closeTimer\`, \`longPressTimer\`) are cleaned up in \`useEffect\` to prevent state updates on unmounted components

## Changed files

- \`apps/web/src/components/shared/MessageReactions.tsx\` — sole change; public API unchanged, all three callsites (DMs, Channels, ChannelView) unaffected

## Test plan

- [ ] Hover over a reaction pill in a DM — rich card appears after ~300ms
- [ ] Hover over a reaction pill in a channel — same behaviour
- [ ] Move mouse from pill into the popover card — card stays open
- [ ] Move mouse out of card — card closes after ~150ms
- [ ] Short-tap a reaction on mobile/touch emulation — reaction toggles, no popover
- [ ] Long-press a reaction (500ms+) on mobile — popover opens with emoji, count, and names; reaction is NOT toggled on release
- [ ] Drag finger while holding — long-press cancelled, popover does not open
- [ ] "You" shown for current user's reaction; other names listed correctly
- [ ] More than 10 reactors shows "and N more"
- [ ] Unmount during open (navigate away mid-hover) — no warnings about state updates on unmounted component

🤖 Generated with [Claude Code](https://claude.com/claude-code)