### PR TITLE
feat(channels): add delete_channel_message AI tool

### DIFF
--- a/apps/web/src/lib/ai/core/__tests__/tool-filtering.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/tool-filtering.test.ts
@@ -106,6 +106,8 @@ describe('isWriteTool / isWebSearchTool predicates', () => {
   it('classifies write tools correctly', () => {
     expect(isWriteTool('create_page')).toBe(true);
     expect(isWriteTool('trash')).toBe(true);
+    expect(isWriteTool('send_channel_message')).toBe(true);
+    expect(isWriteTool('delete_channel_message')).toBe(true);
     expect(isWriteTool('read_page')).toBe(false);
     expect(isWriteTool('web_search')).toBe(false);
   });

--- a/apps/web/src/lib/ai/core/tool-filtering.ts
+++ b/apps/web/src/lib/ai/core/tool-filtering.ts
@@ -26,6 +26,7 @@ const WRITE_TOOLS = new Set([
   'update_task',
   // Channel operations
   'send_channel_message',
+  'delete_channel_message',
   // Calendar write operations
   'create_calendar_event',
   'update_calendar_event',

--- a/apps/web/src/lib/ai/tools/__tests__/channel-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/channel-tools.test.ts
@@ -106,7 +106,7 @@ import { canActorEditPage } from '../actor-permissions';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import { db } from '@pagespace/db/db';
 import { broadcastInboxEvent } from '@/lib/websocket/socket-utils';
-import { channelMessageRepository } from '@pagespace/lib/services/channel-message-repository';
+import { channelMessageRepository, type ChannelMessageRow } from '@pagespace/lib/services/channel-message-repository';
 import type { ToolExecutionContext } from '../../core';
 
 const mockCanActorEditPage = vi.mocked(canActorEditPage);
@@ -157,7 +157,15 @@ describe('channel-tools', () => {
       isActive: true,
       aiMeta: null,
       createdAt: new Date('2026-02-10T12:00:00.000Z'),
-    });
+      fileId: null,
+      attachmentMeta: null,
+      editedAt: null,
+      parentId: null,
+      replyCount: 0,
+      lastReplyAt: null,
+      mirroredFromId: null,
+      quotedMessageId: null,
+    } satisfies ChannelMessageRow);
     mockSoftDeleteChannelMessage.mockResolvedValue(1);
     mockBroadcastInboxEvent.mockResolvedValue(undefined);
   });
@@ -569,7 +577,15 @@ describe('channel-tools', () => {
         isActive: true,
         aiMeta: null,
         createdAt: new Date(),
-      });
+        fileId: null,
+        attachmentMeta: null,
+        editedAt: null,
+        parentId: null,
+        replyCount: 0,
+        lastReplyAt: null,
+        mirroredFromId: null,
+        quotedMessageId: null,
+      } satisfies ChannelMessageRow);
 
       const context = {
         toolCallId: '1', messages: [],
@@ -633,7 +649,15 @@ describe('channel-tools', () => {
         isActive: true,
         aiMeta: { senderType: 'global_assistant', senderName: 'Test User' },
         createdAt: new Date(),
-      });
+        fileId: null,
+        attachmentMeta: null,
+        editedAt: null,
+        parentId: null,
+        replyCount: 0,
+        lastReplyAt: null,
+        mirroredFromId: null,
+        quotedMessageId: null,
+      } satisfies ChannelMessageRow);
 
       const context = {
         toolCallId: '1', messages: [],

--- a/apps/web/src/lib/ai/tools/__tests__/channel-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/channel-tools.test.ts
@@ -3,9 +3,9 @@ import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 /**
  * Channel Tools Tests
  *
- * Tests for the send_channel_message AI tool that allows LLMs to post
- * messages in channels. Covers authentication, permission checks,
- * channel validation, and sender identity (global assistant vs page agent).
+ * Tests for the send_channel_message and delete_channel_message AI tools.
+ * Covers authentication, permission checks, channel validation, ownership
+ * enforcement, and sender identity (global assistant vs page agent).
  */
 
 // Mock database
@@ -55,10 +55,18 @@ vi.mock('../actor-permissions', () => ({
 }));
 
 vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
-    getActorInfo: vi.fn().mockResolvedValue({
+  getActorInfo: vi.fn().mockResolvedValue({
     actorEmail: 'test@example.com',
     actorDisplayName: 'Test User',
   }),
+  logMessageActivity: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/services/channel-message-repository', () => ({
+  channelMessageRepository: {
+    findChannelMessageInPage: vi.fn(),
+    softDeleteChannelMessage: vi.fn(),
+  },
 }));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
     loggers: {
@@ -98,6 +106,7 @@ import { canActorEditPage } from '../actor-permissions';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import { db } from '@pagespace/db/db';
 import { broadcastInboxEvent } from '@/lib/websocket/socket-utils';
+import { channelMessageRepository } from '@pagespace/lib/services/channel-message-repository';
 import type { ToolExecutionContext } from '../../core';
 
 const mockCanActorEditPage = vi.mocked(canActorEditPage);
@@ -107,6 +116,8 @@ const mockDbInsert = db.insert as unknown as Mock;
 const mockPagesFindFirst = db.query.pages.findFirst as unknown as Mock;
 const mockChannelMessagesFindFirst = db.query.channelMessages.findFirst as unknown as Mock;
 const mockDriveMembersFindMany = db.query.driveMembers.findMany as unknown as Mock;
+const mockFindChannelMessageInPage = vi.mocked(channelMessageRepository.findChannelMessageInPage);
+const mockSoftDeleteChannelMessage = vi.mocked(channelMessageRepository.softDeleteChannelMessage);
 
 // Helper to safely extract result from tool execution (handles AsyncIterable union)
 type ToolResult = Record<string, unknown>;
@@ -115,6 +126,12 @@ const executeToolAs = async (
   context: Parameters<NonNullable<typeof channelTools.send_channel_message.execute>>[1]
 ) =>
   channelTools.send_channel_message.execute!(args, context) as unknown as Promise<ToolResult>;
+
+const executeDeleteAs = async (
+  args: { channelId: string; messageId: string },
+  context: Parameters<NonNullable<typeof channelTools.delete_channel_message.execute>>[1]
+) =>
+  channelTools.delete_channel_message.execute!(args, context) as unknown as Promise<ToolResult>;
 
 describe('channel-tools', () => {
   beforeEach(() => {
@@ -132,6 +149,16 @@ describe('channel-tools', () => {
       reactions: [],
     });
     mockDriveMembersFindMany.mockResolvedValue([]);
+    mockFindChannelMessageInPage.mockResolvedValue({
+      id: 'msg-1',
+      pageId: 'ch-1',
+      userId: 'user-123',
+      content: 'Hello',
+      isActive: true,
+      aiMeta: null,
+      createdAt: new Date('2026-02-10T12:00:00.000Z'),
+    });
+    mockSoftDeleteChannelMessage.mockResolvedValue(1);
     mockBroadcastInboxEvent.mockResolvedValue(undefined);
   });
 
@@ -437,6 +464,189 @@ describe('channel-tools', () => {
           context
         )
       ).rejects.toThrow('Message content cannot be empty');
+    });
+  });
+
+  describe('delete_channel_message', () => {
+    const channel = {
+      id: 'ch-1',
+      title: 'General',
+      type: 'CHANNEL',
+      driveId: 'drive-1',
+    };
+
+    it('has correct tool definition', () => {
+      expect(channelTools.delete_channel_message).toBeDefined();
+      expect(channelTools.delete_channel_message.description).toContain('delete');
+    });
+
+    it('requires user authentication', async () => {
+      const context = { toolCallId: '1', messages: [], experimental_context: {} };
+
+      await expect(
+        channelTools.delete_channel_message.execute!(
+          { channelId: 'ch-1', messageId: 'msg-1' },
+          context
+        )
+      ).rejects.toThrow('User authentication required');
+    });
+
+    it('throws error when channel not found', async () => {
+      mockPagesFindFirst.mockResolvedValue(null);
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      await expect(
+        channelTools.delete_channel_message.execute!(
+          { channelId: 'non-existent', messageId: 'msg-1' },
+          context
+        )
+      ).rejects.toThrow('Channel with ID "non-existent" not found');
+    });
+
+    it('returns error when page is not a CHANNEL type', async () => {
+      mockPagesFindFirst.mockResolvedValue({ ...channel, type: 'DOCUMENT' });
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      const result = await executeDeleteAs(
+        { channelId: 'ch-1', messageId: 'msg-1' },
+        context
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Page is not a channel');
+    });
+
+    it('throws error when user lacks edit permission', async () => {
+      mockPagesFindFirst.mockResolvedValue(channel);
+      mockCanActorEditPage.mockResolvedValue(false);
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      await expect(
+        channelTools.delete_channel_message.execute!(
+          { channelId: 'ch-1', messageId: 'msg-1' },
+          context
+        )
+      ).rejects.toThrow('Insufficient permissions to delete messages in this channel');
+    });
+
+    it('returns error when message not found in channel', async () => {
+      mockPagesFindFirst.mockResolvedValue(channel);
+      mockFindChannelMessageInPage.mockResolvedValue(null);
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      const result = await executeDeleteAs(
+        { channelId: 'ch-1', messageId: 'missing-msg' },
+        context
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Message not found');
+    });
+
+    it('returns permission error when message belongs to a different user', async () => {
+      mockPagesFindFirst.mockResolvedValue(channel);
+      mockFindChannelMessageInPage.mockResolvedValue({
+        id: 'msg-1',
+        pageId: 'ch-1',
+        userId: 'other-user',
+        content: 'Someone else message',
+        isActive: true,
+        aiMeta: null,
+        createdAt: new Date(),
+      });
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      const result = await executeDeleteAs(
+        { channelId: 'ch-1', messageId: 'msg-1' },
+        context
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Permission denied');
+    });
+
+    it('returns already-deleted error when soft delete returns 0', async () => {
+      mockPagesFindFirst.mockResolvedValue(channel);
+      mockSoftDeleteChannelMessage.mockResolvedValue(0);
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      const result = await executeDeleteAs(
+        { channelId: 'ch-1', messageId: 'msg-1' },
+        context
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Message already deleted');
+    });
+
+    it('successfully deletes own message and returns confirmation', async () => {
+      mockPagesFindFirst.mockResolvedValue(channel);
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      const result = await executeDeleteAs(
+        { channelId: 'ch-1', messageId: 'msg-1' },
+        context
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.messageId).toBe('msg-1');
+      expect(result.channelId).toBe('ch-1');
+      expect(result.channelTitle).toBe('General');
+      expect(mockSoftDeleteChannelMessage).toHaveBeenCalledWith('msg-1');
+    });
+
+    it('successfully deletes own AI-generated message', async () => {
+      mockPagesFindFirst.mockResolvedValue(channel);
+      mockFindChannelMessageInPage.mockResolvedValue({
+        id: 'msg-1',
+        pageId: 'ch-1',
+        userId: 'user-123',
+        content: 'AI-generated post',
+        isActive: true,
+        aiMeta: { senderType: 'global_assistant', senderName: 'Test User' },
+        createdAt: new Date(),
+      });
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      const result = await executeDeleteAs(
+        { channelId: 'ch-1', messageId: 'msg-1' },
+        context
+      );
+
+      expect(result.success).toBe(true);
+      expect(mockSoftDeleteChannelMessage).toHaveBeenCalledWith('msg-1');
     });
   });
 });

--- a/apps/web/src/lib/ai/tools/channel-tools.ts
+++ b/apps/web/src/lib/ai/tools/channel-tools.ts
@@ -9,6 +9,7 @@ import { eq, and, isNotNull } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core'
 import { driveMembers } from '@pagespace/db/schema/members'
 import { channelMessages, channelReadStatus } from '@pagespace/db/schema/chat';
+import { channelMessageRepository } from '@pagespace/lib/services/channel-message-repository';
 import { createSignedBroadcastHeaders } from '@pagespace/lib/auth/broadcast-auth';
 import { broadcastInboxEvent } from '@/lib/websocket/socket-utils';
 import { type ToolExecutionContext } from '../core';
@@ -259,6 +260,108 @@ export const channelTools = {
           channelId: maskIdentifier(channelId),
         });
         throw new Error(`Failed to send channel message: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  }),
+
+  /**
+   * Delete a message from a channel
+   */
+  delete_channel_message: tool({
+    description:
+      'Delete a message from a channel. Can only delete messages that were sent by or on behalf of the authenticated user (including AI-generated messages). Use this to clean up test messages, remove erroneous posts, or manage channel content.',
+    inputSchema: z.object({
+      channelId: z.string().describe('The unique ID of the channel page containing the message'),
+      messageId: z.string().describe('The unique ID of the message to delete'),
+    }),
+    execute: async ({ channelId, messageId }, { experimental_context: context }) => {
+      const userId = (context as ToolExecutionContext)?.userId;
+      if (!userId) {
+        throw new Error('User authentication required');
+      }
+
+      try {
+        // Verify the channel exists
+        const channel = await db.query.pages.findFirst({
+          where: and(eq(pages.id, channelId), eq(pages.isTrashed, false)),
+          columns: { id: true, title: true, type: true },
+        });
+        if (!channel) {
+          throw new Error(`Channel with ID "${channelId}" not found`);
+        }
+
+        if (channel.type !== 'CHANNEL') {
+          return {
+            success: false,
+            error: 'Page is not a channel',
+            message: `This page is a ${channel.type}. Use delete_channel_message only on CHANNEL pages.`,
+          };
+        }
+
+        // Check edit permissions
+        const canEdit = await canActorEditPage(context as ToolExecutionContext, channel.id);
+        if (!canEdit) {
+          throw new Error('Insufficient permissions to delete messages in this channel');
+        }
+
+        // Verify the message exists in this channel
+        const message = await channelMessageRepository.findChannelMessageInPage({ messageId, pageId: channelId });
+        if (!message) {
+          return {
+            success: false,
+            error: 'Message not found',
+            message: `Message "${messageId}" was not found in channel "${channel.title}". It may have already been deleted.`,
+          };
+        }
+
+        // Only the user who authored (or triggered) the message may delete it
+        if (message.userId !== userId) {
+          return {
+            success: false,
+            error: 'Permission denied',
+            message: 'You can only delete messages that were sent by or on behalf of you.',
+          };
+        }
+
+        const deleted = await channelMessageRepository.softDeleteChannelMessage(messageId);
+        if (deleted === 0) {
+          return {
+            success: false,
+            error: 'Message already deleted',
+            message: `Message "${messageId}" has already been deleted.`,
+          };
+        }
+
+        // Broadcast deletion to real-time channel (fire-and-forget)
+        if (process.env.INTERNAL_REALTIME_URL) {
+          const requestBody = JSON.stringify({
+            channelId,
+            event: 'message_deleted',
+            payload: { messageId },
+          });
+          fetch(`${process.env.INTERNAL_REALTIME_URL}/api/broadcast`, {
+            method: 'POST',
+            headers: createSignedBroadcastHeaders(requestBody),
+            body: requestBody,
+          }).catch(() => {
+            channelLogger.error('Failed to broadcast message_deleted from delete_channel_message tool');
+          });
+        }
+
+        return {
+          success: true,
+          messageId,
+          channelId,
+          channelTitle: channel.title,
+          message: `Successfully deleted message from channel "${channel.title}"`,
+        };
+      } catch (error) {
+        channelLogger.error('Failed to delete channel message', error instanceof Error ? error : undefined, {
+          userId: maskIdentifier(userId),
+          channelId: maskIdentifier(channelId),
+          messageId: maskIdentifier(messageId),
+        });
+        throw new Error(`Failed to delete channel message: ${error instanceof Error ? error.message : String(error)}`);
       }
     },
   }),

--- a/apps/web/src/lib/ai/tools/channel-tools.ts
+++ b/apps/web/src/lib/ai/tools/channel-tools.ts
@@ -284,7 +284,7 @@ export const channelTools = {
         // Verify the channel exists
         const channel = await db.query.pages.findFirst({
           where: and(eq(pages.id, channelId), eq(pages.isTrashed, false)),
-          columns: { id: true, title: true, type: true },
+          columns: { id: true, title: true, type: true, driveId: true },
         });
         if (!channel) {
           throw new Error(`Channel with ID "${channelId}" not found`);
@@ -331,6 +331,26 @@ export const channelTools = {
             message: `Message "${messageId}" has already been deleted.`,
           };
         }
+
+        // Log activity for audit trail (fire-and-forget)
+        const toolContext = context as ToolExecutionContext;
+        getActorInfo(userId)
+          .then(actorInfo => {
+            logMessageActivity(userId, 'message_delete', {
+              id: messageId,
+              pageId: channelId,
+              driveId: channel.driveId,
+              conversationType: 'channel',
+            }, actorInfo, {
+              isAiGenerated: true,
+              aiProvider: toolContext.aiProvider ?? 'unknown',
+              aiModel: toolContext.aiModel ?? 'unknown',
+              aiConversationId: toolContext.conversationId,
+            });
+          })
+          .catch(() => {
+            channelLogger.warn('Failed to get actor info for activity logging');
+          });
 
         // Broadcast deletion to real-time channel (fire-and-forget)
         if (process.env.INTERNAL_REALTIME_URL) {


### PR DESCRIPTION
## Summary

- Adds `delete_channel_message` to `channelTools` in `apps/web/src/lib/ai/tools/channel-tools.ts`
- Agents (global assistant and drive-scoped) can now delete channel messages they authored, including AI-generated messages
- Added to `WRITE_TOOLS` in `tool-filtering.ts` so it is correctly excluded from read-only sessions
- Auto-registered via the existing `...channelTools` spread in the tool registry — no registry changes needed

## Motivation

A scheduled agent (Morning Pulse) posted test messages to a channel. Neither the global assistant nor drive-scoped agents could clean them up — `delete_channel_message` didn't exist. Manual UI deletion was the only option.

## How it works

1. Validates `userId` from tool execution context
2. Verifies the target page exists and is type `CHANNEL`
3. Checks `canActorEditPage` (same permission gate as `send_channel_message`)
4. Looks up the message via `channelMessageRepository.findChannelMessageInPage` to confirm it belongs to the channel
5. Ownership check: `message.userId === userId` — covers both human and AI-generated messages (AI messages store the triggering user's ID)
6. Soft-deletes via `channelMessageRepository.softDeleteChannelMessage` (idempotent — returns 0 if already deleted)
7. Fire-and-forget `message_delete` activity log for audit trail
8. Fire-and-forget `message_deleted` realtime broadcast so the UI updates immediately

## Files changed

- `apps/web/src/lib/ai/tools/channel-tools.ts` — new `delete_channel_message` tool
- `apps/web/src/lib/ai/core/tool-filtering.ts` — adds tool to `WRITE_TOOLS` set
- `apps/web/src/lib/ai/tools/__tests__/channel-tools.test.ts` — 9 tests covering auth, permissions, ownership, AI-message deletion, idempotency, and happy path
- `apps/web/src/lib/ai/core/__tests__/tool-filtering.test.ts` — verifies `delete_channel_message` is classified as a write tool

## Test plan

- [ ] Use `send_channel_message` to post a test message, capture the `messageId`
- [ ] Call `delete_channel_message` with that `channelId` + `messageId` — message disappears from UI in real-time
- [ ] Call again — returns "already deleted" error (idempotency)
- [ ] Call with another user's `messageId` — returns permission denied
- [ ] Confirm tool is absent in a read-only session

🤖 Generated with [Claude Code](https://claude.com/claude-code)