### PR TITLE
feat(permissions): Discord-style open-by-default drive membership

### DIFF
--- a/apps/web/src/app/api/ai/chat/messages/[messageId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ai/chat/messages/[messageId]/__tests__/route.test.ts
@@ -120,6 +120,8 @@ type PageLookupResult = {
   originalParentId: string | null;
   contentMode: 'html' | 'markdown';
   excludeFromSearch: boolean;
+  isPrivate: boolean;
+  createdBy: string | null;
 };
 
 const mockPageLookup = (overrides: Partial<PageLookupResult> = {}): PageLookupResult => ({
@@ -160,6 +162,8 @@ const mockPageLookup = (overrides: Partial<PageLookupResult> = {}): PageLookupRe
   originalParentId: null,
   contentMode: 'html',
   excludeFromSearch: false,
+  isPrivate: false,
+  createdBy: null,
   ...overrides,
 });
 

--- a/apps/web/src/app/api/ai/page-agents/create/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/create/route.ts
@@ -115,6 +115,7 @@ export async function POST(request: Request) {
       // Agents can use 'standard' or 'pro' as friendly aliases
       aiProvider: aiProvider || 'pagespace',
       aiModel: aiModel || 'standard',
+      createdBy: userId,
     };
 
     // Add optional configuration (save even if empty array)

--- a/apps/web/src/app/api/drives/[driveId]/pages/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/pages/route.ts
@@ -18,16 +18,34 @@ const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 const UNREAD_INDICATOR_CUTOFF_DATE = new Date('2026-02-03T00:00:00.000Z');
 
 async function getPermittedPages(driveId: string, userId: string) {
-  // Check if user is a drive member - currently unused but will be needed for member-level permissions
-  // const membership = await db.query.driveMembers.findFirst({
-  //   where: and(
-  //     eq(driveMembers.driveId, driveId),
-  //     eq(driveMembers.userId, userId)
-  //   )
-  // });
+  // Rule 4: any accepted drive member can read non-private pages
+  const memberCheck = await db.select({ id: driveMembers.id })
+    .from(driveMembers)
+    .where(and(
+      eq(driveMembers.driveId, driveId),
+      eq(driveMembers.userId, userId),
+      isNotNull(driveMembers.acceptedAt)
+    ))
+    .limit(1);
 
-  // Get pages user has explicit permissions for
-  const permittedPageIdsQuery = await db.selectDistinct({ id: pages.id })
+  const isMember = memberCheck.length > 0;
+
+  const permittedPageIdSet = new Set<string>();
+
+  if (isMember) {
+    // MEMBER gets implicit read on all non-private pages in the drive
+    const nonPrivatePages = await db.selectDistinct({ id: pages.id })
+      .from(pages)
+      .where(and(
+        eq(pages.driveId, driveId),
+        eq(pages.isTrashed, false),
+        eq(pages.isPrivate, false)
+      ));
+    for (const p of nonPrivatePages) permittedPageIdSet.add(p.id);
+  }
+
+  // Also include pages with explicit canView grants
+  const explicitPages = await db.selectDistinct({ id: pages.id })
     .from(pages)
     .leftJoin(pagePermissions, eq(pages.id, pagePermissions.pageId))
     .where(and(
@@ -36,29 +54,28 @@ async function getPermittedPages(driveId: string, userId: string) {
       eq(pagePermissions.userId, userId),
       eq(pagePermissions.canView, true)
     ));
-  const permittedPageIds = permittedPageIdsQuery.map(p => p.id);
+  for (const p of explicitPages) permittedPageIdSet.add(p.id);
+
+  const permittedPageIds = Array.from(permittedPageIdSet);
 
   if (permittedPageIds.length === 0) {
     return [];
   }
 
-  // If user has any permissions, also get ancestor pages for tree structure
-  let ancestorIds: string[] = [];
-  if (permittedPageIds.length > 0) {
-    const ancestorIdsQuery = await db.execute(sql`
-      WITH RECURSIVE ancestors AS (
-        SELECT id, "parentId"
-        FROM pages
-        WHERE id IN ${permittedPageIds}
-        UNION ALL
-        SELECT p.id, p."parentId"
-        FROM pages p
-        JOIN ancestors a ON p.id = a."parentId"
-      )
-      SELECT id FROM ancestors;
-    `);
-    ancestorIds = (ancestorIdsQuery.rows as { id: string }[]).map(r => r.id);
-  }
+  // Also get ancestor pages for tree structure
+  const ancestorIdsQuery = await db.execute(sql`
+    WITH RECURSIVE ancestors AS (
+      SELECT id, "parentId"
+      FROM pages
+      WHERE id IN ${permittedPageIds}
+      UNION ALL
+      SELECT p.id, p."parentId"
+      FROM pages p
+      JOIN ancestors a ON p.id = a."parentId"
+    )
+    SELECT id FROM ancestors;
+  `);
+  const ancestorIds = (ancestorIdsQuery.rows as { id: string }[]).map(r => r.id);
 
   const allVisiblePageIds = [...new Set([...permittedPageIds, ...ancestorIds])];
 

--- a/apps/web/src/app/api/pages/[pageId]/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/route.ts
@@ -7,6 +7,7 @@ import { trackPageOperation } from '@pagespace/lib/monitoring/activity-tracker';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope, isMCPAuthResult } from '@/lib/auth';
 import { jsonResponse } from '@pagespace/lib/utils/api-utils';
 import { pageService } from '@/services/api';
+import { canUserSharePage } from '@pagespace/lib/permissions/permissions';
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
@@ -47,6 +48,7 @@ const patchSchema = z.object({
   aiModel: z.string().optional(),
   parentId: z.string().nullable().optional(),
   isPaginated: z.boolean().optional(),
+  isPrivate: z.boolean().optional(),
   expectedRevision: z.number().int().min(0).optional(),
   changeGroupId: z.string().optional(), // Groups related edits in activity log
 });
@@ -68,6 +70,14 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ pageId
     const body = await req.json();
     const safeBody = patchSchema.parse(body);
     const { expectedRevision, changeGroupId, ...updates } = safeBody;
+
+    // isPrivate is a visibility-level change — requires share permission
+    if (updates.isPrivate !== undefined) {
+      const canShare = await canUserSharePage(userId, pageId);
+      if (!canShare) {
+        return NextResponse.json({ error: 'Only page owners and drive admins can change page visibility' }, { status: 403 });
+      }
+    }
 
     const isMCP = isMCPAuthResult(auth);
     const mcpMeta = isMCP ? { source: 'mcp' as const } : undefined;

--- a/apps/web/src/app/api/pages/[pageId]/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/route.ts
@@ -69,10 +69,12 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ pageId
   try {
     const body = await req.json();
     const safeBody = patchSchema.parse(body);
-    const { expectedRevision, changeGroupId, ...updates } = safeBody;
+    const { expectedRevision, changeGroupId, isPrivate: isPrivateUpdate, ...contentUpdates } = safeBody;
 
-    // isPrivate is a visibility-level change — requires share permission
-    if (updates.isPrivate !== undefined) {
+    // isPrivate is a visibility-level change — requires share permission, NOT edit permission.
+    // Apply it through the service with skipPermissionCheck so users with canShare but not
+    // canEdit (e.g. page creator) can still toggle privacy.
+    if (isPrivateUpdate !== undefined) {
       const canShare = await canUserSharePage(userId, pageId);
       if (!canShare) {
         return NextResponse.json({ error: 'Only page owners and drive admins can change page visibility' }, { status: 403 });
@@ -85,9 +87,15 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ pageId
       ? { changeGroupId, metadata: mcpMeta }
       : undefined;
 
+    // Build the full updates object, applying isPrivate with skipPermissionCheck when present
+    const updates = isPrivateUpdate !== undefined
+      ? { ...contentUpdates, isPrivate: isPrivateUpdate }
+      : contentUpdates;
+
     const result = await pageService.updatePage(pageId, userId, updates, {
       expectedRevision,
       context,
+      skipPermissionCheck: isPrivateUpdate !== undefined && Object.keys(contentUpdates).length === 0,
     });
 
     if (!result.success) {

--- a/apps/web/src/app/api/tasks/__tests__/route.test.ts
+++ b/apps/web/src/app/api/tasks/__tests__/route.test.ts
@@ -154,6 +154,8 @@ const createPageFixture = (overrides: Partial<{
   parentId: null,
   originalParentId: null,
   excludeFromSearch: overrides.excludeFromSearch ?? false,
+  isPrivate: false,
+  createdBy: null,
 });
 
 const createTaskListFixture = (overrides: Partial<{

--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/ShareDialog.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/ShareDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { usePageStore } from '@/hooks/usePage';
 import { usePageTree } from '@/hooks/usePageTree';
 import { findNodeAndParent } from '@/lib/tree/tree-utils';
@@ -32,11 +32,12 @@ import { useMobile } from '@/hooks/useMobile';
 import { Input } from '@/components/ui/input';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { PermissionsList } from './PermissionsList';
 import { toast } from 'sonner';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { post, fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { post, fetchWithAuth, patch } from '@/lib/auth/auth-fetch';
 import { PageShareLinkSection } from './PageShareLinkSection';
 
 export function ShareDialog({ pageId: propPageId }: { pageId?: string | null } = {}) {
@@ -50,6 +51,12 @@ export function ShareDialog({ pageId: propPageId }: { pageId?: string | null } =
   const [isOpen, setIsOpen] = useState(false);
   const [email, setEmail] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isPrivate, setIsPrivate] = useState(false);
+  const [isTogglingPrivacy, setIsTogglingPrivacy] = useState(false);
+
+  useEffect(() => {
+    if (page) setIsPrivate(!!page.isPrivate);
+  }, [page?.id, page?.isPrivate]);
   const [offPlatformEmail, setOffPlatformEmail] = useState<string | null>(null);
   const [expiryDays, setExpiryDays] = useState<number | null>(null);
   const [permissions, setPermissions] = useState({
@@ -67,6 +74,20 @@ export function ShareDialog({ pageId: propPageId }: { pageId?: string | null } =
   const isMobile = useMobile();
 
   if (!page) return null;
+
+  const handlePrivacyToggle = async (newValue: boolean) => {
+    setIsPrivate(newValue);
+    setIsTogglingPrivacy(true);
+    try {
+      await patch(`/api/pages/${page.id}`, { isPrivate: newValue });
+      toast.success(newValue ? 'Page is now private' : 'Page is now visible to all drive members');
+    } catch {
+      setIsPrivate(!newValue);
+      toast.error('Failed to update page visibility');
+    } finally {
+      setIsTogglingPrivacy(false);
+    }
+  };
 
   const handlePermissionChange = (permission: string, checked: boolean) => {
     const newPerms = { ...permissions };
@@ -218,6 +239,23 @@ export function ShareDialog({ pageId: propPageId }: { pageId?: string | null } =
             </AlertDescription>
           </Alert>
         ) : (
+          <>
+            <div className="mt-4 flex items-center justify-between rounded-lg border p-4">
+              <div>
+                <p className="text-sm font-medium">Private page</p>
+                <p className="text-xs text-muted-foreground">
+                  {isPrivate
+                    ? 'Only you and people you\'ve explicitly shared with can see this page'
+                    : 'All drive members can read this page'}
+                </p>
+              </div>
+              <Switch
+                checked={isPrivate}
+                onCheckedChange={handlePrivacyToggle}
+                disabled={isTogglingPrivacy}
+                aria-label="Toggle page privacy"
+              />
+            </div>
           <Tabs defaultValue="share" className="mt-4">
             <TabsList>
               <TabsTrigger value="share">
@@ -388,6 +426,7 @@ export function ShareDialog({ pageId: propPageId }: { pageId?: string | null } =
               <PermissionsList key={permissionsVersion} />
             </TabsContent>
           </Tabs>
+          </>
         )}
       </DialogContent>
     </Dialog>

--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/ShareDialog.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/ShareDialog.tsx
@@ -56,7 +56,7 @@ export function ShareDialog({ pageId: propPageId }: { pageId?: string | null } =
 
   useEffect(() => {
     if (page) setIsPrivate(!!page.isPrivate);
-  }, [page?.id, page?.isPrivate]);
+  }, [page]);
   const [offPlatformEmail, setOffPlatformEmail] = useState<string | null>(null);
   const [expiryDays, setExpiryDays] = useState<number | null>(null);
   const [permissions, setPermissions] = useState({

--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -598,7 +598,7 @@ export const pageWriteTools = {
           revision: 0,
           stateHash,
           updatedAt: new Date(),
-          createdBy: context.userId,
+          createdBy: userId,
         });
 
         // AI_CHAT pages are agents — they need a drive membership to act with

--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -598,6 +598,7 @@ export const pageWriteTools = {
           revision: 0,
           stateHash,
           updatedAt: new Date(),
+          createdBy: context.userId,
         });
 
         // AI_CHAT pages are agents — they need a drive membership to act with

--- a/apps/web/src/lib/repositories/page-agent-repository.ts
+++ b/apps/web/src/lib/repositories/page-agent-repository.ts
@@ -38,6 +38,7 @@ export interface AgentData {
   enabledTools?: string[] | null;
   aiProvider?: string | null;
   aiModel?: string | null;
+  createdBy?: string | null;
 }
 
 export interface CreatedAgent {

--- a/apps/web/src/services/api/page-service.ts
+++ b/apps/web/src/services/api/page-service.ts
@@ -256,6 +256,7 @@ export interface UpdatePageParams {
   aiModel?: string;
   parentId?: string | null;
   isPaginated?: boolean;
+  isPrivate?: boolean;
 }
 
 export interface UpdatePageOptions {
@@ -704,6 +705,7 @@ export const pageService = {
         updatedAt: Date;
         revision: number;
         stateHash: string;
+        createdBy: string;
         aiProvider?: string | null;
         aiModel?: string | null;
         systemPrompt?: string | null;
@@ -722,6 +724,7 @@ export const pageService = {
         updatedAt: new Date(),
         revision: 0,
         stateHash: '',
+        createdBy: userId,
       };
 
       if (isAIChatPage(params.type as PageTypeEnum)) {

--- a/apps/web/src/services/api/page-service.ts
+++ b/apps/web/src/services/api/page-service.ts
@@ -263,6 +263,7 @@ export interface UpdatePageOptions {
   expectedRevision?: number;
   context?: Omit<PageMutationContext, 'userId'>;
   source?: PageVersionSource;
+  skipPermissionCheck?: boolean;
 }
 
 type TransactionType = Parameters<Parameters<typeof db.transaction>[0]>[0];
@@ -401,10 +402,12 @@ export const pageService = {
     updates: UpdatePageParams,
     options?: UpdatePageOptions
   ): Promise<UpdatePageResult> {
-    // Check authorization
-    const canEdit = await canUserEditPage(userId, pageId);
-    if (!canEdit) {
-      return { success: false, error: 'You need edit permission to modify this page', status: 403 };
+    // Check authorization (can be skipped by callers that have already verified a sufficient permission)
+    if (!options?.skipPermissionCheck) {
+      const canEdit = await canUserEditPage(userId, pageId);
+      if (!canEdit) {
+        return { success: false, error: 'You need edit permission to modify this page', status: 403 };
+      }
     }
 
     // Validate parent change

--- a/packages/db/drizzle/0132_gifted_cerise.sql
+++ b/packages/db/drizzle/0132_gifted_cerise.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "pages" ADD COLUMN "isPrivate" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "pages" ADD COLUMN "createdBy" text;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "pages" ADD CONSTRAINT "pages_createdBy_users_id_fk" FOREIGN KEY ("createdBy") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/packages/db/drizzle/0133_default_member_read.sql
+++ b/packages/db/drizzle/0133_default_member_read.sql
@@ -1,0 +1,61 @@
+-- Update accessible_page_ids_for_user to implement Discord-style open-by-default
+-- within a drive. Rule 4 (new): an accepted drive member can read any page in
+-- that drive unless the page is explicitly marked isPrivate=true.
+--
+-- Resolution rules (a user sees a page iff ANY of the following holds):
+--   1. They own the drive that contains the page.
+--   2. They are a drive_members row with role='ADMIN' AND acceptedAt IS NOT NULL.
+--   3. They have a page_permissions row with canView=true and either
+--      expiresAt IS NULL or expiresAt > now().
+--   4. They are any accepted drive member AND page.isPrivate=false.
+--      (Drive MEMBER role gets implicit read on non-private pages.)
+
+DROP FUNCTION IF EXISTS accessible_page_ids_for_user(text);
+--> statement-breakpoint
+CREATE FUNCTION accessible_page_ids_for_user(uid text)
+RETURNS TABLE(page_id text)
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+PARALLEL SAFE
+SET search_path = pg_catalog, public
+AS $$
+  SELECT p.id
+  FROM pages p
+  WHERE p."isTrashed" = false
+    AND EXISTS (
+      SELECT 1 FROM drives d
+      WHERE d.id = p."driveId"
+        AND d."isTrashed" = false
+        AND (
+          d."ownerId" = uid
+          OR EXISTS (
+            SELECT 1 FROM drive_members dm
+            WHERE dm."driveId" = d.id
+              AND dm."userId" = uid
+              AND dm.role = 'ADMIN'
+              AND dm."acceptedAt" IS NOT NULL
+          )
+          OR EXISTS (
+            SELECT 1 FROM page_permissions pp
+            WHERE pp."pageId" = p.id
+              AND pp."userId" = uid
+              AND pp."canView" = true
+              AND (pp."expiresAt" IS NULL OR pp."expiresAt" > now())
+          )
+          OR (
+            p."isPrivate" = false
+            AND EXISTS (
+              SELECT 1 FROM drive_members dm
+              WHERE dm."driveId" = d.id
+                AND dm."userId" = uid
+                AND dm."acceptedAt" IS NOT NULL
+            )
+          )
+        )
+    );
+$$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "pages_is_private_drive_id_idx"
+  ON "pages" ("driveId", "isPrivate")
+  WHERE "isTrashed" = false;

--- a/packages/db/drizzle/meta/0132_snapshot.json
+++ b/packages/db/drizzle/meta/0132_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "09ccafca-c7eb-4974-a58d-8cb70c1624e5",
-  "prevId": "6d611378-aff1-4408-9f9e-bb50654f6d90",
+  "id": "7e38aace-c580-41cc-a793-c83b9fc3bd73",
+  "prevId": "09ccafca-c7eb-4974-a58d-8cb70c1624e5",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -376,166 +376,6 @@
           ]
         }
       }
-    },
-    "public.mcp_token_drives": {
-      "name": "mcp_token_drives",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "tokenId": {
-          "name": "tokenId",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "driveId": {
-          "name": "driveId",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "createdAt": {
-          "name": "createdAt",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "role": {
-          "name": "role",
-          "type": "MemberRole",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'MEMBER'"
-        },
-        "customRoleId": {
-          "name": "customRoleId",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "addedBy": {
-          "name": "addedBy",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        }
-      },
-      "indexes": {
-        "mcp_token_drives_token_id_idx": {
-          "name": "mcp_token_drives_token_id_idx",
-          "columns": [
-            {
-              "expression": "tokenId",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "mcp_token_drives_drive_id_idx": {
-          "name": "mcp_token_drives_drive_id_idx",
-          "columns": [
-            {
-              "expression": "driveId",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "mcp_token_drives_token_drive_unique": {
-          "name": "mcp_token_drives_token_drive_unique",
-          "columns": [
-            {
-              "expression": "tokenId",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "driveId",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "mcp_token_drives_tokenId_mcp_tokens_id_fk": {
-          "name": "mcp_token_drives_tokenId_mcp_tokens_id_fk",
-          "tableFrom": "mcp_token_drives",
-          "tableTo": "mcp_tokens",
-          "columnsFrom": [
-            "tokenId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "mcp_token_drives_driveId_drives_id_fk": {
-          "name": "mcp_token_drives_driveId_drives_id_fk",
-          "tableFrom": "mcp_token_drives",
-          "tableTo": "drives",
-          "columnsFrom": [
-            "driveId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "mcp_token_drives_customRoleId_drive_roles_id_fk": {
-          "name": "mcp_token_drives_customRoleId_drive_roles_id_fk",
-          "tableFrom": "mcp_token_drives",
-          "tableTo": "drive_roles",
-          "columnsFrom": [
-            "customRoleId"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        },
-        "mcp_token_drives_addedBy_users_id_fk": {
-          "name": "mcp_token_drives_addedBy_users_id_fk",
-          "tableFrom": "mcp_token_drives",
-          "tableTo": "users",
-          "columnsFrom": [
-            "addedBy"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {}
     },
     "public.mcp_tokens": {
       "name": "mcp_tokens",
@@ -2335,6 +2175,19 @@
           "notNull": true,
           "default": false
         },
+        "isPrivate": {
+          "name": "isPrivate",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "createdAt": {
           "name": "createdAt",
           "type": "timestamp",
@@ -2467,6 +2320,19 @@
         }
       },
       "foreignKeys": {
+        "pages_createdBy_users_id_fk": {
+          "name": "pages_createdBy_users_id_fk",
+          "tableFrom": "pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "createdBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
         "pages_driveId_drives_id_fk": {
           "name": "pages_driveId_drives_id_fk",
           "tableFrom": "pages",
@@ -3361,6 +3227,166 @@
           ]
         }
       }
+    },
+    "public.mcp_token_drives": {
+      "name": "mcp_token_drives",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tokenId": {
+          "name": "tokenId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driveId": {
+          "name": "driveId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "MemberRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEMBER'"
+        },
+        "customRoleId": {
+          "name": "customRoleId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "addedBy": {
+          "name": "addedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mcp_token_drives_token_id_idx": {
+          "name": "mcp_token_drives_token_id_idx",
+          "columns": [
+            {
+              "expression": "tokenId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_token_drives_drive_id_idx": {
+          "name": "mcp_token_drives_drive_id_idx",
+          "columns": [
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mcp_token_drives_token_drive_unique": {
+          "name": "mcp_token_drives_token_drive_unique",
+          "columns": [
+            {
+              "expression": "tokenId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "driveId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mcp_token_drives_tokenId_mcp_tokens_id_fk": {
+          "name": "mcp_token_drives_tokenId_mcp_tokens_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "mcp_tokens",
+          "columnsFrom": [
+            "tokenId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_token_drives_driveId_drives_id_fk": {
+          "name": "mcp_token_drives_driveId_drives_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "drives",
+          "columnsFrom": [
+            "driveId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mcp_token_drives_customRoleId_drive_roles_id_fk": {
+          "name": "mcp_token_drives_customRoleId_drive_roles_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "drive_roles",
+          "columnsFrom": [
+            "customRoleId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "mcp_token_drives_addedBy_users_id_fk": {
+          "name": "mcp_token_drives_addedBy_users_id_fk",
+          "tableFrom": "mcp_token_drives",
+          "tableTo": "users",
+          "columnsFrom": [
+            "addedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
     },
     "public.page_permissions": {
       "name": "page_permissions",

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -925,6 +925,20 @@
       "when": 1779561969627,
       "tag": "0131_big_mentor",
       "breakpoints": true
+    },
+    {
+      "idx": 132,
+      "version": "7",
+      "when": 1779582391083,
+      "tag": "0132_gifted_cerise",
+      "breakpoints": true
+    },
+    {
+      "idx": 133,
+      "version": "7",
+      "when": 1779582461866,
+      "tag": "0133_default_member_read",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/core.ts
+++ b/packages/db/src/schema/core.ts
@@ -55,6 +55,8 @@ export const pages = pgTable('pages', {
   extractionMetadata: jsonb('extractionMetadata'),
   contentHash: text('contentHash'),
   excludeFromSearch: boolean('excludeFromSearch').default(false).notNull(),
+  isPrivate: boolean('isPrivate').default(false).notNull(),
+  createdBy: text('createdBy').references(() => users.id, { onDelete: 'set null' }),
   createdAt: timestamp('createdAt', { mode: 'date' }).defaultNow().notNull(),
   updatedAt: timestamp('updatedAt', { mode: 'date' }).notNull().$onUpdate(() => new Date()),
   trashedAt: timestamp('trashedAt', { mode: 'date' }),

--- a/packages/lib/src/__tests__/permissions.test.ts
+++ b/packages/lib/src/__tests__/permissions.test.ts
@@ -174,12 +174,29 @@ describe('permissions system', () => {
       })
     })
 
-    it('does not grant admin permissions to regular drive members', async () => {
+    it('grants read-only access to regular drive members on non-private pages', async () => {
       // Add otherUser as regular member (not admin) to the drive
       await factories.createDriveMember(testDrive.id, otherUser.id, { role: 'MEMBER' })
 
-      // Regular member without explicit permissions should not have access
+      // Regular member gets default read-only access on non-private pages (Discord @everyone model)
       const access = await getUserAccessLevel(otherUser.id, testPage.id)
+      expect(access).toEqual({
+        canView: true,
+        canEdit: false,
+        canShare: false,
+        canDelete: false,
+      })
+    })
+
+    it('denies access to regular drive members on private pages', async () => {
+      // Add otherUser as regular member (not admin) to the drive
+      await factories.createDriveMember(testDrive.id, otherUser.id, { role: 'MEMBER' })
+
+      // Create a private page
+      const privatePage = await factories.createPage(testDrive.id, { isPrivate: true })
+
+      // Regular member cannot access private pages without explicit grant
+      const access = await getUserAccessLevel(otherUser.id, privatePage.id)
       expect(access).toBeNull()
     })
   })

--- a/packages/lib/src/permissions/__tests__/batch-page-permissions.test.ts
+++ b/packages/lib/src/permissions/__tests__/batch-page-permissions.test.ts
@@ -69,8 +69,9 @@ const USER = 'user_abc';
 interface Row {
   pageId: string;
   isTrashed: boolean;
+  isPrivate: boolean;
   driveOwnerId: string | null;
-  adminMemberId: string | null;
+  memberRole: string | null;
   explicitCanView: boolean | null;
   explicitCanEdit: boolean | null;
   explicitCanShare: boolean | null;
@@ -79,12 +80,14 @@ interface Row {
 
 const FULL = { canView: true, canEdit: true, canShare: true, canDelete: true };
 const NONE = { canView: false, canEdit: false, canShare: false, canDelete: false };
+const READ_ONLY = { canView: true, canEdit: false, canShare: false, canDelete: false };
 
 function makeRow(overrides: Partial<Row> & { pageId: string }): Row {
   return {
     isTrashed: false,
+    isPrivate: false,
     driveOwnerId: null,
-    adminMemberId: null,
+    memberRole: null,
     explicitCanView: null,
     explicitCanEdit: null,
     explicitCanShare: null,
@@ -149,21 +152,20 @@ describe('getBatchPagePermissions', () => {
   });
 
   it('given an accepted ADMIN member, should grant all four permissions', async () => {
-    // Invariant from the CTE: the drive_members LEFT JOIN already filters on
-    // role = 'ADMIN' AND acceptedAt IS NOT NULL, so a non-null adminMemberId
-    // here encodes an accepted admin.
-    stubQueryRows([makeRow({ pageId: 'p1', adminMemberId: 'member_x' })]);
+    // drive_members LEFT JOIN filters acceptedAt IS NOT NULL, so memberRole = 'ADMIN'
+    // encodes an accepted admin.
+    stubQueryRows([makeRow({ pageId: 'p1', memberRole: 'ADMIN' })]);
 
     const result = await getBatchPagePermissions(USER, ['p1']);
 
     expect(result.get('p1')).toEqual(FULL);
   });
 
-  it('given an unaccepted ADMIN invite (adminMemberId null), should fall through to explicit-grant check', async () => {
-    // The CTE's acceptedAt IS NOT NULL predicate causes an unaccepted admin
-    // invite to yield adminMemberId = null. With no explicit grant, this
-    // degrades to all-false.
-    stubQueryRows([makeRow({ pageId: 'p1', adminMemberId: null })]);
+  it('given an unaccepted invite (memberRole null), should fall through to explicit-grant check', async () => {
+    // The drive_members LEFT JOIN's acceptedAt IS NOT NULL predicate causes
+    // unaccepted invites to yield memberRole = null. With no explicit grant,
+    // this degrades to all-false.
+    stubQueryRows([makeRow({ pageId: 'p1', memberRole: null })]);
 
     const result = await getBatchPagePermissions(USER, ['p1']);
 
@@ -214,8 +216,24 @@ describe('getBatchPagePermissions', () => {
     expect(result.get('p1')).toEqual(NONE);
   });
 
-  it('given an inaccessible pageId (row exists, no grants), should return all four false', async () => {
-    stubQueryRows([makeRow({ pageId: 'p1' })]);
+  it('given an accepted MEMBER on a non-private page, should grant read-only access', async () => {
+    stubQueryRows([makeRow({ pageId: 'p1', memberRole: 'MEMBER' })]);
+
+    const result = await getBatchPagePermissions(USER, ['p1']);
+
+    expect(result.get('p1')).toEqual(READ_ONLY);
+  });
+
+  it('given an accepted MEMBER on a private page, should deny access', async () => {
+    stubQueryRows([makeRow({ pageId: 'p1', memberRole: 'MEMBER', isPrivate: true })]);
+
+    const result = await getBatchPagePermissions(USER, ['p1']);
+
+    expect(result.get('p1')).toEqual(NONE);
+  });
+
+  it('given an inaccessible pageId (row exists, no grants, private page), should return all four false', async () => {
+    stubQueryRows([makeRow({ pageId: 'p1', isPrivate: true })]);
 
     const result = await getBatchPagePermissions(USER, ['p1']);
 
@@ -236,7 +254,7 @@ describe('getBatchPagePermissions', () => {
   it('given a mixed batch, should classify each pageId independently', async () => {
     stubQueryRows([
       makeRow({ pageId: 'owned', driveOwnerId: USER }),
-      makeRow({ pageId: 'admin', adminMemberId: 'member_1' }),
+      makeRow({ pageId: 'admin', memberRole: 'ADMIN' }),
       makeRow({
         pageId: 'granted',
         explicitCanView: true,
@@ -245,7 +263,9 @@ describe('getBatchPagePermissions', () => {
         explicitCanDelete: false,
       }),
       makeRow({ pageId: 'trashed', isTrashed: true, driveOwnerId: USER }),
-      makeRow({ pageId: 'denied' }),
+      makeRow({ pageId: 'member_open', memberRole: 'MEMBER' }),
+      makeRow({ pageId: 'member_private', memberRole: 'MEMBER', isPrivate: true }),
+      makeRow({ pageId: 'denied', isPrivate: true }),
     ]);
 
     const result = await getBatchPagePermissions(USER, [
@@ -253,6 +273,8 @@ describe('getBatchPagePermissions', () => {
       'admin',
       'granted',
       'trashed',
+      'member_open',
+      'member_private',
       'denied',
       'missing',
     ]);
@@ -266,9 +288,11 @@ describe('getBatchPagePermissions', () => {
       canDelete: false,
     });
     expect(result.get('trashed')).toEqual(NONE);
+    expect(result.get('member_open')).toEqual(READ_ONLY);
+    expect(result.get('member_private')).toEqual(NONE);
     expect(result.get('denied')).toEqual(NONE);
     expect(result.get('missing')).toEqual(NONE);
-    expect(result.size).toBe(6);
+    expect(result.size).toBe(8);
   });
 
   it('should filter drive_members join on acceptedAt IS NOT NULL (matches single-page path)', async () => {

--- a/packages/lib/src/permissions/__tests__/permissions.test.ts
+++ b/packages/lib/src/permissions/__tests__/permissions.test.ts
@@ -344,11 +344,12 @@ describe('getUserAccessLevel', () => {
     expect(result).toBeNull();
   });
 
-  it('logs no-permissions message when silent=false and no explicit permissions', async () => {
+  it('logs no-permissions message when silent=false and no explicit permissions and not a drive member', async () => {
     mockValidators(true, true);
-    const page = [{ id: VALID_PAGE, driveId: VALID_DRIVE, driveOwnerId: 'other-owner' }];
+    const page = [{ id: VALID_PAGE, driveId: VALID_DRIVE, driveOwnerId: 'other-owner', isPrivate: false }];
 
     vi.mocked(db.select)
+      // page + drive lookup
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           leftJoin: vi.fn().mockReturnValue({
@@ -356,11 +357,19 @@ describe('getUserAccessLevel', () => {
           }),
         }),
       } as unknown as ReturnType<typeof db.select>)
+      // admin check → not admin
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
         }),
       } as unknown as ReturnType<typeof db.select>)
+      // explicit pagePermissions → none
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+        }),
+      } as unknown as ReturnType<typeof db.select>)
+      // member check → not a member (so rule 4 doesn't grant access)
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
@@ -829,7 +838,8 @@ describe('getUserAccessiblePagesInDrive', () => {
     expect(result).toEqual(['page-1']);
   });
 
-  it('returns only explicitly permissioned pages for regular member', async () => {
+  it('returns non-private pages plus explicit pages for drive member', async () => {
+    const nonPrivatePageIds = [{ id: 'non-private-page' }];
     const permPages = [{ pageId: 'page-with-perm' }];
     vi.mocked(db.select)
       // drive lookup (not owner)
@@ -839,6 +849,51 @@ describe('getUserAccessiblePagesInDrive', () => {
         }),
       } as unknown as ReturnType<typeof db.select>)
       // admin check (not admin)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+        }),
+      } as unknown as ReturnType<typeof db.select>)
+      // member check → is a member (MEMBER role)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ id: 'member-row' }]) }),
+        }),
+      } as unknown as ReturnType<typeof db.select>)
+      // non-private pages visible to all members
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(nonPrivatePageIds),
+        }),
+      } as unknown as ReturnType<typeof db.select>)
+      // explicit permissions
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          leftJoin: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(permPages) }),
+        }),
+      } as unknown as ReturnType<typeof db.select>);
+
+    const result = await getUserAccessiblePagesInDrive(VALID_USER, VALID_DRIVE);
+    expect(result).toContain('non-private-page');
+    expect(result).toContain('page-with-perm');
+  });
+
+  it('returns only explicit pages for non-member without drive membership', async () => {
+    const permPages = [{ pageId: 'page-with-perm' }];
+    vi.mocked(db.select)
+      // drive lookup (not owner)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ ownerId: 'other-user' }]) }),
+        }),
+      } as unknown as ReturnType<typeof db.select>)
+      // admin check (not admin)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+        }),
+      } as unknown as ReturnType<typeof db.select>)
+      // member check → not a member
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
@@ -894,25 +949,40 @@ describe('getUserAccessiblePagesInDriveWithDetails', () => {
     expect(result[0].permissions).toEqual({ canView: true, canEdit: true, canShare: true, canDelete: true });
   });
 
-  it('returns pages with explicit permissions for non-owner', async () => {
+  it('returns non-private pages with default read and explicit pages with their grants for drive member', async () => {
+    const nonPrivatePages = [
+      { id: 'non-private-1', title: 'Open Page', type: 'DOCUMENT', parentId: null, position: 1, isTrashed: false },
+    ];
     const permPages = [
-      { id: 'page-1', title: 'Page 1', type: 'DOCUMENT', parentId: null, position: 1, isTrashed: false,
-        canView: true, canEdit: false, canShare: false, canDelete: false },
+      { id: 'page-with-perm', title: 'Edit Page', type: 'DOCUMENT', parentId: null, position: 2, isTrashed: false,
+        canView: true, canEdit: true, canShare: false, canDelete: false },
     ];
     vi.mocked(db.select)
-      // drive lookup
+      // drive lookup (not owner)
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ ownerId: 'other-user' }]) }),
         }),
       } as unknown as ReturnType<typeof db.select>)
-      // admin check
+      // admin check → not admin
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
         }),
       } as unknown as ReturnType<typeof db.select>)
-      // pages with permissions join
+      // member check → is a member
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ id: 'member-row' }]) }),
+        }),
+      } as unknown as ReturnType<typeof db.select>)
+      // non-private pages (MEMBER default read)
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(nonPrivatePages),
+        }),
+      } as unknown as ReturnType<typeof db.select>)
+      // explicit pages with permission join
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           innerJoin: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(permPages) }),
@@ -920,8 +990,10 @@ describe('getUserAccessiblePagesInDriveWithDetails', () => {
       } as unknown as ReturnType<typeof db.select>);
 
     const result = await getUserAccessiblePagesInDriveWithDetails(VALID_USER, VALID_DRIVE);
-    expect(result).toHaveLength(1);
-    expect(result[0].permissions).toEqual({ canView: true, canEdit: false, canShare: false, canDelete: false });
+    const openPage = result.find(p => p.id === 'non-private-1');
+    const editPage = result.find(p => p.id === 'page-with-perm');
+    expect(openPage?.permissions).toEqual({ canView: true, canEdit: false, canShare: false, canDelete: false });
+    expect(editPage?.permissions).toEqual({ canView: true, canEdit: true, canShare: false, canDelete: false });
   });
 });
 

--- a/packages/lib/src/permissions/__tests__/zero-trust-boundaries.test.ts
+++ b/packages/lib/src/permissions/__tests__/zero-trust-boundaries.test.ts
@@ -276,16 +276,26 @@ describe('Zero-Trust Permission Boundaries (Integration)', () => {
     });
   });
 
-  describe('MEMBER role requires explicit page permissions', () => {
-    it('given user with MEMBER role on drive, should NOT auto-access pages', async () => {
+  describe('MEMBER role — open-by-default (Discord @everyone model)', () => {
+    it('given MEMBER and non-private page, should get read-only access', async () => {
+      // testPage defaults to isPrivate: false (non-private)
       await factories.createDriveMember(testDrive.id, otherUser.id, { role: 'MEMBER' });
 
       const result = await getUserAccessLevel(otherUser.id, testPage.id);
 
+      expect(result).toEqual({ canView: true, canEdit: false, canShare: false, canDelete: false });
+    });
+
+    it('given MEMBER and private page, should be denied', async () => {
+      const privatePage = await factories.createPage(testDrive.id, { isPrivate: true });
+      await factories.createDriveMember(testDrive.id, otherUser.id, { role: 'MEMBER' });
+
+      const result = await getUserAccessLevel(otherUser.id, privatePage.id);
+
       expect(result).toBeNull();
     });
 
-    it('given MEMBER with explicit page permission, should have that access level', async () => {
+    it('given MEMBER with explicit edit grant on non-private page, explicit grant wins', async () => {
       await factories.createDriveMember(testDrive.id, otherUser.id, { role: 'MEMBER' });
 
       await factories.createPagePermission(testPage.id, otherUser.id, {
@@ -304,10 +314,10 @@ describe('Zero-Trust Permission Boundaries (Integration)', () => {
       expect(result?.canDelete).toBe(false);
     });
 
-    it('given MEMBER, should only access pages with explicit permissions', async () => {
+    it('given MEMBER with explicit grant on one page, can also read other non-private pages', async () => {
       await factories.createDriveMember(testDrive.id, otherUser.id, { role: 'MEMBER' });
 
-      const secondPage = await factories.createPage(testDrive.id);
+      const secondPage = await factories.createPage(testDrive.id);  // non-private by default
 
       await factories.createPagePermission(testPage.id, otherUser.id, {
         canView: true,
@@ -317,11 +327,40 @@ describe('Zero-Trust Permission Boundaries (Integration)', () => {
         grantedBy: testUser.id,
       });
 
+      // testPage: explicit grant → canEdit
       const access1 = await getUserAccessLevel(otherUser.id, testPage.id);
+      // secondPage: MEMBER default → canView only
       const access2 = await getUserAccessLevel(otherUser.id, secondPage.id);
 
       expect(access1?.canView).toBe(true);
-      expect(access2).toBeNull();
+      expect(access1?.canEdit).toBe(true);
+      expect(access2?.canView).toBe(true);
+      expect(access2?.canEdit).toBe(false);
+    });
+
+    it('given MEMBER with explicit grant on private page, can read it', async () => {
+      const privatePage = await factories.createPage(testDrive.id, { isPrivate: true });
+      await factories.createDriveMember(testDrive.id, otherUser.id, { role: 'MEMBER' });
+
+      await factories.createPagePermission(privatePage.id, otherUser.id, {
+        canView: true,
+        canEdit: false,
+        canShare: false,
+        canDelete: false,
+        grantedBy: testUser.id,
+      });
+
+      const result = await getUserAccessLevel(otherUser.id, privatePage.id);
+
+      expect(result?.canView).toBe(true);
+      expect(result?.canEdit).toBe(false);
+    });
+
+    it('given non-member with no permissions, cannot read non-private page', async () => {
+      // otherUser has no drive membership at all
+      const result = await getUserAccessLevel(otherUser.id, testPage.id);
+
+      expect(result).toBeNull();
     });
   });
 

--- a/packages/lib/src/permissions/permission-mutations.ts
+++ b/packages/lib/src/permissions/permission-mutations.ts
@@ -123,12 +123,26 @@ async function getPageIfCanShare(
     };
   }
 
-  // Check if user is the page creator (can share their own page)
+  // Check if user is the page creator AND still has active drive membership
   if (page.createdBy === userId) {
-    return {
-      ok: true,
-      page: { pageId: page.id, driveId: page.driveId },
-    };
+    const creatorMembership = await db
+      .select({ id: driveMembers.id })
+      .from(driveMembers)
+      .where(
+        and(
+          eq(driveMembers.driveId, page.driveId),
+          eq(driveMembers.userId, userId),
+          isNotNull(driveMembers.acceptedAt)
+        )
+      )
+      .limit(1);
+
+    if (creatorMembership.length > 0) {
+      return {
+        ok: true,
+        page: { pageId: page.id, driveId: page.driveId },
+      };
+    }
   }
 
   // Check if user is drive admin (can share)

--- a/packages/lib/src/permissions/permission-mutations.ts
+++ b/packages/lib/src/permissions/permission-mutations.ts
@@ -98,6 +98,7 @@ async function getPageIfCanShare(
       id: pages.id,
       driveId: pages.driveId,
       driveOwnerId: drives.ownerId,
+      createdBy: pages.createdBy,
     })
     .from(pages)
     .leftJoin(drives, eq(pages.driveId, drives.id))
@@ -116,6 +117,14 @@ async function getPageIfCanShare(
 
   // Check if user is drive owner (can share)
   if (page.driveOwnerId === userId) {
+    return {
+      ok: true,
+      page: { pageId: page.id, driveId: page.driveId },
+    };
+  }
+
+  // Check if user is the page creator (can share their own page)
+  if (page.createdBy === userId) {
     return {
       ok: true,
       page: { pageId: page.id, driveId: page.driveId },

--- a/packages/lib/src/permissions/permissions.ts
+++ b/packages/lib/src/permissions/permissions.ts
@@ -122,6 +122,7 @@ export async function getUserAccessLevel(
       id: pages.id,
       driveId: pages.driveId,
       driveOwnerId: drives.ownerId,
+      isPrivate: pages.isPrivate,
     })
     .from(pages)
     .leftJoin(drives, eq(pages.driveId, drives.id))
@@ -224,6 +225,25 @@ export async function getUserAccessLevel(
       .limit(1);
 
     if (permission.length === 0) {
+      // Rule 4: any accepted drive member can read non-private pages (Discord @everyone)
+      if (pageData.driveId && !pageData.isPrivate) {
+        const membership = await db.select({ id: driveMembers.id })
+          .from(driveMembers)
+          .where(and(
+            eq(driveMembers.driveId, pageData.driveId),
+            eq(driveMembers.userId, validUserId),
+            isNotNull(driveMembers.acceptedAt)
+          ))
+          .limit(1);
+
+        if (membership.length > 0) {
+          if (!silent) {
+            loggers.api.debug(`[PERMISSIONS] User is drive member, page is not private - granting read access`);
+          }
+          return { canView: true, canEdit: false, canShare: false, canDelete: false };
+        }
+      }
+
       if (!silent) {
         loggers.api.debug(`[PERMISSIONS] No explicit permissions found (or expired) - denying access`);
       }
@@ -377,7 +397,30 @@ export async function getUserAccessiblePagesInDrive(
     return allPages.map((page: { id: string }) => page.id);
   }
 
-  const permissions = await db.select({ pageId: pagePermissions.pageId })
+  // Rule 4: MEMBER gets implicit read on non-private pages
+  const isMember = await db.select({ id: driveMembers.id })
+    .from(driveMembers)
+    .where(and(
+      eq(driveMembers.driveId, driveId),
+      eq(driveMembers.userId, userId),
+      isNotNull(driveMembers.acceptedAt)
+    ))
+    .limit(1);
+
+  const pageIdSet = new Set<string>();
+
+  if (isMember.length > 0) {
+    const nonPrivatePages = await db.select({ id: pages.id })
+      .from(pages)
+      .where(and(
+        eq(pages.driveId, driveId),
+        eq(pages.isPrivate, false),
+        eq(pages.isTrashed, false)
+      ));
+    for (const p of nonPrivatePages) pageIdSet.add(p.id);
+  }
+
+  const explicitPermissions = await db.select({ pageId: pagePermissions.pageId })
     .from(pagePermissions)
     .leftJoin(pages, eq(pagePermissions.pageId, pages.id))
     .where(and(
@@ -387,7 +430,9 @@ export async function getUserAccessiblePagesInDrive(
       or(isNull(pagePermissions.expiresAt), gt(pagePermissions.expiresAt, new Date()))
     ));
 
-  return permissions.map((entry: { pageId: string }) => entry.pageId);
+  for (const entry of explicitPermissions) pageIdSet.add(entry.pageId);
+
+  return Array.from(pageIdSet);
 }
 
 /**
@@ -468,7 +513,46 @@ export async function getUserAccessiblePagesInDriveWithDetails(
     }));
   }
 
-  const pagesWithPermissions = await db.select({
+  const memberCheck = await db.select({ id: driveMembers.id })
+    .from(driveMembers)
+    .where(and(
+      eq(driveMembers.driveId, driveId),
+      eq(driveMembers.userId, userId),
+      isNotNull(driveMembers.acceptedAt)
+    ))
+    .limit(1);
+
+  const isMember = memberCheck.length > 0;
+
+  const pageMap = new Map<string, PageWithPermissions>();
+
+  // Rule 4: MEMBER gets implicit canView on non-private pages
+  if (isMember) {
+    const nonPrivatePages = await db.select({
+      id: pages.id,
+      title: pages.title,
+      type: pages.type,
+      parentId: pages.parentId,
+      position: pages.position,
+      isTrashed: pages.isTrashed,
+    })
+    .from(pages)
+    .where(and(
+      eq(pages.driveId, driveId),
+      eq(pages.isTrashed, false),
+      eq(pages.isPrivate, false)
+    ));
+
+    for (const page of nonPrivatePages) {
+      pageMap.set(page.id, {
+        ...page,
+        permissions: { canView: true, canEdit: false, canShare: false, canDelete: false },
+      });
+    }
+  }
+
+  // Explicit pagePermissions override the defaults
+  const explicitPages = await db.select({
     id: pages.id,
     title: pages.title,
     type: pages.type,
@@ -490,20 +574,24 @@ export async function getUserAccessiblePagesInDriveWithDetails(
     or(isNull(pagePermissions.expiresAt), gt(pagePermissions.expiresAt, new Date()))
   ));
 
-  return pagesWithPermissions.map((page): PageWithPermissions => ({
-    id: page.id,
-    title: page.title,
-    type: page.type,
-    parentId: page.parentId,
-    position: page.position,
-    isTrashed: page.isTrashed,
-    permissions: {
-      canView: page.canView,
-      canEdit: page.canEdit,
-      canShare: page.canShare,
-      canDelete: page.canDelete,
-    }
-  }));
+  for (const page of explicitPages) {
+    pageMap.set(page.id, {
+      id: page.id,
+      title: page.title,
+      type: page.type,
+      parentId: page.parentId,
+      position: page.position,
+      isTrashed: page.isTrashed,
+      permissions: {
+        canView: page.canView,
+        canEdit: page.canEdit,
+        canShare: page.canShare,
+        canDelete: page.canDelete,
+      },
+    });
+  }
+
+  return Array.from(pageMap.values());
 }
 
 /**
@@ -803,8 +891,9 @@ export async function getBatchPagePermissions(
       .select({
         pageId: pages.id,
         isTrashed: pages.isTrashed,
+        isPrivate: pages.isPrivate,
         driveOwnerId: drives.ownerId,
-        adminMemberId: driveMembers.id,
+        memberRole: driveMembers.role,
         explicitCanView: pagePermissions.canView,
         explicitCanEdit: pagePermissions.canEdit,
         explicitCanShare: pagePermissions.canShare,
@@ -817,7 +906,6 @@ export async function getBatchPagePermissions(
         and(
           eq(driveMembers.driveId, pages.driveId),
           eq(driveMembers.userId, userId),
-          eq(driveMembers.role, 'ADMIN'),
           isNotNull(driveMembers.acceptedAt)
         )
       )
@@ -840,7 +928,8 @@ export async function getBatchPagePermissions(
       }
 
       const isOwner = row.driveOwnerId === userId;
-      const isAdmin = row.adminMemberId !== null;
+      const isAdmin = row.memberRole === 'ADMIN';
+      const isMember = row.memberRole !== null;
 
       if (isOwner || isAdmin) {
         results.set(row.pageId, {
@@ -858,6 +947,17 @@ export async function getBatchPagePermissions(
           canEdit: row.explicitCanEdit ?? false,
           canShare: row.explicitCanShare ?? false,
           canDelete: row.explicitCanDelete ?? false,
+        });
+        continue;
+      }
+
+      // Rule 4: any accepted drive member gets read access to non-private pages
+      if (isMember && !row.isPrivate) {
+        results.set(row.pageId, {
+          canView: true,
+          canEdit: false,
+          canShare: false,
+          canDelete: false,
         });
       }
     }

--- a/packages/lib/src/repositories/page-repository.ts
+++ b/packages/lib/src/repositories/page-repository.ts
@@ -53,6 +53,7 @@ export interface CreatePageInput {
   extractionMethod?: string;
   extractionMetadata?: Record<string, unknown>;
   contentHash?: string;
+  createdBy?: string | null;
 }
 
 export interface UpdatePageInput {
@@ -179,6 +180,7 @@ export const pageRepository = {
         revision: data.revision ?? 0,
         stateHash: data.stateHash ?? null,
         updatedAt: data.updatedAt ?? new Date(),
+        createdBy: data.createdBy ?? null,
         ...(data.extractionMethod && { extractionMethod: data.extractionMethod }),
         ...(data.extractionMetadata && { extractionMetadata: data.extractionMetadata }),
         ...(data.contentHash && { contentHash: data.contentHash }),

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -73,6 +73,7 @@ export interface Page {
   extractionMethod?: ExtractionMethod;
   extractionMetadata?: ExtractionMetadata;
   contentHash?: string;
+  isPrivate?: boolean;
 }
 
 export interface Drive {


### PR DESCRIPTION
## Summary

Implements Eric's request: default role includes read permissions on all non-private pages. Drive members work like Discord's @everyone — they can read any page that isn't explicitly marked private. Page owners can toggle privacy from the Share dialog.

**Model mapping:**
| Discord | PageSpace |
|---------|-----------|
| Server | Drive |
| Channel | Page |
| @everyone | MEMBER role |
| Private channel | \`isPrivate = true\` page |

## Key changes

- **Schema** (\`packages/db/src/schema/core.ts\`): Added \`isPrivate boolean DEFAULT false NOT NULL\` and \`createdBy uuid FK → users\` to the pages table
- **Migrations**: \`0132\` adds the columns; \`0133\` updates \`accessible_page_ids_for_user()\` SQL function with the new MEMBER + non-private read path
- **Permission engine** (\`permissions.ts\`): Four-tier resolution — drive owner → ADMIN → MEMBER+non-private (new) → explicit \`pagePermissions\`
- **Page creator as owner**: \`createdBy\` user can grant permissions on their page (like a Discord channel owner), but only while they have active drive membership
- **API**: All page creation paths set \`createdBy\`; PATCH \`/api/pages/[pageId]\` accepts \`isPrivate\` gated behind \`canShare\`; \`skipPermissionCheck\` flag lets share-capable users toggle privacy without edit rights
- **UI**: \`ShareDialog\` gains a "Private page" Switch toggle for users with share permission

## Authorization for privacy toggle

Changing \`isPrivate\` requires \`canShare\` — only drive owners, admins, and explicit share grantees can mark a page private. Regular members (who gain default read) cannot lock themselves out.

## Test plan

- [x] Unit tests: batch-page-permissions — updated \`Row\` interface from \`adminMemberId\` to \`memberRole\` + \`isPrivate\`, added Rule-4 MEMBER tests (15/15 pass)
- [x] Zero-trust boundary tests updated with MEMBER open-by-default assertions
- [x] Integration permission tests (\`packages/lib/src/__tests__/permissions.test.ts\`) — updated for new MEMBER read-only default
- [ ] Integration test (requires Docker postgres): verify MEMBER can read non-private pages, denied on private pages
- [ ] Manual: invite user as MEMBER, confirm they see non-private pages without explicit grants
- [ ] Manual: toggle private on a page via Share dialog, confirm MEMBER is denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)