### PR TITLE
feat(billing): gate voice mode to pro+ and lock providers to pagespace

### DIFF
--- a/apps/web/src/app/api/ai/settings/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/settings/__tests__/route.test.ts
@@ -139,7 +139,7 @@ describe('AI settings route', () => {
       expect(body.pageSpaceBackend).toBe('glm');
     });
 
-    it('marks each cloud provider available when its env var is set', async () => {
+    it('masks non-pagespace providers as unavailable in cloud mode even when env vars are set', async () => {
       process.env.ANTHROPIC_DEFAULT_API_KEY = 'a';
       process.env.OPENAI_DEFAULT_API_KEY = 'b';
       process.env.GOOGLE_AI_DEFAULT_API_KEY = 'c';
@@ -149,24 +149,23 @@ describe('AI settings route', () => {
       const response = await GET(makeRequest('GET'));
       const body = await response.json();
 
-      expect(body.providers.anthropic.isAvailable).toBe(true);
-      expect(body.providers.openai.isAvailable).toBe(true);
-      expect(body.providers.google.isAvailable).toBe(true);
-      expect(body.providers.xai.isAvailable).toBe(true);
-      expect(body.providers.openrouter.isAvailable).toBe(true);
-      expect(body.providers.openrouter_free.isAvailable).toBe(true);
+      // Cloud mode: only pagespace is exposed; all others are masked
+      expect(body.providers.anthropic.isAvailable).toBe(false);
+      expect(body.providers.openai.isAvailable).toBe(false);
+      expect(body.providers.google.isAvailable).toBe(false);
+      expect(body.providers.xai.isAvailable).toBe(false);
+      expect(body.providers.openrouter.isAvailable).toBe(false);
+      expect(body.providers.openrouter_free.isAvailable).toBe(false);
+      expect(body.providers.pagespace.isAvailable).toBe(true);
     });
 
-    it('marks ollama available only when OLLAMA_BASE_URL is set', async () => {
-      const before = await GET(makeRequest('GET'));
-      expect((await before.json()).providers.ollama.isAvailable).toBe(false);
-
+    it('masks ollama as unavailable in cloud mode regardless of OLLAMA_BASE_URL', async () => {
       process.env.OLLAMA_BASE_URL = 'http://localhost:11434';
-      const after = await GET(makeRequest('GET'));
-      expect((await after.json()).providers.ollama.isAvailable).toBe(true);
+      const response = await GET(makeRequest('GET'));
+      expect((await response.json()).providers.ollama.isAvailable).toBe(false);
     });
 
-    it('hides cloud providers in onprem mode regardless of env state', async () => {
+    it('exposes configured local providers in onprem mode without masking', async () => {
       vi.mocked(isOnPrem).mockReturnValue(true);
       process.env.ANTHROPIC_DEFAULT_API_KEY = 'set';
       process.env.OLLAMA_BASE_URL = 'http://localhost:11434';
@@ -174,8 +173,10 @@ describe('AI settings route', () => {
       const response = await GET(makeRequest('GET'));
       const body = await response.json();
 
+      // On-prem: cloud providers still hidden (not in ONPREM_ALLOWED_PROVIDERS)
       expect(body.providers.anthropic.isAvailable).toBe(false);
       expect(body.providers.openai.isAvailable).toBe(false);
+      // On-prem: local providers are NOT masked — ollama shows up
       expect(body.providers.ollama.isAvailable).toBe(true);
     });
 
@@ -226,7 +227,22 @@ describe('AI settings route', () => {
   });
 
   describe('PATCH', () => {
-    it('updates the user selection when provider is available', async () => {
+    it('updates the user selection when provider is pagespace', async () => {
+      const response = await PATCH(makeRequest('PATCH', {
+        provider: 'pagespace',
+        model: 'glm-4.5-air',
+      }));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(aiSettingsRepository.updateProviderSettings).toHaveBeenCalledWith(mockUserId, {
+        provider: 'pagespace',
+        model: 'glm-4.5-air',
+      });
+    });
+
+    it('returns 503 for non-pagespace providers in cloud mode', async () => {
       process.env.ANTHROPIC_DEFAULT_API_KEY = 'a';
 
       const response = await PATCH(makeRequest('PATCH', {
@@ -235,24 +251,18 @@ describe('AI settings route', () => {
       }));
       const body = await response.json();
 
-      expect(response.status).toBe(200);
-      expect(body.success).toBe(true);
-      expect(aiSettingsRepository.updateProviderSettings).toHaveBeenCalledWith(mockUserId, {
-        provider: 'anthropic',
-        model: 'claude-sonnet-4-6',
-      });
+      expect(response.status).toBe(503);
+      expect(body.error).toContain('not available on this instance');
+      expect(aiSettingsRepository.updateProviderSettings).not.toHaveBeenCalled();
     });
 
-    it('returns 503 when the requested provider is not configured', async () => {
-      const response = await PATCH(makeRequest('PATCH', {
-        provider: 'anthropic',
-        model: 'claude-sonnet-4-6',
-      }));
-      const body = await response.json();
+    it('allows non-pagespace providers in onprem mode when configured', async () => {
+      vi.mocked(isOnPrem).mockReturnValue(true);
+      process.env.OLLAMA_BASE_URL = 'http://localhost:11434';
 
-      expect(response.status).toBe(503);
-      expect(body.error).toContain('not configured');
-      expect(aiSettingsRepository.updateProviderSettings).not.toHaveBeenCalled();
+      const response = await PATCH(makeRequest('PATCH', { provider: 'ollama' }));
+
+      expect(response.status).toBe(200);
     });
 
     it('returns 400 for an unknown provider', async () => {
@@ -264,22 +274,12 @@ describe('AI settings route', () => {
       expect(response.status).toBe(400);
     });
 
-    it('returns 400 when model is missing for a non-local provider', async () => {
-      process.env.ANTHROPIC_DEFAULT_API_KEY = 'a';
-
-      const response = await PATCH(makeRequest('PATCH', { provider: 'anthropic' }));
+    it('returns 400 when model is missing for pagespace', async () => {
+      const response = await PATCH(makeRequest('PATCH', { provider: 'pagespace' }));
       const body = await response.json();
 
       expect(response.status).toBe(400);
       expect(body.error).toContain('Model is required');
-    });
-
-    it('allows local providers without a model', async () => {
-      process.env.OLLAMA_BASE_URL = 'http://localhost:11434';
-
-      const response = await PATCH(makeRequest('PATCH', { provider: 'ollama' }));
-
-      expect(response.status).toBe(200);
     });
 
     it('returns 403 when pro-tier model selected on free subscription', async () => {

--- a/apps/web/src/app/api/ai/settings/route.ts
+++ b/apps/web/src/app/api/ai/settings/route.ts
@@ -16,6 +16,9 @@ import { isOnPrem } from '@pagespace/lib/deployment-mode';
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
 
+// Providers exposed to users. Expand this as per-provider billing tiers are set up.
+const USER_VISIBLE_PROVIDERS = new Set(['pagespace']);
+
 const GONE_RESPONSE = {
   error: 'Per-user API key configuration has been retired. AI providers are now managed at the deployment level.',
 };
@@ -39,7 +42,13 @@ export async function GET(request: Request) {
 
     const user = await aiSettingsRepository.getUserSettings(userId);
     const pageSpaceSettings = getDefaultPageSpaceSettings();
-    const providers = buildProviderAvailabilityMap(availabilityOptions());
+    const rawProviders = buildProviderAvailabilityMap(availabilityOptions());
+    const providers = Object.fromEntries(
+      Object.entries(rawProviders).map(([k, v]) => [
+        k,
+        { isAvailable: USER_VISIBLE_PROVIDERS.has(k) ? v.isAvailable : false },
+      ])
+    );
 
     auditRequest(request, { eventType: 'data.read', userId, resourceType: 'ai_settings', resourceId: userId, details: {
       action: 'get_settings',
@@ -98,6 +107,13 @@ export async function PATCH(request: Request) {
       return NextResponse.json(
         { error: `Invalid provider. Must be one of: ${ALL_PROVIDER_NAMES.join(', ')}` },
         { status: 400 }
+      );
+    }
+
+    if (!USER_VISIBLE_PROVIDERS.has(provider)) {
+      return NextResponse.json(
+        { error: `Provider "${provider}" is not available on this instance.` },
+        { status: 503 }
       );
     }
 

--- a/apps/web/src/app/api/ai/settings/route.ts
+++ b/apps/web/src/app/api/ai/settings/route.ts
@@ -43,12 +43,15 @@ export async function GET(request: Request) {
     const user = await aiSettingsRepository.getUserSettings(userId);
     const pageSpaceSettings = getDefaultPageSpaceSettings();
     const rawProviders = buildProviderAvailabilityMap(availabilityOptions());
-    const providers = Object.fromEntries(
-      Object.entries(rawProviders).map(([k, v]) => [
-        k,
-        { isAvailable: USER_VISIBLE_PROVIDERS.has(k) ? v.isAvailable : false },
-      ])
-    );
+    // On-prem deployments expose all configured local providers; cloud masks everything except pagespace.
+    const providers = isOnPrem()
+      ? rawProviders
+      : Object.fromEntries(
+          Object.entries(rawProviders).map(([k, v]) => [
+            k,
+            { isAvailable: USER_VISIBLE_PROVIDERS.has(k) ? v.isAvailable : false },
+          ])
+        );
 
     auditRequest(request, { eventType: 'data.read', userId, resourceType: 'ai_settings', resourceId: userId, details: {
       action: 'get_settings',
@@ -110,7 +113,7 @@ export async function PATCH(request: Request) {
       );
     }
 
-    if (!USER_VISIBLE_PROVIDERS.has(provider)) {
+    if (!isOnPrem() && !USER_VISIBLE_PROVIDERS.has(provider)) {
       return NextResponse.json(
         { error: `Provider "${provider}" is not available on this instance.` },
         { status: 503 }

--- a/apps/web/src/app/api/voice/synthesize/route.ts
+++ b/apps/web/src/app/api/voice/synthesize/route.ts
@@ -16,8 +16,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { aiSettingsRepository } from '@/lib/repositories/ai-settings-repository';
 import { isBillingEnabled } from '@pagespace/lib/deployment-mode';
-
-const VOICE_TIERS = new Set(['pro', 'founder', 'business']);
+import { PAID_TIERS } from '@/lib/subscription/rate-limit-middleware';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 
@@ -40,7 +39,7 @@ export async function POST(request: Request) {
 
     if (isBillingEnabled()) {
       const user = await aiSettingsRepository.getUserSettings(userId);
-      if (!VOICE_TIERS.has(user?.subscriptionTier ?? 'free')) {
+      if (!PAID_TIERS.has(user?.subscriptionTier ?? 'free')) {
         return NextResponse.json(
           {
             error: 'Pro plan required',

--- a/apps/web/src/app/api/voice/synthesize/route.ts
+++ b/apps/web/src/app/api/voice/synthesize/route.ts
@@ -14,6 +14,10 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { getManagedProviderKey } from '@/lib/ai/core/ai-utils';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { aiSettingsRepository } from '@/lib/repositories/ai-settings-repository';
+import { isBillingEnabled } from '@pagespace/lib/deployment-mode';
+
+const VOICE_TIERS = new Set(['pro', 'founder', 'business']);
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 
@@ -33,6 +37,20 @@ export async function POST(request: Request) {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
     if (isAuthError(auth)) return auth.error;
     const userId = auth.userId;
+
+    if (isBillingEnabled()) {
+      const user = await aiSettingsRepository.getUserSettings(userId);
+      if (!VOICE_TIERS.has(user?.subscriptionTier ?? 'free')) {
+        return NextResponse.json(
+          {
+            error: 'Pro plan required',
+            message: 'Voice mode requires a Pro or above subscription.',
+            upgradeUrl: '/settings/billing',
+          },
+          { status: 403 }
+        );
+      }
+    }
 
     // Get managed OpenAI key for TTS
     const openAISettings = getManagedProviderKey('openai');

--- a/apps/web/src/app/api/voice/transcribe/route.ts
+++ b/apps/web/src/app/api/voice/transcribe/route.ts
@@ -14,8 +14,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { aiSettingsRepository } from '@/lib/repositories/ai-settings-repository';
 import { isBillingEnabled } from '@pagespace/lib/deployment-mode';
-
-const VOICE_TIERS = new Set(['pro', 'founder', 'business']);
+import { PAID_TIERS } from '@/lib/subscription/rate-limit-middleware';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 
@@ -41,7 +40,7 @@ export async function POST(request: Request) {
 
     if (isBillingEnabled()) {
       const user = await aiSettingsRepository.getUserSettings(userId);
-      if (!VOICE_TIERS.has(user?.subscriptionTier ?? 'free')) {
+      if (!PAID_TIERS.has(user?.subscriptionTier ?? 'free')) {
         return NextResponse.json(
           {
             error: 'Pro plan required',

--- a/apps/web/src/app/api/voice/transcribe/route.ts
+++ b/apps/web/src/app/api/voice/transcribe/route.ts
@@ -12,6 +12,10 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { getManagedProviderKey } from '@/lib/ai/core/ai-utils';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { aiSettingsRepository } from '@/lib/repositories/ai-settings-repository';
+import { isBillingEnabled } from '@pagespace/lib/deployment-mode';
+
+const VOICE_TIERS = new Set(['pro', 'founder', 'business']);
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 
@@ -34,6 +38,20 @@ export async function POST(request: Request) {
     const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
     if (isAuthError(auth)) return auth.error;
     const userId = auth.userId;
+
+    if (isBillingEnabled()) {
+      const user = await aiSettingsRepository.getUserSettings(userId);
+      if (!VOICE_TIERS.has(user?.subscriptionTier ?? 'free')) {
+        return NextResponse.json(
+          {
+            error: 'Pro plan required',
+            message: 'Voice mode requires a Pro or above subscription.',
+            upgradeUrl: '/settings/billing',
+          },
+          { status: 403 }
+        );
+      }
+    }
 
     // Get managed OpenAI key for Whisper
     const openAISettings = getManagedProviderKey('openai');

--- a/apps/web/src/app/settings/ai/page.tsx
+++ b/apps/web/src/app/settings/ai/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { CheckCircle2, ArrowLeft, Server, AlertCircle } from 'lucide-react';
+import { CheckCircle2, ArrowLeft, Server } from 'lucide-react';
 import { toast } from 'sonner';
 import { useRouter } from 'next/navigation';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
@@ -19,21 +19,6 @@ interface ProviderSettingsResponse {
   pageSpaceBackend: 'glm' | 'google' | 'openrouter' | null;
   providers: Record<string, ProviderAvailability>;
 }
-
-const PROVIDER_LABELS: Record<string, string> = {
-  pagespace: 'PageSpace AI',
-  openrouter: 'OpenRouter',
-  openrouter_free: 'OpenRouter (Free models)',
-  google: 'Google AI',
-  openai: 'OpenAI',
-  anthropic: 'Anthropic',
-  xai: 'xAI (Grok)',
-  ollama: 'Ollama (Local)',
-  lmstudio: 'LM Studio (Local)',
-  glm: 'GLM Coder Plan',
-  minimax: 'MiniMax',
-  azure_openai: 'Azure OpenAI',
-};
 
 export default function AiSettingsPage() {
   const router = useRouter();
@@ -58,10 +43,7 @@ export default function AiSettingsPage() {
     return () => { cancelled = true; };
   }, []);
 
-  const orderedProviders = Object.keys(PROVIDER_LABELS);
-  const availableCount = data
-    ? orderedProviders.filter((p) => data.providers[p]?.isAvailable).length
-    : 0;
+  const isAvailable = !!data?.providers['pagespace']?.isAvailable;
 
   return (
     <div className="container mx-auto py-10 space-y-8 px-10">
@@ -75,11 +57,9 @@ export default function AiSettingsPage() {
           <ArrowLeft className="h-4 w-4 mr-2" />
           Back to Settings
         </Button>
-        <h1 className="text-3xl font-bold mb-2">AI Providers</h1>
+        <h1 className="text-3xl font-bold mb-2">AI Provider</h1>
         <p className="text-muted-foreground">
-          AI provider credentials are managed at the deployment level. This page
-          shows which providers are configured on this PageSpace instance and which
-          you can select in the model picker.
+          PageSpace AI is included with your account and powers all AI features on this instance.
         </p>
       </div>
 
@@ -87,12 +67,7 @@ export default function AiSettingsPage() {
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Server className="h-5 w-5" />
-            Available providers
-            {data && (
-              <Badge variant="secondary" className="ml-2">
-                {availableCount} of {orderedProviders.length}
-              </Badge>
-            )}
+            Available provider
           </CardTitle>
         </CardHeader>
         <CardContent>
@@ -101,42 +76,20 @@ export default function AiSettingsPage() {
           ) : !data ? (
             <p className="text-sm text-muted-foreground">Could not load provider availability.</p>
           ) : (
-            <div className="grid gap-2 sm:grid-cols-2">
-              {orderedProviders.map((id) => {
-                const label = PROVIDER_LABELS[id];
-                const available = !!data.providers[id]?.isAvailable;
-                return (
-                  <div
-                    key={id}
-                    className="flex items-center justify-between rounded-md border p-3"
-                  >
-                    <span className="font-medium text-sm">{label}</span>
-                    {available ? (
-                      <Badge variant="default" className="bg-green-500">
-                        <CheckCircle2 className="h-3 w-3 mr-1" />
-                        Available
-                      </Badge>
-                    ) : (
-                      <Badge variant="secondary">Unavailable</Badge>
-                    )}
-                  </div>
-                );
-              })}
+            <div className="flex items-center justify-between rounded-md border p-3 max-w-sm">
+              <span className="font-medium text-sm">PageSpace AI</span>
+              {isAvailable ? (
+                <Badge variant="default" className="bg-green-500">
+                  <CheckCircle2 className="h-3 w-3 mr-1" />
+                  Available
+                </Badge>
+              ) : (
+                <Badge variant="secondary">Unavailable</Badge>
+              )}
             </div>
           )}
         </CardContent>
       </Card>
-
-      <div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground flex gap-3">
-        <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
-        <div>
-          PageSpace no longer accepts per-user API keys. To add a new provider,
-          a deployment operator needs to set the matching{' '}
-          <code className="text-xs bg-muted px-1 rounded">*_DEFAULT_API_KEY</code>{' '}
-          environment variable (or base URL for local providers like Ollama and
-          LM Studio).
-        </div>
-      </div>
     </div>
   );
 }

--- a/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
+++ b/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
@@ -349,7 +349,7 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    {Object.entries(AI_PROVIDERS).map(([key, provider]) => {
+                    {Object.entries(AI_PROVIDERS).filter(([key]) => key === 'pagespace').map(([key, provider]) => {
                       const configured = isProviderConfigured(key);
                       return (
                         <SelectItem key={key} value={key} disabled={!configured}>

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarSettingsTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarSettingsTab.tsx
@@ -504,10 +504,8 @@ const SidebarSettingsTab: React.FC<SidebarSettingsTabProps> = ({
             </CardHeader>
             <CardContent>
               <div className="space-y-2">
-                {/* Display all providers dynamically */}
-                {Object.entries(AI_PROVIDERS).map(([key, provider]) => {
-                  // Skip openrouter_free in the status display as it uses the same key as openrouter
-                  if (key === 'openrouter_free') return null;
+                {/* Display only user-visible providers */}
+                {Object.entries(AI_PROVIDERS).filter(([key]) => key === 'pagespace').map(([key, provider]) => {
                   
                   const isConfigured = isProviderConfigured(key);
                   const displayName = key === 'pagespace' ? `${provider.name} (Default)` : provider.name;
@@ -546,7 +544,7 @@ const SidebarSettingsTab: React.FC<SidebarSettingsTabProps> = ({
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    {Object.entries(AI_PROVIDERS).map(([key, provider]) => {
+                    {Object.entries(AI_PROVIDERS).filter(([key]) => key === 'pagespace').map(([key, provider]) => {
                       const configured = isProviderConfigured(key);
                       return (
                         <SelectItem key={key} value={key}>

--- a/apps/web/src/components/ui/floating-input/InputFooter.tsx
+++ b/apps/web/src/components/ui/floating-input/InputFooter.tsx
@@ -11,6 +11,10 @@ import { Mic, AudioLines, MicOff } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ProviderModelSelector } from '@/components/ai/chat/input/ProviderModelSelector';
 import { ToolsPopover } from './ToolsPopover';
+import { useAssistantSettingsStore } from '@/stores/useAssistantSettingsStore';
+import { isBillingEnabled } from '@/lib/deployment-mode';
+
+const VOICE_TIERS = new Set(['pro', 'founder', 'business']);
 
 export interface InputFooterProps {
   /** Whether web search is enabled */
@@ -106,6 +110,9 @@ export function InputFooter({
   disabled = false,
   className,
 }: InputFooterProps) {
+  const subscriptionTier = useAssistantSettingsStore((s) => s.subscriptionTier);
+  const isVoiceProGated = isBillingEnabled() && !VOICE_TIERS.has(subscriptionTier);
+
   return (
     <div
       className={cn(
@@ -152,8 +159,8 @@ export function InputFooter({
             <Button
               variant="ghost"
               size="sm"
-              onClick={onVoiceModeClick}
-              disabled={disabled}
+              onClick={isVoiceProGated ? undefined : onVoiceModeClick}
+              disabled={disabled || isVoiceProGated}
               className={cn(
                 'h-8 w-8 p-0 transition-all duration-200 hover:bg-transparent dark:hover:bg-transparent',
                 isVoiceModeActive
@@ -163,12 +170,20 @@ export function InputFooter({
             >
               <AudioLines className="h-4 w-4" />
               <span className="sr-only">
-                {isVoiceModeActive ? 'Exit voice mode' : 'Enter voice mode'}
+                {isVoiceProGated
+                  ? 'Voice mode requires Pro'
+                  : isVoiceModeActive
+                    ? 'Exit voice mode'
+                    : 'Enter voice mode'}
               </span>
             </Button>
           </TooltipTrigger>
           <TooltipContent side="top">
-            {isVoiceModeActive ? 'Exit voice mode' : 'Voice mode (hands-free)'}
+            {isVoiceProGated
+              ? 'Voice mode requires a Pro plan'
+              : isVoiceModeActive
+                ? 'Exit voice mode'
+                : 'Voice mode (hands-free)'}
           </TooltipContent>
         </Tooltip>
 

--- a/apps/web/src/components/ui/floating-input/InputFooter.tsx
+++ b/apps/web/src/components/ui/floating-input/InputFooter.tsx
@@ -14,7 +14,7 @@ import { ToolsPopover } from './ToolsPopover';
 import { useAssistantSettingsStore } from '@/stores/useAssistantSettingsStore';
 import { isBillingEnabled } from '@/lib/deployment-mode';
 
-const VOICE_TIERS = new Set(['pro', 'founder', 'business']);
+const PAID_TIERS = new Set(['pro', 'founder', 'business']);
 
 export interface InputFooterProps {
   /** Whether web search is enabled */
@@ -111,7 +111,7 @@ export function InputFooter({
   className,
 }: InputFooterProps) {
   const subscriptionTier = useAssistantSettingsStore((s) => s.subscriptionTier);
-  const isVoiceProGated = isBillingEnabled() && !VOICE_TIERS.has(subscriptionTier);
+  const isVoiceProGated = isBillingEnabled() && !PAID_TIERS.has(subscriptionTier);
 
   return (
     <div

--- a/apps/web/src/lib/subscription/rate-limit-middleware.ts
+++ b/apps/web/src/lib/subscription/rate-limit-middleware.ts
@@ -5,6 +5,9 @@ import { isBillingEnabled } from '@pagespace/lib/deployment-mode';
 import type { ProviderType } from '@pagespace/lib/services/rate-limit-cache';
 import { getProviderTier } from '@/lib/ai/core/ai-providers-config';
 
+/** Subscription tiers that have access to paid features (voice mode, etc.). */
+export const PAID_TIERS = new Set(['pro', 'founder', 'business']);
+
 export interface RateLimitResult {
   allowed: boolean;
   remaining: number;

--- a/apps/web/src/stores/useAssistantSettingsStore.ts
+++ b/apps/web/src/stores/useAssistantSettingsStore.ts
@@ -27,6 +27,7 @@ interface AssistantSettingsState {
   currentProvider: string | null;
   currentModel: string | null;
   isAnyProviderConfigured: boolean;
+  subscriptionTier: string;
 
   // Chat input toggles (persisted to localStorage)
   webSearchEnabled: boolean;
@@ -55,6 +56,7 @@ export const useAssistantSettingsStore = create<AssistantSettingsState>()((set, 
   currentProvider: null,
   currentModel: null,
   isAnyProviderConfigured: false,
+  subscriptionTier: 'free',
   webSearchEnabled: false,
   writeMode: true, // Default to write mode (full access)
   isLoading: false,
@@ -152,6 +154,7 @@ export const useAssistantSettingsStore = create<AssistantSettingsState>()((set, 
           currentProvider: data.currentProvider || null,
           currentModel: data.currentModel || null,
           isAnyProviderConfigured: data.isAnyProviderConfigured || false,
+          subscriptionTier: data.userSubscriptionTier || 'free',
           isInitialized: true,
           isLoading: false,
         });


### PR DESCRIPTION
## Summary

- **Voice mode is now Pro+ only** — free users see the voice button disabled with a tooltip explaining it requires a Pro plan. API routes (\`/api/voice/transcribe\`, \`/api/voice/synthesize\`) return 403 for free-tier users on billing-enabled deployments. On-prem and tenant deployments are unaffected (\`isBillingEnabled()\` guards the check).
- **Only the PageSpace provider is exposed to users** — the \`/api/ai/settings\` GET response masks all non-pagespace providers as unavailable, PATCH rejects selection of any other provider. On-prem deployments bypass the mask so ollama/lmstudio remain accessible. The agent settings dropdown, sidebar settings tab, and \`/settings/ai\` page show only PageSpace AI. The chat input model selector is handled by the API mask.
- **\`subscriptionTier\` added to \`useAssistantSettingsStore\`** — sourced from the existing API response, no new network call needed.
- **\`PAID_TIERS\` extracted to shared constant** in \`rate-limit-middleware.ts\`, used by both voice routes.

When per-provider billing tiers are ready, expand \`USER_VISIBLE_PROVIDERS\` in \`apps/web/src/app/api/ai/settings/route.ts\`.

## Files changed

| File | Change |
|------|--------|
| \`stores/useAssistantSettingsStore.ts\` | Add \`subscriptionTier\` field |
| \`floating-input/InputFooter.tsx\` | Disable voice button for free tier |
| \`api/voice/transcribe/route.ts\` | 403 for free users; use shared PAID_TIERS |
| \`api/voice/synthesize/route.ts\` | 403 for free users; use shared PAID_TIERS |
| \`lib/subscription/rate-limit-middleware.ts\` | Export \`PAID_TIERS\` constant |
| \`api/ai/settings/route.ts\` | \`USER_VISIBLE_PROVIDERS\` gate in GET + PATCH; on-prem bypass |
| \`page-agents/PageAgentSettingsTab.tsx\` | Filter provider list to pagespace |
| \`SidebarSettingsTab.tsx\` | Filter status display and provider select to pagespace |
| \`settings/ai/page.tsx\` | Single pagespace card, cleaned up copy |
| \`api/ai/settings/__tests__/route.test.ts\` | Update tests to assert cloud masking and on-prem bypass |

## Test plan

- [ ] Free user: voice button is disabled, tooltip says "Voice mode requires a Pro plan"
- [ ] Free user: direct POST to \`/api/voice/transcribe\` returns 403
- [ ] Pro user: voice mode works normally
- [ ] On-prem deployment: voice works for all users (billing disabled)
- [ ] On-prem deployment: ollama/lmstudio appear in provider lists
- [ ] Agent settings provider dropdown shows only "PageSpace"
- [ ] Sidebar settings tab provider display shows only "PageSpace"
- [ ] \`/settings/ai\` shows only the PageSpace AI card
- [ ] Provider model selector in chat shows only pagespace models
- [ ] PATCH \`/api/ai/settings\` with \`provider: "openai"\` returns 503

🤖 Generated with [Claude Code](https://claude.com/claude-code)