### PR TITLE
feat(roles): show Member built-in role and add page privacy controls

### DIFF
--- a/apps/web/src/components/layout/left-sidebar/page-tree/PageTreeItem.tsx
+++ b/apps/web/src/components/layout/left-sidebar/page-tree/PageTreeItem.tsx
@@ -17,6 +17,8 @@ import {
   CheckSquare,
   FolderInput,
   Copy,
+  Lock,
+  LockOpen,
 } from "lucide-react";
 import { useTouchDevice } from "@/hooks/useTouchDevice";
 import { useCapacitor } from "@/hooks/useCapacitor";
@@ -244,6 +246,18 @@ export const PageTreeItem = React.memo(function PageTreeItem({
     }
   };
 
+  const handlePrivacyToggle = async () => {
+    const nextPrivate = !item.isPrivate;
+    const toastId = toast.loading(nextPrivate ? "Protecting page..." : "Unprotecting page...");
+    try {
+      await patch(`/api/pages/${item.id}`, { isPrivate: nextPrivate });
+      await mutate();
+      toast.success(nextPrivate ? "Page is now private." : "Page is now accessible to all members.", { id: toastId });
+    } catch {
+      toast.error("Error updating page privacy.", { id: toastId });
+    }
+  };
+
   return (
     <>
       <div
@@ -353,6 +367,11 @@ export const PageTreeItem = React.memo(function PageTreeItem({
                 {item.title}
               </Link>
 
+              {/* Private page indicator */}
+              {item.isPrivate && (
+                <Lock className="h-3 w-3 flex-shrink-0 text-muted-foreground ml-1" aria-label="Private page" />
+              )}
+
               {/* Currently viewing indicators */}
               <PageViewersInline pageId={item.id} />
 
@@ -423,6 +442,14 @@ export const PageTreeItem = React.memo(function PageTreeItem({
                     )}
                   />
                   <span>{isFavorite(item.id) ? "Unfavorite" : "Favorite"}</span>
+                </ContextMenuItem>
+                <ContextMenuItem onSelect={handlePrivacyToggle}>
+                  {item.isPrivate ? (
+                    <LockOpen className="mr-2 h-4 w-4" />
+                  ) : (
+                    <Lock className="mr-2 h-4 w-4" />
+                  )}
+                  <span>{item.isPrivate ? "Unprotect page" : "Protect page"}</span>
                 </ContextMenuItem>
                 <ContextMenuSeparator />
                 <ContextMenuItem onSelect={handleEnterMultiSelect}>

--- a/apps/web/src/components/layout/left-sidebar/page-tree/PageTreeItem.tsx
+++ b/apps/web/src/components/layout/left-sidebar/page-tree/PageTreeItem.tsx
@@ -252,7 +252,7 @@ export const PageTreeItem = React.memo(function PageTreeItem({
     try {
       await patch(`/api/pages/${item.id}`, { isPrivate: nextPrivate });
       await mutate();
-      toast.success(nextPrivate ? "Page is now private." : "Page is now accessible to all members.", { id: toastId });
+      toast.success(nextPrivate ? "Page is now private" : "Page is now visible to all drive members", { id: toastId });
     } catch {
       toast.error("Error updating page privacy.", { id: toastId });
     }

--- a/apps/web/src/components/settings/RolesManager.tsx
+++ b/apps/web/src/components/settings/RolesManager.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Plus, Pencil, Trash2, GripVertical, Star, Shield } from 'lucide-react';
+import { Plus, Pencil, Trash2, GripVertical, Star, Shield, Users, Eye } from 'lucide-react';
 import { useToast } from '@/hooks/useToast';
 import { useSocket } from '@/hooks/useSocket';
 import type { DriveEventPayload } from '@/lib/websocket';
@@ -182,6 +182,33 @@ export function RolesManager({ driveId }: RolesManagerProps) {
                 </div>
                 <p className="text-sm text-muted-foreground">
                   Full access to all pages and settings. Cannot be modified.
+                </p>
+              </div>
+
+              <div className="w-[72px]" /> {/* Spacer for action buttons alignment */}
+            </div>
+
+            {/* Built-in Member role - default for all drive members */}
+            <div className="flex items-center gap-3 p-3 rounded-lg border border-border bg-muted/20">
+              <div className="w-4 h-4 flex items-center justify-center">
+                <Users className="w-4 h-4 text-muted-foreground" />
+              </div>
+
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 mb-1">
+                  <Badge variant="secondary">
+                    Member
+                  </Badge>
+                  <Badge variant="outline" className="text-xs">
+                    Built-in
+                  </Badge>
+                  <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                    <Eye className="w-3 h-3" />
+                    View only
+                  </span>
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  Default role for all members. Read-only access to non-private pages. Cannot be modified.
                 </p>
               </div>
 


### PR DESCRIPTION
## Summary

- **RolesManager**: adds a "Member" built-in role card below Admin, displaying the Discord-style @everyone equivalent — shows View-only access to non-private pages, marked Built-in and non-editable
- **PageTreeItem**: renders a small lock icon inline next to private page titles in the sidebar tree so users can see at a glance which pages are protected
- **PageTreeItem**: adds "Protect page" / "Unprotect page" to the right-click context menu, toggling `isPrivate` via the existing `PATCH /api/pages/:id` endpoint

No DB or API changes — the backend (`resolve-role-permissions.ts`, `isPrivate` field, and the pages PATCH route) was already complete from PR #1409.

## Test plan

- [ ] Drive Settings → Roles: confirm Admin and Member built-in cards both appear; Member shows "View only" and "Built-in" badges
- [ ] Right-click a page → "Protect page" → lock icon appears next to the page in the sidebar
- [ ] Right-click protected page → "Unprotect page" → lock icon disappears
- [ ] Member-role user cannot see protected pages they have no explicit access to

🤖 Generated with [Claude Code](https://claude.com/claude-code)