### PR TITLE
fix(center-panel): fall back to direct API fetch when page not in tree

### DIFF
--- a/apps/e2e/tests/06-task-list.spec.ts
+++ b/apps/e2e/tests/06-task-list.spec.ts
@@ -33,3 +33,45 @@ test('New Task button focuses the task input and creates a task', async ({ page,
 
   await expect(page.getByText(taskTitle).first()).toBeVisible();
 });
+
+test('clicking a task navigates to its page without a page-not-found error', async ({ page, request, driveId }) => {
+  const csrfResponse = await request.get('/api/auth/csrf');
+  const { csrfToken } = (await csrfResponse.json()) as { csrfToken: string };
+
+  const createResponse = await request.post('/api/pages', {
+    headers: { 'X-CSRF-Token': csrfToken },
+    data: {
+      title: `E2E Task List Nav ${Date.now()}`,
+      type: 'TASK_LIST',
+      driveId,
+      parentId: null,
+    },
+  });
+  expect(createResponse.status()).toBe(201);
+  const { id: pageId } = (await createResponse.json()) as { id: string };
+
+  await page.goto(`/dashboard/${driveId}/${pageId}`);
+
+  const newTaskBtn = page.getByRole('button', { name: 'New Task' });
+  await expect(newTaskBtn).toBeVisible();
+  await newTaskBtn.click();
+
+  const taskTitle = `E2E Nav Task ${Date.now()}`;
+  const [taskCreateResponse] = await Promise.all([
+    page.waitForResponse(`**/api/pages/${pageId}/tasks`),
+    page.keyboard.type(taskTitle).then(() => page.keyboard.press('Enter')),
+  ]);
+  expect(taskCreateResponse.status()).toBe(201);
+  const { pageId: taskPageId } = (await taskCreateResponse.json()) as { pageId: string };
+
+  // Wait for the task title to appear then click through to its document page
+  await expect(page.getByText(taskTitle).first()).toBeVisible();
+  await page.getByText(taskTitle).first().click();
+
+  // Wait for navigation to the task's document page
+  await page.waitForURL(`**/dashboard/${driveId}/${taskPageId}`, { timeout: 8000 });
+
+  // The fallback fetch should resolve the page even if the tree hasn't revalidated yet
+  await expect(page.getByText('Page not found in the current tree.')).not.toBeVisible();
+  await expect(page.getByText('Page not found.')).not.toBeVisible();
+});

--- a/apps/web/src/components/layout/middle-content/CenterPanel.tsx
+++ b/apps/web/src/components/layout/middle-content/CenterPanel.tsx
@@ -152,7 +152,7 @@ const PageContent = memo(({ pageId }: { pageId: string | null }) => {
 
   const page: TreePage = pageResult
     ? pageResult.node
-    : { ...fallbackPage!, children: [], aiChat: null };
+    : { ...fallbackPage!, aiChat: null };
 
   // Dynamic component selection using centralized config
   const componentMap = {

--- a/apps/web/src/components/layout/middle-content/CenterPanel.tsx
+++ b/apps/web/src/components/layout/middle-content/CenterPanel.tsx
@@ -27,9 +27,16 @@ import { cn } from '@/lib/utils';
 import { usePageStore } from '@/hooks/usePage';
 import { useGlobalDriveSocket } from '@/hooks/useGlobalDriveSocket';
 import { usePageRefresh } from '@/hooks/usePageRefresh';
-import { post } from '@/lib/auth/auth-fetch';
+import { post, fetchWithAuth } from '@/lib/auth/auth-fetch';
+import useSWR from 'swr';
 
 const LOADING_TIMEOUT_MS = 12000; // Show retry hint after 12 seconds
+
+const fetcher = (url: string) =>
+  fetchWithAuth(url).then(r => {
+    if (!r.ok) throw new Error('Failed to fetch');
+    return r.json();
+  });
 
 // Memoized page content component to prevent unnecessary re-renders
 const PageContent = memo(({ pageId }: { pageId: string | null }) => {
@@ -40,6 +47,16 @@ const PageContent = memo(({ pageId }: { pageId: string | null }) => {
   const [loadingTimedOut, setLoadingTimedOut] = useState(false);
   const retryCount = useRef(0);
   const [timerKey, setTimerKey] = useState(0);
+
+  // Compute tree lookup before early returns — pure recursive search, safe on empty tree.
+  const pageResult = pageId ? findNodeAndParent(tree, pageId) : null;
+
+  // If the tree has loaded but doesn't have this page yet (race condition on fresh creation
+  // or deep links), fetch it directly so rendering isn't blocked on tree revalidation.
+  const { data: fallbackPage, isLoading: fallbackLoading, error: fallbackError } = useSWR<TreePage>(
+    (!isLoading && !!pageId && !pageResult) ? `/api/pages/${pageId}` : null,
+    fetcher
+  );
 
   const handleRetry = useCallback(() => {
     setLoadingTimedOut(false);
@@ -122,17 +139,20 @@ const PageContent = memo(({ pageId }: { pageId: string | null }) => {
     );
   }
 
-  const pageResult = findNodeAndParent(tree, pageId);
-
   if (!pageResult) {
-    return (
-      <div className="p-4 text-center text-muted-foreground">
-        Page not found in the current tree.
-      </div>
-    );
+    if (fallbackLoading) return <Skeleton className="h-full w-full" />;
+    if (fallbackError || !fallbackPage) {
+      return (
+        <div className="p-4 text-center text-muted-foreground">
+          Page not found.
+        </div>
+      );
+    }
   }
 
-  const { node: page } = pageResult;
+  const page: TreePage = pageResult
+    ? pageResult.node
+    : { ...fallbackPage!, children: [], aiChat: null };
 
   // Dynamic component selection using centralized config
   const componentMap = {

--- a/apps/web/src/components/layout/middle-content/CenterPanel.tsx
+++ b/apps/web/src/components/layout/middle-content/CenterPanel.tsx
@@ -55,7 +55,8 @@ const PageContent = memo(({ pageId }: { pageId: string | null }) => {
   // or deep links), fetch it directly so rendering isn't blocked on tree revalidation.
   const { data: fallbackPage, isLoading: fallbackLoading, error: fallbackError } = useSWR<TreePage>(
     (!isLoading && !!pageId && !pageResult) ? `/api/pages/${pageId}` : null,
-    fetcher
+    fetcher,
+    { errorRetryCount: 3 }
   );
 
   const handleRetry = useCallback(() => {


### PR DESCRIPTION
## Summary

- **Root cause:** `CenterPanel` used the page tree as its only data source — if the tree hadn't revalidated yet after a page was created (race condition), it rendered "Page not found in the current tree." instead of the page
- **Fix:** When `findNodeAndParent` returns null after the tree has finished loading, activate a conditional `useSWR('/api/pages/${pageId}')` fallback. Tree remains the fast path (no extra round-trip when warm); fallback only fires when needed
- **Fallback shape:** Spreads API response directly with only `aiChat: null` added explicitly (not returned by endpoint). API children are preserved — `FolderView` gets real contents on fallback instead of an empty `[]`
- **Test:** New E2E test in `06-task-list.spec.ts` — creates a task, immediately clicks its title, asserts no page-not-found error and correct URL navigation

## Why not just invalidate the tree on task creation?

That's a bandaid. Any navigation that races ahead of the tree (deep links, share links, redirects) would still break. Making the content area resilient by fetching directly is the correct fix — the tree should be an optimisation, not a hard dependency.

## Test plan

- [ ] Create a task in a task list page and immediately click the task title — should open the document page, no error
- [ ] `cd apps/e2e && npx playwright test 06-task-list` — both tests pass
- [ ] Deep-link to an existing page URL in a new tab — should load correctly even before the tree populates
- [ ] Deep-link to a folder page — should show folder contents (not empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)