### PR TITLE
fix(kanban): tighten task card vertical padding

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskKanbanView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskKanbanView.tsx
@@ -166,7 +166,7 @@ function TaskCard({
         isDragging && 'opacity-50 ring-2 ring-primary'
       )}
     >
-      <CardContent className="p-3">
+      <CardContent className="px-3 py-2">
         {/* Header: Drag handle + Checkbox + Title + Actions */}
         <div className="flex items-start gap-2">
           {canEdit && dragHandleProps && (
@@ -260,7 +260,7 @@ function TaskCard({
         </div>
 
         {/* Metadata row */}
-        <div className="flex flex-wrap items-center gap-1.5 mt-2 ml-6">
+        <div className="flex flex-wrap items-center gap-1.5 mt-1 ml-6">
           {/* Priority badge */}
           <Badge className={cn('text-xs px-1.5 py-0', PRIORITY_CONFIG[task.priority].color)}>
             {PRIORITY_CONFIG[task.priority].label}


### PR DESCRIPTION
## Summary

- Reduce `CardContent` padding from `p-3` to `px-3 py-2` — trims 4px top and bottom from each card
- Collapse metadata row gap from `mt-2` to `mt-1` — closes another 4px between title and badge row
- Cards are ~12px shorter overall, feeling more compact without losing readability

## Test plan

- [ ] Open a task list in kanban view — cards should feel more compact
- [ ] Verify priority badge, assignee, due date, and trigger badge still display correctly
- [ ] Check drag-and-drop still works as expected
- [ ] Compare a column with tasks vs a "No tasks" column — visual weight difference should be reduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refined task card padding and metadata row spacing for improved visual appearance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1431?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->