### PR TITLE
style(threads): make thread reply indicator more visible

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -18,7 +18,7 @@ import { MessageDropZone } from './MessageDropZone';
 import { MessageReactions, type Reaction } from '@/components/shared/MessageReactions';
 import { MessageHoverToolbar } from '@/components/shared/MessageHoverToolbar';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Lock, Check, X } from 'lucide-react';
+import { Lock, Check, X, MessageSquareText } from 'lucide-react';
 import { MessageAttachment } from '@/components/shared/MessageAttachment';
 import MessageQuoteBlock from '@/components/messages/MessageQuoteBlock';
 import { ThreadOriginBadge } from '@/components/messages/ThreadOriginBadge';
@@ -706,11 +706,12 @@ function ChannelView({ page }: ChannelViewProps) {
                                       openThread({ source: 'channel', contextId: page.id, parentId: m.id })
                                     }
                                     data-testid={`thread-footer-${m.id}`}
-                                    className="mt-1 self-start text-xs text-muted-foreground hover:text-foreground hover:underline"
+                                    className="mt-1 self-start flex items-center gap-1 text-xs font-medium text-primary rounded px-1.5 py-0.5 -ml-1.5 hover:bg-primary/10 transition-colors"
                                   >
+                                    <MessageSquareText size={12} aria-hidden />
                                     {replyCount} {replyCount === 1 ? 'reply' : 'replies'}
                                     {m.lastReplyAt
-                                      ? ` · last reply ${formatDistanceToNow(new Date(m.lastReplyAt), { addSuffix: true })}`
+                                      ? ` · ${formatDistanceToNow(new Date(m.lastReplyAt), { addSuffix: true })}`
                                       : ''}
                                   </button>
                                 )}


### PR DESCRIPTION
## Summary

- Replaces muted gray `text-muted-foreground` with `text-primary` (brand blue) so reply counts are immediately noticeable
- Adds a `MessageSquareText` icon for Slack-style iconographic affordance
- Adds a rounded hover background pill (`hover:bg-primary/10`) matching Slack's hover pattern — no underline

## Before / After

**Before:** `4 replies · 2 hours ago` — gray, no affordance  
**After:** 🔵 icon + `4 replies · 2 hours ago` — blue, icon, hover pill

## Test plan

- [ ] Open a channel with messages that have replies — confirm indicator is blue + has icon
- [ ] Hover over the indicator — confirm light tinted background pill appears
- [ ] Click the indicator — confirm thread panel opens correctly
- [ ] Messages with no replies — confirm no indicator rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated thread reply footer button styling and icon appearance
  * Changed last reply timestamp display to show relative time format with updated formatting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->