### PR TITLE
fix(tasks): keep nested task-lists visible as tasks in their parent

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/restore/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/restore/route.ts
@@ -9,7 +9,7 @@ import { trackPageOperation } from '@pagespace/lib/monitoring/activity-tracker';
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { authenticateRequestWithOptions, isAuthError, isMCPAuthResult, checkMCPPageScope } from '@/lib/auth';
 import { applyPageMutation } from '@/services/api/page-mutation-service';
-import { syncTaskItemOnMove } from '@/services/api/task-sync-service';
+import { ensureTaskItemForPage } from '@/services/api/task-sync-service';
 import { createChangeGroupId, inferChangeGroupType } from '@pagespace/lib/monitoring/change-group';
 import { type DeferredWorkflowTrigger } from '@pagespace/lib/monitoring/activity-logger';
 
@@ -71,11 +71,10 @@ async function recursivelyRestore(
     if (moveResult.deferredTrigger) triggers.push(moveResult.deferredTrigger);
 
     // Re-parenting an orphan back under a restored TASK_LIST must restore its task_items row.
-    await syncTaskItemOnMove(tx, {
-      movedPageId: child.id,
-      movedPageType: child.type,
-      oldParentId: null,
-      newParentId: pageId,
+    await ensureTaskItemForPage(tx, {
+      pageId: child.id,
+      pageType: child.type,
+      parentId: pageId,
       userId: context.userId,
     });
   }

--- a/apps/web/src/app/api/pages/[pageId]/restore/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/restore/route.ts
@@ -9,6 +9,7 @@ import { trackPageOperation } from '@pagespace/lib/monitoring/activity-tracker';
 import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { authenticateRequestWithOptions, isAuthError, isMCPAuthResult, checkMCPPageScope } from '@/lib/auth';
 import { applyPageMutation } from '@/services/api/page-mutation-service';
+import { syncTaskItemOnMove } from '@/services/api/task-sync-service';
 import { createChangeGroupId, inferChangeGroupType } from '@pagespace/lib/monitoring/change-group';
 import { type DeferredWorkflowTrigger } from '@pagespace/lib/monitoring/activity-logger';
 
@@ -53,7 +54,7 @@ async function recursivelyRestore(
   }
 
   const orphanedChildren = await tx
-    .select({ id: pages.id, revision: pages.revision })
+    .select({ id: pages.id, revision: pages.revision, type: pages.type })
     .from(pages)
     .where(eq(pages.originalParentId, pageId));
 
@@ -68,6 +69,15 @@ async function recursivelyRestore(
       tx,
     });
     if (moveResult.deferredTrigger) triggers.push(moveResult.deferredTrigger);
+
+    // Re-parenting an orphan back under a restored TASK_LIST must restore its task_items row.
+    await syncTaskItemOnMove(tx, {
+      movedPageId: child.id,
+      movedPageType: child.type,
+      oldParentId: null,
+      newParentId: pageId,
+      userId: context.userId,
+    });
   }
 
   return triggers;

--- a/apps/web/src/app/api/pages/[pageId]/tasks/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/__tests__/route.test.ts
@@ -65,7 +65,7 @@ vi.mock('@pagespace/db/db', () => {
   // 1. childPages: await db.select().from(pages).where(...)           — thenable chain
   // 2. triggerRows: await db.select().from(triggers).where().groupBy()
   // 3. subTaskRows: await db.select().from(items).innerJoin().where().groupBy()
-  const makeSelectChain = (result: unknown[] = [{ id: 'child-page-id' }]) => {
+  const makeSelectChain = (result: unknown[] = [{ id: 'child-page-id', pageId: 'child-page-id' }]) => {
     const chain: Record<string, unknown> = {
       then: (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
         Promise.resolve(result).then(resolve, reject),
@@ -196,7 +196,7 @@ describe('Task API Routes', () => {
   const mockTaskListId = 'tasklist-789';
 
   // Build a thenable select chain that resolves to `result`
-  const makeSelectChain = (result: unknown[] = [{ id: 'child-page-id' }]) => {
+  const makeSelectChain = (result: unknown[] = [{ id: 'child-page-id', pageId: 'child-page-id' }]) => {
     const chain: Record<string, unknown> = {
       then: (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
         Promise.resolve(result).then(resolve, reject),
@@ -352,8 +352,9 @@ describe('Task API Routes', () => {
       vi.mocked(authenticateRequestWithOptions).mockResolvedValue({ userId: mockUserId } as never);
       vi.mocked(canUserViewPage).mockResolvedValue(true);
       vi.mocked(db.query.taskLists.findFirst).mockResolvedValue(mockTaskList as never);
-      // childPages query returns only the non-trashed page (DB filters isTrashed=false)
-      vi.mocked(db.select).mockImplementationOnce(() => makeSelectChain([{ id: 'p-1' }]) as never);
+      // childPages query returns only the non-trashed page (DB filters isTrashed=false).
+      // The same shape feeds the self-heal existence check (reads pageId) so it's a no-op.
+      vi.mocked(db.select).mockImplementation(() => makeSelectChain([{ id: 'p-1', pageId: 'p-1' }]) as never);
       // taskItems.findMany only receives p-1 in its inArray clause, returns the active task
       vi.mocked(db.query.taskItems.findMany).mockResolvedValue([activeTask] as never);
 

--- a/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/tasks/route.ts
@@ -13,6 +13,7 @@ import { broadcastTaskEvent, broadcastPageEvent, createPageEventPayload } from '
 import { getActorInfo, logPageActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { createTaskAssignedNotification } from '@pagespace/lib/notifications/notifications';
 import { computeHasContent } from './task-utils';
+import { backfillMissingTaskItems } from '@/services/api/task-sync-service';
 
 const AUTH_OPTIONS_READ = { allow: ['session', 'mcp'] as const, requireCSRF: false };
 const AUTH_OPTIONS_WRITE = { allow: ['session', 'mcp'] as const, requireCSRF: true };
@@ -136,6 +137,10 @@ export async function GET(req: Request, { params }: { params: Promise<{ pageId: 
       statusConfigs,
     });
   }
+
+  // Self-heal: any TASK_LIST child missing its task_items row (created or moved via a
+  // path that skipped the sync) gets backfilled here so it always shows up as a task.
+  await backfillMissingTaskItems(db, { parentId: pageId, childPageIds, userId });
 
   // Build query - include assignees relation
   const query = db.query.taskItems.findMany({

--- a/apps/web/src/app/api/pages/bulk-copy/route.ts
+++ b/apps/web/src/app/api/pages/bulk-copy/route.ts
@@ -12,6 +12,7 @@ import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
 import { createId } from '@paralleldrive/cuid2';
 import { getActorInfo, logPageActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { createChangeGroupId } from '@pagespace/lib/monitoring/change-group';
+import { ensureTaskItemForPage } from '@/services/api/task-sync-service';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 
@@ -190,6 +191,14 @@ export async function POST(request: Request) {
           contentHash: page.contentHash,
         });
 
+        // A TASK_LIST copied under a TASK_LIST parent must appear as a task.
+        await ensureTaskItemForPage(tx, {
+          pageId: newPageId,
+          pageType: page.type,
+          parentId: targetParentId,
+          userId,
+        });
+
         copiedCount += 1;
         nextPosition += 1;
 
@@ -199,7 +208,8 @@ export async function POST(request: Request) {
             tx,
             page.id,
             newPageId,
-            targetDriveId
+            targetDriveId,
+            userId
           );
           copiedCount += childCount;
         }
@@ -253,7 +263,8 @@ async function copyChildrenRecursively(
   tx: Parameters<Parameters<typeof db.transaction>[0]>[0],
   sourceParentId: string,
   newParentId: string,
-  targetDriveId: string
+  targetDriveId: string,
+  userId: string
 ): Promise<number> {
   const children = await tx.query.pages.findMany({
     where: and(
@@ -306,6 +317,14 @@ async function copyChildrenRecursively(
       contentHash: child.contentHash,
     });
 
+    // A TASK_LIST copied under a TASK_LIST parent must appear as a task.
+    await ensureTaskItemForPage(tx, {
+      pageId: newChildId,
+      pageType: child.type,
+      parentId: newParentId,
+      userId,
+    });
+
     copiedCount += 1;
 
     // Recursively copy grandchildren
@@ -313,7 +332,8 @@ async function copyChildrenRecursively(
       tx,
       child.id,
       newChildId,
-      targetDriveId
+      targetDriveId,
+      userId
     );
     copiedCount += grandchildCount;
   }

--- a/apps/web/src/app/api/pages/bulk-delete/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/bulk-delete/__tests__/route.test.ts
@@ -59,8 +59,14 @@ vi.mock('@pagespace/db/db', () => {
   const txUpdateSet = vi.fn().mockReturnValue({ where: txUpdateWhere });
   const txUpdate = vi.fn().mockReturnValue({ set: txUpdateSet });
   const txQueryPagesFindMany = vi.fn().mockResolvedValue([]);
+  // Children-to-reparent lookup added by the task_items sync. Resolves to no children
+  // so the per-child syncTaskItemOnMove loop is a no-op in these tests.
+  const txSelectWhere = vi.fn().mockResolvedValue([]);
+  const txSelectFrom = vi.fn().mockReturnValue({ where: txSelectWhere });
+  const txSelect = vi.fn().mockReturnValue({ from: txSelectFrom });
   const tx = {
     update: txUpdate,
+    select: txSelect,
     query: { pages: { findMany: txQueryPagesFindMany } },
   };
   const transaction = vi.fn(async (fn: (t: unknown) => Promise<void>) => {
@@ -73,11 +79,12 @@ vi.mock('@pagespace/db/db', () => {
       },
       transaction,
     },
-    __test__: { txUpdate, txUpdateSet, txUpdateWhere, txQueryPagesFindMany, transaction },
+    __test__: { txUpdate, txUpdateSet, txUpdateWhere, txQueryPagesFindMany, txSelect, txSelectFrom, txSelectWhere, transaction },
   };
 });
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn((a: unknown, b: unknown) => [a, b]),
+  and: vi.fn((...conds: unknown[]) => conds),
   inArray: vi.fn((a: unknown, b: unknown) => [a, b]),
 }));
 vi.mock('@pagespace/db/schema/core', () => ({
@@ -95,11 +102,14 @@ import { logPageActivity } from '@pagespace/lib/monitoring/activity-logger';
 // @ts-expect-error - accessing test-only export
 import { db, __test__ as dbTest } from '@pagespace/db/db';
 
-const { txUpdate, txUpdateSet, txUpdateWhere, txQueryPagesFindMany, transaction: mockTransaction } = dbTest as {
+const { txUpdate, txUpdateSet, txUpdateWhere, txQueryPagesFindMany, txSelect, txSelectFrom, txSelectWhere, transaction: mockTransaction } = dbTest as {
   txUpdate: ReturnType<typeof vi.fn>;
   txUpdateSet: ReturnType<typeof vi.fn>;
   txUpdateWhere: ReturnType<typeof vi.fn>;
   txQueryPagesFindMany: ReturnType<typeof vi.fn>;
+  txSelect: ReturnType<typeof vi.fn>;
+  txSelectFrom: ReturnType<typeof vi.fn>;
+  txSelectWhere: ReturnType<typeof vi.fn>;
   transaction: ReturnType<typeof vi.fn>;
 };
 
@@ -160,9 +170,14 @@ function setupSuccessScenario() {
   txUpdateSet.mockReturnValue({ where: txUpdateWhere });
   txUpdate.mockReturnValue({ set: txUpdateSet });
   txQueryPagesFindMany.mockResolvedValue([]);
+  // Children-to-reparent lookup added by the task_items sync; no children by default.
+  txSelectWhere.mockResolvedValue([]);
+  txSelectFrom.mockReturnValue({ where: txSelectWhere });
+  txSelect.mockReturnValue({ from: txSelectFrom });
   mockTransaction.mockImplementation(async (fn: (t: unknown) => Promise<void>) => {
     await fn({
       update: txUpdate,
+      select: txSelect,
       query: { pages: { findMany: txQueryPagesFindMany } },
     });
   });

--- a/apps/web/src/app/api/pages/bulk-delete/route.ts
+++ b/apps/web/src/app/api/pages/bulk-delete/route.ts
@@ -4,12 +4,13 @@ import { broadcastPageEvent, createPageEventPayload } from '@/lib/websocket';
 import { loggers } from '@pagespace/lib/logging/logger-config'
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { db } from '@pagespace/db/db'
-import { eq, inArray } from '@pagespace/db/operators'
+import { and, eq, inArray } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core';
 import { authenticateRequestWithOptions, isAuthError, getAllowedDriveIds, isMCPAuthResult } from '@/lib/auth';
 import { canUserDeletePage } from '@pagespace/lib/permissions/permissions';
 import { getActorInfo, logPageActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { createChangeGroupId } from '@pagespace/lib/monitoring/change-group';
+import { syncTaskItemOnMove } from '@/services/api/task-sync-service';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 
@@ -95,13 +96,30 @@ export async function DELETE(request: Request) {
         if (trashChildren) {
           await trashChildrenRecursively(tx, page.id, now);
         } else {
-          // Move children to parent's parent
+          // Move children up to the deleted page's parent. Sync task_items per child so
+          // a TASK_LIST leaving a deleted TASK_LIST loses its row (or gains one if the
+          // new grandparent is also a TASK_LIST).
+          const children = await tx
+            .select({ id: pages.id, type: pages.type })
+            .from(pages)
+            .where(and(eq(pages.parentId, page.id), eq(pages.isTrashed, false)));
+
           await tx.update(pages)
             .set({
               parentId: page.parentId,
               updatedAt: now,
             })
             .where(eq(pages.parentId, page.id));
+
+          for (const child of children) {
+            await syncTaskItemOnMove(tx, {
+              movedPageId: child.id,
+              movedPageType: child.type,
+              oldParentId: page.id,
+              newParentId: page.parentId,
+              userId,
+            });
+          }
         }
       }
     });

--- a/apps/web/src/services/api/__tests__/task-membership.test.ts
+++ b/apps/web/src/services/api/__tests__/task-membership.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import {
+  TASK_LIST_TYPE,
+  shouldHaveTaskItem,
+  resolveTaskItemSyncAction,
+  nextTaskItemPosition,
+  buildTaskItemInsert,
+  selectMissingTaskItemPageIds,
+} from '../task-membership';
+
+describe('shouldHaveTaskItem', () => {
+  it('is true only when a TASK_LIST page sits under a TASK_LIST parent', () => {
+    expect(shouldHaveTaskItem({ pageType: TASK_LIST_TYPE, parentType: TASK_LIST_TYPE })).toBe(true);
+  });
+
+  it('is false when the page itself is not a TASK_LIST', () => {
+    expect(shouldHaveTaskItem({ pageType: 'DOCUMENT', parentType: TASK_LIST_TYPE })).toBe(false);
+  });
+
+  it('is false when the parent is not a TASK_LIST', () => {
+    expect(shouldHaveTaskItem({ pageType: TASK_LIST_TYPE, parentType: 'FOLDER' })).toBe(false);
+  });
+
+  it('is false when the parent type is null or undefined (root / unknown)', () => {
+    expect(shouldHaveTaskItem({ pageType: TASK_LIST_TYPE, parentType: null })).toBe(false);
+    expect(shouldHaveTaskItem({ pageType: TASK_LIST_TYPE, parentType: undefined })).toBe(false);
+  });
+});
+
+describe('resolveTaskItemSyncAction', () => {
+  const base = {
+    movedPageType: TASK_LIST_TYPE,
+    oldParentId: 'old',
+    newParentId: 'new',
+    oldParentType: TASK_LIST_TYPE,
+    newParentType: TASK_LIST_TYPE,
+  };
+
+  it('no-ops for non TASK_LIST pages', () => {
+    expect(resolveTaskItemSyncAction({ ...base, movedPageType: 'DOCUMENT' })).toEqual({
+      shouldRemove: false,
+      shouldAdd: false,
+    });
+  });
+
+  it('no-ops when the parent did not change (pure reorder)', () => {
+    expect(
+      resolveTaskItemSyncAction({ ...base, oldParentId: 'same', newParentId: 'same' }),
+    ).toEqual({ shouldRemove: false, shouldAdd: false });
+  });
+
+  it('removes and adds when moving between two TASK_LIST parents', () => {
+    expect(resolveTaskItemSyncAction(base)).toEqual({ shouldRemove: true, shouldAdd: true });
+  });
+
+  it('only adds when moving from a non-TASK_LIST parent into a TASK_LIST parent', () => {
+    expect(
+      resolveTaskItemSyncAction({ ...base, oldParentType: 'FOLDER' }),
+    ).toEqual({ shouldRemove: false, shouldAdd: true });
+  });
+
+  it('only adds when moving from root (no old parent) into a TASK_LIST parent', () => {
+    expect(
+      resolveTaskItemSyncAction({ ...base, oldParentId: null, oldParentType: null }),
+    ).toEqual({ shouldRemove: false, shouldAdd: true });
+  });
+
+  it('only removes when moving out of a TASK_LIST parent into a non-TASK_LIST parent', () => {
+    expect(
+      resolveTaskItemSyncAction({ ...base, newParentType: 'FOLDER' }),
+    ).toEqual({ shouldRemove: true, shouldAdd: false });
+  });
+
+  it('only removes when moving out of a TASK_LIST parent to root', () => {
+    expect(
+      resolveTaskItemSyncAction({ ...base, newParentId: null, newParentType: null }),
+    ).toEqual({ shouldRemove: true, shouldAdd: false });
+  });
+});
+
+describe('nextTaskItemPosition', () => {
+  it('places a new item after the last child', () => {
+    expect(nextTaskItemPosition(4)).toBe(5);
+  });
+
+  it('defaults to slot 1 when there is no last child', () => {
+    expect(nextTaskItemPosition(null)).toBe(1);
+    expect(nextTaskItemPosition(undefined)).toBe(1);
+  });
+});
+
+describe('buildTaskItemInsert', () => {
+  it('builds a pending/medium row positioned after the last child', () => {
+    expect(
+      buildTaskItemInsert({ pageId: 'p1', userId: 'u1', lastChildPosition: 2 }),
+    ).toEqual({
+      userId: 'u1',
+      pageId: 'p1',
+      status: 'pending',
+      priority: 'medium',
+      position: 3,
+    });
+  });
+
+  it('positions at slot 1 for an empty parent', () => {
+    expect(
+      buildTaskItemInsert({ pageId: 'p1', userId: 'u1', lastChildPosition: null }),
+    ).toMatchObject({ position: 1 });
+  });
+});
+
+describe('selectMissingTaskItemPageIds', () => {
+  it('returns child page ids that have no task item yet, order preserved', () => {
+    expect(
+      selectMissingTaskItemPageIds({
+        childPageIds: ['a', 'b', 'c'],
+        existingTaskItemPageIds: ['b'],
+      }),
+    ).toEqual(['a', 'c']);
+  });
+
+  it('returns an empty array when every child already has a task item', () => {
+    expect(
+      selectMissingTaskItemPageIds({
+        childPageIds: ['a', 'b'],
+        existingTaskItemPageIds: ['a', 'b'],
+      }),
+    ).toEqual([]);
+  });
+
+  it('dedupes repeated child ids', () => {
+    expect(
+      selectMissingTaskItemPageIds({
+        childPageIds: ['a', 'a', 'b'],
+        existingTaskItemPageIds: [],
+      }),
+    ).toEqual(['a', 'b']);
+  });
+
+  it('handles an empty child list', () => {
+    expect(
+      selectMissingTaskItemPageIds({ childPageIds: [], existingTaskItemPageIds: ['x'] }),
+    ).toEqual([]);
+  });
+});

--- a/apps/web/src/services/api/__tests__/task-sync-service.test.ts
+++ b/apps/web/src/services/api/__tests__/task-sync-service.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Schema tables are opaque markers in these tests; the mock tx ignores them.
+vi.mock('@pagespace/db/schema/core', () => ({ pages: { id: 'pages.id', parentId: 'pages.parentId', isTrashed: 'pages.isTrashed', position: 'pages.position', type: 'pages.type' } }));
+vi.mock('@pagespace/db/schema/tasks', () => ({
+  taskLists: { pageId: 'taskLists.pageId' },
+  taskItems: { pageId: 'taskItems.pageId' },
+  taskStatusConfigs: {},
+  DEFAULT_TASK_STATUSES: [
+    { slug: 'pending', name: 'To Do', color: 'c', group: 'todo', position: 0 },
+  ],
+}));
+vi.mock('@pagespace/db/operators', () => ({
+  eq: vi.fn((a, b) => ['eq', a, b]),
+  and: vi.fn((...c) => ['and', ...c]),
+  desc: vi.fn((c) => ['desc', c]),
+  inArray: vi.fn((c, v) => ['inArray', c, v]),
+}));
+
+// The shells import `db` only as a type; provide a stub so the module loads.
+vi.mock('@pagespace/db/db', () => ({ db: {} }));
+
+import {
+  ensureTaskItemForPage,
+  syncTaskItemOnMove,
+  backfillMissingTaskItems,
+} from '../task-sync-service';
+
+/**
+ * Build a mock transaction context.
+ *
+ * @param config.pageTypes        map of pageId -> type, consulted by getPageType
+ * @param config.existingItems    set of pageIds that already have a task_items row
+ * @param config.existingTaskList whether the parent already has a task_lists row
+ * @param config.lastPosition     position of the last child page (for new item position)
+ */
+function makeTx(config: {
+  pageTypes?: Record<string, string>;
+  existingItems?: Set<string>;
+  existingTaskList?: boolean;
+  lastPosition?: number | null;
+} = {}) {
+  const {
+    pageTypes = {},
+    existingItems = new Set<string>(),
+    existingTaskList = true,
+    lastPosition = null,
+  } = config;
+
+  const taskItemInserts: Array<Record<string, unknown>> = [];
+  const taskListInserts: Array<Record<string, unknown>> = [];
+  const deletedPageIds: string[] = [];
+
+  // getPageType: tx.select(...).from(pages).where(eq(pages.id, X)).limit(1)
+  // The where condition we built is ['eq', 'pages.id', X]; pull X back out.
+  const selectChain = {
+    from: () => selectChain,
+    where: (cond: unknown[]) => {
+      const id = cond?.[2] as string;
+      return { limit: () => Promise.resolve(id in pageTypes ? [{ type: pageTypes[id] }] : []) };
+    },
+  };
+
+  const tx = {
+    select: vi.fn(() => selectChain),
+    delete: vi.fn(() => ({ where: (cond: unknown[]) => { deletedPageIds.push(cond?.[2] as string); return Promise.resolve(); } })),
+    insert: vi.fn((table: { pageId?: string }) => ({
+      values: (vals: Record<string, unknown> | Record<string, unknown>[]) => {
+        const isTaskItems = table?.pageId === 'taskItems.pageId';
+        if (isTaskItems) taskItemInserts.push(vals as Record<string, unknown>);
+        else if (table?.pageId === 'taskLists.pageId') taskListInserts.push(vals as Record<string, unknown>);
+        return { returning: () => Promise.resolve([{ id: 'tasklist-1' }]) };
+      },
+    })),
+    query: {
+      taskLists: { findFirst: vi.fn(async () => (existingTaskList ? { id: 'tasklist-1' } : undefined)) },
+      taskItems: { findFirst: vi.fn(async (args: { where: unknown[] }) => {
+        const id = args.where?.[2] as string;
+        return existingItems.has(id) ? { id: 'item-1', pageId: id } : undefined;
+      }) },
+      pages: { findFirst: vi.fn(async () => (lastPosition === null ? undefined : { position: lastPosition })) },
+    },
+  };
+
+  return { tx, taskItemInserts, taskListInserts, deletedPageIds };
+}
+
+describe('ensureTaskItemForPage', () => {
+  it('does nothing for a non-TASK_LIST page (no parent lookup, no insert)', async () => {
+    const { tx, taskItemInserts } = makeTx({ pageTypes: { parent: 'TASK_LIST' } });
+    await ensureTaskItemForPage(tx as never, { pageId: 'doc', pageType: 'DOCUMENT', parentId: 'parent', userId: 'u' });
+    expect(tx.select).not.toHaveBeenCalled();
+    expect(taskItemInserts).toHaveLength(0);
+  });
+
+  it('does nothing for a root TASK_LIST (no parent)', async () => {
+    const { tx, taskItemInserts } = makeTx();
+    await ensureTaskItemForPage(tx as never, { pageId: 'list', pageType: 'TASK_LIST', parentId: null, userId: 'u' });
+    expect(taskItemInserts).toHaveLength(0);
+  });
+
+  it('does nothing when the parent is not a TASK_LIST', async () => {
+    const { tx, taskItemInserts } = makeTx({ pageTypes: { parent: 'FOLDER' } });
+    await ensureTaskItemForPage(tx as never, { pageId: 'list', pageType: 'TASK_LIST', parentId: 'parent', userId: 'u' });
+    expect(taskItemInserts).toHaveLength(0);
+  });
+
+  it('creates a task_items row for a TASK_LIST nested under a TASK_LIST', async () => {
+    const { tx, taskItemInserts } = makeTx({ pageTypes: { parent: 'TASK_LIST' }, lastPosition: 2 });
+    await ensureTaskItemForPage(tx as never, { pageId: 'list', pageType: 'TASK_LIST', parentId: 'parent', userId: 'u' });
+    expect(taskItemInserts).toEqual([
+      { userId: 'u', pageId: 'list', status: 'pending', priority: 'medium', position: 3 },
+    ]);
+  });
+
+  it('is idempotent — skips insert when the row already exists', async () => {
+    const { tx, taskItemInserts } = makeTx({ pageTypes: { parent: 'TASK_LIST' }, existingItems: new Set(['list']) });
+    await ensureTaskItemForPage(tx as never, { pageId: 'list', pageType: 'TASK_LIST', parentId: 'parent', userId: 'u' });
+    expect(taskItemInserts).toHaveLength(0);
+  });
+
+  it('creates the parent task_lists row first when it is missing', async () => {
+    const { tx, taskItemInserts, taskListInserts } = makeTx({ pageTypes: { parent: 'TASK_LIST' }, existingTaskList: false });
+    await ensureTaskItemForPage(tx as never, { pageId: 'list', pageType: 'TASK_LIST', parentId: 'parent', userId: 'u' });
+    expect(taskListInserts).toHaveLength(1);
+    expect(taskItemInserts).toHaveLength(1);
+  });
+});
+
+describe('syncTaskItemOnMove', () => {
+  it('no-ops for non-TASK_LIST pages', async () => {
+    const { tx, taskItemInserts, deletedPageIds } = makeTx();
+    await syncTaskItemOnMove(tx as never, { movedPageId: 'd', movedPageType: 'DOCUMENT', oldParentId: 'a', newParentId: 'b', userId: 'u' });
+    expect(taskItemInserts).toHaveLength(0);
+    expect(deletedPageIds).toHaveLength(0);
+  });
+
+  it('removes from old list and adds to new list when moving between TASK_LISTs', async () => {
+    const { tx, taskItemInserts, deletedPageIds } = makeTx({ pageTypes: { old: 'TASK_LIST', new: 'TASK_LIST' } });
+    await syncTaskItemOnMove(tx as never, { movedPageId: 'list', movedPageType: 'TASK_LIST', oldParentId: 'old', newParentId: 'new', userId: 'u' });
+    expect(deletedPageIds).toEqual(['list']);
+    expect(taskItemInserts).toHaveLength(1);
+    expect(taskItemInserts[0]).toMatchObject({ pageId: 'list', position: 1 });
+  });
+
+  it('only removes when moving out of a TASK_LIST into a non-TASK_LIST', async () => {
+    const { tx, taskItemInserts, deletedPageIds } = makeTx({ pageTypes: { old: 'TASK_LIST', new: 'FOLDER' } });
+    await syncTaskItemOnMove(tx as never, { movedPageId: 'list', movedPageType: 'TASK_LIST', oldParentId: 'old', newParentId: 'new', userId: 'u' });
+    expect(deletedPageIds).toEqual(['list']);
+    expect(taskItemInserts).toHaveLength(0);
+  });
+
+  it('only adds when moving from root into a TASK_LIST', async () => {
+    const { tx, taskItemInserts, deletedPageIds } = makeTx({ pageTypes: { new: 'TASK_LIST' } });
+    await syncTaskItemOnMove(tx as never, { movedPageId: 'list', movedPageType: 'TASK_LIST', oldParentId: null, newParentId: 'new', userId: 'u' });
+    expect(deletedPageIds).toHaveLength(0);
+    expect(taskItemInserts).toHaveLength(1);
+  });
+});
+
+describe('backfillMissingTaskItems', () => {
+  function makeDb(existingPageIds: string[], txParts: ReturnType<typeof makeTx>) {
+    const selectChain = {
+      from: () => selectChain,
+      where: () => Promise.resolve(existingPageIds.map(pageId => ({ pageId }))),
+    };
+    return {
+      select: vi.fn(() => selectChain),
+      transaction: vi.fn(async (cb: (tx: unknown) => Promise<void>) => cb(txParts.tx)),
+    };
+  }
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it('does nothing when there are no children', async () => {
+    const parts = makeTx();
+    const database = makeDb([], parts);
+    await backfillMissingTaskItems(database as never, { parentId: 'p', childPageIds: [], userId: 'u' });
+    expect(database.select).not.toHaveBeenCalled();
+    expect(database.transaction).not.toHaveBeenCalled();
+  });
+
+  it('does not open a transaction when every child already has a task item', async () => {
+    const parts = makeTx({ pageTypes: { p: 'TASK_LIST' } });
+    const database = makeDb(['a', 'b'], parts);
+    await backfillMissingTaskItems(database as never, { parentId: 'p', childPageIds: ['a', 'b'], userId: 'u' });
+    expect(database.select).toHaveBeenCalledTimes(1);
+    expect(database.transaction).not.toHaveBeenCalled();
+    expect(parts.taskItemInserts).toHaveLength(0);
+  });
+
+  it('backfills only the children missing a task item', async () => {
+    const parts = makeTx({ pageTypes: { p: 'TASK_LIST' } });
+    const database = makeDb(['a'], parts);
+    await backfillMissingTaskItems(database as never, { parentId: 'p', childPageIds: ['a', 'b', 'c'], userId: 'u' });
+    expect(database.transaction).toHaveBeenCalledTimes(1);
+    expect(parts.taskItemInserts.map(r => r.pageId)).toEqual(['b', 'c']);
+  });
+});

--- a/apps/web/src/services/api/__tests__/task-sync-service.test.ts
+++ b/apps/web/src/services/api/__tests__/task-sync-service.test.ts
@@ -69,7 +69,8 @@ function makeTx(config: {
         const isTaskItems = table?.pageId === 'taskItems.pageId';
         if (isTaskItems) taskItemInserts.push(vals as Record<string, unknown>);
         else if (table?.pageId === 'taskLists.pageId') taskListInserts.push(vals as Record<string, unknown>);
-        return { returning: () => Promise.resolve([{ id: 'tasklist-1' }]) };
+        // taskItems insert is awaited via .onConflictDoNothing(); taskLists via .returning().
+        return { onConflictDoNothing: () => Promise.resolve(), returning: () => Promise.resolve([{ id: 'tasklist-1' }]) };
       },
     })),
     query: {

--- a/apps/web/src/services/api/page-service.ts
+++ b/apps/web/src/services/api/page-service.ts
@@ -17,6 +17,7 @@ import { createChangeGroupId, inferChangeGroupType } from '@pagespace/lib/monito
 import { logActivityWithTx, type DeferredWorkflowTrigger } from '@pagespace/lib/monitoring/activity-logger';
 import { createId } from '@paralleldrive/cuid2';
 import { applyPageMutation, PageRevisionMismatchError, type PageMutationContext } from './page-mutation-service';
+import { ensureTaskItemForPage } from './task-sync-service';
 
 /**
  * Helper to convert DB page result to PageData type
@@ -760,6 +761,15 @@ export const pageService = {
       pageData.stateHash = stateHash;
 
       const [page] = await tx.insert(pages).values(pageData).returning();
+
+      // Keep the task-list membership invariant: a TASK_LIST created under a
+      // TASK_LIST parent must have its task_items row, no matter the entry point.
+      await ensureTaskItemForPage(tx, {
+        pageId: page.id,
+        pageType: page.type,
+        parentId: page.parentId,
+        userId,
+      });
 
       if (isAIChatPage(params.type as PageTypeEnum)) {
         await tx.insert(driveAgentMembers).values({

--- a/apps/web/src/services/api/task-membership.ts
+++ b/apps/web/src/services/api/task-membership.ts
@@ -1,0 +1,99 @@
+/**
+ * Pure decision logic for task-list membership.
+ *
+ * Membership of a page in a task list is determined by the page tree: a TASK_LIST
+ * page whose `parentId` points to another TASK_LIST page is a task in that parent.
+ * The `task_items` row is a metadata sidecar (status, priority, position, assignee)
+ * that must mirror that relationship.
+ *
+ * These functions decide WHAT must change. The imperative shells in
+ * `task-sync-service.ts` look up types and perform the database I/O.
+ */
+
+export const TASK_LIST_TYPE = 'TASK_LIST';
+
+/**
+ * A page belongs in its parent's task list iff it is a TASK_LIST nested under a
+ * TASK_LIST. A root page (null/undefined parent type) never qualifies.
+ */
+export const shouldHaveTaskItem = (input: {
+  pageType: string;
+  parentType: string | null | undefined;
+}): boolean =>
+  input.pageType === TASK_LIST_TYPE && input.parentType === TASK_LIST_TYPE;
+
+export interface TaskItemSyncAction {
+  readonly shouldRemove: boolean;
+  readonly shouldAdd: boolean;
+}
+
+/**
+ * Decide which `task_items` mutations a page move requires:
+ * - remove the row when the page leaves a TASK_LIST parent
+ * - add the row when the page lands under a TASK_LIST parent
+ *
+ * No-op for non-TASK_LIST pages and for pure reorders (parent unchanged).
+ */
+export const resolveTaskItemSyncAction = (input: {
+  movedPageType: string;
+  oldParentId: string | null;
+  newParentId: string | null;
+  oldParentType: string | null | undefined;
+  newParentType: string | null | undefined;
+}): TaskItemSyncAction => {
+  if (input.movedPageType !== TASK_LIST_TYPE || input.oldParentId === input.newParentId) {
+    return { shouldRemove: false, shouldAdd: false };
+  }
+  return {
+    shouldRemove: input.oldParentId !== null && input.oldParentType === TASK_LIST_TYPE,
+    shouldAdd: input.newParentId !== null && input.newParentType === TASK_LIST_TYPE,
+  };
+};
+
+/**
+ * Next position for a new task item: after the last child, defaulting to slot 1.
+ */
+export const nextTaskItemPosition = (lastChildPosition: number | null | undefined): number =>
+  (lastChildPosition ?? 0) + 1;
+
+export interface TaskItemInsert {
+  readonly userId: string;
+  readonly pageId: string;
+  readonly status: 'pending';
+  readonly priority: 'medium';
+  readonly position: number;
+}
+
+/**
+ * Build the row for a new task item linked to a page.
+ */
+export const buildTaskItemInsert = (input: {
+  pageId: string;
+  userId: string;
+  lastChildPosition: number | null | undefined;
+}): TaskItemInsert => ({
+  userId: input.userId,
+  pageId: input.pageId,
+  status: 'pending',
+  priority: 'medium',
+  position: nextTaskItemPosition(input.lastChildPosition),
+});
+
+/**
+ * Given candidate child page ids and the ids that already have a task item,
+ * return those still missing one — order preserved, deduped.
+ */
+export const selectMissingTaskItemPageIds = (input: {
+  childPageIds: readonly string[];
+  existingTaskItemPageIds: readonly string[];
+}): string[] => {
+  const existing = new Set(input.existingTaskItemPageIds);
+  const seen = new Set<string>();
+  const missing: string[] = [];
+  for (const id of input.childPageIds) {
+    if (existing.has(id) || seen.has(id)) continue;
+    seen.add(id);
+    missing.push(id);
+  }
+  return missing;
+};

--- a/apps/web/src/services/api/task-sync-service.ts
+++ b/apps/web/src/services/api/task-sync-service.ts
@@ -1,18 +1,101 @@
 import { db } from '@pagespace/db/db'
-import { eq, and, desc } from '@pagespace/db/operators'
+import { eq, and, desc, inArray } from '@pagespace/db/operators'
 import { pages } from '@pagespace/db/schema/core'
 import { taskLists, taskItems, taskStatusConfigs, DEFAULT_TASK_STATUSES } from '@pagespace/db/schema/tasks'
+import {
+  TASK_LIST_TYPE,
+  shouldHaveTaskItem,
+  resolveTaskItemSyncAction,
+  buildTaskItemInsert,
+  selectMissingTaskItemPageIds,
+} from './task-membership'
 
 type Tx = typeof db
 
 /**
- * Sync task_items membership when a page is moved.
+ * Imperative shells over the pure membership logic in `task-membership.ts`.
  *
- * Invariant: every TASK_LIST page whose pages.parentId points to another TASK_LIST page
- * must have exactly one task_items row with pageId = that page's id.
- *
- * - Moving INTO a TASK_LIST parent → create the task_items row (idempotent)
- * - Moving OUT OF a TASK_LIST parent → delete the task_items row
+ * Invariant: every TASK_LIST page whose `pages.parentId` points to another TASK_LIST
+ * page must have exactly one `task_items` row with pageId = that page's id. These shells
+ * are the single place that enforces it; the pure functions decide what to do.
+ */
+
+async function getPageType(tx: Tx, pageId: string): Promise<string | null> {
+  const [page] = await tx
+    .select({ type: pages.type })
+    .from(pages)
+    .where(eq(pages.id, pageId))
+    .limit(1)
+  return page?.type ?? null
+}
+
+/**
+ * Create the `task_items` row for a page under a known TASK_LIST parent.
+ * Idempotent — does nothing if the row already exists. Ensures the parent's
+ * `task_lists` row and default status configs exist first.
+ */
+async function addTaskItemUnderParent(
+  tx: Tx,
+  params: { pageId: string; parentId: string; userId: string },
+): Promise<void> {
+  const { pageId, parentId, userId } = params
+
+  let taskList = await tx.query.taskLists.findFirst({
+    where: eq(taskLists.pageId, parentId),
+  })
+
+  if (!taskList) {
+    const [created] = await tx.insert(taskLists).values({
+      userId,
+      pageId: parentId,
+      title: 'Task List',
+      status: 'pending',
+    }).returning()
+    taskList = created
+
+    await tx.insert(taskStatusConfigs).values(
+      DEFAULT_TASK_STATUSES.map(s => ({ taskListId: created.id, ...s }))
+    )
+  }
+
+  const existing = await tx.query.taskItems.findFirst({
+    where: eq(taskItems.pageId, pageId),
+  })
+  if (existing) return
+
+  const lastChild = await tx.query.pages.findFirst({
+    where: and(eq(pages.parentId, parentId), eq(pages.isTrashed, false)),
+    orderBy: [desc(pages.position)],
+  })
+
+  await tx.insert(taskItems).values(
+    buildTaskItemInsert({ pageId, userId, lastChildPosition: lastChild?.position ?? null }),
+  )
+}
+
+/**
+ * Ensure a freshly created or re-parented page has its `task_items` row when it is a
+ * TASK_LIST nested under a TASK_LIST. No-op otherwise. Use from every page-creation path.
+ */
+export async function ensureTaskItemForPage(
+  tx: Tx,
+  params: { pageId: string; pageType: string; parentId: string | null; userId: string },
+): Promise<void> {
+  const { pageId, pageType, parentId, userId } = params
+
+  // Short-circuit before any I/O: only TASK_LIST pages with a parent can qualify.
+  if (pageType !== TASK_LIST_TYPE || !parentId) return
+
+  const parentType = await getPageType(tx, parentId)
+  if (!shouldHaveTaskItem({ pageType, parentType })) return
+
+  await addTaskItemUnderParent(tx, { pageId, parentId, userId })
+}
+
+/**
+ * Sync `task_items` membership when a page is moved.
+ * - Moving INTO a TASK_LIST parent → create the row (idempotent)
+ * - Moving OUT OF a TASK_LIST parent → delete the row
  */
 export async function syncTaskItemOnMove(
   tx: Tx,
@@ -26,72 +109,58 @@ export async function syncTaskItemOnMove(
 ): Promise<void> {
   const { movedPageId, movedPageType, oldParentId, newParentId, userId } = params
 
-  if (movedPageType !== 'TASK_LIST') return
+  // Cheap guards before any parent lookups.
+  if (movedPageType !== TASK_LIST_TYPE || oldParentId === newParentId) return
 
-  // No parent change — just a position reorder within the same parent, nothing to sync
-  if (oldParentId === newParentId) return
+  const oldParentType = oldParentId ? await getPageType(tx, oldParentId) : null
+  const newParentType = newParentId ? await getPageType(tx, newParentId) : null
 
-  // Remove from old parent if it was a TASK_LIST
-  if (oldParentId) {
-    const [oldParent] = await tx
-      .select({ type: pages.type })
-      .from(pages)
-      .where(eq(pages.id, oldParentId))
-      .limit(1)
+  const action = resolveTaskItemSyncAction({
+    movedPageType,
+    oldParentId,
+    newParentId,
+    oldParentType,
+    newParentType,
+  })
 
-    if (oldParent?.type === 'TASK_LIST') {
-      await tx.delete(taskItems).where(eq(taskItems.pageId, movedPageId))
-    }
+  if (action.shouldRemove) {
+    await tx.delete(taskItems).where(eq(taskItems.pageId, movedPageId))
   }
 
-  // Add to new parent if it's a TASK_LIST
-  if (newParentId) {
-    const [newParent] = await tx
-      .select({ type: pages.type })
-      .from(pages)
-      .where(eq(pages.id, newParentId))
-      .limit(1)
-
-    if (newParent?.type !== 'TASK_LIST') return
-
-    // Get or create task_lists row for the new parent page
-    let taskList = await tx.query.taskLists.findFirst({
-      where: eq(taskLists.pageId, newParentId),
-    })
-
-    if (!taskList) {
-      const [created] = await tx.insert(taskLists).values({
-        userId,
-        pageId: newParentId,
-        title: 'Task List',
-        status: 'pending',
-      }).returning()
-      taskList = created
-
-      await tx.insert(taskStatusConfigs).values(
-        DEFAULT_TASK_STATUSES.map(s => ({ taskListId: created.id, ...s }))
-      )
-    }
-
-    // Idempotent: skip if task_items row already exists
-    const existing = await tx.query.taskItems.findFirst({
-      where: eq(taskItems.pageId, movedPageId),
-    })
-    if (existing) return
-
-    // Position after the last task in the new parent
-    const lastChild = await tx.query.pages.findFirst({
-      where: and(eq(pages.parentId, newParentId), eq(pages.isTrashed, false)),
-      orderBy: [desc(pages.position)],
-    })
-    const position = (lastChild?.position ?? 0) + 1
-
-    await tx.insert(taskItems).values({
-      userId,
-      pageId: movedPageId,
-      status: 'pending',
-      priority: 'medium',
-      position,
-    })
+  if (action.shouldAdd && newParentId) {
+    await addTaskItemUnderParent(tx, { pageId: movedPageId, parentId: newParentId, userId })
   }
+}
+
+/**
+ * Self-heal: ensure every given TASK_LIST child of `parentId` has a `task_items` row.
+ * Backfills rows missed by any creation/move path (or created before this invariant
+ * was enforced). Caller is responsible for passing only TASK_LIST children of `parentId`.
+ *
+ * Reads on the connection first and only opens a transaction when something is actually
+ * missing, so the common (nothing-to-heal) case on this hot read path stays cheap.
+ */
+export async function backfillMissingTaskItems(
+  database: Tx,
+  params: { parentId: string; childPageIds: string[]; userId: string },
+): Promise<void> {
+  const { parentId, childPageIds, userId } = params
+  if (childPageIds.length === 0) return
+
+  const existingRows = await database
+    .select({ pageId: taskItems.pageId })
+    .from(taskItems)
+    .where(inArray(taskItems.pageId, childPageIds))
+
+  const missing = selectMissingTaskItemPageIds({
+    childPageIds,
+    existingTaskItemPageIds: existingRows.map(r => r.pageId),
+  })
+  if (missing.length === 0) return
+
+  await database.transaction(async (tx) => {
+    for (const pageId of missing) {
+      await addTaskItemUnderParent(tx, { pageId, parentId, userId })
+    }
+  })
 }

--- a/apps/web/src/services/api/task-sync-service.ts
+++ b/apps/web/src/services/api/task-sync-service.ts
@@ -68,9 +68,12 @@ async function addTaskItemUnderParent(
     orderBy: [desc(pages.position)],
   })
 
+  // ON CONFLICT DO NOTHING guards the self-heal race: concurrent GETs on a legacy list
+  // can both pass the findFirst check above, and task_items.pageId is unique — without
+  // this a second insert would 500 the read. The findFirst stays as a cheap fast path.
   await tx.insert(taskItems).values(
     buildTaskItemInsert({ pageId, userId, lastChildPosition: lastChild?.position ?? null }),
-  )
+  ).onConflictDoNothing({ target: taskItems.pageId })
 }
 
 /**


### PR DESCRIPTION
## Problem

A **Task List** page nested inside another Task List should show up as a task item in the parent list — but it didn't reliably, **no matter where it was created from or moved from**.

**Root cause:** Task-list membership is determined by the page tree (`pages.parentId` → a TASK_LIST parent), but the parent-list view (`GET /api/pages/[pageId]/tasks`) also requires a `task_items` sidecar row. Several write paths created or re-parented the page **without** creating that row, so the sub-list was silently invisible.

Paths that broke the invariant:
- `pageService.createPage` — the generic "new page" button **and** MCP `create_page` (the main "created anywhere" gap)
- `bulk-copy` (top-level + recursive children)
- restore-from-trash (orphan re-parent loop)
- `bulk-delete` (child re-parent loop)

The dedicated create-task button, drag-reorder, and bulk-move already created the row correctly.

## Approach

Decision logic is factored into a **pure module** (`task-membership.ts`) with thin DB shells in `task-sync-service.ts`. The invariant is then enforced at every path that sets `parentId`, plus a self-healing read path:

- **`task-membership.ts`** (pure, no I/O): `shouldHaveTaskItem`, `resolveTaskItemSyncAction`, `nextTaskItemPosition`, `buildTaskItemInsert`, `selectMissingTaskItemPageIds`.
- **`task-sync-service.ts`** (shells): `ensureTaskItemForPage`, `syncTaskItemOnMove` (refactored to reuse the pure resolver), `backfillMissingTaskItems`.
- Wired into `createPage`, `bulk-copy`, `restore`, `bulk-delete`.
- **GET `/tasks` self-heals**: backfills any missing row on read so existing broken data repairs itself on next view. It checks on the connection first and only opens a transaction when something is actually missing, keeping the hot read path cheap.

## Tests

- 19 pure-logic tests (`task-membership.test.ts`)
- 13 shell-orchestration tests (`task-sync-service.test.ts`)
- Existing route-test mocks updated to model the new in-transaction queries
- **144 tests pass** across the 6 affected files; touched files typecheck and lint clean.

## Validation

```
vitest run (6 affected files) → 144 passed
tsc --noEmit → 0 errors in touched files
eslint (touched files) → clean
```

End-to-end check against a live instance (MCP create/move/trash/restore flows) is still worth doing before merge; the unit/integration layer is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)