### PR TITLE
fix(mentions): prevent list from overflowing below popup frame

### DIFF
--- a/apps/web/src/components/mentions/MentionPicker.tsx
+++ b/apps/web/src/components/mentions/MentionPicker.tsx
@@ -3,7 +3,6 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { cn } from '@/lib/utils';
 import { Input } from '@/components/ui/input';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   Popover,
@@ -102,7 +101,7 @@ export function MentionPickerPanel({
         </Tabs>
       )}
 
-      <ScrollArea className="max-h-64">
+      <div className="max-h-64 overflow-y-auto overscroll-contain">
         {loading ? (
           <div className="p-3 text-sm text-muted-foreground flex items-center gap-2">
             <span className="animate-spin inline-block w-3 h-3 border-2 border-current border-t-transparent rounded-full" />
@@ -160,7 +159,7 @@ export function MentionPickerPanel({
             })}
           </ul>
         )}
-      </ScrollArea>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/mentions/MentionPickerPortal.tsx
+++ b/apps/web/src/components/mentions/MentionPickerPortal.tsx
@@ -5,7 +5,7 @@ import { createPortal } from 'react-dom';
 import { MentionPickerPanel, TAB_TYPES, type TabType } from './MentionPicker';
 import type { MentionSuggestion, MentionType } from '@/types/mentions';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
-import type { Position } from '@/services/positioningService';
+import { getViewportHeight, type Position } from '@/services/positioningService';
 
 export interface MentionPickerPortalProps {
   isOpen: boolean;
@@ -112,16 +112,16 @@ export function MentionPickerPortal({
   if (!isOpen || !position) return null;
   if (typeof document === 'undefined') return null;
 
+  const viewportH = getViewportHeight();
   const maxHeight =
     position.bottom !== undefined
-      ? `calc(100vh - ${position.bottom + 8}px)`
-      : `calc(100vh - ${(position.top ?? 0) + 8}px)`;
+      ? `${viewportH - position.bottom - 8}px`
+      : `${viewportH - (position.top ?? 0) - 8}px`;
 
   const style: React.CSSProperties = {
     position: 'fixed',
     zIndex: 50,
     maxHeight,
-    overflow: 'hidden',
     ...(position.bottom !== undefined
       ? { bottom: position.bottom, left: position.left }
       : { top: position.top, left: position.left }),

--- a/apps/web/src/components/mentions/MentionPickerPortal.tsx
+++ b/apps/web/src/components/mentions/MentionPickerPortal.tsx
@@ -112,9 +112,16 @@ export function MentionPickerPortal({
   if (!isOpen || !position) return null;
   if (typeof document === 'undefined') return null;
 
+  const maxHeight =
+    position.bottom !== undefined
+      ? `calc(100vh - ${position.bottom + 8}px)`
+      : `calc(100vh - ${(position.top ?? 0) + 8}px)`;
+
   const style: React.CSSProperties = {
     position: 'fixed',
     zIndex: 50,
+    maxHeight,
+    overflow: 'hidden',
     ...(position.bottom !== undefined
       ? { bottom: position.bottom, left: position.left }
       : { top: position.top, left: position.left }),


### PR DESCRIPTION
## Summary

- **Root cause 1 — `MentionPickerPanel`**: The `<ScrollArea className="max-h-64">` wrapper wasn't scrolling because Radix's internal Viewport uses `height: 100%`, which doesn't resolve against `max-height` alone (only against an explicit definite height). Result: all items rendered without any height constraint. Fixed by replacing it with a plain `<div className="max-h-64 overflow-y-auto overscroll-contain">` — the same pattern used in the TipTap suggestion list and well-specified CSS.

- **Root cause 2 — `MentionPickerPortal`**: The portal wrapper had `overflow: hidden` (via Tailwind class) but no max-height, so the div's auto height grew to fit all items and `overflow-hidden` clipped nothing. Fixed by adding a viewport-aware `maxHeight` computed from the anchor position, giving `overflow: hidden` a definite bound to clip against.

## Test plan

- [ ] Type `@` in a channel message input — picker appears
- [ ] With many results (groups + pages), confirm all items stay inside the rounded popup frame
- [ ] Confirm the list scrolls with mouse wheel or arrow keys rather than overflowing
- [ ] Test near the bottom of the viewport (bottom-anchored) and near the top (top-anchored) to verify `maxHeight` calc works in both directions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved mention picker styling and layout handling for better display consistency and scrolling behavior in the suggestion list and portal positioning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1408?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->