### PR TITLE
feat(ai-tools): explicit task verb tools (create/delete/reorder)

### DIFF
--- a/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
@@ -44,6 +44,9 @@ vi.mock('../../tools/search-tools', () => ({
 vi.mock('../../tools/task-management-tools', () => ({
   taskManagementTools: {
     update_task: { name: 'update_task', description: 'Update task' },
+    create_task: { name: 'create_task', description: 'Create task' },
+    delete_task: { name: 'delete_task', description: 'Delete task' },
+    reorder_task: { name: 'reorder_task', description: 'Reorder task' },
   },
 }));
 

--- a/apps/web/src/lib/ai/core/system-prompt.ts
+++ b/apps/web/src/lib/ai/core/system-prompt.ts
@@ -45,7 +45,7 @@ const CATEGORY_MAP: Record<string, string> = {
   list_trash: 'pages', list_conversations: 'pages', read_conversation: 'pages',
   rename_page: 'pages', trash: 'pages', restore: 'pages', move_page: 'pages', edit_sheet_cells: 'pages',
   glob_search: 'search',
-  update_task: 'tasks', get_assigned_tasks: 'tasks',
+  update_task: 'tasks', create_task: 'tasks', delete_task: 'tasks', reorder_task: 'tasks', get_assigned_tasks: 'tasks',
   update_agent_config: 'agents', list_agents: 'agents', multi_drive_list_agents: 'agents', ask_agent: 'agents',
   web_search: 'search',
   get_activity: 'activity',

--- a/apps/web/src/lib/ai/core/tool-filtering.ts
+++ b/apps/web/src/lib/ai/core/tool-filtering.ts
@@ -24,6 +24,9 @@ const WRITE_TOOLS = new Set([
   'update_agent_config',
   // Task operations
   'update_task',
+  'create_task',
+  'delete_task',
+  'reorder_task',
   // Channel operations
   'send_channel_message',
   // Calendar write operations

--- a/apps/web/src/lib/ai/tools/__tests__/task-verb-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/task-verb-tools.test.ts
@@ -1,0 +1,396 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { z } from 'zod';
+
+// Mock database and dependencies (mirrors task-management-tools.test.ts so the
+// shared task-helpers exercised by the new verb tools resolve against the same
+// in-memory db mock — no real DB).
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn(),
+    orderBy: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    set: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    values: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+    returning: vi.fn(),
+    transaction: vi.fn(),
+    query: {
+      taskItems: { findFirst: vi.fn(), findMany: vi.fn() },
+      taskLists: { findFirst: vi.fn() },
+      pages: { findFirst: vi.fn() },
+      taskStatusConfigs: { findMany: vi.fn().mockResolvedValue([]) },
+    },
+  },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn(),
+  and: vi.fn(),
+  desc: vi.fn(),
+  asc: vi.fn(),
+  isNull: vi.fn(),
+  inArray: vi.fn(),
+}));
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'id', parentId: 'parentId', revision: 'revision' },
+}));
+vi.mock('@pagespace/db/schema/tasks', () => ({
+  taskLists: { id: 'id', pageId: 'pageId', userId: 'userId' },
+  taskItems: { id: 'id', position: 'position' },
+  taskStatusConfigs: { taskListId: 'taskListId', position: 'position' },
+  taskAssignees: { taskId: 'taskId' },
+}));
+
+const { deferredTriggerMock } = vi.hoisted(() => ({
+  deferredTriggerMock: vi.fn(),
+}));
+vi.mock('@/services/api/page-mutation-service', () => ({
+  applyPageMutation: vi.fn().mockResolvedValue({
+    pageId: 'p',
+    driveId: 'd',
+    nextRevision: 1,
+    deferredTrigger: deferredTriggerMock,
+  }),
+  PageRevisionMismatchError: class PageRevisionMismatchError extends Error {
+    currentRevision = 0;
+    expectedRevision?: number;
+  },
+}));
+
+vi.mock('@/lib/workflows/task-trigger-helpers', () => ({
+  createTaskTriggerWorkflow: vi.fn(),
+  syncTaskDueDateTrigger: vi.fn(),
+  cancelTaskDueDateTrigger: vi.fn(),
+  fireCompletionTrigger: vi.fn(),
+  disableTaskTriggers: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  canUserEditPage: vi.fn(),
+  canUserViewPage: vi.fn(),
+  getUserDriveAccess: vi.fn(),
+}));
+vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
+  logPageActivity: vi.fn(),
+  getActorInfo: vi.fn().mockResolvedValue({ actorEmail: 'test@test.com' }),
+}));
+
+vi.mock('@pagespace/lib/content/page-types.config', () => ({
+  getDefaultContent: vi.fn(() => ''),
+  getCreatablePageTypes: vi.fn(() => ['DOCUMENT', 'FOLDER', 'TASK_LIST']),
+}));
+vi.mock('@pagespace/lib/utils/enums', () => ({
+  PageType: { DOCUMENT: 'DOCUMENT' },
+}));
+
+vi.mock('@/lib/websocket', () => ({
+  broadcastTaskEvent: vi.fn(),
+  broadcastPageEvent: vi.fn(),
+  createPageEventPayload: vi.fn(),
+}));
+
+vi.mock('@/lib/tasks/completion-guard', () => ({
+  assertSubTasksComplete: vi.fn().mockResolvedValue(undefined),
+  SubtasksIncompleteError: class SubtasksIncompleteError extends Error {
+    readonly code = 'SUBTASKS_INCOMPLETE' as const;
+    constructor(public readonly pending: number, public readonly total: number) {
+      super(`Complete all sub-tasks first (${pending} of ${total} remaining)`);
+      this.name = 'SubtasksIncompleteError';
+    }
+  },
+}));
+
+import { taskManagementTools } from '../task-management-tools';
+import { db } from '@pagespace/db/db';
+import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
+import type { ToolExecutionContext } from '../../core';
+
+const mockDb = vi.mocked(db);
+const mockCanUserEditPage = vi.mocked(canUserEditPage);
+
+const context = {
+  toolCallId: '1',
+  messages: [],
+  experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+};
+
+describe('task verb tools', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default db.select chain (supports both innerJoin and direct .where paths).
+    mockDb.select = vi.fn(() => ({
+      from: vi.fn(() => ({
+        innerJoin: vi.fn(() => ({
+          where: vi.fn(() => ({
+            orderBy: vi.fn().mockResolvedValue([]),
+          })),
+        })),
+        where: vi.fn(() => ({
+          orderBy: vi.fn().mockResolvedValue([]),
+        })),
+      })),
+    })) as unknown as typeof mockDb.select;
+  });
+
+  describe('create_task', () => {
+    it('requires pageId and title (rejects missing title)', () => {
+      const schema = taskManagementTools.create_task.inputSchema as z.ZodTypeAny;
+      expect(() => schema.parse({ pageId: 'page-1' })).toThrow();
+      // pageId + title parses cleanly
+      expect(schema.parse({ pageId: 'page-1', title: 'Do the thing' })).toMatchObject({
+        pageId: 'page-1',
+        title: 'Do the thing',
+      });
+    });
+
+    it('creates a task and its linked TASK_LIST page', async () => {
+      mockDb.query.taskLists.findFirst = vi.fn().mockResolvedValue({
+        id: 'list-1',
+        pageId: 'page-1',
+        userId: 'user-123',
+        title: 'My Tasks',
+        description: null,
+        status: 'pending',
+      });
+      mockDb.query.taskStatusConfigs.findMany = vi.fn().mockResolvedValue([]);
+      mockDb.query.taskItems.findMany = vi.fn().mockResolvedValue([]);
+      mockCanUserEditPage.mockResolvedValue(true);
+
+      let capturedPageInsert: Record<string, unknown> | null = null;
+      mockDb.transaction = vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => {
+        let insertCallCount = 0;
+        const tx = {
+          insert: vi.fn(() => ({
+            values: vi.fn((vals: Record<string, unknown>) => {
+              insertCallCount++;
+              if (insertCallCount === 1) capturedPageInsert = vals;
+              return {
+                returning: vi.fn().mockResolvedValue(
+                  insertCallCount === 1
+                    ? [{ id: 'new-page', title: 'New Task', type: 'TASK_LIST' }]
+                    : [{ id: 'new-task', pageId: 'new-page', status: 'pending', priority: 'medium', position: 0, dueDate: null, assigneeId: null, assigneeAgentId: null, metadata: {}, completedAt: null }]
+                ),
+              };
+            }),
+          })),
+        };
+        return cb(tx);
+      }) as unknown as typeof mockDb.transaction;
+
+      // pages.findFirst: taskListPage, lastChildPage(null), then driveId lookup.
+      mockDb.query.pages.findFirst = vi.fn()
+        .mockResolvedValueOnce({ id: 'page-1', type: 'TASK_LIST', title: 'My Task List', driveId: 'drive-1' })
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ driveId: 'drive-1' });
+
+      const result = await taskManagementTools.create_task.execute!(
+        { pageId: 'page-1', title: 'New Task' },
+        context
+      );
+
+      expect(capturedPageInsert).toMatchObject({ type: 'TASK_LIST', content: '' });
+      expect(result).toEqual(
+        expect.objectContaining({
+          success: true,
+          action: 'created',
+          task: expect.objectContaining({ id: 'new-task', title: 'New Task' }),
+        }),
+      );
+    });
+
+    it('rejects when the target page is not a TASK_LIST', async () => {
+      mockDb.query.pages.findFirst = vi.fn().mockResolvedValue({
+        id: 'page-1',
+        type: 'DOCUMENT',
+        title: 'Regular Doc',
+        driveId: 'drive-1',
+      });
+      mockCanUserEditPage.mockResolvedValue(true);
+
+      await expect(
+        taskManagementTools.create_task.execute!(
+          { pageId: 'page-1', title: 'New Task' },
+          context
+        )
+      ).rejects.toThrow('Page must be a TASK_LIST page to add tasks');
+    });
+  });
+
+  describe('delete_task', () => {
+    it('requires a taskId', () => {
+      const schema = taskManagementTools.delete_task.inputSchema as z.ZodTypeAny;
+      expect(() => schema.parse({})).toThrow();
+      expect(schema.parse({ taskId: 'task-1' })).toMatchObject({ taskId: 'task-1' });
+    });
+
+    it('hard-deletes the task and trashes its linked page', async () => {
+      mockDb.query.taskItems.findFirst = vi.fn().mockResolvedValue({
+        id: 'task-1',
+        pageId: 'doc-page-1',
+        page: { title: 'Old Task', parentId: 'task-list-page-1' },
+      });
+      mockDb.query.taskItems.findMany = vi.fn().mockResolvedValue([]);
+      mockDb.query.taskLists.findFirst = vi.fn().mockResolvedValue({
+        id: 'list-1',
+        pageId: 'task-list-page-1',
+        userId: 'user-123',
+        title: 'My Tasks',
+        description: null,
+        status: 'pending',
+      });
+      mockDb.query.pages.findFirst = vi.fn().mockResolvedValue({ driveId: 'drive-1' });
+      mockCanUserEditPage.mockResolvedValue(true);
+
+      const deleteCalls: unknown[] = [];
+      const tx = {
+        select: vi.fn().mockReturnThis(),
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue([{ revision: 5 }]),
+        delete: vi.fn(() => ({
+          where: vi.fn().mockImplementation((arg: unknown) => {
+            deleteCalls.push(arg);
+            return Promise.resolve();
+          }),
+        })),
+      };
+      mockDb.transaction = vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb(tx)) as unknown as typeof mockDb.transaction;
+
+      const result = await taskManagementTools.delete_task.execute!(
+        { taskId: 'task-1' },
+        context
+      );
+
+      const { applyPageMutation } = await import('@/services/api/page-mutation-service');
+      const { disableTaskTriggers } = await import('@/lib/workflows/task-trigger-helpers');
+
+      expect(applyPageMutation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pageId: 'doc-page-1',
+          operation: 'trash',
+          expectedRevision: 5,
+        }),
+      );
+      expect(disableTaskTriggers).toHaveBeenCalledWith('task-1', expect.any(String));
+      expect(deferredTriggerMock).toHaveBeenCalled();
+      expect(deleteCalls.length).toBeGreaterThanOrEqual(1);
+      expect(result).toEqual(
+        expect.objectContaining({
+          success: true,
+          action: 'deleted',
+          task: expect.objectContaining({ id: 'task-1', pageId: 'doc-page-1' }),
+          taskList: expect.objectContaining({ id: 'list-1' }),
+          tasks: expect.any(Array),
+        }),
+      );
+    });
+
+    it('rejects when the actor lacks edit permission', async () => {
+      mockDb.query.taskItems.findFirst = vi.fn().mockResolvedValue({
+        id: 'task-1',
+        pageId: 'doc-page-1',
+        page: { title: 'Old Task', parentId: 'task-list-page-1' },
+      });
+      mockDb.query.taskLists.findFirst = vi.fn().mockResolvedValue({
+        id: 'list-1',
+        pageId: 'task-list-page-1',
+        userId: 'other-user',
+      });
+      mockCanUserEditPage.mockResolvedValue(false);
+
+      await expect(
+        taskManagementTools.delete_task.execute!(
+          { taskId: 'task-1' },
+          context
+        )
+      ).rejects.toThrow('You do not have permission to update tasks on this page');
+    });
+  });
+
+  describe('reorder_task', () => {
+    it('requires taskId and position', () => {
+      const schema = taskManagementTools.reorder_task.inputSchema as z.ZodTypeAny;
+      expect(() => schema.parse({ taskId: 'task-1' })).toThrow();
+      expect(() => schema.parse({ position: 2 })).toThrow();
+      expect(schema.parse({ taskId: 'task-1', position: 2 })).toMatchObject({ taskId: 'task-1', position: 2 });
+    });
+
+    it('moves the task and re-densifies peers', async () => {
+      mockDb.query.taskItems.findFirst = vi.fn().mockResolvedValue({
+        id: 'task-2',
+        pageId: 'doc-2',
+        position: 1,
+        status: 'pending',
+        priority: 'medium',
+        assigneeId: null,
+        assigneeAgentId: null,
+        dueDate: null,
+        completedAt: null,
+        page: { title: 'Middle Task', parentId: 'task-list-page-1' },
+      });
+      mockDb.query.taskLists.findFirst = vi.fn().mockResolvedValue({
+        id: 'list-1',
+        pageId: 'task-list-page-1',
+        userId: 'user-123',
+        title: 'My Tasks',
+        description: null,
+        status: 'pending',
+      });
+      mockDb.query.taskItems.findMany = vi.fn().mockResolvedValue([]);
+      mockDb.query.pages.findFirst = vi.fn().mockResolvedValue({ driveId: 'drive-1' });
+      mockCanUserEditPage.mockResolvedValue(true);
+
+      const peerRows = [
+        { id: 'task-1', position: 0 },
+        { id: 'task-2', position: 1 },
+        { id: 'task-3', position: 2 },
+        { id: 'task-4', position: 3 },
+      ];
+      mockDb.select = vi.fn(() => ({
+        from: vi.fn().mockReturnThis(),
+        innerJoin: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        orderBy: vi.fn().mockResolvedValue(peerRows),
+      })) as unknown as typeof mockDb.select;
+
+      const reorderTxMock = vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => {
+        const tx = {
+          update: vi.fn(() => ({
+            set: vi.fn(() => ({
+              where: vi.fn().mockResolvedValue(undefined),
+            })),
+          })),
+        };
+        return cb(tx);
+      });
+      mockDb.transaction = reorderTxMock as unknown as typeof mockDb.transaction;
+
+      const result = await taskManagementTools.reorder_task.execute!(
+        { taskId: 'task-2', position: 3 },
+        context
+      );
+
+      expect(reorderTxMock).toHaveBeenCalled();
+      expect(result).toEqual(
+        expect.objectContaining({
+          success: true,
+          action: 'updated',
+          task: expect.objectContaining({ id: 'task-2', position: 3 }),
+        }),
+      );
+    });
+
+    it('rejects when the task does not exist', async () => {
+      mockDb.query.taskItems.findFirst = vi.fn().mockResolvedValue(null);
+
+      await expect(
+        taskManagementTools.reorder_task.execute!(
+          { taskId: 'missing', position: 0 },
+          context
+        )
+      ).rejects.toThrow('Task not found');
+    });
+  });
+});

--- a/apps/web/src/lib/ai/tools/__tests__/task-verb-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/task-verb-tools.test.ts
@@ -105,10 +105,12 @@ vi.mock('@/lib/tasks/completion-guard', () => ({
 import { taskManagementTools } from '../task-management-tools';
 import { db } from '@pagespace/db/db';
 import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
+import { broadcastTaskEvent } from '@/lib/websocket';
 import type { ToolExecutionContext } from '../../core';
 
 const mockDb = vi.mocked(db);
 const mockCanUserEditPage = vi.mocked(canUserEditPage);
+const mockBroadcastTaskEvent = vi.mocked(broadcastTaskEvent);
 
 const context = {
   toolCallId: '1',
@@ -198,6 +200,15 @@ describe('task verb tools', () => {
           task: expect.objectContaining({ id: 'new-task', title: 'New Task' }),
         }),
       );
+    });
+
+    it('rejects a blank/whitespace title', async () => {
+      await expect(
+        taskManagementTools.create_task.execute!(
+          { pageId: 'page-1', title: '   ' },
+          context
+        )
+      ).rejects.toThrow('Title cannot be empty');
     });
 
     it('rejects when the target page is not a TASK_LIST', async () => {
@@ -373,6 +384,10 @@ describe('task verb tools', () => {
       );
 
       expect(reorderTxMock).toHaveBeenCalled();
+      // Reorders must broadcast so collaborators/other clients see the move.
+      expect(mockBroadcastTaskEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'task_updated', taskId: 'task-2' }),
+      );
       expect(result).toEqual(
         expect.objectContaining({
           success: true,

--- a/apps/web/src/lib/ai/tools/task-helpers.ts
+++ b/apps/web/src/lib/ai/tools/task-helpers.ts
@@ -227,6 +227,27 @@ export function serializeTaskItem(t: EnrichedTaskItem) {
   };
 }
 
+/**
+ * Emit the `task_updated` event so collaborators and other clients see field
+ * edits and reorders. Shared by update_task and reorder_task so both surfaces
+ * broadcast the same payload shape.
+ */
+export async function broadcastTaskUpdated(params: {
+  taskId: string;
+  userId: string;
+  taskListPageId: string | null;
+  title: string;
+  note?: string;
+}): Promise<void> {
+  await broadcastTaskEvent({
+    type: 'task_updated',
+    taskId: params.taskId,
+    userId: params.userId,
+    pageId: params.taskListPageId || undefined,
+    data: { title: params.title, note: params.note },
+  });
+}
+
 /** Serialize the refreshed task list to the tool response shape. */
 export function serializeTaskList(
   tl: typeof taskLists.$inferSelect | undefined,
@@ -329,6 +350,12 @@ export async function createTask(
 ) {
   const { pageId, title, status, priority, assigneeId, assigneeAgentId, assigneeIds, dueDate, note, position, agentTrigger } = params;
 
+  // Reject blank/whitespace titles, matching the update path and REST task route.
+  const trimmedTitle = title.trim();
+  if (!trimmedTitle) {
+    throw new Error('Title cannot be empty');
+  }
+
   // Get the TASK_LIST page and verify access
   const taskListPage = await db.query.pages.findFirst({
     where: and(eq(pages.id, pageId), eq(pages.isTrashed, false)),
@@ -426,7 +453,7 @@ export async function createTask(
   const result = await db.transaction(async (tx) => {
     // Create task list page (description + sub-tasks live here)
     const [taskPage] = await tx.insert(pages).values({
-      title,
+      title: trimmedTitle,
       type: 'TASK_LIST',
       parentId: pageId,
       driveId: taskListPage.driveId,

--- a/apps/web/src/lib/ai/tools/task-helpers.ts
+++ b/apps/web/src/lib/ai/tools/task-helpers.ts
@@ -1,0 +1,706 @@
+import { db } from '@pagespace/db/db'
+import { eq, and, desc, asc, inArray } from '@pagespace/db/operators'
+import { pages } from '@pagespace/db/schema/core'
+import { taskLists, taskItems, taskStatusConfigs, taskAssignees } from '@pagespace/db/schema/tasks';
+import { type ToolExecutionContext } from '../core';
+import { broadcastTaskEvent, broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
+import { canActorEditPage } from './actor-permissions';
+import { logPageActivity, getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
+import type { DeferredWorkflowTrigger } from '@pagespace/lib/monitoring/activity-logger';
+import { createTaskTriggerWorkflow, disableTaskTriggers } from '@/lib/workflows/task-trigger-helpers';
+import type { AgentTriggerInput } from '@/lib/workflows/task-trigger-helpers';
+import { applyPageMutation, PageRevisionMismatchError } from '@/services/api/page-mutation-service';
+
+/**
+ * The Drizzle transaction handle passed to `db.transaction(async (tx) => ...)`.
+ * Derived from the live db type so it never drifts.
+ */
+export type DbTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+/**
+ * Normalize an agentTrigger payload: trim prompt/instructionPageId and collapse
+ * an empty trigger (no prompt and no instruction page) to undefined so a blank
+ * object doesn't schedule a no-op workflow.
+ */
+export function normalizeTaskAgentTriggerInput(value: unknown): unknown {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return value;
+  }
+
+  const candidate = value as {
+    prompt?: unknown;
+    instructionPageId?: unknown;
+  };
+
+  const prompt = typeof candidate.prompt === 'string' ? candidate.prompt.trim() : '';
+  const instructionPageId = typeof candidate.instructionPageId === 'string' ? candidate.instructionPageId.trim() : '';
+
+  if (!prompt && !instructionPageId) {
+    return undefined;
+  }
+
+  return {
+    ...candidate,
+    ...(prompt ? { prompt } : {}),
+    ...(instructionPageId ? { instructionPageId } : {}),
+  };
+}
+
+/**
+ * Extract AI attribution context with actor info for activity logging.
+ */
+export async function getAiContextWithActor(context: ToolExecutionContext) {
+  const actorInfo = await getActorInfo(context.userId);
+  // Build chain metadata (Tier 1)
+  const chainMetadata = {
+    ...(context.parentAgentId && { parentAgentId: context.parentAgentId }),
+    ...(context.parentConversationId && { parentConversationId: context.parentConversationId }),
+    ...(context.agentChain?.length && { agentChain: context.agentChain }),
+    ...(context.requestOrigin && { requestOrigin: context.requestOrigin }),
+  };
+
+  return {
+    ...actorInfo,
+    isAiGenerated: true,
+    aiProvider: context.aiProvider,
+    aiModel: context.aiModel,
+    aiConversationId: context.conversationId,
+    metadata: Object.keys(chainMetadata).length > 0 ? chainMetadata : undefined,
+  };
+}
+
+/**
+ * Verify page access for page-linked task lists.
+ */
+export async function verifyPageAccess(context: ToolExecutionContext, pageId: string): Promise<boolean> {
+  return canActorEditPage(context, pageId);
+}
+
+async function fetchTaskForUpdate(taskId: string) {
+  return db.query.taskItems.findFirst({
+    where: eq(taskItems.id, taskId),
+    with: {
+      page: { columns: { title: true, parentId: true } },
+    },
+  });
+}
+
+/** A task row joined with its linked page's title/parentId. */
+export type TaskForUpdate = NonNullable<Awaited<ReturnType<typeof fetchTaskForUpdate>>>;
+
+/**
+ * Resolve the existing task and its owning task list, then verify the actor may
+ * edit it. Throws with a human-readable message on missing task/list or
+ * insufficient permission. Shared by update_task, delete_task, and reorder_task.
+ */
+export async function resolveTaskForUpdate(
+  context: ToolExecutionContext,
+  userId: string,
+  taskId: string,
+): Promise<{ existingTask: TaskForUpdate; taskList: typeof taskLists.$inferSelect }> {
+  const existingTask = await fetchTaskForUpdate(taskId);
+
+  if (!existingTask) {
+    throw new Error('Task not found');
+  }
+
+  const taskList = await db.query.taskLists.findFirst({
+    where: eq(taskLists.pageId, existingTask.page?.parentId ?? ''),
+  });
+
+  if (!taskList) {
+    throw new Error('Task list not found');
+  }
+
+  if (taskList.pageId) {
+    const hasAccess = await verifyPageAccess(context, taskList.pageId);
+    if (!hasAccess) {
+      throw new Error('You do not have permission to update tasks on this page');
+    }
+  } else if (taskList.userId !== userId) {
+    throw new Error('You do not have permission to update this task');
+  }
+
+  return { existingTask, taskList };
+}
+
+/**
+ * Replace a task's assignees inside a transaction.
+ *
+ * `assigneeIds` as an array is treated as a full replace (matching the REST
+ * PATCH route, so callers can clear all assignees with []). Otherwise the legacy
+ * single-assignee fields are synced into the junction table when provided.
+ */
+export async function syncTaskAssignees(
+  tx: DbTransaction,
+  taskId: string,
+  params: {
+    assigneeIds?: { type: 'user' | 'agent'; id: string }[];
+    assigneeId?: string | null;
+    assigneeAgentId?: string | null;
+  },
+): Promise<void> {
+  const { assigneeIds, assigneeId, assigneeAgentId } = params;
+
+  if (Array.isArray(assigneeIds)) {
+    await tx.delete(taskAssignees).where(eq(taskAssignees.taskId, taskId));
+    const rows = assigneeIds
+      .filter(a => a.id)
+      .map(a => ({
+        taskId,
+        ...(a.type === 'user' ? { userId: a.id } : { agentPageId: a.id }),
+      }));
+    if (rows.length > 0) {
+      await tx.insert(taskAssignees).values(rows);
+    }
+
+    // Sync legacy fields
+    const firstUser = assigneeIds.find(a => a.type === 'user' && a.id);
+    const firstAgent = assigneeIds.find(a => a.type === 'agent' && a.id);
+    await tx.update(taskItems).set({
+      assigneeId: firstUser?.id || null,
+      assigneeAgentId: firstAgent?.id || null,
+    }).where(eq(taskItems.id, taskId));
+  } else if (assigneeId !== undefined || assigneeAgentId !== undefined) {
+    // Legacy single-assignee: sync to junction table
+    await tx.delete(taskAssignees).where(eq(taskAssignees.taskId, taskId));
+    const rows: { taskId: string; userId?: string; agentPageId?: string }[] = [];
+    if (assigneeId) rows.push({ taskId, userId: assigneeId });
+    if (assigneeAgentId) rows.push({ taskId, agentPageId: assigneeAgentId });
+    if (rows.length > 0) await tx.insert(taskAssignees).values(rows);
+  }
+}
+
+async function fetchEnrichedTasks(parentPageId: string) {
+  return db.query.taskItems.findMany({
+    where: inArray(taskItems.pageId, db.select({ id: pages.id }).from(pages).where(and(
+      eq(pages.parentId, parentPageId),
+      eq(pages.type, 'TASK_LIST'),
+      eq(pages.isTrashed, false),
+    ))),
+    orderBy: [asc(taskItems.position)],
+    with: {
+      assignee: { columns: { id: true, name: true, image: true } },
+      assigneeAgent: { columns: { id: true, title: true, type: true } },
+      page: { columns: { title: true } },
+      assignees: {
+        with: {
+          user: { columns: { id: true, name: true } },
+          agentPage: { columns: { id: true, title: true } },
+        },
+      },
+    },
+  });
+}
+
+type EnrichedTaskItem = Awaited<ReturnType<typeof fetchEnrichedTasks>>[number];
+
+/** Serialize one enriched task row to the tool response shape (shared by all task tools). */
+export function serializeTaskItem(t: EnrichedTaskItem) {
+  return {
+    id: t.id,
+    title: t.page?.title ?? '',
+    status: t.status,
+    priority: t.priority,
+    assigneeId: t.assigneeId,
+    assigneeAgentId: t.assigneeAgentId,
+    dueDate: t.dueDate,
+    position: t.position,
+    completedAt: t.completedAt,
+    pageId: t.pageId,
+    assignee: t.assignee ? {
+      id: t.assignee.id,
+      name: t.assignee.name,
+      image: t.assignee.image,
+    } : null,
+    assigneeAgent: t.assigneeAgent ? {
+      id: t.assigneeAgent.id,
+      title: t.assigneeAgent.title,
+      type: t.assigneeAgent.type,
+    } : null,
+    assignees: t.assignees?.map(a => ({
+      userId: a.userId,
+      agentPageId: a.agentPageId,
+      user: a.user ? { id: a.user.id, name: a.user.name } : null,
+      agentPage: a.agentPage ? { id: a.agentPage.id, title: a.agentPage.title } : null,
+    })) || [],
+  };
+}
+
+/** Serialize the refreshed task list to the tool response shape. */
+export function serializeTaskList(
+  tl: typeof taskLists.$inferSelect | undefined,
+  driveId: string | undefined,
+) {
+  return tl ? {
+    id: tl.id,
+    title: tl.title,
+    description: tl.description,
+    status: tl.status,
+    pageId: tl.pageId,
+    driveId,
+  } : null;
+}
+
+type TaskResponseTask = Pick<
+  typeof taskItems.$inferSelect,
+  'id' | 'status' | 'priority' | 'assigneeId' | 'assigneeAgentId' | 'dueDate' | 'position' | 'completedAt' | 'pageId'
+>;
+
+/**
+ * Build the shared create/update/reorder response: the acted-on task, the
+ * refreshed task list (with driveId), and every task in the list. Callers pass
+ * the parent TASK_LIST page id used to scope the list query.
+ */
+export async function buildTaskListResponse(params: {
+  action: 'created' | 'updated';
+  parentPageId: string;
+  taskListId: string;
+  resultTask: TaskResponseTask;
+  resultTitle: string;
+  message: string;
+}) {
+  const { action, parentPageId, taskListId, resultTask, resultTitle, message } = params;
+
+  // Get all tasks for response with assignee relations
+  const allTasks = await fetchEnrichedTasks(parentPageId);
+
+  // Refresh task list with page info for driveId
+  const refreshedTaskList = await db.query.taskLists.findFirst({
+    where: eq(taskLists.id, taskListId),
+  });
+
+  // Get driveId from the associated page
+  let driveId: string | undefined;
+  if (refreshedTaskList?.pageId) {
+    const taskListPage = await db.query.pages.findFirst({
+      where: eq(pages.id, refreshedTaskList.pageId),
+      columns: { driveId: true },
+    });
+    driveId = taskListPage?.driveId;
+  }
+
+  return {
+    success: true,
+    action,
+    task: {
+      id: resultTask.id,
+      title: resultTitle,
+      status: resultTask.status,
+      priority: resultTask.priority,
+      assigneeId: resultTask.assigneeId,
+      assigneeAgentId: resultTask.assigneeAgentId,
+      dueDate: resultTask.dueDate,
+      position: resultTask.position,
+      completedAt: resultTask.completedAt,
+      pageId: resultTask.pageId,
+    },
+    taskList: serializeTaskList(refreshedTaskList, driveId),
+    tasks: allTasks.map(serializeTaskItem),
+    message,
+  };
+}
+
+export interface CreateTaskParams {
+  pageId: string;
+  title: string;
+  status?: string;
+  priority?: 'low' | 'medium' | 'high';
+  assigneeId?: string | null;
+  assigneeAgentId?: string | null;
+  assigneeIds?: { type: 'user' | 'agent'; id: string }[];
+  dueDate?: string | null;
+  note?: string;
+  position?: number;
+  agentTrigger?: AgentTriggerInput;
+}
+
+/**
+ * Create a task on a TASK_LIST page: validates access + status, auto-creates the
+ * task_list record, inserts a linked TASK_LIST page (holding the description /
+ * sub-tasks) plus the task row, wires assignees and any agent trigger, then
+ * broadcasts and returns the refreshed list. Shared by create_task and the
+ * create branch of update_task.
+ */
+export async function createTask(
+  context: ToolExecutionContext,
+  userId: string,
+  params: CreateTaskParams,
+) {
+  const { pageId, title, status, priority, assigneeId, assigneeAgentId, assigneeIds, dueDate, note, position, agentTrigger } = params;
+
+  // Get the TASK_LIST page and verify access
+  const taskListPage = await db.query.pages.findFirst({
+    where: and(eq(pages.id, pageId), eq(pages.isTrashed, false)),
+    columns: { id: true, driveId: true, type: true, title: true },
+  });
+
+  if (!taskListPage) {
+    throw new Error('Page not found');
+  }
+
+  if (taskListPage.type !== 'TASK_LIST') {
+    throw new Error('Page must be a TASK_LIST page to add tasks');
+  }
+
+  const hasAccess = await verifyPageAccess(context, pageId);
+  if (!hasAccess) {
+    throw new Error('You do not have permission to add tasks to this page');
+  }
+
+  // Find or create task_list record for this page
+  let taskList = await db.query.taskLists.findFirst({
+    where: eq(taskLists.pageId, pageId),
+  });
+
+  if (!taskList) {
+    // Auto-create task_list record for this page
+    const [newTaskList] = await db.insert(taskLists).values({
+      userId,
+      pageId,
+      title: taskListPage.title,
+      status: 'pending',
+      metadata: {
+        createdAt: new Date().toISOString(),
+        autoCreated: true,
+      },
+    }).returning();
+    taskList = newTaskList;
+  }
+
+  // Determine position for new task
+  const existingTasks = await db
+    .select({ position: taskItems.position })
+    .from(taskItems)
+    .innerJoin(pages, eq(pages.id, taskItems.pageId))
+    .where(and(
+      eq(pages.parentId, pageId),
+      eq(pages.type, 'TASK_LIST'),
+      eq(pages.isTrashed, false),
+    ))
+    .orderBy(desc(taskItems.position));
+
+  const nextTaskPosition = position ?? (existingTasks.length > 0 ? (existingTasks[0]?.position || 0) + 1 : 0);
+
+  // Get next page position for the child document
+  const lastChildPage = await db.query.pages.findFirst({
+    where: and(eq(pages.parentId, pageId), eq(pages.isTrashed, false)),
+    orderBy: [desc(pages.position)],
+  });
+  const nextPagePosition = (lastChildPage?.position ?? 0) + 1;
+
+  // Validate assigneeAgentId if provided
+  if (assigneeAgentId) {
+    const agentPage = await db.query.pages.findFirst({
+      where: and(
+        eq(pages.id, assigneeAgentId),
+        eq(pages.type, 'AI_CHAT'),
+        eq(pages.isTrashed, false)
+      ),
+      columns: { id: true, driveId: true },
+    });
+
+    if (!agentPage) {
+      throw new Error('Invalid agent ID - must be an AI agent page');
+    }
+
+    if (agentPage.driveId !== taskListPage.driveId) {
+      throw new Error('Agent must be in the same drive as the task list');
+    }
+  }
+
+  // Validate custom status if provided
+  const resolvedStatus = status || 'pending';
+  const statusConfigsForList = await db.query.taskStatusConfigs.findMany({
+    where: eq(taskStatusConfigs.taskListId, taskList!.id),
+    columns: { slug: true, group: true },
+  });
+  if (statusConfigsForList.length > 0 && status) {
+    const matched = statusConfigsForList.find(c => c.slug === status);
+    if (!matched) {
+      throw new Error(`Invalid status "${status}". Valid: ${statusConfigsForList.map(c => c.slug).join(', ')}`);
+    }
+  }
+
+  // Create task list page and task in transaction
+  const result = await db.transaction(async (tx) => {
+    // Create task list page (description + sub-tasks live here)
+    const [taskPage] = await tx.insert(pages).values({
+      title,
+      type: 'TASK_LIST',
+      parentId: pageId,
+      driveId: taskListPage.driveId,
+      content: '',
+      position: nextPagePosition,
+      updatedAt: new Date(),
+    }).returning();
+
+    // Create task with link to the page
+    const primaryUserId = assigneeId || (assigneeIds?.find(a => a.type === 'user')?.id) || null;
+    const primaryAgentId = assigneeAgentId || (assigneeIds?.find(a => a.type === 'agent')?.id) || null;
+
+    const [newTask] = await tx.insert(taskItems).values({
+      userId,
+      pageId: taskPage.id,
+      status: resolvedStatus,
+      priority: priority || 'medium',
+      assigneeId: primaryUserId,
+      assigneeAgentId: primaryAgentId,
+      dueDate: dueDate ? new Date(dueDate) : null,
+      position: nextTaskPosition,
+      metadata: {
+        createdAt: new Date().toISOString(),
+        note,
+      },
+    }).returning();
+
+    // Create multiple assignees in junction table
+    const assigneeRows: { taskId: string; userId?: string; agentPageId?: string }[] = [];
+    if (assigneeIds && assigneeIds.length > 0) {
+      for (const a of assigneeIds) {
+        if (a.type === 'user') assigneeRows.push({ taskId: newTask.id, userId: a.id });
+        else if (a.type === 'agent') assigneeRows.push({ taskId: newTask.id, agentPageId: a.id });
+      }
+    } else {
+      if (primaryUserId) assigneeRows.push({ taskId: newTask.id, userId: primaryUserId });
+      if (primaryAgentId) assigneeRows.push({ taskId: newTask.id, agentPageId: primaryAgentId });
+    }
+    if (assigneeRows.length > 0) {
+      await tx.insert(taskAssignees).values(assigneeRows);
+    }
+
+    // Create agent trigger workflow if requested
+    if (agentTrigger) {
+      if (!taskListPage.driveId) {
+        throw new Error('Agent triggers require a drive-based task list');
+      }
+      await createTaskTriggerWorkflow({
+        database: tx,
+        driveId: taskListPage.driveId,
+        userId,
+        taskId: newTask.id,
+        taskMetadata: newTask.metadata as Record<string, unknown> | null,
+        agentTrigger,
+        dueDate: dueDate ? new Date(dueDate) : null,
+        timezone: context.timezone || 'UTC',
+      });
+    }
+
+    return { task: newTask, page: taskPage };
+  });
+
+  const resultTask = result.task;
+  const createdPage = result.page;
+  const resultTitle = createdPage.title;
+
+  // Broadcast creation events
+  await Promise.all([
+    broadcastTaskEvent({
+      type: 'task_added',
+      taskId: resultTask.id,
+      taskListId: taskList.id,
+      userId,
+      pageId,
+      data: { title: resultTitle, priority: resultTask.priority, pageId: createdPage.id },
+    }),
+    broadcastPageEvent(
+      createPageEventPayload(taskListPage.driveId, createdPage.id, 'created', {
+        parentId: pageId,
+        title: resultTitle,
+        type: 'TASK_LIST',
+      }),
+    ),
+  ]);
+
+  // Log activity for AI-generated task/page creation
+  const aiContext = await getAiContextWithActor(context);
+  logPageActivity(userId, 'create', {
+    id: createdPage.id,
+    title: resultTitle,
+    driveId: taskListPage.driveId,
+  }, {
+    ...aiContext,
+    metadata: {
+      ...aiContext.metadata,
+      taskId: resultTask.id,
+      taskTitle: resultTitle,
+    },
+  });
+
+  return buildTaskListResponse({
+    action: 'created',
+    parentPageId: pageId,
+    taskListId: taskList.id,
+    resultTask,
+    resultTitle,
+    message: `Created task "${resultTitle}" with linked document page`,
+  });
+}
+
+/**
+ * Hard-delete a task and trash its linked TASK_LIST page.
+ *
+ * disableTaskTriggers MUST run before the taskItems delete: task_triggers has
+ * ON DELETE CASCADE on taskItemId, so deleting the task first wipes the trigger
+ * rows and the helper's SELECT returns empty, leaking orphan workflows rows.
+ * Returns the refreshed list so client UIs drop the deleted task immediately.
+ * Shared by delete_task and the delete branch of update_task.
+ */
+export async function deleteTask(
+  context: ToolExecutionContext,
+  userId: string,
+  existingTask: TaskForUpdate,
+  taskList: typeof taskLists.$inferSelect,
+  reason: string,
+) {
+  const taskId = existingTask.id;
+  const taskListPageId = taskList.pageId;
+  const taskListId = taskList.id;
+  const linkedPageId = existingTask.pageId;
+  const existingTitle = existingTask.page?.title ?? '';
+  const actorInfo = await getActorInfo(userId);
+
+  await disableTaskTriggers(taskId, reason);
+
+  // Trash linked TASK_LIST page and hard-delete the task row in one transaction.
+  // taskAssignees rows cascade-delete via FK on taskItems.
+  // applyPageMutation returns a deferredTrigger that callers passing their own tx
+  // must invoke after commit so downstream workflows tied to page activity fire.
+  let deferredTrigger: DeferredWorkflowTrigger | undefined;
+  try {
+    await db.transaction(async (tx) => {
+      const [linkedPage] = await tx
+        .select({ revision: pages.revision })
+        .from(pages)
+        .where(eq(pages.id, linkedPageId))
+        .limit(1);
+
+      if (linkedPage) {
+        const mutationResult = await applyPageMutation({
+          pageId: linkedPageId,
+          operation: 'trash',
+          updates: { isTrashed: true, trashedAt: new Date() },
+          updatedFields: ['isTrashed', 'trashedAt'],
+          expectedRevision: linkedPage.revision,
+          context: {
+            userId,
+            actorEmail: actorInfo.actorEmail,
+            actorDisplayName: actorInfo.actorDisplayName ?? undefined,
+            isAiGenerated: true,
+            aiProvider: context.aiProvider,
+            aiModel: context.aiModel,
+            aiConversationId: context.conversationId,
+            metadata: {
+              taskId,
+              taskListId,
+              taskListPageId,
+            },
+          },
+          tx,
+        });
+        deferredTrigger = mutationResult.deferredTrigger;
+      }
+
+      await tx.delete(taskItems).where(eq(taskItems.id, taskId));
+    });
+    deferredTrigger?.();
+  } catch (error) {
+    if (error instanceof PageRevisionMismatchError) {
+      throw new Error(`Linked page was modified concurrently — retry the delete: ${error.message}`);
+    }
+    throw error;
+  }
+
+  // Look up driveId for the page-trashed broadcast (best-effort)
+  let deletedDriveId: string | undefined;
+  if (taskListPageId) {
+    const taskListPage = await db.query.pages.findFirst({
+      where: eq(pages.id, taskListPageId),
+      columns: { driveId: true },
+    });
+    deletedDriveId = taskListPage?.driveId;
+  }
+
+  const broadcasts: Promise<void>[] = [
+    broadcastTaskEvent({
+      type: 'task_deleted',
+      taskId,
+      taskListId,
+      userId,
+      pageId: taskListPageId || undefined,
+      data: { id: taskId, title: existingTitle },
+    }),
+  ];
+  if (deletedDriveId) {
+    broadcasts.push(
+      broadcastPageEvent(
+        createPageEventPayload(deletedDriveId, linkedPageId, 'trashed', {
+          title: existingTitle,
+          parentId: taskListPageId || undefined,
+        }),
+      ),
+    );
+  }
+  await Promise.all(broadcasts);
+
+  // Return the refreshed task list + remaining tasks so client UIs
+  // (e.g. useAggregatedTasks → TasksDropdown) can drop the deleted
+  // task immediately instead of waiting for a subsequent tool call.
+  const remainingTasks = await fetchEnrichedTasks(taskList.pageId!);
+  const refreshedTaskList = await db.query.taskLists.findFirst({
+    where: eq(taskLists.id, taskListId),
+  });
+
+  return {
+    success: true,
+    action: 'deleted' as const,
+    task: {
+      id: existingTask.id,
+      title: existingTitle,
+      pageId: linkedPageId,
+    },
+    taskList: serializeTaskList(refreshedTaskList, deletedDriveId),
+    tasks: remainingTasks.map(serializeTaskItem),
+    message: `Deleted task "${existingTitle}" and trashed its linked page`,
+  };
+}
+
+/**
+ * Move a task to `position` within its list and re-densify peer positions to
+ * 0..n-1. Returns the clamped index actually assigned. Shared by reorder_task
+ * and the reorder branch of update_task.
+ */
+export async function reorderTaskPeers(
+  taskListPageId: string,
+  taskId: string,
+  position: number,
+): Promise<number> {
+  const peers = await db
+    .select({ id: taskItems.id, position: taskItems.position })
+    .from(taskItems)
+    .innerJoin(pages, eq(pages.id, taskItems.pageId))
+    .where(and(
+      eq(pages.parentId, taskListPageId),
+      eq(pages.type, 'TASK_LIST'),
+      eq(pages.isTrashed, false),
+    ))
+    .orderBy(asc(taskItems.position));
+
+  const filtered = peers.filter(p => p.id !== taskId);
+  const clamped = Math.max(0, Math.min(Math.trunc(position), filtered.length));
+  const reordered = [
+    ...filtered.slice(0, clamped).map(p => p.id),
+    taskId,
+    ...filtered.slice(clamped).map(p => p.id),
+  ];
+
+  await db.transaction(async (tx) => {
+    for (let i = 0; i < reordered.length; i++) {
+      await tx.update(taskItems)
+        .set({ position: i })
+        .where(eq(taskItems.id, reordered[i]));
+    }
+  });
+
+  return clamped;
+}

--- a/apps/web/src/lib/ai/tools/task-management-tools.ts
+++ b/apps/web/src/lib/ai/tools/task-management-tools.ts
@@ -28,6 +28,7 @@ import {
   deleteTask,
   reorderTaskPeers,
   buildTaskListResponse,
+  broadcastTaskUpdated,
 } from './task-helpers';
 
 const STATUS_GROUP_DEFAULT_COLORS: Record<string, string> = {
@@ -388,13 +389,13 @@ Agent Triggers:
 
         resultTitle = trimmedTitle ?? existingTask.page?.title ?? '';
 
-        // Broadcast update event
-        await broadcastTaskEvent({
-          type: 'task_updated',
+        // Broadcast update event (shared with reorder_task for a consistent payload)
+        await broadcastTaskUpdated({
           taskId: resultTask.id,
           userId,
-          pageId: taskList.pageId || undefined,
-          data: { title: resultTitle, note },
+          taskListPageId: taskList.pageId,
+          title: resultTitle,
+          note,
         });
 
         return await buildTaskListResponse({
@@ -524,6 +525,13 @@ The position is clamped to the valid range. Returns the refreshed task list refl
         const { existingTask, taskList } = await resolveTaskForUpdate(ctx, userId, taskId);
         const clamped = await reorderTaskPeers(taskList.pageId!, taskId, position);
         const resultTitle = existingTask.page?.title ?? '';
+        // Broadcast so collaborators/other clients see the reorder, matching update_task.
+        await broadcastTaskUpdated({
+          taskId,
+          userId,
+          taskListPageId: taskList.pageId,
+          title: resultTitle,
+        });
         return await buildTaskListResponse({
           action: 'updated',
           parentPageId: taskList.pageId!,

--- a/apps/web/src/lib/ai/tools/task-management-tools.ts
+++ b/apps/web/src/lib/ai/tools/task-management-tools.ts
@@ -3,82 +3,38 @@ import { z } from 'zod';
 import { db } from '@pagespace/db/db'
 import { eq, and, desc, asc, isNull, inArray } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core'
-import { taskLists, taskItems, taskStatusConfigs, taskAssignees, DEFAULT_TASK_STATUSES } from '@pagespace/db/schema/tasks';
+import { taskLists, taskItems, taskStatusConfigs, DEFAULT_TASK_STATUSES } from '@pagespace/db/schema/tasks';
 import { type ToolExecutionContext } from '../core';
-import { broadcastTaskEvent, broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
+import { broadcastTaskEvent } from '@/lib/websocket';
 import { canActorViewPage, canActorAccessDrive } from './actor-permissions';
 import { canActorEditPage } from './actor-permissions';
-import { logPageActivity, getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import { PageType } from '@pagespace/lib/utils/enums';
 import {
   syncTaskDueDateTrigger,
   cancelTaskDueDateTrigger,
   fireCompletionTrigger,
   createTaskTriggerWorkflow,
-  disableTaskTriggers,
 } from '@/lib/workflows/task-trigger-helpers';
 import { agentTriggerBaseSchema } from '@/lib/workflows/agent-trigger-shared';
 import { applyPageMutation, PageRevisionMismatchError } from '@/services/api/page-mutation-service';
 import { assertSubTasksComplete, SubtasksIncompleteError } from '@/lib/tasks/completion-guard';
 import type { DeferredWorkflowTrigger } from '@pagespace/lib/monitoring/activity-logger';
+import {
+  normalizeTaskAgentTriggerInput,
+  getAiContextWithActor,
+  resolveTaskForUpdate,
+  syncTaskAssignees,
+  createTask,
+  deleteTask,
+  reorderTaskPeers,
+  buildTaskListResponse,
+} from './task-helpers';
 
 const STATUS_GROUP_DEFAULT_COLORS: Record<string, string> = {
   todo: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300',
   in_progress: 'bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-300',
   done: 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300',
 };
-
-function normalizeTaskAgentTriggerInput(value: unknown): unknown {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return value;
-  }
-
-  const candidate = value as {
-    prompt?: unknown;
-    instructionPageId?: unknown;
-  };
-
-  const prompt = typeof candidate.prompt === 'string' ? candidate.prompt.trim() : '';
-  const instructionPageId = typeof candidate.instructionPageId === 'string' ? candidate.instructionPageId.trim() : '';
-
-  if (!prompt && !instructionPageId) {
-    return undefined;
-  }
-
-  return {
-    ...candidate,
-    ...(prompt ? { prompt } : {}),
-    ...(instructionPageId ? { instructionPageId } : {}),
-  };
-}
-
-// Helper: Extract AI attribution context with actor info for activity logging
-async function getAiContextWithActor(context: ToolExecutionContext) {
-  const actorInfo = await getActorInfo(context.userId);
-  // Build chain metadata (Tier 1)
-  const chainMetadata = {
-    ...(context.parentAgentId && { parentAgentId: context.parentAgentId }),
-    ...(context.parentConversationId && { parentConversationId: context.parentConversationId }),
-    ...(context.agentChain?.length && { agentChain: context.agentChain }),
-    ...(context.requestOrigin && { requestOrigin: context.requestOrigin }),
-  };
-
-  return {
-    ...actorInfo,
-    isAiGenerated: true,
-    aiProvider: context.aiProvider,
-    aiModel: context.aiModel,
-    aiConversationId: context.conversationId,
-    metadata: Object.keys(chainMetadata).length > 0 ? chainMetadata : undefined,
-  };
-}
-
-/**
- * Helper to verify page access for page-linked task lists
- */
-async function verifyPageAccess(context: ToolExecutionContext, pageId: string): Promise<boolean> {
-  return canActorEditPage(context, pageId);
-}
 
 export const taskManagementTools = {
   /**
@@ -141,7 +97,7 @@ Agent Triggers:
       ).describe('Schedule an AI agent to run at task due date or on completion. Requires a drive-based task list.'),
     }),
     execute: async (params, { experimental_context: context }) => {
-      const { taskId, pageId, delete: deleteTask, title, status, priority, assigneeId, assigneeAgentId, assigneeIds, dueDate, note, position, agentTrigger } = params;
+      const { taskId, pageId, delete: deleteFlag, title, status, priority, assigneeId, assigneeAgentId, assigneeIds, dueDate, note, position, agentTrigger } = params;
       const userId = (context as ToolExecutionContext)?.userId;
 
       if (!userId) {
@@ -150,13 +106,13 @@ Agent Triggers:
 
       // Determine if this is an update, create, or delete operation
       const isUpdate = !!taskId;
-      const isDelete = isUpdate && deleteTask === true;
+      const isDelete = isUpdate && deleteFlag === true;
 
       if (!isUpdate && !pageId) {
         throw new Error('Either taskId (to update) or pageId (to create) must be provided');
       }
 
-      if (!isUpdate && deleteTask === true) {
+      if (!isUpdate && deleteFlag === true) {
         throw new Error('delete requires a taskId');
       }
 
@@ -165,814 +121,420 @@ Agent Triggers:
       }
 
       try {
-        let taskList: typeof taskLists.$inferSelect | undefined;
-        let resultTask;
+        if (!isUpdate) {
+          // CREATE — requires pageId of a TASK_LIST page
+          return await createTask(context as ToolExecutionContext, userId, {
+            pageId: pageId!,
+            title: title!,
+            status,
+            priority,
+            assigneeId,
+            assigneeAgentId,
+            assigneeIds,
+            dueDate,
+            note,
+            position,
+            agentTrigger,
+          });
+        }
+
+        // UPDATE / DELETE / REORDER — taskId resolves the existing task + list
+        const { existingTask, taskList } = await resolveTaskForUpdate(
+          context as ToolExecutionContext,
+          userId,
+          taskId!,
+        );
+
+        if (isDelete) {
+          return await deleteTask(
+            context as ToolExecutionContext,
+            userId,
+            existingTask,
+            taskList,
+            'Task deleted via update_task',
+          );
+        }
+
+        let resultTask: typeof taskItems.$inferSelect = existingTask;
         let resultTitle = '';
-        let message: string;
 
-        if (isUpdate) {
-          // UPDATE existing task
-          const existingTask = await db.query.taskItems.findFirst({
-            where: eq(taskItems.id, taskId),
-            with: {
-              page: { columns: { title: true, parentId: true } },
-            },
+        // Get driveId for agent validation (if task list has a page)
+        let taskListDriveId: string | undefined;
+        if (taskList.pageId) {
+          const taskListPage = await db.query.pages.findFirst({
+            where: eq(pages.id, taskList.pageId),
+            columns: { driveId: true },
+          });
+          taskListDriveId = taskListPage?.driveId;
+        }
+
+        // Validate assigneeAgentId if provided
+        if (assigneeAgentId) {
+          const agentPage = await db.query.pages.findFirst({
+            where: and(
+              eq(pages.id, assigneeAgentId),
+              eq(pages.type, 'AI_CHAT'),
+              eq(pages.isTrashed, false)
+            ),
+            columns: { id: true, driveId: true },
           });
 
-          if (!existingTask) {
-            throw new Error('Task not found');
+          if (!agentPage) {
+            throw new Error('Invalid agent ID - must be an AI agent page');
           }
 
-          taskList = await db.query.taskLists.findFirst({
-            where: eq(taskLists.pageId, existingTask.page?.parentId ?? ''),
-          });
-
-          if (!taskList) {
-            throw new Error('Task list not found');
+          if (taskListDriveId && agentPage.driveId !== taskListDriveId) {
+            throw new Error('Agent must be in the same drive as the task list');
           }
+        }
 
-          // Verify permissions
-          if (taskList.pageId) {
-            const hasAccess = await verifyPageAccess(context as ToolExecutionContext, taskList.pageId);
-            if (!hasAccess) {
-              throw new Error('You do not have permission to update tasks on this page');
+        // Fetch status configs for rollup and validation
+        const validConfigs = await db.query.taskStatusConfigs.findMany({
+          where: eq(taskStatusConfigs.taskListId, taskList.id),
+          columns: { slug: true, group: true },
+        });
+
+        // Build update object — title is owned by the linked page, synced separately below.
+        const updateData: Partial<typeof taskItems.$inferInsert> = {};
+        let trimmedTitle: string | undefined;
+        if (title !== undefined) {
+          if (typeof title !== 'string' || title.trim().length === 0) {
+            throw new Error('Title cannot be empty');
+          }
+          trimmedTitle = title.trim();
+        }
+        if (status !== undefined) {
+          if (validConfigs.length > 0) {
+            const matched = validConfigs.find(c => c.slug === status);
+            if (!matched) {
+              throw new Error(`Invalid status "${status}". Valid: ${validConfigs.map(c => c.slug).join(', ')}`);
             }
-          } else if (taskList.userId !== userId) {
-            throw new Error('You do not have permission to update this task');
+            updateData.status = status;
+            updateData.completedAt = matched.group === 'done' ? new Date() : null;
+          } else {
+            updateData.status = status;
+            updateData.completedAt = status === 'completed' ? new Date() : null;
           }
-
-          // DELETE branch — short-circuits all field updates
-          if (isDelete) {
-            const taskListPageId = taskList.pageId;
-            const taskListId = taskList.id;
-            const linkedPageId = existingTask.pageId;
-            const existingTitle = existingTask.page?.title ?? '';
-            const actorInfo = await getActorInfo(userId);
-
-            // disableTaskTriggers MUST run BEFORE the taskItems delete:
-            // task_triggers has ON DELETE CASCADE on taskItemId, so deleting
-            // the task first wipes the trigger rows and the helper's SELECT
-            // returns empty — leaking orphan workflows rows.
-            await disableTaskTriggers(taskId, 'Task deleted via update_task');
-
-            // Trash linked TASK_LIST page and hard-delete the task row in one transaction.
-            // taskAssignees rows cascade-delete via FK on taskItems.
-            // applyPageMutation returns a deferredTrigger that callers passing their own tx
-            // must invoke after commit so downstream workflows tied to page activity fire.
-            let deferredTrigger: DeferredWorkflowTrigger | undefined;
-            try {
-              await db.transaction(async (tx) => {
-                const [linkedPage] = await tx
-                  .select({ revision: pages.revision })
-                  .from(pages)
-                  .where(eq(pages.id, linkedPageId))
-                  .limit(1);
-
-                if (linkedPage) {
-                  const mutationResult = await applyPageMutation({
-                    pageId: linkedPageId,
-                    operation: 'trash',
-                    updates: { isTrashed: true, trashedAt: new Date() },
-                    updatedFields: ['isTrashed', 'trashedAt'],
-                    expectedRevision: linkedPage.revision,
-                    context: {
-                      userId,
-                      actorEmail: actorInfo.actorEmail,
-                      actorDisplayName: actorInfo.actorDisplayName ?? undefined,
-                      isAiGenerated: true,
-                      aiProvider: (context as ToolExecutionContext).aiProvider,
-                      aiModel: (context as ToolExecutionContext).aiModel,
-                      aiConversationId: (context as ToolExecutionContext).conversationId,
-                      metadata: {
-                        taskId,
-                        taskListId,
-                        taskListPageId,
-                      },
-                    },
-                    tx,
-                  });
-                  deferredTrigger = mutationResult.deferredTrigger;
-                }
-
-                await tx.delete(taskItems).where(eq(taskItems.id, taskId));
-              });
-              deferredTrigger?.();
-            } catch (error) {
-              if (error instanceof PageRevisionMismatchError) {
-                throw new Error(`Linked page was modified concurrently — retry the delete: ${error.message}`);
-              }
-              throw error;
-            }
-
-            // Look up driveId for the page-trashed broadcast (best-effort)
-            let deletedDriveId: string | undefined;
-            if (taskListPageId) {
-              const taskListPage = await db.query.pages.findFirst({
-                where: eq(pages.id, taskListPageId),
-                columns: { driveId: true },
-              });
-              deletedDriveId = taskListPage?.driveId;
-            }
-
-            const broadcasts: Promise<void>[] = [
-              broadcastTaskEvent({
-                type: 'task_deleted',
-                taskId,
-                taskListId,
-                userId,
-                pageId: taskListPageId || undefined,
-                data: { id: taskId, title: existingTitle },
-              }),
-            ];
-            if (deletedDriveId) {
-              broadcasts.push(
-                broadcastPageEvent(
-                  createPageEventPayload(deletedDriveId, linkedPageId, 'trashed', {
-                    title: existingTitle,
-                    parentId: taskListPageId || undefined,
-                  }),
-                ),
-              );
-            }
-            await Promise.all(broadcasts);
-
-            // Return the refreshed task list + remaining tasks so client UIs
-            // (e.g. useAggregatedTasks → TasksDropdown) can drop the deleted
-            // task immediately instead of waiting for a subsequent tool call.
-            const remainingTasks = await db.query.taskItems.findMany({
-              where: inArray(taskItems.pageId, db.select({ id: pages.id }).from(pages).where(and(
-                eq(pages.parentId, taskList.pageId!),
-                eq(pages.type, 'TASK_LIST'),
-                eq(pages.isTrashed, false),
-              ))),
-              orderBy: [asc(taskItems.position)],
-              with: {
-                assignee: { columns: { id: true, name: true, image: true } },
-                assigneeAgent: { columns: { id: true, title: true, type: true } },
-                page: { columns: { title: true } },
-                assignees: {
-                  with: {
-                    user: { columns: { id: true, name: true } },
-                    agentPage: { columns: { id: true, title: true } },
-                  },
-                },
-              },
-            });
-            const refreshedTaskList = await db.query.taskLists.findFirst({
-              where: eq(taskLists.id, taskListId),
-            });
-
-            return {
-              success: true,
-              action: 'deleted' as const,
-              task: {
-                id: existingTask.id,
-                title: existingTitle,
-                pageId: linkedPageId,
-              },
-              taskList: refreshedTaskList ? {
-                id: refreshedTaskList.id,
-                title: refreshedTaskList.title,
-                description: refreshedTaskList.description,
-                status: refreshedTaskList.status,
-                pageId: refreshedTaskList.pageId,
-                driveId: deletedDriveId,
-              } : null,
-              tasks: remainingTasks.map(t => ({
-                id: t.id,
-                title: t.page?.title ?? '',
-                status: t.status,
-                priority: t.priority,
-                assigneeId: t.assigneeId,
-                assigneeAgentId: t.assigneeAgentId,
-                dueDate: t.dueDate,
-                position: t.position,
-                completedAt: t.completedAt,
-                pageId: t.pageId,
-                assignee: t.assignee ? {
-                  id: t.assignee.id,
-                  name: t.assignee.name,
-                  image: t.assignee.image,
-                } : null,
-                assigneeAgent: t.assigneeAgent ? {
-                  id: t.assigneeAgent.id,
-                  title: t.assigneeAgent.title,
-                  type: t.assigneeAgent.type,
-                } : null,
-                assignees: t.assignees?.map(a => ({
-                  userId: a.userId,
-                  agentPageId: a.agentPageId,
-                  user: a.user ? { id: a.user.id, name: a.user.name } : null,
-                  agentPage: a.agentPage ? { id: a.agentPage.id, title: a.agentPage.title } : null,
-                })) || [],
-              })),
-              message: `Deleted task "${existingTitle}" and trashed its linked page`,
-            };
-          }
-
-          // Get driveId for agent validation (if task list has a page)
-          let taskListDriveId: string | undefined;
-          if (taskList.pageId) {
-            const taskListPage = await db.query.pages.findFirst({
-              where: eq(pages.id, taskList.pageId),
-              columns: { driveId: true },
-            });
-            taskListDriveId = taskListPage?.driveId;
-          }
-
-          // Validate assigneeAgentId if provided
-          if (assigneeAgentId) {
-            const agentPage = await db.query.pages.findFirst({
-              where: and(
-                eq(pages.id, assigneeAgentId),
-                eq(pages.type, 'AI_CHAT'),
-                eq(pages.isTrashed, false)
-              ),
-              columns: { id: true, driveId: true },
-            });
-
-            if (!agentPage) {
-              throw new Error('Invalid agent ID - must be an AI agent page');
-            }
-
-            if (taskListDriveId && agentPage.driveId !== taskListDriveId) {
-              throw new Error('Agent must be in the same drive as the task list');
-            }
-          }
-
-          // Fetch status configs for rollup and validation
-          const validConfigs = await db.query.taskStatusConfigs.findMany({
-            where: eq(taskStatusConfigs.taskListId, taskList.id),
-            columns: { slug: true, group: true },
-          });
-
-          // Build update object — title is owned by the linked page, synced separately below.
-          const updateData: Partial<typeof taskItems.$inferInsert> = {};
-          let trimmedTitle: string | undefined;
-          if (title !== undefined) {
-            if (typeof title !== 'string' || title.trim().length === 0) {
-              throw new Error('Title cannot be empty');
-            }
-            trimmedTitle = title.trim();
-          }
-          if (status !== undefined) {
-            if (validConfigs.length > 0) {
-              const matched = validConfigs.find(c => c.slug === status);
-              if (!matched) {
-                throw new Error(`Invalid status "${status}". Valid: ${validConfigs.map(c => c.slug).join(', ')}`);
-              }
-              updateData.status = status;
-              updateData.completedAt = matched.group === 'done' ? new Date() : null;
-            } else {
-              updateData.status = status;
-              updateData.completedAt = status === 'completed' ? new Date() : null;
-            }
-          }
-          // Completion guard: cannot mark a task done while it has incomplete sub-tasks
-          if (updateData.completedAt instanceof Date && existingTask.pageId) {
-            try {
-              await assertSubTasksComplete(existingTask.pageId);
-            } catch (error) {
-              if (error instanceof SubtasksIncompleteError) {
-                return {
-                  success: false,
-                  error: error.message,
-                  pending: error.pending,
-                  total: error.total,
-                };
-              }
-              throw error;
-            }
-          }
-
-          if (priority !== undefined) updateData.priority = priority;
-          if (assigneeId !== undefined) updateData.assigneeId = assigneeId;
-          if (assigneeAgentId !== undefined) updateData.assigneeAgentId = assigneeAgentId;
-          if (dueDate !== undefined) updateData.dueDate = dueDate ? new Date(dueDate) : null;
-
-          // Add note to metadata
-          if (note || status !== undefined) {
-            updateData.metadata = {
-              ...(existingTask.metadata as Record<string, unknown> || {}),
-              lastUpdate: {
-                at: new Date().toISOString(),
-                note,
-                ...(status !== undefined ? { statusChange: { from: existingTask.status, to: status } } : {}),
-              },
-            };
-          }
-
-          let updateTitleDeferred: DeferredWorkflowTrigger | undefined;
-          const aiContextForTitle = trimmedTitle !== undefined
-            ? await getAiContextWithActor(context as ToolExecutionContext)
-            : null;
+        }
+        // Completion guard: cannot mark a task done while it has incomplete sub-tasks
+        if (updateData.completedAt instanceof Date && existingTask.pageId) {
           try {
-            resultTask = await db.transaction(async (tx) => {
-              let updatedTask: typeof taskItems.$inferSelect = existingTask;
-              if (Object.keys(updateData).length > 0) {
-                [updatedTask] = await tx
-                  .update(taskItems)
-                  .set(updateData)
-                  .where(eq(taskItems.id, taskId))
-                  .returning();
-              }
-
-              // Sync title to the linked page (single source of truth).
-              if (trimmedTitle !== undefined && aiContextForTitle) {
-                const [linkedPage] = await tx
-                  .select({ revision: pages.revision })
-                  .from(pages)
-                  .where(eq(pages.id, existingTask.pageId))
-                  .limit(1);
-
-                if (linkedPage) {
-                  const mutationResult = await applyPageMutation({
-                    pageId: existingTask.pageId,
-                    operation: 'update',
-                    updates: { title: trimmedTitle },
-                    updatedFields: ['title'],
-                    expectedRevision: linkedPage.revision,
-                    context: {
-                      userId,
-                      actorEmail: aiContextForTitle.actorEmail,
-                      actorDisplayName: aiContextForTitle.actorDisplayName ?? undefined,
-                      isAiGenerated: true,
-                      aiProvider: (context as ToolExecutionContext).aiProvider,
-                      aiModel: (context as ToolExecutionContext).aiModel,
-                      aiConversationId: (context as ToolExecutionContext).conversationId,
-                      metadata: {
-                        taskId,
-                        taskListId: taskList?.id,
-                        taskListPageId: taskList?.pageId ?? undefined,
-                      },
-                    },
-                    tx,
-                  });
-                  updateTitleDeferred = mutationResult.deferredTrigger;
-                }
-              }
-
-              // Handle multiple assignees — Array.isArray treats [] as a full replace,
-              // matching the REST PATCH route so callers can clear all assignees.
-              if (Array.isArray(assigneeIds)) {
-                await tx.delete(taskAssignees).where(eq(taskAssignees.taskId, taskId));
-                const rows = assigneeIds
-                  .filter(a => a.id)
-                  .map(a => ({
-                    taskId,
-                    ...(a.type === 'user' ? { userId: a.id } : { agentPageId: a.id }),
-                  }));
-                if (rows.length > 0) {
-                  await tx.insert(taskAssignees).values(rows);
-                }
-
-                // Sync legacy fields
-                const firstUser = assigneeIds.find(a => a.type === 'user' && a.id);
-                const firstAgent = assigneeIds.find(a => a.type === 'agent' && a.id);
-                await tx.update(taskItems).set({
-                  assigneeId: firstUser?.id || null,
-                  assigneeAgentId: firstAgent?.id || null,
-                }).where(eq(taskItems.id, taskId));
-              } else if (assigneeId !== undefined || assigneeAgentId !== undefined) {
-                // Legacy single-assignee: sync to junction table
-                await tx.delete(taskAssignees).where(eq(taskAssignees.taskId, taskId));
-                const rows: { taskId: string; userId?: string; agentPageId?: string }[] = [];
-                if (assigneeId) rows.push({ taskId, userId: assigneeId });
-                if (assigneeAgentId) rows.push({ taskId, agentPageId: assigneeAgentId });
-                if (rows.length > 0) await tx.insert(taskAssignees).values(rows);
-              }
-
-              return updatedTask;
-            });
-            updateTitleDeferred?.();
+            await assertSubTasksComplete(existingTask.pageId);
           } catch (error) {
-            if (error instanceof PageRevisionMismatchError) {
-              throw new Error(`Linked page was modified concurrently — retry the update: ${error.message}`);
+            if (error instanceof SubtasksIncompleteError) {
+              return {
+                success: false,
+                error: error.message,
+                pending: error.pending,
+                total: error.total,
+              };
             }
             throw error;
           }
+        }
 
-          // Reorder: when position is provided alongside taskId, move the task
-          // to the requested index and re-densify peer positions to 0..n-1.
-          if (position !== undefined) {
-            const peers = await db
-              .select({ id: taskItems.id, position: taskItems.position })
-              .from(taskItems)
-              .innerJoin(pages, eq(pages.id, taskItems.pageId))
-              .where(and(
-                eq(pages.parentId, taskList.pageId!),
-                eq(pages.type, 'TASK_LIST'),
-                eq(pages.isTrashed, false),
-              ))
-              .orderBy(asc(taskItems.position));
+        if (priority !== undefined) updateData.priority = priority;
+        if (assigneeId !== undefined) updateData.assigneeId = assigneeId;
+        if (assigneeAgentId !== undefined) updateData.assigneeAgentId = assigneeAgentId;
+        if (dueDate !== undefined) updateData.dueDate = dueDate ? new Date(dueDate) : null;
 
-            const filtered = peers.filter(p => p.id !== taskId);
-            const clamped = Math.max(0, Math.min(Math.trunc(position), filtered.length));
-            const reordered = [
-              ...filtered.slice(0, clamped).map(p => p.id),
-              taskId,
-              ...filtered.slice(clamped).map(p => p.id),
-            ];
+        // Add note to metadata
+        if (note || status !== undefined) {
+          updateData.metadata = {
+            ...(existingTask.metadata as Record<string, unknown> || {}),
+            lastUpdate: {
+              at: new Date().toISOString(),
+              note,
+              ...(status !== undefined ? { statusChange: { from: existingTask.status, to: status } } : {}),
+            },
+          };
+        }
 
-            await db.transaction(async (tx) => {
-              for (let i = 0; i < reordered.length; i++) {
-                await tx.update(taskItems)
-                  .set({ position: i })
-                  .where(eq(taskItems.id, reordered[i]));
+        let updateTitleDeferred: DeferredWorkflowTrigger | undefined;
+        const aiContextForTitle = trimmedTitle !== undefined
+          ? await getAiContextWithActor(context as ToolExecutionContext)
+          : null;
+        try {
+          resultTask = await db.transaction(async (tx) => {
+            let updatedTask: typeof taskItems.$inferSelect = existingTask;
+            if (Object.keys(updateData).length > 0) {
+              [updatedTask] = await tx
+                .update(taskItems)
+                .set(updateData)
+                .where(eq(taskItems.id, taskId))
+                .returning();
+            }
+
+            // Sync title to the linked page (single source of truth).
+            if (trimmedTitle !== undefined && aiContextForTitle) {
+              const [linkedPage] = await tx
+                .select({ revision: pages.revision })
+                .from(pages)
+                .where(eq(pages.id, existingTask.pageId))
+                .limit(1);
+
+              if (linkedPage) {
+                const mutationResult = await applyPageMutation({
+                  pageId: existingTask.pageId,
+                  operation: 'update',
+                  updates: { title: trimmedTitle },
+                  updatedFields: ['title'],
+                  expectedRevision: linkedPage.revision,
+                  context: {
+                    userId,
+                    actorEmail: aiContextForTitle.actorEmail,
+                    actorDisplayName: aiContextForTitle.actorDisplayName ?? undefined,
+                    isAiGenerated: true,
+                    aiProvider: (context as ToolExecutionContext).aiProvider,
+                    aiModel: (context as ToolExecutionContext).aiModel,
+                    aiConversationId: (context as ToolExecutionContext).conversationId,
+                    metadata: {
+                      taskId,
+                      taskListId: taskList?.id,
+                      taskListPageId: taskList?.pageId ?? undefined,
+                    },
+                  },
+                  tx,
+                });
+                updateTitleDeferred = mutationResult.deferredTrigger;
               }
-            });
-
-            // Reflect the densified position on resultTask so the response is accurate
-            resultTask = { ...resultTask, position: clamped };
-          }
-
-          // Update task list status based on task completion
-          if (status !== undefined) {
-            const doneStatusSlugs = validConfigs.length > 0
-              ? new Set(validConfigs.filter(c => c.group === 'done').map(c => c.slug))
-              : new Set(['completed']);
-            const inProgressSlugs = validConfigs.length > 0
-              ? new Set(validConfigs.filter(c => c.group === 'in_progress').map(c => c.slug))
-              : new Set(['in_progress']);
-
-            const siblingTasks = await db
-              .select({ id: taskItems.id, status: taskItems.status })
-              .from(taskItems)
-              .innerJoin(pages, eq(pages.id, taskItems.pageId))
-              .where(and(
-                eq(pages.parentId, taskList.pageId!),
-                eq(pages.type, 'TASK_LIST'),
-                eq(pages.isTrashed, false),
-              ));
-
-            const allCompleted = siblingTasks.every(t =>
-              t.id === taskId ? doneStatusSlugs.has(status) : doneStatusSlugs.has(t.status)
-            );
-
-            if (allCompleted) {
-              await db.update(taskLists).set({ status: 'completed' }).where(eq(taskLists.id, taskList.id));
-            } else if (inProgressSlugs.has(status)) {
-              await db.update(taskLists).set({ status: 'in_progress' }).where(and(
-                eq(taskLists.id, taskList.id),
-                eq(taskLists.status, 'pending')
-              ));
             }
-          }
 
-          // Create agent trigger workflow BEFORE firing cascades so the workflow
-          // exists when fireCompletionTrigger looks for it
-          if (agentTrigger) {
-            if (!taskListDriveId) {
-              return { success: false, error: 'Agent triggers require a drive-based task list' };
-            }
-            await createTaskTriggerWorkflow({
-              database: db,
-              driveId: taskListDriveId,
-              userId,
-              taskId,
-              taskMetadata: resultTask.metadata as Record<string, unknown> | null,
-              agentTrigger,
-              dueDate: resultTask.dueDate,
-              timezone: (context as ToolExecutionContext).timezone || 'UTC',
-            });
-          }
+            // Replace assignees (array = full replace; legacy single fields otherwise).
+            await syncTaskAssignees(tx, taskId!, { assigneeIds, assigneeId, assigneeAgentId });
 
-          // Task trigger cascades
-          if (dueDate !== undefined) {
-            void syncTaskDueDateTrigger(taskId, dueDate ? new Date(dueDate) : null);
-          }
-          if (status !== undefined) {
-            const completedSlugs = validConfigs.length > 0
-              ? new Set(validConfigs.filter(c => c.group === 'done').map(c => c.slug))
-              : new Set(['completed']);
-            if (completedSlugs.has(status) && !existingTask.completedAt) {
-              void cancelTaskDueDateTrigger(taskId, 'Task completed before due date');
-              void fireCompletionTrigger(taskId);
-            }
-          }
-
-          resultTitle = trimmedTitle ?? existingTask.page?.title ?? '';
-
-          // Broadcast update event
-          await broadcastTaskEvent({
-            type: 'task_updated',
-            taskId: resultTask.id,
-            userId,
-            pageId: taskList.pageId || undefined,
-            data: { title: resultTitle, note },
+            return updatedTask;
           });
-
-          message = `Updated task "${resultTitle}"`;
-        } else {
-          // CREATE new task - requires pageId of a TASK_LIST page
-
-          // Get the TASK_LIST page and verify access
-          const taskListPage = await db.query.pages.findFirst({
-            where: and(eq(pages.id, pageId!), eq(pages.isTrashed, false)),
-            columns: { id: true, driveId: true, type: true, title: true },
-          });
-
-          if (!taskListPage) {
-            throw new Error('Page not found');
+          updateTitleDeferred?.();
+        } catch (error) {
+          if (error instanceof PageRevisionMismatchError) {
+            throw new Error(`Linked page was modified concurrently — retry the update: ${error.message}`);
           }
+          throw error;
+        }
 
-          if (taskListPage.type !== 'TASK_LIST') {
-            throw new Error('Page must be a TASK_LIST page to add tasks');
-          }
+        // Reorder: when position is provided alongside taskId, move the task
+        // to the requested index and re-densify peer positions to 0..n-1.
+        if (position !== undefined) {
+          const clamped = await reorderTaskPeers(taskList.pageId!, taskId!, position);
+          // Reflect the densified position on resultTask so the response is accurate
+          resultTask = { ...resultTask, position: clamped };
+        }
 
-          const hasAccess = await verifyPageAccess(context as ToolExecutionContext, pageId!);
-          if (!hasAccess) {
-            throw new Error('You do not have permission to add tasks to this page');
-          }
+        // Update task list status based on task completion
+        if (status !== undefined) {
+          const doneStatusSlugs = validConfigs.length > 0
+            ? new Set(validConfigs.filter(c => c.group === 'done').map(c => c.slug))
+            : new Set(['completed']);
+          const inProgressSlugs = validConfigs.length > 0
+            ? new Set(validConfigs.filter(c => c.group === 'in_progress').map(c => c.slug))
+            : new Set(['in_progress']);
 
-          // Find or create task_list record for this page
-          taskList = await db.query.taskLists.findFirst({
-            where: eq(taskLists.pageId, pageId!),
-          });
-
-          if (!taskList) {
-            // Auto-create task_list record for this page
-            const [newTaskList] = await db.insert(taskLists).values({
-              userId,
-              pageId: pageId!,
-              title: taskListPage.title,
-              status: 'pending',
-              metadata: {
-                createdAt: new Date().toISOString(),
-                autoCreated: true,
-              },
-            }).returning();
-            taskList = newTaskList;
-          }
-
-          // Determine position for new task
-          const existingTasks = await db
-            .select({ position: taskItems.position })
+          const siblingTasks = await db
+            .select({ id: taskItems.id, status: taskItems.status })
             .from(taskItems)
             .innerJoin(pages, eq(pages.id, taskItems.pageId))
             .where(and(
-              eq(pages.parentId, pageId!),
+              eq(pages.parentId, taskList.pageId!),
               eq(pages.type, 'TASK_LIST'),
               eq(pages.isTrashed, false),
-            ))
-            .orderBy(desc(taskItems.position));
+            ));
 
-          const nextTaskPosition = position ?? (existingTasks.length > 0 ? (existingTasks[0]?.position || 0) + 1 : 0);
+          const allCompleted = siblingTasks.every(t =>
+            t.id === taskId ? doneStatusSlugs.has(status) : doneStatusSlugs.has(t.status)
+          );
 
-          // Get next page position for the child document
-          const lastChildPage = await db.query.pages.findFirst({
-            where: and(eq(pages.parentId, pageId!), eq(pages.isTrashed, false)),
-            orderBy: [desc(pages.position)],
-          });
-          const nextPagePosition = (lastChildPage?.position ?? 0) + 1;
-
-          // Validate assigneeAgentId if provided
-          if (assigneeAgentId) {
-            const agentPage = await db.query.pages.findFirst({
-              where: and(
-                eq(pages.id, assigneeAgentId),
-                eq(pages.type, 'AI_CHAT'),
-                eq(pages.isTrashed, false)
-              ),
-              columns: { id: true, driveId: true },
-            });
-
-            if (!agentPage) {
-              throw new Error('Invalid agent ID - must be an AI agent page');
-            }
-
-            if (agentPage.driveId !== taskListPage.driveId) {
-              throw new Error('Agent must be in the same drive as the task list');
-            }
+          if (allCompleted) {
+            await db.update(taskLists).set({ status: 'completed' }).where(eq(taskLists.id, taskList.id));
+          } else if (inProgressSlugs.has(status)) {
+            await db.update(taskLists).set({ status: 'in_progress' }).where(and(
+              eq(taskLists.id, taskList.id),
+              eq(taskLists.status, 'pending')
+            ));
           }
-
-          // Validate custom status if provided
-          const resolvedStatus = status || 'pending';
-          const statusConfigsForList = await db.query.taskStatusConfigs.findMany({
-            where: eq(taskStatusConfigs.taskListId, taskList!.id),
-            columns: { slug: true, group: true },
-          });
-          if (statusConfigsForList.length > 0 && status) {
-            const matched = statusConfigsForList.find(c => c.slug === status);
-            if (!matched) {
-              throw new Error(`Invalid status "${status}". Valid: ${statusConfigsForList.map(c => c.slug).join(', ')}`);
-            }
-          }
-
-          // Create task list page and task in transaction
-          const result = await db.transaction(async (tx) => {
-            // Create task list page (description + sub-tasks live here)
-            const [taskPage] = await tx.insert(pages).values({
-              title: title!,
-              type: 'TASK_LIST',
-              parentId: pageId!,
-              driveId: taskListPage.driveId,
-              content: '',
-              position: nextPagePosition,
-              updatedAt: new Date(),
-            }).returning();
-
-            // Create task with link to the page
-            const primaryUserId = assigneeId || (assigneeIds?.find(a => a.type === 'user')?.id) || null;
-            const primaryAgentId = assigneeAgentId || (assigneeIds?.find(a => a.type === 'agent')?.id) || null;
-
-            const [newTask] = await tx.insert(taskItems).values({
-              userId,
-              pageId: taskPage.id,
-              status: resolvedStatus,
-              priority: priority || 'medium',
-              assigneeId: primaryUserId,
-              assigneeAgentId: primaryAgentId,
-              dueDate: dueDate ? new Date(dueDate) : null,
-              position: nextTaskPosition,
-              metadata: {
-                createdAt: new Date().toISOString(),
-                note,
-              },
-            }).returning();
-
-            // Create multiple assignees in junction table
-            const assigneeRows: { taskId: string; userId?: string; agentPageId?: string }[] = [];
-            if (assigneeIds && assigneeIds.length > 0) {
-              for (const a of assigneeIds) {
-                if (a.type === 'user') assigneeRows.push({ taskId: newTask.id, userId: a.id });
-                else if (a.type === 'agent') assigneeRows.push({ taskId: newTask.id, agentPageId: a.id });
-              }
-            } else {
-              if (primaryUserId) assigneeRows.push({ taskId: newTask.id, userId: primaryUserId });
-              if (primaryAgentId) assigneeRows.push({ taskId: newTask.id, agentPageId: primaryAgentId });
-            }
-            if (assigneeRows.length > 0) {
-              await tx.insert(taskAssignees).values(assigneeRows);
-            }
-
-            // Create agent trigger workflow if requested
-            if (agentTrigger) {
-              if (!taskListPage.driveId) {
-                throw new Error('Agent triggers require a drive-based task list');
-              }
-              await createTaskTriggerWorkflow({
-                database: tx,
-                driveId: taskListPage.driveId,
-                userId,
-                taskId: newTask.id,
-                taskMetadata: newTask.metadata as Record<string, unknown> | null,
-                agentTrigger,
-                dueDate: dueDate ? new Date(dueDate) : null,
-                timezone: (context as ToolExecutionContext).timezone || 'UTC',
-              });
-            }
-
-            return { task: newTask, page: taskPage };
-          });
-
-          resultTask = result.task;
-          const createdPage = result.page;
-          resultTitle = createdPage.title;
-
-          // Broadcast creation events
-          await Promise.all([
-            broadcastTaskEvent({
-              type: 'task_added',
-              taskId: resultTask.id,
-              taskListId: taskList.id,
-              userId,
-              pageId: pageId!,
-              data: { title: resultTitle, priority: resultTask.priority, pageId: createdPage.id },
-            }),
-            broadcastPageEvent(
-              createPageEventPayload(taskListPage.driveId, createdPage.id, 'created', {
-                parentId: pageId,
-                title: resultTitle,
-                type: 'TASK_LIST',
-              }),
-            ),
-          ]);
-
-          // Log activity for AI-generated task/page creation
-          const aiContext = await getAiContextWithActor(context as ToolExecutionContext);
-          logPageActivity(userId, 'create', {
-            id: createdPage.id,
-            title: resultTitle,
-            driveId: taskListPage.driveId,
-          }, {
-            ...aiContext,
-            metadata: {
-              ...aiContext.metadata,
-              taskId: resultTask.id,
-              taskTitle: resultTitle,
-            },
-          });
-
-          message = `Created task "${resultTitle}" with linked document page`;
         }
 
-        // Get all tasks for response with assignee relations
-        const allTasks = await db.query.taskItems.findMany({
-          where: inArray(taskItems.pageId, db.select({ id: pages.id }).from(pages).where(and(
-            eq(pages.parentId, pageId!),
-            eq(pages.type, 'TASK_LIST'),
-            eq(pages.isTrashed, false),
-          ))),
-          orderBy: [asc(taskItems.position)],
-          with: {
-            assignee: {
-              columns: {
-                id: true,
-                name: true,
-                image: true,
-              },
-            },
-            assigneeAgent: {
-              columns: {
-                id: true,
-                title: true,
-                type: true,
-              },
-            },
-            page: {
-              columns: { title: true },
-            },
-            assignees: {
-              with: {
-                user: { columns: { id: true, name: true } },
-                agentPage: { columns: { id: true, title: true } },
-              },
-            },
-          },
-        });
-
-        // Refresh task list with page info for driveId
-        const refreshedTaskList = await db.query.taskLists.findFirst({
-          where: eq(taskLists.id, taskList!.id),
-        });
-
-        // Get driveId from the associated page
-        let driveId: string | undefined;
-        if (refreshedTaskList?.pageId) {
-          const taskListPage = await db.query.pages.findFirst({
-            where: eq(pages.id, refreshedTaskList.pageId),
-            columns: { driveId: true },
-          });
-          driveId = taskListPage?.driveId;
-        }
-
-        return {
-          success: true,
-          action: isUpdate ? 'updated' : 'created',
-          task: {
-            id: resultTask.id,
-            title: resultTitle,
-            status: resultTask.status,
-            priority: resultTask.priority,
-            assigneeId: resultTask.assigneeId,
-            assigneeAgentId: resultTask.assigneeAgentId,
+        // Create agent trigger workflow BEFORE firing cascades so the workflow
+        // exists when fireCompletionTrigger looks for it
+        if (agentTrigger) {
+          if (!taskListDriveId) {
+            return { success: false, error: 'Agent triggers require a drive-based task list' };
+          }
+          await createTaskTriggerWorkflow({
+            database: db,
+            driveId: taskListDriveId,
+            userId,
+            taskId,
+            taskMetadata: resultTask.metadata as Record<string, unknown> | null,
+            agentTrigger,
             dueDate: resultTask.dueDate,
-            position: resultTask.position,
-            completedAt: resultTask.completedAt,
-            pageId: resultTask.pageId,
-          },
-          taskList: refreshedTaskList ? {
-            id: refreshedTaskList.id,
-            title: refreshedTaskList.title,
-            description: refreshedTaskList.description,
-            status: refreshedTaskList.status,
-            pageId: refreshedTaskList.pageId,
-            driveId,
-          } : null,
-          tasks: allTasks.map(t => ({
-            id: t.id,
-            title: t.page?.title ?? '',
-            status: t.status,
-            priority: t.priority,
-            assigneeId: t.assigneeId,
-            assigneeAgentId: t.assigneeAgentId,
-            dueDate: t.dueDate,
-            position: t.position,
-            completedAt: t.completedAt,
-            pageId: t.pageId,
-            assignee: t.assignee ? {
-              id: t.assignee.id,
-              name: t.assignee.name,
-              image: t.assignee.image,
-            } : null,
-            assigneeAgent: t.assigneeAgent ? {
-              id: t.assigneeAgent.id,
-              title: t.assigneeAgent.title,
-              type: t.assigneeAgent.type,
-            } : null,
-            assignees: t.assignees?.map(a => ({
-              userId: a.userId,
-              agentPageId: a.agentPageId,
-              user: a.user ? { id: a.user.id, name: a.user.name } : null,
-              agentPage: a.agentPage ? { id: a.agentPage.id, title: a.agentPage.title } : null,
-            })) || [],
-          })),
-          message,
-        };
+            timezone: (context as ToolExecutionContext).timezone || 'UTC',
+          });
+        }
+
+        // Task trigger cascades
+        if (dueDate !== undefined) {
+          void syncTaskDueDateTrigger(taskId, dueDate ? new Date(dueDate) : null);
+        }
+        if (status !== undefined) {
+          const completedSlugs = validConfigs.length > 0
+            ? new Set(validConfigs.filter(c => c.group === 'done').map(c => c.slug))
+            : new Set(['completed']);
+          if (completedSlugs.has(status) && !existingTask.completedAt) {
+            void cancelTaskDueDateTrigger(taskId, 'Task completed before due date');
+            void fireCompletionTrigger(taskId);
+          }
+        }
+
+        resultTitle = trimmedTitle ?? existingTask.page?.title ?? '';
+
+        // Broadcast update event
+        await broadcastTaskEvent({
+          type: 'task_updated',
+          taskId: resultTask.id,
+          userId,
+          pageId: taskList.pageId || undefined,
+          data: { title: resultTitle, note },
+        });
+
+        return await buildTaskListResponse({
+          action: 'updated',
+          // Preserves prior behavior: the update response scoped its task list
+          // by the (absent) pageId param, not by taskList.pageId.
+          parentPageId: pageId!,
+          taskListId: taskList.id,
+          resultTask,
+          resultTitle,
+          message: `Updated task "${resultTitle}"`,
+        });
       } catch (error) {
         console.error('Error in update_task:', error);
         throw new Error(`Failed to ${isUpdate ? 'update' : 'create'} task: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  }),
+
+  /**
+   * Create a task on a TASK_LIST page.
+   * Explicit create verb — no update/delete/reorder inference.
+   */
+  create_task: tool({
+    description: `Create a new task on a TASK_LIST page.
+
+A linked TASK_LIST page is automatically created as a child to hold the task description and any sub-tasks; its title stays synced with the task title. DO NOT delete that page directly — use delete_task instead.
+
+Status:
+- Task lists support custom statuses. Default statuses: pending, in_progress, blocked, completed
+- Use a status slug that exists in the task list's configuration (read_page on the TASK_LIST page returns availableStatuses); create new slugs with create_task_status first.
+
+Assignment:
+- Use assigneeIds array to assign multiple users and/or agents — each entry: { type: 'user'|'agent', id: 'string' }
+- Or use legacy assigneeId/assigneeAgentId for single assignment.
+
+Agent Triggers:
+- Provide agentTrigger with agentPageId and either prompt or instructionPageId to schedule an AI agent at the due date (triggerType 'due_date', requires dueDate) or on completion (triggerType 'completion'). Requires a drive-based task list.`,
+    inputSchema: z.object({
+      pageId: z.string().describe('TASK_LIST page ID to add the task to'),
+      title: z.string().describe('Task title'),
+      status: z.string().optional().describe('Task status slug (e.g. pending, in_progress, completed, blocked, or any custom status). Defaults to pending.'),
+      priority: z.enum(['low', 'medium', 'high']).optional().describe('Task priority (defaults to medium)'),
+      assigneeId: z.string().nullable().optional().describe('User ID to assign. Legacy single-assignee field.'),
+      assigneeAgentId: z.string().nullable().optional().describe('Agent page ID to assign. Legacy single-assignee field.'),
+      assigneeIds: z.array(z.object({
+        type: z.enum(['user', 'agent']),
+        id: z.string(),
+      })).optional().describe('Multiple assignees. Each: { type: "user"|"agent", id: "..." }'),
+      dueDate: z.string().nullable().optional().describe('Due date in ISO format'),
+      note: z.string().optional().describe('Note stored in task metadata'),
+      position: z.number().optional().describe('Position in the list (defaults to end)'),
+      agentTrigger: z.preprocess(
+        normalizeTaskAgentTriggerInput,
+        agentTriggerBaseSchema.extend({
+          triggerType: z.enum(['due_date', 'completion']).default('due_date').describe('When to trigger: at due date or on completion'),
+        }).optional()
+      ).describe('Schedule an AI agent to run at task due date or on completion. Requires a drive-based task list.'),
+    }),
+    execute: async (params, { experimental_context: context }) => {
+      const ctx = context as ToolExecutionContext;
+      const userId = ctx?.userId;
+
+      if (!userId) {
+        throw new Error('User authentication required');
+      }
+
+      try {
+        return await createTask(ctx, userId, params);
+      } catch (error) {
+        console.error('Error in create_task:', error);
+        throw new Error(`Failed to create task: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  }),
+
+  /**
+   * Delete a task and trash its linked TASK_LIST page.
+   * Explicit delete verb — hard-removes the task.
+   */
+  delete_task: tool({
+    description: `Hard-delete a task and trash its linked TASK_LIST page.
+
+This permanently removes the task row and moves its linked page to the trash. Returns the refreshed task list so clients can drop the deleted task immediately.`,
+    inputSchema: z.object({
+      taskId: z.string().describe('ID of the task to delete'),
+    }),
+    execute: async ({ taskId }, { experimental_context: context }) => {
+      const ctx = context as ToolExecutionContext;
+      const userId = ctx?.userId;
+
+      if (!userId) {
+        throw new Error('User authentication required');
+      }
+
+      try {
+        const { existingTask, taskList } = await resolveTaskForUpdate(ctx, userId, taskId);
+        return await deleteTask(ctx, userId, existingTask, taskList, 'Task deleted via delete_task');
+      } catch (error) {
+        console.error('Error in delete_task:', error);
+        throw new Error(`Failed to delete task: ${error instanceof Error ? error.message : String(error)}`);
+      }
+    },
+  }),
+
+  /**
+   * Move a task to a new position and re-densify peer positions.
+   * Explicit reorder verb.
+   */
+  reorder_task: tool({
+    description: `Move a task to a new index in its list and re-densify peer positions to 0..n-1.
+
+The position is clamped to the valid range. Returns the refreshed task list reflecting the new ordering.`,
+    inputSchema: z.object({
+      taskId: z.string().describe('ID of the task to move'),
+      position: z.number().describe('Target index in the list (0-based; clamped to the list length)'),
+    }),
+    execute: async ({ taskId, position }, { experimental_context: context }) => {
+      const ctx = context as ToolExecutionContext;
+      const userId = ctx?.userId;
+
+      if (!userId) {
+        throw new Error('User authentication required');
+      }
+
+      try {
+        const { existingTask, taskList } = await resolveTaskForUpdate(ctx, userId, taskId);
+        const clamped = await reorderTaskPeers(taskList.pageId!, taskId, position);
+        const resultTitle = existingTask.page?.title ?? '';
+        return await buildTaskListResponse({
+          action: 'updated',
+          parentPageId: taskList.pageId!,
+          taskListId: taskList.id,
+          resultTask: { ...existingTask, position: clamped },
+          resultTitle,
+          message: `Reordered task "${resultTitle}" to position ${clamped}`,
+        });
+      } catch (error) {
+        console.error('Error in reorder_task:', error);
+        throw new Error(`Failed to reorder task: ${error instanceof Error ? error.message : String(error)}`);
       }
     },
   }),


### PR DESCRIPTION
## What & why

Sub-PR 1 of 3 in the `update_task` lump→split sequence. `update_task` is a ~895-line monolith that infers its mode (create/update/delete/reorder) from which optional fields are present. We're splitting it into explicit verb tools to reduce model parameter errors and sharpen per-agent `enabledTools` curation.

**This PR is additive and behavior-preserving:** new explicit verbs become available; `update_task` keeps its exact current behavior (still does all four modes). No user-facing behavior change.

Stacked on `feat/split-update-task` (Epic 1, agent cron workflows). Base = `feat/split-update-task`, **not** master.

## Changes

- **New `apps/web/src/lib/ai/tools/task-helpers.ts`** — extracts the sub-routines previously inlined in `update_task.execute` into a single source of truth:
  - `resolveTaskForUpdate` (task/list lookup + permission check)
  - `syncTaskAssignees` (assignee junction replace + legacy single-assignee sync)
  - `createTask` (linked TASK_LIST page + task insert + agent-trigger wiring)
  - `deleteTask` (disable triggers → trash linked page → hard-delete → broadcasts → refreshed list)
  - `reorderTaskPeers` (peer re-densification)
  - `serializeTaskItem` / `serializeTaskList` / `buildTaskListResponse` (shared response shaping)
  - moved module helpers `normalizeTaskAgentTriggerInput`, `getAiContextWithActor`, `verifyPageAccess`
  - reuses Epic 1's `agentTriggerBaseSchema` / `createTaskTriggerWorkflow` — no inline agent-trigger schema reintroduced
- **Three new tools** in `taskManagementTools`, each delegating to the helpers:
  - `create_task` — required `pageId`+`title`; optional status/priority/assignees/dueDate/note/position/agentTrigger
  - `delete_task` — required `taskId`; hard-deletes + trashes the linked page
  - `reorder_task` — required `taskId`+`position`; moves + re-densifies peers
- **`update_task` refactored to delegate** to the same helpers — zero duplicated create/delete/reorder logic, exact behavior preserved.
- **Registration:** verbs auto-register via the `...taskManagementTools` spread; write verbs added to `WRITE_TOOLS`; categorized under `tasks` in the system prompt; `core/ai-tools.test.ts` registry mock updated. `update_task`'s public schema/description is unchanged.
- **Tests:** new `__tests__/task-verb-tools.test.ts` (happy path + a rejection for each verb); existing `task-management-tools.test.ts` passes **without edits** — the proof that `update_task` behavior is preserved.

## Verification

- `bun run --filter 'web' typecheck` — clean
- eslint on changed files — clean
- `task-management-tools.test.ts` (17) + `task-verb-tools.test.ts` (9) + `ai-tools.test.ts` + `tool-filtering.test.ts` — all pass
- Broader `src/lib/ai` suite: 837 pass. The one unrelated failure (`activity-tools.test.ts`, "role \"test\" does not exist") is a pre-existing DB-role/env issue, untouched by this PR.

## Notes / deviations

- Per the task's correction, the new tools **are** registered (ai-tools.ts spread + WRITE_TOOLS) so they're usable now; `update_task` is left full-behavior (narrowing happens in PR3). `enabledTools` migration is PR2.
- `buildTaskListResponse` for the `update_task` path is intentionally passed the (absent) `pageId` param to preserve the pre-existing list-scoping behavior of the update response; the new `reorder_task` tool uses the correct `taskList.pageId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)