### PR TITLE
fix(editor): guard TipTap commands against destroyed editor

### DIFF
--- a/apps/web/src/components/editors/LinkButton.tsx
+++ b/apps/web/src/components/editors/LinkButton.tsx
@@ -30,25 +30,11 @@ const LinkButton = ({ editor, variant = 'toolbar' }: LinkButtonProps) => {
   const [value, setValue] = React.useState('');
   const inputId = React.useId();
 
-  if (!editor || editor.isDestroyed) return null;
-
-  const isActive = editor.isActive('link');
-  const submittable = Boolean(normalizeUrl(value));
-
-  const handleOpenChange = (next: boolean) => {
-    if (next) {
-      const existing = (editor.getAttributes('link').href as string | undefined) ?? '';
-      setValue(existing);
-    }
-    setOpen(next);
-  };
-
   // Bind Mod-K to open the popover from the toolbar instance only — the bubble
   // menu's instance is unmounted when there's no selection, and we want a
   // single, predictable handler regardless of selection state.
   React.useEffect(() => {
-    if (variant !== 'toolbar') return;
-    if (!editor || editor.isDestroyed) return;
+    if (variant !== 'toolbar' || !editor || editor.isDestroyed) return;
     const root = editor.view.dom as HTMLElement;
     const onKeyDown = (event: KeyboardEvent) => {
       if ((event.metaKey || event.ctrlKey) && (event.key === 'k' || event.key === 'K')) {
@@ -61,6 +47,19 @@ const LinkButton = ({ editor, variant = 'toolbar' }: LinkButtonProps) => {
     root.addEventListener('keydown', onKeyDown);
     return () => root.removeEventListener('keydown', onKeyDown);
   }, [editor, variant]);
+
+  if (!editor || editor.isDestroyed) return null;
+
+  const isActive = editor.isActive('link');
+  const submittable = Boolean(normalizeUrl(value));
+
+  const handleOpenChange = (next: boolean) => {
+    if (next) {
+      const existing = (editor.getAttributes('link').href as string | undefined) ?? '';
+      setValue(existing);
+    }
+    setOpen(next);
+  };
 
   const apply = () => {
     const href = normalizeUrl(value);

--- a/apps/web/src/components/editors/LinkButton.tsx
+++ b/apps/web/src/components/editors/LinkButton.tsx
@@ -8,7 +8,7 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 
 interface LinkButtonProps {
-  editor: Editor;
+  editor: Editor | null;
   variant?: 'toolbar' | 'bubble';
 }
 
@@ -30,6 +30,8 @@ const LinkButton = ({ editor, variant = 'toolbar' }: LinkButtonProps) => {
   const [value, setValue] = React.useState('');
   const inputId = React.useId();
 
+  if (!editor || editor.isDestroyed) return null;
+
   const isActive = editor.isActive('link');
   const submittable = Boolean(normalizeUrl(value));
 
@@ -46,6 +48,7 @@ const LinkButton = ({ editor, variant = 'toolbar' }: LinkButtonProps) => {
   // single, predictable handler regardless of selection state.
   React.useEffect(() => {
     if (variant !== 'toolbar') return;
+    if (!editor || editor.isDestroyed) return;
     const root = editor.view.dom as HTMLElement;
     const onKeyDown = (event: KeyboardEvent) => {
       if ((event.metaKey || event.ctrlKey) && (event.key === 'k' || event.key === 'K')) {

--- a/apps/web/src/components/editors/RichEditor.tsx
+++ b/apps/web/src/components/editors/RichEditor.tsx
@@ -176,7 +176,7 @@ const RichEditor = ({ value, onChange, onEditorChange, readOnly = false, isPagin
   }, [editor]);
 
   useEffect(() => {
-    if (editor) {
+    if (editor && !editor.isDestroyed) {
       const currentSerialized = serializeEditorContent(editor, isMarkdownMode);
       // Check if value is empty and current content is just the default empty state
       const isEmptyValue = !value || value.trim() === '';
@@ -254,7 +254,7 @@ const RichEditor = ({ value, onChange, onEditorChange, readOnly = false, isPagin
   useEffect(() => {
     onEditorChange(editor);
     // Blur the editor if it's read-only to prevent focus
-    if (editor && readOnly && isEditorViewMounted) {
+    if (editor && !editor.isDestroyed && readOnly && isEditorViewMounted) {
       editor.commands.blur();
     }
     return () => {

--- a/apps/web/src/components/editors/RichEditor.tsx
+++ b/apps/web/src/components/editors/RichEditor.tsx
@@ -264,7 +264,7 @@ const RichEditor = ({ value, onChange, onEditorChange, readOnly = false, isPagin
 
   return (
     <div className="relative flex flex-col w-full h-full">
-      {editor && isEditorViewMounted && !readOnly && (
+      {editor && !editor.isDestroyed && isEditorViewMounted && !readOnly && (
         <BubbleMenu
           editor={editor}
           pluginKey="bubbleMenu"
@@ -285,7 +285,7 @@ const RichEditor = ({ value, onChange, onEditorChange, readOnly = false, isPagin
           <button onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()} className={`p-2 rounded ${editor.isActive('heading', { level: 3 }) ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'}`}><Heading3 size={16} /></button>
         </BubbleMenu>
       )}
-      {editor && isEditorViewMounted && !readOnly && (
+      {editor && !editor.isDestroyed && isEditorViewMounted && !readOnly && (
         <FloatingMenu
           editor={editor}
           pluginKey="floatingMenu"

--- a/apps/web/src/components/editors/Toolbar.tsx
+++ b/apps/web/src/components/editors/Toolbar.tsx
@@ -109,7 +109,7 @@ const Toolbar = ({ editor, contentMode = 'html' }: ToolbarProps) => {
     };
   }, [editor]);
 
-  if (!editor) {
+  if (!editor || editor.isDestroyed) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

- Fixes crash `Cannot read properties of null (reading 'commands')` / `null is not an object (evaluating 'this.commandManager.commands')` that triggers the Layout Error Boundary when navigating away from a document page
- TipTap destroys the editor on unmount but `LinkButton`, `Toolbar`, and `RichEditor` could still call `.commands`, `.isActive()`, `.chain()` etc. before React finishes cleanup — `commandManager` is null on a destroyed editor
- Added `editor.isDestroyed` guards at every command call site in the three affected components

## Test plan

- [ ] Open a document page, navigate to another page — Layout Error Boundary should no longer appear
- [ ] Open a document, use bold/italic/link toolbar, navigate away — no crash
- [ ] `bun run --filter 'web' build` passes with no TypeScript errors
- [ ] `bun run test:unit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)