### PR TITLE
fix(favorites): keep favorites in sync across devices

### DIFF
--- a/apps/web/src/components/drives/DrivesBrowser.tsx
+++ b/apps/web/src/components/drives/DrivesBrowser.tsx
@@ -21,7 +21,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { useDriveStore, type Drive } from "@/hooks/useDrive";
-import { useFavorites } from "@/hooks/useFavorites";
+import { useFavorites, useFavoritesSync } from "@/hooks/useFavorites";
 import { fetchWithAuth } from "@/lib/auth/auth-fetch";
 import CreateDriveDialog from "@/components/layout/left-sidebar/CreateDriveDialog";
 import { DriveContextMenu } from "./DriveContextMenu";
@@ -72,20 +72,13 @@ export default function DrivesBrowser() {
 
   const {
     isFavorite,
-    fetchFavorites,
-    isSynced,
     driveIds: favoriteDriveIds,
   } = useFavorites();
+  useFavoritesSync();
 
   useEffect(() => {
     fetchDrives(false, true);
   }, [fetchDrives]);
-
-  useEffect(() => {
-    if (!isSynced) {
-      fetchFavorites();
-    }
-  }, [isSynced, fetchFavorites]);
 
   const handleSort = (key: SortKey) => {
     if (key === sortKey) {

--- a/apps/web/src/components/layout/left-sidebar/FavoritesSection.tsx
+++ b/apps/web/src/components/layout/left-sidebar/FavoritesSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback, type MouseEvent } from "react";
+import { useState, useCallback, type MouseEvent } from "react";
 import { useRouter } from "next/navigation";
 import { ChevronDown, ExternalLink, Folder, MoreHorizontal, Star } from "lucide-react";
 import { useTabsStore } from "@/stores/useTabsStore";
@@ -19,7 +19,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PageTypeIcon } from "@/components/common/PageTypeIcon";
-import { useFavorites } from "@/hooks/useFavorites";
+import { useFavorites, useFavoritesSync } from "@/hooks/useFavorites";
 import { useLayoutStore } from "@/stores/useLayoutStore";
 import { useBreakpoint } from "@/hooks/useBreakpoint";
 import { useCapacitor } from "@/hooks/useCapacitor";
@@ -30,7 +30,8 @@ import { toast } from "sonner";
 
 export default function FavoritesSection() {
   const router = useRouter();
-  const { favorites, isLoading, isSynced, fetchFavorites, removeFavoriteById } = useFavorites();
+  const { favorites, isLoading, isSynced, removeFavoriteById } = useFavorites();
+  useFavoritesSync();
   const isSheetBreakpoint = useBreakpoint("(max-width: 1023px)");
   const setLeftSheetOpen = useLayoutStore((state) => state.setLeftSheetOpen);
   const favoritesCollapsed = useLayoutStore((state) => state.favoritesCollapsed);
@@ -39,12 +40,6 @@ export default function FavoritesSection() {
   const { isNative } = useCapacitor();
   const isTablet = useIsTablet();
   const hideTabActions = isNative && !isTablet;
-
-  useEffect(() => {
-    if (!isSynced) {
-      fetchFavorites();
-    }
-  }, [isSynced, fetchFavorites]);
 
   const handleNavigate = useCallback((href: string, itemType: "page" | "drive", e?: MouseEvent) => {
     if (e && shouldOpenInNewTab(e)) {

--- a/apps/web/src/components/layout/navbar/DriveSwitcher.tsx
+++ b/apps/web/src/components/layout/navbar/DriveSwitcher.tsx
@@ -17,7 +17,7 @@ import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { CustomScrollArea } from "@/components/ui/custom-scroll-area";
 import { useDriveStore, type Drive } from "@/hooks/useDrive";
-import { useFavorites } from "@/hooks/useFavorites";
+import { useFavorites, useFavoritesSync } from "@/hooks/useFavorites";
 import { fetchWithAuth } from "@/lib/auth/auth-fetch";
 import CreateDriveDialog from "@/components/layout/left-sidebar/CreateDriveDialog";
 import { cn } from "@/lib/utils";
@@ -36,7 +36,8 @@ export default function DriveSwitcher() {
   const currentDriveId = useDriveStore((state) => state.currentDriveId);
   const setCurrentDrive = useDriveStore((state) => state.setCurrentDrive);
 
-  const { isFavorite, addFavorite, removeFavorite, fetchFavorites, isSynced, driveIds } = useFavorites();
+  const { isFavorite, addFavorite, removeFavorite, driveIds } = useFavorites();
+  useFavoritesSync();
 
   const { driveId } = params;
   const urlDriveId = Array.isArray(driveId) ? driveId[0] : driveId;
@@ -44,12 +45,6 @@ export default function DriveSwitcher() {
   useEffect(() => {
     fetchDrives();
   }, [fetchDrives]);
-
-  useEffect(() => {
-    if (!isSynced) {
-      fetchFavorites();
-    }
-  }, [isSynced, fetchFavorites]);
 
   useEffect(() => {
     if (urlDriveId && drives.length > 0) {

--- a/apps/web/src/hooks/__tests__/useFavorites.test.ts
+++ b/apps/web/src/hooks/__tests__/useFavorites.test.ts
@@ -173,13 +173,29 @@ describe('useFavorites', () => {
       await addPromise;
     });
 
-    it('given API fails, should rollback optimistic update', async () => {
+    it('given API fails and the server cannot be reached, should rollback optimistic update', async () => {
       vi.mocked(post).mockRejectedValue(new Error('API error'));
+      vi.mocked(fetchWithAuth).mockRejectedValue(new Error('Network error'));
 
       await expect(useFavorites.getState().addFavorite('page-123', 'page')).rejects.toThrow();
 
       // Should have rolled back
       expect(useFavorites.getState().pageIds.has('page-123')).toBe(false);
+    });
+
+    it('given a stale cache where the item is already favorited on the server, should reconcile and resolve', async () => {
+      // POST fails as if the server returned 409 "already favorited"
+      vi.mocked(post).mockRejectedValue(new Error('Already favorited'));
+      // Reconcile fetch shows the item IS favorited on the server
+      vi.mocked(fetchWithAuth).mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          favorites: [createMockFavorite({ id: 'fav-1', page: { id: 'page-123', title: 'T', type: 'DOCUMENT', driveId: 'd1', driveName: 'D' } })],
+        }),
+      } as never);
+
+      await expect(useFavorites.getState().addFavorite('page-123', 'page')).resolves.toBeUndefined();
+      expect(useFavorites.getState().isFavorite('page-123', 'page')).toBe(true);
     });
   });
 
@@ -204,17 +220,43 @@ describe('useFavorites', () => {
       expect(del).toHaveBeenCalledWith('/api/user/favorites/fav-1');
     });
 
-    it('given page not in favorites, should just update local state', async () => {
+    it('given page not in favorites locally or on the server, should just clean up local state', async () => {
       useFavorites.setState({
         favorites: [],
-        pageIds: new Set(['page-123']), // In local set but not synced
+        pageIds: new Set(['page-123']), // stale: lookup Set says favorited but it is not
         driveIds: new Set(),
       });
+      // Reconcile fetch confirms it is not favorited
+      vi.mocked(fetchWithAuth).mockResolvedValue({
+        ok: true,
+        json: async () => ({ favorites: [] }),
+      } as never);
 
       await useFavorites.getState().removeFavorite('page-123', 'page');
 
       expect(del).not.toHaveBeenCalled();
       expect(useFavorites.getState().pageIds.has('page-123')).toBe(false);
+    });
+
+    it('given the favorite is missing from the local array but exists on the server, should reconcile and call the delete API', async () => {
+      useFavorites.setState({
+        favorites: [], // stale: array empty even though it is favorited on the server
+        pageIds: new Set(['page-123']),
+        driveIds: new Set(),
+      });
+      // Reconcile fetch returns the real favorite with its DB id
+      vi.mocked(fetchWithAuth).mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          favorites: [createMockFavorite({ id: 'fav-1', page: { id: 'page-123', title: 'T', type: 'DOCUMENT', driveId: 'd1', driveName: 'D' } })],
+        }),
+      } as never);
+      vi.mocked(del).mockResolvedValue({} as never);
+
+      await useFavorites.getState().removeFavorite('page-123', 'page');
+
+      expect(del).toHaveBeenCalledWith('/api/user/favorites/fav-1');
+      expect(useFavorites.getState().isFavorite('page-123', 'page')).toBe(false);
     });
   });
 

--- a/apps/web/src/hooks/useFavorites.ts
+++ b/apps/web/src/hooks/useFavorites.ts
@@ -237,6 +237,16 @@ export const useFavorites = create<FavoritesState>()(
         pageIds: state.pageIds,
         driveIds: state.driveIds,
       }),
+      // Force `isSynced` back to false on every rehydrate. Not persisting it is
+      // not enough: users upgrading from a build that DID persist it still have
+      // `isSynced: true` in localStorage, and the default merge would restore it —
+      // causing the load-time revalidation to be skipped. Overriding here
+      // guarantees every load revalidates against the server.
+      merge: (persisted, current) => ({
+        ...current,
+        ...(persisted as Partial<FavoritesState>),
+        isSynced: false,
+      }),
     }
   )
 );

--- a/apps/web/src/hooks/useFavorites.ts
+++ b/apps/web/src/hooks/useFavorites.ts
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { post, del, fetchWithAuth } from '@/lib/auth/auth-fetch';
@@ -63,6 +64,10 @@ export const useFavorites = create<FavoritesState>()(
       },
 
       addFavorite: async (id: string, itemType: 'page' | 'drive' = 'page') => {
+        // Snapshot the lookup Sets so we can roll back if the server can't be reached
+        const prevPageIds = new Set(get().pageIds);
+        const prevDriveIds = new Set(get().driveIds);
+
         // Optimistic update using functional set to prevent race conditions
         if (itemType === 'page') {
           set(state => ({ pageIds: new Set(state.pageIds).add(id) }));
@@ -72,72 +77,79 @@ export const useFavorites = create<FavoritesState>()(
 
         try {
           await post('/api/user/favorites', { itemType, itemId: id });
-          // Refetch to get the full favorite object with ID
+          // Refetch to get the full favorite object with ID and reconcile with server
           await get().fetchFavorites();
         } catch (error) {
-          // Rollback on error using functional set
-          if (itemType === 'page') {
-            set(state => {
-              const rollbackIds = new Set(state.pageIds);
-              rollbackIds.delete(id);
-              return { pageIds: rollbackIds };
-            });
-          } else {
-            set(state => {
-              const rollbackIds = new Set(state.driveIds);
-              rollbackIds.delete(id);
-              return { driveIds: rollbackIds };
-            });
+          // The POST can fail with 409 ("already favorited") when this device's
+          // cache was stale. Reconcile with the server: if the item ends up
+          // favorited, treat it as success; otherwise surface the error.
+          await get().fetchFavorites();
+          if (get().isSynced) {
+            // Server state is now authoritative (fetchFavorites overwrote the Sets);
+            // succeed if it's favorited, otherwise report the original error.
+            if (get().isFavorite(id, itemType)) {
+              return;
+            }
+            throw error;
           }
+          // Couldn't reach the server to confirm — roll back the optimistic update
+          set({ pageIds: prevPageIds, driveIds: prevDriveIds });
           throw error;
         }
       },
 
       removeFavorite: async (id: string, itemType: 'page' | 'drive' = 'page') => {
-        // Find the favorite from current state
-        const favorite = get().favorites.find(f => {
-          if (itemType === 'page' && f.page?.id === id) return true;
-          if (itemType === 'drive' && f.drive?.id === id) return true;
-          return false;
-        });
+        const matches = (f: FavoriteItem) =>
+          (itemType === 'page' && f.page?.id === id) ||
+          (itemType === 'drive' && f.drive?.id === id);
 
-        // Optimistic update: remove from both the favorites array and the lookup Sets
-        set(state => {
-          const newPageIds = new Set(state.pageIds);
-          const newDriveIds = new Set(state.driveIds);
-          if (itemType === 'page') {
-            newPageIds.delete(id);
-          } else {
-            newDriveIds.delete(id);
-          }
-          const newFavorites = favorite
-            ? state.favorites.filter(f => f.id !== favorite.id)
-            : state.favorites;
-          return { favorites: newFavorites, pageIds: newPageIds, driveIds: newDriveIds };
-        });
+        // We need the favorite's DB id to delete it. If this device's cache is
+        // stale and doesn't contain the entry, reconcile with the server first —
+        // otherwise the removal would silently no-op and the favorite would
+        // reappear on the next sync.
+        let favorite = get().favorites.find(matches);
+        if (!favorite) {
+          await get().fetchFavorites();
+          favorite = get().favorites.find(matches);
+        }
 
         if (!favorite) {
+          // Genuinely not favorited on the server — just make sure the local
+          // lookup Sets are clean so the star reflects reality.
+          set(state => {
+            const newPageIds = new Set(state.pageIds);
+            const newDriveIds = new Set(state.driveIds);
+            if (itemType === 'page') newPageIds.delete(id);
+            else newDriveIds.delete(id);
+            return { pageIds: newPageIds, driveIds: newDriveIds };
+          });
           return;
         }
 
+        // Snapshot for rollback
+        const removeId = favorite.id;
+        const prevFavorites = get().favorites;
+        const prevPageIds = new Set(get().pageIds);
+        const prevDriveIds = new Set(get().driveIds);
+
+        // Optimistic removal from both the favorites array and the lookup Sets
+        set(state => {
+          const newPageIds = new Set(state.pageIds);
+          const newDriveIds = new Set(state.driveIds);
+          if (itemType === 'page') newPageIds.delete(id);
+          else newDriveIds.delete(id);
+          return {
+            favorites: state.favorites.filter(f => f.id !== removeId),
+            pageIds: newPageIds,
+            driveIds: newDriveIds,
+          };
+        });
+
         try {
-          await del(`/api/user/favorites/${favorite.id}`);
+          await del(`/api/user/favorites/${removeId}`);
         } catch (error) {
-          // Rollback on error: restore both the favorites array and the lookup Sets
-          set(state => {
-            const restoredPageIds = new Set(state.pageIds);
-            const restoredDriveIds = new Set(state.driveIds);
-            if (itemType === 'page') {
-              restoredPageIds.add(id);
-            } else {
-              restoredDriveIds.add(id);
-            }
-            return {
-              favorites: [...state.favorites, favorite],
-              pageIds: restoredPageIds,
-              driveIds: restoredDriveIds,
-            };
-          });
+          // Rollback on error
+          set({ favorites: prevFavorites, pageIds: prevPageIds, driveIds: prevDriveIds });
           throw error;
         }
       },
@@ -216,12 +228,59 @@ export const useFavorites = create<FavoritesState>()(
           return value;
         },
       }),
+      // NOTE: `isSynced` is deliberately NOT persisted. The persisted copy is only
+      // a fast first-paint cache; on every load `isSynced` rehydrates as false so
+      // the store revalidates against the database (stale-while-revalidate). This
+      // is what keeps favorites consistent across devices.
       partialize: (state) => ({
         favorites: state.favorites,
         pageIds: state.pageIds,
         driveIds: state.driveIds,
-        isSynced: state.isSynced,
       }),
     }
   )
 );
+
+/**
+ * Keeps the favorites store in sync with the server.
+ *
+ * Favorites are database-backed; the persisted localStorage copy is only a fast
+ * first-paint cache. Because `isSynced` is not persisted, every mount revalidates
+ * against the server. We additionally revalidate when the tab/app regains focus
+ * so a device that was in the background (e.g. mobile) picks up changes made on
+ * another device. `fetchFavorites` de-dupes concurrent calls via `isLoading`, so
+ * mounting this in several components is safe.
+ */
+export function useFavoritesSync(): void {
+  const fetchFavorites = useFavorites((s) => s.fetchFavorites);
+  const isSynced = useFavorites((s) => s.isSynced);
+  const lastRevalidatedAt = useRef(0);
+
+  useEffect(() => {
+    if (!isSynced) {
+      fetchFavorites();
+    }
+  }, [isSynced, fetchFavorites]);
+
+  useEffect(() => {
+    const revalidate = () => {
+      if (typeof document !== 'undefined' && document.visibilityState !== 'visible') {
+        return;
+      }
+      // Throttle bursts (focus + visibilitychange can fire together)
+      const now = Date.now();
+      if (now - lastRevalidatedAt.current < 3000) {
+        return;
+      }
+      lastRevalidatedAt.current = now;
+      fetchFavorites();
+    };
+
+    window.addEventListener('focus', revalidate);
+    document.addEventListener('visibilitychange', revalidate);
+    return () => {
+      window.removeEventListener('focus', revalidate);
+      document.removeEventListener('visibilitychange', revalidate);
+    };
+  }, [fetchFavorites]);
+}


### PR DESCRIPTION
## Problem

Favorites are database-backed, but the client reads them through a Zustand store that **persisted `isSynced` to localStorage**. Once a device had synced, it never re-fetched, so:

- Favorites added/removed on another device (e.g. mobile) never appeared — the device kept rendering its stale localStorage copy.
- Add/remove operated against that stale cache: **remove silently no-oped** when the favorite wasn't in the local `favorites` array (the DELETE was never sent), and **add bounced off a `409 "already favorited"`** (the star rolled back even though it was favorited).

## Fix

- **Stop persisting `isSynced`** — every load now revalidates against the database (stale-while-revalidate; the persisted list remains only a fast first-paint cache).
- **Reset `isSynced` on rehydrate** — not persisting it isn't enough on its own: users upgrading from a build that *did* persist `isSynced: true` would have it merged back by Zustand's default merge, re-skipping the load-time revalidation. A custom persist `merge` now forces `isSynced: false` on every rehydrate, covering the legacy-storage upgrade path. (Addresses review feedback.)
- **`useFavoritesSync` hook** — revalidates on mount and on window `focus` / `visibilitychange` (throttled to 3s), so a backgrounded device (mobile) picks up changes made elsewhere without a manual reload. Wired into `FavoritesSection`, `DriveSwitcher`, and `DrivesBrowser`, replacing their duplicated `if (!isSynced) fetch` effects.
- **`removeFavorite`** reconciles with the server when the favorite is missing from the local cache (fetch → find real id → delete), instead of silently no-oping.
- **`addFavorite`** treats a duplicate (`409`) as success after reconciling with the server, instead of rolling the star back; only rolls back when the server genuinely can't be reached.

## Files

- `apps/web/src/hooks/useFavorites.ts` — store changes + `useFavoritesSync` hook + persist `merge`
- `apps/web/src/components/layout/left-sidebar/FavoritesSection.tsx`
- `apps/web/src/components/layout/navbar/DriveSwitcher.tsx`
- `apps/web/src/components/drives/DrivesBrowser.tsx`
- `apps/web/src/hooks/__tests__/useFavorites.test.ts` — reconcile-path tests

## Validation

- CI green: **Unit Tests**, **Lint & TypeScript Check**, CodeRabbit, and Vercel preview all pass.
- Added store tests for both reconcile paths (stale add → 409 reconcile resolves; stale remove → fetch-then-delete calls the API) and updated the two existing failure-path tests to be deterministic about the new reconcile fetch.

## Notes

- Possible follow-up: real-time invalidation over Socket.IO so other open sessions update live without waiting for focus/reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
