### PR TITLE
feat(mentions): popover-based MentionPicker

### DIFF
--- a/apps/web/src/components/editors/LinkButton.tsx
+++ b/apps/web/src/components/editors/LinkButton.tsx
@@ -30,19 +30,6 @@ const LinkButton = ({ editor, variant = 'toolbar' }: LinkButtonProps) => {
   const [value, setValue] = React.useState('');
   const inputId = React.useId();
 
-  if (!editor || editor.isDestroyed) return null;
-
-  const isActive = editor.isActive('link');
-  const submittable = Boolean(normalizeUrl(value));
-
-  const handleOpenChange = (next: boolean) => {
-    if (next) {
-      const existing = (editor.getAttributes('link').href as string | undefined) ?? '';
-      setValue(existing);
-    }
-    setOpen(next);
-  };
-
   // Bind Mod-K to open the popover from the toolbar instance only — the bubble
   // menu's instance is unmounted when there's no selection, and we want a
   // single, predictable handler regardless of selection state.
@@ -61,6 +48,19 @@ const LinkButton = ({ editor, variant = 'toolbar' }: LinkButtonProps) => {
     root.addEventListener('keydown', onKeyDown);
     return () => root.removeEventListener('keydown', onKeyDown);
   }, [editor, variant]);
+
+  if (!editor || editor.isDestroyed) return null;
+
+  const isActive = editor.isActive('link');
+  const submittable = Boolean(normalizeUrl(value));
+
+  const handleOpenChange = (next: boolean) => {
+    if (next) {
+      const existing = (editor.getAttributes('link').href as string | undefined) ?? '';
+      setValue(existing);
+    }
+    setOpen(next);
+  };
 
   const apply = () => {
     const href = normalizeUrl(value);

--- a/apps/web/src/components/editors/LinkButton.tsx
+++ b/apps/web/src/components/editors/LinkButton.tsx
@@ -30,24 +30,6 @@ const LinkButton = ({ editor, variant = 'toolbar' }: LinkButtonProps) => {
   const [value, setValue] = React.useState('');
   const inputId = React.useId();
 
-  // Bind Mod-K to open the popover from the toolbar instance only — the bubble
-  // menu's instance is unmounted when there's no selection, and we want a
-  // single, predictable handler regardless of selection state.
-  React.useEffect(() => {
-    if (variant !== 'toolbar' || !editor || editor.isDestroyed) return;
-    const root = editor.view.dom as HTMLElement;
-    const onKeyDown = (event: KeyboardEvent) => {
-      if ((event.metaKey || event.ctrlKey) && (event.key === 'k' || event.key === 'K')) {
-        event.preventDefault();
-        const existing = (editor.getAttributes('link').href as string | undefined) ?? '';
-        setValue(existing);
-        setOpen(true);
-      }
-    };
-    root.addEventListener('keydown', onKeyDown);
-    return () => root.removeEventListener('keydown', onKeyDown);
-  }, [editor, variant]);
-
   if (!editor || editor.isDestroyed) return null;
 
   const isActive = editor.isActive('link');
@@ -60,6 +42,25 @@ const LinkButton = ({ editor, variant = 'toolbar' }: LinkButtonProps) => {
     }
     setOpen(next);
   };
+
+  // Bind Mod-K to open the popover from the toolbar instance only — the bubble
+  // menu's instance is unmounted when there's no selection, and we want a
+  // single, predictable handler regardless of selection state.
+  React.useEffect(() => {
+    if (variant !== 'toolbar') return;
+    if (!editor || editor.isDestroyed) return;
+    const root = editor.view.dom as HTMLElement;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && (event.key === 'k' || event.key === 'K')) {
+        event.preventDefault();
+        const existing = (editor.getAttributes('link').href as string | undefined) ?? '';
+        setValue(existing);
+        setOpen(true);
+      }
+    };
+    root.addEventListener('keydown', onKeyDown);
+    return () => root.removeEventListener('keydown', onKeyDown);
+  }, [editor, variant]);
 
   const apply = () => {
     const href = normalizeUrl(value);

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInput.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInput.tsx
@@ -10,6 +10,8 @@ import { ChannelInputFooter } from './ChannelInputFooter';
 import { useAttachmentUpload, type FileAttachment } from '@/hooks/useAttachmentUpload';
 import { formatFileSize } from '@/lib/attachment-utils';
 import { useEditingSession } from '@/stores/useEditingSession';
+import { MentionFormatter } from '@/lib/mentions/mentionConfig';
+import type { MentionSuggestion } from '@/types/mentions';
 
 export type { FileAttachment };
 
@@ -216,9 +218,14 @@ export const ChannelInput = forwardRef<ChannelInputRef, ChannelInputProps>(
       textareaRef.current?.focus();
     };
 
-    // Handle mention button - insert @ to trigger mention popup
-    const handleMentionClick = () => {
-      onChange(value + '@');
+    const handleMentionSelect = (suggestion: MentionSuggestion) => {
+      const text = MentionFormatter.format(
+        suggestion.label,
+        suggestion.id,
+        suggestion.type,
+        'markdown-typed',
+      );
+      onChange(value + text + ' ');
       textareaRef.current?.focus();
     };
 
@@ -389,7 +396,9 @@ export const ChannelInput = forwardRef<ChannelInputRef, ChannelInputProps>(
           {/* Footer with formatting actions */}
           <ChannelInputFooter
             onFormatClick={handleFormatClick}
-            onMentionClick={handleMentionClick}
+            onMentionSelect={driveId ? handleMentionSelect : undefined}
+            driveId={driveId}
+            crossDrive={crossDrive}
             onEmojiSelect={handleEmojiSelect}
             onAttachmentClick={handleAttachmentClick}
             attachmentsEnabled={attachmentsEnabled && hasUploadTarget}

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInputFooter.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelInputFooter.tsx
@@ -23,6 +23,8 @@ import {
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { EmojiPicker } from '@/components/ui/emoji-picker';
+import { MentionPickerPopover } from '@/components/mentions/MentionPicker';
+import type { MentionSuggestion, MentionType } from '@/types/mentions';
 
 export interface ChannelInputFooterProps {
   /** Callback when formatting button clicked */
@@ -31,8 +33,14 @@ export interface ChannelInputFooterProps {
   onAttachmentClick?: () => void;
   /** Callback when emoji is selected */
   onEmojiSelect?: (emoji: string) => void;
-  /** Callback when mention button clicked */
-  onMentionClick?: () => void;
+  /** Callback when a mention suggestion is selected from the picker */
+  onMentionSelect?: (suggestion: MentionSuggestion) => void;
+  /** Drive ID for scoping mention search */
+  driveId?: string;
+  /** Enable cross-drive mention search */
+  crossDrive?: boolean;
+  /** Which mention types to include */
+  allowedMentionTypes?: MentionType[];
   /** Whether attachments are supported */
   attachmentsEnabled?: boolean;
   /** Whether input is disabled */
@@ -63,22 +71,14 @@ const FORMAT_BUTTONS: FormatButton[] = [
   { id: 'list', icon: List, label: 'List', shortcut: '⌘⇧L' },
 ];
 
-/**
- * ChannelInputFooter - Footer actions for channel message input
- *
- * Contains:
- * - Formatting buttons (bold, italic, code, list) in a popover
- * - Attachment button (future: file uploads)
- * - Emoji picker trigger
- * - Mention shortcut button
- *
- * Designed to complement the floating input card design.
- */
 export function ChannelInputFooter({
   onFormatClick,
   onAttachmentClick,
   onEmojiSelect,
-  onMentionClick,
+  onMentionSelect,
+  driveId,
+  crossDrive = false,
+  allowedMentionTypes,
   attachmentsEnabled = false,
   disabled = false,
   alsoSendToParentEnabled = false,
@@ -88,13 +88,31 @@ export function ChannelInputFooter({
   className,
 }: ChannelInputFooterProps) {
   const [emojiPickerOpen, setEmojiPickerOpen] = useState(false);
+  const [mentionPickerOpen, setMentionPickerOpen] = useState(false);
+
+  const mentionButton = (
+    <Button
+      variant="ghost"
+      size="sm"
+      disabled={disabled}
+      className={cn(
+        'h-8 w-8 p-0',
+        'text-muted-foreground hover:text-foreground',
+        'hover:bg-muted/50',
+      )}
+    >
+      <AtSign className="h-4 w-4" />
+      <span className="sr-only">Mention someone</span>
+    </Button>
+  );
+
   return (
     <div
       className={cn(
         'flex items-center justify-between',
         'px-3 py-2',
         'border-t border-border/40',
-        className
+        className,
       )}
     >
       {/* Left group - Formatting & Actions */}
@@ -111,7 +129,7 @@ export function ChannelInputFooter({
                   className={cn(
                     'h-8 w-8 p-0',
                     'text-muted-foreground hover:text-foreground',
-                    'hover:bg-muted/50'
+                    'hover:bg-muted/50',
                   )}
                 >
                   <Bold className="h-4 w-4" />
@@ -143,7 +161,10 @@ export function ChannelInputFooter({
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent side="top">
-                    {btn.label} <span className="text-muted-foreground ml-1">{btn.shortcut}</span>
+                    {btn.label}{' '}
+                    <span className="text-muted-foreground ml-1">
+                      {btn.shortcut}
+                    </span>
                   </TooltipContent>
                 </Tooltip>
               ))}
@@ -154,26 +175,32 @@ export function ChannelInputFooter({
         {/* Divider */}
         <div className="w-px h-4 bg-border/60 mx-1" />
 
-        {/* Mention button */}
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={onMentionClick}
-              disabled={disabled}
-              className={cn(
-                'h-8 w-8 p-0',
-                'text-muted-foreground hover:text-foreground',
-                'hover:bg-muted/50'
-              )}
+        {/* Mention picker */}
+        {onMentionSelect && driveId ? (
+          <Tooltip>
+            <MentionPickerPopover
+              driveId={driveId}
+              crossDrive={crossDrive}
+              allowedTypes={allowedMentionTypes}
+              open={mentionPickerOpen}
+              onOpenChange={setMentionPickerOpen}
+              onMentionSelect={(s) => {
+                onMentionSelect(s);
+                setMentionPickerOpen(false);
+              }}
+              side="top"
+              align="start"
             >
-              <AtSign className="h-4 w-4" />
-              <span className="sr-only">Mention</span>
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="top">Mention someone</TooltipContent>
-        </Tooltip>
+              <TooltipTrigger asChild>{mentionButton}</TooltipTrigger>
+            </MentionPickerPopover>
+            <TooltipContent side="top">Mention someone</TooltipContent>
+          </Tooltip>
+        ) : (
+          <Tooltip>
+            <TooltipTrigger asChild>{mentionButton}</TooltipTrigger>
+            <TooltipContent side="top">Mention someone</TooltipContent>
+          </Tooltip>
+        )}
 
         {/* Emoji picker */}
         <Popover open={emojiPickerOpen} onOpenChange={setEmojiPickerOpen}>
@@ -187,7 +214,7 @@ export function ChannelInputFooter({
                   className={cn(
                     'h-8 w-8 p-0',
                     'text-muted-foreground hover:text-foreground',
-                    'hover:bg-muted/50'
+                    'hover:bg-muted/50',
                   )}
                 >
                   <Smile className="h-4 w-4" />
@@ -245,7 +272,7 @@ export function ChannelInputFooter({
                 className={cn(
                   'h-8 w-8 p-0',
                   'text-muted-foreground hover:text-foreground',
-                  'hover:bg-muted/50'
+                  'hover:bg-muted/50',
                 )}
               >
                 <Paperclip className="h-4 w-4" />

--- a/apps/web/src/components/layout/middle-content/page-views/channel/__tests__/ChannelInput.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/__tests__/ChannelInput.test.tsx
@@ -105,30 +105,39 @@ vi.mock('@/components/ai/chat/input/ChatTextarea', () => {
   return { ChatTextarea: MockChatTextarea };
 });
 
-// Mock the footer so test queries don't fight popovers/tooltips
+// Mock the footer so test queries don't fight popovers/tooltips.
+// capturedFooterMentionSelect lets tests trigger the onMentionSelect callback.
+const { capturedFooterMentionSelect } = vi.hoisted(() => ({
+  capturedFooterMentionSelect: vi.fn(),
+}));
 vi.mock('../ChannelInputFooter', () => ({
   ChannelInputFooter: ({
     onAttachmentClick,
     attachmentsEnabled,
     disabled,
+    onMentionSelect,
   }: {
     onAttachmentClick?: () => void;
     attachmentsEnabled?: boolean;
     disabled?: boolean;
-  }) => (
-    <div data-testid="channel-input-footer">
-      {attachmentsEnabled && (
-        <button
-          type="button"
-          data-testid="attach-button"
-          onClick={onAttachmentClick}
-          disabled={disabled}
-        >
-          Attach
-        </button>
-      )}
-    </div>
-  ),
+    onMentionSelect?: (s: unknown) => void;
+  }) => {
+    capturedFooterMentionSelect.mockImplementation(onMentionSelect ?? (() => {}));
+    return (
+      <div data-testid="channel-input-footer">
+        {attachmentsEnabled && (
+          <button
+            type="button"
+            data-testid="attach-button"
+            onClick={onAttachmentClick}
+            disabled={disabled}
+          >
+            Attach
+          </button>
+        )}
+      </div>
+    );
+  },
 }));
 
 // Capture useAttachmentUpload args + expose a controllable mock state
@@ -404,5 +413,56 @@ describe('ChannelInput — DM upload mode (conversationId)', () => {
     expect(last?.driveId).toBe('drive-1');
     expect(last?.crossDrive).toBe(true);
     expect(last?.popupPlacement).toBe('top');
+  });
+});
+
+describe('ChannelInput mention selection', () => {
+  beforeEach(() => {
+    mockAttachment = null;
+    mockIsUploading = false;
+    vi.clearAllMocks();
+  });
+
+  it('should insert a formatted mention into the value when a suggestion is selected', () => {
+    const onChange = vi.fn();
+    render(
+      <ChannelInput
+        value="Hello "
+        onChange={onChange}
+        onSend={vi.fn()}
+        driveId="drive-1"
+      />,
+    );
+
+    capturedFooterMentionSelect({
+      id: 'user-1',
+      label: 'Alice',
+      type: 'user',
+      data: {},
+    });
+
+    expect(onChange).toHaveBeenCalledWith(expect.stringContaining('Alice'));
+  });
+
+  it('should append a space after the inserted mention', () => {
+    const onChange = vi.fn();
+    render(
+      <ChannelInput
+        value=""
+        onChange={onChange}
+        onSend={vi.fn()}
+        driveId="drive-1"
+      />,
+    );
+
+    capturedFooterMentionSelect({
+      id: 'page-1',
+      label: 'Project Alpha Budget',
+      type: 'page',
+      data: { pageType: 'DOCUMENT', driveId: 'drive-1' },
+    });
+
+    const inserted: string = onChange.mock.calls[0][0];
+    expect(inserted.endsWith(' ')).toBe(true);
   });
 });

--- a/apps/web/src/components/layout/middle-content/page-views/channel/__tests__/ChannelInputFooter.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/__tests__/ChannelInputFooter.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import type { MentionSuggestion } from '@/types/mentions';
+
+// Stub MentionPickerPopover — we test ChannelInputFooter's wiring, not the picker internals
+const { mockPickerOpen } = vi.hoisted(() => ({ mockPickerOpen: vi.fn() }));
+vi.mock('@/components/mentions/MentionPicker', () => ({
+  MentionPickerPopover: ({
+    children,
+    onMentionSelect,
+    open,
+    onOpenChange,
+  }: {
+    children: React.ReactNode;
+    onMentionSelect: (s: MentionSuggestion) => void;
+    open?: boolean;
+    onOpenChange?: (v: boolean) => void;
+  }) => {
+    mockPickerOpen(open);
+    return (
+      <div>
+        <div onClick={() => onOpenChange?.(!open)}>{children}</div>
+        {open && (
+          <div data-testid="mention-picker-popover">
+            <button
+              data-testid="pick-alice"
+              onClick={() =>
+                onMentionSelect({
+                  id: 'user-1',
+                  label: 'Alice',
+                  type: 'user',
+                  data: {},
+                })
+              }
+            >
+              Alice
+            </button>
+          </div>
+        )}
+      </div>
+    );
+  },
+}));
+
+import { ChannelInputFooter } from '../ChannelInputFooter';
+
+describe('ChannelInputFooter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('mention button', () => {
+    it('should render the mention button', () => {
+      render(
+        <ChannelInputFooter
+          onMentionSelect={vi.fn()}
+          driveId="drive-1"
+        />,
+      );
+      expect(screen.getByRole('button', { name: /mention/i })).toBeInTheDocument();
+    });
+
+    it('should open the MentionPickerPopover when the mention button is clicked', async () => {
+      const user = userEvent.setup();
+      render(
+        <ChannelInputFooter
+          onMentionSelect={vi.fn()}
+          driveId="drive-1"
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /mention/i }));
+
+      expect(screen.getByTestId('mention-picker-popover')).toBeInTheDocument();
+    });
+
+    it('should call onMentionSelect with the chosen suggestion', async () => {
+      const onMentionSelect = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <ChannelInputFooter
+          onMentionSelect={onMentionSelect}
+          driveId="drive-1"
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /mention/i }));
+      await user.click(screen.getByTestId('pick-alice'));
+
+      expect(onMentionSelect).toHaveBeenCalledWith({
+        id: 'user-1',
+        label: 'Alice',
+        type: 'user',
+        data: {},
+      });
+    });
+  });
+});

--- a/apps/web/src/components/mentions/MentionPicker.tsx
+++ b/apps/web/src/components/mentions/MentionPicker.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { cn } from '@/lib/utils';
+import { Input } from '@/components/ui/input';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import type { MentionSuggestion, MentionType } from '@/types/mentions';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+
+type TabType = 'all' | 'people' | 'pages' | 'groups';
+
+const TAB_TYPES: Record<TabType, MentionType[]> = {
+  all: ['page', 'user', 'everyone', 'role'],
+  people: ['user'],
+  pages: ['page'],
+  groups: ['everyone', 'role'],
+};
+
+export interface MentionPickerProps {
+  driveId: string;
+  crossDrive?: boolean;
+  allowedTypes?: MentionType[];
+  onMentionSelect: (suggestion: MentionSuggestion) => void;
+  className?: string;
+}
+
+export function MentionPicker({
+  driveId,
+  crossDrive = false,
+  allowedTypes = ['page', 'user', 'everyone', 'role'],
+  onMentionSelect,
+  className,
+}: MentionPickerProps) {
+  const [query, setQuery] = useState('');
+  const [activeTab, setActiveTab] = useState<TabType>('all');
+  const [items, setItems] = useState<MentionSuggestion[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const fetchSuggestions = useCallback(
+    async (q: string, tab: TabType) => {
+      setLoading(true);
+      const types = TAB_TYPES[tab]
+        .filter((t) => allowedTypes.includes(t))
+        .join(',');
+      const url = `/api/mentions/search?q=${encodeURIComponent(q)}&driveId=${encodeURIComponent(driveId)}&types=${types}${crossDrive ? '&crossDrive=true' : ''}`;
+      try {
+        const response = await fetchWithAuth(url);
+        const data: MentionSuggestion[] = await response.json();
+        setItems(data);
+        setSelectedIndex(0);
+      } catch {
+        setItems([]);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [driveId, crossDrive, allowedTypes],
+  );
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      void fetchSuggestions(query, activeTab);
+    }, 200);
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [query, activeTab, fetchSuggestions]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (items.length === 0) return;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setSelectedIndex((i) => (i + 1) % items.length);
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setSelectedIndex((i) => (i - 1 + items.length) % items.length);
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        const item = items[selectedIndex];
+        if (item) onMentionSelect(item);
+      }
+    },
+    [items, selectedIndex, onMentionSelect],
+  );
+
+  return (
+    <div className={cn('w-80', className)} onKeyDown={handleKeyDown}>
+      <div className="p-2 border-b border-border/50">
+        <Input
+          autoFocus
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search mentions..."
+          className="h-8 text-sm"
+        />
+      </div>
+
+      <Tabs
+        value={activeTab}
+        onValueChange={(v) => setActiveTab(v as TabType)}
+      >
+        <TabsList className="w-full grid grid-cols-4 h-auto p-1 bg-muted/30">
+          <TabsTrigger value="all" className="text-xs">All</TabsTrigger>
+          <TabsTrigger value="people" className="text-xs">People</TabsTrigger>
+          <TabsTrigger value="pages" className="text-xs">Pages</TabsTrigger>
+          <TabsTrigger value="groups" className="text-xs">Groups</TabsTrigger>
+        </TabsList>
+      </Tabs>
+
+      <ScrollArea className="max-h-64">
+        {loading ? (
+          <div className="p-3 text-sm text-muted-foreground flex items-center gap-2">
+            <span className="animate-spin inline-block w-3 h-3 border-2 border-current border-t-transparent rounded-full" />
+            Loading…
+          </div>
+        ) : items.length === 0 ? (
+          <div className="p-3 text-sm text-muted-foreground">No results found</div>
+        ) : (
+          <ul role="listbox">
+            {items.map((item, index) => {
+              const isGroup = item.type === 'everyone' || item.type === 'role';
+              return (
+                <li
+                  key={`${item.id}-${index}`}
+                  role="option"
+                  aria-selected={index === selectedIndex}
+                  onClick={() => onMentionSelect(item)}
+                  onMouseEnter={() => setSelectedIndex(index)}
+                  className={cn(
+                    'px-3 py-2 cursor-pointer flex items-center gap-2',
+                    'hover:bg-muted/50 transition-colors',
+                    index === selectedIndex && 'bg-muted/50',
+                  )}
+                >
+                  {isGroup && (
+                    <span
+                      data-testid="group-badge"
+                      className="text-xs font-bold text-white bg-indigo-500 rounded px-1 py-0.5 shrink-0"
+                    >
+                      @
+                    </span>
+                  )}
+                  <span
+                    className={cn(
+                      'text-sm font-medium',
+                      isGroup
+                        ? 'text-indigo-600 dark:text-indigo-400'
+                        : 'text-foreground',
+                    )}
+                  >
+                    {item.label}
+                  </span>
+                  {!isGroup && (
+                    <span className="text-xs text-muted-foreground ml-auto">
+                      {item.type}
+                    </span>
+                  )}
+                  {item.description && (
+                    <span className="text-xs text-muted-foreground truncate">
+                      {item.description}
+                    </span>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </ScrollArea>
+    </div>
+  );
+}
+
+export interface MentionPickerPopoverProps extends MentionPickerProps {
+  children: React.ReactNode;
+  side?: 'top' | 'bottom' | 'left' | 'right';
+  align?: 'start' | 'center' | 'end';
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export function MentionPickerPopover({
+  children,
+  side = 'top',
+  align = 'start',
+  open,
+  onOpenChange,
+  onMentionSelect,
+  ...pickerProps
+}: MentionPickerPopoverProps) {
+  const handleSelect = (suggestion: MentionSuggestion) => {
+    onMentionSelect(suggestion);
+    onOpenChange?.(false);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent
+        side={side}
+        align={align}
+        className="w-auto p-0"
+        sideOffset={8}
+      >
+        <MentionPicker {...pickerProps} onMentionSelect={handleSelect} />
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export default MentionPicker;

--- a/apps/web/src/components/mentions/__tests__/MentionPicker.test.tsx
+++ b/apps/web/src/components/mentions/__tests__/MentionPicker.test.tsx
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MentionPicker } from '../MentionPicker';
+import type { MentionSuggestion } from '@/types/mentions';
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+
+const mockFetch = fetchWithAuth as ReturnType<typeof vi.fn>;
+
+const makeResponse = (items: MentionSuggestion[]) =>
+  Promise.resolve({ json: () => Promise.resolve(items) });
+
+const userSuggestion: MentionSuggestion = {
+  id: 'user-1',
+  label: 'Alice',
+  type: 'user',
+  data: {},
+};
+
+const pageSuggestion: MentionSuggestion = {
+  id: 'page-1',
+  label: 'Project Alpha',
+  type: 'page',
+  data: { pageType: 'DOCUMENT', driveId: 'drive-1' },
+};
+
+const everyoneSuggestion: MentionSuggestion = {
+  id: 'drive-1',
+  label: 'everyone',
+  type: 'everyone',
+  data: { driveId: 'drive-1' },
+};
+
+describe('MentionPicker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReturnValue(makeResponse([]));
+  });
+
+  describe('initial render', () => {
+    it('should render a search input', () => {
+      render(
+        <MentionPicker
+          driveId="drive-1"
+          onMentionSelect={vi.fn()}
+        />
+      );
+      expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument();
+    });
+
+    it('should render all four type tabs', () => {
+      render(
+        <MentionPicker
+          driveId="drive-1"
+          onMentionSelect={vi.fn()}
+        />
+      );
+      expect(screen.getByRole('tab', { name: /all/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /people/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /pages/i })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /groups/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('search input', () => {
+    it('should fetch with the typed query', async () => {
+      const user = userEvent.setup();
+      render(
+        <MentionPicker
+          driveId="drive-1"
+          onMentionSelect={vi.fn()}
+        />
+      );
+
+      await user.type(screen.getByPlaceholderText(/search/i), 'Alice');
+
+      await vi.waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining('q=Alice')
+        );
+      });
+    });
+
+    it('should include the driveId in the fetch URL', async () => {
+      render(
+        <MentionPicker
+          driveId="my-drive"
+          onMentionSelect={vi.fn()}
+        />
+      );
+
+      await vi.waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining('driveId=my-drive')
+        );
+      });
+    });
+  });
+
+  describe('results list', () => {
+    it('should display user suggestions returned by the API', async () => {
+      mockFetch.mockReturnValue(makeResponse([userSuggestion]));
+
+      render(
+        <MentionPicker
+          driveId="drive-1"
+          onMentionSelect={vi.fn()}
+        />
+      );
+
+      await screen.findByText('Alice');
+    });
+
+    it('should display an empty state when API returns no results', async () => {
+      mockFetch.mockReturnValue(makeResponse([]));
+
+      render(
+        <MentionPicker
+          driveId="drive-1"
+          onMentionSelect={vi.fn()}
+        />
+      );
+
+      await screen.findByText(/no results/i);
+    });
+
+    it('should call onMentionSelect with the suggestion when a result is clicked', async () => {
+      const onMentionSelect = vi.fn();
+      mockFetch.mockReturnValue(makeResponse([userSuggestion]));
+      const user = userEvent.setup();
+
+      render(
+        <MentionPicker
+          driveId="drive-1"
+          onMentionSelect={onMentionSelect}
+        />
+      );
+
+      await user.click(await screen.findByText('Alice'));
+
+      expect(onMentionSelect).toHaveBeenCalledWith(userSuggestion);
+    });
+  });
+
+  describe('tab filtering', () => {
+    it('should request only user type when People tab is active', async () => {
+      const user = userEvent.setup();
+      render(
+        <MentionPicker
+          driveId="drive-1"
+          onMentionSelect={vi.fn()}
+        />
+      );
+
+      await user.click(screen.getByRole('tab', { name: /people/i }));
+
+      await vi.waitFor(() => {
+        const lastCall = mockFetch.mock.calls.at(-1)?.[0] as string;
+        expect(lastCall).toContain('types=user');
+        expect(lastCall).not.toContain('page');
+      });
+    });
+
+    it('should request only page type when Pages tab is active', async () => {
+      const user = userEvent.setup();
+      render(
+        <MentionPicker
+          driveId="drive-1"
+          onMentionSelect={vi.fn()}
+        />
+      );
+
+      await user.click(screen.getByRole('tab', { name: /pages/i }));
+
+      await vi.waitFor(() => {
+        const lastCall = mockFetch.mock.calls.at(-1)?.[0] as string;
+        expect(lastCall).toContain('types=page');
+      });
+    });
+
+    it('should request everyone and role types when Groups tab is active', async () => {
+      const user = userEvent.setup();
+      render(
+        <MentionPicker
+          driveId="drive-1"
+          onMentionSelect={vi.fn()}
+        />
+      );
+
+      await user.click(screen.getByRole('tab', { name: /groups/i }));
+
+      await vi.waitFor(() => {
+        const lastCall = mockFetch.mock.calls.at(-1)?.[0] as string;
+        expect(lastCall).toContain('everyone');
+        expect(lastCall).toContain('role');
+      });
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    it('should select the next item on ArrowDown', async () => {
+      mockFetch.mockReturnValue(makeResponse([userSuggestion, pageSuggestion]));
+      const user = userEvent.setup();
+
+      render(
+        <MentionPicker
+          driveId="drive-1"
+          onMentionSelect={vi.fn()}
+        />
+      );
+
+      await screen.findByText('Alice');
+      await user.keyboard('{ArrowDown}');
+
+      const items = screen.getAllByRole('option');
+      expect(items[1]).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('should confirm selection with Enter', async () => {
+      const onMentionSelect = vi.fn();
+      mockFetch.mockReturnValue(makeResponse([userSuggestion, pageSuggestion]));
+      const user = userEvent.setup();
+
+      render(
+        <MentionPicker
+          driveId="drive-1"
+          onMentionSelect={onMentionSelect}
+        />
+      );
+
+      await screen.findByText('Alice');
+      await user.keyboard('{Enter}');
+
+      expect(onMentionSelect).toHaveBeenCalledWith(userSuggestion);
+    });
+  });
+
+  describe('group mention rendering', () => {
+    it('should render everyone suggestion with an @ badge', async () => {
+      mockFetch.mockReturnValue(makeResponse([everyoneSuggestion]));
+
+      render(
+        <MentionPicker
+          driveId="drive-1"
+          onMentionSelect={vi.fn()}
+        />
+      );
+
+      await screen.findByText('everyone');
+      expect(screen.getByTestId('group-badge')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -21,6 +21,29 @@ vi.mock('next/navigation', () => ({
   useSearchParams: vi.fn(() => new URLSearchParams()),
 }))
 
+// jsdom does not implement ResizeObserver or IntersectionObserver.
+// Stub both so components that rely on them (e.g. radix ScrollArea) can mount.
+if (typeof window !== 'undefined') {
+  if (!window.ResizeObserver) {
+    window.ResizeObserver = class ResizeObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+  if (!window.IntersectionObserver) {
+    window.IntersectionObserver = class IntersectionObserver {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+      readonly root = null;
+      readonly rootMargin = '';
+      readonly thresholds: ReadonlyArray<number> = [];
+      takeRecords() { return []; }
+    } as unknown as typeof IntersectionObserver;
+  }
+}
+
 // jsdom does not implement matchMedia. Provide a permissive default that
 // returns false (i.e. desktop, non-touch) so hooks like useMobile / useTouchDevice
 // can boot during component tests without each test re-stubbing it.


### PR DESCRIPTION
## Summary

Adds a popover-based `MentionPicker` for the channel message composer, solving the **spaces-break-mentions** bug in the inline `@` trigger.

**Root cause:** The inline suggestion hook's existing-mention regex `/^[^\s\[\]]+\s/` treats a space as a completed mention, so multi-word page/role names (e.g. `@Project Alpha Budget`) were unreachable via typing.

**Fix:** The `@` button in the channel input footer now opens a dedicated popover picker with its own search input — spaces in the query are completely safe. The inline `@` trigger in the TipTap document editor is unaffected.

---

## Changes

### `apps/web/src/components/mentions/MentionPicker.tsx` _(new)_
- `MentionPicker` — search input + 4 type tabs (All / People / Pages / Groups), debounced fetch to `/api/mentions/search`, keyboard nav (↑↓ Enter), group badge, empty state
- `MentionPickerPopover` — wraps picker in shadcn `Popover`, auto-closes on selection; same pattern as `EmojiPickerPopover`

### `apps/web/src/components/layout/middle-content/page-views/channel/ChannelInputFooter.tsx`
- Removed `onMentionClick` (appended bare `@`)
- Added `onMentionSelect`, `driveId`, `crossDrive`, `allowedMentionTypes` props
- `@` button now opens `MentionPickerPopover` when `onMentionSelect` + `driveId` are present; falls back to plain button if neither is wired

### `apps/web/src/components/layout/middle-content/page-views/channel/ChannelInput.tsx`
- Removed `handleMentionClick`
- Added `handleMentionSelect` — formats via `MentionFormatter.format(..., 'markdown-typed')`, appends a trailing space, calls `onChange`
- Passes `driveId`, `crossDrive`, and `handleMentionSelect` down to footer

### `apps/web/src/test/setup.ts`
- Stubs `ResizeObserver` + `IntersectionObserver` globally so Radix `ScrollArea` mounts cleanly in jsdom

---

## Tests

| File | Tests |
|------|-------|
| `mentions/__tests__/MentionPicker.test.tsx` | 13 |
| `channel/__tests__/ChannelInputFooter.test.tsx` | 3 (new) |
| `channel/__tests__/ChannelInput.test.tsx` | 2 new + 15 existing = 17 |

**33 total — all green.**

Coverage: renders/tabs, fetch query params per tab, results display, empty state, group badge, click selection, keyboard nav (↑↓ Enter), footer popover open/close, mention insertion with trailing space.

---

## Test plan

```bash
bun run --filter 'web' test -- --run \
  src/components/mentions/__tests__/MentionPicker.test.tsx \
  src/components/layout/middle-content/page-views/channel/__tests__/ChannelInputFooter.test.tsx \
  src/components/layout/middle-content/page-views/channel/__tests__/ChannelInput.test.tsx
```

Manual:
- [ ] Open a channel → click `@` button → picker opens
- [ ] Type `Project ` (with a space) → results still appear
- [ ] Switch **Pages** tab → only page-type results
- [ ] Select a result → `@[Label](id:type) ` inserted, popover closes
- [ ] Inline `@` trigger in TipTap document editor still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)