### PR TITLE
fix(privacy): instant revocation when a page is made private

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/__tests__/route.test.ts
@@ -332,8 +332,8 @@ describe('PATCH /api/pages/[pageId]', () => {
     // @ts-expect-error - partial mock
     vi.mocked(db.query.drives.findFirst).mockResolvedValue({ ownerId: 'owner_user' });
     // Default: no members lose access
+    // @ts-expect-error - partial mock chain
     vi.mocked(db.select).mockReturnValue({
-      // @ts-expect-error - partial mock chain
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockResolvedValue([]),
       }),
@@ -600,8 +600,8 @@ describe('PATCH /api/pages/[pageId]', () => {
     it('kicks members who lose implicit access when page transitions false→true', async () => {
       // @ts-expect-error - partial mock: page was public
       vi.mocked(db.query.pages.findFirst).mockResolvedValue({ isPrivate: false });
+      // @ts-expect-error - partial mock chain
       vi.mocked(db.select).mockReturnValue({
-        // @ts-expect-error - partial mock: two members lose access
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockResolvedValue([
             { userId: 'member_1' },

--- a/apps/web/src/app/api/pages/[pageId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/__tests__/route.test.ts
@@ -39,6 +39,46 @@ vi.mock('@/lib/websocket', () => ({
     type,
     ...data,
   })),
+  kickUserFromPage: vi.fn().mockResolvedValue({ success: true, kickedCount: 0, rooms: [] }),
+  kickUserFromPageActivity: vi.fn().mockResolvedValue({ success: true, kickedCount: 0, rooms: [] }),
+}));
+
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  canUserSharePage: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    query: {
+      pages: { findFirst: vi.fn() },
+      drives: { findFirst: vi.fn() },
+    },
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    }),
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  and: vi.fn((...args: unknown[]) => args),
+  eq: vi.fn((a: unknown, b: unknown) => [a, b]),
+  isNotNull: vi.fn((a: unknown) => ({ _isNotNull: true, col: a })),
+  ne: vi.fn((a: unknown, b: unknown) => ({ ne: [a, b] })),
+  not: vi.fn((a: unknown) => ({ not: a })),
+  exists: vi.fn((a: unknown) => ({ exists: a })),
+  or: vi.fn((...args: unknown[]) => args),
+  isNull: vi.fn((a: unknown) => ({ isNull: a })),
+  gt: vi.fn((a: unknown, b: unknown) => ({ gt: [a, b] })),
+  inArray: vi.fn((a: unknown, b: unknown) => ({ inArray: [a, b] })),
+}));
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'pages.id', isPrivate: 'pages.isPrivate' },
+  drives: { id: 'drives.id', ownerId: 'drives.ownerId' },
+}));
+vi.mock('@pagespace/db/schema/members', () => ({
+  driveMembers: { driveId: 'driveMembers.driveId', userId: 'driveMembers.userId', acceptedAt: 'driveMembers.acceptedAt', role: 'driveMembers.role' },
+  pagePermissions: { id: 'pagePermissions.id', pageId: 'pagePermissions.pageId', userId: 'pagePermissions.userId', canView: 'pagePermissions.canView', expiresAt: 'pagePermissions.expiresAt' },
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
@@ -74,10 +114,12 @@ vi.mock('@pagespace/lib/utils/api-utils', () => ({
 
 import { pageService } from '@/services/api';
 import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope, isMCPAuthResult } from '@/lib/auth';
-import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
+import { broadcastPageEvent, createPageEventPayload, kickUserFromPage, kickUserFromPageActivity } from '@/lib/websocket';
+import { canUserSharePage } from '@pagespace/lib/permissions/permissions';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackPageOperation } from '@pagespace/lib/monitoring/activity-tracker';
 import { jsonResponse } from '@pagespace/lib/utils/api-utils';
+import { db } from '@pagespace/db/db';
 
 // Test helpers
 const mockUserId = 'user_123';
@@ -284,6 +326,20 @@ describe('PATCH /api/pages/[pageId]', () => {
     vi.mocked(createPageEventPayload).mockImplementation((driveId: string, pageId: string, type: string, data: Record<string, unknown>) => ({
       driveId, pageId, type, ...data,
     }));
+    vi.mocked(canUserSharePage).mockResolvedValue(true);
+    // @ts-expect-error - partial mock: page is not private by default
+    vi.mocked(db.query.pages.findFirst).mockResolvedValue({ isPrivate: false });
+    // @ts-expect-error - partial mock
+    vi.mocked(db.query.drives.findFirst).mockResolvedValue({ ownerId: 'owner_user' });
+    // Default: no members lose access
+    vi.mocked(db.select).mockReturnValue({
+      // @ts-expect-error - partial mock chain
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    });
+    vi.mocked(kickUserFromPage).mockResolvedValue({ success: true, kickedCount: 0, rooms: [] });
+    vi.mocked(kickUserFromPageActivity).mockResolvedValue({ success: true, kickedCount: 0, rooms: [] });
   });
 
   describe('authentication', () => {
@@ -511,6 +567,75 @@ describe('PATCH /api/pages/[pageId]', () => {
           socketId: 'socket_abc',
         })
       );
+    });
+  });
+
+  describe('privacy change side effects', () => {
+    it('broadcasts page:updated event when isPrivate changes to true', async () => {
+      await PATCH(createRequest({ isPrivate: true }), { params: mockParams });
+
+      expect(createPageEventPayload).toHaveBeenCalledWith(
+        mockDriveId,
+        mockPageId,
+        'updated',
+        expect.objectContaining({ isPrivate: true })
+      );
+      expect(broadcastPageEvent).toHaveBeenCalledTimes(1);
+    });
+
+    it('broadcasts page:updated event when isPrivate changes to false', async () => {
+      // @ts-expect-error - partial mock: page was private
+      vi.mocked(db.query.pages.findFirst).mockResolvedValue({ isPrivate: true });
+
+      await PATCH(createRequest({ isPrivate: false }), { params: mockParams });
+
+      expect(createPageEventPayload).toHaveBeenCalledWith(
+        mockDriveId,
+        mockPageId,
+        'updated',
+        expect.objectContaining({ isPrivate: false })
+      );
+    });
+
+    it('kicks members who lose implicit access when page transitions false→true', async () => {
+      // @ts-expect-error - partial mock: page was public
+      vi.mocked(db.query.pages.findFirst).mockResolvedValue({ isPrivate: false });
+      vi.mocked(db.select).mockReturnValue({
+        // @ts-expect-error - partial mock: two members lose access
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            { userId: 'member_1' },
+            { userId: 'member_2' },
+          ]),
+        }),
+      });
+
+      await PATCH(createRequest({ isPrivate: true }), { params: mockParams });
+
+      expect(kickUserFromPage).toHaveBeenCalledWith(mockPageId, 'member_1', 'page_private');
+      expect(kickUserFromPage).toHaveBeenCalledWith(mockPageId, 'member_2', 'page_private');
+      expect(kickUserFromPageActivity).toHaveBeenCalledWith(mockPageId, 'member_1', 'page_private');
+      expect(kickUserFromPageActivity).toHaveBeenCalledWith(mockPageId, 'member_2', 'page_private');
+    });
+
+    it('does not kick anyone when page is already private (no transition)', async () => {
+      // @ts-expect-error - partial mock: page was already private
+      vi.mocked(db.query.pages.findFirst).mockResolvedValue({ isPrivate: true });
+
+      await PATCH(createRequest({ isPrivate: true }), { params: mockParams });
+
+      expect(kickUserFromPage).not.toHaveBeenCalled();
+      expect(kickUserFromPageActivity).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when user lacks share permission to change privacy', async () => {
+      vi.mocked(canUserSharePage).mockResolvedValue(false);
+
+      const response = await PATCH(createRequest({ isPrivate: true }), { params: mockParams });
+      const body = await response.json();
+
+      expect(response.status).toBe(403);
+      expect(body.error).toMatch(/owner.*admin|admin.*owner|visibility/i);
     });
   });
 

--- a/apps/web/src/app/api/pages/[pageId]/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/route.ts
@@ -9,7 +9,7 @@ import { jsonResponse } from '@pagespace/lib/utils/api-utils';
 import { pageService } from '@/services/api';
 import { canUserSharePage } from '@pagespace/lib/permissions/permissions';
 import { db } from '@pagespace/db/db';
-import { and, eq, isNotNull, ne, not, exists } from '@pagespace/db/operators';
+import { and, eq, isNotNull, ne, not, exists, or, isNull, gt, inArray } from '@pagespace/db/operators';
 import { pages, drives } from '@pagespace/db/schema/core';
 import { driveMembers, pagePermissions } from '@pagespace/db/schema/members';
 
@@ -165,13 +165,15 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ pageId
             eq(driveMembers.driveId, result.driveId),
             isNotNull(driveMembers.acceptedAt),
             ne(driveMembers.userId, drive.ownerId),
-            ne(driveMembers.role, 'ADMIN'),
+            not(inArray(driveMembers.role, ['OWNER', 'ADMIN'])),
             not(exists(
               db.select({ id: pagePermissions.id })
                 .from(pagePermissions)
                 .where(and(
                   eq(pagePermissions.pageId, pageId),
-                  eq(pagePermissions.userId, driveMembers.userId)
+                  eq(pagePermissions.userId, driveMembers.userId),
+                  eq(pagePermissions.canView, true),
+                  or(isNull(pagePermissions.expiresAt), gt(pagePermissions.expiresAt, new Date()))
                 ))
             ))
           ));

--- a/apps/web/src/app/api/pages/[pageId]/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { z } from "zod/v4";
-import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
+import { broadcastPageEvent, createPageEventPayload, kickUserFromPage, kickUserFromPageActivity } from '@/lib/websocket';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackPageOperation } from '@pagespace/lib/monitoring/activity-tracker';
@@ -8,6 +8,10 @@ import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope, isMCPAu
 import { jsonResponse } from '@pagespace/lib/utils/api-utils';
 import { pageService } from '@/services/api';
 import { canUserSharePage } from '@pagespace/lib/permissions/permissions';
+import { db } from '@pagespace/db/db';
+import { and, eq, isNotNull, ne, not, exists } from '@pagespace/db/operators';
+import { pages, drives } from '@pagespace/db/schema/core';
+import { driveMembers, pagePermissions } from '@pagespace/db/schema/members';
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
@@ -87,6 +91,16 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ pageId
       ? { changeGroupId, metadata: mcpMeta }
       : undefined;
 
+    // Capture current isPrivate before the update so we can detect false→true transitions
+    let previousIsPrivate: boolean | undefined;
+    if (isPrivateUpdate !== undefined) {
+      const currentPage = await db.query.pages.findFirst({
+        where: eq(pages.id, pageId),
+        columns: { isPrivate: true },
+      });
+      previousIsPrivate = currentPage?.isPrivate;
+    }
+
     // Build the full updates object, applying isPrivate with skipPermissionCheck when present
     const updates = isPrivateUpdate !== undefined
       ? { ...contentUpdates, isPrivate: isPrivateUpdate }
@@ -132,6 +146,51 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ pageId
           title: result.page.title ?? undefined,
           parentId: result.page.parentId ?? undefined,
           socketId
+        })
+      );
+    }
+
+    // Instant revocation: kick members who lose implicit access when page becomes private
+    if (isPrivateUpdate === true && previousIsPrivate === false) {
+      const drive = await db.query.drives.findFirst({
+        where: eq(drives.id, result.driveId),
+        columns: { ownerId: true },
+      });
+
+      if (drive) {
+        const membersLosingAccess: { userId: string }[] = await db
+          .select({ userId: driveMembers.userId })
+          .from(driveMembers)
+          .where(and(
+            eq(driveMembers.driveId, result.driveId),
+            isNotNull(driveMembers.acceptedAt),
+            ne(driveMembers.userId, drive.ownerId),
+            ne(driveMembers.role, 'ADMIN'),
+            not(exists(
+              db.select({ id: pagePermissions.id })
+                .from(pagePermissions)
+                .where(and(
+                  eq(pagePermissions.pageId, pageId),
+                  eq(pagePermissions.userId, driveMembers.userId)
+                ))
+            ))
+          ));
+
+        await Promise.all(
+          membersLosingAccess.flatMap(({ userId: memberId }) => [
+            kickUserFromPage(pageId, memberId, 'page_private'),
+            kickUserFromPageActivity(pageId, memberId, 'page_private'),
+          ])
+        );
+      }
+    }
+
+    // Broadcast privacy change so connected clients revalidate their tree
+    if (isPrivateUpdate !== undefined) {
+      await broadcastPageEvent(
+        createPageEventPayload(result.driveId, pageId, 'updated', {
+          isPrivate: isPrivateUpdate,
+          socketId,
         })
       );
     }

--- a/apps/web/src/app/api/pages/tree/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/tree/__tests__/route.test.ts
@@ -60,10 +60,15 @@ vi.mock('@pagespace/db/schema/members', () => ({
   driveMembers: { driveId: 'driveMembers.driveId', userId: 'driveMembers.userId', acceptedAt: 'driveMembers.acceptedAt' },
 }));
 
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  getUserAccessiblePagesInDrive: vi.fn(),
+}));
+
 import { POST } from '../route';
 import { authenticateRequestWithOptions, checkMCPDriveScope } from '@/lib/auth';
 import { buildTree } from '@pagespace/lib/content/tree-utils';
 import { db } from '@pagespace/db/db';
+import { getUserAccessiblePagesInDrive } from '@pagespace/lib/permissions/permissions';
 
 // Test helpers
 const mockUserId = 'user_123';
@@ -104,6 +109,8 @@ describe('POST /api/pages/tree', () => {
       { id: 'page_1', parentId: null, position: 0 },
     ]);
     vi.mocked(buildTree).mockReturnValue([{ id: 'page_1', children: [] }] as never);
+    // Default: all pages accessible (used for non-owner path)
+    vi.mocked(getUserAccessiblePagesInDrive).mockResolvedValue(['page_1']);
   });
 
   describe('authentication', () => {
@@ -244,6 +251,70 @@ describe('POST /api/pages/tree', () => {
       ]);
       expect(body.tree[0].id).toBe('page_1');
       expect(buildTree).toHaveBeenCalledWith(mockPages);
+    });
+
+    it('does not call getUserAccessiblePagesInDrive for the drive owner', async () => {
+      // owner set in beforeEach (ownerId: mockUserId)
+      await POST(createRequest({ driveId: mockDriveId }));
+
+      expect(getUserAccessiblePagesInDrive).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('private page filtering', () => {
+    const otherOwnerId = 'other_owner';
+
+    beforeEach(() => {
+      // Switch to non-owner so filtering kicks in
+      // @ts-expect-error - partial mock data
+      vi.mocked(db.query.drives.findFirst).mockResolvedValue({
+        id: mockDriveId,
+        ownerId: otherOwnerId,
+      });
+      // @ts-expect-error - partial mock data
+      vi.mocked(db.query.driveMembers.findFirst).mockResolvedValue({
+        driveId: mockDriveId,
+        userId: mockUserId,
+      });
+    });
+
+    it('filters out pages not in the accessible set for non-owners', async () => {
+      vi.mocked(db.query.pages.findMany).mockResolvedValue([
+        { id: 'public_page', parentId: null, position: 0 },
+        { id: 'private_page', parentId: null, position: 1 },
+      ] as never);
+      // Only public_page is accessible to this member
+      vi.mocked(getUserAccessiblePagesInDrive).mockResolvedValue(['public_page']);
+
+      await POST(createRequest({ driveId: mockDriveId }));
+
+      // buildTree should only receive the accessible page
+      expect(buildTree).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ id: 'public_page' })])
+      );
+      const callArg = vi.mocked(buildTree).mock.calls[0][0] as { id: string }[];
+      expect(callArg.some(p => p.id === 'private_page')).toBe(false);
+    });
+
+    it('calls getUserAccessiblePagesInDrive with correct userId and driveId for non-owners', async () => {
+      vi.mocked(getUserAccessiblePagesInDrive).mockResolvedValue(['page_1']);
+
+      await POST(createRequest({ driveId: mockDriveId }));
+
+      expect(getUserAccessiblePagesInDrive).toHaveBeenCalledWith(mockUserId, mockDriveId);
+    });
+
+    it('shows all pages when all are in the accessible set', async () => {
+      vi.mocked(db.query.pages.findMany).mockResolvedValue([
+        { id: 'page_a', parentId: null, position: 0 },
+        { id: 'page_b', parentId: null, position: 1 },
+      ] as never);
+      vi.mocked(getUserAccessiblePagesInDrive).mockResolvedValue(['page_a', 'page_b']);
+
+      await POST(createRequest({ driveId: mockDriveId }));
+
+      const callArg = vi.mocked(buildTree).mock.calls[0][0] as { id: string }[];
+      expect(callArg).toHaveLength(2);
     });
   });
 

--- a/apps/web/src/app/api/pages/tree/route.ts
+++ b/apps/web/src/app/api/pages/tree/route.ts
@@ -8,6 +8,7 @@ import { driveMembers } from '@pagespace/db/schema/members';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { authenticateRequestWithOptions, isAuthError, checkMCPDriveScope } from '@/lib/auth';
+import { getUserAccessiblePagesInDrive } from '@pagespace/lib/permissions/permissions';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 
@@ -78,9 +79,17 @@ export async function POST(request: Request) {
       orderBy: [asc(pages.position)],
     });
 
-    const pageTree = buildTree(pageResults);
+    // Non-owners must not see private pages they don't have explicit access to.
+    // getUserAccessiblePagesInDrive handles owner/admin (returns all) vs member (non-private + explicit).
+    let visiblePages = pageResults;
+    if (!isOwner) {
+      const accessibleIds = new Set(await getUserAccessiblePagesInDrive(userId, driveId));
+      visiblePages = pageResults.filter(page => accessibleIds.has(page.id));
+    }
 
-    auditRequest(request, { eventType: 'data.read', userId, resourceType: 'drive_page_tree', resourceId: driveId, details: { action: 'build_page_tree', pageCount: pageResults.length } });
+    const pageTree = buildTree(visiblePages);
+
+    auditRequest(request, { eventType: 'data.read', userId, resourceType: 'drive_page_tree', resourceId: driveId, details: { action: 'build_page_tree', pageCount: visiblePages.length } });
 
     return NextResponse.json({ tree: pageTree });
   } catch (error) {

--- a/apps/web/src/hooks/useAccessRevocation.ts
+++ b/apps/web/src/hooks/useAccessRevocation.ts
@@ -15,7 +15,7 @@ import { useSocketStore } from '@/stores/useSocketStore';
 
 interface AccessRevokedPayload {
   room: string;
-  reason: 'member_removed' | 'role_changed' | 'permission_revoked' | 'session_revoked';
+  reason: 'member_removed' | 'role_changed' | 'permission_revoked' | 'session_revoked' | 'page_private';
   metadata?: {
     driveId?: string;
     pageId?: string;
@@ -74,6 +74,9 @@ function getRevocationMessage(payload: AccessRevokedPayload): string {
 
     case 'permission_revoked':
       return 'Your access to this page has been revoked';
+
+    case 'page_private':
+      return 'This page has been made private';
 
     case 'session_revoked':
       return 'Your session has been revoked. Please log in again.';

--- a/apps/web/src/lib/websocket/socket-utils.ts
+++ b/apps/web/src/lib/websocket/socket-utils.ts
@@ -18,7 +18,7 @@ export type DriveMemberOperation = 'member_added' | 'member_role_changed' | 'mem
 export type TaskOperation = 'task_list_created' | 'task_added' | 'task_updated' | 'task_completed' | 'task_deleted' | 'tasks_reordered';
 export type UsageOperation = 'updated';
 export type ActivityOperation = 'logged';
-export type KickReason = 'member_removed' | 'role_changed' | 'permission_revoked' | 'session_revoked';
+export type KickReason = 'member_removed' | 'role_changed' | 'permission_revoked' | 'session_revoked' | 'page_private';
 export type InboxOperation = 'dm_updated' | 'channel_updated' | 'read_status_changed' | 'thread_updated';
 
 export interface ActivityEventPayload {
@@ -39,6 +39,7 @@ export interface PageEventPayload {
   operation: PageOperation;
   title?: string;
   type?: string;
+  isPrivate?: boolean;
   socketId?: string; // Socket ID of the user who triggered this event (to prevent self-refetch)
 }
 
@@ -408,6 +409,7 @@ export function createPageEventPayload(
     parentId?: string | null;
     title?: string;
     type?: string;
+    isPrivate?: boolean;
     socketId?: string;
   } = {}
 ): PageEventPayload {


### PR DESCRIPTION
## Summary

- **Tree filtering**: `POST /api/pages/tree` now calls `getUserAccessiblePagesInDrive()` for non-owner members before building the tree, so private pages are excluded from the sidebar for users who don't have explicit access
- **Instant WebSocket kick**: When `isPrivate` transitions `false → true`, the PATCH handler queries all accepted drive members who only held implicit read access (not owner, not admin, no explicit `pagePermissions` entry) and kicks each of them from the page room and activity room with reason `'page_private'`
- **Broadcast on privacy change**: A `page:updated` event is now emitted whenever `isPrivate` changes so clients that aren't actively in the page room revalidate their tree
- **Client toast**: `useAccessRevocation` handles the new `'page_private'` kick reason with the message "This page has been made private"

## Test plan

- [ ] Open two sessions — admin (User A) and regular member (User B)
- [ ] User B opens a public page and keeps it active
- [ ] User A makes the page private
- [ ] User B is immediately kicked and redirected with "This page has been made private" toast
- [ ] User B's sidebar tree no longer shows the page
- [ ] User A still has full access
- [ ] User B navigating directly to the old URL receives a 403
- [ ] User A makes the page public again → User B's tree revalidates and the page reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)