### PR TITLE
fix(billing): enforce prepaid gate at AI entry points + log usage when metadata missing

### DIFF
--- a/apps/web/src/app/api/ai/chat/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/ai/chat/__tests__/credit-gate.test.ts
@@ -169,6 +169,7 @@ vi.mock('@/lib/ai/core/model-capabilities', () => ({ hasVisionCapability: vi.fn(
 import { POST } from '../route';
 import { authenticateRequestWithOptions } from '@/lib/auth';
 import { canConsumeAI } from '@pagespace/lib/billing/credit-gate';
+import { saveMessageToDatabase } from '@/lib/ai/core';
 import { streamText } from 'ai';
 
 const mockUserId = 'user_123';
@@ -210,6 +211,9 @@ describe('POST /api/ai/chat - prepaid credit gate', () => {
     const body = await response.json();
     expect(body.error).toBe('out_of_credits');
     expect(streamText).not.toHaveBeenCalled();
+    // Side-effect-free denial: the user message must NOT be persisted, so a
+    // retry after a 402 cannot create orphan user-only messages.
+    expect(saveMessageToDatabase).not.toHaveBeenCalled();
   });
 
   it('does not block with a 402 when the gate allows', async () => {

--- a/apps/web/src/app/api/ai/chat/route.ts
+++ b/apps/web/src/app/api/ai/chat/route.ts
@@ -258,10 +258,50 @@ export async function POST(request: Request) {
       userId: maskedUserId,
       chatId: maskedChatId,
     });
-    
-    loggers.ai.info('AI Chat API: Validation passed', { 
-      messageCount: messages.length, 
-      chatId 
+
+    // Resolve the user's provider/model + enforce both pre-model gates (Pro
+    // subscription and prepaid credits) BEFORE any DB writes — conversation
+    // creation, user-message persistence, and mention notifications all happen
+    // below. Running the gates first keeps a denied request side-effect free, so
+    // an out-of-credits user (or a client retrying after a 402) can't create
+    // orphan user-only messages or notifications with no assistant response.
+    const [user] = await db.select().from(users).where(eq(users.id, userId));
+    const currentProvider = selectedProvider || user?.currentAiProvider || 'pagespace';
+    const currentModel = selectedModel || user?.currentAiModel || 'glm-4.5-air';
+
+    const { requiresProSubscription, createSubscriptionRequiredResponse } = await import('@/lib/subscription/rate-limit-middleware');
+    if (requiresProSubscription(currentProvider, currentModel, user?.subscriptionTier)) {
+      loggers.ai.warn('AI Chat API: Pro subscription required', {
+        userId,
+        provider: currentProvider,
+        model: currentModel,
+        subscriptionTier: user?.subscriptionTier
+      });
+      return createSubscriptionRequiredResponse();
+    }
+
+    // Prepaid credit gate: block out-of-credits users before any model invocation.
+    // Safe in billing-disabled deployments (returns unlimited) and lazy-inits balances.
+    const creditGate = await canConsumeAI(userId, (user?.subscriptionTier ?? 'free') as SubscriptionTier);
+    if (!creditGate.allowed) {
+      loggers.ai.warn('AI Chat API: Out of AI credits', {
+        userId,
+        provider: currentProvider,
+        model: currentModel,
+        reason: creditGate.reason,
+      });
+      return NextResponse.json(
+        {
+          error: 'out_of_credits',
+          message: 'You have run out of AI credits. Add credits or wait for your monthly allowance to reset.',
+        },
+        { status: 402 }
+      );
+    }
+
+    loggers.ai.info('AI Chat API: Validation passed', {
+      messageCount: messages.length,
+      chatId
     });
 
     // Get page configuration for custom agent settings (needed early for message saving)
@@ -409,11 +449,6 @@ export async function POST(request: Request) {
         }, { status: 500 });
       }
     }
-    
-    // Get user's current AI provider settings
-    const [user] = await db.select().from(users).where(eq(users.id, userId));
-    const currentProvider = selectedProvider || user?.currentAiProvider || 'pagespace';
-    const currentModel = selectedModel || user?.currentAiModel || 'glm-4.5-air';
 
     // Kick off the userProfiles displayName fetch early so it overlaps with downstream
     // setup (rate-limit checks, tool resolution, conversation load) and never blocks the
@@ -424,39 +459,6 @@ export async function POST(request: Request) {
       .where(eq(userProfiles.userId, userId))
       .limit(1)
       .catch(() => [] as { displayName: string | null }[]);
-
-    // Pro subscription check for special providers
-    const { requiresProSubscription, createSubscriptionRequiredResponse } = await import('@/lib/subscription/rate-limit-middleware');
-
-    // Check if provider requires Pro subscription
-    if (requiresProSubscription(currentProvider, currentModel, user?.subscriptionTier)) {
-      loggers.ai.warn('AI Chat API: Pro subscription required', {
-        userId,
-        provider: currentProvider,
-        model: currentModel,
-        subscriptionTier: user?.subscriptionTier
-      });
-      return createSubscriptionRequiredResponse();
-    }
-
-    // Prepaid credit gate: block out-of-credits users before any model invocation.
-    // Safe in billing-disabled deployments (returns unlimited) and lazy-inits balances.
-    const creditGate = await canConsumeAI(userId, (user?.subscriptionTier ?? 'free') as SubscriptionTier);
-    if (!creditGate.allowed) {
-      loggers.ai.warn('AI Chat API: Out of AI credits', {
-        userId,
-        provider: currentProvider,
-        model: currentModel,
-        reason: creditGate.reason,
-      });
-      return NextResponse.json(
-        {
-          error: 'out_of_credits',
-          message: 'You have run out of AI credits. Add credits or wait for your monthly allowance to reset.',
-        },
-        { status: 402 }
-      );
-    }
 
     // Usage tracking will be handled in onFinish callback for PageSpace providers only
     loggers.ai.debug('AI Chat API: Will track usage in onFinish for PageSpace providers', {

--- a/apps/web/src/app/api/ai/global/[id]/messages/__tests__/credit-gate.test.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/__tests__/credit-gate.test.ts
@@ -278,6 +278,9 @@ describe('POST /api/ai/global/[id]/messages — prepaid credit gate', () => {
     expect(body.error).toBe('out_of_credits');
     expect(streamText).not.toHaveBeenCalled();
     expect(mockCreateStreamLifecycle).not.toHaveBeenCalled();
+    // Side-effect-free denial: the user message must NOT be persisted, so a
+    // retry after a 402 cannot leave a visible user-only message.
+    expect(mockSaveGlobalAssistantMessageToDatabase).not.toHaveBeenCalled();
   });
 
   it('does not block with a 402 when the gate allows', async () => {

--- a/apps/web/src/app/api/ai/global/[id]/messages/route.ts
+++ b/apps/web/src/app/api/ai/global/[id]/messages/route.ts
@@ -314,10 +314,38 @@ export async function POST(
     // Parse web search mode (defaults to false - disabled)
     const webSearchMode = webSearchEnabled === true;
 
+    // Prepaid credit gate: block out-of-credits users BEFORE any DB writes — the
+    // user-message persistence and conversation metadata update happen below.
+    // Running the gate first keeps a denied request side-effect free, so an
+    // out-of-credits user (or a client retrying after a 402) can't leave a
+    // visible user-only message / conversation update with no model response.
+    // Safe in billing-disabled deployments (returns unlimited) and lazy-inits balances.
+    {
+      const [gateUser] = await db
+        .select({ subscriptionTier: users.subscriptionTier })
+        .from(users)
+        .where(eq(users.id, userId));
+      const creditGate = await canConsumeAI(userId, (gateUser?.subscriptionTier ?? 'free') as SubscriptionTier);
+      if (!creditGate.allowed) {
+        loggers.api.warn('Global Assistant Chat API: Out of AI credits', {
+          userId: maskIdentifier(userId),
+          reason: creditGate.reason,
+          conversationId,
+        });
+        return NextResponse.json(
+          {
+            error: 'out_of_credits',
+            message: 'You have run out of AI credits. Add credits or wait for your monthly allowance to reset.',
+          },
+          { status: 402 }
+        );
+      }
+    }
+
     // Process @mentions in the user's message
     let mentionSystemPrompt = '';
     let mentionedPageIds: string[] = [];
-    
+
     // Save user's message immediately to database
     const userMessage = requestMessages[requestMessages.length - 1];
     if (userMessage && userMessage.role === 'user') {
@@ -439,32 +467,6 @@ export async function POST(
         limit: currentUsage.limit,
         conversationId
       });
-    }
-
-    // Prepaid credit gate: block out-of-credits users before any model invocation.
-    // Safe in billing-disabled deployments (returns unlimited) and lazy-inits balances.
-    {
-      const [gateUser] = await db
-        .select({ subscriptionTier: users.subscriptionTier })
-        .from(users)
-        .where(eq(users.id, userId));
-      const creditGate = await canConsumeAI(userId, (gateUser?.subscriptionTier ?? 'free') as SubscriptionTier);
-      if (!creditGate.allowed) {
-        loggers.api.warn('Global Assistant Chat API: Out of AI credits', {
-          userId: maskIdentifier(userId),
-          provider: currentProvider,
-          model: currentModel,
-          reason: creditGate.reason,
-          conversationId,
-        });
-        return NextResponse.json(
-          {
-            error: 'out_of_credits',
-            message: 'You have run out of AI credits. Add credits or wait for your monthly allowance to reset.',
-          },
-          { status: 402 }
-        );
-      }
     }
 
     loggers.api.debug('Global Assistant Chat API: Read-only mode', { isReadOnly: readOnlyMode });


### PR DESCRIPTION
## Why

The prepaid AI-credits bridge records spend **after** a call but never checked a balance **before** serving. `canConsumeAI(userId, tier)` (`packages/lib/src/billing/credit-gate.ts`) was fully implemented and tested but had **zero callers** — so an out-of-credits user was never blocked and the platform silently fronted 100% of overage. This wires the gate into every user-facing AI generation entry point, and fixes one route that skipped billing when usage metadata was missing.

## W1 — gate wired at each entry point

Each route resolves the user's tier (`users.subscriptionTier`, default `free`) and calls `canConsumeAI(userId, tier)` **before invoking the model and before any DB writes**. If `!gate.allowed`, it returns **HTTP 402**:

```json
{ "error": "out_of_credits", "message": "You have run out of AI credits. Add credits or wait for your monthly allowance to reset." }
```

`canConsumeAI` is always safe to call: it returns `{allowed:true, reason:'unlimited'}` when billing is disabled (tenant/onprem) and lazy-inits a balance on `needs_init`.

| Entry point | Placement | 402 behavior |
|---|---|---|
| `api/ai/chat` | after view/edit permission checks, **before** conversation creation + user-message save + mention notifications | 402, no DB side effects, stream never starts |
| `api/ai/global/[id]/messages` | after read-only parsing, **before** the user-message save + conversation metadata update | 402, no DB side effects, lifecycle/stream never created |
| `api/v1/chat/completions` | after provider creation, before `saveMessageToDatabase` + inference | 402 (+ audit `out_of_credits`) |
| `api/ai/page-agents/consult` | after the view-permission check, before `generateText` | 402, provider never configured |
| `api/pulse/generate` | right after the user load (on-demand path) | 402 before any context gathering or persistence |

**Side-effect-free denials (review fix):** in `chat` and `global/[id]/messages` the gates initially ran *after* the database-first block that saves the incoming user message and fires notifications, so an out-of-credits user (or a 402 retry) could leave orphan user-only messages. Both pre-model gates now run ahead of all persistence. Tests assert `saveMessageToDatabase` / `saveGlobalAssistantMessageToDatabase` are **not** called on a 402.

**`pulse/cron` is intentionally NOT gated** — a cron failing to bill shouldn't 500 the batch. Only interactive/user-triggered entry points enforce the hard 402. `credit-gate.ts` was not modified.

## R4 — `global/[id]/messages` no longer skips billing when usage is missing

The usage tracking was wrapped in `if (usage && usage.totalTokens > 0)`, so when the provider returned no usage the call was **never logged or billed** and the orphan-sweep couldn't recover it. It now **always** calls `AIMonitoring.trackUsage(...)` with whatever usage fields exist (0/undefined tokens → $0 cost, but the `aiUsageLogs` row exists), still keyed on the resolved `modelName`.

## Validation

- `bun run --filter 'web' typecheck` — passes.
- Tests (bun + vitest), **69 passing across 8 files**:
  - New `credit-gate.test.ts` for chat / global / consult / pulse, plus extended v1 `route.test.ts`: out-of-credits → 402 (gate mocked `{allowed:false}`); allowed/unlimited → proceeds; model/stream never invoked and **no message persisted** on denial.
  - Global `credit-gate.test.ts` R4 cases: `AIMonitoring.trackUsage` is called even when provider usage is `undefined`, and logs the resolved model with token counts when present.
  - Existing harnesses (chat `mcp-scope` + `stream-socket-events`, global `stream-socket-events`) updated to mock the gate as allowed so prior behavior is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)