### PR TITLE
feat(permissions): Discord-style role-based private page access

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/permissions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/permissions/__tests__/route.test.ts
@@ -23,6 +23,9 @@ vi.mock('@/services/api', () => ({
     canUserViewPermissions: vi.fn(),
     getPagePermissions: vi.fn(),
   },
+  rolePermissionService: {
+    getPageRoleGrants: vi.fn().mockResolvedValue([]),
+  },
 }));
 
 // Mock auth boundary - different auth for GET vs POST/DELETE

--- a/apps/web/src/app/api/pages/[pageId]/permissions/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/permissions/route.ts
@@ -10,7 +10,7 @@ import { createPermissionNotification } from '@pagespace/lib/notifications/notif
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log'
 import { grantPagePermission, revokePagePermission } from '@pagespace/lib/permissions/permission-mutations';
-import { permissionManagementService } from '@/services/api';
+import { permissionManagementService, rolePermissionService } from '@/services/api';
 import { db } from '@pagespace/db/db'
 import { eq } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core';
@@ -41,7 +41,10 @@ export async function GET(req: Request, { params }: { params: Promise<{ pageId: 
     }
 
     // Get permissions
-    const result = await permissionManagementService.getPagePermissions(pageId);
+    const [result, roles] = await Promise.all([
+      permissionManagementService.getPagePermissions(pageId),
+      rolePermissionService.getPageRoleGrants(pageId),
+    ]);
     if (!result.success) {
       return NextResponse.json({ error: result.error }, { status: result.status });
     }
@@ -49,6 +52,7 @@ export async function GET(req: Request, { params }: { params: Promise<{ pageId: 
     return NextResponse.json({
       owner: result.owner,
       permissions: result.permissions,
+      roles,
     });
   } catch (error) {
     loggers.api.error('Error fetching permissions:', error as Error);

--- a/apps/web/src/app/api/pages/[pageId]/role-permissions/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/role-permissions/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from 'next/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { z } from 'zod/v4';
+import { rolePermissionService } from '@/services/api';
+
+const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
+const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
+
+export async function GET(req: Request, { params }: { params: Promise<{ pageId: string }> }) {
+  const auth = await authenticateRequestWithOptions(req, AUTH_OPTIONS_READ);
+  if (isAuthError(auth)) return auth.error;
+
+  const { pageId } = await params;
+
+  const roles = await rolePermissionService.getPageRoleGrants(pageId);
+  return NextResponse.json({ roles });
+}
+
+const putSchema = z.object({
+  roleId: z.string(),
+  canView: z.boolean().default(true),
+  canEdit: z.boolean().default(false),
+  canShare: z.boolean().default(false),
+});
+
+export async function PUT(req: Request, { params }: { params: Promise<{ pageId: string }> }) {
+  const auth = await authenticateRequestWithOptions(req, AUTH_OPTIONS_WRITE);
+  if (isAuthError(auth)) return auth.error;
+
+  const { pageId } = await params;
+
+  const body = await req.json();
+  const parsed = putSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues }, { status: 400 });
+  }
+  const { roleId, canView, canEdit, canShare } = parsed.data;
+
+  const result = await rolePermissionService.setRolePagePermission(
+    auth.userId,
+    pageId,
+    roleId,
+    { canView, canEdit, canShare },
+  );
+
+  if (!result.success) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json({ success: true });
+}
+
+const deleteSchema = z.object({
+  roleId: z.string(),
+});
+
+export async function DELETE(req: Request, { params }: { params: Promise<{ pageId: string }> }) {
+  const auth = await authenticateRequestWithOptions(req, AUTH_OPTIONS_WRITE);
+  if (isAuthError(auth)) return auth.error;
+
+  const { pageId } = await params;
+
+  const body = await req.json();
+  const parsed = deleteSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues }, { status: 400 });
+  }
+
+  const result = await rolePermissionService.removeRolePagePermission(
+    auth.userId,
+    pageId,
+    parsed.data.roleId,
+  );
+
+  if (!result.success) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/apps/web/src/app/api/pages/[pageId]/role-permissions/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/role-permissions/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { z } from 'zod/v4';
-import { rolePermissionService } from '@/services/api';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { permissionManagementService, rolePermissionService } from '@/services/api';
 
 const AUTH_OPTIONS_READ = { allow: ['session'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
@@ -12,8 +14,21 @@ export async function GET(req: Request, { params }: { params: Promise<{ pageId: 
 
   const { pageId } = await params;
 
-  const roles = await rolePermissionService.getPageRoleGrants(pageId);
-  return NextResponse.json({ roles });
+  try {
+    const canView = await permissionManagementService.canUserViewPermissions(auth.userId, pageId);
+    if (!canView) {
+      return NextResponse.json(
+        { error: 'You need share permission to view role access for this page' },
+        { status: 403 }
+      );
+    }
+
+    const roles = await rolePermissionService.getPageRoleGrants(pageId);
+    return NextResponse.json({ roles });
+  } catch (error) {
+    loggers.api.error('Error fetching role permissions:', error as Error);
+    return NextResponse.json({ error: 'Failed to fetch role permissions' }, { status: 500 });
+  }
 }
 
 const putSchema = z.object({
@@ -29,25 +44,38 @@ export async function PUT(req: Request, { params }: { params: Promise<{ pageId: 
 
   const { pageId } = await params;
 
-  const body = await req.json();
-  const parsed = putSchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.issues }, { status: 400 });
+  try {
+    const body = await req.json();
+    const parsed = putSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.issues }, { status: 400 });
+    }
+    const { roleId, canView, canEdit, canShare } = parsed.data;
+
+    const result = await rolePermissionService.setRolePagePermission(
+      auth.userId,
+      pageId,
+      roleId,
+      { canView, canEdit, canShare },
+    );
+
+    if (!result.success) {
+      return NextResponse.json({ error: result.error }, { status: result.status });
+    }
+
+    auditRequest(req, {
+      eventType: 'authz.role_permission.granted',
+      userId: auth.userId,
+      resourceType: 'page',
+      resourceId: pageId,
+      details: { roleId, canView, canEdit, canShare },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    loggers.api.error('Error setting role permission:', error as Error);
+    return NextResponse.json({ error: 'Failed to set role permission' }, { status: 500 });
   }
-  const { roleId, canView, canEdit, canShare } = parsed.data;
-
-  const result = await rolePermissionService.setRolePagePermission(
-    auth.userId,
-    pageId,
-    roleId,
-    { canView, canEdit, canShare },
-  );
-
-  if (!result.success) {
-    return NextResponse.json({ error: result.error }, { status: result.status });
-  }
-
-  return NextResponse.json({ success: true });
 }
 
 const deleteSchema = z.object({
@@ -60,21 +88,34 @@ export async function DELETE(req: Request, { params }: { params: Promise<{ pageI
 
   const { pageId } = await params;
 
-  const body = await req.json();
-  const parsed = deleteSchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.issues }, { status: 400 });
+  try {
+    const body = await req.json();
+    const parsed = deleteSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.issues }, { status: 400 });
+    }
+
+    const result = await rolePermissionService.removeRolePagePermission(
+      auth.userId,
+      pageId,
+      parsed.data.roleId,
+    );
+
+    if (!result.success) {
+      return NextResponse.json({ error: result.error }, { status: result.status });
+    }
+
+    auditRequest(req, {
+      eventType: 'authz.role_permission.revoked',
+      userId: auth.userId,
+      resourceType: 'page',
+      resourceId: pageId,
+      details: { roleId: parsed.data.roleId },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    loggers.api.error('Error removing role permission:', error as Error);
+    return NextResponse.json({ error: 'Failed to remove role permission' }, { status: 500 });
   }
-
-  const result = await rolePermissionService.removeRolePagePermission(
-    auth.userId,
-    pageId,
-    parsed.data.roleId,
-  );
-
-  if (!result.success) {
-    return NextResponse.json({ error: result.error }, { status: result.status });
-  }
-
-  return NextResponse.json({ success: true });
 }

--- a/apps/web/src/app/api/pages/[pageId]/role-permissions/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/role-permissions/route.ts
@@ -64,7 +64,7 @@ export async function PUT(req: Request, { params }: { params: Promise<{ pageId: 
     }
 
     auditRequest(req, {
-      eventType: 'authz.role_permission.granted',
+      eventType: 'authz.permission.granted',
       userId: auth.userId,
       resourceType: 'page',
       resourceId: pageId,
@@ -106,7 +106,7 @@ export async function DELETE(req: Request, { params }: { params: Promise<{ pageI
     }
 
     auditRequest(req, {
-      eventType: 'authz.role_permission.revoked',
+      eventType: 'authz.permission.revoked',
       userId: auth.userId,
       resourceType: 'page',
       resourceId: pageId,

--- a/apps/web/src/components/layout/left-sidebar/page-tree/PageTreeItem.tsx
+++ b/apps/web/src/components/layout/left-sidebar/page-tree/PageTreeItem.tsx
@@ -19,6 +19,7 @@ import {
   Copy,
   Lock,
   LockOpen,
+  Users,
 } from "lucide-react";
 import { useTouchDevice } from "@/hooks/useTouchDevice";
 import { useCapacitor } from "@/hooks/useCapacitor";
@@ -39,6 +40,7 @@ import { DeletePageDialog } from "@/components/dialogs/DeletePageDialog";
 import { RenameDialog } from "@/components/dialogs/RenameDialog";
 import { MovePageDialog } from "@/components/dialogs/MovePageDialog";
 import { CopyPageDialog } from "@/components/dialogs/CopyPageDialog";
+import { ShareDialog } from "@/components/layout/middle-content/content-header/page-settings/ShareDialog";
 import { patch, del, post } from "@/lib/auth/auth-fetch";
 import { Projection } from "@/lib/tree/sortable-tree";
 import { cn } from "@/lib/utils";
@@ -109,6 +111,7 @@ export const PageTreeItem = React.memo(function PageTreeItem({
   const [isRenameOpen, setRenameOpen] = useState(false);
   const [isMoveOpen, setMoveOpen] = useState(false);
   const [isCopyOpen, setCopyOpen] = useState(false);
+  const [isPermissionsOpen, setPermissionsOpen] = useState(false);
   const params = useParams();
   const { addFavorite, removeFavorite, isFavorite } = useFavorites();
   const createTab = useTabsStore((state) => state.createTab);
@@ -451,6 +454,10 @@ export const PageTreeItem = React.memo(function PageTreeItem({
                   )}
                   <span>{item.isPrivate ? "Unprotect page" : "Protect page"}</span>
                 </ContextMenuItem>
+                <ContextMenuItem onSelect={() => setPermissionsOpen(true)}>
+                  <Users className="mr-2 h-4 w-4" />
+                  <span>Permissions</span>
+                </ContextMenuItem>
                 <ContextMenuSeparator />
                 <ContextMenuItem onSelect={handleEnterMultiSelect}>
                   <CheckSquare className="mr-2 h-4 w-4" />
@@ -517,6 +524,13 @@ export const PageTreeItem = React.memo(function PageTreeItem({
         onClose={() => setCopyOpen(false)}
         pages={[pageInfo]}
         onSuccess={() => mutate()}
+      />
+
+      <ShareDialog
+        pageId={item.id}
+        defaultTab="permissions"
+        open={isPermissionsOpen}
+        onOpenChange={setPermissionsOpen}
       />
     </>
   );

--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/PermissionsList.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/PermissionsList.tsx
@@ -169,10 +169,7 @@ export function PermissionsList({ pageId: propPageId }: { pageId?: string | null
       updatedRole[field] = value;
     }
 
-    setData({
-      ...data,
-      roles: data.roles.map(r => r.roleId === roleId ? updatedRole : r),
-    });
+    setData(prev => prev ? { ...prev, roles: prev.roles.map(r => r.roleId === roleId ? updatedRole : r) } : prev);
 
     setUpdatingRoles(prev => new Set(prev).add(roleId));
 
@@ -186,10 +183,7 @@ export function PermissionsList({ pageId: propPageId }: { pageId?: string | null
     } catch (error) {
       console.error(error);
       toast.error('Failed to update role permission.');
-      setData({
-        ...data,
-        roles: data.roles.map(r => r.roleId === roleId ? currentRole : r),
-      });
+      setData(prev => prev ? { ...prev, roles: prev.roles.map(r => r.roleId === roleId ? currentRole : r) } : prev);
     } finally {
       setUpdatingRoles(prev => {
         const newSet = new Set(prev);
@@ -204,10 +198,7 @@ export function PermissionsList({ pageId: propPageId }: { pageId?: string | null
 
     const originalData = data;
 
-    setData({
-      ...data,
-      roles: data.roles.filter(r => r.roleId !== roleId),
-    });
+    setData(prev => prev ? { ...prev, roles: prev.roles.filter(r => r.roleId !== roleId) } : prev);
 
     try {
       await del(`/api/pages/${pageId}/role-permissions`, { roleId });

--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/PermissionsList.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/PermissionsList.tsx
@@ -36,8 +36,9 @@ type PermissionsData = {
   roles: RoleGrant[];
 };
 
-export function PermissionsList() {
-  const pageId = usePageStore((state) => state.pageId);
+export function PermissionsList({ pageId: propPageId }: { pageId?: string | null } = {}) {
+  const storePageId = usePageStore((state) => state.pageId);
+  const pageId = propPageId ?? storePageId;
   const [data, setData] = useState<PermissionsData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [updatingPermissions, setUpdatingPermissions] = useState<Set<string>>(new Set());
@@ -264,9 +265,9 @@ export function PermissionsList() {
               <div className="flex items-center space-x-3">
                 <div
                   className="h-8 w-8 rounded-full flex items-center justify-center"
-                  style={{ backgroundColor: role.color ?? undefined }}
+                  style={{ backgroundColor: role.color ?? 'hsl(var(--muted))' }}
                 >
-                  <Users className="h-4 w-4 text-white" />
+                  <Users className={`h-4 w-4 ${role.color ? 'text-white' : 'text-muted-foreground'}`} />
                 </div>
                 <div>
                   <p className="text-sm font-medium">{role.name}</p>

--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/PermissionsList.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/PermissionsList.tsx
@@ -6,9 +6,10 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Trash2, Shield } from 'lucide-react';
+import { Trash2, Shield, Users } from 'lucide-react';
 import { toast } from 'sonner';
-import { post, del, fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { post, del, put, fetchWithAuth } from '@/lib/auth/auth-fetch';
+import type { RoleGrant } from '@/services/api';
 
 type User = {
   id: string;
@@ -32,6 +33,7 @@ type Permission = {
 type PermissionsData = {
   owner: User;
   permissions: Permission[];
+  roles: RoleGrant[];
 };
 
 export function PermissionsList() {
@@ -39,6 +41,7 @@ export function PermissionsList() {
   const [data, setData] = useState<PermissionsData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [updatingPermissions, setUpdatingPermissions] = useState<Set<string>>(new Set());
+  const [updatingRoles, setUpdatingRoles] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     if (!pageId) return;
@@ -70,32 +73,26 @@ export function PermissionsList() {
   ) => {
     if (!data || !pageId) return;
 
-    // Find current permission
     const currentPerm = data.permissions.find(p => p.userId === userId);
     if (!currentPerm) return;
 
-    // Create updated permission object
     const updatedPerm = { ...currentPerm };
-    
-    // Handle permission dependencies
+
     if (field === 'canView' && !value) {
-      // If removing view, remove all permissions
       updatedPerm.canView = false;
       updatedPerm.canEdit = false;
       updatedPerm.canShare = false;
       updatedPerm.canDelete = false;
     } else if ((field === 'canEdit' || field === 'canShare' || field === 'canDelete') && value) {
-      // If granting other permissions, ensure view is granted
       updatedPerm.canView = true;
       updatedPerm[field] = value;
     } else {
       updatedPerm[field] = value;
     }
 
-    // Optimistic update
     setData({
       ...data,
-      permissions: data.permissions.map(p => 
+      permissions: data.permissions.map(p =>
         p.userId === userId ? updatedPerm : p
       )
     });
@@ -113,10 +110,9 @@ export function PermissionsList() {
     } catch (error) {
       console.error(error);
       toast.error('Failed to update permission.');
-      // Revert optimistic update
       setData({
         ...data,
-        permissions: data.permissions.map(p => 
+        permissions: data.permissions.map(p =>
           p.userId === userId ? currentPerm : p
         )
       });
@@ -133,8 +129,7 @@ export function PermissionsList() {
     if (!data || !pageId) return;
 
     const originalData = data;
-    
-    // Optimistic update
+
     setData({
       ...data,
       permissions: data.permissions.filter(p => p.userId !== userId)
@@ -142,12 +137,83 @@ export function PermissionsList() {
 
     try {
       await del(`/api/pages/${pageId}/permissions`, { userId });
-
       toast.success('Permission removed.');
     } catch (error) {
       console.error(error);
       toast.error('Failed to remove permission.');
-      // Revert optimistic update
+      setData(originalData);
+    }
+  };
+
+  const handleRolePermissionUpdate = async (
+    roleId: string,
+    field: 'canView' | 'canEdit' | 'canShare',
+    value: boolean
+  ) => {
+    if (!data || !pageId) return;
+
+    const currentRole = data.roles.find(r => r.roleId === roleId);
+    if (!currentRole) return;
+
+    const updatedRole = { ...currentRole };
+
+    if (field === 'canView' && !value) {
+      updatedRole.canView = false;
+      updatedRole.canEdit = false;
+      updatedRole.canShare = false;
+    } else if ((field === 'canEdit' || field === 'canShare') && value) {
+      updatedRole.canView = true;
+      updatedRole[field] = value;
+    } else {
+      updatedRole[field] = value;
+    }
+
+    setData({
+      ...data,
+      roles: data.roles.map(r => r.roleId === roleId ? updatedRole : r),
+    });
+
+    setUpdatingRoles(prev => new Set(prev).add(roleId));
+
+    try {
+      await put(`/api/pages/${pageId}/role-permissions`, {
+        roleId,
+        canView: updatedRole.canView,
+        canEdit: updatedRole.canEdit,
+        canShare: updatedRole.canShare,
+      });
+    } catch (error) {
+      console.error(error);
+      toast.error('Failed to update role permission.');
+      setData({
+        ...data,
+        roles: data.roles.map(r => r.roleId === roleId ? currentRole : r),
+      });
+    } finally {
+      setUpdatingRoles(prev => {
+        const newSet = new Set(prev);
+        newSet.delete(roleId);
+        return newSet;
+      });
+    }
+  };
+
+  const handleRemoveRolePermission = async (roleId: string) => {
+    if (!data || !pageId) return;
+
+    const originalData = data;
+
+    setData({
+      ...data,
+      roles: data.roles.filter(r => r.roleId !== roleId),
+    });
+
+    try {
+      await del(`/api/pages/${pageId}/role-permissions`, { roleId });
+      toast.success('Role access removed.');
+    } catch (error) {
+      console.error(error);
+      toast.error('Failed to remove role access.');
       setData(originalData);
     }
   };
@@ -162,7 +228,7 @@ export function PermissionsList() {
     );
   }
 
-  const { owner, permissions } = data;
+  const { owner, permissions, roles } = data;
 
   return (
     <div className="space-y-4">
@@ -186,96 +252,171 @@ export function PermissionsList() {
         </div>
       </div>
 
+      {/* Role Access */}
+      {roles.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Roles</p>
+          {roles.map((role) => (
+            <div
+              key={role.roleId}
+              className="flex items-center justify-between p-3 border rounded-lg"
+            >
+              <div className="flex items-center space-x-3">
+                <div
+                  className="h-8 w-8 rounded-full flex items-center justify-center"
+                  style={{ backgroundColor: role.color ?? undefined }}
+                >
+                  <Users className="h-4 w-4 text-white" />
+                </div>
+                <div>
+                  <p className="text-sm font-medium">{role.name}</p>
+                  <p className="text-xs text-muted-foreground">Role</p>
+                </div>
+              </div>
+
+              <div className="flex items-center space-x-4">
+                <div className="flex items-center space-x-3">
+                  <label className="flex items-center space-x-1">
+                    <Checkbox
+                      checked={role.canView}
+                      disabled={updatingRoles.has(role.roleId)}
+                      onCheckedChange={(checked) =>
+                        handleRolePermissionUpdate(role.roleId, 'canView', !!checked)
+                      }
+                    />
+                    <span className="text-xs">View</span>
+                  </label>
+
+                  <label className="flex items-center space-x-1">
+                    <Checkbox
+                      checked={role.canEdit}
+                      disabled={!role.canView || updatingRoles.has(role.roleId)}
+                      onCheckedChange={(checked) =>
+                        handleRolePermissionUpdate(role.roleId, 'canEdit', !!checked)
+                      }
+                    />
+                    <span className="text-xs">Edit</span>
+                  </label>
+
+                  <label className="flex items-center space-x-1">
+                    <Checkbox
+                      checked={role.canShare}
+                      disabled={!role.canView || updatingRoles.has(role.roleId)}
+                      onCheckedChange={(checked) =>
+                        handleRolePermissionUpdate(role.roleId, 'canShare', !!checked)
+                      }
+                    />
+                    <span className="text-xs">Share</span>
+                  </label>
+                </div>
+
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleRemoveRolePermission(role.roleId)}
+                  className="text-red-600 hover:text-red-700"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
       {/* Shared Users */}
-      {permissions.length === 0 ? (
+      {permissions.length === 0 && roles.length === 0 ? (
         <p className="text-sm text-muted-foreground text-center py-4">
           This page hasn&apos;t been shared with anyone yet.
         </p>
-      ) : (
-        permissions.map((permission) => (
-          <div
-            key={permission.id}
-            className="flex items-center justify-between p-3 border rounded-lg"
-          >
-            <div className="flex items-center space-x-3">
-              <Avatar className="h-8 w-8">
-                <AvatarImage src={permission.user?.image || undefined} />
-                <AvatarFallback>
-                  {permission.user?.name?.[0]?.toUpperCase() || 
-                   permission.user?.email?.[0]?.toUpperCase() || '?'}
-                </AvatarFallback>
-              </Avatar>
-              <div>
-                <p className="text-sm font-medium">
-                  {permission.user?.name || permission.user?.email || 'Unknown User'}
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  {permission.user?.email}
-                </p>
-              </div>
-            </div>
-            
-            <div className="flex items-center space-x-4">
-              {/* Permission Checkboxes */}
+      ) : permissions.length > 0 ? (
+        <div className="space-y-2">
+          {roles.length > 0 && (
+            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">People</p>
+          )}
+          {permissions.map((permission) => (
+            <div
+              key={permission.id}
+              className="flex items-center justify-between p-3 border rounded-lg"
+            >
               <div className="flex items-center space-x-3">
-                <label className="flex items-center space-x-1">
-                  <Checkbox
-                    checked={permission.canView}
-                    disabled={updatingPermissions.has(permission.userId)}
-                    onCheckedChange={(checked) => 
-                      handlePermissionUpdate(permission.userId, 'canView', !!checked)
-                    }
-                  />
-                  <span className="text-xs">View</span>
-                </label>
-                
-                <label className="flex items-center space-x-1">
-                  <Checkbox
-                    checked={permission.canEdit}
-                    disabled={!permission.canView || updatingPermissions.has(permission.userId)}
-                    onCheckedChange={(checked) => 
-                      handlePermissionUpdate(permission.userId, 'canEdit', !!checked)
-                    }
-                  />
-                  <span className="text-xs">Edit</span>
-                </label>
-                
-                <label className="flex items-center space-x-1">
-                  <Checkbox
-                    checked={permission.canShare}
-                    disabled={!permission.canView || updatingPermissions.has(permission.userId)}
-                    onCheckedChange={(checked) => 
-                      handlePermissionUpdate(permission.userId, 'canShare', !!checked)
-                    }
-                  />
-                  <span className="text-xs">Share</span>
-                </label>
-                
-                <label className="flex items-center space-x-1">
-                  <Checkbox
-                    checked={permission.canDelete}
-                    disabled={!permission.canView || updatingPermissions.has(permission.userId)}
-                    onCheckedChange={(checked) => 
-                      handlePermissionUpdate(permission.userId, 'canDelete', !!checked)
-                    }
-                  />
-                  <span className="text-xs">Delete</span>
-                </label>
+                <Avatar className="h-8 w-8">
+                  <AvatarImage src={permission.user?.image || undefined} />
+                  <AvatarFallback>
+                    {permission.user?.name?.[0]?.toUpperCase() ||
+                     permission.user?.email?.[0]?.toUpperCase() || '?'}
+                  </AvatarFallback>
+                </Avatar>
+                <div>
+                  <p className="text-sm font-medium">
+                    {permission.user?.name || permission.user?.email || 'Unknown User'}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {permission.user?.email}
+                  </p>
+                </div>
               </div>
-              
-              {/* Remove Button */}
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => handleRemovePermission(permission.userId)}
-                className="text-red-600 hover:text-red-700"
-              >
-                <Trash2 className="h-4 w-4" />
-              </Button>
+
+              <div className="flex items-center space-x-4">
+                <div className="flex items-center space-x-3">
+                  <label className="flex items-center space-x-1">
+                    <Checkbox
+                      checked={permission.canView}
+                      disabled={updatingPermissions.has(permission.userId)}
+                      onCheckedChange={(checked) =>
+                        handlePermissionUpdate(permission.userId, 'canView', !!checked)
+                      }
+                    />
+                    <span className="text-xs">View</span>
+                  </label>
+
+                  <label className="flex items-center space-x-1">
+                    <Checkbox
+                      checked={permission.canEdit}
+                      disabled={!permission.canView || updatingPermissions.has(permission.userId)}
+                      onCheckedChange={(checked) =>
+                        handlePermissionUpdate(permission.userId, 'canEdit', !!checked)
+                      }
+                    />
+                    <span className="text-xs">Edit</span>
+                  </label>
+
+                  <label className="flex items-center space-x-1">
+                    <Checkbox
+                      checked={permission.canShare}
+                      disabled={!permission.canView || updatingPermissions.has(permission.userId)}
+                      onCheckedChange={(checked) =>
+                        handlePermissionUpdate(permission.userId, 'canShare', !!checked)
+                      }
+                    />
+                    <span className="text-xs">Share</span>
+                  </label>
+
+                  <label className="flex items-center space-x-1">
+                    <Checkbox
+                      checked={permission.canDelete}
+                      disabled={!permission.canView || updatingPermissions.has(permission.userId)}
+                      onCheckedChange={(checked) =>
+                        handlePermissionUpdate(permission.userId, 'canDelete', !!checked)
+                      }
+                    />
+                    <span className="text-xs">Delete</span>
+                  </label>
+                </div>
+
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleRemovePermission(permission.userId)}
+                  className="text-red-600 hover:text-red-700"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
             </div>
-          </div>
-        ))
-      )}
+          ))}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/ShareDialog.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/ShareDialog.tsx
@@ -70,9 +70,14 @@ export function ShareDialog({
   const page = pageResult?.node;
 
   const [internalOpen, setInternalOpen] = useState(false);
-  const isControlled = controlledOpen !== undefined;
+  const isControlled = controlledOpen !== undefined && typeof controlledOnOpenChange === 'function';
   const isOpen = isControlled ? controlledOpen! : internalOpen;
   const setIsOpen = isControlled ? controlledOnOpenChange! : setInternalOpen;
+
+  const [activeTab, setActiveTab] = useState<'share' | 'permissions'>(defaultTab);
+  useEffect(() => {
+    if (isOpen) setActiveTab(defaultTab);
+  }, [isOpen, defaultTab]);
 
   const [email, setEmail] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -109,17 +114,21 @@ export function ShareDialog({
     if (!isOpen || !pageId || !driveId) return;
 
     const fetchRoleData = async () => {
-      const [rolesRes, grantsRes] = await Promise.all([
-        fetchWithAuth(`/api/drives/${driveId}/roles`),
-        fetchWithAuth(`/api/pages/${pageId}/role-permissions`),
-      ]);
-      if (rolesRes.ok) {
-        const { roles } = await rolesRes.json() as { roles: DriveRole[] };
-        setDriveRoles(roles);
-      }
-      if (grantsRes.ok) {
-        const { roles } = await grantsRes.json() as { roles: RoleGrant[] };
-        setGrantedRoles(roles);
+      try {
+        const [rolesRes, grantsRes] = await Promise.all([
+          fetchWithAuth(`/api/drives/${driveId}/roles`),
+          fetchWithAuth(`/api/pages/${pageId}/role-permissions`),
+        ]);
+        if (rolesRes.ok) {
+          const { roles } = await rolesRes.json() as { roles: DriveRole[] };
+          setDriveRoles(roles);
+        }
+        if (grantsRes.ok) {
+          const { roles } = await grantsRes.json() as { roles: RoleGrant[] };
+          setGrantedRoles(roles);
+        }
+      } catch {
+        toast.error('Failed to load role permissions.');
       }
     };
 
@@ -333,7 +342,7 @@ export function ShareDialog({
                 aria-label="Toggle page privacy"
               />
             </div>
-            <Tabs defaultValue={defaultTab} className="mt-4">
+            <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as 'share' | 'permissions')} className="mt-4">
               <TabsList>
                 <TabsTrigger value="share">
                   <Users className="mr-2 h-4 w-4" />

--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/ShareDialog.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/ShareDialog.tsx
@@ -582,7 +582,7 @@ export function ShareDialog({
                 </div>
               </TabsContent>
               <TabsContent value="permissions" className="mt-4">
-                <PermissionsList key={permissionsVersion} />
+                <PermissionsList key={permissionsVersion} pageId={pageId} />
               </TabsContent>
             </Tabs>
           </>

--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/ShareDialog.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/ShareDialog.tsx
@@ -26,6 +26,13 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
 import { Users, UserCog, Lock, Share2 } from 'lucide-react';
 import { useMobile } from '@/hooks/useMobile';
@@ -33,14 +40,27 @@ import { Input } from '@/components/ui/input';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { PermissionsList } from './PermissionsList';
 import { toast } from 'sonner';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { post, fetchWithAuth, patch } from '@/lib/auth/auth-fetch';
+import { post, put, fetchWithAuth, patch } from '@/lib/auth/auth-fetch';
 import { PageShareLinkSection } from './PageShareLinkSection';
+import type { DriveRole } from '@pagespace/lib/services/drive-role-service';
+import type { RoleGrant } from '@/services/api';
 
-export function ShareDialog({ pageId: propPageId }: { pageId?: string | null } = {}) {
+interface ShareDialogProps {
+  pageId?: string | null;
+  defaultTab?: 'share' | 'permissions';
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export function ShareDialog({
+  pageId: propPageId,
+  defaultTab = 'share',
+  open: controlledOpen,
+  onOpenChange: controlledOnOpenChange,
+}: ShareDialogProps = {}) {
   const storePageId = usePageStore((state) => state.pageId);
   const pageId = propPageId !== undefined ? propPageId : storePageId;
   const params = useParams();
@@ -48,7 +68,12 @@ export function ShareDialog({ pageId: propPageId }: { pageId?: string | null } =
   const { tree } = usePageTree(driveId);
   const pageResult = pageId ? findNodeAndParent(tree, pageId) : null;
   const page = pageResult?.node;
-  const [isOpen, setIsOpen] = useState(false);
+
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isControlled = controlledOpen !== undefined;
+  const isOpen = isControlled ? controlledOpen! : internalOpen;
+  const setIsOpen = isControlled ? controlledOnOpenChange! : setInternalOpen;
+
   const [email, setEmail] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isPrivate, setIsPrivate] = useState(false);
@@ -57,6 +82,7 @@ export function ShareDialog({ pageId: propPageId }: { pageId?: string | null } =
   useEffect(() => {
     if (page) setIsPrivate(!!page.isPrivate);
   }, [page]);
+
   const [offPlatformEmail, setOffPlatformEmail] = useState<string | null>(null);
   const [expiryDays, setExpiryDays] = useState<number | null>(null);
   const [permissions, setPermissions] = useState({
@@ -65,13 +91,40 @@ export function ShareDialog({ pageId: propPageId }: { pageId?: string | null } =
     canShare: false,
     canDelete: false,
   });
-  // Add a key to force re-render of PermissionsList
   const [permissionsVersion, setPermissionsVersion] = useState(0);
 
-  // Check user permissions
+  // Role granting state
+  const [driveRoles, setDriveRoles] = useState<DriveRole[]>([]);
+  const [grantedRoles, setGrantedRoles] = useState<RoleGrant[]>([]);
+  const [selectedRoleId, setSelectedRoleId] = useState<string>('');
+  const [rolePermissions, setRolePermissions] = useState({ canView: true, canEdit: false, canShare: false });
+  const [isAddingRole, setIsAddingRole] = useState(false);
+
   const { permissions: userPermissions } = usePermissions(pageId);
   const canShare = userPermissions?.canShare || false;
   const isMobile = useMobile();
+
+  // Fetch drive roles and current role grants when dialog opens
+  useEffect(() => {
+    if (!isOpen || !pageId || !driveId) return;
+
+    const fetchRoleData = async () => {
+      const [rolesRes, grantsRes] = await Promise.all([
+        fetchWithAuth(`/api/drives/${driveId}/roles`),
+        fetchWithAuth(`/api/pages/${pageId}/role-permissions`),
+      ]);
+      if (rolesRes.ok) {
+        const { roles } = await rolesRes.json() as { roles: DriveRole[] };
+        setDriveRoles(roles);
+      }
+      if (grantsRes.ok) {
+        const { roles } = await grantsRes.json() as { roles: RoleGrant[] };
+        setGrantedRoles(roles);
+      }
+    };
+
+    fetchRoleData();
+  }, [isOpen, pageId, driveId]);
 
   if (!page) return null;
 
@@ -93,13 +146,11 @@ export function ShareDialog({ pageId: propPageId }: { pageId?: string | null } =
     const newPerms = { ...permissions };
 
     if (permission === 'canView' && !checked) {
-      // If removing view, remove all other permissions
       newPerms.canView = false;
       newPerms.canEdit = false;
       newPerms.canShare = false;
       newPerms.canDelete = false;
     } else if ((permission === 'canEdit' || permission === 'canShare' || permission === 'canDelete') && checked) {
-      // If granting edit/share/delete, must have view
       newPerms.canView = true;
       newPerms[permission as keyof typeof permissions] = true;
     } else {
@@ -124,11 +175,9 @@ export function ShareDialog({ pageId: propPageId }: { pageId?: string | null } =
     }
     setIsSubmitting(true);
     try {
-      // 1. Find the user by email
       const userResponse = await fetchWithAuth(`/api/users/find?email=${encodeURIComponent(email)}`);
       if (!userResponse.ok) {
         if (userResponse.status === 404) {
-          // User not found — switch to off-platform invite mode
           setOffPlatformEmail(email);
           return;
         }
@@ -137,7 +186,6 @@ export function ShareDialog({ pageId: propPageId }: { pageId?: string | null } =
       }
       const user = await userResponse.json();
 
-      // 2. Create the permission with checkbox values
       await post(`/api/pages/${page.id}/permissions`, {
         userId: user.id,
         ...permissions,
@@ -157,7 +205,6 @@ export function ShareDialog({ pageId: propPageId }: { pageId?: string | null } =
     if (!offPlatformEmail) return;
     setIsSubmitting(true);
     try {
-      // Translate checkbox state → VIEW/EDIT/SHARE array (DELETE excluded for off-platform)
       const permissionsArray: Array<'VIEW' | 'EDIT' | 'SHARE'> = ['VIEW'];
       if (permissions.canEdit) permissionsArray.push('EDIT');
       if (permissions.canShare) permissionsArray.push('SHARE');
@@ -197,8 +244,36 @@ export function ShareDialog({ pageId: propPageId }: { pageId?: string | null } =
     }
   };
 
-  // Show button but disable if no share permission
-  if (!canShare) {
+  const handleAddRole = async () => {
+    if (!selectedRoleId || !pageId) return;
+    setIsAddingRole(true);
+    try {
+      await put(`/api/pages/${pageId}/role-permissions`, {
+        roleId: selectedRoleId,
+        ...rolePermissions,
+      });
+      const role = driveRoles.find(r => r.id === selectedRoleId);
+      if (role) {
+        setGrantedRoles(prev => [
+          ...prev.filter(r => r.roleId !== selectedRoleId),
+          { roleId: role.id, name: role.name, color: role.color, ...rolePermissions },
+        ]);
+      }
+      setSelectedRoleId('');
+      setRolePermissions({ canView: true, canEdit: false, canShare: false });
+      setPermissionsVersion(v => v + 1);
+      toast.success('Role access granted.');
+    } catch {
+      toast.error('Failed to grant role access.');
+    } finally {
+      setIsAddingRole(false);
+    }
+  };
+
+  const ungrantedRoles = driveRoles.filter(r => !grantedRoles.some(g => g.roleId === r.id));
+
+  // Show disabled button when no share permission and not controlled (used as trigger)
+  if (!canShare && !isControlled) {
     return (
       <TooltipProvider>
         <Tooltip>
@@ -218,12 +293,14 @@ export function ShareDialog({ pageId: propPageId }: { pageId?: string | null } =
 
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
-      <DialogTrigger asChild>
-        <Button variant="ghost" size={isMobile ? "icon" : "sm"}>
-          <Share2 className={isMobile ? "h-4 w-4" : "mr-2 h-4 w-4"} />
-          {!isMobile && "Share"}
-        </Button>
-      </DialogTrigger>
+      {!isControlled && (
+        <DialogTrigger asChild>
+          <Button variant="ghost" size={isMobile ? "icon" : "sm"}>
+            <Share2 className={isMobile ? "h-4 w-4" : "mr-2 h-4 w-4"} />
+            {!isMobile && "Share"}
+          </Button>
+        </DialogTrigger>
+      )}
       <DialogContent className="max-w-2xl">
         <DialogHeader>
           <DialogTitle>Share &ldquo;{page.title}&rdquo;</DialogTitle>
@@ -256,176 +333,258 @@ export function ShareDialog({ pageId: propPageId }: { pageId?: string | null } =
                 aria-label="Toggle page privacy"
               />
             </div>
-          <Tabs defaultValue="share" className="mt-4">
-            <TabsList>
-              <TabsTrigger value="share">
-                <Users className="mr-2 h-4 w-4" />
-                Share
-              </TabsTrigger>
-              <TabsTrigger value="permissions">
-                <UserCog className="mr-2 h-4 w-4" />
-                Permissions
-              </TabsTrigger>
-            </TabsList>
-            <TabsContent value="share" className="mt-4 space-y-4">
-              {offPlatformEmail ? (
-                <Alert>
-                  <AlertDescription>
-                    <strong>{offPlatformEmail}</strong> is not yet on PageSpace. They will receive an
-                    email invitation to create an account and access this page.
-                  </AlertDescription>
-                </Alert>
-              ) : null}
-              <div className="flex space-x-2">
-                <Input
-                  type="email"
-                  placeholder="Add people by email..."
-                  className="flex-1"
-                  value={offPlatformEmail ?? email}
-                  onChange={(e) => {
-                    if (offPlatformEmail) {
-                      setOffPlatformEmail(null);
-                    }
-                    setEmail(e.target.value);
-                  }}
-                  disabled={isSubmitting || !canShare || !!offPlatformEmail}
-                />
-                {offPlatformEmail && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setOffPlatformEmail(null)}
-                    disabled={isSubmitting}
-                  >
-                    Cancel
-                  </Button>
-                )}
-              </div>
-
-              {/* Permission Checkboxes */}
-              <div className="border rounded-lg p-4 space-y-3">
-                <h4 className="text-sm font-medium mb-2">Permissions</h4>
-                <div className="grid grid-cols-2 gap-3">
-                  <div className="flex items-center space-x-2">
-                    <Checkbox
-                      id="canView"
-                      checked={permissions.canView}
-                      onCheckedChange={(checked) => handlePermissionChange('canView', !!checked)}
-                    />
-                    <Label htmlFor="canView" className="text-sm">
-                      View
-                      <span className="text-xs text-gray-500 block">Can view this page</span>
-                    </Label>
-                  </div>
-
-                  <div className="flex items-center space-x-2">
-                    <Checkbox
-                      id="canEdit"
-                      checked={permissions.canEdit}
-                      disabled={!permissions.canView}
-                      onCheckedChange={(checked) => handlePermissionChange('canEdit', !!checked)}
-                    />
-                    <Label htmlFor="canEdit" className="text-sm">
-                      Edit
-                      <span className="text-xs text-gray-500 block">Can edit content</span>
-                    </Label>
-                  </div>
-
-                  <div className="flex items-center space-x-2">
-                    <Checkbox
-                      id="canShare"
-                      checked={permissions.canShare}
-                      disabled={!permissions.canView}
-                      onCheckedChange={(checked) => handlePermissionChange('canShare', !!checked)}
-                    />
-                    <Label htmlFor="canShare" className="text-sm">
-                      Share
-                      <span className="text-xs text-gray-500 block">Can share with others</span>
-                    </Label>
-                  </div>
-
-                  {offPlatformEmail ? (
-                    <TooltipProvider>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <div className="flex items-center space-x-2 opacity-50">
-                            <Checkbox id="canDelete" checked={false} disabled />
-                            <Label htmlFor="canDelete" className="text-sm cursor-not-allowed">
-                              Delete
-                              <span className="text-xs text-gray-500 block">Can delete this page</span>
-                            </Label>
-                          </div>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p>Delete cannot be granted to off-platform invites</p>
-                        </TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                  ) : (
-                    <div className="flex items-center space-x-2">
-                      <Checkbox
-                        id="canDelete"
-                        checked={permissions.canDelete}
-                        disabled={!permissions.canView}
-                        onCheckedChange={(checked) => handlePermissionChange('canDelete', !!checked)}
-                      />
-                      <Label htmlFor="canDelete" className="text-sm">
-                        Delete
-                        <span className="text-xs text-gray-500 block">Can delete this page</span>
-                      </Label>
+            <Tabs defaultValue={defaultTab} className="mt-4">
+              <TabsList>
+                <TabsTrigger value="share">
+                  <Users className="mr-2 h-4 w-4" />
+                  Share
+                </TabsTrigger>
+                <TabsTrigger value="permissions">
+                  <UserCog className="mr-2 h-4 w-4" />
+                  Permissions
+                </TabsTrigger>
+              </TabsList>
+              <TabsContent value="share" className="mt-4 space-y-4">
+                {/* Role access section */}
+                {driveRoles.length > 0 && (
+                  <div className="border rounded-lg p-4 space-y-3">
+                    <h4 className="text-sm font-medium">Grant role access</h4>
+                    <p className="text-xs text-muted-foreground">
+                      All members with the selected role will gain access to this page.
+                    </p>
+                    <div className="flex items-center gap-2">
+                      <Select
+                        value={selectedRoleId}
+                        onValueChange={setSelectedRoleId}
+                        disabled={ungrantedRoles.length === 0}
+                      >
+                        <SelectTrigger className="flex-1">
+                          <SelectValue placeholder={ungrantedRoles.length === 0 ? 'All roles have access' : 'Select a role...'} />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {ungrantedRoles.map(role => (
+                            <SelectItem key={role.id} value={role.id}>
+                              <span className="flex items-center gap-2">
+                                {role.color && (
+                                  <span
+                                    className="inline-block h-2.5 w-2.5 rounded-full"
+                                    style={{ backgroundColor: role.color }}
+                                  />
+                                )}
+                                {role.name}
+                              </span>
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
                     </div>
+                    {selectedRoleId && (
+                      <div className="flex items-center gap-4 flex-wrap">
+                        <label className="flex items-center gap-1.5 text-sm cursor-pointer">
+                          <Checkbox
+                            checked={rolePermissions.canView}
+                            onCheckedChange={(checked) => {
+                              const v = !!checked;
+                              setRolePermissions(p => ({
+                                canView: v,
+                                canEdit: v ? p.canEdit : false,
+                                canShare: v ? p.canShare : false,
+                              }));
+                            }}
+                          />
+                          View
+                        </label>
+                        <label className="flex items-center gap-1.5 text-sm cursor-pointer">
+                          <Checkbox
+                            checked={rolePermissions.canEdit}
+                            disabled={!rolePermissions.canView}
+                            onCheckedChange={(checked) =>
+                              setRolePermissions(p => ({ ...p, canView: true, canEdit: !!checked }))
+                            }
+                          />
+                          Edit
+                        </label>
+                        <label className="flex items-center gap-1.5 text-sm cursor-pointer">
+                          <Checkbox
+                            checked={rolePermissions.canShare}
+                            disabled={!rolePermissions.canView}
+                            onCheckedChange={(checked) =>
+                              setRolePermissions(p => ({ ...p, canView: true, canShare: !!checked }))
+                            }
+                          />
+                          Share
+                        </label>
+                        <Button
+                          size="sm"
+                          onClick={handleAddRole}
+                          disabled={isAddingRole || !selectedRoleId}
+                        >
+                          {isAddingRole ? 'Adding...' : 'Add Role'}
+                        </Button>
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* User invite section */}
+                {offPlatformEmail ? (
+                  <Alert>
+                    <AlertDescription>
+                      <strong>{offPlatformEmail}</strong> is not yet on PageSpace. They will receive an
+                      email invitation to create an account and access this page.
+                    </AlertDescription>
+                  </Alert>
+                ) : null}
+                <div className="flex space-x-2">
+                  <Input
+                    type="email"
+                    placeholder="Add people by email..."
+                    className="flex-1"
+                    value={offPlatformEmail ?? email}
+                    onChange={(e) => {
+                      if (offPlatformEmail) {
+                        setOffPlatformEmail(null);
+                      }
+                      setEmail(e.target.value);
+                    }}
+                    disabled={isSubmitting || !canShare || !!offPlatformEmail}
+                  />
+                  {offPlatformEmail && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setOffPlatformEmail(null)}
+                      disabled={isSubmitting}
+                    >
+                      Cancel
+                    </Button>
                   )}
                 </div>
-              </div>
 
-              {offPlatformEmail && (
-                <div className="flex items-center gap-3">
-                  <Label className="text-sm text-muted-foreground whitespace-nowrap">Invite expires</Label>
-                  <Select
-                    value={expiryDays === null ? 'never' : String(expiryDays)}
-                    onValueChange={(v) => setExpiryDays(v === 'never' ? null : Number(v))}
-                  >
-                    <SelectTrigger className="w-36">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="never">Never</SelectItem>
-                      <SelectItem value="1">1 day</SelectItem>
-                      <SelectItem value="7">7 days</SelectItem>
-                      <SelectItem value="30">30 days</SelectItem>
-                    </SelectContent>
-                  </Select>
+                {/* Permission Checkboxes */}
+                <div className="border rounded-lg p-4 space-y-3">
+                  <h4 className="text-sm font-medium mb-2">Permissions</h4>
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="flex items-center space-x-2">
+                      <Checkbox
+                        id="canView"
+                        checked={permissions.canView}
+                        onCheckedChange={(checked) => handlePermissionChange('canView', !!checked)}
+                      />
+                      <Label htmlFor="canView" className="text-sm">
+                        View
+                        <span className="text-xs text-gray-500 block">Can view this page</span>
+                      </Label>
+                    </div>
+
+                    <div className="flex items-center space-x-2">
+                      <Checkbox
+                        id="canEdit"
+                        checked={permissions.canEdit}
+                        disabled={!permissions.canView}
+                        onCheckedChange={(checked) => handlePermissionChange('canEdit', !!checked)}
+                      />
+                      <Label htmlFor="canEdit" className="text-sm">
+                        Edit
+                        <span className="text-xs text-gray-500 block">Can edit content</span>
+                      </Label>
+                    </div>
+
+                    <div className="flex items-center space-x-2">
+                      <Checkbox
+                        id="canShare"
+                        checked={permissions.canShare}
+                        disabled={!permissions.canView}
+                        onCheckedChange={(checked) => handlePermissionChange('canShare', !!checked)}
+                      />
+                      <Label htmlFor="canShare" className="text-sm">
+                        Share
+                        <span className="text-xs text-gray-500 block">Can share with others</span>
+                      </Label>
+                    </div>
+
+                    {offPlatformEmail ? (
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <div className="flex items-center space-x-2 opacity-50">
+                              <Checkbox id="canDelete" checked={false} disabled />
+                              <Label htmlFor="canDelete" className="text-sm cursor-not-allowed">
+                                Delete
+                                <span className="text-xs text-gray-500 block">Can delete this page</span>
+                              </Label>
+                            </div>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p>Delete cannot be granted to off-platform invites</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    ) : (
+                      <div className="flex items-center space-x-2">
+                        <Checkbox
+                          id="canDelete"
+                          checked={permissions.canDelete}
+                          disabled={!permissions.canView}
+                          onCheckedChange={(checked) => handlePermissionChange('canDelete', !!checked)}
+                        />
+                        <Label htmlFor="canDelete" className="text-sm">
+                          Delete
+                          <span className="text-xs text-gray-500 block">Can delete this page</span>
+                        </Label>
+                      </div>
+                    )}
+                  </div>
                 </div>
-              )}
 
-              {offPlatformEmail ? (
-                <Button onClick={handleOffPlatformInvite} disabled={isSubmitting} className="w-full">
-                  {isSubmitting
-                    ? 'Sending Invite...'
-                    : `Invite ${offPlatformEmail} to PageSpace and share this page`}
-                </Button>
-              ) : (
-                <Button onClick={handleInvite} disabled={isSubmitting} className="w-full">
-                  {isSubmitting ? 'Granting Access...' : 'Grant Access'}
-                </Button>
-              )}
+                {offPlatformEmail && (
+                  <div className="flex items-center gap-3">
+                    <Label className="text-sm text-muted-foreground whitespace-nowrap">Invite expires</Label>
+                    <Select
+                      value={expiryDays === null ? 'never' : String(expiryDays)}
+                      onValueChange={(v) => setExpiryDays(v === 'never' ? null : Number(v))}
+                    >
+                      <SelectTrigger className="w-36">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="never">Never</SelectItem>
+                        <SelectItem value="1">1 day</SelectItem>
+                        <SelectItem value="7">7 days</SelectItem>
+                        <SelectItem value="30">30 days</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
 
-              <div className="border-t pt-4">
-                <PageShareLinkSection
-                  pageId={page.id}
-                  permissions={{
-                    canView: permissions.canView,
-                    canEdit: permissions.canEdit,
-                    canShare: permissions.canShare,
-                    canDelete: offPlatformEmail ? false : permissions.canDelete,
-                  }}
-                />
-              </div>
-            </TabsContent>
-            <TabsContent value="permissions" className="mt-4">
-              <PermissionsList key={permissionsVersion} />
-            </TabsContent>
-          </Tabs>
+                {offPlatformEmail ? (
+                  <Button onClick={handleOffPlatformInvite} disabled={isSubmitting} className="w-full">
+                    {isSubmitting
+                      ? 'Sending Invite...'
+                      : `Invite ${offPlatformEmail} to PageSpace and share this page`}
+                  </Button>
+                ) : (
+                  <Button onClick={handleInvite} disabled={isSubmitting} className="w-full">
+                    {isSubmitting ? 'Granting Access...' : 'Grant Access'}
+                  </Button>
+                )}
+
+                <div className="border-t pt-4">
+                  <PageShareLinkSection
+                    pageId={page.id}
+                    permissions={{
+                      canView: permissions.canView,
+                      canEdit: permissions.canEdit,
+                      canShare: permissions.canShare,
+                      canDelete: offPlatformEmail ? false : permissions.canDelete,
+                    }}
+                  />
+                </div>
+              </TabsContent>
+              <TabsContent value="permissions" className="mt-4">
+                <PermissionsList key={permissionsVersion} />
+              </TabsContent>
+            </Tabs>
           </>
         )}
       </DialogContent>

--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/ShareDialog.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/ShareDialog.tsx
@@ -120,12 +120,12 @@ export function ShareDialog({
           fetchWithAuth(`/api/pages/${pageId}/role-permissions`),
         ]);
         if (rolesRes.ok) {
-          const { roles } = await rolesRes.json() as { roles: DriveRole[] };
-          setDriveRoles(roles);
+          const parsed = await rolesRes.json() as { roles?: DriveRole[] };
+          setDriveRoles(parsed.roles ?? []);
         }
         if (grantsRes.ok) {
-          const { roles } = await grantsRes.json() as { roles: RoleGrant[] };
-          setGrantedRoles(roles);
+          const parsed = await grantsRes.json() as { roles?: RoleGrant[] };
+          setGrantedRoles(parsed.roles ?? []);
         }
       } catch {
         toast.error('Failed to load role permissions.');

--- a/apps/web/src/components/layout/middle-content/content-header/page-settings/__tests__/ShareDialog.test.tsx
+++ b/apps/web/src/components/layout/middle-content/content-header/page-settings/__tests__/ShareDialog.test.tsx
@@ -107,6 +107,12 @@ const makeInviteSuccess = () =>
     headers: { 'Content-Type': 'application/json' },
   });
 
+const makeEmptyRolesResponse = () =>
+  new Response(JSON.stringify({ roles: [] }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
 describe('ShareDialog — off-platform invite branch', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -237,7 +243,13 @@ describe('ShareDialog — off-platform invite branch', () => {
   });
 
   it('given /api/users/find returns 200, uses the direct grant path (not share-invite)', async () => {
-    vi.mocked(fetchWithAuth).mockResolvedValueOnce(make200UserResponse());
+    // fetchRoleData fires on dialog open and consumes 2 fetchWithAuth calls
+    // (one for /api/drives/:driveId/roles, one for /api/pages/:pageId/role-permissions)
+    // before handleInvite can call /api/users/find
+    vi.mocked(fetchWithAuth)
+      .mockResolvedValueOnce(makeEmptyRolesResponse())
+      .mockResolvedValueOnce(makeEmptyRolesResponse())
+      .mockResolvedValueOnce(make200UserResponse());
     vi.mocked(post).mockResolvedValueOnce({ id: 'perm_1' });
 
     const user = userEvent.setup();

--- a/apps/web/src/services/api/index.ts
+++ b/apps/web/src/services/api/index.ts
@@ -1,7 +1,7 @@
 export { pageReorderService } from './page-reorder-service';
 export type { ReorderParams, ReorderResult, ReorderSuccess, ReorderError, PageReorderService } from './page-reorder-service';
 
-export { permissionManagementService } from './permission-management-service';
+export { permissionManagementService, rolePermissionService } from './permission-management-service';
 export type {
   PermissionFlags,
   PermissionUser,
@@ -16,6 +16,8 @@ export type {
   RevokePermissionSuccess,
   RevokePermissionError,
   PermissionManagementService,
+  RolePermissionFlags,
+  RoleGrant,
 } from './permission-management-service';
 
 export { pageService } from './page-service';

--- a/apps/web/src/services/api/permission-management-service.ts
+++ b/apps/web/src/services/api/permission-management-service.ts
@@ -325,6 +325,10 @@ export const rolePermissionService = {
     roleId: string,
     permissions: RolePermissionFlags,
   ): Promise<RolePermResult> {
+    if ((permissions.canEdit || permissions.canShare) && !permissions.canView) {
+      return { success: false, error: 'canView must be true when canEdit or canShare is set', status: 400 };
+    }
+
     const canManage = await permissionManagementService.canUserManagePermissions(actorUserId, pageId);
     if (!canManage) return { success: false, error: 'Insufficient permissions', status: 403 };
 

--- a/apps/web/src/services/api/permission-management-service.ts
+++ b/apps/web/src/services/api/permission-management-service.ts
@@ -4,6 +4,7 @@ import { users } from '@pagespace/db/schema/auth'
 import { pages } from '@pagespace/db/schema/core'
 import { pagePermissions, driveMembers } from '@pagespace/db/schema/members';
 import { getUserAccessLevel } from '@pagespace/lib/permissions/permissions';
+import { listDriveRoles, getRoleById, updateDriveRole } from '@pagespace/lib/services/drive-role-service';
 import { createId } from '@paralleldrive/cuid2';
 
 /**
@@ -274,3 +275,102 @@ export const permissionManagementService = {
 };
 
 export type PermissionManagementService = typeof permissionManagementService;
+
+// ============================================================================
+// Role permission types
+// ============================================================================
+
+export interface RolePermissionFlags {
+  canView: boolean;
+  canEdit: boolean;
+  canShare: boolean;
+}
+
+export interface RoleGrant extends RolePermissionFlags {
+  roleId: string;
+  name: string;
+  color: string | null;
+}
+
+type RolePermResult = { success: true } | { success: false; error: string; status: number };
+
+// ============================================================================
+// Role permission service functions
+// ============================================================================
+
+export const rolePermissionService = {
+  async getPageRoleGrants(pageId: string): Promise<RoleGrant[]> {
+    const page = await db.query.pages.findFirst({
+      where: eq(pages.id, pageId),
+      columns: { driveId: true },
+    });
+    if (!page) return [];
+
+    const roles = await listDriveRoles(page.driveId);
+    return roles
+      .filter(role => role.permissions[pageId] != null)
+      .map(role => ({
+        roleId: role.id,
+        name: role.name,
+        color: role.color,
+        canView: role.permissions[pageId].canView,
+        canEdit: role.permissions[pageId].canEdit,
+        canShare: role.permissions[pageId].canShare,
+      }));
+  },
+
+  async setRolePagePermission(
+    actorUserId: string,
+    pageId: string,
+    roleId: string,
+    permissions: RolePermissionFlags,
+  ): Promise<RolePermResult> {
+    const canManage = await permissionManagementService.canUserManagePermissions(actorUserId, pageId);
+    if (!canManage) return { success: false, error: 'Insufficient permissions', status: 403 };
+
+    const page = await db.query.pages.findFirst({
+      where: eq(pages.id, pageId),
+      columns: { driveId: true },
+    });
+    if (!page) return { success: false, error: 'Page not found', status: 404 };
+
+    const role = await getRoleById(page.driveId, roleId);
+    if (!role) return { success: false, error: 'Role not found', status: 404 };
+
+    await updateDriveRole(page.driveId, roleId, {
+      permissions: {
+        ...role.permissions,
+        [pageId]: {
+          canView: permissions.canView,
+          canEdit: permissions.canEdit,
+          canShare: permissions.canShare,
+        },
+      },
+    });
+    return { success: true };
+  },
+
+  async removeRolePagePermission(
+    actorUserId: string,
+    pageId: string,
+    roleId: string,
+  ): Promise<RolePermResult> {
+    const canManage = await permissionManagementService.canUserManagePermissions(actorUserId, pageId);
+    if (!canManage) return { success: false, error: 'Insufficient permissions', status: 403 };
+
+    const page = await db.query.pages.findFirst({
+      where: eq(pages.id, pageId),
+      columns: { driveId: true },
+    });
+    if (!page) return { success: false, error: 'Page not found', status: 404 };
+
+    const role = await getRoleById(page.driveId, roleId);
+    if (!role) return { success: false, error: 'Role not found', status: 404 };
+
+    const remainingPermissions = Object.fromEntries(
+      Object.entries(role.permissions).filter(([key]) => key !== pageId)
+    );
+    await updateDriveRole(page.driveId, roleId, { permissions: remainingPermissions });
+    return { success: true };
+  },
+};


### PR DESCRIPTION
## Summary

Implements Discord-style role-based access for private pages. Page owners can now protect a page and grant entire roles access to it — rather than only per-user overrides — using existing `drive_roles.permissions` JSONB storage (no migration needed). Permission resolution was already wired via #1422.

### What changed

- **Context menu**: Added "Permissions" entry to the page tree right-click menu that opens ShareDialog directly to the Permissions tab targeted at the correct page (not the active page)
- **New API route** `GET/PUT/DELETE /api/pages/[pageId]/role-permissions`: Fetch, set, and remove role grants for a page; all mutations require `canShare` or drive owner/admin; GET requires `canShare`; all mutations emit audit events
- **Extended permissions GET**: `GET /api/pages/[pageId]/permissions` now returns `{ owner, permissions, roles }` — role grants fetched in parallel with user grants
- **PermissionsList**: Shows a "Roles" section with per-role canView/canEdit/canShare toggles and remove button; uses functional `setData` to avoid stale-closure races
- **ShareDialog**: Accepts `defaultTab` and controlled `open/onOpenChange` props; adds "Grant role access" section in Share tab; `Tabs` is now controlled via `activeTab` state so `defaultTab` applies reliably on reopen; controlled-mode contract guarded; `fetchRoleData` wrapped in try/catch
- **Server-side invariant validation**: `setRolePagePermission` rejects `canEdit/canShare: true` with `canView: false` (400)

### Constraints respected

- No DB migration — uses existing `drive_roles.permissions` JSONB
- No `canDelete` for roles — `resolveRolePermissions()` hardcodes `canDelete: false`
- No permission-logic changes — #1422 already handles role resolution

## Test plan

- [ ] Right-click a page → context menu shows "Permissions" entry
- [ ] Click "Permissions" → dialog opens to Permissions tab scoped to the right-clicked page (not the active page)
- [ ] Protect a page → grant a custom role → log in as a member with that role → can access the page
- [ ] Remove the role grant → member gets 403
- [ ] Add a role grant with canEdit=true, canView=false via API → should return 400
- [ ] Reopen the dialog from the context menu repeatedly — always opens to Permissions tab
- [ ] CI: Lint, TypeScript, Unit Tests, Security pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)