### PR TITLE
fix(threads): mobile keyboard + safe area in thread sheet

### DIFF
--- a/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
@@ -781,7 +781,6 @@ export default function InboxDMPage() {
         <SheetContent
           side="right"
           className="w-full sm:max-w-full p-0"
-          style={{ height: 'var(--app-height, 100dvh)', top: 0, bottom: 'auto' }}
         >
           <SheetTitle className="sr-only">Thread</SheetTitle>
           {threadPanel}

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -795,7 +795,6 @@ function ChannelView({ page }: ChannelViewProps) {
         <SheetContent
           side="right"
           className="w-full sm:max-w-full p-0"
-          style={{ height: 'var(--app-height, 100dvh)', top: 0, bottom: 'auto' }}
         >
           <SheetTitle className="sr-only">Thread</SheetTitle>
           {threadPanel}

--- a/apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx
@@ -37,6 +37,7 @@ import { useSocketStore } from '@/stores/useSocketStore';
 import { useThreadInboxStore } from '@/stores/useThreadInboxStore';
 import type { AttachmentMeta, FileRelation } from '@/lib/attachment-utils';
 import { renderMessageParts, convertToMessageParts } from '@/components/messages/MessagePartRenderer';
+import { useMobileKeyboard } from '@/hooks/useMobileKeyboard';
 
 export type ThreadSource = 'channel' | 'dm';
 
@@ -180,6 +181,7 @@ export function ThreadPanel({
   // Clear the unread-thread badge for this root the moment the panel opens.
   // Subsequent fan-outs while the panel is open could re-bump the badge; the
   // page-side mount unsubscribes from the badge by closing the panel.
+  const { isOpen: isKeyboardOpen, height: keyboardHeight } = useMobileKeyboard();
   const clearThreadBadge = useThreadInboxStore((state) => state.clearRoot);
   useEffect(() => {
     clearThreadBadge({ source, contextId, rootMessageId: parentId });
@@ -643,7 +645,7 @@ export function ThreadPanel({
       className="flex h-full w-full flex-col border-l border-border bg-background"
     >
       {/* Header */}
-      <div className="flex items-center justify-between border-b border-border px-4 py-3">
+      <div className="flex items-center justify-between border-b border-border px-4 py-3 pt-[calc(0.75rem+env(safe-area-inset-top,0px))]">
         <div className="flex flex-col">
           <span className="text-sm font-semibold">Thread</span>
           {replyCount > 0 && (
@@ -862,7 +864,9 @@ export function ThreadPanel({
       <div
         className="border-t border-border p-3"
         style={{
-          paddingBottom: 'calc(0.75rem + var(--safe-bottom-offset, 0px))',
+          paddingBottom: isKeyboardOpen
+            ? `calc(0.75rem + ${keyboardHeight}px)`
+            : 'calc(0.75rem + var(--safe-bottom-offset, 0px))',
         }}
       >
         {submitError && (


### PR DESCRIPTION
## Summary

- **Top safe area**: Thread panel header now applies `pt-[calc(0.75rem+env(safe-area-inset-top,0px))]` directly on the header div, so it sits below the notch/status bar regardless of how the panel is wrapped
- **Keyboard reactivity**: `useMobileKeyboard` is now used in `ThreadPanel` — composer `padding-bottom` dynamically lifts the input above the keyboard when open, matching the pattern used in `SidebarChatTab`
- **Double-shrink fix**: Removed the `height: var(--app-height, 100dvh)` + `bottom: auto` inline style from the `SheetContent` wrappers in `ChannelView` and the DM page — Radix's `inset-y-0` already handles full-height positioning; keeping the CSS-var approach alongside the keyboard padding caused a double-shrink conflict and had known iOS WebKit reliability issues for `position: fixed` elements

## Files changed

- `apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx`
- `apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx`
- `apps/web/src/app/dashboard/dms/[conversationId]/page.tsx`

## Test plan

- [ ] Open a channel or DM on mobile (iOS Capacitor or mobile browser)
- [ ] Tap reply on a message → thread sheet slides in from the right
- [ ] Header ("Thread" + follow/close buttons) is fully below the status bar/notch — no bleed
- [ ] Tap the "Reply…" input → keyboard appears → input stays visible above keyboard
- [ ] Messages scroll normally above the input
- [ ] Send a reply → keyboard dismisses, sheet remains open
- [ ] Repeat in a DM conversation (separate code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved mobile experience with better safe area support for devices with display notches and rounded corners.
* Enhanced keyboard handling in thread and DM panels on mobile, automatically adjusting layout when the keyboard appears while composing messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1374?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->