### PR TITLE
fix(pages): trash children by default to stop orphaned pages flooding the sidebar

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/__tests__/route.test.ts
@@ -775,8 +775,18 @@ describe('DELETE /api/pages/[pageId]', () => {
       );
     });
 
-    it('defaults trashChildren to false', async () => {
+    it('defaults trashChildren to true (cascade)', async () => {
       await DELETE(createRequest({}), { params: mockParams });
+
+      expect(pageService.trashPage).toHaveBeenCalledWith(
+        mockPageId,
+        mockUserId,
+        { trashChildren: true }
+      );
+    });
+
+    it('honors an explicit trash_children: false (move children up)', async () => {
+      await DELETE(createRequest({ trash_children: false }), { params: mockParams });
 
       expect(pageService.trashPage).toHaveBeenCalledWith(
         mockPageId,
@@ -877,7 +887,7 @@ describe('DELETE /api/pages/[pageId]', () => {
       expect(pageService.trashPage).toHaveBeenCalledWith(
         mockPageId,
         mockUserId,
-        expect.objectContaining({ trashChildren: false })
+        expect.objectContaining({ trashChildren: true })
       );
     });
   });
@@ -891,7 +901,7 @@ describe('DELETE /api/pages/[pageId]', () => {
         'trash',
         mockPageId,
         expect.objectContaining({
-          trashChildren: false,
+          trashChildren: true,
           pageTitle: 'Test Page',
           pageType: 'DOCUMENT',
         })

--- a/apps/web/src/app/api/pages/[pageId]/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/route.ts
@@ -251,7 +251,7 @@ export async function DELETE(req: Request, { params }: { params: Promise<{ pageI
       body = null;
     }
     const parsedBody = deleteSchema.parse(body);
-    const trashChildren = parsedBody?.trash_children ?? false;
+    const trashChildren = parsedBody?.trash_children ?? true;
 
     const isMCP = isMCPAuthResult(auth);
     const result = await pageService.trashPage(pageId, userId, {

--- a/apps/web/src/components/dialogs/DeletePageDialog.tsx
+++ b/apps/web/src/components/dialogs/DeletePageDialog.tsx
@@ -28,22 +28,27 @@ export function DeletePageDialog({
         <AlertDialogHeader>
           <AlertDialogTitle>Are you sure?</AlertDialogTitle>
           <AlertDialogDescription>
-            This action will move the page to the trash. You can restore it later.
+            {hasChildren
+              ? "This will move the page and everything inside it to the trash. You can restore it later, or choose to keep the contents by moving the page only."
+              : "This action will move the page to the trash. You can restore it later."}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>
           {hasChildren ? (
             <>
-              <AlertDialogAction onClick={() => onConfirm(false)}>
-                Move Folder Only
+              <AlertDialogAction
+                onClick={() => onConfirm(false)}
+                className="bg-secondary text-secondary-foreground hover:bg-secondary/80"
+              >
+                Move Page Only
               </AlertDialogAction>
               <AlertDialogAction onClick={() => onConfirm(true)}>
-                Move Folder and All Contents
+                Move Page and All Contents
               </AlertDialogAction>
             </>
           ) : (
-            <AlertDialogAction onClick={() => onConfirm(false)}>
+            <AlertDialogAction onClick={() => onConfirm(true)}>
               Move to Trash
             </AlertDialogAction>
           )}

--- a/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
@@ -88,6 +88,7 @@ vi.mock('@pagespace/lib/repositories/page-repository', () => ({
     trashMany: vi.fn(),
     restore: vi.fn(),
     getChildIds: vi.fn(),
+    getDirectChildren: vi.fn(),
   },
 }));
 vi.mock('@pagespace/lib/repositories/drive-repository', () => ({
@@ -137,6 +138,8 @@ const mockApplyPageMutation = vi.mocked(applyPageMutation);
 describe('page-write-tools', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: pages have no direct children unless a test says otherwise.
+    mockPageRepo.getDirectChildren.mockResolvedValue([]);
   });
 
   describe('replace_lines', () => {
@@ -639,6 +642,59 @@ describe('page-write-tools', () => {
       // Cascade branch was taken: delete permission checked and descendants enumerated.
       expect(mockCanUserDeletePage).toHaveBeenCalledWith('user-123', 'page-1');
       expect(mockPageRepo.getChildIds).toHaveBeenCalledWith('drive-1', 'page-1');
+      expect(mockApplyPageMutation).toHaveBeenCalledWith(
+        expect.objectContaining({ pageId: 'page-1', operation: 'trash' })
+      );
+    });
+
+    it('re-homes live children to the grandparent when withChildren is false', async () => {
+      mockPageRepo.findById.mockResolvedValue({
+        id: 'page-1',
+        title: 'Parent Page',
+        type: 'TASK_LIST',
+        content: '',
+        contentMode: 'html' as const,
+        driveId: 'drive-1',
+        parentId: 'grandparent-1',
+        position: 1,
+        isTrashed: false,
+        trashedAt: null,
+        revision: 7,
+        stateHash: null,
+      });
+      mockCanUserEditPage.mockResolvedValue(true);
+      mockPageRepo.getDirectChildren.mockResolvedValue([
+        { id: 'child-1', revision: 2 },
+        { id: 'child-2', revision: 3 },
+      ]);
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      const result = await pageWriteTools.trash_page.execute!(
+        { id: 'page-1', withChildren: false },
+        context
+      ) as { success: boolean };
+
+      expect(result.success).toBe(true);
+      // Each live child is moved up to the grandparent (originalParentId recorded for restore)...
+      expect(mockApplyPageMutation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pageId: 'child-1',
+          operation: 'move',
+          updates: { parentId: 'grandparent-1', originalParentId: 'page-1' },
+        })
+      );
+      expect(mockApplyPageMutation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          pageId: 'child-2',
+          operation: 'move',
+          updates: { parentId: 'grandparent-1', originalParentId: 'page-1' },
+        })
+      );
+      // ...and only then is the parent trashed (children are never stranded under it).
       expect(mockApplyPageMutation).toHaveBeenCalledWith(
         expect.objectContaining({ pageId: 'page-1', operation: 'trash' })
       );

--- a/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/page-write-tools.test.ts
@@ -120,7 +120,7 @@ vi.mock('@pagespace/lib/services/drive-member-service', () => ({
 }));
 
 import { pageWriteTools } from '../page-write-tools';
-import { canUserEditPage } from '@pagespace/lib/permissions/permissions';
+import { canUserEditPage, canUserDeletePage } from '@pagespace/lib/permissions/permissions';
 import { getAgentAccessLevel } from '@pagespace/lib/permissions/agent-permissions';
 import { pageRepository } from '@pagespace/lib/repositories/page-repository';
 import { driveRepository } from '@pagespace/lib/repositories/drive-repository';
@@ -128,6 +128,7 @@ import { applyPageMutation } from '@/services/api/page-mutation-service';
 import type { ToolExecutionContext } from '../../core';
 
 const mockCanUserEditPage = vi.mocked(canUserEditPage);
+const mockCanUserDeletePage = vi.mocked(canUserDeletePage);
 const mockGetAgentAccessLevel = vi.mocked(getAgentAccessLevel);
 const mockPageRepo = vi.mocked(pageRepository);
 const mockDriveRepo = vi.mocked(driveRepository);
@@ -594,6 +595,50 @@ describe('page-write-tools', () => {
       expect(result.type).toBe('page');
       expect(result.id).toBe('page-1');
       expect(result.message).toContain('to trash');
+      expect(mockApplyPageMutation).toHaveBeenCalledWith(
+        expect.objectContaining({ pageId: 'page-1', operation: 'trash' })
+      );
+    });
+
+    it('defaults withChildren to true in the input schema (cascade by default)', () => {
+      const schema = pageWriteTools.trash_page.inputSchema as unknown as {
+        parse: (value: unknown) => { withChildren: boolean };
+      };
+      expect(schema.parse({ id: 'page-1' }).withChildren).toBe(true);
+    });
+
+    it('cascades to children when withChildren is true', async () => {
+      mockPageRepo.findById.mockResolvedValue({
+        id: 'page-1',
+        title: 'Parent Page',
+        type: 'TASK_LIST',
+        content: '',
+        contentMode: 'html' as const,
+        driveId: 'drive-1',
+        parentId: null,
+        position: 1,
+        isTrashed: false,
+        trashedAt: null,
+        revision: 1,
+        stateHash: null,
+      });
+      mockCanUserDeletePage.mockResolvedValue(true);
+      mockPageRepo.getChildIds.mockResolvedValue([]);
+
+      const context = {
+        toolCallId: '1', messages: [],
+        experimental_context: { userId: 'user-123' } as ToolExecutionContext,
+      };
+
+      const result = await pageWriteTools.trash_page.execute!(
+        { id: 'page-1', withChildren: true },
+        context
+      ) as { success: boolean; childrenCount?: number };
+
+      expect(result.success).toBe(true);
+      // Cascade branch was taken: delete permission checked and descendants enumerated.
+      expect(mockCanUserDeletePage).toHaveBeenCalledWith('user-123', 'page-1');
+      expect(mockPageRepo.getChildIds).toHaveBeenCalledWith('drive-1', 'page-1');
       expect(mockApplyPageMutation).toHaveBeenCalledWith(
         expect.objectContaining({ pageId: 'page-1', operation: 'trash' })
       );

--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -761,13 +761,13 @@ export const pageWriteTools = {
    * Move a page to trash (soft delete)
    */
   trash_page: tool({
-    description: 'Move a page to trash (soft delete). Optionally trash all child pages recursively with withChildren.',
+    description: 'Move a page to trash (soft delete). By default all child pages are trashed recursively with the parent; pass withChildren: false to instead move children up to the grandparent and keep them.',
     inputSchema: z.object({
       id: z.string().describe('The unique ID of the page to trash'),
       title: z.string().optional().describe('Optional page title for display/error context only — the real title is fetched by ID'),
-      withChildren: z.boolean().optional().default(false).describe('Whether to trash all children recursively'),
+      withChildren: z.boolean().optional().default(true).describe('Whether to trash all children recursively (default true). Set false to move children up to the grandparent instead of trashing them.'),
     }),
-    execute: async ({ id, title, withChildren = false }, { experimental_context: context }) => {
+    execute: async ({ id, title, withChildren = true }, { experimental_context: context }) => {
       const userId = (context as ToolExecutionContext)?.userId;
       if (!userId) {
         throw new Error('User authentication required');

--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -248,6 +248,21 @@ async function trashPage(
       });
     }
   } else {
+    // Re-home live children to the grandparent before trashing the parent, mirroring
+    // pageService.trashPage's move-children-up branch. Without this, the children would
+    // be stranded under a trashed parent and surface as bogus top-level sidebar items.
+    const children = await pageRepository.getDirectChildren(page.driveId, page.id);
+    for (const child of children) {
+      await applyPageMutation({
+        pageId: child.id,
+        operation: 'move',
+        updates: { parentId: page.parentId, originalParentId: page.id },
+        updatedFields: ['parentId', 'originalParentId'],
+        expectedRevision: typeof child.revision === 'number' ? child.revision : undefined,
+        context: baseContext,
+      });
+    }
+
     await applyPageMutation({
       pageId: page.id,
       operation: 'trash',

--- a/packages/lib/src/repositories/__tests__/page-repository.test.ts
+++ b/packages/lib/src/repositories/__tests__/page-repository.test.ts
@@ -406,3 +406,35 @@ describe('pageRepository.getChildIds', () => {
     expect(result).toHaveLength(2);
   });
 });
+
+// ---------------------------------------------------------------------------
+// getDirectChildren
+// ---------------------------------------------------------------------------
+describe('pageRepository.getDirectChildren', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('returns only direct live children with their revisions (non-recursive)', async () => {
+    const rows = [
+      { id: 'child-1', revision: 2 },
+      { id: 'child-2', revision: 5 },
+    ];
+    const whereFn = vi.fn().mockResolvedValue(rows);
+    const fromFn = vi.fn().mockReturnValue({ where: whereFn });
+    vi.mocked(db.select).mockReturnValue({ from: fromFn } as unknown as ReturnType<typeof db.select>);
+
+    const result = await pageRepository.getDirectChildren('drive-1', 'page-1');
+
+    expect(result).toEqual(rows);
+    // Single query — does not recurse into grandchildren.
+    expect(db.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns empty array when there are no children', async () => {
+    const whereFn = vi.fn().mockResolvedValue([]);
+    const fromFn = vi.fn().mockReturnValue({ where: whereFn });
+    vi.mocked(db.select).mockReturnValue({ from: fromFn } as unknown as ReturnType<typeof db.select>);
+
+    const result = await pageRepository.getDirectChildren('drive-1', 'page-1');
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/lib/src/repositories/page-repository.ts
+++ b/packages/lib/src/repositories/page-repository.ts
@@ -312,6 +312,23 @@ export const pageRepository = {
 
     return [...childIds, ...grandChildIds];
   },
+
+  /** Direct (non-recursive) live children of a page, with revisions for optimistic-concurrency moves. */
+  getDirectChildren: async (
+    driveId: string,
+    parentId: string
+  ): Promise<{ id: string; revision: number }[]> => {
+    return db
+      .select({ id: pages.id, revision: pages.revision })
+      .from(pages)
+      .where(
+        and(
+          eq(pages.driveId, driveId),
+          eq(pages.parentId, parentId),
+          eq(pages.isTrashed, false)
+        )
+      );
+  },
 };
 
 export type PageRepository = typeof pageRepository;

--- a/scripts/repair-orphaned-trashed-pages.ts
+++ b/scripts/repair-orphaned-trashed-pages.ts
@@ -1,0 +1,92 @@
+import 'dotenv/config';
+import { db } from '@pagespace/db/db';
+import { pages } from '@pagespace/db/schema/core';
+import { inArray, sql } from '@pagespace/db/operators';
+
+/**
+ * Repair pages orphaned by past non-cascading trashes.
+ *
+ * Historically, trashing a page did NOT trash its children by default — it left
+ * them pointing at the now-trashed parent. Because the sidebar fetches only
+ * non-trashed pages and buildTree promotes any node whose parent is absent to the
+ * root, those live descendants surfaced as bogus top-level items.
+ *
+ * Trashing now cascades by default, so no NEW orphans are created. This script
+ * fixes pre-existing ones by making the data consistent: any live page whose
+ * parent (transitively) is trashed is itself moved to the trash — exactly what
+ * would have happened had the original trash cascaded. parentId is left intact, so
+ * restoring the original trashed ancestor recursively brings the whole branch back.
+ *
+ * Pages deliberately re-homed via the "move children up" option are NOT affected:
+ * their parent is a live grandparent, so they are never matched here.
+ *
+ * Dry run (default — reports only, no writes):
+ *   bun scripts/repair-orphaned-trashed-pages.ts
+ * Apply the fix:
+ *   bun scripts/repair-orphaned-trashed-pages.ts --apply
+ * In Docker:
+ *   docker exec <container> bun scripts/repair-orphaned-trashed-pages.ts --apply
+ */
+async function repair(): Promise<void> {
+  const apply = process.argv.includes('--apply');
+  console.log(`Scanning for live pages stranded under a trashed ancestor... (${apply ? 'APPLY' : 'dry run'})`);
+
+  // Live descendants of any trashed page: seed with live children of trashed
+  // pages, then walk down through further live descendants.
+  const orphanRows = await db.execute<{ id: string; driveId: string; title: string }>(sql`
+    WITH RECURSIVE orphans AS (
+      SELECT child.id, child."driveId", child.title
+      FROM pages child
+      JOIN pages parent ON child."parentId" = parent.id
+      WHERE child."isTrashed" = false
+        AND parent."isTrashed" = true
+
+      UNION
+
+      SELECT child.id, child."driveId", child.title
+      FROM pages child
+      JOIN orphans o ON child."parentId" = o.id
+      WHERE child."isTrashed" = false
+    )
+    SELECT id, "driveId", title FROM orphans;
+  `);
+
+  const orphans = orphanRows.rows;
+  console.log(`Found ${orphans.length} stranded page(s).`);
+
+  if (orphans.length === 0) {
+    console.log('Nothing to repair.');
+    return;
+  }
+
+  // Per-drive breakdown for visibility before any writes.
+  const byDrive = new Map<string, number>();
+  for (const o of orphans) byDrive.set(o.driveId, (byDrive.get(o.driveId) ?? 0) + 1);
+  for (const [driveId, count] of byDrive) {
+    console.log(`  drive ${driveId}: ${count} page(s)`);
+  }
+
+  if (!apply) {
+    console.log('\nDry run only — no changes made. Re-run with --apply to trash these pages.');
+    console.log('Sample:', orphans.slice(0, 10).map(o => `${o.title} (${o.id})`));
+    return;
+  }
+
+  const ids = orphans.map(o => o.id);
+  const now = new Date();
+  await db.transaction(async (tx) => {
+    await tx
+      .update(pages)
+      .set({ isTrashed: true, trashedAt: now })
+      .where(inArray(pages.id, ids));
+  });
+
+  console.log(`\nTrashed ${ids.length} stranded page(s). Restoring the original trashed ancestor will bring them back.`);
+}
+
+repair()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error('Repair failed:', error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Problem

Individual pages — most visibly AI-generated task items — were showing up as **top-level entries in the sidebar** even though their breadcrumb shows them nested several levels deep. This is not task-specific; it affects every page type.

### Root cause

Two cooperating facts:

1. **Trash didn't cascade by default.** Trashing a page *moved its children up to the grandparent* instead of trashing them (single-page `DELETE` defaulted `trash_children` to `false`; the AI/MCP `trash_page` tool defaulted `withChildren` to `false`). Any path that left a live descendant pointing at a now-trashed parent stranded that descendant.
2. **The sidebar promotes stranded pages to the root.** `/api/drives/[driveId]/pages` fetches only non-trashed pages, then `buildTree` pushes any node whose parent isn't in that set to the top level. Breadcrumbs, by contrast, walk the live `parentId` chain with no trash filter — which is why the breadcrumb still shows the trashed ancestor while the sidebar floats the child to the root.

## Fix

**Trashing now cascades to children by default** — what users expect (Google-Drive-style) and the condition that stops orphans from ever being created. "Move children up" remains available as an explicit opt-in.

- `app/api/pages/[pageId]/route.ts` — `trash_children` defaults to `true`.
- `lib/ai/tools/page-write-tools.ts` — `trash_page` defaults `withChildren` to `true`; description updated.
- `components/dialogs/DeletePageDialog.tsx` — **Move Page and All Contents** is the primary action; **Move Page Only** is the secondary opt-in; description clarifies the default.

**Existing orphans** are repaired at the data layer (not hidden at display time): `scripts/repair-orphaned-trashed-pages.ts` finds every live page stranded under a trashed ancestor and moves it to the trash — consistent with what cascade would have done. `parentId` is left intact, so restoring the original trashed ancestor brings the whole branch back. Pages deliberately re-homed via "Move Page Only" are never matched (their parent is a live grandparent).

- **Dry-run by default:** `bun scripts/repair-orphaned-trashed-pages.ts` (reports counts + per-drive breakdown, no writes)
- **Apply:** `bun scripts/repair-orphaned-trashed-pages.ts --apply` (or `docker exec <container> ...` in prod)

## Tests

- `[pageId]` route, `page-write-tools`, and `bulk-delete` suites updated/extended for the new cascade default and explicit opt-out.
- typecheck + lint clean; **107 web + 47 lib tests passing** across affected suites.

## Notes

- The repair script needs a live DB; it has not been run against any environment in this PR.
- Restore already cascades symmetrically (`recursivelyRestore`), so trashed subtrees come back intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Follow-up (review)
- **Codex P2:** the AI/MCP `trash_page` tool's `withChildren: false` branch previously trashed the parent without re-homing its children, stranding them under a trashed parent. Fixed in `e7ead9c4` — it now re-homes direct live children to the grandparent (via new `pageRepository.getDirectChildren`) before trashing the parent, matching `pageService.trashPage`. Tests added.