### PR TITLE
feat(task-list): split view + editor mode

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListDescription.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListDescription.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import dynamic from 'next/dynamic';
+import { type Editor } from '@tiptap/react';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { isRichContentEmpty, usePageContent } from '@/hooks/usePageContent';
 
@@ -36,6 +37,7 @@ interface TaskListDescriptionContentProps {
   canEdit: boolean;
   initialContent: string | null;
   className?: string;
+  onEditorChange?: (editor: Editor | null) => void;
 }
 
 export function TaskListDescriptionContent({
@@ -43,6 +45,7 @@ export function TaskListDescriptionContent({
   canEdit,
   initialContent,
   className,
+  onEditorChange,
 }: TaskListDescriptionContentProps) {
   const { content, save } = usePageContent({ pageId, initialContent });
 
@@ -53,6 +56,7 @@ export function TaskListDescriptionContent({
         onChange={save}
         readOnly={!canEdit}
         contentMode="html"
+        onEditorChange={onEditorChange}
       />
     </div>
   );

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListDescription.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListDescription.tsx
@@ -1,51 +1,59 @@
 'use client';
 
-import { useState } from 'react';
 import dynamic from 'next/dynamic';
 import { ChevronDown, ChevronRight } from 'lucide-react';
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { isRichContentEmpty, usePageContent } from '@/hooks/usePageContent';
 
 const RichEditor = dynamic(() => import('@/components/editors/RichEditor'), { ssr: false });
 
-interface TaskListDescriptionProps {
-  pageId: string;
-  canEdit: boolean;
-  initialContent: string | null;
-}
-
 export const getInitialOpenState = (content: string | null): boolean =>
   !isRichContentEmpty(content);
 
-export function TaskListDescription({ pageId, canEdit, initialContent }: TaskListDescriptionProps) {
-  const [open, setOpen] = useState(() => getInitialOpenState(initialContent));
+interface TaskListDescriptionHeaderProps {
+  open: boolean;
+  onToggle: () => void;
+}
+
+export function TaskListDescriptionHeader({ open, onToggle }: TaskListDescriptionHeaderProps) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className="flex items-center gap-1.5 px-4 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors w-full text-left shrink-0"
+    >
+      {open ? (
+        <ChevronDown className="h-3.5 w-3.5 shrink-0" />
+      ) : (
+        <ChevronRight className="h-3.5 w-3.5 shrink-0" />
+      )}
+      Description
+    </button>
+  );
+}
+
+interface TaskListDescriptionContentProps {
+  pageId: string;
+  canEdit: boolean;
+  initialContent: string | null;
+  className?: string;
+}
+
+export function TaskListDescriptionContent({
+  pageId,
+  canEdit,
+  initialContent,
+  className,
+}: TaskListDescriptionContentProps) {
   const { content, save } = usePageContent({ pageId, initialContent });
 
   return (
-    <Collapsible open={open} onOpenChange={setOpen}>
-      <CollapsibleTrigger asChild>
-        <button
-          type="button"
-          className="flex items-center gap-1.5 px-4 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors w-full text-left"
-        >
-          {open ? (
-            <ChevronDown className="h-3.5 w-3.5 shrink-0" />
-          ) : (
-            <ChevronRight className="h-3.5 w-3.5 shrink-0" />
-          )}
-          Description
-        </button>
-      </CollapsibleTrigger>
-      <CollapsibleContent>
-        <div className="px-4 pb-3">
-          <RichEditor
-            value={content ?? ''}
-            onChange={save}
-            readOnly={!canEdit}
-            contentMode="html"
-          />
-        </div>
-      </CollapsibleContent>
-    </Collapsible>
+    <div className={className}>
+      <RichEditor
+        value={content ?? ''}
+        onChange={save}
+        readOnly={!canEdit}
+        contentMode="html"
+      />
+    </div>
   );
 }

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef, memo, useMemo } from 'react';
+import { type Editor } from '@tiptap/react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 import useSWR, { mutate } from 'swr';
@@ -83,6 +84,7 @@ import { MultiAssigneeSelect } from './MultiAssigneeSelect';
 import { DueDatePicker } from './DueDatePicker';
 import { TaskKanbanView } from './TaskKanbanView';
 import { getInitialOpenState, TaskListDescriptionHeader, TaskListDescriptionContent } from './TaskListDescription';
+import Toolbar from '@/components/editors/Toolbar';
 import { TaskRowDescription } from './TaskRowDescription';
 import { StatusConfigManager } from './StatusConfigManager';
 import { TaskAgentTriggersDialog } from './TaskAgentTriggersDialog';
@@ -446,6 +448,7 @@ function TaskListView({ page }: TaskListViewProps) {
   const viewMode = useLayoutStore((state) => state.taskListViewMode);
   const setViewMode = useLayoutStore((state) => state.setTaskListViewMode);
   const [descriptionOpen, setDescriptionOpen] = useState(() => getInitialOpenState(page.content));
+  const [editorInstance, setEditorInstance] = useState<Editor | null>(null);
   const hasLoadedRef = useRef(false);
 
   // Use centralized socket store for proper authentication
@@ -824,11 +827,13 @@ function TaskListView({ page }: TaskListViewProps) {
             </button>
           </div>
         </div>
+        {canEdit && <Toolbar editor={editorInstance} contentMode="html" />}
         <TaskListDescriptionContent
           pageId={page.id}
           canEdit={canEdit}
           initialContent={page.content}
           className="flex-1 overflow-auto px-4 py-3"
+          onEditorChange={setEditorInstance}
         />
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 px-4 py-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] border-t bg-muted/50 text-sm text-muted-foreground shrink-0">
           <span><strong>{data?.tasks.length || 0}</strong> tasks</span>

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -445,7 +445,7 @@ function TaskListView({ page }: TaskListViewProps) {
   const toggleTaskExpand = (id: string) => setExpandedTaskIds(prev => toggleSet(prev, id));
   const viewMode = useLayoutStore((state) => state.taskListViewMode);
   const setViewMode = useLayoutStore((state) => state.setTaskListViewMode);
-  const [descriptionOpen, setDescriptionOpen] = useState(() => getInitialOpenState(page.content ?? null));
+  const [descriptionOpen, setDescriptionOpen] = useState(() => getInitialOpenState(page.content));
   const hasLoadedRef = useRef(false);
 
   // Use centralized socket store for proper authentication
@@ -912,12 +912,7 @@ function TaskListView({ page }: TaskListViewProps) {
             <div className="hidden md:flex items-center bg-muted rounded-md p-0.5">
               <button
                 onClick={() => setViewMode('editor')}
-                className={cn(
-                  'p-1.5 rounded transition-colors',
-                  viewMode === 'editor'
-                    ? 'bg-background text-foreground shadow-sm'
-                    : 'text-muted-foreground hover:text-foreground'
-                )}
+                className="p-1.5 rounded transition-colors text-muted-foreground hover:text-foreground"
                 title="Editor view"
                 aria-label="Editor view"
               >

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -797,7 +797,7 @@ function TaskListView({ page }: TaskListViewProps) {
       <div className="flex flex-col h-full min-w-0">
         <div className="flex items-center justify-between px-4 py-2 border-b bg-background shrink-0">
           <span className="text-sm font-medium text-muted-foreground">Description</span>
-          <div className="hidden md:flex items-center bg-muted rounded-md p-0.5">
+          <div className="flex items-center bg-muted rounded-md p-0.5">
             <button
               onClick={() => setViewMode('editor')}
               className={cn('p-1.5 rounded transition-colors', 'bg-background text-foreground shadow-sm')}

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -54,6 +54,7 @@ import {
   Pencil,
   Trash2,
   FileText,
+  BookOpen,
   GripVertical,
   LayoutList,
   Kanban,
@@ -81,7 +82,7 @@ import { cn } from '@/lib/utils';
 import { MultiAssigneeSelect } from './MultiAssigneeSelect';
 import { DueDatePicker } from './DueDatePicker';
 import { TaskKanbanView } from './TaskKanbanView';
-import { TaskListDescription } from './TaskListDescription';
+import { getInitialOpenState, TaskListDescriptionHeader, TaskListDescriptionContent } from './TaskListDescription';
 import { TaskRowDescription } from './TaskRowDescription';
 import { StatusConfigManager } from './StatusConfigManager';
 import { TaskAgentTriggersDialog } from './TaskAgentTriggersDialog';
@@ -444,6 +445,7 @@ function TaskListView({ page }: TaskListViewProps) {
   const toggleTaskExpand = (id: string) => setExpandedTaskIds(prev => toggleSet(prev, id));
   const viewMode = useLayoutStore((state) => state.taskListViewMode);
   const setViewMode = useLayoutStore((state) => state.setTaskListViewMode);
+  const [descriptionOpen, setDescriptionOpen] = useState(() => getInitialOpenState(page.content ?? null));
   const hasLoadedRef = useRef(false);
 
   // Use centralized socket store for proper authentication
@@ -790,6 +792,56 @@ function TaskListView({ page }: TaskListViewProps) {
     onConfigureTriggers: setTriggerDialogTask,
   };
 
+  if (viewMode === 'editor') {
+    return (
+      <div className="flex flex-col h-full min-w-0">
+        <div className="flex items-center justify-between px-4 py-2 border-b bg-background shrink-0">
+          <span className="text-sm font-medium text-muted-foreground">Description</span>
+          <div className="hidden md:flex items-center bg-muted rounded-md p-0.5">
+            <button
+              onClick={() => setViewMode('editor')}
+              className={cn('p-1.5 rounded transition-colors', 'bg-background text-foreground shadow-sm')}
+              title="Editor view"
+              aria-label="Editor view"
+            >
+              <BookOpen className="h-4 w-4" />
+            </button>
+            <button
+              onClick={() => setViewMode('table')}
+              className={cn('p-1.5 rounded transition-colors', 'text-muted-foreground hover:text-foreground')}
+              title="Table view"
+              aria-label="Table view"
+            >
+              <LayoutList className="h-4 w-4" />
+            </button>
+            <button
+              onClick={() => setViewMode('kanban')}
+              className={cn('p-1.5 rounded transition-colors', 'text-muted-foreground hover:text-foreground')}
+              title="Kanban view"
+              aria-label="Kanban view"
+            >
+              <Kanban className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+        <TaskListDescriptionContent
+          pageId={page.id}
+          canEdit={canEdit}
+          initialContent={page.content}
+          className="flex-1 overflow-auto px-4 py-3"
+        />
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 px-4 py-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] border-t bg-muted/50 text-sm text-muted-foreground shrink-0">
+          <span><strong>{data?.tasks.length || 0}</strong> tasks</span>
+          <span className="text-xs sm:text-sm">
+            Updated {data?.taskList.updatedAt
+              ? formatDistanceToNow(new Date(data.taskList.updatedAt), { addSuffix: true })
+              : 'never'}
+          </span>
+        </div>
+      </div>
+    );
+  }
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-full">
@@ -808,11 +860,18 @@ function TaskListView({ page }: TaskListViewProps) {
 
   return (
     <div className="flex flex-col h-full min-w-0">
-      <TaskListDescription
-        pageId={page.id}
-        canEdit={canEdit}
-        initialContent={page.content}
+      <TaskListDescriptionHeader
+        open={descriptionOpen}
+        onToggle={() => setDescriptionOpen(prev => !prev)}
       />
+      {descriptionOpen && (
+        <TaskListDescriptionContent
+          pageId={page.id}
+          canEdit={canEdit}
+          initialContent={page.content}
+          className="h-[40%] shrink-0 overflow-auto px-4 py-3 border-b"
+        />
+      )}
       {/* Toolbar */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 px-4 py-3 border-b bg-background">
         <div className="flex flex-col sm:flex-row sm:items-center gap-2">
@@ -851,6 +910,19 @@ function TaskListView({ page }: TaskListViewProps) {
           <div className="flex items-center gap-2 sm:contents">
             {/* View toggle (desktop only) */}
             <div className="hidden md:flex items-center bg-muted rounded-md p-0.5">
+              <button
+                onClick={() => setViewMode('editor')}
+                className={cn(
+                  'p-1.5 rounded transition-colors',
+                  viewMode === 'editor'
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground'
+                )}
+                title="Editor view"
+                aria-label="Editor view"
+              >
+                <BookOpen className="h-4 w-4" />
+              </button>
               <button
                 onClick={() => setViewMode('table')}
                 className={cn(

--- a/apps/web/src/stores/useLayoutStore.ts
+++ b/apps/web/src/stores/useLayoutStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-type TaskListViewMode = 'table' | 'kanban';
+type TaskListViewMode = 'table' | 'kanban' | 'editor';
 export type TaskListPageFilter = 'all' | 'active' | 'completed';
 
 export interface StoredDashboardFilters {


### PR DESCRIPTION
## Summary

- **Bug fix**: when the description was open, it consumed uncontrolled vertical space, shrinking the task list scroll container toward zero — making the "Add task" input unreachable and causing the toolbar to scroll offscreen. Fixed by giving the description a height-capped (`h-[40%]`) scroll container so the task list always gets `flex-1`.
- **Split view**: clicking the description chevron now opens a true dual-scroll layout — description scrolls independently in the top 40%, task list scrolls independently below. The toolbar always sits between them, never inside a scroll container.
- **Editor mode**: new `BookOpen` button in the view toggle (alongside List and Kanban) renders the description full-height as a clean document editor, with a minimal header showing the view toggle to switch back.
- `TaskListViewMode` expanded to `'table' | 'kanban' | 'editor'`, persisted to localStorage as before.

### Additional fixes (post-review)
- **TypeScript narrowing fix**: the editor-mode early return narrowed `viewMode` to `'table' | 'kanban'` downstream, causing a TS2367 error on the editor button's active-state check in the toolbar. Removed the dead conditional (the toolbar is never rendered in editor mode, so the editor button there is always "inactive").
- **Mobile escape**: the editor mode header's view toggle was `hidden md:flex`, meaning mobile users with `editor` persisted in localStorage had no escape route. Removed the breakpoint guard so the toggle is always visible in editor mode.

## Test plan

- [ ] Open description in list mode → both sections scroll independently, toolbar stays visible
- [ ] Scroll to bottom of a long task list, click "Add task" in toolbar → input scrolls into view
- [ ] Click Editor button → full-height description editor, no task rows
- [ ] Switch Editor → List → Kanban → reload → mode persists
- [ ] Open description in kanban mode → same split behavior
- [ ] Enter editor mode on desktop, open on narrow/mobile viewport → view toggle visible, can escape

🤖 Generated with [Claude Code](https://claude.com/claude-code)