### PR TITLE
fix(threads): mobile safe area and keyboard avoidance

### DIFF
--- a/apps/web/src/app/dashboard/channels/[pageId]/page.tsx
+++ b/apps/web/src/app/dashboard/channels/[pageId]/page.tsx
@@ -36,6 +36,7 @@ import { useThreadPanelStore } from '@/stores/useThreadPanelStore';
 import { ThreadPanel } from '@/components/layout/middle-content/page-views/thread/ThreadPanel';
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
 import { useMobile } from '@/hooks/useMobile';
+import { useMobileKeyboard } from '@/hooks/useMobileKeyboard';
 import { formatDistanceToNow } from 'date-fns';
 
 const fetcher = async (url: string) => {
@@ -112,6 +113,7 @@ export default function InboxChannelPage() {
   const { permissions } = usePermissions(pageId);
   const canEdit = permissions?.canEdit || false;
   const isMobile = useMobile();
+  const { isOpen: keyboardOpen, height: keyboardHeight } = useMobileKeyboard();
 
   // Thread panel state — generic across channels and DMs.
   const threadPanelOpen = useThreadPanelStore((state) => state.open);
@@ -807,7 +809,16 @@ export default function InboxChannelPage() {
     )}
     {threadPanel && isMobile && (
       <Sheet open onOpenChange={(o) => { if (!o) closeThread(); }}>
-        <SheetContent side="right" className="w-full sm:max-w-full p-0">
+        <SheetContent
+          side="right"
+          className="w-full sm:max-w-full p-0"
+          style={{
+            height: keyboardOpen ? `calc(100dvh - ${keyboardHeight}px)` : '100dvh',
+            top: 0,
+            bottom: 'auto',
+            paddingTop: 'env(safe-area-inset-top, 0px)',
+          }}
+        >
           <SheetTitle className="sr-only">Thread</SheetTitle>
           {threadPanel}
         </SheetContent>

--- a/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
@@ -31,6 +31,7 @@ import { useThreadPanelStore } from '@/stores/useThreadPanelStore';
 import { ThreadPanel } from '@/components/layout/middle-content/page-views/thread/ThreadPanel';
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
 import { useMobile } from '@/hooks/useMobile';
+import { useMobileKeyboard } from '@/hooks/useMobileKeyboard';
 import { formatDistanceToNow } from 'date-fns';
 import { isFirstInGroup } from '@/lib/messages/grouping';
 
@@ -120,6 +121,7 @@ export default function InboxDMPage() {
   const chatInputRef = useRef<ChannelInputRef>(null);
   const socket = useSocket();
   const isMobile = useMobile();
+  const { isOpen: keyboardOpen, height: keyboardHeight } = useMobileKeyboard();
 
   const threadPanelOpen = useThreadPanelStore((state) => state.open);
   const threadPanelSource = useThreadPanelStore((state) => state.source);
@@ -775,7 +777,12 @@ export default function InboxDMPage() {
         <SheetContent
           side="right"
           className="w-full sm:max-w-full p-0"
-          style={{ height: 'var(--app-height, 100dvh)', top: 0, bottom: 'auto' }}
+          style={{
+            height: keyboardOpen ? `calc(100dvh - ${keyboardHeight}px)` : '100dvh',
+            top: 0,
+            bottom: 'auto',
+            paddingTop: 'env(safe-area-inset-top, 0px)',
+          }}
         >
           <SheetTitle className="sr-only">Thread</SheetTitle>
           {threadPanel}

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -30,6 +30,7 @@ import { useThreadPanelStore } from '@/stores/useThreadPanelStore';
 import { ThreadPanel } from '@/components/layout/middle-content/page-views/thread/ThreadPanel';
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
 import { useMobile } from '@/hooks/useMobile';
+import { useMobileKeyboard } from '@/hooks/useMobileKeyboard';
 import {
   type AttachmentMeta,
   type FileRelation,
@@ -81,6 +82,7 @@ function ChannelView({ page }: ChannelViewProps) {
   const openThread = useThreadPanelStore((state) => state.openThread);
   const closeThread = useThreadPanelStore((state) => state.close);
   const isMobile = useMobile();
+  const { isOpen: keyboardOpen, height: keyboardHeight } = useMobileKeyboard();
 
   const isThreadVisible =
     threadPanelOpen &&
@@ -788,7 +790,12 @@ function ChannelView({ page }: ChannelViewProps) {
         <SheetContent
           side="right"
           className="w-full sm:max-w-full p-0"
-          style={{ height: 'var(--app-height, 100dvh)', top: 0, bottom: 'auto' }}
+          style={{
+            height: keyboardOpen ? `calc(100dvh - ${keyboardHeight}px)` : '100dvh',
+            top: 0,
+            bottom: 'auto',
+            paddingTop: 'env(safe-area-inset-top, 0px)',
+          }}
         >
           <SheetTitle className="sr-only">Thread</SheetTitle>
           {threadPanel}


### PR DESCRIPTION
## Summary

- **Safe area (header in bezel)**: The Sheet's built-in \`pt-[env(safe-area-inset-top)]\` was being silently removed by \`p-0\` passed as className — \`tailwind-merge\` treats \`p-0\` as a shorthand that overrides \`pt-[...]\`. Fixed with \`paddingTop: 'env(safe-area-inset-top, 0px)'\` in the inline \`style\` prop, which always wins over classes.
- **Keyboard avoidance (input hidden)**: The previous \`height: var(--app-height)\` approach relied on CSS variable cascade into a Radix Portal, which was not reliably updating the element's layout. Replaced with \`useMobileKeyboard()\` (MutationObserver-based React state) computing \`calc(100dvh - keyboardHeight)\` directly. On desktop/web the hook returns \`{ isOpen: false, height: 0 }\` so height is \`100dvh\` — no regression.

Both fixes applied to all three mobile thread Sheet locations:
- \`apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx\`
- \`apps/web/src/app/dashboard/dms/[conversationId]/page.tsx\`
- \`apps/web/src/app/dashboard/channels/[pageId]/page.tsx\` *(missed in initial commit, caught in review)*

## Test plan

- [ ] Open a channel on iOS → tap a "N replies" thread footer → thread sheet opens
- [ ] Thread header ("Thread" + Follow button) is visible below the notch/Dynamic Island, not behind it
- [ ] Tap the "Reply…" input → keyboard animates up → composer stays visible just above the keyboard
- [ ] Repeat in a DM conversation thread
- [ ] Repeat in a direct channel page (\`/dashboard/channels/[pageId]\`)
- [ ] Desktop web: thread opens in the 420px sidebar as before, no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)