### PR TITLE
fix(mcp): use non-www pagespace.ai URL in setup docs and in-app config

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ PageSpace includes an MCP server that lets Claude Desktop and other AI tools dir
    npm install -g pagespace-mcp@latest
    ```
 
-2. **Get your token** from [www.pagespace.ai/dashboard/settings/mcp](https://www.pagespace.ai/dashboard/settings/mcp)
+2. **Get your token** from [pagespace.ai/dashboard/settings/mcp](https://pagespace.ai/dashboard/settings/mcp)
 
 3. **Configure Claude Desktop** (add to MCP settings):
    ```json
@@ -109,7 +109,7 @@ PageSpace includes an MCP server that lets Claude Desktop and other AI tools dir
          "command": "npx",
          "args": ["-y", "pagespace-mcp@latest"],
          "env": {
-           "PAGESPACE_API_URL": "https://www.pagespace.ai",
+           "PAGESPACE_API_URL": "https://pagespace.ai",
            "PAGESPACE_AUTH_TOKEN": "your-mcp-token"
          }
        }

--- a/apps/web/src/components/layout/middle-content/page-views/settings/mcp/MCPSettingsView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/settings/mcp/MCPSettingsView.tsx
@@ -180,7 +180,7 @@ export default function MCPSettingsView() {
           command: "npx",
           args: ["-y", "pagespace-mcp@latest"],
           env: {
-            PAGESPACE_API_URL: "https://www.pagespace.ai",
+            PAGESPACE_API_URL: "https://pagespace.ai",
             PAGESPACE_AUTH_TOKEN: token
           }
         }


### PR DESCRIPTION
The www.pagespace.ai host is rejected by origin validation (WEB_APP_URL
is the apex domain), so the MCP server fails to connect when users
copy the documented PAGESPACE_API_URL. Align README and the in-app MCP
settings config generator with the canonical https://pagespace.ai URL
already used in the marketing docs.

https://claude.ai/code/session_01As6NV61ZAg3G14ev7Q5dtF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MCP setup instructions to use the non-www Pagespace domain.

* **Chores**
  * Updated MCP server configuration domain to align with documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->