### PR TITLE
fix(sidebar): show AI chat on all action pages

### DIFF
--- a/apps/web/src/hooks/useDashboardContext.ts
+++ b/apps/web/src/hooks/useDashboardContext.ts
@@ -4,7 +4,7 @@ import { useParams, usePathname } from 'next/navigation';
 
 // Full-page routes that render their own content in the center panel
 // (no GlobalAssistantView). The sidebar should show the chat tab for these.
-const FULL_PAGE_ROUTE_PATTERN = /\/(calendar|drives|tasks|dms|channels)(\/|$)/;
+const FULL_PAGE_ROUTE_PATTERN = /\/(activity|calendar|channels|connections|dms|drives|files|members|storage|tasks|trash|workflows)(\/|$)/;
 
 /**
  * Hook to detect if we're on a "dashboard context" where GlobalAssistantView
@@ -17,8 +17,10 @@ const FULL_PAGE_ROUTE_PATTERN = /\/(calendar|drives|tasks|dms|channels)(\/|$)/;
  * NOT dashboard context:
  * - /dashboard/[driveId]/[pageId] (viewing a specific page)
  * - /dashboard/[driveId]/settings (settings pages)
+ * - /dashboard/activity, /dashboard/trash, /dashboard/storage, /dashboard/connections (full-page routes)
  * - /dashboard/calendar, /dashboard/tasks, /dashboard/dms, /dashboard/channels (full-page routes)
- * - /dashboard/[driveId]/calendar, etc. (drive-level full-page routes)
+ * - /dashboard/[driveId]/activity, /dashboard/[driveId]/trash, /dashboard/[driveId]/workflows (drive-level full-page routes)
+ * - /dashboard/[driveId]/files, /dashboard/[driveId]/members, /dashboard/[driveId]/calendar, etc.
  */
 export function useDashboardContext() {
   const params = useParams();


### PR DESCRIPTION
## Summary

- `useDashboardContext` had a stale `FULL_PAGE_ROUTE_PATTERN` that only covered 5 route segments (`calendar`, `drives`, `tasks`, `dms`, `channels`)
- Routes like `activity`, `trash`, `workflows`, `files`, `members`, `storage`, and `connections` were incorrectly treated as "dashboard context"
- This caused the Chat tab to be hidden in the right sidebar on all those pages at both the dashboard and drive level

## Affected pages (now fixed)

**Dashboard-level:** `/dashboard/activity`, `/dashboard/trash`, `/dashboard/storage`, `/dashboard/connections`, `/dashboard/drives`

**Drive-level:** `/dashboard/[driveId]/activity`, `/dashboard/[driveId]/trash`, `/dashboard/[driveId]/workflows`, `/dashboard/[driveId]/files`, `/dashboard/[driveId]/members`

## Test plan

- [ ] Navigate to `/dashboard/trash` — Chat tab visible in right sidebar
- [ ] Navigate to `/dashboard/activity` — Chat tab visible
- [ ] Open a drive → Trash — Chat tab visible
- [ ] Open a drive → Activity — Chat tab visible
- [ ] Open a drive → Workflows — Chat tab visible
- [ ] Open a drive → Files — Chat tab visible
- [ ] Open a drive → Members — Chat tab visible
- [ ] Open `/dashboard` root — Chat tab still hidden (GlobalAssistantView in center)
- [ ] Open `/dashboard/[driveId]` root — Chat tab still hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* **Enhanced dashboard layout optimization** - Refined route detection to properly exclude the assistant panel from activity, calendar, channels, connections, DMs, drives, files, members, storage, tasks, trash, and workflow pages, improving the full-page viewing experience on these sections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->