### PR TITLE
fix(channels): consistent hyperlink styling in messages and DMs

### DIFF
--- a/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
+++ b/apps/web/src/app/dashboard/dms/[conversationId]/page.tsx
@@ -512,7 +512,7 @@ export default function InboxDMPage() {
             </span>
           </div>
           {m.content && (
-            <div className="text-sm break-words [overflow-wrap:anywhere]">
+            <div className="prose prose-sm dark:prose-invert max-w-none break-words [overflow-wrap:anywhere]">
               {<RichText content={addHardLineBreaks(m.content)} />}
             </div>
           )}

--- a/apps/web/src/components/messages/RichText.tsx
+++ b/apps/web/src/components/messages/RichText.tsx
@@ -285,7 +285,7 @@ function createCustomAnchor(router: RouterLike) {
       <a
         href={href}
         onClick={handleClick}
-        className="min-w-0 max-w-full break-all [overflow-wrap:anywhere] inline-block"
+        className="min-w-0 max-w-full break-all [overflow-wrap:anywhere] inline-block text-primary underline underline-offset-2 hover:opacity-80 transition-opacity cursor-pointer"
         {...props}
       >
         {children}


### PR DESCRIPTION
## Summary

- Links in channel/DM messages were inconsistently styled — blue in most slots but plain/unstyled in the DM thread parent message, depending on whether a `prose` ancestor was present
- Added explicit hyperlink styles (`text-primary underline underline-offset-2 hover:opacity-80`) directly to `createCustomAnchor` in `RichText.tsx` so every link is consistently styled regardless of context
- Added missing `prose prose-sm dark:prose-invert max-w-none` wrapper to the DM thread parent message slot so markdown formatting also matches other message slots

## Test plan

- [ ] Open a DM thread — links in the parent message at the top should be blue + underlined
- [ ] Open a channel, check a message with a URL — should be blue + underlined  
- [ ] Open a DM main conversation with a URL — should be blue + underlined
- [ ] Confirm mention pills still render as pill badges (not underlined)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved formatting and readability of quoted messages in direct message conversations
  * Enhanced link styling in messages with underline, color emphasis, and interactive hover effects

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1441?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->