### PR TITLE
fix(sidebar): align page tree icons by moving chevron to indent gutter

### DIFF
--- a/apps/web/src/components/layout/left-sidebar/index.tsx
+++ b/apps/web/src/components/layout/left-sidebar/index.tsx
@@ -64,22 +64,24 @@ export default function Sidebar({ className }: SidebarProps) {
         className
       )}
     >
-      <div className="flex h-full flex-col px-3 py-3">
+      <div className="flex h-full flex-col py-3">
         {/* Drive Switcher - always visible, at top */}
         {/* On macOS Electron in sheet mode, add left padding to clear stoplight buttons */}
-        <div className={cn("mb-3", isElectronMac && isSheetBreakpoint && "pl-[60px]")}>
+        <div className={cn("px-3 mb-3", isElectronMac && isSheetBreakpoint && "pl-[60px]")}>
           <DriveSwitcher />
         </div>
 
         {/* Primary Navigation (Dashboard, Inbox, Tasks, Calendar) */}
-        <PrimaryNavigation driveId={driveId as string} />
+        <div className="px-3">
+          <PrimaryNavigation driveId={driveId as string} />
+        </div>
 
         {/* Main content area */}
         <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
           {driveId ? (
             <>
               {/* Drive view: Search + PageTree */}
-              <div className="flex items-center gap-2 mb-3 flex-shrink-0">
+              <div className="px-3 flex items-center gap-2 mb-3 flex-shrink-0">
                 <div className="relative flex-1">
                   <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
                   <Input
@@ -119,21 +121,23 @@ export default function Sidebar({ className }: SidebarProps) {
                 )}
               </div>
 
-              <div className="flex-1 min-h-0 overflow-hidden">
+              <div className="flex-1 min-h-0 overflow-hidden pr-3">
                 <PageTree driveId={driveId as string} searchQuery={searchQuery} />
               </div>
             </>
           ) : (
             /* Dashboard view: Pulse, Favorites, Recents */
-            <DashboardSidebar />
+            <div className="px-3 flex-1 flex flex-col min-h-0">
+              <DashboardSidebar />
+            </div>
           )}
         </div>
 
         {/* Drive footer - only shown when in a drive */}
-        {driveId && <DriveFooter canManage={canManage} />}
+        {driveId && <div className="px-3"><DriveFooter canManage={canManage} /></div>}
 
         {/* Dashboard footer - only shown when NOT in a drive */}
-        {!driveId && <DashboardFooter />}
+        {!driveId && <div className="px-3"><DashboardFooter /></div>}
 
       </div>
     </aside>

--- a/apps/web/src/components/layout/left-sidebar/page-tree/PageTreeItem.tsx
+++ b/apps/web/src/components/layout/left-sidebar/page-tree/PageTreeItem.tsx
@@ -287,7 +287,7 @@ export const PageTreeItem = React.memo(function PageTreeItem({
               {...handleProps.attributes}
               data-tree-node-id={item.id}
               className={cn(
-                "group flex items-center px-1 py-1.5 rounded-lg transition-all duration-200 outline-none ring-0 focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0",
+                "group relative flex items-center px-1 py-1.5 rounded-lg transition-all duration-200 outline-none ring-0 focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0",
                 showDropIndicator && dropPosition === "inside" &&
                   "bg-primary/10 dark:bg-primary/20 ring-2 ring-primary ring-inset",
                 !isActive && !showDropIndicator &&
@@ -295,7 +295,7 @@ export const PageTreeItem = React.memo(function PageTreeItem({
                 params.pageId === item.id && "bg-gray-200 dark:bg-gray-700",
                 isInMultiSelectMode && isPageSelected && "bg-primary/10 dark:bg-primary/20 ring-1 ring-primary/50"
               )}
-              style={{ paddingLeft: `${depth * 8 + 4}px` }}
+              style={{ paddingLeft: `${depth * 8 + 20}px` }}
             >
               {/* Multi-select Checkbox */}
               {isInMultiSelectMode && (
@@ -312,7 +312,7 @@ export const PageTreeItem = React.memo(function PageTreeItem({
                 </div>
               )}
 
-              {/* Expand/Collapse Chevron */}
+              {/* Expand/Collapse Chevron — absolutely positioned in the indent gutter so it doesn't shift the icon */}
               {hasChildren && (
                 <button
                   onClick={(e) => {
@@ -322,11 +322,12 @@ export const PageTreeItem = React.memo(function PageTreeItem({
                   onPointerDown={(e) => e.stopPropagation()}
                   aria-expanded={isExpanded}
                   aria-label={isExpanded ? "Collapse" : "Expand"}
-                  className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors cursor-pointer"
+                  className="absolute flex items-center justify-center w-4 h-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors cursor-pointer"
+                  style={{ left: `${depth * 8 + 2}px` }}
                 >
                   <ChevronRight
                     className={cn(
-                      "h-4 w-4 text-gray-500 transition-transform duration-200",
+                      "h-3 w-3 text-gray-500 transition-transform duration-200",
                       isExpanded && "rotate-90"
                     )}
                   />

--- a/apps/web/src/components/layout/left-sidebar/page-tree/PageTreeItem.tsx
+++ b/apps/web/src/components/layout/left-sidebar/page-tree/PageTreeItem.tsx
@@ -295,7 +295,7 @@ export const PageTreeItem = React.memo(function PageTreeItem({
                 params.pageId === item.id && "bg-gray-200 dark:bg-gray-700",
                 isInMultiSelectMode && isPageSelected && "bg-primary/10 dark:bg-primary/20 ring-1 ring-primary/50"
               )}
-              style={{ paddingLeft: `${depth * 8 + 20}px` }}
+              style={{ paddingLeft: `${depth * 8 + 16}px` }}
             >
               {/* Multi-select Checkbox */}
               {isInMultiSelectMode && (
@@ -323,7 +323,7 @@ export const PageTreeItem = React.memo(function PageTreeItem({
                   aria-expanded={isExpanded}
                   aria-label={isExpanded ? "Collapse" : "Expand"}
                   className="absolute flex items-center justify-center w-4 h-4 rounded hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors cursor-pointer"
-                  style={{ left: `${depth * 8 + 2}px` }}
+                  style={{ left: `${depth * 8}px` }}
                 >
                   <ChevronRight
                     className={cn(


### PR DESCRIPTION
## Summary

Top-level sidebar items with children appeared indented relative to childless siblings. The chevron button was rendered inline in the flex row, shifting the icon ~24px right for items that have children — making them look like they were nested one level deeper than siblings without children.

### Root cause
The sidebar's three nested `overflow-hidden` containers prevent negative `left` positioning, so the chevron gutter must come from within the item's own `paddingLeft`. The previous attempt reserved gutter space by increasing all items' `paddingLeft` by 16px — this fixed alignment but pushed every icon further from the left edge.

### Fix
- **`index.tsx`**: Remove blanket `px-3` from the outer sidebar content div. Each section (Drive Switcher, primary nav, search bar, footers, dashboard view) carries its own `px-3`. The page tree section gets `pr-3` for right-side clearance only — no left padding.
- **`PageTreeItem.tsx`**: Items use `paddingLeft: depth*8+16px`. With zero outer left padding, the icon lands at exactly **16px from the sidebar wall** — the same position childless items were at before (`12px outer + 4px item = 16px`). The chevron is `position: absolute` at `left: depth*8`, occupying the 16px gutter without displacing the icon.

### Result
| Item type | Before | After |
|---|---|---|
| Childless (e.g. "General") | icon at 16px from wall | icon at 16px — **unchanged** |
| With children (e.g. "Issues") | icon at 40px from wall | icon at 16px — **aligned** |
| Chevron | pushed icon 24px right | sits in 16px left gutter |

## Test plan

- [ ] Top-level page without children and top-level page with children have icons in the same vertical column
- [ ] Chevron appears to the left of the icon at the sidebar's left edge
- [ ] Drive Switcher, search bar, primary navigation, and footers retain correct left spacing
- [ ] Nested items (depth 1, 2+) indent correctly with chevrons in their respective gutters
- [ ] Clicking the chevron expands/collapses
- [ ] Hover actions (add-child button, viewer avatars) have correct right clearance
- [ ] Drag-to-reorder still works

🤖 Generated with [Claude Code](https://claude.ai/claude-code)