### PR TITLE
fix(ai): fix co-mounted agent panel conflicts (stream stealing, message sync, bootstrap double-consume)

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -38,6 +38,7 @@ import { applyMessageEdit } from '@/lib/ai/streams/applyMessageEdit';
 import { applyMessageDelete } from '@/lib/ai/streams/applyMessageDelete';
 import { shouldRefreshAfterUndo } from '@/lib/ai/streams/shouldRefreshAfterUndo';
 import { shouldPrependConversation } from '@/lib/ai/streams/shouldPrependConversation';
+import { shouldReloadOnComountComplete } from '@/lib/ai/streams/shouldReloadOnComountComplete';
 import { getBrowserSessionId } from '@/lib/ai/core/browser-session-id';
 import { useShallow } from 'zustand/react/shallow';
 
@@ -387,14 +388,20 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
     onConversationDeleted: () => {
       refreshConversations();
     },
-    onStreamComplete: (messageId) => {
+    onStreamComplete: (messageId, completedConvId) => {
       const stream = usePendingStreamsStore.getState().streams.get(messageId);
-      if (!stream || stream.parts.length === 0) return;
 
-      if (stream.conversationId === currentConversationId) {
+      if (stream && stream.parts.length > 0 && stream.conversationId === currentConversationId) {
         setMessages((prev) => [...prev, synthesizeAssistantMessage(messageId, stream.parts)]);
         return;
       }
+
+      if (shouldReloadOnComountComplete(stream, completedConvId, currentConversationId)) {
+        void loadConversation(completedConvId!);
+        return;
+      }
+
+      if (!stream || stream.parts.length === 0) return;
 
       if (currentConversationId === `${page.id}-default`) {
         const { parts, conversationId: streamConvId } = stream;

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -209,8 +209,7 @@ const SidebarChatTab: React.FC = () => {
   // ============================================
   // Agent Chat Configuration
   // ============================================
-  // Namespace prevents the module-level activeStreams Map from colliding with the
-  // middle panel's entry when both surfaces view the same conversationId.
+  // Namespaced key prevents activeStreams collision when both panels view the same conversationId.
   const sidebarChatId = agentConversationId ? `sidebar:${agentConversationId}` : null;
   const agentTransport = useChatTransport(sidebarChatId, '/api/ai/chat');
 

--- a/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
+++ b/apps/web/src/components/layout/right-sidebar/ai-assistant/SidebarChatTab.tsx
@@ -209,7 +209,10 @@ const SidebarChatTab: React.FC = () => {
   // ============================================
   // Agent Chat Configuration
   // ============================================
-  const agentTransport = useChatTransport(agentConversationId, '/api/ai/chat');
+  // Namespace prevents the module-level activeStreams Map from colliding with the
+  // middle panel's entry when both surfaces view the same conversationId.
+  const sidebarChatId = agentConversationId ? `sidebar:${agentConversationId}` : null;
+  const agentTransport = useChatTransport(sidebarChatId, '/api/ai/chat');
 
   const agentChatConfig = useMemo(() => {
     if (!selectedAgent || !agentConversationId || !agentTransport) return null;

--- a/apps/web/src/contexts/__tests__/GlobalChatContext.test.tsx
+++ b/apps/web/src/contexts/__tests__/GlobalChatContext.test.tsx
@@ -102,6 +102,11 @@ vi.mock('@/lib/ai/core/browser-session-id', () => ({
   getBrowserSessionId: mockGetBrowserSessionId,
 }));
 
+vi.mock('@/lib/ai/streams/bootstrapConsumerGuard', () => ({
+  claimBootstrapConsumer: vi.fn(() => true),
+  releaseBootstrapConsumer: vi.fn(),
+}));
+
 const mockFetchWithAuth = vi.fn();
 vi.mock('@/lib/auth/auth-fetch', () => ({
   fetchWithAuth: (...args: unknown[]) => mockFetchWithAuth(...args),

--- a/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
+++ b/apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts
@@ -88,6 +88,11 @@ vi.mock('@/lib/ai/core/browser-session-id', () => ({
   getBrowserSessionId: mockGetBrowserSessionId,
 }));
 
+vi.mock('@/lib/ai/streams/bootstrapConsumerGuard', () => ({
+  claimBootstrapConsumer: vi.fn(() => true),
+  releaseBootstrapConsumer: vi.fn(),
+}));
+
 import { useChannelStreamSocket } from '../useChannelStreamSocket';
 import type {
   AiStreamStartPayload,
@@ -109,6 +114,7 @@ const START_PAYLOAD: AiStreamStartPayload = {
 const COMPLETE_PAYLOAD: AiStreamCompletePayload = {
   messageId: 'msg-1',
   pageId: 'page-a',
+  conversationId: 'conv-1',
 };
 
 const USER_MESSAGE_PAYLOAD: ChatUserMessagePayload = {
@@ -218,7 +224,7 @@ describe('useChannelStreamSocket', () => {
       await act(async () => { resolveJoin(); });
 
       expect(mockRemoveStream).toHaveBeenCalledWith('msg-1');
-      expect(onStreamComplete).toHaveBeenCalledWith('msg-1');
+      expect(onStreamComplete).toHaveBeenCalledWith('msg-1', 'conv-1');
     });
 
     it('should call onStreamComplete before removeStream so stream data is available in the callback (SSE path)', async () => {
@@ -539,7 +545,7 @@ describe('useChannelStreamSocket', () => {
       act(() => { mockSocket._trigger('chat:stream_complete', COMPLETE_PAYLOAD); });
 
       expect(mockRemoveStream).toHaveBeenCalledWith('msg-1');
-      expect(onStreamComplete).toHaveBeenCalledWith('msg-1');
+      expect(onStreamComplete).toHaveBeenCalledWith('msg-1', 'conv-1');
     });
 
     it('should call onStreamComplete before removeStream so stream data is available in the callback (socket path)', () => {
@@ -681,7 +687,7 @@ describe('useChannelStreamSocket', () => {
       await act(async () => { resolveJoin(); });
 
       expect(firstCallback).not.toHaveBeenCalled();
-      expect(secondCallback).toHaveBeenCalledWith('msg-1');
+      expect(secondCallback).toHaveBeenCalledWith('msg-1', 'conv-1');
     });
   });
 

--- a/apps/web/src/hooks/useAgentChannelMultiplayer.ts
+++ b/apps/web/src/hooks/useAgentChannelMultiplayer.ts
@@ -15,6 +15,7 @@ import {
   shouldRefreshOnReconnect,
   type ConnectionStatus,
 } from '@/lib/ai/streams/shouldRefreshOnReconnect';
+import { shouldReloadOnComountComplete } from '@/lib/ai/streams/shouldReloadOnComountComplete';
 
 export interface UseAgentChannelMultiplayerOptions {
   selectedAgent: { id: string } | null;
@@ -112,14 +113,18 @@ export function useAgentChannelMultiplayer({
       if (payload.conversationId !== agentConversationIdRef.current) return;
       setLocalMessagesRef.current((prev) => applyMessageDelete(prev, payload.messageId));
     },
-    onStreamComplete: (messageId) => {
+    onStreamComplete: (messageId, completedConvId) => {
       const stream = usePendingStreamsStore.getState().streams.get(messageId);
-      if (!stream || stream.parts.length === 0) return;
-      if (stream.conversationId !== agentConversationIdRef.current) return;
-      setLocalMessagesRef.current((prev) => [
-        ...prev,
-        synthesizeAssistantMessage(messageId, stream.parts),
-      ]);
+      if (stream && stream.parts.length > 0 && stream.conversationId === agentConversationIdRef.current) {
+        setLocalMessagesRef.current((prev) => [
+          ...prev,
+          synthesizeAssistantMessage(messageId, stream.parts),
+        ]);
+        return;
+      }
+      if (shouldReloadOnComountComplete(stream, completedConvId, agentConversationIdRef.current)) {
+        loadConversationRef.current(completedConvId!);
+      }
     },
     onOwnStreamBootstrap: ({ messageId }) => {
       const dashboard = usePageAgentDashboardStore.getState();

--- a/apps/web/src/hooks/useChannelStreamSocket.ts
+++ b/apps/web/src/hooks/useChannelStreamSocket.ts
@@ -6,6 +6,7 @@ import { getBrowserSessionId } from '@/lib/ai/core/browser-session-id';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { isOwnStream } from '@/lib/ai/streams/isOwnStream';
 import { shouldSkipBootstrappedStream } from '@/lib/ai/streams/shouldSkipBootstrappedStream';
+import { claimBootstrapConsumer, releaseBootstrapConsumer } from '@/lib/ai/streams/bootstrapConsumerGuard';
 import type {
   AiStreamStartPayload,
   AiStreamCompletePayload,
@@ -148,6 +149,7 @@ export function useChannelStreamSocket(
     };
 
     const startConsume = (messageId: string, conversationId?: string) => {
+      if (!claimBootstrapConsumer(messageId)) return;
       const controller = new AbortController();
       controllers.set(messageId, controller);
 
@@ -159,6 +161,7 @@ export function useChannelStreamSocket(
           // asynchronously after controller.abort(); skip post-teardown effects.
           if (cancelled) return;
           controllers.delete(messageId);
+          releaseBootstrapConsumer(messageId);
           try {
             fireComplete(messageId, conversationId);
           } finally {
@@ -169,6 +172,7 @@ export function useChannelStreamSocket(
         .catch((err) => {
           if (cancelled) return;
           controllers.delete(messageId);
+          releaseBootstrapConsumer(messageId);
           // Mark as processed so a subsequent chat:stream_complete event for
           // the same messageId is a no-op for onStreamComplete: the catch
           // path already finalized this stream locally.
@@ -309,8 +313,9 @@ export function useChannelStreamSocket(
       socket.off('chat:conversation_added', handleConversationAdded);
       socket.off('chat:conversation_renamed', handleConversationRenamed);
       socket.off('chat:conversation_deleted', handleConversationDeleted);
-      for (const controller of controllers.values()) {
+      for (const [msgId, controller] of controllers.entries()) {
         controller.abort();
+        releaseBootstrapConsumer(msgId);
       }
       clearPageStreams(channelId);
     };

--- a/apps/web/src/hooks/useChannelStreamSocket.ts
+++ b/apps/web/src/hooks/useChannelStreamSocket.ts
@@ -27,7 +27,7 @@ interface ActiveStreamRow {
 
 export interface UseChannelStreamSocketOptions {
   /** Fires once per messageId on clean finalize (SSE resolve or socket complete); NOT on SSE error. */
-  onStreamComplete?: (messageId: string) => void;
+  onStreamComplete?: (messageId: string, conversationId?: string) => void;
   /** Fires once per messageId when DB bootstrap finds an in-flight stream from this browser session. */
   onOwnStreamBootstrap?: (event: { messageId: string }) => void;
   /** Fires once per own-bootstrapped messageId on any finalize path (resolve, complete, or error). */
@@ -135,10 +135,10 @@ export function useChannelStreamSocket(
     const { addStream, appendPart, removeStream, clearPageStreams } =
       usePendingStreamsStore.getState();
 
-    const fireComplete = (messageId: string) => {
+    const fireComplete = (messageId: string, conversationId?: string) => {
       if (processed.has(messageId)) return;
       processed.add(messageId);
-      onStreamCompleteRef.current?.(messageId);
+      onStreamCompleteRef.current?.(messageId, conversationId);
     };
 
     const fireOwnFinalize = (messageId: string) => {
@@ -147,7 +147,7 @@ export function useChannelStreamSocket(
       onOwnStreamFinalizeRef.current?.({ messageId });
     };
 
-    const startConsume = (messageId: string) => {
+    const startConsume = (messageId: string, conversationId?: string) => {
       const controller = new AbortController();
       controllers.set(messageId, controller);
 
@@ -160,7 +160,7 @@ export function useChannelStreamSocket(
           if (cancelled) return;
           controllers.delete(messageId);
           try {
-            fireComplete(messageId);
+            fireComplete(messageId, conversationId);
           } finally {
             removeStream(messageId);
             fireOwnFinalize(messageId);
@@ -207,7 +207,7 @@ export function useChannelStreamSocket(
             ownStreamIds.add(stream.messageId);
             onOwnStreamBootstrapRef.current?.({ messageId: stream.messageId });
           }
-          startConsume(stream.messageId);
+          startConsume(stream.messageId, stream.conversationId);
         }
       } catch (err) {
         if (cancelled) return;
@@ -228,7 +228,7 @@ export function useChannelStreamSocket(
         isOwn: false,
       });
 
-      startConsume(payload.messageId);
+      startConsume(payload.messageId, payload.conversationId);
     };
 
     const handleStreamComplete = (payload: AiStreamCompletePayload) => {
@@ -239,7 +239,7 @@ export function useChannelStreamSocket(
         controllers.delete(payload.messageId);
       }
       try {
-        fireComplete(payload.messageId);
+        fireComplete(payload.messageId, payload.conversationId);
       } finally {
         removeStream(payload.messageId);
         fireOwnFinalize(payload.messageId);

--- a/apps/web/src/lib/ai/core/__tests__/stream-abort-client.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stream-abort-client.test.ts
@@ -233,4 +233,42 @@ describe('stream-abort-client', () => {
     });
   });
 
+  describe('co-mount collision — same chatId from two surfaces', () => {
+    it('given two surfaces use the same chatId, second setActiveStreamId overwrites the first', async () => {
+      const client = await import('../stream-abort-client');
+
+      // Surface A (middle panel) registers its stream
+      client.setActiveStreamId({ chatId: 'conv-xyz', streamId: 'middle-stream-A' });
+
+      // Surface B (sidebar) registers with the same chatId — this is the bug
+      client.setActiveStreamId({ chatId: 'conv-xyz', streamId: 'sidebar-stream-B' });
+
+      // Middle panel's stop lookup now targets the sidebar's stream (wrong!)
+      const storedId = client.getActiveStreamId({ chatId: 'conv-xyz' });
+      expect(storedId).toBe('sidebar-stream-B');
+    });
+
+    it('given two surfaces use distinct chatIds, each surface retains its own entry', async () => {
+      const client = await import('../stream-abort-client');
+
+      client.setActiveStreamId({ chatId: 'conv-xyz', streamId: 'middle-stream-A' });
+      client.setActiveStreamId({ chatId: 'sidebar:conv-xyz', streamId: 'sidebar-stream-B' });
+
+      expect(client.getActiveStreamId({ chatId: 'conv-xyz' })).toBe('middle-stream-A');
+      expect(client.getActiveStreamId({ chatId: 'sidebar:conv-xyz' })).toBe('sidebar-stream-B');
+    });
+
+    it('given distinct chatIds, clearing sidebar entry does not affect middle panel entry', async () => {
+      const client = await import('../stream-abort-client');
+
+      client.setActiveStreamId({ chatId: 'conv-xyz', streamId: 'middle-stream-A' });
+      client.setActiveStreamId({ chatId: 'sidebar:conv-xyz', streamId: 'sidebar-stream-B' });
+
+      client.clearActiveStreamId({ chatId: 'sidebar:conv-xyz' });
+
+      expect(client.getActiveStreamId({ chatId: 'conv-xyz' })).toBe('middle-stream-A');
+      expect(client.getActiveStreamId({ chatId: 'sidebar:conv-xyz' })).toBeUndefined();
+    });
+  });
+
 });

--- a/apps/web/src/lib/ai/core/__tests__/stream-lifecycle.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/stream-lifecycle.test.ts
@@ -237,6 +237,7 @@ describe('createStreamLifecycle', () => {
       expect(mockBroadcastComplete).toHaveBeenCalledWith({
         messageId: 'msg-1',
         pageId: 'page-1',
+        conversationId: 'conv-1',
         aborted: false,
       });
     });
@@ -254,6 +255,7 @@ describe('createStreamLifecycle', () => {
       expect(mockBroadcastComplete).toHaveBeenCalledWith({
         messageId: 'msg-1',
         pageId: 'page-1',
+        conversationId: 'conv-1',
         aborted: true,
       });
     });

--- a/apps/web/src/lib/ai/core/stream-lifecycle.ts
+++ b/apps/web/src/lib/ai/core/stream-lifecycle.ts
@@ -117,6 +117,7 @@ export const createStreamLifecycle = async (
     broadcastAiStreamComplete({
       messageId,
       pageId: channelId,
+      conversationId,
       aborted,
     }).catch(() => {});
   };

--- a/apps/web/src/lib/ai/streams/__tests__/bootstrapConsumerGuard.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/bootstrapConsumerGuard.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+describe('bootstrapConsumerGuard', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('given a messageId not yet claimed, claimBootstrapConsumer should return true', async () => {
+    const { claimBootstrapConsumer } = await import('../bootstrapConsumerGuard');
+    expect(claimBootstrapConsumer('msg-1')).toBe(true);
+  });
+
+  it('given a messageId already claimed, second call should return false', async () => {
+    const { claimBootstrapConsumer } = await import('../bootstrapConsumerGuard');
+    claimBootstrapConsumer('msg-1');
+    expect(claimBootstrapConsumer('msg-1')).toBe(false);
+  });
+
+  it('given two different messageIds, each should claim independently', async () => {
+    const { claimBootstrapConsumer } = await import('../bootstrapConsumerGuard');
+    expect(claimBootstrapConsumer('msg-A')).toBe(true);
+    expect(claimBootstrapConsumer('msg-B')).toBe(true);
+  });
+
+  it('given a released messageId, it can be claimed again', async () => {
+    const { claimBootstrapConsumer, releaseBootstrapConsumer } = await import('../bootstrapConsumerGuard');
+    claimBootstrapConsumer('msg-1');
+    releaseBootstrapConsumer('msg-1');
+    expect(claimBootstrapConsumer('msg-1')).toBe(true);
+  });
+
+  it('given unmount mid-stream, release should allow a fresh surface to take over', async () => {
+    const { claimBootstrapConsumer, releaseBootstrapConsumer } = await import('../bootstrapConsumerGuard');
+
+    // Surface A claims
+    expect(claimBootstrapConsumer('msg-1')).toBe(true);
+
+    // Surface A unmounts — releases the claim
+    releaseBootstrapConsumer('msg-1');
+
+    // Surface B (remounted) can now claim
+    expect(claimBootstrapConsumer('msg-1')).toBe(true);
+  });
+});

--- a/apps/web/src/lib/ai/streams/__tests__/shouldReloadOnComountComplete.test.ts
+++ b/apps/web/src/lib/ai/streams/__tests__/shouldReloadOnComountComplete.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { shouldReloadOnComountComplete } from '../shouldReloadOnComountComplete';
+import type { PendingStream } from '@/stores/usePendingStreamsStore';
+
+const makeStream = (overrides: Partial<PendingStream> = {}): PendingStream => ({
+  messageId: 'msg-1',
+  pageId: 'page-1',
+  conversationId: 'conv-xyz',
+  triggeredBy: { userId: 'u1', displayName: 'Alice' },
+  parts: [{ type: 'text', text: 'hello' }],
+  isOwn: false,
+  ...overrides,
+});
+
+describe('shouldReloadOnComountComplete', () => {
+  it('given no pending stream and matching conversationId, should return true', () => {
+    expect(shouldReloadOnComountComplete(undefined, 'conv-xyz', 'conv-xyz')).toBe(true);
+  });
+
+  it('given a pending stream with parts and matching conversationId, should return false', () => {
+    const stream = makeStream({ conversationId: 'conv-xyz' });
+    expect(shouldReloadOnComountComplete(stream, 'conv-xyz', 'conv-xyz')).toBe(false);
+  });
+
+  it('given a pending stream with no parts, should return true (treat as missing)', () => {
+    const stream = makeStream({ parts: [] });
+    expect(shouldReloadOnComountComplete(stream, 'conv-xyz', 'conv-xyz')).toBe(true);
+  });
+
+  it('given completedConvId does not match active conversation, should return false', () => {
+    expect(shouldReloadOnComountComplete(undefined, 'conv-other', 'conv-xyz')).toBe(false);
+  });
+
+  it('given completedConvId is undefined, should return false', () => {
+    expect(shouldReloadOnComountComplete(undefined, undefined, 'conv-xyz')).toBe(false);
+  });
+
+  it('given activeConversationId is null, should return false', () => {
+    expect(shouldReloadOnComountComplete(undefined, 'conv-xyz', null)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/ai/streams/bootstrapConsumerGuard.ts
+++ b/apps/web/src/lib/ai/streams/bootstrapConsumerGuard.ts
@@ -1,15 +1,4 @@
-/**
- * Module-level registry that prevents two co-mounted useChannelStreamSocket
- * instances from both consuming the same bootstrapped in-flight stream.
- *
- * On a page reload mid-stream, both the middle panel and sidebar call the
- * bootstrap API and find the same in-flight messageId. Without this guard,
- * both would call startConsume, doubling appendPart calls and producing
- * corrupted ghost text in usePendingStreamsStore.
- *
- * The claim is released on SSE resolve/reject and on unmount so that a
- * remounted surface can take over if the original consumer navigates away.
- */
+// Guards against two co-mounted useChannelStreamSocket instances both SSE-joining the same bootstrapped stream.
 const activeConsumers = new Set<string>();
 
 export function claimBootstrapConsumer(messageId: string): boolean {

--- a/apps/web/src/lib/ai/streams/bootstrapConsumerGuard.ts
+++ b/apps/web/src/lib/ai/streams/bootstrapConsumerGuard.ts
@@ -1,0 +1,23 @@
+/**
+ * Module-level registry that prevents two co-mounted useChannelStreamSocket
+ * instances from both consuming the same bootstrapped in-flight stream.
+ *
+ * On a page reload mid-stream, both the middle panel and sidebar call the
+ * bootstrap API and find the same in-flight messageId. Without this guard,
+ * both would call startConsume, doubling appendPart calls and producing
+ * corrupted ghost text in usePendingStreamsStore.
+ *
+ * The claim is released on SSE resolve/reject and on unmount so that a
+ * remounted surface can take over if the original consumer navigates away.
+ */
+const activeConsumers = new Set<string>();
+
+export function claimBootstrapConsumer(messageId: string): boolean {
+  if (activeConsumers.has(messageId)) return false;
+  activeConsumers.add(messageId);
+  return true;
+}
+
+export function releaseBootstrapConsumer(messageId: string): void {
+  activeConsumers.delete(messageId);
+}

--- a/apps/web/src/lib/ai/streams/shouldReloadOnComountComplete.ts
+++ b/apps/web/src/lib/ai/streams/shouldReloadOnComountComplete.ts
@@ -1,18 +1,6 @@
 import type { PendingStream } from '@/stores/usePendingStreamsStore';
 
-/**
- * Returns true when a co-mounted surface should reload its messages from DB
- * after receiving a chat:stream_complete event for its active conversation.
- *
- * This fires when a stream was driven by a different surface in the same
- * browser session (e.g. middle panel streamed while sidebar was watching
- * the same conversation). Because own-session socket events are filtered by
- * isOwnStream, the non-sending surface never gets the messages directly —
- * it must reload from DB to stay in sync.
- *
- * Returns false when a pending stream entry exists with parts (meaning the
- * normal synthesize-from-store path should handle it instead).
- */
+// Returns true when a co-mounted surface should reload from DB to sync after a same-session stream completes.
 export function shouldReloadOnComountComplete(
   stream: PendingStream | undefined,
   completedConvId: string | undefined,

--- a/apps/web/src/lib/ai/streams/shouldReloadOnComountComplete.ts
+++ b/apps/web/src/lib/ai/streams/shouldReloadOnComountComplete.ts
@@ -1,0 +1,25 @@
+import type { PendingStream } from '@/stores/usePendingStreamsStore';
+
+/**
+ * Returns true when a co-mounted surface should reload its messages from DB
+ * after receiving a chat:stream_complete event for its active conversation.
+ *
+ * This fires when a stream was driven by a different surface in the same
+ * browser session (e.g. middle panel streamed while sidebar was watching
+ * the same conversation). Because own-session socket events are filtered by
+ * isOwnStream, the non-sending surface never gets the messages directly —
+ * it must reload from DB to stay in sync.
+ *
+ * Returns false when a pending stream entry exists with parts (meaning the
+ * normal synthesize-from-store path should handle it instead).
+ */
+export function shouldReloadOnComountComplete(
+  stream: PendingStream | undefined,
+  completedConvId: string | undefined,
+  activeConversationId: string | null,
+): boolean {
+  if (!completedConvId || !activeConversationId) return false;
+  if (completedConvId !== activeConversationId) return false;
+  if (stream && stream.parts.length > 0) return false;
+  return true;
+}

--- a/apps/web/src/lib/websocket/__tests__/socket-utils.test.ts
+++ b/apps/web/src/lib/websocket/__tests__/socket-utils.test.ts
@@ -639,6 +639,20 @@ describe('socket-utils', () => {
       expect(requestBody.payload.aborted).toBe(true);
     });
 
+    it('given a conversationId, should include it in the broadcast payload', async () => {
+      const payload: AiStreamCompletePayload = {
+        messageId: 'msg-1',
+        pageId: 'page-1',
+        conversationId: 'conv-xyz',
+        aborted: false,
+      };
+
+      await broadcastAiStreamComplete(payload);
+
+      const requestBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(requestBody.payload.conversationId).toBe('conv-xyz');
+    });
+
     it('given no INTERNAL_REALTIME_URL, should not call fetch', async () => {
       process.env.INTERNAL_REALTIME_URL = '';
 

--- a/apps/web/src/lib/websocket/socket-utils.ts
+++ b/apps/web/src/lib/websocket/socket-utils.ts
@@ -668,6 +668,7 @@ export interface AiStreamStartPayload {
 export interface AiStreamCompletePayload {
   messageId: string;
   pageId: string;
+  conversationId?: string;
   aborted?: boolean;
 }
 

--- a/plan.md
+++ b/plan.md
@@ -2,6 +2,8 @@
 
 ## Active Epics
 
+- [AI Chat Co-mount Fix](tasks/ai-chat-comount-fix.md) — Fix message stealing and stream-abort conflicts when the same AI agent is open in both the middle panel and right sidebar.
+
 - [OpenAI API v1 Follow-Up](tasks/openai-api-v1-followup.md) — Token usage tracking in `onFinish` + `GET /api/v1/models` discovery endpoint.
 - [Zoom Transcript Integration](tasks/zoom-transcript-integration.md) — Auto-save Zoom meeting transcripts as Document pages in a user-configured drive; webhook-driven, AI summary + action items, cloud-only.
 

--- a/tasks/ai-chat-comount-fix.md
+++ b/tasks/ai-chat-comount-fix.md
@@ -1,0 +1,106 @@
+# AI Chat Co-mount Fix Epic
+
+**Status**: 📋 PLANNED
+**Goal**: Fix message stealing and streaming conflicts when the same AI agent is open in both the middle panel and right sidebar simultaneously.
+
+## Overview
+
+Why: When a user views an AI agent page in the middle panel while also selecting the same agent in the sidebar, both surfaces load the same conversation and compete — the module-level `activeStreams` Map keyed by `conversationId` gets overwritten between surfaces (causing the wrong stream to be aborted), socket `chat:stream_complete` events arrive at both surfaces but each finds no pending stream entry for own-session sends and silently bails, leaving the non-sending surface with stale messages. The fix has three layers: isolate each surface's stream-abort key so stops can't steal, add `conversationId` to the `chat:stream_complete` payload so non-sending surfaces can detect a co-mounted completion and reload, and guard the bootstrap SSE-join path so two co-mounted instances don't double-consume the same in-flight stream.
+
+---
+
+## Stream Abort Collision Tests
+
+Write failing tests demonstrating that two `createStreamTrackingFetch` instances with the same `chatId` overwrite each other's active stream entry.
+
+**Requirements**:
+- Given two surfaces call `setActiveStreamId` with the same `chatId`, should the second call overwrite the first streamId (demonstrating the collision)
+- Given surface A sets streamId then surface B sets a different streamId for the same chatId, calling `abortActiveStream` from surface A's perspective should target surface B's streamId (demonstrating the theft)
+
+---
+
+## Namespace Sidebar Transport chatId
+
+Change `SidebarChatTab` to pass `"sidebar:" + agentConversationId` to `useChatTransport` instead of `agentConversationId` directly.
+
+**Requirements**:
+- Given the sidebar transport uses `sidebar:${conversationId}` as chatId, should `activeStreams` entries for middle panel and sidebar use distinct keys when both view the same conversation
+- Given middle panel streams while sidebar is open on the same conversation, should middle panel's Stop button abort only its own stream
+- Given sidebar streams, should not overwrite the middle panel's active stream entry
+
+---
+
+## Commit: Stream abort isolation ✦
+
+---
+
+## Add conversationId to stream_complete payload
+
+Add `conversationId` to `AiStreamCompletePayload` in `socket-utils.ts` and pass it through `broadcastAiStreamComplete` in `stream-lifecycle.ts`, updating existing tests to cover the field.
+
+**Requirements**:
+- Given `AiStreamCompletePayload`, should include an optional `conversationId` field
+- Given `broadcastAiStreamComplete` is called from the stream lifecycle, should forward the `conversationId` that was already available in `StreamLifecycleParams`
+- Given existing socket-utils tests, should verify `conversationId` is present in the broadcast payload
+
+---
+
+## Thread conversationId through fireComplete
+
+Update `useChannelStreamSocket` so `handleStreamComplete` passes `payload.conversationId` to `fireComplete`, and the `onStreamComplete` callback signature becomes `(messageId: string, conversationId?: string)`.
+
+**Requirements**:
+- Given `chat:stream_complete` fires with a `conversationId`, should the `onStreamComplete` callback receive it as second argument
+- Given the bootstrap SSE path finishes consuming a stream, should also pass the stream's `conversationId` to `onStreamComplete`
+
+---
+
+## Co-mount reload helper tests
+
+Create `apps/web/src/lib/ai/streams/__tests__/shouldReloadOnComountComplete.test.ts` and the corresponding pure helper at `apps/web/src/lib/ai/streams/shouldReloadOnComountComplete.ts`.
+
+**Requirements**:
+- Given no pending stream in the store and completedConvId matches the active conversation, should return `true` (reload needed)
+- Given a pending stream exists with parts and matching conversation, should return `false` (stream handled by synthesize path)
+- Given completedConvId does not match the active conversation, should return `false`
+- Given completedConvId is undefined, should return `false`
+
+---
+
+## Wire co-mount reload into multiplayer hook and AiChatView
+
+Use `shouldReloadOnComountComplete` in `useAgentChannelMultiplayer`'s `onStreamComplete` to call `loadConversation` when the helper returns true, and apply the same fallback in `AiChatView`'s `onStreamComplete` handler.
+
+**Requirements**:
+- Given middle panel sends while sidebar is open on the same conversation, should sidebar auto-reload messages from DB after stream completes
+- Given sidebar sends while middle panel is open on the same conversation, should middle panel auto-reload messages from DB after stream completes
+- Given a remote user (different browser session) streams, should still synthesize the message locally from the pending store (existing behavior unchanged)
+
+---
+
+## Commit: Cross-surface message sync ✦
+
+---
+
+## Bootstrap de-dup guard tests
+
+Add tests to `apps/web/src/hooks/__tests__/useChannelStreamSocket.test.ts` (or create the file) that demonstrate the double-consume problem when two instances bootstrap the same in-flight stream.
+
+**Requirements**:
+- Given two `useChannelStreamSocket` instances bootstrap the same `messageId`, should `appendPart` be called only once per chunk (not doubled)
+- Given the first consumer's surface unmounts, should release the bootstrap claim so the second surface can consume the stream
+
+---
+
+## Implement bootstrap de-dup guard
+
+Add a module-level `activeBootstrapConsumers: Set<string>` in `useChannelStreamSocket.ts`; gate `startConsume` on claiming the set; release on SSE resolve/reject and on the cleanup teardown for aborted controllers.
+
+**Requirements**:
+- Given two co-mounted surfaces bootstrap the same stream, should only one surface call `startConsume`
+- Given the consuming surface unmounts mid-stream, should delete the messageId from the registry so another surface can take over
+- Given a surface unmounts and remounts after the stream ends, should allow fresh consumption of a new bootstrap
+
+---
+
+## Commit: Bootstrap de-dup guard ✦


### PR DESCRIPTION
## Summary

Fixes three bugs that occur when the same AI agent is open simultaneously in the middle panel (`AiChatView`) and right sidebar (`SidebarChatTab`):

- **Stream abort stealing**: Both surfaces shared the same `conversationId` as a key in the module-level `activeStreams` Map. Sidebar streaming overwrote the middle panel's entry, so the middle panel's Stop button would abort the sidebar's stream and vice versa.
- **Message sync failure**: `useChannelStreamSocket` filters own-session socket events via `isOwnStream`, so when the middle panel sent a message, the sidebar's `onUserMessage` and `onStreamComplete` silently dropped the events — leaving the non-sending surface with stale messages.
- **Bootstrap double-consumption**: On page reload mid-stream, both co-mounted surfaces would call `startConsume` for the same bootstrapped `messageId`, doubling `appendPart` calls and producing corrupted ghost text.

## Changes

**Fix 1 — Stream abort isolation** (`SidebarChatTab.tsx`)
- Sidebar's `useChatTransport` key namespaced to `"sidebar:${conversationId}"` — purely a client-side stream-tracking key, the actual `conversationId` in requests still comes from `sendMessage` body options.

**Fix 2 — Cross-surface message sync** (`socket-utils.ts`, `stream-lifecycle.ts`, `useChannelStreamSocket.ts`, `useAgentChannelMultiplayer.ts`, `AiChatView.tsx`)
- Added `conversationId?: string` to `AiStreamCompletePayload` and forwarded it through `broadcastAiStreamComplete`.
- Threaded `conversationId` through `fireComplete` and the `onStreamComplete` callback.
- New `shouldReloadOnComountComplete` pure helper: returns `true` when a stream completes for the active conversation but no pending stream parts exist locally (= co-mounted surface sent it).
- Both `AiChatView` and `useAgentChannelMultiplayer` call `loadConversation` when the helper returns true, keeping the non-sending surface in sync.

**Fix 3 — Bootstrap de-dup guard** (`bootstrapConsumerGuard.ts`, `useChannelStreamSocket.ts`)
- New module-level `Set`-backed guard (`claimBootstrapConsumer` / `releaseBootstrapConsumer`) prevents two co-mounted instances from both SSE-joining the same bootstrapped in-flight stream.
- Claim released on SSE resolve/reject and on unmount cleanup so a remounted surface can take over.

## Test plan

- [ ] Open an AI agent page in the middle panel and select the same agent in the right sidebar (same conversation shown in both)
- [ ] Send from middle panel → stream → click Stop: only middle panel's stream aborts; sidebar is unaffected
- [ ] After stream completes, sidebar auto-refreshes and shows the new messages
- [ ] Send from sidebar → after stream completes, middle panel auto-refreshes and shows the new messages
- [ ] Open agent in middle panel (conversation A), create a new conversation in the sidebar (conversation B) for the same agent — verify sends are fully independent with no cross-contamination
- [ ] Go offline mid-stream, reconnect — stream content should not be doubled

🤖 Generated with [Claude Code](https://claude.com/claude-code)