### PR TITLE
perf(api): select only id+createdAt columns in GET /v1/models

### DIFF
--- a/apps/web/src/app/api/v1/models/route.ts
+++ b/apps/web/src/app/api/v1/models/route.ts
@@ -26,7 +26,7 @@ export async function GET(request: Request): Promise<Response> {
     ? and(eq(pages.type, PageType.AI_CHAT), eq(pages.isTrashed, false), inArray(pages.driveId, allowedDriveIds))
     : and(eq(pages.type, PageType.AI_CHAT), eq(pages.isTrashed, false));
 
-  const rows = await db.select().from(pages).where(whereClause);
+  const rows = await db.select({ id: pages.id, createdAt: pages.createdAt }).from(pages).where(whereClause);
   const permissions = await getBatchPagePermissions(authResult.userId, rows.map((r) => r.id));
 
   const models = rows


### PR DESCRIPTION
## Summary

Follow-up to #1381 (which landed in #1377's train).

`GET /api/v1/models` was selecting full page rows — including large unused columns like `content` and `systemPrompt` — on every models-list call. The response only uses `id` and `createdAt`, so this narrows the projection:

```ts
// before
db.select().from(pages).where(whereClause)

// after
db.select({ id: pages.id, createdAt: pages.createdAt }).from(pages).where(whereClause)
```

`getBatchPagePermissions` only needs the IDs, and the response map only touches `id` and `createdAt`, so no behavior changes.

## Test plan

- [ ] `GET /v1/models` — still returns correct `ps-agent://` model IDs
- [ ] `GET /v1/models` — `created` field is still correct unix timestamp
- [ ] `pnpm test:unit` passes (existing route tests cover the projection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)