### PR TITLE
fix(auth): require real email verification for passkey signup & email change

### DIFF
--- a/apps/web/src/app/api/account/__tests__/get-patch-route.test.ts
+++ b/apps/web/src/app/api/account/__tests__/get-patch-route.test.ts
@@ -88,22 +88,15 @@ vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
   logUserActivity: vi.fn(),
 }));
 
-vi.mock('@pagespace/lib/auth/verification-utils', () => ({
-  createVerificationToken: vi.fn().mockResolvedValue('mock-verification-token'),
-}));
-vi.mock('@pagespace/lib/services/email-service', () => ({
-  sendEmail: vi.fn().mockResolvedValue(undefined),
-}));
-vi.mock('@pagespace/lib/email-templates/VerificationEmail', () => ({
-  VerificationEmail: () => null,
+vi.mock('@/lib/auth/send-verification-email', () => ({
+  sendVerificationEmail: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { GET, PATCH } from '../route';
 import { db } from '@pagespace/db/db';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { createVerificationToken } from '@pagespace/lib/auth/verification-utils';
-import { sendEmail } from '@pagespace/lib/services/email-service';
+import { sendVerificationEmail } from '@/lib/auth/send-verification-email';
 
 // Helper to create mock SessionAuthResult
 const mockWebAuth = (userId: string, tokenVersion = 0): SessionAuthResult => ({
@@ -325,11 +318,11 @@ describe('PATCH /api/account', () => {
   });
 
   it('should return 400 when email is already in use by another user', async () => {
-    // Arrange
-    vi.mocked(db.query.users.findFirst).mockResolvedValue({
-      id: 'different_user',
-      email: 'taken@example.com',
-    } as never);
+    // Arrange — 1st lookup (by id) is the caller's current address; 2nd lookup
+    // (by email) is the conflicting owner of the requested address.
+    vi.mocked(db.query.users.findFirst)
+      .mockResolvedValueOnce({ id: mockUserId, email: 'mine@example.com' } as never)
+      .mockResolvedValueOnce({ id: 'different_user', email: 'taken@example.com' } as never);
 
     const request = new Request('https://example.com/api/account', {
       method: 'PATCH',
@@ -481,14 +474,11 @@ describe('PATCH /api/account', () => {
     // Assert
     expect(response.status).toBe(200);
     expect(setMock).toHaveBeenCalledWith({ email: 'new@example.com', emailVerified: null });
-    expect(createVerificationToken).toHaveBeenCalledWith({
+    expect(sendVerificationEmail).toHaveBeenCalledWith({
       userId: mockUserId,
-      type: 'email_verification',
       email: 'new@example.com',
+      userName: 'Existing Name',
     });
-    expect(sendEmail).toHaveBeenCalledWith(
-      expect.objectContaining({ to: 'new@example.com', subject: 'Verify your PageSpace email' }),
-    );
   });
 
   it('does not reset verification or send email when only the name changes', async () => {
@@ -514,12 +504,11 @@ describe('PATCH /api/account', () => {
     // Assert
     expect(response.status).toBe(200);
     expect(setMock).toHaveBeenCalledWith({ name: 'Updated Name' });
-    expect(createVerificationToken).not.toHaveBeenCalled();
-    expect(sendEmail).not.toHaveBeenCalled();
+    expect(sendVerificationEmail).not.toHaveBeenCalled();
   });
 
   it('does not reset verification when the email matches the current address', async () => {
-    // Arrange — findFirst returns the caller themselves (same email)
+    // Arrange — current-address lookup returns the caller with the same email
     vi.mocked(db.query.users.findFirst).mockResolvedValue({
       id: mockUserId,
       email: 'test@example.com',
@@ -546,13 +535,46 @@ describe('PATCH /api/account', () => {
     // Assert
     expect(response.status).toBe(200);
     expect(setMock).toHaveBeenCalledWith({ email: 'test@example.com' });
-    expect(sendEmail).not.toHaveBeenCalled();
+    expect(sendVerificationEmail).not.toHaveBeenCalled();
+  });
+
+  it('does not reset verification when a mixed-case stored email (OAuth) is resubmitted', async () => {
+    // Regression: emails are not guaranteed lowercase at rest (OAuth stores the
+    // provider value verbatim). Resubmitting the same address must be a no-op,
+    // not a spurious de-verification.
+    vi.mocked(db.query.users.findFirst).mockResolvedValue({
+      id: mockUserId,
+      email: 'John.Doe@gmail.com',
+    } as never);
+
+    const returningMock = vi.fn().mockResolvedValue([{
+      id: mockUserId,
+      name: 'John Doe',
+      email: 'john.doe@gmail.com',
+      image: null,
+    }]);
+    const whereMock = vi.fn().mockReturnValue({ returning: returningMock });
+    const setMock = vi.fn().mockReturnValue({ where: whereMock });
+    vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
+
+    const request = new Request('https://example.com/api/account', {
+      method: 'PATCH',
+      body: JSON.stringify({ email: 'john.doe@gmail.com' }),
+    });
+
+    // Act
+    const response = await PATCH(request);
+
+    // Assert — no emailVerified reset, no verification email
+    expect(response.status).toBe(200);
+    expect(setMock).toHaveBeenCalledWith({ email: 'john.doe@gmail.com' });
+    expect(sendVerificationEmail).not.toHaveBeenCalled();
   });
 
   it('still updates the profile when the verification email fails to send', async () => {
     // Arrange
     vi.mocked(db.query.users.findFirst).mockResolvedValue(null as never);
-    vi.mocked(sendEmail).mockRejectedValueOnce(new Error('SMTP down'));
+    vi.mocked(sendVerificationEmail).mockRejectedValueOnce(new Error('SMTP down'));
 
     const returningMock = vi.fn().mockResolvedValue([{
       id: mockUserId,

--- a/apps/web/src/app/api/account/__tests__/get-patch-route.test.ts
+++ b/apps/web/src/app/api/account/__tests__/get-patch-route.test.ts
@@ -484,6 +484,7 @@ describe('PATCH /api/account', () => {
     expect(createVerificationToken).toHaveBeenCalledWith({
       userId: mockUserId,
       type: 'email_verification',
+      email: 'new@example.com',
     });
     expect(sendEmail).toHaveBeenCalledWith(
       expect.objectContaining({ to: 'new@example.com', subject: 'Verify your PageSpace email' }),

--- a/apps/web/src/app/api/account/__tests__/get-patch-route.test.ts
+++ b/apps/web/src/app/api/account/__tests__/get-patch-route.test.ts
@@ -88,10 +88,22 @@ vi.mock('@pagespace/lib/monitoring/activity-logger', () => ({
   logUserActivity: vi.fn(),
 }));
 
+vi.mock('@pagespace/lib/auth/verification-utils', () => ({
+  createVerificationToken: vi.fn().mockResolvedValue('mock-verification-token'),
+}));
+vi.mock('@pagespace/lib/services/email-service', () => ({
+  sendEmail: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@pagespace/lib/email-templates/VerificationEmail', () => ({
+  VerificationEmail: () => null,
+}));
+
 import { GET, PATCH } from '../route';
 import { db } from '@pagespace/db/db';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
+import { createVerificationToken } from '@pagespace/lib/auth/verification-utils';
+import { sendEmail } from '@pagespace/lib/services/email-service';
 
 // Helper to create mock SessionAuthResult
 const mockWebAuth = (userId: string, tokenVersion = 0): SessionAuthResult => ({
@@ -291,7 +303,9 @@ describe('PATCH /api/account', () => {
     // Assert
     expect(response.status).toBe(200);
     expect(body.email).toBe('new@example.com');
-    expect(setMock).toHaveBeenCalledWith({ email: 'new@example.com' });
+    // A genuine email change also clears verification so the new address must
+    // be re-verified.
+    expect(setMock).toHaveBeenCalledWith({ email: 'new@example.com', emailVerified: null });
   });
 
   it('should return 400 when email format is invalid', async () => {
@@ -439,5 +453,131 @@ describe('PATCH /api/account', () => {
     expect(errorCallArgs[0]).toContain('Profile update error');
     expect(errorCallArgs[1]).toBeInstanceOf(Error);
     expect((errorCallArgs[1] as Error).message).toBe('DB error');
+  });
+
+  it('resets verification and emails the new address when email changes', async () => {
+    // Arrange — new address, not used by anyone
+    vi.mocked(db.query.users.findFirst).mockResolvedValue(null as never);
+
+    const updatedUser = {
+      id: mockUserId,
+      name: 'Existing Name',
+      email: 'new@example.com',
+      image: null,
+    };
+    const returningMock = vi.fn().mockResolvedValue([updatedUser]);
+    const whereMock = vi.fn().mockReturnValue({ returning: returningMock });
+    const setMock = vi.fn().mockReturnValue({ where: whereMock });
+    vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
+
+    const request = new Request('https://example.com/api/account', {
+      method: 'PATCH',
+      body: JSON.stringify({ email: 'new@example.com' }),
+    });
+
+    // Act
+    const response = await PATCH(request);
+
+    // Assert
+    expect(response.status).toBe(200);
+    expect(setMock).toHaveBeenCalledWith({ email: 'new@example.com', emailVerified: null });
+    expect(createVerificationToken).toHaveBeenCalledWith({
+      userId: mockUserId,
+      type: 'email_verification',
+    });
+    expect(sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: 'new@example.com', subject: 'Verify your PageSpace email' }),
+    );
+  });
+
+  it('does not reset verification or send email when only the name changes', async () => {
+    // Arrange
+    const returningMock = vi.fn().mockResolvedValue([{
+      id: mockUserId,
+      name: 'Updated Name',
+      email: 'existing@example.com',
+      image: null,
+    }]);
+    const whereMock = vi.fn().mockReturnValue({ returning: returningMock });
+    const setMock = vi.fn().mockReturnValue({ where: whereMock });
+    vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
+
+    const request = new Request('https://example.com/api/account', {
+      method: 'PATCH',
+      body: JSON.stringify({ name: 'Updated Name' }),
+    });
+
+    // Act
+    const response = await PATCH(request);
+
+    // Assert
+    expect(response.status).toBe(200);
+    expect(setMock).toHaveBeenCalledWith({ name: 'Updated Name' });
+    expect(createVerificationToken).not.toHaveBeenCalled();
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it('does not reset verification when the email matches the current address', async () => {
+    // Arrange — findFirst returns the caller themselves (same email)
+    vi.mocked(db.query.users.findFirst).mockResolvedValue({
+      id: mockUserId,
+      email: 'test@example.com',
+    } as never);
+
+    const returningMock = vi.fn().mockResolvedValue([{
+      id: mockUserId,
+      name: 'Test User',
+      email: 'test@example.com',
+      image: null,
+    }]);
+    const whereMock = vi.fn().mockReturnValue({ returning: returningMock });
+    const setMock = vi.fn().mockReturnValue({ where: whereMock });
+    vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
+
+    const request = new Request('https://example.com/api/account', {
+      method: 'PATCH',
+      body: JSON.stringify({ email: 'test@example.com' }),
+    });
+
+    // Act
+    const response = await PATCH(request);
+
+    // Assert
+    expect(response.status).toBe(200);
+    expect(setMock).toHaveBeenCalledWith({ email: 'test@example.com' });
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it('still updates the profile when the verification email fails to send', async () => {
+    // Arrange
+    vi.mocked(db.query.users.findFirst).mockResolvedValue(null as never);
+    vi.mocked(sendEmail).mockRejectedValueOnce(new Error('SMTP down'));
+
+    const returningMock = vi.fn().mockResolvedValue([{
+      id: mockUserId,
+      name: 'Existing Name',
+      email: 'new@example.com',
+      image: null,
+    }]);
+    const whereMock = vi.fn().mockReturnValue({ returning: returningMock });
+    const setMock = vi.fn().mockReturnValue({ where: whereMock });
+    vi.mocked(db.update).mockReturnValue({ set: setMock } as never);
+
+    const request = new Request('https://example.com/api/account', {
+      method: 'PATCH',
+      body: JSON.stringify({ email: 'new@example.com' }),
+    });
+
+    // Act
+    const response = await PATCH(request);
+    const body = await response.json();
+
+    // Assert
+    expect(response.status).toBe(200);
+    expect(body.email).toBe('new@example.com');
+    expect(loggers.auth.warn).toHaveBeenCalledWith(
+      'Failed to send verification email after email change',
+      expect.objectContaining({ userId: mockUserId }),
+    );
   });
 });

--- a/apps/web/src/app/api/account/route.ts
+++ b/apps/web/src/app/api/account/route.ts
@@ -16,6 +16,10 @@ import { isCloud } from '@pagespace/lib/deployment-mode';
 import { createAnonymizedActorEmail } from '@pagespace/lib/compliance/anonymize';
 import { getActorInfo, logActivity, logUserActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { securityAudit } from '@pagespace/lib/audit/security-audit';
+import { createVerificationToken } from '@pagespace/lib/auth/verification-utils';
+import { sendEmail } from '@pagespace/lib/services/email-service';
+import { VerificationEmail } from '@pagespace/lib/email-templates/VerificationEmail';
+import React from 'react';
 import { stripe } from '@/lib/stripe/client';
 
 const patchBodySchema = z
@@ -82,19 +86,28 @@ export async function PATCH(req: Request) {
       return Response.json({ error: 'Invalid email format' }, { status: 400 });
     }
 
-    if (email !== undefined) {
+    // Did the address actually change? The uniqueness lookup below returns the
+    // caller themselves when the normalized email matches their current one, so
+    // an unfound (undefined) result means a genuine change to a new address.
+    const normalizedEmail = email !== undefined ? email.toLowerCase() : undefined;
+    let emailChanged = false;
+    if (normalizedEmail !== undefined) {
       const existingUser = await db.query.users.findFirst({
-        where: eq(users.email, email),
+        where: eq(users.email, normalizedEmail),
       });
 
       if (existingUser && existingUser.id !== userId) {
         return Response.json({ error: 'Email is already in use' }, { status: 400 });
       }
+      emailChanged = !existingUser;
     }
 
-    const updates: { name?: string; email?: string } = {};
+    const updates: { name?: string; email?: string; emailVerified?: Date | null } = {};
     if (name !== undefined) updates.name = name;
-    if (email !== undefined) updates.email = email.toLowerCase();
+    if (normalizedEmail !== undefined) updates.email = normalizedEmail;
+    // A new address must be re-verified — the old verification proved ownership
+    // of a different inbox. Verification is re-issued via the email below.
+    if (emailChanged) updates.emailVerified = null;
 
     const [updatedUser] = await db
       .update(users)
@@ -109,6 +122,34 @@ export async function PATCH(req: Request) {
 
     if (!updatedUser) {
       return Response.json({ error: 'Failed to update user' }, { status: 500 });
+    }
+
+    // Send a verification email to the NEW address. Best-effort: a delivery
+    // failure must not fail the profile update — the user can resend from the
+    // account banner.
+    if (emailChanged) {
+      try {
+        const verificationToken = await createVerificationToken({
+          userId,
+          type: 'email_verification',
+        });
+        const baseUrl =
+          process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+        const verificationUrl = `${baseUrl}/api/auth/verify-email?token=${verificationToken}`;
+        await sendEmail({
+          to: updatedUser.email,
+          subject: 'Verify your PageSpace email',
+          react: React.createElement(VerificationEmail, {
+            userName: updatedUser.name,
+            verificationUrl,
+          }),
+        });
+      } catch (error) {
+        loggers.auth.warn('Failed to send verification email after email change', {
+          userId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
 
     // Log activity for audit trail (profile updates may be security-relevant)

--- a/apps/web/src/app/api/account/route.ts
+++ b/apps/web/src/app/api/account/route.ts
@@ -16,10 +16,7 @@ import { isCloud } from '@pagespace/lib/deployment-mode';
 import { createAnonymizedActorEmail } from '@pagespace/lib/compliance/anonymize';
 import { getActorInfo, logActivity, logUserActivity } from '@pagespace/lib/monitoring/activity-logger';
 import { securityAudit } from '@pagespace/lib/audit/security-audit';
-import { createVerificationToken } from '@pagespace/lib/auth/verification-utils';
-import { sendEmail } from '@pagespace/lib/services/email-service';
-import { VerificationEmail } from '@pagespace/lib/email-templates/VerificationEmail';
-import React from 'react';
+import { sendVerificationEmail } from '@/lib/auth/send-verification-email';
 import { stripe } from '@/lib/stripe/client';
 
 const patchBodySchema = z
@@ -86,20 +83,28 @@ export async function PATCH(req: Request) {
       return Response.json({ error: 'Invalid email format' }, { status: 400 });
     }
 
-    // Did the address actually change? The uniqueness lookup below returns the
-    // caller themselves when the normalized email matches their current one, so
-    // an unfound (undefined) result means a genuine change to a new address.
-    const normalizedEmail = email !== undefined ? email.toLowerCase() : undefined;
+    const normalizedEmail = email !== undefined ? email.toLowerCase().trim() : undefined;
     let emailChanged = false;
     if (normalizedEmail !== undefined) {
-      const existingUser = await db.query.users.findFirst({
-        where: eq(users.email, normalizedEmail),
+      // Decide "changed" by comparing against the caller's CURRENT stored
+      // address (case-insensitively). Inferring it from a uniqueness miss is
+      // unsound: emails are not guaranteed lowercase at rest (OAuth stores the
+      // provider value verbatim), so a case-sensitive lookup would miss the
+      // user's own row and spuriously de-verify them on a no-op resubmit.
+      const current = await db.query.users.findFirst({
+        where: eq(users.id, userId),
+        columns: { email: true },
       });
+      emailChanged = (current?.email ?? '').toLowerCase() !== normalizedEmail;
 
-      if (existingUser && existingUser.id !== userId) {
-        return Response.json({ error: 'Email is already in use' }, { status: 400 });
+      if (emailChanged) {
+        const existingUser = await db.query.users.findFirst({
+          where: eq(users.email, normalizedEmail),
+        });
+        if (existingUser && existingUser.id !== userId) {
+          return Response.json({ error: 'Email is already in use' }, { status: 400 });
+        }
       }
-      emailChanged = !existingUser;
     }
 
     const updates: { name?: string; email?: string; emailVerified?: Date | null } = {};
@@ -129,21 +134,10 @@ export async function PATCH(req: Request) {
     // account banner.
     if (emailChanged) {
       try {
-        const verificationToken = await createVerificationToken({
+        await sendVerificationEmail({
           userId,
-          type: 'email_verification',
           email: updatedUser.email,
-        });
-        const baseUrl =
-          process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-        const verificationUrl = `${baseUrl}/api/auth/verify-email?token=${verificationToken}`;
-        await sendEmail({
-          to: updatedUser.email,
-          subject: 'Verify your PageSpace email',
-          react: React.createElement(VerificationEmail, {
-            userName: updatedUser.name,
-            verificationUrl,
-          }),
+          userName: updatedUser.name,
         });
       } catch (error) {
         loggers.auth.warn('Failed to send verification email after email change', {

--- a/apps/web/src/app/api/account/route.ts
+++ b/apps/web/src/app/api/account/route.ts
@@ -132,6 +132,7 @@ export async function PATCH(req: Request) {
         const verificationToken = await createVerificationToken({
           userId,
           type: 'email_verification',
+          email: updatedUser.email,
         });
         const baseUrl =
           process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';

--- a/apps/web/src/app/api/auth/__tests__/verify-email.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/verify-email.test.ts
@@ -156,8 +156,9 @@ describe('/api/auth/verify-email', () => {
       );
     });
 
-    it('falls back to the unbound path for tokens with malformed metadata', async () => {
-      // Arrange — metadata is not valid JSON
+    it('rejects tokens with present-but-unparseable metadata (does not silently fall back)', async () => {
+      // Arrange — metadata is present but not valid JSON (corrupt). It must NOT
+      // downgrade to the unbound markEmailVerified path.
       vi.mocked(verifyToken).mockResolvedValue({
         userId: 'test-user-id',
         metadata: 'not-json',
@@ -168,11 +169,17 @@ describe('/api/auth/verify-email', () => {
 
       // Act
       const response = await GET(request);
+      const body = await response.json();
 
       // Assert
-      expect(response.status).toBe(303);
-      expect(markEmailVerified).toHaveBeenCalledWith('test-user-id');
+      expect(response.status).toBe(400);
+      expect(body.error).toBe('Invalid or expired verification token');
+      expect(markEmailVerified).not.toHaveBeenCalled();
       expect(markEmailVerifiedForAddress).not.toHaveBeenCalled();
+      expect(loggers.auth.warn).toHaveBeenCalledWith(
+        'Email verification token has unparseable metadata',
+        { userId: 'test-user-id' },
+      );
     });
   });
 

--- a/apps/web/src/app/api/auth/__tests__/verify-email.test.ts
+++ b/apps/web/src/app/api/auth/__tests__/verify-email.test.ts
@@ -6,6 +6,7 @@ import { NextRequest } from 'next/server';
 vi.mock('@pagespace/lib/auth/verification-utils', () => ({
   verifyToken: vi.fn(),
   markEmailVerified: vi.fn().mockResolvedValue(undefined),
+  markEmailVerifiedForAddress: vi.fn().mockResolvedValue(true),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
@@ -30,7 +31,7 @@ vi.mock('@pagespace/lib/monitoring/activity-tracker', () => ({
   trackAuthEvent: vi.fn(),
 }));
 
-import { verifyToken, markEmailVerified } from '@pagespace/lib/auth/verification-utils';
+import { verifyToken, markEmailVerified, markEmailVerifiedForAddress } from '@pagespace/lib/auth/verification-utils';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
 
@@ -38,8 +39,9 @@ describe('/api/auth/verify-email', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // Default: valid token
-    vi.mocked(verifyToken).mockResolvedValue('test-user-id');
+    // Default: valid legacy token (no bound email in metadata)
+    vi.mocked(verifyToken).mockResolvedValue({ userId: 'test-user-id', metadata: null });
+    vi.mocked(markEmailVerifiedForAddress).mockResolvedValue(true);
   });
 
   describe('successful verification', () => {
@@ -104,6 +106,73 @@ describe('/api/auth/verify-email', () => {
 
       // Assert
       expect(trackAuthEvent).toHaveBeenCalledWith('test-user-id', 'email_verified', {});
+    });
+  });
+
+  describe('address-bound verification', () => {
+    it('verifies the bound address atomically and does not use the unbound path', async () => {
+      // Arrange — token carries a bound email in metadata
+      vi.mocked(verifyToken).mockResolvedValue({
+        userId: 'test-user-id',
+        metadata: JSON.stringify({ email: 'bound@example.com' }),
+      });
+      vi.mocked(markEmailVerifiedForAddress).mockResolvedValue(true);
+
+      const url = new URL('http://localhost/api/auth/verify-email?token=valid-token');
+      const request = new NextRequest(url);
+
+      // Act
+      const response = await GET(request);
+
+      // Assert
+      expect(response.status).toBe(303);
+      expect(markEmailVerifiedForAddress).toHaveBeenCalledWith('test-user-id', 'bound@example.com');
+      expect(markEmailVerified).not.toHaveBeenCalled();
+    });
+
+    it('rejects when the stored email changed since the token was issued', async () => {
+      // Arrange — bound email no longer matches the user's current address
+      vi.mocked(verifyToken).mockResolvedValue({
+        userId: 'test-user-id',
+        metadata: JSON.stringify({ email: 'bound@example.com' }),
+      });
+      vi.mocked(markEmailVerifiedForAddress).mockResolvedValue(false);
+
+      const url = new URL('http://localhost/api/auth/verify-email?token=stale-token');
+      const request = new NextRequest(url);
+
+      // Act
+      const response = await GET(request);
+      const body = await response.json();
+
+      // Assert
+      expect(response.status).toBe(400);
+      expect(body.error).toBe('Invalid or expired verification token');
+      expect(markEmailVerified).not.toHaveBeenCalled();
+      expect(trackAuthEvent).not.toHaveBeenCalled();
+      expect(loggers.auth.warn).toHaveBeenCalledWith(
+        'Email verification token did not match current address',
+        { userId: 'test-user-id' },
+      );
+    });
+
+    it('falls back to the unbound path for tokens with malformed metadata', async () => {
+      // Arrange — metadata is not valid JSON
+      vi.mocked(verifyToken).mockResolvedValue({
+        userId: 'test-user-id',
+        metadata: 'not-json',
+      });
+
+      const url = new URL('http://localhost/api/auth/verify-email?token=valid-token');
+      const request = new NextRequest(url);
+
+      // Act
+      const response = await GET(request);
+
+      // Assert
+      expect(response.status).toBe(303);
+      expect(markEmailVerified).toHaveBeenCalledWith('test-user-id');
+      expect(markEmailVerifiedForAddress).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/app/api/auth/resend-verification/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/resend-verification/__tests__/route.test.ts
@@ -29,16 +29,8 @@ vi.mock('@/lib/repositories/auth-repository', () => ({
   },
 }));
 
-vi.mock('@pagespace/lib/auth/verification-utils', () => ({
-  createVerificationToken: vi.fn().mockResolvedValue('mock-verification-token'),
-}));
-
-vi.mock('@pagespace/lib/services/email-service', () => ({
-  sendEmail: vi.fn().mockResolvedValue(undefined),
-}));
-
-vi.mock('@pagespace/lib/email-templates/VerificationEmail', () => ({
-  VerificationEmail: vi.fn(),
+vi.mock('@/lib/auth/send-verification-email', () => ({
+  sendVerificationEmail: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
@@ -70,17 +62,10 @@ vi.mock('@pagespace/lib/security/distributed-rate-limit', () => ({
   },
 }));
 
-vi.mock('react', () => ({
-  default: {
-    createElement: vi.fn().mockReturnValue({}),
-  },
-}));
-
 import { POST } from '../route';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
 import { authRepository } from '@/lib/repositories/auth-repository';
-import { createVerificationToken } from '@pagespace/lib/auth/verification-utils';
-import { sendEmail } from '@pagespace/lib/services/email-service';
+import { sendVerificationEmail } from '@/lib/auth/send-verification-email';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { checkDistributedRateLimit } from '@pagespace/lib/security/distributed-rate-limit';
 import { NextResponse } from 'next/server';
@@ -228,21 +213,18 @@ describe('POST /api/auth/resend-verification', () => {
   });
 
   describe('successful verification email', () => {
-    it('creates verification token and sends email', async () => {
+    it('sends an address-bound verification email for the current user', async () => {
       const response = await POST(createResendRequest());
       const body = await response.json();
 
       expect(response.status).toBe(200);
       expect(body.message).toContain('Verification email sent successfully');
       expect(authRepository.findUserById).toHaveBeenCalledWith('test-user-id');
-      expect(createVerificationToken).toHaveBeenCalledWith({
+      expect(sendVerificationEmail).toHaveBeenCalledWith({
         userId: 'test-user-id',
-        type: 'email_verification',
         email: 'test@example.com',
+        userName: 'Test User',
       });
-      const sendArgs = vi.mocked(sendEmail).mock.calls[0][0];
-      expect(sendArgs.to).toBe('test@example.com');
-      expect(sendArgs.subject).toBe('Verify your PageSpace email');
     });
 
     it('logs successful email resend', async () => {
@@ -253,38 +235,11 @@ describe('POST /api/auth/resend-verification', () => {
         { userId: 'test-user-id', email: 'te***@example.com' }
       );
     });
-
-    it('constructs correct verification URL', async () => {
-      process.env.WEB_APP_URL = 'https://app.example.com';
-
-      await POST(createResendRequest());
-
-      const sendArgs = vi.mocked(sendEmail).mock.calls[0][0];
-      expect(sendArgs.to).toBe('test@example.com');
-    });
-
-    it('uses NEXT_PUBLIC_APP_URL as fallback', async () => {
-      delete process.env.WEB_APP_URL;
-      process.env.NEXT_PUBLIC_APP_URL = 'https://public.example.com';
-
-      const response = await POST(createResendRequest());
-
-      expect(response.status).toBe(200);
-    });
-
-    it('uses localhost as final fallback', async () => {
-      delete process.env.WEB_APP_URL;
-      delete process.env.NEXT_PUBLIC_APP_URL;
-
-      const response = await POST(createResendRequest());
-
-      expect(response.status).toBe(200);
-    });
   });
 
   describe('email rate limit from service', () => {
-    it('returns 429 when email service throws rate limit error', async () => {
-      vi.mocked(sendEmail).mockRejectedValueOnce(new Error('Too many emails sent'));
+    it('returns 429 when the send throws a rate limit error', async () => {
+      vi.mocked(sendVerificationEmail).mockRejectedValueOnce(new Error('Too many emails sent'));
 
       const response = await POST(createResendRequest());
       const body = await response.json();
@@ -293,8 +248,8 @@ describe('POST /api/auth/resend-verification', () => {
       expect(body.error).toBe('Too many emails sent');
     });
 
-    it('propagates other email errors as 500', async () => {
-      vi.mocked(sendEmail).mockRejectedValueOnce(new Error('SMTP connection failed'));
+    it('propagates other send errors as 500', async () => {
+      vi.mocked(sendVerificationEmail).mockRejectedValueOnce(new Error('SMTP connection failed'));
 
       const response = await POST(createResendRequest());
       const body = await response.json();

--- a/apps/web/src/app/api/auth/resend-verification/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/resend-verification/__tests__/route.test.ts
@@ -238,6 +238,7 @@ describe('POST /api/auth/resend-verification', () => {
       expect(createVerificationToken).toHaveBeenCalledWith({
         userId: 'test-user-id',
         type: 'email_verification',
+        email: 'test@example.com',
       });
       const sendArgs = vi.mocked(sendEmail).mock.calls[0][0];
       expect(sendArgs.to).toBe('test@example.com');

--- a/apps/web/src/app/api/auth/resend-verification/route.ts
+++ b/apps/web/src/app/api/auth/resend-verification/route.ts
@@ -1,13 +1,10 @@
 import { NextResponse } from 'next/server';
 import { authenticateRequestWithOptions, isAuthError } from '@/lib/auth';
-import { createVerificationToken } from '@pagespace/lib/auth/verification-utils';
-import { sendEmail } from '@pagespace/lib/services/email-service';
-import { VerificationEmail } from '@pagespace/lib/email-templates/VerificationEmail';
+import { sendVerificationEmail } from '@/lib/auth/send-verification-email';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { maskEmail } from '@pagespace/lib/audit/mask-email';
 import { checkDistributedRateLimit, DISTRIBUTED_RATE_LIMITS } from '@pagespace/lib/security/distributed-rate-limit';
-import React from 'react';
 import { authRepository } from '@/lib/repositories/auth-repository';
 
 const AUTH_OPTIONS = { allow: ['session'] as const, requireCSRF: true };
@@ -53,25 +50,13 @@ export async function POST(request: Request) {
       );
     }
 
-    // Create new verification token bound to the user's current address.
-    const verificationToken = await createVerificationToken({
-      userId: user.id,
-      type: 'email_verification',
-      email: user.email,
-    });
-
-    const baseUrl = process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-    const verificationUrl = `${baseUrl}/api/auth/verify-email?token=${verificationToken}`;
-
-    // Send verification email (rate limited in sendEmail function)
+    // Send verification email (token bound to the user's current address;
+    // sendEmail applies its own per-address rate limit).
     try {
-      await sendEmail({
-        to: user.email,
-        subject: 'Verify your PageSpace email',
-        react: React.createElement(VerificationEmail, {
-          userName: user.name,
-          verificationUrl
-        }),
+      await sendVerificationEmail({
+        userId: user.id,
+        email: user.email,
+        userName: user.name,
       });
 
       loggers.auth.info('Verification email resent', { userId: user.id, email: maskEmail(user.email) });

--- a/apps/web/src/app/api/auth/resend-verification/route.ts
+++ b/apps/web/src/app/api/auth/resend-verification/route.ts
@@ -53,10 +53,11 @@ export async function POST(request: Request) {
       );
     }
 
-    // Create new verification token
+    // Create new verification token bound to the user's current address.
     const verificationToken = await createVerificationToken({
       userId: user.id,
       type: 'email_verification',
+      email: user.email,
     });
 
     const baseUrl = process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';

--- a/apps/web/src/app/api/auth/signup-passkey/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/signup-passkey/__tests__/route.test.ts
@@ -11,6 +11,16 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 vi.mock('@pagespace/lib/auth/passkey-service', () => ({
   verifySignupRegistration: vi.fn(),
 }));
+vi.mock('@pagespace/lib/auth/verification-utils', () => ({
+  markEmailVerified: vi.fn().mockResolvedValue(undefined),
+  createVerificationToken: vi.fn().mockResolvedValue('mock-verification-token'),
+}));
+vi.mock('@pagespace/lib/services/email-service', () => ({
+  sendEmail: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@pagespace/lib/email-templates/VerificationEmail', () => ({
+  VerificationEmail: () => null,
+}));
 vi.mock('@pagespace/lib/auth/session-service', () => ({
   sessionService: {
     createSession: vi.fn().mockResolvedValue('ps_sess_mock_session_token'),
@@ -93,6 +103,8 @@ vi.mock('@/lib/auth/native-invite-acceptance', () => ({
 import { POST } from '../route';
 import { consumeAnyInviteIfPresent } from '@/lib/auth/native-invite-acceptance';
 import { verifySignupRegistration } from '@pagespace/lib/auth/passkey-service';
+import { markEmailVerified, createVerificationToken } from '@pagespace/lib/auth/verification-utils';
+import { sendEmail } from '@pagespace/lib/services/email-service';
 import { sessionService } from '@pagespace/lib/auth/session-service';
 import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
 import { loggers } from '@pagespace/lib/logging/logger-config';
@@ -629,6 +641,71 @@ describe('POST /api/auth/signup-passkey', () => {
       expect(response.status).toBe(200);
       expect(body.success).toBe(true);
       expect(body.redirectUrl).toContain('inviteError=TOKEN_NOT_FOUND');
+    });
+  });
+
+  describe('email verification', () => {
+    it('non-invited signup sends a verification email and does not mark verified', async () => {
+      const response = await POST(createRequest());
+
+      expect(response.status).toBe(200);
+      expect(markEmailVerified).not.toHaveBeenCalled();
+      expect(createVerificationToken).toHaveBeenCalledWith({
+        userId: 'new-user-1',
+        type: 'email_verification',
+      });
+      expect(sendEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          to: 'user@example.com',
+          subject: 'Verify your PageSpace email',
+        }),
+      );
+    });
+
+    it('signup via a successfully consumed invite marks verified and sends no verification email', async () => {
+      vi.mocked(consumeAnyInviteIfPresent).mockResolvedValueOnce({
+        kind: 'drive',
+        invitedDriveId: 'drive_invited',
+        invitedPageId: null,
+        connectionId: null,
+      });
+
+      const response = await POST(createRequest({ ...validPayload, inviteToken: 'ps_invite_xyz' }));
+
+      expect(response.status).toBe(200);
+      expect(markEmailVerified).toHaveBeenCalledWith('new-user-1');
+      expect(sendEmail).not.toHaveBeenCalled();
+      expect(createVerificationToken).not.toHaveBeenCalled();
+    });
+
+    it('failed invite acceptance falls back to sending a verification email', async () => {
+      vi.mocked(consumeAnyInviteIfPresent).mockResolvedValueOnce({
+        kind: null,
+        invitedDriveId: null,
+        invitedPageId: null,
+        connectionId: null,
+        inviteError: 'EMAIL_MISMATCH',
+      });
+
+      const response = await POST(createRequest({ ...validPayload, inviteToken: 'ps_invite_xyz' }));
+
+      expect(response.status).toBe(200);
+      expect(markEmailVerified).not.toHaveBeenCalled();
+      expect(sendEmail).toHaveBeenCalled();
+    });
+
+    it('a verification-email failure does not fail the signup', async () => {
+      vi.mocked(sendEmail).mockRejectedValueOnce(new Error('SMTP down'));
+
+      const response = await POST(createRequest());
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(loggers.auth.warn).toHaveBeenCalledWith(
+        'Failed to send passkey-signup verification email',
+        expect.objectContaining({ userId: 'new-user-1' }),
+      );
     });
   });
 });

--- a/apps/web/src/app/api/auth/signup-passkey/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/signup-passkey/__tests__/route.test.ts
@@ -13,13 +13,9 @@ vi.mock('@pagespace/lib/auth/passkey-service', () => ({
 }));
 vi.mock('@pagespace/lib/auth/verification-utils', () => ({
   markEmailVerified: vi.fn().mockResolvedValue(undefined),
-  createVerificationToken: vi.fn().mockResolvedValue('mock-verification-token'),
 }));
-vi.mock('@pagespace/lib/services/email-service', () => ({
-  sendEmail: vi.fn().mockResolvedValue(undefined),
-}));
-vi.mock('@pagespace/lib/email-templates/VerificationEmail', () => ({
-  VerificationEmail: () => null,
+vi.mock('@/lib/auth/send-verification-email', () => ({
+  sendVerificationEmail: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock('@pagespace/lib/auth/session-service', () => ({
   sessionService: {
@@ -103,8 +99,8 @@ vi.mock('@/lib/auth/native-invite-acceptance', () => ({
 import { POST } from '../route';
 import { consumeAnyInviteIfPresent } from '@/lib/auth/native-invite-acceptance';
 import { verifySignupRegistration } from '@pagespace/lib/auth/passkey-service';
-import { markEmailVerified, createVerificationToken } from '@pagespace/lib/auth/verification-utils';
-import { sendEmail } from '@pagespace/lib/services/email-service';
+import { markEmailVerified } from '@pagespace/lib/auth/verification-utils';
+import { sendVerificationEmail } from '@/lib/auth/send-verification-email';
 import { sessionService } from '@pagespace/lib/auth/session-service';
 import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
 import { loggers } from '@pagespace/lib/logging/logger-config';
@@ -650,17 +646,11 @@ describe('POST /api/auth/signup-passkey', () => {
 
       expect(response.status).toBe(200);
       expect(markEmailVerified).not.toHaveBeenCalled();
-      expect(createVerificationToken).toHaveBeenCalledWith({
+      expect(sendVerificationEmail).toHaveBeenCalledWith({
         userId: 'new-user-1',
-        type: 'email_verification',
         email: 'user@example.com',
+        userName: 'Test User',
       });
-      expect(sendEmail).toHaveBeenCalledWith(
-        expect.objectContaining({
-          to: 'user@example.com',
-          subject: 'Verify your PageSpace email',
-        }),
-      );
     });
 
     it('signup via a successfully consumed invite marks verified and sends no verification email', async () => {
@@ -675,8 +665,22 @@ describe('POST /api/auth/signup-passkey', () => {
 
       expect(response.status).toBe(200);
       expect(markEmailVerified).toHaveBeenCalledWith('new-user-1');
-      expect(sendEmail).not.toHaveBeenCalled();
-      expect(createVerificationToken).not.toHaveBeenCalled();
+      expect(sendVerificationEmail).not.toHaveBeenCalled();
+    });
+
+    it('signup via a successfully consumed CONNECTION invite also marks verified (inbox ownership proven)', async () => {
+      vi.mocked(consumeAnyInviteIfPresent).mockResolvedValueOnce({
+        kind: 'connection',
+        invitedDriveId: null,
+        invitedPageId: null,
+        connectionId: 'conn_1',
+      });
+
+      const response = await POST(createRequest({ ...validPayload, inviteToken: 'ps_invite_conn' }));
+
+      expect(response.status).toBe(200);
+      expect(markEmailVerified).toHaveBeenCalledWith('new-user-1');
+      expect(sendVerificationEmail).not.toHaveBeenCalled();
     });
 
     it('failed invite acceptance falls back to sending a verification email', async () => {
@@ -692,11 +696,11 @@ describe('POST /api/auth/signup-passkey', () => {
 
       expect(response.status).toBe(200);
       expect(markEmailVerified).not.toHaveBeenCalled();
-      expect(sendEmail).toHaveBeenCalled();
+      expect(sendVerificationEmail).toHaveBeenCalled();
     });
 
     it('a verification-email failure does not fail the signup', async () => {
-      vi.mocked(sendEmail).mockRejectedValueOnce(new Error('SMTP down'));
+      vi.mocked(sendVerificationEmail).mockRejectedValueOnce(new Error('SMTP down'));
 
       const response = await POST(createRequest());
       const body = await response.json();

--- a/apps/web/src/app/api/auth/signup-passkey/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/signup-passkey/__tests__/route.test.ts
@@ -653,6 +653,7 @@ describe('POST /api/auth/signup-passkey', () => {
       expect(createVerificationToken).toHaveBeenCalledWith({
         userId: 'new-user-1',
         type: 'email_verification',
+        email: 'user@example.com',
       });
       expect(sendEmail).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/apps/web/src/app/api/auth/signup-passkey/route.ts
+++ b/apps/web/src/app/api/auth/signup-passkey/route.ts
@@ -1,6 +1,10 @@
 import { NextResponse } from 'next/server';
+import React from 'react';
 import { z } from 'zod/v4';
 import { verifySignupRegistration } from '@pagespace/lib/auth/passkey-service';
+import { markEmailVerified, createVerificationToken } from '@pagespace/lib/auth/verification-utils';
+import { sendEmail } from '@pagespace/lib/services/email-service';
+import { VerificationEmail } from '@pagespace/lib/email-templates/VerificationEmail';
 import { sessionService } from '@pagespace/lib/auth/session-service';
 import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
 import { SESSION_DURATION_MS } from '@pagespace/lib/auth/constants';
@@ -245,6 +249,47 @@ export async function POST(req: Request) {
       user: { id: userId, suspendedAt: null },
       now: new Date(),
     });
+
+    // Email verification. A passkey only proves authenticator control, not email
+    // ownership, so a fresh signup starts unverified. A successfully consumed
+    // BOUND invite token (delivered to this inbox and presented here) is the one
+    // exception — it proves the user accessed the address, so we mark verified.
+    // The broad consumeAllInvitesForEmail drain above is NOT proof: it matches
+    // pending invites by email without proving the user clicked an emailed link.
+    const inviteProvesEmailOwnership =
+      inviteAcceptedKind !== null && inviteAcceptError === null;
+    if (inviteProvesEmailOwnership) {
+      try {
+        await markEmailVerified(userId);
+      } catch (error) {
+        loggers.auth.warn('Failed to mark passkey-signup email verified via invite', {
+          userId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    } else {
+      // Best-effort verification email — must NOT fail the signup. The user can
+      // resend from the account banner if delivery fails.
+      try {
+        const verificationToken = await createVerificationToken({
+          userId,
+          type: 'email_verification',
+        });
+        const baseUrl =
+          process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+        const verificationUrl = `${baseUrl}/api/auth/verify-email?token=${verificationToken}`;
+        await sendEmail({
+          to: email,
+          subject: 'Verify your PageSpace email',
+          react: React.createElement(VerificationEmail, { userName: name, verificationUrl }),
+        });
+      } catch (error) {
+        loggers.auth.warn('Failed to send passkey-signup verification email', {
+          userId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
 
     let deviceTokenValue: string | undefined;
     if (deviceId) {

--- a/apps/web/src/app/api/auth/signup-passkey/route.ts
+++ b/apps/web/src/app/api/auth/signup-passkey/route.ts
@@ -1,10 +1,8 @@
 import { NextResponse } from 'next/server';
-import React from 'react';
 import { z } from 'zod/v4';
 import { verifySignupRegistration } from '@pagespace/lib/auth/passkey-service';
-import { markEmailVerified, createVerificationToken } from '@pagespace/lib/auth/verification-utils';
-import { sendEmail } from '@pagespace/lib/services/email-service';
-import { VerificationEmail } from '@pagespace/lib/email-templates/VerificationEmail';
+import { markEmailVerified } from '@pagespace/lib/auth/verification-utils';
+import { sendVerificationEmail } from '@/lib/auth/send-verification-email';
 import { sessionService } from '@pagespace/lib/auth/session-service';
 import { generateCSRFToken } from '@pagespace/lib/auth/csrf-utils';
 import { SESSION_DURATION_MS } from '@pagespace/lib/auth/constants';
@@ -271,19 +269,7 @@ export async function POST(req: Request) {
       // Best-effort verification email — must NOT fail the signup. The user can
       // resend from the account banner if delivery fails.
       try {
-        const verificationToken = await createVerificationToken({
-          userId,
-          type: 'email_verification',
-          email,
-        });
-        const baseUrl =
-          process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-        const verificationUrl = `${baseUrl}/api/auth/verify-email?token=${verificationToken}`;
-        await sendEmail({
-          to: email,
-          subject: 'Verify your PageSpace email',
-          react: React.createElement(VerificationEmail, { userName: name, verificationUrl }),
-        });
+        await sendVerificationEmail({ userId, email, userName: name });
       } catch (error) {
         loggers.auth.warn('Failed to send passkey-signup verification email', {
           userId,

--- a/apps/web/src/app/api/auth/signup-passkey/route.ts
+++ b/apps/web/src/app/api/auth/signup-passkey/route.ts
@@ -274,6 +274,7 @@ export async function POST(req: Request) {
         const verificationToken = await createVerificationToken({
           userId,
           type: 'email_verification',
+          email,
         });
         const baseUrl =
           process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';

--- a/apps/web/src/app/api/auth/verify-email/route.ts
+++ b/apps/web/src/app/api/auth/verify-email/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { verifyToken, markEmailVerified } from '@pagespace/lib/auth/verification-utils';
+import { verifyToken, markEmailVerified, markEmailVerifiedForAddress } from '@pagespace/lib/auth/verification-utils';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { trackAuthEvent } from '@pagespace/lib/monitoring/activity-tracker';
@@ -13,17 +13,45 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Verification token is required' }, { status: 400 });
     }
 
-    const userId = await verifyToken(token, 'email_verification');
+    const verified = await verifyToken(token, 'email_verification');
 
-    if (!userId) {
+    if (!verified) {
       return NextResponse.json(
         { error: 'Invalid or expired verification token' },
         { status: 400 }
       );
     }
 
-    // Mark email as verified
-    await markEmailVerified(userId);
+    const { userId } = verified;
+
+    // Parse the address this token was bound to (if any). Tokens minted after
+    // address-binding shipped carry the target email so we never verify an
+    // address other than the one the link was sent to.
+    let boundEmail: string | null = null;
+    if (verified.metadata) {
+      try {
+        boundEmail = (JSON.parse(verified.metadata) as { email?: string }).email ?? null;
+      } catch {
+        boundEmail = null;
+      }
+    }
+
+    if (boundEmail) {
+      // Mark verified ONLY if the user's current email still matches the bound
+      // address. If it changed since the token was issued, refuse — otherwise a
+      // token sent to a controlled inbox could verify a different, unowned one.
+      const marked = await markEmailVerifiedForAddress(userId, boundEmail);
+      if (!marked) {
+        loggers.auth.warn('Email verification token did not match current address', { userId });
+        return NextResponse.json(
+          { error: 'Invalid or expired verification token' },
+          { status: 400 }
+        );
+      }
+    } else {
+      // Legacy token issued before address binding — preserve prior behavior.
+      await markEmailVerified(userId);
+    }
 
     // Log verification
     loggers.auth.info('Email verified', { userId });

--- a/apps/web/src/app/api/auth/verify-email/route.ts
+++ b/apps/web/src/app/api/auth/verify-email/route.ts
@@ -26,13 +26,19 @@ export async function GET(request: NextRequest) {
 
     // Parse the address this token was bound to (if any). Tokens minted after
     // address-binding shipped carry the target email so we never verify an
-    // address other than the one the link was sent to.
+    // address other than the one the link was sent to. A null metadata is a
+    // legacy (pre-binding) token; present-but-unparseable metadata is corrupt
+    // and must NOT silently fall through to the unbound path.
     let boundEmail: string | null = null;
     if (verified.metadata) {
       try {
         boundEmail = (JSON.parse(verified.metadata) as { email?: string }).email ?? null;
       } catch {
-        boundEmail = null;
+        loggers.auth.warn('Email verification token has unparseable metadata', { userId });
+        return NextResponse.json(
+          { error: 'Invalid or expired verification token' },
+          { status: 400 }
+        );
       }
     }
 

--- a/apps/web/src/lib/auth/__tests__/send-verification-email.test.ts
+++ b/apps/web/src/lib/auth/__tests__/send-verification-email.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('@pagespace/lib/auth/verification-utils', () => ({
+  createVerificationToken: vi.fn().mockResolvedValue('tok_abc'),
+}));
+vi.mock('@pagespace/lib/services/email-service', () => ({
+  sendEmail: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@pagespace/lib/email-templates/VerificationEmail', () => ({
+  VerificationEmail: () => null,
+}));
+
+import { sendVerificationEmail } from '../send-verification-email';
+import { createVerificationToken } from '@pagespace/lib/auth/verification-utils';
+import { sendEmail } from '@pagespace/lib/services/email-service';
+
+describe('sendVerificationEmail', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('mints an address-bound token and sends to that address with the bound URL', async () => {
+    process.env.WEB_APP_URL = 'https://app.example.com';
+
+    await sendVerificationEmail({ userId: 'u1', email: 'a@example.com', userName: 'Ann' });
+
+    expect(createVerificationToken).toHaveBeenCalledWith({
+      userId: 'u1',
+      type: 'email_verification',
+      email: 'a@example.com',
+    });
+    const args = vi.mocked(sendEmail).mock.calls[0][0];
+    expect(args.to).toBe('a@example.com');
+    expect(args.subject).toBe('Verify your PageSpace email');
+  });
+
+  it('falls back through WEB_APP_URL -> NEXT_PUBLIC_APP_URL -> localhost', async () => {
+    delete process.env.WEB_APP_URL;
+    delete process.env.NEXT_PUBLIC_APP_URL;
+
+    // Should not throw with no env configured (localhost fallback).
+    await expect(
+      sendVerificationEmail({ userId: 'u1', email: 'a@example.com', userName: 'Ann' }),
+    ).resolves.toBeUndefined();
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates send failures to the caller (no internal swallow)', async () => {
+    vi.mocked(sendEmail).mockRejectedValueOnce(new Error('Too many emails sent'));
+
+    await expect(
+      sendVerificationEmail({ userId: 'u1', email: 'a@example.com', userName: 'Ann' }),
+    ).rejects.toThrow('Too many emails sent');
+  });
+});

--- a/apps/web/src/lib/auth/send-verification-email.ts
+++ b/apps/web/src/lib/auth/send-verification-email.ts
@@ -1,0 +1,39 @@
+import React from 'react';
+import { createVerificationToken } from '@pagespace/lib/auth/verification-utils';
+import { sendEmail } from '@pagespace/lib/services/email-service';
+import { VerificationEmail } from '@pagespace/lib/email-templates/VerificationEmail';
+
+/**
+ * Mint an address-bound `email_verification` token and send the verification
+ * email to that address. Binding the token to `email` (stored in token
+ * metadata) lets the verify step refuse to verify any other address than the
+ * one the link was sent to.
+ *
+ * Throws on send failure — callers choose their own error policy (best-effort
+ * for signup/profile updates, surfacing rate limits for explicit resends).
+ * Centralizes the token binding, link path, subject, and template so every
+ * entry point stays consistent.
+ */
+export async function sendVerificationEmail(params: {
+  userId: string;
+  email: string;
+  userName: string;
+}): Promise<void> {
+  const { userId, email, userName } = params;
+
+  const verificationToken = await createVerificationToken({
+    userId,
+    type: 'email_verification',
+    email,
+  });
+
+  const baseUrl =
+    process.env.WEB_APP_URL || process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+  const verificationUrl = `${baseUrl}/api/auth/verify-email?token=${verificationToken}`;
+
+  await sendEmail({
+    to: email,
+    subject: 'Verify your PageSpace email',
+    react: React.createElement(VerificationEmail, { userName, verificationUrl }),
+  });
+}

--- a/packages/lib/src/auth/__tests__/verification-utils.test.ts
+++ b/packages/lib/src/auth/__tests__/verification-utils.test.ts
@@ -36,6 +36,7 @@ vi.mock('@pagespace/db/schema/auth', () => ({
   },
   users: {
     id: 'id',
+    email: 'email',
     emailVerified: 'emailVerified',
   },
 }));
@@ -54,6 +55,7 @@ import {
   createVerificationToken,
   verifyToken,
   markEmailVerified,
+  markEmailVerifiedForAddress,
   isEmailVerified,
 } from '../verification-utils';
 import { db } from '@pagespace/db/db';
@@ -117,6 +119,34 @@ describe('verification-utils', () => {
       const expectedExpiry = Date.now() + 30 * 60 * 1000;
       expect(Math.abs(expiresAt.getTime() - expectedExpiry)).toBeLessThan(5000);
     });
+
+    it('binds the token to a normalized email in metadata when provided', async () => {
+      const mockDelete = vi.fn();
+      const mockInsertValues = vi.fn();
+      vi.mocked(db.delete).mockReturnValue({ where: mockDelete } as never);
+      vi.mocked(db.insert).mockReturnValue({ values: mockInsertValues } as never);
+
+      await createVerificationToken({
+        userId: 'user-1',
+        type: 'email_verification',
+        email: 'User@Example.COM',
+      });
+
+      const insertCall = mockInsertValues.mock.calls[0][0];
+      expect(insertCall.metadata).toBe(JSON.stringify({ email: 'user@example.com' }));
+    });
+
+    it('stores null metadata when no email is bound', async () => {
+      const mockDelete = vi.fn();
+      const mockInsertValues = vi.fn();
+      vi.mocked(db.delete).mockReturnValue({ where: mockDelete } as never);
+      vi.mocked(db.insert).mockReturnValue({ values: mockInsertValues } as never);
+
+      await createVerificationToken({ userId: 'user-1', type: 'email_verification' });
+
+      const insertCall = mockInsertValues.mock.calls[0][0];
+      expect(insertCall.metadata).toBeNull();
+    });
   });
 
   describe('verifyToken', () => {
@@ -168,7 +198,7 @@ describe('verification-utils', () => {
       expect(result).toBeNull();
     });
 
-    it('should return userId and mark token as used when valid', async () => {
+    it('should return userId + metadata and mark token as used when valid', async () => {
       vi.mocked(db.query.verificationTokens.findFirst).mockResolvedValue({
         usedAt: null,
         expiresAt: new Date(Date.now() + 60000),
@@ -176,14 +206,39 @@ describe('verification-utils', () => {
         userId: 'user-1',
         id: 'token-1',
         tokenHash: 'hash',
+        metadata: JSON.stringify({ email: 'user@example.com' }),
       } as never);
 
-      const mockSet = vi.fn(() => ({ where: vi.fn() }));
+      // Atomic claim: update().set().where().returning() -> [{ id }]
+      const mockReturning = vi.fn().mockResolvedValue([{ id: 'token-1' }]);
+      const mockWhere = vi.fn(() => ({ returning: mockReturning }));
+      const mockSet = vi.fn(() => ({ where: mockWhere }));
       vi.mocked(db.update).mockReturnValue({ set: mockSet } as never);
 
       const result = await verifyToken('some-token', 'email_verification');
-      expect(result).toBe('user-1');
+      expect(result).toEqual({ userId: 'user-1', metadata: JSON.stringify({ email: 'user@example.com' }) });
       expect(db.update).toHaveBeenCalledWith(verificationTokens);
+    });
+
+    it('should return null when the atomic claim is lost (already consumed)', async () => {
+      vi.mocked(db.query.verificationTokens.findFirst).mockResolvedValue({
+        usedAt: null,
+        expiresAt: new Date(Date.now() + 60000),
+        type: 'email_verification',
+        userId: 'user-1',
+        id: 'token-1',
+        tokenHash: 'hash',
+        metadata: null,
+      } as never);
+
+      // returning() resolves empty -> another request won the race
+      const mockReturning = vi.fn().mockResolvedValue([]);
+      const mockWhere = vi.fn(() => ({ returning: mockReturning }));
+      const mockSet = vi.fn(() => ({ where: mockWhere }));
+      vi.mocked(db.update).mockReturnValue({ set: mockSet } as never);
+
+      const result = await verifyToken('some-token', 'email_verification');
+      expect(result).toBeNull();
     });
   });
 
@@ -198,6 +253,33 @@ describe('verification-utils', () => {
       const setArg = (mockSet.mock.calls as unknown[][])[0][0] as { emailVerified: unknown };
       expect(setArg.emailVerified).toBeInstanceOf(Date);
       expect(Object.keys(setArg)).toEqual(['emailVerified']);
+    });
+  });
+
+  describe('markEmailVerifiedForAddress', () => {
+    it('returns true and marks verified when the address still matches', async () => {
+      const mockReturning = vi.fn().mockResolvedValue([{ id: 'user-1' }]);
+      const mockWhere = vi.fn(() => ({ returning: mockReturning }));
+      const mockSet = vi.fn(() => ({ where: mockWhere }));
+      vi.mocked(db.update).mockReturnValue({ set: mockSet } as never);
+
+      const result = await markEmailVerifiedForAddress('user-1', 'User@Example.com');
+
+      expect(result).toBe(true);
+      expect(db.update).toHaveBeenCalledWith(users);
+      const setArg = (mockSet.mock.calls as unknown[][])[0][0] as { emailVerified: unknown };
+      expect(setArg.emailVerified).toBeInstanceOf(Date);
+    });
+
+    it('returns false when the address no longer matches (no row updated)', async () => {
+      const mockReturning = vi.fn().mockResolvedValue([]);
+      const mockWhere = vi.fn(() => ({ returning: mockReturning }));
+      const mockSet = vi.fn(() => ({ where: mockWhere }));
+      vi.mocked(db.update).mockReturnValue({ set: mockSet } as never);
+
+      const result = await markEmailVerifiedForAddress('user-1', 'changed@example.com');
+
+      expect(result).toBe(false);
     });
   });
 

--- a/packages/lib/src/auth/passkey-service.test.ts
+++ b/packages/lib/src/auth/passkey-service.test.ts
@@ -995,9 +995,9 @@ describe('Passkey Service', () => {
 
         assert({
           given: 'successful signup verification',
-          should: 'mark email as verified',
-          actual: createdUser?.emailVerified !== null,
-          expected: true,
+          should: 'leave email unverified (proven out-of-band, not by passkey)',
+          actual: createdUser?.emailVerified,
+          expected: null,
         });
 
         // Verify passkey was created

--- a/packages/lib/src/auth/passkey-service.ts
+++ b/packages/lib/src/auth/passkey-service.ts
@@ -899,7 +899,12 @@ export async function verifySignupRegistration(input: unknown): Promise<VerifySi
         provider: 'email',
         role: 'user',
         tokenVersion: 1,
-        emailVerified: new Date(), // Passkey signup = verified (device ownership proven)
+        // Passkey registration proves control of an authenticator, NOT ownership
+        // of the typed email. Leave the address unverified; verification happens
+        // out-of-band — the signup route either marks it verified when a trusted
+        // invite token (delivered to that inbox) is consumed, or sends a
+        // verification email the user must click.
+        emailVerified: null,
         tosAcceptedAt: new Date(),
       });
 

--- a/packages/lib/src/auth/verification-utils.ts
+++ b/packages/lib/src/auth/verification-utils.ts
@@ -11,10 +11,17 @@ interface CreateTokenOptions {
   userId: string;
   type: VerificationType;
   expiresInMinutes?: number;
+  /**
+   * For `email_verification` tokens, the address this token authorizes. Stored
+   * in metadata so the verify step can confirm the user's email is unchanged
+   * before marking it verified — otherwise an in-flight email change could
+   * redirect a token sent to a controlled inbox onto a different address.
+   */
+  email?: string;
 }
 
 export async function createVerificationToken(options: CreateTokenOptions): Promise<string> {
-  const { userId, type, expiresInMinutes = 1440 } = options;
+  const { userId, type, expiresInMinutes = 1440, email } = options;
 
   // Generate cryptographically secure token
   const token = randomBytes(32).toString('hex');
@@ -42,12 +49,22 @@ export async function createVerificationToken(options: CreateTokenOptions): Prom
     tokenPrefix: getTokenPrefix(token),
     type,
     expiresAt,
+    metadata: email ? JSON.stringify({ email: email.toLowerCase() }) : null,
   });
 
   return token;  // Return plaintext to caller (goes in email link)
 }
 
-export async function verifyToken(token: string, expectedType: VerificationType): Promise<string | null> {
+export interface VerifiedToken {
+  userId: string;
+  /** Raw JSON metadata stored with the token, if any (e.g. the bound email). */
+  metadata: string | null;
+}
+
+export async function verifyToken(
+  token: string,
+  expectedType: VerificationType
+): Promise<VerifiedToken | null> {
   // SECURITY: Hash-only lookup - plaintext tokens are never stored
   const tokenHashValue = hashToken(token);
 
@@ -75,13 +92,20 @@ export async function verifyToken(token: string, expectedType: VerificationType)
     return null; // Wrong token type
   }
 
-  // Mark token as used
-  await db
+  // Atomically claim the token: only the first caller flips usedAt from null,
+  // closing the check-then-act race where two requests both pass the usedAt
+  // guard above before either writes.
+  const claimed = await db
     .update(verificationTokens)
     .set({ usedAt: new Date() })
-    .where(eq(verificationTokens.id, record.id));
+    .where(and(eq(verificationTokens.id, record.id), isNull(verificationTokens.usedAt)))
+    .returning({ id: verificationTokens.id });
 
-  return record.userId;
+  if (claimed.length === 0) {
+    return null; // Lost the race — another request already consumed it
+  }
+
+  return { userId: record.userId, metadata: record.metadata };
 }
 
 export async function markEmailVerified(userId: string): Promise<void> {
@@ -89,6 +113,25 @@ export async function markEmailVerified(userId: string): Promise<void> {
     .update(users)
     .set({ emailVerified: new Date() })
     .where(eq(users.id, userId));
+}
+
+/**
+ * Verify a specific address: marks `emailVerified` only when the user's CURRENT
+ * email still equals `email`. The match-and-write is a single atomic UPDATE so
+ * an email change racing with verification cannot verify the wrong address.
+ * Returns true when a row was updated (the address still matched).
+ */
+export async function markEmailVerifiedForAddress(
+  userId: string,
+  email: string
+): Promise<boolean> {
+  const updated = await db
+    .update(users)
+    .set({ emailVerified: new Date() })
+    .where(and(eq(users.id, userId), eq(users.email, email.toLowerCase())))
+    .returning({ id: users.id });
+
+  return updated.length > 0;
 }
 
 export async function isEmailVerified(userId: string): Promise<boolean> {


### PR DESCRIPTION
## Problem

Passkey signups were marked `emailVerified` with **no real verification** — `passkey-service.ts` set `emailVerified: new Date()` the instant a WebAuthn registration completed ("device ownership proven"). That only proves control of an *authenticator*; anyone could type any email and be instantly "verified", and no confirmation email was ever sent.

Related gaps fixed along the way:
- `PATCH /api/account` changed a user's email without clearing `emailVerified`.
- Verification tokens weren't bound to a target address, so an in-flight email change could redirect a token sent to a controlled inbox onto an unowned address (TOCTOU race, raised in review).
- Email-change detection mis-fired for non-lowercase stored emails (OAuth), spuriously de-verifying users on a no-op resubmit (found in self-review).

The magic-link flow already verifies correctly (marks verified only after the emailed link is clicked).

## Changes

1. **Passkey signup** (`passkey-service.ts`) creates users `emailVerified: null`. The signup route (`signup-passkey/route.ts`) marks verified immediately only when a **bound invite token** (delivered to that inbox) is consumed; otherwise it sends a real verification email (best-effort — a send failure never breaks signup).

2. **Account email change** (`account/route.ts` PATCH): a *genuine* change resets `emailVerified` and emails a verification link to the new address. "Changed" is decided by comparing the normalized new address against the caller's **current stored address case-insensitively** — not a uniqueness-lookup miss, which was unsound for OAuth's mixed-case-at-rest emails.

3. **Address-bound tokens (race fix).** `createVerificationToken` stores the normalized target email in token `metadata`; `verifyToken` returns `{ userId, metadata }` and claims the token atomically (`isNull(usedAt)` + `returning`); new `markEmailVerifiedForAddress` marks verified via a single atomic `UPDATE ... WHERE id = ? AND email = ?`. `verify-email` returns 400 on address mismatch, and rejects (not silently downgrades) corrupt token metadata. Legacy null-metadata tokens keep prior behavior.

4. **Dedup.** The token-mint + build-URL + sendEmail block (previously copy-pasted across signup-passkey, account PATCH, resend-verification) is extracted into `sendVerificationEmail()` (`apps/web/src/lib/auth/send-verification-email.ts`). It throws on failure so each caller keeps its own error policy (best-effort vs. surfacing rate limits).

OAuth, magic-link, and the on-prem admin script are unchanged (already correct/intentional).

## Behavior impact

`emailVerified` gates only: sending DMs, creating DM conversations, sending drive invites, sending connection requests, and sharing pages. New passkey users land on the dashboard and can use the app and **accept** invites; they just can't *send* invites/DMs/shares until verified (same as magic-link new users already experience). The account-settings banner + `resend-verification` provide the path.

## Tests / validation

- New/updated unit tests across `verification-utils` (binding metadata, atomic-claim loss, address-match true/false), `verify-email` (bound success, stale-address rejection, corrupt-metadata reject), `signup-passkey` (incl. connection-invite verification), account `PATCH` (incl. OAuth mixed-case regression), `resend-verification`, and the new `sendVerificationEmail` helper.
- Local: web auth/account unit suites green (1553 passing; the 14 failures are the DB-only `admin-role-version` integration test, which needs Postgres and runs under `test-with-db.sh` in CI — unrelated). Typecheck + lint clean. `passkey-service.test.ts` (DB-integration) assertion flipped to expect `emailVerified === null`.

## Review status

- Codex P1 (token/address binding race) addressed, replied with evidence, thread resolved.
- CodeQL `js/user-controlled-bypass` on the token-presence guard dismissed as a false positive (token is cryptographically validated before any action), consistent with the repo's prior dismissals of this rule for auth callbacks. No open code-scanning alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)