### PR TITLE
feat(agents): cross-drive agent membership + membership-scoped drive discovery

### DIFF
--- a/apps/web/src/app/api/ai/page-agents/[agentId]/drives/[driveId]/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/drives/[driveId]/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { removeAgentFromDrive } from '@pagespace/lib/services/drive-agent-service';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+
+const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
+
+/**
+ * DELETE /api/ai/page-agents/[agentId]/drives/[driveId]
+ * Remove this agent's membership in a drive. The home drive cannot be removed.
+ */
+export async function DELETE(
+  request: Request,
+  context: { params: Promise<{ agentId: string; driveId: string }> },
+) {
+  try {
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+    if (isAuthError(auth)) return auth.error;
+    const { userId } = auth;
+
+    const { agentId, driveId } = await context.params;
+
+    const result = await removeAgentFromDrive({
+      actingUserId: userId,
+      agentPageId: agentId,
+      driveId,
+    });
+
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error }, { status: result.status });
+    }
+
+    auditRequest(request, {
+      eventType: 'authz.permission.revoked',
+      userId,
+      resourceType: 'drive',
+      resourceId: driveId,
+      details: { agentPageId: agentId },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    loggers.api.error('Error removing agent from drive:', error as Error);
+    return NextResponse.json({ error: 'Failed to remove agent from drive' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/ai/page-agents/[agentId]/drives/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/[agentId]/drives/route.ts
@@ -1,0 +1,116 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { authenticateRequestWithOptions, isAuthError, checkMCPPageScope } from '@/lib/auth';
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { pages } from '@pagespace/db/schema/core';
+import { canUserViewPage, canUserEditPage } from '@pagespace/lib/permissions/permissions';
+import { addAgentToDrive, listAgentDrives } from '@pagespace/lib/services/drive-agent-service';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+
+const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
+const AUTH_OPTIONS_WRITE = { allow: ['session'] as const, requireCSRF: true };
+
+async function getAgentPage(agentId: string) {
+  const [agent] = await db
+    .select({ id: pages.id, type: pages.type })
+    .from(pages)
+    .where(eq(pages.id, agentId))
+    .limit(1);
+  return agent ?? null;
+}
+
+/**
+ * GET /api/ai/page-agents/[agentId]/drives
+ * List the drives this agent can access (its home drive + memberships).
+ */
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ agentId: string }> },
+) {
+  try {
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_READ);
+    if (isAuthError(auth)) return auth.error;
+
+    const { agentId } = await context.params;
+
+    const agent = await getAgentPage(agentId);
+    if (!agent || agent.type !== 'AI_CHAT') {
+      return NextResponse.json({ error: 'AI agent not found' }, { status: 404 });
+    }
+
+    const scopeError = await checkMCPPageScope(auth, agentId);
+    if (scopeError) return scopeError;
+
+    if (!(await canUserViewPage(auth.userId, agentId))) {
+      return NextResponse.json({ error: 'Insufficient permissions to view this agent' }, { status: 403 });
+    }
+
+    const drives = await listAgentDrives(agentId);
+    return NextResponse.json({ drives });
+  } catch (error) {
+    loggers.api.error('Error listing agent drives:', error as Error);
+    return NextResponse.json({ error: 'Failed to list agent drives' }, { status: 500 });
+  }
+}
+
+const postBodySchema = z.object({
+  driveId: z.string().min(1),
+});
+
+/**
+ * POST /api/ai/page-agents/[agentId]/drives
+ * Add this agent to a drive the acting user can access. Managing an agent's
+ * drives requires edit access to the agent; the role is inherited from (and
+ * capped at) the acting user's access to the target drive.
+ */
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ agentId: string }> },
+) {
+  try {
+    const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS_WRITE);
+    if (isAuthError(auth)) return auth.error;
+    const { userId } = auth;
+
+    const { agentId } = await context.params;
+
+    const agent = await getAgentPage(agentId);
+    if (!agent || agent.type !== 'AI_CHAT') {
+      return NextResponse.json({ error: 'AI agent not found' }, { status: 404 });
+    }
+
+    if (!(await canUserEditPage(userId, agentId))) {
+      return NextResponse.json({ error: 'You do not have permission to manage this agent' }, { status: 403 });
+    }
+
+    const parsed = postBodySchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid request body', issues: parsed.error.flatten().fieldErrors }, { status: 400 });
+    }
+
+    const result = await addAgentToDrive({
+      actingUserId: userId,
+      agentPageId: agentId,
+      driveId: parsed.data.driveId,
+    });
+
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error }, { status: result.status });
+    }
+
+    auditRequest(request, {
+      eventType: 'authz.permission.granted',
+      userId,
+      resourceType: 'drive',
+      resourceId: parsed.data.driveId,
+      details: { agentPageId: agentId, role: result.member.role },
+    });
+
+    return NextResponse.json({ success: true, member: result.member }, { status: 201 });
+  } catch (error) {
+    loggers.api.error('Error adding agent to drive:', error as Error);
+    return NextResponse.json({ error: 'Failed to add agent to drive' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/drives/[driveId]/agents/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/agents/route.ts
@@ -6,7 +6,7 @@ import { eq, and } from '@pagespace/db/operators'
 import { pages, drives } from '@pagespace/db/schema/core';
 import { getUserDriveAccess, canUserViewPage } from '@pagespace/lib/permissions/permissions';
 import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service';
-import { driveAgentMembers, driveRoles } from '@pagespace/db/schema/members';
+import { addAgentToDrive } from '@pagespace/lib/services/drive-agent-service';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
@@ -211,52 +211,19 @@ export async function POST(
 
     const { agentPageId, role, customRoleId } = parsed.data;
 
-    // Verify agentPageId is an AI_CHAT page belonging to this drive
-    const agentPage = await db
-      .select({ id: pages.id, type: pages.type, driveId: pages.driveId })
-      .from(pages)
-      .where(eq(pages.id, agentPageId))
-      .limit(1);
+    // The agent's home drive may differ from this drive. The service authorizes
+    // the caller against the agent + drive and caps the granted role at the
+    // caller's own access.
+    const result = await addAgentToDrive({
+      actingUserId: userId,
+      agentPageId,
+      driveId,
+      requestedRole: role,
+      requestedCustomRoleId: customRoleId ?? null,
+    });
 
-    if (agentPage.length === 0) {
-      return NextResponse.json({ error: 'Agent page not found' }, { status: 404 });
-    }
-    if (agentPage[0].type !== 'AI_CHAT') {
-      return NextResponse.json({ error: 'agentPageId must reference an AI_CHAT page' }, { status: 400 });
-    }
-    if (agentPage[0].driveId !== driveId) {
-      return NextResponse.json({ error: 'Agent page does not belong to this drive' }, { status: 400 });
-    }
-
-    // Validate customRoleId if provided
-    if (customRoleId) {
-      const roleExists = await db
-        .select({ id: driveRoles.id })
-        .from(driveRoles)
-        .where(and(eq(driveRoles.id, customRoleId), eq(driveRoles.driveId, driveId)))
-        .limit(1);
-      if (roleExists.length === 0) {
-        return NextResponse.json({ error: 'Custom role not found in this drive' }, { status: 404 });
-      }
-    }
-
-    let newMember;
-    try {
-      [newMember] = await db
-        .insert(driveAgentMembers)
-        .values({
-          driveId,
-          agentPageId,
-          role,
-          customRoleId: customRoleId ?? null,
-          addedBy: userId,
-        })
-        .returning();
-    } catch (err) {
-      if ((err as { code?: string }).code === '23505') {
-        return NextResponse.json({ error: 'Agent is already a member of this drive' }, { status: 409 });
-      }
-      throw err;
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error }, { status: result.status });
     }
 
     auditRequest(request, {
@@ -267,7 +234,7 @@ export async function POST(
       details: { agentPageId, role, customRoleId },
     });
 
-    return NextResponse.json({ success: true, member: newMember }, { status: 201 });
+    return NextResponse.json({ success: true, member: result.member }, { status: 201 });
   } catch (error) {
     loggers.api.error('Error adding drive agent member:', error as Error);
     return NextResponse.json({ error: 'Failed to add agent member' }, { status: 500 });

--- a/apps/web/src/components/ai/page-agents/AgentDrivesCard.tsx
+++ b/apps/web/src/components/ai/page-agents/AgentDrivesCard.tsx
@@ -1,0 +1,160 @@
+import React, { useMemo, useState } from 'react';
+import useSWR from 'swr';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Loader2, Network, X } from 'lucide-react';
+import { toast } from 'sonner';
+import { fetchWithAuth, post, del } from '@/lib/auth/auth-fetch';
+
+interface AgentDrive {
+  driveId: string;
+  driveName: string;
+  driveSlug: string;
+  role: 'OWNER' | 'ADMIN' | 'MEMBER';
+  customRoleId: string | null;
+  isHome: boolean;
+}
+
+interface DriveOption {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+const jsonFetcher = async (url: string) => {
+  const res = await fetchWithAuth(url);
+  if (!res.ok) throw new Error(`Failed to fetch: ${res.status}`);
+  return res.json();
+};
+
+/**
+ * Manages the set of drives an AI agent can access. The agent's home drive is
+ * always present and cannot be removed; other drives can be added (the agent
+ * inherits the user's access to that drive) or removed.
+ */
+export function AgentDrivesCard({ agentPageId }: { agentPageId: string }) {
+  const { data, mutate, isLoading } = useSWR<{ drives: AgentDrive[] }>(
+    `/api/ai/page-agents/${agentPageId}/drives`,
+    jsonFetcher,
+  );
+  const { data: allDrives } = useSWR<DriveOption[]>('/api/drives', jsonFetcher);
+
+  const [selected, setSelected] = useState<string>('');
+  const [adding, setAdding] = useState(false);
+  const [removingId, setRemovingId] = useState<string | null>(null);
+
+  const agentDrives = useMemo(() => data?.drives ?? [], [data]);
+  const memberIds = useMemo(() => new Set(agentDrives.map((d) => d.driveId)), [agentDrives]);
+  const available = useMemo(
+    () => (allDrives ?? []).filter((d) => !memberIds.has(d.id)),
+    [allDrives, memberIds],
+  );
+
+  const handleAdd = async () => {
+    if (!selected) return;
+    setAdding(true);
+    try {
+      await post(`/api/ai/page-agents/${agentPageId}/drives`, { driveId: selected });
+      toast.success('Agent added to drive');
+      setSelected('');
+      await mutate();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to add agent to drive');
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const handleRemove = async (driveId: string) => {
+    setRemovingId(driveId);
+    try {
+      await del(`/api/ai/page-agents/${agentPageId}/drives/${driveId}`);
+      toast.success('Agent removed from drive');
+      await mutate();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to remove agent from drive');
+    } finally {
+      setRemovingId(null);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <Network className="h-5 w-5" />
+          <div>
+            <CardTitle className="text-lg">Drives this agent can access</CardTitle>
+            <CardDescription>
+              The agent can read and act in these drives using its tools, inheriting your access to each.
+            </CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {isLoading ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading…
+          </div>
+        ) : (
+          <ul className="space-y-2">
+            {agentDrives.map((drive) => (
+              <li
+                key={drive.driveId}
+                className="flex items-center justify-between rounded-md border px-3 py-2"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-medium">{drive.driveName}</span>
+                  {drive.isHome ? (
+                    <Badge variant="outline">Home</Badge>
+                  ) : drive.role === 'ADMIN' || drive.role === 'OWNER' ? (
+                    <Badge className="bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300">Admin</Badge>
+                  ) : (
+                    <Badge className="bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300">Member</Badge>
+                  )}
+                </div>
+                {!drive.isHome && (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleRemove(drive.driveId)}
+                    disabled={removingId === drive.driveId}
+                    aria-label={`Remove access to ${drive.driveName}`}
+                  >
+                    {removingId === drive.driveId ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <X className="h-4 w-4" />
+                    )}
+                  </Button>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div className="flex items-center gap-2">
+          <Select value={selected} onValueChange={setSelected} disabled={available.length === 0 || adding}>
+            <SelectTrigger className="h-8 flex-1 text-sm">
+              <SelectValue placeholder={available.length === 0 ? 'No more drives to add' : 'Add a drive…'} />
+            </SelectTrigger>
+            <SelectContent>
+              {available.map((drive) => (
+                <SelectItem key={drive.id} value={drive.id}>
+                  {drive.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Button type="button" size="sm" onClick={handleAdd} disabled={!selected || adding}>
+            {adding ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Add'}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
+++ b/apps/web/src/components/ai/page-agents/PageAgentSettingsTab.tsx
@@ -14,6 +14,7 @@ import { patch, fetchWithAuth } from '@/lib/auth/auth-fetch';
 import Link from 'next/link';
 import { AI_PROVIDERS } from '@/lib/ai/core/ai-providers-config';
 import { getRoleColorClasses } from '@/lib/utils';
+import { AgentDrivesCard } from './AgentDrivesCard';
 
 interface AgentConfig {
   systemPrompt: string;
@@ -665,6 +666,9 @@ const PageAgentSettingsTab = forwardRef<PageAgentSettingsTabRef, PageAgentSettin
             )}
           </CardContent>
         </Card>
+
+        {/* Drives this agent can access */}
+        <AgentDrivesCard agentPageId={pageId} />
 
         {/* Tool Permissions */}
         <Card>

--- a/apps/web/src/components/members/DriveMembers.tsx
+++ b/apps/web/src/components/members/DriveMembers.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { UserPlus } from 'lucide-react';
 import { MemberRow } from './MemberRow';
 import { AgentMemberRow, type AgentMember } from './AgentMemberRow';
+import { InviteAgentDialog } from './InviteAgentDialog';
 import { AppMemberRow, type AppMember } from './AppMemberRow';
 import { PendingInvitesSection } from './PendingInvitesSection';
 import { DriveShareLinkSection } from './DriveShareLinkSection';
@@ -72,6 +73,7 @@ export function DriveMembers({ driveId }: DriveMembersProps) {
   const [pendingInvites, setPendingInvites] = useState<PendingInvite[]>([]);
   const [currentUserRole, setCurrentUserRole] = useState<'OWNER' | 'ADMIN' | 'MEMBER'>('MEMBER');
   const [loading, setLoading] = useState(true);
+  const [inviteAgentOpen, setInviteAgentOpen] = useState(false);
   const router = useRouter();
   const { toast } = useToast();
   const socket = useSocket();
@@ -254,11 +256,19 @@ export function DriveMembers({ driveId }: DriveMembersProps) {
       </div>
 
       <div>
-        <div className="mb-3">
-          <h2 className="text-lg font-semibold">Agents ({agentMembers.length})</h2>
-          <p className="text-sm text-gray-600 dark:text-gray-400">
-            AI agents with access to this drive
-          </p>
+        <div className="mb-3 flex items-start justify-between gap-2">
+          <div>
+            <h2 className="text-lg font-semibold">Agents ({agentMembers.length})</h2>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              AI agents with access to this drive
+            </p>
+          </div>
+          {(currentUserRole === 'OWNER' || currentUserRole === 'ADMIN') && (
+            <Button variant="outline" size="sm" onClick={() => setInviteAgentOpen(true)}>
+              <UserPlus className="h-4 w-4 mr-2" />
+              Invite Agent
+            </Button>
+          )}
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 divide-y divide-gray-200 dark:divide-gray-700">
           {agentMembers.length === 0 ? (
@@ -313,6 +323,14 @@ export function DriveMembers({ driveId }: DriveMembersProps) {
         invites={pendingInvites}
         currentUserRole={currentUserRole}
         onRevoke={handleRevokeInvite}
+      />
+
+      <InviteAgentDialog
+        driveId={driveId}
+        open={inviteAgentOpen}
+        onOpenChange={setInviteAgentOpen}
+        existingAgentPageIds={agentMembers.map((a) => a.agentPageId)}
+        onInvited={fetchMembers}
       />
     </div>
   );

--- a/apps/web/src/components/members/InviteAgentDialog.tsx
+++ b/apps/web/src/components/members/InviteAgentDialog.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Loader2 } from 'lucide-react';
+import { useToast } from '@/hooks/useToast';
+import { post } from '@/lib/auth/auth-fetch';
+import { usePageAgents } from '@/hooks/page-agents/usePageAgents';
+
+interface InviteAgentDialogProps {
+  driveId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** agentPageIds already members of this drive, excluded from the picker. */
+  existingAgentPageIds: string[];
+  onInvited: () => void;
+}
+
+/**
+ * Invite an AI agent into a drive, mirroring the human invite flow. Lists
+ * agents the inviter can access (across their drives); the granted role is
+ * capped server-side at the inviter's own access to this drive.
+ */
+export function InviteAgentDialog({
+  driveId,
+  open,
+  onOpenChange,
+  existingAgentPageIds,
+  onInvited,
+}: InviteAgentDialogProps) {
+  const { toast } = useToast();
+  const { allAgents, isLoading } = usePageAgents();
+  const [selectedAgent, setSelectedAgent] = useState<string>('');
+  const [role, setRole] = useState<'MEMBER' | 'ADMIN'>('MEMBER');
+  const [submitting, setSubmitting] = useState(false);
+
+  const existing = useMemo(() => new Set(existingAgentPageIds), [existingAgentPageIds]);
+  const candidates = useMemo(
+    () => allAgents.filter((a) => !existing.has(a.id)),
+    [allAgents, existing],
+  );
+
+  const handleSubmit = async () => {
+    if (!selectedAgent) return;
+    setSubmitting(true);
+    try {
+      await post(`/api/drives/${driveId}/agents`, { agentPageId: selectedAgent, role });
+      toast({ title: 'Agent invited', description: 'The agent now has access to this drive.' });
+      setSelectedAgent('');
+      setRole('MEMBER');
+      onOpenChange(false);
+      onInvited();
+    } catch (e) {
+      toast({
+        title: 'Error',
+        description: e instanceof Error ? e.message : 'Failed to invite agent',
+        variant: 'destructive',
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Invite an agent</DialogTitle>
+          <DialogDescription>
+            Give an AI agent access to this drive. It can be an agent from any drive you can access.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-2">
+            <Label>Agent</Label>
+            <Select value={selectedAgent} onValueChange={setSelectedAgent} disabled={isLoading}>
+              <SelectTrigger>
+                <SelectValue
+                  placeholder={
+                    isLoading
+                      ? 'Loading agents…'
+                      : candidates.length === 0
+                      ? 'No agents available to invite'
+                      : 'Select an agent…'
+                  }
+                />
+              </SelectTrigger>
+              <SelectContent>
+                {candidates.map((agent) => (
+                  <SelectItem key={agent.id} value={agent.id}>
+                    {(agent.title || 'Unnamed Agent') + ' — ' + agent.driveName}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Role</Label>
+            <Select value={role} onValueChange={(v) => setRole(v as 'MEMBER' | 'ADMIN')}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="MEMBER">Member</SelectItem>
+                <SelectItem value="ADMIN">Admin</SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-muted-foreground">
+              You can&apos;t grant a role higher than your own access to this drive.
+            </p>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleSubmit} disabled={!selectedAgent || submitting}>
+            {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Invite'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/members/InviteAgentDialog.tsx
+++ b/apps/web/src/components/members/InviteAgentDialog.tsx
@@ -77,7 +77,8 @@ export function InviteAgentDialog({
         <DialogHeader>
           <DialogTitle>Invite an agent</DialogTitle>
           <DialogDescription>
-            Give an AI agent access to this drive. It can be an agent from any drive you can access.
+            Give an AI agent access to this drive. You can invite any agent you manage; the
+            granted role is capped at your own access to this drive.
           </DialogDescription>
         </DialogHeader>
 

--- a/apps/web/src/lib/ai/tools/__tests__/drive-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/drive-tools.test.ts
@@ -39,8 +39,13 @@ vi.mock('@/lib/logging/mask', () => ({
   maskIdentifier: vi.fn((id) => `***${id?.slice(-4) || ''}`),
 }));
 
+vi.mock('@pagespace/lib/services/drive-agent-service', () => ({
+  listAgentDrives: vi.fn(),
+}));
+
 import { driveTools } from '../drive-tools';
 import { db } from '@pagespace/db/db';
+import { listAgentDrives } from '@pagespace/lib/services/drive-agent-service';
 import type { ToolExecutionContext } from '../../core';
 
 const mockDb = vi.mocked(db);
@@ -63,6 +68,31 @@ describe('drive-tools', () => {
       await expect(
         driveTools.list_drives.execute!({}, context)
       ).rejects.toThrow('User authentication required');
+    });
+
+    it('scopes to the agent\'s drives when called by a page-agent', async () => {
+      vi.mocked(listAgentDrives).mockResolvedValue([
+        { driveId: 'd1', driveName: 'Home', driveSlug: 'home', role: 'ADMIN', customRoleId: null, isHome: true },
+        { driveId: 'd2', driveName: 'Hub', driveSlug: 'hub', role: 'MEMBER', customRoleId: null, isHome: false },
+      ]);
+
+      const context = {
+        toolCallId: '1',
+        messages: [],
+        experimental_context: {
+          userId: 'user_1',
+          chatSource: { type: 'page' as const, agentPageId: 'agent_1' },
+        } as ToolExecutionContext,
+      };
+
+      const result = await driveTools.list_drives.execute!({}, context) as {
+        drives: Array<{ id: string; slug: string; title: string }>;
+      };
+
+      expect(listAgentDrives).toHaveBeenCalledWith('agent_1');
+      expect(result.drives.map((d) => d.id)).toEqual(['d1', 'd2']);
+      // The user-scoped DB query path must not be used for an agent actor.
+      expect(mockDb.query.drives.findFirst).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/lib/ai/tools/drive-tools.ts
+++ b/apps/web/src/lib/ai/tools/drive-tools.ts
@@ -9,7 +9,9 @@ import { logDriveActivity, getActorInfo } from '@pagespace/lib/monitoring/activi
 import { getDriveAccessWithDrive } from '@pagespace/lib/services/drive-service';
 import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket';
 import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
+import { listAgentDrives } from '@pagespace/lib/services/drive-agent-service';
 import { type ToolExecutionContext } from '../core';
+import { getAgentPageId } from './actor-permissions';
 
 // Helper: Extract AI attribution context with actor info for activity logging
 async function getAiContextWithActor(context: ToolExecutionContext) {
@@ -43,6 +45,38 @@ export const driveTools = {
       const userId = (context as ToolExecutionContext)?.userId;
       if (!userId) {
         throw new Error('User authentication required');
+      }
+
+      // Page-agents are scoped to their explicit drive memberships (plus their
+      // home drive), so discovery matches where they can actually act. The user
+      // / global assistant path (no agentPageId) stays user-scoped below.
+      const agentPageId = getAgentPageId(context as ToolExecutionContext);
+      if (agentPageId) {
+        try {
+          const agentDrives = await listAgentDrives(agentPageId);
+          return {
+            success: true,
+            drives: agentDrives.map((d) => ({
+              id: d.driveId,
+              slug: d.driveSlug,
+              title: d.driveName,
+              description: '',
+              isDefault: false,
+            })),
+            summary: `Found ${agentDrives.length} workspace${agentDrives.length === 1 ? '' : 's'} this agent can access`,
+            stats: {
+              totalDrives: agentDrives.length,
+              driveNames: agentDrives.map((d) => d.driveName),
+            },
+            nextSteps: agentDrives.length > 0 ? [
+              'Use list_pages with both driveSlug and driveId from above to explore the structure of any workspace',
+              'Use read_page to examine specific documents for context',
+            ] : ['This agent has not been added to any drives yet'],
+          };
+        } catch (error) {
+          console.error('Error reading agent drives:', error);
+          throw new Error('Failed to read drives');
+        }
       }
 
       try {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -182,6 +182,11 @@
       "import": "./dist/services/drive-member-service.js",
       "require": "./dist/services/drive-member-service.js"
     },
+    "./services/drive-agent-service": {
+      "types": "./dist/services/drive-agent-service.d.ts",
+      "import": "./dist/services/drive-agent-service.js",
+      "require": "./dist/services/drive-agent-service.js"
+    },
     "./services/validated-service-token": {
       "types": "./dist/services/validated-service-token.d.ts",
       "import": "./dist/services/validated-service-token.js",
@@ -798,6 +803,9 @@
       ],
       "services/drive-member-service": [
         "./dist/services/drive-member-service.d.ts"
+      ],
+      "services/drive-agent-service": [
+        "./dist/services/drive-agent-service.d.ts"
       ],
       "services/validated-service-token": [
         "./dist/services/validated-service-token.d.ts"

--- a/packages/lib/src/permissions/__tests__/agent-permissions.test.ts
+++ b/packages/lib/src/permissions/__tests__/agent-permissions.test.ts
@@ -28,13 +28,14 @@ vi.mock('@pagespace/db/schema/members', () => ({
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((_a: unknown, _b: unknown) => 'eq'),
   and: vi.fn((...args: unknown[]) => ({ and: args })),
+  inArray: vi.fn((_a: unknown, _b: unknown) => 'inArray'),
 }));
 
 // ---------------------------------------------------------------------------
 // Imports after mocks
 // ---------------------------------------------------------------------------
 
-import { getAgentAccessLevel, hasAgentDriveMembership } from '../agent-permissions';
+import { getAgentAccessLevel, getAgentAccessiblePagesInDrive, hasAgentDriveMembership } from '../agent-permissions';
 import { db } from '@pagespace/db/db';
 
 // ---------------------------------------------------------------------------
@@ -52,6 +53,16 @@ function stubSelect(rows: unknown[]) {
       where: vi.fn().mockReturnValue({
         limit: vi.fn().mockResolvedValue(rows),
       }),
+    }),
+  } as unknown as ReturnType<typeof db.select>;
+}
+
+// Stub for queries that resolve directly from .where() (no .limit()), e.g. the
+// page-enumeration queries in getAgentAccessiblePagesInDrive.
+function stubSelectList(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(rows),
     }),
   } as unknown as ReturnType<typeof db.select>;
 }
@@ -185,5 +196,44 @@ describe('hasAgentDriveMembership', () => {
   it('returns false when no membership row', async () => {
     vi.mocked(db.select).mockReturnValueOnce(stubSelect([]));
     expect(await hasAgentDriveMembership(AGENT_PAGE_ID, DRIVE_ID)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAgentAccessiblePagesInDrive — enumeration by role
+// ---------------------------------------------------------------------------
+
+describe('getAgentAccessiblePagesInDrive', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns [] when the agent has no membership', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(stubSelect([])); // membership lookup
+    expect(await getAgentAccessiblePagesInDrive(AGENT_PAGE_ID, DRIVE_ID)).toEqual([]);
+  });
+
+  it('grants a plain MEMBER (no custom role) view-only access to every page', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: null }])) // membership
+      .mockReturnValueOnce(stubSelectList([
+        { id: 'p1', title: 'A', type: 'DOCUMENT', parentId: null, position: 0, isTrashed: false },
+        { id: 'p2', title: 'B', type: 'DOCUMENT', parentId: null, position: 1, isTrashed: false },
+      ])); // page enumeration
+
+    const result = await getAgentAccessiblePagesInDrive(AGENT_PAGE_ID, DRIVE_ID);
+    expect(result).toHaveLength(2);
+    expect(result.every((p) => p.permissions.canView)).toBe(true);
+    expect(result.every((p) => !p.permissions.canEdit)).toBe(true);
+  });
+
+  it('grants an ADMIN full access to every page', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect([{ role: 'ADMIN', customRoleId: null }]))
+      .mockReturnValueOnce(stubSelectList([
+        { id: 'p1', title: 'A', type: 'DOCUMENT', parentId: null, position: 0, isTrashed: false },
+      ]));
+
+    const result = await getAgentAccessiblePagesInDrive(AGENT_PAGE_ID, DRIVE_ID);
+    expect(result).toHaveLength(1);
+    expect(result[0].permissions).toEqual({ canView: true, canEdit: true, canShare: true, canDelete: true });
   });
 });

--- a/packages/lib/src/permissions/agent-permissions.ts
+++ b/packages/lib/src/permissions/agent-permissions.ts
@@ -48,7 +48,7 @@ export async function getAgentAccessiblePagesInDrive(
 
   const { role, customRoleId } = membership;
 
-  if (role === 'ADMIN') {
+  if (role === 'ADMIN' || role === 'OWNER') {
     const allPages = await db
       .select({
         id: pages.id,
@@ -93,7 +93,26 @@ export async function getAgentAccessiblePagesInDrive(
         permissions: resolveRolePermissions('MEMBER', customPerms, p.id),
       }));
     }
+    // Custom role with no resolvable permissions ⇒ no access.
+    return [];
   }
 
-  return [];
+  // Plain MEMBER (no custom role): blanket view-only over the drive's pages,
+  // consistent with getAgentAccessLevel granting a member canView on any page.
+  const memberPages = await db
+    .select({
+      id: pages.id,
+      title: pages.title,
+      type: pages.type,
+      parentId: pages.parentId,
+      position: pages.position,
+      isTrashed: pages.isTrashed,
+    })
+    .from(pages)
+    .where(and(eq(pages.driveId, driveId), eq(pages.isTrashed, false)));
+
+  return memberPages.map((p) => ({
+    ...p,
+    permissions: resolveRolePermissions('MEMBER', null, p.id),
+  }));
 }

--- a/packages/lib/src/services/__tests__/drive-agent-service.test.ts
+++ b/packages/lib/src/services/__tests__/drive-agent-service.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@pagespace/db/db', () => ({
+  db: { select: vi.fn(), insert: vi.fn(), delete: vi.fn() },
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((_a: unknown, _b: unknown) => 'eq'),
+  and: vi.fn((...args: unknown[]) => ({ and: args })),
+  isNotNull: vi.fn((_a: unknown) => 'isNotNull'),
+}));
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: { id: 'id', type: 'type', driveId: 'driveId' },
+  drives: { id: 'id', name: 'name', slug: 'slug', ownerId: 'ownerId' },
+}));
+vi.mock('@pagespace/db/schema/members', () => ({
+  driveAgentMembers: { id: 'id', driveId: 'driveId', agentPageId: 'agentPageId', role: 'role', customRoleId: 'customRoleId' },
+  driveMembers: { driveId: 'driveId', userId: 'userId', role: 'role', customRoleId: 'customRoleId', acceptedAt: 'acceptedAt' },
+}));
+vi.mock('../../permissions/permissions', () => ({
+  canUserViewPage: vi.fn(),
+  canUserEditPage: vi.fn(),
+  getUserDriveAccess: vi.fn(),
+  isDriveOwnerOrAdmin: vi.fn(),
+}));
+vi.mock('../../permissions/membership-queries', () => ({
+  customRoleBelongsToDrive: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Imports after mocks
+// ---------------------------------------------------------------------------
+
+import { addAgentToDrive } from '../drive-agent-service';
+import { db } from '@pagespace/db/db';
+import { canUserViewPage, getUserDriveAccess } from '../../permissions/permissions';
+import { customRoleBelongsToDrive } from '../../permissions/membership-queries';
+
+const USER = 'user_aaaaaaaaaaaaaaaaaaaaaa';
+const AGENT = 'agent_bbbbbbbbbbbbbbbbbbbbbb';
+const DRIVE = 'drive_cccccccccccccccccccccc';
+
+function stubSelect(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  } as unknown as ReturnType<typeof db.select>;
+}
+
+// Captures the row passed to insert(...).values(...) and resolves returning().
+function stubInsert(captured: Record<string, unknown>[], opts: { throwCode?: string } = {}) {
+  vi.mocked(db.insert).mockReturnValue({
+    values: vi.fn((v: Record<string, unknown>) => {
+      captured.push(v);
+      return {
+        returning: vi.fn(() =>
+          opts.throwCode
+            ? Promise.reject(Object.assign(new Error('dup'), { code: opts.throwCode }))
+            : Promise.resolve([{ id: 'member_1', ...v }]),
+        ),
+      };
+    }),
+  } as unknown as ReturnType<typeof db.insert>);
+}
+
+const AI_CHAT_PAGE = [{ id: AGENT, type: 'AI_CHAT' }];
+
+describe('addAgentToDrive', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('404 when the agent page does not exist', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(stubSelect([]));
+    const res = await addAgentToDrive({ actingUserId: USER, agentPageId: AGENT, driveId: DRIVE });
+    expect(res).toMatchObject({ ok: false, status: 404 });
+  });
+
+  it('400 when the page is not an AI_CHAT page', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(stubSelect([{ id: AGENT, type: 'FOLDER' }]));
+    const res = await addAgentToDrive({ actingUserId: USER, agentPageId: AGENT, driveId: DRIVE });
+    expect(res).toMatchObject({ ok: false, status: 400 });
+  });
+
+  it('403 when the user cannot view the agent', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(stubSelect(AI_CHAT_PAGE));
+    vi.mocked(canUserViewPage).mockResolvedValue(false);
+    const res = await addAgentToDrive({ actingUserId: USER, agentPageId: AGENT, driveId: DRIVE });
+    expect(res).toMatchObject({ ok: false, status: 403 });
+  });
+
+  it('403 when the user has no access to the target drive', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect(AI_CHAT_PAGE))                 // agent lookup
+      .mockReturnValueOnce(stubSelect([{ ownerId: 'someone_else' }])) // drive lookup
+      .mockReturnValueOnce(stubSelect([]));                           // no membership
+    vi.mocked(canUserViewPage).mockResolvedValue(true);
+    vi.mocked(getUserDriveAccess).mockResolvedValue(false);
+    const res = await addAgentToDrive({ actingUserId: USER, agentPageId: AGENT, driveId: DRIVE });
+    expect(res).toMatchObject({ ok: false, status: 403 });
+  });
+
+  it('inherits ADMIN when the granter owns the drive', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect(AI_CHAT_PAGE))            // agent lookup
+      .mockReturnValueOnce(stubSelect([{ ownerId: USER }]));   // drive lookup → owner
+    vi.mocked(canUserViewPage).mockResolvedValue(true);
+    const captured: Record<string, unknown>[] = [];
+    stubInsert(captured);
+
+    const res = await addAgentToDrive({ actingUserId: USER, agentPageId: AGENT, driveId: DRIVE });
+    expect(res.ok).toBe(true);
+    expect(captured[0]).toMatchObject({ role: 'ADMIN', driveId: DRIVE, agentPageId: AGENT, addedBy: USER });
+  });
+
+  it('caps a viewer (page-level access only) at MEMBER', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect(AI_CHAT_PAGE))                 // agent lookup
+      .mockReturnValueOnce(stubSelect([{ ownerId: 'someone_else' }])) // drive lookup
+      .mockReturnValueOnce(stubSelect([]));                           // no drive membership
+    vi.mocked(canUserViewPage).mockResolvedValue(true);
+    vi.mocked(getUserDriveAccess).mockResolvedValue(true); // page-level access
+    const captured: Record<string, unknown>[] = [];
+    stubInsert(captured);
+
+    const res = await addAgentToDrive({ actingUserId: USER, agentPageId: AGENT, driveId: DRIVE });
+    expect(res.ok).toBe(true);
+    expect(captured[0]).toMatchObject({ role: 'MEMBER' });
+  });
+
+  it('rejects a request to grant ADMIN when the granter is only a MEMBER', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect(AI_CHAT_PAGE))                            // agent lookup
+      .mockReturnValueOnce(stubSelect([{ ownerId: 'someone_else' }]))          // drive lookup
+      .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: null }])); // member
+    vi.mocked(canUserViewPage).mockResolvedValue(true);
+
+    const res = await addAgentToDrive({ actingUserId: USER, agentPageId: AGENT, driveId: DRIVE, requestedRole: 'ADMIN' });
+    expect(res).toMatchObject({ ok: false, status: 403 });
+  });
+
+  it('rejects assigning a custom role for non-admin granters', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect(AI_CHAT_PAGE))
+      .mockReturnValueOnce(stubSelect([{ ownerId: 'someone_else' }]))
+      .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: null }]));
+    vi.mocked(canUserViewPage).mockResolvedValue(true);
+
+    const res = await addAgentToDrive({
+      actingUserId: USER,
+      agentPageId: AGENT,
+      driveId: DRIVE,
+      requestedCustomRoleId: 'role_x',
+    });
+    expect(res).toMatchObject({ ok: false, status: 403 });
+    expect(customRoleBelongsToDrive).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 on a duplicate membership (idempotent)', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect(AI_CHAT_PAGE))
+      .mockReturnValueOnce(stubSelect([{ ownerId: USER }]));
+    vi.mocked(canUserViewPage).mockResolvedValue(true);
+    stubInsert([], { throwCode: '23505' });
+
+    const res = await addAgentToDrive({ actingUserId: USER, agentPageId: AGENT, driveId: DRIVE });
+    expect(res).toMatchObject({ ok: false, status: 409 });
+  });
+});

--- a/packages/lib/src/services/__tests__/drive-agent-service.test.ts
+++ b/packages/lib/src/services/__tests__/drive-agent-service.test.ts
@@ -36,7 +36,7 @@ vi.mock('../../permissions/membership-queries', () => ({
 
 import { addAgentToDrive } from '../drive-agent-service';
 import { db } from '@pagespace/db/db';
-import { canUserViewPage, getUserDriveAccess } from '../../permissions/permissions';
+import { canUserEditPage, getUserDriveAccess } from '../../permissions/permissions';
 import { customRoleBelongsToDrive } from '../../permissions/membership-queries';
 
 const USER = 'user_aaaaaaaaaaaaaaaaaaaaaa';
@@ -86,11 +86,16 @@ describe('addAgentToDrive', () => {
     expect(res).toMatchObject({ ok: false, status: 400 });
   });
 
-  it('403 when the user cannot view the agent', async () => {
+  // Regression: view-only access to a shared agent must NOT be enough to bind it
+  // to a drive. Running the agent is gated by edit access, so a view-only granter
+  // could otherwise leak a private drive to everyone who can run the agent.
+  it('403 when the user can only view (not edit) the agent', async () => {
     vi.mocked(db.select).mockReturnValueOnce(stubSelect(AI_CHAT_PAGE));
-    vi.mocked(canUserViewPage).mockResolvedValue(false);
+    vi.mocked(canUserEditPage).mockResolvedValue(false);
     const res = await addAgentToDrive({ actingUserId: USER, agentPageId: AGENT, driveId: DRIVE });
     expect(res).toMatchObject({ ok: false, status: 403 });
+    // Drive access must never be consulted once the agent gate fails.
+    expect(getUserDriveAccess).not.toHaveBeenCalled();
   });
 
   it('403 when the user has no access to the target drive', async () => {
@@ -98,7 +103,7 @@ describe('addAgentToDrive', () => {
       .mockReturnValueOnce(stubSelect(AI_CHAT_PAGE))                 // agent lookup
       .mockReturnValueOnce(stubSelect([{ ownerId: 'someone_else' }])) // drive lookup
       .mockReturnValueOnce(stubSelect([]));                           // no membership
-    vi.mocked(canUserViewPage).mockResolvedValue(true);
+    vi.mocked(canUserEditPage).mockResolvedValue(true);
     vi.mocked(getUserDriveAccess).mockResolvedValue(false);
     const res = await addAgentToDrive({ actingUserId: USER, agentPageId: AGENT, driveId: DRIVE });
     expect(res).toMatchObject({ ok: false, status: 403 });
@@ -108,7 +113,7 @@ describe('addAgentToDrive', () => {
     vi.mocked(db.select)
       .mockReturnValueOnce(stubSelect(AI_CHAT_PAGE))            // agent lookup
       .mockReturnValueOnce(stubSelect([{ ownerId: USER }]));   // drive lookup → owner
-    vi.mocked(canUserViewPage).mockResolvedValue(true);
+    vi.mocked(canUserEditPage).mockResolvedValue(true);
     const captured: Record<string, unknown>[] = [];
     stubInsert(captured);
 
@@ -122,7 +127,7 @@ describe('addAgentToDrive', () => {
       .mockReturnValueOnce(stubSelect(AI_CHAT_PAGE))                 // agent lookup
       .mockReturnValueOnce(stubSelect([{ ownerId: 'someone_else' }])) // drive lookup
       .mockReturnValueOnce(stubSelect([]));                           // no drive membership
-    vi.mocked(canUserViewPage).mockResolvedValue(true);
+    vi.mocked(canUserEditPage).mockResolvedValue(true);
     vi.mocked(getUserDriveAccess).mockResolvedValue(true); // page-level access
     const captured: Record<string, unknown>[] = [];
     stubInsert(captured);
@@ -137,7 +142,7 @@ describe('addAgentToDrive', () => {
       .mockReturnValueOnce(stubSelect(AI_CHAT_PAGE))                            // agent lookup
       .mockReturnValueOnce(stubSelect([{ ownerId: 'someone_else' }]))          // drive lookup
       .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: null }])); // member
-    vi.mocked(canUserViewPage).mockResolvedValue(true);
+    vi.mocked(canUserEditPage).mockResolvedValue(true);
 
     const res = await addAgentToDrive({ actingUserId: USER, agentPageId: AGENT, driveId: DRIVE, requestedRole: 'ADMIN' });
     expect(res).toMatchObject({ ok: false, status: 403 });
@@ -148,7 +153,7 @@ describe('addAgentToDrive', () => {
       .mockReturnValueOnce(stubSelect(AI_CHAT_PAGE))
       .mockReturnValueOnce(stubSelect([{ ownerId: 'someone_else' }]))
       .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: null }]));
-    vi.mocked(canUserViewPage).mockResolvedValue(true);
+    vi.mocked(canUserEditPage).mockResolvedValue(true);
 
     const res = await addAgentToDrive({
       actingUserId: USER,
@@ -164,7 +169,7 @@ describe('addAgentToDrive', () => {
     vi.mocked(db.select)
       .mockReturnValueOnce(stubSelect(AI_CHAT_PAGE))
       .mockReturnValueOnce(stubSelect([{ ownerId: USER }]));
-    vi.mocked(canUserViewPage).mockResolvedValue(true);
+    vi.mocked(canUserEditPage).mockResolvedValue(true);
     stubInsert([], { throwCode: '23505' });
 
     const res = await addAgentToDrive({ actingUserId: USER, agentPageId: AGENT, driveId: DRIVE });

--- a/packages/lib/src/services/drive-agent-service.ts
+++ b/packages/lib/src/services/drive-agent-service.ts
@@ -13,7 +13,7 @@ import { db } from '@pagespace/db/db';
 import { eq, and, isNotNull } from '@pagespace/db/operators';
 import { drives, pages } from '@pagespace/db/schema/core';
 import { driveAgentMembers, driveMembers } from '@pagespace/db/schema/members';
-import { canUserViewPage, canUserEditPage, getUserDriveAccess, isDriveOwnerOrAdmin } from '../permissions/permissions';
+import { canUserEditPage, getUserDriveAccess, isDriveOwnerOrAdmin } from '../permissions/permissions';
 import { customRoleBelongsToDrive } from '../permissions/membership-queries';
 
 export type AgentDriveRole = 'MEMBER' | 'ADMIN';
@@ -103,9 +103,14 @@ export async function addAgentToDrive(input: AddAgentToDriveInput): Promise<AddA
     return { ok: false, status: 400, error: 'agentPageId must reference an AI_CHAT page' };
   }
 
-  // The acting user must be able to use the agent (e.g. a hub agent they can view but don't own).
-  if (!(await canUserViewPage(actingUserId, agentPageId))) {
-    return { ok: false, status: 403, error: 'You do not have access to this agent' };
+  // The acting user must *control* the agent (edit access), not merely view it.
+  // Membership is a property of the agent shared by everyone who can run it
+  // (running is gated by `canUserEditPage` in the chat route), so attaching the
+  // agent to a drive must require the same control. A view-only granter could
+  // otherwise bind a shared agent to a private drive and leak that drive's
+  // content to every user who can run the agent.
+  if (!(await canUserEditPage(actingUserId, agentPageId))) {
+    return { ok: false, status: 403, error: 'You do not have permission to manage this agent' };
   }
 
   const granter = await resolveGranterAccess(actingUserId, driveId);

--- a/packages/lib/src/services/drive-agent-service.ts
+++ b/packages/lib/src/services/drive-agent-service.ts
@@ -1,0 +1,251 @@
+/**
+ * Drive Agent Service - membership of AI agents (AI_CHAT pages) in drives.
+ *
+ * An agent can be a member of drives other than its home drive. Membership is
+ * the sole mechanism that grants an agent's tools access to a drive's content
+ * (see `hasAgentDriveMembership` / `getAgentAccessLevel`). This service is the
+ * single seam for creating/removing those memberships, with authorization and
+ * role-capping applied consistently for both entry points (the agent's own
+ * settings, and the drive-side "invite agent" flow).
+ */
+
+import { db } from '@pagespace/db/db';
+import { eq, and, isNotNull } from '@pagespace/db/operators';
+import { drives, pages } from '@pagespace/db/schema/core';
+import { driveAgentMembers, driveMembers } from '@pagespace/db/schema/members';
+import { canUserViewPage, canUserEditPage, getUserDriveAccess, isDriveOwnerOrAdmin } from '../permissions/permissions';
+import { customRoleBelongsToDrive } from '../permissions/membership-queries';
+
+export type AgentDriveRole = 'MEMBER' | 'ADMIN';
+
+export interface AddAgentToDriveInput {
+  actingUserId: string;
+  agentPageId: string;
+  driveId: string;
+  /** Explicit role request (drive-side invite). Omitted ⇒ inherit the granter's access. */
+  requestedRole?: AgentDriveRole;
+  /** Optional custom drive role to assign (owners/admins only). */
+  requestedCustomRoleId?: string | null;
+}
+
+export type ServiceFailure = { ok: false; status: number; error: string };
+
+export type AddAgentToDriveResult =
+  | { ok: true; status: 201; member: typeof driveAgentMembers.$inferSelect }
+  | ServiceFailure;
+
+export interface AgentDriveMembership {
+  driveId: string;
+  driveName: string;
+  driveSlug: string;
+  role: 'OWNER' | 'ADMIN' | 'MEMBER';
+  customRoleId: string | null;
+  isHome: boolean;
+}
+
+/**
+ * Resolve the acting user's access to a drive, used to cap what they may grant
+ * an agent. Owners/admins may grant up to ADMIN (or a custom role); plain
+ * members and page-level collaborators are capped at MEMBER.
+ */
+async function resolveGranterAccess(
+  userId: string,
+  driveId: string,
+): Promise<{ canGrant: boolean; maxRole: AgentDriveRole; customRoleId: string | null }> {
+  const [drive] = await db
+    .select({ ownerId: drives.ownerId })
+    .from(drives)
+    .where(eq(drives.id, driveId))
+    .limit(1);
+
+  if (!drive) return { canGrant: false, maxRole: 'MEMBER', customRoleId: null };
+  if (drive.ownerId === userId) return { canGrant: true, maxRole: 'ADMIN', customRoleId: null };
+
+  const [membership] = await db
+    .select({ role: driveMembers.role, customRoleId: driveMembers.customRoleId })
+    .from(driveMembers)
+    .where(and(
+      eq(driveMembers.driveId, driveId),
+      eq(driveMembers.userId, userId),
+      isNotNull(driveMembers.acceptedAt),
+    ))
+    .limit(1);
+
+  if (membership) {
+    return {
+      canGrant: true,
+      maxRole: membership.role === 'ADMIN' ? 'ADMIN' : 'MEMBER',
+      customRoleId: membership.customRoleId ?? null,
+    };
+  }
+
+  // Page-level collaborator only (no drive membership): may grant, capped at MEMBER.
+  const hasAccess = await getUserDriveAccess(userId, driveId);
+  return { canGrant: hasAccess, maxRole: 'MEMBER', customRoleId: null };
+}
+
+/**
+ * Add an agent (AI_CHAT page) as a member of a drive. The agent's home drive
+ * may differ from the target drive. The granted role never exceeds the acting
+ * user's own access to the drive.
+ */
+export async function addAgentToDrive(input: AddAgentToDriveInput): Promise<AddAgentToDriveResult> {
+  const { actingUserId, agentPageId, driveId, requestedRole, requestedCustomRoleId } = input;
+
+  const [agentPage] = await db
+    .select({ id: pages.id, type: pages.type })
+    .from(pages)
+    .where(eq(pages.id, agentPageId))
+    .limit(1);
+
+  if (!agentPage) return { ok: false, status: 404, error: 'Agent page not found' };
+  if (agentPage.type !== 'AI_CHAT') {
+    return { ok: false, status: 400, error: 'agentPageId must reference an AI_CHAT page' };
+  }
+
+  // The acting user must be able to use the agent (e.g. a hub agent they can view but don't own).
+  if (!(await canUserViewPage(actingUserId, agentPageId))) {
+    return { ok: false, status: 403, error: 'You do not have access to this agent' };
+  }
+
+  const granter = await resolveGranterAccess(actingUserId, driveId);
+  if (!granter.canGrant) {
+    return { ok: false, status: 403, error: 'You do not have access to this drive' };
+  }
+
+  let effectiveRole: AgentDriveRole;
+  let effectiveCustomRoleId: string | null = null;
+
+  if (requestedCustomRoleId) {
+    if (granter.maxRole !== 'ADMIN') {
+      return { ok: false, status: 403, error: 'Only drive owners and admins can assign custom roles' };
+    }
+    if (!(await customRoleBelongsToDrive(requestedCustomRoleId, driveId))) {
+      return { ok: false, status: 404, error: 'Custom role not found in this drive' };
+    }
+    effectiveRole = 'MEMBER';
+    effectiveCustomRoleId = requestedCustomRoleId;
+  } else if (requestedRole) {
+    if (requestedRole === 'ADMIN' && granter.maxRole !== 'ADMIN') {
+      return { ok: false, status: 403, error: 'You cannot grant a role higher than your own access' };
+    }
+    effectiveRole = requestedRole;
+  } else {
+    // Inherit the granter's access (agent-side add).
+    effectiveRole = granter.maxRole;
+    effectiveCustomRoleId = granter.customRoleId;
+  }
+
+  try {
+    const [member] = await db
+      .insert(driveAgentMembers)
+      .values({
+        driveId,
+        agentPageId,
+        role: effectiveRole,
+        customRoleId: effectiveCustomRoleId,
+        addedBy: actingUserId,
+      })
+      .returning();
+    return { ok: true, status: 201, member };
+  } catch (err) {
+    if ((err as { code?: string }).code === '23505') {
+      return { ok: false, status: 409, error: 'Agent is already a member of this drive' };
+    }
+    throw err;
+  }
+}
+
+/**
+ * Remove an agent's membership from a drive. The agent's home drive cannot be
+ * removed. Allowed for users who control the agent or who own/admin the drive.
+ */
+export async function removeAgentFromDrive(input: {
+  actingUserId: string;
+  agentPageId: string;
+  driveId: string;
+}): Promise<{ ok: true } | ServiceFailure> {
+  const { actingUserId, agentPageId, driveId } = input;
+
+  const [agentPage] = await db
+    .select({ id: pages.id, driveId: pages.driveId })
+    .from(pages)
+    .where(eq(pages.id, agentPageId))
+    .limit(1);
+
+  if (!agentPage) return { ok: false, status: 404, error: 'Agent page not found' };
+  if (agentPage.driveId === driveId) {
+    return { ok: false, status: 400, error: 'Cannot remove an agent from its home drive' };
+  }
+
+  const canManage =
+    (await canUserEditPage(actingUserId, agentPageId)) ||
+    (await isDriveOwnerOrAdmin(actingUserId, driveId));
+  if (!canManage) {
+    return { ok: false, status: 403, error: 'You cannot manage this agent membership' };
+  }
+
+  const deleted = await db
+    .delete(driveAgentMembers)
+    .where(and(eq(driveAgentMembers.agentPageId, agentPageId), eq(driveAgentMembers.driveId, driveId)))
+    .returning({ id: driveAgentMembers.id });
+
+  if (deleted.length === 0) return { ok: false, status: 404, error: 'Membership not found' };
+  return { ok: true };
+}
+
+/**
+ * List the drives an agent can access: its membership rows plus its home drive
+ * (the home drive is always included, even if a legacy agent lacks a membership
+ * row for it).
+ */
+export async function listAgentDrives(agentPageId: string): Promise<AgentDriveMembership[]> {
+  const [agentPage] = await db
+    .select({ driveId: pages.driveId })
+    .from(pages)
+    .where(eq(pages.id, agentPageId))
+    .limit(1);
+
+  if (!agentPage) return [];
+
+  const rows = await db
+    .select({
+      driveId: driveAgentMembers.driveId,
+      role: driveAgentMembers.role,
+      customRoleId: driveAgentMembers.customRoleId,
+      driveName: drives.name,
+      driveSlug: drives.slug,
+    })
+    .from(driveAgentMembers)
+    .innerJoin(drives, eq(driveAgentMembers.driveId, drives.id))
+    .where(eq(driveAgentMembers.agentPageId, agentPageId));
+
+  const result: AgentDriveMembership[] = rows.map((r) => ({
+    driveId: r.driveId,
+    driveName: r.driveName,
+    driveSlug: r.driveSlug,
+    role: r.role,
+    customRoleId: r.customRoleId ?? null,
+    isHome: r.driveId === agentPage.driveId,
+  }));
+
+  if (!result.some((r) => r.isHome)) {
+    const [home] = await db
+      .select({ id: drives.id, name: drives.name, slug: drives.slug })
+      .from(drives)
+      .where(eq(drives.id, agentPage.driveId))
+      .limit(1);
+    if (home) {
+      result.unshift({
+        driveId: home.id,
+        driveName: home.name,
+        driveSlug: home.slug,
+        role: 'ADMIN',
+        customRoleId: null,
+        isHome: true,
+      });
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
## What & why

We have a shared **AI agent hub drive** that everyone can access. The goal: an agent that lives in a user's own drive should be able to **reach the hub's content/"skills"** (and any drive its owner/an admin grants it) using its normal tools — **without copying the agent**, and with its chat **interface staying in its home drive**.

A ground-truth audit showed content access is already gated by `driveAgentMembers` membership; the blockers were narrow: a guard rejecting cross-drive membership, an inconsistent `list_drives` (the only drive tool scoped to the *user* rather than the agent), and no UI to manage it.

## Changes

**Backend**
- `packages/lib/src/services/drive-agent-service.ts` — shared service: `addAgentToDrive` / `removeAgentFromDrive` / `listAgentDrives`. Authorizes `canUserEditPage(agent)` (control over the agent — the same gate as *running* it in the chat route) + `getUserDriveAccess(drive)` and **caps the granted role at the acting user's own access** (owner/admin → ADMIN or custom role; member/viewer → MEMBER). Removing the home drive is refused; inserts are idempotent.
- Relaxed the home-drive guard on `POST /api/drives/[driveId]/agents` (now routed through the service).
- Agent-centric API: `GET/POST /api/ai/page-agents/[agentId]/drives` and `DELETE …/drives/[driveId]`.
- `list_drives` is now **membership-scoped for page-agents** (home drive ∪ memberships), so discovery matches where the agent can actually act — closing a catalog-enumeration leak. The user / global-assistant path is unchanged.
- `getAgentAccessiblePagesInDrive`: a plain `MEMBER` agent can now **enumerate** a drive's pages (view-only), not just `read_page` by id — so a hub-member agent can browse the hub.

**UI**
- "Drives this agent can access" section in the agent settings tab (`AgentDrivesCard`): list / add / remove, with the home drive pinned.
- "Invite Agent" action in the drive members panel (`InviteAgentDialog`): mirrors the human invite with a role selector (role capped server-side).

## Access semantics

- **Role-bound at runtime** — the agent acts with its own `driveAgentMembers` role (MEMBER → view-only, ADMIN → full, custom role → that role's perms).
- **User-bound at grant time** — you can never grant an agent more than you have on the target drive.
- **Agent-control required to grant** — binding an agent to a drive requires *edit* access to the agent (the same gate as running it), not mere view. A membership is shared by everyone who can run the agent, so a view-only granter must not be able to bind a shared agent to a private drive and leak it to the agent's other runners.

## Tests / checks

- New `drive-agent-service` unit tests (auth allow/deny, role inherit + cap, idempotency), incl. a regression asserting view-only access to the agent is rejected (403) before any drive access is consulted; extended `agent-permissions` tests (ADMIN/MEMBER/none enumeration); new `list_drives` agent-scoping case.
- Existing `drive-tools`, `DriveMembers`, and both `agents` route suites pass.
- `apps/web` and `@pagespace/lib` typecheck: **0 errors**. Lint clean.

## Follow-up

Deferred items tracked in #1450 (explicit global override, broader `userId`-tool sweep, per-membership drive-context, and stricter live user-binding semantics). Migration-free PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

