### PR TITLE
feat(task-list): real-time task moves, stable header, unified doc save infrastructure

### DIFF
--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListDescription.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListDescription.tsx
@@ -6,13 +6,11 @@ import { type Editor } from '@tiptap/react';
 import { useDocument } from '@/hooks/useDocument';
 import { useDocumentManagerStore } from '@/stores/useDocumentManagerStore';
 import { useEditingStore } from '@/stores/useEditingStore';
+import { isRichContentEmpty } from '@/hooks/usePageContent';
 
 const RichEditor = dynamic(() => import('@/components/editors/RichEditor'), { ssr: false });
 
-export const isRichContentEmpty = (html: string | null): boolean => {
-  if (!html) return true;
-  return (new DOMParser().parseFromString(html, 'text/html').body.textContent ?? '').trim().length === 0;
-};
+export { isRichContentEmpty };
 
 export const getInitialOpenState = (content: string | null): boolean =>
   !isRichContentEmpty(content);
@@ -20,7 +18,7 @@ export const getInitialOpenState = (content: string | null): boolean =>
 interface TaskListDescriptionContentProps {
   pageId: string;
   canEdit: boolean;
-  initialContent: string | null;
+  initialContent?: string | null;
   className?: string;
   onEditorChange?: (editor: Editor | null) => void;
 }

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListDescription.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListDescription.tsx
@@ -1,36 +1,21 @@
 'use client';
 
+import { useEffect, useRef, useCallback } from 'react';
 import dynamic from 'next/dynamic';
 import { type Editor } from '@tiptap/react';
-import { ChevronDown, ChevronRight } from 'lucide-react';
-import { isRichContentEmpty, usePageContent } from '@/hooks/usePageContent';
+import { useDocument } from '@/hooks/useDocument';
+import { useDocumentManagerStore } from '@/stores/useDocumentManagerStore';
+import { useEditingStore } from '@/stores/useEditingStore';
 
 const RichEditor = dynamic(() => import('@/components/editors/RichEditor'), { ssr: false });
 
+export const isRichContentEmpty = (html: string | null): boolean => {
+  if (!html) return true;
+  return (new DOMParser().parseFromString(html, 'text/html').body.textContent ?? '').trim().length === 0;
+};
+
 export const getInitialOpenState = (content: string | null): boolean =>
   !isRichContentEmpty(content);
-
-interface TaskListDescriptionHeaderProps {
-  open: boolean;
-  onToggle: () => void;
-}
-
-export function TaskListDescriptionHeader({ open, onToggle }: TaskListDescriptionHeaderProps) {
-  return (
-    <button
-      type="button"
-      onClick={onToggle}
-      className="flex items-center gap-1.5 px-4 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors w-full text-left shrink-0"
-    >
-      {open ? (
-        <ChevronDown className="h-3.5 w-3.5 shrink-0" />
-      ) : (
-        <ChevronRight className="h-3.5 w-3.5 shrink-0" />
-      )}
-      Description
-    </button>
-  );
-}
 
 interface TaskListDescriptionContentProps {
   pageId: string;
@@ -47,13 +32,58 @@ export function TaskListDescriptionContent({
   className,
   onEditorChange,
 }: TaskListDescriptionContentProps) {
-  const { content, save } = usePageContent({ pageId, initialContent });
+  const {
+    document: docState,
+    updateContent,
+    saveWithDebounce,
+    forceSave,
+    initializeAndActivate,
+  } = useDocument(pageId);
+
+  // Seed the store from the parent's already-loaded page content to avoid a
+  // redundant network fetch. Only fetches if the document isn't cached yet and
+  // no initialContent was provided (e.g. a standalone mount without a tree page).
+  useEffect(() => {
+    const existing = useDocumentManagerStore.getState().documents.get(pageId);
+    if (existing) return;
+    if (initialContent !== undefined) {
+      useDocumentManagerStore.getState().upsertDocument(pageId, initialContent ?? '', 'html');
+    } else {
+      initializeAndActivate();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pageId]);
+
+  // Register with useEditingStore while dirty so SWR doesn't revalidate mid-edit.
+  useEffect(() => {
+    const componentId = `task-description-${pageId}`;
+    if (docState?.isDirty && canEdit) {
+      useEditingStore.getState().startEditing(componentId, 'document', { pageId });
+    } else {
+      useEditingStore.getState().endEditing(componentId);
+    }
+    return () => { useEditingStore.getState().endEditing(componentId); };
+  }, [docState?.isDirty, pageId, canEdit]);
+
+  // Keep a stable ref so the unmount cleanup always calls the latest forceSave.
+  const forceSaveRef = useRef(forceSave);
+  useEffect(() => { forceSaveRef.current = forceSave; }, [forceSave]);
+  useEffect(() => {
+    return () => { forceSaveRef.current().catch(() => {}); };
+  }, []);
+
+  const handleChange = useCallback((html: string) => {
+    updateContent(html);
+    saveWithDebounce(html);
+  }, [updateContent, saveWithDebounce]);
+
+  const content = docState?.content ?? initialContent ?? '';
 
   return (
     <div className={className}>
       <RichEditor
-        value={content ?? ''}
-        onChange={save}
+        value={content}
+        onChange={handleChange}
         readOnly={!canEdit}
         contentMode="html"
         onEditorChange={onEditorChange}

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListHeader.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListHeader.tsx
@@ -51,6 +51,7 @@ export function TaskListHeader({
       </div>
       <div className="flex items-center bg-muted rounded-md p-0.5">
         <button
+          type="button"
           onClick={() => onViewModeChange('editor')}
           className={cn(
             'p-1.5 rounded transition-colors',
@@ -64,6 +65,7 @@ export function TaskListHeader({
           <BookOpen className="h-4 w-4" />
         </button>
         <button
+          type="button"
           onClick={() => onViewModeChange('table')}
           className={cn(
             'p-1.5 rounded transition-colors',
@@ -77,6 +79,7 @@ export function TaskListHeader({
           <LayoutList className="h-4 w-4" />
         </button>
         <button
+          type="button"
           onClick={() => onViewModeChange('kanban')}
           className={cn(
             'p-1.5 rounded transition-colors',

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListHeader.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListHeader.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+import { ChevronDown, ChevronRight, BookOpen, LayoutList, Kanban } from 'lucide-react';
+import { useDocumentManagerStore, DocumentManagerState } from '@/stores/useDocumentManagerStore';
+import { SaveStatusIndicator } from '@/components/layout/middle-content/content-header/SaveStatusIndicator';
+
+interface TaskListHeaderProps {
+  pageId: string;
+  viewMode: 'table' | 'kanban' | 'editor';
+  onViewModeChange: (mode: 'table' | 'kanban' | 'editor') => void;
+  descriptionOpen?: boolean;
+  onDescriptionToggle?: () => void;
+  canEdit: boolean;
+}
+
+export function TaskListHeader({
+  pageId,
+  viewMode,
+  onViewModeChange,
+  descriptionOpen,
+  onDescriptionToggle,
+  canEdit,
+}: TaskListHeaderProps) {
+  const isDirty  = useDocumentManagerStore((s: DocumentManagerState) => s.documents.get(pageId)?.isDirty ?? false);
+  const isSaving = useDocumentManagerStore((s: DocumentManagerState) => s.savingDocuments.has(pageId));
+  const showSaveStatus = canEdit && (viewMode === 'editor' || descriptionOpen);
+
+  return (
+    <div className="flex items-center justify-between px-4 py-2 border-b bg-background shrink-0">
+      <div className="flex items-center gap-2">
+        {onDescriptionToggle ? (
+          <button
+            type="button"
+            onClick={onDescriptionToggle}
+            className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            {descriptionOpen ? (
+              <ChevronDown className="h-3.5 w-3.5 shrink-0" />
+            ) : (
+              <ChevronRight className="h-3.5 w-3.5 shrink-0" />
+            )}
+            <span className="font-medium">Description</span>
+          </button>
+        ) : (
+          <span className="text-sm font-medium text-muted-foreground">Description</span>
+        )}
+        {showSaveStatus && (
+          <SaveStatusIndicator isDirty={isDirty} isSaving={isSaving} />
+        )}
+      </div>
+      <div className="flex items-center bg-muted rounded-md p-0.5">
+        <button
+          onClick={() => onViewModeChange('editor')}
+          className={cn(
+            'p-1.5 rounded transition-colors',
+            viewMode === 'editor'
+              ? 'bg-background text-foreground shadow-sm'
+              : 'text-muted-foreground hover:text-foreground'
+          )}
+          title="Editor view"
+          aria-label="Editor view"
+        >
+          <BookOpen className="h-4 w-4" />
+        </button>
+        <button
+          onClick={() => onViewModeChange('table')}
+          className={cn(
+            'p-1.5 rounded transition-colors',
+            viewMode === 'table'
+              ? 'bg-background text-foreground shadow-sm'
+              : 'text-muted-foreground hover:text-foreground'
+          )}
+          title="Table view"
+          aria-label="Table view"
+        >
+          <LayoutList className="h-4 w-4" />
+        </button>
+        <button
+          onClick={() => onViewModeChange('kanban')}
+          className={cn(
+            'p-1.5 rounded transition-colors',
+            viewMode === 'kanban'
+              ? 'bg-background text-foreground shadow-sm'
+              : 'text-muted-foreground hover:text-foreground'
+          )}
+          title="Kanban view"
+          aria-label="Kanban view"
+        >
+          <Kanban className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -448,6 +448,9 @@ function TaskListView({ page }: TaskListViewProps) {
   const [descriptionOpen, setDescriptionOpen] = useState(() => getInitialOpenState(page.content));
   const [editorInstance, setEditorInstance] = useState<Editor | null>(null);
   const hasLoadedRef = useRef(false);
+  // Stable ref so the page:moved socket handler always sees the latest task list
+  // without needing data in the socket effect's dependency array.
+  const tasksRef = useRef(data?.tasks);
 
   // Use centralized socket store for proper authentication
   const socket = useSocketStore((state) => state.socket);
@@ -478,6 +481,10 @@ function TaskListView({ page }: TaskListViewProps) {
       refreshInterval: 300000, // 5 minutes
     }
   );
+
+  // Keep tasksRef current so the page:moved handler detects moved-out tasks
+  // even when the socket effect hasn't re-run since the SWR load completed.
+  useEffect(() => { tasksRef.current = data?.tasks; }, [data?.tasks]);
 
   // Connect to socket store when user is available
   useEffect(() => {
@@ -514,10 +521,12 @@ function TaskListView({ page }: TaskListViewProps) {
 
     // Handle tasks moved between lists via drag-and-drop. The reorder API emits
     // page:moved on the drive room (joined by usePageTreeSocket). We need to
-    // refetch when a task enters or leaves this list.
+    // refetch when a task enters or leaves this list. tasksRef (not data) is
+    // used so the handler always sees the current task list regardless of when
+    // this effect was installed relative to the SWR load.
     const handlePageMoved = (payload: { pageId: string; parentId: string | null }) => {
       const movedIn  = payload.parentId === page.id;
-      const movedOut = data?.tasks.some(t => t.pageId === payload.pageId);
+      const movedOut = tasksRef.current?.some(t => t.pageId === payload.pageId);
       if (movedIn || movedOut) mutate(`/api/pages/${page.id}/tasks`);
     };
 
@@ -534,7 +543,7 @@ function TaskListView({ page }: TaskListViewProps) {
       socket.off('task:tasks_reordered', handleTasksReordered);
       socket.off('page:moved', handlePageMoved);
     };
-  }, [socket, connectionStatus, page.id]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [socket, connectionStatus, page.id]);
 
   // Derive dynamic status config from API response
   const statusConfigs = useMemo(() => data?.statusConfigs ?? [], [data?.statusConfigs]);

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -55,10 +55,7 @@ import {
   Pencil,
   Trash2,
   FileText,
-  BookOpen,
   GripVertical,
-  LayoutList,
-  Kanban,
   Zap,
   Bell,
   ChevronRight,
@@ -83,7 +80,8 @@ import { cn } from '@/lib/utils';
 import { MultiAssigneeSelect } from './MultiAssigneeSelect';
 import { DueDatePicker } from './DueDatePicker';
 import { TaskKanbanView } from './TaskKanbanView';
-import { getInitialOpenState, TaskListDescriptionHeader, TaskListDescriptionContent } from './TaskListDescription';
+import { getInitialOpenState, TaskListDescriptionContent } from './TaskListDescription';
+import { TaskListHeader } from './TaskListHeader';
 import Toolbar from '@/components/editors/Toolbar';
 import { TaskRowDescription } from './TaskRowDescription';
 import { StatusConfigManager } from './StatusConfigManager';
@@ -514,18 +512,29 @@ function TaskListView({ page }: TaskListViewProps) {
       mutate(`/api/pages/${page.id}/tasks`);
     };
 
+    // Handle tasks moved between lists via drag-and-drop. The reorder API emits
+    // page:moved on the drive room (joined by usePageTreeSocket). We need to
+    // refetch when a task enters or leaves this list.
+    const handlePageMoved = (payload: { pageId: string; parentId: string | null }) => {
+      const movedIn  = payload.parentId === page.id;
+      const movedOut = data?.tasks.some(t => t.pageId === payload.pageId);
+      if (movedIn || movedOut) mutate(`/api/pages/${page.id}/tasks`);
+    };
+
     socket.on('task:task_added', handleTaskAdded);
     socket.on('task:task_updated', handleTaskUpdated);
     socket.on('task:task_deleted', handleTaskDeleted);
     socket.on('task:tasks_reordered', handleTasksReordered);
+    socket.on('page:moved', handlePageMoved);
 
     return () => {
       socket.off('task:task_added', handleTaskAdded);
       socket.off('task:task_updated', handleTaskUpdated);
       socket.off('task:task_deleted', handleTaskDeleted);
       socket.off('task:tasks_reordered', handleTasksReordered);
+      socket.off('page:moved', handlePageMoved);
     };
-  }, [socket, connectionStatus, page.id]);
+  }, [socket, connectionStatus, page.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Derive dynamic status config from API response
   const statusConfigs = useMemo(() => data?.statusConfigs ?? [], [data?.statusConfigs]);
@@ -798,35 +807,12 @@ function TaskListView({ page }: TaskListViewProps) {
   if (viewMode === 'editor') {
     return (
       <div className="flex flex-col h-full min-w-0">
-        <div className="flex items-center justify-between px-4 py-2 border-b bg-background shrink-0">
-          <span className="text-sm font-medium text-muted-foreground">Description</span>
-          <div className="flex items-center bg-muted rounded-md p-0.5">
-            <button
-              onClick={() => setViewMode('editor')}
-              className={cn('p-1.5 rounded transition-colors', 'bg-background text-foreground shadow-sm')}
-              title="Editor view"
-              aria-label="Editor view"
-            >
-              <BookOpen className="h-4 w-4" />
-            </button>
-            <button
-              onClick={() => setViewMode('table')}
-              className={cn('p-1.5 rounded transition-colors', 'text-muted-foreground hover:text-foreground')}
-              title="Table view"
-              aria-label="Table view"
-            >
-              <LayoutList className="h-4 w-4" />
-            </button>
-            <button
-              onClick={() => setViewMode('kanban')}
-              className={cn('p-1.5 rounded transition-colors', 'text-muted-foreground hover:text-foreground')}
-              title="Kanban view"
-              aria-label="Kanban view"
-            >
-              <Kanban className="h-4 w-4" />
-            </button>
-          </div>
-        </div>
+        <TaskListHeader
+          pageId={page.id}
+          viewMode="editor"
+          onViewModeChange={setViewMode}
+          canEdit={canEdit}
+        />
         {canEdit && <Toolbar editor={editorInstance} contentMode="html" />}
         <TaskListDescriptionContent
           pageId={page.id}
@@ -865,9 +851,13 @@ function TaskListView({ page }: TaskListViewProps) {
 
   return (
     <div className="flex flex-col h-full min-w-0">
-      <TaskListDescriptionHeader
-        open={descriptionOpen}
-        onToggle={() => setDescriptionOpen(prev => !prev)}
+      <TaskListHeader
+        pageId={page.id}
+        viewMode={viewMode}
+        onViewModeChange={setViewMode}
+        descriptionOpen={descriptionOpen}
+        onDescriptionToggle={() => setDescriptionOpen(prev => !prev)}
+        canEdit={canEdit}
       />
       {descriptionOpen && (
         <TaskListDescriptionContent
@@ -913,44 +903,6 @@ function TaskListView({ page }: TaskListViewProps) {
 
         <div className="flex flex-col sm:flex-row sm:items-center gap-2 w-full sm:w-auto">
           <div className="flex items-center gap-2 sm:contents">
-            {/* View toggle (desktop only) */}
-            <div className="hidden md:flex items-center bg-muted rounded-md p-0.5">
-              <button
-                onClick={() => setViewMode('editor')}
-                className="p-1.5 rounded transition-colors text-muted-foreground hover:text-foreground"
-                title="Editor view"
-                aria-label="Editor view"
-              >
-                <BookOpen className="h-4 w-4" />
-              </button>
-              <button
-                onClick={() => setViewMode('table')}
-                className={cn(
-                  'p-1.5 rounded transition-colors',
-                  viewMode === 'table'
-                    ? 'bg-background text-foreground shadow-sm'
-                    : 'text-muted-foreground hover:text-foreground'
-                )}
-                title="Table view"
-                aria-label="Table view"
-              >
-                <LayoutList className="h-4 w-4" />
-              </button>
-              <button
-                onClick={() => setViewMode('kanban')}
-                className={cn(
-                  'p-1.5 rounded transition-colors',
-                  viewMode === 'kanban'
-                    ? 'bg-background text-foreground shadow-sm'
-                    : 'text-muted-foreground hover:text-foreground'
-                )}
-                title="Kanban view"
-                aria-label="Kanban view"
-              >
-                <Kanban className="h-4 w-4" />
-              </button>
-            </div>
-
             {canEdit && (
               <StatusConfigManager
                 pageId={page.id}

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -448,9 +448,6 @@ function TaskListView({ page }: TaskListViewProps) {
   const [descriptionOpen, setDescriptionOpen] = useState(() => getInitialOpenState(page.content));
   const [editorInstance, setEditorInstance] = useState<Editor | null>(null);
   const hasLoadedRef = useRef(false);
-  // Stable ref so the page:moved socket handler always sees the latest task list
-  // without needing data in the socket effect's dependency array.
-  const tasksRef = useRef(data?.tasks);
 
   // Use centralized socket store for proper authentication
   const socket = useSocketStore((state) => state.socket);
@@ -482,8 +479,9 @@ function TaskListView({ page }: TaskListViewProps) {
     }
   );
 
-  // Keep tasksRef current so the page:moved handler detects moved-out tasks
-  // even when the socket effect hasn't re-run since the SWR load completed.
+  // Stable ref so the page:moved handler always sees the current task list
+  // regardless of when the socket effect was installed relative to the SWR load.
+  const tasksRef = useRef(data?.tasks);
   useEffect(() => { tasksRef.current = data?.tasks; }, [data?.tasks]);
 
   // Connect to socket store when user is available


### PR DESCRIPTION
## Summary

- **Real-time task moves**: Add a `page:moved` socket listener to `TaskListView` so tasks moved between lists via drag-and-drop appear/disappear immediately for all viewers. The drive room is already joined by `usePageTreeSocket` so no additional channel join is needed.
- **Stable view toggle**: Extract `TaskListHeader` — a single unified header row rendered in every view mode (list, kanban, editor). View toggle buttons no longer shift position when switching views because they now live in exactly one place.
- **Unified document save infrastructure**: Replace `usePageContent` with `useDocument` in `TaskListDescriptionContent`, bringing the task list description up to the same standard as document pages — conflict detection (409 handling), revision tracking, `useEditingStore` registration, and force-save on unmount. `TaskListHeader` subscribes to `useDocumentManagerStore` directly for `isDirty`/`isSaving` and renders `SaveStatusIndicator`, with no prop drilling.

## Architecture

```
TaskListView  (owns: viewMode, descriptionOpen, task SWR data)
  └─ TaskListHeader  (new — stable header row, reads save state from store)
  └─ TaskListDescriptionContent  (uses useDocument instead of usePageContent)
  └─ [table / kanban content]
```

`TaskListDescriptionHeader` is deleted — replaced by `TaskListHeader`.

## Test plan

- [ ] Open the same task list in two browser windows; drag a task to another list — the first window should see it disappear without a refresh
- [ ] Drag a task from another list into this list — first window should see it appear
- [ ] Switch between List / Kanban / Editor views — view toggle buttons stay at the right edge of the header row, no visual shift
- [ ] Open description panel (table/kanban mode) and type — "Unsaved changes" → "Saving..." → "Saved" appears in the header row
- [ ] Switch to Editor mode and type — same save indicator behavior
- [ ] Edit description, navigate away before debounce fires — force-save triggers on unmount

🤖 Generated with [Claude Code](https://claude.com/claude-code)