### PR TITLE
feat(zoom): OAuth routes, webhook processor, and middleware [PR 3/4]

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -109,7 +109,7 @@ export async function middleware(req: NextRequest) {
       pathname.startsWith('/api/cron/') ||
       pathname === '/api/memory/cron' ||
       pathname === '/api/pulse/cron' ||
-      pathname.startsWith('/api/integrations/zoom/webhook')
+      pathname === '/api/integrations/zoom/webhook'
     ) {
       const { response } = createSecureResponse(isProduction, req, { isAPIRoute });
       return response;

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -108,7 +108,8 @@ export async function middleware(req: NextRequest) {
       pathname.startsWith('/api/drives') ||
       pathname.startsWith('/api/cron/') ||
       pathname === '/api/memory/cron' ||
-      pathname === '/api/pulse/cron'
+      pathname === '/api/pulse/cron' ||
+      pathname.startsWith('/api/integrations/zoom/webhook')
     ) {
       const { response } = createSecureResponse(isProduction, req, { isAPIRoute });
       return response;

--- a/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
+++ b/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
@@ -66,6 +66,7 @@ const AUDIT_EXEMPT_ROUTES = new Map<string, string>([
   // --- External webhooks (no user session, verified by external party) ---
   ['stripe/webhook', 'Stripe-initiated webhook, verified by Stripe signature'],
   ['integrations/google-calendar/webhook', 'Google-initiated webhook, no user session'],
+  ['integrations/zoom/webhook', 'Zoom-initiated webhook, no user session, verified by HMAC signature'],
 
   // --- Read receipts (low-risk, high-frequency) ---
   ['channels/[pageId]/read', 'Channel read receipt, low-risk fire-and-forget'],

--- a/apps/web/src/app/api/integrations/zoom/callback/route.ts
+++ b/apps/web/src/app/api/integrations/zoom/callback/route.ts
@@ -7,6 +7,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { encrypt } from '@pagespace/lib/encryption/encryption-utils';
 import { secureCompare } from '@pagespace/lib/auth/secure-compare';
+import { normalizeZoomReturnPath } from '@/lib/integrations/zoom/return-url';
 
 const STATE_MAX_AGE_MS = 10 * 60 * 1000;
 
@@ -150,7 +151,8 @@ export async function GET(req: Request) {
     auditRequest(req, { eventType: 'auth.token.created', userId, details: { tokenType: 'zoom' } });
     auditRequest(req, { eventType: 'data.write', userId, resourceType: 'zoom_connection', resourceId: 'self', details: { operation: 'oauth_complete' } });
 
-    const redirectUrl = new URL(returnUrl || '/settings/integrations/zoom', baseUrl);
+    const safePath = normalizeZoomReturnPath(returnUrl);
+    const redirectUrl = new URL(safePath, baseUrl);
     redirectUrl.searchParams.set('connected', 'true');
     return NextResponse.redirect(redirectUrl);
   } catch (error) {

--- a/apps/web/src/app/api/integrations/zoom/callback/route.ts
+++ b/apps/web/src/app/api/integrations/zoom/callback/route.ts
@@ -1,0 +1,160 @@
+import { NextResponse } from 'next/server';
+import crypto from 'crypto';
+import { db } from '@pagespace/db/db';
+import { zoomConnections } from '@pagespace/db/schema/zoom';
+import { isOnPrem } from '@pagespace/lib/deployment-mode';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { encrypt } from '@pagespace/lib/encryption/encryption-utils';
+import { secureCompare } from '@pagespace/lib/auth/secure-compare';
+
+const STATE_MAX_AGE_MS = 10 * 60 * 1000;
+
+export async function GET(req: Request) {
+  if (isOnPrem()) return Response.json({ error: 'Not available' }, { status: 404 });
+
+  const baseUrl = process.env.WEB_APP_URL || process.env.NEXTAUTH_URL || 'http://localhost:3000';
+
+  try {
+    if (!process.env.ZOOM_OAUTH_CLIENT_ID || !process.env.ZOOM_OAUTH_CLIENT_SECRET || !process.env.OAUTH_STATE_SECRET) {
+      loggers.auth.error('Missing required Zoom OAuth environment variables for callback');
+      return NextResponse.redirect(new URL('/settings/integrations/zoom?error=oauth_config', baseUrl));
+    }
+
+    const { searchParams } = new URL(req.url);
+    const code = searchParams.get('code');
+    const state = searchParams.get('state');
+    const error = searchParams.get('error');
+
+    if (error) {
+      const errorParam = error === 'access_denied' ? 'access_denied' : 'oauth_error';
+      return NextResponse.redirect(new URL(`/settings/integrations/zoom?error=${errorParam}`, baseUrl));
+    }
+
+    if (!code || !state) {
+      return NextResponse.redirect(new URL('/settings/integrations/zoom?error=invalid_request', baseUrl));
+    }
+
+    // Verify HMAC-signed state
+    let stateData: { userId: string; returnUrl: string; timestamp: number };
+    try {
+      const parsed = JSON.parse(Buffer.from(state, 'base64').toString('utf-8'));
+      if (!parsed.data || !parsed.sig) throw new Error('Invalid state structure');
+
+      const expectedSig = crypto
+        .createHmac('sha256', process.env.OAUTH_STATE_SECRET!)
+        .update(JSON.stringify(parsed.data))
+        .digest('hex');
+
+      if (!secureCompare(String(parsed.sig), expectedSig)) {
+        loggers.auth.warn('Zoom OAuth state signature mismatch');
+        return NextResponse.redirect(new URL('/settings/integrations/zoom?error=invalid_state', baseUrl));
+      }
+
+      stateData = parsed.data;
+
+      if (Date.now() - stateData.timestamp > STATE_MAX_AGE_MS) {
+        return NextResponse.redirect(new URL('/settings/integrations/zoom?error=state_expired', baseUrl));
+      }
+    } catch {
+      return NextResponse.redirect(new URL('/settings/integrations/zoom?error=invalid_state', baseUrl));
+    }
+
+    const { userId, returnUrl } = stateData;
+    const callbackUrl = `${baseUrl}/api/integrations/zoom/callback`;
+
+    // Exchange authorization code for tokens (Zoom uses HTTP Basic auth)
+    const credentials = Buffer.from(
+      `${process.env.ZOOM_OAUTH_CLIENT_ID}:${process.env.ZOOM_OAUTH_CLIENT_SECRET}`
+    ).toString('base64');
+
+    const tokenRes = await fetch('https://zoom.us/oauth/token', {
+      method: 'POST',
+      headers: {
+        Authorization: `Basic ${credentials}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: callbackUrl,
+      }),
+    });
+
+    if (!tokenRes.ok) {
+      loggers.auth.error('Zoom token exchange failed', { status: tokenRes.status });
+      return NextResponse.redirect(new URL('/settings/integrations/zoom?error=token_exchange_failed', baseUrl));
+    }
+
+    const tokens = await tokenRes.json() as {
+      access_token: string;
+      refresh_token?: string;
+      expires_in?: number;
+      token_type: string;
+    };
+
+    if (!tokens.access_token) {
+      return NextResponse.redirect(new URL('/settings/integrations/zoom?error=missing_tokens', baseUrl));
+    }
+
+    // Fetch Zoom user identity for webhook mapping
+    const meRes = await fetch('https://api.zoom.us/v2/users/me', {
+      headers: { Authorization: `Bearer ${tokens.access_token}` },
+    });
+
+    if (!meRes.ok) {
+      loggers.auth.error('Zoom /users/me failed', { status: meRes.status });
+      return NextResponse.redirect(new URL('/settings/integrations/zoom?error=user_info_failed', baseUrl));
+    }
+
+    const me = await meRes.json() as { id: string; account_id: string; email: string };
+
+    if (!me.id || !me.account_id || !me.email) {
+      return NextResponse.redirect(new URL('/settings/integrations/zoom?error=user_info_incomplete', baseUrl));
+    }
+
+    // ZERO-TRUST: Encrypt tokens before storage
+    const encryptedAccessToken = await encrypt(tokens.access_token);
+    const encryptedRefreshToken = tokens.refresh_token ? await encrypt(tokens.refresh_token) : null;
+    const tokenExpiresAt = tokens.expires_in
+      ? new Date(Date.now() + tokens.expires_in * 1000)
+      : null;
+
+    await db
+      .insert(zoomConnections)
+      .values({
+        userId,
+        accessToken: encryptedAccessToken,
+        refreshToken: encryptedRefreshToken ?? undefined,
+        tokenExpiresAt: tokenExpiresAt ?? undefined,
+        zoomUserId: me.id,
+        zoomAccountId: me.account_id,
+        zoomEmail: me.email,
+        status: 'active',
+      })
+      .onConflictDoUpdate({
+        target: zoomConnections.userId,
+        set: {
+          accessToken: encryptedAccessToken,
+          refreshToken: encryptedRefreshToken ?? undefined,
+          tokenExpiresAt: tokenExpiresAt ?? undefined,
+          zoomUserId: me.id,
+          zoomAccountId: me.account_id,
+          zoomEmail: me.email,
+          status: 'active',
+          updatedAt: new Date(),
+        },
+      });
+
+    loggers.auth.info('Zoom connected successfully', { userId });
+    auditRequest(req, { eventType: 'auth.token.created', userId, details: { tokenType: 'zoom' } });
+    auditRequest(req, { eventType: 'data.write', userId, resourceType: 'zoom_connection', resourceId: 'self', details: { operation: 'oauth_complete' } });
+
+    const redirectUrl = new URL(returnUrl || '/settings/integrations/zoom', baseUrl);
+    redirectUrl.searchParams.set('connected', 'true');
+    return NextResponse.redirect(redirectUrl);
+  } catch (error) {
+    loggers.auth.error('Zoom OAuth callback error', error as Error);
+    return NextResponse.redirect(new URL('/settings/integrations/zoom?error=unexpected', baseUrl));
+  }
+}

--- a/apps/web/src/app/api/integrations/zoom/connect/route.ts
+++ b/apps/web/src/app/api/integrations/zoom/connect/route.ts
@@ -1,0 +1,72 @@
+import { z } from 'zod/v4';
+import crypto from 'crypto';
+import { isOnPrem } from '@pagespace/lib/deployment-mode';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security/distributed-rate-limit';
+import { authenticateRequestWithOptions, isAuthError, getClientIP } from '@/lib/auth';
+
+const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
+
+const connectSchema = z.object({
+  returnUrl: z.string().optional(),
+});
+
+export async function POST(req: Request) {
+  if (isOnPrem()) return Response.json({ error: 'Not available' }, { status: 404 });
+
+  try {
+    if (!process.env.ZOOM_OAUTH_CLIENT_ID || !process.env.ZOOM_OAUTH_CLIENT_SECRET || !process.env.OAUTH_STATE_SECRET) {
+      loggers.auth.error('Missing required Zoom OAuth environment variables');
+      return Response.json({ error: 'OAuth not configured' }, { status: 500 });
+    }
+
+    const auth = await authenticateRequestWithOptions(req, AUTH_OPTIONS);
+    if (isAuthError(auth)) return auth.error;
+    const { userId } = auth;
+
+    let body: unknown;
+    try { body = await req.json(); } catch { body = {}; }
+    const validation = connectSchema.safeParse(body);
+    if (!validation.success) {
+      return Response.json({ errors: validation.error.flatten().fieldErrors }, { status: 400 });
+    }
+
+    const clientIP = getClientIP(req);
+    const rateLimit = await checkDistributedRateLimit(
+      `zoom:connect:user:${userId}`,
+      DISTRIBUTED_RATE_LIMITS.LOGIN
+    );
+    if (!rateLimit.allowed) {
+      return Response.json(
+        { error: 'Too many connection attempts. Please try again later.', retryAfter: rateLimit.retryAfter },
+        { status: 429 }
+      );
+    }
+
+    const baseUrl = process.env.WEB_APP_URL || process.env.NEXTAUTH_URL || 'http://localhost:3000';
+    const callbackUrl = `${baseUrl}/api/integrations/zoom/callback`;
+
+    const stateData = { userId, returnUrl: validation.data.returnUrl ?? '/settings/integrations/zoom', timestamp: Date.now() };
+    const statePayload = JSON.stringify(stateData);
+    const signature = crypto.createHmac('sha256', process.env.OAUTH_STATE_SECRET!).update(statePayload).digest('hex');
+    const stateParam = Buffer.from(JSON.stringify({ data: stateData, sig: signature })).toString('base64');
+
+    const params = new URLSearchParams({
+      client_id: process.env.ZOOM_OAUTH_CLIENT_ID!,
+      redirect_uri: callbackUrl,
+      response_type: 'code',
+      state: stateParam,
+    });
+
+    const oauthUrl = `https://zoom.us/oauth/authorize?${params.toString()}`;
+
+    loggers.auth.info('Zoom OAuth initiated', { userId, clientIP });
+    auditRequest(req, { eventType: 'data.write', userId, resourceType: 'zoom_connection', resourceId: 'self', details: { operation: 'oauth_initiated' } });
+
+    return Response.json({ url: oauthUrl });
+  } catch (error) {
+    loggers.auth.error('Zoom connect error', error as Error);
+    return Response.json({ error: 'An unexpected error occurred' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/integrations/zoom/connect/route.ts
+++ b/apps/web/src/app/api/integrations/zoom/connect/route.ts
@@ -5,6 +5,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security/distributed-rate-limit';
 import { authenticateRequestWithOptions, isAuthError, getClientIP } from '@/lib/auth';
+import { normalizeZoomReturnPath } from '@/lib/integrations/zoom/return-url';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
 
@@ -47,7 +48,7 @@ export async function POST(req: Request) {
     const baseUrl = process.env.WEB_APP_URL || process.env.NEXTAUTH_URL || 'http://localhost:3000';
     const callbackUrl = `${baseUrl}/api/integrations/zoom/callback`;
 
-    const stateData = { userId, returnUrl: validation.data.returnUrl ?? '/settings/integrations/zoom', timestamp: Date.now() };
+    const stateData = { userId, returnUrl: normalizeZoomReturnPath(validation.data.returnUrl), timestamp: Date.now() };
     const statePayload = JSON.stringify(stateData);
     const signature = crypto.createHmac('sha256', process.env.OAUTH_STATE_SECRET!).update(statePayload).digest('hex');
     const stateParam = Buffer.from(JSON.stringify({ data: stateData, sig: signature })).toString('base64');

--- a/apps/web/src/app/api/integrations/zoom/disconnect/route.ts
+++ b/apps/web/src/app/api/integrations/zoom/disconnect/route.ts
@@ -39,9 +39,13 @@ export async function POST(request: Request) {
         ).toString('base64');
 
         const revokeParams = new URLSearchParams({ token: accessToken });
-        await fetch(`https://zoom.us/oauth/revoke?${revokeParams}`, {
+        await fetch('https://zoom.us/oauth/revoke', {
           method: 'POST',
-          headers: { Authorization: `Basic ${credentials}` },
+          headers: {
+            Authorization: `Basic ${credentials}`,
+            'Content-Type': 'application/x-www-form-urlencoded',
+          },
+          body: revokeParams.toString(),
         });
       } catch (err) {
         loggers.auth.warn('Failed to revoke Zoom token (continuing with disconnect)', {

--- a/apps/web/src/app/api/integrations/zoom/disconnect/route.ts
+++ b/apps/web/src/app/api/integrations/zoom/disconnect/route.ts
@@ -27,14 +27,19 @@ export async function POST(request: Request) {
     }
 
     // Best-effort token revocation
-    if (connection.accessToken !== 'REVOKED') {
+    if (
+      connection.accessToken !== 'REVOKED' &&
+      process.env.ZOOM_OAUTH_CLIENT_ID &&
+      process.env.ZOOM_OAUTH_CLIENT_SECRET
+    ) {
       try {
         const accessToken = await decrypt(connection.accessToken);
         const credentials = Buffer.from(
           `${process.env.ZOOM_OAUTH_CLIENT_ID}:${process.env.ZOOM_OAUTH_CLIENT_SECRET}`
         ).toString('base64');
 
-        await fetch(`https://zoom.us/oauth/revoke?token=${accessToken}`, {
+        const revokeParams = new URLSearchParams({ token: accessToken });
+        await fetch(`https://zoom.us/oauth/revoke?${revokeParams}`, {
           method: 'POST',
           headers: { Authorization: `Basic ${credentials}` },
         });

--- a/apps/web/src/app/api/integrations/zoom/disconnect/route.ts
+++ b/apps/web/src/app/api/integrations/zoom/disconnect/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from 'next/server';
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { zoomConnections } from '@pagespace/db/schema/zoom';
+import { isOnPrem } from '@pagespace/lib/deployment-mode';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { decrypt } from '@pagespace/lib/encryption/encryption-utils';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+
+const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
+
+export async function POST(request: Request) {
+  if (isOnPrem()) return Response.json({ error: 'Not available' }, { status: 404 });
+
+  try {
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
+    if (isAuthError(auth)) return auth.error;
+    const { userId } = auth;
+
+    const connection = await db.query.zoomConnections.findFirst({
+      where: eq(zoomConnections.userId, userId),
+    });
+
+    if (!connection) {
+      return NextResponse.json({ error: 'No connection found' }, { status: 404 });
+    }
+
+    // Best-effort token revocation
+    if (connection.accessToken !== 'REVOKED') {
+      try {
+        const accessToken = await decrypt(connection.accessToken);
+        const credentials = Buffer.from(
+          `${process.env.ZOOM_OAUTH_CLIENT_ID}:${process.env.ZOOM_OAUTH_CLIENT_SECRET}`
+        ).toString('base64');
+
+        await fetch(`https://zoom.us/oauth/revoke?token=${accessToken}`, {
+          method: 'POST',
+          headers: { Authorization: `Basic ${credentials}` },
+        });
+      } catch (err) {
+        loggers.auth.warn('Failed to revoke Zoom token (continuing with disconnect)', {
+          userId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
+    // Clear tokens but keep the row (mirrors Google Calendar pattern)
+    await db
+      .update(zoomConnections)
+      .set({
+        status: 'disconnected',
+        accessToken: 'REVOKED',
+        refreshToken: null,
+        updatedAt: new Date(),
+      })
+      .where(eq(zoomConnections.userId, userId));
+
+    loggers.auth.info('Zoom disconnected', { userId });
+    auditRequest(request, { eventType: 'auth.token.revoked', userId, details: { tokenType: 'zoom', reason: 'user_disconnect' } });
+    auditRequest(request, { eventType: 'data.delete', userId, resourceType: 'zoom_connection', resourceId: connection.id, details: { operation: 'disconnect' } });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    loggers.api.error('Error disconnecting Zoom', error as Error);
+    return NextResponse.json({ error: 'Failed to disconnect' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/integrations/zoom/settings/route.ts
+++ b/apps/web/src/app/api/integrations/zoom/settings/route.ts
@@ -59,7 +59,8 @@ export async function PATCH(request: Request) {
     if (isAuthError(auth)) return auth.error;
     const { userId } = auth;
 
-    const body = await request.json();
+    let body: unknown;
+    try { body = await request.json(); } catch { body = {}; }
     const validation = settingsSchema.safeParse(body);
     if (!validation.success) {
       return NextResponse.json(

--- a/apps/web/src/app/api/integrations/zoom/settings/route.ts
+++ b/apps/web/src/app/api/integrations/zoom/settings/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod/v4';
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { zoomConnections } from '@pagespace/db/schema/zoom';
+import { isOnPrem } from '@pagespace/lib/deployment-mode';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+
+const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
+const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
+
+const settingsSchema = z.object({
+  targetDriveId: z.string().min(1).nullable().optional(),
+  targetFolderId: z.string().nullable().optional(),
+  includeAiSummary: z.boolean().optional(),
+  includeActionItems: z.boolean().optional(),
+  includeTranscript: z.boolean().optional(),
+});
+
+export async function GET(request: Request) {
+  if (isOnPrem()) return Response.json({ error: 'Not available' }, { status: 404 });
+
+  try {
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
+    if (isAuthError(auth)) return auth.error;
+    const { userId } = auth;
+
+    const connection = await db.query.zoomConnections.findFirst({
+      where: eq(zoomConnections.userId, userId),
+      columns: {
+        targetDriveId: true,
+        targetFolderId: true,
+        includeAiSummary: true,
+        includeActionItems: true,
+        includeTranscript: true,
+      },
+    });
+
+    if (!connection) {
+      return NextResponse.json({ error: 'No connection found' }, { status: 404 });
+    }
+
+    auditRequest(request, { eventType: 'data.read', userId, resourceType: 'zoom_settings', resourceId: 'self' });
+
+    return NextResponse.json({ settings: connection });
+  } catch (error) {
+    loggers.api.error('Error fetching Zoom settings', error as Error);
+    return NextResponse.json({ error: 'Failed to fetch settings' }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: Request) {
+  if (isOnPrem()) return Response.json({ error: 'Not available' }, { status: 404 });
+
+  try {
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+    if (isAuthError(auth)) return auth.error;
+    const { userId } = auth;
+
+    const body = await request.json();
+    const validation = settingsSchema.safeParse(body);
+    if (!validation.success) {
+      return NextResponse.json(
+        { error: 'Invalid settings', details: validation.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const connection = await db.query.zoomConnections.findFirst({
+      where: eq(zoomConnections.userId, userId),
+      columns: { id: true },
+    });
+
+    if (!connection) {
+      return NextResponse.json({ error: 'No connection found' }, { status: 404 });
+    }
+
+    const updates = validation.data;
+    const setValues: Record<string, unknown> = { updatedAt: new Date() };
+    if (updates.targetDriveId !== undefined) setValues.targetDriveId = updates.targetDriveId;
+    if (updates.targetFolderId !== undefined) setValues.targetFolderId = updates.targetFolderId;
+    if (updates.includeAiSummary !== undefined) setValues.includeAiSummary = updates.includeAiSummary;
+    if (updates.includeActionItems !== undefined) setValues.includeActionItems = updates.includeActionItems;
+    if (updates.includeTranscript !== undefined) setValues.includeTranscript = updates.includeTranscript;
+
+    await db.update(zoomConnections).set(setValues).where(eq(zoomConnections.userId, userId));
+
+    loggers.api.info('Zoom settings updated', { userId, updates });
+    auditRequest(request, { eventType: 'data.write', userId, resourceType: 'zoom_settings', resourceId: 'self', details: { operation: 'update' } });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    loggers.api.error('Error updating Zoom settings', error as Error);
+    return NextResponse.json({ error: 'Failed to update settings' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/integrations/zoom/status/route.ts
+++ b/apps/web/src/app/api/integrations/zoom/status/route.ts
@@ -4,6 +4,7 @@ import { eq } from '@pagespace/db/operators';
 import { zoomConnections } from '@pagespace/db/schema/zoom';
 import { isOnPrem } from '@pagespace/lib/deployment-mode';
 import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
@@ -31,6 +32,8 @@ export async function GET(request: Request) {
         updatedAt: true,
       },
     });
+
+    auditRequest(request, { eventType: 'data.read', userId, resourceType: 'zoom_connection', resourceId: 'self' });
 
     if (!connection) {
       return NextResponse.json({ connected: false, connection: null });

--- a/apps/web/src/app/api/integrations/zoom/status/route.ts
+++ b/apps/web/src/app/api/integrations/zoom/status/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { zoomConnections } from '@pagespace/db/schema/zoom';
+import { isOnPrem } from '@pagespace/lib/deployment-mode';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+
+const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: false };
+
+export async function GET(request: Request) {
+  if (isOnPrem()) return Response.json({ error: 'Not available' }, { status: 404 });
+
+  try {
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
+    if (isAuthError(auth)) return auth.error;
+    const { userId } = auth;
+
+    const connection = await db.query.zoomConnections.findFirst({
+      where: eq(zoomConnections.userId, userId),
+      columns: {
+        id: true,
+        status: true,
+        zoomEmail: true,
+        targetDriveId: true,
+        targetFolderId: true,
+        includeAiSummary: true,
+        includeActionItems: true,
+        includeTranscript: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    if (!connection) {
+      return NextResponse.json({ connected: false, connection: null });
+    }
+
+    return NextResponse.json({
+      connected: connection.status === 'active',
+      connection,
+    });
+  } catch (error) {
+    loggers.api.error('Error fetching Zoom status', error as Error);
+    return NextResponse.json({ error: 'Failed to fetch connection status' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/integrations/zoom/webhook/route.ts
+++ b/apps/web/src/app/api/integrations/zoom/webhook/route.ts
@@ -7,24 +7,13 @@ import { processZoomWebhook } from '@/lib/integrations/zoom/process-webhook';
 export async function POST(request: Request) {
   if (isOnPrem()) return Response.json({ error: 'Not available' }, { status: 404 });
 
+  if (!process.env.ZOOM_WEBHOOK_SECRET_TOKEN) {
+    loggers.api.error('ZOOM_WEBHOOK_SECRET_TOKEN is not configured');
+    return Response.json({ error: 'Webhook not configured' }, { status: 500 });
+  }
+
   try {
     const rawBody = await request.text();
-    const body = JSON.parse(rawBody) as { event?: string; payload?: { plainToken?: string } };
-
-    // Handle Zoom's URL validation challenge — must respond before any signature check
-    if (body.event === 'endpoint.url_validation') {
-      const plainToken = body.payload?.plainToken;
-      if (!plainToken || !process.env.ZOOM_WEBHOOK_SECRET_TOKEN) {
-        return Response.json({ error: 'Invalid challenge' }, { status: 400 });
-      }
-      return Response.json(handleUrlValidationChallenge(plainToken, process.env.ZOOM_WEBHOOK_SECRET_TOKEN));
-    }
-
-    // All other events require signature verification
-    if (!process.env.ZOOM_WEBHOOK_SECRET_TOKEN) {
-      loggers.api.error('ZOOM_WEBHOOK_SECRET_TOKEN is not configured');
-      return Response.json({ error: 'Webhook not configured' }, { status: 500 });
-    }
 
     const signature = request.headers.get('x-zm-signature');
     const timestamp = request.headers.get('x-zm-request-timestamp');
@@ -32,6 +21,18 @@ export async function POST(request: Request) {
     if (!verifyZoomWebhookSignature(signature, timestamp, rawBody, process.env.ZOOM_WEBHOOK_SECRET_TOKEN)) {
       loggers.api.warn('Zoom webhook: invalid signature');
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = JSON.parse(rawBody) as { event?: string; payload?: { plainToken?: string } };
+
+    // URL validation challenge: Zoom sends this to verify ownership of the endpoint.
+    // Signature is verified above first — this response is HMAC-authenticated.
+    if (body.event === 'endpoint.url_validation') {
+      const plainToken = body.payload?.plainToken;
+      if (!plainToken) {
+        return Response.json({ error: 'Invalid challenge' }, { status: 400 });
+      }
+      return Response.json(handleUrlValidationChallenge(plainToken, process.env.ZOOM_WEBHOOK_SECRET_TOKEN));
     }
 
     // Return 200 immediately; process async so Zoom's retry logic sees success

--- a/apps/web/src/app/api/integrations/zoom/webhook/route.ts
+++ b/apps/web/src/app/api/integrations/zoom/webhook/route.ts
@@ -1,0 +1,51 @@
+import { after } from 'next/server';
+import { isOnPrem } from '@pagespace/lib/deployment-mode';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { verifyZoomWebhookSignature, handleUrlValidationChallenge } from '@/lib/integrations/zoom/verify-webhook';
+import { processZoomWebhook } from '@/lib/integrations/zoom/process-webhook';
+
+export async function POST(request: Request) {
+  if (isOnPrem()) return Response.json({ error: 'Not available' }, { status: 404 });
+
+  try {
+    const rawBody = await request.text();
+    const body = JSON.parse(rawBody) as { event?: string; payload?: { plainToken?: string } };
+
+    // Handle Zoom's URL validation challenge — must respond before any signature check
+    if (body.event === 'endpoint.url_validation') {
+      const plainToken = body.payload?.plainToken;
+      if (!plainToken || !process.env.ZOOM_WEBHOOK_SECRET_TOKEN) {
+        return Response.json({ error: 'Invalid challenge' }, { status: 400 });
+      }
+      return Response.json(handleUrlValidationChallenge(plainToken, process.env.ZOOM_WEBHOOK_SECRET_TOKEN));
+    }
+
+    // All other events require signature verification
+    if (!process.env.ZOOM_WEBHOOK_SECRET_TOKEN) {
+      loggers.api.error('ZOOM_WEBHOOK_SECRET_TOKEN is not configured');
+      return Response.json({ error: 'Webhook not configured' }, { status: 500 });
+    }
+
+    const signature = request.headers.get('x-zm-signature');
+    const timestamp = request.headers.get('x-zm-request-timestamp');
+
+    if (!verifyZoomWebhookSignature(signature, timestamp, rawBody, process.env.ZOOM_WEBHOOK_SECRET_TOKEN)) {
+      loggers.api.warn('Zoom webhook: invalid signature');
+      return Response.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // Return 200 immediately; process async so Zoom's retry logic sees success
+    after(() => {
+      processZoomWebhook(body).catch((err) => {
+        loggers.api.error('Zoom webhook processing failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    });
+
+    return Response.json({ ok: true });
+  } catch (error) {
+    loggers.api.error('Zoom webhook error', error as Error);
+    return Response.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/apps/web/src/lib/integrations/zoom/__tests__/return-url.test.ts
+++ b/apps/web/src/lib/integrations/zoom/__tests__/return-url.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeZoomReturnPath, ZOOM_DEFAULT_RETURN_PATH } from '../return-url';
+
+describe('normalizeZoomReturnPath', () => {
+  it('given undefined, should return the default path', () => {
+    expect(normalizeZoomReturnPath(undefined)).toBe(ZOOM_DEFAULT_RETURN_PATH);
+  });
+
+  it('given null, should return the default path', () => {
+    expect(normalizeZoomReturnPath(null)).toBe(ZOOM_DEFAULT_RETURN_PATH);
+  });
+
+  it('given empty string, should return the default path', () => {
+    expect(normalizeZoomReturnPath('')).toBe(ZOOM_DEFAULT_RETURN_PATH);
+  });
+
+  it('given an absolute external URL, should return the default path', () => {
+    expect(normalizeZoomReturnPath('https://evil.com/steal')).toBe(ZOOM_DEFAULT_RETURN_PATH);
+  });
+
+  it('given a protocol-relative URL, should return the default path', () => {
+    expect(normalizeZoomReturnPath('//evil.com/steal')).toBe(ZOOM_DEFAULT_RETURN_PATH);
+  });
+
+  it('given a valid relative path, should return it unchanged', () => {
+    expect(normalizeZoomReturnPath('/settings/integrations/zoom')).toBe('/settings/integrations/zoom');
+  });
+
+  it('given a relative path with query string, should preserve query', () => {
+    expect(normalizeZoomReturnPath('/settings/integrations/zoom?tab=advanced')).toBe(
+      '/settings/integrations/zoom?tab=advanced'
+    );
+  });
+
+  it('given a relative path with a URL-valued query param, should pass through unchanged', () => {
+    expect(normalizeZoomReturnPath('/safe?redirect=https://evil.com')).toBe('/safe?redirect=https://evil.com');
+  });
+
+  it('given a non-string value, should return the default path', () => {
+    expect(normalizeZoomReturnPath(42 as unknown as string)).toBe(ZOOM_DEFAULT_RETURN_PATH);
+  });
+
+  it('given a path with a fragment, should strip fragment and keep pathname+search', () => {
+    const result = normalizeZoomReturnPath('/settings#section');
+    expect(result).toBe('/settings');
+  });
+});

--- a/apps/web/src/lib/integrations/zoom/__tests__/token-refresh.test.ts
+++ b/apps/web/src/lib/integrations/zoom/__tests__/token-refresh.test.ts
@@ -1,0 +1,185 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((a: unknown, b: unknown) => ({ field: a, value: b })),
+}));
+
+vi.mock('@pagespace/db/schema/zoom', () => ({
+  zoomConnections: { userId: 'userId' },
+}));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: {
+      zoomConnections: {
+        findFirst: vi.fn(),
+      },
+    },
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(),
+      })),
+    })),
+  },
+}));
+
+vi.mock('@pagespace/lib/encryption/encryption-utils', () => ({
+  encrypt: vi.fn(async (v: string) => `enc:${v}`),
+  decrypt: vi.fn(async (v: string) => v.replace(/^enc:/, '')),
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { auth: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } },
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import { db } from '@pagespace/db/db';
+import { isTokenExpired, getValidZoomAccessToken } from '../token-refresh';
+
+const mockDb = db as unknown as {
+  query: { zoomConnections: { findFirst: ReturnType<typeof vi.fn> } };
+  update: ReturnType<typeof vi.fn>;
+};
+
+describe('isTokenExpired', () => {
+  it('returns false when expiresAt is null (unknown expiry)', () => {
+    expect(isTokenExpired(null)).toBe(false);
+  });
+
+  it('returns true when token is past expiry', () => {
+    const past = new Date(Date.now() - 1000);
+    expect(isTokenExpired(past)).toBe(true);
+  });
+
+  it('returns false when token has plenty of time left', () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000);
+    expect(isTokenExpired(future)).toBe(false);
+  });
+
+  it('returns true when token expires within the buffer window', () => {
+    const soonExpiring = new Date(Date.now() + 2 * 60 * 1000); // 2 min from now, within 5-min buffer
+    expect(isTokenExpired(soonExpiring)).toBe(true);
+  });
+
+  it('returns false when token expires just outside the buffer window', () => {
+    const notYet = new Date(Date.now() + 10 * 60 * 1000); // 10 min from now
+    expect(isTokenExpired(notYet)).toBe(false);
+  });
+});
+
+describe('getValidZoomAccessToken', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ZOOM_OAUTH_CLIENT_ID = 'test-client-id';
+    process.env.ZOOM_OAUTH_CLIENT_SECRET = 'test-client-secret';
+  });
+
+  it('returns requiresReauth when no connection exists', async () => {
+    mockDb.query.zoomConnections.findFirst.mockResolvedValue(null);
+
+    const result = await getValidZoomAccessToken('user-1');
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.requiresReauth).toBe(true);
+  });
+
+  it('returns requiresReauth when connection is not active', async () => {
+    mockDb.query.zoomConnections.findFirst.mockResolvedValue({
+      accessToken: 'enc:tok',
+      refreshToken: 'enc:ref',
+      tokenExpiresAt: null,
+      status: 'disconnected',
+    });
+
+    const result = await getValidZoomAccessToken('user-1');
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.requiresReauth).toBe(true);
+  });
+
+  it('returns stored access token when it is not expired', async () => {
+    const futureExpiry = new Date(Date.now() + 30 * 60 * 1000);
+    mockDb.query.zoomConnections.findFirst.mockResolvedValue({
+      userId: 'user-1',
+      accessToken: 'enc:valid-token',
+      refreshToken: 'enc:refresh-token',
+      tokenExpiresAt: futureExpiry,
+      status: 'active',
+    });
+
+    const result = await getValidZoomAccessToken('user-1');
+    expect(result).toEqual({ success: true, accessToken: 'valid-token' });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('refreshes token when expired and returns new access token', async () => {
+    const pastExpiry = new Date(Date.now() - 1000);
+    mockDb.query.zoomConnections.findFirst.mockResolvedValue({
+      userId: 'user-1',
+      accessToken: 'enc:old-token',
+      refreshToken: 'enc:valid-refresh',
+      tokenExpiresAt: pastExpiry,
+      status: 'active',
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ access_token: 'new-token', expires_in: 3600 }),
+    });
+    const set = vi.fn().mockReturnValue({ where: vi.fn() });
+    mockDb.update.mockReturnValue({ set });
+
+    const result = await getValidZoomAccessToken('user-1');
+    expect(result).toEqual({ success: true, accessToken: 'new-token' });
+    expect(set).toHaveBeenCalledWith(expect.objectContaining({
+      accessToken: 'enc:new-token',
+      status: 'active',
+    }));
+  });
+
+  it('returns requiresReauth when expired and no refresh token stored', async () => {
+    mockDb.query.zoomConnections.findFirst.mockResolvedValue({
+      userId: 'user-1',
+      accessToken: 'enc:old-token',
+      refreshToken: null,
+      tokenExpiresAt: new Date(Date.now() - 1000),
+      status: 'active',
+    });
+
+    const result = await getValidZoomAccessToken('user-1');
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.requiresReauth).toBe(true);
+  });
+
+  it('returns requiresReauth and marks connection expired when refresh call fails', async () => {
+    mockDb.query.zoomConnections.findFirst.mockResolvedValue({
+      userId: 'user-1',
+      accessToken: 'enc:old-token',
+      refreshToken: 'enc:bad-refresh',
+      tokenExpiresAt: new Date(Date.now() - 1000),
+      status: 'active',
+    });
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 401 });
+    const set = vi.fn().mockReturnValue({ where: vi.fn() });
+    mockDb.update.mockReturnValue({ set });
+
+    const result = await getValidZoomAccessToken('user-1');
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.requiresReauth).toBe(true);
+    expect(set).toHaveBeenCalledWith(expect.objectContaining({ status: 'expired' }));
+  });
+
+  it('also handles null tokenExpiresAt (unknown expiry) as not expired', async () => {
+    mockDb.query.zoomConnections.findFirst.mockResolvedValue({
+      userId: 'user-1',
+      accessToken: 'enc:current-token',
+      refreshToken: 'enc:refresh',
+      tokenExpiresAt: null,
+      status: 'active',
+    });
+
+    const result = await getValidZoomAccessToken('user-1');
+    expect(result).toEqual({ success: true, accessToken: 'current-token' });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/integrations/zoom/__tests__/zoom-api-client.test.ts
+++ b/apps/web/src/lib/integrations/zoom/__tests__/zoom-api-client.test.ts
@@ -140,6 +140,13 @@ describe('downloadTranscript', () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  it('rejects http:// URLs even for trusted zoom.us hostname', async () => {
+    const result = await downloadTranscript('token', 'http://zoom.us/rec/file.vtt');
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toContain('HTTPS');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it('accepts zoom.us hostname', async () => {
     mockFetch.mockResolvedValueOnce({ ok: true, text: async () => 'WEBVTT\n' });
     const result = await downloadTranscript('token', 'https://zoom.us/rec/file.vtt');

--- a/apps/web/src/lib/integrations/zoom/__tests__/zoom-api-client.test.ts
+++ b/apps/web/src/lib/integrations/zoom/__tests__/zoom-api-client.test.ts
@@ -1,0 +1,181 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import {
+  buildAuthHeader,
+  buildRecordingsUrl,
+  getRecordings,
+  downloadTranscript,
+} from '../zoom-api-client';
+
+describe('buildAuthHeader', () => {
+  it('returns Authorization Bearer header', () => {
+    const header = buildAuthHeader('tok_abc123');
+    expect(header).toEqual({ Authorization: 'Bearer tok_abc123' });
+  });
+
+  it('does not include token in any URL-like value', () => {
+    const header = buildAuthHeader('secret_token');
+    const headerString = JSON.stringify(header);
+    expect(headerString).not.toContain('access_token=');
+    expect(headerString).not.toContain('?secret_token');
+  });
+});
+
+describe('buildRecordingsUrl', () => {
+  it('uses the hardcoded api.zoom.us base', () => {
+    const url = buildRecordingsUrl('some-uuid');
+    expect(url).toContain('https://api.zoom.us/v2/');
+  });
+
+  it('includes the encoded meeting UUID in the path', () => {
+    const url = buildRecordingsUrl('abc+def/xyz');
+    expect(url).toContain(encodeURIComponent('abc+def/xyz'));
+    expect(url).not.toContain('abc+def/xyz');
+  });
+
+  it('places uuid in the path segment, not a query param', () => {
+    const url = buildRecordingsUrl('meeting-123');
+    const parsed = new URL(url);
+    expect(parsed.hostname).toBe('api.zoom.us');
+    expect(parsed.pathname).toContain('meeting-123');
+    expect(parsed.search).toBe('');
+  });
+
+  it('path ends with /recordings', () => {
+    const url = buildRecordingsUrl('meeting-123');
+    expect(new URL(url).pathname).toMatch(/\/recordings$/);
+  });
+});
+
+describe('getRecordings', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('returns success with data on 200 response', async () => {
+    const mockData = {
+      uuid: 'mtg-uuid',
+      topic: 'Team Standup',
+      start_time: '2024-01-01T10:00:00Z',
+      duration: 30,
+      host_id: 'host-123',
+      recording_files: [{ id: 'f1', file_type: 'TRANSCRIPT', download_url: 'https://zoom.us/rec/f1' }],
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => mockData,
+    });
+
+    const result = await getRecordings('valid_token', 'mtg-uuid');
+    expect(result).toEqual({ success: true, data: mockData });
+  });
+
+  it('returns requiresReauth on 401', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 401 });
+
+    const result = await getRecordings('expired_token', 'mtg-uuid');
+    expect(result).toEqual({ success: false, requiresReauth: true, error: expect.any(String) });
+  });
+
+  it('returns requiresReauth on 403', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 403 });
+
+    const result = await getRecordings('bad_token', 'mtg-uuid');
+    expect(result).toEqual({ success: false, requiresReauth: true, error: expect.any(String) });
+  });
+
+  it('returns error on non-auth failure with statusCode forwarded', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500, statusText: 'Server Error' });
+
+    const result = await getRecordings('token', 'mtg-uuid');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.requiresReauth).toBeFalsy();
+      expect(result.error).toBeTruthy();
+      expect(result.statusCode).toBe(500);
+    }
+  });
+
+  it('returns error on network failure', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+    const result = await getRecordings('token', 'mtg-uuid');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('Network error');
+    }
+  });
+
+  it('sends token in Authorization header, not in URL', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({}) });
+
+    await getRecordings('my_secret_token', 'mtg-uuid');
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [calledUrl, calledInit] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(calledUrl).not.toContain('my_secret_token');
+    expect(JSON.stringify(calledInit?.headers ?? {})).toContain('my_secret_token');
+  });
+});
+
+describe('downloadTranscript', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it('rejects download URLs with non-zoom.us hostname without making a fetch call', async () => {
+    const result = await downloadTranscript('token', 'https://evil.com/vtt/file.vtt');
+    expect(result.success).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects URLs where the TLD is not zoom.us (e.g. evilvoom.us)', async () => {
+    const result = await downloadTranscript('token', 'https://evilvoom.us/file.vtt');
+    expect(result.success).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('accepts zoom.us hostname', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, text: async () => 'WEBVTT\n' });
+    const result = await downloadTranscript('token', 'https://zoom.us/rec/file.vtt');
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toBe('WEBVTT\n');
+  });
+
+  it('accepts *.zoom.us subdomains', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, text: async () => 'WEBVTT\n' });
+    const result = await downloadTranscript('token', 'https://us02web.zoom.us/rec/file.vtt');
+    expect(result.success).toBe(true);
+  });
+
+  it('sends token as Authorization Bearer, not as a URL query param', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, text: async () => 'WEBVTT\n' });
+    await downloadTranscript('secret_dl_token', 'https://zoom.us/rec/file.vtt');
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [calledUrl, calledInit] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(calledUrl).not.toContain('secret_dl_token');
+    expect(calledUrl).not.toContain('access_token=');
+    expect(JSON.stringify(calledInit?.headers ?? {})).toContain('secret_dl_token');
+  });
+
+  it('returns error when download fails', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404 });
+    const result = await downloadTranscript('token', 'https://zoom.us/rec/missing.vtt');
+    expect(result.success).toBe(false);
+  });
+
+  it('returns error without throwing when fetch throws a network error', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('ECONNRESET'));
+    const result = await downloadTranscript('token', 'https://zoom.us/rec/file.vtt');
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain('ECONNRESET');
+    }
+  });
+});

--- a/apps/web/src/lib/integrations/zoom/process-webhook.ts
+++ b/apps/web/src/lib/integrations/zoom/process-webhook.ts
@@ -85,17 +85,20 @@ export async function processZoomWebhook(body: unknown): Promise<void> {
   let vttText: string;
   try {
     const parsedDownloadUrl = new URL(transcriptFile.download_url);
-    if (parsedDownloadUrl.hostname !== 'zoom.us' && !parsedDownloadUrl.hostname.endsWith('.zoom.us')) {
+    const host = parsedDownloadUrl.hostname;
+    if (host !== 'zoom.us' && !host.endsWith('.zoom.us')) {
       loggers.api.error('Zoom webhook: download_url host is not zoom.us', {
-        host: parsedDownloadUrl.hostname,
+        host,
         userId: connection.userId,
       });
       return;
     }
     const accessToken = await decrypt(connection.accessToken);
-    parsedDownloadUrl.searchParams.set('access_token', accessToken);
-    const vttUrl = parsedDownloadUrl.toString();
-    const vttRes = await fetch(vttUrl, { signal: AbortSignal.timeout(30_000) });
+    // Build a clean URL from validated parts only: validated host + path, discarding original query params.
+    const safeUrl = new URL(`https://${host}${parsedDownloadUrl.pathname}`);
+    safeUrl.searchParams.set('access_token', accessToken);
+    // codeql[js/server-side-request-forgery] host is validated against the zoom.us allowlist above
+    const vttRes = await fetch(safeUrl, { signal: AbortSignal.timeout(30_000) });
     if (!vttRes.ok) {
       loggers.api.error('Zoom webhook: failed to download VTT', {
         status: vttRes.status,

--- a/apps/web/src/lib/integrations/zoom/process-webhook.ts
+++ b/apps/web/src/lib/integrations/zoom/process-webhook.ts
@@ -1,10 +1,10 @@
 import { db } from '@pagespace/db/db';
 import { and, eq } from '@pagespace/db/operators';
 import { zoomConnections } from '@pagespace/db/schema/zoom';
-import { decrypt } from '@pagespace/lib/encryption/encryption-utils';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { pageService } from '@/services/api';
 import { getRecordings, downloadTranscript } from './zoom-api-client';
+import { getValidZoomAccessToken } from './token-refresh';
 import { parseVtt, vttToHtml } from './parse-vtt';
 import { buildDocumentHtml } from './build-document';
 import { generateTranscriptSummary } from './generate-summary';
@@ -67,7 +67,16 @@ export async function processZoomWebhook(body: unknown): Promise<void> {
     return;
   }
 
-  const accessToken = await decrypt(connection.accessToken);
+  const tokenResult = await getValidZoomAccessToken(connection.userId);
+  if (!tokenResult.success) {
+    loggers.api.warn('Zoom webhook: could not obtain valid access token', {
+      userId: connection.userId,
+      error: tokenResult.error,
+      requiresReauth: tokenResult.requiresReauth,
+    });
+    return;
+  }
+  const { accessToken } = tokenResult;
 
   // Re-fetch recording details from Zoom API using the meeting UUID from the verified event.
   // We never use download_url directly from the webhook payload — zero-trust.

--- a/apps/web/src/lib/integrations/zoom/process-webhook.ts
+++ b/apps/web/src/lib/integrations/zoom/process-webhook.ts
@@ -4,15 +4,11 @@ import { zoomConnections } from '@pagespace/db/schema/zoom';
 import { decrypt } from '@pagespace/lib/encryption/encryption-utils';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { pageService } from '@/services/api';
+import { getRecordings, downloadTranscript } from './zoom-api-client';
 import { parseVtt, vttToHtml } from './parse-vtt';
 import { buildDocumentHtml } from './build-document';
 import { generateTranscriptSummary } from './generate-summary';
 import { extractActionItems } from './extract-action-items';
-
-interface RecordingFile {
-  file_type: string;
-  download_url: string;
-}
 
 interface ZoomTranscriptPayload {
   event: string;
@@ -25,7 +21,6 @@ interface ZoomTranscriptPayload {
       topic: string;
       start_time: string;
       duration: number;
-      recording_files: RecordingFile[];
     };
   };
 }
@@ -41,7 +36,7 @@ export async function processZoomWebhook(body: unknown): Promise<void> {
   }
 
   const { account_id } = event.payload;
-  const { uuid: meetingUuid, host_id, host_email, topic, start_time, duration, recording_files } = event.payload.object;
+  const { uuid: meetingUuid, host_id, host_email, topic, start_time, duration } = event.payload.object;
 
   // Match the specific host user — host_id is the Zoom user ID of who ran the meeting.
   // Using both host_id and account_id prevents cross-account collision.
@@ -72,47 +67,37 @@ export async function processZoomWebhook(body: unknown): Promise<void> {
     return;
   }
 
-  // Find the VTT transcript file
-  const transcriptFile = Array.isArray(recording_files)
-    ? recording_files.find((f) => f.file_type === 'TRANSCRIPT')
-    : undefined;
-  if (!transcriptFile) {
-    loggers.api.warn('Zoom webhook: no TRANSCRIPT file in recording_files', { topic });
-    return;
-  }
+  const accessToken = await decrypt(connection.accessToken);
 
-  // Fetch VTT content (Zoom recording downloads use access_token query param)
-  let vttText: string;
-  try {
-    const parsedDownloadUrl = new URL(transcriptFile.download_url);
-    const host = parsedDownloadUrl.hostname;
-    if (host !== 'zoom.us' && !host.endsWith('.zoom.us')) {
-      loggers.api.error('Zoom webhook: download_url host is not zoom.us', {
-        host,
-        userId: connection.userId,
-      });
-      return;
-    }
-    const accessToken = await decrypt(connection.accessToken);
-    // Build a clean URL from validated parts only: validated host + path, discarding original query params.
-    const safeUrl = new URL(`https://${host}${parsedDownloadUrl.pathname}`); // codeql[js/server-side-request-forgery,js/request-forgery] host is validated against the zoom.us allowlist above
-    safeUrl.searchParams.set('access_token', accessToken);
-    const vttRes = await fetch(safeUrl, { signal: AbortSignal.timeout(30_000) }); // codeql[js/server-side-request-forgery,js/request-forgery] host is validated against the zoom.us allowlist above
-    if (!vttRes.ok) {
-      loggers.api.error('Zoom webhook: failed to download VTT', {
-        status: vttRes.status,
-        userId: connection.userId,
-      });
-      return;
-    }
-    vttText = await vttRes.text();
-  } catch (err) {
-    loggers.api.error('Zoom webhook: error fetching transcript', {
-      error: err instanceof Error ? err.message : String(err),
+  // Re-fetch recording details from Zoom API using the meeting UUID from the verified event.
+  // We never use download_url directly from the webhook payload — zero-trust.
+  const recordingsResult = await getRecordings(accessToken, meetingUuid);
+  if (!recordingsResult.success) {
+    loggers.api.error('Zoom webhook: failed to fetch recordings from API', {
+      error: recordingsResult.error,
+      requiresReauth: recordingsResult.requiresReauth,
       userId: connection.userId,
     });
     return;
   }
+
+  const transcriptFile = recordingsResult.data.recording_files.find((f) => f.file_type === 'TRANSCRIPT');
+  if (!transcriptFile) {
+    loggers.api.warn('Zoom webhook: no TRANSCRIPT file in recordings response', { topic });
+    return;
+  }
+
+  // Download VTT using Bearer auth — token never appears in URL
+  const downloadResult = await downloadTranscript(accessToken, transcriptFile.download_url);
+  if (!downloadResult.success) {
+    loggers.api.error('Zoom webhook: failed to download transcript', {
+      error: downloadResult.error,
+      userId: connection.userId,
+    });
+    return;
+  }
+
+  const vttText = downloadResult.data;
 
   // Parse VTT and extract plain text for AI calls
   const segments = parseVtt(vttText);

--- a/apps/web/src/lib/integrations/zoom/process-webhook.ts
+++ b/apps/web/src/lib/integrations/zoom/process-webhook.ts
@@ -33,6 +33,11 @@ export async function processZoomWebhook(body: unknown): Promise<void> {
 
   if (event?.event !== 'recording.transcript_completed') return;
 
+  if (!event.payload?.account_id || !event.payload?.object) {
+    loggers.api.warn('Zoom webhook: malformed recording.transcript_completed payload');
+    return;
+  }
+
   const { account_id } = event.payload;
   const { topic, start_time, duration, host_email, recording_files } = event.payload.object;
 
@@ -62,7 +67,9 @@ export async function processZoomWebhook(body: unknown): Promise<void> {
   }
 
   // Find the VTT transcript file
-  const transcriptFile = recording_files.find((f) => f.file_type === 'TRANSCRIPT');
+  const transcriptFile = Array.isArray(recording_files)
+    ? recording_files.find((f) => f.file_type === 'TRANSCRIPT')
+    : undefined;
   if (!transcriptFile) {
     loggers.api.warn('Zoom webhook: no TRANSCRIPT file in recording_files', { topic });
     return;

--- a/apps/web/src/lib/integrations/zoom/process-webhook.ts
+++ b/apps/web/src/lib/integrations/zoom/process-webhook.ts
@@ -1,0 +1,140 @@
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { zoomConnections } from '@pagespace/db/schema/zoom';
+import { decrypt } from '@pagespace/lib/encryption/encryption-utils';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { pageService } from '@/services/api';
+import { parseVtt, vttToHtml } from './parse-vtt';
+import { buildDocumentHtml } from './build-document';
+import { generateTranscriptSummary } from './generate-summary';
+import { extractActionItems } from './extract-action-items';
+
+interface RecordingFile {
+  file_type: string;
+  download_url: string;
+}
+
+interface ZoomTranscriptPayload {
+  event: string;
+  payload: {
+    account_id: string;
+    object: {
+      topic: string;
+      start_time: string;
+      duration: number;
+      host_email: string;
+      recording_files: RecordingFile[];
+    };
+  };
+}
+
+export async function processZoomWebhook(body: unknown): Promise<void> {
+  const event = body as ZoomTranscriptPayload;
+
+  if (event?.event !== 'recording.transcript_completed') return;
+
+  const { account_id } = event.payload;
+  const { topic, start_time, duration, host_email, recording_files } = event.payload.object;
+
+  // Look up the PageSpace user by Zoom account ID
+  const connection = await db.query.zoomConnections.findFirst({
+    where: eq(zoomConnections.zoomAccountId, account_id),
+  });
+
+  if (!connection) {
+    loggers.api.warn('Zoom webhook: no connection found for account', { account_id });
+    return;
+  }
+
+  if (!connection.targetDriveId) {
+    loggers.api.warn('Zoom webhook: connection has no target drive configured', {
+      userId: connection.userId,
+    });
+    return;
+  }
+
+  if (connection.status !== 'active') {
+    loggers.api.warn('Zoom webhook: connection is not active', {
+      userId: connection.userId,
+      status: connection.status,
+    });
+    return;
+  }
+
+  // Find the VTT transcript file
+  const transcriptFile = recording_files.find((f) => f.file_type === 'TRANSCRIPT');
+  if (!transcriptFile) {
+    loggers.api.warn('Zoom webhook: no TRANSCRIPT file in recording_files', { topic });
+    return;
+  }
+
+  // Fetch VTT content (Zoom recording downloads use access_token query param)
+  let vttText: string;
+  try {
+    const accessToken = await decrypt(connection.accessToken);
+    const vttUrl = `${transcriptFile.download_url}?access_token=${encodeURIComponent(accessToken)}`;
+    const vttRes = await fetch(vttUrl);
+    if (!vttRes.ok) {
+      loggers.api.error('Zoom webhook: failed to download VTT', {
+        status: vttRes.status,
+        userId: connection.userId,
+      });
+      return;
+    }
+    vttText = await vttRes.text();
+  } catch (err) {
+    loggers.api.error('Zoom webhook: error fetching transcript', {
+      error: err instanceof Error ? err.message : String(err),
+      userId: connection.userId,
+    });
+    return;
+  }
+
+  // Parse VTT and extract plain text for AI calls
+  const segments = parseVtt(vttText);
+  const transcriptHtml = connection.includeTranscript ? vttToHtml(segments) : '';
+  const plainText = segments.map((s) => `${s.speaker}: ${s.text}`).join('\n');
+
+  // AI enrichment (fail-safe — never blocks page creation)
+  const [summary, actionItems] = await Promise.all([
+    connection.includeAiSummary ? generateTranscriptSummary(connection.userId, plainText) : Promise.resolve(''),
+    connection.includeActionItems ? extractActionItems(connection.userId, plainText) : Promise.resolve([]),
+  ]);
+
+  const html = buildDocumentHtml(
+    { topic, startTime: start_time, duration, hostEmail: host_email },
+    { summary, actionItems, transcriptHtml }
+  );
+
+  // Title: YYYY-MM-DD — Topic
+  const datePrefix = new Date(start_time).toISOString().slice(0, 10);
+  const title = `${datePrefix} — ${topic}`;
+
+  const result = await pageService.createPage(
+    connection.userId,
+    {
+      title,
+      type: 'DOCUMENT',
+      driveId: connection.targetDriveId,
+      parentId: connection.targetFolderId ?? null,
+      content: html,
+      contentMode: 'html',
+    },
+    { context: { metadata: { source: 'zoom_transcript' } } }
+  );
+
+  if (!result.success) {
+    loggers.api.error('Zoom webhook: failed to create transcript page', {
+      error: result.error,
+      userId: connection.userId,
+      topic,
+    });
+    return;
+  }
+
+  loggers.api.info('Zoom transcript page created', {
+    userId: connection.userId,
+    pageId: result.page.id,
+    title,
+  });
+}

--- a/apps/web/src/lib/integrations/zoom/process-webhook.ts
+++ b/apps/web/src/lib/integrations/zoom/process-webhook.ts
@@ -1,5 +1,5 @@
 import { db } from '@pagespace/db/db';
-import { eq } from '@pagespace/db/operators';
+import { and, eq } from '@pagespace/db/operators';
 import { zoomConnections } from '@pagespace/db/schema/zoom';
 import { decrypt } from '@pagespace/lib/encryption/encryption-utils';
 import { loggers } from '@pagespace/lib/logging/logger-config';
@@ -19,10 +19,12 @@ interface ZoomTranscriptPayload {
   payload: {
     account_id: string;
     object: {
+      uuid: string;
+      host_id: string;
+      host_email: string;
       topic: string;
       start_time: string;
       duration: number;
-      host_email: string;
       recording_files: RecordingFile[];
     };
   };
@@ -39,15 +41,19 @@ export async function processZoomWebhook(body: unknown): Promise<void> {
   }
 
   const { account_id } = event.payload;
-  const { topic, start_time, duration, host_email, recording_files } = event.payload.object;
+  const { uuid: meetingUuid, host_id, host_email, topic, start_time, duration, recording_files } = event.payload.object;
 
-  // Look up the PageSpace user by Zoom account ID
+  // Match the specific host user — host_id is the Zoom user ID of who ran the meeting.
+  // Using both host_id and account_id prevents cross-account collision.
   const connection = await db.query.zoomConnections.findFirst({
-    where: eq(zoomConnections.zoomAccountId, account_id),
+    where: and(
+      eq(zoomConnections.zoomUserId, host_id),
+      eq(zoomConnections.zoomAccountId, account_id),
+    ),
   });
 
   if (!connection) {
-    loggers.api.warn('Zoom webhook: no connection found for account', { account_id });
+    loggers.api.warn('Zoom webhook: no connection found for host', { host_id, account_id });
     return;
   }
 
@@ -78,9 +84,18 @@ export async function processZoomWebhook(body: unknown): Promise<void> {
   // Fetch VTT content (Zoom recording downloads use access_token query param)
   let vttText: string;
   try {
+    const parsedDownloadUrl = new URL(transcriptFile.download_url);
+    if (parsedDownloadUrl.hostname !== 'zoom.us' && !parsedDownloadUrl.hostname.endsWith('.zoom.us')) {
+      loggers.api.error('Zoom webhook: download_url host is not zoom.us', {
+        host: parsedDownloadUrl.hostname,
+        userId: connection.userId,
+      });
+      return;
+    }
     const accessToken = await decrypt(connection.accessToken);
-    const vttUrl = `${transcriptFile.download_url}?access_token=${encodeURIComponent(accessToken)}`;
-    const vttRes = await fetch(vttUrl);
+    parsedDownloadUrl.searchParams.set('access_token', accessToken);
+    const vttUrl = parsedDownloadUrl.toString();
+    const vttRes = await fetch(vttUrl, { signal: AbortSignal.timeout(30_000) });
     if (!vttRes.ok) {
       loggers.api.error('Zoom webhook: failed to download VTT', {
         status: vttRes.status,
@@ -127,7 +142,7 @@ export async function processZoomWebhook(body: unknown): Promise<void> {
       content: html,
       contentMode: 'html',
     },
-    { context: { metadata: { source: 'zoom_transcript' } } }
+    { context: { metadata: { source: 'zoom_transcript', meetingUuid } } }
   );
 
   if (!result.success) {
@@ -143,5 +158,6 @@ export async function processZoomWebhook(body: unknown): Promise<void> {
     userId: connection.userId,
     pageId: result.page.id,
     title,
+    meetingUuid,
   });
 }

--- a/apps/web/src/lib/integrations/zoom/process-webhook.ts
+++ b/apps/web/src/lib/integrations/zoom/process-webhook.ts
@@ -95,9 +95,9 @@ export async function processZoomWebhook(body: unknown): Promise<void> {
     }
     const accessToken = await decrypt(connection.accessToken);
     // Build a clean URL from validated parts only: validated host + path, discarding original query params.
-    const safeUrl = new URL(`https://${host}${parsedDownloadUrl.pathname}`);
+    const safeUrl = new URL(`https://${host}${parsedDownloadUrl.pathname}`); // codeql[js/server-side-request-forgery,js/request-forgery] host is validated against the zoom.us allowlist above
     safeUrl.searchParams.set('access_token', accessToken);
-    const vttRes = await fetch(safeUrl, { signal: AbortSignal.timeout(30_000) }); // codeql[js/server-side-request-forgery] host is validated against the zoom.us allowlist above
+    const vttRes = await fetch(safeUrl, { signal: AbortSignal.timeout(30_000) }); // codeql[js/server-side-request-forgery,js/request-forgery] host is validated against the zoom.us allowlist above
     if (!vttRes.ok) {
       loggers.api.error('Zoom webhook: failed to download VTT', {
         status: vttRes.status,

--- a/apps/web/src/lib/integrations/zoom/process-webhook.ts
+++ b/apps/web/src/lib/integrations/zoom/process-webhook.ts
@@ -97,8 +97,7 @@ export async function processZoomWebhook(body: unknown): Promise<void> {
     // Build a clean URL from validated parts only: validated host + path, discarding original query params.
     const safeUrl = new URL(`https://${host}${parsedDownloadUrl.pathname}`);
     safeUrl.searchParams.set('access_token', accessToken);
-    // codeql[js/server-side-request-forgery] host is validated against the zoom.us allowlist above
-    const vttRes = await fetch(safeUrl, { signal: AbortSignal.timeout(30_000) });
+    const vttRes = await fetch(safeUrl, { signal: AbortSignal.timeout(30_000) }); // codeql[js/server-side-request-forgery] host is validated against the zoom.us allowlist above
     if (!vttRes.ok) {
       loggers.api.error('Zoom webhook: failed to download VTT', {
         status: vttRes.status,

--- a/apps/web/src/lib/integrations/zoom/return-url.ts
+++ b/apps/web/src/lib/integrations/zoom/return-url.ts
@@ -1,0 +1,21 @@
+const DEFAULT_RETURN_PATH = '/settings/integrations/zoom';
+
+export function normalizeZoomReturnPath(returnUrl?: string | null): string {
+  if (!returnUrl || typeof returnUrl !== 'string') {
+    return DEFAULT_RETURN_PATH;
+  }
+
+  const trimmed = returnUrl.trim();
+  if (!trimmed.startsWith('/') || trimmed.startsWith('//')) {
+    return DEFAULT_RETURN_PATH;
+  }
+
+  try {
+    const parsed = new URL(trimmed, 'http://localhost');
+    return `${parsed.pathname}${parsed.search}`;
+  } catch {
+    return DEFAULT_RETURN_PATH;
+  }
+}
+
+export { DEFAULT_RETURN_PATH as ZOOM_DEFAULT_RETURN_PATH };

--- a/apps/web/src/lib/integrations/zoom/token-refresh.ts
+++ b/apps/web/src/lib/integrations/zoom/token-refresh.ts
@@ -1,0 +1,126 @@
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { zoomConnections } from '@pagespace/db/schema/zoom';
+import { encrypt, decrypt } from '@pagespace/lib/encryption/encryption-utils';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+
+const TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
+
+export type TokenRefreshResult =
+  | { success: true; accessToken: string }
+  | { success: false; error: string; requiresReauth: boolean };
+
+export const isTokenExpired = (expiresAt: Date | null, bufferMs = TOKEN_REFRESH_BUFFER_MS): boolean => {
+  if (!expiresAt) return false;
+  return Date.now() >= expiresAt.getTime() - bufferMs;
+};
+
+const refreshZoomAccessToken = async (
+  refreshToken: string,
+): Promise<{ accessToken: string; expiresAt: Date } | null> => {
+  const clientId = process.env.ZOOM_OAUTH_CLIENT_ID;
+  const clientSecret = process.env.ZOOM_OAUTH_CLIENT_SECRET;
+
+  if (!clientId || !clientSecret) {
+    loggers.auth.error('Missing Zoom OAuth credentials for token refresh');
+    return null;
+  }
+
+  try {
+    const credentials = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
+    const res = await fetch('https://zoom.us/oauth/token', {
+      method: 'POST',
+      headers: {
+        Authorization: `Basic ${credentials}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({ grant_type: 'refresh_token', refresh_token: refreshToken }),
+      signal: AbortSignal.timeout(15_000),
+    });
+
+    if (!res.ok) {
+      loggers.auth.error('Zoom token refresh HTTP error', { status: res.status });
+      return null;
+    }
+
+    const data = await res.json() as { access_token: string; expires_in?: number };
+    if (!data.access_token) {
+      loggers.auth.error('Zoom token refresh returned no access token');
+      return null;
+    }
+
+    return {
+      accessToken: data.access_token,
+      expiresAt: data.expires_in
+        ? new Date(Date.now() + data.expires_in * 1000)
+        : new Date(Date.now() + 3600 * 1000),
+    };
+  } catch (err) {
+    loggers.auth.error('Zoom token refresh failed', err instanceof Error ? err : new Error(String(err)));
+    return null;
+  }
+};
+
+export const getValidZoomAccessToken = async (userId: string): Promise<TokenRefreshResult> => {
+  const connection = await db.query.zoomConnections.findFirst({
+    where: eq(zoomConnections.userId, userId),
+  });
+
+  if (!connection) {
+    return { success: false, error: 'No Zoom connection found', requiresReauth: true };
+  }
+
+  if (connection.status !== 'active') {
+    return { success: false, error: `Zoom connection is ${connection.status}`, requiresReauth: true };
+  }
+
+  let decryptedAccessToken: string;
+  try {
+    decryptedAccessToken = await decrypt(connection.accessToken);
+  } catch (err) {
+    loggers.auth.error('Failed to decrypt Zoom access token', err instanceof Error ? err : new Error(String(err)));
+    return { success: false, error: 'Token decryption failed', requiresReauth: true };
+  }
+
+  if (!isTokenExpired(connection.tokenExpiresAt)) {
+    return { success: true, accessToken: decryptedAccessToken };
+  }
+
+  if (!connection.refreshToken) {
+    loggers.auth.warn('Zoom token expired and no refresh token available', { userId });
+    return { success: false, error: 'Token expired, re-authentication required', requiresReauth: true };
+  }
+
+  let decryptedRefreshToken: string;
+  try {
+    decryptedRefreshToken = await decrypt(connection.refreshToken);
+  } catch (err) {
+    loggers.auth.error('Failed to decrypt Zoom refresh token', err instanceof Error ? err : new Error(String(err)));
+    return { success: false, error: 'Refresh token decryption failed', requiresReauth: true };
+  }
+
+  loggers.auth.info('Refreshing expired Zoom access token', { userId });
+  const refreshResult = await refreshZoomAccessToken(decryptedRefreshToken);
+
+  if (!refreshResult) {
+    await db
+      .update(zoomConnections)
+      .set({ status: 'expired', updatedAt: new Date() })
+      .where(eq(zoomConnections.userId, userId));
+    return { success: false, error: 'Token refresh failed, re-authentication required', requiresReauth: true };
+  }
+
+  const encryptedAccessToken = await encrypt(refreshResult.accessToken);
+  await db
+    .update(zoomConnections)
+    .set({
+      accessToken: encryptedAccessToken,
+      tokenExpiresAt: refreshResult.expiresAt,
+      status: 'active',
+      updatedAt: new Date(),
+    })
+    .where(eq(zoomConnections.userId, userId));
+
+  loggers.auth.info('Zoom access token refreshed', { userId });
+  return { success: true, accessToken: refreshResult.accessToken };
+};

--- a/apps/web/src/lib/integrations/zoom/zoom-api-client.ts
+++ b/apps/web/src/lib/integrations/zoom/zoom-api-client.ts
@@ -1,0 +1,91 @@
+const ZOOM_API_BASE = 'https://api.zoom.us/v2';
+
+const TRUSTED_ZOOM_HOSTS = ['zoom.us'];
+const TRUSTED_ZOOM_SUFFIX = '.zoom.us';
+
+export type ZoomApiResult<T> =
+  | { success: true; data: T }
+  | { success: false; error: string; statusCode?: number; requiresReauth?: boolean };
+
+export interface ZoomRecordingFile {
+  id: string;
+  file_type: string;
+  download_url: string;
+}
+
+export interface ZoomRecordingsResponse {
+  uuid: string;
+  topic: string;
+  start_time: string;
+  duration: number;
+  host_id: string;
+  recording_files: ZoomRecordingFile[];
+}
+
+export const buildAuthHeader = (accessToken: string): Record<string, string> => ({
+  Authorization: `Bearer ${accessToken}`,
+});
+
+export const buildRecordingsUrl = (meetingUuid: string): string =>
+  `${ZOOM_API_BASE}/meetings/${encodeURIComponent(meetingUuid)}/recordings`;
+
+export const getRecordings = async (
+  accessToken: string,
+  meetingUuid: string,
+): Promise<ZoomApiResult<ZoomRecordingsResponse>> => {
+  try {
+    const url = buildRecordingsUrl(meetingUuid);
+    const res = await fetch(url, {
+      headers: buildAuthHeader(accessToken),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (res.status === 401 || res.status === 403) {
+      return { success: false, requiresReauth: true, error: `Auth error: ${res.status}` };
+    }
+
+    if (!res.ok) {
+      return { success: false, error: `Zoom API error: ${res.status} ${res.statusText}`, statusCode: res.status };
+    }
+
+    const data = (await res.json()) as ZoomRecordingsResponse;
+    return { success: true, data };
+  } catch (err) {
+    return { success: false, error: err instanceof Error ? err.message : String(err) };
+  }
+};
+
+const isTrustedZoomHost = (hostname: string): boolean =>
+  TRUSTED_ZOOM_HOSTS.includes(hostname) || hostname.endsWith(TRUSTED_ZOOM_SUFFIX);
+
+export const downloadTranscript = async (
+  accessToken: string,
+  downloadUrl: string,
+): Promise<ZoomApiResult<string>> => {
+  let parsed: URL;
+  try {
+    parsed = new URL(downloadUrl);
+  } catch {
+    return { success: false, error: 'Invalid download URL' };
+  }
+
+  if (!isTrustedZoomHost(parsed.hostname)) {
+    return { success: false, error: `Untrusted download host: ${parsed.hostname}` };
+  }
+
+  try {
+    const res = await fetch(downloadUrl, {
+      headers: buildAuthHeader(accessToken),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!res.ok) {
+      return { success: false, error: `Download failed: ${res.status}`, statusCode: res.status };
+    }
+
+    const text = await res.text();
+    return { success: true, data: text };
+  } catch (err) {
+    return { success: false, error: err instanceof Error ? err.message : String(err) };
+  }
+};

--- a/apps/web/src/lib/integrations/zoom/zoom-api-client.ts
+++ b/apps/web/src/lib/integrations/zoom/zoom-api-client.ts
@@ -73,6 +73,10 @@ export const downloadTranscript = async (
     return { success: false, error: `Untrusted download host: ${parsed.hostname}` };
   }
 
+  if (parsed.protocol !== 'https:') {
+    return { success: false, error: `Insecure protocol: HTTPS required for transcript download` };
+  }
+
   try {
     const res = await fetch(downloadUrl, {
       headers: buildAuthHeader(accessToken),

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -167,6 +167,10 @@
       "types": "./dist/schema/workflow-runs.d.ts",
       "default": "./dist/schema/workflow-runs.js"
     },
+    "./schema/zoom": {
+      "types": "./dist/schema/zoom.d.ts",
+      "default": "./dist/schema/zoom.js"
+    },
     "./test/factories": {
       "types": "./dist/test/factories.d.ts",
       "default": "./dist/test/factories.js"

--- a/tasks/zoom-transcript-integration.md
+++ b/tasks/zoom-transcript-integration.md
@@ -92,6 +92,21 @@ Create `apps/web/src/app/api/integrations/zoom/settings/route.ts`.
 
 ---
 
+## Zoom API Client
+
+Create `apps/web/src/lib/integrations/zoom/zoom-api-client.ts` following the `google-calendar/api-client.ts` pattern.
+
+**Requirements**:
+- Given an access token, `buildAuthHeader` should return `{ Authorization: 'Bearer {token}' }` — access token must never appear in a URL
+- Given a meeting UUID, `buildRecordingsUrl` should return `https://api.zoom.us/v2/meetings/{encodedUuid}/recordings` with no user-controlled data in the host segment
+- Given a valid access token and meeting UUID, `getRecordings` should fetch from the hardcoded `api.zoom.us` base URL using the Bearer header and return `ZoomApiResult<ZoomRecordingsResponse>`
+- Given a 401 or 403 response, `getRecordings` should return `{ success: false, requiresReauth: true }`
+- Given a `downloadUrl` whose hostname is not `zoom.us` or a `*.zoom.us` subdomain, `downloadTranscript` should return `{ success: false, error: '...' }` without making any network call
+- Given a valid access token and a trusted `downloadUrl`, `downloadTranscript` should fetch using only the `Authorization: Bearer` header — the access token must not appear in the request URL
+- Given a meeting UUID, `buildRecordingsUrl` should return a URL whose path ends with `/recordings`
+- Given a non-2xx, non-auth HTTP response, `getRecordings` should return `{ success: false, statusCode: <httpStatus> }` so callers can distinguish error types
+- Given `downloadTranscript` encounters a network error (fetch throws), should return `{ success: false, error: message }` without throwing
+
 ## Webhook Processor
 
 Create `apps/web/src/lib/integrations/zoom/process-webhook.ts`.
@@ -99,7 +114,8 @@ Create `apps/web/src/lib/integrations/zoom/process-webhook.ts`.
 **Requirements**:
 - Given a `recording.transcript_completed` event body, should look up the `zoomConnections` row by `zoomAccountId` matching `payload.account_id`
 - Given no matching connection or a null `targetDriveId`, should log a warning and return without error (user hasn't configured a target yet)
-- Given a matched connection, should decrypt the access token, find the `file_type === 'TRANSCRIPT'` entry in `payload.object.recording_files`, and fetch the VTT via `GET {downloadUrl}?access_token={token}`
+- Given a matched connection, should decrypt the access token and call `getRecordings(accessToken, meetingUuid)` to re-fetch recording details from the Zoom API — must not use `download_url` from the webhook payload directly
+- Given the recordings response, should find the `file_type === 'TRANSCRIPT'` entry and call `downloadTranscript(accessToken, file.download_url)` using Bearer authentication
 - Given the VTT content, should run `parseVtt` → plain text for AI calls → `vttToHtml` for the document
 - Given `includeAiSummary` is true, should call `generateTranscriptSummary` and include the result
 - Given `includeActionItems` is true, should call `extractActionItems` and include the result

--- a/tasks/zoom-transcript-integration.md
+++ b/tasks/zoom-transcript-integration.md
@@ -103,6 +103,19 @@ Create `apps/web/src/lib/integrations/zoom/zoom-api-client.ts` following the `go
 - Given a 401 or 403 response, `getRecordings` should return `{ success: false, requiresReauth: true }`
 - Given a `downloadUrl` whose hostname is not `zoom.us` or a `*.zoom.us` subdomain, `downloadTranscript` should return `{ success: false, error: '...' }` without making any network call
 - Given a valid access token and a trusted `downloadUrl`, `downloadTranscript` should fetch using only the `Authorization: Bearer` header — the access token must not appear in the request URL
+
+## Token Refresh
+
+Create `apps/web/src/lib/integrations/zoom/token-refresh.ts` following the `google-calendar/token-refresh.ts` pattern.
+
+**Requirements**:
+- Given a null `tokenExpiresAt`, `isTokenExpired` should return false (unknown expiry treated as valid)
+- Given a `tokenExpiresAt` in the past or within the 5-minute buffer, `isTokenExpired` should return true
+- Given an active connection with a non-expired token, `getValidZoomAccessToken` should return the stored decrypted token without calling the Zoom API
+- Given an active connection with an expired token and a valid refresh token, `getValidZoomAccessToken` should POST to `https://zoom.us/oauth/token` with `grant_type=refresh_token`, re-encrypt and store the new token, and return it
+- Given an expired token and no refresh token, `getValidZoomAccessToken` should return `{ success: false, requiresReauth: true }`
+- Given a failed refresh API call, `getValidZoomAccessToken` should update connection status to `'expired'` and return `{ success: false, requiresReauth: true }`
+- Given `processZoomWebhook`, should call `getValidZoomAccessToken` instead of directly decrypting the stored token, so expired tokens are refreshed transparently
 - Given a meeting UUID, `buildRecordingsUrl` should return a URL whose path ends with `/recordings`
 - Given a non-2xx, non-auth HTTP response, `getRecordings` should return `{ success: false, statusCode: <httpStatus> }` so callers can distinguish error types
 - Given `downloadTranscript` encounters a network error (fetch throws), should return `{ success: false, error: message }` without throwing


### PR DESCRIPTION
## Summary

- **Connect/callback routes**: HMAC-signed OAuth state, Zoom token exchange (HTTP Basic auth), \`/users/me\` identity fetch, encrypted upsert to \`zoom_connections\`. Open-redirect prevention via \`normalizeZoomReturnPath()\` at state-encoding time.
- **Status/settings/disconnect routes**: Read connection state, read/write transcript options (AI summary, action items, transcript toggle), token revocation on disconnect (env-var-guarded, URL-safe token encoding via \`URLSearchParams\`). All routes emit \`auditRequest\` calls for data.read/data.write events.
- **Webhook route + processor**: HMAC-SHA256 signature verification runs first for all events, then URL validation challenge handler, then \`after()\` async dispatch. Webhook user lookup matches by both \`host_id\` + \`account_id\`.
- **Zero-trust download** (\`zoom-api-client.ts\`): Re-fetches recording metadata from the Zoom API using the verified \`meetingUuid\` — never uses \`download_url\` from the webhook payload directly. Access token always in \`Authorization: Bearer\` header, never in a URL query parameter. All CodeQL SSRF suppressions removed.
- **Token refresh** (\`token-refresh.ts\`): Before any Zoom API call in the webhook processor, \`getValidZoomAccessToken()\` checks \`tokenExpiresAt\` (with a 5-minute buffer) and uses the stored refresh token if expired — transparent to the caller. Mirrors the \`google-calendar/token-refresh.ts\` pattern. Prevents silent failures for recordings whose webhooks fire after the 1-hour OAuth token lifetime.
- **Middleware**: \`/api/integrations/zoom/webhook\` added to public-route allowlist as exact-path match.

## Security

- All OAuth tokens AES-256-GCM encrypted before storage via \`encrypt()\`
- Webhook signature: both sides SHA-256 hashed before \`timingSafeEqual\` to eliminate length-based timing leaks
- HMAC signature verified **before** all event dispatch including URL validation challenge (eliminates user-controlled bypass path)
- 5-minute replay window on webhook timestamps
- Zero-trust download: access token only in \`Authorization: Bearer\` header, host validated against \`zoom.us\` allowlist before any fetch — no CodeQL suppressions needed
- All Zoom-sourced strings XSS-escaped via \`esc()\` before HTML interpolation
- \`isOnPrem()\` guard at top of every route → 404
- Middleware bypass uses exact-path match to prevent future sub-paths from accidentally inheriting unauthenticated access
- Security audit coverage gate: all user-facing routes have \`auditRequest\` calls; webhook exempt as Zoom-initiated external request (no user session)

## New files

| File | Purpose |
|------|---------|
| \`zoom-api-client.ts\` | Pure URL builders + IO fetch functions (Bearer auth, host validation) |
| \`token-refresh.ts\` | \`isTokenExpired()\` + \`getValidZoomAccessToken()\` with automatic refresh |
| \`zoom-api-client.test.ts\` | 20 tests: auth header, URL building, recordings fetch, transcript download (incl. HTTPS enforcement) |
| \`token-refresh.test.ts\` | 12 tests: expiry logic, fresh token, refresh flow, no-refresh-token, refresh failure |

## Test plan

- [ ] Set \`ZOOM_OAUTH_CLIENT_ID\`, \`ZOOM_OAUTH_CLIENT_SECRET\`, \`ZOOM_WEBHOOK_SECRET_TOKEN\`, \`OAUTH_STATE_SECRET\` env vars
- [ ] Run \`pnpm db:migrate\` to apply the \`zoom_connections\` migration from PR 1
- [ ] \`POST /api/integrations/zoom/connect\` → returns OAuth URL
- [ ] Complete Zoom OAuth flow → callback upserts row, redirects to \`/settings/integrations/zoom\`
- [ ] \`GET /api/integrations/zoom/status\` → \`{ connected: true, connection: { ... } }\`
- [ ] \`PATCH /api/integrations/zoom/settings\` → updates drive/folder/toggles
- [ ] \`POST /api/integrations/zoom/webhook\` with \`endpoint.url_validation\` payload → correct HMAC response (signature verified first)
- [ ] \`POST /api/integrations/zoom/webhook\` with \`recording.transcript_completed\` → 200 immediate, page created async
- [ ] \`POST /api/integrations/zoom/disconnect\` → clears tokens, attempts Zoom token revocation

## Deferred (PR 4/4 scope)

- **Webhook idempotency**: Duplicate Zoom deliveries can create duplicate pages. \`meetingUuid\` is stored in page metadata (\`context.metadata.meetingUuid\`) to support future deduplication queries. Full dedupe ledger requires a schema change tracked for PR 4/4.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
