### PR TITLE
feat(api): token usage tracking + GET /v1/models endpoint

### DIFF
--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -74,17 +74,25 @@ vi.mock('@paralleldrive/cuid2', () => ({
   createId: vi.fn().mockReturnValue('test-id-123'),
 }));
 
+vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
+  AIMonitoring: {
+    trackUsage: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
 vi.mock('ai', async (importOriginal) => {
   const actual = await importOriginal<typeof import('ai')>();
   return {
     ...actual,
-    streamText: vi.fn().mockImplementation(() => ({
-      toUIMessageStream: function* () {
+    streamText: vi.fn().mockImplementation((options: { onFinish?: (data: { text: string; totalUsage: { inputTokens: number; outputTokens: number } }) => Promise<void> }) => ({
+      toUIMessageStream: async function* () {
         yield { type: 'start' };
         yield { type: 'text-delta', id: 'text-1', delta: 'Hello' };
         yield { type: 'finish' };
+        if (options?.onFinish) {
+          await options.onFinish({ text: 'Hello', totalUsage: { inputTokens: 10, outputTokens: 5 } });
+        }
       },
-      usage: Promise.resolve({ inputTokens: 10, outputTokens: 5 }),
     })),
   };
 });
@@ -95,6 +103,7 @@ import { POST } from '../route';
 import { authenticateRequestWithOptions, checkMCPPageScope } from '@/lib/auth';
 import { db } from '@pagespace/db/db';
 import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 
 const mcpAuth = {
   userId: 'user-1',
@@ -268,6 +277,31 @@ describe('POST /api/v1/chat/completions', () => {
       should: 'not return 400 (browser session ID is not required on this MCP-only path)',
       actual: response.status === 400,
       expected: false,
+    });
+  });
+
+  test('calls AIMonitoring.trackUsage with token counts after stream completes', async () => {
+    const response = await POST(makeRequest(validBody));
+    await response.text();
+    const calls = vi.mocked(AIMonitoring.trackUsage).mock.calls;
+    assert({
+      given: 'a successful inference stream',
+      should: 'call AIMonitoring.trackUsage with inputTokens and outputTokens from totalUsage',
+      actual: calls.length > 0
+        ? { inputTokens: calls[0][0].inputTokens, outputTokens: calls[0][0].outputTokens, via: (calls[0][0].metadata as Record<string, unknown>)?.via }
+        : null,
+      expected: { inputTokens: 10, outputTokens: 5, via: 'openai_api_v1' },
+    });
+  });
+
+  test('AIMonitoring.trackUsage failure does not break the SSE stream', async () => {
+    vi.mocked(AIMonitoring.trackUsage).mockRejectedValueOnce(new Error('monitoring down'));
+    const response = await POST(makeRequest(validBody));
+    assert({
+      given: 'AIMonitoring.trackUsage throwing an error',
+      should: 'still return a 200 SSE response',
+      actual: { status: response.status, contentType: response.headers.get('content-type') },
+      expected: { status: 200, contentType: 'text/event-stream' },
     });
   });
 });

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -140,6 +140,7 @@ export async function POST(request: Request): Promise<Response> {
         outputTokens: totalUsage.outputTokens,
         duration: Date.now() - startTime,
         conversationId,
+        messageId: assistantId,
         pageId,
         success: true,
         metadata: { via: 'openai_api_v1' },

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -25,6 +25,7 @@ import { validateInferenceRequest } from '@/lib/ai/openai-api/validate-inference
 import { adaptToOpenAIChunk } from '@/lib/ai/openai-api/adapt-to-openai-chunk';
 import { getProviderTier } from '@/lib/ai/core/ai-providers-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 
 export const maxDuration = 300;
 
@@ -105,13 +106,14 @@ export async function POST(request: Request): Promise<Response> {
   auditRequest(request, { eventType: 'data.write', userId: authResult.userId, resourceType: 'openai_inference', resourceId: pageId, details: { model: modelName, conversationId }, riskScore: 0 });
 
   // 9. Run inference — no UI coupling (no WebSocket, no stream lifecycle, no session ID)
+  const startTime = Date.now();
   const providerType = getProviderTier(page.aiProvider ?? 'pagespace', page.aiModel ?? undefined);
   const sanitized = sanitizeMessagesForModel(messages);
   const aiResult = streamText({
     model: providerResult.model,
     system: systemPrompt,
     messages: convertToModelMessages(sanitized),
-    onFinish: async ({ text }) => {
+    onFinish: async ({ text, totalUsage }) => {
       const assistantId = createId();
       await saveMessageToDatabase({
         messageId: assistantId,
@@ -129,6 +131,21 @@ export async function POST(request: Request): Promise<Response> {
           loggers.ai.error('OpenAI API: failed to increment usage', err as Error);
         });
       }
+
+      await AIMonitoring.trackUsage({
+        userId: authResult.userId,
+        provider: page.aiProvider ?? 'pagespace',
+        model: page.aiModel ?? 'unknown',
+        inputTokens: totalUsage.inputTokens,
+        outputTokens: totalUsage.outputTokens,
+        duration: Date.now() - startTime,
+        conversationId,
+        pageId,
+        success: true,
+        metadata: { via: 'openai_api_v1' },
+      }).catch((err: unknown) => {
+        loggers.ai.error('OpenAI API: failed to track usage', err as Error);
+      });
     },
   });
 

--- a/apps/web/src/app/api/v1/models/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/models/__tests__/route.test.ts
@@ -1,0 +1,203 @@
+import { describe, test, beforeEach, vi } from 'vitest';
+import { assert } from '@/lib/ai/openai-api/__tests__/riteway';
+
+// --- module mocks (must be hoisted before imports) ---
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn((r: unknown) => r != null && typeof r === 'object' && 'error' in r),
+  getAllowedDriveIds: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    }),
+  },
+}));
+
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((_col, val) => ({ __eq: val })),
+  and: vi.fn((...args) => ({ __and: args })),
+  inArray: vi.fn((_col, vals) => ({ __inArray: vals })),
+}));
+
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'pages.id', type: 'pages.type', isTrashed: 'pages.isTrashed', driveId: 'pages.driveId' },
+}));
+
+vi.mock('@pagespace/lib/utils/enums', () => ({
+  PageType: { AI_CHAT: 'AI_CHAT' },
+}));
+
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  canUserViewPage: vi.fn().mockResolvedValue(true),
+}));
+
+// --- imports after mocks ---
+import { NextResponse } from 'next/server';
+import { GET } from '../route';
+import { authenticateRequestWithOptions, getAllowedDriveIds } from '@/lib/auth';
+import { db } from '@pagespace/db/db';
+import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { inArray } from '@pagespace/db/operators';
+
+const mcpAuth = {
+  userId: 'user-1',
+  tokenType: 'mcp' as const,
+  tokenId: 'token-1',
+  allowedDriveIds: [],
+  role: 'user' as const,
+  tokenVersion: 1,
+  adminRoleVersion: 0,
+};
+
+const agentPage1 = {
+  id: 'page-123',
+  type: 'AI_CHAT',
+  title: 'Test Agent',
+  driveId: 'drive-abc',
+  isTrashed: false,
+  createdAt: new Date('2025-01-01T00:00:00Z'),
+};
+
+const agentPage2 = {
+  id: 'page-456',
+  type: 'AI_CHAT',
+  title: 'Second Agent',
+  driveId: 'drive-abc',
+  isTrashed: false,
+  createdAt: new Date('2025-06-01T00:00:00Z'),
+};
+
+const makeRequest = (authHeader = 'Bearer mcp_test123') =>
+  new Request('http://localhost/api/v1/models', {
+    method: 'GET',
+    headers: { Authorization: authHeader },
+  });
+
+describe('GET /api/v1/models', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mcpAuth);
+    vi.mocked(getAllowedDriveIds).mockReturnValue([]);
+    vi.mocked(canUserViewPage).mockResolvedValue(true);
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([agentPage1, agentPage2]),
+      }),
+    } as unknown as ReturnType<typeof db.select>);
+  });
+
+  test('returns 401 when auth fails', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue({
+      error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }),
+    });
+    const response = await GET(makeRequest());
+    assert({
+      given: 'a request with no valid MCP token',
+      should: 'return 401 Unauthorized',
+      actual: response.status,
+      expected: 401,
+    });
+  });
+
+  test('returns 200 with object:list envelope on happy path', async () => {
+    const response = await GET(makeRequest());
+    const body = await response.json() as { object: string; data: unknown[] };
+    assert({
+      given: 'a valid MCP token with accessible AI_CHAT pages',
+      should: 'return 200 with an object:list envelope',
+      actual: { status: response.status, object: body.object, hasData: Array.isArray(body.data) },
+      expected: { status: 200, object: 'list', hasData: true },
+    });
+  });
+
+  test('each model has the correct OpenAI shape', async () => {
+    const response = await GET(makeRequest());
+    const body = await response.json() as { object: string; data: Array<{ id: string; object: string; created: number; owned_by: string }> };
+    const first = body.data[0];
+    assert({
+      given: 'accessible AI_CHAT pages',
+      should: 'shape each as an OpenAI Model object',
+      actual: {
+        id: first.id,
+        object: first.object,
+        createdIsNumber: typeof first.created === 'number',
+        owned_by: first.owned_by,
+      },
+      expected: {
+        id: 'ps-agent://page-123',
+        object: 'model',
+        createdIsNumber: true,
+        owned_by: 'pagespace',
+      },
+    });
+  });
+
+  test('model id uses ps-agent:// prefix', async () => {
+    const response = await GET(makeRequest());
+    const body = await response.json() as { data: Array<{ id: string }> };
+    assert({
+      given: 'an AI_CHAT page with id page-123',
+      should: 'return model id ps-agent://page-123',
+      actual: body.data[0].id,
+      expected: 'ps-agent://page-123',
+    });
+  });
+
+  test('excludes pages where canUserViewPage returns false', async () => {
+    vi.mocked(canUserViewPage).mockImplementation(async (_userId, pageId) =>
+      pageId === 'page-123'
+    );
+    const response = await GET(makeRequest());
+    const body = await response.json() as { data: unknown[] };
+    assert({
+      given: 'canUserViewPage returning false for the second page',
+      should: 'return only the accessible page',
+      actual: body.data.length,
+      expected: 1,
+    });
+  });
+
+  test('returns empty list when no accessible AI_CHAT pages', async () => {
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    } as unknown as ReturnType<typeof db.select>);
+    const response = await GET(makeRequest());
+    const body = await response.json() as { object: string; data: unknown[] };
+    assert({
+      given: 'no AI_CHAT pages in the accessible drives',
+      should: 'return 200 with an empty data array',
+      actual: { status: response.status, object: body.object, data: body.data },
+      expected: { status: 200, object: 'list', data: [] },
+    });
+  });
+
+  test('scoped token builds where clause with inArray for drive filtering', async () => {
+    vi.mocked(getAllowedDriveIds).mockReturnValue(['drive-1', 'drive-2']);
+    await GET(makeRequest());
+    assert({
+      given: 'a scoped MCP token with allowedDriveIds',
+      should: 'call inArray to filter by drive IDs',
+      actual: vi.mocked(inArray).mock.calls.length > 0,
+      expected: true,
+    });
+  });
+
+  test('unscoped token does not call inArray', async () => {
+    vi.mocked(getAllowedDriveIds).mockReturnValue([]);
+    await GET(makeRequest());
+    assert({
+      given: 'an unscoped MCP token with empty allowedDriveIds',
+      should: 'not call inArray (no drive filter applied)',
+      actual: vi.mocked(inArray).mock.calls.length,
+      expected: 0,
+    });
+  });
+});

--- a/apps/web/src/app/api/v1/models/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/models/__tests__/route.test.ts
@@ -34,7 +34,7 @@ vi.mock('@pagespace/lib/utils/enums', () => ({
 }));
 
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
-  canUserViewPage: vi.fn().mockResolvedValue(true),
+  getBatchPagePermissions: vi.fn(),
 }));
 
 // --- imports after mocks ---
@@ -42,8 +42,12 @@ import { NextResponse } from 'next/server';
 import { GET } from '../route';
 import { authenticateRequestWithOptions, getAllowedDriveIds } from '@/lib/auth';
 import { db } from '@pagespace/db/db';
-import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { getBatchPagePermissions } from '@pagespace/lib/permissions/permissions';
 import { inArray } from '@pagespace/db/operators';
+
+type PermLevel = { canView: boolean; canEdit: boolean; canShare: boolean; canDelete: boolean };
+const allow: PermLevel = { canView: true, canEdit: false, canShare: false, canDelete: false };
+const deny: PermLevel = { canView: false, canEdit: false, canShare: false, canDelete: false };
 
 const mcpAuth = {
   userId: 'user-1',
@@ -84,7 +88,9 @@ describe('GET /api/v1/models', () => {
     vi.clearAllMocks();
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mcpAuth);
     vi.mocked(getAllowedDriveIds).mockReturnValue([]);
-    vi.mocked(canUserViewPage).mockResolvedValue(true);
+    vi.mocked(getBatchPagePermissions).mockResolvedValue(
+      new Map([['page-123', allow], ['page-456', allow]])
+    );
     vi.mocked(db.select).mockReturnValue({
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockResolvedValue([agentPage1, agentPage2]),
@@ -149,14 +155,14 @@ describe('GET /api/v1/models', () => {
     });
   });
 
-  test('excludes pages where canUserViewPage returns false', async () => {
-    vi.mocked(canUserViewPage).mockImplementation(async (_userId, pageId) =>
-      pageId === 'page-123'
+  test('excludes pages where permission check returns canView:false', async () => {
+    vi.mocked(getBatchPagePermissions).mockResolvedValue(
+      new Map([['page-123', allow], ['page-456', deny]])
     );
     const response = await GET(makeRequest());
     const body = await response.json() as { data: unknown[] };
     assert({
-      given: 'canUserViewPage returning false for the second page',
+      given: 'getBatchPagePermissions returning canView:false for the second page',
       should: 'return only the accessible page',
       actual: body.data.length,
       expected: 1,
@@ -169,6 +175,7 @@ describe('GET /api/v1/models', () => {
         where: vi.fn().mockResolvedValue([]),
       }),
     } as unknown as ReturnType<typeof db.select>);
+    vi.mocked(getBatchPagePermissions).mockResolvedValue(new Map());
     const response = await GET(makeRequest());
     const body = await response.json() as { object: string; data: unknown[] };
     assert({

--- a/apps/web/src/app/api/v1/models/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/models/__tests__/route.test.ts
@@ -37,6 +37,10 @@ vi.mock('@pagespace/lib/permissions/permissions', () => ({
   getBatchPagePermissions: vi.fn(),
 }));
 
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: vi.fn(),
+}));
+
 // --- imports after mocks ---
 import { NextResponse } from 'next/server';
 import { GET } from '../route';

--- a/apps/web/src/app/api/v1/models/route.ts
+++ b/apps/web/src/app/api/v1/models/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { db } from '@pagespace/db/db';
+import { eq, and, inArray } from '@pagespace/db/operators';
+import { pages } from '@pagespace/db/schema/core';
+import { PageType } from '@pagespace/lib/utils/enums';
+import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import {
+  authenticateRequestWithOptions,
+  isAuthError,
+  getAllowedDriveIds,
+} from '@/lib/auth';
+
+const AUTH_OPTIONS = { allow: ['mcp'] as const, requireCSRF: false };
+
+export async function GET(request: Request): Promise<Response> {
+  const authResult = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
+  if (isAuthError(authResult)) return authResult.error;
+
+  const allowedDriveIds = getAllowedDriveIds(authResult);
+
+  const whereClause = allowedDriveIds.length > 0
+    ? and(eq(pages.type, PageType.AI_CHAT), eq(pages.isTrashed, false), inArray(pages.driveId, allowedDriveIds))
+    : and(eq(pages.type, PageType.AI_CHAT), eq(pages.isTrashed, false));
+
+  const rows = await db.select().from(pages).where(whereClause);
+
+  const accessible = await Promise.all(
+    rows.map(async (page) => {
+      const ok = await canUserViewPage(authResult.userId, page.id);
+      return ok ? page : null;
+    })
+  );
+
+  const models = accessible
+    .filter((p): p is NonNullable<typeof p> => p !== null)
+    .map((page) => ({
+      id: `ps-agent://${page.id}`,
+      object: 'model' as const,
+      created: Math.floor(page.createdAt.getTime() / 1000),
+      owned_by: 'pagespace',
+    }));
+
+  return NextResponse.json({ object: 'list', data: models });
+}

--- a/apps/web/src/app/api/v1/models/route.ts
+++ b/apps/web/src/app/api/v1/models/route.ts
@@ -4,6 +4,7 @@ import { eq, and, inArray } from '@pagespace/db/operators';
 import { pages } from '@pagespace/db/schema/core';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { getBatchPagePermissions } from '@pagespace/lib/permissions/permissions';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import {
   authenticateRequestWithOptions,
   isAuthError,
@@ -14,7 +15,10 @@ const AUTH_OPTIONS = { allow: ['mcp'] as const, requireCSRF: false };
 
 export async function GET(request: Request): Promise<Response> {
   const authResult = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
-  if (isAuthError(authResult)) return authResult.error;
+  if (isAuthError(authResult)) {
+    auditRequest(request, { eventType: 'authz.access.denied', resourceType: 'openai_models', resourceId: 'list', details: { reason: 'auth_failed', method: 'GET' }, riskScore: 0.5 });
+    return authResult.error;
+  }
 
   const allowedDriveIds = getAllowedDriveIds(authResult);
 

--- a/apps/web/src/app/api/v1/models/route.ts
+++ b/apps/web/src/app/api/v1/models/route.ts
@@ -24,21 +24,18 @@ export async function GET(request: Request): Promise<Response> {
 
   const rows = await db.select().from(pages).where(whereClause);
 
-  const accessible = await Promise.all(
-    rows.map(async (page) => {
-      const ok = await canUserViewPage(authResult.userId, page.id);
-      return ok ? page : null;
-    })
-  );
-
-  const models = accessible
-    .filter((p): p is NonNullable<typeof p> => p !== null)
-    .map((page) => ({
-      id: `ps-agent://${page.id}`,
-      object: 'model' as const,
-      created: Math.floor(page.createdAt.getTime() / 1000),
-      owned_by: 'pagespace',
-    }));
+  const models: Array<{ id: string; object: 'model'; created: number; owned_by: string }> = [];
+  for (const page of rows) {
+    const canView = await canUserViewPage(authResult.userId, page.id);
+    if (canView) {
+      models.push({
+        id: `ps-agent://${page.id}`,
+        object: 'model',
+        created: Math.floor(page.createdAt.getTime() / 1000),
+        owned_by: 'pagespace',
+      });
+    }
+  }
 
   return NextResponse.json({ object: 'list', data: models });
 }

--- a/apps/web/src/app/api/v1/models/route.ts
+++ b/apps/web/src/app/api/v1/models/route.ts
@@ -3,7 +3,7 @@ import { db } from '@pagespace/db/db';
 import { eq, and, inArray } from '@pagespace/db/operators';
 import { pages } from '@pagespace/db/schema/core';
 import { PageType } from '@pagespace/lib/utils/enums';
-import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { getBatchPagePermissions } from '@pagespace/lib/permissions/permissions';
 import {
   authenticateRequestWithOptions,
   isAuthError,
@@ -23,19 +23,16 @@ export async function GET(request: Request): Promise<Response> {
     : and(eq(pages.type, PageType.AI_CHAT), eq(pages.isTrashed, false));
 
   const rows = await db.select().from(pages).where(whereClause);
+  const permissions = await getBatchPagePermissions(authResult.userId, rows.map((r) => r.id));
 
-  const models: Array<{ id: string; object: 'model'; created: number; owned_by: string }> = [];
-  for (const page of rows) {
-    const canView = await canUserViewPage(authResult.userId, page.id);
-    if (canView) {
-      models.push({
-        id: `ps-agent://${page.id}`,
-        object: 'model',
-        created: Math.floor(page.createdAt.getTime() / 1000),
-        owned_by: 'pagespace',
-      });
-    }
-  }
+  const models = rows
+    .filter((page) => permissions.get(page.id)?.canView)
+    .map((page) => ({
+      id: `ps-agent://${page.id}`,
+      object: 'model' as const,
+      created: Math.floor(page.createdAt.getTime() / 1000),
+      owned_by: 'pagespace',
+    }));
 
   return NextResponse.json({ object: 'list', data: models });
 }

--- a/plan.md
+++ b/plan.md
@@ -2,7 +2,7 @@
 
 ## Active Epics
 
-- [OpenAI-Compatible Inference API](tasks/openai-inference-api.md) — `POST /api/v1/chat/completions`: MCP tokens as API keys, agents as models, OpenAI SDK drop-in compatible streaming.
+- [OpenAI API v1 Follow-Up](tasks/openai-api-v1-followup.md) — Token usage tracking in `onFinish` + `GET /api/v1/models` discovery endpoint.
 - [Zoom Transcript Integration](tasks/zoom-transcript-integration.md) — Auto-save Zoom meeting transcripts as Document pages in a user-configured drive; webhook-driven, AI summary + action items, cloud-only.
 
 

--- a/tasks/openai-api-v1-followup.md
+++ b/tasks/openai-api-v1-followup.md
@@ -1,6 +1,6 @@
 # OpenAI API v1 Follow-Up Epic
 
-**Status**: 📋 PLANNED
+**Status**: 🔄 IN PROGRESS (PR #1381)
 **Goal**: Close two gaps in the OpenAI-compatible inference API: missing token usage tracking and a missing model discovery endpoint.
 
 ## Overview
@@ -27,7 +27,7 @@ New `GET /api/v1/models` route that returns AI_CHAT pages accessible to the MCP 
 **Requirements**:
 - Given an unscoped MCP token, should return all non-trashed AI_CHAT pages without a drive filter
 - Given a scoped MCP token, should return only AI_CHAT pages whose `driveId` is in `allowedDriveIds`
-- Given a page where `canUserViewPage` returns false, should exclude it from the list
+- Given a page the user cannot view, should exclude it from the list
 - Given an auth failure, should return 401
 - Given no accessible AI_CHAT pages, should return `{ object: 'list', data: [] }` with 200
 - Given accessible pages, should shape each as `{ id: 'ps-agent://<pageId>', object: 'model', created: <unix>, owned_by: 'pagespace' }`

--- a/tasks/openai-api-v1-followup.md
+++ b/tasks/openai-api-v1-followup.md
@@ -1,0 +1,34 @@
+# OpenAI API v1 Follow-Up Epic
+
+**Status**: 📋 PLANNED
+**Goal**: Close two gaps in the OpenAI-compatible inference API: missing token usage tracking and a missing model discovery endpoint.
+
+## Overview
+
+Why: PR #1377 shipped the `POST /api/v1/chat/completions` endpoint but left two incomplete pieces. First, the `onFinish` callback does not call `AIMonitoring.trackUsage`, so actual input/output token counts are never persisted — only the subscription message counter ticks. Second, there is no `GET /api/v1/models` endpoint; every OpenAI SDK client calls this on startup and crashes if it returns 404, making the API unusable out-of-the-box.
+
+---
+
+## Fix Token Usage Tracking in onFinish
+
+Update `POST /api/v1/chat/completions` to call `AIMonitoring.trackUsage` inside `onFinish` with the real token counts from `totalUsage`.
+
+**Requirements**:
+- Given a successful inference, should call `AIMonitoring.trackUsage` with `inputTokens` and `outputTokens` from `totalUsage`
+- Given `AIMonitoring.trackUsage` throwing, should log the error and NOT break the SSE stream response
+- Given the `onFinish` callback, should include `metadata: { via: 'openai_api_v1' }` to distinguish from browser-initiated chats
+
+---
+
+## Add GET /api/v1/models Endpoint
+
+New `GET /api/v1/models` route that returns AI_CHAT pages accessible to the MCP token as OpenAI Model list objects.
+
+**Requirements**:
+- Given an unscoped MCP token, should return all non-trashed AI_CHAT pages without a drive filter
+- Given a scoped MCP token, should return only AI_CHAT pages whose `driveId` is in `allowedDriveIds`
+- Given a page where `canUserViewPage` returns false, should exclude it from the list
+- Given an auth failure, should return 401
+- Given no accessible AI_CHAT pages, should return `{ object: 'list', data: [] }` with 200
+- Given accessible pages, should shape each as `{ id: 'ps-agent://<pageId>', object: 'model', created: <unix>, owned_by: 'pagespace' }`
+- Given a valid request, should return `{ object: 'list', data: [...] }` (standard OpenAI envelope)


### PR DESCRIPTION
## Summary

Follow-up to #1377 (OpenAI-compatible inference API). Closes two gaps that were left out of the initial PR:

- **Token usage tracking**: \`POST /api/v1/chat/completions\` \`onFinish\` now calls \`AIMonitoring.trackUsage\` with real \`inputTokens\`/\`outputTokens\` from \`totalUsage\`. Previously only the subscription message counter was ticked; actual token counts were never persisted. Errors from the monitoring call are caught/logged and never break the SSE stream.

- **\`GET /api/v1/models\`**: New endpoint that returns AI_CHAT pages accessible to the MCP token as OpenAI Model objects (\`{ id: "ps-agent://<pageId>", object: "model", ... }\`). Scoped tokens are filtered by \`allowedDriveIds\` via \`inArray\`; unscoped tokens see all non-trashed AI_CHAT pages they have view permission on. This endpoint is called on startup by every OpenAI SDK client — without it, SDKs crash before sending a single message.

## What changed

| File | Change |
|------|--------|
| \`apps/web/src/app/api/v1/chat/completions/route.ts\` | Add \`startTime\`, destructure \`totalUsage\` in \`onFinish\`, call \`AIMonitoring.trackUsage\` with \`messageId\` |
| \`apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts\` | Update \`streamText\` mock to invoke \`onFinish\`; add 2 new tests (usage tracking, error isolation) |
| \`apps/web/src/app/api/v1/models/route.ts\` | New \`GET /api/v1/models\` route; uses \`getBatchPagePermissions\` (single batch query, not N sequential calls); calls \`auditRequest\` on auth failure |
| \`apps/web/src/app/api/v1/models/__tests__/route.test.ts\` | 7 tests covering auth, envelope shape, model shape, permission filtering, empty list, scoped/unscoped query |

## Auth / security

Same constraints as the completions endpoint: MCP tokens only, no session, no CSRF. Drive scoping via existing \`mcp_token_drives\` junction — no new tables. Auth failures emit \`authz.access.denied\` audit events on both routes.

## Test plan

- [ ] \`pnpm typecheck\` — passes clean
- [ ] \`pnpm test:unit\` — all existing tests pass; new tests cover usage tracking + models endpoint
- [ ] Manual: \`curl -H "Authorization: Bearer mcp_xxx" http://localhost:3000/api/v1/models\` → \`{"object":"list","data":[{"id":"ps-agent://...","object":"model",...}]}\`
- [ ] Manual: Python openai SDK with \`base_url="http://localhost:3000/api/v1"\` → \`client.models.list()\` works before \`client.chat.completions.create(...)\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)