### PR TITLE
feat(messages): date separators in channels and DMs

### DIFF
--- a/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, useRef, useCallback } from 'react';
+import { useEffect, useState, useRef, useCallback, Fragment } from 'react';
 import { useParams } from 'next/navigation';
 import { useAuth } from '@/hooks/useAuth';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
@@ -32,7 +32,8 @@ import { ThreadPanel } from '@/components/layout/middle-content/page-views/threa
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet';
 import { useMobile } from '@/hooks/useMobile';
 import { formatDistanceToNow } from 'date-fns';
-import { isFirstInGroup } from '@/lib/messages/grouping';
+import { isFirstInGroup, formatMessageDate } from '@/lib/messages/grouping';
+import { MessageDateSeparator } from '@/components/messages/MessageDateSeparator';
 
 const fetcher = async (url: string) => {
   const response = await fetchWithAuth(url);
@@ -586,9 +587,14 @@ export default function InboxDMPage() {
               const replyCount = message.replyCount ?? 0;
               const showReplyInThread = !message.id.startsWith('temp-');
               const isLastRead = i === lastReadOwnIndex;
+              const currentDateStr = new Date(message.createdAt).toDateString();
+              const previousDateStr = previous ? new Date(previous.createdAt).toDateString() : null;
+              const showDateSeparator = currentDateStr !== previousDateStr;
 
               return (
-                <div key={message.id} className={`group/msg flex items-start gap-4 ${rowSpacing}`}>
+                <Fragment key={message.id}>
+                {showDateSeparator && <MessageDateSeparator label={formatMessageDate(message.createdAt)} />}
+                <div className={`group/msg flex items-start gap-4 ${rowSpacing}`}>
                   {isFirst ? (
                     <Avatar className="h-10 w-10 flex-shrink-0">
                       {isOwnMessage ? (
@@ -741,6 +747,7 @@ export default function InboxDMPage() {
                     )}
                   </div>
                 </div>
+                </Fragment>
               );
             })}
           </ConversationContent>

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef, useCallback, memo } from 'react';
+import { useState, useEffect, useRef, useCallback, memo, Fragment } from 'react';
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
 import { usePermissions, getPermissionErrorMessage } from '@/hooks/usePermissions';
@@ -34,7 +34,8 @@ import {
   type AttachmentMeta,
   type FileRelation,
 } from '@/lib/attachment-utils';
-import { isFirstInGroup } from '@/lib/messages/grouping';
+import { isFirstInGroup, formatMessageDate } from '@/lib/messages/grouping';
+import { MessageDateSeparator } from '@/components/messages/MessageDateSeparator';
 import { formatDistanceToNow } from 'date-fns';
 
 interface ChannelViewProps {
@@ -611,8 +612,13 @@ function ChannelView({ page }: ChannelViewProps) {
                         const isRealMessage = !m.id.startsWith('temp-') && editingMessageId !== m.id;
                         const showOwnerActions = isOwnMessage && isRealMessage;
                         const replyCount = m.replyCount ?? 0;
+                        const currentDateStr = new Date(m.createdAt).toDateString();
+                        const previousDateStr = previous ? new Date(previous.createdAt).toDateString() : null;
+                        const showDateSeparator = currentDateStr !== previousDateStr;
                         return (
-                        <div key={m.id} className={`group/msg flex items-start gap-4 ${rowSpacing}`}>
+                        <Fragment key={m.id}>
+                        {showDateSeparator && <MessageDateSeparator label={formatMessageDate(m.createdAt)} />}
+                        <div className={`group/msg flex items-start gap-4 ${rowSpacing}`}>
                             {isFirst ? (
                               <Avatar className="shrink-0">
                                   {!isAi && <AvatarImage src={m.user?.image || ''} />}
@@ -745,6 +751,7 @@ function ChannelView({ page }: ChannelViewProps) {
                                 )}
                             </div>
                         </div>
+                        </Fragment>
                         );
                     })}
             </ConversationContent>

--- a/apps/web/src/components/messages/MessageDateSeparator.tsx
+++ b/apps/web/src/components/messages/MessageDateSeparator.tsx
@@ -1,0 +1,11 @@
+export function MessageDateSeparator({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-3 my-3 px-2">
+      <div className="flex-1 h-px bg-border" />
+      <span className="text-xs text-muted-foreground bg-background px-2 py-0.5 rounded-full border border-border whitespace-nowrap">
+        {label}
+      </span>
+      <div className="flex-1 h-px bg-border" />
+    </div>
+  );
+}

--- a/apps/web/src/lib/messages/__tests__/grouping.test.ts
+++ b/apps/web/src/lib/messages/__tests__/grouping.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { isFirstInGroup } from '../grouping';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { isFirstInGroup, formatMessageDate } from '../grouping';
 
 describe('isFirstInGroup', () => {
   const t0 = new Date('2026-05-04T12:00:00Z');
@@ -79,5 +79,66 @@ describe('isFirstInGroup', () => {
         { authorKey: 'u1', createdAt: 'not a date' },
       ),
     ).toBe(true);
+  });
+
+  it('breaks the group when messages cross midnight even within the 5-minute window', () => {
+    // 23:59 → 00:00 next day, 1 minute apart — same author
+    const beforeMidnight = new Date('2026-05-04T23:59:30Z');
+    const afterMidnight = new Date('2026-05-05T00:00:30Z');
+    expect(
+      isFirstInGroup(
+        { authorKey: 'u1', createdAt: afterMidnight },
+        { authorKey: 'u1', createdAt: beforeMidnight },
+      ),
+    ).toBe(true);
+  });
+
+  it('does not break the group when messages are on the same calendar day within the window', () => {
+    // Same day, same author, 2 minutes apart — should still group
+    const a = new Date('2026-05-04T09:00:00Z');
+    const b = new Date('2026-05-04T09:02:00Z');
+    expect(
+      isFirstInGroup(
+        { authorKey: 'u1', createdAt: b },
+        { authorKey: 'u1', createdAt: a },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('formatMessageDate', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns "Today" for a date on the current calendar day', () => {
+    vi.setSystemTime(new Date('2026-05-04T15:00:00Z'));
+    expect(formatMessageDate(new Date('2026-05-04T08:00:00Z'))).toBe('Today');
+  });
+
+  it('returns "Yesterday" for a date on the previous calendar day', () => {
+    vi.setSystemTime(new Date('2026-05-04T15:00:00Z'));
+    expect(formatMessageDate(new Date('2026-05-03T10:00:00Z'))).toBe('Yesterday');
+  });
+
+  it('returns a weekday name for a date within the current week', () => {
+    // 2026-05-04 is a Monday; set "now" to Friday 2026-05-08
+    vi.setSystemTime(new Date('2026-05-08T12:00:00Z'));
+    const result = formatMessageDate(new Date('2026-05-05T10:00:00Z'));
+    expect(result).toBe('Tuesday');
+  });
+
+  it('returns "Month d, yyyy" for dates older than the current week', () => {
+    vi.setSystemTime(new Date('2026-05-17T12:00:00Z'));
+    expect(formatMessageDate(new Date('2026-05-01T10:00:00Z'))).toBe('May 1, 2026');
+  });
+
+  it('accepts ISO string input', () => {
+    vi.setSystemTime(new Date('2026-05-04T15:00:00Z'));
+    expect(formatMessageDate('2026-05-04T08:00:00Z')).toBe('Today');
   });
 });

--- a/apps/web/src/lib/messages/grouping.ts
+++ b/apps/web/src/lib/messages/grouping.ts
@@ -21,9 +21,11 @@ export function isFirstInGroup(
 ): boolean {
   if (!previous) return true;
   if (current.authorKey !== previous.authorKey) return true;
-  const currentMs = new Date(current.createdAt).getTime();
-  const previousMs = new Date(previous.createdAt).getTime();
+  const currentDate = new Date(current.createdAt);
+  const previousDate = new Date(previous.createdAt);
+  const currentMs = currentDate.getTime();
+  const previousMs = previousDate.getTime();
   if (!Number.isFinite(currentMs) || !Number.isFinite(previousMs)) return true;
-  if (new Date(current.createdAt).toDateString() !== new Date(previous.createdAt).toDateString()) return true;
+  if (currentDate.toDateString() !== previousDate.toDateString()) return true;
   return currentMs - previousMs > GROUP_BREAK_MS;
 }

--- a/apps/web/src/lib/messages/grouping.ts
+++ b/apps/web/src/lib/messages/grouping.ts
@@ -1,4 +1,14 @@
+import { isToday, isYesterday, isThisWeek, format } from 'date-fns';
+
 const GROUP_BREAK_MS = 5 * 60 * 1000;
+
+export function formatMessageDate(date: Date | string): string {
+  const d = new Date(date);
+  if (isToday(d)) return 'Today';
+  if (isYesterday(d)) return 'Yesterday';
+  if (isThisWeek(d)) return format(d, 'EEEE');
+  return format(d, 'MMMM d, yyyy');
+}
 
 export interface GroupableMessage {
   authorKey: string;

--- a/apps/web/src/lib/messages/grouping.ts
+++ b/apps/web/src/lib/messages/grouping.ts
@@ -24,5 +24,6 @@ export function isFirstInGroup(
   const currentMs = new Date(current.createdAt).getTime();
   const previousMs = new Date(previous.createdAt).getTime();
   if (!Number.isFinite(currentMs) || !Number.isFinite(previousMs)) return true;
+  if (new Date(current.createdAt).toDateString() !== new Date(previous.createdAt).toDateString()) return true;
   return currentMs - previousMs > GROUP_BREAK_MS;
 }


### PR DESCRIPTION
## Summary

Adds Slack-style date separators (a centered pill between a horizontal rule) between messages whenever the calendar date changes, in both Channel and DM views.

- Shows **"Today"**, **"Yesterday"**, weekday name (within current week), or **"Month d, yyyy"** for older dates
- A date boundary also forces a new visual group (avatar, name, timestamp visible) — so a message sent just after midnight by the same author as one just before midnight correctly starts a new group rather than appearing as a continuation
- Reuses `date-fns` already in the project; date-label logic extracted into a shared `formatMessageDate()` helper in `grouping.ts`

## Files changed

| File | Change |
|------|--------|
| `apps/web/src/lib/messages/grouping.ts` | Added `formatMessageDate()` export; `isFirstInGroup` now also breaks at date boundaries |
| `apps/web/src/components/messages/MessageDateSeparator.tsx` | New pill separator component |
| `apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx` | Wired separator into message map; preserved `relative` class from #1373 |
| `apps/web/src/app/dashboard/dms/[conversationId]/page.tsx` | Same wiring for DM view; preserved `relative` class from #1373 |
| `apps/web/src/lib/messages/__tests__/grouping.test.ts` | New tests for midnight-crossing group break + full `formatMessageDate` coverage |

## Test plan

- [ ] Open a Channel with messages spanning multiple days — date pills appear at each day boundary
- [ ] Open a DM conversation with messages spanning multiple days — same
- [ ] Messages within the same day have no separator between them
- [ ] First message in a list shows its own date separator
- [ ] "Today", "Yesterday", weekday, and full date labels all render correctly
- [ ] A message sent just after midnight by the same author as one just before midnight renders with avatar/name (new group), not as a continuation
- [ ] Pill looks correct in light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)