### PR TITLE
fix(mcp): show MCP token keys as apps in drive members page

### DIFF
--- a/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
+++ b/apps/web/src/app/api/__tests__/security-audit-coverage.test.ts
@@ -88,6 +88,7 @@ const AUDIT_EXEMPT_ROUTES = new Map<string, string>([
   ['drives/[driveId]/access', 'Read-only access check — follow-up'],
   ['drives/[driveId]/agents', 'Agent list for drive — follow-up'],
   ['drives/[driveId]/agents/members', 'Agent member list — read-only, covered by parent drive audit, follow-up'],
+  ['drives/[driveId]/apps/members', 'MCP token (app) member list — read-only, covered by parent drive audit, follow-up'],
   ['drives/[driveId]/assignees', 'Assignee list for drive — follow-up'],
   ['drives/[driveId]/history', 'Drive history view — follow-up'],
   ['drives/[driveId]/integrations', 'Integration list for drive — follow-up'],

--- a/apps/web/src/app/api/drives/[driveId]/apps/[tokenId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/apps/[tokenId]/__tests__/route.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+import type { SessionAuthResult, AuthError } from '@/lib/auth';
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn(),
+}));
+vi.mock('@pagespace/lib/services/drive-member-service', () => ({
+  checkDriveAccess: vi.fn(),
+}));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: {
+    api: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  },
+}));
+vi.mock('@pagespace/lib/audit/audit-log', () => ({
+  auditRequest: vi.fn(),
+}));
+vi.mock('@pagespace/db/db', () => ({
+  db: { select: vi.fn(), update: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((a: unknown, b: unknown) => ({ _type: 'eq', a, b })),
+  and: vi.fn((...args: unknown[]) => ({ _type: 'and', args })),
+}));
+vi.mock('@pagespace/db/schema/members', () => ({
+  mcpTokenDrives: {
+    id: 'col_mtd_id',
+    tokenId: 'col_mtd_tokenId',
+    driveId: 'col_mtd_driveId',
+    role: 'col_mtd_role',
+    customRoleId: 'col_mtd_customRoleId',
+    $inferInsert: {},
+  },
+  driveRoles: {
+    id: 'col_dr_id',
+    driveId: 'col_dr_driveId',
+  },
+}));
+
+import { PATCH, DELETE } from '../route';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service';
+import { db } from '@pagespace/db/db';
+
+const MOCK_USER_ID = 'user_abc';
+const MOCK_DRIVE_ID = 'drive_xyz';
+const MOCK_TOKEN_ID = 'token_123';
+
+const mockAuth = (userId: string): SessionAuthResult => ({
+  userId,
+  tokenVersion: 0,
+  tokenType: 'session',
+  sessionId: 'sess-1',
+  role: 'user',
+  adminRoleVersion: 0,
+});
+
+const mockAuthError = (status = 401): AuthError => ({
+  error: NextResponse.json({ error: 'Unauthorized' }, { status }),
+});
+
+const createContext = (driveId: string, tokenId: string) => ({
+  params: Promise.resolve({ driveId, tokenId }),
+});
+
+const createRequest = (method: string, body?: unknown) =>
+  new Request('https://x.test/api', {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+function setupSelectChain(rows: unknown[]) {
+  const mockLimit = vi.fn().mockResolvedValue(rows);
+  const mockWhere = vi.fn(() => ({ limit: mockLimit }));
+  const mockFrom = vi.fn(() => ({ where: mockWhere }));
+  vi.mocked(db.select).mockReturnValue({ from: mockFrom } as never);
+  return { mockFrom, mockWhere, mockLimit };
+}
+
+function setupUpdateChain(updated: unknown) {
+  const mockReturning = vi.fn().mockResolvedValue([updated]);
+  const mockWhere = vi.fn(() => ({ returning: mockReturning }));
+  const mockSet = vi.fn(() => ({ where: mockWhere }));
+  vi.mocked(db.update).mockReturnValue({ set: mockSet } as never);
+  return { mockSet, mockWhere, mockReturning };
+}
+
+function setupDeleteChain() {
+  const mockWhere = vi.fn().mockResolvedValue([]);
+  vi.mocked(db.delete).mockReturnValue({ where: mockWhere } as never);
+  return { mockWhere };
+}
+
+// ============================================================================
+// PATCH
+// ============================================================================
+
+describe('PATCH /api/drives/[driveId]/apps/[tokenId]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuth(MOCK_USER_ID));
+    vi.mocked(isAuthError).mockReturnValue(false);
+    vi.mocked(checkDriveAccess).mockResolvedValue({
+      isOwner: true, isAdmin: true, isMember: true,
+      drive: { id: MOCK_DRIVE_ID },
+    } as never);
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    vi.mocked(isAuthError).mockReturnValue(true);
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthError(401));
+
+    const res = await PATCH(createRequest('PATCH', { role: 'ADMIN' }), createContext(MOCK_DRIVE_ID, MOCK_TOKEN_ID));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 when drive not found', async () => {
+    vi.mocked(checkDriveAccess).mockResolvedValue({
+      isOwner: false, isAdmin: false, isMember: false, drive: null,
+    } as never);
+
+    const res = await PATCH(createRequest('PATCH', { role: 'ADMIN' }), createContext(MOCK_DRIVE_ID, MOCK_TOKEN_ID));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 when user is not owner or admin', async () => {
+    vi.mocked(checkDriveAccess).mockResolvedValue({
+      isOwner: false, isAdmin: false, isMember: true,
+      drive: { id: MOCK_DRIVE_ID },
+    } as never);
+
+    const res = await PATCH(createRequest('PATCH', { role: 'ADMIN' }), createContext(MOCK_DRIVE_ID, MOCK_TOKEN_ID));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 for invalid body', async () => {
+    const res = await PATCH(createRequest('PATCH', { role: 'SUPERUSER' }), createContext(MOCK_DRIVE_ID, MOCK_TOKEN_ID));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when neither role nor customRoleId provided', async () => {
+    const res = await PATCH(createRequest('PATCH', {}), createContext(MOCK_DRIVE_ID, MOCK_TOKEN_ID));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when app member not found', async () => {
+    setupSelectChain([]);
+
+    const res = await PATCH(createRequest('PATCH', { role: 'ADMIN' }), createContext(MOCK_DRIVE_ID, MOCK_TOKEN_ID));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when customRoleId does not belong to drive', async () => {
+    let selectCallCount = 0;
+    vi.mocked(db.select).mockImplementation(() => {
+      selectCallCount++;
+      const mockLimit = vi.fn().mockResolvedValue(selectCallCount === 1 ? [{ id: 'mtd-1' }] : []);
+      const mockWhere = vi.fn(() => ({ limit: mockLimit }));
+      const mockFrom = vi.fn(() => ({ where: mockWhere }));
+      return { from: mockFrom } as never;
+    });
+
+    const res = await PATCH(createRequest('PATCH', { customRoleId: 'role-other-drive' }), createContext(MOCK_DRIVE_ID, MOCK_TOKEN_ID));
+    expect(res.status).toBe(404);
+  });
+
+  it('updates role successfully', async () => {
+    let selectCallCount = 0;
+    vi.mocked(db.select).mockImplementation(() => {
+      selectCallCount++;
+      const rows = selectCallCount === 1 ? [{ id: 'mtd-1' }] : [];
+      const mockLimit = vi.fn().mockResolvedValue(rows);
+      const mockWhere = vi.fn(() => ({ limit: mockLimit }));
+      const mockFrom = vi.fn(() => ({ where: mockWhere }));
+      return { from: mockFrom } as never;
+    });
+    setupUpdateChain({ id: 'mtd-1', tokenId: MOCK_TOKEN_ID, role: 'ADMIN' });
+
+    const res = await PATCH(createRequest('PATCH', { role: 'ADMIN' }), createContext(MOCK_DRIVE_ID, MOCK_TOKEN_ID));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    vi.mocked(checkDriveAccess).mockRejectedValue(new Error('DB exploded'));
+
+    const res = await PATCH(createRequest('PATCH', { role: 'MEMBER' }), createContext(MOCK_DRIVE_ID, MOCK_TOKEN_ID));
+    expect(res.status).toBe(500);
+  });
+});
+
+// ============================================================================
+// DELETE
+// ============================================================================
+
+describe('DELETE /api/drives/[driveId]/apps/[tokenId]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuth(MOCK_USER_ID));
+    vi.mocked(isAuthError).mockReturnValue(false);
+    vi.mocked(checkDriveAccess).mockResolvedValue({
+      isOwner: true, isAdmin: true, isMember: true,
+      drive: { id: MOCK_DRIVE_ID },
+    } as never);
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    vi.mocked(isAuthError).mockReturnValue(true);
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthError(401));
+
+    const res = await DELETE(createRequest('DELETE'), createContext(MOCK_DRIVE_ID, MOCK_TOKEN_ID));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 when drive not found', async () => {
+    vi.mocked(checkDriveAccess).mockResolvedValue({
+      isOwner: false, isAdmin: false, isMember: false, drive: null,
+    } as never);
+
+    const res = await DELETE(createRequest('DELETE'), createContext(MOCK_DRIVE_ID, MOCK_TOKEN_ID));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 when user is not owner or admin', async () => {
+    vi.mocked(checkDriveAccess).mockResolvedValue({
+      isOwner: false, isAdmin: false, isMember: true,
+      drive: { id: MOCK_DRIVE_ID },
+    } as never);
+
+    const res = await DELETE(createRequest('DELETE'), createContext(MOCK_DRIVE_ID, MOCK_TOKEN_ID));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when app member not found', async () => {
+    setupSelectChain([]);
+
+    const res = await DELETE(createRequest('DELETE'), createContext(MOCK_DRIVE_ID, MOCK_TOKEN_ID));
+    expect(res.status).toBe(404);
+  });
+
+  it('removes app member successfully', async () => {
+    setupSelectChain([{ id: 'mtd-1' }]);
+    setupDeleteChain();
+
+    const res = await DELETE(createRequest('DELETE'), createContext(MOCK_DRIVE_ID, MOCK_TOKEN_ID));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    vi.mocked(checkDriveAccess).mockRejectedValue(new Error('DB exploded'));
+
+    const res = await DELETE(createRequest('DELETE'), createContext(MOCK_DRIVE_ID, MOCK_TOKEN_ID));
+    expect(res.status).toBe(500);
+  });
+});

--- a/apps/web/src/app/api/drives/[driveId]/apps/[tokenId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/apps/[tokenId]/route.ts
@@ -1,0 +1,149 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service';
+import { db } from '@pagespace/db/db';
+import { eq, and } from '@pagespace/db/operators';
+import { mcpTokenDrives, driveRoles } from '@pagespace/db/schema/members';
+
+const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
+
+const patchBodySchema = z.object({
+  role: z.enum(['MEMBER', 'ADMIN']).optional(),
+  customRoleId: z.string().min(1).nullable().optional(),
+});
+
+/**
+ * PATCH /api/drives/{driveId}/apps/{tokenId}
+ * Update role or customRoleId for an MCP token drive member.
+ */
+export async function PATCH(
+  request: Request,
+  context: { params: Promise<{ driveId: string; tokenId: string }> },
+) {
+  try {
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+    if (isAuthError(auth)) return auth.error;
+    const userId = auth.userId;
+
+    const { driveId, tokenId } = await context.params;
+
+    const access = await checkDriveAccess(driveId, userId);
+    if (!access.drive) {
+      return NextResponse.json({ error: 'Drive not found' }, { status: 404 });
+    }
+    if (!access.isOwner && !access.isAdmin) {
+      return NextResponse.json({ error: 'Only drive owners and admins can update app members' }, { status: 403 });
+    }
+
+    const rawBody = await request.json();
+    const parsed = patchBodySchema.safeParse(rawBody);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid request body', issues: parsed.error.flatten().fieldErrors }, { status: 400 });
+    }
+
+    const { role, customRoleId } = parsed.data;
+
+    if (!role && customRoleId === undefined) {
+      return NextResponse.json({ error: 'Provide at least one of: role, customRoleId' }, { status: 400 });
+    }
+
+    const existing = await db
+      .select({ id: mcpTokenDrives.id })
+      .from(mcpTokenDrives)
+      .where(and(eq(mcpTokenDrives.driveId, driveId), eq(mcpTokenDrives.tokenId, tokenId)))
+      .limit(1);
+
+    if (existing.length === 0) {
+      return NextResponse.json({ error: 'App member not found' }, { status: 404 });
+    }
+
+    if (customRoleId) {
+      const roleExists = await db
+        .select({ id: driveRoles.id })
+        .from(driveRoles)
+        .where(and(eq(driveRoles.id, customRoleId), eq(driveRoles.driveId, driveId)))
+        .limit(1);
+      if (roleExists.length === 0) {
+        return NextResponse.json({ error: 'Custom role not found in this drive' }, { status: 404 });
+      }
+    }
+
+    const updateValues: Partial<typeof mcpTokenDrives.$inferInsert> = {};
+    if (role !== undefined) updateValues.role = role;
+    if (customRoleId !== undefined) updateValues.customRoleId = customRoleId;
+
+    const [updated] = await db
+      .update(mcpTokenDrives)
+      .set(updateValues)
+      .where(and(eq(mcpTokenDrives.driveId, driveId), eq(mcpTokenDrives.tokenId, tokenId)))
+      .returning();
+
+    auditRequest(request, {
+      eventType: 'authz.role.assigned',
+      userId,
+      resourceType: 'drive',
+      resourceId: driveId,
+      details: { tokenId, role, customRoleId },
+    });
+
+    return NextResponse.json({ success: true, member: updated });
+  } catch (error) {
+    loggers.api.error('Error updating drive app member:', error as Error);
+    return NextResponse.json({ error: 'Failed to update app member' }, { status: 500 });
+  }
+}
+
+/**
+ * DELETE /api/drives/{driveId}/apps/{tokenId}
+ * Remove an MCP token from drive membership.
+ */
+export async function DELETE(
+  request: Request,
+  context: { params: Promise<{ driveId: string; tokenId: string }> },
+) {
+  try {
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+    if (isAuthError(auth)) return auth.error;
+    const userId = auth.userId;
+
+    const { driveId, tokenId } = await context.params;
+
+    const access = await checkDriveAccess(driveId, userId);
+    if (!access.drive) {
+      return NextResponse.json({ error: 'Drive not found' }, { status: 404 });
+    }
+    if (!access.isOwner && !access.isAdmin) {
+      return NextResponse.json({ error: 'Only drive owners and admins can remove app members' }, { status: 403 });
+    }
+
+    const existing = await db
+      .select({ id: mcpTokenDrives.id })
+      .from(mcpTokenDrives)
+      .where(and(eq(mcpTokenDrives.driveId, driveId), eq(mcpTokenDrives.tokenId, tokenId)))
+      .limit(1);
+
+    if (existing.length === 0) {
+      return NextResponse.json({ error: 'App member not found' }, { status: 404 });
+    }
+
+    await db
+      .delete(mcpTokenDrives)
+      .where(and(eq(mcpTokenDrives.driveId, driveId), eq(mcpTokenDrives.tokenId, tokenId)));
+
+    auditRequest(request, {
+      eventType: 'authz.permission.revoked',
+      userId,
+      resourceType: 'drive',
+      resourceId: driveId,
+      details: { tokenId },
+    });
+
+    return NextResponse.json({ success: true, message: 'App member removed successfully' });
+  } catch (error) {
+    loggers.api.error('Error removing drive app member:', error as Error);
+    return NextResponse.json({ error: 'Failed to remove app member' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/drives/[driveId]/apps/members/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/apps/members/__tests__/route.test.ts
@@ -14,6 +14,8 @@ vi.mock('@pagespace/db/db', () => ({
 }));
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((a: unknown, b: unknown) => ({ _type: 'eq', a, b })),
+  and: vi.fn((...args: unknown[]) => ({ _type: 'and', args })),
+  isNull: vi.fn((col: unknown) => ({ _type: 'isNull', col })),
 }));
 vi.mock('@pagespace/db/schema/members', () => ({
   mcpTokenDrives: {
@@ -38,6 +40,7 @@ import { GET } from '../route';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service';
 import { db } from '@pagespace/db/db';
+import { isNull } from '@pagespace/db/operators';
 
 const MOCK_USER_ID = 'user_abc';
 const MOCK_DRIVE_ID = 'drive_xyz';
@@ -196,6 +199,14 @@ describe('GET /api/drives/[driveId]/apps/members', () => {
         name: 'role-orphan',
         color: null,
       });
+    });
+
+    it('filters out revoked tokens (revokedAt IS NULL in query)', async () => {
+      setupDbChain([]);
+
+      await GET(new Request('https://x.test/api'), createContext(MOCK_DRIVE_ID));
+
+      expect(vi.mocked(isNull)).toHaveBeenCalled();
     });
 
     it('returns ADMIN currentUserRole for admin (non-owner) members', async () => {

--- a/apps/web/src/app/api/drives/[driveId]/apps/members/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/apps/members/__tests__/route.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NextResponse } from 'next/server';
+import type { SessionAuthResult, AuthError } from '@/lib/auth';
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn(),
+}));
+vi.mock('@pagespace/lib/services/drive-member-service', () => ({
+  checkDriveAccess: vi.fn(),
+}));
+vi.mock('@pagespace/db/db', () => ({
+  db: { select: vi.fn() },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((a: unknown, b: unknown) => ({ _type: 'eq', a, b })),
+}));
+vi.mock('@pagespace/db/schema/members', () => ({
+  mcpTokenDrives: {
+    id: 'col_mtd_id',
+    tokenId: 'col_mtd_tokenId',
+    driveId: 'col_mtd_driveId',
+    role: 'col_mtd_role',
+    createdAt: 'col_mtd_createdAt',
+    customRoleId: 'col_mtd_customRoleId',
+  },
+  driveRoles: {
+    id: 'col_dr_id',
+    name: 'col_dr_name',
+    color: 'col_dr_color',
+  },
+}));
+vi.mock('@pagespace/db/schema/auth', () => ({
+  mcpTokens: { id: 'col_mct_id', name: 'col_mct_name' },
+}));
+
+import { GET } from '../route';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service';
+import { db } from '@pagespace/db/db';
+
+const MOCK_USER_ID = 'user_abc';
+const MOCK_DRIVE_ID = 'drive_xyz';
+
+const mockAuth = (userId: string): SessionAuthResult => ({
+  userId,
+  tokenVersion: 0,
+  tokenType: 'session',
+  sessionId: 'sess-1',
+  role: 'user',
+  adminRoleVersion: 0,
+});
+
+const mockAuthError = (status = 401): AuthError => ({
+  error: NextResponse.json({ error: 'Unauthorized' }, { status }),
+});
+
+const createContext = (driveId: string) => ({
+  params: Promise.resolve({ driveId }),
+});
+
+function setupDbChain(rows: unknown[]) {
+  const mockWhere = vi.fn().mockResolvedValue(rows);
+  const mockLeftJoin2 = vi.fn(() => ({ where: mockWhere }));
+  const mockLeftJoin1 = vi.fn(() => ({ leftJoin: mockLeftJoin2 }));
+  const mockFrom = vi.fn(() => ({ leftJoin: mockLeftJoin1 }));
+  vi.mocked(db.select).mockReturnValue({ from: mockFrom } as never);
+  return { mockFrom, mockLeftJoin1, mockLeftJoin2, mockWhere };
+}
+
+describe('GET /api/drives/[driveId]/apps/members', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuth(MOCK_USER_ID));
+    vi.mocked(isAuthError).mockReturnValue(false);
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    vi.mocked(isAuthError).mockReturnValue(true);
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockAuthError(401));
+
+    const res = await GET(new Request('https://x.test/api'), createContext(MOCK_DRIVE_ID));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 when drive not found', async () => {
+    vi.mocked(checkDriveAccess).mockResolvedValue({
+      isOwner: false, isAdmin: false, isMember: false, drive: null,
+    } as never);
+
+    const res = await GET(new Request('https://x.test/api'), createContext(MOCK_DRIVE_ID));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 when user is not a member', async () => {
+    vi.mocked(checkDriveAccess).mockResolvedValue({
+      isOwner: false, isAdmin: false, isMember: false,
+      drive: { id: MOCK_DRIVE_ID },
+    } as never);
+
+    const res = await GET(new Request('https://x.test/api'), createContext(MOCK_DRIVE_ID));
+    expect(res.status).toBe(403);
+  });
+
+  describe('successful responses', () => {
+    beforeEach(() => {
+      vi.mocked(checkDriveAccess).mockResolvedValue({
+        isOwner: true, isAdmin: true, isMember: true,
+        drive: { id: MOCK_DRIVE_ID },
+      } as never);
+    });
+
+    it('returns empty app members list when no apps exist', async () => {
+      setupDbChain([]);
+
+      const res = await GET(new Request('https://x.test/api'), createContext(MOCK_DRIVE_ID));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.appMembers).toEqual([]);
+      expect(body.currentUserRole).toBe('OWNER');
+    });
+
+    it('returns app members with correct shape', async () => {
+      const createdAt = new Date('2026-05-01T00:00:00Z');
+      setupDbChain([
+        {
+          id: 'mtd-1',
+          tokenId: 'token-1',
+          role: 'MEMBER',
+          createdAt,
+          customRoleId: null,
+          name: 'My MCP Key',
+          customRoleName: null,
+          customRoleColor: null,
+        },
+      ]);
+
+      const res = await GET(new Request('https://x.test/api'), createContext(MOCK_DRIVE_ID));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.appMembers).toHaveLength(1);
+      expect(body.appMembers[0]).toMatchObject({
+        id: 'mtd-1',
+        tokenId: 'token-1',
+        role: 'MEMBER',
+        name: 'My MCP Key',
+        customRole: null,
+      });
+    });
+
+    it('includes custom role when present', async () => {
+      setupDbChain([
+        {
+          id: 'mtd-2',
+          tokenId: 'token-2',
+          role: 'MEMBER',
+          createdAt: new Date(),
+          customRoleId: 'role-1',
+          name: 'Another Key',
+          customRoleName: 'Viewer',
+          customRoleColor: 'blue',
+        },
+      ]);
+
+      const res = await GET(new Request('https://x.test/api'), createContext(MOCK_DRIVE_ID));
+      const body = await res.json();
+
+      expect(body.appMembers[0].customRole).toEqual({
+        id: 'role-1',
+        name: 'Viewer',
+        color: 'blue',
+      });
+    });
+
+    it('falls back to customRoleId as name when customRoleName is null', async () => {
+      setupDbChain([
+        {
+          id: 'mtd-3',
+          tokenId: 'token-3',
+          role: 'MEMBER',
+          createdAt: new Date(),
+          customRoleId: 'role-orphan',
+          name: 'Key',
+          customRoleName: null,
+          customRoleColor: null,
+        },
+      ]);
+
+      const res = await GET(new Request('https://x.test/api'), createContext(MOCK_DRIVE_ID));
+      const body = await res.json();
+
+      expect(body.appMembers[0].customRole).toEqual({
+        id: 'role-orphan',
+        name: 'role-orphan',
+        color: null,
+      });
+    });
+
+    it('returns ADMIN currentUserRole for admin (non-owner) members', async () => {
+      vi.mocked(checkDriveAccess).mockResolvedValue({
+        isOwner: false, isAdmin: true, isMember: true,
+        drive: { id: MOCK_DRIVE_ID },
+      } as never);
+      setupDbChain([]);
+
+      const res = await GET(new Request('https://x.test/api'), createContext(MOCK_DRIVE_ID));
+      const body = await res.json();
+
+      expect(body.currentUserRole).toBe('ADMIN');
+    });
+
+    it('returns MEMBER currentUserRole for plain members', async () => {
+      vi.mocked(checkDriveAccess).mockResolvedValue({
+        isOwner: false, isAdmin: false, isMember: true,
+        drive: { id: MOCK_DRIVE_ID },
+      } as never);
+      setupDbChain([]);
+
+      const res = await GET(new Request('https://x.test/api'), createContext(MOCK_DRIVE_ID));
+      const body = await res.json();
+
+      expect(body.currentUserRole).toBe('MEMBER');
+    });
+  });
+
+  it('returns 500 on unexpected error', async () => {
+    vi.mocked(checkDriveAccess).mockRejectedValue(new Error('DB down'));
+
+    const res = await GET(new Request('https://x.test/api'), createContext(MOCK_DRIVE_ID));
+    expect(res.status).toBe(500);
+  });
+});

--- a/apps/web/src/app/api/drives/[driveId]/apps/members/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/apps/members/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service';
 import { db } from '@pagespace/db/db';
-import { eq } from '@pagespace/db/operators';
+import { eq, and, isNull } from '@pagespace/db/operators';
 import { mcpTokenDrives, driveRoles } from '@pagespace/db/schema/members';
 import { mcpTokens } from '@pagespace/db/schema/auth';
 
@@ -43,7 +43,7 @@ export async function GET(
       .from(mcpTokenDrives)
       .leftJoin(mcpTokens, eq(mcpTokenDrives.tokenId, mcpTokens.id))
       .leftJoin(driveRoles, eq(mcpTokenDrives.customRoleId, driveRoles.id))
-      .where(eq(mcpTokenDrives.driveId, driveId));
+      .where(and(eq(mcpTokenDrives.driveId, driveId), isNull(mcpTokens.revokedAt)));
 
     const appMembers = rows.map((row) => ({
       id: row.id,

--- a/apps/web/src/app/api/drives/[driveId]/apps/members/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/apps/members/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service';
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { mcpTokenDrives, driveRoles } from '@pagespace/db/schema/members';
+import { mcpTokens } from '@pagespace/db/schema/auth';
+
+/**
+ * GET /api/drives/{driveId}/apps/members
+ * List all MCP token drive members with their role and token name.
+ */
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ driveId: string }> },
+) {
+  try {
+    const auth = await authenticateRequestWithOptions(request, { allow: ['session'] as const, requireCSRF: false });
+    if (isAuthError(auth)) return auth.error;
+    const { userId } = auth;
+
+    const { driveId } = await context.params;
+
+    const access = await checkDriveAccess(driveId, userId);
+    if (!access.drive) {
+      return NextResponse.json({ error: 'Drive not found' }, { status: 404 });
+    }
+    if (!access.isOwner && !access.isMember) {
+      return NextResponse.json({ error: 'You must be a drive member to view app members' }, { status: 403 });
+    }
+
+    const rows = await db
+      .select({
+        id: mcpTokenDrives.id,
+        tokenId: mcpTokenDrives.tokenId,
+        role: mcpTokenDrives.role,
+        createdAt: mcpTokenDrives.createdAt,
+        customRoleId: mcpTokenDrives.customRoleId,
+        name: mcpTokens.name,
+        customRoleName: driveRoles.name,
+        customRoleColor: driveRoles.color,
+      })
+      .from(mcpTokenDrives)
+      .leftJoin(mcpTokens, eq(mcpTokenDrives.tokenId, mcpTokens.id))
+      .leftJoin(driveRoles, eq(mcpTokenDrives.customRoleId, driveRoles.id))
+      .where(eq(mcpTokenDrives.driveId, driveId));
+
+    const appMembers = rows.map((row) => ({
+      id: row.id,
+      tokenId: row.tokenId,
+      name: row.name,
+      role: row.role,
+      createdAt: row.createdAt,
+      customRole: row.customRoleId
+        ? { id: row.customRoleId, name: row.customRoleName ?? row.customRoleId, color: row.customRoleColor ?? null }
+        : null,
+    }));
+
+    return NextResponse.json({
+      appMembers,
+      currentUserRole: access.isOwner ? 'OWNER' : access.isAdmin ? 'ADMIN' : 'MEMBER',
+    });
+  } catch {
+    return NextResponse.json({ error: 'Failed to fetch app members' }, { status: 500 });
+  }
+}

--- a/apps/web/src/components/members/AppMemberRow.tsx
+++ b/apps/web/src/components/members/AppMemberRow.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { useState } from 'react';
+import { KeyRound, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Select, SelectContent, SelectItem, SelectSeparator, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { getRoleColorClasses } from '@/lib/utils';
+import { patch, del } from '@/lib/auth/auth-fetch';
+import { useToast } from '@/hooks/useToast';
+
+export interface AppMember {
+  id: string;
+  tokenId: string;
+  name: string | null;
+  role: string;
+  createdAt: Date | string;
+  customRole: { id: string; name: string; color: string | null } | null;
+}
+
+interface DriveRole {
+  id: string;
+  name: string;
+  color?: string | null;
+}
+
+interface AppMemberRowProps {
+  app: AppMember;
+  driveId: string;
+  currentUserRole: 'OWNER' | 'ADMIN' | 'MEMBER';
+  driveRoles: DriveRole[];
+  onRoleChange: (tokenId: string, updated: Partial<AppMember>) => void;
+  onRemove: (tokenId: string) => void;
+}
+
+function getRoleBadge(app: AppMember) {
+  if (app.role === 'ADMIN') {
+    return (
+      <Badge className="bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
+        Admin
+      </Badge>
+    );
+  }
+  if (app.customRole) {
+    return (
+      <Badge className={getRoleColorClasses(app.customRole.color ?? undefined)}>
+        {app.customRole.name}
+      </Badge>
+    );
+  }
+  return (
+    <Badge className="bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300">
+      Member
+    </Badge>
+  );
+}
+
+function currentSelectValue(app: AppMember): string {
+  if (app.role === 'ADMIN') return 'ADMIN';
+  if (app.customRole) return app.customRole.id;
+  return 'MEMBER';
+}
+
+export function AppMemberRow({
+  app,
+  driveId,
+  currentUserRole,
+  driveRoles,
+  onRoleChange,
+  onRemove,
+}: AppMemberRowProps) {
+  const { toast } = useToast();
+  const [saving, setSaving] = useState(false);
+  const canManage = currentUserRole === 'OWNER' || currentUserRole === 'ADMIN';
+  const displayName = app.name ?? 'Unnamed App';
+
+  const handleRoleSelect = async (value: string) => {
+    setSaving(true);
+    try {
+      const body: { role: 'MEMBER' | 'ADMIN'; customRoleId: string | null } =
+        value === 'ADMIN'
+          ? { role: 'ADMIN', customRoleId: null }
+          : value === 'MEMBER'
+          ? { role: 'MEMBER', customRoleId: null }
+          : { role: 'MEMBER', customRoleId: value };
+
+      await patch(`/api/drives/${driveId}/apps/${app.tokenId}`, body);
+
+      const customRole = value !== 'ADMIN' && value !== 'MEMBER'
+        ? (driveRoles.find((r) => r.id === value) ?? null)
+        : null;
+
+      onRoleChange(app.tokenId, {
+        role: body.role,
+        customRole: customRole ? { id: customRole.id, name: customRole.name, color: customRole.color ?? null } : null,
+      });
+    } catch {
+      toast({ title: 'Error', description: 'Failed to update app role', variant: 'destructive' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleRemove = async () => {
+    if (!confirm(`Remove ${displayName} from drive members?`)) return;
+    try {
+      await del(`/api/drives/${driveId}/apps/${app.tokenId}`);
+      onRemove(app.tokenId);
+    } catch {
+      toast({ title: 'Error', description: 'Failed to remove app member', variant: 'destructive' });
+    }
+  };
+
+  return (
+    <div className="p-4 flex items-center justify-between hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors">
+      <div className="flex items-center space-x-4">
+        <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
+          <KeyRound className="h-5 w-5 text-muted-foreground" />
+        </div>
+        <div>
+          <div className="flex items-center space-x-2">
+            <p className="font-medium">{displayName}</p>
+            {!canManage && getRoleBadge(app)}
+          </div>
+          <p className="text-xs text-gray-500 dark:text-gray-400">MCP App</p>
+        </div>
+      </div>
+
+      <div className="flex items-center space-x-2">
+        {canManage ? (
+          <Select
+            value={currentSelectValue(app)}
+            onValueChange={handleRoleSelect}
+            disabled={saving}
+          >
+            <SelectTrigger className="w-36 h-8 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="ADMIN">Admin</SelectItem>
+              <SelectItem value="MEMBER">Member</SelectItem>
+              {driveRoles.length > 0 && (
+                <>
+                  <SelectSeparator />
+                  {driveRoles.map((role) => (
+                    <SelectItem key={role.id} value={role.id}>
+                      {role.name}
+                    </SelectItem>
+                  ))}
+                </>
+              )}
+            </SelectContent>
+          </Select>
+        ) : (
+          getRoleBadge(app)
+        )}
+
+        {canManage && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleRemove}
+            className="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+            title="Remove App Member"
+          >
+            <Trash2 className="w-4 h-4" />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/members/DriveMembers.tsx
+++ b/apps/web/src/components/members/DriveMembers.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { UserPlus } from 'lucide-react';
 import { MemberRow } from './MemberRow';
 import { AgentMemberRow, type AgentMember } from './AgentMemberRow';
+import { AppMemberRow, type AppMember } from './AppMemberRow';
 import { PendingInvitesSection } from './PendingInvitesSection';
 import { DriveShareLinkSection } from './DriveShareLinkSection';
 import type { PendingInvite } from './PendingInviteRow';
@@ -66,6 +67,7 @@ const DRIVE_MEMBER_EVENTS = [
 export function DriveMembers({ driveId }: DriveMembersProps) {
   const [members, setMembers] = useState<DriveMember[]>([]);
   const [agentMembers, setAgentMembers] = useState<AgentMember[]>([]);
+  const [appMembers, setAppMembers] = useState<AppMember[]>([]);
   const [driveRoles, setDriveRoles] = useState<DriveRole[]>([]);
   const [pendingInvites, setPendingInvites] = useState<PendingInvite[]>([]);
   const [currentUserRole, setCurrentUserRole] = useState<'OWNER' | 'ADMIN' | 'MEMBER'>('MEMBER');
@@ -81,9 +83,10 @@ export function DriveMembers({ driveId }: DriveMembersProps) {
   const fetchMembers = useCallback(async () => {
     const currentSeq = ++requestSeqRef.current;
     try {
-      const [membersRes, agentMembersRes, rolesRes] = await Promise.all([
+      const [membersRes, agentMembersRes, appMembersRes, rolesRes] = await Promise.all([
         fetchWithAuth(`/api/drives/${driveId}/members`),
         fetchWithAuth(`/api/drives/${driveId}/agents/members`),
+        fetchWithAuth(`/api/drives/${driveId}/apps/members`),
         fetchWithAuth(`/api/drives/${driveId}/roles`),
       ]);
       if (!membersRes.ok) throw new Error('Failed to fetch members');
@@ -96,6 +99,10 @@ export function DriveMembers({ driveId }: DriveMembersProps) {
       if (agentMembersRes.ok) {
         const agentData = await agentMembersRes.json();
         setAgentMembers(agentData.agentMembers ?? []);
+      }
+      if (appMembersRes.ok) {
+        const appData = await appMembersRes.json();
+        setAppMembers(appData.appMembers ?? []);
       }
       if (rolesRes.ok) {
         const rolesData = await rolesRes.json();
@@ -168,6 +175,17 @@ export function DriveMembers({ driveId }: DriveMembersProps) {
   const handleRemoveAgent = (agentPageId: string) => {
     setAgentMembers((prev) => prev.filter((a) => a.agentPageId !== agentPageId));
     toast({ title: 'Agent removed', description: 'Agent member removed successfully' });
+  };
+
+  const handleAppRoleChange = (tokenId: string, updated: Partial<AppMember>) => {
+    setAppMembers((prev) =>
+      prev.map((a) => (a.tokenId === tokenId ? { ...a, ...updated } : a)),
+    );
+  };
+
+  const handleRemoveApp = (tokenId: string) => {
+    setAppMembers((prev) => prev.filter((a) => a.tokenId !== tokenId));
+    toast({ title: 'App removed', description: 'App member removed successfully' });
   };
 
   const handleRevokeInvite = async (inviteId: string) => {
@@ -257,6 +275,34 @@ export function DriveMembers({ driveId }: DriveMembersProps) {
                 driveRoles={driveRoles}
                 onRoleChange={handleAgentRoleChange}
                 onRemove={handleRemoveAgent}
+              />
+            ))
+          )}
+        </div>
+      </div>
+
+      <div>
+        <div className="mb-3">
+          <h2 className="text-lg font-semibold">Apps ({appMembers.length})</h2>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            MCP app tokens with access to this drive
+          </p>
+        </div>
+        <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 divide-y divide-gray-200 dark:divide-gray-700">
+          {appMembers.length === 0 ? (
+            <div className="p-6 text-center text-gray-500 dark:text-gray-400 text-sm">
+              No apps added. MCP keys can be given drive access to read and write pages.
+            </div>
+          ) : (
+            appMembers.map((app) => (
+              <AppMemberRow
+                key={app.id}
+                app={app}
+                driveId={driveId}
+                currentUserRole={currentUserRole}
+                driveRoles={driveRoles}
+                onRoleChange={handleAppRoleChange}
+                onRemove={handleRemoveApp}
               />
             ))
           )}

--- a/apps/web/src/components/members/__tests__/DriveMembers.test.tsx
+++ b/apps/web/src/components/members/__tests__/DriveMembers.test.tsx
@@ -73,15 +73,21 @@ const okAgentMembers = (currentUserRole = 'OWNER') =>
     json: () => Promise.resolve({ agentMembers: [], currentUserRole }),
   });
 
+const okAppMembers = (currentUserRole = 'OWNER') =>
+  Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve({ appMembers: [], currentUserRole }),
+  });
+
 const okRoles = () =>
   Promise.resolve({
     ok: true,
     json: () => Promise.resolve({ roles: [] }),
   });
 
-// fetchMembers() fires 3 parallel requests on each invocation.
+// fetchMembers() fires 4 parallel requests on each invocation (members, agents/members, apps/members, roles).
 // On initial mount, DriveShareLinkSection adds 1 more for /roles (keyed on driveId, not socket events).
-const MEMBER_FETCHES = 3;
+const MEMBER_FETCHES = 4;
 const FETCHES_PER_CALL = MEMBER_FETCHES + 1;
 
 const urlAwareMock = (
@@ -91,6 +97,7 @@ const urlAwareMock = (
 ) =>
   (url: string) => {
     if (url.endsWith('/agents/members')) return okAgentMembers(currentUserRole);
+    if (url.endsWith('/apps/members')) return okAppMembers(currentUserRole);
     if (url.endsWith('/roles')) return okRoles();
     return okMembers(members, currentUserRole, pendingInvites);
   };


### PR DESCRIPTION
## Summary

- Adds \`GET /api/drives/[driveId]/apps/members\` endpoint that queries \`mcp_token_drives\` joined with \`mcpTokens\` and \`driveRoles\`, filtering out revoked tokens (\`revokedAt IS NULL\`)
- Adds \`PATCH\` + \`DELETE /api/drives/[driveId]/apps/[tokenId]\` for role updates and removal, with CSRF, OWNER/ADMIN auth, and audit logging
- Adds \`AppMemberRow.tsx\` component (mirrors \`AgentMemberRow\`) with key icon, role select, and remove button
- Updates \`DriveMembers.tsx\` to fetch and render a new "Apps" section below "Agents"
- Registers \`apps/members\` in the security audit route coverage gate allowlist (read-only, same exemption as \`agents/members\`)
- Adds unit tests for all three new route handlers and fixes existing \`DriveMembers.test.tsx\` to account for the 4th parallel fetch

**Root cause:** PR #1402 built the full backend (DB schema \`mcp_token_drives\` with RBAC, token creation flow) but omitted the API endpoints and UI to display them on the members page. Tokens were stored correctly but never surfaced.

## Test plan

- [ ] Create an MCP key scoped to a drive via Settings → API Keys
- [ ] Open the drive → Members page — key appears in "Apps" section with its name and role badge
- [ ] As OWNER/ADMIN: change role via dropdown — persists on reload
- [ ] As OWNER/ADMIN: click remove — row disappears and token loses drive access
- [ ] Revoke the MCP key — confirm it disappears from the Apps section
- [ ] Confirm "Members" and "Agents" sections are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)