### PR TITLE
chore(marketing): replace Discord with AI Agent Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PageSpace: Where AI Can Actually Work
 
-**[www.pagespace.ai](https://www.pagespace.ai)** • Desktop Apps • [Discord](https://discord.gg/yxDQkTHXT5)
+**[www.pagespace.ai](https://www.pagespace.ai)** • Desktop Apps • [AI Agent Hub](https://pagespace.ai/s/ps_share_oihl5ivoscf0tzx26g0t74degxwi028t)
 
 > PageSpace turns your projects into intelligent workspaces where AI agents collaborate alongside your team with real tools to create, edit, and organize content.
 
@@ -243,7 +243,7 @@ PageSpace provides comprehensive data protection so you never lose work:
 
 ## Community & Support
 
-- **[Discord](https://discord.gg/yxDQkTHXT5)** — community support and discussion
+- **[AI Agent Hub](https://pagespace.ai/s/ps_share_oihl5ivoscf0tzx26g0t74degxwi028t)** — community hub for AI agents and skills
 - **[GitHub Issues](https://github.com/2witstudios/PageSpace/issues)** — bug reports and feature requests
 
 ---

--- a/apps/marketing/src/app/blog/[slug]/data.ts
+++ b/apps/marketing/src/app/blog/[slug]/data.ts
@@ -52,7 +52,7 @@ If you regularly hit the pro daily limit, [upgrade to a higher plan](/pricing) f
 
 Two reasons. Key management was the biggest setup hurdle for new users — most never finished configuring providers, and the experience suffered. Holding encrypted keys for every user was also a meaningful security surface area we didn't need to own. Operators provision once at the deployment level; there's nothing per-user to leak.
 
-If a provider you used regularly has disappeared from your model picker, or a model isn't behaving the way you expect, reach out on Discord or email hello@pagespace.ai.
+If a provider you used regularly has disappeared from your model picker, or a model isn't behaving the way you expect, reach out on the [AI Agent Hub](https://pagespace.ai/s/ps_share_oihl5ivoscf0tzx26g0t74degxwi028t) or email hello@pagespace.ai.
     `,
     author: "Jono",
     date: "2026-05-01",

--- a/apps/marketing/src/app/contact/page.tsx
+++ b/apps/marketing/src/app/contact/page.tsx
@@ -52,12 +52,12 @@ export default function ContactPage() {
                 </div>
                 <h3 className="font-semibold mb-1">Community</h3>
                 <a
-                  href="https://discord.gg/kve8qgzZ8x"
+                  href="https://pagespace.ai/s/ps_share_oihl5ivoscf0tzx26g0t74degxwi028t"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-sm text-muted-foreground hover:text-primary transition-colors"
                 >
-                  Join our Discord
+                  Join our AI Agent Hub
                 </a>
               </div>
             </div>

--- a/apps/marketing/src/app/privacy/page.tsx
+++ b/apps/marketing/src/app/privacy/page.tsx
@@ -222,7 +222,7 @@ export default function PrivacyPolicy() {
             <ul className="list-disc pl-6 mb-4">
               <li><strong>Email:</strong> hello@pagespace.ai</li>
               <li><strong>Support:</strong> Available through the in-app help system</li>
-              <li><strong>Community:</strong> <a href="https://discord.gg/kve8qgzZ8x" className="text-primary hover:underline">PageSpace Discord</a></li>
+              <li><strong>Community:</strong> <a href="https://pagespace.ai/s/ps_share_oihl5ivoscf0tzx26g0t74degxwi028t" className="text-primary hover:underline">AI Agent Hub</a></li>
             </ul>
             <p className="mb-4">
               For data protection requests (access, deletion, portability), please use the subject line &quot;Data Protection Request&quot; in your email.

--- a/apps/marketing/src/app/terms/page.tsx
+++ b/apps/marketing/src/app/terms/page.tsx
@@ -209,7 +209,7 @@ export default function TermsOfService() {
             <ul className="list-disc pl-6 mb-4">
               <li><strong>Email:</strong> hello@pagespace.ai</li>
               <li><strong>Support:</strong> Available through the in-app help system</li>
-              <li><strong>Community:</strong> <a href="https://discord.gg/kve8qgzZ8x" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">PageSpace Discord</a></li>
+              <li><strong>Community:</strong> <a href="https://pagespace.ai/s/ps_share_oihl5ivoscf0tzx26g0t74degxwi028t" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">AI Agent Hub</a></li>
             </ul>
           </section>
         </div>


### PR DESCRIPTION
## Summary

- Replaces all Discord links and references across the marketing site, legal pages, and README with the PageSpace AI Agent Hub
- Affects: contact page, privacy policy, terms of service, blog post, and README (6 occurrences total)
- Single canonical URL used throughout

## Test plan

- [ ] Visit `/contact` — "Join our AI Agent Hub" link opens the AI Agent Hub
- [ ] Visit `/privacy` — Community link in section 15 points to AI Agent Hub
- [ ] Visit `/terms` — Community link in section 16 points to AI Agent Hub
- [ ] Visit blog post `/blog/managed-provider-keys` — inline link renders correctly
- [ ] `grep -r "discord" .` returns zero hits in marketing/README

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated community and support links across README, contact, privacy, and terms pages to direct users to the AI Agent Hub.
  * Updated blog post call-to-action guidance to reference AI Agent Hub and email support options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1352)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->