### PR TITLE
fix(agents): assign MEMBER role on AI chat page creation

### DIFF
--- a/apps/web/src/app/api/ai/page-agents/create/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/create/__tests__/route.test.ts
@@ -16,7 +16,6 @@ vi.mock('@/lib/repositories/page-agent-repository', () => ({
     getDriveById: vi.fn(),
     getParentPage: vi.fn(),
     getNextPosition: vi.fn(),
-    createAgent: vi.fn(),
   },
 }));
 
@@ -67,18 +66,30 @@ vi.mock('@/lib/ai/core', () => ({
   },
 }));
 
-// Mock DB for driveAgentMembers insert
-const { mockInsertValues, mockInsert } = vi.hoisted(() => {
-  const mockInsertValues = vi.fn().mockResolvedValue([]);
+// Mock DB — wraps both the pages insert and membership insert in a transaction.
+// tx.insert(pages).values(data).returning() → [createdAgent]
+// tx.insert(driveAgentMembers).values(data)  → awaitable (no .returning())
+const { mockInsertReturning, mockInsertValues, mockInsert, mockTransaction } = vi.hoisted(() => {
+  const mockInsertReturning = vi.fn().mockResolvedValue([{ id: 'agent_123', title: 'Test Agent', type: 'AI_CHAT' }]);
+  const mockInsertValues = vi.fn().mockReturnValue({ returning: mockInsertReturning });
   const mockInsert = vi.fn().mockReturnValue({ values: mockInsertValues });
-  return { mockInsertValues, mockInsert };
+  const mockTransaction = vi.fn().mockImplementation(
+    async (cb: (tx: { insert: typeof mockInsert }) => Promise<unknown>) =>
+      cb({ insert: mockInsert }),
+  );
+  return { mockInsertReturning, mockInsertValues, mockInsert, mockTransaction };
 });
+
 vi.mock('@pagespace/db/db', () => ({
-  db: { insert: mockInsert },
+  db: { transaction: mockTransaction },
 }));
 
 vi.mock('@pagespace/db/schema/members', () => ({
   driveAgentMembers: 'driveAgentMembers_table',
+}));
+
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: 'pages_table',
 }));
 
 import { pageAgentRepository } from '@/lib/repositories/page-agent-repository';
@@ -86,6 +97,7 @@ import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope } from 
 import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { driveAgentMembers } from '@pagespace/db/schema/members';
+import { pages } from '@pagespace/db/schema/core';
 
 // Test fixtures
 const mockUserId = 'user_123';
@@ -115,9 +127,14 @@ describe('POST /api/ai/page-agents/create', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // Default: db.insert(...).values(...) succeeds
-    mockInsertValues.mockResolvedValue([]);
+    // Re-wire the DB insert chain after clearAllMocks wipes implementations
+    mockInsertReturning.mockResolvedValue([{ id: 'agent_123', title: 'Test Agent', type: 'AI_CHAT' }]);
+    mockInsertValues.mockReturnValue({ returning: mockInsertReturning });
     mockInsert.mockReturnValue({ values: mockInsertValues });
+    mockTransaction.mockImplementation(
+      async (cb: (tx: { insert: typeof mockInsert }) => Promise<unknown>) =>
+        cb({ insert: mockInsert }),
+    );
 
     // Default: authenticated user
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockWebAuth(mockUserId));
@@ -137,13 +154,6 @@ describe('POST /api/ai/page-agents/create', () => {
 
     // Default: position calculation returns 1
     vi.mocked(pageAgentRepository.getNextPosition).mockResolvedValue(1);
-
-    // Default: agent creation succeeds
-    vi.mocked(pageAgentRepository.createAgent).mockResolvedValue({
-      id: 'agent_123',
-      title: 'Test Agent',
-      type: 'AI_CHAT',
-    });
   });
 
   describe('authentication', () => {
@@ -325,7 +335,7 @@ describe('POST /api/ai/page-agents/create', () => {
       });
     });
 
-    it('should pass correct data to repository when creating agent', async () => {
+    it('should pass correct data in transaction when creating agent', async () => {
       const request = createRequest({
         driveId: mockDriveId,
         title: 'Test Agent',
@@ -338,7 +348,10 @@ describe('POST /api/ai/page-agents/create', () => {
 
       await POST(request);
 
-      expect(pageAgentRepository.createAgent).toHaveBeenCalledWith(
+      // First insert in the transaction is the pages row
+      expect(mockInsert).toHaveBeenNthCalledWith(1, pages);
+      expect(mockInsertValues).toHaveBeenNthCalledWith(
+        1,
         expect.objectContaining({
           title: 'Test Agent',
           type: 'AI_CHAT',
@@ -369,7 +382,8 @@ describe('POST /api/ai/page-agents/create', () => {
 
       expect(response.status).toBe(200);
       expect(body.success).toBe(true);
-      expect(pageAgentRepository.createAgent).toHaveBeenCalledWith(
+      expect(mockInsertValues).toHaveBeenNthCalledWith(
+        1,
         expect.objectContaining({
           parentId: 'parent_123',
         })
@@ -421,7 +435,7 @@ describe('POST /api/ai/page-agents/create', () => {
       expect(broadcastPageEvent).toHaveBeenCalledWith(expectedPayload);
     });
 
-    it('should insert a MEMBER drive membership record for the new agent', async () => {
+    it('should insert pages and MEMBER membership atomically in one transaction', async () => {
       const request = createRequest({
         driveId: mockDriveId,
         title: 'Test Agent',
@@ -430,8 +444,16 @@ describe('POST /api/ai/page-agents/create', () => {
 
       await POST(request);
 
-      expect(mockInsert).toHaveBeenCalledWith(driveAgentMembers);
-      expect(mockInsertValues).toHaveBeenCalledWith(
+      // Both inserts happen inside the single transaction
+      expect(mockTransaction).toHaveBeenCalledOnce();
+
+      // First insert: pages table
+      expect(mockInsert).toHaveBeenNthCalledWith(1, pages);
+
+      // Second insert: drive membership with MEMBER role
+      expect(mockInsert).toHaveBeenNthCalledWith(2, driveAgentMembers);
+      expect(mockInsertValues).toHaveBeenNthCalledWith(
+        2,
         expect.objectContaining({
           driveId: mockDriveId,
           agentPageId: 'agent_123',
@@ -443,10 +465,8 @@ describe('POST /api/ai/page-agents/create', () => {
   });
 
   describe('error handling', () => {
-    it('should return 500 when repository throws', async () => {
-      vi.mocked(pageAgentRepository.createAgent).mockRejectedValue(
-        new Error('Database connection failed')
-      );
+    it('should return 500 when transaction throws', async () => {
+      mockTransaction.mockRejectedValue(new Error('Database connection failed'));
 
       const request = createRequest({
         driveId: mockDriveId,
@@ -462,7 +482,7 @@ describe('POST /api/ai/page-agents/create', () => {
     });
 
     it('should not leak internal error details to client', async () => {
-      vi.mocked(pageAgentRepository.createAgent).mockRejectedValue(
+      mockTransaction.mockRejectedValue(
         new Error('SENSITIVE: connection string with password=secret123')
       );
 

--- a/apps/web/src/app/api/ai/page-agents/create/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/page-agents/create/__tests__/route.test.ts
@@ -67,10 +67,25 @@ vi.mock('@/lib/ai/core', () => ({
   },
 }));
 
+// Mock DB for driveAgentMembers insert
+const { mockInsertValues, mockInsert } = vi.hoisted(() => {
+  const mockInsertValues = vi.fn().mockResolvedValue([]);
+  const mockInsert = vi.fn().mockReturnValue({ values: mockInsertValues });
+  return { mockInsertValues, mockInsert };
+});
+vi.mock('@pagespace/db/db', () => ({
+  db: { insert: mockInsert },
+}));
+
+vi.mock('@pagespace/db/schema/members', () => ({
+  driveAgentMembers: 'driveAgentMembers_table',
+}));
+
 import { pageAgentRepository } from '@/lib/repositories/page-agent-repository';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope } from '@/lib/auth';
 import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
+import { driveAgentMembers } from '@pagespace/db/schema/members';
 
 // Test fixtures
 const mockUserId = 'user_123';
@@ -99,6 +114,10 @@ const createRequest = (body: Record<string, unknown>) =>
 describe('POST /api/ai/page-agents/create', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+
+    // Default: db.insert(...).values(...) succeeds
+    mockInsertValues.mockResolvedValue([]);
+    mockInsert.mockReturnValue({ values: mockInsertValues });
 
     // Default: authenticated user
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockWebAuth(mockUserId));
@@ -402,6 +421,25 @@ describe('POST /api/ai/page-agents/create', () => {
       expect(broadcastPageEvent).toHaveBeenCalledWith(expectedPayload);
     });
 
+    it('should insert a MEMBER drive membership record for the new agent', async () => {
+      const request = createRequest({
+        driveId: mockDriveId,
+        title: 'Test Agent',
+        systemPrompt: 'You are helpful.',
+      });
+
+      await POST(request);
+
+      expect(mockInsert).toHaveBeenCalledWith(driveAgentMembers);
+      expect(mockInsertValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          driveId: mockDriveId,
+          agentPageId: 'agent_123',
+          role: 'MEMBER',
+          addedBy: mockUserId,
+        })
+      );
+    });
   });
 
   describe('error handling', () => {

--- a/apps/web/src/app/api/ai/page-agents/create/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/create/route.ts
@@ -9,6 +9,7 @@ import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { pageAgentRepository, type AgentData } from '@/lib/repositories/page-agent-repository';
 import { db } from '@pagespace/db/db';
+import { pages } from '@pagespace/db/schema/core';
 import { driveAgentMembers } from '@pagespace/db/schema/members';
 
 /**
@@ -121,15 +122,22 @@ export async function POST(request: Request) {
       agentData.enabledTools = enabledTools;
     }
 
-    // Create the agent
-    const newAgent = await pageAgentRepository.createAgent(agentData);
+    // Create the agent and membership atomically so there is never an agent
+    // without a drive role (partial failure rolls back both).
+    const newAgent = await db.transaction(async (tx) => {
+      const [created] = await tx
+        .insert(pages)
+        .values(agentData)
+        .returning({ id: pages.id, title: pages.title, type: pages.type });
 
-    // Grant the new agent a default MEMBER role in its drive
-    await db.insert(driveAgentMembers).values({
-      driveId: drive.id,
-      agentPageId: newAgent.id,
-      role: 'MEMBER',
-      addedBy: userId,
+      await tx.insert(driveAgentMembers).values({
+        driveId: drive.id,
+        agentPageId: created.id,
+        role: 'MEMBER',
+        addedBy: userId,
+      });
+
+      return created;
     });
 
     // Broadcast agent creation event

--- a/apps/web/src/app/api/ai/page-agents/create/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/create/route.ts
@@ -8,6 +8,8 @@ import { pageSpaceTools } from '@/lib/ai/core';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { pageAgentRepository, type AgentData } from '@/lib/repositories/page-agent-repository';
+import { db } from '@pagespace/db/db';
+import { driveAgentMembers } from '@pagespace/db/schema/members';
 
 /**
  * POST /api/ai/page-agents/create
@@ -121,6 +123,14 @@ export async function POST(request: Request) {
 
     // Create the agent
     const newAgent = await pageAgentRepository.createAgent(agentData);
+
+    // Grant the new agent a default MEMBER role in its drive
+    await db.insert(driveAgentMembers).values({
+      driveId: drive.id,
+      agentPageId: newAgent.id,
+      role: 'MEMBER',
+      addedBy: userId,
+    });
 
     // Broadcast agent creation event
     await broadcastPageEvent(

--- a/apps/web/src/services/api/page-service.ts
+++ b/apps/web/src/services/api/page-service.ts
@@ -2,6 +2,7 @@ import { db } from '@pagespace/db/db'
 import { eq, and, desc, isNull } from '@pagespace/db/operators'
 import { users } from '@pagespace/db/schema/auth'
 import { pages, drives, chatMessages } from '@pagespace/db/schema/core';
+import { driveAgentMembers } from '@pagespace/db/schema/members';
 import { canUserViewPage, canUserEditPage, canUserDeletePage } from '@pagespace/lib/permissions/permissions'
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger'
 import { detectPageContentFormat } from '@pagespace/lib/content/page-content-format'
@@ -753,6 +754,15 @@ export const pageService = {
       pageData.stateHash = stateHash;
 
       const [page] = await tx.insert(pages).values(pageData).returning();
+
+      if (isAIChatPage(params.type as PageTypeEnum)) {
+        await tx.insert(driveAgentMembers).values({
+          driveId: drive.id,
+          agentPageId: page.id,
+          role: 'MEMBER',
+          addedBy: userId,
+        });
+      }
 
       // Create page version BEFORE acquiring the activity chain lock,
       // so disk I/O (compression + fs.writeFile) doesn't hold the global lock.


### PR DESCRIPTION
## Summary

- AI Chat pages (agents) were created with no `drive_agent_members` record, causing the Settings tab to immediately show "Not a member — Add it via the Members page to grant access"
- Fixed both creation paths to insert a default `MEMBER` role record atomically with page creation
- The MCP API path (`POST /api/ai/page-agents/create`) and the general page service path (`POST /api/pages`) are both covered

## Changes

- **`apps/web/src/app/api/ai/page-agents/create/route.ts`** — inserts `driveAgentMembers` row after `createAgent()`
- **`apps/web/src/services/api/page-service.ts`** — inserts `driveAgentMembers` row inside the DB transaction for `AI_CHAT` pages (atomic rollback on failure)
- **`create/__tests__/route.test.ts`** — asserts membership record is created with correct `driveId`, `agentPageId`, `role: MEMBER`, `addedBy`

## Test plan

- [ ] Create a new AI Chat page via the MCP `create_page` tool or UI
- [ ] Open page → Settings tab → Drive Membership section shows role selector (MEMBER/ADMIN), not "Not a member"
- [ ] Role can be changed to Admin via the selector
- [ ] `pnpm --filter web test` — all 17 tests in `create/__tests__/route.test.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * AI agents are now automatically granted member-level access to their drive upon creation, establishing proper permissions and associations immediately.
  * AI chat pages now automatically create and link membership records, ensuring complete setup during page initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1382?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->