### PR TITLE
style(threads): apply primary reply indicator to channel and DM route pages

### DIFF
--- a/apps/web/src/app/dashboard/channels/[pageId]/page.tsx
+++ b/apps/web/src/app/dashboard/channels/[pageId]/page.tsx
@@ -5,7 +5,7 @@ import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import useSWR from 'swr';
 import { toast } from 'sonner';
-import { Hash, ExternalLink, Lock, Check, X } from 'lucide-react';
+import { Hash, ExternalLink, Lock, Check, MessageSquareText, X } from 'lucide-react';
 import { MessageAttachment } from '@/components/shared/MessageAttachment';
 import { useAuth } from '@/hooks/useAuth';
 import { usePermissions, getPermissionErrorMessage } from '@/hooks/usePermissions';
@@ -727,11 +727,12 @@ export default function InboxChannelPage() {
                           openThread({ source: 'channel', contextId: pageId, parentId: m.id })
                         }
                         data-testid={`thread-footer-${m.id}`}
-                        className="mt-1 self-start text-xs text-muted-foreground hover:text-foreground hover:underline"
+                        className="mt-1 self-start flex items-center gap-1 text-xs font-medium text-primary rounded px-1.5 py-0.5 -ml-1.5 hover:bg-primary/10 transition-colors"
                       >
+                        <MessageSquareText size={12} aria-hidden />
                         {replyCount} {replyCount === 1 ? 'reply' : 'replies'}
                         {m.lastReplyAt
-                          ? ` · last reply ${formatDistanceToNow(new Date(m.lastReplyAt), { addSuffix: true })}`
+                          ? ` · ${formatDistanceToNow(new Date(m.lastReplyAt), { addSuffix: true })}`
                           : ''}
                       </button>
                     )}

--- a/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
@@ -22,7 +22,7 @@ import useSWR from 'swr';
 import { toast } from 'sonner';
 import { useSocket } from '@/hooks/useSocket';
 import { post, patch, del, fetchWithAuth } from '@/lib/auth/auth-fetch';
-import { Check, X } from 'lucide-react';
+import { Check, MessageSquareText, X } from 'lucide-react';
 import MessageQuoteBlock from '@/components/messages/MessageQuoteBlock';
 import { ThreadOriginBadge } from '@/components/messages/ThreadOriginBadge';
 import type { QuotedMessageSnapshot } from '@pagespace/lib/services/quote-enrichment';
@@ -709,11 +709,12 @@ export default function InboxDMPage() {
                           openThread({ source: 'dm', contextId: conversationId, parentId: message.id })
                         }
                         data-testid={`thread-footer-${message.id}`}
-                        className="mt-1 self-start text-xs text-muted-foreground hover:text-foreground hover:underline"
+                        className="mt-1 self-start flex items-center gap-1 text-xs font-medium text-primary rounded px-1.5 py-0.5 -ml-1.5 hover:bg-primary/10 transition-colors"
                       >
+                        <MessageSquareText size={12} aria-hidden />
                         {replyCount} {replyCount === 1 ? 'reply' : 'replies'}
                         {message.lastReplyAt
-                          ? ` · last reply ${formatDistanceToNow(new Date(message.lastReplyAt), { addSuffix: true })}`
+                          ? ` · ${formatDistanceToNow(new Date(message.lastReplyAt), { addSuffix: true })}`
                           : ''}
                       </button>
                     )}


### PR DESCRIPTION
## Summary

- Channel route page (`/dashboard/channels/[pageId]/page.tsx`) and DM route page (`/dashboard/dms/[conversationId]/page.tsx`) were missed in #1371
- Both now match `ChannelView.tsx`: `text-primary` color, `MessageSquareText` icon, pill hover background (`hover:bg-primary/10`), "last reply" prefix dropped from timestamp

## Test plan

- [ ] Open a channel with threaded messages — reply indicator is blue/primary with icon
- [ ] Open a DM with threaded messages — same treatment
- [ ] Verify in both light and dark mode
- [ ] Confirm `ChannelView.tsx` is unchanged (already correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)