### PR TITLE
fix(voice): tighten barge-in VAD sensitivity

### DIFF
--- a/apps/web/src/hooks/useVoiceMode.ts
+++ b/apps/web/src/hooks/useVoiceMode.ts
@@ -518,6 +518,14 @@ export function useVoiceMode({
       // this, TTS audio bleeds through the mic on the first frames after
       // getUserMedia returns (especially after a tool-call response starts).
       await new Promise<void>((resolve) => { setTimeout(resolve, 200); });
+
+      // If a newer call to startBargeInMonitoring() ran during the warmup it
+      // will have replaced (or nulled) bargeInRefs.current.analyser via
+      // stopBargeInMonitoring().  This invocation is stale — exit without
+      // starting a second rAF loop.  The stream tracks were already stopped
+      // by the newer call, so no cleanup is needed here.
+      if (bargeInRefs.current.analyser !== analyser) return;
+
       if (voiceStateRef.current !== 'speaking') {
         stopBargeInMonitoring();
         return;

--- a/apps/web/src/hooks/useVoiceMode.ts
+++ b/apps/web/src/hooks/useVoiceMode.ts
@@ -514,9 +514,26 @@ export function useVoiceMode({
       bargeInRefs.current.stream = stream;
       bargeInRefs.current.analyser = analyser;
 
+      // Allow echo cancellation to calibrate before checking levels — without
+      // this, TTS audio bleeds through the mic on the first frames after
+      // getUserMedia returns (especially after a tool-call response starts).
+      await new Promise<void>((resolve) => { setTimeout(resolve, 200); });
+      if (voiceStateRef.current !== 'speaking') {
+        stopBargeInMonitoring();
+        return;
+      }
+
       const dataArray = new Uint8Array(analyser.frequencyBinCount);
-      const SPEECH_THRESHOLD = 22;
-      const REQUIRED_SPEECH_FRAMES = 15;
+
+      // Restrict detection to the human speech frequency band (85–8000 Hz).
+      // Averaging all bins (0–24 kHz) lets low-frequency rumble and high-
+      // frequency hiss accumulate enough energy to trip the threshold.
+      const hzPerBin = audioContext.sampleRate / analyser.fftSize;
+      const speechStartBin = Math.max(0, Math.floor(85 / hzPerBin));
+      const speechEndBin = Math.min(dataArray.length, Math.ceil(8000 / hzPerBin));
+
+      const SPEECH_THRESHOLD = 35;
+      const REQUIRED_SPEECH_FRAMES = 25;
       let speechFrames = 0;
 
       const checkSpeech = () => {
@@ -528,12 +545,16 @@ export function useVoiceMode({
         }
 
         currentAnalyser.getByteFrequencyData(dataArray);
-        const average = dataArray.reduce((a, b) => a + b, 0) / dataArray.length;
+        let sum = 0;
+        for (let i = speechStartBin; i < speechEndBin; i++) sum += dataArray[i];
+        const average = sum / (speechEndBin - speechStartBin);
 
         if (average >= SPEECH_THRESHOLD) {
           speechFrames += 1;
-        } else if (speechFrames > 0) {
-          speechFrames -= 1;
+        } else {
+          // Reset rather than decrement so intermittent noise cannot
+          // accumulate across quiet gaps to reach the trigger threshold.
+          speechFrames = 0;
         }
 
         if (speechFrames >= REQUIRED_SPEECH_FRAMES) {


### PR DESCRIPTION
## Summary

- Add 200ms startup warmup after mic opens so echo cancellation can calibrate — fixes the most common false trigger: barge-in firing immediately after a tool-call TTS response starts
- Restrict energy measurement to the 85–8000 Hz speech band instead of averaging all 512 FFT bins (0–24 kHz); low-frequency rumble and high-frequency hiss no longer count toward the trigger
- Raise `SPEECH_THRESHOLD` 22 → 35 and `REQUIRED_SPEECH_FRAMES` 15 → 25 (~420ms of sustained speech required, up from ~250ms)
- Reset `speechFrames` to 0 on silence instead of decrementing, so intermittent noise bursts cannot accumulate across quiet gaps to reach the threshold

## Test plan

- [ ] Start voice mode in barge-in mode, let AI give a multi-sentence TTS response — no false trigger
- [ ] Ask something that triggers a tool call; when TTS resumes after the tool result, confirm no immediate barge-in
- [ ] Type on keyboard while TTS plays — confirm no barge-in
- [ ] Say "stop" clearly — confirm barge-in fires within ~500ms
- [ ] Sit silently in a quiet room while TTS plays — confirm no barge-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved speech detection accuracy during text-to-speech playback to better distinguish user speech from background noise. Enhanced audio processing now provides more reliable voice interruption while minimizing false triggers from ambient sounds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1355)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->