### PR TITLE
fix(messages): restore absolute toolbar, pre-reserve space on touch for grouped messages

### DIFF
--- a/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
@@ -34,6 +34,7 @@ import { useMobile } from '@/hooks/useMobile';
 import { formatDistanceToNow } from 'date-fns';
 import { isFirstInGroup, formatMessageDate } from '@/lib/messages/grouping';
 import { MessageDateSeparator } from '@/components/messages/MessageDateSeparator';
+import { cn } from '@/lib/utils';
 
 const fetcher = async (url: string) => {
   const response = await fetchWithAuth(url);
@@ -619,7 +620,7 @@ export default function InboxDMPage() {
                     </div>
                   )}
 
-                  <div className="flex-1 min-w-0">
+                  <div className={cn("flex-1 min-w-0", !isFirst && "[@media(hover:none)]:pr-28")}>
                     {isFirst && (
                       <div className="flex items-center gap-2 mb-1">
                         <span className="font-semibold text-sm">{senderName}</span>

--- a/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState, useRef, useCallback, Fragment } from 'react';
 import { useParams } from 'next/navigation';
-import { cn } from '@/lib/utils';
 import { useAuth } from '@/hooks/useAuth';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import {
@@ -620,7 +619,7 @@ export default function InboxDMPage() {
                     </div>
                   )}
 
-                  <div className={cn("flex-1 min-w-0", !isFirst && "group-hover/msg:pr-28 transition-[padding-right] duration-100")}>
+                  <div className="flex-1 min-w-0">
                     {isFirst && (
                       <div className="flex items-center gap-2 mb-1">
                         <span className="font-semibold text-sm">{senderName}</span>

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -37,6 +37,7 @@ import {
 import { isFirstInGroup, formatMessageDate } from '@/lib/messages/grouping';
 import { MessageDateSeparator } from '@/components/messages/MessageDateSeparator';
 import { formatDistanceToNow } from 'date-fns';
+import { cn } from '@/lib/utils';
 
 interface ChannelRef {
   id: string;
@@ -636,7 +637,7 @@ function ChannelView({ page }: ChannelViewProps) {
                                 </span>
                               </div>
                             )}
-                            <div className="flex flex-col min-w-0 flex-1">
+                            <div className={cn("flex flex-col min-w-0 flex-1", !isFirst && "[@media(hover:none)]:pr-28")}>
                                 {isFirst && (
                                   <div className="flex items-center gap-2">
                                       <span className="font-semibold text-sm">{displayName}</span>

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useEffect, useRef, useCallback, memo, Fragment } from 'react';
-import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
 import { usePermissions, getPermissionErrorMessage } from '@/hooks/usePermissions';
@@ -637,7 +636,7 @@ function ChannelView({ page }: ChannelViewProps) {
                                 </span>
                               </div>
                             )}
-                            <div className={cn("flex flex-col min-w-0 flex-1", !isFirst && "group-hover/msg:pr-28 transition-[padding-right] duration-100")}>
+                            <div className="flex flex-col min-w-0 flex-1">
                                 {isFirst && (
                                   <div className="flex items-center gap-2">
                                       <span className="font-semibold text-sm">{displayName}</span>

--- a/apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/thread/ThreadPanel.tsx
@@ -38,6 +38,7 @@ import { useThreadInboxStore } from '@/stores/useThreadInboxStore';
 import type { AttachmentMeta, FileRelation } from '@/lib/attachment-utils';
 import { renderMessageParts, convertToMessageParts } from '@/components/messages/MessagePartRenderer';
 import { useMobileKeyboard } from '@/hooks/useMobileKeyboard';
+import { cn } from '@/lib/utils';
 
 export type ThreadSource = 'channel' | 'dm';
 
@@ -754,7 +755,7 @@ export function ThreadPanel({
                   {author.image && <AvatarImage src={author.image} />}
                   <AvatarFallback>{initial}</AvatarFallback>
                 </Avatar>
-                <div className="min-w-0 flex-1">
+                <div className={cn("min-w-0 flex-1", "[@media(hover:none)]:pr-28")}>
                   <div className="flex items-center gap-2">
                     <span className="text-sm font-semibold">{author.name}</span>
                     <span className="text-xs text-muted-foreground">

--- a/apps/web/src/components/members/__tests__/DriveMembers.test.tsx
+++ b/apps/web/src/components/members/__tests__/DriveMembers.test.tsx
@@ -164,7 +164,7 @@ describe('DriveMembers', () => {
     mockFetchWithAuth.mockImplementation(urlAwareMock([]));
     render(<DriveMembers driveId="drive-1" />);
     await screen.findByText('Members (0)');
-    expect(mockFetchWithAuth).toHaveBeenCalledTimes(FETCHES_PER_CALL);
+    await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalledTimes(FETCHES_PER_CALL));
 
     socket.__emit('drive:member_added', { driveId: 'other' });
     await new Promise((r) => setTimeout(r, 20));

--- a/apps/web/src/components/members/__tests__/DriveMembers.test.tsx
+++ b/apps/web/src/components/members/__tests__/DriveMembers.test.tsx
@@ -152,7 +152,8 @@ describe('DriveMembers', () => {
     mockFetchWithAuth.mockImplementation(urlAwareMock([]));
     render(<DriveMembers driveId="drive-1" />);
     await screen.findByText('Members (0)');
-    expect(mockFetchWithAuth).toHaveBeenCalledTimes(FETCHES_PER_CALL);
+    // DriveShareLinkSection mounts in a useEffect after currentUserRole resolves — wait for it.
+    await waitFor(() => expect(mockFetchWithAuth).toHaveBeenCalledTimes(FETCHES_PER_CALL));
 
     socket.__emit(event, { driveId: 'drive-1' });
     // Socket event only re-triggers fetchMembers() (3 requests); /roles is keyed on driveId, not socket events.

--- a/apps/web/src/components/shared/MessageHoverToolbar.tsx
+++ b/apps/web/src/components/shared/MessageHoverToolbar.tsx
@@ -79,15 +79,16 @@ export function MessageHoverToolbar({
   return (
     <div
       className={cn(
-        'absolute -top-3 right-2 z-10',
+        'shrink-0 self-start',
         'flex items-center gap-0.5 p-0.5',
         'rounded-md border border-border bg-popover shadow-sm',
         // Hover devices: hidden by default, shown on hover/focus or when picker is open.
         // Touch / no-hover devices: always visible so message actions remain reachable.
         'opacity-0 group-hover/msg:opacity-100 focus-within:opacity-100',
-        '[@media(hover:none)]:opacity-100',
+        'pointer-events-none group-hover/msg:pointer-events-auto focus-within:pointer-events-auto',
+        '[@media(hover:none)]:opacity-100 [@media(hover:none)]:pointer-events-auto',
         'transition-opacity',
-        pickerOpen && 'opacity-100',
+        pickerOpen && 'opacity-100 pointer-events-auto',
         className,
       )}
     >

--- a/apps/web/src/components/shared/MessageHoverToolbar.tsx
+++ b/apps/web/src/components/shared/MessageHoverToolbar.tsx
@@ -79,7 +79,7 @@ export function MessageHoverToolbar({
   return (
     <div
       className={cn(
-        'shrink-0 self-start',
+        'shrink-0',
         'flex items-center gap-0.5 p-0.5',
         'rounded-md border border-border bg-popover shadow-sm',
         // Hover devices: hidden by default, shown on hover/focus or when picker is open.

--- a/apps/web/src/components/shared/MessageHoverToolbar.tsx
+++ b/apps/web/src/components/shared/MessageHoverToolbar.tsx
@@ -79,7 +79,7 @@ export function MessageHoverToolbar({
   return (
     <div
       className={cn(
-        'shrink-0',
+        'absolute -top-3 right-2 z-10',
         'flex items-center gap-0.5 p-0.5',
         'rounded-md border border-border bg-popover shadow-sm',
         // Hover devices: hidden by default, shown on hover/focus or when picker is open.


### PR DESCRIPTION
## Summary

- Restores `absolute -top-3 right-2 z-10` positioning on `MessageHoverToolbar` — toolbar no longer lives in the flex flow, so message text always gets full width
- For grouped messages on touch/no-hover devices (mobile, iPad), adds `[@media(hover:none)]:pr-28` to the content div — pre-reserves 112px on the right so the always-visible toolbar has a clear zone and never overlaps text
- Initial messages (with author header) don't need the padding — the header already provides vertical separation from the toolbar

**Why this works:**
- Desktop hover: toolbar appears briefly on hover in an absolute overlay — Slack-style, acceptable
- Mobile/touch: toolbar is permanently visible, but text wraps 112px from the right edge, clearing the ~108px toolbar zone

**Why previous approaches failed:**
- PR #1388 (`absolute` + `pr-28` always): `@media(hover:none)` only targets the static case; brief overlap still happened at medium widths on hover
- PR #1389 (flex sibling): no overlap ever, but permanently narrowed text by ~100px on all devices

## Test plan

- [ ] DM with consecutive messages from same sender — grouped messages show full-width text on desktop
- [ ] Hover over a grouped message on desktop — toolbar appears without covering text
- [ ] Mobile viewport (or devtools touch emulation) — toolbar always visible, text wraps clear of toolbar zone
- [ ] iPad viewport — same as mobile check
- [ ] Initial messages (with author header) — unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Optimized message row spacing and padding to improve usability on touch/no-hover devices
  * Adjusted message hover toolbar positioning for clearer visual hierarchy and consistent overlay behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1391?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->