### PR TITLE
feat(privacy): AI agent chats private by default with explicit multiplayer toggle

### DIFF
--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -389,12 +389,13 @@ describe('POST /api/ai/chat — lifecycle handoff', () => {
   });
 
   describe('conversation privacy gate on broadcast', () => {
-    it('should broadcast when conversation has no conversations row (legacy)', async () => {
+    it('should NOT broadcast when conversation row is missing (fail closed)', async () => {
+      mockCreateConversation.mockRejectedValueOnce(new Error('db down'));
       mockGetConversation.mockResolvedValueOnce(null);
 
       await POST(makeRequest({ conversationId: 'conv-1' }));
 
-      expect(mockBroadcastChatUserMessage).toHaveBeenCalledTimes(1);
+      expect(mockBroadcastChatUserMessage).not.toHaveBeenCalled();
     });
 
     it('should broadcast when conversation isShared is true', async () => {

--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -16,6 +16,7 @@ const {
   mockBroadcastChatUserMessage,
   mockSaveMessageToDatabase,
   mockGetConversation,
+  mockCreateConversation,
 } = vi.hoisted(() => ({
   mockCreateStreamLifecycle: vi.fn(),
   mockLifecyclePushPart: vi.fn(),
@@ -23,6 +24,7 @@ const {
   mockBroadcastChatUserMessage: vi.fn().mockResolvedValue(undefined),
   mockSaveMessageToDatabase: vi.fn().mockResolvedValue(undefined),
   mockGetConversation: vi.fn().mockResolvedValue(null), // default: legacy (no row) → broadcast
+  mockCreateConversation: vi.fn().mockResolvedValue(undefined),
 }));
 
 interface MockUIStreamOptions {
@@ -188,6 +190,7 @@ vi.mock('@/lib/logging/mask', () => ({
 vi.mock('@/lib/repositories/conversation-repository', () => ({
   conversationRepository: {
     getConversation: mockGetConversation,
+    createConversation: mockCreateConversation,
   },
 }));
 

--- a/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/stream-socket-events.test.ts
@@ -362,6 +362,7 @@ describe('POST /api/ai/chat — lifecycle handoff', () => {
 
   describe('user-message broadcast', () => {
     it('given a POST with a user message, should broadcast chat:user_message after the DB save resolves with the saved message and full envelope', async () => {
+      mockGetConversation.mockResolvedValueOnce({ id: 'conv-1', userId: 'user-1', isShared: true });
       await POST(makeRequest({ browserSessionId: 'session-7' }));
 
       expect(mockBroadcastChatUserMessage).toHaveBeenCalledTimes(1);

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -324,7 +324,9 @@ export async function POST(request: Request) {
     // Eagerly ensure a conversations row exists so the creator can always see
     // their own conversation. isShared defaults to false (private). Idempotent
     // via onConflictDoNothing, so safe for every message in a conversation.
-    conversationRepository.createConversation(conversationId, userId!, chatId).catch(() => {});
+    // Awaited so the row is visible to the broadcast gate below; errors are
+    // swallowed (non-fatal) and the gate falls back to no-broadcast on failure.
+    await conversationRepository.createConversation(conversationId, userId!, chatId).catch(() => {});
 
     // Process @mentions in the user's message
     let mentionSystemPrompt = '';
@@ -829,9 +831,10 @@ export async function POST(request: Request) {
     const displayName = userProfile?.displayName ?? user?.name ?? 'Someone';
 
     if (userMessage && userMessage.role === 'user') {
-      // Only broadcast to the page channel if the conversation is shared (or legacy with no row)
+      // Only broadcast to the page channel if the conversation is explicitly shared.
+      // Fail closed: no broadcast if the row is missing or private.
       const convRow = await conversationRepository.getConversation(conversationId!).catch(() => null);
-      const shouldBroadcast = !convRow || convRow.isShared;
+      const shouldBroadcast = convRow?.isShared === true;
       if (shouldBroadcast) {
         broadcastChatUserMessage({
           message: userMessage,

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -321,6 +321,11 @@ export async function POST(request: Request) {
       isNewConversation: !requestConversationId
     });
 
+    // Eagerly ensure a conversations row exists so the creator can always see
+    // their own conversation. isShared defaults to false (private). Idempotent
+    // via onConflictDoNothing, so safe for every message in a conversation.
+    conversationRepository.createConversation(conversationId, userId!, chatId).catch(() => {});
+
     // Process @mentions in the user's message
     let mentionSystemPrompt = '';
     let mentionedPageIds: string[] = [];

--- a/apps/web/src/components/ai/page-agents/PageAgentHistoryTab.tsx
+++ b/apps/web/src/components/ai/page-agents/PageAgentHistoryTab.tsx
@@ -90,19 +90,26 @@ const ConversationCard = memo(function ConversationCard({
           </div>
         </div>
         <div className="flex items-center gap-1 shrink-0">
+          {conversation.isShared && !conversation.isOwner && (
+            <span className="flex items-center gap-1 text-xs text-muted-foreground px-1">
+              <Users className="h-3 w-3" />
+              Shared
+            </span>
+          )}
           {conversation.isOwner && onToggleShare && (
             <Button
-              variant="ghost"
-              size="icon"
+              variant={conversation.isShared ? 'secondary' : 'ghost'}
+              size="sm"
               onClick={(e) => {
                 e.stopPropagation();
                 onToggleShare();
               }}
-              title={conversation.isShared ? 'Make private' : 'Share with drive members'}
+              title={conversation.isShared ? 'Make private' : 'Share with everyone on this page'}
+              className="h-7 px-2 gap-1 text-xs"
             >
               {conversation.isShared
-                ? <Users className="h-4 w-4 text-primary" />
-                : <Lock className="h-4 w-4 text-muted-foreground" />
+                ? <><Users className="h-3 w-3" />Shared</>
+                : <><Lock className="h-3 w-3" />Private</>
               }
             </Button>
           )}

--- a/apps/web/src/lib/repositories/conversation-repository.ts
+++ b/apps/web/src/lib/repositories/conversation-repository.ts
@@ -128,7 +128,6 @@ export const conversationRepository = {
   /**
    * List conversations for an agent with stats, ordered by most recent.
    * Only returns conversations the user owns, plus any explicitly shared ones.
-   * Legacy conversations (no conversations row) are treated as shared.
    */
   async listConversations(
     agentId: string,
@@ -196,7 +195,6 @@ export const conversationRepository = {
       WHERE (
         conv."userId" = ${userId}
         OR conv."isShared" = true
-        OR conv.id IS NULL
       )
       ORDER BY cs.last_message_time DESC
       LIMIT ${limit}
@@ -220,7 +218,6 @@ export const conversationRepository = {
         AND (
           conv."userId" = ${userId}
           OR conv."isShared" = true
-          OR conv.id IS NULL
         )
     `);
 


### PR DESCRIPTION
## Summary

- Drops the `OR conv.id IS NULL` fallback in `listConversations` and `countConversations` — this was the only path by which legacy messages (without a `conversations` row) leaked to all page members
- Adds an eager `conversations` row creation in the chat route so that every conversation — including the implicit first one on a new page — has an owner record from the first message onward; this means dropping the legacy fallback is now safe
- New conversations have always been created with `isShared: false`, so together these changes make all chats private by default
- The existing per-conversation `isShared` toggle is the explicit opt-in for shared/multiplayer history
- Updated the conversation card in the history tab to show labeled **Private** / **Shared** buttons instead of bare icons; non-owners of shared conversations see a read-only "Shared" label

## Test plan

- [ ] Two users with access to the same AI_CHAT page — confirm each only sees their own conversations
- [ ] First message on a brand-new AI_CHAT page creates a conversations row (visible to creator, invisible to others)
- [ ] User A clicks "Private" button to share a conversation — confirm User B can now see it with a "Shared" label
- [ ] User A clicks "Shared" to un-share — confirm User B loses visibility
- [ ] Legacy conversations without a `conversations` row are no longer visible to other users

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced conversation sharing interface with visual "Shared"/"Private" status indicators and improved owner controls.

* **Bug Fixes**
  * Strengthened conversation privacy filtering to ensure only owned or explicitly shared conversations are accessible, closing visibility gaps for legacy conversations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1427?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->