### PR TITLE
feat(api): conversation threading for OpenAI-compatible endpoint

### DIFF
--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -112,6 +112,7 @@ import { db } from '@pagespace/db/db';
 import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 import { chatMessageRepository } from '@/lib/repositories/chat-message-repository';
+import { sanitizeMessagesForModel } from '@/lib/ai/core';
 
 const mcpAuth = {
   userId: 'user-1',
@@ -346,6 +347,22 @@ describe('POST /api/v1/chat/completions', () => {
       should: 'still return a 200 SSE stream',
       actual: response.status,
       expected: 200,
+    });
+  });
+
+  test('thread mode: DB history messages are prepended before the new user message', async () => {
+    const dbMessages = [
+      { id: 'db-1', pageId: 'page-123', conversationId: 'conv-abc', userId: 'user-1', role: 'user', content: 'Prior question', messageType: 'standard' as const, isActive: true, createdAt: new Date(), editedAt: null, toolCalls: null, toolResults: null },
+      { id: 'db-2', pageId: 'page-123', conversationId: 'conv-abc', userId: null, role: 'assistant', content: 'Prior answer', messageType: 'standard' as const, isActive: true, createdAt: new Date(), editedAt: null, toolCalls: null, toolResults: null },
+    ];
+    vi.mocked(chatMessageRepository.getMessagesForPage).mockResolvedValueOnce(dbMessages);
+    await POST(makeRequest({ ...validBody, conversation_id: 'conv-abc' }));
+    const sanitizeCalls = vi.mocked(sanitizeMessagesForModel).mock.calls;
+    assert({
+      given: 'a thread mode request with 2 prior DB messages and 1 new user message',
+      should: 'pass 3 messages to sanitizeMessagesForModel (2 history + 1 new)',
+      actual: sanitizeCalls[0]?.[0]?.length,
+      expected: 3,
     });
   });
 

--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -61,7 +61,10 @@ vi.mock('@/lib/ai/core', () => ({
   buildSystemPrompt: vi.fn().mockReturnValue('You are a helpful agent.'),
   sanitizeMessagesForModel: vi.fn((msgs: unknown[]) => msgs),
   saveMessageToDatabase: vi.fn().mockResolvedValue(undefined),
-  convertDbMessageToUIMessage: vi.fn((m: unknown) => m),
+  convertDbMessageToUIMessage: vi.fn((m: unknown) => {
+    const msg = m as { id: string; role: string; content: string };
+    return { id: msg.id, role: msg.role as 'user' | 'assistant', parts: [{ type: 'text' as const, text: msg.content || '' }] };
+  }),
   extractMessageContent: vi.fn().mockReturnValue('Hello'),
   isProviderError: vi.fn((r: unknown) => r != null && typeof r === 'object' && 'error' in r && 'status' in r),
 }));
@@ -72,6 +75,10 @@ vi.mock('@/lib/subscription/usage-service', () => ({
 
 vi.mock('@paralleldrive/cuid2', () => ({
   createId: vi.fn().mockReturnValue('test-id-123'),
+}));
+
+vi.mock('@/lib/repositories/chat-message-repository', () => ({
+  chatMessageRepository: { getMessagesForPage: vi.fn().mockResolvedValue([]) },
 }));
 
 vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
@@ -104,6 +111,7 @@ import { authenticateRequestWithOptions, checkMCPPageScope } from '@/lib/auth';
 import { db } from '@pagespace/db/db';
 import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
+import { chatMessageRepository } from '@/lib/repositories/chat-message-repository';
 
 const mcpAuth = {
   userId: 'user-1',
@@ -149,6 +157,7 @@ describe('POST /api/v1/chat/completions', () => {
         where: vi.fn().mockResolvedValue([agentPage]),
       }),
     } as unknown as ReturnType<typeof db.select>);
+    vi.mocked(chatMessageRepository.getMessagesForPage).mockResolvedValue([]);
   });
 
   test('returns 401 when auth fails', async () => {
@@ -302,6 +311,61 @@ describe('POST /api/v1/chat/completions', () => {
       should: 'still return a 200 SSE response',
       actual: { status: response.status, contentType: response.headers.get('content-type') },
       expected: { status: 200, contentType: 'text/event-stream' },
+    });
+  });
+
+  test('thread mode: calls getMessagesForPage with pageId and conversationId', async () => {
+    const dbMessages = [
+      { id: 'db-1', pageId: 'page-123', conversationId: 'conv-abc', userId: 'user-1', role: 'user', content: 'Prior message', messageType: 'standard' as const, isActive: true, createdAt: new Date(), editedAt: null, toolCalls: null, toolResults: null },
+      { id: 'db-2', pageId: 'page-123', conversationId: 'conv-abc', userId: null, role: 'assistant', content: 'Prior response', messageType: 'standard' as const, isActive: true, createdAt: new Date(), editedAt: null, toolCalls: null, toolResults: null },
+    ];
+    vi.mocked(chatMessageRepository.getMessagesForPage).mockResolvedValueOnce(dbMessages);
+    const response = await POST(makeRequest({ ...validBody, conversation_id: 'conv-abc' }));
+    const calls = vi.mocked(chatMessageRepository.getMessagesForPage).mock.calls;
+    assert({
+      given: 'a request with a valid conversation_id',
+      should: 'call getMessagesForPage with the pageId and conversationId and return 200',
+      actual: {
+        status: response.status,
+        calledWithPageId: calls[0]?.[0],
+        calledWithConvId: calls[0]?.[1],
+      },
+      expected: {
+        status: 200,
+        calledWithPageId: 'page-123',
+        calledWithConvId: 'conv-abc',
+      },
+    });
+  });
+
+  test('thread mode: empty history is allowed (first message in thread)', async () => {
+    vi.mocked(chatMessageRepository.getMessagesForPage).mockResolvedValueOnce([]);
+    const response = await POST(makeRequest({ ...validBody, conversation_id: 'conv-new' }));
+    assert({
+      given: 'a thread mode request where no prior messages exist',
+      should: 'still return a 200 SSE stream',
+      actual: response.status,
+      expected: 200,
+    });
+  });
+
+  test('openai mode: does not call getMessagesForPage when conversation_id is absent', async () => {
+    await POST(makeRequest(validBody));
+    assert({
+      given: 'a request without a conversation_id',
+      should: 'not call getMessagesForPage',
+      actual: vi.mocked(chatMessageRepository.getMessagesForPage).mock.calls.length,
+      expected: 0,
+    });
+  });
+
+  test('whitespace-only conversation_id is treated as absent', async () => {
+    await POST(makeRequest({ ...validBody, conversation_id: '   ' }));
+    assert({
+      given: 'a conversation_id containing only whitespace',
+      should: 'not call getMessagesForPage',
+      actual: vi.mocked(chatMessageRepository.getMessagesForPage).mock.calls.length,
+      expected: 0,
     });
   });
 });

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -92,17 +92,14 @@ export async function POST(request: Request): Promise<Response> {
   // 8. Build message context and save new user message
   const isThreadMode = incomingConversationId !== undefined;
   const conversationId = isThreadMode ? incomingConversationId : createId();
+  const userMessage = messages[messages.length - 1];
 
   let inferenceMessages = messages;
-
   if (isThreadMode) {
     const dbMessages = await chatMessageRepository.getMessagesForPage(pageId, conversationId);
-    const historyMessages = dbMessages.map(convertDbMessageToUIMessage);
-    const newUserMessage = messages[messages.length - 1];
-    inferenceMessages = [...historyMessages, newUserMessage];
+    inferenceMessages = [...dbMessages.map(convertDbMessageToUIMessage), userMessage];
   }
 
-  const userMessage = messages[messages.length - 1];
   const userMessageId = userMessage.id;
   if (userMessage && userMessage.role === 'user') {
     await saveMessageToDatabase({

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -19,8 +19,10 @@ import {
   saveMessageToDatabase,
   extractMessageContent,
   isProviderError,
+  convertDbMessageToUIMessage,
 } from '@/lib/ai/core';
 import { incrementUsage } from '@/lib/subscription/usage-service';
+import { chatMessageRepository } from '@/lib/repositories/chat-message-repository';
 import { validateInferenceRequest } from '@/lib/ai/openai-api/validate-inference-request';
 import { adaptToOpenAIChunk } from '@/lib/ai/openai-api/adapt-to-openai-chunk';
 import { getProviderTier } from '@/lib/ai/core/ai-providers-config';
@@ -52,7 +54,7 @@ export async function POST(request: Request): Promise<Response> {
     return NextResponse.json({ error: validation.error }, { status: validation.status });
   }
 
-  const { pageId, model: modelName, messages, driveContext: _driveContext } = validation.data;
+  const { pageId, model: modelName, messages, driveContext: _driveContext, conversationId: incomingConversationId } = validation.data;
 
   // 3. MCP drive-scope check
   const scopeError = await checkMCPPageScope(authResult, pageId);
@@ -87,9 +89,20 @@ export async function POST(request: Request): Promise<Response> {
   const systemPrompt = page.systemPrompt
     ?? buildSystemPrompt('page', undefined, false);
 
-  // 8. Save user message (database-first — before streaming starts)
+  // 8. Build message context and save new user message
+  const isThreadMode = incomingConversationId !== undefined;
+  const conversationId = isThreadMode ? incomingConversationId : createId();
+
+  let inferenceMessages = messages;
+
+  if (isThreadMode) {
+    const dbMessages = await chatMessageRepository.getMessagesForPage(pageId, conversationId);
+    const historyMessages = dbMessages.map(convertDbMessageToUIMessage);
+    const newUserMessage = messages[messages.length - 1];
+    inferenceMessages = [...historyMessages, newUserMessage];
+  }
+
   const userMessage = messages[messages.length - 1];
-  const conversationId = createId();
   const userMessageId = userMessage.id;
   if (userMessage && userMessage.role === 'user') {
     await saveMessageToDatabase({
@@ -108,7 +121,7 @@ export async function POST(request: Request): Promise<Response> {
   // 9. Run inference — no UI coupling (no WebSocket, no stream lifecycle, no session ID)
   const startTime = Date.now();
   const providerType = getProviderTier(page.aiProvider ?? 'pagespace', page.aiModel ?? undefined);
-  const sanitized = sanitizeMessagesForModel(messages);
+  const sanitized = sanitizeMessagesForModel(inferenceMessages);
   const aiResult = streamText({
     model: providerResult.model,
     system: systemPrompt,

--- a/apps/web/src/lib/ai/openai-api/__tests__/validate-inference-request.test.ts
+++ b/apps/web/src/lib/ai/openai-api/__tests__/validate-inference-request.test.ts
@@ -191,4 +191,28 @@ describe('validateInferenceRequest', () => {
       expected: { ok: false, status: 400 },
     });
   });
+
+  test('conversation_id is extracted and returned as conversationId', () => {
+    const messages = [{ role: 'user' as const, id: 'msg-1', content: 'Hi', parts: [{ type: 'text' as const, text: 'Hi' }] }];
+    const body = { model: 'ps-agent://page-123', messages, conversation_id: 'conv-xyz' };
+    const result = validateInferenceRequest(body);
+    assert({
+      given: 'a body with a conversation_id field',
+      should: 'include conversationId in the parsed data',
+      actual: result.ok ? result.data.conversationId : undefined,
+      expected: 'conv-xyz',
+    });
+  });
+
+  test('whitespace-only conversation_id is treated as absent', () => {
+    const messages = [{ role: 'user' as const, id: 'msg-1', content: 'Hi', parts: [{ type: 'text' as const, text: 'Hi' }] }];
+    const body = { model: 'ps-agent://page-123', messages, conversation_id: '   ' };
+    const result = validateInferenceRequest(body);
+    assert({
+      given: 'a conversation_id containing only whitespace',
+      should: 'return undefined for conversationId',
+      actual: result.ok ? result.data.conversationId : 'error',
+      expected: undefined,
+    });
+  });
 });

--- a/apps/web/src/lib/ai/openai-api/validate-inference-request.ts
+++ b/apps/web/src/lib/ai/openai-api/validate-inference-request.ts
@@ -87,8 +87,7 @@ export const validateInferenceRequest = (body: unknown): ValidationResult => {
 
   const driveContext = typeof raw.drive_context === 'string' ? raw.drive_context : undefined;
 
-  const rawConvId = typeof raw.conversation_id === 'string' ? raw.conversation_id.trim() : undefined;
-  const conversationId = rawConvId || undefined;
+  const conversationId = (typeof raw.conversation_id === 'string' && raw.conversation_id.trim()) || undefined;
 
   return {
     ok: true,

--- a/apps/web/src/lib/ai/openai-api/validate-inference-request.ts
+++ b/apps/web/src/lib/ai/openai-api/validate-inference-request.ts
@@ -7,6 +7,7 @@ export interface ValidatedInferenceRequest {
   messages: UIMessage[];
   stream: true;
   driveContext?: string;
+  conversationId?: string;
 }
 
 export type ValidationResult =
@@ -86,6 +87,9 @@ export const validateInferenceRequest = (body: unknown): ValidationResult => {
 
   const driveContext = typeof raw.drive_context === 'string' ? raw.drive_context : undefined;
 
+  const rawConvId = typeof raw.conversation_id === 'string' ? raw.conversation_id.trim() : undefined;
+  const conversationId = rawConvId || undefined;
+
   return {
     ok: true,
     data: {
@@ -94,6 +98,7 @@ export const validateInferenceRequest = (body: unknown): ValidationResult => {
       messages: normalized,
       stream: true,
       driveContext,
+      conversationId,
     },
   };
 };

--- a/prototypes/pagespace-chat/package.json
+++ b/prototypes/pagespace-chat/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "pagespace-chat-prototype",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --port 3001",
+    "build": "next build",
+    "start": "next start --port 3001"
+  },
+  "dependencies": {
+    "next": "15.3.1",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/prototypes/pagespace-chat/src/app/api/chat/route.ts
+++ b/prototypes/pagespace-chat/src/app/api/chat/route.ts
@@ -1,0 +1,32 @@
+import { streamChat } from '@/lib/pagespace';
+
+export const runtime = 'nodejs';
+
+export async function POST(request: Request): Promise<Response> {
+  let body: { messages: Array<{ role: 'user' | 'assistant'; content: string }>; conversation_id?: string };
+  try {
+    body = await request.json() as typeof body;
+  } catch {
+    return Response.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  const apiKey = process.env.PAGESPACE_API_KEY;
+  const baseUrl = process.env.PAGESPACE_BASE_URL ?? 'http://localhost:3000';
+  const model = process.env.PAGESPACE_MODEL ?? 'ps-agent://default';
+
+  if (!apiKey) {
+    return Response.json({ error: 'PAGESPACE_API_KEY not configured' }, { status: 500 });
+  }
+
+  const { messages, conversation_id: conversationId } = body;
+
+  const stream = await streamChat({ apiKey, baseUrl, model, messages, conversationId });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    },
+  });
+}

--- a/prototypes/pagespace-chat/src/app/layout.tsx
+++ b/prototypes/pagespace-chat/src/app/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = { title: 'PageSpace Chat Prototype' };
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body style={{ margin: 0, fontFamily: 'system-ui, sans-serif' }}>{children}</body>
+    </html>
+  );
+}

--- a/prototypes/pagespace-chat/src/app/page.tsx
+++ b/prototypes/pagespace-chat/src/app/page.tsx
@@ -1,0 +1,8 @@
+import { ChatShell } from '@/components/ChatShell';
+
+export default function Home() {
+  // Pass activeConvId from a URL param or env var to enable thread mode.
+  // Without it, the prototype operates in OpenAI mode (client sends full history).
+  const activeConvId = process.env.DEMO_CONVERSATION_ID;
+  return <ChatShell activeConvId={activeConvId} />;
+}

--- a/prototypes/pagespace-chat/src/components/ChatShell.tsx
+++ b/prototypes/pagespace-chat/src/components/ChatShell.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useState, useRef, FormEvent } from 'react';
+
+interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+interface ChatShellProps {
+  activeConvId?: string;
+}
+
+export function ChatShell({ activeConvId }: ChatShellProps) {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+  const [streaming, setStreaming] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  async function submit(e: FormEvent) {
+    e.preventDefault();
+    const text = input.trim();
+    if (!text || streaming) return;
+
+    const userMessage: Message = { role: 'user', content: text };
+    setMessages((prev) => [...prev, userMessage]);
+    setInput('');
+    setStreaming(true);
+
+    const abortController = new AbortController();
+    abortRef.current = abortController;
+
+    // In thread mode, send only the latest user message — server loads history.
+    // In openai mode, send the full accumulated history.
+    const history = activeConvId ? [userMessage] : [...messages, userMessage];
+
+    try {
+      const response = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          messages: history,
+          ...(activeConvId ? { conversation_id: activeConvId } : {}),
+        }),
+        signal: abortController.signal,
+      });
+
+      if (!response.ok || !response.body) {
+        throw new Error(`Request failed: ${response.status}`);
+      }
+
+      setMessages((prev) => [...prev, { role: 'assistant', content: '' }]);
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        const chunk = decoder.decode(value, { stream: true });
+        for (const line of chunk.split('\n')) {
+          if (!line.startsWith('data:')) continue;
+          const data = line.slice('data:'.length).trim();
+          if (data === '[DONE]') break;
+          try {
+            const parsed = JSON.parse(data) as { choices?: Array<{ delta?: { content?: string } }> };
+            const delta = parsed.choices?.[0]?.delta?.content;
+            if (delta) {
+              setMessages((prev) => {
+                const next = [...prev];
+                next[next.length - 1] = {
+                  role: 'assistant',
+                  content: (next[next.length - 1]?.content ?? '') + delta,
+                };
+                return next;
+              });
+            }
+          } catch {
+            // skip malformed SSE lines
+          }
+        }
+      }
+    } catch (err) {
+      if ((err as Error).name !== 'AbortError') {
+        setMessages((prev) => [...prev, { role: 'assistant', content: '[Error: request failed]' }]);
+      }
+    } finally {
+      setStreaming(false);
+      abortRef.current = null;
+    }
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', maxWidth: 720, margin: '0 auto', padding: '1rem' }}>
+      {activeConvId && (
+        <div style={{ fontSize: 12, color: '#888', marginBottom: 8 }}>Thread: {activeConvId}</div>
+      )}
+      <div style={{ flex: 1, overflowY: 'auto', marginBottom: '1rem', display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        {messages.map((m, i) => (
+          <div key={i} style={{ alignSelf: m.role === 'user' ? 'flex-end' : 'flex-start', background: m.role === 'user' ? '#0070f3' : '#f0f0f0', color: m.role === 'user' ? '#fff' : '#000', padding: '0.5rem 0.75rem', borderRadius: 8, maxWidth: '80%', whiteSpace: 'pre-wrap' }}>
+            {m.content}
+          </div>
+        ))}
+        {streaming && messages[messages.length - 1]?.role !== 'assistant' && (
+          <div style={{ alignSelf: 'flex-start', color: '#888', fontStyle: 'italic' }}>…</div>
+        )}
+      </div>
+      <form onSubmit={submit} style={{ display: 'flex', gap: '0.5rem' }}>
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Message…"
+          disabled={streaming}
+          style={{ flex: 1, padding: '0.5rem', borderRadius: 4, border: '1px solid #ccc' }}
+        />
+        <button type="submit" disabled={streaming || !input.trim()} style={{ padding: '0.5rem 1rem' }}>
+          {streaming ? '…' : 'Send'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/prototypes/pagespace-chat/src/lib/pagespace.ts
+++ b/prototypes/pagespace-chat/src/lib/pagespace.ts
@@ -1,0 +1,37 @@
+export interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface StreamChatOptions {
+  apiKey: string;
+  baseUrl: string;
+  model: string;
+  messages: Message[];
+  conversationId?: string;
+}
+
+export async function streamChat(options: StreamChatOptions): Promise<ReadableStream<Uint8Array>> {
+  const { apiKey, baseUrl, model, messages, conversationId } = options;
+
+  // In thread mode, only send the latest user message — server loads history from DB
+  const payload = conversationId
+    ? { model, messages: [messages[messages.length - 1]], conversation_id: conversationId }
+    : { model, messages };
+
+  const response = await fetch(`${baseUrl}/api/v1/chat/completions`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok || !response.body) {
+    const errorText = await response.text().catch(() => 'unknown error');
+    throw new Error(`PageSpace API error ${response.status}: ${errorText}`);
+  }
+
+  return response.body;
+}

--- a/prototypes/pagespace-chat/tsconfig.json
+++ b/prototypes/pagespace-chat/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

- \`POST /api/v1/chat/completions\` now accepts an optional \`conversation_id\` in the request body
- **Thread mode** (\`conversation_id\` present): server loads existing messages from the DB via \`chatMessageRepository.getMessagesForPage\`, prepends them to the single new user message from the request, runs inference with full context, and saves only the two new messages under the provided \`conversationId\`
- **OpenAI mode** (\`conversation_id\` absent): existing behavior is completely unchanged — client sends full history, server generates a new \`conversationId\`
- Whitespace-only \`conversation_id\` is treated as absent
- New prototype at \`prototypes/pagespace-chat/\` demonstrates the client-side integration pattern

## Files changed

- \`apps/web/src/lib/ai/openai-api/validate-inference-request.ts\` — adds \`conversationId?: string\` to \`ValidatedInferenceRequest\`, extracts and trims \`raw.conversation_id\`
- \`apps/web/src/app/api/v1/chat/completions/route.ts\` — imports \`chatMessageRepository\` and \`convertDbMessageToUIMessage\`, branches on thread vs OpenAI mode
- \`apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts\` — 4 new integration tests covering thread happy path, empty history, OpenAI mode unchanged, whitespace \`conversation_id\`
- \`apps/web/src/lib/ai/openai-api/__tests__/validate-inference-request.test.ts\` — 2 new unit tests for \`conversationId\` extraction and whitespace handling at the validator level
- \`prototypes/pagespace-chat/\` — standalone Next.js prototype with \`streamChat()\`, \`ChatShell\`, and a route handler

## Test plan

- [x] All 15 route integration tests pass (\`pnpm --filter web test src/app/api/v1/chat/completions/\`)
- [x] All 16 validator unit tests pass (\`pnpm --filter web test src/lib/ai/openai-api/__tests__/validate-inference-request\`)
- [x] No new typecheck errors in changed files
- [x] No new lint errors in changed files
- [x] OpenAI mode existing tests all pass — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)