### PR TITLE
feat(ai-tools): list_drive_members + list_collaborators

### DIFF
--- a/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
@@ -98,8 +98,16 @@ vi.mock('../../tools/channel-tools', () => ({
   },
 }));
 
+vi.mock('../../tools/member-tools', () => ({
+  memberTools: {
+    list_drive_members: { name: 'list_drive_members', description: 'List drive members' },
+    list_collaborators: { name: 'list_collaborators', description: 'List collaborators' },
+  },
+}));
+
 import { pageSpaceTools, corePageSpaceTools } from '../ai-tools';
 import { CORE_TOOL_NAMES } from '../stub-tools';
+import { memberTools } from '../../tools/member-tools';
 import { driveTools } from '../../tools/drive-tools';
 import { pageReadTools } from '../../tools/page-read-tools';
 import { pageWriteTools } from '../../tools/page-write-tools';
@@ -121,6 +129,7 @@ describe('ai-tools', () => {
 
     it('equals the merged object of all tool modules', () => {
       expect(pageSpaceTools).toEqual({
+        ...memberTools,
         ...driveTools,
         ...pageReadTools,
         ...pageWriteTools,
@@ -138,6 +147,7 @@ describe('ai-tools', () => {
 
     it('has no key collisions between tool modules', () => {
       const moduleKeysets = [
+        Object.keys(memberTools),
         Object.keys(driveTools),
         Object.keys(pageReadTools),
         Object.keys(pageWriteTools),

--- a/apps/web/src/lib/ai/core/ai-tools.ts
+++ b/apps/web/src/lib/ai/core/ai-tools.ts
@@ -1,3 +1,4 @@
+import { memberTools } from '../tools/member-tools';
 import { driveTools } from '../tools/drive-tools';
 import { pageReadTools } from '../tools/page-read-tools';
 import { pageWriteTools } from '../tools/page-write-tools';
@@ -13,6 +14,7 @@ import { channelTools } from '../tools/channel-tools';
 import { CORE_TOOL_NAMES } from './stub-tools';
 
 export const pageSpaceTools = {
+  ...memberTools,
   ...driveTools,
   ...pageReadTools,
   ...pageWriteTools,

--- a/apps/web/src/lib/ai/core/tool-filtering.ts
+++ b/apps/web/src/lib/ai/core/tool-filtering.ts
@@ -127,6 +127,8 @@ export function getToolsSummary(isReadOnly: boolean, webSearchEnabled = true): {
 } {
   const allTools = [
     // Read tools
+    'list_drive_members',
+    'list_collaborators',
     'list_drives',
     'list_pages',
     'read_page',

--- a/apps/web/src/lib/ai/tools/__tests__/member-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/member-tools.test.ts
@@ -102,7 +102,7 @@ describe('member-tools', () => {
     it('has correct tool definition', () => {
       expect(typeof memberTools.list_collaborators).toBe('object');
       expect(typeof memberTools.list_collaborators.description).toBe('string');
-      expect(memberTools.list_collaborators.description).toContain('userId');
+      expect(memberTools.list_collaborators.description).toContain('user ID');
     });
 
     it('requires user authentication', async () => {

--- a/apps/web/src/lib/ai/tools/__tests__/member-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/member-tools.test.ts
@@ -37,7 +37,7 @@ import { checkDriveAccess, listDriveMembers } from '@pagespace/lib/services/driv
 import type { ToolExecutionContext } from '../../core';
 
 const mockCheckDriveAccess = vi.mocked(checkDriveAccess);
-const mockListDriveMembers = vi.mocked(listDriveMembers);
+vi.mocked(listDriveMembers);
 
 const makeContext = (userId: string) => ({
   toolCallId: '1',

--- a/apps/web/src/lib/ai/tools/__tests__/member-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/member-tools.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    select: vi.fn(),
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn(),
+  and: vi.fn(),
+  inArray: vi.fn(),
+}));
+vi.mock('@pagespace/db/schema/core', () => ({
+  drives: { id: 'id', ownerId: 'ownerId' },
+}));
+vi.mock('@pagespace/db/schema/auth', () => ({
+  users: { id: 'id', name: 'name', email: 'email' },
+}));
+vi.mock('@pagespace/db/schema/members', () => ({
+  userProfiles: { userId: 'userId', displayName: 'displayName', avatarUrl: 'avatarUrl' },
+}));
+vi.mock('@pagespace/db/schema/social', () => ({
+  connections: {
+    user1Id: 'user1Id',
+    user2Id: 'user2Id',
+    status: 'status',
+    acceptedAt: 'acceptedAt',
+  },
+}));
+vi.mock('@pagespace/lib/services/drive-member-service', () => ({
+  checkDriveAccess: vi.fn(),
+  listDriveMembers: vi.fn(),
+}));
+
+import { memberTools } from '../member-tools';
+import { checkDriveAccess, listDriveMembers } from '@pagespace/lib/services/drive-member-service';
+import type { ToolExecutionContext } from '../../core';
+
+const mockCheckDriveAccess = vi.mocked(checkDriveAccess);
+const mockListDriveMembers = vi.mocked(listDriveMembers);
+
+const makeContext = (userId: string) => ({
+  toolCallId: '1',
+  messages: [],
+  experimental_context: { userId } as ToolExecutionContext,
+});
+
+describe('member-tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('list_drive_members', () => {
+    it('has correct tool definition', () => {
+      expect(typeof memberTools.list_drive_members).toBe('object');
+      expect(typeof memberTools.list_drive_members.description).toBe('string');
+      expect(memberTools.list_drive_members.description).toContain('userId');
+    });
+
+    it('requires user authentication', async () => {
+      const context = { toolCallId: '1', messages: [], experimental_context: {} };
+
+      await expect(
+        memberTools.list_drive_members.execute!({ driveId: 'drive1' }, context)
+      ).rejects.toThrow('User authentication required');
+    });
+
+    it('returns error when drive not found', async () => {
+      mockCheckDriveAccess.mockResolvedValueOnce({
+        isOwner: false,
+        isAdmin: false,
+        isMember: false,
+        drive: null,
+      });
+
+      const result = await memberTools.list_drive_members.execute!(
+        { driveId: 'missing-drive' },
+        makeContext('user1')
+      );
+
+      expect(result).toMatchObject({ success: false, error: 'Drive not found' });
+    });
+
+    it('returns error when user is not a member', async () => {
+      mockCheckDriveAccess.mockResolvedValueOnce({
+        isOwner: false,
+        isAdmin: false,
+        isMember: false,
+        drive: { id: 'drive1', name: 'Test Drive' } as never,
+      });
+
+      const result = await memberTools.list_drive_members.execute!(
+        { driveId: 'drive1' },
+        makeContext('user1')
+      );
+
+      expect(result).toMatchObject({ success: false, error: expect.stringContaining('member') });
+    });
+  });
+
+  describe('list_collaborators', () => {
+    it('has correct tool definition', () => {
+      expect(typeof memberTools.list_collaborators).toBe('object');
+      expect(typeof memberTools.list_collaborators.description).toBe('string');
+      expect(memberTools.list_collaborators.description).toContain('userId');
+    });
+
+    it('requires user authentication', async () => {
+      const context = { toolCallId: '1', messages: [], experimental_context: {} };
+
+      await expect(
+        memberTools.list_collaborators.execute!({}, context)
+      ).rejects.toThrow('User authentication required');
+    });
+  });
+});

--- a/apps/web/src/lib/ai/tools/member-tools.ts
+++ b/apps/web/src/lib/ai/tools/member-tools.ts
@@ -13,7 +13,7 @@ export const memberTools = {
   list_drive_members: tool({
     description: 'List all members of a drive/workspace with their user IDs, names, emails, and roles. Use this before assigning tasks, inviting people by ID, or sending channel messages — it gives you the userId needed for those operations.',
     inputSchema: z.object({
-      driveId: z.string().describe('The ID of the drive to list members for'),
+      driveId: z.string().regex(/^[a-z][a-z0-9]{1,31}$/, 'Invalid drive ID format').describe('The ID of the drive to list members for'),
     }),
     execute: async ({ driveId }, { experimental_context: context }) => {
       const userId = (context as ToolExecutionContext)?.userId;
@@ -58,6 +58,8 @@ export const memberTools = {
 
       for (const m of memberRows) {
         if (!m.user?.id || !m.acceptedAt) continue;
+        // Skip if already added as owner (owner can have an accepted drive_members row too)
+        if (ownerRow?.id && m.user.id === ownerRow.id) continue;
         result.push({
           userId: m.user.id,
           name: m.user.name,

--- a/apps/web/src/lib/ai/tools/member-tools.ts
+++ b/apps/web/src/lib/ai/tools/member-tools.ts
@@ -1,0 +1,144 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import { db } from '@pagespace/db/db';
+import { eq, and, inArray } from '@pagespace/db/operators';
+import { drives } from '@pagespace/db/schema/core';
+import { users } from '@pagespace/db/schema/auth';
+import { userProfiles } from '@pagespace/db/schema/members';
+import { connections } from '@pagespace/db/schema/social';
+import { checkDriveAccess, listDriveMembers } from '@pagespace/lib/services/drive-member-service';
+import { type ToolExecutionContext } from '../core';
+
+export const memberTools = {
+  list_drive_members: tool({
+    description: 'List all members of a drive/workspace with their user IDs, names, emails, and roles. Use this before assigning tasks, inviting people by ID, or sending channel messages — it gives you the userId needed for those operations.',
+    inputSchema: z.object({
+      driveId: z.string().describe('The ID of the drive to list members for'),
+    }),
+    execute: async ({ driveId }, { experimental_context: context }) => {
+      const userId = (context as ToolExecutionContext)?.userId;
+      if (!userId) throw new Error('User authentication required');
+
+      const access = await checkDriveAccess(driveId, userId);
+      if (!access.drive) return { success: false, error: 'Drive not found' };
+      if (!access.isOwner && !access.isMember) {
+        return { success: false, error: 'You must be a drive member to view members' };
+      }
+
+      // Fetch owner — stored in drives.ownerId, not in drive_members table
+      const [ownerRow] = await db
+        .select({
+          id: users.id,
+          name: users.name,
+          email: users.email,
+          displayName: userProfiles.displayName,
+          avatarUrl: userProfiles.avatarUrl,
+        })
+        .from(drives)
+        .leftJoin(users, eq(drives.ownerId, users.id))
+        .leftJoin(userProfiles, eq(drives.ownerId, userProfiles.userId))
+        .where(eq(drives.id, driveId))
+        .limit(1);
+
+      // Fetch accepted members
+      const memberRows = await listDriveMembers(driveId);
+
+      const result = [];
+
+      if (ownerRow?.id) {
+        result.push({
+          userId: ownerRow.id,
+          name: ownerRow.name,
+          displayName: ownerRow.displayName ?? ownerRow.name,
+          email: ownerRow.email,
+          role: 'OWNER' as const,
+          avatarUrl: ownerRow.avatarUrl ?? null,
+        });
+      }
+
+      for (const m of memberRows) {
+        if (!m.user?.id || !m.acceptedAt) continue;
+        result.push({
+          userId: m.user.id,
+          name: m.user.name,
+          displayName: m.profile?.displayName ?? m.user.name,
+          email: m.user.email,
+          role: m.role,
+          avatarUrl: m.profile?.avatarUrl ?? null,
+        });
+      }
+
+      return {
+        success: true,
+        members: result,
+        summary: `${result.length} member${result.length === 1 ? '' : 's'} in "${access.drive.name}"`,
+        stats: { total: result.length, driveName: access.drive.name },
+        nextSteps: ["Use a member's userId to assign tasks, send channel messages, or invite them to pages"],
+      };
+    },
+  }),
+
+  list_collaborators: tool({
+    description: "List all users you're connected to (accepted connections). Returns their user IDs, names, and emails — useful for finding people across drives to assign, invite, or message.",
+    inputSchema: z.object({}),
+    execute: async ({}, { experimental_context: context }) => {
+      const userId = (context as ToolExecutionContext)?.userId;
+      if (!userId) throw new Error('User authentication required');
+
+      // connections is bidirectional — user can be user1Id or user2Id
+      const asUser1 = await db
+        .select({ otherId: connections.user2Id, connectedSince: connections.acceptedAt })
+        .from(connections)
+        .where(and(eq(connections.user1Id, userId), eq(connections.status, 'ACCEPTED')));
+
+      const asUser2 = await db
+        .select({ otherId: connections.user1Id, connectedSince: connections.acceptedAt })
+        .from(connections)
+        .where(and(eq(connections.user2Id, userId), eq(connections.status, 'ACCEPTED')));
+
+      const all = [...asUser1, ...asUser2];
+
+      if (all.length === 0) {
+        return {
+          success: true,
+          collaborators: [],
+          summary: 'No accepted connections yet',
+          stats: { total: 0 },
+          nextSteps: ['Connections are accepted friend/collaborator requests on PageSpace'],
+        };
+      }
+
+      const otherIds = all.map((c) => c.otherId);
+      const connectedSinceMap = new Map(all.map((c) => [c.otherId, c.connectedSince]));
+
+      const userRows = await db
+        .select({
+          id: users.id,
+          name: users.name,
+          email: users.email,
+          displayName: userProfiles.displayName,
+          avatarUrl: userProfiles.avatarUrl,
+        })
+        .from(users)
+        .leftJoin(userProfiles, eq(users.id, userProfiles.userId))
+        .where(inArray(users.id, otherIds));
+
+      const collaborators = userRows.map((u) => ({
+        userId: u.id,
+        name: u.name,
+        displayName: u.displayName ?? u.name,
+        email: u.email,
+        avatarUrl: u.avatarUrl ?? null,
+        connectedSince: connectedSinceMap.get(u.id) ?? null,
+      }));
+
+      return {
+        success: true,
+        collaborators,
+        summary: `${collaborators.length} collaborator${collaborators.length === 1 ? '' : 's'}`,
+        stats: { total: collaborators.length },
+        nextSteps: ["Use a collaborator's userId to assign tasks, invite them to a drive, or send them a message"],
+      };
+    },
+  }),
+};


### PR DESCRIPTION
## Summary

- Agents had no way to discover people's user IDs, making task assignment, drive invites, and channel messaging impossible without knowing IDs upfront
- Adds `list_drive_members(driveId)` — returns all members of a drive (including owner, who lives in `drives.ownerId` not `drive_members`) with userId, name, email, role, avatarUrl. Deduplicates owner if they also have a `drive_members` row
- Adds `list_collaborators()` — returns the current user's accepted connections across the platform, handling the bidirectional `connections` table correctly
- Both are **non-core** tools: registered in `pageSpaceTools` but not `CORE_TOOL_NAMES`, so schemas aren't pushed upfront — agents find them via `tool_search "member"`

## Security / PII scoping

Both tools return only what the authenticated user can see via existing APIs:
- `list_drive_members`: gated by `checkDriveAccess(driveId, userId)` — same as `GET /api/drives/[driveId]/members`
- `list_collaborators`: scoped to the caller's own accepted connections — same data as `GET /api/connections?status=ACCEPTED`

Agent always runs as the `userId` from the authenticated session — access is bounded by that user's permissions.

## Test plan

- [ ] In a drive chat, ask agent "Who are the members of this drive?" — should call `tool_search` then `list_drive_members`, returning names + IDs including the owner (no duplicates if owner is also in drive_members)
- [ ] Follow up "Assign the first task to [member name]" — agent should use the userId from the previous call
- [ ] Ask "List my collaborators" — returns accepted connections
- [ ] Verify access gate: agent in drive A cannot list members of drive B it doesn't belong to
- [ ] Verify driveId format validation rejects non-CUID2 strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)