### PR TITLE
feat(video): inline video previews in messages and pages

### DIFF
--- a/apps/web/src/app/api/files/[id]/thumbnail/route.ts
+++ b/apps/web/src/app/api/files/[id]/thumbnail/route.ts
@@ -7,6 +7,7 @@ import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
 import { isFilePage } from '@pagespace/lib/content/page-types.config';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { generatePresignedUrl } from '@/lib/presigned-url';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -47,6 +48,8 @@ export async function GET(request: NextRequest, context: RouteParams) {
 
     const [, contentHash, preset] = match;
     const presignedUrl = await generatePresignedUrl(contentHash, preset, 3600);
+
+    auditRequest(request, { eventType: 'data.read', userId: user.id, resourceType: 'file', resourceId: page.id, details: { source: 'thumbnail', mimeType: page.mimeType } });
 
     return NextResponse.redirect(presignedUrl, 307);
   } catch (error) {

--- a/apps/web/src/app/api/files/[id]/thumbnail/route.ts
+++ b/apps/web/src/app/api/files/[id]/thumbnail/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { verifyAuth } from '@/lib/auth';
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { pages } from '@pagespace/db/schema/core';
+import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { isFilePage } from '@pagespace/lib/content/page-types.config';
+import { PageType } from '@pagespace/lib/utils/enums';
+import { generatePresignedUrl } from '@/lib/presigned-url';
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+export async function GET(request: NextRequest, context: RouteParams) {
+  try {
+    const { id } = await context.params;
+
+    const user = await verifyAuth(request);
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const page = await db.query.pages.findFirst({ where: eq(pages.id, id) });
+
+    if (!page || !isFilePage(page.type as PageType) || !page.mimeType?.startsWith('video/')) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    const canView = await canUserViewPage(user.id, page.id);
+    if (!canView) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const meta = page.extractionMetadata as { thumbnailKey?: string } | null;
+    const thumbnailKey = meta?.thumbnailKey;
+
+    if (!thumbnailKey) {
+      return NextResponse.json({ error: 'Thumbnail not ready' }, { status: 404 });
+    }
+
+    // thumbnailKey is "cache/{hash}/thumbnail.webp" — split into hash + preset
+    const match = thumbnailKey.match(/^cache\/([a-f0-9]+)\/(.+)$/i);
+    if (!match) {
+      return NextResponse.json({ error: 'Invalid thumbnail key' }, { status: 500 });
+    }
+
+    const [, contentHash, preset] = match;
+    const presignedUrl = await generatePresignedUrl(contentHash, preset, 3600);
+
+    return NextResponse.redirect(presignedUrl, 307);
+  } catch (error) {
+    console.error('Thumbnail error:', error);
+    return NextResponse.json({ error: 'Failed to load thumbnail' }, { status: 500 });
+  }
+}

--- a/apps/web/src/components/layout/middle-content/page-views/file/FileViewer.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/file/FileViewer.tsx
@@ -8,6 +8,7 @@ import ImageViewer from './viewers/ImageViewer';
 import CodeViewer from './viewers/CodeViewer';
 import DocxViewer from './viewers/DocxViewer';
 import GenericFileViewer from './viewers/GenericFileViewer';
+import VideoViewer from './viewers/VideoViewer';
 
 interface FileViewerProps {
   page: TreePage;
@@ -18,6 +19,7 @@ function getFileType(mimeType: string | undefined, fileName: string | undefined)
   if (!mimeType) return 'generic';
   
   if (mimeType.startsWith('image/')) return 'image';
+  if (mimeType.startsWith('video/')) return 'video';
   if (mimeType === 'application/pdf') return 'pdf';
   if (mimeType.startsWith('text/') || isCodeFile(fileName)) return 'code';
   if (isWordDocument(mimeType)) return 'docx';
@@ -70,6 +72,8 @@ export default function FileViewer({ page }: FileViewerProps) {
         return <PDFViewer page={page} />;
       case 'image':
         return <ImageViewer page={page} />;
+      case 'video':
+        return <VideoViewer page={page} />;
       case 'code':
         return <CodeViewer page={page} />;
       case 'docx':

--- a/apps/web/src/components/layout/middle-content/page-views/file/viewers/VideoViewer.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/file/viewers/VideoViewer.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { TreePage } from '@/hooks/usePageTree';
+
+export default function VideoViewer({ page }: { page: TreePage }) {
+  const [isLoading, setIsLoading] = useState(true);
+
+  return (
+    <div className="relative flex items-center justify-center h-full p-4 bg-muted/10">
+      {isLoading && (
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+          <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        </div>
+      )}
+      {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+      <video
+        key={page.id}
+        src={`/api/files/${page.id}/view`}
+        poster={`/api/files/${page.id}/thumbnail`}
+        controls
+        preload="metadata"
+        className="max-w-full max-h-full rounded-lg"
+        style={{ visibility: isLoading ? 'hidden' : 'visible' }}
+        onCanPlay={() => setIsLoading(false)}
+        onError={() => setIsLoading(false)}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/middle-content/page-views/file/viewers/VideoViewer.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/file/viewers/VideoViewer.tsx
@@ -23,7 +23,7 @@ export default function VideoViewer({ page }: { page: TreePage }) {
         preload="metadata"
         className="max-w-full max-h-full rounded-lg"
         style={{ visibility: isLoading ? 'hidden' : 'visible' }}
-        onCanPlay={() => setIsLoading(false)}
+        onLoadedMetadata={() => setIsLoading(false)}
         onError={() => setIsLoading(false)}
       />
     </div>

--- a/apps/web/src/components/shared/MessageAttachment.tsx
+++ b/apps/web/src/components/shared/MessageAttachment.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useRef, useCallback } from 'react';
-import { FileIcon, FileText, Download, Video, Plus, Minus, RotateCcw } from 'lucide-react';
+import { FileIcon, FileText, Download, Plus, Minus, RotateCcw } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
@@ -247,33 +247,14 @@ export function MessageAttachment({ message }: MessageAttachmentProps) {
   if (isVideoAttachment(message)) {
     return (
       <div className="mt-2">
-        <button
-          type="button"
-          onClick={() => setPreviewOpen(true)}
-          className="flex items-center gap-3 p-3 bg-muted/50 hover:bg-muted rounded-lg border border-border/50 max-w-sm transition-colors cursor-pointer"
-        >
-          <div className="w-10 h-10 rounded bg-muted flex items-center justify-center shrink-0">
-            <Video className="h-5 w-5 text-muted-foreground" />
-          </div>
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium truncate">{name}</p>
-            {size != null && (
-              <p className="text-xs text-muted-foreground">{formatFileSize(size)}</p>
-            )}
-          </div>
-        </button>
-
-        <Dialog open={previewOpen} onOpenChange={setPreviewOpen}>
-          <DialogContent className="max-w-[90vw] max-h-[90vh] p-2">
-            <DialogTitle className="sr-only">Video preview</DialogTitle>
-            {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
-            <video
-              src={`/api/files/${fileId}/view`}
-              controls
-              className="max-w-full max-h-[85vh] mx-auto"
-            />
-          </DialogContent>
-        </Dialog>
+        {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+        <video
+          src={`/api/files/${fileId}/view`}
+          controls
+          preload="metadata"
+          className="rounded-lg max-h-72 max-w-sm w-full border border-border/50 bg-black/5"
+        />
+        <p className="text-xs text-muted-foreground mt-1 truncate max-w-sm">{name}</p>
       </div>
     );
   }


### PR DESCRIPTION
## Summary

- **Inline video in channels/DMs** — replaces the icon-button stub in `MessageAttachment` with a native `<video controls preload="metadata">` rendered directly in the message stream, matching image inline treatment
- **Thumbnail API** (`/api/files/[id]/thumbnail`) — serves the ffmpeg-extracted WebP poster frame from `pages.extractionMetadata.thumbnailKey`; returns 404 gracefully if video hasn't been processed yet
- **VideoViewer** — new FILE-page viewer with loading spinner (resolves on `loadedmetadata`), `poster` from the thumbnail endpoint, and native controls; wired into `FileViewer` alongside image/pdf/code viewers
- **Security audit coverage** — `auditRequest` added to thumbnail route so the security gate CI check passes

## Test plan

- [ ] Upload an `.mp4` to a channel — video renders inline with native controls, no dialog
- [ ] Scrub/play to confirm presigned-URL redirect works for video seeking
- [ ] Open a FILE-type video page in the drive — VideoViewer renders with spinner then video
- [ ] If processor has run, poster thumbnail appears before playback starts
- [ ] If processor hasn't run yet, video still plays (404 on thumbnail = no poster, graceful)
- [ ] Existing image attachments still render inline with zoom dialog

## Notes

- The `/view` route for videos issues a 307 redirect to a presigned S3/Tigris URL. Video seeking (HTTP range requests) works correctly assuming the bucket CORS policy allows `Range` headers — verify in manual testing by seeking mid-video.
- `preload="metadata"` loads only the video header (~1 roundtrip), not the full file.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)