### PR TITLE
perf(tasks): optimistic assignee updates

### DIFF
--- a/apps/web/src/components/tasks/task-hooks.ts
+++ b/apps/web/src/components/tasks/task-hooks.ts
@@ -109,8 +109,10 @@ export function useTaskMutations(
   const handleMultiAssigneeChange = useCallback(async (task: Task, assigneeIds: { type: 'user' | 'agent'; id: string }[]) => {
     if (!task.taskListPageId) return;
 
+    const originalAssignees = task.assignees ?? [];
+
     const existingById = new Map<string, TaskAssigneeData>();
-    for (const a of task.assignees ?? []) {
+    for (const a of originalAssignees) {
       if (a.userId) existingById.set(`user-${a.userId}`, a);
       if (a.agentPageId) existingById.set(`agent-${a.agentPageId}`, a);
     }
@@ -135,7 +137,7 @@ export function useTaskMutations(
       mutate(`/api/pages/${task.taskListPageId}/tasks`);
     } catch (err) {
       handleError(err as Error, 'Failed to update assignees');
-      setTasks(prev => prev.map(t => t.id === task.id ? task : t));
+      setTasks(prev => prev.map(t => t.id === task.id ? { ...t, assignees: originalAssignees } : t));
     }
   }, [setTasks, onPageMutate, onSuccess, handleError]);
 

--- a/apps/web/src/components/tasks/task-hooks.ts
+++ b/apps/web/src/components/tasks/task-hooks.ts
@@ -4,7 +4,7 @@ import { useState, useCallback, useRef } from 'react';
 import { mutate } from 'swr';
 import { toast } from 'sonner';
 import { patch, del, post } from '@/lib/auth/auth-fetch';
-import type { Task, StatusConfigsByTaskList } from './types';
+import type { Task, StatusConfigsByTaskList, TaskAssigneeData } from './types';
 import type { TaskStatusConfig, TaskPriority } from '@/components/layout/middle-content/page-views/task-list/task-list-types';
 import { buildStatusConfig } from '@/components/layout/middle-content/page-views/task-list/task-list-types';
 import { DEFAULT_STATUS_CONFIG } from '@/lib/task-status-config';

--- a/apps/web/src/components/tasks/task-hooks.ts
+++ b/apps/web/src/components/tasks/task-hooks.ts
@@ -109,16 +109,35 @@ export function useTaskMutations(
   const handleMultiAssigneeChange = useCallback(async (task: Task, assigneeIds: { type: 'user' | 'agent'; id: string }[]) => {
     if (!task.taskListPageId) return;
 
+    const existingById = new Map<string, TaskAssigneeData>();
+    for (const a of task.assignees ?? []) {
+      if (a.userId) existingById.set(`user-${a.userId}`, a);
+      if (a.agentPageId) existingById.set(`agent-${a.agentPageId}`, a);
+    }
+
+    const optimisticAssignees: TaskAssigneeData[] = assigneeIds.map(({ type, id }) =>
+      existingById.get(`${type}-${id}`) ?? {
+        id: `optimistic-${type}-${id}`,
+        taskId: task.id,
+        userId: type === 'user' ? id : null,
+        agentPageId: type === 'agent' ? id : null,
+      }
+    );
+
+    setTasks(prev => prev.map(t =>
+      t.id === task.id ? { ...t, assignees: optimisticAssignees } : t
+    ));
+
     try {
       await patch(`/api/pages/${task.taskListPageId}/tasks/${task.id}`, { assigneeIds });
       onPageMutate?.(task.taskListPageId);
       onSuccess?.();
-      // Refetch to get updated assignee data - assignees have relation data
       mutate(`/api/pages/${task.taskListPageId}/tasks`);
     } catch (err) {
       handleError(err as Error, 'Failed to update assignees');
+      setTasks(prev => prev.map(t => t.id === task.id ? task : t));
     }
-  }, [onPageMutate, onSuccess, handleError]);
+  }, [setTasks, onPageMutate, onSuccess, handleError]);
 
   const handleDueDateChange = useCallback(async (task: Task, dueDate: Date | null) => {
     if (!task.taskListPageId) return;


### PR DESCRIPTION
## Summary

- `handleMultiAssigneeChange` was the only mutation in `useTaskMutations` that waited for the full API round-trip before updating the UI — every other mutation (status, priority, due date, title, delete) used `setTasks()` for immediate local updates
- Now builds an optimistic `TaskAssigneeData[]` from the current task's existing relation data and calls `setTasks()` immediately, matching the pattern used by all sibling mutations
- Rolls back to the original task state on error

## How it works

For the optimistic list:
- **Kept assignees** → reuses existing `TaskAssigneeData` entry (preserves `user`/`agentPage` details — avatars stay intact)
- **Removed assignees** → excluded immediately
- **New assignees** → skeleton entry (IDs only; name/avatar fills in after the revalidation that already runs on success)

## Test plan

- [ ] Assign a user to a task — avatar appears in the row immediately with no lag
- [ ] Remove an assignee — disappears instantly
- [ ] Hard-refresh — persisted state matches
- [ ] Simulate network failure (DevTools offline) — assignment rolls back to previous state

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Multi-assignee updates now apply immediately in the UI with optimistic feedback.
  * If an assignment update fails, the previous assignees are restored and an error notification is shown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1383?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->