### PR TITLE
feat(voice): replace barge-in with conversation mode

### DIFF
--- a/apps/web/src/components/ai/voice/VoiceCallPanel.tsx
+++ b/apps/web/src/components/ai/voice/VoiceCallPanel.tsx
@@ -101,7 +101,7 @@ export function VoiceCallPanel({
   }, [isAIStreaming]);
 
   // When stream ends, flush any buffered tail. queueSentence drops chunks
-  // when the user is mid-barge-in (listening/processing), so this is safe.
+  // while the user is listening/processing, so this is safe.
   useEffect(() => {
     if (isAIStreaming) return;
     const tail = pendingTextRef.current;

--- a/apps/web/src/components/ai/voice/VoiceCallPanel.tsx
+++ b/apps/web/src/components/ai/voice/VoiceCallPanel.tsx
@@ -161,12 +161,10 @@ export function VoiceCallPanel({
           ? 'Waiting for response...'
           : voiceState === 'speaking'
             ? isSpeaking
-              ? interactionMode === 'barge-in'
-                ? 'Speaking — interrupt anytime'
-                : 'Speaking...'
+              ? 'Speaking...'
               : 'Preparing audio...'
-            : interactionMode === 'barge-in'
-              ? 'Ready — speak anytime'
+            : interactionMode === 'conversation'
+              ? 'Ready — listening after AI responds'
               : 'Tap the mic to speak';
 
   const micColor =

--- a/apps/web/src/components/ai/voice/VoiceModeOverlay.tsx
+++ b/apps/web/src/components/ai/voice/VoiceModeOverlay.tsx
@@ -306,8 +306,8 @@ export function VoiceModeOverlay({
 
           {/* Interaction mode hint */}
           <p className="text-sm text-muted-foreground text-center">
-            {interactionMode === 'barge-in'
-              ? 'Speak anytime to interrupt'
+            {interactionMode === 'conversation'
+              ? 'Listens automatically after AI responds'
               : 'Press Space or tap to toggle'}
           </p>
 

--- a/apps/web/src/components/ai/voice/VoiceModeSettings.tsx
+++ b/apps/web/src/components/ai/voice/VoiceModeSettings.tsx
@@ -40,7 +40,7 @@ const INTERACTION_MODE_OPTIONS: { value: VoiceInteractionMode; label: string; de
  * VoiceModeSettings - Settings panel for voice mode configuration.
  *
  * Allows users to configure:
- * - Interaction mode (tap-to-speak vs barge-in)
+ * - Interaction mode (tap-to-speak vs conversation)
  * - TTS voice selection
  * - TTS speed
  * - Auto-send transcriptions

--- a/apps/web/src/components/ai/voice/VoiceModeSettings.tsx
+++ b/apps/web/src/components/ai/voice/VoiceModeSettings.tsx
@@ -30,9 +30,9 @@ const INTERACTION_MODE_OPTIONS: { value: VoiceInteractionMode; label: string; de
     description: 'Tap the mic to start/stop recording',
   },
   {
-    value: 'barge-in',
-    label: 'Barge-in',
-    description: 'Automatically listens - speak to interrupt AI',
+    value: 'conversation',
+    label: 'Conversation',
+    description: 'Automatically listens after AI finishes speaking',
   },
 ];
 

--- a/apps/web/src/hooks/useVoiceMode.ts
+++ b/apps/web/src/hooks/useVoiceMode.ts
@@ -586,7 +586,6 @@ export function useVoiceMode({
     }
   }, [
     isEnabled,
-    interactionMode,
     stopBargeInMonitoring,
     getAudioContext,
     bargeInStore,

--- a/apps/web/src/hooks/useVoiceMode.ts
+++ b/apps/web/src/hooks/useVoiceMode.ts
@@ -85,8 +85,8 @@ export interface UseVoiceModeReturn {
   bargeIn: () => void;
 
   // Settings
-  interactionMode: 'barge-in' | 'tap-to-speak';
-  setInteractionMode: (mode: 'barge-in' | 'tap-to-speak') => void;
+  interactionMode: 'conversation' | 'tap-to-speak';
+  setInteractionMode: (mode: 'conversation' | 'tap-to-speak') => void;
   ttsVoice: TTSVoice;
   setTTSVoice: (voice: TTSVoice) => void;
   autoSend: boolean;
@@ -482,7 +482,7 @@ export function useVoiceMode({
 
   // Voice Activity Detection while TTS is speaking (real barge-in).
   const startBargeInMonitoring = useCallback(async () => {
-    if (!isEnabled || interactionMode !== 'barge-in') return;
+    if (!isEnabled) return;
 
     stopBargeInMonitoring();
 
@@ -711,7 +711,7 @@ export function useVoiceMode({
             // Read live store state to avoid stale closure — always auto-listen after TTS
             const { isEnabled: liveEnabled, interactionMode: liveMode } =
               useVoiceModeStore.getState();
-            if (liveEnabled && liveMode === 'barge-in') {
+            if (liveEnabled && liveMode === 'conversation') {
               playbackRefs.current.autoListenTimer = setTimeout(() => {
                 playbackRefs.current.autoListenTimer = null;
                 void startListening();
@@ -727,9 +727,6 @@ export function useVoiceMode({
           prefetchedAudioRef.current = prefetchAudio(speechQueueRef.current[0]);
         }
 
-        if (interactionMode === 'barge-in' && isEnabled) {
-          void startBargeInMonitoring();
-        }
       } catch (err) {
         const message = getSynthesisErrorMessage(err);
         setError(message);

--- a/apps/web/src/hooks/useVoiceMode.ts
+++ b/apps/web/src/hooks/useVoiceMode.ts
@@ -56,7 +56,7 @@ export interface UseVoiceModeOptions {
   onSpeakComplete?: () => void;
   /** Callback when an error occurs */
   onError?: (error: string) => void;
-  /** Callback to abort the in-flight LLM stream on barge-in */
+  /** Callback to abort the in-flight LLM stream when user interrupts playback */
   onStopStream?: () => void;
   /** Language for transcription (default: 'en') */
   language?: string;
@@ -125,8 +125,7 @@ interface BargeInRefs {
  * - Audio recording via MediaRecorder API
  * - Speech-to-text via OpenAI Whisper
  * - Text-to-speech via OpenAI TTS
- * - Barge-in support (interrupt TTS when user speaks)
- * - Two interaction modes: tap-to-speak and barge-in
+ * - Two interaction modes: tap-to-speak and conversation (auto-listen after TTS)
  */
 export function useVoiceMode({
   onTranscript,
@@ -726,7 +725,6 @@ export function useVoiceMode({
         if (speechQueueRef.current.length > 0 && !prefetchedAudioRef.current) {
           prefetchedAudioRef.current = prefetchAudio(speechQueueRef.current[0]);
         }
-
       } catch (err) {
         const message = getSynthesisErrorMessage(err);
         setError(message);

--- a/apps/web/src/stores/__tests__/useVoiceModeStore.test.ts
+++ b/apps/web/src/stores/__tests__/useVoiceModeStore.test.ts
@@ -53,4 +53,29 @@ describe('useVoiceModeStore', () => {
     expect(state.owner).toBeNull();
     expect(state.voiceState).toBe('idle');
   });
+
+  describe('loadSettings', () => {
+    it('defaults to conversation mode when nothing is stored', () => {
+      useVoiceModeStore.getState().loadSettings();
+      expect(useVoiceModeStore.getState().interactionMode).toBe('conversation');
+    });
+
+    it('migrates legacy barge-in value to conversation', () => {
+      localStorage.setItem('pagespace:voice:interactionMode', 'barge-in');
+      useVoiceModeStore.getState().loadSettings();
+      expect(useVoiceModeStore.getState().interactionMode).toBe('conversation');
+    });
+
+    it('preserves tap-to-speak when stored', () => {
+      localStorage.setItem('pagespace:voice:interactionMode', 'tap-to-speak');
+      useVoiceModeStore.getState().loadSettings();
+      expect(useVoiceModeStore.getState().interactionMode).toBe('tap-to-speak');
+    });
+
+    it('preserves conversation when already stored as conversation', () => {
+      localStorage.setItem('pagespace:voice:interactionMode', 'conversation');
+      useVoiceModeStore.getState().loadSettings();
+      expect(useVoiceModeStore.getState().interactionMode).toBe('conversation');
+    });
+  });
 });

--- a/apps/web/src/stores/__tests__/useVoiceModeStore.test.ts
+++ b/apps/web/src/stores/__tests__/useVoiceModeStore.test.ts
@@ -60,10 +60,11 @@ describe('useVoiceModeStore', () => {
       expect(useVoiceModeStore.getState().interactionMode).toBe('conversation');
     });
 
-    it('migrates legacy barge-in value to conversation', () => {
+    it('migrates legacy barge-in value to conversation and persists it', () => {
       localStorage.setItem('pagespace:voice:interactionMode', 'barge-in');
       useVoiceModeStore.getState().loadSettings();
       expect(useVoiceModeStore.getState().interactionMode).toBe('conversation');
+      expect(localStorage.getItem('pagespace:voice:interactionMode')).toBe('conversation');
     });
 
     it('preserves tap-to-speak when stored', () => {

--- a/apps/web/src/stores/useVoiceModeStore.ts
+++ b/apps/web/src/stores/useVoiceModeStore.ts
@@ -208,6 +208,9 @@ export const useVoiceModeStore = create<VoiceModeState>()((set, get) => ({
     // 'barge-in' was the previous name for 'conversation' — migrate it
     const interactionMode: VoiceInteractionMode =
       rawMode === 'tap-to-speak' ? 'tap-to-speak' : 'conversation';
+    if (rawMode !== interactionMode) {
+      localStorage.setItem(VOICE_INTERACTION_MODE_KEY, interactionMode);
+    }
     const ttsVoice = localStorage.getItem(VOICE_TTS_VOICE_KEY) as TTSVoice | null;
     const autoSend = localStorage.getItem(VOICE_AUTO_SEND_KEY);
 

--- a/apps/web/src/stores/useVoiceModeStore.ts
+++ b/apps/web/src/stores/useVoiceModeStore.ts
@@ -3,7 +3,7 @@
  *
  * Manages voice mode state for hands-free AI interaction.
  * Supports two interaction modes:
- * - Barge-in: Automatically detects speech and interrupts TTS playback
+ * - Conversation: Auto-listens after TTS finishes playing
  * - Tap-to-speak: Manual control with tap to start/stop recording
  *
  * Uses OpenAI's Whisper for STT and OpenAI TTS for speech synthesis.
@@ -18,7 +18,7 @@ const VOICE_TTS_VOICE_KEY = 'pagespace:voice:ttsVoice';
 const VOICE_AUTO_SEND_KEY = 'pagespace:voice:autoSend';
 
 export type VoiceModeOwner = 'global-assistant' | 'ai-page' | 'sidebar-chat';
-export type VoiceInteractionMode = 'barge-in' | 'tap-to-speak';
+export type VoiceInteractionMode = 'conversation' | 'tap-to-speak';
 
 export type VoiceState =
   | 'idle' // Voice mode off
@@ -88,7 +88,7 @@ export const useVoiceModeStore = create<VoiceModeState>()((set, get) => ({
   owner: null,
   voiceState: 'idle',
   hasLoadedSettings: false,
-  interactionMode: 'barge-in',
+  interactionMode: 'conversation',
   ttsVoice: 'nova',
   ttsSpeed: 1.0,
   autoSend: true,
@@ -204,12 +204,19 @@ export const useVoiceModeStore = create<VoiceModeState>()((set, get) => ({
     }
 
     // Note: We intentionally don't restore isEnabled - user should explicitly enable voice mode each session
-    const interactionMode = localStorage.getItem(VOICE_INTERACTION_MODE_KEY) as VoiceInteractionMode | null;
+    const rawMode = localStorage.getItem(VOICE_INTERACTION_MODE_KEY);
+    // Migrate legacy 'barge-in' value to 'conversation'
+    const interactionMode: VoiceInteractionMode =
+      rawMode === 'barge-in' || rawMode === 'conversation'
+        ? 'conversation'
+        : rawMode === 'tap-to-speak'
+          ? 'tap-to-speak'
+          : 'conversation';
     const ttsVoice = localStorage.getItem(VOICE_TTS_VOICE_KEY) as TTSVoice | null;
     const autoSend = localStorage.getItem(VOICE_AUTO_SEND_KEY);
 
     set({
-      interactionMode: interactionMode || 'barge-in',
+      interactionMode,
       ttsVoice: ttsVoice || 'nova',
       autoSend: autoSend !== 'false', // Default true
       hasLoadedSettings: true,

--- a/apps/web/src/stores/useVoiceModeStore.ts
+++ b/apps/web/src/stores/useVoiceModeStore.ts
@@ -208,7 +208,7 @@ export const useVoiceModeStore = create<VoiceModeState>()((set, get) => ({
     // 'barge-in' was the previous name for 'conversation' — migrate it
     const interactionMode: VoiceInteractionMode =
       rawMode === 'tap-to-speak' ? 'tap-to-speak' : 'conversation';
-    if (rawMode !== interactionMode) {
+    if (rawMode === 'barge-in') {
       localStorage.setItem(VOICE_INTERACTION_MODE_KEY, interactionMode);
     }
     const ttsVoice = localStorage.getItem(VOICE_TTS_VOICE_KEY) as TTSVoice | null;

--- a/apps/web/src/stores/useVoiceModeStore.ts
+++ b/apps/web/src/stores/useVoiceModeStore.ts
@@ -205,13 +205,9 @@ export const useVoiceModeStore = create<VoiceModeState>()((set, get) => ({
 
     // Note: We intentionally don't restore isEnabled - user should explicitly enable voice mode each session
     const rawMode = localStorage.getItem(VOICE_INTERACTION_MODE_KEY);
-    // Migrate legacy 'barge-in' value to 'conversation'
+    // 'barge-in' was the previous name for 'conversation' — migrate it
     const interactionMode: VoiceInteractionMode =
-      rawMode === 'barge-in' || rawMode === 'conversation'
-        ? 'conversation'
-        : rawMode === 'tap-to-speak'
-          ? 'tap-to-speak'
-          : 'conversation';
+      rawMode === 'tap-to-speak' ? 'tap-to-speak' : 'conversation';
     const ttsVoice = localStorage.getItem(VOICE_TTS_VOICE_KEY) as TTSVoice | null;
     const autoSend = localStorage.getItem(VOICE_AUTO_SEND_KEY);
 


### PR DESCRIPTION
## Summary

- Removes mid-TTS VAD monitoring that was falsely stopping playback as soon as the AI started speaking
- Auto-listen now fires 300ms **after** TTS finishes, not during playback
- Renames the \`'barge-in'\` interaction mode to \`'conversation'\` across the store, hook, and all UI components
- Migrates any persisted \`'barge-in'\` localStorage value to \`'conversation'\` on load so existing users aren't broken
- Adds unit tests covering the localStorage migration (default, barge-in→conversation, tap-to-speak preserved)

## Test plan

- [ ] Switch to Conversation mode in voice settings
- [ ] Send a message → AI responds → TTS plays to completion without interruption
- [ ] After TTS ends, mic auto-starts listening after ~300ms
- [ ] Tap-to-speak mode still works as before
- [ ] Open DevTools, set \`pagespace:voice:interactionMode\` to \`'barge-in'\`, reload — verify it migrates to \`'conversation'\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)