### PR TITLE
feat(sandbox): PR4 — register flag-gated bash/writeFile/readFile tools in agent chat

### DIFF
--- a/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/ai-tools.test.ts
@@ -119,7 +119,17 @@ vi.mock('../../tools/member-tools', () => ({
   },
 }));
 
-import { pageSpaceTools, corePageSpaceTools } from '../ai-tools';
+// Stub the sandbox tools so the builder can be exercised without loading the DB
+// module graph or the real Vercel client.
+vi.mock('../../tools/sandbox-tools', () => ({
+  buildSandboxTools: () => ({
+    bash: { name: 'bash', description: 'Run a shell command' },
+    writeFile: { name: 'writeFile', description: 'Write a file' },
+    readFile: { name: 'readFile', description: 'Read a file' },
+  }),
+}));
+
+import { pageSpaceTools, corePageSpaceTools, buildPageSpaceTools } from '../ai-tools';
 import { CORE_TOOL_NAMES } from '../stub-tools';
 import { memberTools } from '../../tools/member-tools';
 import { driveTools } from '../../tools/drive-tools';
@@ -204,6 +214,46 @@ describe('ai-tools', () => {
           throw new Error(`Tool "${name}" is ${tool}`);
         }
       }
+    });
+
+    it('omits the code-execution tools by default (flag off)', () => {
+      expect(pageSpaceTools).not.toHaveProperty('bash');
+      expect(pageSpaceTools).not.toHaveProperty('writeFile');
+      expect(pageSpaceTools).not.toHaveProperty('readFile');
+    });
+  });
+
+  describe('buildPageSpaceTools code-execution gating', () => {
+    it('given the flag disabled, should not register bash/writeFile/readFile or call the factory', () => {
+      let built = false;
+      const tools = buildPageSpaceTools({
+        codeExecutionEnabled: false,
+        sandboxToolsFactory: () => {
+          built = true;
+          return { bash: {}, writeFile: {}, readFile: {} } as never;
+        },
+      });
+      expect(tools).not.toHaveProperty('bash');
+      expect(tools).not.toHaveProperty('writeFile');
+      expect(tools).not.toHaveProperty('readFile');
+      expect(built).toBe(false);
+    });
+
+    it('given the flag enabled, should register bash/writeFile/readFile alongside the base tools', () => {
+      const tools = buildPageSpaceTools({
+        codeExecutionEnabled: true,
+        sandboxToolsFactory: () =>
+          ({
+            bash: { name: 'bash' },
+            writeFile: { name: 'writeFile' },
+            readFile: { name: 'readFile' },
+          }) as never,
+      });
+      expect(tools).toHaveProperty('bash');
+      expect(tools).toHaveProperty('writeFile');
+      expect(tools).toHaveProperty('readFile');
+      // Base tools remain present.
+      expect(tools).toHaveProperty('list_drives');
     });
   });
 

--- a/apps/web/src/lib/ai/core/ai-tools.ts
+++ b/apps/web/src/lib/ai/core/ai-tools.ts
@@ -1,3 +1,5 @@
+import type { Tool } from 'ai';
+import { isCodeExecutionEnabled } from '@pagespace/lib/services/sandbox/can-run-code';
 import { memberTools } from '../tools/member-tools';
 import { driveTools } from '../tools/drive-tools';
 import { pageReadTools } from '../tools/page-read-tools';
@@ -12,9 +14,10 @@ import { calendarReadTools } from '../tools/calendar-read-tools';
 import { calendarWriteTools } from '../tools/calendar-write-tools';
 import { channelTools } from '../tools/channel-tools';
 import { workflowTools } from '../tools/workflow-tools';
+import { buildSandboxTools } from '../tools/sandbox-tools';
 import { CORE_TOOL_NAMES } from './stub-tools';
 
-export const pageSpaceTools = {
+const baseTools = {
   ...memberTools,
   ...driveTools,
   ...pageReadTools,
@@ -30,6 +33,32 @@ export const pageSpaceTools = {
   ...channelTools,
   ...workflowTools,
 };
+
+/**
+ * Assemble the agent tool registry, registering the code-execution tools
+ * (`bash` / `writeFile` / `readFile`) ONLY when the global kill-switch is on.
+ *
+ * Code execution is the highest-risk surface in the product, so it ships
+ * default-OFF: with `CODE_EXECUTION_ENABLED` unset (the default), the tools are
+ * never added to the registry, never discoverable via `tool_search`, and never
+ * reachable by a model. Staged rollout rides this env kill-switch plus the
+ * per-call `canRunCode` authz (drive owner/admin), not a separate flag table —
+ * there is none. The sandbox factory is injected so the off-path never loads the
+ * DB module graph or constructs the Vercel client, and both branches are unit
+ * tested without real IO.
+ */
+export function buildPageSpaceTools({
+  codeExecutionEnabled = isCodeExecutionEnabled(),
+  sandboxToolsFactory = buildSandboxTools,
+}: {
+  codeExecutionEnabled?: boolean;
+  sandboxToolsFactory?: () => Record<string, Tool>;
+} = {}) {
+  if (!codeExecutionEnabled) return { ...baseTools };
+  return { ...baseTools, ...sandboxToolsFactory() };
+}
+
+export const pageSpaceTools = buildPageSpaceTools();
 
 export type PageSpaceTools = typeof pageSpaceTools;
 

--- a/apps/web/src/lib/ai/tools/__tests__/sandbox-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/sandbox-tools.test.ts
@@ -8,7 +8,7 @@ vi.mock('@pagespace/db/operators', () => ({ eq: () => undefined }));
 vi.mock('@pagespace/db/schema/core', () => ({ drives: {} }));
 vi.mock('@pagespace/db/schema/auth', () => ({ users: {} }));
 
-import { createSandboxTools, type ResolveSandboxContext } from '../sandbox-tools';
+import { createSandboxTools, type ResolveSandboxContext, type SandboxGate } from '../sandbox-tools';
 import type { SandboxRunDeps, SandboxActorContext } from '@pagespace/lib/services/sandbox/tool-runners';
 
 const ctx: SandboxActorContext = {
@@ -21,6 +21,7 @@ const ctx: SandboxActorContext = {
 };
 
 const okResolve: ResolveSandboxContext = async () => ctx;
+const okGate: SandboxGate = async () => ({ ok: true });
 
 function fakeRunDeps(): SandboxRunDeps {
   return {
@@ -51,7 +52,7 @@ function exec(tool: { execute?: unknown }, args: unknown, context: unknown) {
 
 describe('createSandboxTools', () => {
   it('bash: given a resolvable context, should delegate to the runner and return its result', async () => {
-    const tools = createSandboxTools({ runDeps: fakeRunDeps(), resolveContext: okResolve });
+    const tools = createSandboxTools({ runDeps: fakeRunDeps(), resolveContext: okResolve, gate: okGate });
     const result = await exec(tools.bash, { command: 'echo hi' }, {});
     expect(result).toMatchObject({ success: true, stdout: 'hi', exitCode: 0 });
   });
@@ -66,26 +67,65 @@ describe('createSandboxTools', () => {
     const tools = createSandboxTools({
       runDeps,
       resolveContext: async () => ({ error: 'no drive' }),
+      gate: okGate,
     });
     const result = await exec(tools.bash, { command: 'echo hi' }, {});
     expect(result).toEqual({ success: false, error: 'no drive' });
     expect(acquired).toBe(false);
   });
 
+  it('bash: given the gate denies, should surface the gate error without provisioning', async () => {
+    let acquired = false;
+    const runDeps = fakeRunDeps();
+    runDeps.acquireSandbox = async () => {
+      acquired = true;
+      return { ok: true, sandboxId: 'sbx', resumed: false };
+    };
+    const tools = createSandboxTools({
+      runDeps,
+      resolveContext: okResolve,
+      gate: async () => ({ ok: false, reason: 'rate_limited', error: 'over budget', retryAfter: 30 }),
+    });
+    const result = await exec(tools.bash, { command: 'echo hi' }, {});
+    expect(result).toEqual({ success: false, error: 'over budget', retryAfter: 30 });
+    expect(acquired).toBe(false);
+  });
+
+  it('writeFile: given the gate denies, should not write', async () => {
+    let wrote = false;
+    const runDeps = fakeRunDeps();
+    runDeps.reconnect = async () => ({
+      sandboxId: 'sbx',
+      runCommand: async () => ({ exitCode: 0, stdout: '', stderr: '' }),
+      writeFiles: async () => {
+        wrote = true;
+      },
+      readFileToBuffer: async () => Buffer.from(''),
+    });
+    const tools = createSandboxTools({
+      runDeps,
+      resolveContext: okResolve,
+      gate: async () => ({ ok: false, reason: 'kill_switch_off', error: 'disabled' }),
+    });
+    const result = await exec(tools.writeFile, { path: 'a.txt', content: 'x' }, {});
+    expect(result).toEqual({ success: false, error: 'disabled' });
+    expect(wrote).toBe(false);
+  });
+
   it('writeFile: should delegate and report bytes written', async () => {
-    const tools = createSandboxTools({ runDeps: fakeRunDeps(), resolveContext: okResolve });
+    const tools = createSandboxTools({ runDeps: fakeRunDeps(), resolveContext: okResolve, gate: okGate });
     const result = await exec(tools.writeFile, { path: 'a.txt', content: 'hello' }, {});
     expect(result).toMatchObject({ success: true, path: 'a.txt', bytesWritten: 5 });
   });
 
   it('readFile: should delegate and return file contents', async () => {
-    const tools = createSandboxTools({ runDeps: fakeRunDeps(), resolveContext: okResolve });
+    const tools = createSandboxTools({ runDeps: fakeRunDeps(), resolveContext: okResolve, gate: okGate });
     const result = await exec(tools.readFile, { path: 'a.txt' }, {});
     expect(result).toMatchObject({ success: true, path: 'a.txt', content: 'data' });
   });
 
   it('bash inputSchema: should reject an empty command', () => {
-    const tools = createSandboxTools({ runDeps: fakeRunDeps(), resolveContext: okResolve });
+    const tools = createSandboxTools({ runDeps: fakeRunDeps(), resolveContext: okResolve, gate: okGate });
     const schema = tools.bash.inputSchema as { safeParse: (v: unknown) => { success: boolean } };
     expect(schema.safeParse({ command: '' }).success).toBe(false);
     expect(schema.safeParse({ command: 'ls' }).success).toBe(true);

--- a/apps/web/src/lib/ai/tools/sandbox-tools.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools.ts
@@ -48,6 +48,10 @@ import {
   chargeCodeExecutionBudget,
 } from '@pagespace/lib/services/sandbox/quota';
 import { writeCodeExecutionAudit } from '@pagespace/lib/services/sandbox/audit';
+import {
+  gateSandboxToolCall,
+  type SandboxToolGateResult,
+} from '@pagespace/lib/services/sandbox/tool-gate';
 import { getActorInfo } from '@pagespace/lib/monitoring/activity-logger';
 import type { SubscriptionTier } from '@pagespace/lib/services/subscription-utils';
 import { type ToolExecutionContext } from '../core';
@@ -76,29 +80,59 @@ export type ResolveSandboxContext = (
   context: ToolExecutionContext | undefined,
 ) => Promise<SandboxActorContext | { error: string }>;
 
+/** The call-time authz/quota gate, bound to the resolved actor context. */
+export type SandboxGate = (ctx: SandboxActorContext) => Promise<SandboxToolGateResult>;
+
 export interface SandboxToolsDeps {
   runDeps: SandboxRunDeps;
   resolveContext: ResolveSandboxContext;
+  gate: SandboxGate;
 }
 
 function readContext(options: unknown): ToolExecutionContext | undefined {
   return (options as { experimental_context?: ToolExecutionContext })?.experimental_context;
 }
 
-export function createSandboxTools({ runDeps, resolveContext }: SandboxToolsDeps): {
+// Translate a gate denial into the tool-facing error object (mirrors the
+// runners' `{ success: false, error }` shape and carries any retry hint).
+function gateDenial(
+  denied: Extract<SandboxToolGateResult, { ok: false }>,
+): { success: false; error: string; retryAfter?: number } {
+  return {
+    success: false,
+    error: denied.error,
+    ...(denied.retryAfter ? { retryAfter: denied.retryAfter } : {}),
+  };
+}
+
+export function createSandboxTools({ runDeps, resolveContext, gate }: SandboxToolsDeps): {
   bash: Tool;
   writeFile: Tool;
   readFile: Tool;
 } {
+  // Resolve the actor, then run the call-time gate (kill-switch + canRunCode +
+  // quota) BEFORE delegating to the runner — a denial returns a safe error and
+  // never reaches provisioning. The runner re-enforces every check; this is the
+  // defence-in-depth chokepoint at the tool boundary.
+  const open = async (
+    options: unknown,
+  ): Promise<{ ok: true; ctx: SandboxActorContext } | { ok: false; error: { success: false; error: string; retryAfter?: number } }> => {
+    const ctx = await resolveContext(readContext(options));
+    if ('error' in ctx) return { ok: false, error: { success: false, error: ctx.error } };
+    const decision = await gate(ctx);
+    if (!decision.ok) return { ok: false, error: gateDenial(decision) };
+    return { ok: true, ctx };
+  };
+
   return {
     bash: tool({
       description:
         'Run a shell command in this conversation\'s isolated sandbox. Returns stdout, stderr, and the exit code. No network access; the filesystem is ephemeral and scoped to the sandbox.',
       inputSchema: bashInputSchema,
       execute: async ({ command, cwd }, options) => {
-        const ctx = await resolveContext(readContext(options));
-        if ('error' in ctx) return { success: false, error: ctx.error };
-        return runBashInSandbox({ command, cwd, ctx, deps: runDeps });
+        const opened = await open(options);
+        if (!opened.ok) return opened.error;
+        return runBashInSandbox({ command, cwd, ctx: opened.ctx, deps: runDeps });
       },
     }),
 
@@ -107,9 +141,9 @@ export function createSandboxTools({ runDeps, resolveContext }: SandboxToolsDeps
         'Write a file inside this conversation\'s sandbox. The path is relative to the sandbox root and cannot escape it.',
       inputSchema: writeFileInputSchema,
       execute: async ({ path, content }, options) => {
-        const ctx = await resolveContext(readContext(options));
-        if ('error' in ctx) return { success: false, error: ctx.error };
-        return writeSandboxFile({ path, content, ctx, deps: runDeps });
+        const opened = await open(options);
+        if (!opened.ok) return opened.error;
+        return writeSandboxFile({ path, content, ctx: opened.ctx, deps: runDeps });
       },
     }),
 
@@ -118,9 +152,9 @@ export function createSandboxTools({ runDeps, resolveContext }: SandboxToolsDeps
         'Read a file from this conversation\'s sandbox. The path is relative to the sandbox root and cannot escape it.',
       inputSchema: readFileInputSchema,
       execute: async ({ path }, options) => {
-        const ctx = await resolveContext(readContext(options));
-        if ('error' in ctx) return { success: false, error: ctx.error };
-        return readSandboxFile({ path, ctx, deps: runDeps });
+        const opened = await open(options);
+        if (!opened.ok) return opened.error;
+        return readSandboxFile({ path, ctx: opened.ctx, deps: runDeps });
       },
     }),
   };
@@ -221,5 +255,14 @@ export function buildSandboxTools(): { bash: Tool; writeFile: Tool; readFile: To
   return createSandboxTools({
     runDeps: buildRealSandboxRunDeps(),
     resolveContext: resolveSandboxActorContext,
+    gate: (ctx) =>
+      gateSandboxToolCall({
+        userId: ctx.userId,
+        driveId: ctx.driveId,
+        tenantId: ctx.tenantId,
+        requestOrigin: ctx.requestOrigin,
+        agentPageId: ctx.agentPageId,
+        tier: ctx.tier,
+      }),
   });
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -247,6 +247,11 @@
       "import": "./dist/services/sandbox/tool-runners.js",
       "require": "./dist/services/sandbox/tool-runners.js"
     },
+    "./services/sandbox/tool-gate": {
+      "types": "./dist/services/sandbox/tool-gate.d.ts",
+      "import": "./dist/services/sandbox/tool-gate.js",
+      "require": "./dist/services/sandbox/tool-gate.js"
+    },
     "./services/upload-validation": {
       "types": "./dist/services/upload-validation.d.ts",
       "import": "./dist/services/upload-validation.js",

--- a/packages/lib/src/services/sandbox/__tests__/tool-gate.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/tool-gate.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { gateSandboxToolCall, type SandboxToolGateDeps } from '../tool-gate';
+
+// A fully-permissive set of injected deps; each test overrides the one boundary
+// it exercises so a single denial is never masked by another check.
+function allowDeps(overrides: Partial<SandboxToolGateDeps> = {}): SandboxToolGateDeps {
+  return {
+    isEnabled: () => true,
+    authorize: async () => ({ ok: true }),
+    checkQuota: async () => ({ allowed: true }),
+    ...overrides,
+  };
+}
+
+const input = {
+  userId: 'u1',
+  driveId: 'd1',
+  tenantId: 't1',
+  tier: 'pro' as const,
+};
+
+describe('gateSandboxToolCall', () => {
+  it('given the kill-switch off, should deny before any authz or quota IO', async () => {
+    let authorized = false;
+    let quotaChecked = false;
+    const result = await gateSandboxToolCall({
+      ...input,
+      deps: allowDeps({
+        isEnabled: () => false,
+        authorize: async () => {
+          authorized = true;
+          return { ok: true };
+        },
+        checkQuota: async () => {
+          quotaChecked = true;
+          return { allowed: true };
+        },
+      }),
+    });
+    expect(result).toEqual({ ok: false, reason: 'kill_switch_off', error: expect.any(String) });
+    expect(authorized).toBe(false);
+    expect(quotaChecked).toBe(false);
+  });
+
+  it('given an actor without drive access, should deny and not check quota', async () => {
+    let quotaChecked = false;
+    const result = await gateSandboxToolCall({
+      ...input,
+      deps: allowDeps({
+        authorize: async () => ({ ok: false, reason: 'no_drive_access' }),
+        checkQuota: async () => {
+          quotaChecked = true;
+          return { allowed: true };
+        },
+      }),
+    });
+    expect(result).toMatchObject({ ok: false, reason: 'no_drive_access' });
+    expect(quotaChecked).toBe(false);
+  });
+
+  it('given an authorized actor over the daily budget, should deny with rate_limited and retryAfter', async () => {
+    const result = await gateSandboxToolCall({
+      ...input,
+      deps: allowDeps({
+        checkQuota: async () => ({ allowed: false, reason: 'rate_limited', retryAfter: 42 }),
+      }),
+    });
+    expect(result).toMatchObject({ ok: false, reason: 'rate_limited', retryAfter: 42 });
+  });
+
+  it('given an authorized actor at the concurrency ceiling, should deny with concurrency_limit', async () => {
+    const result = await gateSandboxToolCall({
+      ...input,
+      deps: allowDeps({
+        checkQuota: async () => ({ allowed: false, reason: 'concurrency_limit' }),
+      }),
+    });
+    expect(result).toMatchObject({ ok: false, reason: 'concurrency_limit' });
+  });
+
+  it('given kill-switch on, authorized, and within quota, should allow', async () => {
+    const result = await gateSandboxToolCall({ ...input, deps: allowDeps() });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('given an authorize dependency that throws, should fail closed to a denial', async () => {
+    const result = await gateSandboxToolCall({
+      ...input,
+      deps: allowDeps({
+        authorize: async () => {
+          throw new Error('db down');
+        },
+      }),
+    });
+    expect(result).toMatchObject({ ok: false, reason: 'error' });
+  });
+
+  it('given an agent-origin run, should pass requestOrigin and agentPageId through to authorize', async () => {
+    let seen: { requestOrigin?: string; agentPageId?: string } = {};
+    await gateSandboxToolCall({
+      ...input,
+      requestOrigin: 'agent',
+      agentPageId: 'agent-page-1',
+      deps: allowDeps({
+        authorize: async ({ requestOrigin, agentPageId }) => {
+          seen = { requestOrigin, agentPageId };
+          return { ok: true };
+        },
+      }),
+    });
+    expect(seen).toEqual({ requestOrigin: 'agent', agentPageId: 'agent-page-1' });
+  });
+});

--- a/packages/lib/src/services/sandbox/tool-gate.ts
+++ b/packages/lib/src/services/sandbox/tool-gate.ts
@@ -1,0 +1,130 @@
+/**
+ * Call-time gate for the agent code-execution tools.
+ *
+ * This is the single authorization chokepoint the `bash` / `writeFile` /
+ * `readFile` tools run BEFORE they touch the runner — kill-switch, then
+ * `canRunCode` authz, then the advisory quota preflight — so a denied call
+ * returns a safe tool error and never reaches provisioning. It composes the PR1
+ * primitives unchanged:
+ *
+ *   - `isCodeExecutionEnabled` — the global env kill-switch (default OFF);
+ *   - `canRunCode` — drive membership + role (and the agent's own drive access
+ *     for agent-origin runs), fail-closed;
+ *   - `checkCodeExecutionQuota` — the NON-incrementing read of concurrency +
+ *     daily budget.
+ *
+ * It is defence in depth, not a replacement: the runner (`tool-runners.ts`)
+ * still re-checks the kill-switch, reserves the concurrency slot, re-authorizes
+ * on sandbox resume (via the lifecycle), and issues the single real budget
+ * charge. The gate's quota call is advisory and non-incrementing, so running it
+ * here never double-charges — it only short-circuits an obviously-denied call at
+ * the tool boundary, where the result is a clean `{ ok: false }` instead of a
+ * half-provisioned run.
+ *
+ * Fail-closed by construction: every dependency is injected (defaults wire the
+ * real implementations) and any thrown error resolves to a denial.
+ */
+
+import type { SubscriptionTier } from '../subscription-utils';
+import {
+  canRunCode,
+  isCodeExecutionEnabled,
+  type CanRunCodeInput,
+  type CanRunCodeResult,
+} from './can-run-code';
+import { checkCodeExecutionQuota, type CodeExecutionQuotaDecision } from './quota';
+
+export type SandboxToolGateDenialReason =
+  | 'kill_switch_off'
+  | 'no_drive_access'
+  | 'insufficient_role'
+  | 'no_agent_access'
+  | 'concurrency_limit'
+  | 'rate_limited'
+  | 'error';
+
+export type SandboxToolGateResult =
+  | { ok: true }
+  | { ok: false; reason: SandboxToolGateDenialReason; error: string; retryAfter?: number };
+
+/** Safe, model-facing messages. Mirrors the runner's denial copy for consistency. */
+const DENIAL_MESSAGES: Record<SandboxToolGateDenialReason, string> = {
+  kill_switch_off: 'Code execution is disabled.',
+  no_drive_access: 'You do not have access to run code in this drive.',
+  insufficient_role: 'Running code requires drive owner or admin access.',
+  no_agent_access: 'This agent is not permitted to run code in this drive.',
+  concurrency_limit: 'Too many concurrent runs. Wait for a run to finish and retry.',
+  rate_limited: 'Daily code-execution budget reached. Try again later.',
+  error: 'Code execution could not be authorized.',
+};
+
+const deny = (
+  reason: SandboxToolGateDenialReason,
+  retryAfter?: number,
+): SandboxToolGateResult => ({
+  ok: false,
+  reason,
+  error: DENIAL_MESSAGES[reason],
+  ...(retryAfter ? { retryAfter } : {}),
+});
+
+/**
+ * IO dependencies, injected so tests exercise the composition with fakes instead
+ * of mocking the database. Defaults wire the real PR1 implementations.
+ */
+export interface SandboxToolGateDeps {
+  isEnabled: () => boolean;
+  authorize: (input: CanRunCodeInput) => Promise<CanRunCodeResult>;
+  checkQuota: (input: {
+    userId: string;
+    driveId: string;
+    tenantId?: string;
+    tier: SubscriptionTier;
+  }) => Promise<CodeExecutionQuotaDecision>;
+}
+
+const defaultDeps: SandboxToolGateDeps = {
+  isEnabled: isCodeExecutionEnabled,
+  authorize: canRunCode,
+  checkQuota: checkCodeExecutionQuota,
+};
+
+export interface SandboxToolGateInput {
+  userId: string;
+  driveId: string;
+  tenantId?: string;
+  requestOrigin?: 'user' | 'agent';
+  agentPageId?: string;
+  tier: SubscriptionTier;
+  deps?: SandboxToolGateDeps;
+}
+
+export async function gateSandboxToolCall({
+  userId,
+  driveId,
+  tenantId,
+  requestOrigin,
+  agentPageId,
+  tier,
+  deps = defaultDeps,
+}: SandboxToolGateInput): Promise<SandboxToolGateResult> {
+  try {
+    // Kill-switch first: the cheapest check, and a disabled feature must deny
+    // before any DB round-trip in authz or quota.
+    if (!deps.isEnabled()) return deny('kill_switch_off');
+
+    const authorization = await deps.authorize({ userId, driveId, requestOrigin, agentPageId });
+    if (!authorization.ok) {
+      // canRunCode's reasons are a subset of the gate's; map the kill-switch
+      // value through to the gate reason and pass the authz reasons straight.
+      return deny(authorization.reason);
+    }
+
+    const quota = await deps.checkQuota({ userId, driveId, tenantId, tier });
+    if (!quota.allowed) return deny(quota.reason, quota.retryAfter);
+
+    return { ok: true };
+  } catch {
+    return deny('error');
+  }
+}


### PR DESCRIPTION
## PR4 — Register tools in agent chat (Agent Code Execution epic, final PR)

The exposure surface. Lands behind a **default-OFF** kill-switch; nothing is reachable by agents until the flag is enabled.

### Scope
- `packages/lib/src/services/sandbox/tool-gate.ts` — call-time gate (kill-switch → `canRunCode` authz → non-incrementing quota preflight), fail-closed, injected deps. Defence-in-depth in front of the runner.
- `apps/web/src/lib/ai/tools/sandbox-tools.ts` — thin AI SDK `tool()` wrappers (`bash`/`writeFile`/`readFile`) delegating to PR3 runners; schema + size limits + context resolution only.
- `apps/web/src/lib/ai/core/ai-tools.ts` — flag-gated registration into `pageSpaceTools` (absent when the kill-switch is OFF).
- Tests for all three; `packages/lib` exports updated.

### Requirements
- Given the feature flag disabled (default), the tools are NOT registered.
- Given a tool invocation, gates on `canRunCode` + kill-switch + quota at call time before provisioning; denied → safe returned error (no throw).
- Given tool input, zod-validated with explicit size limits.

Builds on merged PR1 (safety), PR2 (lifecycle), PR3 (tools/runners). Ships **default-OFF**; rollout is staged per-tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)