### PR TITLE
feat(migration): backfill enabledTools with task verb tools

### DIFF
--- a/scripts/__tests__/backfill-task-verb-tools.test.ts
+++ b/scripts/__tests__/backfill-task-verb-tools.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
   addTaskVerbTools,
-  isStringArray,
   TASK_VERB_TOOLS,
   TRIGGER_TOOL,
 } from '../lib/task-verb-tools';
@@ -42,6 +41,27 @@ describe('addTaskVerbTools', () => {
     ]);
   });
 
+  it('appends verbs to a mixed array containing update_task, keeping non-string entries', () => {
+    // Mirrors runtime: the allowlist grants update_task via Array.includes,
+    // so a legacy/mixed array must still receive the verbs without dropping junk.
+    const input = ['update_task', 123, 'read_page'];
+    const result = addTaskVerbTools(input);
+    expect(result).toEqual([
+      'update_task',
+      123,
+      'read_page',
+      'create_task',
+      'delete_task',
+      'reorder_task',
+    ]);
+  });
+
+  it('is a no-op for a mixed array that does not contain update_task', () => {
+    const input = ['read_page', 42, { tool: 'x' }];
+    const result = addTaskVerbTools(input);
+    expect(result).toEqual(input);
+  });
+
   it('is idempotent across repeated application', () => {
     const once = addTaskVerbTools([TRIGGER_TOOL]);
     const twice = addTaskVerbTools(once);
@@ -54,19 +74,5 @@ describe('addTaskVerbTools', () => {
 
   it('exposes the expected verb tool names', () => {
     expect(TASK_VERB_TOOLS).toEqual(['create_task', 'delete_task', 'reorder_task']);
-  });
-});
-
-describe('isStringArray', () => {
-  it('accepts an array of strings', () => {
-    expect(isStringArray(['update_task'])).toBe(true);
-    expect(isStringArray([])).toBe(true);
-  });
-
-  it('rejects null, non-arrays, and arrays with non-string entries', () => {
-    expect(isStringArray(null)).toBe(false);
-    expect(isStringArray('update_task')).toBe(false);
-    expect(isStringArray({ 0: 'update_task' })).toBe(false);
-    expect(isStringArray(['update_task', 42])).toBe(false);
   });
 });

--- a/scripts/__tests__/backfill-task-verb-tools.test.ts
+++ b/scripts/__tests__/backfill-task-verb-tools.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import {
+  addTaskVerbTools,
+  isStringArray,
+  TASK_VERB_TOOLS,
+  TRIGGER_TOOL,
+} from '../lib/task-verb-tools';
+
+describe('addTaskVerbTools', () => {
+  it('adds the three verbs when update_task is present', () => {
+    const result = addTaskVerbTools([TRIGGER_TOOL]);
+    expect(result).toEqual([
+      'update_task',
+      'create_task',
+      'delete_task',
+      'reorder_task',
+    ]);
+  });
+
+  it('is a no-op when the verbs are already present', () => {
+    const input = ['update_task', 'create_task', 'delete_task', 'reorder_task'];
+    const result = addTaskVerbTools(input);
+    expect(result).toEqual(input);
+  });
+
+  it('is a no-op when update_task is absent', () => {
+    const input = ['read_page', 'search', 'create_page'];
+    const result = addTaskVerbTools(input);
+    expect(result).toEqual(input);
+  });
+
+  it('preserves other tools and their order, appending only missing verbs', () => {
+    const input = ['read_page', 'update_task', 'create_task', 'search'];
+    const result = addTaskVerbTools(input);
+    expect(result).toEqual([
+      'read_page',
+      'update_task',
+      'create_task',
+      'search',
+      'delete_task',
+      'reorder_task',
+    ]);
+  });
+
+  it('is idempotent across repeated application', () => {
+    const once = addTaskVerbTools([TRIGGER_TOOL]);
+    const twice = addTaskVerbTools(once);
+    expect(twice).toEqual(once);
+  });
+
+  it('leaves an empty allowlist untouched', () => {
+    expect(addTaskVerbTools([])).toEqual([]);
+  });
+
+  it('exposes the expected verb tool names', () => {
+    expect(TASK_VERB_TOOLS).toEqual(['create_task', 'delete_task', 'reorder_task']);
+  });
+});
+
+describe('isStringArray', () => {
+  it('accepts an array of strings', () => {
+    expect(isStringArray(['update_task'])).toBe(true);
+    expect(isStringArray([])).toBe(true);
+  });
+
+  it('rejects null, non-arrays, and arrays with non-string entries', () => {
+    expect(isStringArray(null)).toBe(false);
+    expect(isStringArray('update_task')).toBe(false);
+    expect(isStringArray({ 0: 'update_task' })).toBe(false);
+    expect(isStringArray(['update_task', 42])).toBe(false);
+  });
+});

--- a/scripts/backfill-task-verb-tools.ts
+++ b/scripts/backfill-task-verb-tools.ts
@@ -27,11 +27,7 @@
 import { db } from '@pagespace/db/db';
 import { pages } from '@pagespace/db/schema/core';
 import { eq, sql } from '@pagespace/db/operators';
-import {
-  addTaskVerbTools,
-  isStringArray,
-  TRIGGER_TOOL,
-} from './lib/task-verb-tools';
+import { addTaskVerbTools, TRIGGER_TOOL } from './lib/task-verb-tools';
 
 async function backfill(dryRun: boolean): Promise<void> {
   console.log(
@@ -51,10 +47,10 @@ async function backfill(dryRun: boolean): Promise<void> {
   for (const row of rows) {
     scanned += 1;
 
-    if (!isStringArray(row.enabledTools)) {
-      // Defensive: the @> filter matches jsonb arrays, but guard against any
-      // legacy non-string entries rather than corrupting the value.
-      console.warn(`⚠️  Skipping page ${row.id}: enabledTools is not a string array.`);
+    if (!Array.isArray(row.enabledTools)) {
+      // The @> filter only matches jsonb arrays; this guards the unexpected
+      // (e.g. a jsonb scalar) rather than corrupting the value.
+      console.warn(`⚠️  Skipping page ${row.id}: enabledTools is not an array.`);
       skipped += 1;
       continue;
     }

--- a/scripts/backfill-task-verb-tools.ts
+++ b/scripts/backfill-task-verb-tools.ts
@@ -1,0 +1,96 @@
+#!/usr/bin/env bun
+/**
+ * Backfill Script: Grant task verb tools to AI_CHAT agents
+ *
+ * Sub-PR 2 of 3 (additive migration, hard cutover plan).
+ *
+ * Sub-PR 1 split the monolithic `update_task` AI tool into explicit verbs
+ * (`create_task`, `delete_task`, `reorder_task`). Per-page AI agents store a
+ * curated allowlist of tool names in `pages.enabledTools` (jsonb array). When
+ * that allowlist is set, the agent may only call those tools. Sub-PR 3 will
+ * narrow `update_task` to field-only edits, so BEFORE that cutover every agent
+ * currently allowed `update_task` must also be granted the new verbs.
+ *
+ * For every `pages` row whose `enabledTools` array contains `"update_task"`,
+ * this script appends `"create_task"`, `"delete_task"`, `"reorder_task"` if not
+ * already present (preserving existing entries and order). Rows where
+ * `enabledTools` is null (unrestricted agents) or does not contain
+ * `update_task` are left untouched. Running it twice produces no changes.
+ *
+ * Usage:
+ *   bun scripts/backfill-task-verb-tools.ts [--dry-run]
+ *
+ * Options:
+ *   --dry-run   Report what would change without writing to the database.
+ */
+
+import { db } from '@pagespace/db/db';
+import { pages } from '@pagespace/db/schema/core';
+import { eq, sql } from '@pagespace/db/operators';
+import {
+  addTaskVerbTools,
+  isStringArray,
+  TRIGGER_TOOL,
+} from './lib/task-verb-tools';
+
+async function backfill(dryRun: boolean): Promise<void> {
+  console.log(
+    `🚀 Backfilling enabledTools with task verb tools${dryRun ? ' (dry run)' : ''}...`,
+  );
+
+  // Narrow to candidate rows in SQL: jsonb arrays that contain "update_task".
+  const rows = await db
+    .select({ id: pages.id, enabledTools: pages.enabledTools })
+    .from(pages)
+    .where(sql`${pages.enabledTools} @> ${JSON.stringify([TRIGGER_TOOL])}::jsonb`);
+
+  let scanned = 0;
+  let updated = 0;
+  let skipped = 0;
+
+  for (const row of rows) {
+    scanned += 1;
+
+    if (!isStringArray(row.enabledTools)) {
+      // Defensive: the @> filter matches jsonb arrays, but guard against any
+      // legacy non-string entries rather than corrupting the value.
+      console.warn(`⚠️  Skipping page ${row.id}: enabledTools is not a string array.`);
+      skipped += 1;
+      continue;
+    }
+
+    const next = addTaskVerbTools(row.enabledTools);
+    if (next.length === row.enabledTools.length) {
+      // Already has every verb — no change needed (idempotent).
+      skipped += 1;
+      continue;
+    }
+
+    if (dryRun) {
+      console.log(
+        `  would update page ${row.id}: [${row.enabledTools.join(', ')}] -> [${next.join(', ')}]`,
+      );
+    } else {
+      await db.update(pages).set({ enabledTools: next }).where(eq(pages.id, row.id));
+    }
+    updated += 1;
+  }
+
+  console.log(
+    `✅ Backfill ${dryRun ? 'dry run ' : ''}complete. scanned: ${scanned}, ${
+      dryRun ? 'would update' : 'updated'
+    }: ${updated}, unchanged: ${skipped}`,
+  );
+}
+
+if (require.main === module) {
+  const dryRun = process.argv.slice(2).includes('--dry-run');
+  backfill(dryRun)
+    .then(() => process.exit(0))
+    .catch((error) => {
+      console.error('💥 Backfill failed:', error);
+      process.exit(1);
+    });
+}
+
+export { backfill };

--- a/scripts/lib/task-verb-tools.ts
+++ b/scripts/lib/task-verb-tools.ts
@@ -8,6 +8,12 @@
  * (sub-PR 3), every agent currently allowed `update_task` must also be granted
  * the new verbs so it does not lose create/delete/reorder ability.
  *
+ * The runtime grants a tool purely via `Array.includes(name)`, so a legacy or
+ * mixed array (e.g. containing non-string junk alongside `"update_task"`) still
+ * grants `update_task` at runtime. This transform mirrors that: it acts on any
+ * array that contains the string `"update_task"`, regardless of what else is in
+ * it, and preserves every existing entry untouched.
+ *
  * This module is intentionally dependency-free so it can be unit-tested without
  * touching the database.
  */
@@ -22,12 +28,15 @@ export const TASK_VERB_TOOLS = ['create_task', 'delete_task', 'reorder_task'] as
  * Add the task verb tools to an enabledTools allowlist when it grants
  * `update_task`.
  *
- * - If `update_task` is absent, the array is returned unchanged.
- * - Existing entries and their order are preserved; only missing verbs are
- *   appended (in {@link TASK_VERB_TOOLS} order).
+ * Mirrors runtime allowlist semantics (`Array.includes`):
+ * - If the array does not contain the string `"update_task"`, it is returned
+ *   unchanged.
+ * - Otherwise the missing verbs are appended (in {@link TASK_VERB_TOOLS}
+ *   order). All existing entries — including any non-string values — are
+ *   preserved in place; nothing is dropped or reordered.
  * - Idempotent: a second call on the result produces no further changes.
  */
-export function addTaskVerbTools(tools: string[]): string[] {
+export function addTaskVerbTools(tools: unknown[]): unknown[] {
   if (!tools.includes(TRIGGER_TOOL)) {
     return tools;
   }
@@ -38,13 +47,4 @@ export function addTaskVerbTools(tools: string[]): string[] {
   }
 
   return [...tools, ...missing];
-}
-
-/**
- * Type guard for a JSONB `enabledTools` value that is a plain array of strings.
- * `enabledTools` is nullable (unrestricted agents) and historically loosely
- * typed, so callers must validate before transforming.
- */
-export function isStringArray(value: unknown): value is string[] {
-  return Array.isArray(value) && value.every((item) => typeof item === 'string');
 }

--- a/scripts/lib/task-verb-tools.ts
+++ b/scripts/lib/task-verb-tools.ts
@@ -1,0 +1,50 @@
+/**
+ * Pure helpers for the enabledTools task-verb backfill.
+ *
+ * Sub-PR 1 split the monolithic `update_task` AI tool into explicit verbs
+ * (`create_task`, `delete_task`, `reorder_task`). Per-page AI agents
+ * (AI_CHAT pages) store a curated allowlist of tool names in
+ * `pages.enabledTools`. Before `update_task` is narrowed to field-only edits
+ * (sub-PR 3), every agent currently allowed `update_task` must also be granted
+ * the new verbs so it does not lose create/delete/reorder ability.
+ *
+ * This module is intentionally dependency-free so it can be unit-tested without
+ * touching the database.
+ */
+
+/** The tool whose presence triggers the backfill. */
+export const TRIGGER_TOOL = 'update_task';
+
+/** The verb tools that must be granted alongside `update_task`. */
+export const TASK_VERB_TOOLS = ['create_task', 'delete_task', 'reorder_task'] as const;
+
+/**
+ * Add the task verb tools to an enabledTools allowlist when it grants
+ * `update_task`.
+ *
+ * - If `update_task` is absent, the array is returned unchanged.
+ * - Existing entries and their order are preserved; only missing verbs are
+ *   appended (in {@link TASK_VERB_TOOLS} order).
+ * - Idempotent: a second call on the result produces no further changes.
+ */
+export function addTaskVerbTools(tools: string[]): string[] {
+  if (!tools.includes(TRIGGER_TOOL)) {
+    return tools;
+  }
+
+  const missing = TASK_VERB_TOOLS.filter((verb) => !tools.includes(verb));
+  if (missing.length === 0) {
+    return tools;
+  }
+
+  return [...tools, ...missing];
+}
+
+/**
+ * Type guard for a JSONB `enabledTools` value that is a plain array of strings.
+ * `enabledTools` is nullable (unrestricted agents) and historically loosely
+ * typed, so callers must validate before transforming.
+ */
+export function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}

--- a/scripts/vitest.config.ts
+++ b/scripts/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     globals: false,
     testTimeout: 30_000,
     hookTimeout: 60_000,
-    include: ['__tests__/tenant-*.test.ts', '__tests__/cutover-*.test.ts', '__tests__/changelog-*.test.ts'],
+    include: ['__tests__/tenant-*.test.ts', '__tests__/cutover-*.test.ts', '__tests__/changelog-*.test.ts', '__tests__/backfill-*.test.ts'],
     pool: 'forks',
     poolOptions: {
       forks: { singleFork: true },


### PR DESCRIPTION
## Sub-PR 2 of 3 — additive backfill

Splits the monolithic \`update_task\` AI tool into explicit verbs. Sub-PR 1 (already merged into this base branch) added \`create_task\`, \`delete_task\`, \`reorder_task\`. Sub-PR 3 will narrow \`update_task\` to field-only edits.

Per-page AI agents (AI_CHAT pages) store a curated allowlist of tool names in \`pages.enabledTools\` (jsonb array, `packages/db/src/schema/core.ts`). When set, the agent may only call those tools. **Before** the sub-PR 3 cutover, every agent currently allowed \`update_task\` must also be granted the three new verbs — otherwise it silently loses the ability to create/delete/reorder tasks.

This PR is **additive only**: it does not touch \`update_task\` (that's sub-PR 3).

## What's here

- **`scripts/lib/task-verb-tools.ts`** — pure, dependency-free transform:
  - `addTaskVerbTools(tools: string[]): string[]` — when \`update_task\` is present, appends any missing verbs (`create_task`, `delete_task`, `reorder_task`); preserves existing entries + order; idempotent. No-op when \`update_task\` absent.
  - `isStringArray()` jsonb guard.
- **`scripts/backfill-task-verb-tools.ts`** — follows the existing backfill-script pattern (`backfill-file-storage.ts`, `migrate-provider-types.ts`): db subpath imports, jsonb `@>` containment filter to fetch only candidate rows, `--dry-run` flag, summary logging. Leaves `null` allowlists (unrestricted agents) and arrays without \`update_task\` untouched. Idempotent (re-running changes nothing).
- **`scripts/__tests__/backfill-task-verb-tools.test.ts`** — unit tests for the pure transform, **no DB** (covers: adds the three verbs; no-op when already present; no-op when absent; preserves other tools/order; idempotent; empty array).
- **`scripts/vitest.config.ts`** — extended `include` to pick up `__tests__/backfill-*.test.ts`.

No `any` types. Subpath db imports per `scripts/eslint.config.mjs`.

## How this runs in production

`bun run db:migrate` only runs **Drizzle SQL migrations** from `packages/db/drizzle/` (CLAUDE.md forbids hand-writing files there). Data backfills in this repo are **standalone scripts run manually**, not auto-run — same as `backfill-file-storage.ts` and `migrate-provider-types.ts`.

A Drizzle data migration was rejected because (a) the project rule bans hand-authored SQL in `packages/db/drizzle/`, and (b) the dedupe/append-missing logic must be a unit-tested pure function — which mandates a TS script. So a TS backfill script run via the existing **migrate** container is the consistent choice.

The migrate image (`apps/web/Dockerfile.migrate`) already copies `scripts/` and builds `@pagespace/db`, so the script is available in the deploy container. Intended one-off invocation, after deploying the image that contains this branch:

\`\`\`bash
# dry run first
docker compose -f docker-compose.prod.yml run --rm migrate bun scripts/backfill-task-verb-tools.ts --dry-run
# then for real
docker compose -f docker-compose.prod.yml run --rm migrate bun scripts/backfill-task-verb-tools.ts
\`\`\`

Must be run **before** sub-PR 3 ships. Idempotent, so safe to re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)