### PR TITLE
fix(billing): make Stripe funding failures retryable (follow-up to merged #1480)

### DIFF
--- a/apps/web/src/app/api/stripe/webhook/route.ts
+++ b/apps/web/src/app/api/stripe/webhook/route.ts
@@ -6,7 +6,7 @@ import { subscriptions, stripeEvents } from '@pagespace/db/schema/subscriptions'
 import { stripe, Stripe, getTierFromPrice } from '@/lib/stripe';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { maskEmail } from '@pagespace/lib/audit/mask-email';
-import { applyStripeFunding } from '@pagespace/lib/billing/credit-funding';
+import { applyStripeFunding, type FundingEvent } from '@pagespace/lib/billing/credit-funding';
 
 export async function POST(request: NextRequest) {
   try {
@@ -64,7 +64,7 @@ export async function POST(request: NextRequest) {
         case 'checkout.session.completed':
           await handleCheckoutCompleted(event.data.object as Stripe.Checkout.Session);
           // Fund the top-up bucket from a credit-pack purchase (no-op for other modes).
-          await applyStripeFunding(event);
+          await fundOrLetStripeRetry(event);
           break;
 
         case 'invoice.payment_failed':
@@ -74,7 +74,7 @@ export async function POST(request: NextRequest) {
         case 'invoice.paid':
           await handleInvoicePaid(event.data.object as Stripe.Invoice);
           // Reset the monthly credit bucket to the tier allowance on each renewal.
-          await applyStripeFunding(event);
+          await fundOrLetStripeRetry(event);
           break;
 
         default:
@@ -111,6 +111,31 @@ export async function POST(request: NextRequest) {
       { error: 'Webhook processing failed' },
       { status: 500 }
     );
+  }
+}
+
+/**
+ * Run prepaid-credit funding for a paid event, making a funding failure RETRYABLE.
+ *
+ * The stripeEvents idempotency marker is committed BEFORE processing, so a swallowed
+ * funding failure would be lost forever: Stripe's redelivery would short-circuit as
+ * "already processed" (the insert above conflicts and returns 200), and the local
+ * backfill cron reconciles only usage rows, not Stripe funding. To keep paid credit
+ * from vanishing on a transient DB error, we delete that marker on a funding failure
+ * and rethrow — the webhook then returns 500 and Stripe redelivers, reprocessing the
+ * event. Funding is idempotent on creditLedger.stripeRef, so the balance is credited
+ * exactly once even though the event is processed twice.
+ *
+ * Safe to reprocess: the handlers that run before funding are no-ops/log-only on the
+ * funding-relevant events — handleInvoicePaid only logs, and handleCheckoutCompleted
+ * acts only for mode 'subscription' (a credit-pack top-up is mode 'payment').
+ */
+async function fundOrLetStripeRetry(event: FundingEvent) {
+  try {
+    await applyStripeFunding(event);
+  } catch (fundingError) {
+    await db.delete(stripeEvents).where(eq(stripeEvents.id, event.id));
+    throw fundingError;
   }
 }
 

--- a/apps/web/src/app/api/stripe/webhook/route.ts
+++ b/apps/web/src/app/api/stripe/webhook/route.ts
@@ -6,7 +6,7 @@ import { subscriptions, stripeEvents } from '@pagespace/db/schema/subscriptions'
 import { stripe, Stripe, getTierFromPrice } from '@/lib/stripe';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { maskEmail } from '@pagespace/lib/audit/mask-email';
-import { applyStripeFunding, type FundingEvent } from '@pagespace/lib/billing/credit-funding';
+import { applyStripeFunding } from '@pagespace/lib/billing/credit-funding';
 
 export async function POST(request: NextRequest) {
   try {
@@ -62,9 +62,13 @@ export async function POST(request: NextRequest) {
           break;
 
         case 'checkout.session.completed':
-          await handleCheckoutCompleted(event.data.object as Stripe.Checkout.Session);
-          // Fund the top-up bucket from a credit-pack purchase (no-op for other modes).
-          await fundOrLetStripeRetry(event);
+          // Whole path is retryable: a transient failure in EITHER the handler or
+          // funding clears the idempotency marker so Stripe redelivers (see below).
+          await withFundingRetry(event.id, async () => {
+            await handleCheckoutCompleted(event.data.object as Stripe.Checkout.Session);
+            // Fund the top-up bucket from a credit-pack purchase (no-op for other modes).
+            await applyStripeFunding(event);
+          });
           break;
 
         case 'invoice.payment_failed':
@@ -72,9 +76,11 @@ export async function POST(request: NextRequest) {
           break;
 
         case 'invoice.paid':
-          await handleInvoicePaid(event.data.object as Stripe.Invoice);
-          // Reset the monthly credit bucket to the tier allowance on each renewal.
-          await fundOrLetStripeRetry(event);
+          await withFundingRetry(event.id, async () => {
+            await handleInvoicePaid(event.data.object as Stripe.Invoice);
+            // Reset the monthly credit bucket to the tier allowance on each renewal.
+            await applyStripeFunding(event);
+          });
           break;
 
         default:
@@ -115,27 +121,33 @@ export async function POST(request: NextRequest) {
 }
 
 /**
- * Run prepaid-credit funding for a paid event, making a funding failure RETRYABLE.
+ * Run a funding-relevant event path with RETRYABLE failure semantics.
  *
- * The stripeEvents idempotency marker is committed BEFORE processing, so a swallowed
- * funding failure would be lost forever: Stripe's redelivery would short-circuit as
- * "already processed" (the insert above conflicts and returns 200), and the local
+ * The stripeEvents idempotency marker is committed BEFORE processing, so any error
+ * in this path would otherwise be lost forever: Stripe's redelivery short-circuits
+ * as "already processed" (the insert above conflicts and returns 200), and the local
  * backfill cron reconciles only usage rows, not Stripe funding. To keep paid credit
- * from vanishing on a transient DB error, we delete that marker on a funding failure
- * and rethrow — the webhook then returns 500 and Stripe redelivers, reprocessing the
- * event. Funding is idempotent on creditLedger.stripeRef, so the balance is credited
- * exactly once even though the event is processed twice.
+ * from vanishing on a transient DB error, we delete that marker on ANY failure and
+ * rethrow — the webhook then returns 500 and Stripe redelivers, reprocessing the
+ * whole path. Funding is idempotent on creditLedger.stripeRef, so the balance is
+ * credited exactly once even though the event is processed twice.
  *
- * Safe to reprocess: the handlers that run before funding are no-ops/log-only on the
- * funding-relevant events — handleInvoicePaid only logs, and handleCheckoutCompleted
- * acts only for mode 'subscription' (a credit-pack top-up is mode 'payment').
+ * The cleanup must wrap the WHOLE path, not just the funding call: the pre-funding
+ * handler also does DB I/O (handleInvoicePaid looks the user up; handleCheckoutCompleted
+ * links the customer), and a transient failure there must be retryable too — otherwise
+ * the event is marked processed and funding never runs on redelivery.
+ *
+ * Safe to reprocess: on these events the pre-funding handlers are log-only/idempotent
+ * (handleInvoicePaid only logs; handleCheckoutCompleted's sole throwable is an
+ * idempotent customer-link upsert, and acts only for mode 'subscription' — a credit-pack
+ * top-up is mode 'payment'; its provisioning POST swallows its own errors).
  */
-async function fundOrLetStripeRetry(event: FundingEvent) {
+async function withFundingRetry(eventId: string, run: () => Promise<void>) {
   try {
-    await applyStripeFunding(event);
-  } catch (fundingError) {
-    await db.delete(stripeEvents).where(eq(stripeEvents.id, event.id));
-    throw fundingError;
+    await run();
+  } catch (err) {
+    await db.delete(stripeEvents).where(eq(stripeEvents.id, eventId));
+    throw err;
   }
 }
 

--- a/packages/lib/src/billing/__tests__/credit-funding.test.ts
+++ b/packages/lib/src/billing/__tests__/credit-funding.test.ts
@@ -240,11 +240,21 @@ describe('applyStripeFunding', () => {
     expect(mockDb.transaction).not.toHaveBeenCalled();
   });
 
-  it('never throws out of the webhook: a funding failure is logged and swallowed', async () => {
+  it('rethrows a genuine funding failure (logged) so the webhook can let Stripe redeliver', async () => {
     mockDb.select.mockReturnValue(userSelectReturning(PRO_USER));
     mockDb.transaction.mockRejectedValueOnce(new Error('db boom'));
-    await expect(applyStripeFunding(invoiceEvent)).resolves.toBeUndefined();
+    await expect(applyStripeFunding(invoiceEvent)).rejects.toThrow('db boom');
     expect(mockApiLogger.error).toHaveBeenCalled();
+  });
+
+  it('does NOT throw for non-actionable cases (unknown customer, ignored, billing-disabled)', async () => {
+    // "Nothing to do" must not look like a failure — otherwise the webhook would
+    // needlessly clear the idempotency marker and 500 on a no-op.
+    mockDb.select.mockReturnValue(userSelectReturning([])); // no user
+    await expect(applyStripeFunding(invoiceEvent)).resolves.toBeUndefined();
+    await expect(applyStripeFunding(subscriptionCheckoutEvent)).resolves.toBeUndefined(); // ignored
+    mockIsBillingEnabled.mockReturnValue(false);
+    await expect(applyStripeFunding(invoiceEvent)).resolves.toBeUndefined(); // billing disabled
   });
 
   it('skips funding (and never opens a transaction) when no user matches the Stripe customer', async () => {

--- a/packages/lib/src/billing/credit-funding.ts
+++ b/packages/lib/src/billing/credit-funding.ts
@@ -16,11 +16,11 @@
  *     so a redelivered Stripe event credits the balance exactly once.
  *   - Atomic: the ledger insert and the balance write share one transaction, so a
  *     failure rolls back both — funding is all-or-nothing, never half-applied.
- *   - Safe: never throws into the webhook. A funding failure is logged and the
- *     subscription/payment record is unaffected; the balance is simply not updated
- *     for that event. (Recovery is not automatic — the webhook's coarse
- *     stripeEvents guard means a swallowed failure won't be retried by Stripe — so
- *     funding failures are surfaced via the logs above for operator follow-up.)
+ *   - Retryable: a genuine failure (e.g. a transient DB/transaction error) is logged
+ *     and RE-THROWN, not swallowed, so the webhook can let Stripe redeliver the
+ *     event. Because funding keys on stripeRef, a reprocess credits exactly once.
+ *     Non-actionable cases (billing disabled, ignored events, unknown customer,
+ *     missing ids) return quietly — they are "nothing to do", not failures.
  */
 
 import { db } from '@pagespace/db/db';
@@ -261,8 +261,9 @@ async function applyTopupFunding(event: FundingEvent, packCents: number): Promis
  * classifier, then runs the matching funding path. A no-op when billing is
  * disabled (tenant/onprem), for tier_change events (the next invoice.paid refills
  * at the new allowance — tier persistence is handled by the subscription handler),
- * and for ignored events. Never throws: a funding failure is logged and swallowed
- * so the webhook's subscription/payment handling and 200 response are unaffected.
+ * and for ignored events. On a genuine failure it logs and RE-THROWS so the caller
+ * (the webhook) can surface a non-2xx and let Stripe redeliver; funding is
+ * idempotent on stripeRef, so a reprocess credits exactly once.
  */
 export async function applyStripeFunding(event: FundingEvent): Promise<void> {
   if (!isBillingEnabled()) return; // tenant/onprem credit via the control plane, not Stripe
@@ -281,10 +282,15 @@ export async function applyStripeFunding(event: FundingEvent): Promise<void> {
         break;
     }
   } catch (error) {
+    // Log with funding context, then rethrow: the webhook clears the processed-event
+    // marker on a funding failure so Stripe's redelivery reprocesses (otherwise the
+    // coarse stripeEvents guard would short-circuit the retry and the paid credit
+    // would be lost permanently).
     loggers.api.error(
-      'credit funding failed',
+      'credit funding failed; rethrowing so Stripe can redeliver',
       error instanceof Error ? error : undefined,
       { eventId: event.id, kind: action.kind },
     );
+    throw error instanceof Error ? error : new Error(String(error));
   }
 }


### PR DESCRIPTION
## Why — follow-up to the merged #1480

PR #1480 (`feat(billing): fund prepaid balances from Stripe`) was **merged into `pu/credits-remediation` at the point of commit `d3081deebe`** — it landed the funding shell, the top-up concurrency fix, and the claw-back fix (`consumeStatus: 'applied'`). But the merge happened **before** I finished addressing a Codex **P1**: funding-failure retryability. That fix (`6df5d8760`) was left stranded on the closed branch, so the merged base still **swallows** funding failures.

This PR lands just that fix.

## The bug (Codex P1, confirmed)

`apps/web/src/app/api/stripe/webhook/route.ts` commits its `stripeEvents` idempotency marker **before** processing. The funding code currently catches and **swallows** any error, so the webhook still marks the event processed and returns 200. On a transient DB/transaction failure during `invoice.paid` or a credit-pack `checkout.session.completed`:
- Stripe's redelivery of the same event short-circuits at the marker insert-conflict ("already processed"), and
- the backfill cron reconciles only **usage** rows, not Stripe **funding**,

so a paying customer can be left **permanently uncredited**.

## The fix

- `applyStripeFunding` now logs and **re-throws** genuine failures. Non-actionable cases (billing disabled, ignored events, unknown customer, missing ids) still return quietly — a no-op must not look like a failure.
- The webhook wraps funding in `fundOrLetStripeRetry`: on a funding failure it `db.delete`s the `stripeEvents` marker and rethrows, so the route returns 500 and Stripe redelivers → the event is reprocessed. Funding is idempotent on `creditLedger.stripeRef`, so the balance is still credited **exactly once**.
- Safe to reprocess these events: the pre-funding handlers are log-only/no-op (`handleInvoicePaid` only logs; `handleCheckoutCompleted` acts only for `mode:'subscription'`, whereas a credit-pack top-up is `mode:'payment'`).

## Files changed
- `packages/lib/src/billing/credit-funding.ts` — log+rethrow on genuine failure
- `apps/web/src/app/api/stripe/webhook/route.ts` — `fundOrLetStripeRetry` wrapper
- `packages/lib/src/billing/__tests__/credit-funding.test.ts` — rethrow-on-failure + non-actionable-no-throw tests

## Validation
- `bun run --filter '@pagespace/lib' typecheck` & `bun run --filter 'web' typecheck` — clean for touched files.
- `bun run vitest run src/billing/__tests__/` — **83 passed**, including the base's `credits-flow.integration.test.ts` (which exercises this funding path end-to-end and guards the no-claw-back regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
