### PR TITLE
fix(mentions): clamp suggestion popup width to 256–320px for all input sizes

### DIFF
--- a/apps/web/src/components/mentions/MentionPicker.tsx
+++ b/apps/web/src/components/mentions/MentionPicker.tsx
@@ -76,7 +76,7 @@ export function MentionPickerPanel({
   ).length;
 
   return (
-    <div className={cn('w-80', className)} onKeyDown={handleKeyDown}>
+    <div className={cn('w-full', className)} onKeyDown={handleKeyDown}>
       <div className="p-2 border-b border-border/50">
         <Input
           autoFocus

--- a/apps/web/src/components/mentions/MentionPickerPortal.tsx
+++ b/apps/web/src/components/mentions/MentionPickerPortal.tsx
@@ -120,7 +120,7 @@ export function MentionPickerPortal({
       : `${viewportH - (position.top ?? 0) - 8}px`;
 
   const actualWidth = Math.min(Math.max(position.width ?? 256, 256), 320);
-  const clampedLeft = Math.min(Math.max(position.left, 8), viewportW - actualWidth - 8);
+  const clampedLeft = Math.max(8, Math.min(position.left, viewportW - actualWidth - 8));
 
   const style: React.CSSProperties = {
     position: 'fixed',

--- a/apps/web/src/components/mentions/MentionPickerPortal.tsx
+++ b/apps/web/src/components/mentions/MentionPickerPortal.tsx
@@ -113,19 +113,23 @@ export function MentionPickerPortal({
   if (typeof document === 'undefined') return null;
 
   const viewportH = getViewportHeight();
+  const viewportW = window.visualViewport?.width ?? window.innerWidth;
   const maxHeight =
     position.bottom !== undefined
       ? `${viewportH - position.bottom - 8}px`
       : `${viewportH - (position.top ?? 0) - 8}px`;
 
+  const actualWidth = Math.min(Math.max(position.width ?? 256, 256), 320);
+  const clampedLeft = Math.min(Math.max(position.left, 8), viewportW - actualWidth - 8);
+
   const style: React.CSSProperties = {
     position: 'fixed',
     zIndex: 50,
     maxHeight,
+    width: actualWidth,
     ...(position.bottom !== undefined
-      ? { bottom: position.bottom, left: position.left }
-      : { top: position.top, left: position.left }),
-    ...(position.width ? { width: position.width } : {}),
+      ? { bottom: position.bottom, left: clampedLeft }
+      : { top: position.top, left: clampedLeft }),
   };
 
   return createPortal(


### PR DESCRIPTION
## Summary

- `MentionPickerPanel` had a hardcoded `w-80` (320px) causing the popup to overflow and be clipped by `overflow-hidden` in narrow sidebars, and to stretch to full viewport width in wide channel/DM inputs after the container width was passed through
- `MentionPickerPortal` now computes `actualWidth = clamp(textarea_width, 256px, 320px)` — narrow sidebars get a 256px floor (fits 4 tabs + search comfortably), wide inputs are capped at 320px (original size)
- Left position is clamped to prevent the popup from bleeding off the right edge of the viewport
- `MentionPickerPanel` switches from `w-80` to `w-full` so the portal container governs the width

## Test plan

- [ ] Type `@` in a narrow sidebar chat input — popup is ~256px, fully visible, tabs not clipped
- [ ] Type `@` in a wide channel/DM input — popup is 320px, same as before
- [ ] Resize the right sidebar to min/max and confirm popup width adapts on next open
- [ ] Confirm popup never bleeds off the right edge of the screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)