### PR TITLE
fix(permissions): wire custom roles into human user page access checks

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/__tests__/route.test.ts
@@ -71,14 +71,16 @@ vi.mock('@pagespace/db/operators', () => ({
   isNull: vi.fn((a: unknown) => ({ isNull: a })),
   gt: vi.fn((a: unknown, b: unknown) => ({ gt: [a, b] })),
   inArray: vi.fn((a: unknown, b: unknown) => ({ inArray: [a, b] })),
+  sql: vi.fn((...args: unknown[]) => ({ sql: args })),
 }));
 vi.mock('@pagespace/db/schema/core', () => ({
   pages: { id: 'pages.id', isPrivate: 'pages.isPrivate' },
   drives: { id: 'drives.id', ownerId: 'drives.ownerId' },
 }));
 vi.mock('@pagespace/db/schema/members', () => ({
-  driveMembers: { driveId: 'driveMembers.driveId', userId: 'driveMembers.userId', acceptedAt: 'driveMembers.acceptedAt', role: 'driveMembers.role' },
+  driveMembers: { driveId: 'driveMembers.driveId', userId: 'driveMembers.userId', acceptedAt: 'driveMembers.acceptedAt', role: 'driveMembers.role', customRoleId: 'driveMembers.customRoleId' },
   pagePermissions: { id: 'pagePermissions.id', pageId: 'pagePermissions.pageId', userId: 'pagePermissions.userId', canView: 'pagePermissions.canView', expiresAt: 'pagePermissions.expiresAt' },
+  driveRoles: { id: 'driveRoles.id', permissions: 'driveRoles.permissions' },
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
@@ -616,6 +618,24 @@ describe('PATCH /api/pages/[pageId]', () => {
       expect(kickUserFromPage).toHaveBeenCalledWith(mockPageId, 'member_2', 'page_private');
       expect(kickUserFromPageActivity).toHaveBeenCalledWith(mockPageId, 'member_1', 'page_private');
       expect(kickUserFromPageActivity).toHaveBeenCalledWith(mockPageId, 'member_2', 'page_private');
+    });
+
+    it('does not kick members who retain access via custom role when page transitions false→true', async () => {
+      // The DB query excludes members with custom role access — they return [] from the kick query
+      // @ts-expect-error - partial mock: page was public
+      vi.mocked(db.query.pages.findFirst).mockResolvedValue({ isPrivate: false });
+      // @ts-expect-error - partial mock chain: empty result means all members with implicit access
+      // are already excluded by the NOT EXISTS subqueries (explicit perms + custom role)
+      vi.mocked(db.select).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      });
+
+      await PATCH(createRequest({ isPrivate: true }), { params: mockParams });
+
+      expect(kickUserFromPage).not.toHaveBeenCalled();
+      expect(kickUserFromPageActivity).not.toHaveBeenCalled();
     });
 
     it('does not kick anyone when page is already private (no transition)', async () => {

--- a/apps/web/src/app/api/pages/[pageId]/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/route.ts
@@ -9,9 +9,9 @@ import { jsonResponse } from '@pagespace/lib/utils/api-utils';
 import { pageService } from '@/services/api';
 import { canUserSharePage } from '@pagespace/lib/permissions/permissions';
 import { db } from '@pagespace/db/db';
-import { and, eq, isNotNull, ne, not, exists, or, isNull, gt, inArray } from '@pagespace/db/operators';
+import { and, eq, isNotNull, ne, not, exists, or, isNull, gt, inArray, sql } from '@pagespace/db/operators';
 import { pages, drives } from '@pagespace/db/schema/core';
-import { driveMembers, pagePermissions } from '@pagespace/db/schema/members';
+import { driveMembers, pagePermissions, driveRoles } from '@pagespace/db/schema/members';
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
@@ -174,6 +174,14 @@ export async function PATCH(req: Request, { params }: { params: Promise<{ pageId
                   eq(pagePermissions.userId, driveMembers.userId),
                   eq(pagePermissions.canView, true),
                   or(isNull(pagePermissions.expiresAt), gt(pagePermissions.expiresAt, new Date()))
+                ))
+            )),
+            not(exists(
+              db.select({ id: driveRoles.id })
+                .from(driveRoles)
+                .where(and(
+                  eq(driveRoles.id, driveMembers.customRoleId),
+                  sql`${driveRoles.permissions} -> ${pageId} ->> 'canView' = 'true'`
                 ))
             ))
           ));

--- a/packages/lib/src/permissions/__tests__/batch-page-permissions.test.ts
+++ b/packages/lib/src/permissions/__tests__/batch-page-permissions.test.ts
@@ -18,6 +18,7 @@ vi.mock('@pagespace/db/schema/members', () => ({
     userId: 'userId',
     role: 'role',
     acceptedAt: 'acceptedAt',
+    customRoleId: 'customRoleId',
   },
   pagePermissions: {
     pageId: 'pageId',
@@ -27,6 +28,11 @@ vi.mock('@pagespace/db/schema/members', () => ({
     canShare: 'canShare',
     canDelete: 'canDelete',
     expiresAt: 'expiresAt',
+  },
+  driveRoles: {
+    id: 'id',
+    driveId: 'driveId',
+    permissions: 'permissions',
   },
 }));
 vi.mock('@pagespace/db/operators', () => ({
@@ -50,7 +56,7 @@ vi.mock('../../logging/logger-config', () => ({
   },
 }));
 
-vi.mock('../../validators', () => ({
+vi.mock('../../validators/id-validators', () => ({
   parseUserId: vi.fn(),
   parsePageId: vi.fn(),
 }));
@@ -76,6 +82,7 @@ interface Row {
   explicitCanEdit: boolean | null;
   explicitCanShare: boolean | null;
   explicitCanDelete: boolean | null;
+  customRolePerms: Record<string, { canView: boolean; canEdit: boolean; canShare: boolean }> | null;
 }
 
 const FULL = { canView: true, canEdit: true, canShare: true, canDelete: true };
@@ -92,6 +99,7 @@ function makeRow(overrides: Partial<Row> & { pageId: string }): Row {
     explicitCanEdit: null,
     explicitCanShare: null,
     explicitCanDelete: null,
+    customRolePerms: null,
     ...overrides,
   };
 }
@@ -103,13 +111,15 @@ function makeRow(overrides: Partial<Row> & { pageId: string }): Row {
  *     .leftJoin(drives, ...)
  *     .leftJoin(driveMembers, ...)
  *     .leftJoin(pagePermissions, ...)
+ *     .leftJoin(driveRoles, ...)
  *     .where(...)
  *
  * The terminal `.where(...)` resolves to the provided rows.
  */
 function stubQueryRows(rows: Row[]) {
   const where = vi.fn().mockResolvedValue(rows);
-  const leftJoin3 = vi.fn().mockReturnValue({ where });
+  const leftJoin4 = vi.fn().mockReturnValue({ where });
+  const leftJoin3 = vi.fn().mockReturnValue({ leftJoin: leftJoin4, where });
   const leftJoin2 = vi.fn().mockReturnValue({ leftJoin: leftJoin3, where });
   const leftJoin1 = vi.fn().mockReturnValue({ leftJoin: leftJoin2, where });
   const from = vi.fn().mockReturnValue({ leftJoin: leftJoin1, where });
@@ -303,9 +313,85 @@ describe('getBatchPagePermissions', () => {
     expect(vi.mocked(isNotNull)).toHaveBeenCalledWith('acceptedAt');
   });
 
+  it('given MEMBER with custom role entry {canView:true, canEdit:true} on a PRIVATE page, should grant custom role permissions', async () => {
+    stubQueryRows([
+      makeRow({
+        pageId: 'p1',
+        memberRole: 'MEMBER',
+        isPrivate: true,
+        customRolePerms: { 'p1': { canView: true, canEdit: true, canShare: false } },
+      }),
+    ]);
+
+    const result = await getBatchPagePermissions(USER, ['p1']);
+
+    expect(result.get('p1')).toEqual({ canView: true, canEdit: true, canShare: false, canDelete: false });
+  });
+
+  it('given MEMBER with custom role entry {canView:true, canEdit:true} on a NON-PRIVATE page, should grant custom role permissions instead of read-only', async () => {
+    stubQueryRows([
+      makeRow({
+        pageId: 'p1',
+        memberRole: 'MEMBER',
+        isPrivate: false,
+        customRolePerms: { 'p1': { canView: true, canEdit: true, canShare: false } },
+      }),
+    ]);
+
+    const result = await getBatchPagePermissions(USER, ['p1']);
+
+    expect(result.get('p1')).toEqual({ canView: true, canEdit: true, canShare: false, canDelete: false });
+  });
+
+  it('given MEMBER with custom role but NO entry for this page on a non-private page, should fall through to Rule 4', async () => {
+    stubQueryRows([
+      makeRow({
+        pageId: 'p1',
+        memberRole: 'MEMBER',
+        isPrivate: false,
+        customRolePerms: { 'other-page': { canView: true, canEdit: true, canShare: false } },
+      }),
+    ]);
+
+    const result = await getBatchPagePermissions(USER, ['p1']);
+
+    expect(result.get('p1')).toEqual({ canView: true, canEdit: false, canShare: false, canDelete: false });
+  });
+
+  it('given MEMBER with custom role but NO entry for this page on a private page, should deny access', async () => {
+    stubQueryRows([
+      makeRow({
+        pageId: 'p1',
+        memberRole: 'MEMBER',
+        isPrivate: true,
+        customRolePerms: { 'other-page': { canView: true, canEdit: true, canShare: false } },
+      }),
+    ]);
+
+    const result = await getBatchPagePermissions(USER, ['p1']);
+
+    expect(result.get('p1')).toEqual({ canView: false, canEdit: false, canShare: false, canDelete: false });
+  });
+
+  it('given MEMBER with custom role entry {canView:false} on a non-private page, should deny access (explicit deny beats Rule 4)', async () => {
+    stubQueryRows([
+      makeRow({
+        pageId: 'p1',
+        memberRole: 'MEMBER',
+        isPrivate: false,
+        customRolePerms: { 'p1': { canView: false, canEdit: false, canShare: false } },
+      }),
+    ]);
+
+    const result = await getBatchPagePermissions(USER, ['p1']);
+
+    expect(result.get('p1')).toEqual({ canView: false, canEdit: false, canShare: false, canDelete: false });
+  });
+
   it('given a DB failure, should return the pre-seeded deny map (fail-closed) and log', async () => {
     const where = vi.fn().mockRejectedValue(new Error('DB down'));
-    const leftJoin3 = vi.fn().mockReturnValue({ where });
+    const leftJoin4 = vi.fn().mockReturnValue({ where });
+    const leftJoin3 = vi.fn().mockReturnValue({ leftJoin: leftJoin4, where });
     const leftJoin2 = vi.fn().mockReturnValue({ leftJoin: leftJoin3, where });
     const leftJoin1 = vi.fn().mockReturnValue({ leftJoin: leftJoin2, where });
     const from = vi.fn().mockReturnValue({ leftJoin: leftJoin1, where });

--- a/packages/lib/src/permissions/__tests__/permissions.test.ts
+++ b/packages/lib/src/permissions/__tests__/permissions.test.ts
@@ -17,11 +17,12 @@ vi.mock('@pagespace/db/schema/core', () => ({
   drives: { id: 'id', ownerId: 'ownerId' },
 }));
 vi.mock('@pagespace/db/schema/members', () => ({
-  driveMembers: { driveId: 'driveId', userId: 'userId', role: 'role', id: 'id', acceptedAt: 'acceptedAt' },
+  driveMembers: { driveId: 'driveId', userId: 'userId', role: 'role', id: 'id', acceptedAt: 'acceptedAt', customRoleId: 'customRoleId' },
   pagePermissions: {
     pageId: 'pageId', userId: 'userId', canView: 'canView', canEdit: 'canEdit',
     canShare: 'canShare', canDelete: 'canDelete', expiresAt: 'expiresAt', id: 'id',
   },
+  driveRoles: { id: 'id', driveId: 'driveId', permissions: 'permissions' },
 }));
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((_a, _b) => 'eq'),
@@ -264,7 +265,7 @@ describe('getUserAccessLevel', () => {
   it('returns full access when user is drive admin', async () => {
     mockValidators(true, true);
     const page = [{ id: VALID_PAGE, driveId: VALID_DRIVE, driveOwnerId: 'other-owner' }];
-    const adminMembership = [{ id: 'member-id' }];
+    const membership = [{ role: 'ADMIN', customRoleId: null }];
 
     vi.mocked(db.select)
       // First call: page lookup
@@ -275,10 +276,10 @@ describe('getUserAccessLevel', () => {
           }),
         }),
       } as unknown as ReturnType<typeof db.select>)
-      // Second call: admin check
+      // Second call: combined membership query
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(adminMembership) }),
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(membership) }),
         }),
       } as unknown as ReturnType<typeof db.select>);
 
@@ -300,10 +301,10 @@ describe('getUserAccessLevel', () => {
           }),
         }),
       } as unknown as ReturnType<typeof db.select>)
-      // admin check (no admin)
+      // combined membership query (MEMBER, no custom role)
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ role: 'MEMBER', customRoleId: null }]) }),
         }),
       } as unknown as ReturnType<typeof db.select>)
       // explicit permissions
@@ -322,6 +323,7 @@ describe('getUserAccessLevel', () => {
     const page = [{ id: VALID_PAGE, driveId: VALID_DRIVE, driveOwnerId: 'other-owner' }];
 
     vi.mocked(db.select)
+      // page lookup
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           leftJoin: vi.fn().mockReturnValue({
@@ -329,11 +331,13 @@ describe('getUserAccessLevel', () => {
           }),
         }),
       } as unknown as ReturnType<typeof db.select>)
+      // combined membership query → not a member at all
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
         }),
       } as unknown as ReturnType<typeof db.select>)
+      // explicit permissions → none
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
@@ -357,19 +361,13 @@ describe('getUserAccessLevel', () => {
           }),
         }),
       } as unknown as ReturnType<typeof db.select>)
-      // admin check → not admin
+      // combined membership query → not a member
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
         }),
       } as unknown as ReturnType<typeof db.select>)
       // explicit pagePermissions → none
-      .mockReturnValueOnce({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
-        }),
-      } as unknown as ReturnType<typeof db.select>)
-      // member check → not a member (so rule 4 doesn't grant access)
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
@@ -389,6 +387,7 @@ describe('getUserAccessLevel', () => {
     const explicitPerm = [{ canView: true, canEdit: false, canShare: false, canDelete: false }];
 
     vi.mocked(db.select)
+      // page lookup
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           leftJoin: vi.fn().mockReturnValue({
@@ -396,11 +395,13 @@ describe('getUserAccessLevel', () => {
           }),
         }),
       } as unknown as ReturnType<typeof db.select>)
+      // combined membership query (MEMBER, no custom role)
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ role: 'MEMBER', customRoleId: null }]) }),
         }),
       } as unknown as ReturnType<typeof db.select>)
+      // explicit permissions
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(explicitPerm) }),
@@ -854,10 +855,10 @@ describe('getUserAccessiblePagesInDrive', () => {
           where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
         }),
       } as unknown as ReturnType<typeof db.select>)
-      // member check → is a member (MEMBER role)
+      // member check → is a member (no custom role)
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ id: 'member-row' }]) }),
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ id: 'member-row', customRoleId: null }]) }),
         }),
       } as unknown as ReturnType<typeof db.select>)
       // non-private pages visible to all members
@@ -970,10 +971,10 @@ describe('getUserAccessiblePagesInDriveWithDetails', () => {
           where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([]) }),
         }),
       } as unknown as ReturnType<typeof db.select>)
-      // member check → is a member
+      // member check → is a member (no custom role)
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ id: 'member-row' }]) }),
+          where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue([{ id: 'member-row', customRoleId: null }]) }),
         }),
       } as unknown as ReturnType<typeof db.select>)
       // non-private pages (MEMBER default read)

--- a/packages/lib/src/permissions/__tests__/user-access-level-roles.test.ts
+++ b/packages/lib/src/permissions/__tests__/user-access-level-roles.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    select: vi.fn(),
+  },
+}));
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'id', driveId: 'driveId', isPrivate: 'isPrivate' },
+  drives: { id: 'id', ownerId: 'ownerId' },
+}));
+vi.mock('@pagespace/db/schema/members', () => ({
+  driveMembers: {
+    driveId: 'driveId',
+    userId: 'userId',
+    role: 'role',
+    id: 'id',
+    acceptedAt: 'acceptedAt',
+    customRoleId: 'customRoleId',
+  },
+  pagePermissions: {
+    pageId: 'pageId',
+    userId: 'userId',
+    canView: 'canView',
+    canEdit: 'canEdit',
+    canShare: 'canShare',
+    canDelete: 'canDelete',
+    expiresAt: 'expiresAt',
+    id: 'id',
+  },
+  driveRoles: { id: 'id', driveId: 'driveId', permissions: 'permissions' },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((_a: unknown, _b: unknown) => 'eq'),
+  and: vi.fn((...args: unknown[]) => ({ and: args })),
+  or: vi.fn((...args: unknown[]) => ({ or: args })),
+  isNull: vi.fn((a: unknown) => ({ isNull: a })),
+  isNotNull: vi.fn((a: unknown) => ({ isNotNull: a })),
+  gt: vi.fn((a: unknown, b: unknown) => ({ gt: { a, b } })),
+  inArray: vi.fn((a: unknown, b: unknown) => ({ inArray: { a, b } })),
+}));
+vi.mock('../../logging/logger-config', () => ({
+  loggers: {
+    api: {
+      debug: vi.fn(),
+      error: vi.fn(),
+    },
+  },
+}));
+vi.mock('../../validators/id-validators', () => ({
+  parseUserId: vi.fn(),
+  parsePageId: vi.fn(),
+}));
+
+import { getUserAccessLevel } from '../permissions';
+import { db } from '@pagespace/db/db';
+import { parseUserId, parsePageId } from '../../validators/id-validators';
+
+const VALID_USER = 'clxxxxxxxxxxxxxxxxxxxxxxx';
+const VALID_PAGE = 'clyyyyyyyyyyyyyyyyyyyyyyy';
+const VALID_DRIVE = 'clzzzzzzzzzzzzzzzzzzzzzzz';
+const CUSTOM_ROLE_ID = 'clrolexxxxxxxxxxxxxxxxxx';
+
+function mockValidators() {
+  vi.mocked(parseUserId).mockReturnValue({ success: true, data: VALID_USER });
+  vi.mocked(parsePageId).mockReturnValue({ success: true, data: VALID_PAGE });
+}
+
+function makePageRow(isPrivate = false) {
+  return [{ id: VALID_PAGE, driveId: VALID_DRIVE, driveOwnerId: 'other-owner', isPrivate }];
+}
+
+function mockSelectChain(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }),
+    }),
+  } as unknown as ReturnType<typeof db.select>;
+}
+
+function mockSelectChainWithLeftJoin(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      leftJoin: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }),
+      }),
+    }),
+  } as unknown as ReturnType<typeof db.select>;
+}
+
+describe('getUserAccessLevel — custom role (MEMBER path)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockValidators();
+  });
+
+  it('given MEMBER with custom role entry {canView:true} on a PRIVATE page, returns read-only', async () => {
+    const rolePerms = { [VALID_PAGE]: { canView: true, canEdit: false, canShare: false } };
+    vi.mocked(db.select)
+      .mockReturnValueOnce(mockSelectChainWithLeftJoin(makePageRow(true)))
+      .mockReturnValueOnce(mockSelectChain([{ role: 'MEMBER', customRoleId: CUSTOM_ROLE_ID }]))
+      .mockReturnValueOnce(mockSelectChain([]))
+      .mockReturnValueOnce(mockSelectChain([{ permissions: rolePerms }]));
+
+    const result = await getUserAccessLevel(VALID_USER, VALID_PAGE);
+    expect(result).toEqual({ canView: true, canEdit: false, canShare: false, canDelete: false });
+  });
+
+  it('given MEMBER with custom role entry {canView:true, canEdit:true} on a PRIVATE page, returns canEdit too', async () => {
+    const rolePerms = { [VALID_PAGE]: { canView: true, canEdit: true, canShare: false } };
+    vi.mocked(db.select)
+      .mockReturnValueOnce(mockSelectChainWithLeftJoin(makePageRow(true)))
+      .mockReturnValueOnce(mockSelectChain([{ role: 'MEMBER', customRoleId: CUSTOM_ROLE_ID }]))
+      .mockReturnValueOnce(mockSelectChain([]))
+      .mockReturnValueOnce(mockSelectChain([{ permissions: rolePerms }]));
+
+    const result = await getUserAccessLevel(VALID_USER, VALID_PAGE);
+    expect(result).toEqual({ canView: true, canEdit: true, canShare: false, canDelete: false });
+  });
+
+  it('given MEMBER with custom role entry {canView:true, canShare:true} on a PRIVATE page, returns canShare too', async () => {
+    const rolePerms = { [VALID_PAGE]: { canView: true, canEdit: false, canShare: true } };
+    vi.mocked(db.select)
+      .mockReturnValueOnce(mockSelectChainWithLeftJoin(makePageRow(true)))
+      .mockReturnValueOnce(mockSelectChain([{ role: 'MEMBER', customRoleId: CUSTOM_ROLE_ID }]))
+      .mockReturnValueOnce(mockSelectChain([]))
+      .mockReturnValueOnce(mockSelectChain([{ permissions: rolePerms }]));
+
+    const result = await getUserAccessLevel(VALID_USER, VALID_PAGE);
+    expect(result).toEqual({ canView: true, canEdit: false, canShare: true, canDelete: false });
+  });
+
+  it('given MEMBER with custom role but NO entry for this PRIVATE page, returns null', async () => {
+    const rolePerms = { 'other-page': { canView: true, canEdit: true, canShare: false } };
+    vi.mocked(db.select)
+      .mockReturnValueOnce(mockSelectChainWithLeftJoin(makePageRow(true)))
+      .mockReturnValueOnce(mockSelectChain([{ role: 'MEMBER', customRoleId: CUSTOM_ROLE_ID }]))
+      .mockReturnValueOnce(mockSelectChain([]))
+      .mockReturnValueOnce(mockSelectChain([{ permissions: rolePerms }]));
+
+    const result = await getUserAccessLevel(VALID_USER, VALID_PAGE);
+    expect(result).toBeNull();
+  });
+
+  it('given MEMBER with custom role but NO entry for this NON-PRIVATE page, returns read-only via Rule 4', async () => {
+    const rolePerms = { 'other-page': { canView: true, canEdit: true, canShare: false } };
+    vi.mocked(db.select)
+      .mockReturnValueOnce(mockSelectChainWithLeftJoin(makePageRow(false)))
+      .mockReturnValueOnce(mockSelectChain([{ role: 'MEMBER', customRoleId: CUSTOM_ROLE_ID }]))
+      .mockReturnValueOnce(mockSelectChain([]))
+      .mockReturnValueOnce(mockSelectChain([{ permissions: rolePerms }]));
+
+    const result = await getUserAccessLevel(VALID_USER, VALID_PAGE);
+    expect(result).toEqual({ canView: true, canEdit: false, canShare: false, canDelete: false });
+  });
+
+  it('given MEMBER with custom role entry {canView:false} on a NON-PRIVATE page, denies (explicit deny beats Rule 4)', async () => {
+    const rolePerms = { [VALID_PAGE]: { canView: false, canEdit: false, canShare: false } };
+    vi.mocked(db.select)
+      .mockReturnValueOnce(mockSelectChainWithLeftJoin(makePageRow(false)))
+      .mockReturnValueOnce(mockSelectChain([{ role: 'MEMBER', customRoleId: CUSTOM_ROLE_ID }]))
+      .mockReturnValueOnce(mockSelectChain([]))
+      .mockReturnValueOnce(mockSelectChain([{ permissions: rolePerms }]));
+
+    const result = await getUserAccessLevel(VALID_USER, VALID_PAGE);
+    expect(result).toBeNull();
+  });
+
+  it('given MEMBER with NO custom role on NON-PRIVATE page, returns read-only via Rule 4', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(mockSelectChainWithLeftJoin(makePageRow(false)))
+      .mockReturnValueOnce(mockSelectChain([{ role: 'MEMBER', customRoleId: null }]))
+      .mockReturnValueOnce(mockSelectChain([]));
+
+    const result = await getUserAccessLevel(VALID_USER, VALID_PAGE);
+    expect(result).toEqual({ canView: true, canEdit: false, canShare: false, canDelete: false });
+  });
+
+  it('given MEMBER with NO custom role on PRIVATE page, returns null', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(mockSelectChainWithLeftJoin(makePageRow(true)))
+      .mockReturnValueOnce(mockSelectChain([{ role: 'MEMBER', customRoleId: null }]))
+      .mockReturnValueOnce(mockSelectChain([]));
+
+    const result = await getUserAccessLevel(VALID_USER, VALID_PAGE);
+    expect(result).toBeNull();
+  });
+
+  it('given ADMIN, returns full access', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(mockSelectChainWithLeftJoin(makePageRow(true)))
+      .mockReturnValueOnce(mockSelectChain([{ role: 'ADMIN', customRoleId: null }]));
+
+    const result = await getUserAccessLevel(VALID_USER, VALID_PAGE);
+    expect(result).toEqual({ canView: true, canEdit: true, canShare: true, canDelete: true });
+  });
+
+  it('given drive owner, returns full access', async () => {
+    const ownerPage = [{ id: VALID_PAGE, driveId: VALID_DRIVE, driveOwnerId: VALID_USER, isPrivate: false }];
+    vi.mocked(db.select)
+      .mockReturnValueOnce(mockSelectChainWithLeftJoin(ownerPage));
+
+    const result = await getUserAccessLevel(VALID_USER, VALID_PAGE);
+    expect(result).toEqual({ canView: true, canEdit: true, canShare: true, canDelete: true });
+  });
+
+  it('given explicit pagePermissions row, it beats custom role', async () => {
+    const rolePerms = { [VALID_PAGE]: { canView: true, canEdit: false, canShare: false } };
+    const explicitPerm = [{ canView: true, canEdit: true, canShare: true, canDelete: false }];
+    vi.mocked(db.select)
+      .mockReturnValueOnce(mockSelectChainWithLeftJoin(makePageRow(true)))
+      .mockReturnValueOnce(mockSelectChain([{ role: 'MEMBER', customRoleId: CUSTOM_ROLE_ID }]))
+      .mockReturnValueOnce(mockSelectChain(explicitPerm));
+
+    const result = await getUserAccessLevel(VALID_USER, VALID_PAGE);
+    expect(result).toEqual({ canView: true, canEdit: true, canShare: true, canDelete: false });
+    expect(db.select).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/lib/src/permissions/__tests__/user-accessible-pages-roles.test.ts
+++ b/packages/lib/src/permissions/__tests__/user-accessible-pages-roles.test.ts
@@ -154,6 +154,27 @@ describe('getUserAccessiblePagesInDrive — custom role path', () => {
     expect(result).toHaveLength(0);
   });
 
+  it('given MEMBER with custom role entry {canView:false} on a NON-PRIVATE page, should remove it from accessible set', async () => {
+    const rolePerms = { 'non-private-page': { canView: false, canEdit: false, canShare: false } };
+    vi.mocked(db.select)
+      // 1. drive lookup (not owner)
+      .mockReturnValueOnce(mockChainWhere([{ ownerId: 'other-user' }]))
+      // 2. admin check (not admin)
+      .mockReturnValueOnce(mockChainWhere([]))
+      // 3. member check → has custom role
+      .mockReturnValueOnce(mockChainWhere([{ id: 'row', customRoleId: CUSTOM_ROLE_ID }]))
+      // 4. non-private pages (includes page that role will deny)
+      .mockReturnValueOnce(mockChainWhereNoLimit([{ id: 'non-private-page' }]))
+      // 5. fetchCustomRolePermissions internal call
+      .mockReturnValueOnce(mockChainWhere([{ permissions: rolePerms }]))
+      // 6. explicit permissions (none)
+      .mockReturnValueOnce(mockChainLeftJoinWhere([]));
+
+    const result = await getUserAccessiblePagesInDrive(VALID_USER, VALID_DRIVE);
+    expect(result).not.toContain('non-private-page');
+    expect(result).toHaveLength(0);
+  });
+
   it('given MEMBER with NO custom role, should behave unchanged (non-private + explicit only)', async () => {
     vi.mocked(db.select)
       // 1. drive lookup (not owner)
@@ -203,6 +224,31 @@ describe('getUserAccessiblePagesInDriveWithDetails — custom role path', () => 
     const page = result.find(p => p.id === 'page-1');
     expect(page).toBeDefined();
     expect(page?.permissions).toEqual({ canView: true, canEdit: true, canShare: false, canDelete: false });
+  });
+
+  it('given MEMBER with custom role entry {canView:false} on a NON-PRIVATE page, should remove it from the page map', async () => {
+    const rolePerms = { 'non-private-page': { canView: false, canEdit: false, canShare: false } };
+    const nonPrivatePage = [
+      { id: 'non-private-page', title: 'Public', type: 'DOCUMENT', parentId: null, position: 1, isTrashed: false },
+    ];
+    vi.mocked(db.select)
+      // 1. drive lookup (not owner)
+      .mockReturnValueOnce(mockChainWhere([{ ownerId: 'other-user' }]))
+      // 2. admin check (not admin)
+      .mockReturnValueOnce(mockChainWhere([]))
+      // 3. member check → has custom role
+      .mockReturnValueOnce(mockChainWhere([{ id: 'row', customRoleId: CUSTOM_ROLE_ID }]))
+      // 4. non-private pages (includes page that role will deny)
+      .mockReturnValueOnce(mockChainWhereNoLimit(nonPrivatePage))
+      // 5. fetchCustomRolePermissions internal call
+      .mockReturnValueOnce(mockChainWhere([{ permissions: rolePerms }]))
+      // no role pages query — no canView=true entries
+      // 6. explicit pages (none)
+      .mockReturnValueOnce(mockChainInnerJoinWhere([]));
+
+    const result = await getUserAccessiblePagesInDriveWithDetails(VALID_USER, VALID_DRIVE);
+    expect(result.find(p => p.id === 'non-private-page')).toBeUndefined();
+    expect(result).toHaveLength(0);
   });
 
   it('given MEMBER with custom role granting canView on a PRIVATE page, should include it with role perms', async () => {

--- a/packages/lib/src/permissions/__tests__/user-accessible-pages-roles.test.ts
+++ b/packages/lib/src/permissions/__tests__/user-accessible-pages-roles.test.ts
@@ -126,11 +126,36 @@ describe('getUserAccessiblePagesInDrive — custom role path', () => {
       .mockReturnValueOnce(mockChainWhereNoLimit([]))
       // 5. fetchCustomRolePermissions internal call
       .mockReturnValueOnce(mockChainWhere([{ permissions: rolePerms }]))
-      // 6. explicit permissions
+      // 6. DB validation of canView=true IDs (filters stale/trashed/wrong-drive pages)
+      .mockReturnValueOnce(mockChainWhereNoLimit([{ id: 'private-page' }]))
+      // 7. explicit permissions
       .mockReturnValueOnce(mockChainLeftJoinWhere([]));
 
     const result = await getUserAccessiblePagesInDrive(VALID_USER, VALID_DRIVE);
     expect(result).toContain('private-page');
+  });
+
+  it('given MEMBER with custom role granting canView on a stale/trashed page, should NOT include it', async () => {
+    const rolePerms = { 'stale-page': { canView: true, canEdit: false, canShare: false } };
+    vi.mocked(db.select)
+      // 1. drive lookup (not owner)
+      .mockReturnValueOnce(mockChainWhere([{ ownerId: 'other-user' }]))
+      // 2. admin check (not admin)
+      .mockReturnValueOnce(mockChainWhere([]))
+      // 3. member check → has custom role
+      .mockReturnValueOnce(mockChainWhere([{ id: 'row', customRoleId: CUSTOM_ROLE_ID }]))
+      // 4. non-private pages (none)
+      .mockReturnValueOnce(mockChainWhereNoLimit([]))
+      // 5. fetchCustomRolePermissions internal call
+      .mockReturnValueOnce(mockChainWhere([{ permissions: rolePerms }]))
+      // 6. DB validation — stale-page doesn't pass (e.g., trashed or wrong drive)
+      .mockReturnValueOnce(mockChainWhereNoLimit([]))
+      // 7. explicit permissions (none)
+      .mockReturnValueOnce(mockChainLeftJoinWhere([]));
+
+    const result = await getUserAccessiblePagesInDrive(VALID_USER, VALID_DRIVE);
+    expect(result).not.toContain('stale-page');
+    expect(result).toHaveLength(0);
   });
 
   it('given MEMBER with custom role with NO canView entry for private page, should NOT include it', async () => {

--- a/packages/lib/src/permissions/__tests__/user-accessible-pages-roles.test.ts
+++ b/packages/lib/src/permissions/__tests__/user-accessible-pages-roles.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    select: vi.fn(),
+  },
+}));
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: {
+    id: 'id',
+    driveId: 'driveId',
+    isPrivate: 'isPrivate',
+    isTrashed: 'isTrashed',
+    title: 'title',
+    type: 'type',
+    parentId: 'parentId',
+    position: 'position',
+  },
+  drives: { id: 'id', ownerId: 'ownerId' },
+}));
+vi.mock('@pagespace/db/schema/members', () => ({
+  driveMembers: {
+    driveId: 'driveId',
+    userId: 'userId',
+    role: 'role',
+    id: 'id',
+    acceptedAt: 'acceptedAt',
+    customRoleId: 'customRoleId',
+  },
+  pagePermissions: {
+    pageId: 'pageId',
+    userId: 'userId',
+    canView: 'canView',
+    canEdit: 'canEdit',
+    canShare: 'canShare',
+    canDelete: 'canDelete',
+    expiresAt: 'expiresAt',
+    id: 'id',
+  },
+  driveRoles: { id: 'id', driveId: 'driveId', permissions: 'permissions' },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((_a: unknown, _b: unknown) => 'eq'),
+  and: vi.fn((...args: unknown[]) => ({ and: args })),
+  or: vi.fn((...args: unknown[]) => ({ or: args })),
+  isNull: vi.fn((a: unknown) => ({ isNull: a })),
+  isNotNull: vi.fn((a: unknown) => ({ isNotNull: a })),
+  gt: vi.fn((a: unknown, b: unknown) => ({ gt: { a, b } })),
+  inArray: vi.fn((a: unknown, b: unknown) => ({ inArray: { a, b } })),
+}));
+vi.mock('../../logging/logger-config', () => ({
+  loggers: {
+    api: {
+      debug: vi.fn(),
+      error: vi.fn(),
+    },
+  },
+}));
+vi.mock('../../validators/id-validators', () => ({
+  parseUserId: vi.fn(),
+  parsePageId: vi.fn(),
+}));
+
+import { getUserAccessiblePagesInDrive, getUserAccessiblePagesInDriveWithDetails } from '../permissions';
+import { db } from '@pagespace/db/db';
+
+const VALID_USER = 'clxxxxxxxxxxxxxxxxxxxxxxx';
+const VALID_DRIVE = 'clzzzzzzzzzzzzzzzzzzzzzzz';
+const CUSTOM_ROLE_ID = 'clrolexxxxxxxxxxxxxxxxxx';
+
+function mockChainWhere(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({ limit: vi.fn().mockResolvedValue(rows) }),
+    }),
+  } as unknown as ReturnType<typeof db.select>;
+}
+
+function mockChainWhereNoLimit(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(rows),
+    }),
+  } as unknown as ReturnType<typeof db.select>;
+}
+
+function mockChainWhereInArray(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(rows),
+    }),
+  } as unknown as ReturnType<typeof db.select>;
+}
+
+function mockChainLeftJoinWhere(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      leftJoin: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(rows) }),
+    }),
+  } as unknown as ReturnType<typeof db.select>;
+}
+
+function mockChainInnerJoinWhere(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      innerJoin: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(rows) }),
+    }),
+  } as unknown as ReturnType<typeof db.select>;
+}
+
+describe('getUserAccessiblePagesInDrive — custom role path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('given MEMBER with custom role granting canView on a PRIVATE page, should include that private page', async () => {
+    const rolePerms = { 'private-page': { canView: true, canEdit: false, canShare: false } };
+    vi.mocked(db.select)
+      // 1. drive lookup (not owner)
+      .mockReturnValueOnce(mockChainWhere([{ ownerId: 'other-user' }]))
+      // 2. admin check (not admin)
+      .mockReturnValueOnce(mockChainWhere([]))
+      // 3. member check → has custom role
+      .mockReturnValueOnce(mockChainWhere([{ id: 'row', customRoleId: CUSTOM_ROLE_ID }]))
+      // 4. non-private pages
+      .mockReturnValueOnce(mockChainWhereNoLimit([]))
+      // 5. fetchCustomRolePermissions internal call
+      .mockReturnValueOnce(mockChainWhere([{ permissions: rolePerms }]))
+      // 6. explicit permissions
+      .mockReturnValueOnce(mockChainLeftJoinWhere([]));
+
+    const result = await getUserAccessiblePagesInDrive(VALID_USER, VALID_DRIVE);
+    expect(result).toContain('private-page');
+  });
+
+  it('given MEMBER with custom role with NO canView entry for private page, should NOT include it', async () => {
+    const rolePerms = { 'private-page': { canView: false, canEdit: false, canShare: false } };
+    vi.mocked(db.select)
+      // 1. drive lookup (not owner)
+      .mockReturnValueOnce(mockChainWhere([{ ownerId: 'other-user' }]))
+      // 2. admin check (not admin)
+      .mockReturnValueOnce(mockChainWhere([]))
+      // 3. member check → has custom role
+      .mockReturnValueOnce(mockChainWhere([{ id: 'row', customRoleId: CUSTOM_ROLE_ID }]))
+      // 4. non-private pages (none)
+      .mockReturnValueOnce(mockChainWhereNoLimit([]))
+      // 5. fetchCustomRolePermissions internal call
+      .mockReturnValueOnce(mockChainWhere([{ permissions: rolePerms }]))
+      // 6. explicit permissions (none)
+      .mockReturnValueOnce(mockChainLeftJoinWhere([]));
+
+    const result = await getUserAccessiblePagesInDrive(VALID_USER, VALID_DRIVE);
+    expect(result).not.toContain('private-page');
+    expect(result).toHaveLength(0);
+  });
+
+  it('given MEMBER with NO custom role, should behave unchanged (non-private + explicit only)', async () => {
+    vi.mocked(db.select)
+      // 1. drive lookup (not owner)
+      .mockReturnValueOnce(mockChainWhere([{ ownerId: 'other-user' }]))
+      // 2. admin check (not admin)
+      .mockReturnValueOnce(mockChainWhere([]))
+      // 3. member check → no custom role
+      .mockReturnValueOnce(mockChainWhere([{ id: 'row', customRoleId: null }]))
+      // 4. non-private pages
+      .mockReturnValueOnce(mockChainWhereNoLimit([{ id: 'non-private-page' }]))
+      // 5. explicit permissions
+      .mockReturnValueOnce(mockChainLeftJoinWhere([]));
+
+    const result = await getUserAccessiblePagesInDrive(VALID_USER, VALID_DRIVE);
+    expect(result).toContain('non-private-page');
+    expect(db.select).toHaveBeenCalledTimes(5);
+  });
+});
+
+describe('getUserAccessiblePagesInDriveWithDetails — custom role path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('given MEMBER with custom role granting canEdit on a NON-PRIVATE page, should return canEdit true', async () => {
+    const rolePerms = { 'page-1': { canView: true, canEdit: true, canShare: false } };
+    const nonPrivatePages = [
+      { id: 'page-1', title: 'Page 1', type: 'DOCUMENT', parentId: null, position: 1, isTrashed: false },
+    ];
+    vi.mocked(db.select)
+      // 1. drive lookup (not owner)
+      .mockReturnValueOnce(mockChainWhere([{ ownerId: 'other-user' }]))
+      // 2. admin check (not admin)
+      .mockReturnValueOnce(mockChainWhere([]))
+      // 3. member check → has custom role
+      .mockReturnValueOnce(mockChainWhere([{ id: 'row', customRoleId: CUSTOM_ROLE_ID }]))
+      // 4. non-private pages (page-1)
+      .mockReturnValueOnce(mockChainWhereNoLimit(nonPrivatePages))
+      // 5. fetchCustomRolePermissions internal call
+      .mockReturnValueOnce(mockChainWhere([{ permissions: rolePerms }]))
+      // 6. role pages query (inArray)
+      .mockReturnValueOnce(mockChainWhereInArray(nonPrivatePages))
+      // 7. explicit pages (none)
+      .mockReturnValueOnce(mockChainInnerJoinWhere([]));
+
+    const result = await getUserAccessiblePagesInDriveWithDetails(VALID_USER, VALID_DRIVE);
+    const page = result.find(p => p.id === 'page-1');
+    expect(page).toBeDefined();
+    expect(page?.permissions).toEqual({ canView: true, canEdit: true, canShare: false, canDelete: false });
+  });
+
+  it('given MEMBER with custom role granting canView on a PRIVATE page, should include it with role perms', async () => {
+    const rolePerms = { 'private-1': { canView: true, canEdit: false, canShare: false } };
+    const privatePage = [
+      { id: 'private-1', title: 'Private', type: 'DOCUMENT', parentId: null, position: 1, isTrashed: false },
+    ];
+    vi.mocked(db.select)
+      // 1. drive lookup (not owner)
+      .mockReturnValueOnce(mockChainWhere([{ ownerId: 'other-user' }]))
+      // 2. admin check (not admin)
+      .mockReturnValueOnce(mockChainWhere([]))
+      // 3. member check → has custom role
+      .mockReturnValueOnce(mockChainWhere([{ id: 'row', customRoleId: CUSTOM_ROLE_ID }]))
+      // 4. non-private pages (none — private-1 is private)
+      .mockReturnValueOnce(mockChainWhereNoLimit([]))
+      // 5. fetchCustomRolePermissions internal call
+      .mockReturnValueOnce(mockChainWhere([{ permissions: rolePerms }]))
+      // 6. role pages query (inArray)
+      .mockReturnValueOnce(mockChainWhereInArray(privatePage))
+      // 7. explicit pages (none)
+      .mockReturnValueOnce(mockChainInnerJoinWhere([]));
+
+    const result = await getUserAccessiblePagesInDriveWithDetails(VALID_USER, VALID_DRIVE);
+    const page = result.find(p => p.id === 'private-1');
+    expect(page).toBeDefined();
+    expect(page?.permissions).toEqual({ canView: true, canEdit: false, canShare: false, canDelete: false });
+  });
+});

--- a/packages/lib/src/permissions/permissions.ts
+++ b/packages/lib/src/permissions/permissions.ts
@@ -1,9 +1,11 @@
 import { db } from '@pagespace/db/db';
 import { and, eq, or, isNull, isNotNull, gt, inArray } from '@pagespace/db/operators';
 import { pages, drives } from '@pagespace/db/schema/core';
-import { driveMembers, pagePermissions } from '@pagespace/db/schema/members';
+import { driveMembers, pagePermissions, driveRoles } from '@pagespace/db/schema/members';
 import { loggers } from '../logging/logger-config';
 import { parseUserId, parsePageId } from '../validators/id-validators';
+import { fetchCustomRolePermissions, type CustomRolePerms } from './membership-queries';
+import { resolveRolePermissions } from './resolve-role-permissions';
 
 /**
  * Permission level for a single page.
@@ -187,27 +189,29 @@ export async function getUserAccessLevel(
       };
     }
 
+    let memberRole: string | null = null;
+    let memberCustomRoleId: string | null = null;
+
     if (pageData.driveId) {
-      const adminMembership = await db.select()
+      const memberRow = await db.select({ role: driveMembers.role, customRoleId: driveMembers.customRoleId })
         .from(driveMembers)
         .where(and(
           eq(driveMembers.driveId, pageData.driveId),
           eq(driveMembers.userId, validUserId),
-          eq(driveMembers.role, 'ADMIN'),
           isNotNull(driveMembers.acceptedAt)
         ))
         .limit(1);
 
-      if (adminMembership.length > 0) {
-        if (!silent) {
-          loggers.api.debug(`[PERMISSIONS] User is drive admin - granting full access`);
+      if (memberRow.length > 0) {
+        memberRole = memberRow[0].role;
+        memberCustomRoleId = memberRow[0].customRoleId;
+
+        if (memberRole === 'ADMIN') {
+          if (!silent) {
+            loggers.api.debug(`[PERMISSIONS] User is drive admin - granting full access`);
+          }
+          return { canView: true, canEdit: true, canShare: true, canDelete: true };
         }
-        return {
-          canView: true,
-          canEdit: true,
-          canShare: true,
-          canDelete: true,
-        };
       }
     }
 
@@ -225,23 +229,19 @@ export async function getUserAccessLevel(
       .limit(1);
 
     if (permission.length === 0) {
-      // Rule 4: any accepted drive member can read non-private pages (Discord @everyone)
-      if (pageData.driveId && !pageData.isPrivate) {
-        const membership = await db.select({ id: driveMembers.id })
-          .from(driveMembers)
-          .where(and(
-            eq(driveMembers.driveId, pageData.driveId),
-            eq(driveMembers.userId, validUserId),
-            isNotNull(driveMembers.acceptedAt)
-          ))
-          .limit(1);
-
-        if (membership.length > 0) {
-          if (!silent) {
-            loggers.api.debug(`[PERMISSIONS] User is drive member, page is not private - granting read access`);
-          }
-          return { canView: true, canEdit: false, canShare: false, canDelete: false };
+      if (memberCustomRoleId && pageData.driveId) {
+        const rolePerms = await fetchCustomRolePermissions(memberCustomRoleId, pageData.driveId);
+        if (rolePerms && (rolePerms as CustomRolePerms)[validPageId] !== undefined) {
+          const resolved = resolveRolePermissions('MEMBER', rolePerms as CustomRolePerms, validPageId);
+          return resolved.canView ? resolved : null;
         }
+      }
+
+      if (memberRole !== null && pageData.driveId && !pageData.isPrivate) {
+        if (!silent) {
+          loggers.api.debug(`[PERMISSIONS] User is drive member, page is not private - granting read access`);
+        }
+        return { canView: true, canEdit: false, canShare: false, canDelete: false };
       }
 
       if (!silent) {
@@ -397,8 +397,7 @@ export async function getUserAccessiblePagesInDrive(
     return allPages.map((page: { id: string }) => page.id);
   }
 
-  // Rule 4: MEMBER gets implicit read on non-private pages
-  const isMember = await db.select({ id: driveMembers.id })
+  const memberCheck = await db.select({ id: driveMembers.id, customRoleId: driveMembers.customRoleId })
     .from(driveMembers)
     .where(and(
       eq(driveMembers.driveId, driveId),
@@ -407,9 +406,11 @@ export async function getUserAccessiblePagesInDrive(
     ))
     .limit(1);
 
+  const memberRow = memberCheck[0] ?? null;
+
   const pageIdSet = new Set<string>();
 
-  if (isMember.length > 0) {
+  if (memberRow) {
     const nonPrivatePages = await db.select({ id: pages.id })
       .from(pages)
       .where(and(
@@ -418,6 +419,16 @@ export async function getUserAccessiblePagesInDrive(
         eq(pages.isTrashed, false)
       ));
     for (const p of nonPrivatePages) pageIdSet.add(p.id);
+
+    if (memberRow.customRoleId) {
+      const rolePerms = await fetchCustomRolePermissions(memberRow.customRoleId, driveId);
+      if (rolePerms) {
+        const visiblePageIds = Object.entries(rolePerms)
+          .filter(([, p]) => p.canView)
+          .map(([id]) => id);
+        for (const id of visiblePageIds) pageIdSet.add(id);
+      }
+    }
   }
 
   const explicitPermissions = await db.select({ pageId: pagePermissions.pageId })
@@ -513,7 +524,7 @@ export async function getUserAccessiblePagesInDriveWithDetails(
     }));
   }
 
-  const memberCheck = await db.select({ id: driveMembers.id })
+  const memberCheck = await db.select({ id: driveMembers.id, customRoleId: driveMembers.customRoleId })
     .from(driveMembers)
     .where(and(
       eq(driveMembers.driveId, driveId),
@@ -548,6 +559,36 @@ export async function getUserAccessiblePagesInDriveWithDetails(
         ...page,
         permissions: { canView: true, canEdit: false, canShare: false, canDelete: false },
       });
+    }
+  }
+
+  const memberCustomRoleId = memberCheck[0]?.customRoleId ?? null;
+  if (memberCustomRoleId) {
+    const rolePerms = await fetchCustomRolePermissions(memberCustomRoleId, driveId);
+    if (rolePerms) {
+      const visiblePageIds = Object.entries(rolePerms)
+        .filter(([, p]) => p.canView)
+        .map(([id]) => id);
+
+      if (visiblePageIds.length > 0) {
+        const rolePages = await db.select({
+          id: pages.id,
+          title: pages.title,
+          type: pages.type,
+          parentId: pages.parentId,
+          position: pages.position,
+          isTrashed: pages.isTrashed,
+        })
+        .from(pages)
+        .where(and(inArray(pages.id, visiblePageIds), eq(pages.driveId, driveId), eq(pages.isTrashed, false)));
+
+        for (const page of rolePages) {
+          pageMap.set(page.id, {
+            ...page,
+            permissions: resolveRolePermissions('MEMBER', rolePerms, page.id),
+          });
+        }
+      }
     }
   }
 
@@ -898,6 +939,7 @@ export async function getBatchPagePermissions(
         explicitCanEdit: pagePermissions.canEdit,
         explicitCanShare: pagePermissions.canShare,
         explicitCanDelete: pagePermissions.canDelete,
+        customRolePerms: driveRoles.permissions,
       })
       .from(pages)
       .leftJoin(drives, eq(drives.id, pages.driveId))
@@ -918,6 +960,13 @@ export async function getBatchPagePermissions(
             isNull(pagePermissions.expiresAt),
             gt(pagePermissions.expiresAt, new Date())
           )
+        )
+      )
+      .leftJoin(
+        driveRoles,
+        and(
+          eq(driveRoles.id, driveMembers.customRoleId),
+          eq(driveRoles.driveId, pages.driveId)
         )
       )
       .where(inArray(pages.id, pageIds));
@@ -949,6 +998,15 @@ export async function getBatchPagePermissions(
           canDelete: row.explicitCanDelete ?? false,
         });
         continue;
+      }
+
+      if (row.customRolePerms) {
+        const perms = row.customRolePerms as CustomRolePerms;
+        const entry = perms[row.pageId];
+        if (entry !== undefined) {
+          results.set(row.pageId, resolveRolePermissions('MEMBER', perms, row.pageId));
+          continue;
+        }
       }
 
       // Rule 4: any accepted drive member gets read access to non-private pages

--- a/packages/lib/src/permissions/permissions.ts
+++ b/packages/lib/src/permissions/permissions.ts
@@ -423,13 +423,25 @@ export async function getUserAccessiblePagesInDrive(
     if (memberRow.customRoleId) {
       const rolePerms = await fetchCustomRolePermissions(memberRow.customRoleId, driveId);
       if (rolePerms) {
+        const visiblePageIds = Object.entries(rolePerms)
+          .filter(([, p]) => p.canView)
+          .map(([id]) => id);
+
+        if (visiblePageIds.length > 0) {
+          // Validate IDs against the DB to exclude stale, trashed, or out-of-drive pages
+          const validRolePages = await db.select({ id: pages.id })
+            .from(pages)
+            .where(and(
+              inArray(pages.id, visiblePageIds),
+              eq(pages.driveId, driveId),
+              eq(pages.isTrashed, false)
+            ));
+          for (const page of validRolePages) pageIdSet.add(page.id);
+        }
+
+        // Explicit deny beats Rule 4: remove non-private pages the role disallows
         for (const [id, p] of Object.entries(rolePerms)) {
-          if (p.canView) {
-            pageIdSet.add(id);
-          } else {
-            // Explicit deny beats Rule 4 for non-private pages already in the set
-            pageIdSet.delete(id);
-          }
+          if (!p.canView) pageIdSet.delete(id);
         }
       }
     }

--- a/packages/lib/src/permissions/permissions.ts
+++ b/packages/lib/src/permissions/permissions.ts
@@ -423,10 +423,14 @@ export async function getUserAccessiblePagesInDrive(
     if (memberRow.customRoleId) {
       const rolePerms = await fetchCustomRolePermissions(memberRow.customRoleId, driveId);
       if (rolePerms) {
-        const visiblePageIds = Object.entries(rolePerms)
-          .filter(([, p]) => p.canView)
-          .map(([id]) => id);
-        for (const id of visiblePageIds) pageIdSet.add(id);
+        for (const [id, p] of Object.entries(rolePerms)) {
+          if (p.canView) {
+            pageIdSet.add(id);
+          } else {
+            // Explicit deny beats Rule 4 for non-private pages already in the set
+            pageIdSet.delete(id);
+          }
+        }
       }
     }
   }
@@ -587,6 +591,13 @@ export async function getUserAccessiblePagesInDriveWithDetails(
             ...page,
             permissions: resolveRolePermissions('MEMBER', rolePerms, page.id),
           });
+        }
+      }
+
+      // Explicit deny beats Rule 4: remove non-private pages the role disallows
+      for (const [id, p] of Object.entries(rolePerms)) {
+        if (!p.canView) {
+          pageMap.delete(id);
         }
       }
     }


### PR DESCRIPTION
## Summary

- **Root cause**: \`driveRoles.permissions\` (JSONB: \`Record<pageId, {canView,canEdit,canShare}>\`) was fully wired for AI agents and MCP tokens but had **zero effect on human users**. \`permissions.ts\` never read \`customRoleId\` from \`driveMembers\` or called \`resolveRolePermissions()\`.
- **Fix**: All four human permission functions now implement the correct priority stack — owner → admin → explicit grant → **custom role** → Rule 4 (@everyone) → denied.
- **No schema changes** — the JSONB structure already supported this; it just wasn't consulted.
- **Kick-on-protect fix**: The privacy instant-revocation query now also excludes members who retain access via a custom role (the previous exclusion only covered explicit \`pagePermissions\` rows).

## Functions fixed

| Function | Change |
|---|---|
| \`getUserAccessLevel()\` | Replaced separate admin-only query with combined membership query (\`role + customRoleId\`); checks custom role after explicit grants, before Rule 4 |
| \`getBatchPagePermissions()\` | Added \`driveRoles\` left join to the existing single-query batch; custom role resolution step inserted between explicit grant and Rule 4 (preserves one-DB-call invariant) |
| \`getUserAccessiblePagesInDrive()\` | Member check now fetches \`customRoleId\`; adds validated pages where \`role.canView=true\` (DB-validated: not trashed, same drive); removes pages where role has \`canView=false\` |
| \`getUserAccessiblePagesInDriveWithDetails()\` | Same pattern; custom role pages overwrite Rule 4 read-only with the richer role-derived permission level; \`canView=false\` entries remove pages granted by Rule 4 |
| Privacy kick (\`PATCH /api/pages/:id\`) | Extended the kick exclusion query to also skip members whose custom role grants \`canView\` on the page via JSONB |

## Behaviour

- Custom role with \`canView:true\` on a **private** page → member can now access it
- Custom role with \`canEdit:true\` on any page → member gets edit access (not just read-only)
- Custom role with explicit \`canView:false\` on a non-private page → access denied (beats Rule 4)
- Custom role has **no entry** for a page → falls through to Rule 4 (unchanged)
- Explicit \`pagePermissions\` row always takes precedence over custom role (step 3 before 4)
- \`canDelete\` remains always-false for MEMBER/custom-role path (enforced by \`resolveRolePermissions\`)
- Members with custom role access are not kicked when a page is made private
- Stale/trashed page IDs from custom role JSONB are filtered via DB validation before inclusion

## Tests

- \`user-access-level-roles.test.ts\` — 11 new tests covering all \`getUserAccessLevel\` custom role cases
- \`user-accessible-pages-roles.test.ts\` — 8 new tests for accessible pages custom role paths (including deny and stale-ID cases)
- \`batch-page-permissions.test.ts\` — 5 new custom role cases; updated mock chain for 4th join
- \`permissions.test.ts\` — updated mocks to match restructured combined membership query
- \`route.test.ts\` — new test: members with custom role access are not kicked during privacy transition

93 tests pass across the modified/created files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)