### PR TITLE
fix(dm,channel): action toolbar no longer covers grouped message text

### DIFF
--- a/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
@@ -588,7 +588,7 @@ export default function InboxDMPage() {
               const isLastRead = i === lastReadOwnIndex;
 
               return (
-                <div key={message.id} className={`group/msg flex items-start gap-4 ${rowSpacing}`}>
+                <div key={message.id} className={`group/msg flex items-start gap-4 ${rowSpacing} relative`}>
                   {isFirst ? (
                     <Avatar className="h-10 w-10 flex-shrink-0">
                       {isOwnMessage ? (
@@ -613,7 +613,7 @@ export default function InboxDMPage() {
                     </div>
                   )}
 
-                  <div className="flex-1 min-w-0 relative">
+                  <div className="flex-1 min-w-0">
                     {isFirst && (
                       <div className="flex items-center gap-2 mb-1">
                         <span className="font-semibold text-sm">{senderName}</span>
@@ -719,27 +719,26 @@ export default function InboxDMPage() {
                         onRemoveReaction={(emoji) => handleRemoveReaction(message.id, emoji)}
                       />
                     )}
-                    {isRealMessage && (
-                      <MessageHoverToolbar
-                        canReact={true}
-                        canEdit={showOwnerActions}
-                        canDelete={showOwnerActions}
-                        canReplyInThread={showReplyInThread}
-                        canQuoteReply={true}
-                        reactions={message.reactions}
-                        currentUserId={user?.id}
-                        className={!isFirst ? 'top-0' : undefined}
-                        onAddReaction={(emoji) => handleAddReaction(message.id, emoji)}
-                        onRemoveReaction={(emoji) => handleRemoveReaction(message.id, emoji)}
-                        onQuoteReply={() => handleStartQuote(message)}
-                        onEdit={() => { setEditingMessageId(message.id); setEditContent(message.content); }}
-                        onDelete={() => handleDeleteMessage(message.id)}
-                        onReplyInThread={() =>
-                          openThread({ source: 'dm', contextId: conversationId, parentId: message.id })
-                        }
-                      />
-                    )}
                   </div>
+                  {isRealMessage && (
+                    <MessageHoverToolbar
+                      canReact={true}
+                      canEdit={showOwnerActions}
+                      canDelete={showOwnerActions}
+                      canReplyInThread={showReplyInThread}
+                      canQuoteReply={true}
+                      reactions={message.reactions}
+                      currentUserId={user?.id}
+                      onAddReaction={(emoji) => handleAddReaction(message.id, emoji)}
+                      onRemoveReaction={(emoji) => handleRemoveReaction(message.id, emoji)}
+                      onQuoteReply={() => handleStartQuote(message)}
+                      onEdit={() => { setEditingMessageId(message.id); setEditContent(message.content); }}
+                      onDelete={() => handleDeleteMessage(message.id)}
+                      onReplyInThread={() =>
+                        openThread({ source: 'dm', contextId: conversationId, parentId: message.id })
+                      }
+                    />
+                  )}
                 </div>
               );
             })}

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -612,7 +612,7 @@ function ChannelView({ page }: ChannelViewProps) {
                         const showOwnerActions = isOwnMessage && isRealMessage;
                         const replyCount = m.replyCount ?? 0;
                         return (
-                        <div key={m.id} className={`group/msg flex items-start gap-4 ${rowSpacing}`}>
+                        <div key={m.id} className={`group/msg flex items-start gap-4 ${rowSpacing} relative`}>
                             {isFirst ? (
                               <Avatar className="shrink-0">
                                   {!isAi && <AvatarImage src={m.user?.image || ''} />}
@@ -625,7 +625,7 @@ function ChannelView({ page }: ChannelViewProps) {
                                 </span>
                               </div>
                             )}
-                            <div className="flex flex-col min-w-0 flex-1 relative">
+                            <div className="flex flex-col min-w-0 flex-1">
                                 {isFirst && (
                                   <div className="flex items-center gap-2">
                                       <span className="font-semibold text-sm">{displayName}</span>
@@ -723,27 +723,26 @@ function ChannelView({ page }: ChannelViewProps) {
                                     canReact={permissions?.canView || false}
                                   />
                                 )}
-                                {isRealMessage && (
-                                  <MessageHoverToolbar
-                                    canReact={permissions?.canView || false}
-                                    canEdit={showOwnerActions}
-                                    canDelete={showOwnerActions}
-                                    canReplyInThread={!m.id.startsWith('temp-')}
-                                    canQuoteReply={true}
-                                    reactions={m.reactions}
-                                    currentUserId={user?.id}
-                                    className={!isFirst ? 'top-0' : undefined}
-                                    onAddReaction={(emoji) => handleAddReaction(m.id, emoji)}
-                                    onRemoveReaction={(emoji) => handleRemoveReaction(m.id, emoji)}
-                                    onQuoteReply={() => handleStartQuote(m)}
-                                    onEdit={() => { setEditingMessageId(m.id); setEditContent(m.content); }}
-                                    onDelete={() => handleDeleteMessage(m.id)}
-                                    onReplyInThread={() =>
-                                      openThread({ source: 'channel', contextId: page.id, parentId: m.id })
-                                    }
-                                  />
-                                )}
                             </div>
+                            {isRealMessage && (
+                              <MessageHoverToolbar
+                                canReact={permissions?.canView || false}
+                                canEdit={showOwnerActions}
+                                canDelete={showOwnerActions}
+                                canReplyInThread={!m.id.startsWith('temp-')}
+                                canQuoteReply={true}
+                                reactions={m.reactions}
+                                currentUserId={user?.id}
+                                onAddReaction={(emoji) => handleAddReaction(m.id, emoji)}
+                                onRemoveReaction={(emoji) => handleRemoveReaction(m.id, emoji)}
+                                onQuoteReply={() => handleStartQuote(m)}
+                                onEdit={() => { setEditingMessageId(m.id); setEditContent(m.content); }}
+                                onDelete={() => handleDeleteMessage(m.id)}
+                                onReplyInThread={() =>
+                                  openThread({ source: 'channel', contextId: page.id, parentId: m.id })
+                                }
+                              />
+                            )}
                         </div>
                         );
                     })}


### PR DESCRIPTION
## Summary

- In DM and Channel pages, the `MessageHoverToolbar` (react/reply/quote/etc.) was absolutely positioned *inside* the text content div. For grouped (non-first) messages a `top-0` override was used, placing the toolbar at the exact top of the content div — the same line as the message text.
- Fix: moved the toolbar to be a direct child of the outer message row div, which now carries `relative`. The toolbar's default `-top-3 right-2` positions it above the row's top edge for every message, regardless of grouping — no overlap with text.
- Removed the `className={!isFirst ? 'top-0' : undefined}` special case entirely.

## Test plan

- [ ] Open a DM conversation, send 2+ consecutive messages from the same user (grouped)
- [ ] Desktop: hover over a grouped message — toolbar appears above the text row, not on top of it
- [ ] Mobile / DevTools touch simulation: toolbar is visible above the message row, not covering the first line of text
- [ ] First messages in a group behave as before
- [ ] Hover show/hide transition still works on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)