### PR TITLE
fix(ai): pagespace shows setup required in page agent settings

### DIFF
--- a/apps/web/src/lib/ai/shared/hooks/useProviderSettings.ts
+++ b/apps/web/src/lib/ai/shared/hooks/useProviderSettings.ts
@@ -83,6 +83,12 @@ export function useProviderSettings({
   const isProviderConfigured = useCallback(
     (provider: string): boolean => {
       if (!providerSettings) return false;
+      // pagespace availability is tracked directly on the providers map, not via its glm backend.
+      // getBackendProvider('pagespace') returns 'glm', but glm may be false while pagespace is true
+      // (e.g. when Google or OpenRouter is the active backend).
+      if (provider === 'pagespace') {
+        return providerSettings.providers.pagespace?.isAvailable ?? false;
+      }
       const backendProvider = getBackendProvider(provider);
       const status =
         providerSettings.providers[backendProvider as keyof typeof providerSettings.providers] ??


### PR DESCRIPTION
## Summary

- `isProviderConfigured('pagespace')` in `useProviderSettings.ts` was mapping `pagespace` → `glm` via `getBackendProvider`, then checking `providers.glm.isAvailable`
- When Google or OpenRouter is the active backend, `glm` is `false` — so the page agent settings tab showed "(Setup Required)" for PageSpace even though it was working
- The `??` fallback to check `providers.pagespace` never fired because `providers.glm` exists in the map (just with `isAvailable: false`), not `undefined`
- Fix: add a special case that checks `providers.pagespace.isAvailable` directly — matching the logic already used in `SidebarSettingsTab.tsx` (which is why the input area worked fine)

## Test plan

- [ ] Open a page with AI agent settings
- [ ] Verify PageSpace no longer shows "(Setup Required)" in the provider dropdown
- [ ] Verify PageSpace can be selected and saved as the agent provider
- [ ] Verify other providers still show correct availability status

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved provider configuration detection logic for enhanced system reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1363?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->