### PR TITLE
fix(billing): durable AI-usage persistence + stop $0 ledger churn

### DIFF
--- a/packages/lib/src/billing/__tests__/credit-consume.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-consume.test.ts
@@ -5,6 +5,7 @@ const mockIsBillingEnabled = vi.hoisted(() => vi.fn(() => true));
 const mockDb = vi.hoisted(() => ({
   insert: vi.fn(),
   transaction: vi.fn(),
+  update: vi.fn(),
 }));
 const mockAiLogger = vi.hoisted(() => ({ debug: vi.fn(), error: vi.fn() }));
 
@@ -102,6 +103,22 @@ describe('consumeCredits', () => {
 
     // Neither the balance nor the ledger is updated -> the row stays 'pending'.
     expect(update).not.toHaveBeenCalled();
+  });
+
+  it('settles a zero-charge call (free model / tool-only log) as skipped, without opening the balance transaction', async () => {
+    // cost 0 -> markupCents 0 -> nothing to draw down. The claim row is still
+    // written (idempotency/orphan-sweep marker) but we must NOT take the balance
+    // row lock or run a $0 decrement for it.
+    mockDb.insert.mockReturnValue(claimReturning([{ id: 'led_zero' }]));
+    let ledgerSet: Record<string, unknown> | undefined;
+    const where = vi.fn().mockResolvedValue(undefined);
+    mockDb.update.mockReturnValue({ set: (v: Record<string, unknown>) => { ledgerSet = v; return { where }; } });
+
+    await consumeCredits({ aiUsageLogId: 'aul_free', userId: 'u1', costDollars: 0 });
+
+    expect(mockDb.transaction).not.toHaveBeenCalled();
+    expect(mockDb.update).toHaveBeenCalledTimes(1);
+    expect(ledgerSet).toEqual({ consumeStatus: 'skipped' });
   });
 
   it('skips an invalid cost (negative or non-finite) without claiming a ledger row', async () => {

--- a/packages/lib/src/billing/credit-consume.ts
+++ b/packages/lib/src/billing/credit-consume.ts
@@ -126,6 +126,26 @@ export async function consumeCredits(input: ConsumeCreditsInput): Promise<void> 
     return;
   }
 
+  // A zero-charge call (free/local model, or a tool-only analytics log carrying
+  // no tokens) has nothing to draw down. Settle the claimed row as 'skipped'
+  // without opening the balance transaction — no row lock, no $0 decrement. The
+  // claim row still exists, so the reconcile cron's orphan sweep treats this call
+  // as already handled and never re-processes it.
+  if (amountCents === 0) {
+    try {
+      await db
+        .update(creditLedger)
+        .set({ consumeStatus: 'skipped' })
+        .where(eq(creditLedger.id, ledgerId));
+    } catch (error) {
+      loggers.ai.debug('credit zero-charge settle failed', {
+        error: (error as Error).message,
+        aiUsageLogId: input.aiUsageLogId,
+      });
+    }
+    return;
+  }
+
   // 2. Decrement the balance and settle the ledger row, atomically.
   try {
     await db.transaction((tx) => decrementAndSettle(tx, ledgerId, input.userId, amountCents));

--- a/packages/lib/src/monitoring/__tests__/ai-monitoring.test.ts
+++ b/packages/lib/src/monitoring/__tests__/ai-monitoring.test.ts
@@ -222,6 +222,29 @@ describe('trackAIUsage', () => {
     expect(arg.costDollars).toBeGreaterThan(0);
   });
 
+  it('awaits persistence before returning so the write/charge cannot be dropped on a serverless freeze', async () => {
+    // Durability: trackAIUsage must not return until writeAiUsage AND the consume
+    // have settled. We resolve writeAiUsage on a later microtask and assert that,
+    // by the time the awaited trackAIUsage resolves, consumeCredits already ran —
+    // WITHOUT any post-call setTimeout flush. A fire-and-forget chain would fail this.
+    let resolveWrite!: (id: string) => void;
+    mockWriteAiUsage.mockReturnValueOnce(new Promise<string>((res) => { resolveWrite = res; }));
+    const tracked = trackAIUsage({
+      userId: 'user-1',
+      provider: 'anthropic',
+      model: 'claude-3-5-sonnet-20241022',
+      inputTokens: 1000,
+      outputTokens: 500,
+    });
+    expect(mockConsumeCredits).not.toHaveBeenCalled(); // write hasn't resolved yet
+    resolveWrite('aul_durable');
+    await tracked;
+    // No setTimeout(0) flush here — if trackAIUsage were fire-and-forget this would be empty.
+    expect(mockConsumeCredits).toHaveBeenCalledWith(
+      expect.objectContaining({ aiUsageLogId: 'aul_durable', userId: 'user-1' }),
+    );
+  });
+
   it('does not debit credits when the call failed (success=false)', async () => {
     mockWriteAiUsage.mockResolvedValueOnce('aul_43');
     await trackAIUsage({ userId: 'user-1', provider: 'openai', model: 'gpt-4o', success: false, error: 'fail' });

--- a/packages/lib/src/monitoring/__tests__/ai-monitoring.test.ts
+++ b/packages/lib/src/monitoring/__tests__/ai-monitoring.test.ts
@@ -400,6 +400,30 @@ describe('trackAIToolUsage', () => {
       })
     );
   });
+
+  it('propagates the awaited persistence promise so the tool-call path is durable too', async () => {
+    // trackAIToolUsage must RETURN trackAIUsage's promise — otherwise a caller that
+    // `await`s trackToolUsage resolves before writeAiUsage settles, and the analytics
+    // log can be dropped on a serverless freeze. We hold writeAiUsage open and assert
+    // the awaited trackAIToolUsage does NOT resolve until the write settles. A wrapper
+    // that didn't return the inner promise would resolve immediately and fail this.
+    let resolveWrite!: (id: string) => void;
+    mockWriteAiUsage.mockReturnValueOnce(new Promise<string>((res) => { resolveWrite = res; }));
+    let resolved = false;
+    const tracked = trackAIToolUsage({
+      userId: 'user-1',
+      provider: 'openai',
+      model: 'gpt-4o',
+      toolName: 'searchPages',
+      success: true,
+    }).then(() => { resolved = true; });
+    await Promise.resolve(); // flush microtasks — write is still pending
+    expect(resolved).toBe(false);
+    resolveWrite('aul_tool');
+    await tracked;
+    expect(resolved).toBe(true);
+    expect(mockWriteAiUsage).toHaveBeenCalledTimes(1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/lib/src/monitoring/ai-monitoring.ts
+++ b/packages/lib/src/monitoring/ai-monitoring.ts
@@ -603,52 +603,60 @@ export async function trackAIUsage(data: AIUsageData): Promise<void> {
     const cost = calculateCost(data.model, inputTokens, outputTokens);
     const success = data.success !== false;
 
-    // Fire and forget - don't await. On a successful, persisted call, debit the
+    // Persist the usage log, then (on a successful, persisted call) debit the
     // user's prepaid credit balance (cost × markup); failed calls are not billed.
-    writeAiUsage({
-      userId: data.userId,
-      provider: data.provider,
-      model: data.model,
-      inputTokens,
-      outputTokens,
-      totalTokens,
-      cost,
-      duration: data.duration,
-      conversationId: data.conversationId,
-      messageId: data.messageId,
-      pageId: data.pageId,
-      driveId: data.driveId,
-      success,
-      error: data.error,
+    //
+    // AWAITED, not fire-and-forget: callers reach this from a stream onFinish or
+    // a post-response handler and `await` trackAIUsage. A detached promise can be
+    // dropped when a serverless function freezes/returns, losing BOTH the usage
+    // log AND the charge — and with no aiUsageLogs row the reconcile cron's orphan
+    // sweep has nothing to recover from. Awaiting makes the write durable before
+    // the request returns. Still never throws into the AI request (see catch).
+    try {
+      const aiUsageLogId = await writeAiUsage({
+        userId: data.userId,
+        provider: data.provider,
+        model: data.model,
+        inputTokens,
+        outputTokens,
+        totalTokens,
+        cost,
+        duration: data.duration,
+        conversationId: data.conversationId,
+        messageId: data.messageId,
+        pageId: data.pageId,
+        driveId: data.driveId,
+        success,
+        error: data.error,
 
-      // Context tracking
-      contextMessages: data.contextMessages,
-      contextSize: data.contextSize,
-      systemPromptTokens: data.systemPromptTokens,
-      toolDefinitionTokens: data.toolDefinitionTokens,
-      conversationTokens: data.conversationTokens,
-      messageCount: data.messageCount,
-      wasTruncated: data.wasTruncated,
-      truncationStrategy: data.truncationStrategy,
+        // Context tracking
+        contextMessages: data.contextMessages,
+        contextSize: data.contextSize,
+        systemPromptTokens: data.systemPromptTokens,
+        toolDefinitionTokens: data.toolDefinitionTokens,
+        conversationTokens: data.conversationTokens,
+        messageCount: data.messageCount,
+        wasTruncated: data.wasTruncated,
+        truncationStrategy: data.truncationStrategy,
 
-      metadata: {
-        ...data.metadata,
-        streamingDuration: data.streamingDuration,
-      },
-    }).then((aiUsageLogId) => {
+        metadata: {
+          ...data.metadata,
+          streamingDuration: data.streamingDuration,
+        },
+      });
       if (aiUsageLogId && success) {
-        void consumeCredits({ aiUsageLogId, userId: data.userId, costDollars: cost })
+        await consumeCredits({ aiUsageLogId, userId: data.userId, costDollars: cost })
           .catch((error) => {
             loggers.ai.debug('credit consume failed', { error: (error as Error).message });
           });
       }
-    }).catch((error) => {
+    } catch (error) {
       loggers.ai.debug('AI usage tracking failed', {
         error: (error as Error).message,
         model: data.model,
         provider: data.provider
       });
-    });
+    }
   } catch (error) {
     loggers.ai.debug('AI usage calculation failed', { 
       error: (error as Error).message 

--- a/packages/lib/src/monitoring/ai-monitoring.ts
+++ b/packages/lib/src/monitoring/ai-monitoring.ts
@@ -682,8 +682,12 @@ export interface AIToolUsage {
   pageId?: string;
 }
 
-export async function trackAIToolUsage(data: AIToolUsage): Promise<void> {
-  trackAIUsage({
+export function trackAIToolUsage(data: AIToolUsage): Promise<void> {
+  // Return (not just call) trackAIUsage so the same durability guarantee applies
+  // here: a caller that `await`s trackAIToolUsage waits for the tool-analytics log
+  // (and its zero-charge ledger settlement) to persist before returning, instead
+  // of resolving immediately and risking a dropped write on a serverless freeze.
+  return trackAIUsage({
     userId: data.userId,
     provider: data.provider,
     model: data.model,


### PR DESCRIPTION
## Why

Follow-up to the prepaid AI-credits audit (epic #1471). PR #1475 (`pu/audit-leaks`) fixed the **metering** leaks — unmetered call sites and the resolved-model-name `$0` bug. This PR fixes two **persistence/correctness** gaps that #1475 left untouched. Both are pure correctness/safety — **no billing-policy change** (failed calls are still not billed; markup/allowances unchanged).

## What's fixed

### 1. Durability — usage log + charge could be silently dropped *(was HIGH)*
`trackAIUsage` detached the `writeAiUsage(...).then(consumeCredits)` chain and returned before it settled. Call sites `await trackAIUsage` from a stream `onFinish` / post-response handler — but awaiting it only awaited the synchronous body; the DB write was still fire-and-forget. If a serverless function froze/returned first, **both the `aiUsageLogs` row and the credit charge were lost**, and because the reconcile cron's orphan sweep keys off `aiUsageLogs`, there was nothing left to recover from — the charge was gone permanently.

Now the `writeAiUsage → consumeCredits` chain is **awaited**, so the usage log is durable before the request returns. It still never throws into the AI request (the surrounding try/catch is preserved).

`packages/lib/src/monitoring/ai-monitoring.ts`

### 2. `$0` ledger churn — needless balance transaction per free/tool call *(was MEDIUM)*
A free/local model, or a tool-only analytics log carrying no tokens (`trackAIToolUsage` → `trackAIUsage` with no usage → cost `0`), produced `amountCents === 0` but `consumeCredits` still opened the balance transaction, took the `FOR UPDATE` row lock, ran a `$0` decrement, and wrote a misleading `applied`/`monthly` ledger row. In an agent tool loop that serialized N no-op locks on the user's balance row.

Now a zero-charge call **settles the claimed row as `skipped` without the balance transaction** (no lock, no `$0` decrement). The claim row still exists, so the orphan sweep stays idempotent and never re-processes it.

`packages/lib/src/billing/credit-consume.ts`

## Testing
- `+1` durability test: asserts `consumeCredits` has **not** run before `writeAiUsage` resolves, then runs once the awaited `trackAIUsage` resolves — **with no `setTimeout(0)` flush**, which a fire-and-forget chain would fail.
- `+1` zero-charge test: `costDollars: 0` ⇒ no `db.transaction`, ledger row set to `consumeStatus: 'skipped'`.
- `credit-consume` + `ai-monitoring` suites: **76 passed**.
- Typecheck: zero new errors from these changes (the `tx` implicit-any noise at `credit-consume.ts` is pre-existing worktree tsc-resolution noise on the unchanged `Tx`-derived functions, identical on `master`).
- Lint: clean on changed source files.

## Deferred (need a product/architecture decision, not unilateral)
Documented in the audit but intentionally **not** changed here:
- **`success:false` drops real provider spend** on errored/aborted streams — charging for failed generations is a billing-policy call (#1475 also punted it).
- **Reserve floor `0` + no per-user in-flight concurrency cap** — bounds how far one user can front unpaid usage; needs a chosen floor + concurrency limit.
- **Sub-cent rounding to `0`** — high-volume cheap calls each round their markup to `0¢`; needs a fractional-cent/millicent accumulation design.
- **`bucket` majority-label** on split monthly/topup spends (cosmetic unless reporting reconciles by bucket).

## Relationship to #1475
Independent branch off `master`. Touches different regions of `ai-monitoring.ts` (the `trackAIUsage` body, not the `AI_PRICING` table #1475 edits) and `credit-consume.ts` (not touched by #1475) — merges cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> **Update (Codex P2):** `trackAIToolUsage` now `return`s the `trackAIUsage` promise rather than discarding it, so the durability guarantee also covers the tool-call analytics path (a caller that `await`s `trackToolUsage` now waits for the write to persist). +1 test.