### PR TITLE
fix(billing): meter all AI provider calls and bill resolved model names

### DIFF
--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -494,7 +494,10 @@ export async function POST(request: Request) {
       return createProviderErrorResponse(providerResult);
     }
 
-    const { model } = providerResult;
+    // Use the resolved model name for billing. currentModel may be a PageSpace
+    // tier alias ('standard'/'pro') or an unpriced default ('glm-4.5-air'), which
+    // would meter at $0; providerResult.modelName is the real backend model id.
+    const { model, modelName: resolvedModelName } = providerResult;
 
     // Update user's current provider/model if changed
     await updateUserProviderSettings(userId, selectedProvider, selectedModel);
@@ -1082,7 +1085,7 @@ export async function POST(request: Request) {
               await AIMonitoring.trackUsage({
                 userId: userId!,
                 provider: currentProvider,
-                model: currentModel,
+                model: resolvedModelName,
                 inputTokens,
                 outputTokens,
                 totalTokens,
@@ -1108,7 +1111,7 @@ export async function POST(request: Request) {
                   await AIMonitoring.trackToolUsage({
                     userId: userId!,
                     provider: currentProvider,
-                    model: currentModel,
+                    model: resolvedModelName,
                     toolName: toolCall.toolName,
                     toolId: toolCall.toolCallId,
                     args: undefined,

--- a/apps/web/src/app/api/ai/page-agents/consult/route.ts
+++ b/apps/web/src/app/api/ai/page-agents/consult/route.ts
@@ -140,7 +140,7 @@ async function getConfiguredModel(userId: string, agentConfig: { aiProvider?: st
     throw new Error(providerResult.error);
   }
 
-  return providerResult.model;
+  return providerResult;
 }
 
 /**
@@ -247,11 +247,16 @@ export async function POST(request: Request) {
 
     // Get configured AI model for agent
     let model;
+    let resolvedProvider = agent.aiProvider || 'pagespace';
+    let resolvedModelName = agent.aiModel || 'glm-4.5-air';
     try {
-      model = await getConfiguredModel(userId, {
+      const providerResult = await getConfiguredModel(userId, {
         aiProvider: agent.aiProvider,
         aiModel: agent.aiModel
       });
+      model = providerResult.model;
+      resolvedProvider = providerResult.provider;
+      resolvedModelName = providerResult.modelName;
     } catch (providerError) {
       loggers.api.error('Agent consultation provider setup error:', providerError as Error);
       return NextResponse.json(
@@ -459,15 +464,16 @@ export async function POST(request: Request) {
           errors: toolErrors,
         });
       }
-      // Track AI usage
-      const usage = result.usage;
+      // Track AI usage. This is a tool loop (stepCountIs(100)); use totalUsage so
+      // every round-trip is billed, not just the final step.
+      const usage = result.totalUsage;
       AIMonitoring.trackUsage({
         userId,
-        provider: agent.aiProvider || 'pagespace',
-        model: agent.aiModel || 'glm-4.5-air',
+        provider: resolvedProvider,
+        model: resolvedModelName,
         inputTokens: usage?.inputTokens,
         outputTokens: usage?.outputTokens,
-        totalTokens: usage ? ((usage.inputTokens ?? 0) + (usage.outputTokens ?? 0)) : undefined,
+        totalTokens: usage?.totalTokens ?? (usage ? ((usage.inputTokens ?? 0) + (usage.outputTokens ?? 0)) : undefined),
         pageId: agentId,
         driveId: agent.driveId,
         success: true,

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -144,8 +144,8 @@ export async function POST(request: Request): Promise<Response> {
 
       await AIMonitoring.trackUsage({
         userId: authResult.userId,
-        provider: page.aiProvider ?? 'pagespace',
-        model: page.aiModel ?? 'unknown',
+        provider: providerResult.provider,
+        model: providerResult.modelName,
         inputTokens: totalUsage.inputTokens,
         outputTokens: totalUsage.outputTokens,
         duration: Date.now() - startTime,

--- a/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/agent-communication-tools.test.ts
@@ -93,6 +93,13 @@ vi.mock('../../core/integration-tool-resolver', () => ({
   resolvePageAgentIntegrationTools: vi.fn().mockResolvedValue({}),
 }));
 
+vi.mock('@pagespace/lib/monitoring/ai-monitoring', () => ({
+  AIMonitoring: {
+    trackUsage: vi.fn(),
+    trackToolUsage: vi.fn(),
+  },
+}));
+
 // Mock core AI modules
 vi.mock('../../core', () => ({
   sanitizeMessagesForModel: vi.fn((msgs) => msgs),
@@ -112,6 +119,7 @@ import { createAIProvider, saveMessageToDatabase } from '../../core';
 import type { ToolExecutionContext } from '../../core';
 import { generateText } from 'ai';
 import { resolvePageAgentIntegrationTools } from '../../core/integration-tool-resolver';
+import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 
 const mockDb = vi.mocked(db);
 const mockCanActorViewPage = vi.mocked(canActorViewPage);
@@ -199,12 +207,16 @@ describe('agent-communication-tools', () => {
       } as never);
       vi.mocked(createAIProvider).mockResolvedValue({
         model: { modelId: 'test-model' } as unknown as ReturnType<typeof createAIProvider> extends Promise<infer T> ? T extends { model: infer M } ? M : never : never,
+        provider: 'pagespace',
+        modelName: 'glm-5',
       } as Awaited<ReturnType<typeof createAIProvider>>);
       vi.mocked(generateText).mockResolvedValue({
         text: 'Agent response',
         steps: [],
+        totalUsage: { inputTokens: 100, outputTokens: 200, totalTokens: 300 },
       } as unknown as ReturnType<typeof generateText> extends Promise<infer T> ? T : never);
       vi.mocked(saveMessageToDatabase).mockResolvedValue(undefined);
+      vi.mocked(AIMonitoring.trackUsage).mockClear();
     });
 
     it('has correct tool definition', () => {
@@ -325,6 +337,40 @@ describe('agent-communication-tools', () => {
 
       beforeEach(() => {
         mockDb.query.pages.findFirst = vi.fn().mockResolvedValue(mockAgent);
+      });
+
+      it('meters the sub-agent run against the resolved model with aggregated usage (PR #1475 leak fix)', async () => {
+        const context = {
+          toolCallId: '1',
+          messages: [],
+          experimental_context: {
+            userId: 'user-123',
+          } as ToolExecutionContext,
+        };
+
+        await agentCommunicationTools.ask_agent!.execute!(
+          {
+            agentPath: '/test/agent',
+            agentId: 'agent-1',
+            question: 'Test question',
+          },
+          context
+        );
+
+        // ask_agent runs a tool loop (stepCountIs(20)); it must bill the requesting
+        // user against the resolved backend model (glm-5), not the unmetered alias,
+        // using totalUsage so every round-trip is counted.
+        expect(AIMonitoring.trackUsage).toHaveBeenCalledWith(
+          expect.objectContaining({
+            userId: 'user-123',
+            provider: 'pagespace',
+            model: 'glm-5',
+            inputTokens: 100,
+            outputTokens: 200,
+            totalTokens: 300,
+            success: true,
+          })
+        );
       });
 
       it('should set parentAgentId from calling agent location context', async () => {

--- a/apps/web/src/lib/ai/tools/agent-communication-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-communication-tools.ts
@@ -26,6 +26,7 @@ import { searchTools } from './search-tools';
 import { taskManagementTools } from './task-management-tools';
 import { agentTools } from './agent-tools';
 import { loggers } from '@pagespace/lib/logging/logger-config';
+import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 
 // Nesting cap. Intent is 3+ for richer agent-to-agent composition, but held at 2
 // until inner stepCountIs budget is reworked — see PR #713. Raising this without
@@ -54,7 +55,7 @@ async function getConfiguredModel(userId: string, agentConfig: { aiProvider?: st
     throw new Error(providerResult.error);
   }
 
-  return providerResult.model;
+  return providerResult;
 }
 
 /**
@@ -525,10 +526,11 @@ export const agentCommunicationTools = {
         systemPrompt += `\n\nYou are being consulted by another agent or user${executionContext?.locationContext?.currentPage?.title ? ` (${executionContext.locationContext.currentPage.title})` : ''}. This is a persistent conversation - you have access to the full conversation history. Respond helpfully based on your expertise and the conversation context.`;
         
         // 8. Get configured model for agent
-        const model = await getConfiguredModel(userId, {
-          aiProvider: targetAgent.aiProvider,
-          aiModel: targetAgent.aiModel
-        });
+        const { model, provider: resolvedProvider, modelName: resolvedModelName } =
+          await getConfiguredModel(userId, {
+            aiProvider: targetAgent.aiProvider,
+            aiModel: targetAgent.aiModel
+          });
         
         // 9. Filter tools for agent
         const agentTools = filterToolsForAgent(targetAgent.enabledTools as string[] | null);
@@ -591,6 +593,23 @@ export const agentCommunicationTools = {
               experimental_context: nestedContext,
               maxRetries: 3,
             });
+
+        // Bill the requesting user for the sub-agent run. Use totalUsage so all
+        // tool-loop round-trips (up to stepCountIs(20)) are metered, not just the
+        // final step. Tracked against the resolved model name so the cost is real.
+        AIMonitoring.trackUsage({
+          userId,
+          provider: resolvedProvider,
+          model: resolvedModelName,
+          inputTokens: response.totalUsage?.inputTokens,
+          outputTokens: response.totalUsage?.outputTokens,
+          totalTokens: response.totalUsage?.totalTokens,
+          conversationId: activeConversationId,
+          pageId: agentId,
+          driveId: targetAgent.driveId,
+          success: true,
+          metadata: { feature: 'ask_agent', agentCallDepth: callDepth + 1 },
+        });
 
         // 12. Extract response text with error checking
         // Collect text from all steps — response.text only returns the final step,

--- a/apps/web/src/lib/integrations/zoom/extract-action-items.ts
+++ b/apps/web/src/lib/integrations/zoom/extract-action-items.ts
@@ -1,6 +1,7 @@
 import { generateText } from 'ai';
 import { createAIProvider, isProviderError } from '@/lib/ai/core';
 import { loggers } from '@pagespace/lib/logging/logger-config';
+import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 import type { ActionItem } from './build-document';
 
 const SYSTEM_PROMPT =
@@ -20,14 +21,27 @@ export async function extractActionItems(
       return [];
     }
 
-    const { text } = await generateText({
+    const result = await generateText({
       model: provider.model,
       system: SYSTEM_PROMPT,
       prompt: transcriptPlainText,
       maxOutputTokens: 512,
     });
 
-    const jsonText = text.trim().replace(/^```json\s*/i, '').replace(/\s*```$/, '');
+    AIMonitoring.trackUsage({
+      userId,
+      provider: provider.provider,
+      model: provider.modelName,
+      inputTokens: result.usage?.inputTokens,
+      outputTokens: result.usage?.outputTokens,
+      totalTokens: result.usage
+        ? (result.usage.inputTokens ?? 0) + (result.usage.outputTokens ?? 0)
+        : undefined,
+      success: true,
+      metadata: { feature: 'zoom_action_items' },
+    });
+
+    const jsonText = result.text.trim().replace(/^```json\s*/i, '').replace(/\s*```$/, '');
     const parsed = JSON.parse(jsonText);
 
     if (!Array.isArray(parsed)) return [];

--- a/apps/web/src/lib/integrations/zoom/generate-summary.ts
+++ b/apps/web/src/lib/integrations/zoom/generate-summary.ts
@@ -1,6 +1,7 @@
 import { generateText } from 'ai';
 import { createAIProvider, isProviderError } from '@/lib/ai/core';
 import { loggers } from '@pagespace/lib/logging/logger-config';
+import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 
 const SYSTEM_PROMPT =
   'Summarize this meeting transcript in 3–5 bullet points. Focus on decisions made and key outcomes. Be concise.';
@@ -16,14 +17,27 @@ export async function generateTranscriptSummary(
       return '';
     }
 
-    const { text } = await generateText({
+    const result = await generateText({
       model: provider.model,
       system: SYSTEM_PROMPT,
       prompt: transcriptPlainText,
       maxOutputTokens: 512,
     });
 
-    return text.trim();
+    AIMonitoring.trackUsage({
+      userId,
+      provider: provider.provider,
+      model: provider.modelName,
+      inputTokens: result.usage?.inputTokens,
+      outputTokens: result.usage?.outputTokens,
+      totalTokens: result.usage
+        ? (result.usage.inputTokens ?? 0) + (result.usage.outputTokens ?? 0)
+        : undefined,
+      success: true,
+      metadata: { feature: 'zoom_summary' },
+    });
+
+    return result.text.trim();
   } catch (err) {
     loggers.api.warn('Zoom summary: generation failed', { error: err instanceof Error ? err.message : String(err) });
     return '';

--- a/apps/web/src/lib/memory/compaction-service.ts
+++ b/apps/web/src/lib/memory/compaction-service.ts
@@ -9,6 +9,7 @@
 import { generateText } from 'ai';
 import { createAIProvider, isProviderError } from '@/lib/ai/core';
 import { loggers } from '@pagespace/lib/logging/logger-config';
+import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 import {
   updatePersonalization,
   getCurrentPersonalization,
@@ -112,6 +113,19 @@ Reorganize this into a more concise version (target: under ${targetLength} chara
       ],
       temperature: 0.3,
       maxRetries: 2,
+    });
+
+    AIMonitoring.trackUsage({
+      userId,
+      provider: providerResult.provider,
+      model: providerResult.modelName,
+      inputTokens: result.usage?.inputTokens,
+      outputTokens: result.usage?.outputTokens,
+      totalTokens: result.usage
+        ? (result.usage.inputTokens ?? 0) + (result.usage.outputTokens ?? 0)
+        : undefined,
+      success: true,
+      metadata: { feature: 'memory_compaction', field: fieldName },
     });
 
     const compactedContent = result.text.trim();

--- a/apps/web/src/lib/memory/discovery-service.ts
+++ b/apps/web/src/lib/memory/discovery-service.ts
@@ -15,6 +15,7 @@ import { driveMembers } from '@pagespace/db/schema/members'
 import { conversations, messages } from '@pagespace/db/schema/conversations';
 import { createAIProvider, isProviderError } from '@/lib/ai/core';
 import { loggers } from '@pagespace/lib/logging/logger-config';
+import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 
 export interface DiscoveryResult {
   worldview: string[];
@@ -225,6 +226,19 @@ async function runDiscoveryPass(
       ],
       temperature: 0.3,
       maxRetries: 2,
+    });
+
+    AIMonitoring.trackUsage({
+      userId,
+      provider: providerResult.provider,
+      model: providerResult.modelName,
+      inputTokens: result.usage?.inputTokens,
+      outputTokens: result.usage?.outputTokens,
+      totalTokens: result.usage
+        ? (result.usage.inputTokens ?? 0) + (result.usage.outputTokens ?? 0)
+        : undefined,
+      success: true,
+      metadata: { feature: 'memory_discovery', pass: passName },
     });
 
     // Parse JSON array from response

--- a/apps/web/src/lib/memory/integration-service.ts
+++ b/apps/web/src/lib/memory/integration-service.ts
@@ -12,6 +12,7 @@ import { eq } from '@pagespace/db/operators'
 import { userPersonalization } from '@pagespace/db/schema/personalization';
 import { createAIProvider, isProviderError } from '@/lib/ai/core';
 import { loggers } from '@pagespace/lib/logging/logger-config';
+import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 import type { DiscoveryResult } from './discovery-service';
 
 export interface UserPersonalizationData {
@@ -208,6 +209,19 @@ Remember: Only approve genuinely new, significant insights. Return JSON with dec
       ],
       temperature: 0.2,
       maxRetries: 2,
+    });
+
+    AIMonitoring.trackUsage({
+      userId,
+      provider: providerResult.provider,
+      model: providerResult.modelName,
+      inputTokens: result.usage?.inputTokens,
+      outputTokens: result.usage?.outputTokens,
+      totalTokens: result.usage
+        ? (result.usage.inputTokens ?? 0) + (result.usage.outputTokens ?? 0)
+        : undefined,
+      success: true,
+      metadata: { feature: 'memory_integration' },
     });
 
     const text = result.text.trim();

--- a/packages/lib/src/monitoring/__tests__/ai-monitoring.test.ts
+++ b/packages/lib/src/monitoring/__tests__/ai-monitoring.test.ts
@@ -132,6 +132,24 @@ describe('calculateCost', () => {
     expect(calculateCost('completely-unknown-model', 1_000_000, 1_000_000)).toBe(0);
   });
 
+  // Regression guard: every PageSpace-tier backend model must be priced. These are
+  // the resolved model ids that createAIProvider returns for the pagespace provider
+  // (standard -> glm-4.7, pro -> glm-5) plus the agent/chat default glm-4.5-air. If
+  // any of these is missing from AI_PRICING it meters at $0 and the platform eats the
+  // spend (see PR #1475 — glm-4.5-air was previously unpriced).
+  it.each(['glm-4.5-air', 'glm-4.7', 'glm-5'])(
+    'prices PageSpace-tier model "%s" above $0',
+    (model) => {
+      expect(calculateCost(model, 1_000_000, 1_000_000)).toBeGreaterThan(0);
+    }
+  );
+
+  it('prices glm-4.5-air at its published rate (0.35 in / 1.55 out per 1M)', () => {
+    expect(calculateCost('glm-4.5-air', 1_000_000, 1_000_000)).toBe(
+      Number((1.90).toFixed(6))
+    );
+  });
+
   it('should handle zero tokens', () => {
     expect(calculateCost('gpt-4o', 0, 0)).toBe(0);
   });

--- a/packages/lib/src/monitoring/ai-monitoring.ts
+++ b/packages/lib/src/monitoring/ai-monitoring.ts
@@ -248,6 +248,7 @@ export const AI_PRICING = {
   'glm-5': { input: 1.00, output: 3.20 },
   'glm-4.7': { input: 0.39, output: 1.90 },
   'glm-4.6': { input: 0.39, output: 1.90 },
+  'glm-4.5-air': { input: 0.35, output: 1.55 },
 
   // MiniMax Direct Models (Native)
   'MiniMax-M2.5': { input: 0.30, output: 1.20 },


### PR DESCRIPTION
## Why

Billing for the prepaid AI-credits bridge (#1471) only happens for calls that flow through `AIMonitoring.trackUsage` → `consumeCredits` with a **real `userId`** and a **model present in `AI_PRICING`**. Any AI provider call that skips that path — or records an unpriced model string — is spend the platform eats. An audit of every LLM call site found 7 leaks across two classes.

> No embedding/RAG calls exist in the codebase (search is keyword + Brave API), so there is no embedding leak class.

## Leaks fixed

### Class 1 — completely unmetered (no `trackUsage` at all; real `userId` was already in scope)

| Call site | Notes |
|---|---|
| `ask_agent` (`agent-communication-tools.ts`) | **Biggest leak.** User-triggerable tool loop of up to `stepCountIs(20)` round-trips, never billed. Also reached by **every channel @mention** of an agent (`agent-mention-responder.ts`), which inherits the fix. `getConfiguredModel` now returns the full `ProviderResult`; meters `response.totalUsage` so all round-trips count. |
| Memory `discovery` / `integration` / `compaction` | Run **per active user on the memory cron**, on the expensive `pro`/glm-5 tier; discovery fires 3 passes/run. Biggest *passive* drain. |
| Zoom `extract-action-items` / `generate-summary` | Per webhook. |

### Class 2 — metered but recorded `$0` (tracked the raw stored model, not the resolved one)

PageSpace tier aliases (`standard`/`pro`) and the unpriced default `glm-4.5-air` all fall through to `AI_PRICING.default = { input: 0, output: 0 }`, so a real glm call was billed `$0`. Now track the resolved `providerResult.modelName`:

- `/api/v1/chat/completions` — was `page.aiModel ?? 'unknown'`
- `page-agents/consult` — was `agent.aiModel || 'glm-4.5-air'`; **also** switched to `result.totalUsage` (it's a `stepCountIs(100)` tool loop that was billing only the final step)
- `/api/ai/chat` — was raw `currentModel`

### Catalog ↔ pricing drift
- Added `glm-4.5-air` to `AI_PRICING` (`0.35`/`1.55`, matching `z-ai/glm-4.5-air`). It was selectable via the `glm` provider but unpriced → metered `$0`.

## Not double-billing
`ask_agent`'s inner `generateText` is a genuinely separate provider call (the sub-agent), distinct from any outer orchestrator stream that invoked the tool. Billing both is correct — they are two real model invocations.

## Unchanged (already correct)
Global assistant, pulse generate, pulse cron, and the workflow executor already tracked `providerResult.modelName` with a real `userId`. The `openrouter_free` `:free` models remain `$0` (genuinely free upstream). The error-path `trackUsage` in `/api/ai/chat` is left as-is — it sets `success: false`, which is never billed.

## Tests added (regression guards)
- **ai-monitoring**: PageSpace-tier backend models (`glm-4.5-air`, `glm-4.7`, `glm-5`) all price above `$0`, and `glm-4.5-air` bills at its published rate. Catches future catalog↔pricing drift.
- **agent-communication-tools**: `ask_agent` bills the requesting user against the resolved model (`glm-5`) using `totalUsage`, proving the previously-unmetered path is now metered.

## Validation (local, with workspace packages built — mirrors CI `^build`)
- `typecheck`: **0 errors** across the web app.
- Tests: **245+ pass** — ai-monitoring (69), agent-communication-tools (23), v1/completions (16), memory + zoom (142). All green.
- Lint: clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)