### PR TITLE
fix(messages): action toolbar in flex flow, not absolute

### DIFF
--- a/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState, useRef, useCallback, Fragment } from 'react';
 import { useParams } from 'next/navigation';
-import { cn } from '@/lib/utils';
 import { useAuth } from '@/hooks/useAuth';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import {
@@ -620,7 +619,7 @@ export default function InboxDMPage() {
                     </div>
                   )}
 
-                  <div className={cn("flex-1 min-w-0", !isFirst && "group-hover/msg:pr-28 transition-[padding-right] duration-100")}>
+                  <div className="flex-1 min-w-0">
                     {isFirst && (
                       <div className="flex items-center gap-2 mb-1">
                         <span className="font-semibold text-sm">{senderName}</span>

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useEffect, useRef, useCallback, memo, Fragment } from 'react';
-import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
 import { usePermissions, getPermissionErrorMessage } from '@/hooks/usePermissions';
@@ -637,7 +636,7 @@ function ChannelView({ page }: ChannelViewProps) {
                                 </span>
                               </div>
                             )}
-                            <div className={cn("flex flex-col min-w-0 flex-1", !isFirst && "group-hover/msg:pr-28 transition-[padding-right] duration-100")}>
+                            <div className="flex flex-col min-w-0 flex-1">
                                 {isFirst && (
                                   <div className="flex items-center gap-2">
                                       <span className="font-semibold text-sm">{displayName}</span>

--- a/apps/web/src/components/members/__tests__/DriveMembers.test.tsx
+++ b/apps/web/src/components/members/__tests__/DriveMembers.test.tsx
@@ -164,7 +164,7 @@ describe('DriveMembers', () => {
     mockFetchWithAuth.mockImplementation(urlAwareMock([]));
     render(<DriveMembers driveId="drive-1" />);
     await screen.findByText('Members (0)');
-    expect(mockFetchWithAuth).toHaveBeenCalledTimes(FETCHES_PER_CALL);
+    await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalledTimes(FETCHES_PER_CALL));
 
     socket.__emit('drive:member_added', { driveId: 'other' });
     await new Promise((r) => setTimeout(r, 20));

--- a/apps/web/src/components/members/__tests__/DriveMembers.test.tsx
+++ b/apps/web/src/components/members/__tests__/DriveMembers.test.tsx
@@ -152,7 +152,8 @@ describe('DriveMembers', () => {
     mockFetchWithAuth.mockImplementation(urlAwareMock([]));
     render(<DriveMembers driveId="drive-1" />);
     await screen.findByText('Members (0)');
-    expect(mockFetchWithAuth).toHaveBeenCalledTimes(FETCHES_PER_CALL);
+    // DriveShareLinkSection mounts in a useEffect after currentUserRole resolves — wait for it.
+    await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalledTimes(FETCHES_PER_CALL));
 
     socket.__emit(event, { driveId: 'drive-1' });
     // Socket event only re-triggers fetchMembers() (3 requests); /roles is keyed on driveId, not socket events.

--- a/apps/web/src/components/shared/MessageHoverToolbar.tsx
+++ b/apps/web/src/components/shared/MessageHoverToolbar.tsx
@@ -79,15 +79,16 @@ export function MessageHoverToolbar({
   return (
     <div
       className={cn(
-        'absolute -top-3 right-2 z-10',
+        'shrink-0 self-start',
         'flex items-center gap-0.5 p-0.5',
         'rounded-md border border-border bg-popover shadow-sm',
         // Hover devices: hidden by default, shown on hover/focus or when picker is open.
         // Touch / no-hover devices: always visible so message actions remain reachable.
         'opacity-0 group-hover/msg:opacity-100 focus-within:opacity-100',
-        '[@media(hover:none)]:opacity-100',
+        'pointer-events-none group-hover/msg:pointer-events-auto focus-within:pointer-events-auto',
+        '[@media(hover:none)]:opacity-100 [@media(hover:none)]:pointer-events-auto',
         'transition-opacity',
-        pickerOpen && 'opacity-100',
+        pickerOpen && 'opacity-100 pointer-events-auto',
         className,
       )}
     >

--- a/apps/web/src/components/shared/MessageHoverToolbar.tsx
+++ b/apps/web/src/components/shared/MessageHoverToolbar.tsx
@@ -79,7 +79,7 @@ export function MessageHoverToolbar({
   return (
     <div
       className={cn(
-        'shrink-0 self-start',
+        'shrink-0',
         'flex items-center gap-0.5 p-0.5',
         'rounded-md border border-border bg-popover shadow-sm',
         // Hover devices: hidden by default, shown on hover/focus or when picker is open.


### PR DESCRIPTION
## Summary

- Removes `absolute -top-3 right-2 z-10` from `MessageHoverToolbar`
- Toolbar is now a `shrink-0 self-start` flex sibling in the message row
- `flex-1` on the content div grows only up to the toolbar boundary — text physically cannot extend beneath it
- Adds `pointer-events-none` when invisible so invisible buttons aren't accidentally tappable

## Why the previous fix (#1388) wasn't enough

#1388 moved the toolbar outside the content div (correct), but it was still `absolute`. Absolutely-positioned elements are removed from the layout flow, so `flex-1` still filled the full row width and text still ran under the toolbar. The `pr-28` padding hack was a fragile workaround — wrong at narrow widths, wrong on iPad (which may report `hover:hover` with a keyboard), and sensitive to the exact toolbar pixel width.

## Root fix

Making the toolbar a normal flex item means the browser's layout engine enforces the boundary. No padding math, no media query edge cases, no device-specific hacks.

## Test plan

- [ ] Desktop: hover a grouped message — toolbar appears to the right, no text overlap
- [ ] Desktop narrow window: same check at a narrow viewport
- [ ] Mobile (touch): toolbar always visible, text in adjacent column, no overlap
- [ ] iPad (portrait + landscape): same as mobile
- [ ] Initial messages (with author header): toolbar still appears correctly at top-right

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Simplified message row styling in conversations and channels for clearer, more consistent layout.

* **Bug Fixes**
  * Improved message hover toolbar positioning and visibility on touch devices and while the emoji picker is open.

* **Tests**
  * Stabilized member-related tests by reducing timing flakiness around socket-driven refetch behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1389?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->