### PR TITLE
feat(ai): web_fetch tool — read direct URLs as markdown

### DIFF
--- a/apps/web/src/components/ui/floating-input/ToolsPopover.tsx
+++ b/apps/web/src/components/ui/floating-input/ToolsPopover.tsx
@@ -134,7 +134,7 @@ export function ToolsPopover({
                 'text-sm',
                 webSearchEnabled ? 'text-foreground' : 'text-muted-foreground'
               )}>
-                Web Search
+                Web
               </span>
             </div>
             <Switch

--- a/apps/web/src/lib/ai/core/tool-filtering.ts
+++ b/apps/web/src/lib/ai/core/tool-filtering.ts
@@ -36,7 +36,7 @@ const WRITE_TOOLS = new Set([
 ]);
 
 // Web search tools (excluded when web search is disabled)
-const WEB_SEARCH_TOOLS = new Set(['web_search']);
+const WEB_SEARCH_TOOLS = new Set(['web_search', 'web_fetch']);
 
 /**
  * Check if a tool modifies content
@@ -146,6 +146,7 @@ export function getToolsSummary(isReadOnly: boolean, webSearchEnabled = true): {
     'glob_search',
     'multi_drive_search',
     'web_search',
+    'web_fetch',
     // Agent communication
     'ask_agent',
     // Write tools

--- a/apps/web/src/lib/ai/tools/__tests__/web-search-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/web-search-tools.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Mock dependencies
+vi.mock('dns', () => ({
+  promises: {
+    lookup: vi.fn(),
+  },
+}));
+
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
     loggers: {
     ai: {
@@ -23,6 +29,7 @@ vi.mock('../../core', () => ({}));
 
 import { webSearchTools } from '../web-search-tools';
 import type { ToolExecutionContext } from '../../core';
+import { promises as dnsMock } from 'dns';
 
 type WebSearchResult = Exclude<
   Awaited<ReturnType<NonNullable<(typeof webSearchTools.web_search)['execute']>>>,
@@ -262,6 +269,189 @@ describe('web-search-tools', () => {
       expect(result.metadata.searchEngine).toBe('brave');
       expect(result.metadata.recencyFilter).toBe('oneMonth');
       expect(result.metadata.domainFilter).toBe('github.com');
+    });
+  });
+});
+
+// ─── web_fetch tests ────────────────────────────────────────────────────────
+
+const mockDnsLookup = vi.mocked(dnsMock.lookup);
+
+/** Build a minimal fetch Response with a streaming body. */
+function mockFetchResponse(
+  body: string,
+  {
+    status = 200,
+    contentType = 'text/html; charset=utf-8',
+    contentLength,
+  }: { status?: number; contentType?: string; contentLength?: number } = {}
+) {
+  const headers = new Map<string, string>([['content-type', contentType]]);
+  if (contentLength !== undefined) headers.set('content-length', String(contentLength));
+
+  const bytes = new TextEncoder().encode(body);
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) { c.enqueue(bytes); c.close(); },
+  });
+
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    headers: { get: (name: string) => headers.get(name) ?? null },
+    body: stream,
+  };
+}
+
+describe('web_fetch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+    // Default: public DNS resolves to a public IP
+    mockDnsLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }] as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('has correct tool definition', () => {
+    expect(webSearchTools.web_fetch).toBeDefined();
+    expect(webSearchTools.web_fetch.description).toContain('Fetch and read');
+  });
+
+  it('requires user authentication', async () => {
+    await expect(
+      webSearchTools.web_fetch!.execute!(
+        { url: 'https://example.com', maxLength: 20000 },
+        mockContext()
+      )
+    ).rejects.toThrow('User authentication required');
+  });
+
+  describe('SSRF protection', () => {
+    it('rejects http:// URLs before any DNS or fetch', async () => {
+      const result = await webSearchTools.web_fetch!.execute!(
+        { url: 'http://example.com', maxLength: 20000 },
+        mockContext('user-123')
+      ) as Record<string, unknown>;
+      expect(result.success).toBe(false);
+      expect(String(result.error)).toMatch(/https/i);
+      expect(fetch).not.toHaveBeenCalled();
+      expect(mockDnsLookup).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['loopback', 'https://127.0.0.1'],
+      ['RFC1918 class A', 'https://10.0.0.1'],
+      ['RFC1918 class B', 'https://172.16.0.1'],
+      ['RFC1918 class C', 'https://192.168.1.1'],
+      ['link-local/metadata', 'https://169.254.169.254'],
+    ])('blocks %s address %s', async (_label, url) => {
+      const result = await webSearchTools.web_fetch!.execute!(
+        { url, maxLength: 20000 },
+        mockContext('user-123')
+      ) as Record<string, unknown>;
+      expect(result.success).toBe(false);
+      expect(String(result.error)).toMatch(/private|internal/i);
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('blocks localhost', async () => {
+      const result = await webSearchTools.web_fetch!.execute!(
+        { url: 'https://localhost', maxLength: 20000 },
+        mockContext('user-123')
+      ) as Record<string, unknown>;
+      expect(result.success).toBe(false);
+      expect(String(result.error)).toMatch(/private|internal/i);
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('blocks when DNS resolves to a private IP (DNS rebinding)', async () => {
+      mockDnsLookup.mockResolvedValue([{ address: '10.0.0.1', family: 4 }] as never);
+      const result = await webSearchTools.web_fetch!.execute!(
+        { url: 'https://evil.example.com', maxLength: 20000 },
+        mockContext('user-123')
+      ) as Record<string, unknown>;
+      expect(result.success).toBe(false);
+      expect(String(result.error)).toMatch(/private|internal/i);
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('fails closed when DNS resolution fails', async () => {
+      mockDnsLookup.mockRejectedValue(new Error('ENOTFOUND'));
+      const result = await webSearchTools.web_fetch!.execute!(
+        { url: 'https://nxdomain.invalid', maxLength: 20000 },
+        mockContext('user-123')
+      ) as Record<string, unknown>;
+      expect(result.success).toBe(false);
+      expect(String(result.error)).toMatch(/resolve/i);
+      expect(fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('content validation', () => {
+    it('rejects non-HTML content types', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockFetchResponse('%PDF-1.4', { contentType: 'application/pdf' })
+      );
+      const result = await webSearchTools.web_fetch!.execute!(
+        { url: 'https://example.com/doc.pdf', maxLength: 20000 },
+        mockContext('user-123')
+      ) as Record<string, unknown>;
+      expect(result.success).toBe(false);
+      expect(String(result.error)).toMatch(/content type/i);
+    });
+
+    it('rejects when Content-Length exceeds 5 MB', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockFetchResponse('', { contentLength: 6 * 1024 * 1024 })
+      );
+      const result = await webSearchTools.web_fetch!.execute!(
+        { url: 'https://example.com', maxLength: 20000 },
+        mockContext('user-123')
+      ) as Record<string, unknown>;
+      expect(result.success).toBe(false);
+      expect(String(result.error)).toMatch(/too large/i);
+    });
+  });
+
+  describe('happy path', () => {
+    it('returns markdown for valid HTML', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockFetchResponse('<html><body><h1>Hello</h1><p>World</p></body></html>')
+      );
+      const result = await webSearchTools.web_fetch!.execute!(
+        { url: 'https://example.com', maxLength: 20000 },
+        mockContext('user-123')
+      ) as Record<string, unknown>;
+      expect(result.success).toBe(true);
+      expect(String(result.content)).toContain('Hello');
+      expect(result.truncated).toBe(false);
+    });
+
+    it('truncates and flags when content exceeds maxLength', async () => {
+      const longHtml = '<p>' + 'a'.repeat(2000) + '</p>';
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(mockFetchResponse(longHtml));
+      const result = await webSearchTools.web_fetch!.execute!(
+        { url: 'https://example.com', maxLength: 100 },
+        mockContext('user-123')
+      ) as Record<string, unknown>;
+      expect(result.success).toBe(true);
+      expect(result.truncated).toBe(true);
+      expect(String(result.content).length).toBeLessThanOrEqual(100);
+    });
+
+    it('does not truncate when content fits within maxLength', async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+        mockFetchResponse('<p>Short content</p>')
+      );
+      const result = await webSearchTools.web_fetch!.execute!(
+        { url: 'https://example.com', maxLength: 20000 },
+        mockContext('user-123')
+      ) as Record<string, unknown>;
+      expect(result.success).toBe(true);
+      expect(result.truncated).toBe(false);
     });
   });
 });

--- a/apps/web/src/lib/ai/tools/__tests__/web-search-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/web-search-tools.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Mock dependencies
+const mockLookupFn = vi.fn();
 vi.mock('dns', () => ({
-  promises: {
-    lookup: vi.fn(),
-  },
+  default: { promises: { lookup: mockLookupFn } },
+  promises: { lookup: mockLookupFn },
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
@@ -29,7 +29,6 @@ vi.mock('../../core', () => ({}));
 
 import { webSearchTools } from '../web-search-tools';
 import type { ToolExecutionContext } from '../../core';
-import { promises as dnsMock } from 'dns';
 
 type WebSearchResult = Exclude<
   Awaited<ReturnType<NonNullable<(typeof webSearchTools.web_search)['execute']>>>,
@@ -275,8 +274,6 @@ describe('web-search-tools', () => {
 
 // ─── web_fetch tests ────────────────────────────────────────────────────────
 
-const mockDnsLookup = vi.mocked(dnsMock.lookup);
-
 /** Build a minimal fetch Response with a streaming body. */
 function mockFetchResponse(
   body: string,
@@ -308,7 +305,7 @@ describe('web_fetch', () => {
     vi.clearAllMocks();
     global.fetch = vi.fn();
     // Default: public DNS resolves to a public IP
-    mockDnsLookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }] as never);
+    mockLookupFn.mockResolvedValue([{ address: '93.184.216.34', family: 4 }] as never);
   });
 
   afterEach(() => {
@@ -338,7 +335,7 @@ describe('web_fetch', () => {
       expect(result.success).toBe(false);
       expect(String(result.error)).toMatch(/https/i);
       expect(fetch).not.toHaveBeenCalled();
-      expect(mockDnsLookup).not.toHaveBeenCalled();
+      expect(mockLookupFn).not.toHaveBeenCalled();
     });
 
     it.each([
@@ -368,7 +365,7 @@ describe('web_fetch', () => {
     });
 
     it('blocks when DNS resolves to a private IP (DNS rebinding)', async () => {
-      mockDnsLookup.mockResolvedValue([{ address: '10.0.0.1', family: 4 }] as never);
+      mockLookupFn.mockResolvedValue([{ address: '10.0.0.1', family: 4 }] as never);
       const result = await webSearchTools.web_fetch!.execute!(
         { url: 'https://evil.example.com', maxLength: 20000 },
         mockContext('user-123')
@@ -379,7 +376,7 @@ describe('web_fetch', () => {
     });
 
     it('fails closed when DNS resolution fails', async () => {
-      mockDnsLookup.mockRejectedValue(new Error('ENOTFOUND'));
+      mockLookupFn.mockRejectedValue(new Error('ENOTFOUND'));
       const result = await webSearchTools.web_fetch!.execute!(
         { url: 'https://nxdomain.invalid', maxLength: 20000 },
         mockContext('user-123')

--- a/apps/web/src/lib/ai/tools/__tests__/web-search-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/web-search-tools.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Mock dependencies
-const mockLookupFn = vi.fn();
+const mockLookupFn = vi.hoisted(() => vi.fn());
 vi.mock('dns', () => ({
   default: { promises: { lookup: mockLookupFn } },
   promises: { lookup: mockLookupFn },

--- a/apps/web/src/lib/ai/tools/web-search-tools.ts
+++ b/apps/web/src/lib/ai/tools/web-search-tools.ts
@@ -118,6 +118,22 @@ async function performWebSearch({
   }
 }
 
+/** Block SSRF: rejects loopback, RFC1918, link-local, and cloud-metadata hosts. */
+function isPrivateHost(hostname: string): boolean {
+  const h = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (h === 'localhost' || h === '::1' || h === '0.0.0.0') return true;
+  const ipv4 = h.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+  if (ipv4) {
+    const [a, b] = [Number(ipv4[1]), Number(ipv4[2])];
+    if (a === 10) return true;                          // 10.0.0.0/8
+    if (a === 127) return true;                         // 127.0.0.0/8 loopback
+    if (a === 169 && b === 254) return true;            // 169.254.0.0/16 link-local + AWS metadata
+    if (a === 172 && b >= 16 && b <= 31) return true;  // 172.16.0.0/12
+    if (a === 192 && b === 168) return true;            // 192.168.0.0/16
+  }
+  return false;
+}
+
 export const webSearchTools = {
   web_search: tool({
     description: `Search the web for current information, news, documentation, and real-time data. Use this when:
@@ -224,6 +240,14 @@ Returns the page content converted to readable markdown.`,
       if (!userId) throw new Error('User authentication required');
 
       try {
+        const parsed = new URL(url);
+        if (parsed.protocol !== 'https:') {
+          return { success: false, url, error: 'Only HTTPS URLs are supported', content: '', nextSteps: ['Use an https:// URL'] };
+        }
+        if (isPrivateHost(parsed.hostname)) {
+          return { success: false, url, error: 'Fetching private or internal hosts is not allowed', content: '', nextSteps: ['Provide a publicly accessible URL'] };
+        }
+
         webSearchLogger.debug('Fetching URL', { userId: maskIdentifier(userId), url });
 
         const response = await fetch(url, {

--- a/apps/web/src/lib/ai/tools/web-search-tools.ts
+++ b/apps/web/src/lib/ai/tools/web-search-tools.ts
@@ -1,5 +1,6 @@
 import { tool } from 'ai';
 import { z } from 'zod';
+import TurndownService from 'turndown';
 import { type ToolExecutionContext } from '../core';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { maskIdentifier } from '@/lib/logging/mask';
@@ -118,9 +119,6 @@ async function performWebSearch({
 }
 
 export const webSearchTools = {
-  /**
-   * Search the web for current information using Brave Search API
-   */
   web_search: tool({
     description: `Search the web for current information, news, documentation, and real-time data. Use this when:
 - User asks about current events, news, or recent developments
@@ -202,6 +200,81 @@ Returns structured search results with titles, links, summaries, and publication
             'Check if BRAVE_API_KEY environment variable is configured',
             'Try a different search query',
             'If the error persists, inform the user that web search is temporarily unavailable',
+          ],
+        };
+      }
+    },
+  }),
+
+  web_fetch: tool({
+    description: `Fetch and read the full content of a specific URL as clean markdown. Use this when:
+- You have a direct URL and need its full content (not just a snippet)
+- web_search returned a link you want to read in detail
+- User provides a URL they want you to read
+- Fetching documentation, articles, GitHub files, API references
+
+Returns the page content converted to readable markdown.`,
+    inputSchema: z.object({
+      url: z.string().url().describe('The full URL to fetch (must start with https://)'),
+      maxLength: z.number().min(1000).max(50000).optional().default(20000)
+        .describe('Max characters of markdown to return (default 20000)'),
+    }),
+    execute: async ({ url, maxLength = 20000 }, { experimental_context: context }) => {
+      const userId = (context as ToolExecutionContext)?.userId;
+      if (!userId) throw new Error('User authentication required');
+
+      try {
+        webSearchLogger.debug('Fetching URL', { userId: maskIdentifier(userId), url });
+
+        const response = await fetch(url, {
+          headers: { 'User-Agent': 'Mozilla/5.0 (compatible; PageSpace/1.0)' },
+          signal: AbortSignal.timeout(15000),
+        });
+
+        if (!response.ok) {
+          throw new Error(`Fetch failed: ${response.status} ${response.statusText}`);
+        }
+
+        const html = await response.text();
+        const cleaned = html
+          .replace(/<script[\s\S]*?<\/script>/gi, '')
+          .replace(/<style[\s\S]*?<\/style>/gi, '');
+
+        const td = new TurndownService({ headingStyle: 'atx', codeBlockStyle: 'fenced' });
+        const markdown = td.turndown(cleaned).slice(0, maxLength);
+
+        webSearchLogger.info('URL fetch complete', {
+          userId: maskIdentifier(userId),
+          url,
+          markdownLength: markdown.length,
+          truncated: markdown.length === maxLength,
+        });
+
+        return {
+          success: true,
+          url,
+          contentLength: markdown.length,
+          truncated: markdown.length === maxLength,
+          content: markdown,
+          nextSteps: [
+            'Read and synthesize the fetched content',
+            'Cite the source URL when referencing this content',
+            'If content is truncated, focus on the most relevant sections',
+          ],
+        };
+      } catch (error) {
+        webSearchLogger.error('URL fetch failed', error as Error, {
+          userId: maskIdentifier(userId),
+          url,
+        });
+        return {
+          success: false,
+          url,
+          error: error instanceof Error ? error.message : 'Unknown error',
+          content: '',
+          nextSteps: [
+            'Check the URL is publicly accessible (not behind auth or paywall)',
+            'Try web_search to find an alternative source',
           ],
         };
       }

--- a/apps/web/src/lib/ai/tools/web-search-tools.ts
+++ b/apps/web/src/lib/ai/tools/web-search-tools.ts
@@ -259,26 +259,38 @@ Returns the page content converted to readable markdown.`,
           throw new Error(`Fetch failed: ${response.status} ${response.statusText}`);
         }
 
+        const contentType = response.headers.get('content-type') ?? '';
+        if (!contentType.includes('text/html') && !contentType.includes('text/plain')) {
+          return {
+            success: false,
+            url,
+            error: `Unsupported content type: ${contentType}`,
+            content: '',
+            nextSteps: ['This URL returns non-HTML content. Try web_search for a different source.'],
+          };
+        }
+
         const html = await response.text();
         const cleaned = html
           .replace(/<script[\s\S]*?<\/script>/gi, '')
           .replace(/<style[\s\S]*?<\/style>/gi, '');
 
         const td = new TurndownService({ headingStyle: 'atx', codeBlockStyle: 'fenced' });
-        const markdown = td.turndown(cleaned).slice(0, maxLength);
+        const fullMarkdown = td.turndown(cleaned);
+        const markdown = fullMarkdown.slice(0, maxLength);
 
         webSearchLogger.info('URL fetch complete', {
           userId: maskIdentifier(userId),
           url,
           markdownLength: markdown.length,
-          truncated: markdown.length === maxLength,
+          truncated: fullMarkdown.length > maxLength,
         });
 
         return {
           success: true,
           url,
           contentLength: markdown.length,
-          truncated: markdown.length === maxLength,
+          truncated: fullMarkdown.length > maxLength,
           content: markdown,
           nextSteps: [
             'Read and synthesize the fetched content',

--- a/apps/web/src/lib/ai/tools/web-search-tools.ts
+++ b/apps/web/src/lib/ai/tools/web-search-tools.ts
@@ -1,3 +1,4 @@
+import { promises as dnsPromises } from 'dns';
 import { tool } from 'ai';
 import { z } from 'zod';
 import TurndownService from 'turndown';
@@ -8,9 +9,15 @@ import { maskIdentifier } from '@/lib/logging/mask';
 const webSearchLogger = loggers.ai.child({ module: 'web-search-tools' });
 
 const BRAVE_SEARCH_URL = 'https://api.search.brave.com/res/v1/web/search';
+const MAX_FETCH_BYTES = 5 * 1024 * 1024; // 5 MB hard cap on buffered response
 
 function safeHostname(url: string): string {
   try { return new URL(url).hostname; } catch { return ''; }
+}
+
+/** Strips query string and fragment before logging to avoid leaking tokens in URL params. */
+function redactUrl(url: string): string {
+  try { const u = new URL(url); return u.origin + u.pathname; } catch { return '[unparseable url]'; }
 }
 
 /** Map internal recency filter values to Brave's freshness parameter */
@@ -118,20 +125,45 @@ async function performWebSearch({
   }
 }
 
-/** Block SSRF: rejects loopback, RFC1918, link-local, and cloud-metadata hosts. */
-function isPrivateHost(hostname: string): boolean {
-  const h = hostname.toLowerCase().replace(/^\[|\]$/g, '');
-  if (h === 'localhost' || h === '::1' || h === '0.0.0.0') return true;
+/** Returns true for any IP that must not be fetched (loopback, RFC1918, link-local, IPv6 private). */
+function isPrivateIp(ip: string): boolean {
+  const h = ip.toLowerCase().replace(/^\[|\]$/g, '');
+  if (h === 'localhost' || h === '0.0.0.0') return true;
+  // IPv6
+  if (h === '::1') return true;
+  if (h.startsWith('fe80:')) return true;                   // fe80::/10 link-local
+  if (h.startsWith('fc') || h.startsWith('fd')) return true; // fc00::/7 unique-local
+  if (h.startsWith('::ffff:')) return isPrivateIp(h.slice(7)); // IPv4-mapped
+  // IPv4
   const ipv4 = h.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
   if (ipv4) {
     const [a, b] = [Number(ipv4[1]), Number(ipv4[2])];
     if (a === 10) return true;                          // 10.0.0.0/8
     if (a === 127) return true;                         // 127.0.0.0/8 loopback
-    if (a === 169 && b === 254) return true;            // 169.254.0.0/16 link-local + AWS metadata
+    if (a === 169 && b === 254) return true;            // 169.254.0.0/16 link-local + cloud metadata
     if (a === 172 && b >= 16 && b <= 31) return true;  // 172.16.0.0/12
     if (a === 192 && b === 168) return true;            // 192.168.0.0/16
   }
   return false;
+}
+
+/**
+ * Resolves hostname to all addresses and rejects if any is private.
+ * Catches public hostnames that resolve to internal IPs (DNS rebinding mitigation).
+ * Throws on block or DNS failure (fail-closed).
+ */
+async function validatePublicHost(hostname: string): Promise<void> {
+  if (isPrivateIp(hostname)) throw new Error('Fetching private or internal hosts is not allowed');
+  let addresses: { address: string; family: number }[];
+  try {
+    addresses = await dnsPromises.lookup(hostname, { all: true });
+  } catch {
+    throw new Error('Unable to resolve hostname');
+  }
+  if (!addresses.length) throw new Error('Hostname resolved to no addresses');
+  for (const { address } of addresses) {
+    if (isPrivateIp(address)) throw new Error('Fetching private or internal hosts is not allowed');
+  }
 }
 
 export const webSearchTools = {
@@ -244,11 +276,14 @@ Returns the page content converted to readable markdown.`,
         if (parsed.protocol !== 'https:') {
           return { success: false, url, error: 'Only HTTPS URLs are supported', content: '', nextSteps: ['Use an https:// URL'] };
         }
-        if (isPrivateHost(parsed.hostname)) {
-          return { success: false, url, error: 'Fetching private or internal hosts is not allowed', content: '', nextSteps: ['Provide a publicly accessible URL'] };
+
+        try {
+          await validatePublicHost(parsed.hostname);
+        } catch (e) {
+          return { success: false, url, error: (e as Error).message, content: '', nextSteps: ['Provide a publicly accessible URL'] };
         }
 
-        webSearchLogger.debug('Fetching URL', { userId: maskIdentifier(userId), url });
+        webSearchLogger.debug('Fetching URL', { userId: maskIdentifier(userId), url: redactUrl(url) });
 
         const response = await fetch(url, {
           headers: { 'User-Agent': 'Mozilla/5.0 (compatible; PageSpace/1.0)' },
@@ -270,7 +305,40 @@ Returns the page content converted to readable markdown.`,
           };
         }
 
-        const html = await response.text();
+        const clHeader = response.headers.get('content-length');
+        if (clHeader && Number(clHeader) > MAX_FETCH_BYTES) {
+          return {
+            success: false,
+            url,
+            error: `Response too large (${Math.round(Number(clHeader) / 1024 / 1024)} MB, max 5 MB)`,
+            content: '',
+            nextSteps: ['Try web_search for a summary of this content'],
+          };
+        }
+
+        // Stream body with hard byte cap to avoid buffering large responses
+        const reader = response.body?.getReader();
+        if (!reader) throw new Error('Response body is not readable');
+        const chunks: Uint8Array[] = [];
+        let bytesRead = 0;
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done || !value) break;
+          const remaining = MAX_FETCH_BYTES - bytesRead;
+          if (value.length >= remaining) {
+            chunks.push(value.subarray(0, remaining));
+            bytesRead += remaining;
+            await reader.cancel();
+            break;
+          }
+          chunks.push(value);
+          bytesRead += value.length;
+        }
+        const allBytes = new Uint8Array(bytesRead);
+        let offset = 0;
+        for (const chunk of chunks) { allBytes.set(chunk, offset); offset += chunk.length; }
+        const html = new TextDecoder().decode(allBytes);
+
         const cleaned = html
           .replace(/<script[\s\S]*?<\/script>/gi, '')
           .replace(/<style[\s\S]*?<\/style>/gi, '');
@@ -281,7 +349,7 @@ Returns the page content converted to readable markdown.`,
 
         webSearchLogger.info('URL fetch complete', {
           userId: maskIdentifier(userId),
-          url,
+          url: redactUrl(url),
           markdownLength: markdown.length,
           truncated: fullMarkdown.length > maxLength,
         });
@@ -301,7 +369,7 @@ Returns the page content converted to readable markdown.`,
       } catch (error) {
         webSearchLogger.error('URL fetch failed', error as Error, {
           userId: maskIdentifier(userId),
-          url,
+          url: redactUrl(url),
         });
         return {
           success: false,


### PR DESCRIPTION
## Summary

Adds \`web_fetch\` AI tool that fetches any public URL and returns its full content as clean markdown, controlled by the same toggle as \`web_search\`.

### What changed
- **New tool: \`web_fetch\`** — fetches a URL, converts HTML→markdown via TurndownService (already a project dep), returns up to 20k chars by default
- **Toggle**: \`web_fetch\` joins \`WEB_SEARCH_TOOLS\` — one "Web" toggle gates both tools
- **Label**: "Web Search" → "Web" in ToolsPopover

### Security hardening
- **SSRF protection**: \`validatePublicHost()\` resolves hostname via \`dns.lookup({ all: true })\` and checks every returned IP — blocks literal IPs and catches public hostnames that resolve to private ranges (DNS rebinding mitigation). Covers RFC1918, loopback, link-local, AWS metadata (169.254.x), and IPv6 private (fe80::/10, fc00::/7, ::ffff: mapped). Fail-closed on DNS failure.
- **https-only**: non-HTTPS protocol rejected before any network I/O
- **Content-Type guard**: rejects binary responses (PDFs, images, ZIPs) before attempting HTML→markdown
- **Streaming body with 5 MB cap**: replaces \`response.text()\` with a \`ReadableStream\` reader that hard-caps byte consumption; also checks \`Content-Length\` header for an early reject
- **URL redaction in logs**: \`redactUrl()\` strips query string and fragment before logging to prevent token/secret leakage

## Test plan

- [ ] Enable Web toggle, ask AI to fetch a public URL → readable markdown
- [ ] Disable Web toggle → both \`web_search\` and \`web_fetch\` unavailable
- [ ] Toggle label reads "Web" in ToolsPopover
- [ ] Fetch \`https://192.168.1.1\` → SSRF block error
- [ ] Fetch \`https://169.254.169.254/latest/meta-data/\` → SSRF block error
- [ ] Fetch a PDF URL → content-type error
- [ ] Fetch a paywalled URL → graceful HTTP error response

🤖 Generated with [Claude Code](https://claude.com/claude-code)