### PR TITLE
feat(uploads): direct-to-S3 presigned upload (foundation)

### DIFF
--- a/apps/processor/src/api/__tests__/ingest.test.ts
+++ b/apps/processor/src/api/__tests__/ingest.test.ts
@@ -180,3 +180,54 @@ describe('POST /ingest/by-page/:pageId', () => {
     expect(response.body.error).toContain('Invalid content hash');
   });
 });
+
+describe('POST /ingest/pull/:pageId (verified direct-to-S3 ingest)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsValidContentHash.mockReturnValue(true);
+    mockGetPageForIngestion.mockResolvedValue({
+      id: 'page-1',
+      contentHash: VALID_HASH,
+      mimeType: 'image/png',
+      originalFileName: 'photo.png',
+    });
+    mockAssertFileAccess.mockResolvedValue({ allowed: true });
+    mockAddJob.mockResolvedValue('pull-job-1');
+  });
+
+  it('returns 401 when no auth', async () => {
+    const response = await request(createApp()).post('/ingest/pull/page-1');
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 403 when page binding mismatches', async () => {
+    const app = createApp({ userId: 'user-1', resourceBinding: { type: 'page', id: 'other-page' } });
+    const response = await request(app).post('/ingest/pull/page-1');
+    expect(response.status).toBe(403);
+  });
+
+  it('returns 404 when page not found', async () => {
+    mockGetPageForIngestion.mockResolvedValue(null);
+    const response = await request(createApp({ userId: 'user-1' })).post('/ingest/pull/page-1');
+    expect(response.status).toBe(404);
+  });
+
+  it('returns 400 when contentHash is invalid', async () => {
+    mockIsValidContentHash.mockReturnValue(false);
+    const response = await request(createApp({ userId: 'user-1' })).post('/ingest/pull/page-1');
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 403 when assertFileAccess throws', async () => {
+    mockAssertFileAccess.mockRejectedValue(new Error('Access denied'));
+    const response = await request(createApp({ userId: 'user-1' })).post('/ingest/pull/page-1');
+    expect(response.status).toBe(403);
+  });
+
+  it('enqueues the pull-verify job (not ingest-file) with pageId + contentHash', async () => {
+    const response = await request(createApp({ userId: 'user-1' })).post('/ingest/pull/page-1');
+    expect(response.status).toBe(200);
+    expect(response.body.jobId).toBe('pull-job-1');
+    expect(mockAddJob).toHaveBeenCalledWith('pull-verify', { pageId: 'page-1', contentHash: VALID_HASH });
+  });
+});

--- a/apps/processor/src/api/__tests__/s3-pull-adapter.test.ts
+++ b/apps/processor/src/api/__tests__/s3-pull-adapter.test.ts
@@ -18,7 +18,7 @@ const mocks = vi.hoisted(() => ({
   extractVideoThumbnail: vi.fn(),
 }));
 
-vi.mock('../../cache/content-store', () => ({
+vi.mock('../../server', () => ({
   contentStore: {
     getOriginal: mocks.getOriginal,
     deleteOriginal: mocks.deleteOriginal,

--- a/apps/processor/src/api/__tests__/s3-pull-adapter.test.ts
+++ b/apps/processor/src/api/__tests__/s3-pull-adapter.test.ts
@@ -61,7 +61,10 @@ beforeEach(() => {
   mocks.isAllowedContentType.mockReturnValue(true);
   mocks.detectContentType.mockResolvedValue({ label: 'pdf', mimeType: 'application/pdf', score: 0.9, source: 'magika' });
   mocks.extractTextContent.mockResolvedValue('extracted text');
-  mocks.generateImageVariants.mockResolvedValue({ thumbnail: Buffer.from('t'), preview: Buffer.from('p') });
+  mocks.generateImageVariants.mockResolvedValue({
+    thumbnail: { buffer: Buffer.from('t'), mimeType: 'image/webp' },
+    'ai-chat': { buffer: Buffer.from('j'), mimeType: 'image/jpeg' },
+  });
   mocks.extractVideoMetadata.mockResolvedValue({ duration: 10, width: 640, height: 480 });
   mocks.extractVideoThumbnail.mockResolvedValue(Buffer.from('thumb'));
 });
@@ -114,6 +117,16 @@ describe('runPullPipeline — zero-trust gates', () => {
     expect(mocks.setPageFailed).toHaveBeenCalled();
   });
 
+  it('still marks the page failed when deleting the rejected object throws', async () => {
+    mocks.getOriginal.mockResolvedValue(BYTES);
+    mocks.verifyContentHash.mockReturnValue(false);
+    mocks.deleteOriginal.mockRejectedValue(new Error('S3 down'));
+
+    await runPullPipeline({ pageId: 'page-1', contentHash: HASH }, NO_WAIT);
+
+    expect(mocks.setPageFailed).toHaveBeenCalled();
+  });
+
   it('does not delete or persist when verification passes and type is allowed', async () => {
     mocks.getOriginal.mockResolvedValue(BYTES);
     await runPullPipeline({ pageId: 'page-1', contentHash: HASH }, NO_WAIT);
@@ -139,7 +152,9 @@ describe('runPullPipeline — dispatch by detected type', () => {
     await runPullPipeline({ pageId: 'page-1', contentHash: HASH }, NO_WAIT);
 
     expect(mocks.generateImageVariants).toHaveBeenCalledWith(BYTES);
-    expect(mocks.saveCache).toHaveBeenCalled();
+    // each variant must be cached with its own MIME type, not a hardcoded one
+    expect(mocks.saveCache).toHaveBeenCalledWith(HASH, 'thumbnail', expect.anything(), 'image/webp');
+    expect(mocks.saveCache).toHaveBeenCalledWith(HASH, 'ai-chat', expect.anything(), 'image/jpeg');
     expect(mocks.setPageVisual).toHaveBeenCalledWith('page-1');
   });
 

--- a/apps/processor/src/api/__tests__/s3-pull-adapter.test.ts
+++ b/apps/processor/src/api/__tests__/s3-pull-adapter.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getOriginal: vi.fn(),
+  deleteOriginal: vi.fn().mockResolvedValue(true),
+  saveCache: vi.fn().mockResolvedValue({}),
+  setPageProcessing: vi.fn().mockResolvedValue(undefined),
+  setPageCompleted: vi.fn().mockResolvedValue(undefined),
+  setPageVisual: vi.fn().mockResolvedValue(undefined),
+  setPageVideoProcessed: vi.fn().mockResolvedValue(undefined),
+  setPageFailed: vi.fn().mockResolvedValue(undefined),
+  verifyContentHash: vi.fn(),
+  detectContentType: vi.fn(),
+  isAllowedContentType: vi.fn(),
+  extractTextContent: vi.fn(),
+  generateImageVariants: vi.fn(),
+  extractVideoMetadata: vi.fn(),
+  extractVideoThumbnail: vi.fn(),
+}));
+
+vi.mock('../../cache/content-store', () => ({
+  contentStore: {
+    getOriginal: mocks.getOriginal,
+    deleteOriginal: mocks.deleteOriginal,
+    saveCache: mocks.saveCache,
+  },
+}));
+
+vi.mock('../../db', () => ({
+  setPageProcessing: mocks.setPageProcessing,
+  setPageCompleted: mocks.setPageCompleted,
+  setPageVisual: mocks.setPageVisual,
+  setPageVideoProcessed: mocks.setPageVideoProcessed,
+  setPageFailed: mocks.setPageFailed,
+}));
+
+vi.mock('../../services/processing-pipeline', () => ({
+  verifyContentHash: mocks.verifyContentHash,
+  detectContentType: mocks.detectContentType,
+  isAllowedContentType: mocks.isAllowedContentType,
+  extractTextContent: mocks.extractTextContent,
+  generateImageVariants: mocks.generateImageVariants,
+  extractVideoMetadata: mocks.extractVideoMetadata,
+  extractVideoThumbnail: mocks.extractVideoThumbnail,
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { processor: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } },
+}));
+
+import { fetchObjectFromS3, runPullPipeline } from '../s3-pull-adapter';
+
+const HASH = 'c'.repeat(64);
+const BYTES = Buffer.from('stored-bytes');
+const NO_WAIT = { delayMs: 0 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.deleteOriginal.mockResolvedValue(true);
+  mocks.verifyContentHash.mockReturnValue(true);
+  mocks.isAllowedContentType.mockReturnValue(true);
+  mocks.detectContentType.mockResolvedValue({ label: 'pdf', mimeType: 'application/pdf', score: 0.9, source: 'magika' });
+  mocks.extractTextContent.mockResolvedValue('extracted text');
+  mocks.generateImageVariants.mockResolvedValue({ thumbnail: Buffer.from('t'), preview: Buffer.from('p') });
+  mocks.extractVideoMetadata.mockResolvedValue({ duration: 10, width: 640, height: 480 });
+  mocks.extractVideoThumbnail.mockResolvedValue(Buffer.from('thumb'));
+});
+
+describe('fetchObjectFromS3', () => {
+  it('returns the object bytes when present on the first try', async () => {
+    mocks.getOriginal.mockResolvedValue(BYTES);
+    const result = await fetchObjectFromS3(HASH, NO_WAIT);
+    expect(result).toEqual(BYTES);
+    expect(mocks.getOriginal).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries up to 3 times when the object is not yet committed', async () => {
+    mocks.getOriginal
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(BYTES);
+    const result = await fetchObjectFromS3(HASH, NO_WAIT);
+    expect(result).toEqual(BYTES);
+    expect(mocks.getOriginal).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws after exhausting all retries', async () => {
+    mocks.getOriginal.mockResolvedValue(null);
+    await expect(fetchObjectFromS3(HASH, NO_WAIT)).rejects.toThrow();
+    expect(mocks.getOriginal).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('runPullPipeline — zero-trust gates', () => {
+  it('deletes the object and fails the job when the stored bytes do not match the hash', async () => {
+    mocks.getOriginal.mockResolvedValue(BYTES);
+    mocks.verifyContentHash.mockReturnValue(false);
+
+    await runPullPipeline({ pageId: 'page-1', contentHash: HASH }, NO_WAIT);
+
+    expect(mocks.deleteOriginal).toHaveBeenCalledWith(HASH);
+    expect(mocks.setPageFailed).toHaveBeenCalled();
+    expect(mocks.setPageCompleted).not.toHaveBeenCalled();
+  });
+
+  it('deletes the object and fails the job when the detected type is disallowed', async () => {
+    mocks.getOriginal.mockResolvedValue(BYTES);
+    mocks.detectContentType.mockResolvedValue({ label: 'elf', mimeType: 'application/octet-stream', score: 0.9, source: 'magika' });
+    mocks.isAllowedContentType.mockReturnValue(false);
+
+    await runPullPipeline({ pageId: 'page-1', contentHash: HASH }, NO_WAIT);
+
+    expect(mocks.deleteOriginal).toHaveBeenCalledWith(HASH);
+    expect(mocks.setPageFailed).toHaveBeenCalled();
+  });
+
+  it('does not delete or persist when verification passes and type is allowed', async () => {
+    mocks.getOriginal.mockResolvedValue(BYTES);
+    await runPullPipeline({ pageId: 'page-1', contentHash: HASH }, NO_WAIT);
+    expect(mocks.deleteOriginal).not.toHaveBeenCalled();
+  });
+});
+
+describe('runPullPipeline — dispatch by detected type', () => {
+  it('extracts text and marks the page completed for a PDF', async () => {
+    mocks.getOriginal.mockResolvedValue(BYTES);
+    mocks.detectContentType.mockResolvedValue({ label: 'pdf', mimeType: 'application/pdf', score: 0.9, source: 'magika' });
+
+    await runPullPipeline({ pageId: 'page-1', contentHash: HASH }, NO_WAIT);
+
+    expect(mocks.extractTextContent).toHaveBeenCalledWith(BYTES, 'application/pdf');
+    expect(mocks.setPageCompleted).toHaveBeenCalledWith('page-1', 'extracted text', expect.anything(), expect.any(String));
+  });
+
+  it('generates image variants and marks the page visual for an image', async () => {
+    mocks.getOriginal.mockResolvedValue(BYTES);
+    mocks.detectContentType.mockResolvedValue({ label: 'png', mimeType: 'image/png', score: 0.9, source: 'magika' });
+
+    await runPullPipeline({ pageId: 'page-1', contentHash: HASH }, NO_WAIT);
+
+    expect(mocks.generateImageVariants).toHaveBeenCalledWith(BYTES);
+    expect(mocks.saveCache).toHaveBeenCalled();
+    expect(mocks.setPageVisual).toHaveBeenCalledWith('page-1');
+  });
+
+  it('extracts metadata + thumbnail and records video processing for a video', async () => {
+    mocks.getOriginal.mockResolvedValue(BYTES);
+    mocks.detectContentType.mockResolvedValue({ label: 'mp4', mimeType: 'video/mp4', score: 0.9, source: 'magika' });
+
+    await runPullPipeline({ pageId: 'page-1', contentHash: HASH }, NO_WAIT);
+
+    expect(mocks.extractVideoMetadata).toHaveBeenCalledWith(BYTES);
+    expect(mocks.extractVideoThumbnail).toHaveBeenCalledWith(BYTES);
+    expect(mocks.setPageVideoProcessed).toHaveBeenCalled();
+  });
+
+  it('falls back to visual for an allowed but unsupported type', async () => {
+    mocks.getOriginal.mockResolvedValue(BYTES);
+    mocks.detectContentType.mockResolvedValue({ label: 'bin', mimeType: 'application/octet-stream', score: 0.9, source: 'magika' });
+
+    await runPullPipeline({ pageId: 'page-1', contentHash: HASH }, NO_WAIT);
+
+    expect(mocks.setPageVisual).toHaveBeenCalledWith('page-1');
+    expect(mocks.setPageCompleted).not.toHaveBeenCalled();
+  });
+
+  it('marks the page failed when the object can never be fetched', async () => {
+    mocks.getOriginal.mockResolvedValue(null);
+    await runPullPipeline({ pageId: 'page-1', contentHash: HASH }, NO_WAIT);
+    expect(mocks.setPageFailed).toHaveBeenCalled();
+  });
+});

--- a/apps/processor/src/api/ingest.ts
+++ b/apps/processor/src/api/ingest.ts
@@ -69,4 +69,54 @@ router.post('/by-page/:pageId', async (req, res) => {
   }
 });
 
+// Verified ingest for direct-to-S3 uploads. Unlike /by-page (which trusts the
+// page's declared mimeType), this enqueues the pull-verify pipeline that
+// re-hashes the stored bytes and runs Magika before any processing/serving.
+router.post('/pull/:pageId', async (req, res) => {
+  try {
+    const auth = req.auth;
+    if (!auth) {
+      return res.status(401).json({ error: 'Service authentication required' });
+    }
+
+    const { pageId } = req.params;
+
+    const binding = auth.resourceBinding;
+    if (binding?.type === 'page' && binding.id !== pageId) {
+      loggers.security.warn('pull-verify denied: page binding mismatch', {
+        userId: auth.userId,
+        requestedPageId: pageId,
+        boundPageId: binding.id,
+      });
+      return res.status(403).json({ error: 'Access denied: token is bound to a different page' });
+    }
+
+    const page = await getPageForIngestion(pageId);
+    if (!page) {
+      return res.status(404).json({ error: 'Page not found' });
+    }
+
+    const { contentHash } = page;
+    if (!contentHash || !isValidContentHash(contentHash)) {
+      return res.status(400).json({ error: 'Page content hash is invalid' });
+    }
+
+    try {
+      await assertFileAccess(auth, contentHash, 'edit');
+    } catch {
+      return res.status(403).json({ error: 'Access denied for requested file' });
+    }
+
+    const jobId = await queueManager.addJob('pull-verify', { pageId, contentHash });
+    return res.json({ success: true, jobId });
+
+  } catch (error) {
+    if (error instanceof InvalidContentHashError) {
+      return res.status(400).json({ error: 'Invalid content hash' });
+    }
+    console.error('Failed to enqueue pull-verify:', error);
+    return res.status(500).json({ error: 'Failed to enqueue pull-verify' });
+  }
+});
+
 export const ingestRouter: ExpressRouter = router;

--- a/apps/processor/src/api/s3-pull-adapter.ts
+++ b/apps/processor/src/api/s3-pull-adapter.ts
@@ -54,8 +54,8 @@ export async function fetchObjectFromS3(contentHash: string, opts: FetchOptions 
 
 const TEXT_EXTRACTABLE = new Set([
   'application/pdf',
+  // .docx only — mammoth cannot read legacy binary .doc (application/msword)
   'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-  'application/msword',
   'text/plain',
   'text/markdown',
   'text/csv',
@@ -78,8 +78,7 @@ export async function runPullPipeline(job: PullJob, fetchOpts: FetchOptions = {}
   // Zero-trust: the stored bytes must hash to the declared content hash.
   if (!verifyContentHash(bytes, contentHash)) {
     loggers.processor.warn('Content hash mismatch — deleting object', { pageId, contentHash });
-    await contentStore.deleteOriginal(contentHash);
-    await setPageFailed(pageId, 'Stored content does not match the declared hash');
+    await rejectAndFail(pageId, contentHash, 'Stored content does not match the declared hash');
     return;
   }
 
@@ -87,8 +86,7 @@ export async function runPullPipeline(job: PullJob, fetchOpts: FetchOptions = {}
   const detected = await detectContentType(bytes);
   if (!isAllowedContentType(detected)) {
     loggers.processor.warn('Disallowed content type — deleting object', { pageId, contentHash, label: detected.label });
-    await contentStore.deleteOriginal(contentHash);
-    await setPageFailed(pageId, `Disallowed content type: ${detected.label}`);
+    await rejectAndFail(pageId, contentHash, `Disallowed content type: ${detected.label}`);
     return;
   }
 
@@ -100,12 +98,26 @@ export async function runPullPipeline(job: PullJob, fetchOpts: FetchOptions = {}
   }
 }
 
+/**
+ * Delete the rejected object and mark the page failed. The delete is best-effort
+ * — a storage error must not prevent the page from being marked failed, or a
+ * rejected upload would linger in 'processing' forever.
+ */
+async function rejectAndFail(pageId: string, contentHash: string, reason: string): Promise<void> {
+  try {
+    await contentStore.deleteOriginal(contentHash);
+  } catch (err) {
+    loggers.processor.error('Failed to delete rejected object', err instanceof Error ? err : undefined, { pageId, contentHash });
+  }
+  await setPageFailed(pageId, reason);
+}
+
 async function dispatch(pageId: string, contentHash: string, bytes: Buffer, mimeType: string): Promise<void> {
   if (mimeType.startsWith('image/')) {
     const variants = await generateImageVariants(bytes);
     await Promise.all(
-      Object.entries(variants).map(([preset, buf]) =>
-        contentStore.saveCache(contentHash, preset, buf, 'image/webp'),
+      Object.entries(variants).map(([preset, variant]) =>
+        contentStore.saveCache(contentHash, preset, variant.buffer, variant.mimeType),
       ),
     );
     await setPageVisual(pageId);

--- a/apps/processor/src/api/s3-pull-adapter.ts
+++ b/apps/processor/src/api/s3-pull-adapter.ts
@@ -1,0 +1,133 @@
+import { contentStore } from '../cache/content-store';
+import {
+  setPageProcessing,
+  setPageCompleted,
+  setPageVisual,
+  setPageVideoProcessed,
+  setPageFailed,
+} from '../db';
+import {
+  verifyContentHash,
+  detectContentType,
+  isAllowedContentType,
+  extractTextContent,
+  generateImageVariants,
+  extractVideoMetadata,
+  extractVideoThumbnail,
+} from '../services/processing-pipeline';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+
+/**
+ * S3 pull adapter — the only layer that performs I/O. It fetches the stored
+ * object, runs the pure pipeline, and handles rejection/deletion. No processing
+ * logic lives here; transformation is delegated to processing-pipeline.
+ */
+
+export interface PullJob {
+  pageId: string;
+  contentHash: string;
+}
+
+interface FetchOptions {
+  maxAttempts?: number;
+  delayMs?: number;
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Fetch the object bytes, retrying on a not-yet-committed object. The object may
+ * not be readable the instant the job fires (read-after-write lag), so retry up
+ * to 3 times with a 1s backoff before giving up.
+ */
+export async function fetchObjectFromS3(contentHash: string, opts: FetchOptions = {}): Promise<Buffer> {
+  const maxAttempts = opts.maxAttempts ?? 3;
+  const delayMs = opts.delayMs ?? 1000;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const bytes = await contentStore.getOriginal(contentHash);
+    if (bytes) return bytes;
+    if (attempt < maxAttempts) await sleep(delayMs);
+  }
+  throw new Error(`Object not found in S3 after ${maxAttempts} attempts: ${contentHash}`);
+}
+
+const TEXT_EXTRACTABLE = new Set([
+  'application/pdf',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/msword',
+  'text/plain',
+  'text/markdown',
+  'text/csv',
+  'application/json',
+]);
+
+export async function runPullPipeline(job: PullJob, fetchOpts: FetchOptions = {}): Promise<void> {
+  const { pageId, contentHash } = job;
+
+  let bytes: Buffer;
+  try {
+    await setPageProcessing(pageId);
+    bytes = await fetchObjectFromS3(contentHash, fetchOpts);
+  } catch (err) {
+    loggers.processor.error('S3 pull failed', err instanceof Error ? err : undefined, { pageId, contentHash });
+    await setPageFailed(pageId, err instanceof Error ? err.message : 'Failed to fetch object');
+    return;
+  }
+
+  // Zero-trust: the stored bytes must hash to the declared content hash.
+  if (!verifyContentHash(bytes, contentHash)) {
+    loggers.processor.warn('Content hash mismatch — deleting object', { pageId, contentHash });
+    await contentStore.deleteOriginal(contentHash);
+    await setPageFailed(pageId, 'Stored content does not match the declared hash');
+    return;
+  }
+
+  // Zero-trust: Magika on the actual bytes overrides the declared MIME type.
+  const detected = await detectContentType(bytes);
+  if (!isAllowedContentType(detected)) {
+    loggers.processor.warn('Disallowed content type — deleting object', { pageId, contentHash, label: detected.label });
+    await contentStore.deleteOriginal(contentHash);
+    await setPageFailed(pageId, `Disallowed content type: ${detected.label}`);
+    return;
+  }
+
+  try {
+    await dispatch(pageId, contentHash, bytes, detected.mimeType);
+  } catch (err) {
+    loggers.processor.error('Processing failed', err instanceof Error ? err : undefined, { pageId, contentHash });
+    await setPageFailed(pageId, err instanceof Error ? err.message : 'Processing failed');
+  }
+}
+
+async function dispatch(pageId: string, contentHash: string, bytes: Buffer, mimeType: string): Promise<void> {
+  if (mimeType.startsWith('image/')) {
+    const variants = await generateImageVariants(bytes);
+    await Promise.all(
+      Object.entries(variants).map(([preset, buf]) =>
+        contentStore.saveCache(contentHash, preset, buf, 'image/webp'),
+      ),
+    );
+    await setPageVisual(pageId);
+    return;
+  }
+
+  if (mimeType.startsWith('video/')) {
+    const [metadata, thumbnail] = await Promise.all([
+      extractVideoMetadata(bytes),
+      extractVideoThumbnail(bytes),
+    ]);
+    await contentStore.saveCache(contentHash, 'thumbnail.webp', thumbnail, 'image/webp');
+    await setPageVideoProcessed(pageId, { ...metadata, thumbnailKey: `cache/${contentHash}/thumbnail.webp` });
+    return;
+  }
+
+  if (TEXT_EXTRACTABLE.has(mimeType)) {
+    const text = await extractTextContent(bytes, mimeType);
+    await setPageCompleted(pageId, text ?? '', { mimeType }, 'text');
+    return;
+  }
+
+  // Allowed but not specifically processable — keep the file, mark visual.
+  await setPageVisual(pageId);
+}

--- a/apps/processor/src/api/s3-pull-adapter.ts
+++ b/apps/processor/src/api/s3-pull-adapter.ts
@@ -1,4 +1,4 @@
-import { contentStore } from '../cache/content-store';
+import { contentStore } from '../server';
 import {
   setPageProcessing,
   setPageCompleted,

--- a/apps/processor/src/services/__tests__/processing-pipeline-media.test.ts
+++ b/apps/processor/src/services/__tests__/processing-pipeline-media.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import sharp from 'sharp';
+
+// OCR is the only dependency mocked here — tesseract loads a language model and
+// is far too slow/heavy for a unit test. sharp and pdfjs run in-process against
+// real fixture bytes, so those paths are exercised for real.
+vi.mock('tesseract.js', () => ({
+  default: {
+    recognize: vi.fn().mockResolvedValue({ data: { text: 'RECOGNIZED TEXT' } }),
+  },
+}));
+
+import {
+  generateImageVariants,
+  extractTextContent,
+} from '../processing-pipeline';
+
+const PNG_BYTES = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+  0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+  0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41,
+  0x54, 0x08, 0x99, 0x63, 0xf8, 0xcf, 0xc0, 0x00,
+  0x00, 0x00, 0x03, 0x00, 0x01, 0x5b, 0x7e, 0x2b,
+  0x1c, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e,
+  0x44, 0xae, 0x42, 0x60, 0x82,
+]);
+
+const PDF_BYTES = Buffer.from(
+  '%PDF-1.4\n' +
+    '1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n' +
+    '2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n' +
+    '3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]>>endobj\n' +
+    'xref\n0 4\n0000000000 65535 f \n' +
+    '0000000010 00000 n \n0000000060 00000 n \n0000000110 00000 n \n' +
+    'trailer<</Size 4/Root 1 0 R>>\nstartxref\n180\n%%EOF\n',
+  'binary',
+);
+
+// A real 300x300 image (above the thumbnail/preset width caps) so the resize
+// branch is exercised and sharp has real pixels to work with.
+async function make300pxPng(): Promise<Buffer> {
+  return sharp({
+    create: { width: 300, height: 300, channels: 3, background: { r: 120, g: 80, b: 200 } },
+  }).png().toBuffer();
+}
+
+describe('generateImageVariants', () => {
+  it('produces a buffer for each standard preset from real image bytes', async () => {
+    const variants = await generateImageVariants(await make300pxPng());
+    for (const preset of ['ai-chat', 'ai-vision', 'thumbnail', 'preview']) {
+      expect(Buffer.isBuffer(variants[preset])).toBe(true);
+      expect(variants[preset].length).toBeGreaterThan(0);
+    }
+  }, 15000);
+
+  it('encodes the thumbnail preset as a real webp image capped at its max width', async () => {
+    const variants = await generateImageVariants(await make300pxPng());
+    const meta = await sharp(variants.thumbnail).metadata();
+    expect(meta.format).toBe('webp');
+    expect(meta.width).toBeLessThanOrEqual(200);
+  }, 15000);
+});
+
+describe('extractTextContent', () => {
+  it('decodes plain text content directly', async () => {
+    const text = await extractTextContent(Buffer.from('hello world', 'utf-8'), 'text/plain');
+    expect(text).toBe('hello world');
+  });
+
+  it('pretty-prints JSON content', async () => {
+    const text = await extractTextContent(Buffer.from('{"a":1}', 'utf-8'), 'application/json');
+    expect(text).toContain('"a": 1');
+  });
+
+  it('returns a string (not null) for a valid PDF without throwing', async () => {
+    const text = await extractTextContent(PDF_BYTES, 'application/pdf');
+    expect(typeof text).toBe('string');
+  }, 15000);
+
+  it('runs OCR for image content types', async () => {
+    const text = await extractTextContent(PNG_BYTES, 'image/png');
+    expect(text).toBe('RECOGNIZED TEXT');
+  });
+
+  it('returns null for an unsupported content type', async () => {
+    const text = await extractTextContent(Buffer.from([0, 1, 2]), 'application/zip');
+    expect(text).toBeNull();
+  });
+});

--- a/apps/processor/src/services/__tests__/processing-pipeline-media.test.ts
+++ b/apps/processor/src/services/__tests__/processing-pipeline-media.test.ts
@@ -50,16 +50,18 @@ describe('generateImageVariants', () => {
   it('produces a buffer for each standard preset from real image bytes', async () => {
     const variants = await generateImageVariants(await make300pxPng());
     for (const preset of ['ai-chat', 'ai-vision', 'thumbnail', 'preview']) {
-      expect(Buffer.isBuffer(variants[preset])).toBe(true);
-      expect(variants[preset].length).toBeGreaterThan(0);
+      expect(Buffer.isBuffer(variants[preset].buffer)).toBe(true);
+      expect(variants[preset].buffer.length).toBeGreaterThan(0);
     }
   }, 15000);
 
-  it('encodes the thumbnail preset as a real webp image capped at its max width', async () => {
+  it('reports each variant MIME type matching its encoded format', async () => {
     const variants = await generateImageVariants(await make300pxPng());
-    const meta = await sharp(variants.thumbnail).metadata();
-    expect(meta.format).toBe('webp');
-    expect(meta.width).toBeLessThanOrEqual(200);
+    expect(variants.thumbnail.mimeType).toBe('image/webp');
+    expect(variants['ai-chat'].mimeType).toBe('image/jpeg');
+    const thumbMeta = await sharp(variants.thumbnail.buffer).metadata();
+    expect(thumbMeta.format).toBe('webp');
+    expect(thumbMeta.width).toBeLessThanOrEqual(200);
   }, 15000);
 });
 

--- a/apps/processor/src/services/__tests__/processing-pipeline-video.test.ts
+++ b/apps/processor/src/services/__tests__/processing-pipeline-video.test.ts
@@ -5,18 +5,20 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // are not mocked; only the subprocess + temp-file boundary is.
 const mocks = vi.hoisted(() => ({
   execFile: vi.fn(),
+  mkdtemp: vi.fn().mockResolvedValue('/tmp/pipeline-xxxx'),
   writeFile: vi.fn().mockResolvedValue(undefined),
   readFile: vi.fn(),
-  unlink: vi.fn().mockResolvedValue(undefined),
+  rm: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('child_process', () => ({ execFile: mocks.execFile }));
 vi.mock('util', () => ({ promisify: () => mocks.execFile }));
 vi.mock('fs/promises', () => ({
-  default: { writeFile: mocks.writeFile, readFile: mocks.readFile, unlink: mocks.unlink },
+  default: { mkdtemp: mocks.mkdtemp, writeFile: mocks.writeFile, readFile: mocks.readFile, rm: mocks.rm },
+  mkdtemp: mocks.mkdtemp,
   writeFile: mocks.writeFile,
   readFile: mocks.readFile,
-  unlink: mocks.unlink,
+  rm: mocks.rm,
 }));
 
 import { extractVideoMetadata, extractVideoThumbnail } from '../processing-pipeline';
@@ -25,8 +27,9 @@ const VIDEO_BYTES = Buffer.from('fake-mp4-bytes');
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.mkdtemp.mockResolvedValue('/tmp/pipeline-xxxx');
   mocks.writeFile.mockResolvedValue(undefined);
-  mocks.unlink.mockResolvedValue(undefined);
+  mocks.rm.mockResolvedValue(undefined);
 });
 
 describe('extractVideoMetadata', () => {
@@ -48,7 +51,7 @@ describe('extractVideoMetadata', () => {
   it('cleans up the temp input file even when ffprobe fails', async () => {
     mocks.execFile.mockRejectedValue(new Error('ffprobe boom'));
     await expect(extractVideoMetadata(VIDEO_BYTES)).rejects.toThrow();
-    expect(mocks.unlink).toHaveBeenCalled();
+    expect(mocks.rm).toHaveBeenCalled();
   });
 });
 
@@ -64,6 +67,6 @@ describe('extractVideoThumbnail', () => {
   it('cleans up temp files even when ffmpeg fails', async () => {
     mocks.execFile.mockRejectedValue(new Error('ffmpeg boom'));
     await expect(extractVideoThumbnail(VIDEO_BYTES)).rejects.toThrow();
-    expect(mocks.unlink).toHaveBeenCalled();
+    expect(mocks.rm).toHaveBeenCalled();
   });
 });

--- a/apps/processor/src/services/__tests__/processing-pipeline-video.test.ts
+++ b/apps/processor/src/services/__tests__/processing-pipeline-video.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ffmpeg/ffprobe are mocked because the binaries are not guaranteed in CI — this
+// matches the existing video-processor test strategy. The functions under test
+// are not mocked; only the subprocess + temp-file boundary is.
+const mocks = vi.hoisted(() => ({
+  execFile: vi.fn(),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  readFile: vi.fn(),
+  unlink: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('child_process', () => ({ execFile: mocks.execFile }));
+vi.mock('util', () => ({ promisify: () => mocks.execFile }));
+vi.mock('fs/promises', () => ({
+  default: { writeFile: mocks.writeFile, readFile: mocks.readFile, unlink: mocks.unlink },
+  writeFile: mocks.writeFile,
+  readFile: mocks.readFile,
+  unlink: mocks.unlink,
+}));
+
+import { extractVideoMetadata, extractVideoThumbnail } from '../processing-pipeline';
+
+const VIDEO_BYTES = Buffer.from('fake-mp4-bytes');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.writeFile.mockResolvedValue(undefined);
+  mocks.unlink.mockResolvedValue(undefined);
+});
+
+describe('extractVideoMetadata', () => {
+  it('returns duration, width, and height parsed from ffprobe output', async () => {
+    mocks.execFile.mockResolvedValue({
+      stdout: JSON.stringify({ streams: [{ duration: '12.5', width: 1920, height: 1080 }] }),
+    });
+    const meta = await extractVideoMetadata(VIDEO_BYTES);
+    expect(meta).toEqual({ duration: 12.5, width: 1920, height: 1080 });
+  });
+
+  it('returns an object with undefined fields when ffprobe finds no video stream', async () => {
+    mocks.execFile.mockResolvedValue({ stdout: JSON.stringify({ streams: [] }) });
+    const meta = await extractVideoMetadata(VIDEO_BYTES);
+    expect(meta.duration).toBeUndefined();
+    expect(meta.width).toBeUndefined();
+  });
+
+  it('cleans up the temp input file even when ffprobe fails', async () => {
+    mocks.execFile.mockRejectedValue(new Error('ffprobe boom'));
+    await expect(extractVideoMetadata(VIDEO_BYTES)).rejects.toThrow();
+    expect(mocks.unlink).toHaveBeenCalled();
+  });
+});
+
+describe('extractVideoThumbnail', () => {
+  it('returns the thumbnail bytes produced by ffmpeg', async () => {
+    const thumb = Buffer.from('webp-thumb-bytes');
+    mocks.execFile.mockResolvedValue({ stdout: '', stderr: '' });
+    mocks.readFile.mockResolvedValue(thumb);
+    const result = await extractVideoThumbnail(VIDEO_BYTES);
+    expect(result).toEqual(thumb);
+  });
+
+  it('cleans up temp files even when ffmpeg fails', async () => {
+    mocks.execFile.mockRejectedValue(new Error('ffmpeg boom'));
+    await expect(extractVideoThumbnail(VIDEO_BYTES)).rejects.toThrow();
+    expect(mocks.unlink).toHaveBeenCalled();
+  });
+});

--- a/apps/processor/src/services/__tests__/processing-pipeline.test.ts
+++ b/apps/processor/src/services/__tests__/processing-pipeline.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+import crypto from 'crypto';
+
+import {
+  verifyContentHash,
+  isAllowedContentType,
+  detectContentType,
+  type MagikaResult,
+} from '../processing-pipeline';
+
+// --- Fixtures (real bytes so detection runs against the loaded Magika model) ---
+
+const PNG_BYTES = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+  0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+  0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41,
+  0x54, 0x08, 0x99, 0x63, 0xf8, 0xcf, 0xc0, 0x00,
+  0x00, 0x00, 0x03, 0x00, 0x01, 0x5b, 0x7e, 0x2b,
+  0x1c, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e,
+  0x44, 0xae, 0x42, 0x60, 0x82,
+]);
+
+const PDF_BYTES = Buffer.from(
+  '%PDF-1.4\n' +
+    '1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n' +
+    '2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n' +
+    '3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]>>endobj\n' +
+    'xref\n0 4\n0000000000 65535 f \n' +
+    '0000000010 00000 n \n0000000060 00000 n \n0000000110 00000 n \n' +
+    'trailer<</Size 4/Root 1 0 R>>\nstartxref\n180\n%%EOF\n',
+  'binary',
+);
+
+// Minimal ELF64 executable that Magika classifies as `elf` (header + realistic payload).
+function makeElf64(): Buffer {
+  const payloadSize = 8192;
+  const buf = Buffer.alloc(64 + 56 + payloadSize);
+  let off = 0;
+  buf.writeUInt8(0x7f, off++);
+  buf.writeUInt8(0x45, off++);
+  buf.writeUInt8(0x4c, off++);
+  buf.writeUInt8(0x46, off++);
+  buf.writeUInt8(2, off++);
+  buf.writeUInt8(1, off++);
+  buf.writeUInt8(1, off++);
+  buf.writeUInt8(0, off++);
+  buf.writeUInt8(0, off++);
+  off = 16;
+  buf.writeUInt16LE(2, off); off += 2;
+  buf.writeUInt16LE(0x3e, off); off += 2;
+  buf.writeUInt32LE(1, off); off += 4;
+  buf.writeBigUInt64LE(0x400078n, off); off += 8;
+  buf.writeBigUInt64LE(64n, off); off += 8;
+  buf.writeBigUInt64LE(0n, off); off += 8;
+  buf.writeUInt32LE(0, off); off += 4;
+  buf.writeUInt16LE(64, off); off += 2;
+  buf.writeUInt16LE(56, off); off += 2;
+  buf.writeUInt16LE(1, off); off += 2;
+  buf.writeUInt16LE(0, off); off += 2;
+  buf.writeUInt16LE(0, off); off += 2;
+  buf.writeUInt16LE(0, off); off += 2;
+  off = 64;
+  buf.writeUInt32LE(1, off); off += 4;
+  buf.writeUInt32LE(5, off); off += 4;
+  buf.writeBigUInt64LE(0n, off); off += 8;
+  buf.writeBigUInt64LE(0x400000n, off); off += 8;
+  buf.writeBigUInt64LE(0x400000n, off); off += 8;
+  buf.writeBigUInt64LE(BigInt(64 + 56 + payloadSize), off); off += 8;
+  buf.writeBigUInt64LE(BigInt(64 + 56 + payloadSize), off); off += 8;
+  buf.writeBigUInt64LE(0x200000n, off); off += 8;
+  let state = 0x5eedbee5;
+  for (let i = 0; i < payloadSize; i++) {
+    state = (state * 1103515245 + 12345) & 0x7fffffff;
+    buf.writeUInt8(state & 0xff, 64 + 56 + i);
+  }
+  return buf;
+}
+
+function sha256(bytes: Buffer): string {
+  return crypto.createHash('sha256').update(bytes).digest('hex');
+}
+
+function makeResult(label: string, mimeType = 'application/octet-stream'): MagikaResult {
+  return { label, mimeType, score: 0.99, source: 'magika' };
+}
+
+describe('verifyContentHash', () => {
+  it('given bytes and their true SHA-256, returns true', () => {
+    expect(verifyContentHash(PNG_BYTES, sha256(PNG_BYTES))).toBe(true);
+  });
+
+  it('given bytes and a mismatched hash, returns false — never trusts the client value', () => {
+    expect(verifyContentHash(PNG_BYTES, sha256(PDF_BYTES))).toBe(false);
+  });
+
+  it('given an uppercase expected hash, still matches the lowercase digest', () => {
+    expect(verifyContentHash(PNG_BYTES, sha256(PNG_BYTES).toUpperCase())).toBe(true);
+  });
+
+  it('given a malformed expected hash, returns false rather than throwing', () => {
+    expect(verifyContentHash(PNG_BYTES, 'not-a-hash')).toBe(false);
+  });
+});
+
+describe('isAllowedContentType', () => {
+  it('allows a PNG image', () => {
+    expect(isAllowedContentType(makeResult('png', 'image/png'))).toBe(true);
+  });
+
+  it('allows a PDF document', () => {
+    expect(isAllowedContentType(makeResult('pdf', 'application/pdf'))).toBe(true);
+  });
+
+  it('allows an MP4 video', () => {
+    expect(isAllowedContentType(makeResult('mp4', 'video/mp4'))).toBe(true);
+  });
+
+  it('rejects an ELF executable', () => {
+    expect(isAllowedContentType(makeResult('elf'))).toBe(false);
+  });
+
+  it('rejects a Windows PE executable', () => {
+    expect(isAllowedContentType(makeResult('pebin'))).toBe(false);
+  });
+
+  it('rejects a Mach-O executable', () => {
+    expect(isAllowedContentType(makeResult('macho'))).toBe(false);
+  });
+
+  it('rejects HTML', () => {
+    expect(isAllowedContentType(makeResult('html'))).toBe(false);
+  });
+
+  it('rejects SVG', () => {
+    expect(isAllowedContentType(makeResult('svg'))).toBe(false);
+  });
+
+  it('rejects JavaScript', () => {
+    expect(isAllowedContentType(makeResult('javascript'))).toBe(false);
+  });
+
+  it('rejects a Python script', () => {
+    expect(isAllowedContentType(makeResult('python'))).toBe(false);
+  });
+
+  it('rejects a shell script', () => {
+    expect(isAllowedContentType(makeResult('shell'))).toBe(false);
+  });
+});
+
+describe('detectContentType', () => {
+  it('classifies real PNG bytes as png via the loaded magika model', async () => {
+    const result = await detectContentType(PNG_BYTES);
+    expect(result.source).toBe('magika');
+    expect(result.label).toBe('png');
+    expect(result.mimeType).toBe('image/png');
+  }, 15000);
+
+  it('classifies real PDF bytes as pdf', async () => {
+    const result = await detectContentType(PDF_BYTES);
+    expect(result.label).toBe('pdf');
+  }, 15000);
+
+  it('classifies a real ELF executable as elf, which isAllowedContentType then rejects', async () => {
+    const result = await detectContentType(makeElf64());
+    expect(result.label).toBe('elf');
+    expect(isAllowedContentType(result)).toBe(false);
+  }, 15000);
+});

--- a/apps/processor/src/services/content-detector.ts
+++ b/apps/processor/src/services/content-detector.ts
@@ -125,6 +125,29 @@ function mapResult(raw: MagikaResultShape | null | undefined): DetectedContentTy
   };
 }
 
+/**
+ * Byte-based detection — the single place that invokes Magika. Accepts the file
+ * bytes directly so callers that already hold the buffer (e.g. the S3-pull
+ * pipeline) don't have to round-trip through the filesystem.
+ */
+export async function detectContentTypeFromBytes(bytes: Buffer): Promise<DetectedContentType> {
+  try {
+    const magika = await getInstance();
+    if (!magika) return FALLBACK_DETECTION;
+
+    const raw = (await withTimeout(
+      magika.identifyBytes(new Uint8Array(bytes)),
+      DETECTION_TIMEOUT_MS,
+    )) as MagikaResultShape;
+    return mapResult(raw);
+  } catch (err) {
+    processorLogger.warn('content-detector classify failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return FALLBACK_DETECTION;
+  }
+}
+
 export async function detectContentType(filePath: string): Promise<DetectedContentType> {
   let bytes: Buffer;
   try {
@@ -137,22 +160,7 @@ export async function detectContentType(filePath: string): Promise<DetectedConte
     return FALLBACK_DETECTION;
   }
 
-  try {
-    const magika = await getInstance();
-    if (!magika) return FALLBACK_DETECTION;
-
-    const raw = (await withTimeout(
-      magika.identifyBytes(new Uint8Array(bytes)),
-      DETECTION_TIMEOUT_MS,
-    )) as MagikaResultShape;
-    return mapResult(raw);
-  } catch (err) {
-    processorLogger.warn('content-detector classify failed', {
-      tempPath: filePath,
-      error: err instanceof Error ? err.message : String(err),
-    });
-    return FALLBACK_DETECTION;
-  }
+  return detectContentTypeFromBytes(bytes);
 }
 
 /** test-only helper: drops the memoised singleton and clears any backoff window */

--- a/apps/processor/src/services/processing-pipeline.ts
+++ b/apps/processor/src/services/processing-pipeline.ts
@@ -139,12 +139,15 @@ export async function generateImageVariants(bytes: Buffer): Promise<ImageVariant
 }
 
 async function withTempFile<T>(bytes: Buffer, suffix: string, work: (inputPath: string) => Promise<T>): Promise<T> {
-  const inputPath = path.join(os.tmpdir(), `pipeline-${crypto.randomUUID()}${suffix}`);
+  // mkdtemp creates a private (0700), unpredictably-named directory, avoiding the
+  // symlink/race hazards of writing a known-named file into the shared temp dir.
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'pipeline-'));
+  const inputPath = path.join(dir, `input${suffix}`);
   try {
     await fs.writeFile(inputPath, bytes);
     return await work(inputPath);
   } finally {
-    await fs.unlink(inputPath).catch(() => {});
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
   }
 }
 
@@ -169,16 +172,13 @@ export function extractVideoMetadata(bytes: Buffer): Promise<VideoMetadata> {
 /** Grab the first frame as a webp thumbnail via ffmpeg. Bytes in, thumbnail bytes out. */
 export function extractVideoThumbnail(bytes: Buffer): Promise<Buffer> {
   return withTempFile(bytes, '.video', async (inputPath) => {
+    // Thumbnail lands inside the same private temp dir, cleaned up by withTempFile.
     const thumbPath = `${inputPath}-thumb.webp`;
-    try {
-      await execFileAsync(
-        'ffmpeg',
-        ['-y', '-i', inputPath, '-vf', 'select=eq(n\\,0)', '-vframes', '1', '-f', 'webp', thumbPath],
-        { timeout: FFMPEG_TIMEOUT_MS, killSignal: 'SIGKILL', maxBuffer: 1024 * 1024 },
-      );
-      return await fs.readFile(thumbPath);
-    } finally {
-      await fs.unlink(thumbPath).catch(() => {});
-    }
+    await execFileAsync(
+      'ffmpeg',
+      ['-y', '-i', inputPath, '-vf', 'select=eq(n\\,0)', '-vframes', '1', '-f', 'webp', thumbPath],
+      { timeout: FFMPEG_TIMEOUT_MS, killSignal: 'SIGKILL', maxBuffer: 1024 * 1024 },
+    );
+    return fs.readFile(thumbPath);
   });
 }

--- a/apps/processor/src/services/processing-pipeline.ts
+++ b/apps/processor/src/services/processing-pipeline.ts
@@ -60,7 +60,11 @@ export function isAllowedContentType(result: MagikaResult): boolean {
   return !BLOCKED_LABELS.has(result.label.toLowerCase());
 }
 
-export type ImageVariants = Record<string, Buffer>;
+export interface ImageVariant {
+  buffer: Buffer;
+  mimeType: string;
+}
+export type ImageVariants = Record<string, ImageVariant>;
 
 export interface VideoMetadata {
   duration?: number;
@@ -82,10 +86,9 @@ export async function extractTextContent(bytes: Buffer, contentType: string): Pr
   if (contentType === 'application/pdf') {
     return extractPdfText(bytes);
   }
-  if (
-    contentType === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' ||
-    contentType === 'application/msword'
-  ) {
+  // mammoth only reads OOXML .docx — not legacy binary .doc. .doc falls through
+  // to null and is handled as a non-text (visual) file.
+  if (contentType === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document') {
     const result = await mammoth.extractRawText({ buffer: bytes });
     return cleanText(result.value);
   }
@@ -133,7 +136,7 @@ export async function generateImageVariants(bytes: Buffer): Promise<ImageVariant
     if (preset.format === 'jpeg') pipeline = pipeline.jpeg({ quality: preset.quality, progressive: true, mozjpeg: true });
     else if (preset.format === 'webp') pipeline = pipeline.webp({ quality: preset.quality, effort: 4 });
     else pipeline = pipeline.png({ quality: preset.quality, compressionLevel: 9, adaptiveFiltering: true });
-    variants[name] = await pipeline.toBuffer();
+    variants[name] = { buffer: await pipeline.toBuffer(), mimeType: `image/${preset.format}` };
   }
   return variants;
 }

--- a/apps/processor/src/services/processing-pipeline.ts
+++ b/apps/processor/src/services/processing-pipeline.ts
@@ -1,0 +1,184 @@
+import crypto from 'crypto';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import sharp from 'sharp';
+import mammoth from 'mammoth';
+import Tesseract from 'tesseract.js';
+import {
+  detectContentTypeFromBytes,
+  type DetectedContentType,
+} from './content-detector';
+import { IMAGE_PRESETS } from '../types';
+import type { PDFLoadingTask, PDFTextItem } from '../types/pdfjs';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Pure processing pipeline — single-responsibility functions that accept bytes
+ * and return typed results. The security core (hash verification + content-type
+ * gating) lives here so the S3-pull adapter can verify stored bytes before any
+ * Postgres write. Magika is invoked through `detectContentType`, the sole
+ * content-detection entry point.
+ */
+
+export type MagikaResult = DetectedContentType;
+
+const HEX_64 = /^[0-9a-f]{64}$/i;
+
+/**
+ * Zero-trust: SHA-256 the actual bytes and compare to the client-supplied hash.
+ * Content integrity (not a secret), so a direct compare is correct — there is no
+ * preimage an attacker can grind out via timing.
+ */
+export function verifyContentHash(bytes: Buffer, expectedHash: string): boolean {
+  if (!HEX_64.test(expectedHash)) return false;
+  const actual = crypto.createHash('sha256').update(bytes).digest('hex');
+  return actual === expectedHash.toLowerCase();
+}
+
+export function detectContentType(bytes: Buffer): Promise<MagikaResult> {
+  return detectContentTypeFromBytes(bytes);
+}
+
+// Magika labels that must never be stored regardless of declared MIME type:
+// browser-executable markup, scripts, and native executables. Magika's actual
+// bytes-classification overrides whatever Content-Type the client declared.
+const BLOCKED_LABELS: ReadonlySet<string> = new Set([
+  // executables / runnable binaries
+  'elf', 'pebin', 'macho', 'msdos', 'dex', 'msi',
+  // markup that executes script in a browser
+  'html', 'xhtml', 'svg',
+  // scripts
+  'javascript', 'typescript', 'python', 'shell', 'batch', 'powershell',
+  'ruby', 'perl', 'php', 'vba', 'lua', 'asp', 'jsp', 'awk', 'tcl', 'vbscript',
+]);
+
+export function isAllowedContentType(result: MagikaResult): boolean {
+  return !BLOCKED_LABELS.has(result.label.toLowerCase());
+}
+
+export type ImageVariants = Record<string, Buffer>;
+
+export interface VideoMetadata {
+  duration?: number;
+  width?: number;
+  height?: number;
+}
+
+const FFMPEG_TIMEOUT_MS = 120_000;
+const FFPROBE_TIMEOUT_MS = 30_000;
+
+const TEXT_DECODE_TYPES = new Set(['text/plain', 'text/markdown', 'text/csv']);
+
+/**
+ * Extract searchable text from a document or image. Documents (PDF/DOCX/text/
+ * JSON) are parsed in-process; images are run through OCR. Returns null for any
+ * content type with no text to extract.
+ */
+export async function extractTextContent(bytes: Buffer, contentType: string): Promise<string | null> {
+  if (contentType === 'application/pdf') {
+    return extractPdfText(bytes);
+  }
+  if (
+    contentType === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' ||
+    contentType === 'application/msword'
+  ) {
+    const result = await mammoth.extractRawText({ buffer: bytes });
+    return cleanText(result.value);
+  }
+  if (TEXT_DECODE_TYPES.has(contentType)) {
+    return cleanText(bytes.toString('utf-8'));
+  }
+  if (contentType === 'application/json') {
+    return cleanText(JSON.stringify(JSON.parse(bytes.toString('utf-8')), null, 2));
+  }
+  if (contentType.startsWith('image/')) {
+    const { data } = await Tesseract.recognize(bytes, 'eng');
+    return cleanText(data.text);
+  }
+  return null;
+}
+
+function cleanText(text: string): string {
+  return text.replace(/\0/g, '').trim();
+}
+
+async function extractPdfText(bytes: Buffer): Promise<string> {
+  const pdfjsLib = await import('pdfjs-dist');
+  const getDocument = pdfjsLib.getDocument as unknown as
+    (params: { data: Uint8Array; disableWorker: boolean }) => PDFLoadingTask;
+  const pdf = await getDocument({ data: new Uint8Array(bytes), disableWorker: true }).promise;
+
+  const parts: string[] = [];
+  for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
+    const page = await pdf.getPage(pageNum);
+    const textContent = await page.getTextContent();
+    parts.push(textContent.items.map((item: PDFTextItem) => item.str).join(' '));
+  }
+  return cleanText(parts.join('\n\n'));
+}
+
+/** Resize+re-encode the image into every standard preset. Bytes in, bytes per preset out. */
+export async function generateImageVariants(bytes: Buffer): Promise<ImageVariants> {
+  const variants: ImageVariants = {};
+  const { width } = await sharp(bytes).metadata();
+  for (const [name, preset] of Object.entries(IMAGE_PRESETS)) {
+    let pipeline = sharp(bytes).rotate();
+    if (width && width > preset.maxWidth) {
+      pipeline = pipeline.resize(preset.maxWidth, preset.maxHeight, { fit: 'inside', withoutEnlargement: true });
+    }
+    if (preset.format === 'jpeg') pipeline = pipeline.jpeg({ quality: preset.quality, progressive: true, mozjpeg: true });
+    else if (preset.format === 'webp') pipeline = pipeline.webp({ quality: preset.quality, effort: 4 });
+    else pipeline = pipeline.png({ quality: preset.quality, compressionLevel: 9, adaptiveFiltering: true });
+    variants[name] = await pipeline.toBuffer();
+  }
+  return variants;
+}
+
+async function withTempFile<T>(bytes: Buffer, suffix: string, work: (inputPath: string) => Promise<T>): Promise<T> {
+  const inputPath = path.join(os.tmpdir(), `pipeline-${crypto.randomUUID()}${suffix}`);
+  try {
+    await fs.writeFile(inputPath, bytes);
+    return await work(inputPath);
+  } finally {
+    await fs.unlink(inputPath).catch(() => {});
+  }
+}
+
+/** Probe video dimensions + duration via ffprobe. Bytes in, plain metadata object out. */
+export function extractVideoMetadata(bytes: Buffer): Promise<VideoMetadata> {
+  return withTempFile(bytes, '.video', async (inputPath) => {
+    const { stdout } = await execFileAsync(
+      'ffprobe',
+      ['-v', 'quiet', '-print_format', 'json', '-show_streams', '-select_streams', 'v:0', inputPath],
+      { timeout: FFPROBE_TIMEOUT_MS, killSignal: 'SIGKILL', maxBuffer: 5 * 1024 * 1024 },
+    );
+    const probe = JSON.parse(stdout) as { streams?: Array<{ duration?: string; width?: number; height?: number }> };
+    const stream = probe.streams?.[0];
+    return {
+      duration: stream?.duration ? parseFloat(stream.duration) : undefined,
+      width: stream?.width,
+      height: stream?.height,
+    };
+  });
+}
+
+/** Grab the first frame as a webp thumbnail via ffmpeg. Bytes in, thumbnail bytes out. */
+export function extractVideoThumbnail(bytes: Buffer): Promise<Buffer> {
+  return withTempFile(bytes, '.video', async (inputPath) => {
+    const thumbPath = `${inputPath}-thumb.webp`;
+    try {
+      await execFileAsync(
+        'ffmpeg',
+        ['-y', '-i', inputPath, '-vf', 'select=eq(n\\,0)', '-vframes', '1', '-f', 'webp', thumbPath],
+        { timeout: FFMPEG_TIMEOUT_MS, killSignal: 'SIGKILL', maxBuffer: 1024 * 1024 },
+      );
+      return await fs.readFile(thumbPath);
+    } finally {
+      await fs.unlink(thumbPath).catch(() => {});
+    }
+  });
+}

--- a/apps/processor/src/types/index.ts
+++ b/apps/processor/src/types/index.ts
@@ -69,6 +69,12 @@ export interface VideoProcessJobData {
   mimeType: string;
 }
 
+/** Direct-to-S3 verified ingest: pull bytes, hash/Magika gate, then process. */
+export interface PullVerifyJobData {
+  pageId: string;
+  contentHash: string;
+}
+
 export interface VideoProcessResult {
   success: boolean;
   duration?: number;
@@ -85,6 +91,7 @@ export type JobDataMap = {
   'text-extract': TextExtractJobData;
   'ocr-process': OCRJobData;
   'video-process': VideoProcessJobData;
+  'pull-verify': PullVerifyJobData;
   'siem-delivery': Record<string, never>;
 };
 

--- a/apps/processor/src/workers/__tests__/queue-manager-full.test.ts
+++ b/apps/processor/src/workers/__tests__/queue-manager-full.test.ts
@@ -59,6 +59,10 @@ vi.mock('../video-processor', () => ({
   isVideo: vi.fn().mockReturnValue(false),
 }));
 
+vi.mock('../../api/s3-pull-adapter', () => ({
+  runPullPipeline: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { QueueManager, mapJobState } from '../queue-manager';
 import { setPageProcessing, setPageCompleted, setPageFailed, setPageVisual } from '../../db';
 import { needsTextExtraction, extractText } from '../text-extractor';
@@ -103,15 +107,17 @@ describe('QueueManager', () => {
       await qm.initialize();
 
       expect(mockBossStart).toHaveBeenCalledTimes(1);
-      expect(mockBossWork).toHaveBeenCalledTimes(6);
+      expect(mockBossWork).toHaveBeenCalledTimes(7);
       expect(mockBossWork.mock.calls[0][0]).toBe('ingest-file');
       expect(mockBossWork.mock.calls[1][0]).toBe('image-optimize');
       expect(mockBossWork.mock.calls[2][0]).toBe('text-extract');
       expect(mockBossWork.mock.calls[3][0]).toBe('ocr-process');
       expect(mockBossWork.mock.calls[4][0]).toBe('video-process');
       expect(mockBossWork.mock.calls[5][0]).toBe('siem-delivery');
-      expect(mockBossCreateQueue).toHaveBeenCalledTimes(6);
+      expect(mockBossWork.mock.calls[6][0]).toBe('pull-verify');
+      expect(mockBossCreateQueue).toHaveBeenCalledTimes(7);
       expect(mockBossCreateQueue).toHaveBeenCalledWith('ingest-file');
+      expect(mockBossCreateQueue).toHaveBeenCalledWith('pull-verify');
       expect(mockBossCreateQueue).toHaveBeenCalledWith('image-optimize');
       expect(mockBossCreateQueue).toHaveBeenCalledWith('text-extract');
       expect(mockBossCreateQueue).toHaveBeenCalledWith('ocr-process');

--- a/apps/processor/src/workers/__tests__/queue-manager.test.ts
+++ b/apps/processor/src/workers/__tests__/queue-manager.test.ts
@@ -35,6 +35,7 @@ describe('QueueManager type contracts', () => {
   it('given QueueStats record, should be keyed by QueueName', () => {
     const status: Record<QueueName, QueueStats> = {
       'ingest-file': { active: 0, pending: 0, completed: 0, failed: 0 },
+      'pull-verify': { active: 0, pending: 0, completed: 0, failed: 0 },
       'image-optimize': { active: 0, pending: 0, completed: 0, failed: 0 },
       'text-extract': { active: 0, pending: 0, completed: 0, failed: 0 },
       'ocr-process': { active: 0, pending: 0, completed: 0, failed: 0 },
@@ -44,9 +45,9 @@ describe('QueueManager type contracts', () => {
 
     assert({
       given: 'a Record<QueueName, QueueStats>',
-      should: 'have 6 queue keys',
+      should: 'have 7 queue keys',
       actual: Object.keys(status).length,
-      expected: 6,
+      expected: 7,
     });
   });
 });

--- a/apps/processor/src/workers/queue-manager.ts
+++ b/apps/processor/src/workers/queue-manager.ts
@@ -9,6 +9,7 @@ import type {
   TextExtractJobData,
   OCRJobData,
   VideoProcessJobData,
+  PullVerifyJobData,
   TextExtractResult,
   IngestResult,
 } from '../types';
@@ -78,6 +79,7 @@ export class QueueManager {
 
     try {
       await this.boss.createQueue('ingest-file');
+      await this.boss.createQueue('pull-verify');
       await this.boss.createQueue('image-optimize');
       await this.boss.createQueue('text-extract');
       await this.boss.createQueue('ocr-process');
@@ -97,6 +99,7 @@ export class QueueManager {
     const { extractText } = await import('./text-extractor');
     const { processOCR } = await import('./ocr-processor');
     const { processVideo } = await import('./video-processor');
+    const { runPullPipeline } = await import('../api/s3-pull-adapter');
 
     // Unified ingestion worker
     await this.boss.work('ingest-file',
@@ -228,6 +231,14 @@ export class QueueManager {
 
     // Schedule SIEM delivery every 30 seconds
     await this.boss.schedule('siem-delivery', '*/30 * * * * *', {}, { retryLimit: 0 });
+
+    // Direct-to-S3 verified ingest: byte-verify (hash + Magika) before processing.
+    await this.boss.work('pull-verify',
+      async ([job]) => {
+        await runPullPipeline(job.data as PullVerifyJobData);
+        return { success: true } satisfies IngestResult;
+      }
+    );
   }
 
   async addJob<Q extends QueueName>(
@@ -281,7 +292,7 @@ export class QueueManager {
   }
 
   getQueueStatus(): Record<QueueName, QueueStats> {
-    const queues: QueueName[] = ['ingest-file', 'image-optimize', 'text-extract', 'ocr-process', 'video-process', 'siem-delivery'];
+    const queues: QueueName[] = ['ingest-file', 'pull-verify', 'image-optimize', 'text-extract', 'ocr-process', 'video-process', 'siem-delivery'];
     const perQueue = this.cachedStates?.queues ?? {};
 
     const status = {} as Record<QueueName, QueueStats>;

--- a/apps/processor/src/workers/queue-manager.ts
+++ b/apps/processor/src/workers/queue-manager.ts
@@ -235,8 +235,10 @@ export class QueueManager {
     // Direct-to-S3 verified ingest: byte-verify (hash + Magika) before processing.
     await this.boss.work('pull-verify',
       async ([job]) => {
+        // runPullPipeline sets the page's real status (visual/completed/failed);
+        // this return is just the pg-boss job result.
         await runPullPipeline(job.data as PullVerifyJobData);
-        return { success: true } satisfies IngestResult;
+        return { success: true };
       }
     );
   }

--- a/apps/web/src/app/api/upload/cancel/__tests__/route.test.ts
+++ b/apps/web/src/app/api/upload/cancel/__tests__/route.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn((r: unknown) => r !== null && typeof r === 'object' && 'error' in r),
+}));
+
+vi.mock('@pagespace/lib/services/upload-semaphore', () => ({
+  uploadSemaphore: { verifySlotOwner: vi.fn(), releaseUploadSlot: vi.fn() },
+}));
+
+vi.mock('@pagespace/lib/services/storage-limits', () => ({
+  updateActiveUploads: vi.fn(),
+}));
+
+import { POST } from '../route';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+import { uploadSemaphore } from '@pagespace/lib/services/upload-semaphore';
+import { updateActiveUploads } from '@pagespace/lib/services/storage-limits';
+
+const JOB_ID = 'user-1-slot-abc';
+
+function makeAuth(userId = 'user-1') {
+  return { userId, tokenType: 'session' as const, tokenVersion: 0, sessionId: 's', role: 'user' as const, adminRoleVersion: 0 };
+}
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/upload/cancel', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(authenticateRequestWithOptions).mockResolvedValue(makeAuth());
+  vi.mocked(uploadSemaphore.verifySlotOwner).mockReturnValue(true);
+  vi.mocked(updateActiveUploads).mockResolvedValue(undefined);
+});
+
+describe('POST /api/upload/cancel', () => {
+  it('returns 401 when not authenticated', async () => {
+    vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ error: new Response(null, { status: 401 }) } as never);
+    const res = await POST(makeRequest({ jobId: JOB_ID }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when jobId is missing', async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it('releases the slot and decrements activeUploads for a slot the user owns', async () => {
+    const res = await POST(makeRequest({ jobId: JOB_ID }));
+    expect(res.status).toBe(200);
+    expect(uploadSemaphore.releaseUploadSlot).toHaveBeenCalledWith(JOB_ID);
+    expect(updateActiveUploads).toHaveBeenCalledWith('user-1', -1);
+  });
+
+  it('does not release a slot the user does not own', async () => {
+    vi.mocked(uploadSemaphore.verifySlotOwner).mockReturnValue(false);
+    const res = await POST(makeRequest({ jobId: JOB_ID }));
+    expect(res.status).toBe(403);
+    expect(uploadSemaphore.releaseUploadSlot).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/upload/cancel/__tests__/route.test.ts
+++ b/apps/web/src/app/api/upload/cancel/__tests__/route.test.ts
@@ -3,10 +3,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
   isAuthError: vi.fn((r: unknown) => r !== null && typeof r === 'object' && 'error' in r),
+  checkMCPCreateScope: vi.fn(() => null),
 }));
 
 vi.mock('@pagespace/lib/services/upload-semaphore', () => ({
-  uploadSemaphore: { verifySlotOwner: vi.fn(), releaseUploadSlot: vi.fn() },
+  uploadSemaphore: { verifySlotOwner: vi.fn(), getSlotMetadata: vi.fn(), releaseUploadSlot: vi.fn() },
 }));
 
 vi.mock('@pagespace/lib/services/storage-limits', () => ({
@@ -39,6 +40,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(authenticateRequestWithOptions).mockResolvedValue(makeAuth());
   vi.mocked(uploadSemaphore.verifySlotOwner).mockReturnValue(true);
+  vi.mocked(uploadSemaphore.getSlotMetadata).mockReturnValue({ contentHash: 'a'.repeat(64), driveId: 'drive-1', fileSize: 1024, mimeType: 'image/jpeg' });
   vi.mocked(updateActiveUploads).mockResolvedValue(undefined);
 });
 

--- a/apps/web/src/app/api/upload/cancel/__tests__/route.test.ts
+++ b/apps/web/src/app/api/upload/cancel/__tests__/route.test.ts
@@ -13,10 +13,13 @@ vi.mock('@pagespace/lib/services/storage-limits', () => ({
   updateActiveUploads: vi.fn(),
 }));
 
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+
 import { POST } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
 import { uploadSemaphore } from '@pagespace/lib/services/upload-semaphore';
 import { updateActiveUploads } from '@pagespace/lib/services/storage-limits';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const JOB_ID = 'user-1-slot-abc';
 
@@ -56,6 +59,7 @@ describe('POST /api/upload/cancel', () => {
     expect(res.status).toBe(200);
     expect(uploadSemaphore.releaseUploadSlot).toHaveBeenCalledWith(JOB_ID);
     expect(updateActiveUploads).toHaveBeenCalledWith('user-1', -1);
+    expect(auditRequest).toHaveBeenCalled();
   });
 
   it('does not release a slot the user does not own', async () => {

--- a/apps/web/src/app/api/upload/cancel/route.ts
+++ b/apps/web/src/app/api/upload/cancel/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { authenticateRequestWithOptions, isAuthError, checkMCPCreateScope } from '@/lib/auth';
 import { uploadSemaphore } from '@pagespace/lib/services/upload-semaphore';
 import { updateActiveUploads } from '@pagespace/lib/services/storage-limits';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
@@ -29,8 +29,15 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Missing jobId' }, { status: 400 });
   }
 
+  const reserved = uploadSemaphore.getSlotMetadata(jobId, userId);
   if (!uploadSemaphore.verifySlotOwner(jobId, userId)) {
     return NextResponse.json({ error: 'Invalid or expired jobId' }, { status: 403 });
+  }
+
+  // A drive-scoped MCP token may only cancel uploads within its scope.
+  if (reserved) {
+    const scopeError = checkMCPCreateScope(auth, reserved.driveId);
+    if (scopeError) return scopeError;
   }
 
   uploadSemaphore.releaseUploadSlot(jobId);

--- a/apps/web/src/app/api/upload/cancel/route.ts
+++ b/apps/web/src/app/api/upload/cancel/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { uploadSemaphore } from '@pagespace/lib/services/upload-semaphore';
 import { updateActiveUploads } from '@pagespace/lib/services/storage-limits';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 
@@ -34,6 +35,14 @@ export async function POST(request: Request) {
 
   uploadSemaphore.releaseUploadSlot(jobId);
   await updateActiveUploads(userId, -1);
+
+  auditRequest(request, {
+    eventType: 'data.write',
+    userId,
+    resourceType: 'file',
+    resourceId: jobId,
+    details: { action: 'upload-cancel' },
+  });
 
   return NextResponse.json({ success: true });
 }

--- a/apps/web/src/app/api/upload/cancel/route.ts
+++ b/apps/web/src/app/api/upload/cancel/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { uploadSemaphore } from '@pagespace/lib/services/upload-semaphore';
+import { updateActiveUploads } from '@pagespace/lib/services/storage-limits';
+
+const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
+
+/**
+ * Release an upload slot reserved by /presign when the client-side upload fails
+ * before /complete runs. Without this, a failed upload's slot leaks until the
+ * semaphore's stale-slot sweep.
+ */
+export async function POST(request: Request) {
+  const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
+  if (isAuthError(auth)) return auth.error;
+
+  const { userId } = auth;
+
+  let body: { jobId?: string };
+  try {
+    body = (await request.json()) as { jobId?: string };
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const { jobId } = body;
+  if (!jobId) {
+    return NextResponse.json({ error: 'Missing jobId' }, { status: 400 });
+  }
+
+  if (!uploadSemaphore.verifySlotOwner(jobId, userId)) {
+    return NextResponse.json({ error: 'Invalid or expired jobId' }, { status: 403 });
+  }
+
+  uploadSemaphore.releaseUploadSlot(jobId);
+  await updateActiveUploads(userId, -1);
+
+  return NextResponse.json({ success: true });
+}

--- a/apps/web/src/app/api/upload/complete/__tests__/route.test.ts
+++ b/apps/web/src/app/api/upload/complete/__tests__/route.test.ts
@@ -45,7 +45,7 @@ vi.mock('@pagespace/lib/services/storage-limits', () => ({
 
 vi.mock('@pagespace/lib/services/upload-semaphore', () => ({
   uploadSemaphore: {
-    verifySlotOwner: vi.fn(),
+    getSlotMetadata: vi.fn(),
     releaseUploadSlot: vi.fn(),
   },
 }));
@@ -108,15 +108,14 @@ function makeRequest(body: Record<string, unknown>) {
   });
 }
 
+// Only jobId/title/parentId are read from the body now; the rest is trusted slot metadata.
 const VALID_BODY = {
   jobId: MOCK_JOB_ID,
-  contentHash: VALID_HASH,
-  driveId: 'drive-1',
   title: 'photo.jpg',
-  mimeType: 'image/jpeg',
-  fileSize: 2048,
   parentId: null,
 };
+
+const SLOT_META = { contentHash: VALID_HASH, driveId: 'drive-1', fileSize: 2048, mimeType: 'image/jpeg' };
 
 const MOCK_PAGE = { id: 'page-abc', title: 'photo.jpg', type: 'FILE', driveId: 'drive-1', contentHash: VALID_HASH };
 
@@ -125,7 +124,7 @@ beforeEach(() => {
   capturedPageValues = undefined;
   vi.mocked(authenticateRequestWithOptions).mockResolvedValue(makeAuth());
   vi.mocked(getUserDrivePermissions).mockResolvedValue({ hasAccess: true, isOwner: true, isAdmin: false, isMember: false, canEdit: true });
-  vi.mocked(uploadSemaphore.verifySlotOwner).mockReturnValue(true);
+  vi.mocked(uploadSemaphore.getSlotMetadata).mockReturnValue(SLOT_META);
   vi.mocked(enqueueProcessorJob).mockResolvedValue(undefined);
   vi.mocked(updateActiveUploads).mockResolvedValue(undefined);
 
@@ -142,10 +141,18 @@ describe('POST /api/upload/complete', () => {
   });
 
   describe('jobId verification', () => {
-    it('returns 403 when jobId does not belong to the authenticated user', async () => {
-      vi.mocked(uploadSemaphore.verifySlotOwner).mockReturnValue(false);
+    it('returns 403 when the jobId has no reserved slot for the user', async () => {
+      vi.mocked(uploadSemaphore.getSlotMetadata).mockReturnValue(null);
       const res = await POST(makeRequest(VALID_BODY));
       expect(res.status).toBe(403);
+    });
+
+    it('uses the slot metadata (not the request body) for the trusted upload params', async () => {
+      // Body lies about the drive; the route must use the reserved drive-1 instead.
+      const res = await POST(makeRequest({ ...VALID_BODY, driveId: 'attacker-drive', contentHash: 'f'.repeat(64) }));
+      expect(res.status).toBe(200);
+      expect(capturedPageValues?.driveId).toBe('drive-1');
+      expect(capturedPageValues?.contentHash).toBe(VALID_HASH);
     });
 
     it('returns 400 when required fields are missing', async () => {

--- a/apps/web/src/app/api/upload/complete/__tests__/route.test.ts
+++ b/apps/web/src/app/api/upload/complete/__tests__/route.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
   isAuthError: vi.fn((r: unknown) => r !== null && typeof r === 'object' && 'error' in r),
+  checkMCPCreateScope: vi.fn(() => null),
 }));
 
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
@@ -235,7 +236,7 @@ describe('POST /api/upload/complete', () => {
   describe('slot leak prevention', () => {
     it('releases the slot even when the processor job enqueue fails', async () => {
       vi.mocked(enqueueProcessorJob).mockRejectedValue(new Error('processor down'));
-      const res = await POST(makeRequest(VALID_BODY));
+      await POST(makeRequest(VALID_BODY));
       // Response may vary but slot must be released
       expect(uploadSemaphore.releaseUploadSlot).toHaveBeenCalledWith(MOCK_JOB_ID);
     });

--- a/apps/web/src/app/api/upload/complete/__tests__/route.test.ts
+++ b/apps/web/src/app/api/upload/complete/__tests__/route.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn((r: unknown) => r !== null && typeof r === 'object' && 'error' in r),
+}));
+
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  getUserDrivePermissions: vi.fn(),
+}));
+
+const mockTransaction = vi.fn();
+
+vi.mock('@pagespace/db/db', () => ({
+  db: {
+    transaction: (...args: unknown[]) => mockTransaction(...args),
+  },
+}));
+
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn(),
+  isNull: vi.fn(),
+  desc: vi.fn(),
+}));
+
+vi.mock('@pagespace/db/schema/core', () => ({
+  pages: 'pages',
+  drives: 'drives',
+}));
+
+vi.mock('@pagespace/db/schema/storage', () => ({
+  files: 'files',
+  filePages: 'filePages',
+}));
+
+vi.mock('@pagespace/lib/utils/enums', () => ({
+  PageType: { FILE: 'FILE' },
+}));
+
+vi.mock('@pagespace/lib/services/storage-limits', () => ({
+  updateActiveUploads: vi.fn(),
+  updateStorageUsage: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/services/upload-semaphore', () => ({
+  uploadSemaphore: {
+    verifySlotOwner: vi.fn(),
+    releaseUploadSlot: vi.fn(),
+  },
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } },
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+
+vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
+  getActorInfo: vi.fn().mockResolvedValue({}),
+  logFileActivity: vi.fn(),
+}));
+
+vi.mock('@/lib/upload/processor-effects', () => ({
+  enqueueProcessorJob: vi.fn(),
+}));
+
+import { POST } from '../route';
+import { authenticateRequestWithOptions } from '@/lib/auth';
+import { getUserDrivePermissions } from '@pagespace/lib/permissions/permissions';
+import { uploadSemaphore } from '@pagespace/lib/services/upload-semaphore';
+import { updateActiveUploads } from '@pagespace/lib/services/storage-limits';
+import { enqueueProcessorJob } from '@/lib/upload/processor-effects';
+
+// Captures the values passed to tx.insert(pages).values(...) for assertion
+let capturedPageValues: Record<string, unknown> | undefined;
+
+function makeTxImpl() {
+  return async (fn: (tx: unknown) => Promise<unknown>) => {
+    const tx = {
+      insert: (table: unknown) => ({
+        values: (vals: Record<string, unknown>) => {
+          if (table === 'pages') capturedPageValues = vals;
+          return {
+            returning: vi.fn().mockResolvedValue([MOCK_PAGE]),
+            onConflictDoNothing: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: VALID_HASH }]) }),
+            onConflictDoUpdate: vi.fn().mockResolvedValue([]),
+          };
+        },
+      }),
+    };
+    return fn(tx);
+  };
+}
+
+const VALID_HASH = 'b'.repeat(64);
+const MOCK_JOB_ID = 'user-1-slot-xyz';
+
+function makeAuth(userId = 'user-1') {
+  return { userId, tokenType: 'session' as const, tokenVersion: 0, sessionId: 's', role: 'user' as const, adminRoleVersion: 0 };
+}
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/upload/complete', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+const VALID_BODY = {
+  jobId: MOCK_JOB_ID,
+  contentHash: VALID_HASH,
+  driveId: 'drive-1',
+  title: 'photo.jpg',
+  mimeType: 'image/jpeg',
+  fileSize: 2048,
+  parentId: null,
+};
+
+const MOCK_PAGE = { id: 'page-abc', title: 'photo.jpg', type: 'FILE', driveId: 'drive-1', contentHash: VALID_HASH };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  capturedPageValues = undefined;
+  vi.mocked(authenticateRequestWithOptions).mockResolvedValue(makeAuth());
+  vi.mocked(getUserDrivePermissions).mockResolvedValue({ hasAccess: true, isOwner: true, isAdmin: false, isMember: false, canEdit: true });
+  vi.mocked(uploadSemaphore.verifySlotOwner).mockReturnValue(true);
+  vi.mocked(enqueueProcessorJob).mockResolvedValue(undefined);
+  vi.mocked(updateActiveUploads).mockResolvedValue(undefined);
+
+  mockTransaction.mockImplementation(makeTxImpl());
+});
+
+describe('POST /api/upload/complete', () => {
+  describe('authentication', () => {
+    it('returns 401 when the request is not authenticated', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ error: new Response(null, { status: 401 }) } as never);
+      const res = await POST(makeRequest(VALID_BODY));
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('jobId verification', () => {
+    it('returns 403 when jobId does not belong to the authenticated user', async () => {
+      vi.mocked(uploadSemaphore.verifySlotOwner).mockReturnValue(false);
+      const res = await POST(makeRequest(VALID_BODY));
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 400 when required fields are missing', async () => {
+      const { jobId: _, ...incomplete } = VALID_BODY;
+      const res = await POST(makeRequest(incomplete));
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('drive access', () => {
+    it('returns 404 when the drive does not exist', async () => {
+      vi.mocked(getUserDrivePermissions).mockResolvedValue(null);
+      const res = await POST(makeRequest(VALID_BODY));
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 403 when the user cannot edit the drive', async () => {
+      vi.mocked(getUserDrivePermissions).mockResolvedValue({ hasAccess: true, isOwner: false, isAdmin: false, isMember: true, canEdit: false });
+      const res = await POST(makeRequest(VALID_BODY));
+      expect(res.status).toBe(403);
+    });
+
+    it('does not create a page record when drive access is denied', async () => {
+      vi.mocked(getUserDrivePermissions).mockResolvedValue(null);
+      await POST(makeRequest(VALID_BODY));
+      expect(mockTransaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('page record', () => {
+    it('stores the raw content hash in filePath, not the S3 key', async () => {
+      await POST(makeRequest(VALID_BODY));
+      expect(capturedPageValues?.filePath).toBe(VALID_HASH);
+    });
+  });
+
+  describe('happy path', () => {
+    it('returns 200 with the created page', async () => {
+      const res = await POST(makeRequest(VALID_BODY));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.success).toBe(true);
+      expect(body.page).toBeDefined();
+    });
+
+    it('releases the upload slot after successful insert', async () => {
+      await POST(makeRequest(VALID_BODY));
+      expect(uploadSemaphore.releaseUploadSlot).toHaveBeenCalledWith(MOCK_JOB_ID);
+    });
+
+    it('decrements activeUploads after successful insert', async () => {
+      await POST(makeRequest(VALID_BODY));
+      expect(updateActiveUploads).toHaveBeenCalledWith('user-1', -1);
+    });
+
+    it('enqueues the processor job after the DB transaction commits', async () => {
+      await POST(makeRequest(VALID_BODY));
+      expect(enqueueProcessorJob).toHaveBeenCalledWith('user-1', 'drive-1', expect.any(String));
+    });
+
+    it('does not enqueue the processor job inside the DB transaction', async () => {
+      const callOrder: string[] = [];
+      mockTransaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) => {
+        const tx = {
+          insert: () => ({
+            values: () => ({
+              returning: vi.fn().mockResolvedValue([MOCK_PAGE]),
+              onConflictDoNothing: () => ({ returning: vi.fn().mockResolvedValue([{ id: VALID_HASH }]) }),
+              onConflictDoUpdate: vi.fn().mockResolvedValue([]),
+            }),
+          }),
+        };
+        const result = await fn(tx);
+        callOrder.push('tx-complete');
+        return result;
+      });
+      vi.mocked(enqueueProcessorJob).mockImplementation(async () => {
+        callOrder.push('enqueue');
+      });
+
+      await POST(makeRequest(VALID_BODY));
+      const txIdx = callOrder.indexOf('tx-complete');
+      const enqIdx = callOrder.indexOf('enqueue');
+      expect(txIdx).toBeLessThan(enqIdx);
+    });
+  });
+
+  describe('slot leak prevention', () => {
+    it('releases the slot even when the processor job enqueue fails', async () => {
+      vi.mocked(enqueueProcessorJob).mockRejectedValue(new Error('processor down'));
+      const res = await POST(makeRequest(VALID_BODY));
+      // Response may vary but slot must be released
+      expect(uploadSemaphore.releaseUploadSlot).toHaveBeenCalledWith(MOCK_JOB_ID);
+    });
+  });
+});

--- a/apps/web/src/app/api/upload/complete/route.ts
+++ b/apps/web/src/app/api/upload/complete/route.ts
@@ -151,27 +151,34 @@ export async function POST(request: Request) {
   }
 
   uploadSemaphore.releaseUploadSlot(jobId);
-  await updateActiveUploads(userId, -1);
 
+  // The page is committed. Everything below is best-effort bookkeeping — a
+  // failure here must not turn a successful upload into a 500 (which would make
+  // the client retry and duplicate the page).
   try {
-    await enqueueProcessorJob(userId, driveId, newPage.id);
+    await updateActiveUploads(userId, -1);
+
+    try {
+      await enqueueProcessorJob(userId, driveId, newPage.id);
+    } catch (err) {
+      console.error('Failed to enqueue processor job:', err);
+    }
+
+    await updateStorageUsage(userId, fileSize, { pageId: newPage.id, driveId, eventType: 'upload' });
+
+    auditRequest(request, {
+      eventType: 'data.write',
+      userId,
+      resourceType: 'file',
+      resourceId: contentHash,
+      details: { driveId, pageId: newPage.id },
+    });
+
+    const actorInfo = await getActorInfo(userId);
+    logFileActivity(userId, 'upload', { fileId: contentHash, fileName: title, fileType: mimeType, fileSize, driveId, pageId: newPage.id }, actorInfo);
   } catch (err) {
-    // Processor enqueue failure must not fail the upload response — page record is committed
-    console.error('Failed to enqueue processor job:', err);
+    console.error('Post-commit bookkeeping failed for upload:', err);
   }
-
-  await updateStorageUsage(userId, fileSize, { pageId: newPage.id, driveId, eventType: 'upload' });
-
-  auditRequest(request, {
-    eventType: 'data.write',
-    userId,
-    resourceType: 'file',
-    resourceId: contentHash,
-    details: { driveId, pageId: newPage.id },
-  });
-
-  const actorInfo = await getActorInfo(userId);
-  logFileActivity(userId, 'upload', { fileId: contentHash, fileName: title, fileType: mimeType, fileSize, driveId, pageId: newPage.id }, actorInfo);
 
   return NextResponse.json({ success: true, page: newPage });
 }

--- a/apps/web/src/app/api/upload/complete/route.ts
+++ b/apps/web/src/app/api/upload/complete/route.ts
@@ -1,0 +1,173 @@
+import { NextResponse } from 'next/server';
+import { createId } from '@paralleldrive/cuid2';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { db } from '@pagespace/db/db';
+import { pages } from '@pagespace/db/schema/core';
+import { files, filePages } from '@pagespace/db/schema/storage';
+import { PageType } from '@pagespace/lib/utils/enums';
+import { getUserDrivePermissions } from '@pagespace/lib/permissions/permissions';
+import { updateActiveUploads, updateStorageUsage } from '@pagespace/lib/services/storage-limits';
+import { uploadSemaphore } from '@pagespace/lib/services/upload-semaphore';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { getActorInfo, logFileActivity } from '@pagespace/lib/monitoring/activity-logger';
+import { enqueueProcessorJob } from '@/lib/upload/processor-effects';
+
+const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
+
+interface CompleteRequestBody {
+  jobId: string;
+  contentHash: string;
+  driveId: string;
+  title: string;
+  mimeType: string;
+  fileSize: number;
+  parentId?: string | null;
+}
+
+interface NewPageRecord {
+  id: string;
+  title: string;
+  type: (typeof PageType)[keyof typeof PageType];
+  content: string;
+  processingStatus: string;
+  position: number;
+  driveId: string;
+  parentId: string | null;
+  fileSize: number;
+  mimeType: string;
+  originalFileName: string;
+  filePath: string;
+  contentHash: string;
+  fileMetadata: Record<string, string | number | boolean | undefined>;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+function buildPageRecord(params: {
+  contentHash: string;
+  driveId: string;
+  title: string;
+  mimeType: string;
+  fileSize: number;
+  userId: string;
+  parentId?: string | null;
+}): NewPageRecord {
+  return {
+    id: createId(),
+    title: params.title,
+    type: PageType.FILE,
+    content: '',
+    processingStatus: 'pending',
+    position: Date.now(),
+    driveId: params.driveId,
+    parentId: params.parentId ?? null,
+    fileSize: params.fileSize,
+    mimeType: params.mimeType,
+    originalFileName: params.title,
+    // Store the raw content hash — the processor reads filePath directly as the
+    // content hash (SELECT "filePath" as "contentHash"). The S3 key is derived
+    // from the hash at read time via buildS3Key / generatePresignedUrl.
+    filePath: params.contentHash,
+    contentHash: params.contentHash,
+    fileMetadata: {
+      uploadedAt: new Date().toISOString(),
+      uploadedBy: params.userId,
+      originalName: params.title,
+      contentHash: params.contentHash,
+    },
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+export async function POST(request: Request) {
+  const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
+  if (isAuthError(auth)) return auth.error;
+
+  const { userId } = auth;
+
+  let body: CompleteRequestBody;
+  try {
+    body = await request.json() as CompleteRequestBody;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const { jobId, contentHash, driveId, title, mimeType, fileSize, parentId } = body;
+
+  if (!jobId || !contentHash || !driveId || !title || !mimeType || typeof fileSize !== 'number') {
+    return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+  }
+
+  if (!uploadSemaphore.verifySlotOwner(jobId, userId)) {
+    return NextResponse.json({ error: 'Invalid or expired jobId' }, { status: 403 });
+  }
+
+  const drivePerms = await getUserDrivePermissions(userId, driveId);
+  if (!drivePerms) {
+    return NextResponse.json({ error: 'Drive not found' }, { status: 404 });
+  }
+  if (!drivePerms.canEdit) {
+    return NextResponse.json({ error: 'You do not have permission to upload to this drive' }, { status: 403 });
+  }
+
+  const record = buildPageRecord({ contentHash, driveId, title, mimeType, fileSize, userId, parentId });
+
+  let newPage: typeof pages.$inferSelect;
+  try {
+    newPage = await db.transaction(async (tx) => {
+      const [createdPage] = await tx.insert(pages).values(record).returning();
+
+      await tx
+        .insert(files)
+        .values({
+          id: contentHash,
+          driveId,
+          sizeBytes: fileSize,
+          mimeType,
+          storagePath: contentHash,
+          createdBy: userId,
+        })
+        .onConflictDoNothing();
+
+      await tx
+        .insert(filePages)
+        .values({ fileId: contentHash, pageId: createdPage.id, linkedBy: userId, linkSource: 'presigned-upload' })
+        .onConflictDoUpdate({
+          target: [filePages.fileId, filePages.pageId],
+          set: { linkedBy: userId, linkedAt: new Date(), linkSource: 'presigned-upload' },
+        });
+
+      return createdPage;
+    });
+  } catch (err) {
+    uploadSemaphore.releaseUploadSlot(jobId);
+    await updateActiveUploads(userId, -1).catch(() => undefined);
+    throw err;
+  }
+
+  uploadSemaphore.releaseUploadSlot(jobId);
+  await updateActiveUploads(userId, -1);
+
+  try {
+    await enqueueProcessorJob(userId, driveId, newPage.id);
+  } catch (err) {
+    // Processor enqueue failure must not fail the upload response — page record is committed
+    console.error('Failed to enqueue processor job:', err);
+  }
+
+  await updateStorageUsage(userId, fileSize, { pageId: newPage.id, driveId, eventType: 'upload' });
+
+  auditRequest(request, {
+    eventType: 'data.write',
+    userId,
+    resourceType: 'file',
+    resourceId: contentHash,
+    details: { driveId, pageId: newPage.id },
+  });
+
+  const actorInfo = await getActorInfo(userId);
+  logFileActivity(userId, 'upload', { fileId: contentHash, fileName: title, fileType: mimeType, fileSize, driveId, pageId: newPage.id }, actorInfo);
+
+  return NextResponse.json({ success: true, page: newPage });
+}

--- a/apps/web/src/app/api/upload/complete/route.ts
+++ b/apps/web/src/app/api/upload/complete/route.ts
@@ -16,12 +16,10 @@ const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 
 interface CompleteRequestBody {
   jobId: string;
-  contentHash: string;
-  driveId: string;
   title: string;
-  mimeType: string;
-  fileSize: number;
   parentId?: string | null;
+  // contentHash / driveId / mimeType / fileSize are intentionally NOT read from
+  // the body — they are taken from the presign-reserved slot (see getSlotMetadata).
 }
 
 interface NewPageRecord {
@@ -93,15 +91,20 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
   }
 
-  const { jobId, contentHash, driveId, title, mimeType, fileSize, parentId } = body;
+  const { jobId, title, parentId } = body;
 
-  if (!jobId || !contentHash || !driveId || !title || !mimeType || typeof fileSize !== 'number') {
+  if (!jobId || !title) {
     return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
   }
 
-  if (!uploadSemaphore.verifySlotOwner(jobId, userId)) {
+  // contentHash / driveId / fileSize / mimeType come from the slot reserved at
+  // presign time — never from the client body — so a verified jobId can't be
+  // replayed against a different drive, hash, size, or MIME type.
+  const reserved = uploadSemaphore.getSlotMetadata(jobId, userId);
+  if (!reserved) {
     return NextResponse.json({ error: 'Invalid or expired jobId' }, { status: 403 });
   }
+  const { contentHash, driveId, fileSize, mimeType } = reserved;
 
   // Scoped MCP tokens may only act on the drive they were granted for.
   const scopeError = checkMCPCreateScope(auth, driveId);

--- a/apps/web/src/app/api/upload/complete/route.ts
+++ b/apps/web/src/app/api/upload/complete/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { createId } from '@paralleldrive/cuid2';
-import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { authenticateRequestWithOptions, isAuthError, checkMCPCreateScope } from '@/lib/auth';
 import { db } from '@pagespace/db/db';
 import { pages } from '@pagespace/db/schema/core';
 import { files, filePages } from '@pagespace/db/schema/storage';
@@ -102,6 +102,10 @@ export async function POST(request: Request) {
   if (!uploadSemaphore.verifySlotOwner(jobId, userId)) {
     return NextResponse.json({ error: 'Invalid or expired jobId' }, { status: 403 });
   }
+
+  // Scoped MCP tokens may only act on the drive they were granted for.
+  const scopeError = checkMCPCreateScope(auth, driveId);
+  if (scopeError) return scopeError;
 
   const drivePerms = await getUserDrivePermissions(userId, driveId);
   if (!drivePerms) {

--- a/apps/web/src/app/api/upload/presign/__tests__/route.test.ts
+++ b/apps/web/src/app/api/upload/presign/__tests__/route.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/auth', () => ({
+  authenticateRequestWithOptions: vi.fn(),
+  isAuthError: vi.fn((r: unknown) => r !== null && typeof r === 'object' && 'error' in r),
+}));
+
+vi.mock('@pagespace/lib/permissions/permissions', () => ({
+  getUserDrivePermissions: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/services/storage-limits', () => ({
+  getUserStorageQuota: vi.fn(),
+  updateActiveUploads: vi.fn(),
+}));
+
+vi.mock('@pagespace/lib/services/upload-semaphore', () => ({
+  uploadSemaphore: { acquireUploadSlot: vi.fn(), releaseUploadSlot: vi.fn() },
+}));
+
+vi.mock('@pagespace/lib/logging/logger-config', () => ({
+  loggers: { api: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } },
+}));
+
+vi.mock('@pagespace/lib/audit/audit-log', () => ({ auditRequest: vi.fn() }));
+
+vi.mock('@/lib/upload/s3-effects', () => ({
+  checkObjectExists: vi.fn(),
+  issuePresignedPutUrl: vi.fn(),
+}));
+
+import { POST } from '../route';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { getUserDrivePermissions } from '@pagespace/lib/permissions/permissions';
+import { getUserStorageQuota, updateActiveUploads } from '@pagespace/lib/services/storage-limits';
+import { uploadSemaphore } from '@pagespace/lib/services/upload-semaphore';
+import { checkObjectExists, issuePresignedPutUrl } from '@/lib/upload/s3-effects';
+
+const VALID_HASH = 'a'.repeat(64);
+const MOCK_URL = 'https://tigris.example.com/files/aaa.../original?X-Amz-Signature=abc';
+const MOCK_SLOT = 'user-1-slot-abc';
+
+function makeAuth(userId = 'user-1') {
+  return { userId, tokenType: 'session' as const, tokenVersion: 0, sessionId: 's', role: 'user' as const, adminRoleVersion: 0 };
+}
+
+function makeQuota(tier = 'free' as const) {
+  return { userId: 'user-1', tier, quotaBytes: 500 * 1024 * 1024, usedBytes: 0, availableBytes: 500 * 1024 * 1024, utilizationPercent: 0, warningLevel: 'none' as const };
+}
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request('http://localhost/api/upload/presign', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+const VALID_BODY = {
+  contentHash: VALID_HASH,
+  driveId: 'drive-1',
+  filename: 'photo.jpg',
+  mimeType: 'image/jpeg',
+  fileSize: 1024,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(authenticateRequestWithOptions).mockResolvedValue(makeAuth());
+  vi.mocked(getUserDrivePermissions).mockResolvedValue({ hasAccess: true, isOwner: true, isAdmin: false, isMember: false, canEdit: true });
+  vi.mocked(getUserStorageQuota).mockResolvedValue(makeQuota());
+  vi.mocked(checkObjectExists).mockResolvedValue(false);
+  vi.mocked(issuePresignedPutUrl).mockResolvedValue(MOCK_URL);
+  vi.mocked(uploadSemaphore.acquireUploadSlot).mockResolvedValue(MOCK_SLOT);
+  vi.mocked(updateActiveUploads).mockResolvedValue(undefined);
+});
+
+describe('POST /api/upload/presign', () => {
+  describe('authentication', () => {
+    it('returns 401 when the request is not authenticated', async () => {
+      vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ error: new Response(null, { status: 401 }) } as never);
+      const res = await POST(makeRequest(VALID_BODY));
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('drive access', () => {
+    it('returns 404 when the drive does not exist', async () => {
+      vi.mocked(getUserDrivePermissions).mockResolvedValue(null);
+      const res = await POST(makeRequest(VALID_BODY));
+      expect(res.status).toBe(404);
+    });
+
+    it('returns 403 when the user cannot edit the drive', async () => {
+      vi.mocked(getUserDrivePermissions).mockResolvedValue({ hasAccess: true, isOwner: false, isAdmin: false, isMember: true, canEdit: false });
+      const res = await POST(makeRequest(VALID_BODY));
+      expect(res.status).toBe(403);
+    });
+
+    it('does not issue a presigned URL when drive access is denied', async () => {
+      vi.mocked(getUserDrivePermissions).mockResolvedValue(null);
+      await POST(makeRequest(VALID_BODY));
+      expect(issuePresignedPutUrl).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validation', () => {
+    it('returns 400 when contentHash is not valid hex', async () => {
+      const res = await POST(makeRequest({ ...VALID_BODY, contentHash: 'not-a-hash' }));
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(/hex/i);
+    });
+
+    it('returns 400 when mimeType is blocked', async () => {
+      const res = await POST(makeRequest({ ...VALID_BODY, mimeType: 'text/html' }));
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toMatch(/not allowed/i);
+    });
+
+    it('returns 400 when required fields are missing', async () => {
+      const { contentHash: _, ...incomplete } = VALID_BODY;
+      const res = await POST(makeRequest(incomplete));
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 413 when file size exceeds the tier limit', async () => {
+      vi.mocked(getUserStorageQuota).mockResolvedValue(makeQuota('free'));
+      const overFreeLimit = { ...VALID_BODY, fileSize: 50 * 1024 * 1024 + 1 };
+      const res = await POST(makeRequest(overFreeLimit));
+      expect(res.status).toBe(413);
+    });
+
+    it('returns 500 when getUserStorageQuota returns null', async () => {
+      vi.mocked(getUserStorageQuota).mockResolvedValue(null);
+      const res = await POST(makeRequest(VALID_BODY));
+      expect(res.status).toBe(500);
+    });
+  });
+
+  describe('deduplication', () => {
+    it('returns alreadyExists true without issuing a URL when the object already exists in S3', async () => {
+      vi.mocked(checkObjectExists).mockResolvedValue(true);
+      const res = await POST(makeRequest(VALID_BODY));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.alreadyExists).toBe(true);
+      expect(issuePresignedPutUrl).not.toHaveBeenCalled();
+    });
+
+    it('returns the S3 key so the client can call complete directly on dedup', async () => {
+      vi.mocked(checkObjectExists).mockResolvedValue(true);
+      const res = await POST(makeRequest(VALID_BODY));
+      const body = await res.json();
+      expect(body.key).toBe(`files/${VALID_HASH}/original`);
+    });
+  });
+
+  describe('happy path', () => {
+    it('issues a presigned PUT URL via issuePresignedPutUrl', async () => {
+      const res = await POST(makeRequest(VALID_BODY));
+      expect(res.status).toBe(200);
+      expect(issuePresignedPutUrl).toHaveBeenCalledWith(
+        `files/${VALID_HASH}/original`,
+        'image/jpeg',
+        1024,
+        900,
+      );
+    });
+
+    it('returns url, jobId, key, and expiresAt in the response', async () => {
+      const res = await POST(makeRequest(VALID_BODY));
+      const body = await res.json();
+      expect(body.url).toBe(MOCK_URL);
+      expect(body.jobId).toBe(MOCK_SLOT);
+      expect(body.key).toBe(`files/${VALID_HASH}/original`);
+      expect(typeof body.expiresAt).toBe('string');
+    });
+
+    it('reserves an upload slot via acquireUploadSlot', async () => {
+      await POST(makeRequest(VALID_BODY));
+      expect(uploadSemaphore.acquireUploadSlot).toHaveBeenCalledWith('user-1', 'free', 1024);
+    });
+
+    it('increments activeUploads after acquiring the slot', async () => {
+      await POST(makeRequest(VALID_BODY));
+      expect(updateActiveUploads).toHaveBeenCalledWith('user-1', 1);
+    });
+  });
+
+  describe('slot exhaustion', () => {
+    it('returns 429 when no upload slot is available', async () => {
+      vi.mocked(uploadSemaphore.acquireUploadSlot).mockResolvedValue(null);
+      const res = await POST(makeRequest(VALID_BODY));
+      expect(res.status).toBe(429);
+    });
+
+    it('does not increment activeUploads when slot acquisition fails', async () => {
+      vi.mocked(uploadSemaphore.acquireUploadSlot).mockResolvedValue(null);
+      await POST(makeRequest(VALID_BODY));
+      expect(updateActiveUploads).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/app/api/upload/presign/__tests__/route.test.ts
+++ b/apps/web/src/app/api/upload/presign/__tests__/route.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
   isAuthError: vi.fn((r: unknown) => r !== null && typeof r === 'object' && 'error' in r),
+  checkMCPCreateScope: vi.fn(() => null),
 }));
 
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
@@ -12,6 +13,7 @@ vi.mock('@pagespace/lib/permissions/permissions', () => ({
 vi.mock('@pagespace/lib/services/storage-limits', () => ({
   getUserStorageQuota: vi.fn(),
   updateActiveUploads: vi.fn(),
+  checkStorageQuota: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/services/upload-semaphore', () => ({
@@ -30,9 +32,9 @@ vi.mock('@/lib/upload/s3-effects', () => ({
 }));
 
 import { POST } from '../route';
-import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { authenticateRequestWithOptions, checkMCPCreateScope } from '@/lib/auth';
 import { getUserDrivePermissions } from '@pagespace/lib/permissions/permissions';
-import { getUserStorageQuota, updateActiveUploads } from '@pagespace/lib/services/storage-limits';
+import { getUserStorageQuota, updateActiveUploads, checkStorageQuota } from '@pagespace/lib/services/storage-limits';
 import { uploadSemaphore } from '@pagespace/lib/services/upload-semaphore';
 import { checkObjectExists, issuePresignedPutUrl } from '@/lib/upload/s3-effects';
 
@@ -69,6 +71,7 @@ beforeEach(() => {
   vi.mocked(authenticateRequestWithOptions).mockResolvedValue(makeAuth());
   vi.mocked(getUserDrivePermissions).mockResolvedValue({ hasAccess: true, isOwner: true, isAdmin: false, isMember: false, canEdit: true });
   vi.mocked(getUserStorageQuota).mockResolvedValue(makeQuota());
+  vi.mocked(checkStorageQuota).mockResolvedValue({ allowed: true });
   vi.mocked(checkObjectExists).mockResolvedValue(false);
   vi.mocked(issuePresignedPutUrl).mockResolvedValue(MOCK_URL);
   vi.mocked(uploadSemaphore.acquireUploadSlot).mockResolvedValue(MOCK_SLOT);
@@ -81,6 +84,26 @@ describe('POST /api/upload/presign', () => {
       vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ error: new Response(null, { status: 401 }) } as never);
       const res = await POST(makeRequest(VALID_BODY));
       expect(res.status).toBe(401);
+    });
+  });
+
+  describe('scoped MCP tokens', () => {
+    it('returns the scope error when the MCP token is not scoped to the drive', async () => {
+      vi.mocked(checkMCPCreateScope).mockReturnValueOnce(
+        new Response(JSON.stringify({ error: 'scope' }), { status: 403 }) as never,
+      );
+      const res = await POST(makeRequest(VALID_BODY));
+      expect(res.status).toBe(403);
+      expect(issuePresignedPutUrl).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('storage quota', () => {
+    it('returns 413 when the remaining storage/file-count quota is exceeded', async () => {
+      vi.mocked(checkStorageQuota).mockResolvedValue({ allowed: false, reason: 'Quota exceeded' });
+      const res = await POST(makeRequest(VALID_BODY));
+      expect(res.status).toBe(413);
+      expect(uploadSemaphore.acquireUploadSlot).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/upload/presign/__tests__/route.test.ts
+++ b/apps/web/src/app/api/upload/presign/__tests__/route.test.ts
@@ -211,7 +211,12 @@ describe('POST /api/upload/presign', () => {
 
     it('reserves an upload slot via acquireUploadSlot', async () => {
       await POST(makeRequest(VALID_BODY));
-      expect(uploadSemaphore.acquireUploadSlot).toHaveBeenCalledWith('user-1', 'free', 1024);
+      expect(uploadSemaphore.acquireUploadSlot).toHaveBeenCalledWith('user-1', 'free', 1024, {
+        contentHash: VALID_HASH,
+        driveId: 'drive-1',
+        fileSize: 1024,
+        mimeType: 'image/jpeg',
+      });
     });
 
     it('increments activeUploads after acquiring the slot', async () => {

--- a/apps/web/src/app/api/upload/presign/__tests__/route.test.ts
+++ b/apps/web/src/app/api/upload/presign/__tests__/route.test.ts
@@ -155,6 +155,14 @@ describe('POST /api/upload/presign', () => {
       const body = await res.json();
       expect(body.key).toBe(`files/${VALID_HASH}/original`);
     });
+
+    it('still reserves a slot and returns a jobId on dedup so the client can call complete', async () => {
+      vi.mocked(checkObjectExists).mockResolvedValue(true);
+      const res = await POST(makeRequest(VALID_BODY));
+      const body = await res.json();
+      expect(body.jobId).toBe(MOCK_SLOT);
+      expect(uploadSemaphore.acquireUploadSlot).toHaveBeenCalled();
+    });
   });
 
   describe('happy path', () => {

--- a/apps/web/src/app/api/upload/presign/route.ts
+++ b/apps/web/src/app/api/upload/presign/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from 'next/server';
+import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import {
+  validateContentHash,
+  validateFileSize,
+  validateMimeTypeDeclaration,
+  buildS3Key,
+} from '@pagespace/lib/services/upload-validation';
+import { getUserDrivePermissions } from '@pagespace/lib/permissions/permissions';
+import { getUserStorageQuota, updateActiveUploads } from '@pagespace/lib/services/storage-limits';
+import { uploadSemaphore } from '@pagespace/lib/services/upload-semaphore';
+import { checkObjectExists, issuePresignedPutUrl } from '@/lib/upload/s3-effects';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+
+const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
+const PRESIGN_TTL = 900;
+
+interface PresignRequestBody {
+  contentHash: string;
+  driveId: string;
+  filename: string;
+  mimeType: string;
+  fileSize: number;
+}
+
+export async function POST(request: Request) {
+  const auth = await authenticateRequestWithOptions(request, AUTH_OPTIONS);
+  if (isAuthError(auth)) return auth.error;
+
+  const { userId } = auth;
+
+  let body: PresignRequestBody;
+  try {
+    body = await request.json() as PresignRequestBody;
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+  }
+
+  const { contentHash, driveId, filename, mimeType, fileSize } = body;
+
+  if (!contentHash || !driveId || !filename || !mimeType || typeof fileSize !== 'number') {
+    return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+  }
+
+  const drivePerms = await getUserDrivePermissions(userId, driveId);
+  if (!drivePerms) {
+    return NextResponse.json({ error: 'Drive not found' }, { status: 404 });
+  }
+  if (!drivePerms.canEdit) {
+    return NextResponse.json({ error: 'You do not have permission to upload to this drive' }, { status: 403 });
+  }
+
+  const hashResult = validateContentHash(contentHash);
+  if (!hashResult.ok) {
+    return NextResponse.json({ error: hashResult.error.message }, { status: 400 });
+  }
+
+  const mimeResult = validateMimeTypeDeclaration(mimeType);
+  if (!mimeResult.ok) {
+    return NextResponse.json({ error: mimeResult.error.message }, { status: 400 });
+  }
+
+  const quota = await getUserStorageQuota(userId);
+  if (!quota) {
+    return NextResponse.json({ error: 'Could not retrieve storage quota' }, { status: 500 });
+  }
+
+  const sizeResult = validateFileSize(fileSize, quota.tier);
+  if (!sizeResult.ok) {
+    return NextResponse.json({ error: sizeResult.error.message }, { status: 413 });
+  }
+
+  const key = buildS3Key(contentHash);
+
+  const exists = await checkObjectExists(key);
+  if (exists) {
+    return NextResponse.json({ alreadyExists: true, key });
+  }
+
+  const url = await issuePresignedPutUrl(key, mimeType, fileSize, PRESIGN_TTL);
+
+  const jobId = await uploadSemaphore.acquireUploadSlot(userId, quota.tier, fileSize);
+  if (!jobId) {
+    return NextResponse.json(
+      { error: 'Too many concurrent uploads. Please wait for current uploads to complete.' },
+      { status: 429 },
+    );
+  }
+
+  await updateActiveUploads(userId, 1);
+
+  const expiresAt = new Date(Date.now() + PRESIGN_TTL * 1000).toISOString();
+
+  auditRequest(request, {
+    eventType: 'data.write',
+    userId,
+    resourceType: 'file',
+    resourceId: contentHash,
+    details: { action: 'presign', driveId, filename, fileSize },
+  });
+
+  return NextResponse.json({ url, jobId, key, expiresAt });
+}

--- a/apps/web/src/app/api/upload/presign/route.ts
+++ b/apps/web/src/app/api/upload/presign/route.ts
@@ -58,6 +58,8 @@ export async function POST(request: Request) {
   if (!hashResult.ok) {
     return NextResponse.json({ error: hashResult.error.message }, { status: 400 });
   }
+  // Use the canonicalized (lowercased) hash everywhere downstream.
+  const canonicalHash = hashResult.value;
 
   const mimeResult = validateMimeTypeDeclaration(mimeType);
   if (!mimeResult.ok) {
@@ -80,13 +82,20 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: quotaCheck.reason, storageInfo: quotaCheck.quota }, { status: 413 });
   }
 
-  const key = buildS3Key(contentHash);
+  const key = buildS3Key(canonicalHash);
 
   const exists = await checkObjectExists(key);
 
   // Reserve a slot in both paths so the client always has a jobId to pass to
   // /complete — the dedup path skips the PUT but still creates a page record.
-  const jobId = await uploadSemaphore.acquireUploadSlot(userId, quota.tier, fileSize);
+  // The slot carries the server-trusted upload params so /complete can't be
+  // tricked with a divergent hash/drive/size/mime.
+  const jobId = await uploadSemaphore.acquireUploadSlot(userId, quota.tier, fileSize, {
+    contentHash: canonicalHash,
+    driveId,
+    fileSize,
+    mimeType,
+  });
   if (!jobId) {
     return NextResponse.json(
       { error: 'Too many concurrent uploads. Please wait for current uploads to complete.' },
@@ -110,7 +119,7 @@ export async function POST(request: Request) {
       eventType: 'data.write',
       userId,
       resourceType: 'file',
-      resourceId: contentHash,
+      resourceId: canonicalHash,
       details: { action: 'presign', driveId, filename, fileSize },
     });
 

--- a/apps/web/src/app/api/upload/presign/route.ts
+++ b/apps/web/src/app/api/upload/presign/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { authenticateRequestWithOptions, isAuthError, checkMCPCreateScope } from '@/lib/auth';
 import {
   validateContentHash,
   validateFileSize,
@@ -7,7 +7,7 @@ import {
   buildS3Key,
 } from '@pagespace/lib/services/upload-validation';
 import { getUserDrivePermissions } from '@pagespace/lib/permissions/permissions';
-import { getUserStorageQuota, updateActiveUploads } from '@pagespace/lib/services/storage-limits';
+import { checkStorageQuota, getUserStorageQuota, updateActiveUploads } from '@pagespace/lib/services/storage-limits';
 import { uploadSemaphore } from '@pagespace/lib/services/upload-semaphore';
 import { checkObjectExists, issuePresignedPutUrl } from '@/lib/upload/s3-effects';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
@@ -42,6 +42,10 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
   }
 
+  // Scoped MCP tokens may only act on the drive they were granted for.
+  const scopeError = checkMCPCreateScope(auth, driveId);
+  if (scopeError) return scopeError;
+
   const drivePerms = await getUserDrivePermissions(userId, driveId);
   if (!drivePerms) {
     return NextResponse.json({ error: 'Drive not found' }, { status: 404 });
@@ -68,6 +72,12 @@ export async function POST(request: Request) {
   const sizeResult = validateFileSize(fileSize, quota.tier);
   if (!sizeResult.ok) {
     return NextResponse.json({ error: sizeResult.error.message }, { status: 413 });
+  }
+
+  // Enforce remaining storage + file-count limits, not just per-file size.
+  const quotaCheck = await checkStorageQuota(userId, fileSize);
+  if (!quotaCheck.allowed) {
+    return NextResponse.json({ error: quotaCheck.reason, storageInfo: quotaCheck.quota }, { status: 413 });
   }
 
   const key = buildS3Key(contentHash);

--- a/apps/web/src/app/api/upload/presign/route.ts
+++ b/apps/web/src/app/api/upload/presign/route.ts
@@ -73,12 +73,9 @@ export async function POST(request: Request) {
   const key = buildS3Key(contentHash);
 
   const exists = await checkObjectExists(key);
-  if (exists) {
-    return NextResponse.json({ alreadyExists: true, key });
-  }
 
-  const url = await issuePresignedPutUrl(key, mimeType, fileSize, PRESIGN_TTL);
-
+  // Reserve a slot in both paths so the client always has a jobId to pass to
+  // /complete — the dedup path skips the PUT but still creates a page record.
   const jobId = await uploadSemaphore.acquireUploadSlot(userId, quota.tier, fileSize);
   if (!jobId) {
     return NextResponse.json(
@@ -89,6 +86,11 @@ export async function POST(request: Request) {
 
   await updateActiveUploads(userId, 1);
 
+  if (exists) {
+    return NextResponse.json({ alreadyExists: true, jobId, key });
+  }
+
+  const url = await issuePresignedPutUrl(key, mimeType, fileSize, PRESIGN_TTL);
   const expiresAt = new Date(Date.now() + PRESIGN_TTL * 1000).toISOString();
 
   auditRequest(request, {

--- a/apps/web/src/app/api/upload/presign/route.ts
+++ b/apps/web/src/app/api/upload/presign/route.ts
@@ -94,22 +94,30 @@ export async function POST(request: Request) {
     );
   }
 
-  await updateActiveUploads(userId, 1);
+  // Once the slot is acquired, any failure before we return must release it,
+  // or the slot leaks until the semaphore's stale-slot sweep.
+  try {
+    await updateActiveUploads(userId, 1);
 
-  if (exists) {
-    return NextResponse.json({ alreadyExists: true, jobId, key });
+    if (exists) {
+      return NextResponse.json({ alreadyExists: true, jobId, key });
+    }
+
+    const url = await issuePresignedPutUrl(key, mimeType, fileSize, PRESIGN_TTL);
+    const expiresAt = new Date(Date.now() + PRESIGN_TTL * 1000).toISOString();
+
+    auditRequest(request, {
+      eventType: 'data.write',
+      userId,
+      resourceType: 'file',
+      resourceId: contentHash,
+      details: { action: 'presign', driveId, filename, fileSize },
+    });
+
+    return NextResponse.json({ url, jobId, key, expiresAt });
+  } catch (err) {
+    uploadSemaphore.releaseUploadSlot(jobId);
+    await updateActiveUploads(userId, -1).catch(() => undefined);
+    throw err;
   }
-
-  const url = await issuePresignedPutUrl(key, mimeType, fileSize, PRESIGN_TTL);
-  const expiresAt = new Date(Date.now() + PRESIGN_TTL * 1000).toISOString();
-
-  auditRequest(request, {
-    eventType: 'data.write',
-    userId,
-    resourceType: 'file',
-    resourceId: contentHash,
-    details: { action: 'presign', driveId, filename, fileSize },
-  });
-
-  return NextResponse.json({ url, jobId, key, expiresAt });
 }

--- a/apps/web/src/hooks/useDirectUpload.ts
+++ b/apps/web/src/hooks/useDirectUpload.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { uploadFileToS3, type UploadedPage } from '@/lib/upload/orchestrator';
+
+interface UseDirectUploadOptions {
+  driveId: string;
+  parentId?: string | null;
+  onUploaded?: (page: UploadedPage) => void;
+}
+
+interface UseDirectUploadReturn {
+  isUploading: boolean;
+  progress: number;
+  uploadFiles: (files: File[]) => Promise<void>;
+}
+
+/**
+ * Assembles the direct-to-S3 orchestrator into a React hook. All upload logic
+ * lives in the composed orchestrator functions; this hook only manages the
+ * uploading/progress flags and surfaces per-file failures.
+ */
+export function useDirectUpload({
+  driveId,
+  parentId,
+  onUploaded,
+}: UseDirectUploadOptions): UseDirectUploadReturn {
+  const [isUploading, setIsUploading] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const onUploadedRef = useRef(onUploaded);
+  onUploadedRef.current = onUploaded;
+
+  const uploadFiles = useCallback(
+    async (files: File[]) => {
+      if (files.length === 0) return;
+      setIsUploading(true);
+      setProgress(0);
+
+      try {
+        for (const file of files) {
+          try {
+            const page = await uploadFileToS3(file, { driveId, parentId: parentId ?? null }, setProgress);
+            onUploadedRef.current?.(page);
+          } catch (err) {
+            toast.error(err instanceof Error ? err.message : `Failed to upload ${file.name}`);
+          }
+        }
+      } finally {
+        setIsUploading(false);
+        setProgress(0);
+      }
+    },
+    [driveId, parentId],
+  );
+
+  return { isUploading, progress, uploadFiles };
+}

--- a/apps/web/src/hooks/useDirectUpload.ts
+++ b/apps/web/src/hooks/useDirectUpload.ts
@@ -28,12 +28,16 @@ export function useDirectUpload({
 }: UseDirectUploadOptions): UseDirectUploadReturn {
   const [isUploading, setIsUploading] = useState(false);
   const [progress, setProgress] = useState(0);
+  // Ref guard: setIsUploading is async, so a second call can slip in before the
+  // flag commits. The ref blocks re-entrant batches synchronously.
+  const isUploadingRef = useRef(false);
   const onUploadedRef = useRef(onUploaded);
   onUploadedRef.current = onUploaded;
 
   const uploadFiles = useCallback(
     async (files: File[]) => {
-      if (files.length === 0) return;
+      if (files.length === 0 || isUploadingRef.current) return;
+      isUploadingRef.current = true;
       setIsUploading(true);
       setProgress(0);
 
@@ -47,6 +51,7 @@ export function useDirectUpload({
           }
         }
       } finally {
+        isUploadingRef.current = false;
         setIsUploading(false);
         setProgress(0);
       }

--- a/apps/web/src/lib/upload/__tests__/content-hash.test.ts
+++ b/apps/web/src/lib/upload/__tests__/content-hash.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import crypto from 'crypto';
+import { computeContentHash } from '../content-hash';
+
+// Minimal File polyfill for the Node test environment — computeContentHash only
+// uses File.arrayBuffer(), which jsdom's File does not implement reliably.
+function makeFile(bytes: Uint8Array, name = 'f.bin'): File {
+  return {
+    name,
+    arrayBuffer: async () => bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+  } as unknown as File;
+}
+
+function expectedSha256(bytes: Uint8Array): string {
+  return crypto.createHash('sha256').update(Buffer.from(bytes)).digest('hex');
+}
+
+describe('computeContentHash', () => {
+  it('returns the lowercase 64-char hex SHA-256 of the file bytes', async () => {
+    const bytes = new TextEncoder().encode('hello world');
+    const hash = await computeContentHash(makeFile(bytes));
+    expect(hash).toBe(expectedSha256(bytes));
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is content-addressed — same bytes produce the same hash regardless of filename', async () => {
+    const bytes = new TextEncoder().encode('identical content');
+    const a = await computeContentHash(makeFile(bytes, 'first-name.txt'));
+    const b = await computeContentHash(makeFile(bytes, 'totally-different.dat'));
+    expect(a).toBe(b);
+  });
+
+  it('produces different hashes for different content', async () => {
+    const a = await computeContentHash(makeFile(new TextEncoder().encode('content A')));
+    const b = await computeContentHash(makeFile(new TextEncoder().encode('content B')));
+    expect(a).not.toBe(b);
+  });
+
+  it('hashes empty file content to the known SHA-256 of the empty string', async () => {
+    const hash = await computeContentHash(makeFile(new Uint8Array(0)));
+    expect(hash).toBe('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855');
+  });
+});

--- a/apps/web/src/lib/upload/__tests__/orchestrator.test.ts
+++ b/apps/web/src/lib/upload/__tests__/orchestrator.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../content-hash', () => ({
+  computeContentHash: vi.fn().mockResolvedValue('d'.repeat(64)),
+}));
+
+vi.mock('@/lib/auth/auth-fetch', () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+import {
+  callPresign,
+  callComplete,
+  callCancel,
+  uploadToTigris,
+  uploadFileToS3,
+} from '../orchestrator';
+import { computeContentHash } from '../content-hash';
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+
+function makeFile(name = 'photo.jpg', type = 'image/jpeg', size = 1024): File {
+  return { name, type, size, arrayBuffer: async () => new ArrayBuffer(size) } as unknown as File;
+}
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return { ok, status, json: async () => body } as unknown as Response;
+}
+
+const mockFetch = vi.mocked(fetchWithAuth);
+
+// --- XHR mock --------------------------------------------------------------
+class MockXHR {
+  static instances: MockXHR[] = [];
+  upload = { onprogress: null as ((e: { loaded: number; total: number }) => void) | null };
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  status = 200;
+  method = '';
+  url = '';
+  sentBody: unknown = null;
+  headers: Record<string, string> = {};
+  constructor() { MockXHR.instances.push(this); }
+  open(method: string, url: string) { this.method = method; this.url = url; }
+  setRequestHeader(name: string, value: string) { this.headers[name] = value; }
+  send(body: unknown) {
+    this.sentBody = body;
+    queueMicrotask(() => {
+      this.upload.onprogress?.({ loaded: 512, total: 1024 });
+      this.upload.onprogress?.({ loaded: 1024, total: 1024 });
+      this.onload?.();
+    });
+  }
+}
+
+const originalXHR = global.XMLHttpRequest;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(computeContentHash).mockResolvedValue('d'.repeat(64));
+  MockXHR.instances = [];
+  global.XMLHttpRequest = MockXHR as unknown as typeof XMLHttpRequest;
+});
+
+afterEach(() => {
+  global.XMLHttpRequest = originalXHR;
+});
+
+describe('callPresign', () => {
+  it('POSTs the upload params and returns the parsed presign response', async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({ url: 'https://t/put', jobId: 'job-1', key: 'files/x/original', expiresAt: 'soon' }),
+    );
+
+    const res = await callPresign({ contentHash: 'd'.repeat(64), driveId: 'drive-1', filename: 'a.jpg', mimeType: 'image/jpeg', fileSize: 1024 });
+
+    expect(res.jobId).toBe('job-1');
+    expect(mockFetch).toHaveBeenCalledWith('/api/upload/presign', expect.objectContaining({ method: 'POST' }));
+  });
+
+  it('throws when the presign request fails', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ error: 'too big' }, false, 413));
+    await expect(
+      callPresign({ contentHash: 'd'.repeat(64), driveId: 'd', filename: 'a', mimeType: 'image/jpeg', fileSize: 1 }),
+    ).rejects.toThrow(/too big/);
+  });
+});
+
+describe('uploadToTigris', () => {
+  it('PUTs the file to the presigned URL and reports progress percentages', async () => {
+    const progress: number[] = [];
+    await uploadToTigris('https://tigris/put', makeFile(), (pct) => progress.push(pct));
+    expect(MockXHR.instances[0].method).toBe('PUT');
+    expect(MockXHR.instances[0].url).toBe('https://tigris/put');
+    expect(progress).toEqual([50, 100]);
+  });
+
+  it('sets the Content-Type header to the file type', async () => {
+    await uploadToTigris('https://tigris/put', makeFile('a.jpg', 'image/jpeg'));
+    expect(MockXHR.instances[0].headers['Content-Type']).toBe('image/jpeg');
+  });
+
+  it('sends application/octet-stream for a MIME-less file so it matches the presigned signature', async () => {
+    await uploadToTigris('https://tigris/put', makeFile('data', ''));
+    expect(MockXHR.instances[0].headers['Content-Type']).toBe('application/octet-stream');
+  });
+
+  it('rejects when the PUT returns a non-2xx status', async () => {
+    global.XMLHttpRequest = class extends MockXHR {
+      send() { queueMicrotask(() => { this.status = 403; this.onload?.(); }); }
+    } as unknown as typeof XMLHttpRequest;
+    await expect(uploadToTigris('https://tigris/put', makeFile())).rejects.toThrow();
+  });
+});
+
+describe('callComplete', () => {
+  it('POSTs the completion params and returns the created page', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ success: true, page: { id: 'page-1' } }));
+    const res = await callComplete({ jobId: 'job-1', contentHash: 'd'.repeat(64), driveId: 'drive-1', title: 'a.jpg', mimeType: 'image/jpeg', fileSize: 1024 });
+    expect(res.page.id).toBe('page-1');
+  });
+});
+
+describe('uploadFileToS3', () => {
+  it('runs hash → presign → PUT → complete for a new file', async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ url: 'https://t/put', jobId: 'job-1', key: 'k', expiresAt: 's' }))
+      .mockResolvedValueOnce(jsonResponse({ success: true, page: { id: 'page-1' } }));
+
+    const page = await uploadFileToS3(makeFile(), { driveId: 'drive-1' });
+
+    expect(computeContentHash).toHaveBeenCalled();
+    expect(MockXHR.instances).toHaveLength(1); // PUT happened
+    expect(page.id).toBe('page-1');
+  });
+
+  it('skips the PUT entirely when presign reports the file already exists', async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ alreadyExists: true, jobId: 'job-1', key: 'k' }))
+      .mockResolvedValueOnce(jsonResponse({ success: true, page: { id: 'page-dedup' } }));
+
+    const page = await uploadFileToS3(makeFile(), { driveId: 'drive-1' });
+
+    expect(MockXHR.instances).toHaveLength(0); // no bytes transferred
+    expect(page.id).toBe('page-dedup');
+  });
+
+  it('cancels the reserved slot when the PUT fails — no slot leak', async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ url: 'https://t/put', jobId: 'job-99', key: 'k', expiresAt: 's' }))
+      .mockResolvedValueOnce(jsonResponse({ success: true })); // the cancel call
+    global.XMLHttpRequest = class extends MockXHR {
+      send() { queueMicrotask(() => { this.onerror?.(); }); }
+    } as unknown as typeof XMLHttpRequest;
+
+    await expect(uploadFileToS3(makeFile(), { driveId: 'drive-1' })).rejects.toThrow();
+
+    expect(mockFetch).toHaveBeenCalledWith('/api/upload/cancel', expect.objectContaining({ method: 'POST' }));
+  });
+});
+
+describe('callCancel', () => {
+  it('POSTs the jobId to the cancel endpoint', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ success: true }));
+    await callCancel('job-1');
+    expect(mockFetch).toHaveBeenCalledWith('/api/upload/cancel', expect.objectContaining({ method: 'POST' }));
+  });
+
+  it('never throws even if the cancel request fails — best-effort cleanup', async () => {
+    mockFetch.mockRejectedValue(new Error('network'));
+    await expect(callCancel('job-1')).resolves.toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/upload/__tests__/s3-effects.test.ts
+++ b/apps/web/src/lib/upload/__tests__/s3-effects.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const putObjectCtor = vi.fn();
+const headObjectCtor = vi.fn();
+
+vi.mock('@aws-sdk/client-s3', () => ({
+  PutObjectCommand: class {
+    input: unknown;
+    constructor(input: unknown) {
+      putObjectCtor(input);
+      this.input = input;
+    }
+  },
+  HeadObjectCommand: class {
+    input: unknown;
+    constructor(input: unknown) {
+      headObjectCtor(input);
+      this.input = input;
+    }
+  },
+}));
+
+const mockGetSignedUrl = vi.fn();
+vi.mock('@aws-sdk/s3-request-presigner', () => ({
+  getSignedUrl: (...args: unknown[]) => mockGetSignedUrl(...args),
+}));
+
+const mockSend = vi.fn();
+vi.mock('@/lib/presigned-url', () => ({
+  getS3Client: () => ({ send: mockSend }),
+  getS3Bucket: () => 'test-bucket',
+}));
+
+import { issuePresignedPutUrl, checkObjectExists } from '../s3-effects';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetSignedUrl.mockResolvedValue('https://signed.example.com/put');
+});
+
+describe('issuePresignedPutUrl', () => {
+  it('pins the exact byte length on the signed command so a larger upload is rejected', async () => {
+    await issuePresignedPutUrl('files/abc/original', 'image/jpeg', 4096, 900);
+    expect(putObjectCtor).toHaveBeenCalledWith(
+      expect.objectContaining({ ContentLength: 4096 }),
+    );
+  });
+
+  it('does not pass a Conditions field that the PUT command would silently drop', async () => {
+    await issuePresignedPutUrl('files/abc/original', 'image/jpeg', 4096, 900);
+    const passed = putObjectCtor.mock.calls[0][0] as Record<string, unknown>;
+    expect(passed).not.toHaveProperty('Conditions');
+  });
+
+  it('signs with the requested TTL', async () => {
+    await issuePresignedPutUrl('files/abc/original', 'image/jpeg', 4096, 600);
+    expect(mockGetSignedUrl).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      { expiresIn: 600 },
+    );
+  });
+});
+
+describe('checkObjectExists', () => {
+  it('returns true when HeadObject succeeds', async () => {
+    mockSend.mockResolvedValue({});
+    expect(await checkObjectExists('files/abc/original')).toBe(true);
+  });
+
+  it('returns false when the object is not found', async () => {
+    const notFound = Object.assign(new Error('not found'), { name: 'NotFound' });
+    mockSend.mockRejectedValue(notFound);
+    expect(await checkObjectExists('files/abc/original')).toBe(false);
+  });
+
+  it('rethrows unexpected errors instead of treating them as missing', async () => {
+    mockSend.mockRejectedValue(Object.assign(new Error('boom'), { name: 'AccessDenied' }));
+    await expect(checkObjectExists('files/abc/original')).rejects.toThrow('boom');
+  });
+});

--- a/apps/web/src/lib/upload/content-hash.ts
+++ b/apps/web/src/lib/upload/content-hash.ts
@@ -1,0 +1,13 @@
+/**
+ * Compute the SHA-256 content hash of a file in the browser via WebCrypto.
+ * Standalone and pure — bytes in, lowercase 64-char hex digest out. No React,
+ * no state, no side effects. Content-addressed: the hash depends only on the
+ * bytes, never on the filename or metadata.
+ */
+export async function computeContentHash(file: File): Promise<string> {
+  const buffer = await file.arrayBuffer();
+  const digest = await crypto.subtle.digest('SHA-256', buffer);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}

--- a/apps/web/src/lib/upload/orchestrator.ts
+++ b/apps/web/src/lib/upload/orchestrator.ts
@@ -1,0 +1,151 @@
+import { fetchWithAuth } from '@/lib/auth/auth-fetch';
+import { computeContentHash } from './content-hash';
+
+/**
+ * Direct-to-S3 upload orchestrator. Each step is a single-responsibility async
+ * function; uploadFileToS3 composes them. App endpoints go through fetchWithAuth
+ * (CSRF + credentials); the byte transfer goes straight to Tigris via XHR so
+ * progress events are available. A reserved slot is always released on failure.
+ */
+
+export interface PresignParams {
+  contentHash: string;
+  driveId: string;
+  filename: string;
+  mimeType: string;
+  fileSize: number;
+}
+
+export interface PresignResponse {
+  url?: string;
+  jobId: string;
+  key: string;
+  expiresAt?: string;
+  alreadyExists?: boolean;
+}
+
+export interface CompleteParams {
+  jobId: string;
+  contentHash: string;
+  driveId: string;
+  title: string;
+  mimeType: string;
+  fileSize: number;
+  parentId?: string | null;
+}
+
+export interface UploadedPage {
+  id: string;
+  [key: string]: unknown;
+}
+
+export interface CompletionResponse {
+  success: boolean;
+  page: UploadedPage;
+}
+
+async function errorMessage(res: Response, fallback: string): Promise<string> {
+  const body = (await res.json().catch(() => ({}))) as { error?: string };
+  return body.error || fallback;
+}
+
+export async function callPresign(params: PresignParams): Promise<PresignResponse> {
+  const res = await fetchWithAuth('/api/upload/presign', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(params),
+  });
+  if (!res.ok) throw new Error(await errorMessage(res, 'Failed to presign upload'));
+  return res.json() as Promise<PresignResponse>;
+}
+
+export async function callComplete(params: CompleteParams): Promise<CompletionResponse> {
+  const res = await fetchWithAuth('/api/upload/complete', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(params),
+  });
+  if (!res.ok) throw new Error(await errorMessage(res, 'Failed to complete upload'));
+  return res.json() as Promise<CompletionResponse>;
+}
+
+/** Best-effort slot release — never throws, so cleanup can't mask the original error. */
+export async function callCancel(jobId: string): Promise<void> {
+  try {
+    await fetchWithAuth('/api/upload/cancel', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jobId }),
+    });
+  } catch {
+    // swallow — the semaphore's stale-slot cleanup is the backstop
+  }
+}
+
+/** PUT the file straight to Tigris via XHR so upload progress is observable. */
+export function uploadToTigris(
+  url: string,
+  file: File,
+  onProgress?: (pct: number) => void,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open('PUT', url);
+    // Must match the Content-Type the presigned URL was signed with. presign
+    // derives it the same way (file.type || 'application/octet-stream'), so an
+    // empty file.type would otherwise send no header and break the signature.
+    xhr.setRequestHeader('Content-Type', file.type || 'application/octet-stream');
+    xhr.upload.onprogress = (event: ProgressEvent) => {
+      if (onProgress && event.total > 0) onProgress(Math.round((event.loaded / event.total) * 100));
+    };
+    xhr.onload = () => {
+      if (xhr.status >= 200 && xhr.status < 300) resolve();
+      else reject(new Error(`Upload failed with status ${xhr.status}`));
+    };
+    xhr.onerror = () => reject(new Error('Upload network error'));
+    xhr.send(file);
+  });
+}
+
+export interface UploadTarget {
+  driveId: string;
+  parentId?: string | null;
+}
+
+export async function uploadFileToS3(
+  file: File,
+  target: UploadTarget,
+  onProgress?: (pct: number) => void,
+): Promise<UploadedPage> {
+  const contentHash = await computeContentHash(file);
+  const mimeType = file.type || 'application/octet-stream';
+
+  const presign = await callPresign({
+    contentHash,
+    driveId: target.driveId,
+    filename: file.name,
+    mimeType,
+    fileSize: file.size,
+  });
+
+  try {
+    if (!presign.alreadyExists) {
+      if (!presign.url) throw new Error('Presign response missing upload URL');
+      await uploadToTigris(presign.url, file, onProgress);
+    }
+
+    const completion = await callComplete({
+      jobId: presign.jobId,
+      contentHash,
+      driveId: target.driveId,
+      title: file.name,
+      mimeType,
+      fileSize: file.size,
+      parentId: target.parentId ?? null,
+    });
+    return completion.page;
+  } catch (err) {
+    await callCancel(presign.jobId);
+    throw err;
+  }
+}

--- a/apps/web/src/lib/upload/processor-effects.ts
+++ b/apps/web/src/lib/upload/processor-effects.ts
@@ -1,0 +1,20 @@
+import { createUploadServiceToken } from '@pagespace/lib/services/validated-service-token';
+
+const PROCESSOR_URL = process.env.PROCESSOR_URL || 'http://processor:3003';
+
+export async function enqueueProcessorJob(
+  userId: string,
+  driveId: string,
+  pageId: string,
+): Promise<void> {
+  const { token } = await createUploadServiceToken({ userId, driveId, pageId });
+  const res = await fetch(`${PROCESSOR_URL}/api/ingest/by-page/${pageId}`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({})) as { error?: string };
+    throw new Error(err.error || `Processor ingest failed with status ${res.status}`);
+  }
+}

--- a/apps/web/src/lib/upload/processor-effects.ts
+++ b/apps/web/src/lib/upload/processor-effects.ts
@@ -8,7 +8,9 @@ export async function enqueueProcessorJob(
   pageId: string,
 ): Promise<void> {
   const { token } = await createUploadServiceToken({ userId, driveId, pageId });
-  const res = await fetch(`${PROCESSOR_URL}/api/ingest/by-page/${pageId}`, {
+  // /pull runs the zero-trust pull-verify pipeline (re-hash + Magika gate) rather
+  // than /by-page, which trusts the page's declared mimeType.
+  const res = await fetch(`${PROCESSOR_URL}/api/ingest/pull/${pageId}`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${token}` },
     signal: AbortSignal.timeout(10_000),

--- a/apps/web/src/lib/upload/s3-effects.ts
+++ b/apps/web/src/lib/upload/s3-effects.ts
@@ -1,0 +1,37 @@
+import { HeadObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { getS3Client, getS3Bucket } from '@/lib/presigned-url';
+
+export async function checkObjectExists(key: string): Promise<boolean> {
+  try {
+    await getS3Client().send(new HeadObjectCommand({ Bucket: getS3Bucket(), Key: key }));
+    return true;
+  } catch (err: unknown) {
+    if (err instanceof Error && (err.name === 'NotFound' || err.name === 'NoSuchKey')) {
+      return false;
+    }
+    // 404 from AWS SDK v3 also surfaces as $metadata.httpStatusCode
+    const anyErr = err as { $metadata?: { httpStatusCode?: number } };
+    if (anyErr?.$metadata?.httpStatusCode === 404) return false;
+    throw err;
+  }
+}
+
+export async function issuePresignedPutUrl(
+  key: string,
+  contentType: string,
+  fileSize: number,
+  ttlSeconds: number,
+): Promise<string> {
+  // Zero-trust: ContentLength is signed into the URL, so S3/Tigris rejects any
+  // PUT whose body size differs from the declared fileSize. (content-length-range
+  // is a presigned-POST policy condition and is silently ignored on a PUT command.)
+  const command = new PutObjectCommand({
+    Bucket: getS3Bucket(),
+    Key: key,
+    ContentType: contentType,
+    ContentLength: fileSize,
+  });
+
+  return getSignedUrl(getS3Client(), command, { expiresIn: ttlSeconds });
+}

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -167,6 +167,11 @@
       "import": "./dist/services/upload-semaphore.js",
       "require": "./dist/services/upload-semaphore.js"
     },
+    "./services/upload-validation": {
+      "types": "./dist/services/upload-validation.d.ts",
+      "import": "./dist/services/upload-validation.js",
+      "require": "./dist/services/upload-validation.js"
+    },
     "./services/memory-monitor": {
       "types": "./dist/services/memory-monitor.d.ts",
       "import": "./dist/services/memory-monitor.js",

--- a/packages/lib/src/services/__tests__/upload-semaphore.test.ts
+++ b/packages/lib/src/services/__tests__/upload-semaphore.test.ts
@@ -156,6 +156,29 @@ describe('upload-semaphore', () => {
     });
   });
 
+  describe('verifySlotOwner', () => {
+    it('returns true for the user that reserved the slot', async () => {
+      const slot = await uploadSemaphore.acquireUploadSlot('user-1', 'free', 1024);
+      expect(uploadSemaphore.verifySlotOwner(slot!, 'user-1')).toBe(true);
+    });
+
+    it('returns false for a different user', async () => {
+      const slot = await uploadSemaphore.acquireUploadSlot('user-1', 'free', 1024);
+      expect(uploadSemaphore.verifySlotOwner(slot!, 'user-2')).toBe(false);
+    });
+
+    it('returns false for an unknown slot', () => {
+      expect(uploadSemaphore.verifySlotOwner('does-not-exist', 'user-1')).toBe(false);
+    });
+
+    it('rejects and reclaims a slot older than the timeout', async () => {
+      const slot = await uploadSemaphore.acquireUploadSlot('user-1', 'free', 1024);
+      vi.advanceTimersByTime(11 * 60 * 1000); // past the 10-minute slot timeout
+      expect(uploadSemaphore.verifySlotOwner(slot!, 'user-1')).toBe(false);
+      expect(uploadSemaphore.getStatus().activeSlots).toBe(0);
+    });
+  });
+
   describe('reset', () => {
     it('resets all state', async () => {
       await uploadSemaphore.acquireUploadSlot('user-1', 'free', 1024);

--- a/packages/lib/src/services/__tests__/upload-semaphore.test.ts
+++ b/packages/lib/src/services/__tests__/upload-semaphore.test.ts
@@ -179,6 +179,31 @@ describe('upload-semaphore', () => {
     });
   });
 
+  describe('getSlotMetadata', () => {
+    const META = { contentHash: 'a'.repeat(64), driveId: 'drive-1', fileSize: 1024, mimeType: 'image/jpeg' };
+
+    it('returns the metadata captured at acquire time for the owning user', async () => {
+      const slot = await uploadSemaphore.acquireUploadSlot('user-1', 'free', 1024, META);
+      expect(uploadSemaphore.getSlotMetadata(slot!, 'user-1')).toEqual(META);
+    });
+
+    it('returns null for a different user', async () => {
+      const slot = await uploadSemaphore.acquireUploadSlot('user-1', 'free', 1024, META);
+      expect(uploadSemaphore.getSlotMetadata(slot!, 'user-2')).toBeNull();
+    });
+
+    it('returns null for an expired slot', async () => {
+      const slot = await uploadSemaphore.acquireUploadSlot('user-1', 'free', 1024, META);
+      vi.advanceTimersByTime(11 * 60 * 1000);
+      expect(uploadSemaphore.getSlotMetadata(slot!, 'user-1')).toBeNull();
+    });
+
+    it('returns null when a slot was acquired without metadata', async () => {
+      const slot = await uploadSemaphore.acquireUploadSlot('user-1', 'free', 1024);
+      expect(uploadSemaphore.getSlotMetadata(slot!, 'user-1')).toBeNull();
+    });
+  });
+
   describe('reset', () => {
     it('resets all state', async () => {
       await uploadSemaphore.acquireUploadSlot('user-1', 'free', 1024);

--- a/packages/lib/src/services/__tests__/upload-validation.test.ts
+++ b/packages/lib/src/services/__tests__/upload-validation.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateContentHash,
+  validateFileSize,
+  validateMimeTypeDeclaration,
+  validateTtl,
+  buildS3Key,
+  buildPresignParams,
+} from '../upload-validation';
+
+describe('validateContentHash', () => {
+  it('returns ok for a valid 64-char lowercase hex string', () => {
+    const hash = 'a'.repeat(64);
+    const result = validateContentHash(hash);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toBe(hash);
+  });
+
+  it('returns ok for a valid 64-char hex string with mixed case letters', () => {
+    const hash = 'aAbBcCdDeEfF'.padEnd(64, '0').slice(0, 64);
+    const result = validateContentHash(hash);
+    expect(result.ok).toBe(true);
+  });
+
+  it('returns err for a hash shorter than 64 chars', () => {
+    const result = validateContentHash('a'.repeat(63));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toMatch(/64/);
+  });
+
+  it('returns err for a hash longer than 64 chars', () => {
+    const result = validateContentHash('a'.repeat(65));
+    expect(result.ok).toBe(false);
+  });
+
+  it('returns err for a hash containing non-hex characters', () => {
+    const result = validateContentHash('z'.repeat(64));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toMatch(/hex/i);
+  });
+
+  it('returns err for an empty string', () => {
+    const result = validateContentHash('');
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('validateFileSize', () => {
+  it('returns ok when size is within the free tier limit', () => {
+    const result = validateFileSize(1024, 'free');
+    expect(result.ok).toBe(true);
+  });
+
+  it('returns ok when size exactly equals the tier limit', () => {
+    const limit = 50 * 1024 * 1024; // 50MB free limit
+    const result = validateFileSize(limit, 'free');
+    expect(result.ok).toBe(true);
+  });
+
+  it('returns err when size exceeds the free tier limit', () => {
+    const overLimit = 50 * 1024 * 1024 + 1;
+    const result = validateFileSize(overLimit, 'free');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toMatch(/50MB/i);
+      expect(result.error.message).toMatch(/free/i);
+    }
+  });
+
+  it('returns err when size exceeds the pro tier limit', () => {
+    const overLimit = 250 * 1024 * 1024 + 1;
+    const result = validateFileSize(overLimit, 'pro');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toMatch(/250MB/i);
+  });
+
+  it('returns err when size exceeds the founder tier limit', () => {
+    const overLimit = 500 * 1024 * 1024 + 1;
+    const result = validateFileSize(overLimit, 'founder');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toMatch(/500MB/i);
+  });
+
+  it('returns ok for a large file within the business tier limit', () => {
+    const result = validateFileSize(500 * 1024 * 1024, 'business');
+    expect(result.ok).toBe(true);
+  });
+
+  it('returns err when size exceeds the business tier limit', () => {
+    const overLimit = 1024 * 1024 * 1024 + 1;
+    const result = validateFileSize(overLimit, 'business');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toMatch(/1GB|1024MB/i);
+  });
+
+  it('returns err when size is zero', () => {
+    const result = validateFileSize(0, 'free');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toMatch(/empty/i);
+  });
+
+  it('returns err when size is negative', () => {
+    const result = validateFileSize(-1, 'free');
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe('validateMimeTypeDeclaration', () => {
+  it('returns ok for a standard image type', () => {
+    expect(validateMimeTypeDeclaration('image/jpeg').ok).toBe(true);
+  });
+
+  it('returns ok for a PDF', () => {
+    expect(validateMimeTypeDeclaration('application/pdf').ok).toBe(true);
+  });
+
+  it('returns ok for a video type', () => {
+    expect(validateMimeTypeDeclaration('video/mp4').ok).toBe(true);
+  });
+
+  it('returns err for text/html', () => {
+    const result = validateMimeTypeDeclaration('text/html');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toMatch(/not allowed/i);
+  });
+
+  it('returns err for image/svg+xml', () => {
+    expect(validateMimeTypeDeclaration('image/svg+xml').ok).toBe(false);
+  });
+
+  it('returns err for text/javascript', () => {
+    expect(validateMimeTypeDeclaration('text/javascript').ok).toBe(false);
+  });
+
+  it('returns err for application/javascript', () => {
+    expect(validateMimeTypeDeclaration('application/javascript').ok).toBe(false);
+  });
+
+  it('returns err for application/x-msdownload (Windows executable)', () => {
+    expect(validateMimeTypeDeclaration('application/x-msdownload').ok).toBe(false);
+  });
+
+  it('returns err for application/x-executable', () => {
+    expect(validateMimeTypeDeclaration('application/x-executable').ok).toBe(false);
+  });
+
+  it('returns err for application/x-mach-binary (macOS binary)', () => {
+    expect(validateMimeTypeDeclaration('application/x-mach-binary').ok).toBe(false);
+  });
+
+  it('returns err for application/x-javascript (legacy script alias)', () => {
+    expect(validateMimeTypeDeclaration('application/x-javascript').ok).toBe(false);
+  });
+
+  it('ignores charset parameters when checking', () => {
+    expect(validateMimeTypeDeclaration('text/html; charset=utf-8').ok).toBe(false);
+  });
+
+  it('is case-insensitive', () => {
+    expect(validateMimeTypeDeclaration('TEXT/HTML').ok).toBe(false);
+  });
+});
+
+describe('validateTtl', () => {
+  it('returns ok for a TTL within the 900-second limit', () => {
+    expect(validateTtl(900).ok).toBe(true);
+  });
+
+  it('returns ok for a TTL of 1 second', () => {
+    expect(validateTtl(1).ok).toBe(true);
+  });
+
+  it('returns err when TTL exceeds 900 seconds', () => {
+    const result = validateTtl(901);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.message).toMatch(/900/);
+  });
+
+  it('returns err when TTL is zero', () => {
+    expect(validateTtl(0).ok).toBe(false);
+  });
+
+  it('returns err when TTL is negative', () => {
+    expect(validateTtl(-1).ok).toBe(false);
+  });
+});
+
+describe('buildS3Key', () => {
+  it('returns the canonical path for a given hash', () => {
+    const hash = 'a'.repeat(64);
+    expect(buildS3Key(hash)).toBe(`files/${hash}/original`);
+  });
+
+  it('contains no extra path segments', () => {
+    const key = buildS3Key('b'.repeat(64));
+    expect(key.split('/')).toHaveLength(3);
+  });
+});
+
+describe('buildPresignParams', () => {
+  const hash = 'a'.repeat(64);
+
+  it('returns a plain object with all required fields', () => {
+    const params = buildPresignParams(hash, 'drive-1', 'photo.jpg', 'image/jpeg', 1024, 900);
+    expect(params).toMatchObject({
+      key: `files/${hash}/original`,
+      driveId: 'drive-1',
+      filename: 'photo.jpg',
+      mimeType: 'image/jpeg',
+      fileSize: 1024,
+      ttlSeconds: 900,
+    });
+  });
+
+  it('uses buildS3Key for the key field', () => {
+    const params = buildPresignParams(hash, 'drive-1', 'file.pdf', 'application/pdf', 2048, 600);
+    expect(params.key).toBe(buildS3Key(hash));
+  });
+
+  it('does not infer defaults from environment — all values come from arguments', () => {
+    const params = buildPresignParams(hash, 'drive-2', 'video.mp4', 'video/mp4', 999, 300);
+    expect(params.fileSize).toBe(999);
+    expect(params.ttlSeconds).toBe(300);
+  });
+});

--- a/packages/lib/src/services/__tests__/upload-validation.test.ts
+++ b/packages/lib/src/services/__tests__/upload-validation.test.ts
@@ -22,6 +22,12 @@ describe('validateContentHash', () => {
     expect(result.ok).toBe(true);
   });
 
+  it('canonicalizes a mixed-case hash to lowercase so it maps to one S3 key', () => {
+    const result = validateContentHash('A'.repeat(64));
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value).toBe('a'.repeat(64));
+  });
+
   it('returns err for a hash shorter than 64 chars', () => {
     const result = validateContentHash('a'.repeat(63));
     expect(result.ok).toBe(false);

--- a/packages/lib/src/services/upload-semaphore.ts
+++ b/packages/lib/src/services/upload-semaphore.ts
@@ -1,10 +1,23 @@
 import { STORAGE_TIERS } from './storage-limits';
 import { loggers } from '../logging/logger-config';
 
+/**
+ * Server-trusted upload parameters captured at presign time. /complete reads
+ * these from the slot instead of trusting the client request body, so a client
+ * cannot presign for one drive/hash/size and complete with another.
+ */
+export interface UploadSlotMetadata {
+  contentHash: string;
+  driveId: string;
+  fileSize: number;
+  mimeType: string;
+}
+
 interface UploadSlot {
   userId: string;
   acquiredAt: Date;
   fileSize: number;
+  metadata?: UploadSlotMetadata;
 }
 
 class UploadSemaphore {
@@ -42,7 +55,8 @@ class UploadSemaphore {
   async acquireUploadSlot(
     userId: string,
     tier: keyof typeof STORAGE_TIERS,
-    fileSize: number
+    fileSize: number,
+    metadata?: UploadSlotMetadata
   ): Promise<string | null> {
     if (this.globalPermits <= 0) {
       loggers.api.debug('Upload rejected: global limit reached', {
@@ -63,7 +77,7 @@ class UploadSemaphore {
 
     const slotId = `${userId}-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
     this.userPermits.set(userId, currentUserUploads + 1);
-    this.activeSlots.set(slotId, { userId, acquiredAt: new Date(), fileSize });
+    this.activeSlots.set(slotId, { userId, acquiredAt: new Date(), fileSize, metadata });
     this.globalPermits = Math.max(0, this.globalLimit - this.activeSlots.size);
 
     loggers.api.info('Upload slot granted', {
@@ -155,6 +169,16 @@ class UploadSemaphore {
       return false;
     }
     return true;
+  }
+
+  /**
+   * Return the server-trusted metadata captured at presign time for a slot the
+   * user owns (and that hasn't expired). Returns null otherwise. Callers use
+   * this instead of trusting client-supplied upload parameters.
+   */
+  getSlotMetadata(slotId: string, userId: string): UploadSlotMetadata | null {
+    if (!this.verifySlotOwner(slotId, userId)) return null;
+    return this.activeSlots.get(slotId)?.metadata ?? null;
   }
 
   releaseUserSlots(userId: string): void {

--- a/packages/lib/src/services/upload-semaphore.ts
+++ b/packages/lib/src/services/upload-semaphore.ts
@@ -145,6 +145,10 @@ class UploadSemaphore {
     }
   }
 
+  verifySlotOwner(slotId: string, userId: string): boolean {
+    return this.activeSlots.get(slotId)?.userId === userId;
+  }
+
   releaseUserSlots(userId: string): void {
     const userSlots: string[] = [];
     this.activeSlots.forEach((slot, slotId) => {

--- a/packages/lib/src/services/upload-semaphore.ts
+++ b/packages/lib/src/services/upload-semaphore.ts
@@ -146,7 +146,15 @@ class UploadSemaphore {
   }
 
   verifySlotOwner(slotId: string, userId: string): boolean {
-    return this.activeSlots.get(slotId)?.userId === userId;
+    const slot = this.activeSlots.get(slotId);
+    if (!slot || slot.userId !== userId) return false;
+    // Reject (and reclaim) slots past the timeout rather than waiting for the
+    // once-a-minute sweep — a stale jobId must not still authorize a completion.
+    if (Date.now() - slot.acquiredAt.getTime() > this.slotTimeout) {
+      this.releaseUploadSlot(slotId);
+      return false;
+    }
+    return true;
   }
 
   releaseUserSlots(userId: string): void {

--- a/packages/lib/src/services/upload-validation.ts
+++ b/packages/lib/src/services/upload-validation.ts
@@ -1,0 +1,114 @@
+import type { SubscriptionTier } from './subscription-utils';
+
+// Max file sizes per tier — mirrors STORAGE_TIERS in storage-limits.ts
+// Kept here so this module stays pure (no DB imports transitively)
+const TIER_MAX_FILE_SIZE: Record<SubscriptionTier, number> = {
+  free:     50  * 1024 * 1024,
+  pro:      250 * 1024 * 1024,
+  founder:  500 * 1024 * 1024,
+  business: 1024 * 1024 * 1024,
+};
+
+export interface ValidationError {
+  message: string;
+}
+
+export type ValidationResult<T = void> =
+  | { ok: true; value: T }
+  | { ok: false; error: ValidationError };
+
+export interface PresignParams {
+  key: string;
+  driveId: string;
+  filename: string;
+  mimeType: string;
+  fileSize: number;
+  ttlSeconds: number;
+}
+
+const HEX_RE = /^[0-9a-fA-F]{64}$/;
+
+const BLOCKED_MIME_TYPES = new Set([
+  'text/html',
+  'application/xhtml+xml',
+  'image/svg+xml',
+  'application/xml',
+  'text/xml',
+  'text/javascript',
+  'application/javascript',
+  'application/x-javascript',
+  'text/vbscript',
+  'application/x-executable',
+  'application/x-msdownload',
+  'application/x-mach-binary',
+  'application/vnd.microsoft.portable-executable',
+  'application/x-dosexec',
+]);
+
+export function validateContentHash(hash: string): ValidationResult<string> {
+  if (!HEX_RE.test(hash)) {
+    const msg = hash.length !== 64
+      ? `Content hash must be exactly 64 hex characters (got ${hash.length})`
+      : 'Content hash must contain only hex characters (0-9, a-f)';
+    return { ok: false, error: { message: msg } };
+  }
+  return { ok: true, value: hash };
+}
+
+export function validateFileSize(size: number, tier: SubscriptionTier): ValidationResult {
+  if (size <= 0) {
+    return { ok: false, error: { message: 'File must not be empty' } };
+  }
+  const limit = TIER_MAX_FILE_SIZE[tier];
+  if (size > limit) {
+    const limitMB = limit / (1024 * 1024);
+    const label = limitMB >= 1024 ? `${limitMB / 1024}GB` : `${limitMB}MB`;
+    return {
+      ok: false,
+      error: { message: `File exceeds ${tier} tier limit of ${label}` },
+    };
+  }
+  return { ok: true, value: undefined };
+}
+
+export function validateMimeTypeDeclaration(mimeType: string): ValidationResult {
+  const normalized = mimeType.toLowerCase().split(';')[0].trim();
+  if (BLOCKED_MIME_TYPES.has(normalized)) {
+    return { ok: false, error: { message: `MIME type "${normalized}" is not allowed` } };
+  }
+  return { ok: true, value: undefined };
+}
+
+const MAX_PRESIGN_TTL_SECONDS = 900;
+
+export function validateTtl(ttlSeconds: number): ValidationResult {
+  if (ttlSeconds <= 0 || ttlSeconds > MAX_PRESIGN_TTL_SECONDS) {
+    return {
+      ok: false,
+      error: { message: `TTL must be between 1 and ${MAX_PRESIGN_TTL_SECONDS} seconds` },
+    };
+  }
+  return { ok: true, value: undefined };
+}
+
+export function buildS3Key(hash: string): string {
+  return `files/${hash}/original`;
+}
+
+export function buildPresignParams(
+  hash: string,
+  driveId: string,
+  filename: string,
+  mimeType: string,
+  fileSize: number,
+  ttlSeconds: number,
+): PresignParams {
+  return {
+    key: buildS3Key(hash),
+    driveId,
+    filename,
+    mimeType,
+    fileSize,
+    ttlSeconds,
+  };
+}

--- a/packages/lib/src/services/upload-validation.ts
+++ b/packages/lib/src/services/upload-validation.ts
@@ -52,7 +52,8 @@ export function validateContentHash(hash: string): ValidationResult<string> {
       : 'Content hash must contain only hex characters (0-9, a-f)';
     return { ok: false, error: { message: msg } };
   }
-  return { ok: true, value: hash };
+  // Canonicalize to lowercase so the same digest always maps to one S3 key.
+  return { ok: true, value: hash.toLowerCase() };
 }
 
 export function validateFileSize(size: number, tier: SubscriptionTier): ValidationResult {


### PR DESCRIPTION
## Direct-to-S3 Presigned Upload

Removes the web service from the file-upload data path: the browser hashes the file, gets a short-lived presigned PUT scoped to that exact key+size, uploads **directly to Tigris**, then notifies the web service to create the page record and trigger the processor — which **pulls** the object from S3 and **byte-verifies it (re-hash + Magika) before any processing or serving**.

### What's included (TDD throughout)
- **Pure validation** (`@pagespace/lib/services/upload-validation`) — hash (lowercased) / size / MIME / TTL guards, `buildS3Key`
- **`POST /api/upload/presign`** — MCP scope + drive-access gates, remaining-quota + file-count enforcement, dedup via HeadObject, presigned PUT with **signed `ContentLength`**, slot reservation that stores server-trusted upload metadata; returns `jobId` on both new and dedup paths; releases the slot if setup fails
- **`POST /api/upload/complete`** — reads `contentHash`/`driveId`/`fileSize`/`mimeType` from the **presign-reserved slot** (never the client body), MCP scope + drive-access gates, page record (raw content hash in `filePath`), slot release, verified-ingest enqueue; post-commit bookkeeping can't 500 a committed upload
- **`POST /api/upload/cancel`** — releases a reserved slot on client-side failure, scoped via the slot's drive
- **Processor pure pipeline** — `verifyContentHash`, `detectContentType` (Magika), `isAllowedContentType`, `extractTextContent`, `generateImageVariants` (per-variant MIME), `extractVideoMetadata/Thumbnail`; temp files via private `fs.mkdtemp`
- **Processor S3-pull adapter** (`runPullPipeline`) — 3×/1s-backoff fetch, zero-trust hash + Magika gates (reject **and delete** on failure, even if the delete throws), dispatch to the pure transforms
- **Verified ingest wiring** — new `pull-verify` pg-boss queue/worker + `POST /api/ingest/pull/:pageId`; `/complete` routes through it so direct uploads are byte-verified (legacy/reprocess `/by-page` left unchanged)
- **Frontend** — `computeContentHash` (WebCrypto), composed orchestrator (`presign → XHR PUT → complete`, dedup skips the PUT, Content-Type matches the signed value, slot-leak-safe cancel), `useDirectUpload` hook (re-entrancy guarded)
- **Ops** — Tigris CORS config + apply/verify docs in `PageSpace-Deploy/fly/`

### Zero-trust
Signed `ContentLength` (size enforced at the bucket); presigned PUT TTL ≤ 900s; CORS locked to explicit origins (no wildcards); `/complete` trusts slot metadata over the client body; the processor re-hashes the stored bytes and re-classifies with Magika, **deleting** anything that mismatches or resolves to an executable/HTML/SVG/script regardless of declared MIME, before any processing or serving.

### Review
All Codex + CodeRabbit findings addressed (14 total: MCP scope ×3, storage quota, CodeQL temp file, slot-leak ×2, post-commit-no-500, image-variant MIME, mammoth `.doc`, hook re-entrancy, stale-slot expiry, lowercase-hash, jobId→metadata binding, **verified-ingest wiring**). All review threads resolved.

### Remaining go-live steps (follow-up — do not enable the UI path until done)
The new `/api/upload/*` routes are auth-gated and live but **not UI-wired**:
1. Apply the Tigris CORS config per environment (`PageSpace-Deploy/fly/TIGRIS_CORS.md`) and verify a real browser PUT.
2. Cut `useFileDrop` over to `uploadFileToS3`, then remove the old multipart `/api/upload` path.

### Tests
~150 new tests, all green. Full processor suite 988 passing. `tsc` + `lint` clean across web + processor; all CI checks green.

> Note: `useDirectUpload` has no unit test — `renderHook` is broken in this worktree (the pre-existing `useAttachmentUpload.test.ts` fails identically under React 19 + RTL v16). The hook is thin glue over the fully-tested orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
