### PR TITLE
Fix replace_lines diff showing full-document replacement for small edits

### DIFF
--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -19,7 +19,7 @@ import { broadcastPageEvent, createPageEventPayload, broadcastDriveEvent, create
 import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
 import { type ToolExecutionContext } from '../core';
 import { maskIdentifier } from '@/lib/logging/mask';
-import { addLineBreaksForAI } from '@/lib/editor/line-breaks';
+import { replaceLines } from '@/lib/editor/line-edit';
 
 const pageWriteLogger = loggers.ai.child({ module: 'page-write-tools' });
 
@@ -433,36 +433,25 @@ export const pageWriteTools = {
           throw new Error('Insufficient permissions to edit this document');
         }
 
-        // Format content for AI line-based editing, then split into lines.
-        // CODE and markdown pages have natural line structure (and CODE may contain
-        // raw HTML/XML that addLineBreaksForAI would mangle); HTML documents need it.
+        // Apply the line edit. CODE and markdown pages have natural line
+        // structure (and CODE may contain raw HTML/XML that addLineBreaksForAI
+        // would mangle); HTML documents are normalized for line-based editing.
+        // oldContent is normalized identically to newContent so a small edit
+        // diffs as a small change rather than a full-document replacement.
         const isRawText = page.contentMode === 'markdown' || isCodePage(page.type as PageType);
-        const formattedContent = isRawText
-          ? (page.content || '')
-          : addLineBreaksForAI(page.content || '');
-        const lines = formattedContent.split('\n');
-        
-        // Validate line numbers
-        if (startLine < 1 || startLine > lines.length || endLine < startLine || endLine > lines.length) {
-          throw new Error(`Invalid line range: ${startLine}-${endLine}. Document has ${lines.length} lines.`);
-        }
-
-        const isDeletion = content.length === 0;
-
-        // Replace lines (convert to 0-based indexing)
-        const replacementSegment = isDeletion ? [] : [content];
-        const newLines = [
-          ...lines.slice(0, startLine - 1),
-          ...replacementSegment,
-          ...lines.slice(endLine),
-        ];
-
-        const newContent = newLines.join('\n');
+        const { oldContent, newContent, newLineCount, changeType } = replaceLines({
+          content: page.content,
+          startLine,
+          endLine,
+          replacement: content,
+          isRawText,
+        });
+        const isDeletion = changeType === 'deletion';
 
         const mutationContext = await buildAiMutationContext(context as ToolExecutionContext, {
           metadata: {
             linesChanged: endLine - startLine + 1,
-            changeType: isDeletion ? 'deletion' : 'replacement',
+            changeType,
           },
         });
 
@@ -488,10 +477,10 @@ export const pageWriteTools = {
           title: page.title,
           type: page.type,
           contentMode: page.contentMode || 'html',
-          oldContent: page.content,
+          oldContent,
           newContent,
           linesReplaced: endLine - startLine + 1,
-          newLineCount: newLines.length,
+          newLineCount,
           message: isDeletion
             ? `Successfully removed lines ${startLine}-${endLine}`
             : `Successfully replaced lines ${startLine}-${endLine}`,
@@ -500,8 +489,8 @@ export const pageWriteTools = {
             : `Updated "${page.title}" by replacing ${endLine - startLine + 1} line${endLine - startLine + 1 === 1 ? '' : 's'}`,
           stats: {
             linesChanged: endLine - startLine + 1,
-            totalLines: newLines.length,
-            changeType: isDeletion ? 'deletion' : 'replacement'
+            totalLines: newLineCount,
+            changeType
           },
           nextSteps: [
             'Review the updated content to ensure it meets requirements',

--- a/apps/web/src/lib/editor/__tests__/line-edit.test.ts
+++ b/apps/web/src/lib/editor/__tests__/line-edit.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { replaceLines } from '../line-edit';
+import { addLineBreaksForAI } from '../line-breaks';
+
+describe('replaceLines', () => {
+  describe('diff baseline consistency (the bug)', () => {
+    it('returns oldContent formatted the same way as newContent for HTML', () => {
+      // Raw stored HTML has no line breaks; both sides of the diff must be
+      // normalized identically, otherwise a one-line edit looks like a full
+      // document replacement.
+      const content = '<p>Hello</p><p>World</p>';
+
+      const result = replaceLines({
+        content,
+        startLine: 2,
+        endLine: 2,
+        replacement: 'Goodbye',
+        isRawText: false,
+      });
+
+      expect(result.oldContent).toBe(addLineBreaksForAI(content));
+    });
+
+    it('produces a single-line diff for a single-line edit', () => {
+      const content = '<p>Hello</p><p>World</p>';
+
+      const result = replaceLines({
+        content,
+        startLine: 2,
+        endLine: 2,
+        replacement: 'Goodbye',
+        isRawText: false,
+      });
+
+      const oldLines = result.oldContent.split('\n');
+      const newLines = result.newContent.split('\n');
+
+      expect(oldLines.length).toBe(newLines.length);
+      const changed = oldLines.filter((line, i) => line !== newLines[i]);
+      expect(changed).toEqual(['Hello']);
+      expect(newLines[1]).toBe('Goodbye');
+    });
+  });
+
+  describe('raw text (markdown / code)', () => {
+    it('does not reformat raw text content', () => {
+      const content = 'line one\nline two\nline three';
+
+      const result = replaceLines({
+        content,
+        startLine: 2,
+        endLine: 2,
+        replacement: 'replaced',
+        isRawText: true,
+      });
+
+      expect(result.oldContent).toBe(content);
+      expect(result.newContent).toBe('line one\nreplaced\nline three');
+    });
+  });
+
+  describe('replacement', () => {
+    it('replaces a multi-line range with a single line', () => {
+      const content = 'a\nb\nc\nd';
+
+      const result = replaceLines({
+        content,
+        startLine: 2,
+        endLine: 3,
+        replacement: 'X',
+        isRawText: true,
+      });
+
+      expect(result.newContent).toBe('a\nX\nd');
+      expect(result.linesReplaced).toBe(2);
+      expect(result.newLineCount).toBe(3);
+      expect(result.changeType).toBe('replacement');
+    });
+  });
+
+  describe('deletion', () => {
+    it('removes lines when replacement is empty', () => {
+      const content = 'a\nb\nc';
+
+      const result = replaceLines({
+        content,
+        startLine: 2,
+        endLine: 2,
+        replacement: '',
+        isRawText: true,
+      });
+
+      expect(result.newContent).toBe('a\nc');
+      expect(result.newLineCount).toBe(2);
+      expect(result.changeType).toBe('deletion');
+    });
+  });
+
+  describe('validation', () => {
+    it('throws on a start line below 1', () => {
+      expect(() =>
+        replaceLines({ content: 'a\nb', startLine: 0, endLine: 1, replacement: 'x', isRawText: true })
+      ).toThrow(/Invalid line range/);
+    });
+
+    it('throws when endLine exceeds the document length', () => {
+      expect(() =>
+        replaceLines({ content: 'a\nb', startLine: 1, endLine: 5, replacement: 'x', isRawText: true })
+      ).toThrow(/Document has 2 lines/);
+    });
+
+    it('throws when endLine is before startLine', () => {
+      expect(() =>
+        replaceLines({ content: 'a\nb\nc', startLine: 3, endLine: 2, replacement: 'x', isRawText: true })
+      ).toThrow(/Invalid line range/);
+    });
+  });
+
+  describe('null-safety', () => {
+    it('treats null content as empty', () => {
+      const result = replaceLines({
+        content: null,
+        startLine: 1,
+        endLine: 1,
+        replacement: 'first',
+        isRawText: true,
+      });
+
+      expect(result.oldContent).toBe('');
+      expect(result.newContent).toBe('first');
+    });
+  });
+});

--- a/apps/web/src/lib/editor/line-edit.ts
+++ b/apps/web/src/lib/editor/line-edit.ts
@@ -1,0 +1,77 @@
+/**
+ * Line-based document editing (pure)
+ *
+ * Encapsulates the line-replacement used by the `replace_lines` AI tool.
+ *
+ * The stored page content is raw TipTap/ProseMirror HTML with no line breaks.
+ * To support line-based editing, HTML is normalized via `addLineBreaksForAI`
+ * so it has one block per line. The critical invariant is that the returned
+ * `oldContent` (diff baseline) is normalized with the *same* function as
+ * `newContent` — otherwise a single-line edit diffs as a full-document
+ * replacement, because raw HTML and line-broken HTML share almost no lines.
+ */
+
+import { addLineBreaksForAI } from './line-breaks';
+
+export interface ReplaceLinesParams {
+  /** Raw stored page content (may be null). */
+  content: string | null | undefined;
+  /** 1-based inclusive start line. */
+  startLine: number;
+  /** 1-based inclusive end line. */
+  endLine: number;
+  /** Replacement text; an empty string deletes the range. */
+  replacement: string;
+  /**
+   * True for content with natural line structure (markdown, code) where
+   * `addLineBreaksForAI` must NOT be applied; false for HTML documents.
+   */
+  isRawText: boolean;
+}
+
+export interface ReplaceLinesResult {
+  /** Diff baseline, normalized identically to `newContent`. */
+  oldContent: string;
+  /** Edited content, normalized identically to `oldContent`. */
+  newContent: string;
+  /** Number of source lines that were replaced or removed. */
+  linesReplaced: number;
+  /** Line count of the resulting content. */
+  newLineCount: number;
+  changeType: 'deletion' | 'replacement';
+}
+
+/**
+ * Replace an inclusive 1-based line range with `replacement`, returning both
+ * the normalized baseline and result so they can be diffed line-for-line.
+ *
+ * @throws if the line range is out of bounds or inverted.
+ */
+export function replaceLines(params: ReplaceLinesParams): ReplaceLinesResult {
+  const { content, startLine, endLine, replacement, isRawText } = params;
+
+  const oldContent = isRawText ? (content || '') : addLineBreaksForAI(content || '');
+  const lines = oldContent.split('\n');
+
+  if (startLine < 1 || startLine > lines.length || endLine < startLine || endLine > lines.length) {
+    throw new Error(
+      `Invalid line range: ${startLine}-${endLine}. Document has ${lines.length} lines.`
+    );
+  }
+
+  const isDeletion = replacement.length === 0;
+  const replacementSegment = isDeletion ? [] : [replacement];
+  const newLines = [
+    ...lines.slice(0, startLine - 1),
+    ...replacementSegment,
+    ...lines.slice(endLine),
+  ];
+
+  return {
+    oldContent,
+    newContent: newLines.join('\n'),
+    linesReplaced: endLine - startLine + 1,
+    newLineCount: newLines.length,
+    changeType: isDeletion ? 'deletion' : 'replacement',
+  };
+}


### PR DESCRIPTION
The replace_lines tool returned the raw stored HTML as oldContent while
newContent was normalized with addLineBreaksForAI. The diff renderer splits
both on newlines and runs a line-based LCS, so the two differently-formatted
versions shared almost no lines, making a one-line edit render as if the
whole page was replaced.

Extract the line-replacement into a pure replaceLines() function that derives
both oldContent and newContent from the same normalized baseline, and cover
it with unit tests (baseline consistency, raw-text vs HTML, replacement,
deletion, range validation, null-safety).