### PR TITLE
fix(tasks): New Task button focuses visible input

### DIFF
--- a/apps/e2e/tests/06-task-list.spec.ts
+++ b/apps/e2e/tests/06-task-list.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+import { seedState } from '../fixtures/seed-state';
+
+test('New Task button focuses the task input and creates a task', async ({ page, request }) => {
+  // Seed a Task List page via API
+  const csrfResponse = await request.get('/api/auth/csrf');
+  const { csrfToken } = (await csrfResponse.json()) as { csrfToken: string };
+
+  const createResponse = await request.post('/api/pages', {
+    headers: { 'X-CSRF-Token': csrfToken },
+    data: {
+      title: `E2E Task List ${Date.now()}`,
+      type: 'TASK_LIST',
+      driveId: seedState.driveId,
+      parentId: null,
+    },
+  });
+  expect(createResponse.status()).toBe(201);
+  const { id: pageId } = (await createResponse.json()) as { id: string };
+
+  // Navigate to the task list page
+  await page.goto(`/dashboard/${seedState.driveId}/${pageId}`);
+
+  // Wait for the New Task button to appear (table view is default)
+  const newTaskBtn = page.getByRole('button', { name: 'New Task' });
+  await expect(newTaskBtn).toBeVisible();
+
+  // Click it and assert the desktop input receives focus
+  await newTaskBtn.click();
+  const taskInput = page.locator('#new-task-input');
+  await expect(taskInput).toBeFocused();
+
+  // Type a task title and submit
+  const taskTitle = `E2E task ${Date.now()}`;
+  const [taskCreateResponse] = await Promise.all([
+    page.waitForResponse(`**/api/pages/${pageId}/tasks`),
+    page.keyboard.type(taskTitle).then(() => page.keyboard.press('Enter')),
+  ]);
+  expect(taskCreateResponse.status()).toBe(201);
+
+  // Task title should appear in the list
+  await expect(page.getByText(taskTitle).first()).toBeVisible();
+});

--- a/apps/e2e/tests/06-task-list.spec.ts
+++ b/apps/e2e/tests/06-task-list.spec.ts
@@ -1,8 +1,6 @@
-import { test, expect } from '@playwright/test';
-import { seedState } from '../fixtures/seed-state';
+import { test, expect } from '../fixtures/auth.fixture';
 
-test('New Task button focuses the task input and creates a task', async ({ page, request }) => {
-  // Seed a Task List page via API
+test('New Task button focuses the task input and creates a task', async ({ page, request, driveId }) => {
   const csrfResponse = await request.get('/api/auth/csrf');
   const { csrfToken } = (await csrfResponse.json()) as { csrfToken: string };
 
@@ -11,26 +9,21 @@ test('New Task button focuses the task input and creates a task', async ({ page,
     data: {
       title: `E2E Task List ${Date.now()}`,
       type: 'TASK_LIST',
-      driveId: seedState.driveId,
+      driveId,
       parentId: null,
     },
   });
   expect(createResponse.status()).toBe(201);
   const { id: pageId } = (await createResponse.json()) as { id: string };
 
-  // Navigate to the task list page
-  await page.goto(`/dashboard/${seedState.driveId}/${pageId}`);
+  await page.goto(`/dashboard/${driveId}/${pageId}`);
 
-  // Wait for the New Task button to appear (table view is default)
   const newTaskBtn = page.getByRole('button', { name: 'New Task' });
   await expect(newTaskBtn).toBeVisible();
 
-  // Click it and assert the desktop input receives focus
   await newTaskBtn.click();
-  const taskInput = page.locator('#new-task-input');
-  await expect(taskInput).toBeFocused();
+  await expect(page.locator('#new-task-input')).toBeFocused();
 
-  // Type a task title and submit
   const taskTitle = `E2E task ${Date.now()}`;
   const [taskCreateResponse] = await Promise.all([
     page.waitForResponse(`**/api/pages/${pageId}/tasks`),
@@ -38,6 +31,5 @@ test('New Task button focuses the task input and creates a task', async ({ page,
   ]);
   expect(taskCreateResponse.status()).toBe(201);
 
-  // Task title should appear in the list
   await expect(page.getByText(taskTitle).first()).toBeVisible();
 });

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -832,7 +832,10 @@ function TaskListView({ page }: TaskListViewProps) {
               onClick={() => {
                 const mobileInput = document.getElementById('new-task-input-mobile');
                 const desktopInput = document.getElementById('new-task-input');
-                (mobileInput ?? desktopInput)?.focus();
+                // offsetParent is null for CSS-hidden elements; pick the visible input
+                const input = desktopInput?.offsetParent ? desktopInput : mobileInput;
+                input?.scrollIntoView({ block: 'nearest' });
+                input?.focus();
               }}
             >
               <Plus className="h-4 w-4 mr-1" />


### PR DESCRIPTION
## Summary

- Fixed "New Task" button in table view doing nothing on desktop
- Root cause: `??` null-check selected the mobile input (always in DOM, but CSS-hidden on desktop) instead of the visible desktop input
- Fix uses `offsetParent` to detect which input is actually visible, then `scrollIntoView` before `focus` so the row is in view on long lists
- Added Playwright e2e test (`06-task-list.spec.ts`) to cover the full flow: button click → focus → type → Enter → task created

## Test plan

- [ ] Open a Task List page in table view on desktop, click "New Task" — input row at bottom of table receives focus
- [ ] Same on mobile — mobile input receives focus
- [ ] `pnpm --filter @pagespace/e2e test:e2e -- --grep "New Task"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test for Task List page, validating the complete workflow from task creation through successful submission and UI verification.

* **Bug Fixes**
  * Enhanced focus handling for the "New Task" input field to properly identify and focus the visible input across mobile and desktop layouts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1353)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->