### PR TITLE
fix(dm,channel): action toolbar no longer covers grouped message text

### DIFF
--- a/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useRef, useCallback, Fragment } from 'react';
 import { useParams } from 'next/navigation';
+import { cn } from '@/lib/utils';
 import { useAuth } from '@/hooks/useAuth';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import {
@@ -619,7 +620,7 @@ export default function InboxDMPage() {
                     </div>
                   )}
 
-                  <div className="flex-1 min-w-0">
+                  <div className={cn("flex-1 min-w-0", !isFirst && "group-hover/msg:pr-28 transition-[padding-right] duration-100")}>
                     {isFirst && (
                       <div className="flex items-center gap-2 mb-1">
                         <span className="font-semibold text-sm">{senderName}</span>

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -636,7 +636,7 @@ function ChannelView({ page }: ChannelViewProps) {
                                 </span>
                               </div>
                             )}
-                            <div className="flex flex-col min-w-0 flex-1">
+                            <div className={cn("flex flex-col min-w-0 flex-1", !isFirst && "group-hover/msg:pr-28 transition-[padding-right] duration-100")}>
                                 {isFirst && (
                                   <div className="flex items-center gap-2">
                                       <span className="font-semibold text-sm">{displayName}</span>

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef, useCallback, memo, Fragment } from 'react';
+import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
 import { usePermissions, getPermissionErrorMessage } from '@/hooks/usePermissions';


### PR DESCRIPTION
## Summary

- On hover, grouped message content divs gain `pr-28` (112px) right padding, pushing text clear of the `MessageHoverToolbar` zone
- Applies only to grouped messages (`isFirst === false`) — initial messages are unaffected
- 100ms padding transition keeps the reflow smooth
- Added missing `cn` import to the DM page

## Root cause

The `MessageHoverToolbar` is `absolute -top-3 right-2` and extends ~16px below its container's top edge. Initial messages buffer this with an author header row (~20px), so prose text starts below the toolbar. Grouped messages have no header — prose starts at 0px and the toolbar's lower portion covers the first line at the right edge.

## Test plan

- [ ] Open a DM or channel with consecutive messages from the same sender
- [ ] Hover a grouped message — toolbar appears without overlapping any text
- [ ] Hover an initial message — unchanged behaviour
- [ ] Touch device (or DevTools touch emulation) — toolbar always visible, text still clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved message row spacing across conversations and channels for better visual alignment.
  * Enhanced hover interactions with smoother transitions when hovering over message rows.
  * Optimized spacing for interactive elements displayed on hover.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1388?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->