### PR TITLE
feat: Cmd+F find-in-page for all page types

### DIFF
--- a/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
@@ -341,7 +341,7 @@ export const MessageRenderer: React.FC<MessageRendererProps> = React.memo(({
   // ============================================
   return (
     <>
-      <div key={message.id} className="mb-2">
+      <div key={message.id} data-message-id={message.id} className="mb-2">
         {groupedParts.map((group, index) => {
           if (isTextGroupPart(group)) {
             const isLastTextBlock = index === groupedParts.length - 1;

--- a/apps/web/src/components/editors/RichEditor.tsx
+++ b/apps/web/src/components/editors/RichEditor.tsx
@@ -16,6 +16,7 @@ import { CodeBlockShiki } from '@/lib/editor/code-block';
 import { FontFormatting } from '@/lib/editor/font-formatting';
 import { subscribeToNavigationEvents } from '@/lib/navigation/app-navigation';
 import LinkButton from './LinkButton';
+import { FindExtension } from '@/lib/editor/find-plugin';
 
 interface RichEditorProps {
   value: string;
@@ -88,6 +89,7 @@ const RichEditor = ({ value, onChange, onEditorChange, readOnly = false, isPagin
       TableKit,
       CharacterCount,
       PageMention,
+      FindExtension,
       // Conditionally add pagination based on isPaginated flag
       ...(isPaginated ? [
         PaginationPlus.configure({

--- a/apps/web/src/components/find/FindBar.tsx
+++ b/apps/web/src/components/find/FindBar.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import React, { useEffect, useRef } from 'react';
+import { Search, X, ChevronUp, ChevronDown } from 'lucide-react';
+import { useFindStore } from '@/stores/useFindStore';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+export function FindBar() {
+  const { isOpen, query, currentIndex, totalMatches, close, setQuery, next, prev } =
+    useFindStore();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      close();
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      if (e.shiftKey) prev();
+      else next();
+    } else if (e.key === 'F3') {
+      e.preventDefault();
+      if (e.shiftKey) prev();
+      else next();
+    }
+  };
+
+  const matchLabel = query
+    ? totalMatches === 0
+      ? 'No results'
+      : `${currentIndex + 1} of ${totalMatches}`
+    : '';
+
+  return (
+    <div className="absolute top-2 right-4 z-20 flex items-center gap-1 rounded-lg border bg-background shadow-lg px-2 py-1.5">
+      <Search className="h-4 w-4 text-muted-foreground shrink-0" />
+      <Input
+        ref={inputRef}
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="Find..."
+        className="h-7 w-44 border-0 shadow-none focus-visible:ring-0 px-1 text-sm"
+      />
+      <span className="text-xs text-muted-foreground whitespace-nowrap w-16 text-center">
+        {matchLabel}
+      </span>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-6 w-6"
+        onClick={prev}
+        disabled={totalMatches === 0}
+        aria-label="Previous match"
+      >
+        <ChevronUp className="h-3.5 w-3.5" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-6 w-6"
+        onClick={next}
+        disabled={totalMatches === 0}
+        aria-label="Next match"
+      >
+        <ChevronDown className="h-3.5 w-3.5" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="h-6 w-6"
+        onClick={close}
+        aria-label="Close find bar"
+      >
+        <X className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/components/find/FindBar.tsx
+++ b/apps/web/src/components/find/FindBar.tsx
@@ -49,7 +49,7 @@ export function FindBar() {
         onChange={(e) => setQuery(e.target.value)}
         onKeyDown={handleKeyDown}
         placeholder="Find..."
-        className="h-7 w-44 border-0 shadow-none focus-visible:ring-0 px-1 text-sm"
+        className="find-bar-input h-7 w-44 border-0 shadow-none focus-visible:ring-0 px-1 text-sm"
       />
       <span className="text-xs text-muted-foreground whitespace-nowrap w-16 text-center">
         {matchLabel}

--- a/apps/web/src/components/layout/middle-content/CenterPanel.tsx
+++ b/apps/web/src/components/layout/middle-content/CenterPanel.tsx
@@ -255,6 +255,7 @@ export default function CenterPanel() {
   const { updateNode } = usePageTree(activeDriveId);
   const updateNodeRef = useRef(updateNode);
   const openFind = useFindStore((s) => s.open);
+  const isFindOpen = useFindStore((s) => s.isOpen);
   const resetFind = useFindStore((s) => s.reset);
 
   // Get page refresh configuration for pull-to-refresh
@@ -281,12 +282,18 @@ export default function CenterPanel() {
         const monacoFocused = document.activeElement?.closest('.monaco-editor');
         if (monacoFocused) return;
         e.preventDefault();
-        openFind();
+        if (isFindOpen) {
+          const findInput = document.querySelector<HTMLInputElement>('.find-bar-input');
+          findInput?.focus();
+          findInput?.select();
+        } else {
+          openFind();
+        }
       }
     };
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [openFind]);
+  }, [openFind, isFindOpen]);
 
   // Track page views for recents and clear "has changes" once viewed.
   // This lives in CenterPanel because dashboard route pages intentionally return null.

--- a/apps/web/src/components/layout/middle-content/CenterPanel.tsx
+++ b/apps/web/src/components/layout/middle-content/CenterPanel.tsx
@@ -29,6 +29,8 @@ import { useGlobalDriveSocket } from '@/hooks/useGlobalDriveSocket';
 import { usePageRefresh } from '@/hooks/usePageRefresh';
 import { post, fetchWithAuth } from '@/lib/auth/auth-fetch';
 import useSWR from 'swr';
+import { FindBar } from '@/components/find/FindBar';
+import { useFindStore } from '@/stores/useFindStore';
 
 const LOADING_TIMEOUT_MS = 12000; // Show retry hint after 12 seconds
 
@@ -252,6 +254,8 @@ export default function CenterPanel() {
   const setPageId = usePageStore(state => state.setPageId);
   const { updateNode } = usePageTree(activeDriveId);
   const updateNodeRef = useRef(updateNode);
+  const openFind = useFindStore((s) => s.open);
+  const resetFind = useFindStore((s) => s.reset);
 
   // Get page refresh configuration for pull-to-refresh
   const pageRefresh = usePageRefresh();
@@ -264,6 +268,25 @@ export default function CenterPanel() {
   useEffect(() => {
     setPageId(activePageId);
   }, [activePageId, setPageId]);
+
+  // Reset find state when navigating to a different page
+  useEffect(() => {
+    resetFind();
+  }, [activePageId, resetFind]);
+
+  // Global Cmd+F / Ctrl+F handler — skip when Monaco has focus (CODE pages, CANVAS code tab)
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
+        const monacoFocused = document.activeElement?.closest('.monaco-editor');
+        if (monacoFocused) return;
+        e.preventDefault();
+        openFind();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [openFind]);
 
   // Track page views for recents and clear "has changes" once viewed.
   // This lives in CenterPanel because dashboard route pages intentionally return null.
@@ -326,6 +349,7 @@ export default function CenterPanel() {
       >
         <OptimizedViewHeader pageId={activePageId} />
         <div className="flex-1 min-h-0 relative overflow-hidden">
+          <FindBar />
           <PullToRefresh
             direction="top"
             onRefresh={pageRefresh.refresh}

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -66,6 +66,7 @@ import {
 import { ChatInput, type ChatInputRef } from '@/components/ai/chat/input';
 import { useImageAttachments } from '@/lib/ai/shared/hooks/useImageAttachments';
 import { hasVisionCapability } from '@/lib/ai/core/vision-models';
+import { useFindStore } from '@/stores/useFindStore';
 
 interface AiChatViewProps {
   page: TreePage;
@@ -227,6 +228,40 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
     useChat(chatConfig || {});
 
   const isStreaming = status === 'submitted' || status === 'streaming';
+
+  // Find in page
+  const findQuery = useFindStore((s) => s.query);
+  const findIndex = useFindStore((s) => s.currentIndex);
+  const isFindOpen = useFindStore((s) => s.isOpen);
+  const reportMatches = useFindStore((s) => s.reportMatches);
+  const [findMatchIds, setFindMatchIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!isFindOpen || !findQuery) {
+      setFindMatchIds([]);
+      reportMatches(0);
+      return;
+    }
+    const q = findQuery.toLowerCase();
+    const ids = messages
+      .filter((m) => {
+        const text = (m.parts ?? [])
+          .filter((p) => p.type === 'text')
+          .map((p) => (p as { type: 'text'; text: string }).text)
+          .join(' ');
+        return text.toLowerCase().includes(q);
+      })
+      .map((m) => m.id);
+    setFindMatchIds(ids);
+    reportMatches(ids.length);
+  }, [isFindOpen, findQuery, messages, reportMatches]);
+
+  useEffect(() => {
+    const id = findMatchIds[findIndex];
+    if (!id) return;
+    const el = document.querySelector(`[data-message-id="${id}"]`);
+    el?.scrollIntoView({ block: 'nearest' });
+  }, [findIndex, findMatchIds]);
   const { wrapSend } = useSendHandoff(currentConversationId, status);
   const stop = useChatStop(streamTrackingId, chatStop);
 

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
@@ -21,28 +21,35 @@ vi.mock('next/navigation', () => ({
   useParams: vi.fn(() => ({ driveId: 'test-drive-id' })),
 }));
 
-vi.mock('@ai-sdk/react', () => ({
-  useChat: vi.fn(() => ({
-    messages: [],
+vi.mock('@ai-sdk/react', () => {
+  const chatState = {
+    messages: [] as unknown[],
     sendMessage: vi.fn(),
-    status: 'idle',
-    error: undefined,
+    status: 'idle' as const,
+    error: undefined as Error | undefined,
     regenerate: vi.fn(),
     setMessages: mockSetMessages,
     stop: vi.fn(),
-  })),
-}));
+  };
+  return { useChat: vi.fn(() => chatState) };
+});
 
-vi.mock('swr', () => ({
-  default: vi.fn(() => ({ data: undefined, error: undefined })),
-  useSWRConfig: vi.fn(() => ({ cache: { get: vi.fn(() => undefined) } })),
-}));
+vi.mock('swr', () => {
+  const swrCache = { get: vi.fn(() => undefined) };
+  return {
+    default: vi.fn(() => ({ data: undefined, error: undefined })),
+    useSWRConfig: vi.fn(() => ({ cache: swrCache })),
+  };
+});
 
-vi.mock('@/hooks/useDrive', () => ({
-  useDriveStore: vi.fn((selector: (state: { drives: unknown[] }) => unknown) =>
-    selector({ drives: [] })
-  ),
-}));
+vi.mock('@/hooks/useDrive', () => {
+  const driveState = { drives: [] as unknown[] };
+  return {
+    useDriveStore: vi.fn((selector: (state: typeof driveState) => unknown) =>
+      selector(driveState)
+    ),
+  };
+});
 
 vi.mock('@/hooks/useAuth', () => ({
   useAuth: vi.fn(() => ({ user: { id: 'user-1', name: 'Test User' } })),
@@ -54,12 +61,14 @@ vi.mock('@/stores/useAssistantSettingsStore', () => ({
   ),
 }));
 
-vi.mock('@/stores/useVoiceModeStore', () => ({
-  useVoiceModeStore: vi.fn(
-    (selector: (state: { isEnabled: boolean; owner: null; enable: () => void; disable: () => void }) => unknown) =>
-      selector({ isEnabled: false, owner: null, enable: vi.fn(), disable: vi.fn() })
-  ),
-}));
+vi.mock('@/stores/useVoiceModeStore', () => {
+  const voiceState = { isEnabled: false, owner: null as null, enable: vi.fn(), disable: vi.fn() };
+  return {
+    useVoiceModeStore: vi.fn(
+      (selector: (state: typeof voiceState) => unknown) => selector(voiceState)
+    ),
+  };
+});
 
 vi.mock('@/stores/useEditingStore', () => ({
   useEditingStore: vi.fn(() => ({ register: vi.fn(), unregister: vi.fn() })),
@@ -132,15 +141,16 @@ vi.mock('@/lib/ai/shared', () => ({
   useSendHandoff: vi.fn(() => ({ wrapSend: vi.fn((cb: () => void) => cb()) })),
 }));
 
-vi.mock('@/lib/ai/shared/hooks/useImageAttachments', () => ({
-  useImageAttachments: vi.fn(() => ({
-    attachments: [],
+vi.mock('@/lib/ai/shared/hooks/useImageAttachments', () => {
+  const imageAttachState = {
+    attachments: [] as unknown[],
     addFiles: vi.fn(),
     removeFile: vi.fn(),
     clearFiles: vi.fn(),
-    getFilesForSend: vi.fn(() => []),
-  })),
-}));
+    getFilesForSend: vi.fn(() => [] as unknown[]),
+  };
+  return { useImageAttachments: vi.fn(() => imageAttachState) };
+});
 
 vi.mock('@/lib/tree/tree-utils', () => ({ buildPagePath: vi.fn(() => null) }));
 vi.mock('@/components/ai/page-agents', () => ({

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
@@ -189,6 +189,18 @@ vi.mock('@/components/ai/chat/input', () => ({ ChatInput: vi.fn(() => null) }));
 vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
 vi.mock('zustand/react/shallow', () => ({ useShallow: vi.fn((fn: unknown) => fn) }));
 
+vi.mock('@/stores/useFindStore', () => ({
+  useFindStore: vi.fn((selector: (s: {
+    isOpen: boolean; query: string; currentIndex: number; totalMatches: number;
+    open: () => void; close: () => void; setQuery: () => void;
+    next: () => void; prev: () => void; reportMatches: () => void; reset: () => void;
+  }) => unknown) => selector({
+    isOpen: false, query: '', currentIndex: 0, totalMatches: 0,
+    open: vi.fn(), close: vi.fn(), setQuery: vi.fn(),
+    next: vi.fn(), prev: vi.fn(), reportMatches: vi.fn(), reset: vi.fn(),
+  })),
+}));
+
 import AiChatView from '../AiChatView';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/__tests__/AiChatView.test.tsx
@@ -189,17 +189,16 @@ vi.mock('@/components/ai/chat/input', () => ({ ChatInput: vi.fn(() => null) }));
 vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
 vi.mock('zustand/react/shallow', () => ({ useShallow: vi.fn((fn: unknown) => fn) }));
 
-vi.mock('@/stores/useFindStore', () => ({
-  useFindStore: vi.fn((selector: (s: {
-    isOpen: boolean; query: string; currentIndex: number; totalMatches: number;
-    open: () => void; close: () => void; setQuery: () => void;
-    next: () => void; prev: () => void; reportMatches: () => void; reset: () => void;
-  }) => unknown) => selector({
+vi.mock('@/stores/useFindStore', () => {
+  const findState = {
     isOpen: false, query: '', currentIndex: 0, totalMatches: 0,
     open: vi.fn(), close: vi.fn(), setQuery: vi.fn(),
     next: vi.fn(), prev: vi.fn(), reportMatches: vi.fn(), reset: vi.fn(),
-  })),
-}));
+  };
+  return {
+    useFindStore: vi.fn((selector: (s: typeof findState) => unknown) => selector(findState)),
+  };
+});
 
 import AiChatView from '../AiChatView';
 import { PageType } from '@pagespace/lib/utils/enums';

--- a/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPageView.tsx
@@ -14,6 +14,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { useSocket } from '@/hooks/useSocket';
 import { PageEventPayload } from '@/lib/websocket';
 import { openExternalUrl } from '@/lib/navigation/app-navigation';
+import { useFindStore } from '@/stores/useFindStore';
 
 interface CanvasPageViewProps {
   pageId: string;
@@ -41,6 +42,29 @@ const CanvasPageView = ({ pageId }: CanvasPageViewProps) => {
   } = useDocument(pageId);
 
   const content = documentState?.content ?? '';
+
+  // Find in page (view tab only; code tab uses Monaco's built-in find)
+  const findQuery = useFindStore((s) => s.query);
+  const isFindOpen = useFindStore((s) => s.isOpen);
+  const reportMatches = useFindStore((s) => s.reportMatches);
+
+  useEffect(() => {
+    if (!isFindOpen || !findQuery || activeTab !== 'view') {
+      reportMatches(0);
+      return;
+    }
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(content, 'text/html');
+    const text = (doc.body.textContent ?? '').toLowerCase();
+    const q = findQuery.toLowerCase();
+    let count = 0;
+    let idx = text.indexOf(q);
+    while (idx !== -1) {
+      count++;
+      idx = text.indexOf(q, idx + 1);
+    }
+    reportMatches(count);
+  }, [isFindOpen, findQuery, content, activeTab, reportMatches]);
 
   // Store forceSave in ref to prevent cleanup effects from re-running
   const forceSaveRef = useRef(forceSave);

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef, useCallback, memo, Fragment } from 'react';
+import { useState, useEffect, useRef, useCallback, memo, useMemo, Fragment } from 'react';
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
 import { usePermissions, getPermissionErrorMessage } from '@/hooks/usePermissions';
@@ -38,6 +38,7 @@ import { isFirstInGroup, formatMessageDate } from '@/lib/messages/grouping';
 import { MessageDateSeparator } from '@/components/messages/MessageDateSeparator';
 import { formatDistanceToNow } from 'date-fns';
 import { cn } from '@/lib/utils';
+import { useFindStore } from '@/stores/useFindStore';
 
 interface ChannelRef {
   id: string;
@@ -75,6 +76,37 @@ function ChannelView({ page }: ChannelViewProps) {
   const { user } = useAuth();
   const [messages, setMessages] = useState<MessageWithReactions[]>([]);
   const [inputValue, setInputValue] = useState('');
+
+  // Find in page
+  const findQuery = useFindStore((s) => s.query);
+  const findIndex = useFindStore((s) => s.currentIndex);
+  const isFindOpen = useFindStore((s) => s.isOpen);
+  const reportMatches = useFindStore((s) => s.reportMatches);
+  const [findMatchIds, setFindMatchIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!isFindOpen || !findQuery) {
+      setFindMatchIds([]);
+      reportMatches(0);
+      return;
+    }
+    const q = findQuery.toLowerCase();
+    const ids = messages
+      .filter((m) => m.content?.toLowerCase().includes(q))
+      .map((m) => m.id);
+    setFindMatchIds(ids);
+    reportMatches(ids.length);
+  }, [isFindOpen, findQuery, messages, reportMatches]);
+
+  useEffect(() => {
+    const id = findMatchIds[findIndex];
+    if (!id) return;
+    const el = document.querySelector(`[data-message-id="${id}"]`);
+    el?.scrollIntoView({ block: 'nearest' });
+  }, [findIndex, findMatchIds]);
+
+  const findMatchSet = useMemo(() => new Set(findMatchIds), [findMatchIds]);
+  const currentFindMsgId = findMatchIds[findIndex] ?? null;
   const channelInputRef = useRef<ChannelInputRef>(null);
 
   // Use centralized socket store for proper authentication
@@ -624,7 +656,14 @@ function ChannelView({ page }: ChannelViewProps) {
                         return (
                         <Fragment key={m.id}>
                         {showDateSeparator && <MessageDateSeparator label={formatMessageDate(m.createdAt)} />}
-                        <div className={`group/msg flex items-start gap-4 ${rowSpacing} relative`}>
+                        <div
+                          data-message-id={m.id}
+                          className={cn(
+                            `group/msg flex items-start gap-4 ${rowSpacing} relative rounded`,
+                            findMatchSet.has(m.id) && 'find-highlight',
+                            currentFindMsgId === m.id && 'find-highlight-current',
+                          )}
+                        >
                             {isFirst ? (
                               <Avatar className="shrink-0">
                                   {!isAi && <AvatarImage src={m.user?.image || ''} />}

--- a/apps/web/src/components/layout/middle-content/page-views/document/DocumentView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/document/DocumentView.tsx
@@ -258,14 +258,21 @@ const DocumentView = ({ pageId, driveId }: DocumentViewProps) => {
       reportMatches(0);
       return;
     }
-    dispatchFind(editor.view, findQuery, findIndex);
-    const matches = getPluginMatches(editor.state);
-    reportMatches(matches.length);
-    if (matches[findIndex]) {
-      const { from, to } = matches[findIndex];
-      editor.commands.setTextSelection({ from, to });
-      editor.commands.scrollIntoView();
-    }
+
+    const syncFindState = () => {
+      dispatchFind(editor.view, findQuery, findIndex);
+      const matches = getPluginMatches(editor.state);
+      reportMatches(matches.length);
+      const activeMatch = matches[Math.min(findIndex, Math.max(matches.length - 1, 0))];
+      if (activeMatch) {
+        editor.commands.setTextSelection(activeMatch);
+        editor.commands.scrollIntoView();
+      }
+    };
+
+    syncFindState();
+    editor.on('update', syncFindState);
+    return () => { editor.off('update', syncFindState); };
   }, [isFindOpen, findQuery, findIndex, editor, activeView, reportMatches]);
 
   // Auto-save on window blur

--- a/apps/web/src/components/layout/middle-content/page-views/document/DocumentView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/document/DocumentView.tsx
@@ -14,6 +14,8 @@ import { useAuth } from '@/hooks/useAuth';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useEditingStore } from '@/stores/useEditingStore';
 import { useDocumentManagerStore } from '@/stores/useDocumentManagerStore';
+import { useFindStore } from '@/stores/useFindStore';
+import { dispatchFind, getPluginMatches } from '@/lib/editor/find-plugin';
 import { PullToRefresh } from '@/components/ui/pull-to-refresh';
 import { CustomScrollArea } from '@/components/ui/custom-scroll-area';
 
@@ -239,6 +241,32 @@ const DocumentView = ({ pageId, driveId }: DocumentViewProps) => {
       }
     };
   }, []); // ✅ Empty deps - uses ref for latest forceSave
+
+  // Connect find store to TipTap find plugin
+  const isFindOpen = useFindStore((s) => s.isOpen);
+  const findQuery = useFindStore((s) => s.query);
+  const findIndex = useFindStore((s) => s.currentIndex);
+  const reportMatches = useFindStore((s) => s.reportMatches);
+
+  useEffect(() => {
+    if (!editor || editor.isDestroyed || activeView !== 'rich') {
+      reportMatches(0);
+      return;
+    }
+    if (!isFindOpen || !findQuery) {
+      dispatchFind(editor.view, '', 0);
+      reportMatches(0);
+      return;
+    }
+    dispatchFind(editor.view, findQuery, findIndex);
+    const matches = getPluginMatches(editor.state);
+    reportMatches(matches.length);
+    if (matches[findIndex]) {
+      const { from, to } = matches[findIndex];
+      editor.commands.setTextSelection({ from, to });
+      editor.commands.scrollIntoView();
+    }
+  }, [isFindOpen, findQuery, findIndex, editor, activeView, reportMatches]);
 
   // Auto-save on window blur
   useEffect(() => {

--- a/apps/web/src/components/layout/middle-content/page-views/document/DocumentView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/document/DocumentView.tsx
@@ -259,20 +259,25 @@ const DocumentView = ({ pageId, driveId }: DocumentViewProps) => {
       return;
     }
 
-    const syncFindState = () => {
-      dispatchFind(editor.view, findQuery, findIndex);
-      const matches = getPluginMatches(editor.state);
-      reportMatches(matches.length);
-      const activeMatch = matches[Math.min(findIndex, Math.max(matches.length - 1, 0))];
-      if (activeMatch) {
-        editor.commands.setTextSelection(activeMatch);
-        editor.commands.scrollIntoView();
-      }
-    };
+    // Initial sync: dispatch query/index to plugin and scroll to active match
+    dispatchFind(editor.view, findQuery, findIndex);
+    const initialMatches = getPluginMatches(editor.state);
+    reportMatches(initialMatches.length);
+    const initialMatch = initialMatches[Math.min(findIndex, Math.max(initialMatches.length - 1, 0))];
+    if (initialMatch) {
+      editor.commands.setTextSelection(initialMatch);
+      editor.commands.scrollIntoView();
+    }
 
-    syncFindState();
-    editor.on('update', syncFindState);
-    return () => { editor.off('update', syncFindState); };
+    // Re-read match count when document changes while find is open.
+    // The plugin auto-recomputes matches on docChanged — we only need to
+    // report the new count without re-dispatching (which would loop).
+    const handleDocUpdate = ({ transaction }: { transaction: { docChanged: boolean } }) => {
+      if (!transaction.docChanged) return;
+      reportMatches(getPluginMatches(editor.state).length);
+    };
+    editor.on('update', handleDocUpdate);
+    return () => { editor.off('update', handleDocUpdate); };
   }, [isFindOpen, findQuery, findIndex, editor, activeView, reportMatches]);
 
   // Auto-save on window blur

--- a/apps/web/src/components/layout/middle-content/page-views/folder/FolderView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/folder/FolderView.tsx
@@ -10,6 +10,7 @@ import { GridView } from './GridView';
 import { ListView } from './ListView';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { isFolderPage } from '@pagespace/lib/content/page-types.config';
+import { useFindStore } from '@/stores/useFindStore';
 
 export default function FolderView({ page }: FolderViewProps) {
   const params = useParams();
@@ -20,6 +21,33 @@ export default function FolderView({ page }: FolderViewProps) {
   const [viewMode, setViewMode] = useState<ViewMode>('list');
   const [sortKey, setSortKey] = useState<SortKey>('title');
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
+
+  // Find in page
+  const findQuery = useFindStore((s) => s.query);
+  const findIndex = useFindStore((s) => s.currentIndex);
+  const isFindOpen = useFindStore((s) => s.isOpen);
+  const reportMatches = useFindStore((s) => s.reportMatches);
+
+  const findMatchIds = useMemo(() => {
+    if (!isFindOpen || !findQuery) return [];
+    const q = findQuery.toLowerCase();
+    return (page.children ?? [])
+      .filter((child) => child.title.toLowerCase().includes(q))
+      .map((child) => child.id);
+  }, [isFindOpen, findQuery, page.children]);
+
+  useEffect(() => {
+    reportMatches(findMatchIds.length);
+  }, [findMatchIds, reportMatches]);
+
+  useEffect(() => {
+    const id = findMatchIds[findIndex];
+    if (!id) return;
+    document.querySelector(`[data-item-id="${id}"]`)?.scrollIntoView({ block: 'nearest' });
+  }, [findIndex, findMatchIds]);
+
+  const findMatchSet = useMemo(() => new Set(findMatchIds), [findMatchIds]);
+  const currentFindId = findMatchIds[findIndex] ?? null;
 
   useEffect(() => {
     if (isFolderPage(page.type as PageType) && !page.children) {
@@ -58,13 +86,15 @@ export default function FolderView({ page }: FolderViewProps) {
       ) : (
         <>
           {viewMode === 'grid' ? (
-            <GridView items={sortedChildren} />
+            <GridView items={sortedChildren} findMatchSet={findMatchSet} currentFindId={currentFindId} />
           ) : (
             <ListView
               items={sortedChildren}
               sortKey={sortKey}
               sortDirection={sortDirection}
               onSort={handleSort}
+              findMatchSet={findMatchSet}
+              currentFindId={currentFindId}
             />
           )}
         </>

--- a/apps/web/src/components/layout/middle-content/page-views/folder/FolderView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/folder/FolderView.tsx
@@ -22,32 +22,11 @@ export default function FolderView({ page }: FolderViewProps) {
   const [sortKey, setSortKey] = useState<SortKey>('title');
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc');
 
-  // Find in page
+  // Find in page — subscriptions only; match IDs computed after sortedChildren
   const findQuery = useFindStore((s) => s.query);
   const findIndex = useFindStore((s) => s.currentIndex);
   const isFindOpen = useFindStore((s) => s.isOpen);
   const reportMatches = useFindStore((s) => s.reportMatches);
-
-  const findMatchIds = useMemo(() => {
-    if (!isFindOpen || !findQuery) return [];
-    const q = findQuery.toLowerCase();
-    return (page.children ?? [])
-      .filter((child) => child.title.toLowerCase().includes(q))
-      .map((child) => child.id);
-  }, [isFindOpen, findQuery, page.children]);
-
-  useEffect(() => {
-    reportMatches(findMatchIds.length);
-  }, [findMatchIds, reportMatches]);
-
-  useEffect(() => {
-    const id = findMatchIds[findIndex];
-    if (!id) return;
-    document.querySelector(`[data-item-id="${id}"]`)?.scrollIntoView({ block: 'nearest' });
-  }, [findIndex, findMatchIds]);
-
-  const findMatchSet = useMemo(() => new Set(findMatchIds), [findMatchIds]);
-  const currentFindId = findMatchIds[findIndex] ?? null;
 
   useEffect(() => {
     if (isFolderPage(page.type as PageType) && !page.children) {
@@ -75,6 +54,28 @@ export default function FolderView({ page }: FolderViewProps) {
       return 0;
     });
   }, [page.children, sortKey, sortDirection]);
+
+  // Derived from sortedChildren so navigation order matches rendered order
+  const findMatchIds = useMemo(() => {
+    if (!isFindOpen || !findQuery) return [];
+    const q = findQuery.toLowerCase();
+    return sortedChildren
+      .filter((child) => child.title.toLowerCase().includes(q))
+      .map((child) => child.id);
+  }, [isFindOpen, findQuery, sortedChildren]);
+
+  useEffect(() => {
+    reportMatches(findMatchIds.length);
+  }, [findMatchIds, reportMatches]);
+
+  useEffect(() => {
+    const id = findMatchIds[findIndex];
+    if (!id) return;
+    document.querySelector(`[data-item-id="${id}"]`)?.scrollIntoView({ block: 'nearest' });
+  }, [findIndex, findMatchIds]);
+
+  const findMatchSet = useMemo(() => new Set(findMatchIds), [findMatchIds]);
+  const currentFindId = findMatchIds[findIndex] ?? null;
 
   return (
     <div className="p-4">

--- a/apps/web/src/components/layout/middle-content/page-views/folder/GridView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/folder/GridView.tsx
@@ -3,8 +3,9 @@ import { useParams } from 'next/navigation';
 import { GridViewProps } from './types';
 import { PageTypeIcon } from '@/components/common/PageTypeIcon';
 import { PageType } from '@pagespace/lib/utils/enums';
+import { cn } from '@/lib/utils';
 
-export function GridView({ items }: GridViewProps) {
+export function GridView({ items, findMatchSet, currentFindId }: GridViewProps) {
   const params = useParams();
   const driveId = params.driveId as string;
 
@@ -12,7 +13,14 @@ export function GridView({ items }: GridViewProps) {
     <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 gap-1">
       {items.map((child) => (
         <Link key={child.id} href={`/dashboard/${driveId}/${child.id}`}>
-          <div className="flex flex-col items-center gap-1.5 pt-2 pb-1.5 px-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors cursor-pointer">
+          <div
+            data-item-id={child.id}
+            className={cn(
+              'flex flex-col items-center gap-1.5 pt-2 pb-1.5 px-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors cursor-pointer',
+              findMatchSet?.has(child.id) && 'find-highlight',
+              currentFindId === child.id && 'find-highlight-current',
+            )}
+          >
             <PageTypeIcon type={child.type as PageType} className="h-12 w-12 shrink-0" />
             <span className="text-xs text-center line-clamp-2 w-full leading-tight break-words">
               {child.title}

--- a/apps/web/src/components/layout/middle-content/page-views/folder/ListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/folder/ListView.tsx
@@ -14,8 +14,9 @@ import { ListViewProps, SortKey } from './types';
 import { PageTypeIcon } from '@/components/common/PageTypeIcon';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { toTitleCase } from '@/lib/utils/formatters';
+import { cn } from '@/lib/utils';
 
-export function ListView({ items, sortKey, sortDirection, onSort }: ListViewProps) {
+export function ListView({ items, sortKey, sortDirection, onSort, findMatchSet, currentFindId }: ListViewProps) {
   const params = useParams();
   const driveId = params.driveId as string;
 
@@ -48,7 +49,15 @@ export function ListView({ items, sortKey, sortDirection, onSort }: ListViewProp
       </TableHeader>
       <TableBody>
         {items.map((child) => (
-          <TableRow key={child.id} className="cursor-pointer">
+          <TableRow
+            key={child.id}
+            data-item-id={child.id}
+            className={cn(
+              'cursor-pointer',
+              findMatchSet?.has(child.id) && 'find-highlight',
+              currentFindId === child.id && 'find-highlight-current',
+            )}
+          >
             <TableCell>
               <Link href={`/dashboard/${driveId}/${child.id}`} className="flex items-center">
                 <PageTypeIcon type={child.type as PageType} className="h-5 w-5" />

--- a/apps/web/src/components/layout/middle-content/page-views/folder/types.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/folder/types.ts
@@ -12,6 +12,8 @@ export interface FolderViewProps {
 
 export interface GridViewProps {
   items: TreePage[];
+  findMatchSet?: Set<string>;
+  currentFindId?: string | null;
 }
 
 export interface ListViewProps {
@@ -19,4 +21,6 @@ export interface ListViewProps {
   sortKey: SortKey;
   sortDirection: SortDirection;
   onSort: (key: SortKey) => void;
+  findMatchSet?: Set<string>;
+  currentFindId?: string | null;
 }

--- a/apps/web/src/components/layout/middle-content/page-views/sheet/SheetView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/sheet/SheetView.tsx
@@ -583,22 +583,13 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
     }
     const q = findQuery.toLowerCase();
     const matches: string[] = [];
-    const matchSet = new Set<string>();
-    for (const [addr, raw] of Object.entries(sheet.cells)) {
-      if (raw.toLowerCase().includes(q)) {
-        matches.push(addr);
-        matchSet.add(addr);
-      }
-    }
     for (let r = 0; r < sheet.rowCount; r++) {
       for (let c = 0; c < sheet.columnCount; c++) {
         const addr = encodeCellAddress(r, c);
-        if (!matchSet.has(addr)) {
-          const display = evaluation.display[r]?.[c] ?? '';
-          if (display.toLowerCase().includes(q)) {
-            matches.push(addr);
-            matchSet.add(addr);
-          }
+        const raw = sheet.cells[addr] ?? '';
+        const display = evaluation.display[r]?.[c] ?? '';
+        if (raw.toLowerCase().includes(q) || display.toLowerCase().includes(q)) {
+          matches.push(addr);
         }
       }
     }

--- a/apps/web/src/components/layout/middle-content/page-views/sheet/SheetView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/sheet/SheetView.tsx
@@ -29,6 +29,7 @@ import { useSuggestion } from '@/hooks/useSuggestion';
 import { SuggestionProvider, useSuggestionContext } from '@/components/providers/SuggestionProvider';
 import { MentionPickerPortal } from '@/components/mentions/MentionPickerPortal';
 import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { useFindStore } from '@/stores/useFindStore';
 
 interface SheetViewProps {
   page: TreePage;
@@ -233,6 +234,52 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
       return () => clearTimeout(timer);
     }
   }, [announcement]);
+
+  // Find in page
+  const findQuery = useFindStore((s) => s.query);
+  const findIndex = useFindStore((s) => s.currentIndex);
+  const isFindOpen = useFindStore((s) => s.isOpen);
+  const reportMatches = useFindStore((s) => s.reportMatches);
+  const [findAddresses, setFindAddresses] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!isFindOpen || !findQuery) {
+      setFindAddresses([]);
+      reportMatches(0);
+      return;
+    }
+    const q = findQuery.toLowerCase();
+    const matches: string[] = [];
+    for (const [addr, raw] of Object.entries(sheet.cells)) {
+      if (raw.toLowerCase().includes(q)) {
+        matches.push(addr);
+      }
+    }
+    // Also check display values for computed cells not in raw cells
+    for (let r = 0; r < sheet.rowCount; r++) {
+      for (let c = 0; c < sheet.columnCount; c++) {
+        const addr = encodeCellAddress(r, c);
+        if (!matches.includes(addr)) {
+          const display = evaluation.display[r]?.[c] ?? '';
+          if (display.toLowerCase().includes(q)) {
+            matches.push(addr);
+          }
+        }
+      }
+    }
+    setFindAddresses(matches);
+    reportMatches(matches.length);
+  }, [isFindOpen, findQuery, sheet.cells, sheet.rowCount, sheet.columnCount, evaluation.display, reportMatches]);
+
+  useEffect(() => {
+    const addr = findAddresses[findIndex];
+    if (!addr || !gridRef.current) return;
+    const el = gridRef.current.querySelector(`[data-cell="${addr}"]`);
+    el?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }, [findIndex, findAddresses]);
+
+  const findAddressSet = useMemo(() => new Set(findAddresses), [findAddresses]);
+  const currentFindAddress = findAddresses[findIndex] ?? null;
 
   const formulaInputRef = useRef<HTMLInputElement>(null);
   const gridRef = useRef<HTMLDivElement>(null);
@@ -1914,7 +1961,9 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
                         isPrimaryCell && 'outline outline-2 outline-offset-[-2px] outline-primary',
                         cellError && 'bg-destructive/10 text-destructive',
                         editingCell && editingCell.row === rowIndex && editingCell.column === columnIndex && 'opacity-50',
-                        isDragging && 'select-none'
+                        isDragging && 'select-none',
+                        findAddressSet.has(cellAddress) && 'find-highlight',
+                        currentFindAddress === cellAddress && 'find-highlight-current'
                       )}
                       onMouseDown={(e) => handleCellMouseDown(rowIndex, columnIndex, e)}
                       onMouseEnter={() => handleCellMouseEnter(rowIndex, columnIndex)}

--- a/apps/web/src/components/layout/middle-content/page-views/sheet/SheetView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/sheet/SheetView.tsx
@@ -235,51 +235,12 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
     }
   }, [announcement]);
 
-  // Find in page
+  // Find in page — store subscriptions and state (effects moved after `evaluation` declaration)
   const findQuery = useFindStore((s) => s.query);
   const findIndex = useFindStore((s) => s.currentIndex);
   const isFindOpen = useFindStore((s) => s.isOpen);
   const reportMatches = useFindStore((s) => s.reportMatches);
   const [findAddresses, setFindAddresses] = useState<string[]>([]);
-
-  useEffect(() => {
-    if (!isFindOpen || !findQuery) {
-      setFindAddresses([]);
-      reportMatches(0);
-      return;
-    }
-    const q = findQuery.toLowerCase();
-    const matches: string[] = [];
-    for (const [addr, raw] of Object.entries(sheet.cells)) {
-      if (raw.toLowerCase().includes(q)) {
-        matches.push(addr);
-      }
-    }
-    // Also check display values for computed cells not in raw cells
-    for (let r = 0; r < sheet.rowCount; r++) {
-      for (let c = 0; c < sheet.columnCount; c++) {
-        const addr = encodeCellAddress(r, c);
-        if (!matches.includes(addr)) {
-          const display = evaluation.display[r]?.[c] ?? '';
-          if (display.toLowerCase().includes(q)) {
-            matches.push(addr);
-          }
-        }
-      }
-    }
-    setFindAddresses(matches);
-    reportMatches(matches.length);
-  }, [isFindOpen, findQuery, sheet.cells, sheet.rowCount, sheet.columnCount, evaluation.display, reportMatches]);
-
-  useEffect(() => {
-    const addr = findAddresses[findIndex];
-    if (!addr || !gridRef.current) return;
-    const el = gridRef.current.querySelector(`[data-cell="${addr}"]`);
-    el?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
-  }, [findIndex, findAddresses]);
-
-  const findAddressSet = useMemo(() => new Set(findAddresses), [findAddresses]);
-  const currentFindAddress = findAddresses[findIndex] ?? null;
 
   const formulaInputRef = useRef<HTMLInputElement>(null);
   const gridRef = useRef<HTMLDivElement>(null);
@@ -612,6 +573,49 @@ const SheetViewComponent: React.FC<SheetViewProps> = ({ page }) => {
   );
 
   const evaluation = useMemo(() => evaluateSheet(sheet, evaluationOptions), [sheet, evaluationOptions]);
+
+  // Find effects must live after `evaluation` is declared
+  useEffect(() => {
+    if (!isFindOpen || !findQuery) {
+      setFindAddresses([]);
+      reportMatches(0);
+      return;
+    }
+    const q = findQuery.toLowerCase();
+    const matches: string[] = [];
+    const matchSet = new Set<string>();
+    for (const [addr, raw] of Object.entries(sheet.cells)) {
+      if (raw.toLowerCase().includes(q)) {
+        matches.push(addr);
+        matchSet.add(addr);
+      }
+    }
+    for (let r = 0; r < sheet.rowCount; r++) {
+      for (let c = 0; c < sheet.columnCount; c++) {
+        const addr = encodeCellAddress(r, c);
+        if (!matchSet.has(addr)) {
+          const display = evaluation.display[r]?.[c] ?? '';
+          if (display.toLowerCase().includes(q)) {
+            matches.push(addr);
+            matchSet.add(addr);
+          }
+        }
+      }
+    }
+    setFindAddresses(matches);
+    reportMatches(matches.length);
+  }, [isFindOpen, findQuery, sheet.cells, sheet.rowCount, sheet.columnCount, evaluation.display, reportMatches]);
+
+  useEffect(() => {
+    const addr = findAddresses[findIndex];
+    if (!addr || !gridRef.current) return;
+    const el = gridRef.current.querySelector(`[data-cell="${addr}"]`);
+    el?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }, [findIndex, findAddresses]);
+
+  const findAddressSet = useMemo(() => new Set(findAddresses), [findAddresses]);
+  const currentFindAddress = findAddresses[findIndex] ?? null;
+
   const currentSelection = selection.type === 'single'
     ? clampSelection(selection.cell, sheet)
     : clampSelection(selection.range.start, sheet);

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -9,6 +9,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { usePermissions, canManageDrive } from '@/hooks/usePermissions';
 import { useDriveStore } from '@/hooks/useDrive';
 import { useEditingStore } from '@/stores/useEditingStore';
+import { useFindStore } from '@/stores/useFindStore';
 import { useEditingSession } from '@/stores/useEditingSession';
 import { useLayoutStore } from '@/stores/useLayoutStore';
 import { useTaskListPageFilter } from './useTaskListPageFilter';
@@ -386,6 +387,18 @@ function TaskListView({ page }: TaskListViewProps) {
   const [filter, setFilter] = useTaskListPageFilter(page.id);
   const [search, setSearch] = useState('');
   const [newTaskTitle, setNewTaskTitle] = useState('');
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  // Connect Cmd+F to existing search input
+  const isFindOpen = useFindStore((s) => s.isOpen);
+  const reportMatches = useFindStore((s) => s.reportMatches);
+
+  useEffect(() => {
+    if (isFindOpen) {
+      searchInputRef.current?.focus();
+      searchInputRef.current?.select();
+    }
+  }, [isFindOpen]);
   const [editingTaskId, setEditingTaskId] = useState<string | null>(null);
   const [editingTitle, setEditingTitle] = useState('');
   const [triggerDialogTask, setTriggerDialogTask] = useState<TaskItem | null>(null);
@@ -493,6 +506,13 @@ function TaskListView({ page }: TaskListViewProps) {
 
     return true;
   }) || [];
+
+  // Report filtered task count to find store when search is active
+  useEffect(() => {
+    if (isFindOpen && search) {
+      reportMatches(filteredTasks.length);
+    }
+  }, [isFindOpen, search, filteredTasks.length, reportMatches]);
 
   // Create new task (with optional status for kanban)
   const handleCreateTask = async (title?: string, status?: string) => {
@@ -764,6 +784,7 @@ function TaskListView({ page }: TaskListViewProps) {
           <div className="relative">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
             <Input
+              ref={searchInputRef}
               placeholder="Filter tasks..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -509,8 +509,8 @@ function TaskListView({ page }: TaskListViewProps) {
 
   // Report filtered task count to find store when search is active
   useEffect(() => {
-    if (isFindOpen && search) {
-      reportMatches(filteredTasks.length);
+    if (isFindOpen) {
+      reportMatches(search ? filteredTasks.length : 0);
     }
   }, [isFindOpen, search, filteredTasks.length, reportMatches]);
 

--- a/apps/web/src/lib/editor/find-plugin.ts
+++ b/apps/web/src/lib/editor/find-plugin.ts
@@ -20,14 +20,31 @@ function findMatches(doc: Node, query: string): { from: number; to: number }[] {
   const queryLower = query.toLowerCase();
   const queryLen = query.length;
 
+  // Process each inline-content block, coalescing adjacent text nodes so that
+  // queries spanning marks (e.g. "hel**lo**" searched as "hello") are found.
   doc.descendants((node, pos) => {
-    if (!node.isText || !node.text) return;
-    const text = node.text.toLowerCase();
-    let idx = text.indexOf(queryLower);
+    if (!node.isBlock || !node.inlineContent) return;
+
+    // Build a buffer of all text within this block and a parallel doc-position map
+    const docPositions: number[] = [];
+    let buffer = '';
+    node.forEach((child, offset) => {
+      if (child.isText && child.text) {
+        buffer += child.text.toLowerCase();
+        const childPos = pos + 1 + offset;
+        for (let i = 0; i < child.text.length; i++) {
+          docPositions.push(childPos + i);
+        }
+      }
+    });
+
+    let idx = buffer.indexOf(queryLower);
     while (idx !== -1) {
-      matches.push({ from: pos + idx, to: pos + idx + queryLen });
-      idx = text.indexOf(queryLower, idx + 1);
+      matches.push({ from: docPositions[idx], to: docPositions[idx + queryLen - 1] + 1 });
+      idx = buffer.indexOf(queryLower, idx + 1);
     }
+
+    return false; // don't descend into inline children — we've handled them above
   });
 
   return matches;

--- a/apps/web/src/lib/editor/find-plugin.ts
+++ b/apps/web/src/lib/editor/find-plugin.ts
@@ -25,9 +25,22 @@ function findMatches(doc: Node, query: string): { from: number; to: number }[] {
   doc.descendants((node, pos) => {
     if (!node.isBlock || !node.inlineContent) return;
 
-    // Build a buffer of all text within this block and a parallel doc-position map
-    const docPositions: number[] = [];
+    // Build a buffer of all text within this block and a parallel doc-position map.
+    // Flush the buffer on non-text inline nodes (e.g. mentions, images) so that
+    // `foo[mention]bar` cannot match a query like `foobar` across the boundary.
+    let docPositions: number[] = [];
     let buffer = '';
+
+    const flushBuffer = () => {
+      let idx = buffer.indexOf(queryLower);
+      while (idx !== -1) {
+        matches.push({ from: docPositions[idx], to: docPositions[idx + queryLen - 1] + 1 });
+        idx = buffer.indexOf(queryLower, idx + 1);
+      }
+      buffer = '';
+      docPositions = [];
+    };
+
     node.forEach((child, offset) => {
       if (child.isText && child.text) {
         buffer += child.text.toLowerCase();
@@ -35,14 +48,11 @@ function findMatches(doc: Node, query: string): { from: number; to: number }[] {
         for (let i = 0; i < child.text.length; i++) {
           docPositions.push(childPos + i);
         }
+      } else if (buffer) {
+        flushBuffer();
       }
     });
-
-    let idx = buffer.indexOf(queryLower);
-    while (idx !== -1) {
-      matches.push({ from: docPositions[idx], to: docPositions[idx + queryLen - 1] + 1 });
-      idx = buffer.indexOf(queryLower, idx + 1);
-    }
+    flushBuffer();
 
     return false; // don't descend into inline children — we've handled them above
   });

--- a/apps/web/src/lib/editor/find-plugin.ts
+++ b/apps/web/src/lib/editor/find-plugin.ts
@@ -1,0 +1,108 @@
+import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+import type { EditorState } from '@tiptap/pm/state';
+import { Decoration, DecorationSet } from '@tiptap/pm/view';
+import type { EditorView } from '@tiptap/pm/view';
+import type { Node } from '@tiptap/pm/model';
+
+export const findPluginKey = new PluginKey<FindPluginState>('find');
+
+interface FindPluginState {
+  query: string;
+  matches: { from: number; to: number }[];
+  currentIndex: number;
+  decorations: DecorationSet;
+}
+
+function findMatches(doc: Node, query: string): { from: number; to: number }[] {
+  if (!query) return [];
+  const matches: { from: number; to: number }[] = [];
+  const queryLower = query.toLowerCase();
+  const queryLen = query.length;
+
+  doc.descendants((node, pos) => {
+    if (!node.isText || !node.text) return;
+    const text = node.text.toLowerCase();
+    let idx = text.indexOf(queryLower);
+    while (idx !== -1) {
+      matches.push({ from: pos + idx, to: pos + idx + queryLen });
+      idx = text.indexOf(queryLower, idx + 1);
+    }
+  });
+
+  return matches;
+}
+
+function buildDecorations(
+  doc: Node,
+  matches: { from: number; to: number }[],
+  currentIndex: number,
+): DecorationSet {
+  if (!matches.length) return DecorationSet.empty;
+
+  const decorations = matches.map((match, i) =>
+    Decoration.inline(match.from, match.to, {
+      class: i === currentIndex ? 'find-highlight find-highlight-current' : 'find-highlight',
+    }),
+  );
+
+  return DecorationSet.create(doc, decorations);
+}
+
+export const FindPlugin = new Plugin<FindPluginState>({
+  key: findPluginKey,
+
+  state: {
+    init() {
+      return { query: '', matches: [], currentIndex: 0, decorations: DecorationSet.empty };
+    },
+
+    apply(tr, pluginState, _, newState) {
+      const meta = tr.getMeta(findPluginKey) as
+        | { query: string; currentIndex: number }
+        | undefined;
+
+      if (meta !== undefined) {
+        const matches = findMatches(newState.doc, meta.query);
+        const idx = matches.length ? Math.min(meta.currentIndex, matches.length - 1) : 0;
+        const decorations = buildDecorations(newState.doc, matches, idx);
+        return { query: meta.query, matches, currentIndex: idx, decorations };
+      }
+
+      if (tr.docChanged && pluginState.query) {
+        const matches = findMatches(newState.doc, pluginState.query);
+        const idx = matches.length
+          ? Math.min(pluginState.currentIndex, matches.length - 1)
+          : 0;
+        const decorations = buildDecorations(newState.doc, matches, idx);
+        return { ...pluginState, matches, currentIndex: idx, decorations };
+      }
+
+      return {
+        ...pluginState,
+        decorations: pluginState.decorations.map(tr.mapping, tr.doc),
+      };
+    },
+  },
+
+  props: {
+    decorations(state) {
+      return findPluginKey.getState(state)?.decorations ?? DecorationSet.empty;
+    },
+  },
+});
+
+export function dispatchFind(view: EditorView, query: string, currentIndex: number): void {
+  view.dispatch(view.state.tr.setMeta(findPluginKey, { query, currentIndex }));
+}
+
+export function getPluginMatches(state: EditorState): { from: number; to: number }[] {
+  return findPluginKey.getState(state)?.matches ?? [];
+}
+
+export const FindExtension = Extension.create({
+  name: 'find',
+  addProseMirrorPlugins() {
+    return [FindPlugin];
+  },
+});

--- a/apps/web/src/lib/hotkeys/registry.ts
+++ b/apps/web/src/lib/hotkeys/registry.ts
@@ -43,6 +43,16 @@ export const HOTKEY_REGISTRY: HotkeyDefinition[] = [
     defaultBinding: 'Meta+B',
   },
 
+  // Editing
+  {
+    id: 'editing.find',
+    label: 'Find in Page',
+    description: 'Open the find bar to search within the current page',
+    category: 'editing',
+    defaultBinding: 'Meta+F',
+    allowInInputs: true,
+  },
+
   // Tabs
   {
     id: 'tabs.cycle-next',

--- a/apps/web/src/stores/useFindStore.ts
+++ b/apps/web/src/stores/useFindStore.ts
@@ -1,0 +1,50 @@
+import { create } from 'zustand';
+
+interface FindStore {
+  isOpen: boolean;
+  query: string;
+  currentIndex: number;
+  totalMatches: number;
+  open: () => void;
+  close: () => void;
+  setQuery: (query: string) => void;
+  next: () => void;
+  prev: () => void;
+  reportMatches: (count: number) => void;
+  reset: () => void;
+}
+
+export const useFindStore = create<FindStore>((set, get) => ({
+  isOpen: false,
+  query: '',
+  currentIndex: 0,
+  totalMatches: 0,
+
+  open: () => set({ isOpen: true }),
+
+  close: () => set({ isOpen: false, query: '', currentIndex: 0, totalMatches: 0 }),
+
+  setQuery: (query) => set({ query, currentIndex: 0 }),
+
+  next: () => {
+    const { currentIndex, totalMatches } = get();
+    if (totalMatches === 0) return;
+    set({ currentIndex: (currentIndex + 1) % totalMatches });
+  },
+
+  prev: () => {
+    const { currentIndex, totalMatches } = get();
+    if (totalMatches === 0) return;
+    set({ currentIndex: (currentIndex - 1 + totalMatches) % totalMatches });
+  },
+
+  reportMatches: (count) => {
+    const { currentIndex } = get();
+    set({
+      totalMatches: count,
+      currentIndex: count === 0 ? 0 : Math.min(currentIndex, count - 1),
+    });
+  },
+
+  reset: () => set({ isOpen: false, query: '', currentIndex: 0, totalMatches: 0 }),
+}));

--- a/apps/web/src/stores/useFindStore.ts
+++ b/apps/web/src/stores/useFindStore.ts
@@ -24,7 +24,7 @@ export const useFindStore = create<FindStore>((set, get) => ({
 
   close: () => set({ isOpen: false, query: '', currentIndex: 0, totalMatches: 0 }),
 
-  setQuery: (query) => set({ query, currentIndex: 0 }),
+  setQuery: (query) => set({ query, currentIndex: 0, totalMatches: 0 }),
 
   next: () => {
     const { currentIndex, totalMatches } = get();

--- a/apps/web/src/styles/tiptap.css
+++ b/apps/web/src/styles/tiptap.css
@@ -1,3 +1,14 @@
+.find-highlight {
+  background: oklch(85% 0.15 85 / 0.45);
+  border-radius: 2px;
+}
+
+.find-highlight-current {
+  background: oklch(72% 0.18 55 / 0.65);
+  outline: 1px solid oklch(55% 0.2 55);
+  border-radius: 2px;
+}
+
 .tiptap {
   overflow-wrap: break-word;
   word-wrap: break-word;


### PR DESCRIPTION
## Summary

- Adds a floating find bar (Cmd+F / Ctrl+F) that works across all 9 page types — Document, Sheet, Channel, AI Chat, Task List, Canvas, Folder, File, and Terminal
- CODE pages and Monaco-focused views continue using Monaco's built-in find natively (no interception)
- Find bar floats top-right (browser-style), shows match count, supports Esc/Enter/Shift+Enter/F3 navigation
- Cmd+F re-focuses the find input if the bar is already open

## Architecture

**New files:**
- `useFindStore.ts` — Zustand store: `isOpen`, `query`, `currentIndex`, `totalMatches`, and actions `open/close/setQuery/next/prev/reportMatches/reset`
- `components/find/FindBar.tsx` — Floating overlay component (`absolute top-2 right-4 z-20`)
- `lib/editor/find-plugin.ts` — ProseMirror plugin + TipTap extension for Document pages; coalesces adjacent text nodes across marks so cross-mark queries (e.g. "hel**lo**") are found

**Modified files:**
- `CenterPanel.tsx` — Global Cmd+F handler (skips Monaco), page-change reset, mounts `<FindBar />`
- `RichEditor.tsx` — Adds `FindExtension` to TipTap extensions
- `DocumentView.tsx` — Connects find store ↔ ProseMirror plugin; scrolls to match
- `SheetView.tsx` — Scans raw cells + computed display values; uses Set for O(1) deduplication; find effects placed after `evaluation` useMemo
- `ChannelView.tsx` — Scans message content; applies `data-message-id` attributes
- `AiChatView.tsx` — Scans message `parts` for text
- `MessageRenderer.tsx` — Adds `data-message-id` to message wrappers
- `TaskListView.tsx` — Cmd+F focuses existing search input; reports match count (0 when no search)
- `CanvasPageView.tsx` — Counts text matches in raw HTML via DOMParser (shadow DOM limitation)
- `FolderView.tsx` / `GridView.tsx` / `ListView.tsx` — Match folder item titles; navigation follows `sortedChildren` order
- `tiptap.css` — `.find-highlight` (yellow) / `.find-highlight-current` (orange) utility classes
- `hotkeys/registry.ts` — Registers `editing.find` keybinding entry

## Test plan

- [ ] Open a Document page → Cmd+F → floating bar appears, type text → matches highlight yellow, active match is orange; Enter/Shift+Enter navigate; Esc closes
- [ ] Press Cmd+F again while bar is open → input gets re-focused
- [ ] Open a Code page → Cmd+F opens Monaco's native find (custom bar does NOT appear)
- [ ] Open a Sheet → Cmd+F → type a cell value → matching cells highlighted; arrows navigate
- [ ] Open a Channel → Cmd+F → matching messages highlighted, arrows scroll
- [ ] Open a Task List → Cmd+F → existing search input receives focus; match count shown
- [ ] Open a Folder → Cmd+F → matching item cards/rows highlighted; navigation follows sort order
- [ ] Switch pages → find bar closes and state resets
- [ ] Test cross-mark match in Document: type part of a word that spans a bold mark

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a global "Find in Page" (Cmd/Ctrl+F) with a Find Bar, match counter, prev/next navigation, and keyboard shortcuts (Escape to close, Enter/F3 to navigate).
  * Search integrated across chat, documents (rich editor), folders, sheets, canvas, task lists, and channels with automatic scrolling to matches and visual highlights.
* **Styles**
  * Added highlight styles for matches and the active match.
* **Tests**
  * Updated tests to mock and cover the new find behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1412?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->