### PR TITLE
refactor(ui): unify task and channel pages

### DIFF
--- a/apps/web/src/app/dashboard/[driveId]/channels/page.tsx
+++ b/apps/web/src/app/dashboard/[driveId]/channels/page.tsx
@@ -5,7 +5,5 @@ import ChannelsCenterList from '@/components/inbox/ChannelsCenterList';
 
 export default function DriveChannelsPage() {
   const params = useParams();
-  const driveId = params.driveId as string;
-
-  return <ChannelsCenterList driveId={driveId} />;
+  return <ChannelsCenterList driveId={params.driveId as string} />;
 }

--- a/apps/web/src/app/dashboard/[driveId]/tasks/page.tsx
+++ b/apps/web/src/app/dashboard/[driveId]/tasks/page.tsx
@@ -1,53 +1,13 @@
 'use client';
 
-import { useEffect, Suspense } from 'react';
+import { Suspense } from 'react';
 import { useParams } from 'next/navigation';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useDriveStore } from '@/hooks/useDrive';
 import { TasksDashboard } from '@/components/tasks';
 
 function DriveTasksContent() {
   const params = useParams();
-  const driveId = params.driveId as string;
-  const drives = useDriveStore((state) => state.drives);
-  const isLoading = useDriveStore((state) => state.isLoading);
-  const fetchDrives = useDriveStore((state) => state.fetchDrives);
-
-  useEffect(() => {
-    fetchDrives();
-  }, [fetchDrives]);
-
-  const drive = drives.find(d => d.id === driveId);
-
-  if (isLoading) {
-    return (
-      <div className="h-full overflow-y-auto">
-        <div className="container mx-auto px-4 py-10 sm:px-6 lg:px-10 max-w-5xl">
-          <div className="space-y-6">
-            <Skeleton className="h-8 w-48" />
-            <Skeleton className="h-10 w-full" />
-            <Skeleton className="h-96" />
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  if (!drive) {
-    return (
-      <div className="flex items-center justify-center h-full">
-        <p className="text-muted-foreground">Drive not found</p>
-      </div>
-    );
-  }
-
-  return (
-    <TasksDashboard
-      context="drive"
-      driveId={driveId}
-      driveName={drive.name}
-    />
-  );
+  return <TasksDashboard driveId={params.driveId as string} />;
 }
 
 export default function DriveTasksPage() {

--- a/apps/web/src/app/dashboard/channels/page.tsx
+++ b/apps/web/src/app/dashboard/channels/page.tsx
@@ -1,7 +1,19 @@
 'use client';
 
+import { Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
 import ChannelsCenterList from '@/components/inbox/ChannelsCenterList';
 
+function ChannelsPageContent() {
+  const searchParams = useSearchParams();
+  const driveId = searchParams.get('driveId') ?? undefined;
+  return <ChannelsCenterList driveId={driveId} />;
+}
+
 export default function ChannelsPage() {
-  return <ChannelsCenterList />;
+  return (
+    <Suspense fallback={null}>
+      <ChannelsPageContent />
+    </Suspense>
+  );
 }

--- a/apps/web/src/app/dashboard/tasks/page.tsx
+++ b/apps/web/src/app/dashboard/tasks/page.tsx
@@ -5,7 +5,7 @@ import { TasksDashboard } from '@/components/tasks';
 import { Skeleton } from '@/components/ui/skeleton';
 
 function TasksPageContent() {
-  return <TasksDashboard context="user" />;
+  return <TasksDashboard />;
 }
 
 export default function TasksPage() {

--- a/apps/web/src/components/tasks/FilterComponents.tsx
+++ b/apps/web/src/components/tasks/FilterComponents.tsx
@@ -59,7 +59,7 @@ export function FilterSelect({
 }
 
 export interface DriveSelectProps {
-  context: 'user' | 'drive';
+  isLocked: boolean;
   drives: Drive[];
   selectedDriveId: string | undefined;
   driveFilterId: string | undefined;
@@ -68,14 +68,14 @@ export interface DriveSelectProps {
 }
 
 export function DriveSelect({
-  context,
+  isLocked,
   drives,
   selectedDriveId,
   driveFilterId,
   onDriveChange,
   triggerClassName,
 }: DriveSelectProps) {
-  const value = context === 'drive' ? selectedDriveId : (driveFilterId || 'all');
+  const value = isLocked ? selectedDriveId : (driveFilterId || 'all');
 
   return (
     <Select
@@ -86,7 +86,7 @@ export function DriveSelect({
         <SelectValue placeholder="All drives" />
       </SelectTrigger>
       <SelectContent>
-        {context === 'user' && <SelectItem value="all">All drives</SelectItem>}
+        {!isLocked && <SelectItem value="all">All drives</SelectItem>}
         {drives.map((drive) => (
           <SelectItem key={drive.id} value={drive.id}>
             {drive.name}

--- a/apps/web/src/components/tasks/FilterControls.tsx
+++ b/apps/web/src/components/tasks/FilterControls.tsx
@@ -21,7 +21,7 @@ export type { DueDateFilter, AssigneeFilter, StatusGroupFilter, FilterValues };
 
 export interface FilterControlsProps {
   layout: 'mobile' | 'desktop';
-  context: 'user' | 'drive';
+  isLocked: boolean;
   drives: Drive[];
   selectedDriveId: string | undefined;
   filters: FilterValues;
@@ -34,7 +34,7 @@ export interface FilterControlsProps {
 
 export function FilterControls({
   layout,
-  context,
+  isLocked,
   drives,
   selectedDriveId,
   filters,
@@ -66,7 +66,7 @@ export function FilterControls({
         >
           <div className="flex w-max min-w-full gap-2">
             <DriveSelect
-              context={context}
+              isLocked={isLocked}
               drives={drives}
               selectedDriveId={selectedDriveId}
               driveFilterId={filters.driveId}
@@ -120,7 +120,7 @@ export function FilterControls({
         onChange={(g) => onFiltersChange({ statusGroup: g })}
       />
       <DriveSelect
-        context={context}
+        isLocked={isLocked}
         drives={drives}
         selectedDriveId={selectedDriveId}
         driveFilterId={filters.driveId}

--- a/apps/web/src/components/tasks/TaskFilterSheet.tsx
+++ b/apps/web/src/components/tasks/TaskFilterSheet.tsx
@@ -30,7 +30,7 @@ export type { DueDateFilter, AssigneeFilter, StatusGroupFilter, FilterValues };
 export interface TaskFilterSheetProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  context: 'user' | 'drive';
+  isLocked: boolean;
   drives: Drive[];
   selectedDriveId: string | undefined;
   filters: FilterValues;
@@ -44,7 +44,7 @@ export interface TaskFilterSheetProps {
 export function TaskFilterSheet({
   open,
   onOpenChange,
-  context,
+  isLocked,
   drives,
   selectedDriveId,
   filters,
@@ -108,7 +108,7 @@ export function TaskFilterSheet({
           <div className="space-y-1.5">
             <label className="text-xs font-medium text-muted-foreground">Drive</label>
             <DriveSelect
-              context={context}
+              isLocked={isLocked}
               drives={drives}
               selectedDriveId={selectedDriveId}
               driveFilterId={filters.driveId}

--- a/apps/web/src/components/tasks/TaskStates.tsx
+++ b/apps/web/src/components/tasks/TaskStates.tsx
@@ -32,7 +32,7 @@ export function TaskLoadingSkeleton({ isMobile = false }: TaskLoadingSkeletonPro
 }
 
 export interface TaskEmptyStateProps {
-  context: 'user' | 'drive';
+  isLocked: boolean;
   hasDriveSelected: boolean;
   hasActiveFilters: boolean;
   onClearFilters?: () => void;
@@ -40,21 +40,21 @@ export interface TaskEmptyStateProps {
 }
 
 export function TaskEmptyState({
-  context,
+  isLocked,
   hasDriveSelected,
   hasActiveFilters,
   onClearFilters,
   isMobile = false,
 }: TaskEmptyStateProps) {
   const getTitle = () => {
-    if (context === 'drive' && !hasDriveSelected) {
+    if (isLocked && !hasDriveSelected) {
       return isMobile ? 'Select a drive' : 'Select a drive to view tasks';
     }
     return 'No tasks found';
   };
 
   const getDescription = () => {
-    if (context === 'drive' && !hasDriveSelected) {
+    if (isLocked && !hasDriveSelected) {
       return isMobile ? 'Open filters to choose a drive' : 'Choose a drive from the dropdown above';
     }
     if (hasActiveFilters) {

--- a/apps/web/src/components/tasks/TasksDashboard.tsx
+++ b/apps/web/src/components/tasks/TasksDashboard.tsx
@@ -68,9 +68,7 @@ import { KanbanColumn, KanbanCard } from './TaskKanbanComponents';
 const STATUS_GROUPS: TaskStatusGroup[] = ['todo', 'in_progress', 'done'];
 
 interface TasksDashboardProps {
-  context: 'user' | 'drive';
   driveId?: string;
-  driveName?: string;
 }
 
 interface ExtendedFilters extends TaskFilters {
@@ -80,7 +78,8 @@ interface ExtendedFilters extends TaskFilters {
   statusGroup?: StatusGroupFilter;
 }
 
-export function TasksDashboard({ context, driveId: initialDriveId, driveName }: TasksDashboardProps) {
+export function TasksDashboard({ driveId: propDriveId }: TasksDashboardProps) {
+  const isLocked = !!propDriveId;
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -111,10 +110,10 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
   const [filterSheetOpen, setFilterSheetOpen] = useState(false);
 
   // Filter state — URL params win on mount; otherwise fall back to per-scope persisted prefs.
-  const [selectedDriveId, setSelectedDriveId] = useState<string | undefined>(initialDriveId);
+  const [selectedDriveId, setSelectedDriveId] = useState<string | undefined>(propDriveId);
   const persistDashboardFilter = useLayoutStore((state) => state.setTasksDashboardFilter);
   const [filters, setFilters] = useState<ExtendedFilters>(() => {
-    const initialScopeKey = scopeKeyFor(context, initialDriveId);
+    const initialScopeKey = scopeKeyFor(isLocked ? 'drive' : 'user', propDriveId);
     const stored = useLayoutStore.getState().tasksDashboardFilters[initialScopeKey];
     return pickInitialFilters(searchParams, stored);
   });
@@ -177,8 +176,11 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
 
     router.replace(newUrl, { scroll: false });
 
-    persistDashboardFilter(scopeKeyFor(context, newDriveId), toStoredDashboardFilters(newFilters));
-  }, [router, persistDashboardFilter, context]);
+    const scopeKey = isLocked
+      ? scopeKeyFor('drive', newDriveId ?? propDriveId)
+      : scopeKeyFor('user', undefined);
+    persistDashboardFilter(scopeKey, toStoredDashboardFilters(newFilters));
+  }, [router, persistDashboardFilter, isLocked, propDriveId]);
 
   // Handle search with debounce
   const handleSearchChange = useCallback((value: string) => {
@@ -202,16 +204,10 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
       if (!response.ok) throw new Error('Failed to fetch drives');
       const data = await response.json();
       setDrives(data);
-
-      // If context is 'drive' and no drive selected, select first one
-      if (context === 'drive' && !selectedDriveId && data.length > 0) {
-        setSelectedDriveId(data[0].id);
-      }
     } catch (err) {
       console.error('Error fetching drives:', err);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- selectedDriveId is only checked, not derived from
-  }, [context]);
+  }, []);
 
   // Fetch tasks
   const fetchTasks = useCallback(
@@ -225,13 +221,13 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
 
       try {
         const params = new URLSearchParams();
-        params.set('context', context);
+        params.set('context', isLocked ? 'drive' : 'user');
         params.set('limit', '50');
         params.set('offset', offset.toString());
 
-        if (context === 'drive' && selectedDriveId) {
+        if (isLocked && selectedDriveId) {
           params.set('driveId', selectedDriveId);
-        } else if (context === 'user' && filters.driveId) {
+        } else if (!isLocked && filters.driveId) {
           params.set('driveId', filters.driveId);
         }
         if (filters.status) {
@@ -285,7 +281,7 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
         setLoadingMore(false);
       }
     },
-    [context, selectedDriveId, filters]
+    [isLocked, selectedDriveId, filters]
   );
 
   // Initial load
@@ -295,21 +291,21 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
 
   // Fetch tasks when filters or drive changes
   useEffect(() => {
-    if (context === 'user' || (context === 'drive' && selectedDriveId)) {
+    if (!isLocked || selectedDriveId) {
       fetchTasks();
     }
-  }, [context, selectedDriveId, filters, fetchTasks]);
+  }, [isLocked, selectedDriveId, filters, fetchTasks]);
 
   // Register/unregister editing state for UI refresh protection
   useEffect(() => {
-    const dashboardId = `tasks-dashboard-${context}-${selectedDriveId || 'all'}`;
+    const dashboardId = `tasks-dashboard-${isLocked ? 'drive' : 'user'}-${selectedDriveId || 'all'}`;
     if (editingTaskId) {
       useEditingStore.getState().startEditing(dashboardId, 'form', { componentName: 'TasksDashboard' });
     } else {
       useEditingStore.getState().endEditing(dashboardId);
     }
     return () => useEditingStore.getState().endEditing(dashboardId);
-  }, [editingTaskId, context, selectedDriveId]);
+  }, [editingTaskId, isLocked, selectedDriveId]);
 
   // Handlers
   const handleLoadMore = () => {
@@ -329,7 +325,7 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
   };
 
   const handleDriveChange = (driveId: string) => {
-    if (context === 'drive') {
+    if (isLocked) {
       setSelectedDriveId(driveId);
       const stored = useLayoutStore.getState().tasksDashboardFilters[scopeKeyFor('drive', driveId)];
       const updatedFilters = fromStoredOrDefaults(stored);
@@ -569,11 +565,11 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
     );
   }
 
-  const title = context === 'drive'
-    ? `${driveName || drives.find(d => d.id === selectedDriveId)?.name || 'Drive'} Tasks`
+  const title = isLocked
+    ? `${drives.find(d => d.id === selectedDriveId)?.name || 'Drive'} Tasks`
     : 'My Tasks';
 
-  const description = context === 'drive'
+  const description = isLocked
     ? 'Tasks assigned to you in this drive'
     : filters.driveId
       ? `Your tasks in ${drives.find(d => d.id === filters.driveId)?.name || 'selected drive'}`
@@ -586,7 +582,7 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
     filters.status ||
     filters.priority ||
     (filters.dueDateFilter && filters.dueDateFilter !== 'all') ||
-    (context === 'user' && filters.driveId) ||
+    (!isLocked && filters.driveId) ||
     filters.assigneeFilter === 'all' ||
     (filters.statusGroup && filters.statusGroup !== 'active')
   );
@@ -604,7 +600,7 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
 
     setSearchValue('');
     setFilters(nextFilters);
-    updateUrl(nextFilters, context === 'drive' ? selectedDriveId : undefined);
+    updateUrl(nextFilters, isLocked ? selectedDriveId : undefined);
   };
 
   // Count active filters for the badge on mobile filter button
@@ -613,7 +609,7 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
     filters.status,
     filters.priority,
     filters.dueDateFilter && filters.dueDateFilter !== 'all',
-    context === 'user' && filters.driveId,
+    !isLocked && filters.driveId,
     filters.assigneeFilter === 'all',
     filters.statusGroup && filters.statusGroup !== 'active',
   ].filter(Boolean).length;
@@ -647,7 +643,7 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
                       variant="ghost"
                       size="icon"
                       className="h-9 w-9 shrink-0"
-                      onClick={() => router.push(context === 'drive' && selectedDriveId
+                      onClick={() => router.push(isLocked && selectedDriveId
                         ? `/dashboard/${selectedDriveId}`
                         : '/dashboard'
                       )}
@@ -697,7 +693,7 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
                 {/* Mobile Compact Task List */}
                 {tasks.length === 0 ? (
                   <TaskEmptyState
-                    context={context}
+                    isLocked={isLocked}
                     hasDriveSelected={!!selectedDriveId}
                     hasActiveFilters={hasActiveFilters}
                     onClearFilters={clearFilters}
@@ -749,7 +745,7 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
                 <TaskFilterSheet
                   open={filterSheetOpen}
                   onOpenChange={setFilterSheetOpen}
-                  context={context}
+                  isLocked={isLocked}
                   drives={drives}
                   selectedDriveId={selectedDriveId}
                   filters={filters}
@@ -767,7 +763,7 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
                   <Button
                     variant="ghost"
                     size="sm"
-                    onClick={() => router.push(context === 'drive' && selectedDriveId
+                    onClick={() => router.push(isLocked && selectedDriveId
                       ? `/dashboard/${selectedDriveId}`
                       : '/dashboard'
                     )}
@@ -849,7 +845,7 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
 
                   <FilterControls
                     layout="desktop"
-                    context={context}
+                    isLocked={isLocked}
                     drives={drives}
                     selectedDriveId={selectedDriveId}
                     filters={filters}
@@ -864,7 +860,7 @@ export function TasksDashboard({ context, driveId: initialDriveId, driveName }: 
                 {/* Desktop Tasks View */}
                 {tasks.length === 0 ? (
                   <TaskEmptyState
-                    context={context}
+                    isLocked={isLocked}
                     hasDriveSelected={!!selectedDriveId}
                     hasActiveFilters={hasActiveFilters}
                     onClearFilters={clearFilters}


### PR DESCRIPTION
## Summary

- **Drive-level routes preserved** — `/dashboard/[driveId]/tasks` and `/dashboard/[driveId]/channels` still exist so driveId stays in the URL path. Sidebar keeps full drive context (page tree, Drive Home, ChannelsSidebar) when navigating to tasks/channels from within a drive.
- **Single component** — both routes render the same `TasksDashboard` / `ChannelsCenterList` component. The drive-level page files are now thin wrappers that pass `driveId` from params.
- **`context` prop removed** — `TasksDashboard` no longer takes `context: 'user' | 'drive'` or `driveName`. An `isLocked = !!driveId` boolean replaces all `context === 'drive'` checks throughout the component tree (`DriveSelect`, `FilterControls`, `TaskFilterSheet`, `TaskEmptyState`).
- **Dashboard channels page** gains `?driveId` search-param support for direct-link navigation.

## Test plan

- [ ] From dashboard: click Tasks → `/dashboard/tasks`, all-drives view, no drive pre-selected
- [ ] From dashboard: click Channels → `/dashboard/channels`, all-channels view
- [ ] Navigate into a drive, click Tasks → `/dashboard/[driveId]/tasks`, sidebar stays in drive mode (page tree visible), tasks filtered to that drive
- [ ] Navigate into a drive, click Channels → `/dashboard/[driveId]/channels`, `ChannelsSidebar` renders with drive-filtered list
- [ ] Drive selector in TasksDashboard switches between drives and updates the URL path
- [ ] Clear filters in drive tasks view resets to drive-scoped defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)