### PR TITLE
feat(ai-tools): agent-schedulable cron workflows

### DIFF
--- a/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
@@ -101,7 +101,7 @@ vi.mock('../../tools/channel-tools', () => ({
 vi.mock('../../tools/workflow-tools', () => ({
   workflowTools: {
     create_workflow: { name: 'create_workflow', description: 'Create workflow' },
-    list_workflow: { name: 'list_workflow', description: 'List workflows' },
+    list_workflows: { name: 'list_workflows', description: 'List workflows' },
     update_workflow: { name: 'update_workflow', description: 'Update workflow' },
     delete_workflow: { name: 'delete_workflow', description: 'Delete workflow' },
   },

--- a/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
@@ -98,6 +98,15 @@ vi.mock('../../tools/channel-tools', () => ({
   },
 }));
 
+vi.mock('../../tools/workflow-tools', () => ({
+  workflowTools: {
+    create_workflow: { name: 'create_workflow', description: 'Create workflow' },
+    list_workflow: { name: 'list_workflow', description: 'List workflows' },
+    update_workflow: { name: 'update_workflow', description: 'Update workflow' },
+    delete_workflow: { name: 'delete_workflow', description: 'Delete workflow' },
+  },
+}));
+
 vi.mock('../../tools/member-tools', () => ({
   memberTools: {
     list_drive_members: { name: 'list_drive_members', description: 'List drive members' },
@@ -120,6 +129,7 @@ import { activityTools } from '../../tools/activity-tools';
 import { calendarReadTools } from '../../tools/calendar-read-tools';
 import { calendarWriteTools } from '../../tools/calendar-write-tools';
 import { channelTools } from '../../tools/channel-tools';
+import { workflowTools } from '../../tools/workflow-tools';
 
 describe('ai-tools', () => {
   describe('pageSpaceTools aggregation', () => {
@@ -142,6 +152,7 @@ describe('ai-tools', () => {
         ...calendarReadTools,
         ...calendarWriteTools,
         ...channelTools,
+        ...workflowTools,
       });
     });
 
@@ -160,6 +171,7 @@ describe('ai-tools', () => {
         Object.keys(calendarReadTools),
         Object.keys(calendarWriteTools),
         Object.keys(channelTools),
+        Object.keys(workflowTools),
       ];
 
       const allKeys = moduleKeysets.flat();

--- a/apps/web/src/lib/ai/core/__tests__/tool-filtering.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/tool-filtering.test.ts
@@ -120,18 +120,18 @@ describe('isWriteTool / isWebSearchTool predicates', () => {
     expect(isWriteTool('create_workflow')).toBe(true);
     expect(isWriteTool('update_workflow')).toBe(true);
     expect(isWriteTool('delete_workflow')).toBe(true);
-    expect(isWriteTool('list_workflow')).toBe(false);
+    expect(isWriteTool('list_workflows')).toBe(false);
   });
 
-  it('excludes workflow write tools in read-only mode but keeps list_workflow', () => {
+  it('excludes workflow write tools in read-only mode but keeps list_workflows', () => {
     const tools = {
-      list_workflow: 'r',
+      list_workflows: 'r',
       create_workflow: 'w',
       update_workflow: 'w',
       delete_workflow: 'w',
     };
     const filtered = filterToolsForReadOnly(tools, true);
-    expect(filtered).toHaveProperty('list_workflow');
+    expect(filtered).toHaveProperty('list_workflows');
     expect(filtered).not.toHaveProperty('create_workflow');
     expect(filtered).not.toHaveProperty('update_workflow');
     expect(filtered).not.toHaveProperty('delete_workflow');

--- a/apps/web/src/lib/ai/core/__tests__/tool-filtering.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/tool-filtering.test.ts
@@ -115,4 +115,25 @@ describe('isWriteTool / isWebSearchTool predicates', () => {
     expect(isWebSearchTool('read_page')).toBe(false);
     expect(isWebSearchTool('create_page')).toBe(false);
   });
+
+  it('classifies workflow tools: writes are write tools, list is read', () => {
+    expect(isWriteTool('create_workflow')).toBe(true);
+    expect(isWriteTool('update_workflow')).toBe(true);
+    expect(isWriteTool('delete_workflow')).toBe(true);
+    expect(isWriteTool('list_workflow')).toBe(false);
+  });
+
+  it('excludes workflow write tools in read-only mode but keeps list_workflow', () => {
+    const tools = {
+      list_workflow: 'r',
+      create_workflow: 'w',
+      update_workflow: 'w',
+      delete_workflow: 'w',
+    };
+    const filtered = filterToolsForReadOnly(tools, true);
+    expect(filtered).toHaveProperty('list_workflow');
+    expect(filtered).not.toHaveProperty('create_workflow');
+    expect(filtered).not.toHaveProperty('update_workflow');
+    expect(filtered).not.toHaveProperty('delete_workflow');
+  });
 });

--- a/apps/web/src/lib/ai/core/ai-tools.ts
+++ b/apps/web/src/lib/ai/core/ai-tools.ts
@@ -11,6 +11,7 @@ import { activityTools } from '../tools/activity-tools';
 import { calendarReadTools } from '../tools/calendar-read-tools';
 import { calendarWriteTools } from '../tools/calendar-write-tools';
 import { channelTools } from '../tools/channel-tools';
+import { workflowTools } from '../tools/workflow-tools';
 import { CORE_TOOL_NAMES } from './stub-tools';
 
 export const pageSpaceTools = {
@@ -27,6 +28,7 @@ export const pageSpaceTools = {
   ...calendarReadTools,
   ...calendarWriteTools,
   ...channelTools,
+  ...workflowTools,
 };
 
 export type PageSpaceTools = typeof pageSpaceTools;

--- a/apps/web/src/lib/ai/core/system-prompt.ts
+++ b/apps/web/src/lib/ai/core/system-prompt.ts
@@ -53,7 +53,7 @@ const CATEGORY_MAP: Record<string, string> = {
   create_calendar_event: 'calendar', update_calendar_event: 'calendar', delete_calendar_event: 'calendar',
   rsvp_calendar_event: 'calendar', invite_calendar_attendees: 'calendar', remove_calendar_attendee: 'calendar',
   send_channel_message: 'channels',
-  create_workflow: 'workflows', list_workflow: 'workflows', update_workflow: 'workflows', delete_workflow: 'workflows',
+  create_workflow: 'workflows', list_workflows: 'workflows', update_workflow: 'workflows', delete_workflow: 'workflows',
 };
 
 export function buildNonCoreToolNamesPrompt(toolNames: string[]): string {

--- a/apps/web/src/lib/ai/core/system-prompt.ts
+++ b/apps/web/src/lib/ai/core/system-prompt.ts
@@ -53,6 +53,7 @@ const CATEGORY_MAP: Record<string, string> = {
   create_calendar_event: 'calendar', update_calendar_event: 'calendar', delete_calendar_event: 'calendar',
   rsvp_calendar_event: 'calendar', invite_calendar_attendees: 'calendar', remove_calendar_attendee: 'calendar',
   send_channel_message: 'channels',
+  create_workflow: 'workflows', list_workflow: 'workflows', update_workflow: 'workflows', delete_workflow: 'workflows',
 };
 
 export function buildNonCoreToolNamesPrompt(toolNames: string[]): string {

--- a/apps/web/src/lib/ai/core/tool-filtering.ts
+++ b/apps/web/src/lib/ai/core/tool-filtering.ts
@@ -33,6 +33,10 @@ const WRITE_TOOLS = new Set([
   'rsvp_calendar_event',
   'invite_calendar_attendees',
   'remove_calendar_attendee',
+  // Workflow (cron) operations
+  'create_workflow',
+  'update_workflow',
+  'delete_workflow',
 ]);
 
 // Web search tools (excluded when web search is disabled)
@@ -151,6 +155,8 @@ export function getToolsSummary(isReadOnly: boolean, webSearchEnabled = true): {
     'web_fetch',
     // Agent communication
     'ask_agent',
+    // Workflow read
+    'list_workflow',
     // Write tools
     ...Array.from(WRITE_TOOLS),
   ];

--- a/apps/web/src/lib/ai/core/tool-filtering.ts
+++ b/apps/web/src/lib/ai/core/tool-filtering.ts
@@ -156,7 +156,7 @@ export function getToolsSummary(isReadOnly: boolean, webSearchEnabled = true): {
     // Agent communication
     'ask_agent',
     // Workflow read
-    'list_workflow',
+    'list_workflows',
     // Write tools
     ...Array.from(WRITE_TOOLS),
   ];

--- a/apps/web/src/lib/ai/tools/__tests__/actor-permissions.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/actor-permissions.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockHasAgentDriveMembership, mockCheckDriveAccess } = vi.hoisted(() => ({
+  mockHasAgentDriveMembership: vi.fn(),
+  mockCheckDriveAccess: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  getUserAccessLevel: vi.fn(),
+  getUserDriveAccess: vi.fn(),
+  canUserEditPage: vi.fn(),
+  canUserDeletePage: vi.fn(),
+  getUserAccessiblePagesInDriveWithDetails: vi.fn(),
+}));
+vi.mock('@pagespace/lib/permissions/agent-permissions', () => ({
+  getAgentAccessLevel: vi.fn(),
+  getAgentAccessiblePagesInDrive: vi.fn(),
+  hasAgentDriveMembership: mockHasAgentDriveMembership,
+}));
+vi.mock('@pagespace/lib/services/drive-member-service', () => ({
+  checkDriveAccess: mockCheckDriveAccess,
+}));
+
+import { canActorManageDrive } from '../actor-permissions';
+import type { ToolExecutionContext } from '../../core';
+
+const DRIVE = 'drive-1';
+const userCtx = { userId: 'user-1' } as ToolExecutionContext;
+const agentCtx = {
+  userId: 'user-1',
+  chatSource: { type: 'page', agentPageId: 'agent-1' },
+} as ToolExecutionContext;
+
+describe('canActorManageDrive', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('allows a drive owner', async () => {
+    mockCheckDriveAccess.mockResolvedValue({ isOwner: true, isAdmin: true, isMember: true });
+    expect(await canActorManageDrive(userCtx, DRIVE)).toBe(true);
+  });
+
+  it('allows a drive admin', async () => {
+    mockCheckDriveAccess.mockResolvedValue({ isOwner: false, isAdmin: true, isMember: true });
+    expect(await canActorManageDrive(userCtx, DRIVE)).toBe(true);
+  });
+
+  it('denies a plain member (not owner/admin) — the privilege-escalation guard', async () => {
+    mockCheckDriveAccess.mockResolvedValue({ isOwner: false, isAdmin: false, isMember: true });
+    expect(await canActorManageDrive(userCtx, DRIVE)).toBe(false);
+    expect(mockHasAgentDriveMembership).not.toHaveBeenCalled();
+  });
+
+  it('denies a user with no access', async () => {
+    mockCheckDriveAccess.mockResolvedValue({ isOwner: false, isAdmin: false, isMember: false });
+    expect(await canActorManageDrive(userCtx, DRIVE)).toBe(false);
+  });
+
+  it('gates an agent actor on drive membership, not owner/admin', async () => {
+    mockHasAgentDriveMembership.mockResolvedValue(true);
+    expect(await canActorManageDrive(agentCtx, DRIVE)).toBe(true);
+    expect(mockHasAgentDriveMembership).toHaveBeenCalledWith('agent-1', DRIVE);
+    expect(mockCheckDriveAccess).not.toHaveBeenCalled();
+  });
+
+  it('denies an agent that is not a drive member', async () => {
+    mockHasAgentDriveMembership.mockResolvedValue(false);
+    expect(await canActorManageDrive(agentCtx, DRIVE)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/ai/tools/__tests__/workflow-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/workflow-tools.test.ts
@@ -3,9 +3,9 @@ import { z } from 'zod';
 
 const {
   mockInsert, mockInsertValues, mockReturning,
-  mockSelect, mockSelectFrom, mockSelectWhere,
-  mockUpdate, mockUpdateSet, mockUpdateWhere,
-  mockDelete, mockDeleteWhere,
+  mockSelect, mockSelectWhere,
+  mockUpdate, mockUpdateSet,
+  mockDelete,
   mockCanActorAccessDrive,
   mockValidateAgentTrigger,
   mockValidateCron, mockValidateTimezone, mockGetNextRunDate, mockGetHumanReadableCron,
@@ -23,9 +23,9 @@ const {
   const mockDelete = vi.fn(() => ({ where: mockDeleteWhere }));
   return {
     mockInsert, mockInsertValues, mockReturning,
-    mockSelect, mockSelectFrom, mockSelectWhere,
-    mockUpdate, mockUpdateSet, mockUpdateWhere,
-    mockDelete, mockDeleteWhere,
+    mockSelect, mockSelectWhere,
+    mockUpdate, mockUpdateSet,
+    mockDelete,
     mockCanActorAccessDrive: vi.fn(),
     mockValidateAgentTrigger: vi.fn(),
     mockValidateCron: vi.fn(),

--- a/apps/web/src/lib/ai/tools/__tests__/workflow-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/workflow-tools.test.ts
@@ -220,6 +220,16 @@ describe('update_workflow', () => {
     expect(setArg.nextRunAt).toBeUndefined();
   });
 
+  it('is a no-op (no empty SET) when no fields are provided', async () => {
+    const result = (await workflowTools.update_workflow.execute!({ workflowId: 'wf-1' }, ctx())) as {
+      success: boolean;
+      summary: string;
+    };
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    expect(result.summary).toMatch(/No changes/);
+  });
+
   it('refuses to edit a task- or calendar-managed workflow', async () => {
     mockSelectWhere.mockResolvedValue([TASK_BACKED]);
     await expect(

--- a/apps/web/src/lib/ai/tools/__tests__/workflow-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/workflow-tools.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { z } from 'zod';
+
+const {
+  mockInsert, mockInsertValues, mockReturning,
+  mockCanActorAccessDrive,
+  mockValidateAgentTrigger,
+  mockValidateCron, mockValidateTimezone, mockGetNextRunDate, mockGetHumanReadableCron,
+} = vi.hoisted(() => {
+  const mockReturning = vi.fn().mockResolvedValue([{ id: 'wf-1' }]);
+  const mockInsertValues = vi.fn(() => ({ returning: mockReturning }));
+  const mockInsert = vi.fn(() => ({ values: mockInsertValues }));
+  return {
+    mockInsert, mockInsertValues, mockReturning,
+    mockCanActorAccessDrive: vi.fn(),
+    mockValidateAgentTrigger: vi.fn(),
+    mockValidateCron: vi.fn(),
+    mockValidateTimezone: vi.fn(),
+    mockGetNextRunDate: vi.fn(),
+    mockGetHumanReadableCron: vi.fn(),
+  };
+});
+
+vi.mock('@pagespace/db/db', () => ({ db: { insert: mockInsert } }));
+vi.mock('@pagespace/db/schema/workflows', () => ({ workflows: { id: 'id' } }));
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }) } },
+}));
+vi.mock('../actor-permissions', () => ({ canActorAccessDrive: mockCanActorAccessDrive }));
+vi.mock('@/lib/workflows/agent-trigger-shared', () => ({
+  validateAgentTrigger: mockValidateAgentTrigger,
+  agentTriggerBaseSchema: z.object({
+    agentPageId: z.string(),
+    prompt: z.string().optional(),
+    instructionPageId: z.string().nullable().optional(),
+    contextPageIds: z.array(z.string()).optional(),
+  }),
+}));
+vi.mock('@/lib/workflows/cron-utils', () => ({
+  validateCronExpression: mockValidateCron,
+  validateTimezone: mockValidateTimezone,
+  getNextRunDate: mockGetNextRunDate,
+  getHumanReadableCron: mockGetHumanReadableCron,
+}));
+
+import { workflowTools } from '../workflow-tools';
+
+const NEXT_RUN = new Date('2026-06-01T09:00:00.000Z');
+
+function ctx(overrides: Record<string, unknown> = {}) {
+  return { experimental_context: { userId: 'user-1', ...overrides } };
+}
+
+const validArgs = {
+  driveId: 'drive-1',
+  name: 'Daily summary',
+  cronExpression: '0 9 * * 1-5',
+  agentTrigger: { agentPageId: 'agent-1', prompt: 'summarize' },
+};
+
+describe('create_workflow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockReturning.mockResolvedValue([{ id: 'wf-1' }]);
+    mockCanActorAccessDrive.mockResolvedValue(true);
+    mockValidateAgentTrigger.mockResolvedValue({ agentPageId: 'agent-1' });
+    mockValidateCron.mockReturnValue({ valid: true });
+    mockValidateTimezone.mockReturnValue({ valid: true });
+    mockGetNextRunDate.mockReturnValue(NEXT_RUN);
+    mockGetHumanReadableCron.mockReturnValue('At 09:00 AM, Monday through Friday');
+  });
+
+  it('creates an enabled cron workflow with a computed nextRunAt', async () => {
+    const result = await workflowTools.create_workflow.execute!(validArgs, ctx());
+
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    const values = mockInsertValues.mock.calls[0][0];
+    expect(values).toMatchObject({
+      driveId: 'drive-1',
+      createdBy: 'user-1',
+      name: 'Daily summary',
+      agentPageId: 'agent-1',
+      prompt: 'summarize',
+      cronExpression: '0 9 * * 1-5',
+      triggerType: 'cron',
+      isEnabled: true,
+      nextRunAt: NEXT_RUN,
+    });
+    expect(result).toMatchObject({ success: true, workflowId: 'wf-1', nextRunAt: NEXT_RUN.toISOString() });
+  });
+
+  it('defaults prompt when only an instruction page is provided', async () => {
+    await workflowTools.create_workflow.execute!(
+      { ...validArgs, agentTrigger: { agentPageId: 'agent-1', instructionPageId: 'instr-1' } },
+      ctx(),
+    );
+    const values = mockInsertValues.mock.calls[0][0];
+    expect(values.prompt).toBe('Execute instructions from linked page.');
+    expect(values.instructionPageId).toBe('instr-1');
+  });
+
+  it('rejects a cron expression that is too frequent', async () => {
+    mockValidateCron.mockReturnValue({ valid: false, error: 'Schedule is too frequent — minimum interval is 5 minutes' });
+    await expect(workflowTools.create_workflow.execute!(validArgs, ctx())).rejects.toThrow(/too frequent/);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the actor has no access to the drive', async () => {
+    mockCanActorAccessDrive.mockResolvedValue(false);
+    await expect(workflowTools.create_workflow.execute!(validArgs, ctx())).rejects.toThrow(/No access to the specified drive/);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid timezone', async () => {
+    mockValidateTimezone.mockReturnValue({ valid: false, error: 'Invalid timezone: Mars/Phobos' });
+    await expect(
+      workflowTools.create_workflow.execute!({ ...validArgs, timezone: 'Mars/Phobos' }, ctx()),
+    ).rejects.toThrow(/Invalid timezone/);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('requires authentication', async () => {
+    await expect(
+      workflowTools.create_workflow.execute!(validArgs, { experimental_context: {} }),
+    ).rejects.toThrow(/authentication required/);
+  });
+
+  it('propagates agent-trigger validation failures', async () => {
+    mockValidateAgentTrigger.mockRejectedValue(new Error('Agent page not found or not an AI agent'));
+    await expect(workflowTools.create_workflow.execute!(validArgs, ctx())).rejects.toThrow(/not found or not an AI agent/);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/ai/tools/__tests__/workflow-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/workflow-tools.test.ts
@@ -6,7 +6,7 @@ const {
   mockSelect, mockSelectWhere,
   mockUpdate, mockUpdateSet,
   mockDelete,
-  mockCanActorAccessDrive,
+  mockCanActorManageDrive,
   mockValidateAgentTrigger,
   mockValidateCron, mockValidateTimezone, mockGetNextRunDate, mockGetHumanReadableCron,
 } = vi.hoisted(() => {
@@ -26,7 +26,7 @@ const {
     mockSelect, mockSelectWhere,
     mockUpdate, mockUpdateSet,
     mockDelete,
-    mockCanActorAccessDrive: vi.fn(),
+    mockCanActorManageDrive: vi.fn(),
     mockValidateAgentTrigger: vi.fn(),
     mockValidateCron: vi.fn(),
     mockValidateTimezone: vi.fn(),
@@ -52,7 +52,7 @@ vi.mock('@pagespace/db/schema/workflows', () => ({
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
   loggers: { api: { child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }) } },
 }));
-vi.mock('../actor-permissions', () => ({ canActorAccessDrive: mockCanActorAccessDrive }));
+vi.mock('../actor-permissions', () => ({ canActorManageDrive: mockCanActorManageDrive }));
 vi.mock('@/lib/workflows/agent-trigger-shared', () => ({
   validateAgentTrigger: mockValidateAgentTrigger,
   agentTriggerBaseSchema: z.object({
@@ -93,7 +93,7 @@ describe('create_workflow', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockReturning.mockResolvedValue([{ id: 'wf-1' }]);
-    mockCanActorAccessDrive.mockResolvedValue(true);
+    mockCanActorManageDrive.mockResolvedValue(true);
     mockValidateAgentTrigger.mockResolvedValue({ agentPageId: 'agent-1' });
     mockValidateCron.mockReturnValue({ valid: true });
     mockValidateTimezone.mockReturnValue({ valid: true });
@@ -137,7 +137,7 @@ describe('create_workflow', () => {
   });
 
   it('rejects when the actor has no access to the drive', async () => {
-    mockCanActorAccessDrive.mockResolvedValue(false);
+    mockCanActorManageDrive.mockResolvedValue(false);
     await expect(workflowTools.create_workflow.execute!(validArgs, ctx())).rejects.toThrow(/No access to the specified drive/);
     expect(mockInsert).not.toHaveBeenCalled();
   });
@@ -173,7 +173,7 @@ const TASK_BACKED = { ...STANDALONE, id: 'wf-2', cronExpression: null };
 describe('list_workflows', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockCanActorAccessDrive.mockResolvedValue(true);
+    mockCanActorManageDrive.mockResolvedValue(true);
     mockGetHumanReadableCron.mockReturnValue('At 09:00 AM, Monday through Friday');
     mockSelectWhere.mockResolvedValue([STANDALONE]);
   });
@@ -189,7 +189,7 @@ describe('list_workflows', () => {
   });
 
   it('rejects when the actor cannot access the drive', async () => {
-    mockCanActorAccessDrive.mockResolvedValue(false);
+    mockCanActorManageDrive.mockResolvedValue(false);
     await expect(workflowTools.list_workflows.execute!({ driveId: 'drive-1' }, ctx())).rejects.toThrow(/No access/);
   });
 });
@@ -197,7 +197,7 @@ describe('list_workflows', () => {
 describe('update_workflow', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockCanActorAccessDrive.mockResolvedValue(true);
+    mockCanActorManageDrive.mockResolvedValue(true);
     mockValidateAgentTrigger.mockResolvedValue({ agentPageId: 'agent-1' });
     mockValidateCron.mockReturnValue({ valid: true });
     mockValidateTimezone.mockReturnValue({ valid: true });
@@ -239,7 +239,7 @@ describe('update_workflow', () => {
 describe('delete_workflow', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockCanActorAccessDrive.mockResolvedValue(true);
+    mockCanActorManageDrive.mockResolvedValue(true);
     mockSelectWhere.mockResolvedValue([STANDALONE]);
   });
 

--- a/apps/web/src/lib/ai/tools/__tests__/workflow-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/workflow-tools.test.ts
@@ -170,7 +170,7 @@ const STANDALONE = {
 };
 const TASK_BACKED = { ...STANDALONE, id: 'wf-2', cronExpression: null };
 
-describe('list_workflow', () => {
+describe('list_workflows', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCanActorAccessDrive.mockResolvedValue(true);
@@ -179,7 +179,7 @@ describe('list_workflow', () => {
   });
 
   it('lists standalone cron workflows in the drive', async () => {
-    const result = (await workflowTools.list_workflow.execute!({ driveId: 'drive-1' }, ctx())) as {
+    const result = (await workflowTools.list_workflows.execute!({ driveId: 'drive-1' }, ctx())) as {
       success: boolean;
       workflows: Array<Record<string, unknown>>;
     };
@@ -190,7 +190,7 @@ describe('list_workflow', () => {
 
   it('rejects when the actor cannot access the drive', async () => {
     mockCanActorAccessDrive.mockResolvedValue(false);
-    await expect(workflowTools.list_workflow.execute!({ driveId: 'drive-1' }, ctx())).rejects.toThrow(/No access/);
+    await expect(workflowTools.list_workflows.execute!({ driveId: 'drive-1' }, ctx())).rejects.toThrow(/No access/);
   });
 });
 

--- a/apps/web/src/lib/ai/tools/__tests__/workflow-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/workflow-tools.test.ts
@@ -3,6 +3,9 @@ import { z } from 'zod';
 
 const {
   mockInsert, mockInsertValues, mockReturning,
+  mockSelect, mockSelectFrom, mockSelectWhere,
+  mockUpdate, mockUpdateSet, mockUpdateWhere,
+  mockDelete, mockDeleteWhere,
   mockCanActorAccessDrive,
   mockValidateAgentTrigger,
   mockValidateCron, mockValidateTimezone, mockGetNextRunDate, mockGetHumanReadableCron,
@@ -10,8 +13,19 @@ const {
   const mockReturning = vi.fn().mockResolvedValue([{ id: 'wf-1' }]);
   const mockInsertValues = vi.fn(() => ({ returning: mockReturning }));
   const mockInsert = vi.fn(() => ({ values: mockInsertValues }));
+  const mockSelectWhere = vi.fn().mockResolvedValue([]);
+  const mockSelectFrom = vi.fn(() => ({ where: mockSelectWhere }));
+  const mockSelect = vi.fn(() => ({ from: mockSelectFrom }));
+  const mockUpdateWhere = vi.fn().mockResolvedValue(undefined);
+  const mockUpdateSet = vi.fn(() => ({ where: mockUpdateWhere }));
+  const mockUpdate = vi.fn(() => ({ set: mockUpdateSet }));
+  const mockDeleteWhere = vi.fn().mockResolvedValue(undefined);
+  const mockDelete = vi.fn(() => ({ where: mockDeleteWhere }));
   return {
     mockInsert, mockInsertValues, mockReturning,
+    mockSelect, mockSelectFrom, mockSelectWhere,
+    mockUpdate, mockUpdateSet, mockUpdateWhere,
+    mockDelete, mockDeleteWhere,
     mockCanActorAccessDrive: vi.fn(),
     mockValidateAgentTrigger: vi.fn(),
     mockValidateCron: vi.fn(),
@@ -21,8 +35,20 @@ const {
   };
 });
 
-vi.mock('@pagespace/db/db', () => ({ db: { insert: mockInsert } }));
-vi.mock('@pagespace/db/schema/workflows', () => ({ workflows: { id: 'id' } }));
+vi.mock('@pagespace/db/db', () => ({
+  db: { insert: mockInsert, select: mockSelect, update: mockUpdate, delete: mockDelete },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((field, value) => ({ op: 'eq', field, value })),
+  and: vi.fn((...conds) => ({ op: 'and', conds })),
+  isNotNull: vi.fn((field) => ({ op: 'isNotNull', field })),
+}));
+vi.mock('@pagespace/db/schema/workflows', () => ({
+  workflows: {
+    id: 'id', driveId: 'driveId', name: 'name', agentPageId: 'agentPageId',
+    cronExpression: 'cronExpression', timezone: 'timezone', isEnabled: 'isEnabled', nextRunAt: 'nextRunAt',
+  },
+}));
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
   loggers: { api: { child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }) } },
 }));
@@ -48,7 +74,12 @@ import { workflowTools } from '../workflow-tools';
 const NEXT_RUN = new Date('2026-06-01T09:00:00.000Z');
 
 function ctx(overrides: Record<string, unknown> = {}) {
-  return { experimental_context: { userId: 'user-1', ...overrides } };
+  return { toolCallId: '1', messages: [], experimental_context: { userId: 'user-1', ...overrides } };
+}
+const noAuthCtx = { toolCallId: '1', messages: [], experimental_context: {} };
+
+function firstCallArg(mockFn: { mock: { calls: unknown[][] } }): Record<string, unknown> {
+  return mockFn.mock.calls[0][0] as Record<string, unknown>;
 }
 
 const validArgs = {
@@ -74,7 +105,7 @@ describe('create_workflow', () => {
     const result = await workflowTools.create_workflow.execute!(validArgs, ctx());
 
     expect(mockInsert).toHaveBeenCalledTimes(1);
-    const values = mockInsertValues.mock.calls[0][0];
+    const values = firstCallArg(mockInsertValues);
     expect(values).toMatchObject({
       driveId: 'drive-1',
       createdBy: 'user-1',
@@ -94,7 +125,7 @@ describe('create_workflow', () => {
       { ...validArgs, agentTrigger: { agentPageId: 'agent-1', instructionPageId: 'instr-1' } },
       ctx(),
     );
-    const values = mockInsertValues.mock.calls[0][0];
+    const values = firstCallArg(mockInsertValues);
     expect(values.prompt).toBe('Execute instructions from linked page.');
     expect(values.instructionPageId).toBe('instr-1');
   });
@@ -121,7 +152,7 @@ describe('create_workflow', () => {
 
   it('requires authentication', async () => {
     await expect(
-      workflowTools.create_workflow.execute!(validArgs, { experimental_context: {} }),
+      workflowTools.create_workflow.execute!(validArgs, noAuthCtx),
     ).rejects.toThrow(/authentication required/);
   });
 
@@ -129,5 +160,100 @@ describe('create_workflow', () => {
     mockValidateAgentTrigger.mockRejectedValue(new Error('Agent page not found or not an AI agent'));
     await expect(workflowTools.create_workflow.execute!(validArgs, ctx())).rejects.toThrow(/not found or not an AI agent/);
     expect(mockInsert).not.toHaveBeenCalled();
+  });
+});
+
+const STANDALONE = {
+  id: 'wf-1', driveId: 'drive-1', name: 'Daily summary', agentPageId: 'agent-1',
+  prompt: 'summarize', instructionPageId: null, contextPageIds: [],
+  cronExpression: '0 9 * * 1-5', timezone: 'UTC', isEnabled: true, nextRunAt: NEXT_RUN,
+};
+const TASK_BACKED = { ...STANDALONE, id: 'wf-2', cronExpression: null };
+
+describe('list_workflow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCanActorAccessDrive.mockResolvedValue(true);
+    mockGetHumanReadableCron.mockReturnValue('At 09:00 AM, Monday through Friday');
+    mockSelectWhere.mockResolvedValue([STANDALONE]);
+  });
+
+  it('lists standalone cron workflows in the drive', async () => {
+    const result = (await workflowTools.list_workflow.execute!({ driveId: 'drive-1' }, ctx())) as {
+      success: boolean;
+      workflows: Array<Record<string, unknown>>;
+    };
+    expect(result.success).toBe(true);
+    expect(result.workflows).toHaveLength(1);
+    expect(result.workflows[0]).toMatchObject({ workflowId: 'wf-1', cronExpression: '0 9 * * 1-5' });
+  });
+
+  it('rejects when the actor cannot access the drive', async () => {
+    mockCanActorAccessDrive.mockResolvedValue(false);
+    await expect(workflowTools.list_workflow.execute!({ driveId: 'drive-1' }, ctx())).rejects.toThrow(/No access/);
+  });
+});
+
+describe('update_workflow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCanActorAccessDrive.mockResolvedValue(true);
+    mockValidateAgentTrigger.mockResolvedValue({ agentPageId: 'agent-1' });
+    mockValidateCron.mockReturnValue({ valid: true });
+    mockValidateTimezone.mockReturnValue({ valid: true });
+    mockGetNextRunDate.mockReturnValue(NEXT_RUN);
+    mockGetHumanReadableCron.mockReturnValue('At 10:00 AM, daily');
+    mockSelectWhere.mockResolvedValue([STANDALONE]);
+  });
+
+  it('recomputes nextRunAt when the cron expression changes', async () => {
+    await workflowTools.update_workflow.execute!({ workflowId: 'wf-1', cronExpression: '0 10 * * *' }, ctx());
+    const setArg = firstCallArg(mockUpdateSet);
+    expect(setArg.cronExpression).toBe('0 10 * * *');
+    expect(setArg.nextRunAt).toBe(NEXT_RUN);
+  });
+
+  it('pauses a workflow without rescheduling', async () => {
+    await workflowTools.update_workflow.execute!({ workflowId: 'wf-1', isEnabled: false }, ctx());
+    const setArg = firstCallArg(mockUpdateSet);
+    expect(setArg.isEnabled).toBe(false);
+    expect(setArg.nextRunAt).toBeUndefined();
+  });
+
+  it('refuses to edit a task- or calendar-managed workflow', async () => {
+    mockSelectWhere.mockResolvedValue([TASK_BACKED]);
+    await expect(
+      workflowTools.update_workflow.execute!({ workflowId: 'wf-2', name: 'x' }, ctx()),
+    ).rejects.toThrow(/managed by a task or calendar event/);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the workflow does not exist', async () => {
+    mockSelectWhere.mockResolvedValue([]);
+    await expect(
+      workflowTools.update_workflow.execute!({ workflowId: 'missing', name: 'x' }, ctx()),
+    ).rejects.toThrow(/not found/);
+  });
+});
+
+describe('delete_workflow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCanActorAccessDrive.mockResolvedValue(true);
+    mockSelectWhere.mockResolvedValue([STANDALONE]);
+  });
+
+  it('deletes a standalone workflow', async () => {
+    const result = await workflowTools.delete_workflow.execute!({ workflowId: 'wf-1' }, ctx());
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ success: true, workflowId: 'wf-1' });
+  });
+
+  it('refuses to delete a task- or calendar-managed workflow', async () => {
+    mockSelectWhere.mockResolvedValue([TASK_BACKED]);
+    await expect(
+      workflowTools.delete_workflow.execute!({ workflowId: 'wf-2' }, ctx()),
+    ).rejects.toThrow(/managed by a task or calendar event/);
+    expect(mockDelete).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/ai/tools/actor-permissions.ts
+++ b/apps/web/src/lib/ai/tools/actor-permissions.ts
@@ -12,6 +12,7 @@ import {
   getAgentAccessiblePagesInDrive,
   hasAgentDriveMembership,
 } from '@pagespace/lib/permissions/agent-permissions';
+import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service';
 
 export function getAgentPageId(context: ToolExecutionContext): string | undefined {
   return context.chatSource?.type === 'page' ? context.chatSource.agentPageId : undefined;
@@ -61,6 +62,27 @@ export async function canActorAccessDrive(
   const agentPageId = getAgentPageId(context);
   if (agentPageId) return hasAgentDriveMembership(agentPageId, driveId);
   return getUserDriveAccess(context.userId, driveId);
+}
+
+/**
+ * Whether the actor may manage drive-level resources that require elevated
+ * authority — currently standalone cron workflows. Mirrors the workflows REST
+ * API (apps/web/src/app/api/workflows/route.ts), which gates on owner/admin.
+ *
+ * User actors must be the drive owner or an admin (not merely a member or a
+ * page-permission grantee). Agent actors are gated by their drive membership —
+ * the same authority model used by every other agent write tool — since which
+ * agents may schedule workflows is controlled by the agent's enabledTools
+ * allowlist, configured by an owner/admin.
+ */
+export async function canActorManageDrive(
+  context: ToolExecutionContext,
+  driveId: string,
+): Promise<boolean> {
+  const agentPageId = getAgentPageId(context);
+  if (agentPageId) return hasAgentDriveMembership(agentPageId, driveId);
+  const access = await checkDriveAccess(driveId, context.userId);
+  return access.isOwner || access.isAdmin;
 }
 
 export async function getActorAccessiblePagesInDrive(

--- a/apps/web/src/lib/ai/tools/calendar-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/calendar-write-tools.ts
@@ -12,6 +12,7 @@ import {
   upsertCalendarTriggerWorkflowInTx,
   validateCalendarAgentTrigger,
 } from '@/lib/workflows/calendar-trigger-helpers';
+import { agentTriggerBaseSchema } from '@/lib/workflows/agent-trigger-shared';
 import { isUserDriveMember } from '@pagespace/lib/permissions/permissions';
 import { getDriveMemberUserIds } from '@pagespace/lib/services/drive-member-service';
 import { loggers } from '@pagespace/lib/logging/logger-config';
@@ -98,12 +99,7 @@ export const calendarWriteTools = {
       color: z.string().optional().describe('Color category (default, meeting, deadline, personal, travel, focus)'),
       attendeeIds: z.array(z.string()).optional().describe('User IDs to invite as attendees'),
       pageId: z.string().nullable().optional().describe('Optional page ID to link this event to'),
-      agentTrigger: z.object({
-        agentPageId: z.string().describe('ID of the AI agent page to execute at event time. Use list_agents to find available agents.'),
-        prompt: z.string().max(10000).optional().describe('Instructions for the agent when it runs'),
-        instructionPageId: z.string().optional().describe('Page ID containing detailed instructions (for complex tasks)'),
-        contextPageIds: z.array(z.string()).max(10).optional().describe('Page IDs to include as reference context'),
-      }).optional().describe('Schedule an AI agent to run when this event time arrives. Requires driveId.'),
+      agentTrigger: agentTriggerBaseSchema.optional().describe('Schedule an AI agent to run when this event time arrives. Requires driveId.'),
     }),
     execute: async (
       {
@@ -432,12 +428,7 @@ export const calendarWriteTools = {
       color: z.string().optional().describe('New color category'),
       pageId: z.string().nullable().optional().describe('Page ID to link to'),
       agentTrigger: z.union([
-        z.object({
-          agentPageId: z.string().describe('ID of the AI agent page to execute at event time. Use list_agents to find available agents.'),
-          prompt: z.string().max(10000).optional().describe('Instructions for the agent when it runs'),
-          instructionPageId: z.string().nullable().optional().describe('Page ID containing detailed instructions (for complex tasks)'),
-          contextPageIds: z.array(z.string()).max(10).optional().describe('Page IDs to include as reference context'),
-        }),
+        agentTriggerBaseSchema,
         z.null().describe('Pass null to remove an existing agent trigger.'),
       ]).optional().describe('Upsert (object) or remove (null) the event\'s agent trigger. Requires the event to live in a drive.'),
     }),

--- a/apps/web/src/lib/ai/tools/task-management-tools.ts
+++ b/apps/web/src/lib/ai/tools/task-management-tools.ts
@@ -17,6 +17,7 @@ import {
   createTaskTriggerWorkflow,
   disableTaskTriggers,
 } from '@/lib/workflows/task-trigger-helpers';
+import { agentTriggerBaseSchema } from '@/lib/workflows/agent-trigger-shared';
 import { applyPageMutation, PageRevisionMismatchError } from '@/services/api/page-mutation-service';
 import { assertSubTasksComplete, SubtasksIncompleteError } from '@/lib/tasks/completion-guard';
 import type { DeferredWorkflowTrigger } from '@pagespace/lib/monitoring/activity-logger';
@@ -134,11 +135,7 @@ Agent Triggers:
       position: z.number().optional().describe('Position in the list. For new tasks, defaults to end. For existing tasks (taskId provided), moves the task to this index and re-densifies peer positions.'),
       agentTrigger: z.preprocess(
         normalizeTaskAgentTriggerInput,
-        z.object({
-          agentPageId: z.string().describe('ID of the AI agent page to execute'),
-          prompt: z.string().max(10000).optional().describe('Instructions for the agent when it runs'),
-          instructionPageId: z.string().optional().describe('Page ID containing detailed instructions'),
-          contextPageIds: z.array(z.string()).max(10).optional().describe('Page IDs to include as reference context'),
+        agentTriggerBaseSchema.extend({
           triggerType: z.enum(['due_date', 'completion']).default('due_date').describe('When to trigger: at due date or on completion'),
         }).optional()
       ).describe('Schedule an AI agent to run at task due date or on completion. Requires a drive-based task list.'),

--- a/apps/web/src/lib/ai/tools/workflow-tools.ts
+++ b/apps/web/src/lib/ai/tools/workflow-tools.ts
@@ -218,6 +218,20 @@ The cron expression must not fire more often than every 5 minutes (the polling c
         updates.nextRunAt = getNextRunDate(effectiveCron, effectiveTz);
       }
 
+      // No fields to change — avoid Drizzle's invalid empty `SET` clause (which
+      // errors at the DB layer) and return the workflow's current state.
+      if (Object.keys(updates).length === 0) {
+        return {
+          success: true,
+          workflowId,
+          schedule: getHumanReadableCron(effectiveCron),
+          timezone: effectiveTz,
+          isEnabled: workflow.isEnabled,
+          nextRunAt: workflow.nextRunAt?.toISOString() ?? null,
+          summary: `No changes applied to workflow ${workflowId}.`,
+        };
+      }
+
       await db.update(workflows).set(updates).where(eq(workflows.id, workflowId));
 
       logger.info('Updated cron workflow', { workflowId, fields: Object.keys(updates) });

--- a/apps/web/src/lib/ai/tools/workflow-tools.ts
+++ b/apps/web/src/lib/ai/tools/workflow-tools.ts
@@ -5,7 +5,7 @@ import { eq, and, isNotNull } from '@pagespace/db/operators';
 import { workflows } from '@pagespace/db/schema/workflows';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { type ToolExecutionContext } from '../core';
-import { canActorAccessDrive } from './actor-permissions';
+import { canActorManageDrive } from './actor-permissions';
 import { agentTriggerBaseSchema, validateAgentTrigger } from '@/lib/workflows/agent-trigger-shared';
 import {
   validateCronExpression,
@@ -51,7 +51,7 @@ The cron expression must not fire more often than every 5 minutes (the polling c
       const userId = ctx?.userId;
       if (!userId) throw new Error('User authentication required');
 
-      if (!(await canActorAccessDrive(ctx, driveId))) {
+      if (!(await canActorManageDrive(ctx, driveId))) {
         throw new Error('No access to the specified drive');
       }
 
@@ -117,7 +117,7 @@ The cron expression must not fire more often than every 5 minutes (the polling c
     execute: async ({ driveId }, { experimental_context: context }) => {
       const ctx = context as ToolExecutionContext;
       if (!ctx?.userId) throw new Error('User authentication required');
-      if (!(await canActorAccessDrive(ctx, driveId))) {
+      if (!(await canActorManageDrive(ctx, driveId))) {
         throw new Error('No access to the specified drive');
       }
 
@@ -170,7 +170,7 @@ The cron expression must not fire more often than every 5 minutes (the polling c
 
       const [workflow] = await db.select().from(workflows).where(eq(workflows.id, workflowId));
       if (!workflow) throw new Error('Workflow not found');
-      if (!(await canActorAccessDrive(ctx, workflow.driveId))) {
+      if (!(await canActorManageDrive(ctx, workflow.driveId))) {
         throw new Error('No access to this workflow\'s drive');
       }
       if (!workflow.cronExpression) {
@@ -245,7 +245,7 @@ The cron expression must not fire more often than every 5 minutes (the polling c
 
       const [workflow] = await db.select().from(workflows).where(eq(workflows.id, workflowId));
       if (!workflow) throw new Error('Workflow not found');
-      if (!(await canActorAccessDrive(ctx, workflow.driveId))) {
+      if (!(await canActorManageDrive(ctx, workflow.driveId))) {
         throw new Error('No access to this workflow\'s drive');
       }
       if (!workflow.cronExpression) {

--- a/apps/web/src/lib/ai/tools/workflow-tools.ts
+++ b/apps/web/src/lib/ai/tools/workflow-tools.ts
@@ -1,6 +1,7 @@
 import { tool } from 'ai';
 import { z } from 'zod';
 import { db } from '@pagespace/db/db';
+import { eq, and, isNotNull } from '@pagespace/db/operators';
 import { workflows } from '@pagespace/db/schema/workflows';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { type ToolExecutionContext } from '../core';
@@ -105,6 +106,156 @@ The cron expression must not fire more often than every 5 minutes (the polling c
         nextRunAt: nextRunAt.toISOString(),
         summary: `Created workflow "${name}" — ${getHumanReadableCron(cronExpression)} (${tz}). Next run ${nextRunAt.toISOString()}.`,
       };
+    },
+  }),
+
+  list_workflow: tool({
+    description: 'List the standalone cron workflows in a drive. Does not include task- or calendar-bound triggers, which are managed via update_task / calendar tools.',
+    inputSchema: z.object({
+      driveId: z.string().describe('Drive to list workflows for'),
+    }),
+    execute: async ({ driveId }, { experimental_context: context }) => {
+      const ctx = context as ToolExecutionContext;
+      if (!ctx?.userId) throw new Error('User authentication required');
+      if (!(await canActorAccessDrive(ctx, driveId))) {
+        throw new Error('No access to the specified drive');
+      }
+
+      const rows = await db
+        .select({
+          id: workflows.id,
+          name: workflows.name,
+          agentPageId: workflows.agentPageId,
+          cronExpression: workflows.cronExpression,
+          timezone: workflows.timezone,
+          isEnabled: workflows.isEnabled,
+          nextRunAt: workflows.nextRunAt,
+        })
+        .from(workflows)
+        .where(and(eq(workflows.driveId, driveId), isNotNull(workflows.cronExpression)));
+
+      return {
+        success: true,
+        workflows: rows.map((w) => ({
+          workflowId: w.id,
+          name: w.name,
+          agentPageId: w.agentPageId,
+          schedule: w.cronExpression ? getHumanReadableCron(w.cronExpression) : null,
+          cronExpression: w.cronExpression,
+          timezone: w.timezone,
+          isEnabled: w.isEnabled,
+          nextRunAt: w.nextRunAt ? w.nextRunAt.toISOString() : null,
+        })),
+        summary: `Found ${rows.length} workflow${rows.length === 1 ? '' : 's'} in this drive.`,
+      };
+    },
+  }),
+
+  update_workflow: tool({
+    description: `Update a standalone cron workflow: rename, reschedule (new cronExpression / timezone), pause or resume (isEnabled), or change which agent runs and with what context. Only standalone workflows can be edited here — task- and calendar-bound triggers are managed via their own tools.`,
+    inputSchema: z.object({
+      workflowId: z.string().describe('ID of the workflow to update'),
+      name: z.string().min(1).max(200).optional().describe('New name'),
+      cronExpression: z.string().optional().describe('New cron schedule (min 5-minute interval)'),
+      timezone: z.string().optional().describe('New IANA timezone'),
+      isEnabled: z.boolean().optional().describe('Pause (false) or resume (true) the workflow'),
+      agentTrigger: agentTriggerBaseSchema.partial().optional().describe('Change the agent and/or its prompt, instruction page, or context pages. Omitted fields are left unchanged.'),
+    }),
+    execute: async (
+      { workflowId, name, cronExpression, timezone, isEnabled, agentTrigger },
+      { experimental_context: context },
+    ) => {
+      const ctx = context as ToolExecutionContext;
+      if (!ctx?.userId) throw new Error('User authentication required');
+
+      const [workflow] = await db.select().from(workflows).where(eq(workflows.id, workflowId));
+      if (!workflow) throw new Error('Workflow not found');
+      if (!(await canActorAccessDrive(ctx, workflow.driveId))) {
+        throw new Error('No access to this workflow\'s drive');
+      }
+      if (!workflow.cronExpression) {
+        throw new Error('This workflow is managed by a task or calendar event; edit it there.');
+      }
+
+      const updates: Partial<typeof workflows.$inferInsert> = {};
+
+      if (name !== undefined) updates.name = name;
+      if (isEnabled !== undefined) updates.isEnabled = isEnabled;
+
+      if (agentTrigger) {
+        const merged = {
+          agentPageId: agentTrigger.agentPageId ?? workflow.agentPageId,
+          prompt: agentTrigger.prompt ?? workflow.prompt,
+          instructionPageId:
+            agentTrigger.instructionPageId !== undefined ? agentTrigger.instructionPageId : workflow.instructionPageId,
+          contextPageIds:
+            agentTrigger.contextPageIds !== undefined ? agentTrigger.contextPageIds : (workflow.contextPageIds ?? []),
+        };
+        await validateAgentTrigger(db, { driveId: workflow.driveId, agentTrigger: merged, entityLabel: 'workflow' });
+        updates.agentPageId = merged.agentPageId;
+        updates.prompt = merged.prompt?.trim() || DEFAULT_TRIGGER_PROMPT;
+        updates.instructionPageId = merged.instructionPageId ?? null;
+        updates.contextPageIds = merged.contextPageIds ?? [];
+      }
+
+      const effectiveCron = cronExpression ?? workflow.cronExpression;
+      const effectiveTz = timezone ?? workflow.timezone;
+
+      if (cronExpression !== undefined) {
+        const cronCheck = validateCronExpression(cronExpression);
+        if (!cronCheck.valid) throw new Error(cronCheck.error ?? 'Invalid cron expression');
+        updates.cronExpression = cronExpression;
+      }
+      if (timezone !== undefined) {
+        const tzCheck = validateTimezone(timezone);
+        if (!tzCheck.valid) throw new Error(tzCheck.error ?? `Invalid timezone: ${timezone}`);
+        updates.timezone = timezone;
+      }
+      // Reschedule the next run whenever the schedule or timezone changes, or
+      // when a paused workflow is resumed (a stale nextRunAt may be in the past).
+      if (cronExpression !== undefined || timezone !== undefined || isEnabled === true) {
+        updates.nextRunAt = getNextRunDate(effectiveCron, effectiveTz);
+      }
+
+      await db.update(workflows).set(updates).where(eq(workflows.id, workflowId));
+
+      logger.info('Updated cron workflow', { workflowId, fields: Object.keys(updates) });
+
+      return {
+        success: true,
+        workflowId,
+        schedule: getHumanReadableCron(effectiveCron),
+        timezone: effectiveTz,
+        isEnabled: updates.isEnabled ?? workflow.isEnabled,
+        nextRunAt: updates.nextRunAt ? updates.nextRunAt.toISOString() : (workflow.nextRunAt?.toISOString() ?? null),
+        summary: `Updated workflow ${workflowId}.`,
+      };
+    },
+  }),
+
+  delete_workflow: tool({
+    description: 'Delete a standalone cron workflow. Task- and calendar-bound triggers cannot be deleted here — remove them via their own tools.',
+    inputSchema: z.object({
+      workflowId: z.string().describe('ID of the workflow to delete'),
+    }),
+    execute: async ({ workflowId }, { experimental_context: context }) => {
+      const ctx = context as ToolExecutionContext;
+      if (!ctx?.userId) throw new Error('User authentication required');
+
+      const [workflow] = await db.select().from(workflows).where(eq(workflows.id, workflowId));
+      if (!workflow) throw new Error('Workflow not found');
+      if (!(await canActorAccessDrive(ctx, workflow.driveId))) {
+        throw new Error('No access to this workflow\'s drive');
+      }
+      if (!workflow.cronExpression) {
+        throw new Error('This workflow is managed by a task or calendar event; remove it there.');
+      }
+
+      await db.delete(workflows).where(eq(workflows.id, workflowId));
+
+      logger.info('Deleted cron workflow', { workflowId, driveId: workflow.driveId });
+
+      return { success: true, workflowId, summary: `Deleted workflow "${workflow.name}".` };
     },
   }),
 };

--- a/apps/web/src/lib/ai/tools/workflow-tools.ts
+++ b/apps/web/src/lib/ai/tools/workflow-tools.ts
@@ -1,0 +1,110 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import { db } from '@pagespace/db/db';
+import { workflows } from '@pagespace/db/schema/workflows';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { type ToolExecutionContext } from '../core';
+import { canActorAccessDrive } from './actor-permissions';
+import { agentTriggerBaseSchema, validateAgentTrigger } from '@/lib/workflows/agent-trigger-shared';
+import {
+  validateCronExpression,
+  validateTimezone,
+  getNextRunDate,
+  getHumanReadableCron,
+} from '@/lib/workflows/cron-utils';
+
+const logger = loggers.api.child({ module: 'workflow-tools' });
+
+const DEFAULT_TRIGGER_PROMPT = 'Execute instructions from linked page.';
+
+/**
+ * Tools for standalone, recurring (cron) agent workflows.
+ *
+ * A workflow runs an agent on a schedule with no host entity — distinct from
+ * task triggers (bound to a task's due date / completion) and calendar triggers
+ * (bound to an event's time), which stay inline on their entity tools. The
+ * workflows table and the cron poller (app/api/cron/workflows) already exist;
+ * these tools are the agent-facing surface for creating and managing them. The
+ * shared agentTriggerBaseSchema / validateAgentTrigger keep "who runs, with what
+ * context" identical to the task and calendar surfaces.
+ */
+export const workflowTools = {
+  create_workflow: tool({
+    description: `Create a standalone recurring workflow that runs an AI agent on a cron schedule.
+
+Use this for scheduled, repeating agent work that isn't tied to a task due date or a calendar event — e.g. "every weekday at 9am, summarize new activity". For one-off or entity-bound scheduling, attach an agentTrigger to a task (update_task) or calendar event (create_calendar_event) instead.
+
+The cron expression must not fire more often than every 5 minutes (the polling cadence). Times are interpreted in the workflow timezone.`,
+    inputSchema: z.object({
+      driveId: z.string().describe('Drive the workflow belongs to. The agent and any instruction/context pages must live in this drive.'),
+      name: z.string().min(1).max(200).describe('Human-readable workflow name'),
+      cronExpression: z.string().describe('Cron expression for the schedule, e.g. "0 9 * * 1-5" (weekdays at 9am). Minimum interval 5 minutes.'),
+      timezone: z.string().optional().describe('IANA timezone for the schedule (e.g. "America/New_York"). Defaults to the user timezone, then UTC.'),
+      agentTrigger: agentTriggerBaseSchema.describe('Who runs and with what context. Provide either a prompt or an instructionPageId.'),
+    }),
+    execute: async (
+      { driveId, name, cronExpression, timezone, agentTrigger },
+      { experimental_context: context },
+    ) => {
+      const ctx = context as ToolExecutionContext;
+      const userId = ctx?.userId;
+      if (!userId) throw new Error('User authentication required');
+
+      if (!(await canActorAccessDrive(ctx, driveId))) {
+        throw new Error('No access to the specified drive');
+      }
+
+      const cronCheck = validateCronExpression(cronExpression);
+      if (!cronCheck.valid) {
+        throw new Error(cronCheck.error ?? 'Invalid cron expression');
+      }
+
+      const tz = timezone || ctx.timezone || 'UTC';
+      const tzCheck = validateTimezone(tz);
+      if (!tzCheck.valid) {
+        throw new Error(tzCheck.error ?? `Invalid timezone: ${tz}`);
+      }
+
+      await validateAgentTrigger(db, { driveId, agentTrigger, entityLabel: 'workflow' });
+
+      const nextRunAt = getNextRunDate(cronExpression, tz);
+
+      const [created] = await db
+        .insert(workflows)
+        .values({
+          driveId,
+          createdBy: userId,
+          name,
+          agentPageId: agentTrigger.agentPageId,
+          prompt: agentTrigger.prompt?.trim() || DEFAULT_TRIGGER_PROMPT,
+          contextPageIds: agentTrigger.contextPageIds ?? [],
+          instructionPageId: agentTrigger.instructionPageId ?? null,
+          cronExpression,
+          timezone: tz,
+          triggerType: 'cron',
+          isEnabled: true,
+          nextRunAt,
+        })
+        .returning({ id: workflows.id });
+
+      logger.info('Created cron workflow', {
+        workflowId: created.id,
+        driveId,
+        agentPageId: agentTrigger.agentPageId,
+        cronExpression,
+        timezone: tz,
+      });
+
+      return {
+        success: true,
+        workflowId: created.id,
+        name,
+        schedule: getHumanReadableCron(cronExpression),
+        cronExpression,
+        timezone: tz,
+        nextRunAt: nextRunAt.toISOString(),
+        summary: `Created workflow "${name}" — ${getHumanReadableCron(cronExpression)} (${tz}). Next run ${nextRunAt.toISOString()}.`,
+      };
+    },
+  }),
+};

--- a/apps/web/src/lib/ai/tools/workflow-tools.ts
+++ b/apps/web/src/lib/ai/tools/workflow-tools.ts
@@ -109,7 +109,7 @@ The cron expression must not fire more often than every 5 minutes (the polling c
     },
   }),
 
-  list_workflow: tool({
+  list_workflows: tool({
     description: 'List the standalone cron workflows in a drive. Does not include task- or calendar-bound triggers, which are managed via update_task / calendar tools.',
     inputSchema: z.object({
       driveId: z.string().describe('Drive to list workflows for'),
@@ -213,7 +213,8 @@ The cron expression must not fire more often than every 5 minutes (the polling c
       }
       // Reschedule the next run whenever the schedule or timezone changes, or
       // when a paused workflow is resumed (a stale nextRunAt may be in the past).
-      if (cronExpression !== undefined || timezone !== undefined || isEnabled === true) {
+      const resuming = isEnabled === true && !workflow.isEnabled;
+      if (cronExpression !== undefined || timezone !== undefined || resuming) {
         updates.nextRunAt = getNextRunDate(effectiveCron, effectiveTz);
       }
 

--- a/apps/web/src/lib/workflows/__tests__/agent-trigger-shared.test.ts
+++ b/apps/web/src/lib/workflows/__tests__/agent-trigger-shared.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockQueryPages } = vi.hoisted(() => ({
+  mockQueryPages: { findFirst: vi.fn(), findMany: vi.fn() },
+}));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: { query: { pages: mockQueryPages } },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((field, value) => ({ op: 'eq', field, value })),
+  and: vi.fn((...conds) => ({ op: 'and', conds })),
+  inArray: vi.fn((field, values) => ({ op: 'inArray', field, values })),
+}));
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'id', type: 'type', isTrashed: 'isTrashed', driveId: 'driveId' },
+}));
+
+import {
+  validateAgentTrigger,
+  agentTriggerBaseSchema,
+  MAX_CONTEXT_PAGES,
+} from '../agent-trigger-shared';
+import { db } from '@pagespace/db/db';
+
+const DRIVE = 'drive-1';
+
+describe('validateAgentTrigger', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueryPages.findFirst.mockResolvedValue({ id: 'agent-1', driveId: DRIVE });
+    mockQueryPages.findMany.mockResolvedValue([]);
+  });
+
+  it('returns the validated agent page id for a prompt-only trigger', async () => {
+    const result = await validateAgentTrigger(db, {
+      driveId: DRIVE,
+      entityLabel: 'task list',
+      agentTrigger: { agentPageId: 'agent-1', prompt: 'do the thing' },
+    });
+    expect(result).toEqual({ agentPageId: 'agent-1' });
+  });
+
+  it('rejects a trigger with neither prompt nor instructionPageId', async () => {
+    await expect(
+      validateAgentTrigger(db, {
+        driveId: DRIVE,
+        entityLabel: 'task list',
+        agentTrigger: { agentPageId: 'agent-1' },
+      }),
+    ).rejects.toThrow(/either a prompt or instructionPageId/);
+  });
+
+  it('rejects when the agent page is not found / not an AI agent', async () => {
+    mockQueryPages.findFirst.mockResolvedValueOnce(undefined);
+    await expect(
+      validateAgentTrigger(db, {
+        driveId: DRIVE,
+        entityLabel: 'event',
+        agentTrigger: { agentPageId: 'missing', prompt: 'x' },
+      }),
+    ).rejects.toThrow(/not found or not an AI agent/);
+  });
+
+  it('rejects when the agent lives in a different drive, naming the entity', async () => {
+    mockQueryPages.findFirst.mockResolvedValueOnce({ id: 'agent-1', driveId: 'other-drive' });
+    await expect(
+      validateAgentTrigger(db, {
+        driveId: DRIVE,
+        entityLabel: 'event',
+        agentTrigger: { agentPageId: 'agent-1', prompt: 'x' },
+      }),
+    ).rejects.toThrow(/same drive as the event/);
+  });
+
+  it('rejects when an instruction page is off-drive or trashed', async () => {
+    // first findFirst = agent ok; second findFirst = instruction page missing
+    mockQueryPages.findFirst
+      .mockResolvedValueOnce({ id: 'agent-1', driveId: DRIVE })
+      .mockResolvedValueOnce(undefined);
+    await expect(
+      validateAgentTrigger(db, {
+        driveId: DRIVE,
+        entityLabel: 'task list',
+        agentTrigger: { agentPageId: 'agent-1', instructionPageId: 'instr-1' },
+      }),
+    ).rejects.toThrow(/Instruction page not found/);
+  });
+
+  it('rejects when some context pages are off-drive', async () => {
+    mockQueryPages.findMany.mockResolvedValueOnce([{ id: 'ctx-1' }]); // only 1 of 2 valid
+    await expect(
+      validateAgentTrigger(db, {
+        driveId: DRIVE,
+        entityLabel: 'task list',
+        agentTrigger: { agentPageId: 'agent-1', prompt: 'x', contextPageIds: ['ctx-1', 'ctx-2'] },
+      }),
+    ).rejects.toThrow(/context pages were not found/);
+  });
+
+  it('rejects more than MAX_CONTEXT_PAGES context pages', async () => {
+    const tooMany = Array.from({ length: MAX_CONTEXT_PAGES + 1 }, (_, i) => `ctx-${i}`);
+    await expect(
+      validateAgentTrigger(db, {
+        driveId: DRIVE,
+        entityLabel: 'task list',
+        agentTrigger: { agentPageId: 'agent-1', prompt: 'x', contextPageIds: tooMany },
+      }),
+    ).rejects.toThrow(/at most 10 context pages/);
+  });
+});
+
+describe('agentTriggerBaseSchema', () => {
+  it('accepts the shared payload shape', () => {
+    const parsed = agentTriggerBaseSchema.parse({
+      agentPageId: 'a',
+      prompt: 'p',
+      instructionPageId: null,
+      contextPageIds: ['c1'],
+    });
+    expect(parsed.agentPageId).toBe('a');
+  });
+
+  it('caps contextPageIds at MAX_CONTEXT_PAGES', () => {
+    const tooMany = Array.from({ length: MAX_CONTEXT_PAGES + 1 }, (_, i) => `c-${i}`);
+    expect(() => agentTriggerBaseSchema.parse({ agentPageId: 'a', contextPageIds: tooMany })).toThrow();
+  });
+});

--- a/apps/web/src/lib/workflows/__tests__/task-trigger-helpers.test.ts
+++ b/apps/web/src/lib/workflows/__tests__/task-trigger-helpers.test.ts
@@ -441,7 +441,7 @@ describe('task-trigger-helpers', () => {
       mockQueryPages.findFirst.mockResolvedValueOnce(null);
 
       await expect(createTaskTriggerWorkflow(validParams))
-        .rejects.toThrow('Agent trigger target not found or not an AI agent');
+        .rejects.toThrow('Agent page not found or not an AI agent');
     });
 
     it('given agent page in different drive, should throw', async () => {

--- a/apps/web/src/lib/workflows/agent-trigger-shared.ts
+++ b/apps/web/src/lib/workflows/agent-trigger-shared.ts
@@ -1,0 +1,103 @@
+import { z } from 'zod';
+import type { db as DbType } from '@pagespace/db/db';
+import { eq, and, inArray } from '@pagespace/db/operators';
+import { pages } from '@pagespace/db/schema/core';
+
+/**
+ * The agent-trigger payload shared by every surface that can schedule an AI
+ * agent to run later — task triggers, calendar triggers, and standalone cron
+ * workflows. It answers "who runs, and with what context"; the "when" is
+ * domain-specific and lives with each surface (task due_date/completion,
+ * calendar event time, cron expression).
+ *
+ * Previously this shape was copy-pasted as AgentTriggerInput (tasks) and
+ * CalendarAgentTriggerInput (calendar). Keep it here so the three surfaces can
+ * never drift on what an agent trigger accepts.
+ */
+
+export const MAX_CONTEXT_PAGES = 10;
+
+/**
+ * Zod schema for the shared payload. Task triggers extend this with a
+ * `triggerType` field; calendar and cron use it as-is.
+ */
+export const agentTriggerBaseSchema = z.object({
+  agentPageId: z.string().describe('ID of the AI agent (AI_CHAT) page to execute'),
+  prompt: z.string().max(10000).optional().describe('Instructions for the agent when it runs'),
+  instructionPageId: z.string().nullable().optional().describe('Page ID containing detailed instructions'),
+  contextPageIds: z
+    .array(z.string())
+    .max(MAX_CONTEXT_PAGES)
+    .optional()
+    .describe('Page IDs to include as reference context'),
+});
+
+export type AgentTriggerPayload = z.infer<typeof agentTriggerBaseSchema>;
+
+export interface ValidateAgentTriggerParams {
+  driveId: string;
+  agentTrigger: AgentTriggerPayload;
+  /**
+   * Names the host entity in error messages, e.g. "task list" or "event", so
+   * the rejection reads naturally for the surface the user is on.
+   */
+  entityLabel: string;
+}
+
+/**
+ * Pre-write validation shared by task, calendar, and cron trigger creation:
+ *  - at least a prompt or an instruction page is provided,
+ *  - the context list is within MAX_CONTEXT_PAGES,
+ *  - the agent is an AI_CHAT page in the same drive and not trashed,
+ *  - the instruction and context pages all live in the same drive and aren't trashed.
+ *
+ * Returns the validated agent page id. Throws with a human-readable message on
+ * the first failure.
+ */
+export async function validateAgentTrigger(
+  database: typeof DbType,
+  params: ValidateAgentTriggerParams,
+): Promise<{ agentPageId: string }> {
+  const { driveId, agentTrigger, entityLabel } = params;
+  const promptText = agentTrigger.prompt?.trim() ?? '';
+
+  if (!promptText && !agentTrigger.instructionPageId) {
+    throw new Error('Agent trigger needs either a prompt or instructionPageId');
+  }
+
+  const contextPageIds = agentTrigger.contextPageIds ?? [];
+  if (contextPageIds.length > MAX_CONTEXT_PAGES) {
+    throw new Error(`Agent trigger accepts at most ${MAX_CONTEXT_PAGES} context pages`);
+  }
+
+  const agent = await database.query.pages.findFirst({
+    where: and(eq(pages.id, agentTrigger.agentPageId), eq(pages.type, 'AI_CHAT'), eq(pages.isTrashed, false)),
+    columns: { id: true, driveId: true },
+  });
+  if (!agent) throw new Error('Agent page not found or not an AI agent');
+  if (agent.driveId !== driveId) throw new Error(`Agent must be in the same drive as the ${entityLabel}`);
+
+  if (agentTrigger.instructionPageId) {
+    const instrPage = await database.query.pages.findFirst({
+      where: and(eq(pages.id, agentTrigger.instructionPageId), eq(pages.driveId, driveId), eq(pages.isTrashed, false)),
+      columns: { id: true },
+    });
+    if (!instrPage) throw new Error('Instruction page not found or not in the same drive');
+  }
+
+  if (contextPageIds.length > 0) {
+    const validPages = await database.query.pages.findMany({
+      where: and(
+        inArray(pages.id, contextPageIds),
+        eq(pages.driveId, driveId),
+        eq(pages.isTrashed, false),
+      ),
+      columns: { id: true },
+    });
+    if (validPages.length !== contextPageIds.length) {
+      throw new Error('Some context pages were not found or are not in the same drive');
+    }
+  }
+
+  return { agentPageId: agent.id };
+}

--- a/apps/web/src/lib/workflows/calendar-trigger-helpers.ts
+++ b/apps/web/src/lib/workflows/calendar-trigger-helpers.ts
@@ -1,22 +1,17 @@
 import type { db as DbType } from '@pagespace/db/db';
 import { eq, and, inArray, ne, gt, sql } from '@pagespace/db/operators';
-import { pages } from '@pagespace/db/schema/core';
 import { workflows } from '@pagespace/db/schema/workflows';
 import { calendarTriggers } from '@pagespace/db/schema/calendar-triggers';
 import { workflowRuns } from '@pagespace/db/schema/workflow-runs';
 import { expandOccurrences, type RecurrenceRule } from './recurrence-utils';
+import { validateAgentTrigger, type AgentTriggerPayload } from './agent-trigger-shared';
 
-const MAX_CONTEXT_PAGES = 10;
 const TRIGGER_HORIZON_DAYS = 180;
 
 type DbOrTx = typeof DbType | Parameters<Parameters<typeof DbType.transaction>[0]>[0];
 
-export interface CalendarAgentTriggerInput {
-  agentPageId: string;
-  prompt?: string;
-  instructionPageId?: string | null;
-  contextPageIds?: string[];
-}
+/** @deprecated Use AgentTriggerPayload from agent-trigger-shared. Kept as an alias for call sites. */
+export type CalendarAgentTriggerInput = AgentTriggerPayload;
 
 export interface CreateCalendarTriggerWorkflowParams {
   tx: Parameters<Parameters<typeof DbType.transaction>[0]>[0];
@@ -106,60 +101,19 @@ export interface ValidateCalendarAgentTriggerParams {
 }
 
 /**
- * Pre-write validation for calendar agent triggers. Mirrors the checks
- * task-trigger-helpers does inline for tasks: at least a prompt or instruction
- * page, agent is an AI_CHAT in the same drive, instruction + context pages all
- * live in the same drive and aren't trashed, context list capped at 10.
- *
- * Both the REST POST and the AI create_calendar_event tool call this so the
- * two surfaces can never drift on what's accepted.
+ * Pre-write validation for calendar agent triggers. Thin wrapper over the
+ * shared validateAgentTrigger so the REST POST, the AI create_calendar_event
+ * tool, and the cron workflow tool can never drift on what's accepted.
  */
 export async function validateCalendarAgentTrigger(
   database: typeof DbType,
   params: ValidateCalendarAgentTriggerParams,
 ): Promise<{ agentPageId: string }> {
-  const { driveId, agentTrigger } = params;
-  const promptText = agentTrigger.prompt?.trim() ?? '';
-
-  if (!promptText && !agentTrigger.instructionPageId) {
-    throw new Error('Agent trigger needs either a prompt or instructionPageId');
-  }
-
-  const contextPageIds = agentTrigger.contextPageIds ?? [];
-  if (contextPageIds.length > MAX_CONTEXT_PAGES) {
-    throw new Error(`Agent trigger accepts at most ${MAX_CONTEXT_PAGES} context pages`);
-  }
-
-  const agent = await database.query.pages.findFirst({
-    where: and(eq(pages.id, agentTrigger.agentPageId), eq(pages.type, 'AI_CHAT'), eq(pages.isTrashed, false)),
-    columns: { id: true, driveId: true },
+  return validateAgentTrigger(database, {
+    driveId: params.driveId,
+    agentTrigger: params.agentTrigger,
+    entityLabel: 'event',
   });
-  if (!agent) throw new Error('Agent page not found or not an AI agent');
-  if (agent.driveId !== driveId) throw new Error('Agent must be in the same drive as the event');
-
-  if (agentTrigger.instructionPageId) {
-    const instrPage = await database.query.pages.findFirst({
-      where: and(eq(pages.id, agentTrigger.instructionPageId), eq(pages.driveId, driveId), eq(pages.isTrashed, false)),
-      columns: { id: true },
-    });
-    if (!instrPage) throw new Error('Instruction page not found or not in the same drive');
-  }
-
-  if (contextPageIds.length > 0) {
-    const validPages = await database.query.pages.findMany({
-      where: and(
-        inArray(pages.id, contextPageIds),
-        eq(pages.driveId, driveId),
-        eq(pages.isTrashed, false),
-      ),
-      columns: { id: true },
-    });
-    if (validPages.length !== contextPageIds.length) {
-      throw new Error('Some context pages were not found or are not in the same drive');
-    }
-  }
-
-  return { agentPageId: agent.id };
 }
 
 /**

--- a/apps/web/src/lib/workflows/task-trigger-helpers.ts
+++ b/apps/web/src/lib/workflows/task-trigger-helpers.ts
@@ -1,17 +1,13 @@
 import { db } from '@pagespace/db/db'
 import { eq, and, inArray, isNull } from '@pagespace/db/operators'
-import { pages } from '@pagespace/db/schema/core'
 import { taskItems } from '@pagespace/db/schema/tasks'
 import { workflows } from '@pagespace/db/schema/workflows';
 import { taskTriggers } from '@pagespace/db/schema/task-triggers';
 import { executeWorkflow, type WorkflowExecutionInput } from './workflow-executor';
 import { loggers } from '@pagespace/lib/logging/logger-config';
+import { validateAgentTrigger, type AgentTriggerPayload } from './agent-trigger-shared';
 
-export interface AgentTriggerInput {
-  agentPageId: string;
-  prompt?: string;
-  instructionPageId?: string;
-  contextPageIds?: string[];
+export interface AgentTriggerInput extends AgentTriggerPayload {
   triggerType: 'due_date' | 'completion';
 }
 
@@ -76,40 +72,14 @@ export async function createTaskTriggerWorkflow(params: CreateTaskTriggerWorkflo
   if (triggerType === 'due_date' && !dueDate) {
     throw new Error('Due date is required for due_date triggers');
   }
-  if (!agentTrigger.prompt && !agentTrigger.instructionPageId) {
-    throw new Error('Agent trigger needs either a prompt or instructionPageId');
-  }
 
-  const triggerAgent = await database.query.pages.findFirst({
-    where: and(eq(pages.id, agentTrigger.agentPageId), eq(pages.type, 'AI_CHAT'), eq(pages.isTrashed, false)),
-    columns: { id: true, driveId: true },
+  await validateAgentTrigger(database, {
+    driveId,
+    agentTrigger,
+    entityLabel: 'task list',
   });
-  if (!triggerAgent) throw new Error('Agent trigger target not found or not an AI agent');
-  if (triggerAgent.driveId !== driveId) throw new Error('Agent must be in the same drive as the task list');
-
-  if (agentTrigger.instructionPageId) {
-    const instrPage = await database.query.pages.findFirst({
-      where: and(eq(pages.id, agentTrigger.instructionPageId), eq(pages.driveId, driveId), eq(pages.isTrashed, false)),
-      columns: { id: true },
-    });
-    if (!instrPage) throw new Error('Instruction page not found or not in the same drive');
-  }
 
   const contextPageIds = agentTrigger.contextPageIds ?? [];
-  if (contextPageIds.length > 0) {
-    const validPages = await database.query.pages.findMany({
-      where: and(
-        inArray(pages.id, contextPageIds),
-        eq(pages.driveId, driveId),
-        eq(pages.isTrashed, false),
-      ),
-      columns: { id: true },
-    });
-    if (validPages.length !== contextPageIds.length) {
-      throw new Error('Some context pages were not found or are not in the same drive');
-    }
-  }
-
   const triggerPrompt = agentTrigger.prompt || 'Execute instructions from linked page.';
   const nextRunAt = triggerType === 'due_date' && dueDate ? dueDate : null;
 


### PR DESCRIPTION
## What

Lets AI agents create and manage **standalone recurring (cron) workflows** — scheduled agent work not tied to a task due date or a calendar event (e.g. *"every weekday at 9am, summarize new activity"*). The `workflows` table, cron poller (`app/api/cron/workflows`), and `cron-utils` validators already existed; this PR adds the missing agent-facing tool surface and de-duplicates the shared agent-trigger payload.

## Why

Agents could already attach triggers to tasks (`update_task`) and calendar events (`create_calendar_event`) but had no way to schedule a standalone recurring workflow. Per the lump-vs-split design discussion, cron stays its **own** tool family (a standalone entity with its own lifecycle) rather than being merged into a unified trigger tool — while the genuinely duplicated piece (the `AgentTriggerInput`/`CalendarAgentTriggerInput` payload) is unified at the lib level.

## Changes

- **`agent-trigger-shared.ts`** — single `agentTriggerBaseSchema` + drive-scoped `validateAgentTrigger` helper. Task and calendar triggers now delegate to it; their input schemas consume the shared base. Behavior unchanged (one "agent not found" message unified).
- **`workflow-tools.ts`** — new AI tools:
  - `create_workflow` — validates drive access, cron (min 5-min interval) + timezone via `cron-utils`, and the agent payload; inserts a `triggerType=cron` workflow with a computed `nextRunAt`.
  - `list_workflows` / `update_workflow` / `delete_workflow` — lifecycle management. All scope to **standalone** workflows (`cronExpression IS NOT NULL`) and refuse to mutate task-/calendar-bound workflows.
- **Registry/filtering/discovery** — registered in `pageSpaceTools`; write tools added to `WRITE_TOOLS` (read-only-excluded) with `list_workflows` as a read tool; grouped under a `workflows` category in the global-assistant prompt. `tool_search`/`execute_tool` surface them automatically.

## Security

- All four tools enforce `canActorAccessDrive`; `update`/`delete` authorize against the **server-derived** `workflow.driveId` (no IDOR).
- The `cronExpression IS NOT NULL` guard fences standalone workflows off from task/calendar-managed ones.

## Tests

24 new unit tests (create/list/update/delete happy paths + every rejection, shared validation, read-only filtering). `web` typecheck + lint clean.

## Follow-up (not in this PR)

- No activity-feed entry / websocket broadcast for workflow CRUD yet — worth adding if/when a workflows management UI lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workflow management capabilities: create, list, update, and delete standalone recurring (cron) workflows with agent automation.
  * Enhanced read-only mode to restrict workflow write operations while preserving read access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1444?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->