### PR TITLE
fix(find): make Cmd+F functional in AI chat, channel, and task list

### DIFF
--- a/apps/web/src/components/ai/chat/layouts/ChatLayout.tsx
+++ b/apps/web/src/components/ai/chat/layouts/ChatLayout.tsx
@@ -103,6 +103,8 @@ export interface ChatLayoutProps {
   showMcp?: boolean;
   /** Remote in-progress streams from other users (or other tabs) — rendered inline as assistant messages */
   remoteStreams?: PendingStream[];
+  findMatchSet?: Set<string>;
+  findCurrentMessageId?: string | null;
 }
 
 export interface ChatLayoutRef {
@@ -154,6 +156,8 @@ export const ChatLayout = React.forwardRef<ChatLayoutRef, ChatLayoutProps>(
       onMcpServerToggle,
       showMcp = false,
       remoteStreams = [],
+      findMatchSet,
+      findCurrentMessageId,
     },
     ref
   ) => {
@@ -259,6 +263,8 @@ export const ChatLayout = React.forwardRef<ChatLayoutRef, ChatLayoutProps>(
                 onUndoSuccess={onUndoSuccess}
                 onPullUpRefresh={onPullUpRefresh}
                 remoteStreams={remoteStreams}
+                findMatchSet={findMatchSet}
+                findCurrentMessageId={findCurrentMessageId}
               />
             </motion.div>
           )}

--- a/apps/web/src/components/ai/shared/chat/ChatMessagesArea.tsx
+++ b/apps/web/src/components/ai/shared/chat/ChatMessagesArea.tsx
@@ -13,14 +13,14 @@
  * - Overscan for smooth scrolling
  */
 
-import React, { forwardRef, useImperativeHandle, useState, useCallback, useMemo } from 'react';
+import React, { forwardRef, useImperativeHandle, useState, useCallback, useMemo, useRef, useEffect } from 'react';
 import { UIMessage } from 'ai';
 import { SkeletonMessageBubble } from '@/components/ui/skeleton';
 import { Loader2 } from 'lucide-react';
 import { MessageRenderer } from './MessageRenderer';
 import { StreamingIndicator } from './StreamingIndicator';
 import { UndoAiChangesDialog } from './UndoAiChangesDialog';
-import { VirtualizedMessageList } from './VirtualizedMessageList';
+import { VirtualizedMessageList, VirtualizedMessageListRef } from './VirtualizedMessageList';
 import {
   Conversation,
   ConversationContent,
@@ -66,6 +66,8 @@ interface ChatMessagesAreaProps {
   onPullUpRefresh?: () => Promise<void>;
   /** Remote in-progress streams from other users (or other tabs) — rendered as synthesized assistant messages */
   remoteStreams?: PendingStream[];
+  findMatchSet?: Set<string>;
+  findCurrentMessageId?: string | null;
 }
 
 export interface ChatMessagesAreaRef {
@@ -92,12 +94,15 @@ const ChatMessagesAreaInner = forwardRef<ChatMessagesAreaRef, ChatMessagesAreaPr
       isLoadingOlder = false,
       onPullUpRefresh,
       remoteStreams,
+      findMatchSet,
+      findCurrentMessageId,
     },
     ref
   ) => {
     const [undoDialogMessageId, setUndoDialogMessageId] = useState<string | null>(null);
     const { scrollToBottom } = useStickToBottomContext();
     const scrollRef = useConversationScrollRef();
+    const virtualizerRef = useRef<VirtualizedMessageListRef>(null);
 
     // Pull-up refresh for checking missed messages
     const {
@@ -138,6 +143,18 @@ const ChatMessagesAreaInner = forwardRef<ChatMessagesAreaRef, ChatMessagesAreaPr
       scrollToBottom: () => scrollToBottom(),
     }), [scrollToBottom]);
 
+    // Scroll to the current find match
+    useEffect(() => {
+      if (!findCurrentMessageId) return;
+      if (shouldVirtualize) {
+        const index = messages.findIndex((m) => m.id === findCurrentMessageId);
+        if (index >= 0) virtualizerRef.current?.scrollToIndex(index, { align: 'center' });
+      } else {
+        document.querySelector(`[data-message-id="${findCurrentMessageId}"]`)
+          ?.scrollIntoView({ block: 'center' });
+      }
+    }, [findCurrentMessageId, messages, shouldVirtualize]);
+
     // Dedup remote streams whose messageId has already landed in `messages`
     // (handles the brief frame at completion when the real message has been
     // pushed but `removeStream` has not yet fired).
@@ -166,6 +183,8 @@ const ChatMessagesAreaInner = forwardRef<ChatMessagesAreaRef, ChatMessagesAreaPr
         isLastAssistantMessage={message.id === lastAssistantMessageId}
         isLastUserMessage={message.id === lastUserMessageId}
         isStreaming={isStreaming && message.id === lastAssistantMessageId && message.role === 'assistant'}
+        isHighlighted={findMatchSet?.has(message.id)}
+        isCurrentMatch={findCurrentMessageId === message.id}
       />
     ), [
       isReadOnly,
@@ -175,7 +194,9 @@ const ChatMessagesAreaInner = forwardRef<ChatMessagesAreaRef, ChatMessagesAreaPr
       handleUndoFromHere,
       lastAssistantMessageId,
       lastUserMessageId,
-      isStreaming
+      isStreaming,
+      findMatchSet,
+      findCurrentMessageId,
     ]);
 
     // Loading skeleton
@@ -227,6 +248,7 @@ const ChatMessagesAreaInner = forwardRef<ChatMessagesAreaRef, ChatMessagesAreaPr
           ) : shouldVirtualize ? (
             // Virtualized rendering for large conversations
             <VirtualizedMessageList
+              ref={virtualizerRef}
               messages={messages}
               renderMessage={renderMessage}
               scrollRef={scrollRef}

--- a/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { cn } from '@/lib/utils';
 import { ToolCallRenderer } from './tool-calls';
 
 import { StreamingMarkdown } from './StreamingMarkdown';
@@ -121,6 +122,8 @@ interface MessageRendererProps {
   isLastUserMessage?: boolean;
   /** Whether this message is currently being streamed (for progressive markdown rendering) */
   isStreaming?: boolean;
+  isHighlighted?: boolean;
+  isCurrentMatch?: boolean;
 }
 
 /**
@@ -137,7 +140,9 @@ export const MessageRenderer: React.FC<MessageRendererProps> = React.memo(({
   onTaskUpdate,
   isLastAssistantMessage = false,
   isLastUserMessage = false,
-  isStreaming = false
+  isStreaming = false,
+  isHighlighted = false,
+  isCurrentMatch = false,
 }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
@@ -341,7 +346,7 @@ export const MessageRenderer: React.FC<MessageRendererProps> = React.memo(({
   // ============================================
   return (
     <>
-      <div key={message.id} data-message-id={message.id} className="mb-2">
+      <div key={message.id} data-message-id={message.id} className={cn("mb-2", isHighlighted && "find-highlight", isCurrentMatch && "find-highlight-current")}>
         {groupedParts.map((group, index) => {
           if (isTextGroupPart(group)) {
             const isLastTextBlock = index === groupedParts.length - 1;

--- a/apps/web/src/components/ai/shared/chat/VirtualizedMessageList.tsx
+++ b/apps/web/src/components/ai/shared/chat/VirtualizedMessageList.tsx
@@ -47,7 +47,7 @@ const VirtualizedMessageListInner = forwardRef<VirtualizedMessageListRef, Virtua
       scrollToIndex: (index, options) => {
         virtualizer.scrollToIndex(index, options);
       },
-    }));
+    }), [virtualizer]);
 
     const items = virtualizer.getVirtualItems();
 

--- a/apps/web/src/components/ai/shared/chat/VirtualizedMessageList.tsx
+++ b/apps/web/src/components/ai/shared/chat/VirtualizedMessageList.tsx
@@ -1,130 +1,120 @@
-/**
- * VirtualizedMessageList - High-performance virtualized message list
- *
- * Uses @tanstack/react-virtual for windowed rendering of messages.
- * Designed to work with use-stick-to-bottom for pinned scrolling behavior.
- *
- * Features:
- * - Variable height rows with dynamic measurement
- * - Smooth scrolling with overscan
- * - Works with both full MessageRenderer and CompactMessageRenderer
- * - Integrates with use-stick-to-bottom scroll context
- */
-
-import React, { useRef, useCallback, useEffect, memo } from 'react';
+import React, { useRef, useCallback, useEffect, useImperativeHandle, forwardRef, memo } from 'react';
 import { useVirtualizer, VirtualItem } from '@tanstack/react-virtual';
 import { UIMessage } from 'ai';
 
+export interface VirtualizedMessageListRef {
+  scrollToIndex: (index: number, options?: { align?: 'start' | 'center' | 'end' | 'auto' }) => void;
+}
+
 export interface VirtualizedMessageListProps<T extends UIMessage = UIMessage> {
-  /** Messages to render */
   messages: T[];
-  /** Render function for each message */
   renderMessage: (message: T, index: number) => React.ReactNode;
-  /** Ref to the scroll container element (from use-stick-to-bottom context) */
   scrollRef: React.RefObject<HTMLElement | null>;
-  /** Optional callback when scrolled near top (for loading older messages) */
   onScrollNearTop?: () => void;
-  /** Whether older messages are currently loading */
   isLoadingOlder?: boolean;
-  /** Estimated row height for initial render */
   estimatedRowHeight?: number;
-  /** Number of items to render outside the visible area */
   overscan?: number;
-  /** Gap between messages in pixels */
   gap?: number;
-  /** Additional className for the inner container */
   className?: string;
 }
 
-function VirtualizedMessageListInner<T extends UIMessage = UIMessage>({
-  messages,
-  renderMessage,
-  scrollRef,
-  onScrollNearTop,
-  isLoadingOlder = false,
-  estimatedRowHeight = 80,
-  overscan = 5,
-  gap = 8,
-  className = '',
-}: VirtualizedMessageListProps<T>) {
-  const wasNearTopRef = useRef(false);
+const VirtualizedMessageListInner = forwardRef<VirtualizedMessageListRef, VirtualizedMessageListProps>(
+  (
+    {
+      messages,
+      renderMessage,
+      scrollRef,
+      onScrollNearTop,
+      isLoadingOlder = false,
+      estimatedRowHeight = 80,
+      overscan = 5,
+      gap = 8,
+      className = '',
+    },
+    ref
+  ) => {
+    const wasNearTopRef = useRef(false);
 
-  const virtualizer = useVirtualizer({
-    count: messages.length,
-    getScrollElement: () => scrollRef.current,
-    estimateSize: () => estimatedRowHeight,
-    overscan,
-    gap,
-  });
+    const virtualizer = useVirtualizer({
+      count: messages.length,
+      getScrollElement: () => scrollRef.current,
+      estimateSize: () => estimatedRowHeight,
+      overscan,
+      gap,
+    });
 
-  const items = virtualizer.getVirtualItems();
+    useImperativeHandle(ref, () => ({
+      scrollToIndex: (index, options) => {
+        virtualizer.scrollToIndex(index, options);
+      },
+    }));
 
-  // Handle scroll to detect when near top
-  const handleScroll = useCallback(() => {
-    const scrollElement = scrollRef.current;
-    if (!scrollElement || !onScrollNearTop || isLoadingOlder) return;
+    const items = virtualizer.getVirtualItems();
 
-    const scrollTop = scrollElement.scrollTop;
-    const isNearTop = scrollTop < 100;
+    const handleScroll = useCallback(() => {
+      const scrollElement = scrollRef.current;
+      if (!scrollElement || !onScrollNearTop || isLoadingOlder) return;
 
-    if (isNearTop && !wasNearTopRef.current && messages.length > 0) {
-      onScrollNearTop();
+      const scrollTop = scrollElement.scrollTop;
+      const isNearTop = scrollTop < 100;
+
+      if (isNearTop && !wasNearTopRef.current && messages.length > 0) {
+        onScrollNearTop();
+      }
+
+      wasNearTopRef.current = isNearTop;
+    }, [scrollRef, onScrollNearTop, isLoadingOlder, messages.length]);
+
+    useEffect(() => {
+      const element = scrollRef.current;
+      if (!element) return;
+
+      element.addEventListener('scroll', handleScroll, { passive: true });
+      return () => element.removeEventListener('scroll', handleScroll);
+    }, [scrollRef, handleScroll]);
+
+    useEffect(() => {
+      const rafId = requestAnimationFrame(() => {
+        virtualizer.measure();
+      });
+      return () => cancelAnimationFrame(rafId);
+    }, [messages, virtualizer]);
+
+    if (messages.length === 0) {
+      return null;
     }
 
-    wasNearTopRef.current = isNearTop;
-  }, [scrollRef, onScrollNearTop, isLoadingOlder, messages.length]);
+    return (
+      <div
+        className={`relative w-full ${className}`}
+        style={{
+          height: `${virtualizer.getTotalSize()}px`,
+          contain: 'strict',
+        }}
+      >
+        {items.map((virtualRow: VirtualItem) => {
+          const message = messages[virtualRow.index];
+          if (!message) return null;
 
-  // Attach scroll listener
-  useEffect(() => {
-    const element = scrollRef.current;
-    if (!element) return;
-
-    element.addEventListener('scroll', handleScroll, { passive: true });
-    return () => element.removeEventListener('scroll', handleScroll);
-  }, [scrollRef, handleScroll]);
-
-  // Re-measure when messages change (important for streaming content growth)
-  useEffect(() => {
-    const rafId = requestAnimationFrame(() => {
-      virtualizer.measure();
-    });
-    return () => cancelAnimationFrame(rafId);
-  }, [messages, virtualizer]);
-
-  // Empty state - just return null and let parent handle
-  if (messages.length === 0) {
-    return null;
+          return (
+            <div
+              key={message.id || virtualRow.index}
+              data-index={virtualRow.index}
+              ref={virtualizer.measureElement}
+              className="absolute top-0 left-0 w-full"
+              style={{
+                transform: `translateY(${virtualRow.start}px)`,
+              }}
+            >
+              {renderMessage(message, virtualRow.index)}
+            </div>
+          );
+        })}
+      </div>
+    );
   }
+);
 
-  return (
-    <div
-      className={`relative w-full ${className}`}
-      style={{
-        height: `${virtualizer.getTotalSize()}px`,
-        contain: 'strict',
-      }}
-    >
-      {items.map((virtualRow: VirtualItem) => {
-        const message = messages[virtualRow.index];
-        if (!message) return null;
+VirtualizedMessageListInner.displayName = 'VirtualizedMessageList';
 
-        return (
-          <div
-            key={message.id || virtualRow.index}
-            data-index={virtualRow.index}
-            ref={virtualizer.measureElement}
-            className="absolute top-0 left-0 w-full"
-            style={{
-              transform: `translateY(${virtualRow.start}px)`,
-            }}
-          >
-            {renderMessage(message, virtualRow.index)}
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
-// Memo wrapper with generic type support
-export const VirtualizedMessageList = memo(VirtualizedMessageListInner) as typeof VirtualizedMessageListInner;
+export const VirtualizedMessageList = memo(VirtualizedMessageListInner);

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -245,11 +245,10 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
     const q = findQuery.toLowerCase();
     const ids = messages
       .filter((m) => {
-        const partsText = (m.parts ?? [])
+        const text = (m.parts ?? [])
           .filter((p) => p.type === 'text')
           .map((p) => (p as { type: 'text'; text: string }).text)
           .join(' ');
-        const text = partsText || (typeof m.content === 'string' ? m.content : '');
         return text.toLowerCase().includes(q);
       })
       .map((m) => m.id);

--- a/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/ai-page/AiChatView.tsx
@@ -245,10 +245,11 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
     const q = findQuery.toLowerCase();
     const ids = messages
       .filter((m) => {
-        const text = (m.parts ?? [])
+        const partsText = (m.parts ?? [])
           .filter((p) => p.type === 'text')
           .map((p) => (p as { type: 'text'; text: string }).text)
           .join(' ');
+        const text = partsText || (typeof m.content === 'string' ? m.content : '');
         return text.toLowerCase().includes(q);
       })
       .map((m) => m.id);
@@ -256,12 +257,8 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
     reportMatches(ids.length);
   }, [isFindOpen, findQuery, messages, reportMatches]);
 
-  useEffect(() => {
-    const id = findMatchIds[findIndex];
-    if (!id) return;
-    const el = document.querySelector(`[data-message-id="${id}"]`);
-    el?.scrollIntoView({ block: 'nearest' });
-  }, [findIndex, findMatchIds]);
+  const findMatchSet = useMemo(() => new Set(findMatchIds), [findMatchIds]);
+  const currentFindMsgId = findMatchIds[findIndex] ?? null;
   const { wrapSend } = useSendHandoff(currentConversationId, status);
   const stop = useChatStop(streamTrackingId, chatStop);
 
@@ -844,6 +841,8 @@ const AiChatView: React.FC<AiChatViewProps> = ({ page }) => {
             onMcpServerToggle={setServerEnabled}
             showMcp={isDesktop}
             remoteStreams={remoteStreams}
+            findMatchSet={findMatchSet}
+            findCurrentMessageId={currentFindMsgId}
             renderInput={(props) => (
               <>
                 {isVoiceModeActive && (

--- a/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/channel/ChannelView.tsx
@@ -102,7 +102,7 @@ function ChannelView({ page }: ChannelViewProps) {
     const id = findMatchIds[findIndex];
     if (!id) return;
     const el = document.querySelector(`[data-message-id="${id}"]`);
-    el?.scrollIntoView({ block: 'nearest' });
+    el?.scrollIntoView({ block: 'center' });
   }, [findIndex, findMatchIds]);
 
   const findMatchSet = useMemo(() => new Set(findMatchIds), [findMatchIds]);

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -524,8 +524,9 @@ function TaskListView({ page }: TaskListViewProps) {
     if (!isFindOpen || !findQuery) return;
     const task = filteredTasks[findIndex];
     if (!task) return;
-    document.querySelector(`[data-task-id="${task.id}"]`)
-      ?.scrollIntoView({ block: 'center' });
+    const els = document.querySelectorAll(`[data-task-id="${task.id}"]`);
+    const visibleEl = Array.from(els).find(el => (el as HTMLElement).offsetParent !== null);
+    visibleEl?.scrollIntoView({ block: 'center' });
   }, [findIndex, filteredTasks, isFindOpen, findQuery]);
 
   // Create new task (with optional status for kanban)

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -344,6 +344,7 @@ function SortableTaskRow({ task, canEdit, isCompleted, contextMenu, children }: 
     <TableRow
       ref={setNodeRef}
       style={style}
+      data-task-id={task.id}
       className={cn(
         isCompleted && 'opacity-60',
         isDragging && 'opacity-50 bg-muted'
@@ -391,12 +392,16 @@ function TaskListView({ page }: TaskListViewProps) {
 
   // Connect Cmd+F to existing search input
   const isFindOpen = useFindStore((s) => s.isOpen);
+  const findQuery = useFindStore((s) => s.query);
+  const findIndex = useFindStore((s) => s.currentIndex);
   const reportMatches = useFindStore((s) => s.reportMatches);
 
   useEffect(() => {
     if (isFindOpen) {
       searchInputRef.current?.focus();
       searchInputRef.current?.select();
+    } else {
+      setSearch('');
     }
   }, [isFindOpen]);
   const [editingTaskId, setEditingTaskId] = useState<string | null>(null);
@@ -488,6 +493,8 @@ function TaskListView({ page }: TaskListViewProps) {
   const statusConfigMap = buildStatusConfig(statusConfigs);
   const statusOrder = getStatusOrder(statusConfigs);
 
+  const activeSearch = isFindOpen ? findQuery : search;
+
   // Filter tasks
   const filteredTasks = data?.tasks.filter(task => {
     // Status filter - use group-based completion detection
@@ -496,8 +503,8 @@ function TaskListView({ page }: TaskListViewProps) {
     if (filter === 'completed' && !isDone) return false;
 
     // Search filter
-    if (search) {
-      const searchLower = search.toLowerCase();
+    if (activeSearch) {
+      const searchLower = activeSearch.toLowerCase();
       return (
         task.title.toLowerCase().includes(searchLower) ||
         task.description?.toLowerCase().includes(searchLower)
@@ -510,9 +517,18 @@ function TaskListView({ page }: TaskListViewProps) {
   // Report filtered task count to find store when search is active
   useEffect(() => {
     if (isFindOpen) {
-      reportMatches(search ? filteredTasks.length : 0);
+      reportMatches(findQuery ? filteredTasks.length : 0);
     }
-  }, [isFindOpen, search, filteredTasks.length, reportMatches]);
+  }, [isFindOpen, findQuery, filteredTasks.length, reportMatches]);
+
+  // Scroll to current find match
+  useEffect(() => {
+    if (!isFindOpen || !findQuery) return;
+    const task = filteredTasks[findIndex];
+    if (!task) return;
+    document.querySelector(`[data-task-id="${task.id}"]`)
+      ?.scrollIntoView({ block: 'center' });
+  }, [findIndex, filteredTasks, isFindOpen, findQuery]);
 
   // Create new task (with optional status for kanban)
   const handleCreateTask = async (title?: string, status?: string) => {
@@ -869,8 +885,8 @@ function TaskListView({ page }: TaskListViewProps) {
       {/* Mobile Card View */}
       <div className="flex-1 overflow-auto md:hidden p-4 space-y-3">
         {filteredTasks.map((task) => (
+          <div key={task.id} data-task-id={task.id}>
           <MobileTaskCard
-            key={task.id}
             task={task}
             canEdit={canEdit}
             onToggleComplete={handleToggleComplete}
@@ -896,6 +912,7 @@ function TaskListView({ page }: TaskListViewProps) {
             statusOrder={statusOrder}
             statusConfigs={statusConfigs}
           />
+          </div>
         ))}
 
         {/* Mobile new task input */}

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef, memo } from 'react';
+import { useState, useEffect, useRef, memo, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 import useSWR, { mutate } from 'swr';
@@ -494,7 +494,7 @@ function TaskListView({ page }: TaskListViewProps) {
   const activeSearch = isFindOpen ? findQuery : search;
 
   // Filter tasks
-  const filteredTasks = data?.tasks.filter(task => {
+  const filteredTasks = useMemo(() => data?.tasks.filter(task => {
     // Status filter - use group-based completion detection
     const isDone = isCompletedStatus(task.status, statusConfigs);
     if (filter === 'active' && isDone) return false;
@@ -510,7 +510,7 @@ function TaskListView({ page }: TaskListViewProps) {
     }
 
     return true;
-  }) || [];
+  }) ?? [], [data?.tasks, filter, statusConfigs, activeSearch]);
 
   // Report filtered task count to find store when search is active
   useEffect(() => {

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -400,8 +400,6 @@ function TaskListView({ page }: TaskListViewProps) {
     if (isFindOpen) {
       searchInputRef.current?.focus();
       searchInputRef.current?.select();
-    } else {
-      setSearch('');
     }
   }, [isFindOpen]);
   const [editingTaskId, setEditingTaskId] = useState<string | null>(null);

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -487,9 +487,9 @@ function TaskListView({ page }: TaskListViewProps) {
   }, [socket, connectionStatus, page.id]);
 
   // Derive dynamic status config from API response
-  const statusConfigs: TaskStatusConfig[] = data?.statusConfigs || [];
-  const statusConfigMap = buildStatusConfig(statusConfigs);
-  const statusOrder = getStatusOrder(statusConfigs);
+  const statusConfigs = useMemo(() => data?.statusConfigs ?? [], [data?.statusConfigs]);
+  const statusConfigMap = useMemo(() => buildStatusConfig(statusConfigs), [statusConfigs]);
+  const statusOrder = useMemo(() => getStatusOrder(statusConfigs), [statusConfigs]);
 
   const activeSearch = isFindOpen ? findQuery : search;
 


### PR DESCRIPTION
## Summary

- **AI chat**: Cmd+F was finding messages (count was correct) but had no visual highlighting and scroll was silently broken for conversations ≥50 messages (virtualized list — \`document.querySelector\` returns \`null\` for off-screen elements).
- **Channel**: Scroll used \`block: 'nearest'\` which may not bring the match into view; changed to \`block: 'center'\`.
- **Task list**: \`findQuery\` from the store was never synced into the filter — typing in FindBar did nothing. Navigation (\`findIndex\`) was also not wired. Fixes both, and adds \`data-task-id\` attributes so scroll targeting works.

## Changes

- \`VirtualizedMessageList\` — \`forwardRef\` + \`useImperativeHandle\` to expose \`scrollToIndex\` for virtual scroll navigation
- \`MessageRenderer\` — \`isHighlighted\` / \`isCurrentMatch\` props apply \`find-highlight\` / \`find-highlight-current\` CSS classes
- \`ChatMessagesArea\` — accepts \`findMatchSet\` / \`findCurrentMessageId\`, handles scroll internally (uses virtualizer for large lists, \`querySelector\` otherwise), passes highlight state to \`MessageRenderer\`
- \`ChatLayout\` — threads find props through to \`ChatMessagesArea\`
- \`AiChatView\` — computes \`findMatchSet\` / \`currentFindMsgId\`, removes old broken scroll effect, passes find props down
- \`ChannelView\` — \`block: 'nearest'\` → \`block: 'center'\`
- \`TaskListView\` — syncs \`findQuery\` into filter when find is open, wires \`findIndex\` to scroll, adds \`data-task-id\` to rows; uses \`querySelectorAll\` + \`offsetParent\` check to target only the visible DOM node (avoids picking the hidden mobile element on desktop)

## Test plan

- [ ] AI chat (<50 messages): Cmd+F → type query → matches highlight yellow, current match orange, Next/Prev scrolls and shifts highlight
- [ ] AI chat (≥50 messages): same as above with a long conversation — verify scroll works for off-screen messages
- [ ] Channel: Cmd+F → type query → matching rows highlight, navigating scrolls to them centered
- [ ] Task list: Cmd+F → type query → tasks filter in real time, match count correct, Next/Prev scrolls to each match
- [ ] Document find still works (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)