### PR TITLE
fix(ai-chat): show actual sender name instead of hardcoded You

### DIFF
--- a/apps/web/src/components/ai/shared/chat/CompactMessageRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/CompactMessageRenderer.tsx
@@ -6,6 +6,7 @@ import { MessageEditor } from './MessageEditor';
 import { DeleteMessageDialog } from './DeleteMessageDialog';
 import { CompactTodoListMessage } from './CompactTodoListMessage';
 import { useSocket } from '@/hooks/useSocket';
+import { useAuth } from '@/hooks/useAuth';
 import { ErrorBoundary } from '@/components/ai/shared/ErrorBoundary';
 import { patch, fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useGroupedParts } from './useGroupedParts';
@@ -17,6 +18,7 @@ import styles from './CompactMessageRenderer.module.css';
 interface CompactTextBlockProps {
   parts: TextPart[];
   role: 'user' | 'assistant' | 'system';
+  senderName?: string;
   createdAt?: Date;
   editedAt?: Date | null;
   onEdit?: () => void;
@@ -37,6 +39,7 @@ interface CompactTextBlockProps {
 const CompactTextBlock: React.FC<CompactTextBlockProps> = React.memo(({
   parts,
   role,
+  senderName,
   createdAt,
   editedAt,
   onEdit,
@@ -62,7 +65,7 @@ const CompactTextBlock: React.FC<CompactTextBlockProps> = React.memo(({
       {role === 'user' && (
         <div className="flex items-center mb-0.5">
           <div className="text-xs font-medium text-primary dark:text-primary">
-            You
+            {senderName}
           </div>
         </div>
       )}
@@ -141,6 +144,7 @@ export const CompactMessageRenderer: React.FC<CompactMessageRendererProps> = Rea
   isLastUserMessage = false,
   isStreaming = false
 }) => {
+  const { user } = useAuth();
   const [isEditing, setIsEditing] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -351,6 +355,7 @@ export const CompactMessageRenderer: React.FC<CompactMessageRendererProps> = Rea
                 key={`${message.id}-text-${index}`}
                 parts={group.parts}
                 role={message.role as 'user' | 'assistant' | 'system'}
+                senderName={message.userName ?? user?.name ?? 'Unknown'}
                 createdAt={isLastTextBlock ? createdAt : undefined}
                 editedAt={isLastTextBlock ? editedAt : undefined}
                 onEdit={onEdit ? () => setIsEditing(true) : undefined}

--- a/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
+++ b/apps/web/src/components/ai/shared/chat/MessageRenderer.tsx
@@ -8,6 +8,7 @@ import { MessageEditor } from './MessageEditor';
 import { DeleteMessageDialog } from './DeleteMessageDialog';
 import { TodoListMessage } from './TodoListMessage';
 import { useSocket } from '@/hooks/useSocket';
+import { useAuth } from '@/hooks/useAuth';
 import { ErrorBoundary } from '@/components/ai/shared/ErrorBoundary';
 import { patch, fetchWithAuth } from '@/lib/auth/auth-fetch';
 import { useGroupedParts } from './useGroupedParts';
@@ -18,6 +19,7 @@ import { ImageMessageContent } from './ImageMessageContent';
 interface TextBlockProps {
   parts: TextPart[];
   role: 'user' | 'assistant' | 'system';
+  senderName?: string;
   createdAt?: Date;
   editedAt?: Date | null;
   onEdit?: () => void;
@@ -37,6 +39,7 @@ interface TextBlockProps {
 const TextBlock: React.FC<TextBlockProps> = React.memo(({
   parts,
   role,
+  senderName,
   createdAt,
   editedAt,
   onEdit,
@@ -62,7 +65,7 @@ const TextBlock: React.FC<TextBlockProps> = React.memo(({
       {role === 'user' && (
         <div className="flex items-center mb-1">
           <div className="text-sm font-medium text-primary dark:text-primary">
-            You
+            {senderName}
           </div>
         </div>
       )}
@@ -144,6 +147,7 @@ export const MessageRenderer: React.FC<MessageRendererProps> = React.memo(({
   isHighlighted = false,
   isCurrentMatch = false,
 }) => {
+  const { user } = useAuth();
   const [isEditing, setIsEditing] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -356,6 +360,7 @@ export const MessageRenderer: React.FC<MessageRendererProps> = React.memo(({
                 key={`${message.id}-text-${index}`}
                 parts={group.parts}
                 role={message.role as 'user' | 'assistant' | 'system'}
+                senderName={message.userName ?? user?.name ?? 'Unknown'}
                 createdAt={isLastTextBlock ? createdAt : undefined}
                 editedAt={isLastTextBlock ? editedAt : undefined}
                 onEdit={onEdit ? () => setIsEditing(true) : undefined}

--- a/apps/web/src/components/ai/shared/chat/message-types.ts
+++ b/apps/web/src/components/ai/shared/chat/message-types.ts
@@ -14,6 +14,7 @@ export interface ConversationMessage extends UIMessage {
   isActive?: boolean;
   editedAt?: Date;
   createdAt?: Date;
+  userName?: string | null;
 }
 
 /**

--- a/apps/web/src/lib/ai/core/message-utils.ts
+++ b/apps/web/src/lib/ai/core/message-utils.ts
@@ -83,7 +83,7 @@ interface ToolPart {
 }
 
 /** Extended UIMessage with extra fields stored in our database */
-type ExtendedUIMessage = UIMessage & { editedAt?: Date | null; messageType: string; createdAt?: Date };
+type ExtendedUIMessage = UIMessage & { editedAt?: Date | null; messageType: string; createdAt?: Date; userName?: string | null };
 
 interface DatabaseMessage {
   id: string;
@@ -97,6 +97,7 @@ interface DatabaseMessage {
   isActive: boolean;
   editedAt?: Date | null;
   messageType?: 'standard' | 'todo_list';
+  userName?: string | null;
 }
 
 
@@ -256,7 +257,8 @@ export function convertDbMessageToUIMessage(dbMessage: DatabaseMessage): UIMessa
           totalPartsCount: parsed.partsOrder.length
         });
 
-        return reconstructMessageFromStructuredContent(dbMessage, parsed);
+        const structured = reconstructMessageFromStructuredContent(dbMessage, parsed);
+        return { ...structured, userName: dbMessage.userName } as ExtendedUIMessage;
       }
     } catch {
       // Content is plain text, not structured
@@ -272,6 +274,7 @@ export function convertDbMessageToUIMessage(dbMessage: DatabaseMessage): UIMessa
     createdAt: dbMessage.createdAt,
     editedAt: dbMessage.editedAt,
     messageType: dbMessage.messageType || 'standard',
+    userName: dbMessage.userName,
   } as ExtendedUIMessage;
 }
 

--- a/apps/web/src/lib/repositories/chat-message-repository.ts
+++ b/apps/web/src/lib/repositories/chat-message-repository.ts
@@ -7,6 +7,7 @@
 import { db } from '@pagespace/db/db'
 import { eq, and, lt } from '@pagespace/db/operators'
 import { chatMessages } from '@pagespace/db/schema/core';
+import { users } from '@pagespace/db/schema/auth';
 
 // Types for repository operations
 export interface ChatMessage {
@@ -22,6 +23,8 @@ export interface ChatMessage {
   editedAt: Date | null;
   toolCalls: unknown | null;
   toolResults: unknown | null;
+  userName?: string | null;
+  userImage?: string | null;
 }
 
 /**
@@ -55,8 +58,24 @@ export const chatMessageRepository = {
     conversationId?: string
   ): Promise<ChatMessage[]> {
     const messages = await db
-      .select()
+      .select({
+        id: chatMessages.id,
+        pageId: chatMessages.pageId,
+        conversationId: chatMessages.conversationId,
+        userId: chatMessages.userId,
+        role: chatMessages.role,
+        content: chatMessages.content,
+        messageType: chatMessages.messageType,
+        isActive: chatMessages.isActive,
+        createdAt: chatMessages.createdAt,
+        editedAt: chatMessages.editedAt,
+        toolCalls: chatMessages.toolCalls,
+        toolResults: chatMessages.toolResults,
+        userName: users.name,
+        userImage: users.image,
+      })
       .from(chatMessages)
+      .leftJoin(users, eq(chatMessages.userId, users.id))
       .where(
         conversationId
           ? and(


### PR DESCRIPTION
## Summary

- AI chat messages showed a hardcoded `"You"` label for every user message, regardless of who actually sent it
- This breaks shared conversations where two users are both messaging the same AI chat page
- Now each message displays the actual sender's name, fetched from the DB via a `leftJoin` on the `users` table

## Changes

- **`chat-message-repository.ts`** — `getMessagesForPage()` now joins `users` and returns `userName` + `userImage` on each message (same join pattern already used in `pulse/cron/route.ts`)
- **`message-utils.ts`** — `DatabaseMessage` interface and `convertDbMessageToUIMessage()` now carry `userName` through to the `UIMessage` output
- **`message-types.ts`** — `ConversationMessage` extended with `userName?: string | null`
- **`MessageRenderer.tsx`** + **`CompactMessageRenderer.tsx`** — replace hardcoded `"You"` with `message.userName ?? user?.name ?? 'Unknown'`, using `useAuth()` as fallback for optimistic in-flight messages

## Test plan

- [ ] Open a shared AI Chat page as two different users in separate browsers
- [ ] Send messages from each — each message should show the sender's real name, not "You"
- [ ] AI (assistant) responses remain unaffected — no name label shown for those
- [ ] Sidebar compact chat view also shows correct names
- [ ] Optimistic messages (while sending) show the current user's name via `useAuth()` fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)