### PR TITLE
fix(sandbox): converge all 19 review threads on #1487 (Codex P1 + CodeRabbit)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,11 +2,15 @@ name: Security Tests
 
 on:
   push:
-    branches: [master, develop]
+    branches: [master, develop, pu/flash-sandbox]
     paths:
       - 'packages/lib/src/security/**'
       - 'packages/lib/src/services/sandbox/**'
       - 'packages/db/src/schema/sandbox-sessions.ts'
+      - 'packages/db/drizzle/**'
+      - 'apps/web/src/lib/ai/tools/sandbox-tools.ts'
+      - 'apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts'
+      - 'apps/web/src/lib/ai/core/ai-tools.ts'
       - 'packages/lib/src/auth/**'
       - 'packages/lib/src/permissions/**'
       - 'packages/lib/src/repositories/**'
@@ -32,6 +36,10 @@ on:
       - 'packages/lib/src/security/**'
       - 'packages/lib/src/services/sandbox/**'
       - 'packages/db/src/schema/sandbox-sessions.ts'
+      - 'packages/db/drizzle/**'
+      - 'apps/web/src/lib/ai/tools/sandbox-tools.ts'
+      - 'apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts'
+      - 'apps/web/src/lib/ai/core/ai-tools.ts'
       - 'packages/lib/src/auth/**'
       - 'packages/lib/src/permissions/**'
       - 'packages/lib/src/repositories/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test Suite
 
 on:
   push:
-    branches: [main, master, develop]
+    branches: [main, master, develop, pu/flash-sandbox]
   pull_request:
     branches: [main, master, develop, pu/flash-sandbox]
   workflow_dispatch:

--- a/apps/web/src/lib/ai/core/__tests__/provider-factory.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/provider-factory.test.ts
@@ -224,7 +224,7 @@ describe('provider-factory', () => {
         }
       });
 
-      it('openrouter_free shares the OpenRouter env var', async () => {
+      it('openrouter_free shares the OpenRouter env var and enables response caching', async () => {
         process.env.OPENROUTER_DEFAULT_API_KEY = 'or-key';
 
         const result = await createAIProvider('user-123', {
@@ -233,7 +233,24 @@ describe('provider-factory', () => {
         });
 
         expect(isProviderError(result)).toBe(false);
-        expect(createOpenRouter).toHaveBeenCalledWith({ apiKey: 'or-key' });
+        expect(createOpenRouter).toHaveBeenCalledWith({
+          apiKey: 'or-key',
+          headers: { 'X-OpenRouter-Cache': 'true' },
+        });
+      });
+
+      it('enables OpenRouter response caching via the X-OpenRouter-Cache header', async () => {
+        process.env.OPENROUTER_DEFAULT_API_KEY = 'or-key';
+
+        await createAIProvider('user-123', {
+          selectedProvider: 'openrouter',
+          selectedModel: 'anthropic/claude-opus-4.7',
+        });
+
+        expect(createOpenRouter).toHaveBeenCalledWith({
+          apiKey: 'or-key',
+          headers: { 'X-OpenRouter-Cache': 'true' },
+        });
       });
 
       it('anthropic instantiates createAnthropic with the env key', async () => {

--- a/apps/web/src/lib/ai/core/__tests__/timestamp-utils.test.ts
+++ b/apps/web/src/lib/ai/core/__tests__/timestamp-utils.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   buildTimestampSystemPrompt,
+  floorToBucket,
+  formatTimestampContext,
   getStartOfTodayInTimezone,
   getUserTimeOfDay,
   isValidTimezone,
@@ -9,6 +11,14 @@ import {
   parseNaiveDatetimeInTimezone,
   parseDateTime,
 } from '../timestamp-utils';
+import { OPENROUTER_CACHE_TTL_SECONDS, TIMESTAMP_BUCKET_MS } from '../ai-providers-config';
+
+// RITEway-style assertion: every test answers the 5 questions.
+const assert = ({ given, should, actual, expected }: {
+  given: string; should: string; actual: unknown; expected: unknown;
+}) => expect(actual, `Given ${given}, should ${should}`).toEqual(expected);
+
+const FIVE_MIN_MS = 5 * 60 * 1000;
 
 describe('timestamp-utils', () => {
   beforeEach(() => {
@@ -17,6 +27,62 @@ describe('timestamp-utils', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  describe('cache TTL constants', () => {
+    it('defaults the OpenRouter cache TTL to 300 seconds', () => {
+      assert({
+        given: 'the OpenRouter response-cache default',
+        should: 'be 300 seconds',
+        actual: OPENROUTER_CACHE_TTL_SECONDS,
+        expected: 300,
+      });
+    });
+
+    it('derives the timestamp bucket from the TTL so they cannot drift', () => {
+      assert({
+        given: 'the cache TTL in seconds',
+        should: 'equal the timestamp bucket in milliseconds',
+        actual: TIMESTAMP_BUCKET_MS,
+        expected: OPENROUTER_CACHE_TTL_SECONDS * 1000,
+      });
+    });
+  });
+
+  describe('floorToBucket', () => {
+    it('floors an instant down to the bucket boundary, dropping seconds and sub-bucket minutes', () => {
+      assert({
+        given: 'an instant at 14:03:47.500 and a 5-minute bucket',
+        should: 'floor to 14:00:00.000',
+        actual: floorToBucket(Date.UTC(2024, 5, 15, 14, 3, 47, 500), FIVE_MIN_MS),
+        expected: Date.UTC(2024, 5, 15, 14, 0, 0, 0),
+      });
+    });
+
+    it('floors to the nearest lower 5-minute mark, not the nearest', () => {
+      assert({
+        given: 'an instant at 14:07:30 and a 5-minute bucket',
+        should: 'floor down to 14:05:00 (never round up)',
+        actual: floorToBucket(Date.UTC(2024, 5, 15, 14, 7, 30), FIVE_MIN_MS),
+        expected: Date.UTC(2024, 5, 15, 14, 5, 0),
+      });
+    });
+
+    it('lands on a 5-minute wall-clock boundary even in a half-hour-offset zone', () => {
+      // Asia/Kolkata is UTC+5:30. Flooring the absolute instant to 5 min keeps
+      // the local wall-clock minute a multiple of 5 (offset is a whole multiple of 5).
+      const floored = new Date(floorToBucket(Date.UTC(2024, 5, 15, 14, 3, 47), FIVE_MIN_MS));
+      const minuteInKolkata = parseInt(
+        new Intl.DateTimeFormat('en-US', { timeZone: 'Asia/Kolkata', minute: 'numeric' }).format(floored),
+        10,
+      );
+      assert({
+        given: 'a floored instant rendered in Asia/Kolkata (UTC+5:30)',
+        should: 'sit on a 5-minute wall-clock boundary',
+        actual: minuteInKolkata % 5,
+        expected: 0,
+      });
+    });
   });
 
   describe('isValidTimezone', () => {
@@ -88,6 +154,37 @@ describe('timestamp-utils', () => {
 
       const result = getUserTimeOfDay('Invalid/Timezone');
       expect(result.timeOfDay).toBe('afternoon');
+    });
+
+    it('derives the label from an injected instant without reading the global clock', () => {
+      // System clock is left at the fake-timer epoch (morning); the injected
+      // instant is evening. The result must follow the injected instant.
+      vi.setSystemTime(new Date('2024-06-15T09:00:00Z'));
+      assert({
+        given: 'an injected evening instant (19:00Z) while the global clock reads morning',
+        should: 'return the label for the injected instant, not the global clock',
+        actual: getUserTimeOfDay('UTC', Date.UTC(2024, 5, 15, 19, 0, 0)).timeOfDay,
+        expected: 'evening',
+      });
+    });
+
+    it('labels midnight as morning (guards the ICU "24"-hour edge)', () => {
+      assert({
+        given: 'an injected instant at 00:30 local',
+        should: 'label it morning, never evening (hour normalized mod 24)',
+        actual: getUserTimeOfDay('UTC', Date.UTC(2024, 5, 15, 0, 30, 0)).timeOfDay,
+        expected: 'morning',
+      });
+    });
+
+    it('defaults to the current clock when no instant is injected', () => {
+      vi.setSystemTime(new Date('2024-06-15T19:00:00Z'));
+      assert({
+        given: 'no injected instant',
+        should: 'fall back to the current global clock',
+        actual: getUserTimeOfDay('UTC').timeOfDay,
+        expected: 'evening',
+      });
     });
   });
 
@@ -221,6 +318,72 @@ describe('timestamp-utils', () => {
     });
   });
 
+  describe('formatTimestampContext', () => {
+    it('is deterministic: same inputs produce a byte-identical string', () => {
+      const now = Date.UTC(2024, 5, 15, 14, 2, 30);
+      assert({
+        given: 'the same { now, timezone } passed twice',
+        should: 'return byte-identical strings (no internal clock read)',
+        actual: formatTimestampContext({ now, timezone: 'America/New_York' })
+          === formatTimestampContext({ now, timezone: 'America/New_York' }),
+        expected: true,
+      });
+    });
+
+    it('renders identical text for two instants in the same 5-minute bucket', () => {
+      const early = formatTimestampContext({ now: Date.UTC(2024, 5, 15, 14, 0, 10), timezone: 'America/New_York' });
+      const late = formatTimestampContext({ now: Date.UTC(2024, 5, 15, 14, 4, 59), timezone: 'America/New_York' });
+      assert({
+        given: 'two instants 14:00:10 and 14:04:59 in one 5-minute bucket',
+        should: 'render identical text so the request body hash matches',
+        actual: early === late,
+        expected: true,
+      });
+    });
+
+    it('renders different text across a bucket boundary', () => {
+      const before = formatTimestampContext({ now: Date.UTC(2024, 5, 15, 14, 4, 59), timezone: 'America/New_York' });
+      const after = formatTimestampContext({ now: Date.UTC(2024, 5, 15, 14, 5, 0), timezone: 'America/New_York' });
+      assert({
+        given: 'instants on either side of a 5-minute boundary (14:04:59 vs 14:05:00)',
+        should: 'render different text',
+        actual: before === after,
+        expected: false,
+      });
+    });
+
+    it('renders the full weekday/month/day date', () => {
+      assert({
+        given: 'an instant on Saturday June 15 2024',
+        should: 'render the full date',
+        actual: formatTimestampContext({ now: Date.UTC(2024, 5, 15, 14, 0, 0), timezone: 'UTC' })
+          .includes('Saturday, June 15, 2024'),
+        expected: true,
+      });
+    });
+
+    it('renders minute-granularity time with no seconds', () => {
+      const result = formatTimestampContext({ now: Date.UTC(2024, 5, 15, 14, 3, 47), timezone: 'UTC' });
+      assert({
+        given: 'an instant at 14:03:47 floored to the 5-minute bucket',
+        should: 'render the bucketed minute (2:00 PM) and never a seconds field',
+        actual: result.includes('2:00 PM') && !/\d{1,2}:\d{2}:\d{2}/.test(result),
+        expected: true,
+      });
+    });
+
+    it('formats correctly in a half-hour-offset timezone', () => {
+      // 14:00:00Z in Asia/Kolkata (UTC+5:30) is 7:30 PM the same day.
+      assert({
+        given: 'an instant rendered in Asia/Kolkata (UTC+5:30)',
+        should: 'show the correct local wall-clock time',
+        actual: formatTimestampContext({ now: Date.UTC(2024, 5, 15, 14, 0, 0), timezone: 'Asia/Kolkata' })
+          .includes('7:30 PM'),
+        expected: true,
+      });
+    });
+  });
+
   describe('buildTimestampSystemPrompt', () => {
     it('includes the timezone in the output', () => {
       const result = buildTimestampSystemPrompt('America/Los_Angeles');
@@ -248,6 +411,43 @@ describe('timestamp-utils', () => {
       const result = buildTimestampSystemPrompt('UTC');
       expect(result).toContain('CURRENT TIMESTAMP CONTEXT');
       expect(result).toContain('Current date and time');
+    });
+
+    it('with an injected instant, delegates to the pure core (no timer mocking needed)', () => {
+      const now = Date.UTC(2024, 5, 15, 14, 3, 47);
+      assert({
+        given: 'an injected instant',
+        should: 'equal the pure renderer output for the same instant and timezone',
+        actual: buildTimestampSystemPrompt('America/New_York', now),
+        expected: formatTimestampContext({ now, timezone: 'America/New_York' }),
+      });
+    });
+
+    it('reads the clock once: same bucket via the default arg yields a stable prompt', () => {
+      // Two real-time calls within the same 5-minute bucket must be identical.
+      vi.useRealTimers();
+      try {
+        const bucketStart = floorToBucket(Date.now(), 5 * 60 * 1000);
+        const a = buildTimestampSystemPrompt('UTC', bucketStart + 10_000);
+        const b = buildTimestampSystemPrompt('UTC', bucketStart + 290_000);
+        assert({
+          given: 'two instants in the same 5-minute bucket passed to the default-arg wrapper',
+          should: 'produce identical prompts',
+          actual: a === b,
+          expected: true,
+        });
+      } finally {
+        vi.useFakeTimers();
+      }
+    });
+
+    it('preserves the single-argument call signature for existing callers', () => {
+      assert({
+        given: 'a caller that passes only a timezone (no instant)',
+        should: 'still return a populated prompt string',
+        actual: buildTimestampSystemPrompt('UTC').includes('CURRENT TIMESTAMP CONTEXT'),
+        expected: true,
+      });
     });
   });
 

--- a/apps/web/src/lib/ai/core/ai-providers-config.ts
+++ b/apps/web/src/lib/ai/core/ai-providers-config.ts
@@ -4,6 +4,19 @@
  */
 
 /**
+ * OpenRouter response-cache TTL in seconds. Matches OpenRouter's default for the
+ * `X-OpenRouter-Cache` header, so we don't need to send an explicit TTL header.
+ */
+export const OPENROUTER_CACHE_TTL_SECONDS = 300;
+
+/**
+ * Granularity (ms) the AI system-prompt timestamp is floored to. Derived from the
+ * cache TTL so the two can never drift: a repeat request inside one cache window
+ * produces a byte-identical request body, which is what lets the cache HIT.
+ */
+export const TIMESTAMP_BUCKET_MS = OPENROUTER_CACHE_TTL_SECONDS * 1000;
+
+/**
  * PageSpace Model Aliases
  * Allows agents to use friendly names (standard/pro) instead of underlying model IDs.
  * This abstraction lets agents update their model without knowing the specific backend model.

--- a/apps/web/src/lib/ai/core/provider-factory.ts
+++ b/apps/web/src/lib/ai/core/provider-factory.ts
@@ -108,7 +108,14 @@ export async function createAIProvider(
       if (currentProvider === 'openrouter_free' && !currentModel.endsWith(':free')) {
         return { error: 'openrouter_free only accepts models with the ":free" suffix', status: 400 };
       }
-      const openrouter = createOpenRouter({ apiKey: managed.apiKey });
+      // X-OpenRouter-Cache enables OpenRouter's response cache (default 300s TTL):
+      // byte-identical repeat requests are served from cache at $0 with zeroed
+      // usage. See timestamp-utils.ts — the system-prompt timestamp is bucketed
+      // to the cache window so genuine repeats (regenerate/retry) can HIT.
+      const openrouter = createOpenRouter({
+        apiKey: managed.apiKey,
+        headers: { 'X-OpenRouter-Cache': 'true' },
+      });
       model = openrouter.chat(currentModel);
     } else if (currentProvider === 'google') {
       const managed = getManagedProviderKey('google');

--- a/apps/web/src/lib/ai/core/timestamp-utils.ts
+++ b/apps/web/src/lib/ai/core/timestamp-utils.ts
@@ -4,8 +4,19 @@
  */
 
 import * as chrono from 'chrono-node';
+import { TIMESTAMP_BUCKET_MS } from './ai-providers-config';
 
 const DEFAULT_TIMEZONE = 'UTC';
+
+/**
+ * Floor an epoch-millisecond instant down to a fixed bucket size. Pure and
+ * timezone-independent: because every IANA UTC offset is a whole multiple of
+ * 5 minutes, flooring the absolute instant to a 5-minute bucket also lands on a
+ * 5-minute wall-clock boundary in any timezone.
+ */
+export function floorToBucket(epochMs: number, bucketMs: number): number {
+  return epochMs - (epochMs % bucketMs);
+}
 
 export type TimeOfDay = 'morning' | 'afternoon' | 'evening';
 
@@ -115,9 +126,15 @@ export function parseNaiveDatetimeInTimezone(naiveDatetime: string, timezone: st
 /**
  * Get user's time-of-day based on their timezone
  * @param timezone - IANA timezone string (e.g., "America/New_York")
+ * @param now - Instant (epoch ms) to evaluate; defaults to the current clock.
+ *              Injected so the whole prompt can derive from a single instant
+ *              and so the function is testable without mocking the global clock.
  * @returns Object with hour and timeOfDay string
  */
-export function getUserTimeOfDay(timezone?: string | null): { hour: number; timeOfDay: TimeOfDay } {
+export function getUserTimeOfDay(
+  timezone?: string | null,
+  now: number = Date.now(),
+): { hour: number; timeOfDay: TimeOfDay } {
   const tz = normalizeTimezone(timezone);
 
   // Get the hour in the user's timezone
@@ -127,7 +144,9 @@ export function getUserTimeOfDay(timezone?: string | null): { hour: number; time
     hour12: false,
   });
 
-  const hour = parseInt(formatter.format(new Date()), 10);
+  // `% 24` guards the midnight edge: on some ICU builds en-US hour12:false
+  // renders 00:00 as "24" rather than "00", which would mislabel it as evening.
+  const hour = parseInt(formatter.format(new Date(now)), 10) % 24;
 
   let timeOfDay: TimeOfDay;
   if (hour < 12) timeOfDay = 'morning';
@@ -179,29 +198,61 @@ export function getStartOfTodayInTimezone(timezone?: string | null): Date {
 }
 
 /**
- * Build timestamp system prompt section
- * Provides current date and time context to AI models
- * @param timezone - Optional IANA timezone string (e.g., "America/New_York"). Defaults to UTC.
+ * Pure renderer for the timestamp system-prompt section.
+ *
+ * Deterministic: the same `{ now, timezone }` always produces a byte-identical
+ * string, with no internal clock read. The instant is floored to the cache
+ * bucket (TIMESTAMP_BUCKET_MS) so repeat requests inside one cache window yield
+ * an identical request body — the precondition for an OpenRouter cache HIT.
+ * Seconds are dropped; the date uses explicit Intl fields (not `dateStyle`,
+ * which throws when combined with `hour`/`minute`).
  */
-export function buildTimestampSystemPrompt(timezone?: string | null): string {
+export function formatTimestampContext(
+  { now, timezone }: { now: number; timezone?: string | null },
+): string {
   const tz = normalizeTimezone(timezone);
+  const bucketedNow = new Date(floorToBucket(now, TIMESTAMP_BUCKET_MS));
 
-  const currentTime = new Date().toLocaleString('en-US', {
+  const currentTime = bucketedNow.toLocaleString('en-US', {
     timeZone: tz,
-    dateStyle: 'full',
-    timeStyle: 'long'
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+    timeZoneName: 'short',
   });
 
-  const { timeOfDay } = getUserTimeOfDay(tz);
+  // Derive time-of-day from the bucketed instant too, so the whole block is
+  // stable across a cache window (not just the rendered clock line).
+  const { timeOfDay } = getUserTimeOfDay(tz, bucketedNow.getTime());
 
   return `
 
 CURRENT TIMESTAMP CONTEXT:
-• Current date and time (user's local time): ${currentTime}
+• Current date and time (user's local time, rounded down to the latest 5-minute mark): ${currentTime}
 • Time of day: ${timeOfDay}
 • User's timezone: ${tz}
 • When discussing schedules, deadlines, or time-sensitive matters, use this as your reference point
 • For relative time references (e.g., "today", "tomorrow", "this week"), calculate from the current timestamp above in the user's timezone`;
+}
+
+/**
+ * Build timestamp system prompt section
+ * Provides current date and time context to AI models.
+ *
+ * Thin impure shell: the only clock read (confined to the `now` default arg)
+ * delegates to the pure {@link formatTimestampContext}.
+ * @param timezone - Optional IANA timezone string (e.g., "America/New_York"). Defaults to UTC.
+ * @param now - Instant (epoch ms) to render; defaults to the current clock.
+ */
+export function buildTimestampSystemPrompt(
+  timezone?: string | null,
+  now: number = Date.now(),
+): string {
+  return formatTimestampContext({ now, timezone });
 }
 
 /**

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -63,10 +63,10 @@ const REQUIRED_NODE_MAJOR = 24;
 // out of the graph until a sandbox tool actually runs (only possible once the
 // kill-switch is on), so the off-path never touches it.
 //
-// TODO(agent-code-exec): relocate the Sprites driver to a Node >= 24 runtime
-// (the processor or a dedicated sandbox service) and call it over an internal
-// API, so the Node 22 web process never loads the SDK at all. Tracked separately;
-// until then the guard below keeps the enabled path fail-closed with a clear error.
+// TODO(agent-code-exec, #1491): relocate the Sprites driver to a Node >= 24
+// runtime (the processor or a dedicated sandbox service) and call it over an
+// internal API, so the Node 22 web process never loads the SDK at all. Until then
+// the guard below keeps the enabled path fail-closed with a clear error.
 async function loadSandboxClient(): Promise<ExecSandboxClient> {
   const nodeMajor = Number.parseInt(process.versions.node.split('.')[0] ?? '0', 10);
   if (Number.isFinite(nodeMajor) && nodeMajor < REQUIRED_NODE_MAJOR) {

--- a/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
+++ b/apps/web/src/lib/ai/tools/sandbox-tools-runtime.ts
@@ -48,6 +48,13 @@ function getStore() {
   return storePromise;
 }
 
+// `@fly/sprites` declares `engines.node >= 24` and uses runtime APIs (global
+// WebSocket, …) not guaranteed on the Node 22 web runtime. Until the driver runs
+// on a Node >= 24 service (see TODO below) the web process must FAIL CLOSED before
+// loading the SDK rather than throw a cryptic ESM/engine error on the first real
+// sandbox call.
+const REQUIRED_NODE_MAJOR = 24;
+
 // The Fly Sprites driver is loaded via a DYNAMIC import, never a static one:
 // `@fly/sprites` is ESM-only and declares `engines.node >= 24`, while the web
 // images run Node 22. A static import would pull the SDK into the module graph
@@ -55,10 +62,32 @@ function getStore() {
 // path — and evaluate an unsupported SDK. Deferring it here keeps `@fly/sprites`
 // out of the graph until a sandbox tool actually runs (only possible once the
 // kill-switch is on), so the off-path never touches it.
+//
+// TODO(agent-code-exec): relocate the Sprites driver to a Node >= 24 runtime
+// (the processor or a dedicated sandbox service) and call it over an internal
+// API, so the Node 22 web process never loads the SDK at all. Tracked separately;
+// until then the guard below keeps the enabled path fail-closed with a clear error.
+async function loadSandboxClient(): Promise<ExecSandboxClient> {
+  const nodeMajor = Number.parseInt(process.versions.node.split('.')[0] ?? '0', 10);
+  if (Number.isFinite(nodeMajor) && nodeMajor < REQUIRED_NODE_MAJOR) {
+    throw new Error(
+      `Agent code execution requires Node >= ${REQUIRED_NODE_MAJOR} to load the @fly/sprites driver, but this ` +
+        `runtime is Node ${process.versions.node}. Run the sandbox driver on a Node ${REQUIRED_NODE_MAJOR}+ service ` +
+        `before enabling CODE_EXECUTION_ENABLED.`,
+    );
+  }
+  const m = await import('@pagespace/lib/services/sandbox/sandbox-client/sprites');
+  return m.createSpritesSandboxClient();
+}
+
 function getSandboxClient(): Promise<ExecSandboxClient> {
-  sandboxClientPromise ??= import(
-    '@pagespace/lib/services/sandbox/sandbox-client/sprites'
-  ).then((m) => m.createSpritesSandboxClient());
+  // Memoize the live client, but NEVER memoize a rejection: a one-off import or
+  // construction failure must not poison every later request until restart, so
+  // clear the cache in the failure path and let the next call retry.
+  sandboxClientPromise ??= loadSandboxClient().catch((error) => {
+    sandboxClientPromise = null;
+    throw error;
+  });
   return sandboxClientPromise;
 }
 

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -952,6 +952,30 @@
       "services/sandbox/session-manager": [
         "./dist/services/sandbox/session-manager.d.ts"
       ],
+      "services/sandbox/command-policy": [
+        "./dist/services/sandbox/command-policy.d.ts"
+      ],
+      "services/sandbox/output-limit": [
+        "./dist/services/sandbox/output-limit.d.ts"
+      ],
+      "services/sandbox/egress": [
+        "./dist/services/sandbox/egress.d.ts"
+      ],
+      "services/sandbox/sandbox-paths": [
+        "./dist/services/sandbox/sandbox-paths.d.ts"
+      ],
+      "services/sandbox/sandbox-client/types": [
+        "./dist/services/sandbox/sandbox-client/types.d.ts"
+      ],
+      "services/sandbox/sandbox-client/sprites": [
+        "./dist/services/sandbox/sandbox-client/sprites.d.ts"
+      ],
+      "services/sandbox/tool-runners": [
+        "./dist/services/sandbox/tool-runners.d.ts"
+      ],
+      "services/sandbox/tool-gate": [
+        "./dist/services/sandbox/tool-gate.d.ts"
+      ],
       "services/memory-monitor": [
         "./dist/services/memory-monitor.d.ts"
       ],

--- a/packages/lib/src/security/distributed-rate-limit.ts
+++ b/packages/lib/src/security/distributed-rate-limit.ts
@@ -584,8 +584,9 @@ export const DISTRIBUTED_RATE_LIMITS = {
   },
   // Agent code execution daily run budget. Applied per scoped identifier
   // (user / drive / tenant) so one actor cannot exhaust another's allowance.
-  // The hard cost ceiling is Vercel account-level Spend Management; this is our
-  // app-level run-count control that complements per-tier concurrency limits.
+  // The hard cost ceiling lives in the Fly Sprites control plane (org-level
+  // billing / machine caps); this is our app-level run-count control that
+  // complements per-tier concurrency limits.
   CODE_EXECUTION: {
     maxAttempts: 100,
     windowMs: 24 * 60 * 60 * 1000,

--- a/packages/lib/src/security/distributed-rate-limit.ts
+++ b/packages/lib/src/security/distributed-rate-limit.ts
@@ -363,6 +363,33 @@ export async function resetDistributedRateLimit(identifier: string): Promise<voi
 }
 
 /**
+ * Compensating decrement of a single attempt from the CURRENT window bucket,
+ * floored at zero. Used to roll back a charge that was applied to one scope but
+ * whose sibling scope(s) then failed — so a multi-scope charge stays all-or-
+ * nothing and a run that never executes leaves no skewed budget behind. Best-
+ * effort: a failed decrement is logged, not thrown (the caller is already
+ * surfacing the original failure).
+ */
+export async function decrementDistributedRateLimit(
+  identifier: string,
+  config: RateLimitConfig,
+): Promise<void> {
+  const windowStart = currentWindowStart(config.windowMs);
+  try {
+    await db
+      .update(rateLimitBuckets)
+      .set({ count: sql`GREATEST(${rateLimitBuckets.count} - 1, 0)` })
+      .where(
+        sql`${rateLimitBuckets.key} = ${identifier} AND ${rateLimitBuckets.windowStart} = ${windowStart}`,
+      );
+  } catch (error) {
+    loggers.api.warn('Postgres rate limit decrement (refund) failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
  * Get rate limit status without incrementing.
  * In production, fails closed (reports blocked) when DB is unavailable to avoid
  * returning potentially stale in-memory status in distributed deployments.

--- a/packages/lib/src/services/sandbox/__tests__/egress.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/egress.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildSpriteNetworkPolicy } from '../egress';
+import { buildSpriteNetworkPolicy, normalizeEgressHost } from '../egress';
 
 describe('buildSpriteNetworkPolicy', () => {
   it('given an empty allowlist, should be pure deny-all (default-deny egress)', () => {
@@ -45,5 +45,62 @@ describe('buildSpriteNetworkPolicy', () => {
     const { rules } = buildSpriteNetworkPolicy({ egressAllowlist: ['pypi.org', 'pypi.org', ''] });
     const allows = rules.filter((r) => r.action === 'allow');
     expect(allows).toEqual([{ domain: 'pypi.org', action: 'allow' }]);
+  });
+
+  it('given a bare "*" allow entry, should DROP it so the deny-all catch-all is not shadowed', () => {
+    // First-match-wins: a `*` allow before the terminating deny would open all
+    // egress. It must never reach the rule list.
+    const { rules } = buildSpriteNetworkPolicy({ egressAllowlist: ['*'] });
+    expect(rules).toEqual([{ domain: '*', action: 'deny' }]);
+    expect(rules.some((r) => r.action === 'allow')).toBe(false);
+  });
+
+  it('given IP literals / URLs / ports / localhost, should drop them (domain rules only match names)', () => {
+    const { rules } = buildSpriteNetworkPolicy({
+      egressAllowlist: [
+        '1.2.3.4',
+        '169.254.169.254',
+        'fdaa::1',
+        'https://evil.com/path',
+        'evil.com:8080',
+        'localhost',
+        'foo bar',
+      ],
+    });
+    expect(rules.some((r) => r.action === 'allow')).toBe(false);
+    expect(rules).toEqual([{ domain: '*', action: 'deny' }]);
+  });
+
+  it('given a leading-wildcard host, should normalize and allow it', () => {
+    const { rules } = buildSpriteNetworkPolicy({ egressAllowlist: ['*.GitHub.com'] });
+    expect(rules).toContainEqual({ domain: '*.github.com', action: 'allow' });
+    expect(rules[rules.length - 1]).toEqual({ domain: '*', action: 'deny' });
+  });
+});
+
+describe('normalizeEgressHost', () => {
+  it('should accept literal hostnames and a single leading wildcard, lowercasing/trimming', () => {
+    expect(normalizeEgressHost('  Registry.NPMJS.org ')).toBe('registry.npmjs.org');
+    expect(normalizeEgressHost('*.example.com')).toBe('*.example.com');
+    expect(normalizeEgressHost('pypi.org')).toBe('pypi.org');
+  });
+
+  it('should reject wildcards-without-domain, IP literals, schemes, ports, and single labels', () => {
+    for (const bad of [
+      '',
+      '*',
+      '*.*',
+      '1.2.3.4',
+      '169.254.169.254',
+      'fdaa::1',
+      'http://x.com',
+      'x.com/y',
+      'x.com:443',
+      'user@x.com',
+      'localhost',
+      'a b.com',
+    ]) {
+      expect(normalizeEgressHost(bad)).toBeNull();
+    }
   });
 });

--- a/packages/lib/src/services/sandbox/__tests__/lifecycle.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/lifecycle.test.ts
@@ -40,6 +40,19 @@ describe('planSandboxLifecycle', () => {
     expect(plan).toEqual({ action: 'teardown', sandboxId: 'sbx-1', reason: 'idle' });
   });
 
+  it('given an UNAUTHORIZED actor with an idle-expired session, should still reclaim it BEFORE denying (no stale leak)', () => {
+    // The idle teardown must be reached even for an unauthorized actor, otherwise
+    // the stale warm sandbox leaks. The effect layer re-checks authz before any
+    // re-provision, so reclaiming here never hands back another session's state.
+    const plan = planSandboxLifecycle({
+      authorization: denied,
+      existingSession: stale,
+      now,
+      idleTimeoutMs: 5 * 60 * 1000,
+    });
+    expect(plan).toEqual({ action: 'teardown', sandboxId: 'sbx-1', reason: 'idle' });
+  });
+
   it('given a session-end intent with an existing session, should plan to tear it down', () => {
     const plan = planSandboxLifecycle({
       authorization: allowed,

--- a/packages/lib/src/services/sandbox/__tests__/output-limit.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/output-limit.test.ts
@@ -20,12 +20,30 @@ describe('truncateToBytes', () => {
     expect(result.originalBytes).toBe(10);
   });
 
-  it('given a multi-byte boundary split, should not throw and should report original bytes', () => {
-    // '😀' is 4 UTF-8 bytes; a 2-byte cap splits it.
+  it('given a multi-byte boundary split, should cut on a char boundary and stay within the cap', () => {
+    // '😀' is 4 UTF-8 bytes; a 2-byte cap splits it. A lenient decode would emit
+    // U+FFFD (3 bytes) and BLOW the 2-byte cap; cutting on the boundary yields ''.
     const result = truncateToBytes({ text: '😀😀', maxBytes: 2 });
     expect(result.truncated).toBe(true);
     expect(result.originalBytes).toBe(8);
-    expect(typeof result.text).toBe('string');
+    expect(result.text).toBe('');
+    expect(Buffer.byteLength(result.text, 'utf8')).toBeLessThanOrEqual(2);
+    expect(result.text).not.toContain('�');
+  });
+
+  it('given a mixed ASCII + multi-byte split, should keep the whole-char prefix within the cap', () => {
+    // 'aé' = 'a'(1) + 'é'(2 bytes). maxBytes 2 splits 'é'; result must be 'a'.
+    const result = truncateToBytes({ text: 'aé', maxBytes: 2 });
+    expect(result.text).toBe('a');
+    expect(Buffer.byteLength(result.text, 'utf8')).toBeLessThanOrEqual(2);
+  });
+
+  it('given any cap, the returned text never exceeds maxBytes (replacement-char inflation guard)', () => {
+    const text = '😀aé😀b';
+    for (let maxBytes = 0; maxBytes <= Buffer.byteLength(text, 'utf8'); maxBytes++) {
+      const result = truncateToBytes({ text, maxBytes });
+      expect(Buffer.byteLength(result.text, 'utf8')).toBeLessThanOrEqual(maxBytes);
+    }
   });
 
   it('given empty/no text, should be safe', () => {

--- a/packages/lib/src/services/sandbox/__tests__/quota.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/quota.test.ts
@@ -149,7 +149,7 @@ describe('chargeCodeExecutionBudget', () => {
       userId: 'u1',
       driveId: 'd1',
       tenantId: 't1',
-      deps: { charge: async (id) => { charged.push(id); } },
+      deps: { charge: async (id) => { charged.push(id); }, refund: async () => {} },
     });
     expect(charged.sort()).toEqual(
       ['code-exec:drive:d1', 'code-exec:tenant:t1', 'code-exec:user:u1'].sort(),
@@ -161,8 +161,46 @@ describe('chargeCodeExecutionBudget', () => {
     await chargeCodeExecutionBudget({
       userId: 'u1',
       driveId: 'd1',
-      deps: { charge: async (id) => { charged.push(id); } },
+      deps: { charge: async (id) => { charged.push(id); }, refund: async () => {} },
     });
     expect(charged.sort()).toEqual(['code-exec:drive:d1', 'code-exec:user:u1']);
+  });
+
+  it('given a later scope fails, should refund the already-charged scopes and rethrow (no partial charge)', async () => {
+    const charged: string[] = [];
+    const refunded: string[] = [];
+    await expect(
+      chargeCodeExecutionBudget({
+        userId: 'u1',
+        driveId: 'd1',
+        tenantId: 't1',
+        deps: {
+          // user succeeds, drive succeeds, tenant rejects.
+          charge: async (id) => {
+            if (id === 'code-exec:tenant:t1') throw new Error('tenant budget sink down');
+            charged.push(id);
+          },
+          refund: async (id) => { refunded.push(id); },
+        },
+      }),
+    ).rejects.toThrow('tenant budget sink down');
+    // Every scope charged before the failure is compensated.
+    expect(charged.sort()).toEqual(['code-exec:drive:d1', 'code-exec:user:u1']);
+    expect(refunded.sort()).toEqual(['code-exec:drive:d1', 'code-exec:user:u1']);
+  });
+
+  it('given the FIRST scope fails, should rethrow and refund nothing', async () => {
+    const refunded: string[] = [];
+    await expect(
+      chargeCodeExecutionBudget({
+        userId: 'u1',
+        driveId: 'd1',
+        deps: {
+          charge: async () => { throw new Error('user budget sink down'); },
+          refund: async (id) => { refunded.push(id); },
+        },
+      }),
+    ).rejects.toThrow('user budget sink down');
+    expect(refunded).toEqual([]);
   });
 });

--- a/packages/lib/src/services/sandbox/__tests__/session-key.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/session-key.test.ts
@@ -37,6 +37,12 @@ describe('deriveSessionKey', () => {
     );
   });
 
+  it('given an empty secret, should throw (fail closed — no predictable digest of public ids)', () => {
+    expect(() => deriveSessionKey({ ...base, secret: '' })).toThrow(
+      'Sandbox session secret must not be empty',
+    );
+  });
+
   it('given any inputs, should not embed the raw conversation id (opaque)', () => {
     const key = deriveSessionKey(base);
     expect(key).not.toContain(base.conversationId);

--- a/packages/lib/src/services/sandbox/__tests__/session-manager.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/session-manager.test.ts
@@ -317,7 +317,7 @@ describe('teardownConversationSandbox', () => {
     expect(calls.stop).toEqual(['sbx-existing']);
   });
 
-  it('given the VM stop throwing, should still remove the link and not throw (guaranteed teardown)', async () => {
+  it('given the VM stop throwing (UNCONFIRMED), should keep the link and not throw (no orphaned-VM leak)', async () => {
     const { store, calls: storeCalls } = makeStore(seedRecord());
     const { client } = makeClient({
       stop: async () => {
@@ -329,7 +329,9 @@ describe('teardownConversationSandbox', () => {
       reason: 'crash',
       deps: { store, client, secret: SECRET },
     });
-    expect(result).toEqual({ torn: true });
-    expect(storeCalls.remove).toBe(1);
+    // Stop unconfirmed -> the VM may still be alive, so the link is RETAINED for a
+    // later retry rather than dropped as if the teardown succeeded.
+    expect(result).toEqual({ torn: false });
+    expect(storeCalls.remove).toBe(0);
   });
 });

--- a/packages/lib/src/services/sandbox/__tests__/session-manager.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/session-manager.test.ts
@@ -150,6 +150,30 @@ describe('acquireConversationSandbox', () => {
     expect(storeCalls.save).toBe(1);
   });
 
+  it('given an UNAUTHORIZED actor whose session is idle-expired, should reclaim the stale VM but deny (no fresh provision)', async () => {
+    const stale = seedRecord({ lastActiveAt: new Date('2026-06-01T11:00:00.000Z') });
+    const { store, calls: storeCalls } = makeStore(stale);
+    const { client, calls } = makeClient();
+    const result = await acquireConversationSandbox({
+      ...actor,
+      idleTimeoutMs: 5 * 60 * 1000,
+      deps: {
+        store,
+        client,
+        authorize: async () => ({ ok: false, reason: 'insufficient_role' }),
+        now: () => NOW,
+        secret: SECRET,
+      },
+    });
+    // The stale VM and link are reclaimed (no leak)…
+    expect(calls.stop).toEqual(['sbx-existing']);
+    expect(storeCalls.remove).toBe(1);
+    // …but the unauthorized actor is denied, never handed a fresh sandbox.
+    expect(result).toEqual({ ok: false, reason: 'insufficient_role' });
+    expect(calls.getOrCreate).toEqual([]);
+    expect(storeCalls.save).toBe(0);
+  });
+
   it('given a stored session whose VM has vanished on resume, should drop the stale link and create fresh', async () => {
     const { store, calls: storeCalls } = makeStore(seedRecord());
     const { client, calls } = makeClient({ get: async () => null });

--- a/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
+++ b/packages/lib/src/services/sandbox/__tests__/tool-runners.test.ts
@@ -7,7 +7,7 @@ import {
   type SandboxActorContext,
   type SandboxRunDeps,
 } from '../tool-runners';
-import type { ExecutableSandbox, SandboxRunResult } from '../sandbox-client/types';
+import { SandboxReadLimitError, type ExecutableSandbox, type SandboxRunResult } from '../sandbox-client/types';
 import type { CodeExecutionAuditInput } from '../audit';
 import { SANDBOX_ROOT } from '../sandbox-paths';
 
@@ -207,9 +207,9 @@ describe('runBashInSandbox', () => {
     expect(slots.released).toBe(1);
   });
 
-  it('given a cwd that escapes the sandbox root, should deny path_escape before provisioning', async () => {
+  it('given a cwd that escapes the sandbox root, should deny path_escape, audit it, and never provision', async () => {
     let acquired = false;
-    const { deps } = makeDeps({
+    const { deps, audits } = makeDeps({
       acquireSandbox: async () => {
         acquired = true;
         return { ok: true, sandboxId: 'sbx-1', resumed: false };
@@ -218,6 +218,8 @@ describe('runBashInSandbox', () => {
     const result = await runBashInSandbox({ command: 'ls', cwd: '../../etc', ctx: makeCtx(), deps });
     expect(result).toMatchObject({ success: false, reason: 'path_escape' });
     expect(acquired).toBe(false);
+    // A blocked cwd escape must be audited, like writeFile/readFile path escapes.
+    expect(audits[0]?.anomaly).toBe('blocked_command');
   });
 
   it('given a sh -c invocation, should pass the command as a structured arg array (no host shell string)', async () => {
@@ -332,6 +334,35 @@ describe('readSandboxFile', () => {
     expect(result.success).toBe(true);
     if (!result.success) return;
     expect(result.truncated).toBe(true);
+  });
+
+  it('should forward the output cap to the driver so an oversized read is bounded at the boundary', async () => {
+    let seenMax: number | undefined;
+    const { deps } = makeDeps({
+      reconnect: async () =>
+        makeSandbox({
+          readFileToBuffer: async ({ maxBytes }) => {
+            seenMax = maxBytes;
+            return Buffer.from('ok');
+          },
+        }),
+    });
+    await readSandboxFile({ path: 'a.txt', ctx: makeCtx({ profile: 'minimal' }), deps });
+    expect(seenMax).toBe(32 * 1024); // minimal profile output cap
+  });
+
+  it('given the driver refuses an oversized file, should deny content_too_large and audit a blocked_command', async () => {
+    const { deps, audits } = makeDeps({
+      reconnect: async () =>
+        makeSandbox({
+          readFileToBuffer: async ({ maxBytes }) => {
+            throw new SandboxReadLimitError(maxBytes ?? 0);
+          },
+        }),
+    });
+    const result = await readSandboxFile({ path: 'huge.bin', ctx: makeCtx(), deps });
+    expect(result).toMatchObject({ success: false, reason: 'content_too_large' });
+    expect(audits[0]?.anomaly).toBe('blocked_command');
   });
 
   it('given a traversal path, should deny path_escape before provisioning', async () => {

--- a/packages/lib/src/services/sandbox/egress.ts
+++ b/packages/lib/src/services/sandbox/egress.ts
@@ -26,6 +26,15 @@
  *
  * The allow map is built from a frozen, deduped copy of the input so a caller
  * cannot mutate the shared policy array through the returned object.
+ *
+ * Allowlist entries are VALIDATED before they become `domain` allow rules: under
+ * Sprites' first-match-wins ordered evaluation a `'*'` allow entry would shadow
+ * the terminating `{ domain: '*', action: 'deny' }` catch-all and silently open
+ * all egress, and passing arbitrary non-host strings (IP literals, URLs, ports)
+ * into `domain` is not a fail-closed stance for an egress boundary. Only literal
+ * hostnames (optionally a single leading `*.` wildcard label) survive; everything
+ * else — bare `*`, IPv4/IPv6 literals, schemes/paths/ports, `localhost` — is
+ * dropped. Validation is label-by-label against a bounded pattern (no ReDoS).
  */
 
 import type { NetworkPolicy, PolicyRule } from '@fly/sprites';
@@ -37,12 +46,44 @@ const INCLUDE_DEFAULTS: PolicyRule = Object.freeze({ include: 'defaults' });
 
 const DENY_ALL: PolicyRule = Object.freeze({ domain: '*', action: 'deny' });
 
+// A single DNS label: 1–63 chars, alphanumeric with internal hyphens. Bounded
+// quantifier (no unbounded backtracking) so per-label testing is ReDoS-safe.
+const DNS_LABEL = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
+
+/**
+ * Normalize and validate one allowlist entry to a literal hostname (optionally a
+ * single leading `*.` wildcard). Returns the canonical lowercase host, or null
+ * when the entry is not a safe hostname to emit as a Sprites `domain` allow rule.
+ */
+export function normalizeEgressHost(raw: string): string | null {
+  const host = raw.trim().toLowerCase();
+  if (host.length === 0 || host.length > 253) return null;
+  // Reject schemes, paths, credentials, ports, whitespace, and IPv6 colons.
+  if (/[/@\s:]/.test(host)) return null;
+  let labels = host.split('.');
+  // Must be a dotted domain — rejects bare '*', 'localhost', and single labels.
+  if (labels.length < 2) return null;
+  // Allow exactly one leading wildcard label ('*.example.com'); validate the rest.
+  if (labels[0] === '*') labels = labels.slice(1);
+  // An all-numeric final label means an IPv4 literal (e.g. 1.2.3.4) or otherwise
+  // non-DNS target — domain rules only match name-resolved traffic, so drop it.
+  const tld = labels[labels.length - 1];
+  if (!/^[a-z]{2,}$/.test(tld)) return null;
+  return labels.every((label) => DNS_LABEL.test(label)) ? host : null;
+}
+
 export function buildSpriteNetworkPolicy({
   egressAllowlist = [],
 }: {
   egressAllowlist?: readonly string[];
 } = {}): NetworkPolicy {
-  const hosts = [...new Set(egressAllowlist)].filter((h) => h.length > 0);
+  const hosts = [
+    ...new Set(
+      egressAllowlist
+        .map(normalizeEgressHost)
+        .filter((host): host is string => host !== null),
+    ),
+  ];
   if (hosts.length === 0) {
     // Default-deny: no outbound at all. Pure deny-all — no preset semantics.
     return { rules: [{ ...DENY_ALL }] };

--- a/packages/lib/src/services/sandbox/lifecycle.ts
+++ b/packages/lib/src/services/sandbox/lifecycle.ts
@@ -11,11 +11,13 @@
  *
  *  - **Resume re-authz.** A warm sandbox carries the prior turn's filesystem and
  *    process state. Resuming it for an unauthorized actor is a cross-actor
- *    data-bleed path, so an unauthorized actor is `deny`d EVEN WHEN a session
- *    already exists — the existing handle is never returned.
+ *    data-bleed path, so an unauthorized actor is `deny`d EVEN WHEN a (non-expired)
+ *    session already exists — the existing handle is never returned.
  *  - **Cleanup is unconditional.** On a session-end intent the plan is always
  *    `teardown`, regardless of authorization, so a revoked actor can never strand
- *    a warm sandbox. Authorization gates *use*, never *cleanup*.
+ *    a warm sandbox. An IDLE-expired session is likewise reclaimed before the authz
+ *    gate, so a stale warm sandbox never leaks just because the requesting actor is
+ *    now unauthorized. Authorization gates *use*, never *cleanup*.
  */
 
 import type { CanRunCodeResult, CodeExecutionDenialReason } from './can-run-code';
@@ -68,7 +70,19 @@ export function planSandboxLifecycle({
       : { action: 'noop' };
   }
 
-  // Resume re-authz gate: deny before considering any existing warm sandbox, so
+  // Reclaim an idle-expired session BEFORE the authz gate: a stale warm sandbox
+  // must never leak just because the requesting actor is now unauthorized. The
+  // teardown only reclaims the VM (stop + unlink); it never hands the handle back,
+  // and the effect layer re-checks authorization before re-provisioning, so this
+  // cannot leak another session's state to an unauthorized actor.
+  if (existingSession) {
+    const idleFor = now.getTime() - existingSession.lastActiveAt.getTime();
+    if (idleFor >= idleTimeoutMs) {
+      return { action: 'teardown', sandboxId: existingSession.sandboxId, reason: 'idle' };
+    }
+  }
+
+  // Resume re-authz gate: deny before returning any warm (non-expired) sandbox, so
   // an unauthorized actor is never handed back another session's state.
   if (!authorization.ok) {
     return { action: 'deny', reason: authorization.reason };
@@ -76,11 +90,6 @@ export function planSandboxLifecycle({
 
   if (!existingSession) {
     return { action: 'create' };
-  }
-
-  const idleFor = now.getTime() - existingSession.lastActiveAt.getTime();
-  if (idleFor >= idleTimeoutMs) {
-    return { action: 'teardown', sandboxId: existingSession.sandboxId, reason: 'idle' };
   }
 
   return { action: 'resume', sandboxId: existingSession.sandboxId };

--- a/packages/lib/src/services/sandbox/output-limit.ts
+++ b/packages/lib/src/services/sandbox/output-limit.ts
@@ -4,9 +4,12 @@
  * Untrusted code can emit unbounded output; the policy's `maxOutputBytes` caps
  * what we retain and render in the chat tool-call UI. Truncation is byte-bounded
  * (not character-bounded) so a multi-megabyte stream can never blow the cap via
- * wide characters. A partial multi-byte sequence at the cut is decoded
- * leniently (replacement char) rather than thrown — the output is untrusted log
- * data, so a clean lossy cut is correct.
+ * wide characters. The cut is moved BACK to the nearest UTF-8 character boundary
+ * so it never lands mid-codepoint: that means the result is a clean prefix with
+ * no U+FFFD replacement char — which matters because a replacement char is itself
+ * 3 UTF-8 bytes and, emitted at the boundary, could push the returned text back
+ * OVER `maxBytes` (e.g. '😀😀' capped at 2 bytes). The returned text is therefore
+ * GUARANTEED to be ≤ `maxBytes`.
  */
 
 export interface TruncatedOutput {
@@ -23,13 +26,16 @@ export function truncateToBytes({
   text?: string;
   maxBytes: number;
 }): TruncatedOutput {
-  const originalBytes = Buffer.byteLength(text, 'utf8');
+  const buffer = Buffer.from(text, 'utf8');
+  const originalBytes = buffer.length;
   if (originalBytes <= maxBytes) {
     return { text, truncated: false, originalBytes };
   }
-  // Cut on the byte buffer, then decode leniently so a split multi-byte
-  // sequence at the boundary becomes a replacement char instead of throwing.
-  const cut = Buffer.from(text, 'utf8').subarray(0, maxBytes);
-  const decoded = new TextDecoder('utf-8', { fatal: false }).decode(cut);
-  return { text: decoded, truncated: true, originalBytes };
+  // Walk the cut back off any partial trailing multi-byte sequence so it lands on
+  // a UTF-8 character boundary. A continuation byte matches 0b10xxxxxx; backing up
+  // past them lands on the lead byte of the split codepoint, which we then exclude
+  // — yielding a clean prefix with no replacement char (and so guaranteed ≤ maxBytes).
+  let end = maxBytes;
+  while (end > 0 && (buffer[end] & 0xc0) === 0x80) end--;
+  return { text: buffer.subarray(0, end).toString('utf8'), truncated: true, originalBytes };
 }

--- a/packages/lib/src/services/sandbox/quota.ts
+++ b/packages/lib/src/services/sandbox/quota.ts
@@ -152,14 +152,21 @@ export async function checkCodeExecutionQuota({
 export interface ChargeBudgetDeps {
   /** Increment the daily budget for one scoped identifier (consumes the window). */
   charge: (id: string) => Promise<void>;
+  /** Compensating refund of one scope, to roll back a partially applied charge. */
+  refund: (id: string) => Promise<void>;
 }
 
-// The real charge increments the CODE_EXECUTION sliding window. Lazily imported
-// so unit tests that inject a fake never load the DB module graph.
+// The real charge increments the CODE_EXECUTION sliding window, with a matching
+// compensating refund (decrement) for rollback. Lazily imported so unit tests
+// that inject a fake never load the DB module graph.
 const defaultChargeDeps: ChargeBudgetDeps = {
   charge: (id) =>
     import('../../security/distributed-rate-limit').then((m) =>
       m.checkDistributedRateLimit(id, m.DISTRIBUTED_RATE_LIMITS.CODE_EXECUTION).then(() => undefined),
+    ),
+  refund: (id) =>
+    import('../../security/distributed-rate-limit').then((m) =>
+      m.decrementDistributedRateLimit(id, m.DISTRIBUTED_RATE_LIMITS.CODE_EXECUTION),
     ),
 };
 
@@ -167,8 +174,14 @@ const defaultChargeDeps: ChargeBudgetDeps = {
  * The single real per-run budget charge: increment every scope (user, drive,
  * and — when known — tenant) exactly once. Call this only after a passing
  * preflight and a successful concurrency reservation, so a denied run never
- * charges. Charges run together; a sink failure rejects (the caller treats a
- * failed charge as an `error` denial rather than running uncharged).
+ * charges.
+ *
+ * The multi-scope charge is made ATOMIC by compensation: scopes are charged
+ * sequentially, and if any scope fails the already-charged scopes are refunded
+ * before the error is surfaced. This preserves the module invariant that a run
+ * which does not execute (a partial-charge failure aborts the run) never leaves
+ * a scope's budget consumed — without it, `Promise.all` could charge the user
+ * scope while the tenant scope rejected, permanently skewing quotas.
  */
 export async function chargeCodeExecutionBudget({
   userId,
@@ -181,5 +194,17 @@ export async function chargeCodeExecutionBudget({
   tenantId?: string;
   deps?: ChargeBudgetDeps;
 }): Promise<void> {
-  await Promise.all(budgetScopeIds({ userId, driveId, tenantId }).map((id) => deps.charge(id)));
+  const ids = budgetScopeIds({ userId, driveId, tenantId });
+  const charged: string[] = [];
+  try {
+    for (const id of ids) {
+      await deps.charge(id);
+      charged.push(id);
+    }
+  } catch (error) {
+    // Roll back every scope already charged so a failed multi-scope charge leaves
+    // no partial consumption. Refunds are best-effort; the original error wins.
+    await Promise.allSettled(charged.map((id) => deps.refund(id)));
+    throw error;
+  }
 }

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
@@ -11,6 +11,7 @@ import {
   type SpriteCommandLike,
   type SpriteFsLike,
 } from '../sprites';
+import { SandboxReadLimitError } from '../types';
 import { mapPolicyToSandboxOptions } from '../../sandbox-options';
 import { resolveExecutionPolicy } from '../../execution-policy';
 
@@ -65,6 +66,7 @@ function fakeFs(over: Partial<SpriteFsLike> = {}): SpriteFsLike {
     readFile: async () => Buffer.from('contents'),
     writeFile: async () => {},
     mkdir: async () => {},
+    stat: async () => ({ size: 8 }),
     ...over,
   };
 }
@@ -366,5 +368,30 @@ describe('ExecutableSandbox file ops', () => {
     const { sdk: sdkMissing } = makeSdk({ getSprite: async () => fakeSprite({ fs: missing }) });
     const miss = await createSpritesSandboxClient({ sdk: sdkMissing }).get({ sandboxId: 'k' });
     expect(await miss!.readFileToBuffer({ path: '/workspace/missing.txt' })).toBeNull();
+  });
+
+  it('readFileToBuffer should REFUSE a file larger than maxBytes via stat, BEFORE reading its bytes', async () => {
+    let read = false;
+    const fs = fakeFs({
+      stat: async () => ({ size: 100 }),
+      readFile: async () => {
+        read = true;
+        return Buffer.from('x'.repeat(100));
+      },
+    });
+    const { sdk } = makeSdk({ getSprite: async () => fakeSprite({ fs }) });
+    const handle = await createSpritesSandboxClient({ sdk }).get({ sandboxId: 'k' });
+    await expect(
+      handle!.readFileToBuffer({ path: '/workspace/big.bin', maxBytes: 10 }),
+    ).rejects.toBeInstanceOf(SandboxReadLimitError);
+    // The oversized body is never pulled into the host process.
+    expect(read).toBe(false);
+  });
+
+  it('readFileToBuffer should read a within-cap file (stat passes)', async () => {
+    const fs = fakeFs({ stat: async () => ({ size: 4 }), readFile: async () => Buffer.from('ok!!') });
+    const { sdk } = makeSdk({ getSprite: async () => fakeSprite({ fs }) });
+    const handle = await createSpritesSandboxClient({ sdk }).get({ sandboxId: 'k' });
+    expect((await handle!.readFileToBuffer({ path: '/workspace/a.txt', maxBytes: 10 }))?.toString()).toBe('ok!!');
   });
 });

--- a/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/__tests__/sprites.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'node:events';
 import {
   createSpritesSandboxClient,
   buildSpriteConfig,
+  isSpriteNotFoundError,
   SandboxCommandTimeoutError,
   SandboxOutputLimitError,
   type SpritesSdk,
@@ -99,6 +100,21 @@ function makeSdk(over: Partial<SpritesSdk> = {}) {
   return { sdk, calls, sprite };
 }
 
+describe('isSpriteNotFoundError', () => {
+  it('should classify a 404 APIError and a "status 404" message as not-found', () => {
+    expect(isSpriteNotFoundError(Object.assign(new Error('x'), { statusCode: 404 }))).toBe(true);
+    expect(isSpriteNotFoundError(new Error('Failed to get sprite (status 404): missing'))).toBe(true);
+    expect(isSpriteNotFoundError(Object.assign(new Error('x'), { code: 'ENOENT' }))).toBe(true);
+  });
+
+  it('should NOT classify auth / rate-limit / transport errors as not-found', () => {
+    expect(isSpriteNotFoundError(Object.assign(new Error('x'), { statusCode: 401 }))).toBe(false);
+    expect(isSpriteNotFoundError(Object.assign(new Error('x'), { statusCode: 429 }))).toBe(false);
+    expect(isSpriteNotFoundError(new Error('websocket closed'))).toBe(false);
+    expect(isSpriteNotFoundError(null)).toBe(false);
+  });
+});
+
 describe('buildSpriteConfig', () => {
   it('given policy options, should map RAM, CPUs, storage, and region from the policy', () => {
     expect(buildSpriteConfig({ options })).toEqual({
@@ -119,6 +135,10 @@ describe('buildSpriteConfig', () => {
   });
 });
 
+// A Sprites "not found" surfaces as an APIError carrying statusCode 404 (or a
+// generic Error whose message embeds "status 404"); anything else must propagate.
+const notFound = () => Object.assign(new Error('Failed to get sprite (status 404): missing'), { statusCode: 404 });
+
 describe('createSpritesSandboxClient.getOrCreate', () => {
   it('given an existing Sprite, should resume it by name without creating', async () => {
     const { sdk, calls } = makeSdk();
@@ -128,19 +148,17 @@ describe('createSpritesSandboxClient.getOrCreate', () => {
     expect(calls.created).toEqual([]);
   });
 
-  it('given no existing Sprite, should create fresh and apply the egress lockdown', async () => {
-    const { sdk, calls } = makeSdk({
-      getSprite: async () => {
-        throw new Error('not found');
-      },
-    });
+  it('given a resumed Sprite, should RE-APPLY the egress lockdown before handing it back', async () => {
+    // A process that died after createSprite but before the lockdown would
+    // otherwise resume an unlocked Sprite with open egress: re-affirm on resume.
+    const { sdk, calls } = makeSdk();
     const client = createSpritesSandboxClient({ sdk });
     await client.getOrCreate({ name: 'k', options });
-    expect(calls.created).toEqual(['k']);
+    expect(calls.created).toEqual([]);
     expect(calls.policies).toBe(1);
   });
 
-  it('given the egress lockdown fails, should destroy the Sprite and reject (never hand back open egress)', async () => {
+  it('given the resume lockdown fails, should destroy the Sprite and reject (never resume open egress)', async () => {
     let destroyed: string | null = null;
     const sprite = fakeSprite({
       name: 'k',
@@ -149,9 +167,44 @@ describe('createSpritesSandboxClient.getOrCreate', () => {
       },
     });
     const sdk: SpritesSdk = {
-      getSprite: async () => {
-        throw new Error('not found');
+      getSprite: async () => sprite,
+      createSprite: async () => sprite,
+      deleteSprite: async (name) => {
+        destroyed = name;
       },
+    };
+    const client = createSpritesSandboxClient({ sdk });
+    await expect(client.getOrCreate({ name: 'k', options })).rejects.toThrow('policy api down');
+    expect(destroyed).toBe('k');
+  });
+
+  it('given no existing Sprite, should create fresh and apply the egress lockdown', async () => {
+    const { sdk, calls } = makeSdk({ getSprite: async () => { throw notFound(); } });
+    const client = createSpritesSandboxClient({ sdk });
+    await client.getOrCreate({ name: 'k', options });
+    expect(calls.created).toEqual(['k']);
+    expect(calls.policies).toBe(1);
+  });
+
+  it('given a non-not-found error on lookup, should propagate it (never re-create over a live Sprite)', async () => {
+    const { sdk, calls } = makeSdk({
+      getSprite: async () => { throw Object.assign(new Error('unauthorized'), { statusCode: 401 }); },
+    });
+    const client = createSpritesSandboxClient({ sdk });
+    await expect(client.getOrCreate({ name: 'k', options })).rejects.toThrow('unauthorized');
+    expect(calls.created).toEqual([]);
+  });
+
+  it('given the egress lockdown fails on fresh create, should destroy the Sprite and reject (never hand back open egress)', async () => {
+    let destroyed: string | null = null;
+    const sprite = fakeSprite({
+      name: 'k',
+      updateNetworkPolicy: async () => {
+        throw new Error('policy api down');
+      },
+    });
+    const sdk: SpritesSdk = {
+      getSprite: async () => { throw notFound(); },
       createSprite: async () => sprite,
       deleteSprite: async (name) => {
         destroyed = name;
@@ -164,14 +217,18 @@ describe('createSpritesSandboxClient.getOrCreate', () => {
 });
 
 describe('createSpritesSandboxClient.get / stop', () => {
-  it('given a vanished Sprite, should resolve get to null rather than throwing', async () => {
-    const { sdk } = makeSdk({
-      getSprite: async () => {
-        throw new Error('gone');
-      },
-    });
+  it('given a vanished (not-found) Sprite, should resolve get to null rather than throwing', async () => {
+    const { sdk } = makeSdk({ getSprite: async () => { throw notFound(); } });
     const client = createSpritesSandboxClient({ sdk });
     expect(await client.get({ sandboxId: 'gone' })).toBeNull();
+  });
+
+  it('given a non-not-found error, get should propagate it (a transient outage is not a gone Sprite)', async () => {
+    const { sdk } = makeSdk({
+      getSprite: async () => { throw Object.assign(new Error('rate limited'), { statusCode: 429 }); },
+    });
+    const client = createSpritesSandboxClient({ sdk });
+    await expect(client.get({ sandboxId: 'k' })).rejects.toThrow('rate limited');
   });
 
   it('stop should DESTROY the Sprite (no idle billing)', async () => {

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -7,10 +7,12 @@
  * `getOrCreate` resumes an existing Sprite by name or creates a fresh one.
  *
  * Provisioning is locked down, never platform defaults:
- *  - **Egress** — immediately after a fresh create, the deny-by-default L3
- *    network policy is applied. If that application fails the just-created
- *    Sprite is destroyed and the create rejects: a Sprite is NEVER handed back
- *    without its egress lockdown in place.
+ *  - **Egress** — on EVERY acquire (a fresh create AND a resume of a pre-existing
+ *    Sprite) the deny-by-default L3 network policy is (re)applied before the
+ *    Sprite is handed back. If that application fails the Sprite is destroyed and
+ *    the acquire rejects: a Sprite is NEVER handed back without its egress
+ *    lockdown confirmed, so a crash between create and lockdown — or a resume
+ *    under a tightened egress profile — can never leak open/stale egress.
  *  - **Caps** — RAM / vCPUs / storage / region come from the resolved policy
  *    (`SpriteConfig`), set explicitly per Sprite rather than relying on the quota
  *    defaults.
@@ -285,10 +287,33 @@ const defaultSdk = (): SpritesSdk => {
   };
 };
 
+/**
+ * Classify a Sprites SDK error as a "the named Sprite does not exist" signal,
+ * the ONLY error we may swallow when resolving a Sprite by name. The SDK surfaces
+ * a not-found either as a structured `APIError` carrying `statusCode: 404` or, when
+ * the error body cannot be parsed, as a generic `Error("Failed to get sprite
+ * (status 404): …")`. Everything else — auth (401/403), rate limits (429),
+ * control-plane/transport failures — must propagate so the caller never mistakes a
+ * transient outage for a missing Sprite (and never silently re-creates over one).
+ */
+export function isSpriteNotFoundError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const e = error as { statusCode?: unknown; status?: unknown; code?: unknown; message?: unknown };
+  if (e.statusCode === 404 || e.status === 404) return true;
+  if (e.code === 'ENOENT' || e.code === 'not_found' || e.code === 'NOT_FOUND') return true;
+  const message = typeof e.message === 'string' ? e.message : '';
+  return /\b404\b/.test(message) || /not[\s_-]?found/i.test(message);
+}
+
 // Apply the deny-by-default egress policy and ensure the sandbox root exists.
-// If the egress lockdown cannot be applied the Sprite is destroyed and the
-// error propagates — a Sprite is never returned with open/unknown egress.
-async function lockdownFreshSprite(
+// Run on EVERY acquire — both a fresh create and a resume of a pre-existing
+// Sprite — because the deny-all network policy is the egress boundary and must
+// be (re)affirmed before any command runs: a process that died after
+// `createSprite()` but before this lockdown, or a Sprite resumed under a since-
+// tightened egress profile, would otherwise hand back open/stale egress. If the
+// lockdown cannot be applied the Sprite is destroyed and the error propagates —
+// a Sprite is NEVER returned without its egress lockdown confirmed (fail-closed).
+async function lockdownSprite(
   sdk: SpritesSdk,
   sprite: SpriteInstanceLike,
   options: SandboxCreateOptions,
@@ -311,24 +336,36 @@ export function createSpritesSandboxClient({
 }: { sdk?: SpritesSdk } = {}): ExecSandboxClient {
   return {
     async getOrCreate({ name, options }) {
-      // Resume by name when the Sprite already exists; otherwise create fresh and
-      // lock it down before returning.
+      // Resume by name when the Sprite already exists; otherwise create fresh.
+      // A not-found is the only swallowed error — any other failure (auth, rate
+      // limit, control-plane outage) propagates rather than masquerading as a
+      // missing Sprite that we would wrongly re-create over.
+      let sprite: SpriteInstanceLike;
       try {
-        return wrap(await sdk.getSprite(name));
-      } catch {
-        const sprite = await sdk.createSprite(name, buildSpriteConfig({ options }));
-        await lockdownFreshSprite(sdk, sprite, options);
-        return wrap(sprite);
+        sprite = await sdk.getSprite(name);
+      } catch (error) {
+        if (!isSpriteNotFoundError(error)) throw error;
+        sprite = await sdk.createSprite(name, buildSpriteConfig({ options }));
       }
+      // (Re)apply the egress lockdown before handing back ANY Sprite — fresh or
+      // resumed — so a crash window between create and lockdown, or a resume
+      // under a tightened egress profile, can never leak open/stale egress. Mutable
+      // network policy is re-enforced here; immutable caps (RAM/storage) are fixed
+      // for the warm Sprite's life and a profile change takes effect on the next
+      // cold provision (idle teardown / session end).
+      await lockdownSprite(sdk, sprite, options);
+      return wrap(sprite);
     },
 
     async get({ sandboxId }) {
-      // Reconnect by name; a vanished Sprite surfaces as an error → null so the
-      // lifecycle re-provisions under the same key rather than throwing.
+      // Reconnect by name; a vanished (not-found) Sprite surfaces as null so the
+      // lifecycle re-provisions under the same key. Any other error propagates so
+      // a transient outage is not mistaken for a gone Sprite.
       try {
         return wrap(await sdk.getSprite(sandboxId));
-      } catch {
-        return null;
+      } catch (error) {
+        if (isSpriteNotFoundError(error)) return null;
+        throw error;
       }
     },
 

--- a/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/sprites.ts
@@ -42,12 +42,13 @@ import { SpritesClient, type NetworkPolicy } from '@fly/sprites';
 import { getValidatedEnv } from '../../../config/env-validation';
 import { buildSpriteNetworkPolicy } from '../egress';
 import { SANDBOX_ROOT } from '../sandbox-paths';
-import type {
-  ExecSandboxClient,
-  ExecutableSandbox,
-  SandboxRunResult,
-  RunCommandArgs,
-  WriteFileEntry,
+import {
+  SandboxReadLimitError,
+  type ExecSandboxClient,
+  type ExecutableSandbox,
+  type SandboxRunResult,
+  type RunCommandArgs,
+  type WriteFileEntry,
 } from './types';
 import type { SandboxCreateOptions } from '../sandbox-options';
 
@@ -88,6 +89,7 @@ export interface SpriteFsLike {
   readFile(path: string, encoding: null): Promise<Buffer>;
   writeFile(path: string, data: string | Buffer, options?: { mode?: number }): Promise<void>;
   mkdir(path: string, options?: { recursive?: boolean }): Promise<void>;
+  stat(path: string): Promise<{ size: number }>;
 }
 
 /** The readable-stream subset the driver consumes (stdout/stderr `data` events). */
@@ -265,12 +267,24 @@ function wrap(sprite: SpriteInstanceLike): ExecutableSandbox {
       }
     },
 
-    async readFileToBuffer({ path }: { path: string }): Promise<Buffer | null> {
+    async readFileToBuffer({ path, maxBytes }: { path: string; maxBytes?: number }): Promise<Buffer | null> {
+      const fs = sprite.filesystem('/');
       try {
-        return await sprite.filesystem('/').readFile(path, null);
-      } catch {
-        // A missing file (or any read failure) resolves to null; the runner maps
-        // null to a handled not-found rather than an exception.
+        if (maxBytes !== undefined && maxBytes > 0) {
+          // Stat FIRST so an oversized file is refused before its bytes are pulled
+          // into the host process — the cap is a host-memory DoS guard, not just a
+          // display limit, so it must bound the read at the API boundary. A stat
+          // failure (missing file) falls through to the null not-found path below.
+          const stats = await fs.stat(path);
+          if (typeof stats.size === 'number' && stats.size > maxBytes) {
+            throw new SandboxReadLimitError(maxBytes);
+          }
+        }
+        return await fs.readFile(path, null);
+      } catch (error) {
+        // A refused oversized read propagates; anything else (missing file / read
+        // failure) resolves to null, which the runner maps to a handled not-found.
+        if (error instanceof SandboxReadLimitError) throw error;
         return null;
       }
     },

--- a/packages/lib/src/services/sandbox/sandbox-client/types.ts
+++ b/packages/lib/src/services/sandbox/sandbox-client/types.ts
@@ -13,6 +13,21 @@
 import type { SandboxClient, SandboxHandle } from '../session-manager';
 import type { SandboxCreateOptions } from '../sandbox-options';
 
+/**
+ * Provider-neutral signal that a file read was refused because the file exceeds
+ * the caller's byte cap. Thrown by the driver from `readFileToBuffer` BEFORE the
+ * oversized body is pulled into the host process, so the cap bounds host memory
+ * rather than only trimming an already-materialized buffer. The runner maps it to
+ * a `content_too_large` denial. Kept here (not in a provider module) so the
+ * runners can catch it without importing the Fly Sprites driver.
+ */
+export class SandboxReadLimitError extends Error {
+  constructor(public readonly maxBytes: number) {
+    super(`Sandbox file exceeds the ${maxBytes}-byte read cap`);
+    this.name = 'SandboxReadLimitError';
+  }
+}
+
 /** Result of a single command run inside the sandbox. */
 export interface SandboxRunResult {
   exitCode: number;
@@ -52,7 +67,13 @@ export interface WriteFileEntry {
 export interface ExecutableSandbox extends SandboxHandle {
   runCommand(args: RunCommandArgs): Promise<SandboxRunResult>;
   writeFiles(files: WriteFileEntry[]): Promise<void>;
-  readFileToBuffer(args: { path: string }): Promise<Buffer | null>;
+  /**
+   * Read a file's bytes, or null when it is missing/unreadable. When `maxBytes`
+   * is supplied the driver MUST refuse (throw `SandboxReadLimitError`) a file that
+   * exceeds it BEFORE buffering the whole body, so the cap bounds host memory
+   * rather than only trimming an already-materialized buffer.
+   */
+  readFileToBuffer(args: { path: string; maxBytes?: number }): Promise<Buffer | null>;
 }
 
 /** Extends the PR2 lifecycle seam so one client serves both layers. */

--- a/packages/lib/src/services/sandbox/session-key.ts
+++ b/packages/lib/src/services/sandbox/session-key.ts
@@ -47,6 +47,13 @@ export function deriveSessionKey({
   conversationId,
   secret,
 }: SessionKeyInput): string {
+  // Fail closed on an empty secret: without a key the HMAC degenerates to a
+  // predictable digest of public ids, collapsing the unguessable-name boundary
+  // this function exists to provide. Reject here rather than trusting upstream
+  // env validation to have caught it.
+  if (secret.length === 0) {
+    throw new Error('Sandbox session secret must not be empty');
+  }
   const payload = [NAMESPACE_VERSION, tenantId, driveId, conversationId].join('\0');
   const digest = createHmac('sha3-256', secret).update(payload).digest('hex');
   return `pgs-sbx-${digest}`;

--- a/packages/lib/src/services/sandbox/session-manager.ts
+++ b/packages/lib/src/services/sandbox/session-manager.ts
@@ -81,13 +81,17 @@ export function getSandboxSessionSecret(): string {
   }
 }
 
-// Stop a sandbox best-effort. Teardown must never throw or block — a failed stop
-// is logged-and-swallowed; the platform's own timeout cap reclaims a stuck VM.
-async function safeStop(client: SandboxClient, sandboxId: string): Promise<void> {
+// Stop a sandbox best-effort, REPORTING whether the stop was confirmed. Teardown
+// must never throw or block, so a failure is swallowed — but the boolean lets
+// callers avoid dropping the only handle to a VM that may still be alive (a
+// transient stop failure must not be treated as a confirmed teardown).
+async function safeStop(client: SandboxClient, sandboxId: string): Promise<boolean> {
   try {
     await client.stop({ sandboxId });
+    return true;
   } catch {
     // Intentionally swallowed: cleanup is best-effort and must not surface.
+    return false;
   }
 }
 
@@ -142,7 +146,9 @@ async function provisionFresh({
     });
   } catch {
     // The sandbox exists but we could not record the link — tear it down so it
-    // can never linger as an unreachable, unaudited orphan.
+    // can never linger as an unreachable, unaudited orphan. There is no link to
+    // retain here (the save is what failed), so an unconfirmed stop falls back to
+    // the platform's idle-timeout cap to reclaim the VM.
     await safeStop(deps.client, handle.sandboxId);
     return { ok: false, reason: 'provision_failed' };
   }
@@ -239,8 +245,11 @@ export interface TeardownSandboxInput {
  * Tear down a conversation's sandbox on session end / idle / crash / failure.
  * Idempotent and never throws: the lookup is guarded and the VM stop + link
  * removal are best-effort, so a store or stop failure during cleanup never
- * propagates. A lingering link after a failed removal is self-correcting (the
- * next acquire reconnects to a stopped VM and re-provisions under the same key).
+ * propagates. The link is removed ONLY after a CONFIRMED stop — an unconfirmed
+ * (transiently failed) stop keeps the link so a later teardown / idle reclaim can
+ * retry against the same sandboxId, rather than orphaning a possibly-live VM. A
+ * lingering link after a confirmed stop but failed removal is self-correcting
+ * (the next acquire reconnects to a stopped VM and re-provisions under the key).
  */
 export async function teardownConversationSandbox({
   tenantId,
@@ -267,7 +276,13 @@ export async function teardownConversationSandbox({
     return { torn: false };
   }
 
-  await safeStop(deps.client, existing.sandboxId);
+  const stopped = await safeStop(deps.client, existing.sandboxId);
+  if (!stopped) {
+    // The stop is UNCONFIRMED — the VM may still be running. Keep the link so a
+    // later teardown / idle reclaim can retry against the same sandboxId; dropping
+    // it now would orphan a possibly-live sandbox with no handle to reclaim it.
+    return { torn: false };
+  }
   await safeRemove(deps.store, key);
   return { torn: true };
 }

--- a/packages/lib/src/services/sandbox/session-manager.ts
+++ b/packages/lib/src/services/sandbox/session-manager.ts
@@ -200,9 +200,15 @@ export async function acquireConversationSandbox(
       }
 
       case 'teardown': {
-        // Idle-expired: reclaim the stale VM and its link, then start fresh.
+        // Idle-expired: reclaim the stale VM and its link. The planner reclaims an
+        // idle session BEFORE the authz gate so a stale sandbox never leaks, so we
+        // re-check authorization here and only re-provision for an authorized actor
+        // — an unauthorized actor's reclaim must never hand them a fresh sandbox.
         await safeStop(deps.client, plan.sandboxId);
         await deps.store.remove(key);
+        if (!authorization.ok) {
+          return { ok: false, reason: authorization.reason };
+        }
         return await provisionFresh({ key, input });
       }
 

--- a/packages/lib/src/services/sandbox/session-store.ts
+++ b/packages/lib/src/services/sandbox/session-store.ts
@@ -87,7 +87,11 @@ export async function createDbSandboxSessionStore(): Promise<SandboxSessionStore
         })
         .onConflictDoUpdate({
           target: sandboxSessions.sessionKey,
-          set: { sandboxId, lastActiveAt: now, updatedAt: now },
+          // Refresh userId too: the sessionKey is stable across re-provisioning,
+          // but the actor who creates the replacement sandbox may differ, so the
+          // row's audit metadata must track the live sandbox's creator rather than
+          // keeping the previous owner.
+          set: { userId, sandboxId, lastActiveAt: now, updatedAt: now },
         });
     },
 

--- a/packages/lib/src/services/sandbox/tool-runners.ts
+++ b/packages/lib/src/services/sandbox/tool-runners.ts
@@ -33,7 +33,7 @@ import { resolveSandboxPath, SANDBOX_ROOT } from './sandbox-paths';
 import { buildSandboxEnv } from './sandbox-env';
 import { getValidatedEnv } from '../../config/env-validation';
 import type { AcquireSandboxInput, AcquireSandboxResult } from './session-manager';
-import type { ExecutableSandbox, SandboxRunResult } from './sandbox-client/types';
+import { SandboxReadLimitError, type ExecutableSandbox, type SandboxRunResult } from './sandbox-client/types';
 import type { CodeExecutionQuotaDecision } from './quota';
 import type { CodeExecutionAuditInput, CodeExecutionAnomaly } from './audit';
 
@@ -281,11 +281,22 @@ export async function runBashInSandbox({
     return fail(commandPolicy.reason);
   }
 
-  // A provided working directory must also stay inside the sandbox root.
+  // A provided working directory must also stay inside the sandbox root. A blocked
+  // escape is audited as an anomaly (like writeFile/readFile path escapes) so every
+  // denied sandbox-escape attempt is logged before returning.
   let resolvedCwd: string = SANDBOX_ROOT;
   if (cwd !== undefined) {
     const candidate = resolveSandboxPath(cwd);
-    if (!candidate) return fail('path_escape');
+    if (!candidate) {
+      await safeAudit(deps, ctx, {
+        profile: policy.profile,
+        code: `cd ${cwd} && ${command}`,
+        exitCode: null,
+        durationMs: 0,
+        anomaly: 'blocked_command',
+      });
+      return fail('path_escape');
+    }
     resolvedCwd = candidate;
   }
 
@@ -428,17 +439,21 @@ export async function readSandboxFile({
     const startedAt = deps.now();
     let buffer: Buffer | null;
     try {
-      buffer = await session.sandbox.readFileToBuffer({ path: resolved });
-    } catch {
+      // Pass the output cap so the driver refuses an oversized file BEFORE pulling
+      // it into the host process — the cap bounds host memory, not just the
+      // rendered output (a malicious sandbox could otherwise OOM the app process).
+      buffer = await session.sandbox.readFileToBuffer({ path: resolved, maxBytes: policy.maxOutputBytes });
+    } catch (error) {
       const durationMs = deps.now().getTime() - startedAt.getTime();
+      const tooLarge = error instanceof SandboxReadLimitError;
       await safeAudit(deps, ctx, {
         profile: policy.profile,
         code: `readFile ${path}`,
         exitCode: null,
         durationMs,
-        anomaly: 'nonzero_exit',
+        anomaly: tooLarge ? 'blocked_command' : 'nonzero_exit',
       });
-      return fail('execution_failed');
+      return fail(tooLarge ? 'content_too_large' : 'execution_failed');
     }
     const durationMs = deps.now().getTime() - startedAt.getTime();
     if (buffer === null) {


### PR DESCRIPTION
Converges all **19 unresolved review threads** on #1487 (Codex P1 + CodeRabbit Major/Minor) and syncs the branch with `master`. Each fix is an atomic commit with tests for every behavioral change; the suite is plain Vitest, fail-closed, DI, no barrel imports, no ReDoS, no deployment-mode gate.

Base: **`pu/flash-sandbox`** (integration branch, not master). Do not self-merge.

## Thread → fix map

| # | Thread | Fix | Commit |
|---|--------|-----|--------|
| 1 | `sprites.ts:318` (Codex P1) — re-apply lockdown on Sprite reuse | `getOrCreate` (re)applies the deny-all egress policy on **every** acquire, incl. resume; fail-closed (destroys on failure) | `d584987` |
| 12 | `sprites.ts:320` — reapply/invalidate policy on resume | Same: mutable egress re-enforced on resume; immutable caps documented (fixed for warm life, change on next cold provision) | `d584987` |
| 13 | `sprites.ts:331` — discriminate not-found | `isSpriteNotFoundError` — only 404 swallowed; auth/rate-limit/transport propagate | `d584987` |
| 2 | `sandbox-tools-runtime.ts:61` (Codex P1) — Node 24 SDK on Node 22 | Hard `process.versions.node` guard, fail-closed with actionable error before importing `@fly/sprites`; `TODO` to relocate driver to a Node≥24 service | `8217984` |
| 5 | `sandbox-tools-runtime.ts:62` — memoized rejection | Cache cleared in the `.catch` so a one-off load failure is retried, not poisoned forever | `8217984` |
| 3 | `security.yml:9` — path filters miss web exposure | Added `sandbox-tools.ts`, `sandbox-tools-runtime.ts`, `ai-tools.ts`, `packages/db/drizzle/**` (push + PR) | `c8adcf7` |
| 4 | `security.yml:30` + `test.yml:7` — push not gated | `pu/flash-sandbox` added under `push.branches` in both workflows | `c8adcf7` |
| 6 | `package.json:279` — incomplete `typesVersions` | Added the 8 missing sandbox subpaths (exports/typesVersions now 18/18) | `813f727` |
| 7 | `distributed-rate-limit.ts:588` — stale provider | Budget comment now points at the Fly Sprites control plane | `e12ce26` |
| 8 | `egress.ts:55` — unvalidated allowlist → domain rules | `normalizeEgressHost` accepts only literal hostnames (optional single `*.`), drops bare `*`, IP literals, schemes/ports/`localhost`; per-label bounded validation (no ReDoS) | `afc3404` |
| 9 | `lifecycle.ts:83` — stale session leak on deny | Idle reclaim moved **before** the authz gate; effect layer re-checks authz and only re-provisions for an authorized actor | `e2ddfc2` |
| 10 | `output-limit.ts:34` — replacement char can exceed cap | Cut moved back to a UTF-8 char boundary; result guaranteed ≤ `maxBytes`, no `U+FFFD` inflation | `49265a8` |
| 11 | `quota.ts:185` — non-atomic multi-scope charge | Sequential charge with compensating refund on partial failure; adds `decrementDistributedRateLimit` | `1bc7d42` |
| 14 | `session-key.ts:53` — empty HMAC secret | `deriveSessionKey` throws on empty secret (fail-closed) | `758fd12` |
| 15 | `session-manager.ts:102` — drop link after unconfirmed stop | `safeStop` reports success/failure; teardown removes the link only after a **confirmed** stop, else retains it for retry | `f451d6b` |
| 16 | `session-store.ts:90` — stale `userId` on reuse | `userId` added to the conflict-update set | `44b20f7` |
| 17 | `tool-runners.ts:289` — unaudited cwd escape | Blocked cwd escape now audits a `blocked_command` anomaly | `a2750dd` |
| 18 | `tool-runners.ts:457` — readFile materializes whole file | Driver `stat`s and refuses (neutral `SandboxReadLimitError`) oversized files **before** buffering; runner maps to `content_too_large` | `a2750dd` |

## Validation
- `bun run --filter '@pagespace/lib' test -- src/services/sandbox/` → **187 passed**
- `bun run typecheck` / Turbo build → **13/13 tasks green**
- `bun run --filter 'web' lint` → clean (pre-existing warnings only)
- apps/web jsdom tests are worktree-flaky → rely on CI.

## Notes / honest partials
- **Thread 2/12 (caps):** RAM/storage are immutable on a warm Sprite, so a tier/profile downgrade takes effect on the next **cold** provision (idle teardown / session end), not mid-session. v1 ships a single static profile so no mid-session caps divergence exists. The security-critical mutable boundary (egress) **is** re-enforced on every resume.
- **Thread 2 (real fix):** relocating the Sprites driver to a Node≥24 runtime is a larger architectural change tracked via the `TODO`; this PR ships the fail-closed guard as the interim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
