### PR TITLE
feat(migration): backfill enabledTools with trash/restore verb tools

### DIFF
--- a/scripts/__tests__/backfill-trash-verb-tools.test.ts
+++ b/scripts/__tests__/backfill-trash-verb-tools.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import {
+  addTrashVerbTools,
+  TRASH_VERB_TOOLS,
+  RESTORE_VERB_TOOLS,
+  TRASH_TRIGGER,
+  RESTORE_TRIGGER,
+} from '../lib/trash-verb-tools';
+
+describe('addTrashVerbTools', () => {
+  it('adds the trash verbs when trash is present', () => {
+    const result = addTrashVerbTools([TRASH_TRIGGER]);
+    expect(result).toEqual(['trash', 'trash_page', 'trash_drive']);
+  });
+
+  it('adds the restore verbs when restore is present', () => {
+    const result = addTrashVerbTools([RESTORE_TRIGGER]);
+    expect(result).toEqual(['restore', 'restore_page', 'restore_drive']);
+  });
+
+  it('adds both sets of verbs when trash and restore are present', () => {
+    const result = addTrashVerbTools(['trash', 'restore']);
+    expect(result).toEqual([
+      'trash',
+      'restore',
+      'trash_page',
+      'trash_drive',
+      'restore_page',
+      'restore_drive',
+    ]);
+  });
+
+  it('is a no-op when neither trigger is present', () => {
+    const input = ['read_page', 'search', 'create_page'];
+    const result = addTrashVerbTools(input);
+    expect(result).toEqual(input);
+  });
+
+  it('is a no-op when the trash verbs are already present', () => {
+    const input = ['trash', 'trash_page', 'trash_drive'];
+    const result = addTrashVerbTools(input);
+    expect(result).toEqual(input);
+  });
+
+  it('is a no-op when the restore verbs are already present', () => {
+    const input = ['restore', 'restore_page', 'restore_drive'];
+    const result = addTrashVerbTools(input);
+    expect(result).toEqual(input);
+  });
+
+  it('appends only the missing verb for a partially-populated allowlist', () => {
+    const input = ['trash', 'trash_page', 'restore', 'restore_drive'];
+    const result = addTrashVerbTools(input);
+    expect(result).toEqual([
+      'trash',
+      'trash_page',
+      'restore',
+      'restore_drive',
+      'trash_drive',
+      'restore_page',
+    ]);
+  });
+
+  it('preserves other tools and their order, appending only missing verbs', () => {
+    const input = ['read_page', 'trash', 'search', 'restore'];
+    const result = addTrashVerbTools(input);
+    expect(result).toEqual([
+      'read_page',
+      'trash',
+      'search',
+      'restore',
+      'trash_page',
+      'trash_drive',
+      'restore_page',
+      'restore_drive',
+    ]);
+  });
+
+  it('appends verbs to a mixed array containing trash, keeping non-string entries', () => {
+    // Mirrors runtime: the allowlist grants trash via Array.includes, so a
+    // legacy/mixed array must still receive the verbs without dropping junk.
+    const input = ['trash', 123, 'read_page'];
+    const result = addTrashVerbTools(input);
+    expect(result).toEqual([
+      'trash',
+      123,
+      'read_page',
+      'trash_page',
+      'trash_drive',
+    ]);
+  });
+
+  it('is a no-op for a mixed array that contains neither trigger', () => {
+    const input = ['read_page', 42, { tool: 'x' }];
+    const result = addTrashVerbTools(input);
+    expect(result).toEqual(input);
+  });
+
+  it('is idempotent across repeated application', () => {
+    const once = addTrashVerbTools(['trash', 'restore']);
+    const twice = addTrashVerbTools(once);
+    expect(twice).toEqual(once);
+  });
+
+  it('leaves an empty allowlist untouched', () => {
+    expect(addTrashVerbTools([])).toEqual([]);
+  });
+
+  it('exposes the expected verb tool names', () => {
+    expect(TRASH_VERB_TOOLS).toEqual(['trash_page', 'trash_drive']);
+    expect(RESTORE_VERB_TOOLS).toEqual(['restore_page', 'restore_drive']);
+  });
+});

--- a/scripts/backfill-trash-verb-tools.ts
+++ b/scripts/backfill-trash-verb-tools.ts
@@ -56,8 +56,8 @@ async function backfill(dryRun: boolean): Promise<void> {
     scanned += 1;
 
     if (!Array.isArray(row.enabledTools)) {
-      // The ?| filter only matches jsonb arrays (or objects); this guards the
-      // unexpected (e.g. a jsonb scalar) rather than corrupting the value.
+      // The `@>` filter only matches jsonb arrays; this guards the unexpected
+      // (e.g. a jsonb scalar) rather than corrupting the value.
       console.warn(`⚠️  Skipping page ${row.id}: enabledTools is not an array.`);
       skipped += 1;
       continue;

--- a/scripts/backfill-trash-verb-tools.ts
+++ b/scripts/backfill-trash-verb-tools.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env bun
+/**
+ * Backfill Script: Grant trash/restore verb tools to AI_CHAT agents
+ *
+ * Sub-PR 2 of 3 (additive migration, hard cutover plan).
+ *
+ * Sub-PR 1 split the discriminated `trash`/`restore` AI tools into explicit
+ * per-entity verbs (`trash_page`, `trash_drive`, `restore_page`,
+ * `restore_drive`). Per-page AI agents store a curated allowlist of tool names
+ * in `pages.enabledTools` (jsonb array). When that allowlist is set, the agent
+ * may only call those tools. Sub-PR 3 will remove `trash`/`restore`, so BEFORE
+ * that cutover every agent currently allowed `trash` must also be granted the
+ * trash verbs, and every agent allowed `restore` the restore verbs.
+ *
+ * For every `pages` row whose `enabledTools` array contains `"trash"` or
+ * `"restore"`, this script appends the corresponding verbs if not already
+ * present (preserving existing entries and order). Rows where `enabledTools`
+ * is null (unrestricted agents) or contains neither trigger are left
+ * untouched. Running it twice produces no changes.
+ *
+ * Usage:
+ *   bun scripts/backfill-trash-verb-tools.ts [--dry-run]
+ *
+ * Options:
+ *   --dry-run   Report what would change without writing to the database.
+ */
+
+import { db } from '@pagespace/db/db';
+import { pages } from '@pagespace/db/schema/core';
+import { eq, sql } from '@pagespace/db/operators';
+import {
+  addTrashVerbTools,
+  TRASH_TRIGGER,
+  RESTORE_TRIGGER,
+} from './lib/trash-verb-tools';
+
+async function backfill(dryRun: boolean): Promise<void> {
+  console.log(
+    `🚀 Backfilling enabledTools with trash/restore verb tools${dryRun ? ' (dry run)' : ''}...`,
+  );
+
+  // Narrow to candidate rows in SQL: jsonb arrays that contain "trash" or
+  // "restore" (the `@>` containment operator, mirroring the task-verb backfill).
+  const rows = await db
+    .select({ id: pages.id, enabledTools: pages.enabledTools })
+    .from(pages)
+    .where(
+      sql`${pages.enabledTools} @> ${JSON.stringify([TRASH_TRIGGER])}::jsonb OR ${pages.enabledTools} @> ${JSON.stringify([RESTORE_TRIGGER])}::jsonb`,
+    );
+
+  let scanned = 0;
+  let updated = 0;
+  let skipped = 0;
+
+  for (const row of rows) {
+    scanned += 1;
+
+    if (!Array.isArray(row.enabledTools)) {
+      // The ?| filter only matches jsonb arrays (or objects); this guards the
+      // unexpected (e.g. a jsonb scalar) rather than corrupting the value.
+      console.warn(`⚠️  Skipping page ${row.id}: enabledTools is not an array.`);
+      skipped += 1;
+      continue;
+    }
+
+    const next = addTrashVerbTools(row.enabledTools);
+    if (next.length === row.enabledTools.length) {
+      // Already has every needed verb — no change required (idempotent).
+      skipped += 1;
+      continue;
+    }
+
+    if (dryRun) {
+      console.log(
+        `  would update page ${row.id}: [${row.enabledTools.join(', ')}] -> [${next.join(', ')}]`,
+      );
+    } else {
+      await db.update(pages).set({ enabledTools: next }).where(eq(pages.id, row.id));
+    }
+    updated += 1;
+  }
+
+  console.log(
+    `✅ Backfill ${dryRun ? 'dry run ' : ''}complete. scanned: ${scanned}, ${
+      dryRun ? 'would update' : 'updated'
+    }: ${updated}, unchanged: ${skipped}`,
+  );
+}
+
+if (require.main === module) {
+  const dryRun = process.argv.slice(2).includes('--dry-run');
+  backfill(dryRun)
+    .then(() => process.exit(0))
+    .catch((error) => {
+      console.error('💥 Backfill failed:', error);
+      process.exit(1);
+    });
+}
+
+export { backfill };

--- a/scripts/lib/trash-verb-tools.ts
+++ b/scripts/lib/trash-verb-tools.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure helpers for the enabledTools trash/restore-verb backfill.
+ *
+ * Sub-PR 1 split the discriminated `trash`/`restore` AI tools into explicit
+ * per-entity verbs (`trash_page`, `trash_drive`, `restore_page`,
+ * `restore_drive`). Per-page AI agents (AI_CHAT pages) store a curated
+ * allowlist of tool names in `pages.enabledTools`. Before `trash`/`restore`
+ * are removed (sub-PR 3), every agent currently allowed `trash` must also be
+ * granted the trash verbs, and every agent allowed `restore` must also be
+ * granted the restore verbs, so it does not lose trash/restore ability.
+ *
+ * The runtime grants a tool purely via `Array.includes(name)`, so a legacy or
+ * mixed array (e.g. containing non-string junk alongside `"trash"`) still
+ * grants `trash` at runtime. This transform mirrors that: it acts on any array
+ * that contains the string `"trash"` or `"restore"`, regardless of what else is
+ * in it, and preserves every existing entry untouched.
+ *
+ * This module is intentionally dependency-free so it can be unit-tested without
+ * touching the database.
+ */
+
+/** The tools whose presence triggers the backfill. */
+export const TRASH_TRIGGER = 'trash';
+export const RESTORE_TRIGGER = 'restore';
+
+/** The verb tools that must be granted alongside `trash`. */
+export const TRASH_VERB_TOOLS = ['trash_page', 'trash_drive'] as const;
+
+/** The verb tools that must be granted alongside `restore`. */
+export const RESTORE_VERB_TOOLS = ['restore_page', 'restore_drive'] as const;
+
+/**
+ * Add the trash/restore verb tools to an enabledTools allowlist.
+ *
+ * Mirrors runtime allowlist semantics (`Array.includes`):
+ * - If the array contains the string `"trash"`, the missing trash verbs
+ *   (in {@link TRASH_VERB_TOOLS} order) are appended.
+ * - If the array contains the string `"restore"`, the missing restore verbs
+ *   (in {@link RESTORE_VERB_TOOLS} order) are appended.
+ * - If it contains neither trigger, it is returned unchanged.
+ * - All existing entries — including any non-string values — are preserved in
+ *   place; nothing is dropped or reordered.
+ * - Idempotent: a second call on the result produces no further changes.
+ */
+export function addTrashVerbTools(tools: unknown[]): unknown[] {
+  const missing: string[] = [];
+
+  if (tools.includes(TRASH_TRIGGER)) {
+    missing.push(...TRASH_VERB_TOOLS.filter((verb) => !tools.includes(verb)));
+  }
+
+  if (tools.includes(RESTORE_TRIGGER)) {
+    missing.push(...RESTORE_VERB_TOOLS.filter((verb) => !tools.includes(verb)));
+  }
+
+  if (missing.length === 0) {
+    return tools;
+  }
+
+  return [...tools, ...missing];
+}


### PR DESCRIPTION
## Epic 3 / Sub-PR 2 of 3 — backfill `enabledTools` with trash/restore verb tools

Additive migration. Does **not** remove the legacy `trash`/`restore` tools (that's sub-PR 3).

### Why
Sub-PR 1 (already in this base branch) split the discriminated `trash`/`restore` AI tools into explicit per-entity verbs: `trash_page`, `trash_drive`, `restore_page`, `restore_drive` (delegating to the shared `trashPage`/`trashDrive`/`restorePage`/`restoreDrive` helpers; `trash_drive` requires `confirmDriveName`).

Per-page AI agents store a curated allowlist of tool names in `pages.enabledTools` (jsonb). Before sub-PR 3 removes `trash`/`restore`, every agent allowed `trash` must also be granted `trash_page`+`trash_drive`, and every agent allowed `restore` must also get `restore_page`+`restore_drive` — otherwise those agents silently lose trash/restore capability at the cutover.

This mirrors the Epic 2 task-verb backfill (`scripts/lib/task-verb-tools.ts`, `scripts/backfill-task-verb-tools.ts`) exactly.

### What
- **`scripts/lib/trash-verb-tools.ts`** — pure `addTrashVerbTools(tools: unknown[]): unknown[]`. Appends trash verbs when the array `.includes('trash')` and restore verbs when it `.includes('restore')`, only adding ones not already present. Accepts `unknown[]` and preserves every existing entry (incl. non-strings) to match the runtime allowlist's `Array.includes` semantics — the same legacy/mixed-array case Codex flagged on Epic 2, handled from the start. Idempotent.
- **`scripts/backfill-trash-verb-tools.ts`** — runner mirroring `backfill-task-verb-tools.ts`: same db setup, jsonb `@>` candidate filter (matches `trash` OR `restore`), per-row transform, `--dry-run`, logging, idempotency, non-array guard.
- **`scripts/__tests__/backfill-trash-verb-tools.test.ts`** — 13 transform unit tests: trash-only, restore-only, both, neither, partially-populated, idempotent, mixed `['trash', 123, 'read_page']` (keeps junk + appends), order preservation, empty array, exposed verb names.

### Local verification
CI does not run on PRs to `feat/split-update-task`, so verification is pasted below.

**Transform tests** (`scripts/vitest.config.ts`):
```
$ bunx vitest run __tests__/backfill-trash-verb-tools.test.ts
 ✓ __tests__/backfill-trash-verb-tools.test.ts (13 tests) 3ms
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

**Typecheck** (root tsconfig, strict, new files): clean, exit 0.

**Lint** (`eslint --config scripts/eslint.config.mjs`): clean, exit 0.

No `any` types. The backfill was **not** run against any database — script + tests only.

### Not in scope
- Removing `trash`/`restore` (sub-PR 3).
- Running the migration.

**Do not merge** — opened against `feat/split-update-task` for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
