### PR TITLE
fix(ai): assign drive role when create_page tool creates an agent

### DIFF
--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -12,6 +12,8 @@ import { computePageStateHash, createPageVersion } from '@pagespace/lib/services
 import { pageRepository } from '@pagespace/lib/repositories/page-repository';
 import { driveRepository } from '@pagespace/lib/repositories/drive-repository';
 import { createChangeGroupId } from '@pagespace/lib/monitoring/change-group';
+import { db } from '@pagespace/db/db';
+import { driveAgentMembers } from '@pagespace/db/schema/members';
 import { applyPageMutation, type PageMutationContext } from '@/services/api/page-mutation-service';
 import { broadcastPageEvent, createPageEventPayload, broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket';
 import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
@@ -597,6 +599,17 @@ export const pageWriteTools = {
           stateHash,
           updatedAt: new Date(),
         });
+
+        // AI_CHAT pages are agents — they need a drive membership to act with
+        // permissions. Without this row the agent has no role and is denied access.
+        if (isAIChatPage(type as PageType)) {
+          await db.insert(driveAgentMembers).values({
+            driveId: drive.id,
+            agentPageId: newPage.id,
+            role: 'MEMBER',
+            addedBy: userId,
+          });
+        }
 
         await createPageVersion({
           pageId: newPage.id,


### PR DESCRIPTION
The create_page AI tool inserted an AI_CHAT page but never created a
driveAgentMembers row, so agents created via tool call had no role and
were denied access. The /api/ai/page-agents/create route already does
this; this brings the tool path in line.

https://claude.ai/code/session_01Ls7FbL2kFcxdAhSYb8sVJx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI agent membership is now automatically configured when creating AI chat pages, ensuring proper access control and agent setup without requiring manual configuration steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1394?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->