### PR TITLE
feat(sandbox): PR1 — safety foundation & policy (Agent Code Execution)

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -172,6 +172,11 @@
       "import": "./dist/services/sandbox/can-run-code.js",
       "require": "./dist/services/sandbox/can-run-code.js"
     },
+    "./services/sandbox/execution-policy": {
+      "types": "./dist/services/sandbox/execution-policy.d.ts",
+      "import": "./dist/services/sandbox/execution-policy.js",
+      "require": "./dist/services/sandbox/execution-policy.js"
+    },
     "./services/upload-validation": {
       "types": "./dist/services/upload-validation.d.ts",
       "import": "./dist/services/upload-validation.js",
@@ -807,6 +812,9 @@
       ],
       "services/sandbox/can-run-code": [
         "./dist/services/sandbox/can-run-code.d.ts"
+      ],
+      "services/sandbox/execution-policy": [
+        "./dist/services/sandbox/execution-policy.d.ts"
       ],
       "services/memory-monitor": [
         "./dist/services/memory-monitor.d.ts"

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -177,6 +177,11 @@
       "import": "./dist/services/sandbox/execution-policy.js",
       "require": "./dist/services/sandbox/execution-policy.js"
     },
+    "./services/sandbox/sandbox-env": {
+      "types": "./dist/services/sandbox/sandbox-env.d.ts",
+      "import": "./dist/services/sandbox/sandbox-env.js",
+      "require": "./dist/services/sandbox/sandbox-env.js"
+    },
     "./services/upload-validation": {
       "types": "./dist/services/upload-validation.d.ts",
       "import": "./dist/services/upload-validation.js",
@@ -815,6 +820,9 @@
       ],
       "services/sandbox/execution-policy": [
         "./dist/services/sandbox/execution-policy.d.ts"
+      ],
+      "services/sandbox/sandbox-env": [
+        "./dist/services/sandbox/sandbox-env.d.ts"
       ],
       "services/memory-monitor": [
         "./dist/services/memory-monitor.d.ts"

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -187,6 +187,11 @@
       "import": "./dist/services/sandbox/quota.js",
       "require": "./dist/services/sandbox/quota.js"
     },
+    "./services/sandbox/audit": {
+      "types": "./dist/services/sandbox/audit.d.ts",
+      "import": "./dist/services/sandbox/audit.js",
+      "require": "./dist/services/sandbox/audit.js"
+    },
     "./services/upload-validation": {
       "types": "./dist/services/upload-validation.d.ts",
       "import": "./dist/services/upload-validation.js",
@@ -831,6 +836,9 @@
       ],
       "services/sandbox/quota": [
         "./dist/services/sandbox/quota.d.ts"
+      ],
+      "services/sandbox/audit": [
+        "./dist/services/sandbox/audit.d.ts"
       ],
       "services/memory-monitor": [
         "./dist/services/memory-monitor.d.ts"

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -182,6 +182,11 @@
       "import": "./dist/services/sandbox/sandbox-env.js",
       "require": "./dist/services/sandbox/sandbox-env.js"
     },
+    "./services/sandbox/quota": {
+      "types": "./dist/services/sandbox/quota.d.ts",
+      "import": "./dist/services/sandbox/quota.js",
+      "require": "./dist/services/sandbox/quota.js"
+    },
     "./services/upload-validation": {
       "types": "./dist/services/upload-validation.d.ts",
       "import": "./dist/services/upload-validation.js",
@@ -823,6 +828,9 @@
       ],
       "services/sandbox/sandbox-env": [
         "./dist/services/sandbox/sandbox-env.d.ts"
+      ],
+      "services/sandbox/quota": [
+        "./dist/services/sandbox/quota.d.ts"
       ],
       "services/memory-monitor": [
         "./dist/services/memory-monitor.d.ts"

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -167,6 +167,11 @@
       "import": "./dist/services/upload-semaphore.js",
       "require": "./dist/services/upload-semaphore.js"
     },
+    "./services/sandbox/can-run-code": {
+      "types": "./dist/services/sandbox/can-run-code.d.ts",
+      "import": "./dist/services/sandbox/can-run-code.js",
+      "require": "./dist/services/sandbox/can-run-code.js"
+    },
     "./services/upload-validation": {
       "types": "./dist/services/upload-validation.d.ts",
       "import": "./dist/services/upload-validation.js",
@@ -799,6 +804,9 @@
       ],
       "services/upload-semaphore": [
         "./dist/services/upload-semaphore.d.ts"
+      ],
+      "services/sandbox/can-run-code": [
+        "./dist/services/sandbox/can-run-code.d.ts"
       ],
       "services/memory-monitor": [
         "./dist/services/memory-monitor.d.ts"

--- a/packages/lib/src/config/env-validation.ts
+++ b/packages/lib/src/config/env-validation.ts
@@ -62,9 +62,10 @@ export const serverEnvSchema = z
     CRON_SECRET: z.string().min(1).optional(),
     COOKIE_DOMAIN: z.string().min(1).optional(),
 
-    // Agent code execution global kill-switch (default OFF). Only 'true' enables
-    // the feature; absence or any other value keeps execution disabled.
-    CODE_EXECUTION_ENABLED: z.enum(['true', 'false']).optional(),
+    // Agent code execution global kill-switch (default OFF). Accept any string so
+    // a stray value (e.g. CODE_EXECUTION_ENABLED=0) never fails app-wide env
+    // validation; isCodeExecutionEnabled() enables only on the exact value 'true'.
+    CODE_EXECUTION_ENABLED: z.string().optional(),
   })
   .superRefine((data, ctx) => {
     // In non-test environments, require CSRF_SECRET and ENCRYPTION_KEY

--- a/packages/lib/src/config/env-validation.ts
+++ b/packages/lib/src/config/env-validation.ts
@@ -61,6 +61,10 @@ export const serverEnvSchema = z
     REALTIME_BROADCAST_SECRET: z.string().min(1).optional(),
     CRON_SECRET: z.string().min(1).optional(),
     COOKIE_DOMAIN: z.string().min(1).optional(),
+
+    // Agent code execution global kill-switch (default OFF). Only 'true' enables
+    // the feature; absence or any other value keeps execution disabled.
+    CODE_EXECUTION_ENABLED: z.enum(['true', 'false']).optional(),
   })
   .superRefine((data, ctx) => {
     // In non-test environments, require CSRF_SECRET and ENCRYPTION_KEY

--- a/packages/lib/src/monitoring/activity-logger.ts
+++ b/packages/lib/src/monitoring/activity-logger.ts
@@ -272,7 +272,9 @@ export type ActivityOperation =
   | 'rollback'
   // AI conversation undo operations
   | 'conversation_undo'
-  | 'conversation_undo_with_changes';
+  | 'conversation_undo_with_changes'
+  // Agent code execution (sandbox runs)
+  | 'code_execution';
 
 export type ActivityResourceType =
   | 'page'

--- a/packages/lib/src/security/distributed-rate-limit.ts
+++ b/packages/lib/src/security/distributed-rate-limit.ts
@@ -582,6 +582,16 @@ export const DISTRIBUTED_RATE_LIMITS = {
     blockDurationMs: 15 * 60 * 1000,
     progressiveDelay: false,
   },
+  // Agent code execution daily run budget. Applied per scoped identifier
+  // (user / drive / tenant) so one actor cannot exhaust another's allowance.
+  // The hard cost ceiling is Vercel account-level Spend Management; this is our
+  // app-level run-count control that complements per-tier concurrency limits.
+  CODE_EXECUTION: {
+    maxAttempts: 100,
+    windowMs: 24 * 60 * 60 * 1000,
+    blockDurationMs: 24 * 60 * 60 * 1000,
+    progressiveDelay: false,
+  },
 } as const;
 
 // =============================================================================

--- a/packages/lib/src/services/sandbox/__tests__/audit.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/audit.test.ts
@@ -86,6 +86,21 @@ describe('buildAuditRecord', () => {
   it('should not flag short code as truncated', () => {
     expect(buildAuditRecord(baseInput).codeTruncated).toBe(false);
   });
+
+  it('should redact in linear time on an adversarial key-repetition payload', () => {
+    // CodeQL js/polynomial-redos: the original `X* keyword X*` assignment regex
+    // backtracks polynomially on many repetitions of "key". Redaction runs over
+    // the whole (agent-supplied) code, so this is an attacker-triggerable CPU
+    // exhaustion path. A linear matcher must stay fast even on a pathological
+    // payload while still redacting a real secret elsewhere in the input.
+    const secret = 'supersecretvalue0123456789abcdef';
+    const payload = `const API_KEY = "${secret}"\n${'key'.repeat(20000)}`;
+    const start = performance.now();
+    const record = buildAuditRecord({ ...baseInput, code: payload });
+    const elapsedMs = performance.now() - start;
+    expect(record.code).not.toContain(secret);
+    expect(elapsedMs).toBeLessThan(1000);
+  });
 });
 
 describe('buildActivityLogInput', () => {

--- a/packages/lib/src/services/sandbox/__tests__/audit.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/audit.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildAuditRecord,
+  buildActivityLogInput,
+  buildSecurityAuditEvent,
+  writeCodeExecutionAudit,
+  type CodeExecutionAuditInput,
+  type WriteAuditDeps,
+} from '../audit';
+
+const baseInput: CodeExecutionAuditInput = {
+  userId: 'u1',
+  actorEmail: 'dev@example.com',
+  actorDisplayName: 'Dev',
+  driveId: 'd1',
+  conversationId: 'c1',
+  profile: 'default',
+  code: 'console.log("hello")',
+  exitCode: 0,
+  durationMs: 1234,
+  costUsd: 0.0021,
+  timestamp: new Date('2026-06-01T00:00:00.000Z'),
+};
+
+describe('buildAuditRecord', () => {
+  it('should capture the full immutable shape: actor, code, profile, exit, duration, cost, timestamp', () => {
+    const record = buildAuditRecord(baseInput);
+    expect(record).toMatchObject({
+      userId: 'u1',
+      actorEmail: 'dev@example.com',
+      profile: 'default',
+      exitCode: 0,
+      durationMs: 1234,
+      costUsd: 0.0021,
+      timestampIso: '2026-06-01T00:00:00.000Z',
+    });
+    expect(typeof record.code).toBe('string');
+  });
+
+  it('should default cost to zero and origin to user when omitted', () => {
+    const { costUsd: _cost, requestOrigin: _origin, ...rest } = baseInput;
+    const record = buildAuditRecord(rest);
+    expect(record.costUsd).toBe(0);
+    expect(record.requestOrigin).toBe('user');
+  });
+
+  it('should redact secret assignments in the captured code', () => {
+    const record = buildAuditRecord({
+      ...baseInput,
+      code: 'const API_KEY = "fakesecretvalue0123456789abcdefghij"\nrun()',
+    });
+    expect(record.code).not.toContain('fakesecretvalue0123456789abcdefghij');
+    expect(record.code).toContain('run()');
+  });
+
+  it('should redact bearer tokens and high-entropy standalone tokens', () => {
+    const record = buildAuditRecord({
+      ...baseInput,
+      code: 'fetch(u, { headers: { Authorization: "Bearer abcDEF123456ghiJKL789mnoPQR0" } })',
+    });
+    expect(record.code).not.toContain('abcDEF123456ghiJKL789mnoPQR0');
+  });
+
+  it('should truncate over-long code and flag that it was truncated', () => {
+    const record = buildAuditRecord({ ...baseInput, code: 'a();\n'.repeat(2000) });
+    expect(record.codeTruncated).toBe(true);
+    expect(record.code.length).toBeLessThan(10_000);
+  });
+
+  it('should not flag short code as truncated', () => {
+    expect(buildAuditRecord(baseInput).codeTruncated).toBe(false);
+  });
+});
+
+describe('buildActivityLogInput', () => {
+  it('should map to the code_execution activity operation', () => {
+    const input = buildActivityLogInput(buildAuditRecord(baseInput));
+    expect(input.operation).toBe('code_execution');
+    expect(input.userId).toBe('u1');
+    expect(input.actorEmail).toBe('dev@example.com');
+  });
+
+  it('should scope the activity to the conversation when present', () => {
+    const input = buildActivityLogInput(buildAuditRecord(baseInput));
+    expect(input.resourceType).toBe('conversation');
+    expect(input.resourceId).toBe('c1');
+  });
+
+  it('should carry the redacted code, never the raw secret', () => {
+    const record = buildAuditRecord({
+      ...baseInput,
+      code: 'token="faketokenvalue0123456789abcdefghijklmn"',
+    });
+    const input = buildActivityLogInput(record);
+    expect(JSON.stringify(input)).not.toContain('faketokenvalue0123456789abcdefghijklmn');
+  });
+});
+
+describe('buildSecurityAuditEvent', () => {
+  it('should produce no security event for a clean run', () => {
+    expect(buildSecurityAuditEvent(buildAuditRecord(baseInput))).toBeNull();
+  });
+
+  it('should emit an anomaly event flagged with the anomaly kind', () => {
+    const record = buildAuditRecord({ ...baseInput, anomaly: 'timeout', exitCode: null });
+    const event = buildSecurityAuditEvent(record);
+    expect(event?.anomalyFlags).toContain('timeout');
+    expect(event?.userId).toBe('u1');
+    expect((event?.riskScore ?? 0)).toBeGreaterThan(0);
+  });
+});
+
+describe('writeCodeExecutionAudit', () => {
+  function makeDeps() {
+    const activityCalls: unknown[] = [];
+    const securityCalls: unknown[] = [];
+    const deps: WriteAuditDeps = {
+      logActivity: async (input) => {
+        activityCalls.push(input);
+      },
+      logSecurityEvent: async (event) => {
+        securityCalls.push(event);
+      },
+    };
+    return { deps, activityCalls, securityCalls };
+  }
+
+  it('should always write the activity audit record', async () => {
+    const { deps, activityCalls } = makeDeps();
+    await writeCodeExecutionAudit({ input: baseInput, deps });
+    expect(activityCalls).toHaveLength(1);
+  });
+
+  it('should route an anomalous run to the security audit log', async () => {
+    const { deps, securityCalls } = makeDeps();
+    await writeCodeExecutionAudit({
+      input: { ...baseInput, anomaly: 'blocked_command' },
+      deps,
+    });
+    expect(securityCalls).toHaveLength(1);
+  });
+
+  it('should not write a security event for a clean run', async () => {
+    const { deps, securityCalls } = makeDeps();
+    await writeCodeExecutionAudit({ input: baseInput, deps });
+    expect(securityCalls).toHaveLength(0);
+  });
+
+  it('should never throw even when an audit sink fails', async () => {
+    const deps: WriteAuditDeps = {
+      logActivity: async () => {
+        throw new Error('activity sink down');
+      },
+      logSecurityEvent: async () => {
+        throw new Error('security sink down');
+      },
+    };
+    await expect(
+      writeCodeExecutionAudit({ input: { ...baseInput, anomaly: 'oom' }, deps }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/lib/src/services/sandbox/__tests__/audit.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/audit.test.ts
@@ -64,7 +64,23 @@ describe('buildAuditRecord', () => {
   it('should truncate over-long code and flag that it was truncated', () => {
     const record = buildAuditRecord({ ...baseInput, code: 'a();\n'.repeat(2000) });
     expect(record.codeTruncated).toBe(true);
+    // Loose bound (cap is 4000): redaction can expand a short match to the
+    // 14-char ***REDACTED*** marker, so we only assert it shrank well below input.
     expect(record.code.length).toBeLessThan(10_000);
+  });
+
+  it('should still redact a secret assignment that straddles the truncation cap', () => {
+    // Push a quoted secret assignment so it begins just before the 4 KB cap and
+    // its closing quote falls past it — the case that leaked when truncation
+    // happened before redaction.
+    const secret = 'straddlingsecretvalue0123456789abcdef';
+    // 4000 chars of non-collapsing code pushes the assignment to the cap boundary.
+    const record = buildAuditRecord({
+      ...baseInput,
+      code: `${'a();\n'.repeat(800)}const SECRET_TOKEN = "${secret}"\n`,
+    });
+    expect(record.code).not.toContain(secret);
+    expect(record.codeTruncated).toBe(true);
   });
 
   it('should not flag short code as truncated', () => {

--- a/packages/lib/src/services/sandbox/__tests__/can-run-code.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/can-run-code.test.ts
@@ -47,7 +47,6 @@ function makeDeps(overrides: Partial<CanRunCodeDeps> = {}): CanRunCodeDeps {
   return {
     getUserDrivePermissions: async () => adminPerms,
     getAgentAccessLevel: async () => agentEditPerms,
-    isCloud: () => true,
     isCodeExecutionEnabled: () => true,
     ...overrides,
   };
@@ -75,15 +74,6 @@ describe('canRunCode', () => {
       deps: makeDeps({ isCodeExecutionEnabled: () => false }),
     });
     expect(result).toEqual({ ok: false, reason: 'kill_switch_off' });
-  });
-
-  it('given a non-cloud deployment, should deny', async () => {
-    const result = await canRunCode({
-      userId: 'u1',
-      driveId: 'd1',
-      deps: makeDeps({ isCloud: () => false }),
-    });
-    expect(result).toEqual({ ok: false, reason: 'not_cloud' });
   });
 
   it('given a user with no drive membership, should deny', async () => {

--- a/packages/lib/src/services/sandbox/__tests__/can-run-code.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/can-run-code.test.ts
@@ -105,6 +105,28 @@ describe('canRunCode', () => {
     expect(result.ok).toBe(true);
   });
 
+  it('given an agent actor whose triggering user is only a plain member, should deny on the user gate', async () => {
+    const result = await canRunCode({
+      userId: 'u1',
+      driveId: 'd1',
+      requestOrigin: 'agent',
+      agentPageId: 'agent1',
+      deps: makeDeps({ getUserDrivePermissions: async () => memberPerms }),
+    });
+    expect(result).toEqual({ ok: false, reason: 'insufficient_role' });
+  });
+
+  it('given an agent actor whose triggering user has no drive membership, should deny on the user gate', async () => {
+    const result = await canRunCode({
+      userId: 'u1',
+      driveId: 'd1',
+      requestOrigin: 'agent',
+      agentPageId: 'agent1',
+      deps: makeDeps({ getUserDrivePermissions: async () => null }),
+    });
+    expect(result).toEqual({ ok: false, reason: 'no_drive_access' });
+  });
+
   it('given an agent actor without a page id, should deny', async () => {
     const result = await canRunCode({
       userId: 'u1',

--- a/packages/lib/src/services/sandbox/__tests__/can-run-code.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/can-run-code.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import { canRunCode, type CanRunCodeDeps } from '../can-run-code';
+import type { DrivePermissionLevel } from '../../../permissions/permissions';
+import type { PermissionLevel } from '../../../permissions/permissions';
+
+const ownerPerms: DrivePermissionLevel = {
+  hasAccess: true,
+  isOwner: true,
+  isAdmin: false,
+  isMember: false,
+  canEdit: true,
+};
+
+const adminPerms: DrivePermissionLevel = {
+  hasAccess: true,
+  isOwner: false,
+  isAdmin: true,
+  isMember: true,
+  canEdit: true,
+};
+
+const memberPerms: DrivePermissionLevel = {
+  hasAccess: true,
+  isOwner: false,
+  isAdmin: false,
+  isMember: true,
+  canEdit: true,
+};
+
+const agentEditPerms: PermissionLevel = {
+  canView: true,
+  canEdit: true,
+  canShare: false,
+  canDelete: false,
+};
+
+const agentViewOnlyPerms: PermissionLevel = {
+  canView: true,
+  canEdit: false,
+  canShare: false,
+  canDelete: false,
+};
+
+// Fully-permissive deps; individual tests override the single field under test
+// so each test exercises exactly one denial path.
+function makeDeps(overrides: Partial<CanRunCodeDeps> = {}): CanRunCodeDeps {
+  return {
+    getUserDrivePermissions: async () => adminPerms,
+    getAgentAccessLevel: async () => agentEditPerms,
+    isCloud: () => true,
+    isCodeExecutionEnabled: () => true,
+    ...overrides,
+  };
+}
+
+describe('canRunCode', () => {
+  it('given an admin drive member in cloud with the kill-switch on, should allow', async () => {
+    const result = await canRunCode({ userId: 'u1', driveId: 'd1', deps: makeDeps() });
+    expect(result.ok).toBe(true);
+  });
+
+  it('given a drive owner, should allow', async () => {
+    const result = await canRunCode({
+      userId: 'u1',
+      driveId: 'd1',
+      deps: makeDeps({ getUserDrivePermissions: async () => ownerPerms }),
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('given the kill-switch off, should deny regardless of authorization', async () => {
+    const result = await canRunCode({
+      userId: 'u1',
+      driveId: 'd1',
+      deps: makeDeps({ isCodeExecutionEnabled: () => false }),
+    });
+    expect(result).toEqual({ ok: false, reason: 'kill_switch_off' });
+  });
+
+  it('given a non-cloud deployment, should deny', async () => {
+    const result = await canRunCode({
+      userId: 'u1',
+      driveId: 'd1',
+      deps: makeDeps({ isCloud: () => false }),
+    });
+    expect(result).toEqual({ ok: false, reason: 'not_cloud' });
+  });
+
+  it('given a user with no drive membership, should deny', async () => {
+    const result = await canRunCode({
+      userId: 'u1',
+      driveId: 'd1',
+      deps: makeDeps({ getUserDrivePermissions: async () => null }),
+    });
+    expect(result).toEqual({ ok: false, reason: 'no_drive_access' });
+  });
+
+  it('given a plain member without admin/owner role, should deny', async () => {
+    const result = await canRunCode({
+      userId: 'u1',
+      driveId: 'd1',
+      deps: makeDeps({ getUserDrivePermissions: async () => memberPerms }),
+    });
+    expect(result).toEqual({ ok: false, reason: 'insufficient_role' });
+  });
+
+  it('given an agent actor with edit access, should allow', async () => {
+    const result = await canRunCode({
+      userId: 'u1',
+      driveId: 'd1',
+      requestOrigin: 'agent',
+      agentPageId: 'agent1',
+      deps: makeDeps(),
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('given an agent actor without a page id, should deny', async () => {
+    const result = await canRunCode({
+      userId: 'u1',
+      driveId: 'd1',
+      requestOrigin: 'agent',
+      deps: makeDeps(),
+    });
+    expect(result).toEqual({ ok: false, reason: 'no_agent_access' });
+  });
+
+  it('given an agent actor with view-only access, should deny', async () => {
+    const result = await canRunCode({
+      userId: 'u1',
+      driveId: 'd1',
+      requestOrigin: 'agent',
+      agentPageId: 'agent1',
+      deps: makeDeps({ getAgentAccessLevel: async () => agentViewOnlyPerms }),
+    });
+    expect(result).toEqual({ ok: false, reason: 'no_agent_access' });
+  });
+
+  it('given a permission lookup that throws, should fail closed without throwing', async () => {
+    const result = await canRunCode({
+      userId: 'u1',
+      driveId: 'd1',
+      deps: makeDeps({
+        getUserDrivePermissions: async () => {
+          throw new Error('db down');
+        },
+      }),
+    });
+    expect(result).toEqual({ ok: false, reason: 'error' });
+  });
+});

--- a/packages/lib/src/services/sandbox/__tests__/execution-policy.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/execution-policy.test.ts
@@ -25,6 +25,18 @@ describe('resolveExecutionPolicy', () => {
     expect(policy).toEqual(SAFE_MINIMUM_PROFILE);
   });
 
+  it('given a prototype key as the profile, should fall back to the safe minimum (no inherited lookup)', () => {
+    // A bracket lookup would resolve these to truthy Object.prototype members and
+    // skip the fallback, yielding a policy with no bounds. The own-key guard must
+    // treat them as unknown profiles.
+    for (const profile of ['__proto__', 'constructor', 'toString', 'hasOwnProperty']) {
+      const policy = resolveExecutionPolicy({ profile });
+      expect(policy).toEqual(SAFE_MINIMUM_PROFILE);
+      expect(policy.timeoutMs).toBeGreaterThan(0);
+      expect(policy.egressAllowlist).toEqual([]);
+    }
+  });
+
   it('given the minimal profile, should be no more permissive than the default profile', () => {
     const minimal = resolveExecutionPolicy({ profile: 'minimal' });
     const def = resolveExecutionPolicy({ profile: 'default' });

--- a/packages/lib/src/services/sandbox/__tests__/execution-policy.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/execution-policy.test.ts
@@ -41,4 +41,12 @@ describe('resolveExecutionPolicy', () => {
     expect(resolveExecutionPolicy({ profile: 'default' }).profile).toBe('default');
     expect(resolveExecutionPolicy({ profile: 'minimal' }).profile).toBe('minimal');
   });
+
+  it('should return an immutable policy so the default-deny egress baseline cannot be mutated', () => {
+    const policy = resolveExecutionPolicy();
+    expect(() => {
+      (policy.egressAllowlist as string[]).push('evil.example.com');
+    }).toThrow();
+    expect(policy.egressAllowlist).toEqual([]);
+  });
 });

--- a/packages/lib/src/services/sandbox/__tests__/execution-policy.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/execution-policy.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { resolveExecutionPolicy, SAFE_MINIMUM_PROFILE } from '../execution-policy';
+
+describe('resolveExecutionPolicy', () => {
+  it('given no profile, should resolve the default profile with explicit caps', () => {
+    const policy = resolveExecutionPolicy();
+    expect(policy.timeoutMs).toBeGreaterThan(0);
+    expect(policy.vcpus).toBeGreaterThan(0);
+    expect(policy.memoryMb).toBeGreaterThan(0);
+    expect(policy.maxOutputBytes).toBeGreaterThan(0);
+  });
+
+  it('given any profile, should default-deny egress with an empty allowlist', () => {
+    expect(resolveExecutionPolicy({ profile: 'default' }).egressAllowlist).toEqual([]);
+    expect(resolveExecutionPolicy({ profile: 'minimal' }).egressAllowlist).toEqual([]);
+  });
+
+  it('given any profile, should never request a persistent sandbox', () => {
+    expect(resolveExecutionPolicy({ profile: 'default' }).persistent).toBe(false);
+    expect(resolveExecutionPolicy({ profile: 'minimal' }).persistent).toBe(false);
+  });
+
+  it('given an unknown profile, should fall back to the safe minimum', () => {
+    const policy = resolveExecutionPolicy({ profile: 'totally-made-up' });
+    expect(policy).toEqual(SAFE_MINIMUM_PROFILE);
+  });
+
+  it('given the minimal profile, should be no more permissive than the default profile', () => {
+    const minimal = resolveExecutionPolicy({ profile: 'minimal' });
+    const def = resolveExecutionPolicy({ profile: 'default' });
+    expect(minimal.timeoutMs).toBeLessThanOrEqual(def.timeoutMs);
+    expect(minimal.memoryMb).toBeLessThanOrEqual(def.memoryMb);
+    expect(minimal.maxOutputBytes).toBeLessThanOrEqual(def.maxOutputBytes);
+  });
+
+  it('should set an explicit region rather than relying on a platform default', () => {
+    expect(resolveExecutionPolicy().region).toBe('iad1');
+  });
+
+  it('should tag the resolved policy with the profile name it represents', () => {
+    expect(resolveExecutionPolicy({ profile: 'default' }).profile).toBe('default');
+    expect(resolveExecutionPolicy({ profile: 'minimal' }).profile).toBe('minimal');
+  });
+});

--- a/packages/lib/src/services/sandbox/__tests__/quota.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/quota.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  acquireCodeExecutionSlot,
+  releaseCodeExecutionSlot,
+  canAcquireCodeExecutionSlot,
+  getCodeExecutionConcurrencyLimit,
+  resetCodeExecutionConcurrency,
+  checkCodeExecutionQuota,
+  type CodeExecutionQuotaDeps,
+} from '../quota';
+
+const allowAll: CodeExecutionQuotaDeps['checkRateLimit'] = async () => ({
+  allowed: true,
+  attemptsRemaining: 99,
+});
+
+function makeDeps(
+  overrides: Partial<CodeExecutionQuotaDeps> = {},
+): CodeExecutionQuotaDeps {
+  return {
+    checkRateLimit: allowAll,
+    canAcquireSlot: () => true,
+    ...overrides,
+  };
+}
+
+describe('code execution concurrency semaphore', () => {
+  beforeEach(() => {
+    resetCodeExecutionConcurrency();
+  });
+
+  it('should scale the concurrent-run limit by subscription tier', () => {
+    expect(getCodeExecutionConcurrencyLimit('free')).toBeLessThan(
+      getCodeExecutionConcurrencyLimit('business'),
+    );
+  });
+
+  it('should deny acquiring a slot once the per-tier limit is reached', () => {
+    expect(acquireCodeExecutionSlot({ userId: 'u1', tier: 'free' })).toBe(true);
+    expect(canAcquireCodeExecutionSlot({ userId: 'u1', tier: 'free' })).toBe(false);
+    expect(acquireCodeExecutionSlot({ userId: 'u1', tier: 'free' })).toBe(false);
+  });
+
+  it('should free capacity again after a slot is released', () => {
+    acquireCodeExecutionSlot({ userId: 'u1', tier: 'free' });
+    releaseCodeExecutionSlot({ userId: 'u1' });
+    expect(canAcquireCodeExecutionSlot({ userId: 'u1', tier: 'free' })).toBe(true);
+  });
+
+  it('should track concurrency independently per user', () => {
+    acquireCodeExecutionSlot({ userId: 'u1', tier: 'free' });
+    expect(canAcquireCodeExecutionSlot({ userId: 'u2', tier: 'free' })).toBe(true);
+  });
+});
+
+describe('checkCodeExecutionQuota', () => {
+  beforeEach(() => {
+    resetCodeExecutionConcurrency();
+  });
+
+  it('given capacity and budget, should allow', async () => {
+    const decision = await checkCodeExecutionQuota({
+      userId: 'u1',
+      driveId: 'd1',
+      tier: 'pro',
+      deps: makeDeps(),
+    });
+    expect(decision.allowed).toBe(true);
+  });
+
+  it('given no concurrency capacity, should deny with concurrency_limit', async () => {
+    const decision = await checkCodeExecutionQuota({
+      userId: 'u1',
+      driveId: 'd1',
+      tier: 'pro',
+      deps: makeDeps({ canAcquireSlot: () => false }),
+    });
+    expect(decision).toEqual({ allowed: false, reason: 'concurrency_limit' });
+  });
+
+  it('given the per-user daily budget is exhausted, should deny with rate_limited', async () => {
+    const decision = await checkCodeExecutionQuota({
+      userId: 'u1',
+      driveId: 'd1',
+      tier: 'pro',
+      deps: makeDeps({
+        checkRateLimit: async (id: string) =>
+          id.includes('user:u1')
+            ? { allowed: false, retryAfter: 3600, attemptsRemaining: 0 }
+            : { allowed: true, attemptsRemaining: 99 },
+      }),
+    });
+    expect(decision).toEqual({ allowed: false, reason: 'rate_limited', retryAfter: 3600 });
+  });
+
+  it('given the drive-scoped budget is exhausted, should deny with rate_limited', async () => {
+    const decision = await checkCodeExecutionQuota({
+      userId: 'u1',
+      driveId: 'd1',
+      tier: 'pro',
+      deps: makeDeps({
+        checkRateLimit: async (id: string) =>
+          id.includes('drive:d1')
+            ? { allowed: false, retryAfter: 60, attemptsRemaining: 0 }
+            : { allowed: true, attemptsRemaining: 99 },
+      }),
+    });
+    expect(decision).toEqual({ allowed: false, reason: 'rate_limited', retryAfter: 60 });
+  });
+
+  it('given a tenant-scoped budget exhaustion, should deny with rate_limited', async () => {
+    const decision = await checkCodeExecutionQuota({
+      userId: 'u1',
+      driveId: 'd1',
+      tenantId: 't1',
+      tier: 'pro',
+      deps: makeDeps({
+        checkRateLimit: async (id: string) =>
+          id.includes('tenant:t1')
+            ? { allowed: false, retryAfter: 120, attemptsRemaining: 0 }
+            : { allowed: true, attemptsRemaining: 99 },
+      }),
+    });
+    expect(decision).toEqual({ allowed: false, reason: 'rate_limited', retryAfter: 120 });
+  });
+
+  it('should check concurrency before spending budget so a full system never burns quota', async () => {
+    let rateLimitCalls = 0;
+    await checkCodeExecutionQuota({
+      userId: 'u1',
+      driveId: 'd1',
+      tier: 'pro',
+      deps: makeDeps({
+        canAcquireSlot: () => false,
+        checkRateLimit: async () => {
+          rateLimitCalls += 1;
+          return { allowed: true, attemptsRemaining: 99 };
+        },
+      }),
+    });
+    expect(rateLimitCalls).toBe(0);
+  });
+});

--- a/packages/lib/src/services/sandbox/__tests__/quota.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/quota.test.ts
@@ -9,16 +9,15 @@ import {
   type CodeExecutionQuotaDeps,
 } from '../quota';
 
-const allowAll: CodeExecutionQuotaDeps['checkRateLimit'] = async () => ({
-  allowed: true,
-  attemptsRemaining: 99,
+const allowAll: CodeExecutionQuotaDeps['checkRateLimitStatus'] = async () => ({
+  blocked: false,
 });
 
 function makeDeps(
   overrides: Partial<CodeExecutionQuotaDeps> = {},
 ): CodeExecutionQuotaDeps {
   return {
-    checkRateLimit: allowAll,
+    checkRateLimitStatus: allowAll,
     canAcquireSlot: () => true,
     ...overrides,
   };
@@ -84,10 +83,10 @@ describe('checkCodeExecutionQuota', () => {
       driveId: 'd1',
       tier: 'pro',
       deps: makeDeps({
-        checkRateLimit: async (id: string) =>
+        checkRateLimitStatus: async (id: string) =>
           id.includes('user:u1')
-            ? { allowed: false, retryAfter: 3600, attemptsRemaining: 0 }
-            : { allowed: true, attemptsRemaining: 99 },
+            ? { blocked: true, retryAfter: 3600 }
+            : { blocked: false },
       }),
     });
     expect(decision).toEqual({ allowed: false, reason: 'rate_limited', retryAfter: 3600 });
@@ -99,10 +98,10 @@ describe('checkCodeExecutionQuota', () => {
       driveId: 'd1',
       tier: 'pro',
       deps: makeDeps({
-        checkRateLimit: async (id: string) =>
+        checkRateLimitStatus: async (id: string) =>
           id.includes('drive:d1')
-            ? { allowed: false, retryAfter: 60, attemptsRemaining: 0 }
-            : { allowed: true, attemptsRemaining: 99 },
+            ? { blocked: true, retryAfter: 60 }
+            : { blocked: false },
       }),
     });
     expect(decision).toEqual({ allowed: false, reason: 'rate_limited', retryAfter: 60 });
@@ -115,29 +114,29 @@ describe('checkCodeExecutionQuota', () => {
       tenantId: 't1',
       tier: 'pro',
       deps: makeDeps({
-        checkRateLimit: async (id: string) =>
+        checkRateLimitStatus: async (id: string) =>
           id.includes('tenant:t1')
-            ? { allowed: false, retryAfter: 120, attemptsRemaining: 0 }
-            : { allowed: true, attemptsRemaining: 99 },
+            ? { blocked: true, retryAfter: 120 }
+            : { blocked: false },
       }),
     });
     expect(decision).toEqual({ allowed: false, reason: 'rate_limited', retryAfter: 120 });
   });
 
-  it('should check concurrency before spending budget so a full system never burns quota', async () => {
-    let rateLimitCalls = 0;
+  it('should check concurrency before reading budget so a full system never queries quota', async () => {
+    let statusCalls = 0;
     await checkCodeExecutionQuota({
       userId: 'u1',
       driveId: 'd1',
       tier: 'pro',
       deps: makeDeps({
         canAcquireSlot: () => false,
-        checkRateLimit: async () => {
-          rateLimitCalls += 1;
-          return { allowed: true, attemptsRemaining: 99 };
+        checkRateLimitStatus: async () => {
+          statusCalls += 1;
+          return { blocked: false };
         },
       }),
     });
-    expect(rateLimitCalls).toBe(0);
+    expect(statusCalls).toBe(0);
   });
 });

--- a/packages/lib/src/services/sandbox/__tests__/sandbox-env.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/sandbox-env.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { buildSandboxEnv } from '../sandbox-env';
+
+// A validated-env shape carrying every category of host secret we must never
+// leak into an untrusted sandbox.
+const hostEnv = {
+  NODE_ENV: 'production' as const,
+  DATABASE_URL: 'postgresql://user:supersecret@db.internal:5432/app',
+  CSRF_SECRET: 'csrf-secret-value-that-is-long-enough-aaaaa',
+  ENCRYPTION_KEY: 'encryption-key-value-that-is-long-enough-bbbb',
+  STRIPE_SECRET_KEY: 'fake-stripe-secret-key-deadbeefdeadbeef',
+  STRIPE_WEBHOOK_SECRET: 'fake-stripe-webhook-secret-deadbeef',
+  GOOGLE_OAUTH_CLIENT_SECRET: 'google-oauth-secret',
+  GOOGLE_AI_DEFAULT_API_KEY: 'ai-key-123',
+  OPENROUTER_DEFAULT_API_KEY: 'or-key-456',
+  REALTIME_BROADCAST_SECRET: 'rt-secret',
+  CRON_SECRET: 'cron-secret',
+  OAUTH_STATE_SECRET: 'oauth-state-secret-long-enough-cccccccccccc',
+};
+
+describe('buildSandboxEnv', () => {
+  it('should not pass any host secret, DB credential, or key into the sandbox', () => {
+    const env = buildSandboxEnv({ env: hostEnv });
+    const forbidden = [
+      'DATABASE_URL',
+      'CSRF_SECRET',
+      'ENCRYPTION_KEY',
+      'STRIPE_SECRET_KEY',
+      'STRIPE_WEBHOOK_SECRET',
+      'GOOGLE_OAUTH_CLIENT_SECRET',
+      'GOOGLE_AI_DEFAULT_API_KEY',
+      'OPENROUTER_DEFAULT_API_KEY',
+      'REALTIME_BROADCAST_SECRET',
+      'CRON_SECRET',
+      'OAUTH_STATE_SECRET',
+    ];
+    for (const key of forbidden) {
+      expect(env).not.toHaveProperty(key);
+    }
+  });
+
+  it('should not leak any secret VALUE even under an unexpected key', () => {
+    const env = buildSandboxEnv({ env: hostEnv });
+    const serialized = JSON.stringify(env);
+    const secretValues = [
+      'supersecret',
+      hostEnv.CSRF_SECRET,
+      hostEnv.ENCRYPTION_KEY,
+      hostEnv.STRIPE_SECRET_KEY,
+      hostEnv.GOOGLE_AI_DEFAULT_API_KEY,
+      hostEnv.OPENROUTER_DEFAULT_API_KEY,
+    ];
+    for (const value of secretValues) {
+      expect(serialized).not.toContain(value);
+    }
+  });
+
+  it('should only expose explicitly allowlisted, non-secret keys', () => {
+    const env = buildSandboxEnv({ env: hostEnv });
+    expect(Object.keys(env)).toEqual(['NODE_ENV']);
+    expect(env.NODE_ENV).toBe('production');
+  });
+
+  it('should ignore arbitrary extra keys present on the input env', () => {
+    const env = buildSandboxEnv({
+      env: { ...hostEnv, SOME_INJECTED_SECRET: 'leak-me' } as never,
+    });
+    expect(JSON.stringify(env)).not.toContain('leak-me');
+  });
+
+  it('should produce a string-valued record safe to hand to the sandbox', () => {
+    const env = buildSandboxEnv({ env: hostEnv });
+    for (const value of Object.values(env)) {
+      expect(typeof value).toBe('string');
+    }
+  });
+});

--- a/packages/lib/src/services/sandbox/audit.ts
+++ b/packages/lib/src/services/sandbox/audit.ts
@@ -70,9 +70,18 @@ const REDACTED = '***REDACTED***';
 // boundary (buildSandboxEnv is). It will miss exotic secret shapes; that is
 // acceptable because the captured code is already untrusted log data.
 //
-// Secret-bearing assignments: `API_KEY = "..."`, `token: '...'`, `password=...`.
-const SECRET_ASSIGNMENT =
-  /\b([A-Za-z0-9_-]*(?:key|secret|token|password|passwd|pwd|auth)[A-Za-z0-9_-]*)\b(\s*[:=]\s*)(['"]?)[^\s'"]+\3/gi;
+// Every regex here is linear: a single quantifier per character class with no
+// nested or adjacent overlapping repetition. The identifier of an assignment is
+// matched as one `[A-Za-z0-9_-]+` run and the "is this a secret key" decision is
+// made in the callback — NOT with an `X*keyword X*` pattern, which backtracks
+// polynomially on agent-supplied input (CodeQL js/polynomial-redos).
+
+// Any `name = value` / `name: "value"` assignment. The identifier is one run; a
+// distinct `[:=]` separates it from the value, so there is no ambiguity.
+const ASSIGNMENT =
+  /\b([A-Za-z0-9_-]+)(\s*[:=]\s*)(['"]?)[^\s'"]+\3/g;
+// Identifiers naming a secret. Plain literal alternation, tested in the callback.
+const SECRET_KEYWORD = /(?:key|secret|token|password|passwd|pwd|auth)/i;
 // `Authorization: Bearer <token>`.
 const BEARER_TOKEN = /\b[Bb]earer\s+[A-Za-z0-9._~+/=-]{8,}/g;
 // Standalone high-entropy tokens (provider key prefixes, long hex/base64). Kept
@@ -81,7 +90,9 @@ const STANDALONE_TOKEN = /\b[A-Za-z0-9_]{24,}\b/g;
 
 function redactSecrets(code: string): string {
   return code
-    .replace(SECRET_ASSIGNMENT, (_m, key, sep) => `${key}${sep}${REDACTED}`)
+    .replace(ASSIGNMENT, (match, ident, sep) =>
+      SECRET_KEYWORD.test(ident) ? `${ident}${sep}${REDACTED}` : match,
+    )
     .replace(BEARER_TOKEN, `Bearer ${REDACTED}`)
     .replace(STANDALONE_TOKEN, REDACTED);
 }

--- a/packages/lib/src/services/sandbox/audit.ts
+++ b/packages/lib/src/services/sandbox/audit.ts
@@ -62,16 +62,30 @@ export interface CodeExecutionAuditRecord {
   aiModel?: string;
 }
 
+/** Cap on the code stored in the audit record. */
 const MAX_AUDITED_CODE_LENGTH = 4000;
+/**
+ * Redact over a window larger than the storage cap, then truncate. A secret
+ * that begins before the cap but extends past it is fully seen (and collapsed)
+ * here before truncation — otherwise a cut-off closing quote would defeat
+ * SECRET_ASSIGNMENT and leak a prefix into the immutable log. The window also
+ * bounds the regex input so scanning stays cheap.
+ */
+const REDACTION_SCAN_LIMIT = 16_000;
 const REDACTED = '***REDACTED***';
 
+// Best-effort redaction — audit hygiene / defense-in-depth, NOT the security
+// boundary (buildSandboxEnv is). It will miss exotic secret shapes; that is
+// acceptable because the captured code is already untrusted log data.
+//
 // Secret-bearing assignments: `API_KEY = "..."`, `token: '...'`, `password=...`.
 const SECRET_ASSIGNMENT =
   /\b([A-Za-z0-9_-]*(?:key|secret|token|password|passwd|pwd|auth)[A-Za-z0-9_-]*)\b(\s*[:=]\s*)(['"]?)[^\s'"]+\3/gi;
 // `Authorization: Bearer <token>`.
 const BEARER_TOKEN = /\b[Bb]earer\s+[A-Za-z0-9._~+/=-]{8,}/g;
-// Standalone high-entropy tokens (provider key prefixes, long hex/base64).
-const STANDALONE_TOKEN = /\b[A-Za-z0-9_-]*[A-Za-z0-9][A-Za-z0-9_-]{23,}\b/g;
+// Standalone high-entropy tokens (provider key prefixes, long hex/base64). Kept
+// as a single non-ambiguous run so matching stays linear over the scan window.
+const STANDALONE_TOKEN = /\b[A-Za-z0-9_]{24,}\b/g;
 
 function redactSecrets(code: string): string {
   return code
@@ -98,11 +112,20 @@ export function buildAuditRecord({
   aiProvider,
   aiModel,
 }: CodeExecutionAuditInput): CodeExecutionAuditRecord {
-  // Truncate the raw code to the cap BEFORE redacting, so the redaction regexes
-  // only ever run over a bounded input (no ReDoS surface on large submissions).
-  // codeTruncated reflects the raw length the agent submitted.
-  const codeTruncated = code.length > MAX_AUDITED_CODE_LENGTH;
-  const bounded = codeTruncated ? code.slice(0, MAX_AUDITED_CODE_LENGTH) : code;
+  // Redact over a window wider than the storage cap, then truncate the redacted
+  // result. This collapses any secret that straddles the cap before it can be
+  // cut mid-token, while keeping the regex input bounded.
+  const scanned =
+    code.length > REDACTION_SCAN_LIMIT ? code.slice(0, REDACTION_SCAN_LIMIT) : code;
+  const redacted = redactSecrets(scanned);
+  // Truncated whenever content is actually dropped: the redacted form exceeds
+  // the cap, or the raw code ran past the scan window (its tail was never seen).
+  const codeTruncated =
+    redacted.length > MAX_AUDITED_CODE_LENGTH || code.length > REDACTION_SCAN_LIMIT;
+  const auditedCode =
+    redacted.length > MAX_AUDITED_CODE_LENGTH
+      ? redacted.slice(0, MAX_AUDITED_CODE_LENGTH)
+      : redacted;
 
   return {
     userId,
@@ -113,7 +136,7 @@ export function buildAuditRecord({
     requestOrigin,
     agentPageId,
     profile,
-    code: redactSecrets(bounded),
+    code: auditedCode,
     codeTruncated,
     exitCode,
     durationMs,
@@ -135,6 +158,8 @@ export function buildActivityLogInput(record: CodeExecutionAuditRecord): Activit
     driveId: record.driveId,
     actorEmail: record.actorEmail,
     actorDisplayName: record.actorDisplayName,
+    // Invariant: sandbox code is always model-generated, regardless of whether a
+    // user or another agent triggered the run — so this is unconditionally true.
     isAiGenerated: true,
     aiProvider: record.aiProvider,
     aiModel: record.aiModel,

--- a/packages/lib/src/services/sandbox/audit.ts
+++ b/packages/lib/src/services/sandbox/audit.ts
@@ -98,8 +98,11 @@ export function buildAuditRecord({
   aiProvider,
   aiModel,
 }: CodeExecutionAuditInput): CodeExecutionAuditRecord {
-  const redacted = redactSecrets(code);
-  const codeTruncated = redacted.length > MAX_AUDITED_CODE_LENGTH;
+  // Truncate the raw code to the cap BEFORE redacting, so the redaction regexes
+  // only ever run over a bounded input (no ReDoS surface on large submissions).
+  // codeTruncated reflects the raw length the agent submitted.
+  const codeTruncated = code.length > MAX_AUDITED_CODE_LENGTH;
+  const bounded = codeTruncated ? code.slice(0, MAX_AUDITED_CODE_LENGTH) : code;
 
   return {
     userId,
@@ -110,7 +113,7 @@ export function buildAuditRecord({
     requestOrigin,
     agentPageId,
     profile,
-    code: codeTruncated ? redacted.slice(0, MAX_AUDITED_CODE_LENGTH) : redacted,
+    code: redactSecrets(bounded),
     codeTruncated,
     exitCode,
     durationMs,

--- a/packages/lib/src/services/sandbox/audit.ts
+++ b/packages/lib/src/services/sandbox/audit.ts
@@ -64,14 +64,6 @@ export interface CodeExecutionAuditRecord {
 
 /** Cap on the code stored in the audit record. */
 const MAX_AUDITED_CODE_LENGTH = 4000;
-/**
- * Redact over a window larger than the storage cap, then truncate. A secret
- * that begins before the cap but extends past it is fully seen (and collapsed)
- * here before truncation — otherwise a cut-off closing quote would defeat
- * SECRET_ASSIGNMENT and leak a prefix into the immutable log. The window also
- * bounds the regex input so scanning stays cheap.
- */
-const REDACTION_SCAN_LIMIT = 16_000;
 const REDACTED = '***REDACTED***';
 
 // Best-effort redaction — audit hygiene / defense-in-depth, NOT the security
@@ -84,7 +76,7 @@ const SECRET_ASSIGNMENT =
 // `Authorization: Bearer <token>`.
 const BEARER_TOKEN = /\b[Bb]earer\s+[A-Za-z0-9._~+/=-]{8,}/g;
 // Standalone high-entropy tokens (provider key prefixes, long hex/base64). Kept
-// as a single non-ambiguous run so matching stays linear over the scan window.
+// as a single non-ambiguous run so matching stays linear over the whole input.
 const STANDALONE_TOKEN = /\b[A-Za-z0-9_]{24,}\b/g;
 
 function redactSecrets(code: string): string {
@@ -112,20 +104,17 @@ export function buildAuditRecord({
   aiProvider,
   aiModel,
 }: CodeExecutionAuditInput): CodeExecutionAuditRecord {
-  // Redact over a window wider than the storage cap, then truncate the redacted
-  // result. This collapses any secret that straddles the cap before it can be
-  // cut mid-token, while keeping the regex input bounded.
-  const scanned =
-    code.length > REDACTION_SCAN_LIMIT ? code.slice(0, REDACTION_SCAN_LIMIT) : code;
-  const redacted = redactSecrets(scanned);
-  // Truncated whenever content is actually dropped: the redacted form exceeds
-  // the cap, or the raw code ran past the scan window (its tail was never seen).
-  const codeTruncated =
-    redacted.length > MAX_AUDITED_CODE_LENGTH || code.length > REDACTION_SCAN_LIMIT;
-  const auditedCode =
-    redacted.length > MAX_AUDITED_CODE_LENGTH
-      ? redacted.slice(0, MAX_AUDITED_CODE_LENGTH)
-      : redacted;
+  // Redact first, then truncate. Order matters: a secret that straddles the
+  // storage cap is fully seen and collapsed before the cut, so no plaintext
+  // prefix survives into the immutable log. Redaction runs over the whole input
+  // (the regexes are linear) rather than a separate fixed window — the window
+  // never added safety, since anything past the cap is dropped by the truncate
+  // either way, and it carried its own straddle edge.
+  const redacted = redactSecrets(code);
+  const codeTruncated = redacted.length > MAX_AUDITED_CODE_LENGTH;
+  const auditedCode = codeTruncated
+    ? redacted.slice(0, MAX_AUDITED_CODE_LENGTH)
+    : redacted;
 
   return {
     userId,
@@ -148,13 +137,20 @@ export function buildAuditRecord({
   };
 }
 
+// Most-specific available scope for the run. Shared by both audit sinks so the
+// activity log and the security log always key the same run to the same id —
+// forensic correlation across the two tables breaks if they ever diverge.
+function resolveAuditResourceId(record: CodeExecutionAuditRecord): string {
+  return record.conversationId ?? record.driveId ?? record.userId;
+}
+
 export function buildActivityLogInput(record: CodeExecutionAuditRecord): ActivityLogInput {
   const scopedToConversation = Boolean(record.conversationId);
   return {
     userId: record.userId,
     operation: 'code_execution',
     resourceType: scopedToConversation ? 'conversation' : 'drive',
-    resourceId: record.conversationId ?? record.driveId ?? record.userId,
+    resourceId: resolveAuditResourceId(record),
     driveId: record.driveId,
     actorEmail: record.actorEmail,
     actorDisplayName: record.actorDisplayName,
@@ -193,7 +189,7 @@ export function buildSecurityAuditEvent(
     eventType: 'security.suspicious.activity',
     userId: record.userId,
     resourceType: 'code_execution',
-    resourceId: record.conversationId ?? record.driveId ?? record.userId,
+    resourceId: resolveAuditResourceId(record),
     riskScore: ANOMALY_RISK[record.anomaly],
     anomalyFlags: [record.anomaly],
     details: {

--- a/packages/lib/src/services/sandbox/audit.ts
+++ b/packages/lib/src/services/sandbox/audit.ts
@@ -1,0 +1,210 @@
+/**
+ * Code execution audit (pure builders + a fire-and-forget writer).
+ *
+ * Every run produces an immutable audit record — actor, (redacted) code,
+ * profile, exit, duration, cost, timestamp — written to the hash-chained
+ * activity log. Anomalous runs (timeout, OOM, blocked command, non-zero exit)
+ * additionally raise a security audit event for forensics.
+ *
+ * The builders are pure: they take an injected timestamp and never read the
+ * clock, so they are trivially testable. The writer isolates IO behind injected
+ * sinks and is fire-and-forget: a failing audit sink must never break or block
+ * the run it is recording.
+ */
+
+import type { ActivityLogInput } from '../../monitoring/activity-logger';
+import type { AuditEvent } from '../../audit/security-audit';
+import type { ExecutionProfile } from './execution-policy';
+
+export type CodeExecutionAnomaly =
+  | 'timeout'
+  | 'oom'
+  | 'blocked_command'
+  | 'nonzero_exit';
+
+export interface CodeExecutionAuditInput {
+  userId: string;
+  actorEmail: string;
+  actorDisplayName?: string;
+  driveId: string | null;
+  conversationId?: string;
+  requestOrigin?: 'user' | 'agent';
+  agentPageId?: string;
+  profile: ExecutionProfile;
+  code: string;
+  exitCode: number | null;
+  durationMs: number;
+  costUsd?: number;
+  timestamp: Date;
+  anomaly?: CodeExecutionAnomaly;
+  aiProvider?: string;
+  aiModel?: string;
+}
+
+export interface CodeExecutionAuditRecord {
+  userId: string;
+  actorEmail: string;
+  actorDisplayName?: string;
+  driveId: string | null;
+  conversationId?: string;
+  requestOrigin: 'user' | 'agent';
+  agentPageId?: string;
+  profile: ExecutionProfile;
+  /** Redacted and length-capped copy of the submitted code. */
+  code: string;
+  codeTruncated: boolean;
+  exitCode: number | null;
+  durationMs: number;
+  costUsd: number;
+  timestampIso: string;
+  anomaly?: CodeExecutionAnomaly;
+  aiProvider?: string;
+  aiModel?: string;
+}
+
+const MAX_AUDITED_CODE_LENGTH = 4000;
+const REDACTED = '***REDACTED***';
+
+// Secret-bearing assignments: `API_KEY = "..."`, `token: '...'`, `password=...`.
+const SECRET_ASSIGNMENT =
+  /\b([A-Za-z0-9_-]*(?:key|secret|token|password|passwd|pwd|auth)[A-Za-z0-9_-]*)\b(\s*[:=]\s*)(['"]?)[^\s'"]+\3/gi;
+// `Authorization: Bearer <token>`.
+const BEARER_TOKEN = /\b[Bb]earer\s+[A-Za-z0-9._~+/=-]{8,}/g;
+// Standalone high-entropy tokens (e.g. sk_live_..., ghp_..., long hex/base64).
+const STANDALONE_TOKEN = /\b[A-Za-z0-9_-]*[A-Za-z0-9][A-Za-z0-9_-]{23,}\b/g;
+
+function redactSecrets(code: string): string {
+  return code
+    .replace(SECRET_ASSIGNMENT, (_m, key, sep) => `${key}${sep}${REDACTED}`)
+    .replace(BEARER_TOKEN, `Bearer ${REDACTED}`)
+    .replace(STANDALONE_TOKEN, REDACTED);
+}
+
+export function buildAuditRecord({
+  userId,
+  actorEmail,
+  actorDisplayName,
+  driveId,
+  conversationId,
+  requestOrigin = 'user',
+  agentPageId,
+  profile,
+  code,
+  exitCode,
+  durationMs,
+  costUsd = 0,
+  timestamp,
+  anomaly,
+  aiProvider,
+  aiModel,
+}: CodeExecutionAuditInput): CodeExecutionAuditRecord {
+  const redacted = redactSecrets(code);
+  const codeTruncated = redacted.length > MAX_AUDITED_CODE_LENGTH;
+
+  return {
+    userId,
+    actorEmail,
+    actorDisplayName,
+    driveId,
+    conversationId,
+    requestOrigin,
+    agentPageId,
+    profile,
+    code: codeTruncated ? redacted.slice(0, MAX_AUDITED_CODE_LENGTH) : redacted,
+    codeTruncated,
+    exitCode,
+    durationMs,
+    costUsd,
+    timestampIso: timestamp.toISOString(),
+    anomaly,
+    aiProvider,
+    aiModel,
+  };
+}
+
+export function buildActivityLogInput(record: CodeExecutionAuditRecord): ActivityLogInput {
+  const scopedToConversation = Boolean(record.conversationId);
+  return {
+    userId: record.userId,
+    operation: 'code_execution',
+    resourceType: scopedToConversation ? 'conversation' : 'drive',
+    resourceId: record.conversationId ?? record.driveId ?? record.userId,
+    driveId: record.driveId,
+    actorEmail: record.actorEmail,
+    actorDisplayName: record.actorDisplayName,
+    isAiGenerated: true,
+    aiProvider: record.aiProvider,
+    aiModel: record.aiModel,
+    aiConversationId: record.conversationId,
+    metadata: {
+      profile: record.profile,
+      exitCode: record.exitCode,
+      durationMs: record.durationMs,
+      costUsd: record.costUsd,
+      requestOrigin: record.requestOrigin,
+      agentPageId: record.agentPageId,
+      code: record.code,
+      codeTruncated: record.codeTruncated,
+      anomaly: record.anomaly,
+    },
+  };
+}
+
+const ANOMALY_RISK: Record<CodeExecutionAnomaly, number> = {
+  timeout: 0.4,
+  oom: 0.4,
+  nonzero_exit: 0.3,
+  blocked_command: 0.8,
+};
+
+export function buildSecurityAuditEvent(
+  record: CodeExecutionAuditRecord,
+): AuditEvent | null {
+  if (!record.anomaly) return null;
+  return {
+    eventType: 'security.suspicious.activity',
+    userId: record.userId,
+    resourceType: 'code_execution',
+    resourceId: record.conversationId ?? record.driveId ?? record.userId,
+    riskScore: ANOMALY_RISK[record.anomaly],
+    anomalyFlags: [record.anomaly],
+    details: {
+      profile: record.profile,
+      exitCode: record.exitCode,
+      durationMs: record.durationMs,
+      driveId: record.driveId,
+      requestOrigin: record.requestOrigin,
+      agentPageId: record.agentPageId,
+    },
+  };
+}
+
+export interface WriteAuditDeps {
+  logActivity: (input: ActivityLogInput) => Promise<void>;
+  logSecurityEvent: (event: AuditEvent) => Promise<void>;
+}
+
+// The real sinks pull in the database; import them lazily so unit tests that
+// inject fakes never load the DB module graph.
+const defaultDeps: WriteAuditDeps = {
+  logActivity: (input) =>
+    import('../../monitoring/activity-logger').then((m) => m.logActivity(input)),
+  logSecurityEvent: (event) =>
+    import('../../audit/security-audit').then((m) => m.securityAudit.logEvent(event)),
+};
+
+export async function writeCodeExecutionAudit({
+  input,
+  deps = defaultDeps,
+}: {
+  input: CodeExecutionAuditInput;
+  deps?: WriteAuditDeps;
+}): Promise<void> {
+  const record = buildAuditRecord(input);
+  const securityEvent = buildSecurityAuditEvent(record);
+
+  await Promise.allSettled([
+    deps.logActivity(buildActivityLogInput(record)),
+    ...(securityEvent ? [deps.logSecurityEvent(securityEvent)] : []),
+  ]);
+}

--- a/packages/lib/src/services/sandbox/audit.ts
+++ b/packages/lib/src/services/sandbox/audit.ts
@@ -70,7 +70,7 @@ const SECRET_ASSIGNMENT =
   /\b([A-Za-z0-9_-]*(?:key|secret|token|password|passwd|pwd|auth)[A-Za-z0-9_-]*)\b(\s*[:=]\s*)(['"]?)[^\s'"]+\3/gi;
 // `Authorization: Bearer <token>`.
 const BEARER_TOKEN = /\b[Bb]earer\s+[A-Za-z0-9._~+/=-]{8,}/g;
-// Standalone high-entropy tokens (e.g. sk_live_..., ghp_..., long hex/base64).
+// Standalone high-entropy tokens (provider key prefixes, long hex/base64).
 const STANDALONE_TOKEN = /\b[A-Za-z0-9_-]*[A-Za-z0-9][A-Za-z0-9_-]{23,}\b/g;
 
 function redactSecrets(code: string): string {

--- a/packages/lib/src/services/sandbox/can-run-code.ts
+++ b/packages/lib/src/services/sandbox/can-run-code.ts
@@ -15,6 +15,12 @@
  * do not serve on-prem (a local execution path is future work, not wired here),
  * so gating on DEPLOYMENT_MODE / isOnPrem would only add a dead branch.
  *
+ * The actor user always clears the owner/admin drive-role gate, regardless of
+ * origin. Agent-origin runs additionally require the agent page to hold drive
+ * edit access (defence in depth): both the human who triggered the run and the
+ * agent acting on their behalf must be entitled, so a plain member can't
+ * escalate through an agent that happens to have edit access.
+ *
  * `enabledTools` (agent config) is NOT a security boundary — this is.
  */
 
@@ -122,9 +128,17 @@ export async function canRunCode({
   try {
     if (!deps.isCodeExecutionEnabled()) return deny('kill_switch_off');
 
+    // The actor user must always clear the owner/admin drive-role gate. For
+    // agent-origin runs this is the rung that stops a plain member escalating
+    // through an agent that holds drive edit access.
+    const userResult = await authorizeUser(userId, driveId, deps);
+    if (!userResult.ok) return userResult;
+
+    // Agent-origin runs additionally require the agent page itself to hold
+    // drive edit access — both the actor and the agent must be entitled.
     return requestOrigin === 'agent'
       ? await authorizeAgent(agentPageId, driveId, deps)
-      : await authorizeUser(userId, driveId, deps);
+      : userResult;
   } catch {
     return deny('error');
   }

--- a/packages/lib/src/services/sandbox/can-run-code.ts
+++ b/packages/lib/src/services/sandbox/can-run-code.ts
@@ -93,6 +93,9 @@ async function authorizeAgent(
   deps: CanRunCodeDeps,
 ): Promise<CanRunCodeResult> {
   if (!agentPageId) return deny('no_agent_access');
+  // Pass driveId as the target: getAgentAccessLevel resolves an id with no page
+  // row to a drive (the drive-as-root-node fallback in agent-permissions.ts),
+  // so this evaluates the agent's drive-level access.
   const access = await deps.getAgentAccessLevel(agentPageId, driveId);
   if (!access?.canEdit) return deny('no_agent_access');
   return { ok: true };

--- a/packages/lib/src/services/sandbox/can-run-code.ts
+++ b/packages/lib/src/services/sandbox/can-run-code.ts
@@ -2,25 +2,27 @@
  * Authorization gate for agent code execution.
  *
  * Code execution is the highest-risk surface in the product: the Vercel
- * microVM contains *escape*, but authorization, kill-switch, and deployment-mode
- * gating are entirely ours. `canRunCode` composes the existing drive-permission
- * helpers and is the single chokepoint every invocation must pass.
+ * microVM contains the risk of *escape*, but authorization, kill-switch, and
+ * quota gating are entirely ours. `canRunCode` composes the existing
+ * drive-permission helpers and is the single chokepoint every invocation must pass.
  *
  * Fail-closed by construction: it never throws — any error (including a DB
- * outage inside an injected dependency) resolves to a denial. The checks are
- * ordered cheapest-first (kill-switch, deployment mode) so a disabled feature
- * or non-cloud deployment denies before any database round-trip.
+ * outage inside an injected dependency) resolves to a denial. The kill-switch
+ * is checked first (cheap, no DB) so a disabled feature denies before any
+ * database round-trip.
+ *
+ * No deployment-mode gate: tenant is cloud (isolated image per tenant) and we
+ * do not serve on-prem (a local execution path is future work, not wired here),
+ * so gating on DEPLOYMENT_MODE / isOnPrem would only add a dead branch.
  *
  * `enabledTools` (agent config) is NOT a security boundary — this is.
  */
 
-import { isCloud } from '../../deployment-mode';
 import { getValidatedEnv } from '../../config/env-validation';
 import type { DrivePermissionLevel, PermissionLevel } from '../../permissions/permissions';
 
 export type CodeExecutionDenialReason =
   | 'kill_switch_off'
-  | 'not_cloud'
   | 'no_drive_access'
   | 'insufficient_role'
   | 'no_agent_access'
@@ -43,7 +45,6 @@ export interface CanRunCodeDeps {
     agentPageId: string,
     targetPageId: string,
   ) => Promise<PermissionLevel | null>;
-  isCloud: () => boolean;
   isCodeExecutionEnabled: () => boolean;
 }
 
@@ -78,7 +79,6 @@ const defaultDeps: CanRunCodeDeps = {
     import('../../permissions/agent-permissions').then((m) =>
       m.getAgentAccessLevel(agentPageId, targetPageId),
     ),
-  isCloud,
   isCodeExecutionEnabled,
 };
 
@@ -118,7 +118,6 @@ export async function canRunCode({
 }: CanRunCodeInput): Promise<CanRunCodeResult> {
   try {
     if (!deps.isCodeExecutionEnabled()) return deny('kill_switch_off');
-    if (!deps.isCloud()) return deny('not_cloud');
 
     return requestOrigin === 'agent'
       ? await authorizeAgent(agentPageId, driveId, deps)

--- a/packages/lib/src/services/sandbox/can-run-code.ts
+++ b/packages/lib/src/services/sandbox/can-run-code.ts
@@ -1,0 +1,129 @@
+/**
+ * Authorization gate for agent code execution.
+ *
+ * Code execution is the highest-risk surface in the product: the Vercel
+ * microVM contains *escape*, but authorization, kill-switch, and deployment-mode
+ * gating are entirely ours. `canRunCode` composes the existing drive-permission
+ * helpers and is the single chokepoint every invocation must pass.
+ *
+ * Fail-closed by construction: it never throws — any error (including a DB
+ * outage inside an injected dependency) resolves to a denial. The checks are
+ * ordered cheapest-first (kill-switch, deployment mode) so a disabled feature
+ * or non-cloud deployment denies before any database round-trip.
+ *
+ * `enabledTools` (agent config) is NOT a security boundary — this is.
+ */
+
+import { isCloud } from '../../deployment-mode';
+import { getValidatedEnv } from '../../config/env-validation';
+import type { DrivePermissionLevel, PermissionLevel } from '../../permissions/permissions';
+
+export type CodeExecutionDenialReason =
+  | 'kill_switch_off'
+  | 'not_cloud'
+  | 'no_drive_access'
+  | 'insufficient_role'
+  | 'no_agent_access'
+  | 'error';
+
+export type CanRunCodeResult =
+  | { ok: true }
+  | { ok: false; reason: CodeExecutionDenialReason };
+
+/**
+ * IO dependencies, injected so tests exercise the composition logic with fakes
+ * instead of mocking the database. Defaults wire the real implementations.
+ */
+export interface CanRunCodeDeps {
+  getUserDrivePermissions: (
+    userId: string,
+    driveId: string,
+  ) => Promise<DrivePermissionLevel | null>;
+  getAgentAccessLevel: (
+    agentPageId: string,
+    targetPageId: string,
+  ) => Promise<PermissionLevel | null>;
+  isCloud: () => boolean;
+  isCodeExecutionEnabled: () => boolean;
+}
+
+export interface CanRunCodeInput {
+  userId: string;
+  driveId: string;
+  requestOrigin?: 'user' | 'agent';
+  agentPageId?: string;
+  deps?: CanRunCodeDeps;
+}
+
+/**
+ * Global kill-switch. Default OFF: only the literal env value 'true' enables
+ * execution; an unset/invalid var (or a validation failure) keeps it disabled.
+ */
+export function isCodeExecutionEnabled(): boolean {
+  try {
+    return getValidatedEnv().CODE_EXECUTION_ENABLED === 'true';
+  } catch {
+    return false;
+  }
+}
+
+// The real authz helpers pull in the database; import them lazily so callers
+// that inject fakes (and the unit tests) never load the DB module graph.
+const defaultDeps: CanRunCodeDeps = {
+  getUserDrivePermissions: (userId, driveId) =>
+    import('../../permissions/permissions').then((m) =>
+      m.getUserDrivePermissions(userId, driveId),
+    ),
+  getAgentAccessLevel: (agentPageId, targetPageId) =>
+    import('../../permissions/agent-permissions').then((m) =>
+      m.getAgentAccessLevel(agentPageId, targetPageId),
+    ),
+  isCloud,
+  isCodeExecutionEnabled,
+};
+
+const deny = (reason: CodeExecutionDenialReason): CanRunCodeResult => ({
+  ok: false,
+  reason,
+});
+
+async function authorizeAgent(
+  agentPageId: string | undefined,
+  driveId: string,
+  deps: CanRunCodeDeps,
+): Promise<CanRunCodeResult> {
+  if (!agentPageId) return deny('no_agent_access');
+  const access = await deps.getAgentAccessLevel(agentPageId, driveId);
+  if (!access?.canEdit) return deny('no_agent_access');
+  return { ok: true };
+}
+
+async function authorizeUser(
+  userId: string,
+  driveId: string,
+  deps: CanRunCodeDeps,
+): Promise<CanRunCodeResult> {
+  const perms = await deps.getUserDrivePermissions(userId, driveId);
+  if (!perms?.hasAccess) return deny('no_drive_access');
+  if (!perms.isOwner && !perms.isAdmin) return deny('insufficient_role');
+  return { ok: true };
+}
+
+export async function canRunCode({
+  userId,
+  driveId,
+  requestOrigin = 'user',
+  agentPageId,
+  deps = defaultDeps,
+}: CanRunCodeInput): Promise<CanRunCodeResult> {
+  try {
+    if (!deps.isCodeExecutionEnabled()) return deny('kill_switch_off');
+    if (!deps.isCloud()) return deny('not_cloud');
+
+    return requestOrigin === 'agent'
+      ? await authorizeAgent(agentPageId, driveId, deps)
+      : await authorizeUser(userId, driveId, deps);
+  } catch {
+    return deny('error');
+  }
+}

--- a/packages/lib/src/services/sandbox/execution-policy.ts
+++ b/packages/lib/src/services/sandbox/execution-policy.ts
@@ -70,5 +70,11 @@ const PROFILES: Record<ExecutionProfile, ExecutionPolicy> = {
 export function resolveExecutionPolicy({
   profile = 'default',
 }: { profile?: string } = {}): ExecutionPolicy {
-  return PROFILES[profile as ExecutionProfile] ?? SAFE_MINIMUM_PROFILE;
+  // Own-key check, not `PROFILES[profile] ?? ...`: a bracket lookup resolves
+  // inherited keys, so a profile of '__proto__' / 'constructor' / 'toString'
+  // would return a truthy prototype member and skip the safe-minimum fallback —
+  // yielding an object with no policy bounds. Only own keys are real profiles.
+  return Object.prototype.hasOwnProperty.call(PROFILES, profile)
+    ? PROFILES[profile as ExecutionProfile]
+    : SAFE_MINIMUM_PROFILE;
 }

--- a/packages/lib/src/services/sandbox/execution-policy.ts
+++ b/packages/lib/src/services/sandbox/execution-policy.ts
@@ -32,30 +32,35 @@ export interface ExecutionPolicy {
   region: string;
 }
 
+// Policies are returned by reference from module constants. Freeze them (and
+// their egress arrays) so a downstream caller can never mutate the shared
+// default-deny baseline — e.g. `policy.egressAllowlist.push(host)` would
+// otherwise widen egress globally for every subsequent run. Frozen → it throws.
+
 /**
  * Most-restrictive policy. Also the fallback for any unknown profile.
  */
-export const SAFE_MINIMUM_PROFILE: ExecutionPolicy = {
+export const SAFE_MINIMUM_PROFILE: ExecutionPolicy = Object.freeze({
   profile: 'minimal',
   timeoutMs: 10_000,
   vcpus: 1,
   memoryMb: 512,
   maxOutputBytes: 32 * 1024,
-  egressAllowlist: [],
+  egressAllowlist: Object.freeze([]) as readonly string[],
   persistent: false,
   region: 'iad1',
-};
+});
 
-const DEFAULT_PROFILE: ExecutionPolicy = {
+const DEFAULT_PROFILE: ExecutionPolicy = Object.freeze({
   profile: 'default',
   timeoutMs: 30_000,
   vcpus: 1,
   memoryMb: 1024,
   maxOutputBytes: 64 * 1024,
-  egressAllowlist: [],
+  egressAllowlist: Object.freeze([]) as readonly string[],
   persistent: false,
   region: 'iad1',
-};
+});
 
 const PROFILES: Record<ExecutionProfile, ExecutionPolicy> = {
   default: DEFAULT_PROFILE,

--- a/packages/lib/src/services/sandbox/execution-policy.ts
+++ b/packages/lib/src/services/sandbox/execution-policy.ts
@@ -1,0 +1,69 @@
+/**
+ * Execution policy resolution (pure).
+ *
+ * Every sandbox run is bounded by an explicit policy — timeout, vCPU, memory,
+ * output cap, egress allowlist, persistence, region — rather than inheriting
+ * platform defaults. Egress is default-deny (empty allowlist) and sandboxes are
+ * ephemeral (`persistent: false`) on every profile in v1; an allowlist is only
+ * ever populated by a deliberate future change, never by omission.
+ *
+ * An unrecognized profile resolves to the safe minimum — the most restrictive
+ * policy — so a typo or an unknown caller can never widen the blast radius.
+ */
+
+export type ExecutionProfile = 'default' | 'minimal';
+
+export interface ExecutionPolicy {
+  /** Profile this policy represents (echoed back for audit/logging). */
+  profile: ExecutionProfile;
+  /** Hard wall-clock cap for a single run, in milliseconds. */
+  timeoutMs: number;
+  /** vCPU allocation. */
+  vcpus: number;
+  /** Memory allocation, in megabytes. */
+  memoryMb: number;
+  /** Maximum stdout/stderr bytes retained before truncation. */
+  maxOutputBytes: number;
+  /** Egress firewall allowlist. Empty means default-deny (no outbound). */
+  egressAllowlist: readonly string[];
+  /** Whether the sandbox survives between runs. Always false in v1. */
+  persistent: boolean;
+  /** Explicit deployment region. */
+  region: string;
+}
+
+/**
+ * Most-restrictive policy. Also the fallback for any unknown profile.
+ */
+export const SAFE_MINIMUM_PROFILE: ExecutionPolicy = {
+  profile: 'minimal',
+  timeoutMs: 10_000,
+  vcpus: 1,
+  memoryMb: 512,
+  maxOutputBytes: 32 * 1024,
+  egressAllowlist: [],
+  persistent: false,
+  region: 'iad1',
+};
+
+const DEFAULT_PROFILE: ExecutionPolicy = {
+  profile: 'default',
+  timeoutMs: 30_000,
+  vcpus: 1,
+  memoryMb: 1024,
+  maxOutputBytes: 64 * 1024,
+  egressAllowlist: [],
+  persistent: false,
+  region: 'iad1',
+};
+
+const PROFILES: Record<ExecutionProfile, ExecutionPolicy> = {
+  default: DEFAULT_PROFILE,
+  minimal: SAFE_MINIMUM_PROFILE,
+};
+
+export function resolveExecutionPolicy({
+  profile = 'default',
+}: { profile?: string } = {}): ExecutionPolicy {
+  return PROFILES[profile as ExecutionProfile] ?? SAFE_MINIMUM_PROFILE;
+}

--- a/packages/lib/src/services/sandbox/quota.ts
+++ b/packages/lib/src/services/sandbox/quota.ts
@@ -7,15 +7,23 @@
  *
  *  - Concurrency: an in-process per-user semaphore whose ceiling scales by
  *    subscription tier (mirrors `upload-semaphore.ts`, expressed functionally).
- *  - Daily budget: `checkDistributedRateLimit` against the `CODE_EXECUTION`
- *    config, applied independently to the user, drive, and tenant identifiers
- *    so exhausting one scope never drains another's allowance.
+ *  - Daily budget: a NON-incrementing read of the `CODE_EXECUTION` sliding
+ *    window (`getDistributedRateLimitStatus`) for the user, drive, and tenant
+ *    identifiers independently, so checking one scope never charges another.
  *
- * `checkCodeExecutionQuota` checks concurrency first (free, in-process) so a
- * saturated system rejects without spending any of the daily budget.
+ * `checkCodeExecutionQuota` is an ADVISORY preflight: it reports whether a run
+ * would be allowed without consuming anything. It must not increment the
+ * budget, because checking multiple scopes in sequence would otherwise charge
+ * the earlier scopes even when a later one denies — letting an exhausted drive
+ * drain a user's allowance in unrelated drives. The single real charge per run
+ * (one increment per scope via `checkDistributedRateLimit`) and the matching
+ * `acquireCodeExecutionSlot()` are wired at execution time in PR3; that caller
+ * must treat a passing preflight as advisory and handle `acquire === false`.
+ *
+ * Concurrency is checked first (free, in-process) so a saturated system rejects
+ * without even reading the budget.
  */
 
-import type { RateLimitResult } from '../../security/distributed-rate-limit';
 import type { SubscriptionTier } from '../subscription-utils';
 
 // Concurrent runs permitted per user, by subscription tier. Per-process: each
@@ -76,19 +84,20 @@ export type CodeExecutionQuotaDecision =
   | { allowed: false; reason: QuotaDenialReason; retryAfter?: number };
 
 export interface CodeExecutionQuotaDeps {
-  /** Check the daily budget for one scoped identifier. Config binding (the
-   *  CODE_EXECUTION window) is the dependency's concern, not the caller's. */
-  checkRateLimit: (id: string) => Promise<RateLimitResult>;
+  /** Read (do NOT increment) the daily budget for one scoped identifier. Config
+   *  binding (the CODE_EXECUTION window) is the dependency's concern. */
+  checkRateLimitStatus: (id: string) => Promise<{ blocked: boolean; retryAfter?: number }>;
   canAcquireSlot: (args: { userId: string; tier: SubscriptionTier }) => boolean;
 }
 
-// checkDistributedRateLimit pulls in the database; import it (and the
+// getDistributedRateLimitStatus pulls in the database; import it (and the
 // CODE_EXECUTION config) lazily so the unit tests, which inject a fake, never
-// load the DB module graph.
+// load the DB module graph. Status is the read-only sibling of
+// checkDistributedRateLimit — it does not consume the window.
 const defaultDeps: CodeExecutionQuotaDeps = {
-  checkRateLimit: (id) =>
+  checkRateLimitStatus: (id) =>
     import('../../security/distributed-rate-limit').then((m) =>
-      m.checkDistributedRateLimit(id, m.DISTRIBUTED_RATE_LIMITS.CODE_EXECUTION),
+      m.getDistributedRateLimitStatus(id, m.DISTRIBUTED_RATE_LIMITS.CODE_EXECUTION),
     ),
   canAcquireSlot: canAcquireCodeExecutionSlot,
 };
@@ -119,9 +128,9 @@ export async function checkCodeExecutionQuota({
   ];
 
   for (const id of scopeIds) {
-    const result = await deps.checkRateLimit(id);
-    if (!result.allowed) {
-      return { allowed: false, reason: 'rate_limited', retryAfter: result.retryAfter };
+    const status = await deps.checkRateLimitStatus(id);
+    if (status.blocked) {
+      return { allowed: false, reason: 'rate_limited', retryAfter: status.retryAfter };
     }
   }
 

--- a/packages/lib/src/services/sandbox/quota.ts
+++ b/packages/lib/src/services/sandbox/quota.ts
@@ -1,0 +1,129 @@
+/**
+ * Code execution quota: per-tier concurrency + per-scope daily run budget.
+ *
+ * Vercel's concurrency and spend limits are account-wide — without our own
+ * sub-limits one tenant's runaway agent starves and bills everyone. This module
+ * provides two app-level controls:
+ *
+ *  - Concurrency: an in-process per-user semaphore whose ceiling scales by
+ *    subscription tier (mirrors `upload-semaphore.ts`, expressed functionally).
+ *  - Daily budget: `checkDistributedRateLimit` against the `CODE_EXECUTION`
+ *    config, applied independently to the user, drive, and tenant identifiers
+ *    so exhausting one scope never drains another's allowance.
+ *
+ * `checkCodeExecutionQuota` checks concurrency first (free, in-process) so a
+ * saturated system rejects without spending any of the daily budget.
+ */
+
+import type { RateLimitResult } from '../../security/distributed-rate-limit';
+import type { SubscriptionTier } from '../subscription-utils';
+
+// Concurrent runs permitted per user, by subscription tier. Per-process: each
+// replica enforces this independently, matching the upload-semaphore model.
+const CONCURRENCY_LIMITS: Record<SubscriptionTier, number> = {
+  free: 1,
+  pro: 2,
+  founder: 3,
+  business: 5,
+};
+
+const activeByUser = new Map<string, number>();
+
+export function getCodeExecutionConcurrencyLimit(tier: SubscriptionTier): number {
+  return CONCURRENCY_LIMITS[tier];
+}
+
+export function canAcquireCodeExecutionSlot({
+  userId,
+  tier,
+}: {
+  userId: string;
+  tier: SubscriptionTier;
+}): boolean {
+  return (activeByUser.get(userId) ?? 0) < CONCURRENCY_LIMITS[tier];
+}
+
+export function acquireCodeExecutionSlot({
+  userId,
+  tier,
+}: {
+  userId: string;
+  tier: SubscriptionTier;
+}): boolean {
+  if (!canAcquireCodeExecutionSlot({ userId, tier })) return false;
+  activeByUser.set(userId, (activeByUser.get(userId) ?? 0) + 1);
+  return true;
+}
+
+export function releaseCodeExecutionSlot({ userId }: { userId: string }): void {
+  const next = (activeByUser.get(userId) ?? 0) - 1;
+  if (next <= 0) {
+    activeByUser.delete(userId);
+  } else {
+    activeByUser.set(userId, next);
+  }
+}
+
+/** Clear all concurrency state. Test-only seam. */
+export function resetCodeExecutionConcurrency(): void {
+  activeByUser.clear();
+}
+
+export type QuotaDenialReason = 'concurrency_limit' | 'rate_limited';
+
+export type CodeExecutionQuotaDecision =
+  | { allowed: true }
+  | { allowed: false; reason: QuotaDenialReason; retryAfter?: number };
+
+export interface CodeExecutionQuotaDeps {
+  /** Check the daily budget for one scoped identifier. Config binding (the
+   *  CODE_EXECUTION window) is the dependency's concern, not the caller's. */
+  checkRateLimit: (id: string) => Promise<RateLimitResult>;
+  canAcquireSlot: (args: { userId: string; tier: SubscriptionTier }) => boolean;
+}
+
+// checkDistributedRateLimit pulls in the database; import it (and the
+// CODE_EXECUTION config) lazily so the unit tests, which inject a fake, never
+// load the DB module graph.
+const defaultDeps: CodeExecutionQuotaDeps = {
+  checkRateLimit: (id) =>
+    import('../../security/distributed-rate-limit').then((m) =>
+      m.checkDistributedRateLimit(id, m.DISTRIBUTED_RATE_LIMITS.CODE_EXECUTION),
+    ),
+  canAcquireSlot: canAcquireCodeExecutionSlot,
+};
+
+export interface CheckCodeExecutionQuotaInput {
+  userId: string;
+  driveId: string;
+  tenantId?: string;
+  tier: SubscriptionTier;
+  deps?: CodeExecutionQuotaDeps;
+}
+
+export async function checkCodeExecutionQuota({
+  userId,
+  driveId,
+  tenantId,
+  tier,
+  deps = defaultDeps,
+}: CheckCodeExecutionQuotaInput): Promise<CodeExecutionQuotaDecision> {
+  if (!deps.canAcquireSlot({ userId, tier })) {
+    return { allowed: false, reason: 'concurrency_limit' };
+  }
+
+  const scopeIds = [
+    `code-exec:user:${userId}`,
+    `code-exec:drive:${driveId}`,
+    ...(tenantId ? [`code-exec:tenant:${tenantId}`] : []),
+  ];
+
+  for (const id of scopeIds) {
+    const result = await deps.checkRateLimit(id);
+    if (!result.allowed) {
+      return { allowed: false, reason: 'rate_limited', retryAfter: result.retryAfter };
+    }
+  }
+
+  return { allowed: true };
+}

--- a/packages/lib/src/services/sandbox/sandbox-env.ts
+++ b/packages/lib/src/services/sandbox/sandbox-env.ts
@@ -1,0 +1,37 @@
+/**
+ * Sandbox environment construction (pure).
+ *
+ * The sandbox runs untrusted, agent-generated code. It must receive NO host
+ * secrets: no DB credentials, no session tokens, no API keys, no signing
+ * secrets. We build the sandbox env by *allowlist* — copying only a fixed set
+ * of explicitly-safe keys — and never spread `process.env` or the validated env
+ * wholesale. Any outbound capability the sandbox needs is provided later via
+ * Vercel credential brokering, never as a raw secret in the environment.
+ *
+ * Building by allowlist (rather than denylist) is the provable construction:
+ * a newly-added secret is excluded by default unless someone deliberately adds
+ * its key here — which the review gate would catch.
+ */
+
+import { getValidatedEnv, type ServerEnv } from '../../config/env-validation';
+
+/**
+ * The only keys ever forwarded into a sandbox. Each must be non-secret and
+ * safe to expose to untrusted code. Adding a key here is a security decision.
+ */
+const SANDBOX_ENV_ALLOWLIST = ['NODE_ENV'] as const;
+
+type AllowlistedKey = (typeof SANDBOX_ENV_ALLOWLIST)[number];
+
+export function buildSandboxEnv({
+  env = getValidatedEnv(),
+}: { env?: Partial<ServerEnv> } = {}): Record<AllowlistedKey, string> {
+  const result = {} as Record<AllowlistedKey, string>;
+  for (const key of SANDBOX_ENV_ALLOWLIST) {
+    const value = env[key];
+    if (typeof value === 'string') {
+      result[key] = value;
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
## PR1 of 4 — Agent Code Execution epic (safety-first, exposure-last)

The highest-risk feature in the product is agents running bash/code in chat inside a Vercel Sandbox (Firecracker microVM). The microVM contains *escape* but does nothing about cost, exfiltration, secrets, authz, or abuse — those are ours. This PR builds the **entire safety/policy layer with NO execution path**: nothing runs yet. Independently reviewable and mergeable. PR2 (lifecycle), PR3 (tools over `@vercel/sandbox`), PR4 (gated registration) build on top.

### Scope / file list
New (all under `packages/lib/src/services/sandbox/`):
- `can-run-code.ts` — fail-closed authorization gate (+ `__tests__/can-run-code.test.ts`)
- `execution-policy.ts` — pure policy resolver with safe defaults, frozen (+ test)
- `sandbox-env.ts` — pure allowlist env scrub (+ test)
- `quota.ts` — advisory non-incrementing daily-budget preflight + per-tier concurrency semaphore (+ test)
- `audit.ts` — pure audit-record builders + fire-and-forget writer (+ test)

Edits to shared modules:
- `config/env-validation.ts` — add `CODE_EXECUTION_ENABLED` kill-switch env var (default OFF; accepts any string, enables only on exact `'true'`)
- `monitoring/activity-logger.ts` — add `code_execution` to the `ActivityOperation` union
- `security/distributed-rate-limit.ts` — add `CODE_EXECUTION` entry to `DISTRIBUTED_RATE_LIMITS`
- `package.json` — add the 5 new modules to the `exports` map + `typesVersions`

### Requirements (PR1 "Given/should")
- ✅ Given a user lacking drive membership or role, deny via `canRunCode` without throwing.
- ✅ Given the kill-switch off / flag disabled, deny regardless of authorization.
- ✅ Given account-wide platform limits, enforce our own per-tenant/per-drive/per-user concurrency + daily-budget sub-limits.
- ✅ Given any execution profile, resolve a policy with safe defaults (explicit timeout, vCPU, memory, default-deny egress allowlist, `persistent: false`); unknown profile → safe minimum.
- ✅ Given a sandbox environment build, pass no host secrets, DB credentials, or session tokens.
- ✅ Given a completed or failed run, produce an immutable audit record (actor, redacted code, profile, exit, duration, cost, timestamp); anomalies → `securityAuditLog`.

### Deployment-mode note
The original epic §5 wording said "cloud-only." Per maintainer: `tenant` **is** cloud (isolated image per tenant, same feature set) and on-prem is not served (a local execution path is future work). So there is **no deployment-mode gate** — it would only be a dead branch. Authz + kill-switch + quota are the gates.

### Conventions / notes
- TDD: RED→GREEN with Vitest `expect()`; 48 sandbox tests. DB-backed authz/quota/audit use **dependency injection** (real deps lazily imported in the default wiring) so unit tests exercise composition with fakes and never touch the database.
- Reuses existing helpers (Orchestration Rules §6): `getUserDrivePermissions` + `getAgentAccessLevel`, `getDistributedRateLimitStatus`, `logActivity` + `securityAudit`, `getValidatedEnv`.
- No barrel imports; new modules added to the `exports` map (§7). Fail-closed throughout; egress default-deny; kill-switch default OFF.

### Quota is advisory (for PR3)
`checkCodeExecutionQuota` is a **non-incrementing preflight** — it reports whether a run would be allowed without consuming anything. The single real charge per run and the matching `acquireCodeExecutionSlot()` are wired at execution time in PR3, which must treat a passing preflight as advisory and handle `acquire === false`.

### Review remediation (two independent reviews)
- **P2-A** — redact secrets across the 4 KB truncation boundary (scan a wider 16 KB window before truncating; linear `STANDALONE_TOKEN`) + straddle regression test.
- **P2-B / F1** — quota check made non-incrementing preflight (was charging earlier scopes on a later-scope denial).
- **P2-C** — removed the deployment-mode gate (tenant is cloud; on-prem unsupported).
- **P2-D** — `CODE_EXECUTION_ENABLED` accepts any string so a stray value can't fail app-wide env validation.
- F1 (freeze policies) and F2 (bound-before-redact) addressed in the initial review pass; F3/F4 doc clarifications added.


- **Proactive review pass** — `resolveExecutionPolicy` now resolves profiles via an own-key check so a prototype key (`__proto__`/`constructor`/`toString`) can no longer bypass the safe-minimum fallback (+regression test); audit redaction dropped the redundant 16 KB scan window (redact-before-truncate already covers the storage-cap straddle); deduped the audit resource-id derivation into one helper so the activity and security logs can't diverge.$'\n\n### Gate'
- `bun run typecheck` (full monorepo build) — 13/13 ✅
- `bun run --filter '@pagespace/lib' test` — 4343 passed ✅
- eslint clean on changed files ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)