### PR TITLE
feat(ui): surface OpenAI-compatible API in MCP Settings and agent settings tab

### DIFF
--- a/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
+++ b/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
@@ -7,10 +7,11 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSeparator, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
-import { Loader2, Bot, FolderTree, Shield } from 'lucide-react';
+import { Loader2, Bot, FolderTree, Shield, Copy, Check, Code2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useForm, Controller } from 'react-hook-form';
 import { patch, fetchWithAuth } from '@/lib/auth/auth-fetch';
+import Link from 'next/link';
 import { AI_PROVIDERS } from '@/lib/ai/core/ai-providers-config';
 import { getRoleColorClasses } from '@/lib/utils';
 
@@ -50,6 +51,42 @@ interface PageAgentSettingsTabProps {
   onModelChange: (model: string) => void;
   isProviderConfigured: (provider: string) => boolean;
   onSavingChange?: (isSaving: boolean) => void;
+}
+
+function ApiModelIdCard({ pageId }: { pageId: string }) {
+  const [copied, setCopied] = useState(false);
+  const modelId = `ps-agent://${pageId}`;
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(modelId);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <Code2 className="h-5 w-5" />
+          API Model ID
+        </CardTitle>
+        <CardDescription>
+          Use with the OpenAI-compatible API —{' '}
+          <Link href="/settings/mcp" className="underline underline-offset-2">
+            see MCP Settings for setup
+          </Link>
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center gap-2">
+          <code className="flex-1 rounded-md bg-muted px-3 py-2 font-mono text-sm">{modelId}</code>
+          <Button size="sm" variant="outline" onClick={handleCopy}>
+            {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
 }
 
 export interface PageAgentSettingsTabRef {
@@ -334,6 +371,9 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
   return (
     <div className="p-4">
       <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col space-y-6">
+        {/* API Model ID */}
+        <ApiModelIdCard pageId={pageId} />
+
         {/* AI Provider & Model Selection */}
         <Card>
           <CardHeader>

--- a/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
+++ b/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
@@ -80,7 +80,7 @@ function ApiModelIdCard({ pageId }: { pageId: string }) {
       <CardContent>
         <div className="flex items-center gap-2">
           <code className="flex-1 rounded-md bg-muted px-3 py-2 font-mono text-sm">{modelId}</code>
-          <Button size="sm" variant="outline" onClick={handleCopy}>
+          <Button type="button" size="sm" variant="outline" onClick={handleCopy}>
             {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
           </Button>
         </div>

--- a/apps/web/src/components/layout/middle-content/page-views/settings/mcp/MCPSettingsView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/settings/mcp/MCPSettingsView.tsx
@@ -20,7 +20,8 @@ import {
   Alert,
   AlertDescription,
 } from '@/components/ui/alert';
-import { Trash2, Copy, Plus, Eye, EyeOff, Key, Terminal, Check, Download, AlertTriangle, ArrowLeft, Shield } from 'lucide-react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Trash2, Copy, Plus, Eye, EyeOff, Key, Terminal, Check, Download, AlertTriangle, ArrowLeft, Shield, Code2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { formatDistanceToNow } from 'date-fns';
 import { useRouter } from 'next/navigation';
@@ -48,6 +49,118 @@ interface Drive {
   id: string;
   name: string;
   slug: string;
+}
+
+function CopyButton({ text, label }: { text: string; label?: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <Button
+      size="sm"
+      variant="outline"
+      onClick={() => {
+        navigator.clipboard.writeText(text);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }}
+    >
+      {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+      {label && <span className="ml-1">{label}</span>}
+    </Button>
+  );
+}
+
+function OpenAIApiCard() {
+  const baseUrl = typeof window !== 'undefined' ? `${window.location.origin}/api/v1` : '/api/v1';
+
+  const pythonSnippet = `from openai import OpenAI
+
+client = OpenAI(
+    base_url="${baseUrl}",
+    api_key="YOUR_MCP_TOKEN",
+)
+
+response = client.chat.completions.create(
+    model="ps-agent://<pageId>",
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+print(response.choices[0].message.content)`;
+
+  const tsSnippet = `import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "${baseUrl}",
+  apiKey: "YOUR_MCP_TOKEN",
+});
+
+const response = await client.chat.completions.create({
+  model: "ps-agent://<pageId>",
+  messages: [{ role: "user", content: "Hello!" }],
+});
+console.log(response.choices[0].message.content);`;
+
+  const curlSnippet = `curl ${baseUrl}/chat/completions \\
+  -H "Authorization: Bearer YOUR_MCP_TOKEN" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "model": "ps-agent://<pageId>",
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'`;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Code2 className="h-5 w-5" />
+          OpenAI-Compatible API
+        </CardTitle>
+        <CardDescription>
+          Use any MCP token as an API key with the OpenAI SDK or any compatible client
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-1">
+          <p className="text-sm font-medium">Base URL</p>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 rounded-md bg-muted px-3 py-2 font-mono text-sm">{baseUrl}</code>
+            <CopyButton text={baseUrl} />
+          </div>
+        </div>
+
+        <div className="space-y-1">
+          <p className="text-sm font-medium">Code examples</p>
+          <Tabs defaultValue="python">
+            <TabsList>
+              <TabsTrigger value="python">Python</TabsTrigger>
+              <TabsTrigger value="typescript">TypeScript</TabsTrigger>
+              <TabsTrigger value="curl">curl</TabsTrigger>
+            </TabsList>
+            {[
+              { value: 'python', code: pythonSnippet },
+              { value: 'typescript', code: tsSnippet },
+              { value: 'curl', code: curlSnippet },
+            ].map(({ value, code }) => (
+              <TabsContent key={value} value={value}>
+                <div className="relative">
+                  <pre className="rounded-lg bg-muted p-4 overflow-x-auto text-xs">
+                    <code className="font-mono">{code}</code>
+                  </pre>
+                  <div className="absolute top-2 right-2">
+                    <CopyButton text={code} />
+                  </div>
+                </div>
+              </TabsContent>
+            ))}
+          </Tabs>
+        </div>
+
+        <p className="text-xs text-muted-foreground">
+          Replace <code className="rounded bg-muted px-1">YOUR_MCP_TOKEN</code> with any token from above.
+          Replace <code className="rounded bg-muted px-1">ps-agent://&lt;pageId&gt;</code> with the model ID
+          found on each agent&apos;s <strong>Settings</strong> tab.
+        </p>
+      </CardContent>
+    </Card>
+  );
 }
 
 export default function MCPSettingsView() {
@@ -555,6 +668,9 @@ export default function MCPSettingsView() {
 
         </CardContent>
       </Card>
+
+      {/* OpenAI-Compatible API */}
+      <OpenAIApiCard />
 
       <Alert>
         <AlertTriangle className="h-4 w-4" />

--- a/apps/web/src/components/layout/middle-content/page-views/settings/mcp/MCPSettingsView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/settings/mcp/MCPSettingsView.tsx
@@ -55,6 +55,7 @@ function CopyButton({ text, label }: { text: string; label?: string }) {
   const [copied, setCopied] = useState(false);
   return (
     <Button
+      type="button"
       size="sm"
       variant="outline"
       onClick={() => {

--- a/apps/web/src/components/layout/middle-content/page-views/settings/mcp/MCPSettingsView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/settings/mcp/MCPSettingsView.tsx
@@ -79,11 +79,13 @@ client = OpenAI(
     api_key="YOUR_MCP_TOKEN",
 )
 
-response = client.chat.completions.create(
+stream = client.chat.completions.create(
     model="ps-agent://<pageId>",
     messages=[{"role": "user", "content": "Hello!"}],
+    stream=True,
 )
-print(response.choices[0].message.content)`;
+for chunk in stream:
+    print(chunk.choices[0].delta.content or "", end="", flush=True)`;
 
   const tsSnippet = `import OpenAI from "openai";
 
@@ -92,18 +94,22 @@ const client = new OpenAI({
   apiKey: "YOUR_MCP_TOKEN",
 });
 
-const response = await client.chat.completions.create({
+const stream = await client.chat.completions.create({
   model: "ps-agent://<pageId>",
   messages: [{ role: "user", content: "Hello!" }],
+  stream: true,
 });
-console.log(response.choices[0].message.content);`;
+for await (const chunk of stream) {
+  process.stdout.write(chunk.choices[0]?.delta?.content ?? "");
+}`;
 
   const curlSnippet = `curl ${baseUrl}/chat/completions \\
   -H "Authorization: Bearer YOUR_MCP_TOKEN" \\
   -H "Content-Type: application/json" \\
   -d '{
     "model": "ps-agent://<pageId>",
-    "messages": [{"role": "user", "content": "Hello!"}]
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "stream": true
   }'`;
 
   return (


### PR DESCRIPTION
## Summary

- **MCP Settings page** — new "OpenAI-Compatible API" card below Quick MCP Setup: dynamic base URL (`window.location.origin/api/v1`, correct for self-hosted), copy button, and Python / TypeScript / curl tabs with minimal OpenAI SDK snippets
- **Agent settings tab** — new "API Model ID" card at the top showing `ps-agent://<pageId>` with a copy button and a link to MCP Settings; lets developers grab a model string without touching the API

Both surfaces are read-only UI additions — no backend changes.

## Test plan

- [ ] Open `/settings/mcp` — "OpenAI-Compatible API" card visible below Quick MCP Setup
- [ ] Base URL reflects current origin (cloud vs self-hosted)
- [ ] Python / TypeScript / curl tabs render correct snippets; copy buttons work
- [ ] Open any AI Chat page → Settings tab → "API Model ID" card at top
- [ ] Model ID shows `ps-agent://<pageId>` and copy button works
- [ ] "see MCP Settings for setup" link navigates to `/settings/mcp`
- [ ] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)