### PR TITLE
fix(pulse): correct activity attribution and stop restricted-page leak

### DIFF
--- a/apps/web/src/app/api/pulse/cron/route.ts
+++ b/apps/web/src/app/api/pulse/cron/route.ts
@@ -33,6 +33,7 @@ import {
   type DiffRequest,
 } from '@pagespace/lib/content/diff-generator';
 import { readPageContent } from '@pagespace/lib/services/page-content-store';
+import { accessiblePageIds } from '@pagespace/lib/permissions/accessible-page-ids';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 import { validateSignedCronRequest } from '@/lib/auth/cron-auth';
@@ -151,6 +152,12 @@ async function generatePulseForUser(userId: string, now: Date): Promise<void> {
     ));
   const driveIds = userDrives.map(d => d.driveId);
 
+  // Pages the user is actually permitted to view (owner | drive-admin |
+  // explicit page permission). Drive membership alone does NOT grant access
+  // to every page in a drive, so Pulse must scope all page content, diffs,
+  // and per-page activity to this set or it leaks restricted pages.
+  const accessiblePages = new Set(await accessiblePageIds(userId));
+
   // ========================================
   // 1. WORKSPACE CONTEXT - Drives and team members
   // ========================================
@@ -225,6 +232,7 @@ async function generatePulseForUser(userId: string, now: Date): Promise<void> {
   // ========================================
   const pageActivities = rawActivity.filter(
     a => a.pageId &&
+         accessiblePages.has(a.pageId) &&
          a.driveId &&
          a.resourceType === 'page' &&
          (a.operation === 'update' || a.operation === 'create') &&
@@ -344,6 +352,7 @@ async function generatePulseForUser(userId: string, now: Date): Promise<void> {
     .select({
       actorId: activityLogs.userId,
       actorName: activityLogs.actorDisplayName,
+      actorEmail: activityLogs.actorEmail,
       operation: activityLogs.operation,
       resourceType: activityLogs.resourceType,
       resourceId: activityLogs.resourceId,
@@ -367,12 +376,18 @@ async function generatePulseForUser(userId: string, now: Date): Promise<void> {
 
   allActivity.forEach(a => {
     if (a.resourceType !== 'page' || !a.resourceId) return;
-    const key = `${a.actorId}-${a.resourceId}`;
+    // For page resources, resourceId is the pageId — enforce view permission.
+    if (!accessiblePages.has(a.resourceId)) return;
+    // Key on the denormalized actorEmail (NOT NULL, snapshotted per row).
+    // userId is nullable (FK ON DELETE SET NULL / system actors); keying on
+    // it collapses every null-user row on a page into one bucket and
+    // mislabels them as whichever actor was seen first.
+    const key = `${a.actorEmail}-${a.resourceId}`;
     const driveName = driveDetails.find(d => d.id === a.driveId)?.name || 'Unknown';
 
     if (!activityByPersonPage[key]) {
       activityByPersonPage[key] = {
-        person: a.actorName || 'Someone',
+        person: a.actorName ?? a.actorEmail,
         pageId: a.resourceId,
         pageTitle: a.resourceTitle || 'Untitled',
         driveName,
@@ -471,7 +486,9 @@ async function generatePulseForUser(userId: string, now: Date): Promise<void> {
     .orderBy(desc(chatMessages.createdAt))
     .limit(15) : [];
 
-  const chatsByPage = recentPageChats.reduce((acc, chat) => {
+  const chatsByPage = recentPageChats
+    .filter(chat => chat.pageId && accessiblePages.has(chat.pageId))
+    .reduce((acc, chat) => {
     const key = chat.pageId;
     if (!acc[key]) {
       acc[key] = {
@@ -625,6 +642,7 @@ async function generatePulseForUser(userId: string, now: Date): Promise<void> {
     contentChanges: contentDiffs.map((diff: StackedDiff & { driveId: string }) => ({
       page: diff.pageTitle || 'Untitled',
       actors: diff.actors,
+      primaryActor: diff.primaryActor,
       editCount: diff.collapsedCount,
       timeRange: diff.timeRange,
       isAiGenerated: diff.isAiGenerated,
@@ -815,9 +833,9 @@ What would be genuinely useful or interesting to say right now? Maybe it's an ob
       mentions: contextData.mentions.map(m => ({ by: m.by, inPage: m.inPage })),
       notifications: [],
       sharedWithYou: contextData.sharedWithYou.map(s => ({ page: s.page, by: s.by })),
-      contentChanges: contextData.contentChanges.slice(0, 5).map((c: { page: string; actors: string[] }) => ({
+      contentChanges: contextData.contentChanges.slice(0, 5).map((c: { page: string; primaryActor: string }) => ({
         page: c.page,
-        by: c.actors[0] || 'Someone',
+        by: c.primaryActor || 'Someone',
       })),
       pages: {
         updatedToday: contextData.activitySummary.filter(a => new Date(a.lastActive) >= startOfToday).length,

--- a/apps/web/src/app/api/pulse/generate/route.ts
+++ b/apps/web/src/app/api/pulse/generate/route.ts
@@ -34,6 +34,7 @@ import {
   type DiffRequest,
 } from '@pagespace/lib/content/diff-generator';
 import { readPageContent } from '@pagespace/lib/services/page-content-store';
+import { accessiblePageIds } from '@pagespace/lib/permissions/accessible-page-ids';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 
@@ -89,6 +90,12 @@ export async function POST(req: Request) {
         isNotNull(driveMembers.acceptedAt)
       ));
     const driveIds = userDrives.map(d => d.driveId);
+
+    // Pages the user is actually permitted to view (owner | drive-admin |
+    // explicit page permission). Drive membership alone does NOT grant access
+    // to every page in a drive, so Pulse must scope all page content, diffs,
+    // and per-page activity to this set or it leaks restricted pages.
+    const accessiblePages = new Set(await accessiblePageIds(userId));
 
     // ========================================
     // 1. WORKSPACE CONTEXT
@@ -166,6 +173,7 @@ export async function POST(req: Request) {
     // Filter to page content changes that we can diff
     const pageActivities = rawActivity.filter(
       a => a.pageId &&
+           accessiblePages.has(a.pageId) &&
            a.driveId &&
            a.resourceType === 'page' &&
            (a.operation === 'update' || a.operation === 'create') &&
@@ -282,12 +290,18 @@ export async function POST(req: Request) {
 
     rawActivity.forEach(a => {
       if (a.resourceType !== 'page' || !a.resourceId) return;
-      const key = `${a.actorId}-${a.resourceId}`;
+      // For page resources, resourceId is the pageId — enforce view permission.
+      if (!accessiblePages.has(a.resourceId)) return;
+      // Key on the denormalized actorEmail (NOT NULL, snapshotted per row).
+      // userId is nullable (FK ON DELETE SET NULL / system actors); keying on
+      // it collapses every null-user row on a page into one bucket and
+      // mislabels them as whichever actor was seen first.
+      const key = `${a.actorEmail}-${a.resourceId}`;
       const driveName = driveDetails.find(d => d.id === a.driveId)?.name || 'Unknown';
 
       if (!activityByPersonPage[key]) {
         activityByPersonPage[key] = {
-          person: a.actorName || 'Someone',
+          person: a.actorName ?? a.actorEmail,
           pageId: a.resourceId,
           pageTitle: a.resourceTitle || 'Untitled',
           driveName,
@@ -380,7 +394,9 @@ export async function POST(req: Request) {
       .orderBy(desc(chatMessages.createdAt))
       .limit(15) : [];
 
-    const chatsByPage = recentPageChats.reduce((acc, chat) => {
+    const chatsByPage = recentPageChats
+      .filter(chat => chat.pageId && accessiblePages.has(chat.pageId))
+      .reduce((acc, chat) => {
       const key = chat.pageId;
       if (!acc[key]) {
         acc[key] = {
@@ -512,6 +528,7 @@ export async function POST(req: Request) {
       contentChanges: contentDiffs.map((diff: StackedDiff & { driveId: string }) => ({
         page: diff.pageTitle || 'Untitled',
         actors: diff.actors,
+        primaryActor: diff.primaryActor,
         editCount: diff.collapsedCount,
         timeRange: diff.timeRange,
         isAiGenerated: diff.isAiGenerated,
@@ -682,9 +699,9 @@ What would be genuinely useful or interesting to say right now? Maybe it's an ob
         mentions: contextData.mentions.map(m => ({ by: m.by, inPage: m.inPage })),
         notifications: [],
         sharedWithYou: contextData.sharedWithYou.map(s => ({ page: s.page, by: s.by })),
-        contentChanges: contextData.contentChanges.slice(0, 5).map((c: { page: string; actors: string[] }) => ({
+        contentChanges: contextData.contentChanges.slice(0, 5).map((c: { page: string; primaryActor: string }) => ({
           page: c.page,
-          by: c.actors[0] || 'Someone',
+          by: c.primaryActor || 'Someone',
         })),
         pages: {
           updatedToday: contextData.activitySummary.filter(a => new Date(a.lastActive) >= startOfToday).length,

--- a/packages/lib/src/__tests__/activity-diff-utils.test.ts
+++ b/packages/lib/src/__tests__/activity-diff-utils.test.ts
@@ -327,6 +327,30 @@ describe('activity-diff-utils', () => {
       expect(result!.actors).toContain('Bob');
     });
 
+    it('attributes primaryActor to the most recent contributor, not the first', () => {
+      const group = createMockGroup();
+      group.first = { ...group.first, actorDisplayName: 'Alice' };
+      group.last = { ...group.last, actorDisplayName: 'Bob' };
+      group.activities = [group.first, group.last];
+
+      const result = generateStackedDiff('Before', 'After', group);
+
+      expect(result).not.toBeNull();
+      // The "after" content reflects Bob's edit — he must get the credit.
+      expect(result!.primaryActor).toBe('Bob');
+    });
+
+    it('falls back to actorEmail for primaryActor when display name is missing', () => {
+      const group = createMockGroup();
+      group.last = { ...group.last, actorDisplayName: null, actorEmail: 'bob@example.com' };
+      group.activities = [group.first, group.last];
+
+      const result = generateStackedDiff('Before', 'After', group);
+
+      expect(result).not.toBeNull();
+      expect(result!.primaryActor).toBe('bob@example.com');
+    });
+
     it('marks isAiGenerated if any activity is AI-generated', () => {
       const group = createMockGroup({ isAiGenerated: true });
       const result = generateStackedDiff('Before', 'After', group);
@@ -422,6 +446,7 @@ describe('activity-diff-utils', () => {
       collapsedCount: 1,
       timeRange: { from: '2024-01-01T10:00:00Z', to: '2024-01-01T10:05:00Z' },
       actors: ['user@example.com'],
+      primaryActor: 'user@example.com',
       unifiedDiff: 'x'.repeat(diffSize),
       stats: { additions, deletions, unchanged: 0, totalChanges: 1 },
       isAiGenerated: false,
@@ -507,6 +532,7 @@ describe('activity-diff-utils', () => {
         collapsedCount: 1,
         timeRange: { from: '2024-01-01T10:00:00Z', to: '2024-01-01T10:05:00Z' },
         actors: ['user@example.com'],
+        primaryActor: 'user@example.com',
         unifiedDiff: largeDiff,
         stats: { additions: 1000, deletions: 500, unchanged: 0, totalChanges: 1 },
         isAiGenerated: false,

--- a/packages/lib/src/content/activity-diff-utils.ts
+++ b/packages/lib/src/content/activity-diff-utils.ts
@@ -28,6 +28,13 @@ export interface StackedDiff {
   };
   /** Unique actors who made changes (emails or display names) */
   actors: string[];
+  /**
+   * The actor responsible for the resulting ("after") content of this diff.
+   * This is the most recent contributor in the group, not the first — the
+   * stacked diff's "after" state reflects their edit. Use this for "who
+   * changed X" attribution instead of actors[0].
+   */
+  primaryActor: string;
   /** Git-style unified diff - main content for AI consumption */
   unifiedDiff: string;
   /** Addition/deletion statistics */
@@ -192,6 +199,7 @@ export function generateStackedDiff(
           : group.last.timestamp.toISOString(),
       },
       actors: getUniqueActors(group.activities),
+      primaryActor: getPrimaryActor(group),
       unifiedDiff: '[Content too large for diff - showing stats only]',
       stats: {
         additions,
@@ -230,6 +238,7 @@ export function generateStackedDiff(
         : group.last.timestamp.toISOString(),
     },
     actors: getUniqueActors(group.activities),
+    primaryActor: getPrimaryActor(group),
     unifiedDiff,
     stats,
     isAiGenerated: group.activities.some(a => a.isAiGenerated),
@@ -340,14 +349,31 @@ function calculateDiffStats(oldContent: string, newContent: string): DiffStats {
 }
 
 /**
+ * Resolves a single activity to a stable display identity.
+ * Falls back to the denormalized email (always present) when no display name
+ * was snapshotted, so an actor is never silently relabelled as "Someone".
+ */
+function actorIdentity(activity: ActivityForDiff): string {
+  return activity.actorDisplayName ?? activity.actorEmail;
+}
+
+/**
  * Gets unique actor names from activities
  */
 function getUniqueActors(activities: ActivityForDiff[]): string[] {
   const actors = new Set<string>();
   for (const activity of activities) {
-    actors.add(activity.actorDisplayName ?? activity.actorEmail);
+    actors.add(actorIdentity(activity));
   }
   return Array.from(actors);
+}
+
+/**
+ * The actor whose edit produced the group's resulting ("after") content.
+ * Activities in a group are ordered oldest→newest, so this is the last one.
+ */
+function getPrimaryActor(group: ActivityDiffGroup): string {
+  return actorIdentity(group.last);
 }
 
 /**


### PR DESCRIPTION
Two related defects in Pulse summary generation:

Wrong-identity attribution:
- Stacked content diffs were credited to actors[0] (the earliest
  contributor by timestamp) while the diff body reflects the latest
  revision. Added StackedDiff.primaryActor (the most recent
  contributor) and use it for "who changed X".
- The per-page activity aggregation keyed on activityLogs.userId,
  which is nullable (FK ON DELETE SET NULL / system actors). Every
  null-user row on a page collapsed into one bucket labelled with
  whichever actor was processed first. Now keyed on the denormalized,
  non-null actorEmail, and the display name falls back to actorEmail
  instead of "Someone" so an actor is never silently relabelled.

Data leak:
- Activity, content diffs, and page-chat were scoped to drive
  membership only. Drive membership does not grant access to every
  page in a drive (owner | drive-admin | explicit page permission).
  Pulse now scopes all page content/diffs/activity/chat to
  accessiblePageIds(userId), so restricted-page content can no longer
  surface in another member's summary or persisted context.

https://claude.ai/code/session_01Ncpho1d2qN6DGnMHeJqZ68