### PR TITLE
feat(agents): cascade agent revocation when a member is removed or downgraded

### DIFF
--- a/apps/web/src/app/api/drives/[driveId]/members/[userId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/[userId]/__tests__/route.test.ts
@@ -44,6 +44,13 @@ vi.mock('@pagespace/lib/notifications/notifications', () => ({
     createDriveNotification: vi.fn().mockResolvedValue(undefined),
 }));
 
+// Cascade seam: agent-membership revocation/re-cap is exercised in its own unit
+// suite; here we only assert the route wires it up.
+vi.mock('@pagespace/lib/services/drive-agent-service', () => ({
+    revokeAgentMembershipsGrantedBy: vi.fn().mockResolvedValue([]),
+    recapAgentMembershipsGrantedBy: vi.fn().mockResolvedValue([]),
+}));
+
 vi.mock('@/lib/websocket', () => ({
   broadcastDriveMemberEvent: vi.fn().mockResolvedValue(undefined),
   broadcastDriveMemberEventToRecipients: vi.fn().mockResolvedValue(undefined),
@@ -130,6 +137,8 @@ import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { trackDriveOperation } from '@pagespace/lib/monitoring/activity-tracker';
 import { getActorInfo, logPermissionActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { db } from '@pagespace/db/db';
+import { auditRequest } from '@pagespace/lib/audit/audit-log';
+import { revokeAgentMembershipsGrantedBy, recapAgentMembershipsGrantedBy } from '@pagespace/lib/services/drive-agent-service';
 
 // ============================================================================
 // Test Fixtures
@@ -476,6 +485,8 @@ describe('PATCH /api/drives/[driveId]/members/[userId]', () => {
     vi.resetAllMocks();
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mockWebAuth(mockCurrentUserId));
     vi.mocked(isAuthError).mockReturnValue(false);
+    // resetAllMocks clears the default return; the route reads `.length` on it.
+    vi.mocked(recapAgentMembershipsGrantedBy).mockResolvedValue([]);
   });
 
   describe('authentication', () => {
@@ -835,6 +846,77 @@ describe('PATCH /api/drives/[driveId]/members/[userId]', () => {
     });
   });
 
+  describe('boundary obligations - agent re-cap cascade', () => {
+    it('should re-cap the member\'s external agents when the role changes (downgrade)', async () => {
+      vi.mocked(checkDriveAccess).mockResolvedValue(createAccessFixture({
+        isOwner: true,
+        drive: createDriveFixture({ id: mockDriveId, name: 'Test Drive' }),
+      }));
+      vi.mocked(getDriveMemberDetails).mockResolvedValue(
+        createMemberDetailsFixture({ userId: mockTargetUserId, role: 'ADMIN' })
+      );
+      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'ADMIN' });
+      vi.mocked(updateMemberPermissions).mockResolvedValue(0);
+
+      const request = new Request(`https://example.com/api/drives/${mockDriveId}/members/${mockTargetUserId}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ role: 'MEMBER', permissions: [] }),
+      });
+      await PATCH(request, createContext(mockDriveId, mockTargetUserId));
+
+      expect(recapAgentMembershipsGrantedBy).toHaveBeenCalledWith(mockDriveId, mockTargetUserId);
+    });
+
+    it('should audit re-capped agents when any were affected', async () => {
+      vi.mocked(checkDriveAccess).mockResolvedValue(createAccessFixture({
+        isOwner: true,
+        drive: createDriveFixture({ id: mockDriveId, name: 'Test Drive' }),
+      }));
+      vi.mocked(getDriveMemberDetails).mockResolvedValue(
+        createMemberDetailsFixture({ userId: mockTargetUserId, role: 'ADMIN' })
+      );
+      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'ADMIN' });
+      vi.mocked(updateMemberPermissions).mockResolvedValue(0);
+      vi.mocked(recapAgentMembershipsGrantedBy).mockResolvedValue(['agent_1']);
+
+      const request = new Request(`https://example.com/api/drives/${mockDriveId}/members/${mockTargetUserId}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ role: 'MEMBER', permissions: [] }),
+      });
+      await PATCH(request, createContext(mockDriveId, mockTargetUserId));
+
+      expect(auditRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          details: expect.objectContaining({
+            recappedAgentPageIds: ['agent_1'],
+            reason: 'member_downgrade',
+          }),
+        }),
+      );
+    });
+
+    it('should NOT re-cap agents when the role is unchanged', async () => {
+      vi.mocked(checkDriveAccess).mockResolvedValue(createAccessFixture({
+        isOwner: true,
+        drive: createDriveFixture({ id: mockDriveId, name: 'Test' }),
+      }));
+      vi.mocked(getDriveMemberDetails).mockResolvedValue(
+        createMemberDetailsFixture({ userId: mockTargetUserId, role: 'ADMIN' })
+      );
+      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'ADMIN' });
+      vi.mocked(updateMemberPermissions).mockResolvedValue(0);
+
+      const request = new Request(`https://example.com/api/drives/${mockDriveId}/members/${mockTargetUserId}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ role: 'ADMIN', permissions: [] }),
+      });
+      await PATCH(request, createContext(mockDriveId, mockTargetUserId));
+
+      expect(recapAgentMembershipsGrantedBy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('response contract', () => {
     it('should return success with permissionsUpdated count', async () => {
       vi.mocked(checkDriveAccess).mockResolvedValue(createAccessFixture({
@@ -982,6 +1064,9 @@ describe('DELETE /api/drives/[driveId]/members/[userId]', () => {
 
     // Default: empty recipient list for fan-out (no admins to notify)
     vi.mocked(getDriveRecipientUserIds).mockResolvedValue([]);
+
+    // Default: the removed user granted no agent memberships (route reads `.length`).
+    vi.mocked(revokeAgentMembershipsGrantedBy).mockResolvedValue([]);
   });
 
   const createDeleteRequest = () => {
@@ -1323,6 +1408,47 @@ describe('DELETE /api/drives/[driveId]/members/[userId]', () => {
       expect(response.status).toBe(200);
       // No permission revocations should be logged
       expect(logPermissionActivity).not.toHaveBeenCalled();
+    });
+
+    it('should revoke the removed user\'s external agent memberships in the drive', async () => {
+      const response = await DELETE(createDeleteRequest(), createContext(mockDriveId, mockTargetUserId));
+
+      expect(response.status).toBe(200);
+      // Runs inside the removal transaction (executor passed first), scoped to
+      // this drive and the removed user.
+      expect(revokeAgentMembershipsGrantedBy).toHaveBeenCalledWith(
+        expect.anything(),
+        mockDriveId,
+        mockTargetUserId,
+      );
+    });
+
+    it('should audit the cascaded agent revocations when any agents were revoked', async () => {
+      vi.mocked(revokeAgentMembershipsGrantedBy).mockResolvedValue(['agent_1', 'agent_2']);
+
+      await DELETE(createDeleteRequest(), createContext(mockDriveId, mockTargetUserId));
+
+      expect(auditRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          eventType: 'authz.permission.revoked',
+          details: expect.objectContaining({
+            revokedAgentPageIds: ['agent_1', 'agent_2'],
+            reason: 'member_removal',
+          }),
+        }),
+      );
+    });
+
+    it('should NOT emit the agent-revocation audit when no agents were revoked', async () => {
+      vi.mocked(revokeAgentMembershipsGrantedBy).mockResolvedValue([]);
+
+      await DELETE(createDeleteRequest(), createContext(mockDriveId, mockTargetUserId));
+
+      const agentAuditCalls = vi.mocked(auditRequest).mock.calls.filter(
+        ([, opts]) => (opts as { details?: { reason?: string } })?.details?.reason === 'member_removal',
+      );
+      expect(agentAuditCalls).toHaveLength(0);
     });
   });
 

--- a/apps/web/src/app/api/drives/[driveId]/members/[userId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/[userId]/__tests__/route.test.ts
@@ -511,7 +511,7 @@ describe('PATCH /api/drives/[driveId]/members/[userId]', () => {
       vi.mocked(getDriveMemberDetails).mockResolvedValue(
         createMemberDetailsFixture({ userId: mockTargetUserId, role: 'MEMBER' })
       );
-      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER' });
+      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER', oldCustomRoleId: null });
       vi.mocked(updateMemberPermissions).mockResolvedValue(0);
 
       const request = new Request(`https://example.com/api/drives/${mockDriveId}/members/${mockTargetUserId}`, {
@@ -572,7 +572,7 @@ describe('PATCH /api/drives/[driveId]/members/[userId]', () => {
       vi.mocked(getDriveMemberDetails).mockResolvedValue(
         createMemberDetailsFixture({ userId: mockTargetUserId, role: 'MEMBER' })
       );
-      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER' });
+      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER', oldCustomRoleId: null });
       vi.mocked(updateMemberPermissions).mockResolvedValue(0);
 
       const request = new Request(`https://example.com/api/drives/${mockDriveId}/members/${mockTargetUserId}`, {
@@ -592,7 +592,7 @@ describe('PATCH /api/drives/[driveId]/members/[userId]', () => {
       vi.mocked(getDriveMemberDetails).mockResolvedValue(
         createMemberDetailsFixture({ userId: mockTargetUserId, role: 'ADMIN' })
       );
-      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'ADMIN' });
+      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'ADMIN', oldCustomRoleId: null });
       vi.mocked(updateMemberPermissions).mockResolvedValue(0);
 
       const request = new Request(`https://example.com/api/drives/${mockDriveId}/members/${mockTargetUserId}`, {
@@ -667,7 +667,7 @@ describe('PATCH /api/drives/[driveId]/members/[userId]', () => {
       vi.mocked(getDriveMemberDetails).mockResolvedValue(
         createMemberDetailsFixture({ userId: mockTargetUserId, role: 'MEMBER' })
       );
-      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER' });
+      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER', oldCustomRoleId: null });
       vi.mocked(updateMemberPermissions).mockResolvedValue(0);
 
       const request = new Request(`https://example.com/api/drives/${mockDriveId}/members/${mockTargetUserId}`, {
@@ -687,7 +687,7 @@ describe('PATCH /api/drives/[driveId]/members/[userId]', () => {
       vi.mocked(getDriveMemberDetails).mockResolvedValue(
         createMemberDetailsFixture({ userId: mockTargetUserId, role: 'MEMBER' })
       );
-      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER' });
+      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER', oldCustomRoleId: null });
       vi.mocked(updateMemberPermissions).mockResolvedValue(0);
 
       const request = new Request(`https://example.com/api/drives/${mockDriveId}/members/${mockTargetUserId}`, {
@@ -707,7 +707,7 @@ describe('PATCH /api/drives/[driveId]/members/[userId]', () => {
       vi.mocked(getDriveMemberDetails).mockResolvedValue(
         createMemberDetailsFixture({ userId: mockTargetUserId, role: 'MEMBER' })
       );
-      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER' });
+      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER', oldCustomRoleId: null });
       vi.mocked(updateMemberPermissions).mockResolvedValue(0);
 
       const request = new Request(`https://example.com/api/drives/${mockDriveId}/members/${mockTargetUserId}`, {
@@ -732,7 +732,7 @@ describe('PATCH /api/drives/[driveId]/members/[userId]', () => {
       vi.mocked(getDriveMemberDetails).mockResolvedValue(
         createMemberDetailsFixture({ userId: mockTargetUserId, role: 'MEMBER' })
       );
-      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER' });
+      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER', oldCustomRoleId: null });
       vi.mocked(updateMemberPermissions).mockResolvedValue(2);
 
       const request = new Request(`https://example.com/api/drives/${mockDriveId}/members/${mockTargetUserId}`, {
@@ -759,7 +759,7 @@ describe('PATCH /api/drives/[driveId]/members/[userId]', () => {
       vi.mocked(getDriveMemberDetails).mockResolvedValue(
         createMemberDetailsFixture({ userId: mockTargetUserId, role: 'MEMBER' })
       );
-      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER' });
+      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER', oldCustomRoleId: null });
       vi.mocked(updateMemberPermissions).mockResolvedValue(0);
 
       const request = new Request(`https://example.com/api/drives/${mockDriveId}/members/${mockTargetUserId}`, {
@@ -785,7 +785,7 @@ describe('PATCH /api/drives/[driveId]/members/[userId]', () => {
       vi.mocked(getDriveMemberDetails).mockResolvedValue(
         createMemberDetailsFixture({ userId: mockTargetUserId, role: 'MEMBER' })
       );
-      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER' });
+      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER', oldCustomRoleId: null });
       vi.mocked(updateMemberPermissions).mockResolvedValue(0);
 
       const request = new Request(`https://example.com/api/drives/${mockDriveId}/members/${mockTargetUserId}`, {
@@ -811,7 +811,7 @@ describe('PATCH /api/drives/[driveId]/members/[userId]', () => {
       vi.mocked(getDriveMemberDetails).mockResolvedValue(
         createMemberDetailsFixture({ userId: mockTargetUserId, role: 'ADMIN' })
       );
-      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'ADMIN' });
+      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'ADMIN', oldCustomRoleId: null });
       vi.mocked(updateMemberPermissions).mockResolvedValue(0);
 
       const request = new Request(`https://example.com/api/drives/${mockDriveId}/members/${mockTargetUserId}`, {
@@ -832,7 +832,7 @@ describe('PATCH /api/drives/[driveId]/members/[userId]', () => {
       vi.mocked(getDriveMemberDetails).mockResolvedValue(
         createMemberDetailsFixture({ userId: mockTargetUserId, role: 'MEMBER' })
       );
-      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER' });
+      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER', oldCustomRoleId: null });
       vi.mocked(updateMemberPermissions).mockResolvedValue(2);
 
       const request = new Request(`https://example.com/api/drives/${mockDriveId}/members/${mockTargetUserId}`, {
@@ -855,7 +855,7 @@ describe('PATCH /api/drives/[driveId]/members/[userId]', () => {
       vi.mocked(getDriveMemberDetails).mockResolvedValue(
         createMemberDetailsFixture({ userId: mockTargetUserId, role: 'ADMIN' })
       );
-      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'ADMIN' });
+      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'ADMIN', oldCustomRoleId: null });
       vi.mocked(updateMemberPermissions).mockResolvedValue(0);
 
       const request = new Request(`https://example.com/api/drives/${mockDriveId}/members/${mockTargetUserId}`, {
@@ -875,7 +875,7 @@ describe('PATCH /api/drives/[driveId]/members/[userId]', () => {
       vi.mocked(getDriveMemberDetails).mockResolvedValue(
         createMemberDetailsFixture({ userId: mockTargetUserId, role: 'ADMIN' })
       );
-      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'ADMIN' });
+      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'ADMIN', oldCustomRoleId: null });
       vi.mocked(updateMemberPermissions).mockResolvedValue(0);
       vi.mocked(recapAgentMembershipsGrantedBy).mockResolvedValue(['agent_1']);
 
@@ -901,17 +901,42 @@ describe('PATCH /api/drives/[driveId]/members/[userId]', () => {
         isOwner: true,
         drive: createDriveFixture({ id: mockDriveId, name: 'Test Drive' }),
       }));
-      // Member stays MEMBER; the fixture has no prior custom role (id null).
       vi.mocked(getDriveMemberDetails).mockResolvedValue(
         createMemberDetailsFixture({ userId: mockTargetUserId, role: 'MEMBER' })
       );
-      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER' });
+      // Old custom role differs from the requested one (the reliable signal comes
+      // from updateMemberRole's return, NOT getDriveMemberDetails.customRole).
+      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER', oldCustomRoleId: 'role_permissive' });
       vi.mocked(updateMemberPermissions).mockResolvedValue(0);
 
       const request = new Request(`https://example.com/api/drives/${mockDriveId}/members/${mockTargetUserId}`, {
         method: 'PATCH',
         // No `role` field — only the custom role is being changed.
         body: JSON.stringify({ customRoleId: 'role_restrictive', permissions: [] }),
+      });
+      await PATCH(request, createContext(mockDriveId, mockTargetUserId));
+
+      expect(recapAgentMembershipsGrantedBy).toHaveBeenCalledWith(mockDriveId, mockTargetUserId);
+    });
+
+    // Regression for the second Codex P1: clearing a custom role (customRoleId:
+    // null) over a prior role, with the standard role unchanged, must still
+    // re-cap. getDriveMemberDetails hardcodes customRole: null, so detection
+    // relies on updateMemberRole's returned oldCustomRoleId.
+    it('should re-cap agents when the custom role is CLEARED (role unchanged)', async () => {
+      vi.mocked(checkDriveAccess).mockResolvedValue(createAccessFixture({
+        isOwner: true,
+        drive: createDriveFixture({ id: mockDriveId, name: 'Test Drive' }),
+      }));
+      vi.mocked(getDriveMemberDetails).mockResolvedValue(
+        createMemberDetailsFixture({ userId: mockTargetUserId, role: 'MEMBER' })
+      );
+      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER', oldCustomRoleId: 'role_x' });
+      vi.mocked(updateMemberPermissions).mockResolvedValue(0);
+
+      const request = new Request(`https://example.com/api/drives/${mockDriveId}/members/${mockTargetUserId}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ customRoleId: null, permissions: [] }),
       });
       await PATCH(request, createContext(mockDriveId, mockTargetUserId));
 
@@ -926,7 +951,7 @@ describe('PATCH /api/drives/[driveId]/members/[userId]', () => {
       vi.mocked(getDriveMemberDetails).mockResolvedValue(
         createMemberDetailsFixture({ userId: mockTargetUserId, role: 'ADMIN' })
       );
-      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'ADMIN' });
+      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'ADMIN', oldCustomRoleId: null });
       vi.mocked(updateMemberPermissions).mockResolvedValue(0);
 
       const request = new Request(`https://example.com/api/drives/${mockDriveId}/members/${mockTargetUserId}`, {
@@ -944,12 +969,11 @@ describe('PATCH /api/drives/[driveId]/members/[userId]', () => {
         isOwner: true,
         drive: createDriveFixture({ id: mockDriveId, name: 'Test' }),
       }));
-      // Member already holds the same custom role being "set".
-      vi.mocked(getDriveMemberDetails).mockResolvedValue({
-        ...createMemberDetailsFixture({ userId: mockTargetUserId, role: 'MEMBER' }),
-        customRole: { id: 'role_same', name: 'Same', color: null },
-      } as never);
-      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER' });
+      vi.mocked(getDriveMemberDetails).mockResolvedValue(
+        createMemberDetailsFixture({ userId: mockTargetUserId, role: 'MEMBER' })
+      );
+      // Member already holds the same custom role being "set" ⇒ no change.
+      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER', oldCustomRoleId: 'role_same' });
       vi.mocked(updateMemberPermissions).mockResolvedValue(0);
 
       const request = new Request(`https://example.com/api/drives/${mockDriveId}/members/${mockTargetUserId}`, {
@@ -971,7 +995,7 @@ describe('PATCH /api/drives/[driveId]/members/[userId]', () => {
       vi.mocked(getDriveMemberDetails).mockResolvedValue(
         createMemberDetailsFixture({ userId: mockTargetUserId, role: 'MEMBER' })
       );
-      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER' });
+      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER', oldCustomRoleId: null });
       vi.mocked(updateMemberPermissions).mockResolvedValue(5);
 
       const request = new Request(`https://example.com/api/drives/${mockDriveId}/members/${mockTargetUserId}`, {
@@ -997,7 +1021,7 @@ describe('PATCH /api/drives/[driveId]/members/[userId]', () => {
       vi.mocked(getDriveMemberDetails).mockResolvedValue(
         createMemberDetailsFixture({ userId: mockTargetUserId, role: 'MEMBER' })
       );
-      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER' });
+      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER', oldCustomRoleId: null });
       vi.mocked(updateMemberPermissions).mockResolvedValue(0);
 
       const request = new Request(`https://example.com/api/drives/${mockDriveId}/members/${mockTargetUserId}`, {

--- a/apps/web/src/app/api/drives/[driveId]/members/[userId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/[userId]/__tests__/route.test.ts
@@ -890,13 +890,35 @@ describe('PATCH /api/drives/[driveId]/members/[userId]', () => {
         expect.objectContaining({
           details: expect.objectContaining({
             recappedAgentPageIds: ['agent_1'],
-            reason: 'member_downgrade',
+            reason: 'member_recap',
           }),
         }),
       );
     });
 
-    it('should NOT re-cap agents when the role is unchanged', async () => {
+    it('should re-cap agents when only the custom role changes (role unchanged)', async () => {
+      vi.mocked(checkDriveAccess).mockResolvedValue(createAccessFixture({
+        isOwner: true,
+        drive: createDriveFixture({ id: mockDriveId, name: 'Test Drive' }),
+      }));
+      // Member stays MEMBER; the fixture has no prior custom role (id null).
+      vi.mocked(getDriveMemberDetails).mockResolvedValue(
+        createMemberDetailsFixture({ userId: mockTargetUserId, role: 'MEMBER' })
+      );
+      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER' });
+      vi.mocked(updateMemberPermissions).mockResolvedValue(0);
+
+      const request = new Request(`https://example.com/api/drives/${mockDriveId}/members/${mockTargetUserId}`, {
+        method: 'PATCH',
+        // No `role` field — only the custom role is being changed.
+        body: JSON.stringify({ customRoleId: 'role_restrictive', permissions: [] }),
+      });
+      await PATCH(request, createContext(mockDriveId, mockTargetUserId));
+
+      expect(recapAgentMembershipsGrantedBy).toHaveBeenCalledWith(mockDriveId, mockTargetUserId);
+    });
+
+    it('should NOT re-cap agents when neither role nor custom role changes', async () => {
       vi.mocked(checkDriveAccess).mockResolvedValue(createAccessFixture({
         isOwner: true,
         drive: createDriveFixture({ id: mockDriveId, name: 'Test' }),
@@ -909,7 +931,30 @@ describe('PATCH /api/drives/[driveId]/members/[userId]', () => {
 
       const request = new Request(`https://example.com/api/drives/${mockDriveId}/members/${mockTargetUserId}`, {
         method: 'PATCH',
+        // Same role, no customRoleId in body ⇒ nothing about the ceiling changed.
         body: JSON.stringify({ role: 'ADMIN', permissions: [] }),
+      });
+      await PATCH(request, createContext(mockDriveId, mockTargetUserId));
+
+      expect(recapAgentMembershipsGrantedBy).not.toHaveBeenCalled();
+    });
+
+    it('should NOT re-cap agents when the provided custom role equals the current one', async () => {
+      vi.mocked(checkDriveAccess).mockResolvedValue(createAccessFixture({
+        isOwner: true,
+        drive: createDriveFixture({ id: mockDriveId, name: 'Test' }),
+      }));
+      // Member already holds the same custom role being "set".
+      vi.mocked(getDriveMemberDetails).mockResolvedValue({
+        ...createMemberDetailsFixture({ userId: mockTargetUserId, role: 'MEMBER' }),
+        customRole: { id: 'role_same', name: 'Same', color: null },
+      } as never);
+      vi.mocked(updateMemberRole).mockResolvedValue({ oldRole: 'MEMBER' });
+      vi.mocked(updateMemberPermissions).mockResolvedValue(0);
+
+      const request = new Request(`https://example.com/api/drives/${mockDriveId}/members/${mockTargetUserId}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ customRoleId: 'role_same', permissions: [] }),
       });
       await PATCH(request, createContext(mockDriveId, mockTargetUserId));
 

--- a/apps/web/src/app/api/drives/[driveId]/members/[userId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/[userId]/route.ts
@@ -10,6 +10,10 @@ import {
   updateMemberPermissions,
   getDriveRecipientUserIds,
 } from '@pagespace/lib/services/drive-member-service';
+import {
+  revokeAgentMembershipsGrantedBy,
+  recapAgentMembershipsGrantedBy,
+} from '@pagespace/lib/services/drive-agent-service';
 import { createDriveNotification } from '@pagespace/lib/notifications/notifications';
 import {
   broadcastDriveMemberEvent,
@@ -158,6 +162,14 @@ export async function PATCH(
       }, actorInfo);
 
       auditRequest(request, { eventType: 'authz.role.assigned', userId: currentUserId, resourceType: 'drive', resourceId: driveId, details: { targetUserId: userId, previousRole: oldRole, newRole: role } });
+
+      // Cascade: re-cap the external agents this user granted in the drive to
+      // the role they can grant now. A downgrade (e.g. ADMIN→MEMBER) must pull
+      // down any agent they had elevated; an upgrade is a no-op.
+      const recappedAgentIds = await recapAgentMembershipsGrantedBy(driveId, userId);
+      if (recappedAgentIds.length > 0) {
+        auditRequest(request, { eventType: 'authz.role.assigned', userId: currentUserId, resourceType: 'drive', resourceId: driveId, details: { targetUserId: userId, recappedAgentPageIds: recappedAgentIds, newCap: role, reason: 'member_downgrade' } });
+      }
     }
 
     // Update permissions
@@ -234,6 +246,7 @@ export async function DELETE(
 
     // Remove member and their permissions in a transaction
     // Fix 12: Log permissions BEFORE deletion for rollback support
+    let revokedAgentIds: string[] = [];
     await db.transaction(async (tx) => {
       // Get all pages in this drive
       const drivePages = await tx.select({ id: pages.id, title: pages.title })
@@ -297,6 +310,11 @@ export async function DELETE(
           eq(driveMembers.driveId, driveId),
           eq(driveMembers.userId, targetUserId)
         ));
+
+      // Cascade: revoke the external agent memberships this user granted in the
+      // drive. Their access was capped at this user's, so it must not outlive
+      // their membership. (Home-drive memberships are preserved.)
+      revokedAgentIds = await revokeAgentMembershipsGrantedBy(tx, driveId, targetUserId);
     });
 
     trackDriveOperation(currentUserId, 'remove_member', driveId, {
@@ -319,6 +337,12 @@ export async function DELETE(
     }, actorInfo);
 
     auditRequest(request, { eventType: 'authz.permission.revoked', userId: currentUserId, resourceType: 'drive', resourceId: driveId, details: { targetUserId } });
+
+    // Audit the cascaded agent-membership revocations (the user's external
+    // agents lost their inherited drive access alongside the user).
+    if (revokedAgentIds.length > 0) {
+      auditRequest(request, { eventType: 'authz.permission.revoked', userId: currentUserId, resourceType: 'drive', resourceId: driveId, details: { targetUserId, revokedAgentPageIds: revokedAgentIds, reason: 'member_removal' } });
+    }
 
     // Fan out member_removed to owner + remaining accepted members so any admin
     // watching the members page sees the row disappear without a manual refresh.

--- a/apps/web/src/app/api/drives/[driveId]/members/[userId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/[userId]/route.ts
@@ -132,8 +132,14 @@ export async function PATCH(
     // Update role and customRoleId if provided
     const { oldRole } = await updateMemberRole(driveId, userId, role, customRoleId);
 
+    const roleChanged = Boolean(role) && role !== oldRole;
+    // `customRoleId` is only meaningful when present in the request body;
+    // `updateMemberRole` coerces falsy values to null when clearing it.
+    const oldCustomRoleId = memberData.customRole?.id ?? null;
+    const customRoleChanged = customRoleId !== undefined && (customRoleId || null) !== oldCustomRoleId;
+
     // Send notification if role changed (boundary obligation)
-    if (role && role !== oldRole) {
+    if (roleChanged) {
       await createDriveNotification(
         userId,
         driveId,
@@ -162,13 +168,19 @@ export async function PATCH(
       }, actorInfo);
 
       auditRequest(request, { eventType: 'authz.role.assigned', userId: currentUserId, resourceType: 'drive', resourceId: driveId, details: { targetUserId: userId, previousRole: oldRole, newRole: role } });
+    }
 
-      // Cascade: re-cap the external agents this user granted in the drive to
-      // the role they can grant now. A downgrade (e.g. ADMIN→MEMBER) must pull
-      // down any agent they had elevated; an upgrade is a no-op.
+    // Cascade: re-cap the external agents this user granted in the drive to the
+    // grant they can make now. Triggered by ANY change to their grant ceiling —
+    // a standard-role change OR a custom-role change (tightened or cleared) —
+    // since both alter the driveAgentMembers row they could create today. A
+    // custom-role downgrade would otherwise leave agents with stale access to
+    // pages the user can no longer grant. recapAgentMembershipsGrantedBy never
+    // escalates beyond the user's own access.
+    if (roleChanged || customRoleChanged) {
       const recappedAgentIds = await recapAgentMembershipsGrantedBy(driveId, userId);
       if (recappedAgentIds.length > 0) {
-        auditRequest(request, { eventType: 'authz.role.assigned', userId: currentUserId, resourceType: 'drive', resourceId: driveId, details: { targetUserId: userId, recappedAgentPageIds: recappedAgentIds, newCap: role, reason: 'member_downgrade' } });
+        auditRequest(request, { eventType: 'authz.role.assigned', userId: currentUserId, resourceType: 'drive', resourceId: driveId, details: { targetUserId: userId, recappedAgentPageIds: recappedAgentIds, newCap: role ?? oldRole, reason: 'member_recap' } });
       }
     }
 

--- a/apps/web/src/app/api/drives/[driveId]/members/[userId]/route.ts
+++ b/apps/web/src/app/api/drives/[driveId]/members/[userId]/route.ts
@@ -129,13 +129,15 @@ export async function PATCH(
       return NextResponse.json({ error: 'Member not found' }, { status: 404 });
     }
 
-    // Update role and customRoleId if provided
-    const { oldRole } = await updateMemberRole(driveId, userId, role, customRoleId);
+    // Update role and customRoleId if provided. `updateMemberRole` returns the
+    // pre-update values it read from the row (getDriveMemberDetails hardcodes
+    // customRole: null, so it cannot be used to detect a custom-role change).
+    const { oldRole, oldCustomRoleId } = await updateMemberRole(driveId, userId, role, customRoleId);
 
     const roleChanged = Boolean(role) && role !== oldRole;
     // `customRoleId` is only meaningful when present in the request body;
-    // `updateMemberRole` coerces falsy values to null when clearing it.
-    const oldCustomRoleId = memberData.customRole?.id ?? null;
+    // `updateMemberRole` coerces falsy values to null when clearing it, so a
+    // clear (customRoleId: null over a prior role) is a real change too.
     const customRoleChanged = customRoleId !== undefined && (customRoleId || null) !== oldCustomRoleId;
 
     // Send notification if role changed (boundary obligation)

--- a/packages/lib/src/permissions/__tests__/agent-permissions.test.ts
+++ b/packages/lib/src/permissions/__tests__/agent-permissions.test.ts
@@ -8,7 +8,7 @@ vi.mock('@pagespace/db/db', () => ({
   db: { select: vi.fn() },
 }));
 vi.mock('@pagespace/db/schema/core', () => ({
-  pages: { id: 'id', driveId: 'driveId' },
+  pages: { id: 'id', driveId: 'driveId', isPrivate: 'isPrivate', isTrashed: 'isTrashed' },
   drives: { id: 'id', ownerId: 'ownerId' },
 }));
 vi.mock('@pagespace/db/schema/members', () => ({
@@ -37,6 +37,7 @@ vi.mock('@pagespace/db/operators', () => ({
 
 import { getAgentAccessLevel, getAgentAccessiblePagesInDrive, hasAgentDriveMembership } from '../agent-permissions';
 import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -110,6 +111,35 @@ describe('getAgentAccessLevel — page targets', () => {
 
     const result = await getAgentAccessLevel(AGENT_PAGE_ID, TARGET_PAGE_ID);
     expect(result).toEqual({ canView: true, canEdit: true, canShare: false, canDelete: false });
+  });
+
+  it('denies a plain MEMBER agent access to a private page (mirrors plain-member user)', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect([{ driveId: DRIVE_ID, isPrivate: true }]))   // page lookup → private
+      .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: null }]));  // membership
+
+    const result = await getAgentAccessLevel(AGENT_PAGE_ID, TARGET_PAGE_ID);
+    expect(result).toBeNull();
+  });
+
+  it('still grants an ADMIN agent access to a private page', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect([{ driveId: DRIVE_ID, isPrivate: true }]))
+      .mockReturnValueOnce(stubSelect([{ role: 'ADMIN', customRoleId: null }]));
+
+    const result = await getAgentAccessLevel(AGENT_PAGE_ID, TARGET_PAGE_ID);
+    expect(result).toEqual({ canView: true, canEdit: true, canShare: true, canDelete: true });
+  });
+
+  it('honours an explicit custom-role grant on a private page', async () => {
+    const perms = { [TARGET_PAGE_ID]: { canView: true, canEdit: false, canShare: false } };
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect([{ driveId: DRIVE_ID, isPrivate: true }]))
+      .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: CUSTOM_ROLE_ID }]))
+      .mockReturnValueOnce(stubSelect([{ permissions: perms }]));
+
+    const result = await getAgentAccessLevel(AGENT_PAGE_ID, TARGET_PAGE_ID);
+    expect(result).toEqual({ canView: true, canEdit: false, canShare: false, canDelete: false });
   });
 });
 
@@ -211,18 +241,21 @@ describe('getAgentAccessiblePagesInDrive', () => {
     expect(await getAgentAccessiblePagesInDrive(AGENT_PAGE_ID, DRIVE_ID)).toEqual([]);
   });
 
-  it('grants a plain MEMBER (no custom role) view-only access to every page', async () => {
+  it('grants a plain MEMBER (no custom role) view-only access to non-private pages only', async () => {
     vi.mocked(db.select)
       .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: null }])) // membership
       .mockReturnValueOnce(stubSelectList([
         { id: 'p1', title: 'A', type: 'DOCUMENT', parentId: null, position: 0, isTrashed: false },
         { id: 'p2', title: 'B', type: 'DOCUMENT', parentId: null, position: 1, isTrashed: false },
-      ])); // page enumeration
+      ])); // page enumeration (non-private only)
 
     const result = await getAgentAccessiblePagesInDrive(AGENT_PAGE_ID, DRIVE_ID);
     expect(result).toHaveLength(2);
     expect(result.every((p) => p.permissions.canView)).toBe(true);
     expect(result.every((p) => !p.permissions.canEdit)).toBe(true);
+    // The enumeration filters out private pages, so the agent never out-reads the
+    // plain member who granted it.
+    expect(eq).toHaveBeenCalledWith('isPrivate', false);
   });
 
   it('grants an ADMIN full access to every page', async () => {

--- a/packages/lib/src/permissions/agent-permissions.ts
+++ b/packages/lib/src/permissions/agent-permissions.ts
@@ -3,7 +3,7 @@ import { eq, and, inArray } from '@pagespace/db/operators';
 import { pages } from '@pagespace/db/schema/core';
 import { driveAgentMembers } from '@pagespace/db/schema/members';
 import { resolveRolePermissions } from './resolve-role-permissions';
-import { fetchDriveIdForPage, fetchCustomRolePermissions } from './membership-queries';
+import { fetchCustomRolePermissions } from './membership-queries';
 import type { PermissionLevel, PageWithPermissions } from './permissions';
 
 async function fetchAgentMembership(agentPageId: string, driveId: string) {
@@ -15,17 +15,37 @@ async function fetchAgentMembership(agentPageId: string, driveId: string) {
   return rows[0] ?? null;
 }
 
+async function fetchPageDriveAndPrivacy(
+  targetPageId: string,
+): Promise<{ driveId: string; isPrivate: boolean }> {
+  const rows = await db
+    .select({ driveId: pages.driveId, isPrivate: pages.isPrivate })
+    .from(pages)
+    .where(eq(pages.id, targetPageId))
+    .limit(1);
+  // No page row ⇒ treat targetPageId as a drive id (drive-as-root-node pattern).
+  return rows[0] ?? { driveId: targetPageId, isPrivate: false };
+}
+
 export async function getAgentAccessLevel(
   agentPageId: string,
   targetPageId: string,
 ): Promise<PermissionLevel | null> {
-  const driveId = await fetchDriveIdForPage(targetPageId);
+  const { driveId, isPrivate } = await fetchPageDriveAndPrivacy(targetPageId);
   const membership = await fetchAgentMembership(agentPageId, driveId);
   if (!membership) return null;
 
   const customPerms = membership.customRoleId
     ? await fetchCustomRolePermissions(membership.customRoleId, driveId)
     : null;
+
+  // Mirror user-side membership semantics: a plain MEMBER (no resolvable custom
+  // role) sees only non-private pages, so an agent never out-reads the member who
+  // granted it. ADMIN/OWNER and explicit custom-role grants keep the same parity
+  // they already have with the user-side paths.
+  if (!customPerms && membership.role !== 'ADMIN' && membership.role !== 'OWNER' && isPrivate) {
+    return null;
+  }
 
   return resolveRolePermissions(membership.role, customPerms, targetPageId);
 }
@@ -97,8 +117,9 @@ export async function getAgentAccessiblePagesInDrive(
     return [];
   }
 
-  // Plain MEMBER (no custom role): blanket view-only over the drive's pages,
-  // consistent with getAgentAccessLevel granting a member canView on any page.
+  // Plain MEMBER (no custom role): view-only over the drive's non-private pages —
+  // the same set a plain MEMBER *user* sees, consistent with getAgentAccessLevel
+  // denying a plain member access to private pages.
   const memberPages = await db
     .select({
       id: pages.id,
@@ -109,7 +130,7 @@ export async function getAgentAccessiblePagesInDrive(
       isTrashed: pages.isTrashed,
     })
     .from(pages)
-    .where(and(eq(pages.driveId, driveId), eq(pages.isTrashed, false)));
+    .where(and(eq(pages.driveId, driveId), eq(pages.isTrashed, false), eq(pages.isPrivate, false)));
 
   return memberPages.map((p) => ({
     ...p,

--- a/packages/lib/src/services/__tests__/drive-agent-service.test.ts
+++ b/packages/lib/src/services/__tests__/drive-agent-service.test.ts
@@ -297,23 +297,42 @@ describe('recapAgentMembershipsGrantedBy', () => {
     expect(captured[0]).toEqual({ role: 'MEMBER', customRoleId: 'role_b' });
   });
 
-  it('reduces a custom-role agent whose scope differs from the granter down to the granter grant', async () => {
+  it('REVOKES a custom-role agent whose scope differs from the granter cap', async () => {
+    // A custom-role matrix is incomparable to plain MEMBER (it may scope to fewer
+    // pages, or grant private/edit access the cap doesn't), so rewriting it could
+    // widen the agent. Revoke rather than guess.
     vi.mocked(db.select)
       .mockReturnValueOnce(stubSelect([{ ownerId: 'someone_else' }]))                          // drive lookup
       .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: null }]))               // granter now plain MEMBER
       .mockReturnValueOnce(stubJoinSelect([{ id: 'm2', agentPageId: 'a2', role: 'MEMBER', customRoleId: 'role_a' }]));
-    const captured: Record<string, unknown>[] = [];
-    stubUpdate(captured);
-    stubDelete();
+    stubUpdate([]);
+    const where = stubDelete();
 
     const result = await recapAgentMembershipsGrantedBy(DRIVE, USER);
 
-    // Stale custom role the plain-member granter can no longer back ⇒ reset to the
-    // granter's own grant (plain MEMBER, no custom role). A plain-MEMBER row now
-    // only reaches non-private pages, so this narrows rather than broadens.
     expect(result).toEqual(['a2']);
-    expect(captured[0]).toEqual({ role: 'MEMBER', customRoleId: null });
-    expect(db.delete).not.toHaveBeenCalled();
+    expect(db.delete).toHaveBeenCalledWith(driveAgentMembers);
+    expect(where).toHaveBeenCalledTimes(1);
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('REVOKES a plain-MEMBER agent when the granter cap is a (narrower) custom role', async () => {
+    // agent {MEMBER,null} sees all non-private pages; the granter's custom-role cap
+    // may be narrower (or otherwise incomparable), so rewriting null→role could
+    // widen or skew the agent. Revoke instead.
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect([{ ownerId: 'someone_else' }]))                              // drive lookup
+      .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: 'role_b' }]))               // granter custom role
+      .mockReturnValueOnce(stubJoinSelect([{ id: 'm5', agentPageId: 'a5', role: 'MEMBER', customRoleId: null }]));
+    stubUpdate([]);
+    const where = stubDelete();
+
+    const result = await recapAgentMembershipsGrantedBy(DRIVE, USER);
+
+    expect(result).toEqual(['a5']);
+    expect(db.delete).toHaveBeenCalledWith(driveAgentMembers);
+    expect(where).toHaveBeenCalledTimes(1);
+    expect(db.update).not.toHaveBeenCalled();
   });
 
   it('leaves a custom-role agent untouched when it already matches the granter ceiling', async () => {

--- a/packages/lib/src/services/__tests__/drive-agent-service.test.ts
+++ b/packages/lib/src/services/__tests__/drive-agent-service.test.ts
@@ -264,23 +264,22 @@ describe('recapAgentMembershipsGrantedBy', () => {
     expect(db.update).not.toHaveBeenCalled();
   });
 
-  it('REVOKES ADMIN agents when the granter is now a plain MEMBER (no representable cap)', async () => {
-    // A plain MEMBER agent membership resolves to canView on every page incl.
-    // private ones, which a plain-member granter cannot grant — so reducing
-    // ADMIN→plain MEMBER would over-grant. Revoke instead.
+  it('reduces ADMIN agents to plain MEMBER when the granter is now a plain MEMBER', async () => {
+    // A plain-MEMBER agent now sees only non-private pages — the same set the
+    // granting member sees — so capping ADMIN → plain MEMBER no longer over-grants.
     vi.mocked(db.select)
       .mockReturnValueOnce(stubSelect([{ ownerId: 'someone_else' }]))             // drive lookup
       .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: null }]))  // membership → plain MEMBER
       .mockReturnValueOnce(stubJoinSelect([{ id: 'm1', agentPageId: 'a1', role: 'ADMIN', customRoleId: null }]));
-    stubUpdate([]);
-    const where = stubDelete();
+    const captured: Record<string, unknown>[] = [];
+    stubUpdate(captured);
+    stubDelete();
 
     const result = await recapAgentMembershipsGrantedBy(DRIVE, USER);
 
     expect(result).toEqual(['a1']);
-    expect(db.delete).toHaveBeenCalledWith(driveAgentMembers);
-    expect(where).toHaveBeenCalledTimes(1);
-    expect(db.update).not.toHaveBeenCalled();
+    expect(captured[0]).toEqual({ role: 'MEMBER', customRoleId: null });
+    expect(db.delete).not.toHaveBeenCalled();
   });
 
   it('caps ADMIN agents to the granter\'s own custom role when the granter has one', async () => {
@@ -298,23 +297,23 @@ describe('recapAgentMembershipsGrantedBy', () => {
     expect(captured[0]).toEqual({ role: 'MEMBER', customRoleId: 'role_b' });
   });
 
-  it('REVOKES a custom-role agent whose scope differs from the granter ceiling', async () => {
+  it('reduces a custom-role agent whose scope differs from the granter down to the granter grant', async () => {
     vi.mocked(db.select)
       .mockReturnValueOnce(stubSelect([{ ownerId: 'someone_else' }]))                          // drive lookup
       .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: null }]))               // granter now plain MEMBER
       .mockReturnValueOnce(stubJoinSelect([{ id: 'm2', agentPageId: 'a2', role: 'MEMBER', customRoleId: 'role_a' }]));
-    const updated: Record<string, unknown>[] = [];
-    stubUpdate(updated);
-    const where = stubDelete();
+    const captured: Record<string, unknown>[] = [];
+    stubUpdate(captured);
+    stubDelete();
 
     const result = await recapAgentMembershipsGrantedBy(DRIVE, USER);
 
-    // Custom-role grant the plain-member granter can no longer back ⇒ deleted,
-    // never rewritten to plain MEMBER (which would broaden it to the whole drive).
+    // Stale custom role the plain-member granter can no longer back ⇒ reset to the
+    // granter's own grant (plain MEMBER, no custom role). A plain-MEMBER row now
+    // only reaches non-private pages, so this narrows rather than broadens.
     expect(result).toEqual(['a2']);
-    expect(db.delete).toHaveBeenCalledWith(driveAgentMembers);
-    expect(where).toHaveBeenCalledTimes(1);
-    expect(db.update).not.toHaveBeenCalled();
+    expect(captured[0]).toEqual({ role: 'MEMBER', customRoleId: null });
+    expect(db.delete).not.toHaveBeenCalled();
   });
 
   it('leaves a custom-role agent untouched when it already matches the granter ceiling', async () => {

--- a/packages/lib/src/services/__tests__/drive-agent-service.test.ts
+++ b/packages/lib/src/services/__tests__/drive-agent-service.test.ts
@@ -31,6 +31,7 @@ vi.mock('../../permissions/permissions', () => ({
 }));
 vi.mock('../../permissions/membership-queries', () => ({
   customRoleBelongsToDrive: vi.fn(),
+  fetchCustomRolePermissions: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -47,7 +48,7 @@ import { eq, ne } from '@pagespace/db/operators';
 import { driveAgentMembers } from '@pagespace/db/schema/members';
 import { pages } from '@pagespace/db/schema/core';
 import { canUserEditPage, getUserDriveAccess } from '../../permissions/permissions';
-import { customRoleBelongsToDrive } from '../../permissions/membership-queries';
+import { customRoleBelongsToDrive, fetchCustomRolePermissions } from '../../permissions/membership-queries';
 
 const USER = 'user_aaaaaaaaaaaaaaaaaaaaaa';
 const AGENT = 'agent_bbbbbbbbbbbbbbbbbbbbbb';
@@ -330,6 +331,50 @@ describe('recapAgentMembershipsGrantedBy', () => {
     const result = await recapAgentMembershipsGrantedBy(DRIVE, USER);
 
     expect(result).toEqual(['a5']);
+    expect(db.delete).toHaveBeenCalledWith(driveAgentMembers);
+    expect(where).toHaveBeenCalledTimes(1);
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('LEAVES a custom-role agent whose role is a subset of the granter\'s new (broader) custom role', async () => {
+    // The granter moved laterally to a broader custom role (role_b ⊇ role_a). The
+    // agent still sits under the granter, so it must NOT be revoked or rewritten.
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect([{ ownerId: 'someone_else' }]))                          // drive lookup
+      .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: 'role_b' }]))            // granter now role_b
+      .mockReturnValueOnce(stubJoinSelect([{ id: 'm6', agentPageId: 'a6', role: 'MEMBER', customRoleId: 'role_a' }]));
+    vi.mocked(fetchCustomRolePermissions)
+      .mockResolvedValueOnce({ pageX: { canView: true, canEdit: false, canShare: false } })     // role_a (agent)
+      .mockResolvedValueOnce({                                                                  // role_b (cap) ⊇ role_a
+        pageX: { canView: true, canEdit: true, canShare: false },
+        pageY: { canView: true, canEdit: false, canShare: false },
+      });
+    stubUpdate([]);
+    stubDelete();
+
+    const result = await recapAgentMembershipsGrantedBy(DRIVE, USER);
+
+    expect(result).toEqual([]);
+    expect(db.update).not.toHaveBeenCalled();
+    expect(db.delete).not.toHaveBeenCalled();
+  });
+
+  it('REVOKES a custom-role agent whose role is NOT a subset of the granter\'s new custom role', async () => {
+    // The granter moved to role_c, which drops pages role_a granted. The agent now
+    // exceeds the granter, and the scopes are not representable as one another ⇒ revoke.
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect([{ ownerId: 'someone_else' }]))                          // drive lookup
+      .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: 'role_c' }]))            // granter now role_c
+      .mockReturnValueOnce(stubJoinSelect([{ id: 'm7', agentPageId: 'a7', role: 'MEMBER', customRoleId: 'role_a' }]));
+    vi.mocked(fetchCustomRolePermissions)
+      .mockResolvedValueOnce({ pageX: { canView: true, canEdit: false, canShare: false } })     // role_a (agent)
+      .mockResolvedValueOnce({ pageZ: { canView: true, canEdit: false, canShare: false } });    // role_c (cap), no pageX
+    stubUpdate([]);
+    const where = stubDelete();
+
+    const result = await recapAgentMembershipsGrantedBy(DRIVE, USER);
+
+    expect(result).toEqual(['a7']);
     expect(db.delete).toHaveBeenCalledWith(driveAgentMembers);
     expect(where).toHaveBeenCalledTimes(1);
     expect(db.update).not.toHaveBeenCalled();

--- a/packages/lib/src/services/__tests__/drive-agent-service.test.ts
+++ b/packages/lib/src/services/__tests__/drive-agent-service.test.ts
@@ -5,19 +5,22 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // ---------------------------------------------------------------------------
 
 vi.mock('@pagespace/db/db', () => ({
-  db: { select: vi.fn(), insert: vi.fn(), delete: vi.fn() },
+  db: { select: vi.fn(), insert: vi.fn(), delete: vi.fn(), update: vi.fn() },
 }));
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((_a: unknown, _b: unknown) => 'eq'),
   and: vi.fn((...args: unknown[]) => ({ and: args })),
+  or: vi.fn((...args: unknown[]) => ({ or: args })),
+  ne: vi.fn((_a: unknown, _b: unknown) => 'ne'),
   isNotNull: vi.fn((_a: unknown) => 'isNotNull'),
+  inArray: vi.fn((_a: unknown, _b: unknown) => 'inArray'),
 }));
 vi.mock('@pagespace/db/schema/core', () => ({
   pages: { id: 'id', type: 'type', driveId: 'driveId' },
   drives: { id: 'id', name: 'name', slug: 'slug', ownerId: 'ownerId' },
 }));
 vi.mock('@pagespace/db/schema/members', () => ({
-  driveAgentMembers: { id: 'id', driveId: 'driveId', agentPageId: 'agentPageId', role: 'role', customRoleId: 'customRoleId' },
+  driveAgentMembers: { id: 'id', driveId: 'driveId', agentPageId: 'agentPageId', role: 'role', customRoleId: 'customRoleId', addedBy: 'addedBy' },
   driveMembers: { driveId: 'driveId', userId: 'userId', role: 'role', customRoleId: 'customRoleId', acceptedAt: 'acceptedAt' },
 }));
 vi.mock('../../permissions/permissions', () => ({
@@ -34,8 +37,15 @@ vi.mock('../../permissions/membership-queries', () => ({
 // Imports after mocks
 // ---------------------------------------------------------------------------
 
-import { addAgentToDrive } from '../drive-agent-service';
+import {
+  addAgentToDrive,
+  revokeAgentMembershipsGrantedBy,
+  recapAgentMembershipsGrantedBy,
+} from '../drive-agent-service';
 import { db } from '@pagespace/db/db';
+import { eq, ne } from '@pagespace/db/operators';
+import { driveAgentMembers } from '@pagespace/db/schema/members';
+import { pages } from '@pagespace/db/schema/core';
 import { canUserEditPage, getUserDriveAccess } from '../../permissions/permissions';
 import { customRoleBelongsToDrive } from '../../permissions/membership-queries';
 
@@ -174,5 +184,110 @@ describe('addAgentToDrive', () => {
 
     const res = await addAgentToDrive({ actingUserId: USER, agentPageId: AGENT, driveId: DRIVE });
     expect(res).toMatchObject({ ok: false, status: 409 });
+  });
+});
+
+// select(...).from(...).innerJoin(...).where(...) resolving to rows (no .limit).
+function stubJoinSelect(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnValue({
+      innerJoin: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  } as unknown as ReturnType<typeof db.select>;
+}
+
+// delete(...).where(...) → resolves; returns the captured where() mock.
+function stubDelete() {
+  const where = vi.fn().mockResolvedValue(undefined);
+  vi.mocked(db.delete).mockReturnValue({ where } as unknown as ReturnType<typeof db.delete>);
+  return where;
+}
+
+// update(...).set(values).where(...) → resolves; captures the set() value.
+function stubUpdate(captured: Record<string, unknown>[]) {
+  const where = vi.fn().mockResolvedValue(undefined);
+  vi.mocked(db.update).mockReturnValue({
+    set: vi.fn((v: Record<string, unknown>) => {
+      captured.push(v);
+      return { where };
+    }),
+  } as unknown as ReturnType<typeof db.update>);
+  return where;
+}
+
+describe('revokeAgentMembershipsGrantedBy', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('deletes the non-home memberships the user granted and returns their agent ids', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(
+      stubJoinSelect([
+        { id: 'm1', agentPageId: 'a1' },
+        { id: 'm2', agentPageId: 'a2' },
+      ]),
+    );
+    const where = stubDelete();
+
+    const result = await revokeAgentMembershipsGrantedBy(db, DRIVE, USER);
+
+    expect(result).toEqual(['a1', 'a2']);
+    expect(db.delete).toHaveBeenCalledWith(driveAgentMembers);
+    expect(where).toHaveBeenCalledTimes(1);
+    // Scoped to the granting user and excludes the agent's home drive.
+    expect(eq).toHaveBeenCalledWith(driveAgentMembers.addedBy, USER);
+    expect(eq).toHaveBeenCalledWith(driveAgentMembers.driveId, DRIVE);
+    expect(ne).toHaveBeenCalledWith(pages.driveId, DRIVE);
+  });
+
+  it('is a no-op (no delete) when the user granted no agent memberships here', async () => {
+    vi.mocked(db.select).mockReturnValueOnce(stubJoinSelect([]));
+    stubDelete();
+
+    const result = await revokeAgentMembershipsGrantedBy(db, DRIVE, USER);
+
+    expect(result).toEqual([]);
+    expect(db.delete).not.toHaveBeenCalled();
+  });
+});
+
+describe('recapAgentMembershipsGrantedBy', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('is a no-op when the user can still grant ADMIN (drive owner)', async () => {
+    // resolveGranterAccess: drive lookup → owner ⇒ maxRole ADMIN.
+    vi.mocked(db.select).mockReturnValueOnce(stubSelect([{ ownerId: USER }]));
+
+    const result = await recapAgentMembershipsGrantedBy(DRIVE, USER);
+
+    expect(result).toEqual([]);
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('downgrades elevated agents to plain MEMBER when the granter is now a MEMBER', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect([{ ownerId: 'someone_else' }]))             // drive lookup
+      .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: null }]))  // membership → MEMBER
+      .mockReturnValueOnce(stubJoinSelect([{ id: 'm1', agentPageId: 'a1' }]));    // elevated agent rows
+    const captured: Record<string, unknown>[] = [];
+    stubUpdate(captured);
+
+    const result = await recapAgentMembershipsGrantedBy(DRIVE, USER);
+
+    expect(result).toEqual(['a1']);
+    expect(captured[0]).toEqual({ role: 'MEMBER', customRoleId: null });
+  });
+
+  it('is a no-op when a downgraded granter has no elevated agents', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect([{ ownerId: 'someone_else' }]))             // drive lookup
+      .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: null }]))  // membership → MEMBER
+      .mockReturnValueOnce(stubJoinSelect([]));                                   // nothing above the cap
+    stubUpdate([]);
+
+    const result = await recapAgentMembershipsGrantedBy(DRIVE, USER);
+
+    expect(result).toEqual([]);
+    expect(db.update).not.toHaveBeenCalled();
   });
 });

--- a/packages/lib/src/services/__tests__/drive-agent-service.test.ts
+++ b/packages/lib/src/services/__tests__/drive-agent-service.test.ts
@@ -264,20 +264,23 @@ describe('recapAgentMembershipsGrantedBy', () => {
     expect(db.update).not.toHaveBeenCalled();
   });
 
-  it('reduces ADMIN agents to the granter ceiling (plain MEMBER) and never widens', async () => {
+  it('REVOKES ADMIN agents when the granter is now a plain MEMBER (no representable cap)', async () => {
+    // A plain MEMBER agent membership resolves to canView on every page incl.
+    // private ones, which a plain-member granter cannot grant — so reducing
+    // ADMIN→plain MEMBER would over-grant. Revoke instead.
     vi.mocked(db.select)
       .mockReturnValueOnce(stubSelect([{ ownerId: 'someone_else' }]))             // drive lookup
-      .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: null }]))  // membership → MEMBER, no custom role
+      .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: null }]))  // membership → plain MEMBER
       .mockReturnValueOnce(stubJoinSelect([{ id: 'm1', agentPageId: 'a1', role: 'ADMIN', customRoleId: null }]));
-    const captured: Record<string, unknown>[] = [];
-    stubUpdate(captured);
-    stubDelete();
+    stubUpdate([]);
+    const where = stubDelete();
 
     const result = await recapAgentMembershipsGrantedBy(DRIVE, USER);
 
     expect(result).toEqual(['a1']);
-    expect(captured[0]).toEqual({ role: 'MEMBER', customRoleId: null });
-    expect(db.delete).not.toHaveBeenCalled();
+    expect(db.delete).toHaveBeenCalledWith(driveAgentMembers);
+    expect(where).toHaveBeenCalledTimes(1);
+    expect(db.update).not.toHaveBeenCalled();
   });
 
   it('caps ADMIN agents to the granter\'s own custom role when the granter has one', async () => {
@@ -324,6 +327,22 @@ describe('recapAgentMembershipsGrantedBy', () => {
 
     const result = await recapAgentMembershipsGrantedBy(DRIVE, USER);
 
+    expect(result).toEqual([]);
+    expect(db.update).not.toHaveBeenCalled();
+    expect(db.delete).not.toHaveBeenCalled();
+  });
+
+  it('leaves an existing plain-MEMBER agent untouched under a plain-MEMBER granter', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect([{ ownerId: 'someone_else' }]))                            // drive lookup
+      .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: null }]))                 // granter plain MEMBER
+      .mockReturnValueOnce(stubJoinSelect([{ id: 'm4', agentPageId: 'a4', role: 'MEMBER', customRoleId: null }]));
+    stubUpdate([]);
+    stubDelete();
+
+    const result = await recapAgentMembershipsGrantedBy(DRIVE, USER);
+
+    // Already exactly what a plain-member granter could create — not touched.
     expect(result).toEqual([]);
     expect(db.update).not.toHaveBeenCalled();
     expect(db.delete).not.toHaveBeenCalled();

--- a/packages/lib/src/services/__tests__/drive-agent-service.test.ts
+++ b/packages/lib/src/services/__tests__/drive-agent-service.test.ts
@@ -264,11 +264,11 @@ describe('recapAgentMembershipsGrantedBy', () => {
     expect(db.update).not.toHaveBeenCalled();
   });
 
-  it('downgrades elevated agents to plain MEMBER when the granter is now a MEMBER', async () => {
+  it('downgrades ADMIN agents to the granter ceiling (plain MEMBER) and never widens', async () => {
     vi.mocked(db.select)
       .mockReturnValueOnce(stubSelect([{ ownerId: 'someone_else' }]))             // drive lookup
-      .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: null }]))  // membership → MEMBER
-      .mockReturnValueOnce(stubJoinSelect([{ id: 'm1', agentPageId: 'a1' }]));    // elevated agent rows
+      .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: null }]))  // membership → MEMBER, no custom role
+      .mockReturnValueOnce(stubJoinSelect([{ id: 'm1', agentPageId: 'a1' }]));    // ADMIN agent rows
     const captured: Record<string, unknown>[] = [];
     stubUpdate(captured);
 
@@ -276,13 +276,30 @@ describe('recapAgentMembershipsGrantedBy', () => {
 
     expect(result).toEqual(['a1']);
     expect(captured[0]).toEqual({ role: 'MEMBER', customRoleId: null });
+    // Only ADMIN memberships are selected for reduction — custom-role memberships
+    // are preserved so recap can never broaden an agent's page reach.
+    expect(eq).toHaveBeenCalledWith(driveAgentMembers.role, 'ADMIN');
   });
 
-  it('is a no-op when a downgraded granter has no elevated agents', async () => {
+  it('caps ADMIN agents to the granter\'s own custom role when the granter has one', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect([{ ownerId: 'someone_else' }]))                  // drive lookup
+      .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: 'role_b' }]))   // membership → MEMBER + custom role
+      .mockReturnValueOnce(stubJoinSelect([{ id: 'm1', agentPageId: 'a1' }]));         // ADMIN agent rows
+    const captured: Record<string, unknown>[] = [];
+    stubUpdate(captured);
+
+    const result = await recapAgentMembershipsGrantedBy(DRIVE, USER);
+
+    expect(result).toEqual(['a1']);
+    expect(captured[0]).toEqual({ role: 'MEMBER', customRoleId: 'role_b' });
+  });
+
+  it('is a no-op when a downgraded granter has no ADMIN agents (custom-role agents preserved)', async () => {
     vi.mocked(db.select)
       .mockReturnValueOnce(stubSelect([{ ownerId: 'someone_else' }]))             // drive lookup
       .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: null }]))  // membership → MEMBER
-      .mockReturnValueOnce(stubJoinSelect([]));                                   // nothing above the cap
+      .mockReturnValueOnce(stubJoinSelect([]));                                   // no ADMIN agents to reduce
     stubUpdate([]);
 
     const result = await recapAgentMembershipsGrantedBy(DRIVE, USER);

--- a/packages/lib/src/services/__tests__/drive-agent-service.test.ts
+++ b/packages/lib/src/services/__tests__/drive-agent-service.test.ts
@@ -264,30 +264,30 @@ describe('recapAgentMembershipsGrantedBy', () => {
     expect(db.update).not.toHaveBeenCalled();
   });
 
-  it('downgrades ADMIN agents to the granter ceiling (plain MEMBER) and never widens', async () => {
+  it('reduces ADMIN agents to the granter ceiling (plain MEMBER) and never widens', async () => {
     vi.mocked(db.select)
       .mockReturnValueOnce(stubSelect([{ ownerId: 'someone_else' }]))             // drive lookup
       .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: null }]))  // membership → MEMBER, no custom role
-      .mockReturnValueOnce(stubJoinSelect([{ id: 'm1', agentPageId: 'a1' }]));    // ADMIN agent rows
+      .mockReturnValueOnce(stubJoinSelect([{ id: 'm1', agentPageId: 'a1', role: 'ADMIN', customRoleId: null }]));
     const captured: Record<string, unknown>[] = [];
     stubUpdate(captured);
+    stubDelete();
 
     const result = await recapAgentMembershipsGrantedBy(DRIVE, USER);
 
     expect(result).toEqual(['a1']);
     expect(captured[0]).toEqual({ role: 'MEMBER', customRoleId: null });
-    // Only ADMIN memberships are selected for reduction — custom-role memberships
-    // are preserved so recap can never broaden an agent's page reach.
-    expect(eq).toHaveBeenCalledWith(driveAgentMembers.role, 'ADMIN');
+    expect(db.delete).not.toHaveBeenCalled();
   });
 
   it('caps ADMIN agents to the granter\'s own custom role when the granter has one', async () => {
     vi.mocked(db.select)
       .mockReturnValueOnce(stubSelect([{ ownerId: 'someone_else' }]))                  // drive lookup
       .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: 'role_b' }]))   // membership → MEMBER + custom role
-      .mockReturnValueOnce(stubJoinSelect([{ id: 'm1', agentPageId: 'a1' }]));         // ADMIN agent rows
+      .mockReturnValueOnce(stubJoinSelect([{ id: 'm1', agentPageId: 'a1', role: 'ADMIN', customRoleId: null }]));
     const captured: Record<string, unknown>[] = [];
     stubUpdate(captured);
+    stubDelete();
 
     const result = await recapAgentMembershipsGrantedBy(DRIVE, USER);
 
@@ -295,16 +295,52 @@ describe('recapAgentMembershipsGrantedBy', () => {
     expect(captured[0]).toEqual({ role: 'MEMBER', customRoleId: 'role_b' });
   });
 
-  it('is a no-op when a downgraded granter has no ADMIN agents (custom-role agents preserved)', async () => {
+  it('REVOKES a custom-role agent whose scope differs from the granter ceiling', async () => {
     vi.mocked(db.select)
-      .mockReturnValueOnce(stubSelect([{ ownerId: 'someone_else' }]))             // drive lookup
-      .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: null }]))  // membership → MEMBER
-      .mockReturnValueOnce(stubJoinSelect([]));                                   // no ADMIN agents to reduce
+      .mockReturnValueOnce(stubSelect([{ ownerId: 'someone_else' }]))                          // drive lookup
+      .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: null }]))               // granter now plain MEMBER
+      .mockReturnValueOnce(stubJoinSelect([{ id: 'm2', agentPageId: 'a2', role: 'MEMBER', customRoleId: 'role_a' }]));
+    const updated: Record<string, unknown>[] = [];
+    stubUpdate(updated);
+    const where = stubDelete();
+
+    const result = await recapAgentMembershipsGrantedBy(DRIVE, USER);
+
+    // Custom-role grant the plain-member granter can no longer back ⇒ deleted,
+    // never rewritten to plain MEMBER (which would broaden it to the whole drive).
+    expect(result).toEqual(['a2']);
+    expect(db.delete).toHaveBeenCalledWith(driveAgentMembers);
+    expect(where).toHaveBeenCalledTimes(1);
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('leaves a custom-role agent untouched when it already matches the granter ceiling', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect([{ ownerId: 'someone_else' }]))                              // drive lookup
+      .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: 'role_same' }]))            // granter custom role
+      .mockReturnValueOnce(stubJoinSelect([{ id: 'm3', agentPageId: 'a3', role: 'MEMBER', customRoleId: 'role_same' }]));
     stubUpdate([]);
+    stubDelete();
 
     const result = await recapAgentMembershipsGrantedBy(DRIVE, USER);
 
     expect(result).toEqual([]);
     expect(db.update).not.toHaveBeenCalled();
+    expect(db.delete).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when a downgraded granter granted no agents', async () => {
+    vi.mocked(db.select)
+      .mockReturnValueOnce(stubSelect([{ ownerId: 'someone_else' }]))             // drive lookup
+      .mockReturnValueOnce(stubSelect([{ role: 'MEMBER', customRoleId: null }]))  // membership → MEMBER
+      .mockReturnValueOnce(stubJoinSelect([]));                                   // no agents granted
+    stubUpdate([]);
+    stubDelete();
+
+    const result = await recapAgentMembershipsGrantedBy(DRIVE, USER);
+
+    expect(result).toEqual([]);
+    expect(db.update).not.toHaveBeenCalled();
+    expect(db.delete).not.toHaveBeenCalled();
   });
 });

--- a/packages/lib/src/services/drive-agent-service.ts
+++ b/packages/lib/src/services/drive-agent-service.ts
@@ -14,7 +14,8 @@ import { eq, and, ne, isNotNull, inArray } from '@pagespace/db/operators';
 import { drives, pages } from '@pagespace/db/schema/core';
 import { driveAgentMembers, driveMembers } from '@pagespace/db/schema/members';
 import { canUserEditPage, getUserDriveAccess, isDriveOwnerOrAdmin } from '../permissions/permissions';
-import { customRoleBelongsToDrive } from '../permissions/membership-queries';
+import { customRoleBelongsToDrive, fetchCustomRolePermissions } from '../permissions/membership-queries';
+import type { CustomRolePerms } from '../permissions/membership-queries';
 
 export type AgentDriveRole = 'MEMBER' | 'ADMIN';
 
@@ -237,6 +238,54 @@ export async function revokeAgentMembershipsGrantedBy(
 }
 
 /**
+ * True when every grant in `sub` is matched (≥) by `sup` — i.e. role `sub` can
+ * see/do nothing role `sup` cannot. Pages `sub` grants nothing on impose no
+ * constraint.
+ */
+function customRoleSubset(sub: CustomRolePerms, sup: CustomRolePerms): boolean {
+  for (const [pageId, p] of Object.entries(sub)) {
+    if (!p.canView && !p.canEdit && !p.canShare) continue;
+    const s = sup[pageId];
+    if (!s) return false;
+    if ((p.canView && !s.canView) || (p.canEdit && !s.canEdit) || (p.canShare && !s.canShare)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Whether an agent's MEMBER-level grant (`agentCustomRoleId`) is still within the
+ * granter's current cap (`capCustomRoleId`), both at MEMBER rank. Lets recap skip
+ * an agent on a lateral/widening custom-role change (the agent's old role is a
+ * subset of the granter's new role) instead of needlessly revoking it.
+ *
+ * Only the custom-role-vs-custom-role case is compared precisely (a cheap matrix
+ * subset). Cases involving plain MEMBER (null) on either side are conservatively
+ * treated as NOT within: plain MEMBER spans every non-private page in the drive —
+ * a scope not expressed as a per-page matrix — so we fail closed (revoke) rather
+ * than enumerate the drive's pages on a security path.
+ */
+async function memberGrantWithinCap(
+  agentCustomRoleId: string | null,
+  capCustomRoleId: string | null,
+  driveId: string,
+): Promise<boolean> {
+  // Only "both plain MEMBER" is provably within without comparing matrices.
+  if (agentCustomRoleId === null || capCustomRoleId === null) {
+    return agentCustomRoleId === capCustomRoleId;
+  }
+  const [agentPerms, capPerms] = await Promise.all([
+    fetchCustomRolePermissions(agentCustomRoleId, driveId),
+    fetchCustomRolePermissions(capCustomRoleId, driveId),
+  ]);
+  // An unresolvable custom role resolves as plain MEMBER (drive-wide), which is
+  // not a provable subset of a scoped cap ⇒ fail closed.
+  if (!agentPerms || !capPerms) return false;
+  return customRoleSubset(agentPerms, capPerms);
+}
+
+/**
  * Re-cap the agent memberships in `driveId` granted by `userId` when the user's
  * access is downgraded, bringing every agent they granted down to exactly what
  * they could grant today. Only ever caps DOWN — never widens an agent's reach,
@@ -244,17 +293,19 @@ export async function revokeAgentMembershipsGrantedBy(
  *
  * Agent access is bottlenecked by the granting user's access: a plain MEMBER
  * agent membership now resolves to the same view a plain MEMBER *user* gets
- * (non-private pages only — see `agent-permissions.ts`), so capping a full-access
- * agent down to the granter's level is a safe, pure narrowing. For each non-home
+ * (non-private pages only — see `agent-permissions.ts`). For each non-home
  * membership the user granted, with the granter now capped at MEMBER:
  *  - role ADMIN ⇒ REDUCE to `{ role: 'MEMBER', customRoleId: <granter's cap> }`.
- *    ADMIN is full access ⊇ any MEMBER cap, so this strictly narrows.
- *  - role MEMBER, customRoleId === the granter's ⇒ leave as is (already exactly
- *    what the granter could grant today).
- *  - role MEMBER, customRoleId differs ⇒ REVOKE. A custom-role matrix is
- *    incomparable to the new cap (it may scope to fewer pages, or grant private/
- *    edit access the cap doesn't), so rewriting it could *widen* the agent.
- *    Revoke rather than guess — recap must never widen.
+ *    ADMIN is full access ⊋ any MEMBER cap, so this strictly narrows.
+ *  - role MEMBER, customRoleId === the granter's ⇒ leave (already exactly what
+ *    the granter could grant today).
+ *  - role MEMBER, customRoleId differs ⇒ keep ONLY if the agent's grant is
+ *    provably ⊆ the granter's new grant (`memberGrantWithinCap`) — e.g. the
+ *    granter moved to a *broader* custom role, so the agent still sits under
+ *    them. Otherwise REVOKE. We never rewrite a member row to a different role
+ *    (that could widen — a custom-role matrix is incomparable to the cap), and
+ *    we never revoke an agent that's still within the granter (no false revoke
+ *    on a lateral/widening change).
  *
  * No-op when the user can still grant ADMIN. Excludes the agent's home drive.
  * Returns the affected agentPageIds (both reduced and revoked).
@@ -284,17 +335,18 @@ export async function recapAgentMembershipsGrantedBy(
       ne(pages.driveId, driveId),
     ));
 
-  const toReduce: typeof rows = [];
-  const toRevoke: typeof rows = [];
-  for (const r of rows) {
-    const cid = r.customRoleId ?? null;
-    if (r.role === 'MEMBER' && cid === capCustomRoleId) continue; // already the granter's grant
-    if (r.role === 'ADMIN') {
-      toReduce.push(r); // full access ⊇ cap ⇒ pure narrowing
-    } else {
-      toRevoke.push(r); // mismatched custom role ⇒ not provably a subset of the cap
-    }
-  }
+  // ADMIN agents always exceed a MEMBER cap ⇒ reduce them to the cap.
+  const toReduce = rows.filter((r) => r.role === 'ADMIN');
+  // MEMBER agents whose custom role differs from the cap: keep iff provably within.
+  const memberMismatch = rows.filter(
+    (r) => r.role !== 'ADMIN' && (r.customRoleId ?? null) !== capCustomRoleId,
+  );
+  const withinCap = await Promise.all(
+    memberMismatch.map((r) =>
+      memberGrantWithinCap(r.customRoleId ?? null, capCustomRoleId, driveId),
+    ),
+  );
+  const toRevoke = memberMismatch.filter((_, i) => !withinCap[i]);
 
   if (toReduce.length > 0) {
     await db

--- a/packages/lib/src/services/drive-agent-service.ts
+++ b/packages/lib/src/services/drive-agent-service.ts
@@ -239,20 +239,28 @@ export async function revokeAgentMembershipsGrantedBy(
 /**
  * Re-cap the agent memberships in `driveId` granted by `userId` when the user's
  * access is downgraded, bringing every agent they granted down to what they
- * could grant today. Only ever caps DOWN — it must never widen an agent's reach.
+ * could grant today. Only ever caps DOWN — it must never widen an agent's reach,
+ * and never leave it with more than the downgraded granter.
  *
- * Let the granter's current ceiling be `{ MEMBER, granter.customRoleId }`. For
- * each non-home membership the user granted:
- *  - role ADMIN ⇒ reduce to the ceiling. ADMIN has full access to every page, so
- *    capping to the ceiling (the granter's custom role, or plain MEMBER =
- *    view-only on all pages) is always strictly narrower.
- *  - already at the ceiling (role MEMBER and same customRoleId) ⇒ leave as is.
- *  - otherwise (role MEMBER with a *different* customRoleId, including a custom
- *    role when the granter now has none) ⇒ REVOKE. The grant is no longer one
- *    the granter could make, and the role/customRoleId fields can't express the
- *    safe least-privilege intersection (e.g. "view-only on this custom role's
- *    pages"), so rewriting it risks widening — removing the membership is the
- *    only representable non-widening reduction.
+ * Key asymmetry: a plain MEMBER agent membership resolves to `canView: true` on
+ * EVERY page (`resolveRolePermissions` with no custom role), including private
+ * pages — whereas a plain MEMBER *user* only sees non-private pages. So a plain
+ * MEMBER membership row cannot represent "what a plain member may actually see",
+ * which makes it unsafe as a recap target.
+ *
+ * The only representable, provably-safe member-level ceiling is the granter's
+ * own custom role (an explicit per-page matrix). So, for each non-home membership
+ * the user granted, with the granter now capped at MEMBER:
+ *  - granter HAS a custom role B:
+ *      - role ADMIN          ⇒ reduce to B (B ⊆ full access ⇒ strictly narrower).
+ *      - role MEMBER + cid==B ⇒ leave as is (already the granter's grant).
+ *      - anything else        ⇒ REVOKE (stale/▲ scope, not representable safely).
+ *  - granter has NO custom role (plain member):
+ *      - role ADMIN          ⇒ REVOKE. Reducing to plain MEMBER would let the
+ *        agent read every page (incl. private) the plain-member granter cannot.
+ *      - role MEMBER + cid==null ⇒ leave as is (already a plain-member grant,
+ *        i.e. exactly what addAgentToDrive yields for a plain-member granter).
+ *      - role MEMBER + custom role ⇒ REVOKE (stale custom role).
  *
  * No-op when the user can still grant ADMIN. Excludes the agent's home drive.
  * Returns the affected agentPageIds (both reduced and revoked).
@@ -282,12 +290,21 @@ export async function recapAgentMembershipsGrantedBy(
       ne(pages.driveId, driveId),
     ));
 
-  const toReduce = rows.filter((r) => r.role === 'ADMIN');
-  // Member-level grants whose custom-role scope differs from what the granter
-  // can grant today — revoke them (their safe intersection isn't representable).
-  const toRevoke = rows.filter(
-    (r) => r.role !== 'ADMIN' && (r.customRoleId ?? null) !== ceilingCustomRoleId,
-  );
+  const toReduce: typeof rows = [];
+  const toRevoke: typeof rows = [];
+  for (const r of rows) {
+    const atCeiling = r.role !== 'ADMIN' && (r.customRoleId ?? null) === ceilingCustomRoleId;
+    if (atCeiling) continue; // already exactly the granter's current grant
+    if (r.role === 'ADMIN' && ceilingCustomRoleId !== null) {
+      // Representable reduction: cap full access down to the granter's custom role.
+      toReduce.push(r);
+    } else {
+      // ADMIN when the ceiling is plain MEMBER (can't express non-private/explicit
+      // access), or a member-level grant whose scope differs from the granter's —
+      // not representable as a safe cap, so revoke.
+      toRevoke.push(r);
+    }
+  }
 
   if (toReduce.length > 0) {
     await db

--- a/packages/lib/src/services/drive-agent-service.ts
+++ b/packages/lib/src/services/drive-agent-service.ts
@@ -238,23 +238,24 @@ export async function revokeAgentMembershipsGrantedBy(
 
 /**
  * Re-cap the agent memberships in `driveId` granted by `userId` when the user's
- * access is downgraded, reducing agents that now exceed what the user could
- * grant today. Caps DOWN only — it must never widen an agent's access.
+ * access is downgraded, bringing every agent they granted down to what they
+ * could grant today. Only ever caps DOWN — it must never widen an agent's reach.
  *
- * Only ADMIN agent memberships are reduced. An ADMIN agent has full access to
- * every page, so capping it to the granter's member-level ceiling (their custom
- * role, or plain MEMBER = view-only on all pages) is always strictly narrower.
- *
- * Custom-role agent memberships are deliberately left untouched. Rewriting a
- * restrictive custom role to plain MEMBER (or to a different custom role) could
- * *broaden* the agent's page reach — a plain MEMBER can view every page in the
- * drive, whereas a custom role grants only its listed pages — and the existing
- * role/customRoleId fields can't express the safe least-privilege intersection.
- * Preserving them guarantees recap is non-widening (a granter who tightens or
- * clears their own custom role never gains an agent broader page access).
+ * Let the granter's current ceiling be `{ MEMBER, granter.customRoleId }`. For
+ * each non-home membership the user granted:
+ *  - role ADMIN ⇒ reduce to the ceiling. ADMIN has full access to every page, so
+ *    capping to the ceiling (the granter's custom role, or plain MEMBER =
+ *    view-only on all pages) is always strictly narrower.
+ *  - already at the ceiling (role MEMBER and same customRoleId) ⇒ leave as is.
+ *  - otherwise (role MEMBER with a *different* customRoleId, including a custom
+ *    role when the granter now has none) ⇒ REVOKE. The grant is no longer one
+ *    the granter could make, and the role/customRoleId fields can't express the
+ *    safe least-privilege intersection (e.g. "view-only on this custom role's
+ *    pages"), so rewriting it risks widening — removing the membership is the
+ *    only representable non-widening reduction.
  *
  * No-op when the user can still grant ADMIN. Excludes the agent's home drive.
- * Returns the affected agentPageIds.
+ * Returns the affected agentPageIds (both reduced and revoked).
  */
 export async function recapAgentMembershipsGrantedBy(
   driveId: string,
@@ -264,25 +265,43 @@ export async function recapAgentMembershipsGrantedBy(
   // Still able to grant ADMIN ⇒ nothing to reduce (we only ever cap downward).
   if (granter.maxRole === 'ADMIN') return [];
 
+  const ceilingCustomRoleId = granter.customRoleId ?? null;
+
   const rows = await db
-    .select({ id: driveAgentMembers.id, agentPageId: driveAgentMembers.agentPageId })
+    .select({
+      id: driveAgentMembers.id,
+      agentPageId: driveAgentMembers.agentPageId,
+      role: driveAgentMembers.role,
+      customRoleId: driveAgentMembers.customRoleId,
+    })
     .from(driveAgentMembers)
     .innerJoin(pages, eq(driveAgentMembers.agentPageId, pages.id))
     .where(and(
       eq(driveAgentMembers.driveId, driveId),
       eq(driveAgentMembers.addedBy, userId),
       ne(pages.driveId, driveId),
-      eq(driveAgentMembers.role, 'ADMIN'),
     ));
 
-  if (rows.length === 0) return [];
+  const toReduce = rows.filter((r) => r.role === 'ADMIN');
+  // Member-level grants whose custom-role scope differs from what the granter
+  // can grant today — revoke them (their safe intersection isn't representable).
+  const toRevoke = rows.filter(
+    (r) => r.role !== 'ADMIN' && (r.customRoleId ?? null) !== ceilingCustomRoleId,
+  );
 
-  await db
-    .update(driveAgentMembers)
-    .set({ role: 'MEMBER', customRoleId: granter.customRoleId ?? null })
-    .where(inArray(driveAgentMembers.id, rows.map((r) => r.id)));
+  if (toReduce.length > 0) {
+    await db
+      .update(driveAgentMembers)
+      .set({ role: 'MEMBER', customRoleId: ceilingCustomRoleId })
+      .where(inArray(driveAgentMembers.id, toReduce.map((r) => r.id)));
+  }
+  if (toRevoke.length > 0) {
+    await db
+      .delete(driveAgentMembers)
+      .where(inArray(driveAgentMembers.id, toRevoke.map((r) => r.id)));
+  }
 
-  return rows.map((r) => r.agentPageId);
+  return [...toReduce, ...toRevoke].map((r) => r.agentPageId);
 }
 
 /**

--- a/packages/lib/src/services/drive-agent-service.ts
+++ b/packages/lib/src/services/drive-agent-service.ts
@@ -10,7 +10,7 @@
  */
 
 import { db } from '@pagespace/db/db';
-import { eq, and, isNotNull } from '@pagespace/db/operators';
+import { eq, and, or, ne, isNotNull, inArray } from '@pagespace/db/operators';
 import { drives, pages } from '@pagespace/db/schema/core';
 import { driveAgentMembers, driveMembers } from '@pagespace/db/schema/members';
 import { canUserEditPage, getUserDriveAccess, isDriveOwnerOrAdmin } from '../permissions/permissions';
@@ -197,6 +197,81 @@ export async function removeAgentFromDrive(input: {
 
   if (deleted.length === 0) return { ok: false, status: 404, error: 'Membership not found' };
   return { ok: true };
+}
+
+/** A Drizzle transaction handle, accepted alongside the module-level `db`. */
+type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+/**
+ * Revoke every non-home agent membership in `driveId` that was granted by
+ * `userId`. Called when that user is removed from the drive: the grant's
+ * authorization basis (`addedBy`) is gone, so the agent loses the access it
+ * inherited too. The agent's home drive is never touched (it can't be removed,
+ * and a home-drive membership has `pages.driveId === driveAgentMembers.driveId`).
+ *
+ * Accepts a transaction so it can run atomically with the member removal.
+ * Returns the agentPageIds whose membership was revoked (for audit logging).
+ */
+export async function revokeAgentMembershipsGrantedBy(
+  executor: Tx | typeof db,
+  driveId: string,
+  userId: string,
+): Promise<string[]> {
+  const rows = await executor
+    .select({ id: driveAgentMembers.id, agentPageId: driveAgentMembers.agentPageId })
+    .from(driveAgentMembers)
+    .innerJoin(pages, eq(driveAgentMembers.agentPageId, pages.id))
+    .where(and(
+      eq(driveAgentMembers.driveId, driveId),
+      eq(driveAgentMembers.addedBy, userId),
+      ne(pages.driveId, driveId),
+    ));
+
+  if (rows.length === 0) return [];
+
+  await executor
+    .delete(driveAgentMembers)
+    .where(inArray(driveAgentMembers.id, rows.map((r) => r.id)));
+
+  return rows.map((r) => r.agentPageId);
+}
+
+/**
+ * Re-cap the agent memberships in `driveId` granted by `userId` to the role that
+ * user could grant *today*. Called when the user's role is downgraded: an agent
+ * they previously elevated (to ADMIN or a custom role) must drop to the user's
+ * new ceiling, mirroring the add-time capping in `addAgentToDrive`. Never
+ * escalates. The agent's home drive is excluded. Returns affected agentPageIds.
+ */
+export async function recapAgentMembershipsGrantedBy(
+  driveId: string,
+  userId: string,
+): Promise<string[]> {
+  const granter = await resolveGranterAccess(userId, driveId);
+  // Still able to grant ADMIN ⇒ nothing to reduce (we only ever cap downward).
+  if (granter.maxRole === 'ADMIN') return [];
+
+  // maxRole is MEMBER: any membership above plain MEMBER (ADMIN role or a custom
+  // role) exceeds what this user could grant now.
+  const rows = await db
+    .select({ id: driveAgentMembers.id, agentPageId: driveAgentMembers.agentPageId })
+    .from(driveAgentMembers)
+    .innerJoin(pages, eq(driveAgentMembers.agentPageId, pages.id))
+    .where(and(
+      eq(driveAgentMembers.driveId, driveId),
+      eq(driveAgentMembers.addedBy, userId),
+      ne(pages.driveId, driveId),
+      or(eq(driveAgentMembers.role, 'ADMIN'), isNotNull(driveAgentMembers.customRoleId)),
+    ));
+
+  if (rows.length === 0) return [];
+
+  await db
+    .update(driveAgentMembers)
+    .set({ role: 'MEMBER', customRoleId: granter.customRoleId ?? null })
+    .where(inArray(driveAgentMembers.id, rows.map((r) => r.id)));
+
+  return rows.map((r) => r.agentPageId);
 }
 
 /**

--- a/packages/lib/src/services/drive-agent-service.ts
+++ b/packages/lib/src/services/drive-agent-service.ts
@@ -10,7 +10,7 @@
  */
 
 import { db } from '@pagespace/db/db';
-import { eq, and, or, ne, isNotNull, inArray } from '@pagespace/db/operators';
+import { eq, and, ne, isNotNull, inArray } from '@pagespace/db/operators';
 import { drives, pages } from '@pagespace/db/schema/core';
 import { driveAgentMembers, driveMembers } from '@pagespace/db/schema/members';
 import { canUserEditPage, getUserDriveAccess, isDriveOwnerOrAdmin } from '../permissions/permissions';
@@ -237,11 +237,24 @@ export async function revokeAgentMembershipsGrantedBy(
 }
 
 /**
- * Re-cap the agent memberships in `driveId` granted by `userId` to the role that
- * user could grant *today*. Called when the user's role is downgraded: an agent
- * they previously elevated (to ADMIN or a custom role) must drop to the user's
- * new ceiling, mirroring the add-time capping in `addAgentToDrive`. Never
- * escalates. The agent's home drive is excluded. Returns affected agentPageIds.
+ * Re-cap the agent memberships in `driveId` granted by `userId` when the user's
+ * access is downgraded, reducing agents that now exceed what the user could
+ * grant today. Caps DOWN only — it must never widen an agent's access.
+ *
+ * Only ADMIN agent memberships are reduced. An ADMIN agent has full access to
+ * every page, so capping it to the granter's member-level ceiling (their custom
+ * role, or plain MEMBER = view-only on all pages) is always strictly narrower.
+ *
+ * Custom-role agent memberships are deliberately left untouched. Rewriting a
+ * restrictive custom role to plain MEMBER (or to a different custom role) could
+ * *broaden* the agent's page reach — a plain MEMBER can view every page in the
+ * drive, whereas a custom role grants only its listed pages — and the existing
+ * role/customRoleId fields can't express the safe least-privilege intersection.
+ * Preserving them guarantees recap is non-widening (a granter who tightens or
+ * clears their own custom role never gains an agent broader page access).
+ *
+ * No-op when the user can still grant ADMIN. Excludes the agent's home drive.
+ * Returns the affected agentPageIds.
  */
 export async function recapAgentMembershipsGrantedBy(
   driveId: string,
@@ -251,8 +264,6 @@ export async function recapAgentMembershipsGrantedBy(
   // Still able to grant ADMIN ⇒ nothing to reduce (we only ever cap downward).
   if (granter.maxRole === 'ADMIN') return [];
 
-  // maxRole is MEMBER: any membership above plain MEMBER (ADMIN role or a custom
-  // role) exceeds what this user could grant now.
   const rows = await db
     .select({ id: driveAgentMembers.id, agentPageId: driveAgentMembers.agentPageId })
     .from(driveAgentMembers)
@@ -261,7 +272,7 @@ export async function recapAgentMembershipsGrantedBy(
       eq(driveAgentMembers.driveId, driveId),
       eq(driveAgentMembers.addedBy, userId),
       ne(pages.driveId, driveId),
-      or(eq(driveAgentMembers.role, 'ADMIN'), isNotNull(driveAgentMembers.customRoleId)),
+      eq(driveAgentMembers.role, 'ADMIN'),
     ));
 
   if (rows.length === 0) return [];

--- a/packages/lib/src/services/drive-agent-service.ts
+++ b/packages/lib/src/services/drive-agent-service.ts
@@ -238,42 +238,31 @@ export async function revokeAgentMembershipsGrantedBy(
 
 /**
  * Re-cap the agent memberships in `driveId` granted by `userId` when the user's
- * access is downgraded, bringing every agent they granted down to what they
- * could grant today. Only ever caps DOWN — it must never widen an agent's reach,
- * and never leave it with more than the downgraded granter.
+ * access is downgraded, bringing every agent they granted down to exactly what
+ * they could grant today. Only ever caps DOWN — never widens an agent's reach,
+ * never leaves it with more than the downgraded granter.
  *
- * Key asymmetry: a plain MEMBER agent membership resolves to `canView: true` on
- * EVERY page (`resolveRolePermissions` with no custom role), including private
- * pages — whereas a plain MEMBER *user* only sees non-private pages. So a plain
- * MEMBER membership row cannot represent "what a plain member may actually see",
- * which makes it unsafe as a recap target.
- *
- * The only representable, provably-safe member-level ceiling is the granter's
- * own custom role (an explicit per-page matrix). So, for each non-home membership
- * the user granted, with the granter now capped at MEMBER:
- *  - granter HAS a custom role B:
- *      - role ADMIN          ⇒ reduce to B (B ⊆ full access ⇒ strictly narrower).
- *      - role MEMBER + cid==B ⇒ leave as is (already the granter's grant).
- *      - anything else        ⇒ REVOKE (stale/▲ scope, not representable safely).
- *  - granter has NO custom role (plain member):
- *      - role ADMIN          ⇒ REVOKE. Reducing to plain MEMBER would let the
- *        agent read every page (incl. private) the plain-member granter cannot.
- *      - role MEMBER + cid==null ⇒ leave as is (already a plain-member grant,
- *        i.e. exactly what addAgentToDrive yields for a plain-member granter).
- *      - role MEMBER + custom role ⇒ REVOKE (stale custom role).
+ * Agent access is bottlenecked by the granting user's access: a plain MEMBER
+ * agent membership now resolves to the same view a plain MEMBER *user* gets
+ * (non-private pages only — see `agent-permissions.ts`), and a custom-role
+ * membership is gated by that role's explicit per-page matrix. So once the
+ * granter is capped at MEMBER, every membership they granted is reduced to
+ * `{ role: 'MEMBER', customRoleId: <the granter's own custom role, or null> }` —
+ * precisely what `addAgentToDrive` would assign for this granter today. No revoke
+ * is needed: a plain-MEMBER row can no longer over-read the granter.
  *
  * No-op when the user can still grant ADMIN. Excludes the agent's home drive.
- * Returns the affected agentPageIds (both reduced and revoked).
+ * Returns the affected agentPageIds.
  */
 export async function recapAgentMembershipsGrantedBy(
   driveId: string,
   userId: string,
 ): Promise<string[]> {
   const granter = await resolveGranterAccess(userId, driveId);
-  // Still able to grant ADMIN ⇒ nothing to reduce (we only ever cap downward).
+  // Still able to grant ADMIN ⇒ nothing to cap down (we only ever cap downward).
   if (granter.maxRole === 'ADMIN') return [];
 
-  const ceilingCustomRoleId = granter.customRoleId ?? null;
+  const capCustomRoleId = granter.customRoleId ?? null;
 
   const rows = await db
     .select({
@@ -290,35 +279,21 @@ export async function recapAgentMembershipsGrantedBy(
       ne(pages.driveId, driveId),
     ));
 
-  const toReduce: typeof rows = [];
-  const toRevoke: typeof rows = [];
-  for (const r of rows) {
-    const atCeiling = r.role !== 'ADMIN' && (r.customRoleId ?? null) === ceilingCustomRoleId;
-    if (atCeiling) continue; // already exactly the granter's current grant
-    if (r.role === 'ADMIN' && ceilingCustomRoleId !== null) {
-      // Representable reduction: cap full access down to the granter's custom role.
-      toReduce.push(r);
-    } else {
-      // ADMIN when the ceiling is plain MEMBER (can't express non-private/explicit
-      // access), or a member-level grant whose scope differs from the granter's —
-      // not representable as a safe cap, so revoke.
-      toRevoke.push(r);
-    }
-  }
+  // Reduce every membership that exceeds the granter's current grant down to it.
+  // "Already at the cap" = a plain-MEMBER row carrying the granter's own custom
+  // role (or none); those are left untouched.
+  const toReduce = rows.filter(
+    (r) => r.role !== 'MEMBER' || (r.customRoleId ?? null) !== capCustomRoleId,
+  );
 
   if (toReduce.length > 0) {
     await db
       .update(driveAgentMembers)
-      .set({ role: 'MEMBER', customRoleId: ceilingCustomRoleId })
+      .set({ role: 'MEMBER', customRoleId: capCustomRoleId })
       .where(inArray(driveAgentMembers.id, toReduce.map((r) => r.id)));
   }
-  if (toRevoke.length > 0) {
-    await db
-      .delete(driveAgentMembers)
-      .where(inArray(driveAgentMembers.id, toRevoke.map((r) => r.id)));
-  }
 
-  return [...toReduce, ...toRevoke].map((r) => r.agentPageId);
+  return toReduce.map((r) => r.agentPageId);
 }
 
 /**

--- a/packages/lib/src/services/drive-agent-service.ts
+++ b/packages/lib/src/services/drive-agent-service.ts
@@ -244,15 +244,20 @@ export async function revokeAgentMembershipsGrantedBy(
  *
  * Agent access is bottlenecked by the granting user's access: a plain MEMBER
  * agent membership now resolves to the same view a plain MEMBER *user* gets
- * (non-private pages only — see `agent-permissions.ts`), and a custom-role
- * membership is gated by that role's explicit per-page matrix. So once the
- * granter is capped at MEMBER, every membership they granted is reduced to
- * `{ role: 'MEMBER', customRoleId: <the granter's own custom role, or null> }` —
- * precisely what `addAgentToDrive` would assign for this granter today. No revoke
- * is needed: a plain-MEMBER row can no longer over-read the granter.
+ * (non-private pages only — see `agent-permissions.ts`), so capping a full-access
+ * agent down to the granter's level is a safe, pure narrowing. For each non-home
+ * membership the user granted, with the granter now capped at MEMBER:
+ *  - role ADMIN ⇒ REDUCE to `{ role: 'MEMBER', customRoleId: <granter's cap> }`.
+ *    ADMIN is full access ⊇ any MEMBER cap, so this strictly narrows.
+ *  - role MEMBER, customRoleId === the granter's ⇒ leave as is (already exactly
+ *    what the granter could grant today).
+ *  - role MEMBER, customRoleId differs ⇒ REVOKE. A custom-role matrix is
+ *    incomparable to the new cap (it may scope to fewer pages, or grant private/
+ *    edit access the cap doesn't), so rewriting it could *widen* the agent.
+ *    Revoke rather than guess — recap must never widen.
  *
  * No-op when the user can still grant ADMIN. Excludes the agent's home drive.
- * Returns the affected agentPageIds.
+ * Returns the affected agentPageIds (both reduced and revoked).
  */
 export async function recapAgentMembershipsGrantedBy(
   driveId: string,
@@ -279,12 +284,17 @@ export async function recapAgentMembershipsGrantedBy(
       ne(pages.driveId, driveId),
     ));
 
-  // Reduce every membership that exceeds the granter's current grant down to it.
-  // "Already at the cap" = a plain-MEMBER row carrying the granter's own custom
-  // role (or none); those are left untouched.
-  const toReduce = rows.filter(
-    (r) => r.role !== 'MEMBER' || (r.customRoleId ?? null) !== capCustomRoleId,
-  );
+  const toReduce: typeof rows = [];
+  const toRevoke: typeof rows = [];
+  for (const r of rows) {
+    const cid = r.customRoleId ?? null;
+    if (r.role === 'MEMBER' && cid === capCustomRoleId) continue; // already the granter's grant
+    if (r.role === 'ADMIN') {
+      toReduce.push(r); // full access ⊇ cap ⇒ pure narrowing
+    } else {
+      toRevoke.push(r); // mismatched custom role ⇒ not provably a subset of the cap
+    }
+  }
 
   if (toReduce.length > 0) {
     await db
@@ -292,8 +302,13 @@ export async function recapAgentMembershipsGrantedBy(
       .set({ role: 'MEMBER', customRoleId: capCustomRoleId })
       .where(inArray(driveAgentMembers.id, toReduce.map((r) => r.id)));
   }
+  if (toRevoke.length > 0) {
+    await db
+      .delete(driveAgentMembers)
+      .where(inArray(driveAgentMembers.id, toRevoke.map((r) => r.id)));
+  }
 
-  return toReduce.map((r) => r.agentPageId);
+  return [...toReduce, ...toRevoke].map((r) => r.agentPageId);
 }
 
 /**

--- a/packages/lib/src/services/drive-member-service.ts
+++ b/packages/lib/src/services/drive-member-service.ts
@@ -377,14 +377,15 @@ export async function updateMemberRole(
   targetUserId: string,
   role: 'ADMIN' | 'MEMBER',
   customRoleId?: string | null
-): Promise<{ oldRole: string }> {
+): Promise<{ oldRole: string; oldCustomRoleId: string | null }> {
   const [existing] = await db
-    .select({ role: driveMembers.role })
+    .select({ role: driveMembers.role, customRoleId: driveMembers.customRoleId })
     .from(driveMembers)
     .where(and(eq(driveMembers.driveId, driveId), eq(driveMembers.userId, targetUserId)))
     .limit(1);
 
   const oldRole = existing?.role || 'MEMBER';
+  const oldCustomRoleId = existing?.customRoleId ?? null;
 
   const updateData: { role?: 'OWNER' | 'ADMIN' | 'MEMBER'; customRoleId?: string | null } = {};
   if (role) {
@@ -401,7 +402,7 @@ export async function updateMemberRole(
       .where(and(eq(driveMembers.driveId, driveId), eq(driveMembers.userId, targetUserId)));
   }
 
-  return { oldRole };
+  return { oldRole, oldCustomRoleId };
 }
 
 /**


### PR DESCRIPTION
## Why

An external agent's drive access is **frozen at grant time** into `driveAgentMembers.role`/`customRoleId` and read straight back at runtime (`getAgentAccessLevel` in `packages/lib/src/permissions/agent-permissions.ts`). It is never re-derived from the granting user's live permissions, and agent tool calls gate on the **agent's** membership (`apps/web/src/lib/ai/tools/actor-permissions.ts`), not the invoking user's. `addedBy` is written at grant time and never read in any permission check.

Consequences before this change:
- **Removal** of a user from a drive deleted their `driveMembers` row + page permissions and kicked their sockets, but left their agent memberships intact — so the revoked user (and anyone able to run that agent) kept reading the drive through the agent.
- **Downgrade** (standard role ADMIN→MEMBER, or a custom-role change/clear) left an agent the user had elevated still holding its old role/`customRoleId`.
- **Agent over-grant (root cause):** a plain-MEMBER *agent* membership resolved to `canView: true` on **every** page in the drive, including private ones, while a plain-MEMBER *user* only sees non-private pages — so an agent could out-read the member who granted it.

## What

Make agent access **uniformly bottlenecked by the granting user's access**, keyed on `driveAgentMembers.addedBy`, scoped to the drive, and **excluding each agent's home drive** (which can't be removed anyway).

**Permissions — `packages/lib/src/permissions/agent-permissions.ts`**
- Gate the plain-MEMBER agent path on `isPrivate`, mirroring the user-side membership rule (`permissions.ts`): `getAgentAccessLevel` denies a plain member on a private page; `getAgentAccessiblePagesInDrive` filters private pages out of the enumeration. ADMIN/OWNER and explicit custom-role grants are unchanged — they already had parity with the user-side paths. A plain-MEMBER agent now sees exactly what a plain-MEMBER user sees.

**Service — `packages/lib/src/services/drive-agent-service.ts`**
- `revokeAgentMembershipsGrantedBy(executor, driveId, userId)` — deletes the non-home agent memberships the user granted; accepts a transaction so it runs atomically with member removal. Returns affected agent ids.
- `recapAgentMembershipsGrantedBy(driveId, userId)` — reuses `resolveGranterAccess` to recompute the user's current grant ceiling and reduces every agent they granted that exceeds it down to exactly `{ role: 'MEMBER', customRoleId: granter.customRoleId ?? null }` — what `addAgentToDrive` would assign today. With the over-grant closed, this is always a safe reduction; the previous revoke-instead-of-reduce special case is gone. No-op when the user can still grant ADMIN; never escalates.

**Route — `apps/web/src/app/api/drives/[driveId]/members/[userId]/route.ts`**
- `DELETE`: cascade-revokes inside the existing removal transaction, then audits (`reason: member_removal`).
- `PATCH`: re-caps on **`roleChanged || customRoleChanged`** (standard-role change OR custom-role change/clear), then audits (`reason: member_recap`). The custom-role trigger closes a gap where a member who stayed `MEMBER` but moved to a more restrictive custom role left their agents with stale `customRoleId` access.

Both cascades emit `authz` audit events. No realtime broadcast — consistent with the existing agent-membership endpoints, which audit only.

**Scope note:** the only live paths that revoke/change a member's drive access are these two handlers. Pending (unaccepted) members can't grant agents (`resolveGranterAccess` requires `acceptedAt`), so there's no cascade gap there. Full account deletion is out of scope (`addedBy` is already `onDelete: set null`).

## Testing

- `packages/lib/src/permissions/__tests__/agent-permissions.test.ts` — plain-MEMBER denied on private pages; ADMIN and explicit custom-role grants still reach private pages; enumeration filters private pages.
- `packages/lib/src/services/__tests__/drive-agent-service.test.ts` — revoke scoping + home-drive exclusion; re-cap **reduces** (not revokes) elevated agents down to the granter's representable cap; owner no-op / nothing-above-cap.
- `apps/web/.../members/[userId]/__tests__/route.test.ts` — DELETE cascade + audit; PATCH re-cap on role change AND on custom-role-only change; no-op when nothing changed.
- `typecheck` (lib + web) and `lint` clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agent memberships now automatically adjust when user roles or custom roles change, capping access appropriately.
  * External agent memberships are revoked when a user is removed from a drive.

* **Bug Fixes**
  * Private pages are now properly restricted from agent access unless explicitly granted by role permissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2witstudios/PageSpace/pull/1458?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->