### PR TITLE
fix(billing): bound credit backfill drain loop on no-progress, not just MAX_PASSES

### DIFF
--- a/packages/lib/src/billing/__tests__/credit-backfill.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-backfill.test.ts
@@ -122,9 +122,9 @@ describe('backfillCredits', () => {
     expect(result).toEqual({ retried: BATCH + 50, orphans: 0 });
   });
 
-  it('stops after the safety cap even if a sweep keeps returning a full batch', async () => {
-    // Every pass returns a full BATCH of orphans (simulating rows that never
-    // settle and keep reappearing). The loop must not run unbounded.
+  it('stops after the safety cap even if a sweep keeps returning a full batch of fresh rows', async () => {
+    // Every pass returns a full BATCH of DISTINCT orphans (forward progress each
+    // pass, so the no-progress break never fires). The cap must still bound it.
     for (let pass = 0; pass < 100; pass++) {
       queuePass([], fill(BATCH, (i) => ({ aiUsageLogId: `aul_${pass}_${i}`, userId: 'u1', cost: 0.01 })));
     }
@@ -134,6 +134,31 @@ describe('backfillCredits', () => {
     // MAX_PASSES = 50 -> 50 passes × 2 selects.
     expect(mockDb.select).toHaveBeenCalledTimes(100);
     expect(result.orphans).toBe(BATCH * 50);
+    // The cap (not natural drain) terminated the loop, so it must warn.
+    expect(mockAiLogger.debug).toHaveBeenCalledWith(
+      'credit backfill hit MAX_PASSES; backlog may remain',
+      expect.any(Object),
+    );
+  });
+
+  it('stops early (no-progress break) when a full batch of unprocessable rows repeats', async () => {
+    // A balance-less pending row stays 'pending' (decrementAndSettle no-ops), so
+    // every pass re-fetches the SAME full batch. The loop must detect no forward
+    // progress and stop after the second pass — not re-attempt it MAX_PASSES times.
+    const stuck = fill(BATCH, (i) => ({ id: `led_stuck_${i}` }));
+    for (let pass = 0; pass < 100; pass++) queuePass([...stuck], []);
+
+    const result = await backfillCredits();
+
+    // Pass 0 + pass 1 (identical fingerprint detected) = 2 passes × 2 selects.
+    expect(mockDb.select).toHaveBeenCalledTimes(4);
+    expect(mockSettlePending).toHaveBeenCalledTimes(BATCH * 2);
+    expect(result.retried).toBe(BATCH * 2);
+    // Stalled, not capped -> no MAX_PASSES warning.
+    expect(mockAiLogger.debug).not.toHaveBeenCalledWith(
+      'credit backfill hit MAX_PASSES; backlog may remain',
+      expect.any(Object),
+    );
   });
 
   it('bills a success:false orphan that carries real cost (errored-but-real spend)', async () => {

--- a/packages/lib/src/billing/credit-backfill.ts
+++ b/packages/lib/src/billing/credit-backfill.ts
@@ -36,11 +36,20 @@ export async function backfillCredits(): Promise<BackfillResult> {
   let retried = 0;
   let orphanCount = 0;
 
+  // Fingerprint of the rows a pass fetched. If two consecutive passes fetch the
+  // exact same set, nothing settled between them and re-running can't make
+  // progress — e.g. balance-less 'pending' rows that decrementAndSettle leaves
+  // untouched (credit-consume.ts), which would otherwise be re-attempted every
+  // pass up to MAX_PASSES. Stop instead of churning the same unprocessable rows.
+  let prevFingerprint = '';
+
   // Drain the backlog: each settled/consumed row drops out of the next sweep
   // (pending rows flip off 'pending'; orphans gain a ledger row), so re-querying
   // makes forward progress. Keep going until a pass returns fewer than BATCH from
-  // both sweeps (nothing more to fetch), bounded by MAX_PASSES.
-  for (let pass = 0; pass < MAX_PASSES; pass++) {
+  // both sweeps (nothing more to fetch) or stops making progress, bounded by
+  // MAX_PASSES.
+  let pass = 0;
+  for (; pass < MAX_PASSES; pass++) {
     const pending = await db
       .select({ id: creditLedger.id })
       .from(creditLedger)
@@ -96,12 +105,21 @@ export async function backfillCredits(): Promise<BackfillResult> {
     // sweep means more rows may remain — loop again (up to MAX_PASSES).
     if (pending.length < BATCH && orphans.length < BATCH) break;
 
-    if (pass === MAX_PASSES - 1) {
-      loggers.ai.debug('credit backfill hit MAX_PASSES; backlog may remain', {
-        retried,
-        orphans: orphanCount,
-      });
-    }
+    // Sorted so the comparison is order-independent (the sweeps have no ORDER BY).
+    const fingerprint =
+      pending.map((p) => p.id).sort().join(',') +
+      '|' +
+      orphans.map((o) => o.aiUsageLogId).sort().join(',');
+    if (fingerprint === prevFingerprint) break; // no forward progress — give up this run
+    prevFingerprint = fingerprint;
+  }
+
+  // Loop ran to the cap rather than draining/stalling — a real backlog remains.
+  if (pass === MAX_PASSES) {
+    loggers.ai.debug('credit backfill hit MAX_PASSES; backlog may remain', {
+      retried,
+      orphans: orphanCount,
+    });
   }
 
   return { retried, orphans: orphanCount };


### PR DESCRIPTION
## Context

Follow-up hardening to the credit backfill drain loop landed in #1479 (merged into `pu/credits-remediation` as `4bae4d195`). #1479 made `backfillCredits()` loop until a pass returns `< BATCH` from both sweeps, bounded by `MAX_PASSES = 50`. This PR addresses a review finding on that loop that arrived after #1479 was merged.

## Problem

`decrementAndSettle` (`credit-consume.ts`) intentionally leaves a ledger row `'pending'` when the user has no balance row yet (lazy-init / pre-gate users) — "never mark a call 'applied' without decrementing it." Such a row never drops out of the pending sweep. The drain loop would therefore **re-fetch and re-attempt the same unprocessable batch on every pass up to `MAX_PASSES`**: with ≥ `BATCH` balance-less pending rows, every 10-minute cron run executes all 50 passes (≈10,000 no-op `settlePendingLedgerRow` transactions per run, forever). The loop's "each settled row drops out → forward progress" invariant doesn't hold for the balance-less case.

(`credit-consume.ts` is owned elsewhere and is correct as-is — the fix belongs in the loop.)

## Changes (`credit-backfill.ts`)

- **No-forward-progress break.** Each pass fingerprints its fetched rows (sorted, so order-independent). Two identical consecutive passes mean nothing settled between them, so the loop stops instead of churning the same rows. A truly stuck full batch now ends in **2 passes, not 50**. Partial progress still drains normally via the existing short-pass break, and `MAX_PASSES` remains the absolute backstop.
- **Hoisted the cap-exhaustion warning** out of the loop body so it fires exactly when the loop ran to `MAX_PASSES` (a genuine remaining backlog) rather than on a narrow last-iteration batch-size coincidence — and it's now covered by a test.

## Verification
- `bun run --filter '@pagespace/lib' typecheck` — clean (after merging current base, which pulled in the sibling credits-funding/gate/core/consume work).
- `eslint` on the changed source — clean.
- Full `@pagespace/lib` vitest suite — **179 files / 4384 tests pass**.
- Targeted backfill tests: stuck full batch **stops early** (no-progress break, 2 passes, no `MAX_PASSES` warning); distinct full batches **run to the cap and warn**; existing drain / errored-orphan / `gt(cost,0)` sweep assertions still pass.

## File ownership
Touches only `packages/lib/src/billing/credit-backfill.ts` and its co-located test (plus a clean merge of the updated base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)