### PR TITLE
fix(invite): allow invite when custom role selected

### DIFF
--- a/apps/web/src/app/dashboard/[driveId]/members/invite/page.tsx
+++ b/apps/web/src/app/dashboard/[driveId]/members/invite/page.tsx
@@ -171,10 +171,10 @@ export default function InviteMemberPage() {
           canShare: perms.canShare,
         }));
 
-      if (permissionArray.length === 0) {
+      if (permissionArray.length === 0 && !backendCustomRoleId) {
         toast({
           title: 'No permissions selected',
-          description: 'Please select at least one permission to grant',
+          description: 'Please assign a role or select at least one page permission',
           variant: 'destructive',
         });
         return;


### PR DESCRIPTION
## Summary

- Fixes invite being blocked with "select at least one permission" when a custom role is already selected
- The validation guard now only fires when there is **neither** a custom role **nor** any manually-set page permissions
- Updated error description to reflect the combined condition

## Root cause

`handleInvite` required a non-empty `permissionArray` for all non-admin, non-email invites. When a custom role is selected, `customRoleId` is sent to the backend — but the permissions Map can be empty due to `applyRolePermissions` timing (pages not loaded yet). The backend already accepts an empty permissions array alongside a `customRoleId`, so the frontend guard was over-eager.

## Test plan

- [ ] Select a user, pick a custom role (e.g. Member), click Invite — should succeed
- [ ] Select a user, pick "No role", click Invite with no permissions checked — error toast should still appear
- [ ] Email invite flow unaffected (separate code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when inviting team members to ensure complete permission configuration. The system now requires users to assign either a role or select specific page permissions. Previously, certain configurations could allow incomplete setups. Updated error messaging guides users on proper role and permission assignment requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1415?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->