### PR TITLE
feat(tasks): sub-task awareness — completion guard, read_page enrichment, progress data

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/__tests__/route.test.ts
@@ -137,6 +137,17 @@ vi.mock('@/lib/websocket', () => ({
   createPageEventPayload: vi.fn(() => ({})),
 }));
 
+vi.mock('@/lib/tasks/completion-guard', () => ({
+  assertSubTasksComplete: vi.fn().mockResolvedValue(undefined),
+  SubtasksIncompleteError: class SubtasksIncompleteError extends Error {
+    readonly code = 'SUBTASKS_INCOMPLETE' as const;
+    constructor(public readonly pending: number, public readonly total: number) {
+      super(`Complete all sub-tasks first (${pending} of ${total} remaining)`);
+      this.name = 'SubtasksIncompleteError';
+    }
+  },
+}));
+
 // ---------- Imports (after mocks) ----------
 
 import { PATCH, DELETE } from '../route';
@@ -146,6 +157,7 @@ import { db } from '@pagespace/db/db';
 import { broadcastTaskEvent, broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { applyPageMutation } from '@/services/api/page-mutation-service';
 import { createTaskAssignedNotification, createMentionNotification } from '@pagespace/lib/notifications/notifications';
+import { assertSubTasksComplete, SubtasksIncompleteError } from '@/lib/tasks/completion-guard';
 
 // ---------- Helpers ----------
 
@@ -997,6 +1009,41 @@ describe('PATCH /api/pages/[pageId]/tasks/[taskId]', () => {
     expect(response.status).toBe(200);
   });
 
+
+  it('returns 422 when assertSubTasksComplete throws SubtasksIncompleteError', async () => {
+    setupAuth();
+    setupCanEdit(true);
+    setupTaskLookup({ id: mockTaskListId }, { ...baseTask, completedAt: null });
+    vi.mocked(db.query.taskStatusConfigs.findMany).mockResolvedValue([
+      { slug: 'open', group: 'todo' },
+      { slug: 'finished', group: 'done' },
+    ] as never);
+    vi.mocked(assertSubTasksComplete).mockRejectedValueOnce(
+      new SubtasksIncompleteError(2, 3)
+    );
+
+    const response = await PATCH(createPatchRequest({ status: 'finished' }), context);
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error).toContain('Complete all sub-tasks first');
+    expect(body.pending).toBe(2);
+    expect(body.total).toBe(3);
+  });
+
+  it('does not call assertSubTasksComplete when status is not done-group', async () => {
+    setupAuth();
+    setupCanEdit(true);
+    setupTaskLookup({ id: mockTaskListId }, { ...baseTask });
+    vi.mocked(db.query.taskStatusConfigs.findMany).mockResolvedValue([
+      { slug: 'open', group: 'todo' },
+      { slug: 'finished', group: 'done' },
+    ] as never);
+    setupTransaction({ ...baseTask, status: 'open' });
+    setupRelationsLookup({ ...baseTask, status: 'open', assignee: null, assigneeAgent: null, user: null, assignees: [] });
+
+    await PATCH(createPatchRequest({ status: 'open' }), context);
+    expect(assertSubTasksComplete).not.toHaveBeenCalled();
+  });
 
   it('does not fire createMentionNotification when description is not part of the update', async () => {
     setupAuth();

--- a/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/__tests__/route.test.ts
@@ -1030,6 +1030,23 @@ describe('PATCH /api/pages/[pageId]/tasks/[taskId]', () => {
     expect(body.total).toBe(3);
   });
 
+  it('returns 422 in fallback mode when completing a task with incomplete sub-tasks', async () => {
+    setupAuth();
+    setupCanEdit(true);
+    setupTaskLookup({ id: mockTaskListId }, { ...baseTask, completedAt: null });
+    vi.mocked(db.query.taskStatusConfigs.findMany).mockResolvedValue([] as never);
+    vi.mocked(assertSubTasksComplete).mockRejectedValueOnce(
+      new SubtasksIncompleteError(1, 2)
+    );
+
+    const response = await PATCH(createPatchRequest({ status: 'completed' }), context);
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.error).toContain('Complete all sub-tasks first');
+    expect(body.pending).toBe(1);
+    expect(body.total).toBe(2);
+  });
+
   it('does not call assertSubTasksComplete when status is not done-group', async () => {
     setupAuth();
     setupCanEdit(true);

--- a/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/[taskId]/route.ts
@@ -13,6 +13,7 @@ import type { DeferredWorkflowTrigger } from '@pagespace/lib/monitoring/activity
 import { createTaskAssignedNotification } from '@pagespace/lib/notifications/notifications';
 
 import { syncTaskDueDateTrigger, cancelTaskDueDateTrigger, fireCompletionTrigger, disableTaskTriggers } from '@/lib/workflows/task-trigger-helpers';
+import { assertSubTasksComplete, SubtasksIncompleteError } from '@/lib/tasks/completion-guard';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 
@@ -183,6 +184,21 @@ export async function PATCH(
 
   if (position !== undefined) {
     updates.position = position;
+  }
+
+  // Completion guard: cannot mark a task done while it has incomplete sub-tasks
+  if (updates.completedAt instanceof Date && existingTask.pageId) {
+    try {
+      await assertSubTasksComplete(existingTask.pageId);
+    } catch (error) {
+      if (error instanceof SubtasksIncompleteError) {
+        return NextResponse.json(
+          { error: error.message, pending: error.pending, total: error.total },
+          { status: 422 }
+        );
+      }
+      throw error;
+    }
   }
 
   const actorInfo = await getActorInfo(userId);

--- a/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
@@ -401,14 +401,19 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
   const taskList = await getOrCreateTaskListForPage(pageId, userId);
 
   // Validate status against task list's status configs
+  let initialCompletedAt: Date | null = null;
   if (status) {
     const validStatuses = await db.query.taskStatusConfigs.findMany({
       where: eq(taskStatusConfigs.taskListId, taskList.id),
-      columns: { slug: true },
+      columns: { slug: true, group: true },
     });
     const validSlugs = validStatuses.map(s => s.slug);
     if (validSlugs.length > 0 && !validSlugs.includes(status)) {
       return NextResponse.json({ error: `Invalid status "${status}". Valid statuses: ${validSlugs.join(', ')}` }, { status: 400 });
+    }
+    const matchedConfig = validStatuses.find(s => s.slug === status);
+    if (matchedConfig?.group === 'done' || (!matchedConfig && status === 'completed')) {
+      initialCompletedAt = new Date();
     }
   }
 
@@ -447,6 +452,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
       assigneeAgentId: primaryAgentId,
       dueDate: dueDate ? new Date(dueDate) : null,
       position: nextPosition,
+      completedAt: initialCompletedAt,
     }).returning();
 
     // Create assignees in junction table

--- a/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { db } from '@pagespace/db/db'
-import { eq, and, desc, asc, inArray, count } from '@pagespace/db/operators'
+import { eq, and, desc, asc, inArray, count, isNotNull } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core'
 import { taskLists, taskItems, taskStatusConfigs, taskAssignees } from '@pagespace/db/schema/tasks';
 import { taskTriggers } from '@pagespace/db/schema/task-triggers';
@@ -248,21 +248,31 @@ export async function GET(req: Request, { params }: { params: Promise<{ pageId: 
     }
   }
 
-  // Batch-count sub-tasks for each task's linked page via pages.parentId
+  // Batch-count sub-tasks (total + completed) for each task's linked page via pages.parentId
   const subTaskCountByPageId = new Map<string, number>();
+  const subTaskCompletedByPageId = new Map<string, number>();
   const linkedPageIds = tasks.map(t => t.pageId).filter((id): id is string => !!id);
   if (linkedPageIds.length > 0) {
-    const subTaskRows = await db
-      .select({ parentId: pages.parentId, total: count() })
-      .from(taskItems)
-      .innerJoin(pages, eq(pages.id, taskItems.pageId))
-      .where(and(
-        inArray(pages.parentId, linkedPageIds),
-        eq(pages.isTrashed, false),
-      ))
-      .groupBy(pages.parentId);
+    const baseWhere = and(inArray(pages.parentId, linkedPageIds), eq(pages.isTrashed, false));
+    const [subTaskRows, completedSubTaskRows] = await Promise.all([
+      db
+        .select({ parentId: pages.parentId, total: count() })
+        .from(taskItems)
+        .innerJoin(pages, eq(pages.id, taskItems.pageId))
+        .where(baseWhere)
+        .groupBy(pages.parentId),
+      db
+        .select({ parentId: pages.parentId, total: count() })
+        .from(taskItems)
+        .innerJoin(pages, eq(pages.id, taskItems.pageId))
+        .where(and(baseWhere, isNotNull(taskItems.completedAt)))
+        .groupBy(pages.parentId),
+    ]);
     for (const row of subTaskRows) {
       if (row.parentId) subTaskCountByPageId.set(row.parentId, Number(row.total));
+    }
+    for (const row of completedSubTaskRows) {
+      if (row.parentId) subTaskCompletedByPageId.set(row.parentId, Number(row.total));
     }
   }
 
@@ -272,6 +282,7 @@ export async function GET(req: Request, { params }: { params: Promise<{ pageId: 
     activeTriggerCount: triggerCountByTaskId.get(t.id) ?? 0,
     hasContent: computeHasContent(page?.content),
     subTaskCount: subTaskCountByPageId.get(t.pageId ?? '') ?? 0,
+    subTaskCompletedCount: subTaskCompletedByPageId.get(t.pageId ?? '') ?? 0,
     page: page ? { id: page.id, type: page.type, isTrashed: page.isTrashed, position: page.position } : null,
   }));
 

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/TaskListView.tsx
@@ -621,6 +621,14 @@ function TaskListView({ page }: TaskListViewProps) {
       }) || 'pending';
       await handleStatusChange(task.id, todoStatus);
     } else {
+      // Block completion when sub-tasks are incomplete
+      const subTaskCount = task.subTaskCount ?? 0;
+      const subTaskCompletedCount = task.subTaskCompletedCount ?? 0;
+      if (subTaskCount > 0 && subTaskCompletedCount < subTaskCount) {
+        const pending = subTaskCount - subTaskCompletedCount;
+        toast.error(`Finish ${pending} sub-task${pending > 1 ? 's' : ''} first`);
+        return;
+      }
       // Move to first "done" group status
       const doneStatus = statusOrder.find(slug => {
         const cfg = statusConfigMap[slug];

--- a/apps/web/src/components/layout/middle-content/page-views/task-list/task-list-types.ts
+++ b/apps/web/src/components/layout/middle-content/page-views/task-list/task-list-types.ts
@@ -49,6 +49,7 @@ export interface TaskItem {
   activeTriggerCount?: number;
   hasContent?: boolean;
   subTaskCount?: number;
+  subTaskCompletedCount?: number;
   completedAt: string | null;
   createdAt: string;
   updatedAt: string;

--- a/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-read-tools.test.ts
@@ -475,6 +475,7 @@ describe('page-read-tools', () => {
         } as unknown as typeof mockDb.query.taskStatusConfigs;
 
         // db.select().from().innerJoin().where().orderBy() for tasks (title joined from pages)
+        // db.select().from().innerJoin().where().groupBy() for sub-task count aggregates
         mockDb.select = vi.fn(() => ({
           from: vi.fn().mockReturnThis(),
           innerJoin: vi.fn().mockReturnThis(),
@@ -493,6 +494,7 @@ describe('page-read-tools', () => {
               pageId: `page-task-${i}`,
             }))
           ),
+          groupBy: vi.fn().mockResolvedValue([]),
         })) as unknown as typeof mockDb.select;
 
         mockGetUserAccessLevel.mockResolvedValue(createMockAccessLevel('editor'));

--- a/apps/web/src/lib/ai/tools/__tests__/task-management-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/task-management-tools.test.ts
@@ -89,6 +89,17 @@ vi.mock('@/lib/websocket', () => ({
   createPageEventPayload: vi.fn(),
 }));
 
+vi.mock('@/lib/tasks/completion-guard', () => ({
+  assertSubTasksComplete: vi.fn().mockResolvedValue(undefined),
+  SubtasksIncompleteError: class SubtasksIncompleteError extends Error {
+    readonly code = 'SUBTASKS_INCOMPLETE' as const;
+    constructor(public readonly pending: number, public readonly total: number) {
+      super(`Complete all sub-tasks first (${pending} of ${total} remaining)`);
+      this.name = 'SubtasksIncompleteError';
+    }
+  },
+}));
+
 import { taskManagementTools } from '../task-management-tools';
 import { db } from '@pagespace/db/db';
 import { canUserEditPage } from '@pagespace/lib/permissions/permissions';

--- a/apps/web/src/lib/ai/tools/__tests__/task-management-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/task-management-tools.test.ts
@@ -104,6 +104,7 @@ import { taskManagementTools } from '../task-management-tools';
 import { db } from '@pagespace/db/db';
 import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import type { ToolExecutionContext } from '../../core';
+import { assertSubTasksComplete, SubtasksIncompleteError } from '@/lib/tasks/completion-guard';
 
 const mockDb = vi.mocked(db);
 const mockCanUserEditPage = vi.mocked(canUserEditPage);
@@ -636,6 +637,38 @@ describe('task-management-tools', () => {
         expect(reorderTxMock).toHaveBeenCalled();
         // Result should reflect the clamped/densified position
         expect((result as { task: { position: number } }).task.position).toBe(3);
+      });
+    });
+
+    describe('completion guard', () => {
+      it('returns structured failure when completing a task with incomplete sub-tasks', async () => {
+        mockDb.query.taskItems.findFirst = vi.fn().mockResolvedValue({
+          id: 'task-1',
+          taskListId: 'list-1',
+          pageId: 'task-page-1',
+          completedAt: null,
+        });
+        mockDb.query.taskLists.findFirst = vi.fn().mockResolvedValue({
+          id: 'list-1',
+          pageId: 'tasklist-page-1',
+          userId: 'user-123',
+        });
+        mockCanUserEditPage.mockResolvedValue(true);
+        mockDb.query.taskStatusConfigs.findMany = vi.fn().mockResolvedValue([]);
+        vi.mocked(assertSubTasksComplete).mockRejectedValueOnce(
+          new SubtasksIncompleteError(2, 3)
+        );
+
+        const context = {
+          toolCallId: '1', messages: [],
+          experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+        };
+
+        const result = await taskManagementTools.update_task.execute!(
+          { taskId: 'task-1', status: 'completed' },
+          context
+        );
+        expect(result).toMatchObject({ success: false, pending: 2, total: 3 });
       });
     });
 

--- a/apps/web/src/lib/ai/tools/page-read-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-read-tools.ts
@@ -275,6 +275,52 @@ export const pageReadTools = {
 
           const slugToGroup = new Map(availableStatuses.map(s => [s.slug, s.group]));
 
+          // Resolve parent task list (if this list is nested under another task)
+          let parentTaskList: { pageId: string; title: string; taskListId: string } | null = null;
+          if (page.parentId) {
+            const parentPage = await db.query.pages.findFirst({
+              where: and(eq(pages.id, page.parentId), eq(pages.isTrashed, false)),
+              columns: { id: true, title: true, type: true },
+            });
+            if (parentPage?.type === 'TASK_LIST') {
+              const parentList = await db.query.taskLists.findFirst({
+                where: eq(taskLists.pageId, parentPage.id),
+                columns: { id: true },
+              });
+              if (parentList) {
+                parentTaskList = { pageId: parentPage.id, title: parentPage.title, taskListId: parentList.id };
+              }
+            }
+          }
+
+          // Batch sub-task counts (total + completed) per task page
+          const taskPageIds = tasks.map(t => t.pageId).filter((id): id is string => !!id);
+          const subTaskCountMap = new Map<string, number>();
+          const subTaskCompletedMap = new Map<string, number>();
+          if (taskPageIds.length > 0) {
+            const baseWhere = and(inArray(pages.parentId, taskPageIds), eq(pages.isTrashed, false));
+            const [subTaskRows, completedRows] = await Promise.all([
+              db
+                .select({ parentId: pages.parentId, total: count() })
+                .from(taskItems)
+                .innerJoin(pages, eq(pages.id, taskItems.pageId))
+                .where(baseWhere)
+                .groupBy(pages.parentId),
+              db
+                .select({ parentId: pages.parentId, total: count() })
+                .from(taskItems)
+                .innerJoin(pages, eq(pages.id, taskItems.pageId))
+                .where(and(baseWhere, isNotNull(taskItems.completedAt)))
+                .groupBy(pages.parentId),
+            ]);
+            for (const row of subTaskRows) {
+              if (row.parentId) subTaskCountMap.set(row.parentId, Number(row.total));
+            }
+            for (const row of completedRows) {
+              if (row.parentId) subTaskCompletedMap.set(row.parentId, Number(row.total));
+            }
+          }
+
           // Dynamic progress breakdown — keyed by both group and slug so
           // custom statuses surface alongside the standard groups.
           const totalTasks = tasks.length;
@@ -294,8 +340,10 @@ export const pageReadTools = {
           return {
             success: true,
             title: page.title,
+            description: page.content || null,
             type: 'TASK_LIST',
             taskListId: taskList.id,
+            parentTaskList,
             tasks: tasks.map(t => ({
               id: t.id,
               title: t.title,
@@ -306,6 +354,8 @@ export const pageReadTools = {
               dueDate: t.dueDate,
               completedAt: t.completedAt,
               linkedPageId: t.pageId,
+              subTaskCount: subTaskCountMap.get(t.pageId ?? '') ?? 0,
+              subTaskCompletedCount: subTaskCompletedMap.get(t.pageId ?? '') ?? 0,
             })),
             availableStatuses,
             progress: {

--- a/apps/web/src/lib/ai/tools/task-management-tools.ts
+++ b/apps/web/src/lib/ai/tools/task-management-tools.ts
@@ -18,6 +18,7 @@ import {
   disableTaskTriggers,
 } from '@/lib/workflows/task-trigger-helpers';
 import { applyPageMutation, PageRevisionMismatchError } from '@/services/api/page-mutation-service';
+import { assertSubTasksComplete, SubtasksIncompleteError } from '@/lib/tasks/completion-guard';
 import type { DeferredWorkflowTrigger } from '@pagespace/lib/monitoring/activity-logger';
 
 const STATUS_GROUP_DEFAULT_COLORS: Record<string, string> = {
@@ -430,6 +431,23 @@ Agent Triggers:
               updateData.completedAt = status === 'completed' ? new Date() : null;
             }
           }
+          // Completion guard: cannot mark a task done while it has incomplete sub-tasks
+          if (updateData.completedAt instanceof Date && existingTask.pageId) {
+            try {
+              await assertSubTasksComplete(existingTask.pageId);
+            } catch (error) {
+              if (error instanceof SubtasksIncompleteError) {
+                return {
+                  success: false,
+                  error: error.message,
+                  pending: error.pending,
+                  total: error.total,
+                };
+              }
+              throw error;
+            }
+          }
+
           if (priority !== undefined) updateData.priority = priority;
           if (assigneeId !== undefined) updateData.assigneeId = assigneeId;
           if (assigneeAgentId !== undefined) updateData.assigneeAgentId = assigneeAgentId;

--- a/apps/web/src/lib/tasks/__tests__/completion-guard.test.ts
+++ b/apps/web/src/lib/tasks/__tests__/completion-guard.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    select: vi.fn(),
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((_a: unknown, _b: unknown) => ({ eq: [_a, _b] })),
+  and: vi.fn((...c: unknown[]) => ({ and: c })),
+}));
+vi.mock('@pagespace/db/schema/core', () => ({ pages: { id: 'id', parentId: 'parentId', isTrashed: 'isTrashed' } }));
+vi.mock('@pagespace/db/schema/tasks', () => ({ taskItems: { completedAt: 'completedAt', pageId: 'pageId' } }));
+
+import { assertSubTasksComplete, SubtasksIncompleteError } from '../completion-guard';
+import { db } from '@pagespace/db/db';
+
+function mockSubTasks(rows: Array<{ completedAt: Date | null }>) {
+  vi.mocked(db.select).mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      innerJoin: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  } as never);
+}
+
+describe('assertSubTasksComplete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resolves without error when there are no sub-tasks', async () => {
+    mockSubTasks([]);
+    await expect(assertSubTasksComplete('task-page-1')).resolves.toBeUndefined();
+  });
+
+  it('resolves without error when all sub-tasks are complete', async () => {
+    mockSubTasks([
+      { completedAt: new Date('2024-01-01') },
+      { completedAt: new Date('2024-01-02') },
+    ]);
+    await expect(assertSubTasksComplete('task-page-1')).resolves.toBeUndefined();
+  });
+
+  it('throws SubtasksIncompleteError when one sub-task is incomplete', async () => {
+    mockSubTasks([
+      { completedAt: new Date('2024-01-01') },
+      { completedAt: null },
+    ]);
+    await expect(assertSubTasksComplete('task-page-1')).rejects.toThrow(SubtasksIncompleteError);
+  });
+
+  it('reports correct pending and total counts', async () => {
+    mockSubTasks([
+      { completedAt: new Date() },
+      { completedAt: null },
+      { completedAt: null },
+    ]);
+    const error = await assertSubTasksComplete('task-page-1').catch(e => e);
+    expect(error).toBeInstanceOf(SubtasksIncompleteError);
+    expect(error.pending).toBe(2);
+    expect(error.total).toBe(3);
+  });
+
+  it('throws with all sub-tasks incomplete', async () => {
+    mockSubTasks([{ completedAt: null }, { completedAt: null }]);
+    const error = await assertSubTasksComplete('task-page-1').catch(e => e);
+    expect(error).toBeInstanceOf(SubtasksIncompleteError);
+    expect(error.pending).toBe(2);
+    expect(error.total).toBe(2);
+  });
+});
+
+describe('SubtasksIncompleteError', () => {
+  it('has correct code, pending, total, and message', () => {
+    const err = new SubtasksIncompleteError(3, 5);
+    expect(err.code).toBe('SUBTASKS_INCOMPLETE');
+    expect(err.pending).toBe(3);
+    expect(err.total).toBe(5);
+    expect(err.message).toContain('3');
+    expect(err.message).toContain('5');
+    expect(err.name).toBe('SubtasksIncompleteError');
+    expect(err).toBeInstanceOf(Error);
+  });
+});

--- a/apps/web/src/lib/tasks/completion-guard.ts
+++ b/apps/web/src/lib/tasks/completion-guard.ts
@@ -1,0 +1,37 @@
+import { db } from '@pagespace/db/db'
+import { eq, and } from '@pagespace/db/operators'
+import { pages } from '@pagespace/db/schema/core'
+import { taskItems } from '@pagespace/db/schema/tasks'
+
+export class SubtasksIncompleteError extends Error {
+  readonly code = 'SUBTASKS_INCOMPLETE' as const;
+  constructor(
+    public readonly pending: number,
+    public readonly total: number,
+  ) {
+    super(`Complete all sub-tasks first (${pending} of ${total} remaining)`);
+    this.name = 'SubtasksIncompleteError';
+  }
+}
+
+/**
+ * Throws SubtasksIncompleteError if the task page has any non-trashed child
+ * tasks that haven't been completed. Leaf tasks (no children) always pass.
+ */
+export async function assertSubTasksComplete(taskPageId: string): Promise<void> {
+  const subTasks = await db
+    .select({ completedAt: taskItems.completedAt })
+    .from(taskItems)
+    .innerJoin(pages, eq(pages.id, taskItems.pageId))
+    .where(and(
+      eq(pages.parentId, taskPageId),
+      eq(pages.isTrashed, false),
+    ));
+
+  if (subTasks.length === 0) return;
+
+  const pending = subTasks.filter(t => t.completedAt === null).length;
+  if (pending > 0) {
+    throw new SubtasksIncompleteError(pending, subTasks.length);
+  }
+}


### PR DESCRIPTION
## Summary

- **Completion guard**: Tasks cannot be marked done while they have incomplete sub-tasks. Enforced at the API level (HTTP 422) and the MCP \`update_task\` tool (structured error result), with a UI fast-path toast in \`TaskListView\` to avoid the round-trip.
- **Progress data**: \`/api/pages/[pageId]/tasks\` now returns \`subTaskCompletedCount\` per task alongside the existing \`subTaskCount\`, using a parallel DB query. \`TaskItem\` type updated accordingly.
- **read_page enrichment**: \`read_page\` on a TASK_LIST now includes \`description\` (page content), \`parentTaskList\` (title + ID when nested under another task), and \`subTaskCount\`/\`subTaskCompletedCount\` per task item.
- **completedAt consistency**: Task creation (POST) now sets \`completedAt\` when the initial status maps to \`group = 'done'\`, matching what PATCH already did. This ensures \`completedAt\` is the single source of truth across creation, update, the completion guard, and progress queries.

## Architecture

A new shared utility \`apps/web/src/lib/tasks/completion-guard.ts\` exports \`assertSubTasksComplete(taskPageId)\` — a single function called by both the HTTP PATCH route and the MCP tool. This keeps the constraint consistent across all clients without duplicating query logic.

## What's not in this PR

UI progress bars (\`SubTaskProgress\` component, indeterminate checkbox state, footer completion counter) are the next task and will follow in a subsequent PR.

## Test plan

- [ ] PATCH a task with incomplete sub-tasks to \`completed\` → expect 422 with \`{ error, pending, total }\`
- [ ] PATCH same task after completing all sub-tasks → succeeds
- [ ] MCP \`update_task\` with a done-group status on a task with incomplete sub-tasks → tool returns \`{ success: false, error, pending, total }\`
- [ ] Click checkbox on a task with incomplete sub-tasks in the UI → toast "Finish N sub-task(s) first" appears, no API call made
- [ ] \`read_page\` on a nested task list → response includes \`description\`, \`parentTaskList\` with title/ID, per-task \`subTaskCompletedCount\`
- [ ] \`GET /api/pages/:id/tasks\` → each task row includes \`subTaskCompletedCount\`
- [ ] Create a task directly in a done-group Kanban column → \`completedAt\` is set, sub-task progress counts are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tasks now prevent completion when sub-tasks remain incomplete, displaying a notification with the pending count.
  * Sub-task completion metrics are tracked and displayed per task, showing total and completed counts.
  * API returns detailed error responses when completing a task with incomplete sub-tasks, including pending/total counts.

* **Tests**
  * Added comprehensive test coverage for sub-task completion validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1440?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->