### PR TITLE
fix(voice): heading pause + missing final sentences

### DIFF
--- a/apps/web/src/components/ai/voice/VoiceCallPanel.tsx
+++ b/apps/web/src/components/ai/voice/VoiceCallPanel.tsx
@@ -100,15 +100,27 @@ export function VoiceCallPanel({
     pendingTextRef.current = '';
   }, [isAIStreaming]);
 
-  // When stream ends, flush any buffered tail. queueSentence drops chunks
-  // when the user is mid-barge-in (listening/processing), so this is safe.
+  // When stream ends, flush any buffered tail. Also pick up tokens that arrived
+  // in the same React render as the isAIStreaming=false transition — those are
+  // missed by the streaming effect (which bails on !streamingText) but become
+  // visible once latestAssistantMessage is set a render later.
   useEffect(() => {
     if (isAIStreaming) return;
-    const tail = pendingTextRef.current;
+    let tail = pendingTextRef.current;
     pendingTextRef.current = '';
+
+    if (
+      latestAssistantMessage?.text &&
+      streamingSpokenRef.current > 0 &&
+      streamingSpokenRef.current < latestAssistantMessage.text.length
+    ) {
+      tail += latestAssistantMessage.text.slice(streamingSpokenRef.current);
+      streamingSpokenRef.current = latestAssistantMessage.text.length;
+    }
+
     if (!tail.trim()) return;
     for (const chunk of flushForTts(tail)) queueSentence(chunk);
-  }, [isAIStreaming, queueSentence]);
+  }, [isAIStreaming, queueSentence, latestAssistantMessage]);
 
   // Fallback: speak full message when voice mode was activated after streaming ended
   useEffect(() => {

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -450,7 +450,7 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
     const lastAssistantMsg = [...messages].reverse().find((m) => m.role === 'assistant');
     if (!lastAssistantMsg) return;
     const textParts = lastAssistantMsg.parts?.filter((p) => p.type === 'text') ?? [];
-    const text = textParts.map((p) => (p as { text: string }).text).join(' ');
+    const text = textParts.map((p) => (p as { text: string }).text).join('');
     if (!text.trim()) return;
     if (lastAssistantMsg.id === voiceBaselineRef.current) return;
 

--- a/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/dashboard/GlobalAssistantView.tsx
@@ -761,7 +761,7 @@ const GlobalAssistantView: React.FC = () => {
     const lastAssistantMsg = [...messages].reverse().find((m) => m.role === 'assistant');
     if (!lastAssistantMsg) return;
     const textParts = lastAssistantMsg.parts?.filter((p) => p.type === 'text') ?? [];
-    const text = textParts.map((p) => (p as { text: string }).text).join(' ');
+    const text = textParts.map((p) => (p as { text: string }).text).join('');
     if (!text.trim()) return;
     if (lastAssistantMsg.id === voiceBaselineRef.current) return;
 

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -540,7 +540,7 @@ const SidebarChatTab: React.FC = () => {
     const lastAssistantMsg = [...messages].reverse().find((m) => m.role === 'assistant');
     if (!lastAssistantMsg) return;
     const textParts = lastAssistantMsg.parts?.filter((p) => p.type === 'text') ?? [];
-    const text = textParts.map((p) => (p as { text: string }).text).join(' ');
+    const text = textParts.map((p) => (p as { text: string }).text).join('');
     if (!text.trim()) return;
     if (lastAssistantMsg.id === voiceBaselineRef.current) return;
 

--- a/apps/web/src/lib/voice/__tests__/chunkForTts.test.ts
+++ b/apps/web/src/lib/voice/__tests__/chunkForTts.test.ts
@@ -224,6 +224,32 @@ describe('chunkStreamingForTts', () => {
     const all = result.ready.join(' ');
     expect(all).not.toContain('..');
   });
+
+  it('treats a complete ATX heading line as a flush point (no sentence needed)', () => {
+    // A heading with only a single trailing newline must not wait for the
+    // section's first sentence — it should flush immediately so the TTS queue
+    // stays primed and the prefetch window can fill.
+    const result = chunkStreamingForTts('## Section Title\n');
+    expect(result.ready.length).toBeGreaterThan(0);
+    expect(result.ready.join(' ')).toContain('Section Title');
+    expect(result.pending).toBe('');
+  });
+
+  it('flushes a heading before accumulating the section body', () => {
+    // Buffer has heading + partial first sentence; the heading should be in
+    // ready and the partial sentence should stay in pending.
+    const result = chunkStreamingForTts('## Overview\nThis is the first');
+    expect(result.ready.join(' ')).toContain('Overview');
+    expect(result.pending).toContain('first');
+  });
+
+  it('handles all heading levels (h1–h6) as flush points', () => {
+    for (let level = 1; level <= 6; level++) {
+      const hashes = '#'.repeat(level);
+      const result = chunkStreamingForTts(`${hashes} Heading ${level}\n`);
+      expect(result.ready.length).toBeGreaterThan(0);
+    }
+  });
 });
 
 describe('flushForTts', () => {

--- a/apps/web/src/lib/voice/chunkForTts.ts
+++ b/apps/web/src/lib/voice/chunkForTts.ts
@@ -23,6 +23,7 @@ const BARE_URL = /\bhttps?:\/\/\S+/g;
 
 const SENTENCE_BOUNDARY = /(?<!\d)[.!?]+(?=\s|$)/g;
 const PARAGRAPH_BREAK = /\n{2,}/g;
+const HEADING_LINE = /^[ \t]*#{1,6}[ \t]+[^\n]*\n/gm;
 
 const DEFAULT_MAX_CHARS = 1500;
 
@@ -96,6 +97,12 @@ function findLastSafeBoundary(buffer: string): number {
     last = m.index + m[0].length;
   }
   for (const m of searchable.matchAll(PARAGRAPH_BREAK)) {
+    const end = m.index + m[0].length;
+    if (end > last) last = end;
+  }
+  // Treat a complete ATX heading line as a flush point so headings don't
+  // accumulate in pending waiting for the section's first sentence.
+  for (const m of searchable.matchAll(HEADING_LINE)) {
     const end = m.index + m[0].length;
     if (end > last) last = end;
   }


### PR DESCRIPTION
## Summary

- **Heading pause**: ATX heading lines (\`## Title\n\`) now flush immediately as their own TTS chunk instead of waiting for the section's first sentence. Adds \`HEADING_LINE\` as a third boundary type in \`findLastSafeBoundary()\` — the heading is queued as spoken text (e.g. \`"Section Title"\`) while the previous paragraph's audio is still playing, keeping the prefetch window full and eliminating the inter-chunk gap.

- **Missing last sentences**: Fixes a React render-batching race where the Vercel AI SDK batches the final stream tokens and \`isStreaming=false\` into the same render. At that moment \`streamingAssistantText\` is \`null\`, so the streaming effect bails and those final tokens are never queued. The flush effect now also depends on \`latestAssistantMessage\` and slices out the gap (\`latestAssistantMessage.text.slice(streamingSpokenRef.current)\`) one render later when \`setLastAIResponse\` fires with the complete response.

- **Offset alignment** (all three VoiceCallPanel hosts): \`setLastAIResponse\` in \`AiChatView\`, \`GlobalAssistantView\`, and \`SidebarChatTab\` now uses \`join('')\` (matching \`streamingAssistantText\`) so the byte offset in \`streamingSpokenRef\` is valid for the gap slice.

## Files changed

| File | Change |
|------|--------|
| \`apps/web/src/lib/voice/chunkForTts.ts\` | Add \`HEADING_LINE\` boundary; extend \`findLastSafeBoundary()\` |
| \`apps/web/src/components/ai/voice/VoiceCallPanel.tsx\` | Flush effect picks up gap via \`latestAssistantMessage\` |
| \`apps/web/src/components/layout/…/AiChatView.tsx\` | \`join(' ')\` → \`join('')\` |
| \`apps/web/src/components/layout/…/GlobalAssistantView.tsx\` | \`join(' ')\` → \`join('')\` |
| \`apps/web/src/components/layout/…/SidebarChatTab.tsx\` | \`join(' ')\` → \`join('')\` |
| \`apps/web/src/lib/voice/__tests__/chunkForTts.test.ts\` | 3 new heading boundary tests (45 total) |

## Test plan

- [ ] Prompt that produces a multi-section markdown response with \`##\` headings — each heading should begin speaking within ~200ms of the previous paragraph ending, no silence
- [ ] Prompt that produces a long response ending with 2–3 clear sentences — all sentences spoken, none dropped
- [ ] Verify in AiChatView, GlobalAssistantView (dashboard), and SidebarChatTab voice panels
- [ ] Verify barge-in and non-barge-in modes are unaffected
- [ ] 45 unit tests pass in \`chunkForTts.test.ts\` (3 new heading boundary tests added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)