### PR TITLE
fix(admin): accurate global prompt dashboard

### DIFF
--- a/apps/web/src/app/admin/global-prompt/GlobalPromptClient.tsx
+++ b/apps/web/src/app/admin/global-prompt/GlobalPromptClient.tsx
@@ -257,7 +257,7 @@ export default function GlobalPromptClient({ data }: GlobalPromptClientProps) {
             <div className="flex items-center justify-between">
               <CardTitle className="flex items-center gap-2">
                 <Wrench className="h-5 w-5" />
-                Tool Definitions ({modeFilteredTools.length} available in {selectedMode === 'fullAccess' ? 'Full Access' : 'Read-Only'} mode)
+                Upfront Tool Definitions ({modeFilteredTools.length} sent with full schemas in {selectedMode === 'fullAccess' ? 'Full Access' : 'Read-Only'} mode)
               </CardTitle>
               <Button
                 variant="outline"
@@ -346,16 +346,35 @@ export default function GlobalPromptClient({ data }: GlobalPromptClientProps) {
               })}
             </Accordion>
 
-            {/* Denied Tools for this Mode */}
+            {/* Core tools blocked by read-only mode */}
             {deniedTools.length > 0 && (
               <div className="mt-6 pt-6 border-t">
                 <h4 className="text-sm font-medium mb-3 text-red-600 dark:text-red-400">
-                  Denied Tools in {selectedMode === 'fullAccess' ? 'Full Access' : 'Read-Only'} mode ({deniedTools.length})
+                  Core tools blocked in Read-Only mode ({deniedTools.length})
                 </h4>
                 <div className="flex flex-wrap gap-2">
                   {deniedTools.map((tool) => (
                     <Badge key={tool.name} variant="secondary" className="font-mono text-xs opacity-50">
                       {tool.name}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Non-core tools accessible via execute_tool */}
+            {(currentModeData.nonCoreToolNames?.length ?? 0) > 0 && (
+              <div className="mt-6 pt-6 border-t">
+                <h4 className="text-sm font-medium mb-1">
+                  Non-Core Tools — accessible via <code className="bg-muted px-1 py-0.5 rounded text-xs">execute_tool</code> ({currentModeData.nonCoreToolNames.length})
+                </h4>
+                <p className="text-xs text-muted-foreground mb-3">
+                  These tools are not sent upfront. The model calls <code className="bg-muted px-1 py-0.5 rounded">tool_search</code> to discover schemas, then <code className="bg-muted px-1 py-0.5 rounded">execute_tool</code> to run them.
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {currentModeData.nonCoreToolNames.map((name) => (
+                    <Badge key={name} variant="outline" className="font-mono text-xs">
+                      {name}
                     </Badge>
                   ))}
                 </div>

--- a/apps/web/src/app/admin/global-prompt/page.tsx
+++ b/apps/web/src/app/admin/global-prompt/page.tsx
@@ -150,10 +150,7 @@ export default function AdminGlobalPromptPage() {
   }
 
   const roles = Object.keys(data.promptData);
-  const totalSections = Object.values(data.promptData).reduce(
-    (sum, role) => sum + role.sections.length,
-    0
-  );
+  const totalSections = Object.values(data.promptData)[0]?.sections.length ?? 0;
 
   return (
     <div className="space-y-6">
@@ -289,7 +286,7 @@ export default function AdminGlobalPromptPage() {
           <div className="grid grid-cols-2 md:grid-cols-5 gap-4 text-sm">
             <div className="text-center">
               <div className="text-2xl font-bold text-primary">{roles.length}</div>
-              <div className="text-muted-foreground">Agent Roles</div>
+              <div className="text-muted-foreground">Access Modes</div>
             </div>
             <div className="text-center">
               <div className="text-2xl font-bold text-primary">{totalSections}</div>
@@ -299,7 +296,7 @@ export default function AdminGlobalPromptPage() {
               <div className="text-2xl font-bold text-primary">
                 {data.toolSchemas?.length || Object.values(data.promptData)[0]?.toolsAllowed.length || 0}
               </div>
-              <div className="text-muted-foreground">Total Tools</div>
+              <div className="text-muted-foreground">Upfront Tools</div>
             </div>
             <div className="text-center">
               <div className="text-2xl font-bold text-primary">

--- a/apps/web/src/app/api/admin/global-prompt/route.ts
+++ b/apps/web/src/app/api/admin/global-prompt/route.ts
@@ -426,9 +426,7 @@ export const GET = withAdminAuth(async (adminUser, request) => {
       },
       locationContext: locationContext ?? null,
       chatSource: {
-        type: 'page' as const,
-        agentPageId: '[agent-page-id]',
-        agentTitle: '[agent-title]',
+        type: 'global' as const,
       },
       enabledTools: null,
     };

--- a/apps/web/src/app/api/admin/global-prompt/route.ts
+++ b/apps/web/src/app/api/admin/global-prompt/route.ts
@@ -15,7 +15,6 @@ import {
   type CompletePayloadResult,
   type LocationContext,
   type ToolDefinitionForExtraction,
-  getToolsSummary,
   pageSpaceTools,
   extractToolSchemas,
   calculateTotalToolTokens,
@@ -26,6 +25,7 @@ import {
   buildInlineInstructions,
   buildGlobalAssistantInstructions,
 } from '@/lib/ai/core';
+import { CORE_TOOL_NAMES } from '@/lib/ai/core/stub-tools';
 import { db } from '@pagespace/db/db'
 import { eq, and, asc } from '@pagespace/db/operators'
 import { drives, pages } from '@pagespace/db/schema/core'
@@ -47,6 +47,7 @@ interface ModePromptData {
   totalTokens: number;
   toolsAllowed: string[];
   toolsDenied: string[];
+  nonCoreToolNames: string[];
   permissions: {
     canRead: boolean;
     canWrite: boolean;
@@ -311,8 +312,7 @@ export const GET = withAdminAuth(async (adminUser, request) => {
         });
       }
 
-      // Get tool permissions summary
-      const toolsSummary = getToolsSummary(isReadOnly);
+      // Tool summary comes from completePayload (core tools + tool_search + execute_tool)
 
       // Append async context sections to the full prompt
       const fullPromptWithAsyncContext =
@@ -338,8 +338,9 @@ export const GET = withAdminAuth(async (adminUser, request) => {
         fullPrompt: fullPromptWithAsyncContext,
         sections,
         totalTokens: completePayload.tokenEstimates.total,
-        toolsAllowed: toolsSummary.allowed,
-        toolsDenied: toolsSummary.denied,
+        toolsAllowed: completePayload.toolsSummary.allowed,
+        toolsDenied: completePayload.toolsSummary.denied,
+        nonCoreToolNames: completePayload.nonCoreToolNames,
         permissions: {
           canRead: true,
           canWrite: !isReadOnly,
@@ -350,34 +351,93 @@ export const GET = withAdminAuth(async (adminUser, request) => {
       };
     }
 
-    // Extract full tool schemas for display (all tools, not filtered by mode)
-    const toolsForExtraction: Record<string, ToolDefinitionForExtraction> = {};
+    // Extract core tool schemas only (what's sent upfront in the Global Assistant)
+    const coreToolsForDisplay: Record<string, ToolDefinitionForExtraction> = {};
     for (const [name, tool] of Object.entries(pageSpaceTools)) {
-      toolsForExtraction[name] = {
-        description: tool.description,
-        parameters: tool.inputSchema,
-      };
+      if (CORE_TOOL_NAMES.has(name)) {
+        coreToolsForDisplay[name] = {
+          description: tool.description,
+          parameters: tool.inputSchema,
+        };
+      }
     }
-    const allToolSchemas = extractToolSchemas(toolsForExtraction);
+    const coreToolSchemas = extractToolSchemas(coreToolsForDisplay);
+
+    // Add tool_search and execute_tool (dynamic at runtime, static schemas for display)
+    const toolSearchJsonSchema = {
+      type: 'object' as const,
+      properties: {
+        query: {
+          type: 'string' as const,
+          description: 'Either "select:name1,name2" for specific tools or a search keyword',
+        },
+      },
+      required: ['query'],
+    };
+    const executeToolJsonSchema = {
+      type: 'object' as const,
+      properties: {
+        tool_name: { type: 'string' as const },
+        parameters: { type: 'object' as const, properties: {}, required: [] },
+      },
+      required: ['tool_name'],
+    };
+
+    const allToolSchemas = [
+      ...coreToolSchemas,
+      {
+        name: 'tool_search',
+        description:
+          'Get full parameter schemas for any PageSpace tool before calling it. Use "select:name1,name2" for specific tools by name, or a keyword like "calendar", "agent", "task", "channel", "drive" to find all tools in that area.',
+        parameters: toolSearchJsonSchema,
+        tokenEstimate: estimateSystemPromptTokens(
+          JSON.stringify({ name: 'tool_search', parameters: toolSearchJsonSchema })
+        ),
+      },
+      {
+        name: 'execute_tool',
+        description:
+          'Execute any PageSpace tool by name. Call tool_search first to discover available tools and get their parameter schemas.',
+        parameters: executeToolJsonSchema,
+        tokenEstimate: estimateSystemPromptTokens(
+          JSON.stringify({ name: 'execute_tool', parameters: executeToolJsonSchema })
+        ),
+      },
+    ];
     const totalToolTokens = calculateTotalToolTokens(allToolSchemas);
 
-    // Build experimental context (what gets passed to tool execute functions)
+    // Non-core tool names (accessible via execute_tool, not sent upfront)
+    const allNonCoreToolNames = Object.keys(pageSpaceTools).filter(
+      n => !CORE_TOOL_NAMES.has(n)
+    );
+
+    // Build experimental context matching the real chat route shape (preview values shown)
     const experimentalContext = {
       userId: adminUser.id,
-      chatId: '[chat-id-placeholder]',
+      timezone: undefined,
+      aiProvider: '[varies by chat]',
+      aiModel: '[varies by chat]',
+      conversationId: '[generated per conversation]',
       modelCapabilities: {
-        supportsStreaming: true,
-        supportsToolCalling: true,
-        hasVision: false, // Varies by model
-        maxTokens: 128000, // Example value
+        hasVision: false,
+        hasTools: true,
+        model: '[varies by chat]',
+        provider: '[varies by chat]',
       },
-      locationContext: locationContext || null,
+      locationContext: locationContext ?? null,
+      chatSource: {
+        type: 'page' as const,
+        agentPageId: '[agent-page-id]',
+        agentTitle: '[agent-title]',
+      },
+      enabledTools: null,
     };
 
     return Response.json({
       promptData,
       toolSchemas: allToolSchemas,
       totalToolTokens,
+      nonCoreToolNames: allNonCoreToolNames,
       experimentalContext,
       availableDrives,
       availablePages: availablePages.map(p => ({

--- a/apps/web/src/lib/ai/core/complete-request-builder.ts
+++ b/apps/web/src/lib/ai/core/complete-request-builder.ts
@@ -5,8 +5,9 @@
  * Used by the admin global-prompt viewer to show the exact context window.
  */
 
-import { buildSystemPrompt } from './system-prompt';
-import { filterToolsForReadOnly, getToolsSummary } from './tool-filtering';
+import { buildSystemPrompt, buildNonCoreToolNamesPrompt } from './system-prompt';
+import { filterToolsForReadOnly, isWriteTool } from './tool-filtering';
+import { CORE_TOOL_NAMES } from './stub-tools';
 import { buildTimestampSystemPrompt } from './timestamp-utils';
 import { buildMentionSystemPrompt } from './mention-processor';
 import {
@@ -54,12 +55,23 @@ export interface CompleteAIRequest {
   }>;
   experimental_context: {
     userId: string;
+    timezone: string | undefined;
+    aiProvider: string;
+    aiModel: string;
+    conversationId: string;
     locationContext?: LocationContext;
     modelCapabilities: {
-      supportsStreaming: boolean;
-      supportsToolCalling: boolean;
       hasVision: boolean;
+      hasTools: boolean;
+      model: string;
+      provider: string;
     };
+    chatSource: {
+      type: 'page';
+      agentPageId: string;
+      agentTitle: string;
+    };
+    enabledTools: string[] | null;
   };
 }
 
@@ -76,6 +88,7 @@ export interface CompletePayloadResult {
     allowed: string[];
     denied: string[];
   };
+  nonCoreToolNames: string[];
 }
 
 interface BuildCompleteRequestConfig {
@@ -146,26 +159,77 @@ export function buildCompleteRequest(
     );
   }
 
-  // Complete system prompt
+  // Apply read-only filtering (same logic as real Global Assistant)
+  const allFilteredTools = filterToolsForReadOnly(pageSpaceTools, isReadOnly);
+
+  // Core tools get full schemas upfront; non-core tools are accessible via execute_tool
+  const coreFilteredTools = Object.fromEntries(
+    Object.entries(allFilteredTools).filter(([name]) => CORE_TOOL_NAMES.has(name))
+  );
+  const nonCoreToolNames = Object.keys(allFilteredTools).filter(n => !CORE_TOOL_NAMES.has(n));
+
+  // Append non-core tool names to system prompt (matches real Global Assistant behavior)
+  const nonCoreNamesSection = buildNonCoreToolNamesPrompt(nonCoreToolNames);
+
+  // Complete system prompt (with non-core tool names section, matching real Global Assistant)
   const systemPrompt =
     baseSystemPrompt +
     mentionSystemPrompt +
     timestampSystemPrompt +
-    inlineInstructions;
+    inlineInstructions +
+    (nonCoreNamesSection ? '\n\n' + nonCoreNamesSection : '');
 
-  // Get filtered tools based on read-only mode
-  const filteredTools = filterToolsForReadOnly(pageSpaceTools, isReadOnly);
-  const toolsSummary = getToolsSummary(isReadOnly);
-
-  // Convert tools to the format we display
-  const toolsForExtraction: Record<string, ToolDefinitionForExtraction> = {};
-  for (const [name, tool] of Object.entries(filteredTools)) {
-    toolsForExtraction[name] = {
+  // Build core tool schemas
+  const coreToolsForExtraction: Record<string, ToolDefinitionForExtraction> = {};
+  for (const [name, tool] of Object.entries(coreFilteredTools)) {
+    coreToolsForExtraction[name] = {
       description: tool.description,
       parameters: tool.inputSchema,
     };
   }
-  const toolSchemas = extractToolSchemas(toolsForExtraction);
+  const coreToolSchemas = extractToolSchemas(coreToolsForExtraction);
+
+  // tool_search and execute_tool are added dynamically at runtime; represent them with static schemas
+  const toolSearchJsonSchema = {
+    type: 'object' as const,
+    properties: {
+      query: {
+        type: 'string' as const,
+        description: 'Either "select:name1,name2" for specific tools or a search keyword',
+      },
+    },
+    required: ['query'],
+  };
+  const executeToolJsonSchema = {
+    type: 'object' as const,
+    properties: {
+      tool_name: { type: 'string' as const },
+      parameters: { type: 'object' as const, properties: {}, required: [] },
+    },
+    required: ['tool_name'],
+  };
+
+  const toolSchemas: ToolSchemaInfo[] = [
+    ...coreToolSchemas,
+    {
+      name: 'tool_search',
+      description:
+        'Get full parameter schemas for any PageSpace tool before calling it. Use "select:name1,name2" for specific tools by name, or a keyword like "calendar", "agent", "task", "channel", "drive" to find all tools in that area.',
+      parameters: toolSearchJsonSchema,
+      tokenEstimate: estimateSystemPromptTokens(
+        JSON.stringify({ name: 'tool_search', parameters: toolSearchJsonSchema })
+      ),
+    },
+    {
+      name: 'execute_tool',
+      description:
+        'Execute any PageSpace tool by name. Call tool_search first to discover available tools and get their parameter schemas.',
+      parameters: executeToolJsonSchema,
+      tokenEstimate: estimateSystemPromptTokens(
+        JSON.stringify({ name: 'execute_tool', parameters: executeToolJsonSchema })
+      ),
+    },
+  ];
 
   // Convert to ToolDefinition format
   const tools: ToolDefinition[] = toolSchemas.map(
@@ -176,15 +240,33 @@ export function buildCompleteRequest(
     })
   );
 
-  // Build experimental context
+  // Tool summary: upfront tools for this mode (core filtered by read-only + tool_search + execute_tool)
+  const coreAllowedNames = Object.keys(coreFilteredTools);
+  const toolsSummary = {
+    allowed: [...coreAllowedNames, 'tool_search', 'execute_tool'],
+    denied: isReadOnly ? Array.from(CORE_TOOL_NAMES).filter(n => isWriteTool(n)) : [],
+  };
+
+  // Build experimental context matching the real chat route shape
   const experimental_context = {
     userId: '[user-id]',
+    timezone: undefined as string | undefined,
+    aiProvider: '[varies by chat]',
+    aiModel: '[varies by chat]',
+    conversationId: '[generated per conversation]',
     locationContext: locationContext || undefined,
     modelCapabilities: {
-      supportsStreaming: true,
-      supportsToolCalling: true,
       hasVision: false,
+      hasTools: true,
+      model: '[varies by chat]',
+      provider: '[varies by chat]',
     },
+    chatSource: {
+      type: 'page' as const,
+      agentPageId: '[agent-page-id]',
+      agentTitle: '[agent-title]',
+    },
+    enabledTools: null as string[] | null,
   };
 
   // Build example messages
@@ -230,6 +312,7 @@ export function buildCompleteRequest(
     formattedString,
     tokenEstimates,
     toolsSummary,
+    nonCoreToolNames,
   };
 }
 

--- a/apps/web/src/lib/ai/core/complete-request-builder.ts
+++ b/apps/web/src/lib/ai/core/complete-request-builder.ts
@@ -262,9 +262,7 @@ export function buildCompleteRequest(
       provider: '[varies by chat]',
     },
     chatSource: {
-      type: 'page' as const,
-      agentPageId: '[agent-page-id]',
-      agentTitle: '[agent-title]',
+      type: 'global' as const,
     },
     enabledTools: null as string[] | null,
   };

--- a/apps/web/src/lib/ai/core/complete-request-builder.ts
+++ b/apps/web/src/lib/ai/core/complete-request-builder.ts
@@ -67,9 +67,7 @@ export interface CompleteAIRequest {
       provider: string;
     };
     chatSource: {
-      type: 'page';
-      agentPageId: string;
-      agentTitle: string;
+      type: 'global';
     };
     enabledTools: string[] | null;
   };

--- a/apps/web/src/lib/ai/types/global-prompt.ts
+++ b/apps/web/src/lib/ai/types/global-prompt.ts
@@ -56,6 +56,10 @@ export interface CompleteAIRequest {
   }>;
   experimental_context: {
     userId: string;
+    timezone: string | undefined;
+    aiProvider: string;
+    aiModel: string;
+    conversationId: string;
     locationContext?: {
       currentPage?: {
         id: string;
@@ -71,10 +75,17 @@ export interface CompleteAIRequest {
       breadcrumbs?: Array<{ id: string; title: string }>;
     };
     modelCapabilities: {
-      supportsStreaming: boolean;
-      supportsToolCalling: boolean;
       hasVision: boolean;
+      hasTools: boolean;
+      model: string;
+      provider: string;
     };
+    chatSource: {
+      type: 'page';
+      agentPageId: string;
+      agentTitle: string;
+    };
+    enabledTools: string[] | null;
   };
 }
 
@@ -89,22 +100,24 @@ export interface CompletePayloadResult {
   request: CompleteAIRequest;
   formattedString: string;
   tokenEstimates: TokenEstimates;
+  nonCoreToolNames: string[];
 }
 
 export interface RolePromptData {
-  role: string;
+  mode: 'fullAccess' | 'readOnly';
   fullPrompt: string;
   sections: PromptSection[];
   totalTokens: number;
   toolsAllowed: string[];
   toolsDenied: string[];
+  nonCoreToolNames: string[];
   permissions: {
     canRead: boolean;
     canWrite: boolean;
     canDelete: boolean;
-    requiresConfirmation: boolean;
+    canOrganize: boolean;
   };
-  // Complete payload for this role (exact LLM request)
+  // Complete payload for this mode (exact LLM request)
   completePayload?: CompletePayloadResult;
 }
 
@@ -125,12 +138,15 @@ export interface PageInfo {
 
 export interface ExperimentalContext {
   userId: string;
-  chatId: string;
+  timezone: string | undefined;
+  aiProvider: string;
+  aiModel: string;
+  conversationId: string;
   modelCapabilities: {
-    supportsStreaming: boolean;
-    supportsToolCalling: boolean;
     hasVision: boolean;
-    maxTokens: number;
+    hasTools: boolean;
+    model: string;
+    provider: string;
   };
   locationContext: {
     currentDrive?: {
@@ -138,7 +154,20 @@ export interface ExperimentalContext {
       name: string;
       slug: string;
     };
+    currentPage?: {
+      id: string;
+      title: string;
+      type: string;
+      path: string;
+    };
+    breadcrumbs?: Array<{ id: string; title: string }>;
   } | null;
+  chatSource: {
+    type: 'page';
+    agentPageId: string;
+    agentTitle: string;
+  };
+  enabledTools: string[] | null;
 }
 
 export interface GlobalPromptResponse {
@@ -148,6 +177,7 @@ export interface GlobalPromptResponse {
   experimentalContext?: ExperimentalContext;
   availableDrives?: DriveInfo[];
   availablePages?: PageInfo[];
+  nonCoreToolNames?: string[];
   metadata: {
     generatedAt: string;
     adminUser: {

--- a/apps/web/src/lib/ai/types/global-prompt.ts
+++ b/apps/web/src/lib/ai/types/global-prompt.ts
@@ -81,9 +81,7 @@ export interface CompleteAIRequest {
       provider: string;
     };
     chatSource: {
-      type: 'page';
-      agentPageId: string;
-      agentTitle: string;
+      type: 'global';
     };
     enabledTools: string[] | null;
   };
@@ -163,9 +161,7 @@ export interface ExperimentalContext {
     breadcrumbs?: Array<{ id: string; title: string }>;
   } | null;
   chatSource: {
-    type: 'page';
-    agentPageId: string;
-    agentTitle: string;
+    type: 'global';
   };
   enabledTools: string[] | null;
 }


### PR DESCRIPTION
## Summary

- Applies the real Global Assistant tool model (core/non-core split) to the admin prompt viewer
- \`tool_search\` and \`execute_tool\` now appear in the upfront tool schemas
- Non-core tools listed separately with an explanation of the \`execute_tool\` dispatch pattern
- \`experimentalContext\` now shows the correct field names matching \`chat/route.ts\` (\`conversationId\`, \`timezone\`, \`aiProvider\`, \`aiModel\`, \`chatSource: { type: 'global' }\`, \`enabledTools\`, updated \`modelCapabilities\` shape)
- System prompt preview now includes \`buildNonCoreToolNamesPrompt\` section (the non-core tool names the real Global Assistant appends)
- Fixed \`ExperimentalContext\`, \`RolePromptData\`, \`CompletePayloadResult\` type definitions to match runtime shapes
- Stats: "Agent Roles" → "Access Modes", "Total Tools" → "Upfront Tools", prompt section count no longer doubled

## Test plan

- [ ] Load \`/admin/global-prompt\` — stats show "Access Modes: 2", correct (non-doubled) section count, "Upfront Tools: ~10"
- [ ] Expand Tool Definitions card — shows 8 core tools + \`tool_search\` + \`execute_tool\` only
- [ ] Non-Core Tools section appears below with all non-core tool names and explanation
- [ ] In Read-Only mode, write core tools appear in "Core tools blocked" section
- [ ] Expand Experimental Context — shows \`conversationId\`, \`timezone\`, \`aiProvider\`, \`aiModel\`, \`chatSource: { type: 'global' }\`, \`enabledTools\` with \`[varies by chat]\` placeholders
- [ ] Complete LLM Payload includes the non-core tool names section in the system prompt
- [ ] \`pnpm typecheck\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)