### PR TITLE
fix(ai): allow global channel IDs in stream-join permission check

### DIFF
--- a/apps/web/src/app/api/ai/chat/stream-join/[messageId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/chat/stream-join/[messageId]/__tests__/route.test.ts
@@ -163,6 +163,27 @@ describe('GET /api/ai/chat/stream-join/[messageId]', () => {
 
       expect(canUserViewPage).toHaveBeenCalledWith(mockUserId, mockPageId);
     });
+
+    it('given a global channel pageId owned by the requesting user, should allow without calling canUserViewPage', async () => {
+      const globalMeta = { ...mockMeta, pageId: `user:${mockUserId}:global` };
+      testRegistry.register(mockMessageId, globalMeta);
+
+      const response = await GET(makeRequest(), makeContext(mockMessageId));
+      testRegistry.finish(mockMessageId);
+
+      expect(response.status).toBe(200);
+      expect(canUserViewPage).not.toHaveBeenCalled();
+    });
+
+    it('given a global channel pageId owned by a different user, should return 403', async () => {
+      const globalMeta = { ...mockMeta, pageId: `user:other-user-999:global` };
+      testRegistry.register(mockMessageId, globalMeta);
+
+      const response = await GET(makeRequest(), makeContext(mockMessageId));
+
+      expect(response.status).toBe(403);
+      expect(canUserViewPage).not.toHaveBeenCalled();
+    });
   });
 
   describe('SSE streaming', () => {

--- a/apps/web/src/app/api/ai/chat/stream-join/[messageId]/route.ts
+++ b/apps/web/src/app/api/ai/chat/stream-join/[messageId]/route.ts
@@ -3,6 +3,7 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
 import { streamMulticastRegistry } from '@/lib/ai/core/stream-multicast-registry';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { parseGlobalChannelId } from '@pagespace/lib/ai/global-channel-id';
 
 export const dynamic = 'force-dynamic';
 
@@ -33,7 +34,10 @@ export async function GET(
     return NextResponse.json({ error: 'Stream not found' }, { status: 404 });
   }
 
-  const canView = await canUserViewPage(userId, meta.pageId);
+  const channelOwner = parseGlobalChannelId(meta.pageId);
+  const canView = channelOwner !== null
+    ? channelOwner === userId
+    : await canUserViewPage(userId, meta.pageId);
   if (!canView) {
     auditRequest(request, {
       eventType: 'authz.access.denied',


### PR DESCRIPTION
## Summary

- The `stream-join` route was calling `canUserViewPage()` with the synthetic `user:<id>:global` channel ID format used by the global AI assistant
- That string is not a real page CUID2, so the permission system's `parsePageId()` rejects it → `canUserViewPage` always returns `false` → 403 on every global AI stream join
- This caused the `authz.access.denied` audit log to be spammed on every stream attempt, and global AI chat streaming was broken

**Root cause**: `active-streams/route.ts` already handled this correctly with a `parseGlobalChannelId()` two-branch check, but `stream-join/[messageId]/route.ts` didn't.

**Fix**: Added the same pattern — check if `meta.pageId` is a global channel ID first; if so, verify the owner matches the requesting user directly. Fall through to `canUserViewPage` only for real page IDs.

## Test plan

- [ ] Two new test cases added: global channel owned by requesting user → 200 (no `canUserViewPage` call); global channel owned by different user → 403
- [ ] Existing 18 stream-join route tests continue to pass
- [ ] Verify in browser: global AI chat streams without `authz.access.denied` spam in server logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)