### PR TITLE
feat(billing): AI unit-economics observability (margin queries + admin view)

### DIFF
--- a/apps/web/src/app/admin/AdminLayoutClient.tsx
+++ b/apps/web/src/app/admin/AdminLayoutClient.tsx
@@ -15,7 +15,8 @@ export default function AdminLayoutClient({
   const pathname = usePathname();
   const router = useRouter();
   const currentTab = pathname === '/admin' ? 'overview' :
-                     pathname.includes('/global-prompt') ? 'global-prompt' : 'overview';
+                     pathname.includes('/global-prompt') ? 'global-prompt' :
+                     pathname.includes('/unit-economics') ? 'unit-economics' : 'overview';
 
   return (
     <div className="min-h-screen bg-background px-4 py-6 sm:px-6 lg:px-10">
@@ -45,6 +46,9 @@ export default function AdminLayoutClient({
             </TabsTrigger>
             <TabsTrigger value="global-prompt" asChild>
               <Link href="/admin/global-prompt">Global Prompt</Link>
+            </TabsTrigger>
+            <TabsTrigger value="unit-economics" asChild>
+              <Link href="/admin/unit-economics">Unit Economics</Link>
             </TabsTrigger>
           </TabsList>
 

--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { MessageSquare, ExternalLink } from "lucide-react";
+import { MessageSquare, ExternalLink, TrendingUp } from "lucide-react";
 
 const ADMIN_APP_URL = process.env.NEXT_PUBLIC_ADMIN_APP_URL ?? 'http://localhost:3005';
 
@@ -17,6 +17,17 @@ export default function AdminPage() {
               Global Prompt
             </CardTitle>
             <CardDescription>View AI system prompt and context</CardDescription>
+          </CardHeader>
+        </Card>
+      </Link>
+      <Link href="/admin/unit-economics">
+        <Card className="transition-colors hover:bg-accent h-full">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <TrendingUp className="h-5 w-5" />
+              Unit Economics
+            </CardTitle>
+            <CardDescription>AI real cost vs charged credits, margin, and outstanding debt</CardDescription>
           </CardHeader>
         </Card>
       </Link>

--- a/apps/web/src/app/admin/unit-economics/page.tsx
+++ b/apps/web/src/app/admin/unit-economics/page.tsx
@@ -1,0 +1,439 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { AlertCircle, Download, TrendingUp } from "lucide-react";
+import { fetchWithAuth } from "@/lib/auth/auth-fetch";
+
+type Range = "24h" | "7d" | "30d" | "all";
+type Granularity = "day" | "month";
+
+interface Summary {
+  realCostCents: number;
+  chargedCents: number;
+  appliedCents: number;
+  requestCount: number;
+  debtCents: number;
+  marginCents: number;
+  marginPct: number | null;
+}
+
+interface PeriodRow {
+  period: string;
+  realCostCents: number;
+  chargedCents: number;
+  appliedCents: number;
+  requestCount: number;
+  marginCents: number;
+  marginPct: number | null;
+}
+
+interface ModelRow {
+  provider: string;
+  model: string;
+  realCostCents: number;
+  chargedCents: number;
+  appliedCents: number;
+  requestCount: number;
+  marginCents: number;
+  marginPct: number | null;
+}
+
+interface SpenderRow {
+  userId: string;
+  userName: string | null;
+  userEmail: string | null;
+  realCostCents: number;
+  chargedCents: number;
+  appliedCents: number;
+  requestCount: number;
+  marginCents: number;
+  marginPct: number | null;
+}
+
+interface DebtRow {
+  userId: string;
+  userName: string | null;
+  userEmail: string | null;
+  debtCents: number;
+}
+
+interface UnitEconomicsResponse {
+  range: Range;
+  granularity: Granularity;
+  summary: Summary;
+  byPeriod: PeriodRow[];
+  byModel: ModelRow[];
+  topSpenders: SpenderRow[];
+  debtByUser: DebtRow[];
+}
+
+function usd(cents: number): string {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(cents / 100);
+}
+
+function pct(value: number | null): string {
+  return value === null ? "—" : `${value.toFixed(1)}%`;
+}
+
+function marginClass(value: number | null): string {
+  if (value === null) return "text-muted-foreground";
+  if (value < 0) return "text-red-600 dark:text-red-400";
+  return "text-green-600 dark:text-green-400";
+}
+
+function userLabel(row: { userName: string | null; userEmail: string | null; userId: string }): string {
+  return row.userEmail ?? row.userName ?? row.userId;
+}
+
+export default function AdminUnitEconomicsPage() {
+  const [data, setData] = useState<UnitEconomicsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [range, setRange] = useState<Range>("30d");
+  const [granularity, setGranularity] = useState<Granularity>("day");
+
+  const fetchData = useCallback(async (r: Range, g: Granularity) => {
+    try {
+      setLoading(true);
+      const params = new URLSearchParams({ range: r, granularity: g });
+      const response = await fetchWithAuth(`/api/admin/unit-economics?${params.toString()}`);
+      if (!response.ok) {
+        throw new Error("Failed to fetch unit-economics data");
+      }
+      const json = (await response.json()) as UnitEconomicsResponse;
+      setData(json);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData(range, granularity);
+  }, [fetchData, range, granularity]);
+
+  const downloadCsv = useCallback(async () => {
+    const params = new URLSearchParams({ range, granularity, format: "csv" });
+    const response = await fetchWithAuth(`/api/admin/unit-economics?${params.toString()}`);
+    if (!response.ok) return;
+    const blob = await response.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `unit-economics-${range}.csv`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }, [range, granularity]);
+
+  if (loading && !data) {
+    return (
+      <div className="space-y-4">
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-8 w-64" />
+            <Skeleton className="h-4 w-96" />
+          </CardHeader>
+        </Card>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {[...Array(4)].map((_, i) => (
+            <Card key={i}>
+              <CardHeader>
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-8 w-32" />
+              </CardHeader>
+            </Card>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error && !data) {
+    return (
+      <Alert variant="destructive">
+        <AlertCircle className="h-4 w-4" />
+        <AlertDescription>Error loading unit economics: {error}</AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (!data) {
+    return (
+      <Alert variant="destructive">
+        <AlertCircle className="h-4 w-4" />
+        <AlertDescription>No data received</AlertDescription>
+      </Alert>
+    );
+  }
+
+  const { summary } = data;
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <TrendingUp className="h-5 w-5" />
+            AI Unit Economics
+          </CardTitle>
+          <CardDescription>
+            Real provider cost vs charged credits and gross margin, per period, model, and user.
+            All figures are in USD.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-wrap items-end gap-4">
+            <div className="flex flex-col gap-1.5">
+              <Label className="text-xs text-muted-foreground">Range</Label>
+              <Select value={range} onValueChange={(v) => setRange(v as Range)}>
+                <SelectTrigger className="w-[140px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="24h">Last 24 hours</SelectItem>
+                  <SelectItem value="7d">Last 7 days</SelectItem>
+                  <SelectItem value="30d">Last 30 days</SelectItem>
+                  <SelectItem value="all">All time</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label className="text-xs text-muted-foreground">Granularity</Label>
+              <Select value={granularity} onValueChange={(v) => setGranularity(v as Granularity)}>
+                <SelectTrigger className="w-[120px]">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="day">Daily</SelectItem>
+                  <SelectItem value="month">Monthly</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <Button variant="outline" size="sm" onClick={downloadCsv} className="gap-2">
+              <Download className="h-4 w-4" />
+              Export CSV
+            </Button>
+            {loading && <span className="text-sm text-muted-foreground">Loading…</span>}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Summary cards */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Real cost</CardDescription>
+            <CardTitle className="text-2xl">{usd(summary.realCostCents)}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Charged credits</CardDescription>
+            <CardTitle className="text-2xl">{usd(summary.chargedCents)}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Gross margin</CardDescription>
+            <CardTitle className={`text-2xl ${marginClass(summary.marginPct)}`}>
+              {usd(summary.marginCents)}
+              <span className="ml-2 text-base">({pct(summary.marginPct)})</span>
+            </CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Outstanding debt</CardDescription>
+            <CardTitle className="text-2xl">{usd(summary.debtCents)}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Requests</CardDescription>
+            <CardTitle className="text-2xl">{summary.requestCount.toLocaleString()}</CardTitle>
+          </CardHeader>
+        </Card>
+      </div>
+
+      {/* Margin by model/provider */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Margin by model</CardTitle>
+          <CardDescription>Which providers and models earn or lose money.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {data.byModel.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No billed AI usage in this range.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Provider</TableHead>
+                  <TableHead>Model</TableHead>
+                  <TableHead className="text-right">Real cost</TableHead>
+                  <TableHead className="text-right">Charged</TableHead>
+                  <TableHead className="text-right">Margin</TableHead>
+                  <TableHead className="text-right">Margin %</TableHead>
+                  <TableHead className="text-right">Requests</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data.byModel.map((row) => (
+                  <TableRow key={`${row.provider}/${row.model}`}>
+                    <TableCell>{row.provider}</TableCell>
+                    <TableCell className="font-mono text-xs">{row.model}</TableCell>
+                    <TableCell className="text-right">{usd(row.realCostCents)}</TableCell>
+                    <TableCell className="text-right">{usd(row.chargedCents)}</TableCell>
+                    <TableCell className={`text-right ${marginClass(row.marginPct)}`}>
+                      {usd(row.marginCents)}
+                    </TableCell>
+                    <TableCell className={`text-right ${marginClass(row.marginPct)}`}>
+                      {pct(row.marginPct)}
+                    </TableCell>
+                    <TableCell className="text-right">{row.requestCount.toLocaleString()}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Top spenders */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Top spenders</CardTitle>
+          <CardDescription>Users by charged credits, with our real cost and margin.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {data.topSpenders.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No billed AI usage in this range.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>User</TableHead>
+                  <TableHead className="text-right">Real cost</TableHead>
+                  <TableHead className="text-right">Charged</TableHead>
+                  <TableHead className="text-right">Margin</TableHead>
+                  <TableHead className="text-right">Margin %</TableHead>
+                  <TableHead className="text-right">Requests</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data.topSpenders.map((row) => (
+                  <TableRow key={row.userId}>
+                    <TableCell className="max-w-[260px] truncate">{userLabel(row)}</TableCell>
+                    <TableCell className="text-right">{usd(row.realCostCents)}</TableCell>
+                    <TableCell className="text-right">{usd(row.chargedCents)}</TableCell>
+                    <TableCell className={`text-right ${marginClass(row.marginPct)}`}>
+                      {usd(row.marginCents)}
+                    </TableCell>
+                    <TableCell className={`text-right ${marginClass(row.marginPct)}`}>
+                      {pct(row.marginPct)}
+                    </TableCell>
+                    <TableCell className="text-right">{row.requestCount.toLocaleString()}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Outstanding debt */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Outstanding debt</CardTitle>
+          <CardDescription>Uncovered AI cost we couldn&apos;t collect, by user.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {data.debtByUser.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No outstanding debt in this range.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>User</TableHead>
+                  <TableHead className="text-right">Debt</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data.debtByUser.map((row) => (
+                  <TableRow key={row.userId}>
+                    <TableCell className="max-w-[260px] truncate">{userLabel(row)}</TableCell>
+                    <TableCell className="text-right text-red-600 dark:text-red-400">
+                      {usd(row.debtCents)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Margin over time */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Margin over time</CardTitle>
+          <CardDescription>Real cost vs charged credits per {granularity === "month" ? "month" : "day"}.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {data.byPeriod.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No billed AI usage in this range.</p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Period</TableHead>
+                  <TableHead className="text-right">Real cost</TableHead>
+                  <TableHead className="text-right">Charged</TableHead>
+                  <TableHead className="text-right">Margin</TableHead>
+                  <TableHead className="text-right">Margin %</TableHead>
+                  <TableHead className="text-right">Requests</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data.byPeriod.map((row) => (
+                  <TableRow key={row.period}>
+                    <TableCell className="font-mono text-xs">
+                      {new Date(row.period).toLocaleDateString()}
+                    </TableCell>
+                    <TableCell className="text-right">{usd(row.realCostCents)}</TableCell>
+                    <TableCell className="text-right">{usd(row.chargedCents)}</TableCell>
+                    <TableCell className={`text-right ${marginClass(row.marginPct)}`}>
+                      {usd(row.marginCents)}
+                    </TableCell>
+                    <TableCell className={`text-right ${marginClass(row.marginPct)}`}>
+                      {pct(row.marginPct)}
+                    </TableCell>
+                    <TableCell className="text-right">{row.requestCount.toLocaleString()}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/app/api/admin/unit-economics/route.ts
+++ b/apps/web/src/app/api/admin/unit-economics/route.ts
@@ -1,0 +1,175 @@
+import { NextResponse } from 'next/server';
+import { withAdminAuth } from '@/lib/auth';
+import {
+  getDateRange,
+  getUnitEconomicsSummary,
+  getMarginByPeriod,
+  getMarginByModel,
+  getTopSpendersByMargin,
+  getOutstandingDebtByUser,
+  type Granularity,
+} from '@/lib/monitoring';
+import { loggers } from '@pagespace/lib/logging/logger-config';
+
+type Range = '24h' | '7d' | '30d' | 'all';
+
+function parseRange(value: string | null): Range {
+  return value === '24h' || value === '7d' || value === '30d' || value === 'all' ? value : '30d';
+}
+
+function parseGranularity(value: string | null): Granularity {
+  return value === 'month' ? 'month' : 'day';
+}
+
+function centsToDollars(cents: number): string {
+  return (cents / 100).toFixed(2);
+}
+
+/** Escape a CSV field per RFC 4180 (quote if it contains comma, quote, or newline). */
+function csvField(value: string | number | null): string {
+  const s = value === null ? '' : String(value);
+  return /[",\n\r]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+function toCsv(rows: (string | number | null)[][]): string {
+  return rows.map((row) => row.map(csvField).join(',')).join('\r\n');
+}
+
+/**
+ * GET /api/admin/unit-economics
+ * AI unit-economics snapshot: real provider cost vs charged credits, gross
+ * margin, per model/provider, top spenders, and outstanding debt.
+ * ADMIN ONLY — exposes revenue/cost internals.
+ *
+ * Query params:
+ *   - range:       24h | 7d | 30d (default) | all
+ *   - granularity: day (default) | month — period bucketing for the time series
+ *   - format:      json (default) | csv — csv emits a monthly cost-vs-revenue snapshot
+ */
+export const GET = withAdminAuth(async (_adminUser, request) => {
+  try {
+    const { searchParams } = new URL(request.url);
+    const range = parseRange(searchParams.get('range'));
+    const granularity = parseGranularity(searchParams.get('granularity'));
+    const format = searchParams.get('format') === 'csv' ? 'csv' : 'json';
+
+    const { startDate, endDate } = getDateRange(range);
+
+    const [summary, byPeriod, byModel, topSpenders, debtByUser] = await Promise.all([
+      getUnitEconomicsSummary(startDate, endDate),
+      getMarginByPeriod(startDate, endDate, granularity),
+      getMarginByModel(startDate, endDate),
+      getTopSpendersByMargin(startDate, endDate, 10),
+      getOutstandingDebtByUser(startDate, endDate, 10),
+    ]);
+
+    if (format === 'csv') {
+      const header = [
+        'section',
+        'key',
+        'realCostUSD',
+        'chargedUSD',
+        'appliedUSD',
+        'marginUSD',
+        'marginPct',
+        'requests',
+        'debtUSD',
+      ];
+      const rows: (string | number | null)[][] = [header];
+
+      rows.push([
+        'summary',
+        range,
+        centsToDollars(summary.realCostCents),
+        centsToDollars(summary.chargedCents),
+        centsToDollars(summary.appliedCents),
+        centsToDollars(summary.marginCents),
+        summary.marginPct === null ? '' : summary.marginPct.toFixed(2),
+        summary.requestCount,
+        centsToDollars(summary.debtCents),
+      ]);
+
+      for (const r of byPeriod) {
+        rows.push([
+          'period',
+          typeof r.period === 'string' ? r.period : String(r.period),
+          centsToDollars(r.realCostCents),
+          centsToDollars(r.chargedCents),
+          centsToDollars(r.appliedCents),
+          centsToDollars(r.marginCents),
+          r.marginPct === null ? '' : r.marginPct.toFixed(2),
+          r.requestCount,
+          '',
+        ]);
+      }
+
+      for (const r of byModel) {
+        rows.push([
+          'model',
+          `${r.provider}/${r.model}`,
+          centsToDollars(r.realCostCents),
+          centsToDollars(r.chargedCents),
+          centsToDollars(r.appliedCents),
+          centsToDollars(r.marginCents),
+          r.marginPct === null ? '' : r.marginPct.toFixed(2),
+          r.requestCount,
+          '',
+        ]);
+      }
+
+      for (const r of topSpenders) {
+        rows.push([
+          'spender',
+          r.userEmail ?? r.userName ?? r.userId,
+          centsToDollars(r.realCostCents),
+          centsToDollars(r.chargedCents),
+          centsToDollars(r.appliedCents),
+          centsToDollars(r.marginCents),
+          r.marginPct === null ? '' : r.marginPct.toFixed(2),
+          r.requestCount,
+          '',
+        ]);
+      }
+
+      for (const r of debtByUser) {
+        rows.push([
+          'debt',
+          r.userEmail ?? r.userName ?? r.userId,
+          '',
+          '',
+          '',
+          '',
+          '',
+          '',
+          centsToDollars(r.debtCents),
+        ]);
+      }
+
+      return new NextResponse(toCsv(rows), {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/csv; charset=utf-8',
+          'Content-Disposition': `attachment; filename="unit-economics-${range}.csv"`,
+        },
+      });
+    }
+
+    return NextResponse.json({
+      range,
+      granularity,
+      startDate,
+      endDate,
+      summary,
+      byPeriod,
+      byModel,
+      topSpenders,
+      debtByUser,
+    });
+  } catch (error) {
+    loggers.api.error('Error fetching unit-economics data:', error as Error);
+    return NextResponse.json(
+      { error: 'Failed to fetch unit-economics data' },
+      { status: 500 },
+    );
+  }
+});

--- a/apps/web/src/lib/monitoring/__tests__/unit-economics-queries.test.ts
+++ b/apps/web/src/lib/monitoring/__tests__/unit-economics-queries.test.ts
@@ -65,6 +65,7 @@ vi.mock('@pagespace/db/schema/credits', () => ({
     bucket: 'CREDIT_LEDGER_BUCKET',
     amountCents: 'CREDIT_LEDGER_AMOUNT_CENTS',
     appliedCents: 'CREDIT_LEDGER_APPLIED_CENTS',
+    chargeMillicents: 'CREDIT_LEDGER_CHARGE_MILLICENTS',
     realCostCents: 'CREDIT_LEDGER_REAL_COST_CENTS',
     aiUsageLogId: 'CREDIT_LEDGER_AI_USAGE_LOG_ID',
     createdAt: 'CREDIT_LEDGER_CREATED_AT',

--- a/apps/web/src/lib/monitoring/__tests__/unit-economics-queries.test.ts
+++ b/apps/web/src/lib/monitoring/__tests__/unit-economics-queries.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Hoisted mock state ────────────────────────────────────────────────────────
+// A FIFO queue of result sets. Each call to db.select() dequeues the next set,
+// in the order the queries run. Tests push the rows they want each query to see.
+const resultQueue = vi.hoisted(() => [] as unknown[][]);
+
+const mockEq = vi.hoisted(() => vi.fn((col: unknown, val: unknown) => ({ type: 'eq', col, val })));
+const mockGte = vi.hoisted(() => vi.fn((col: unknown, val: unknown) => ({ type: 'gte', col, val })));
+const mockLte = vi.hoisted(() => vi.fn((col: unknown, val: unknown) => ({ type: 'lte', col, val })));
+const mockAnd = vi.hoisted(() => vi.fn((...args: unknown[]) => ({ type: 'and', args })));
+const mockDesc = vi.hoisted(() => vi.fn((col: unknown) => col));
+const mockCount = vi.hoisted(() => vi.fn(() => 'COUNT'));
+const mockSql = vi.hoisted(() => {
+  const tag = vi.fn(() => 'SQL') as unknown as { (..._a: unknown[]): string; raw: (s: string) => string };
+  tag.raw = vi.fn((s: string) => s) as unknown as (s: string) => string;
+  return tag;
+});
+
+// Chainable db mock whose terminal resolves to the next queued result set.
+const makeChain = vi.hoisted(() => () => {
+  const rows = resultQueue.length ? resultQueue.shift()! : [];
+  const promise = Promise.resolve(rows);
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.innerJoin = vi.fn(() => chain);
+  chain.where = vi.fn(() => chain);
+  chain.groupBy = vi.fn(() => chain);
+  chain.orderBy = vi.fn(() => chain);
+  chain.limit = vi.fn(() => promise);
+  chain.then = (resolve: (v: unknown[]) => void, reject?: (e: unknown) => void) =>
+    promise.then(resolve, reject);
+  return chain;
+});
+
+const mockSelect = vi.hoisted(() => vi.fn(() => makeChain()));
+
+vi.mock('@pagespace/db/db', () => ({
+  db: { select: mockSelect },
+}));
+
+vi.mock('@pagespace/db/schema/monitoring', () => ({
+  aiUsageLogs: {
+    id: 'AI_USAGE_ID',
+    timestamp: 'AI_USAGE_TIMESTAMP',
+    provider: 'AI_USAGE_PROVIDER',
+    model: 'AI_USAGE_MODEL',
+    cost: 'AI_USAGE_COST',
+    totalTokens: 'AI_USAGE_TOTAL_TOKENS',
+    success: 'AI_USAGE_SUCCESS',
+    userId: 'AI_USAGE_USER_ID',
+    conversationId: 'AI_USAGE_CONVERSATION_ID',
+  },
+  systemLogs: {},
+  errorLogs: {},
+  apiMetrics: {},
+  userActivities: {},
+}));
+
+vi.mock('@pagespace/db/schema/credits', () => ({
+  creditLedger: {
+    id: 'CREDIT_LEDGER_ID',
+    userId: 'CREDIT_LEDGER_USER_ID',
+    entryType: 'CREDIT_LEDGER_ENTRY_TYPE',
+    bucket: 'CREDIT_LEDGER_BUCKET',
+    amountCents: 'CREDIT_LEDGER_AMOUNT_CENTS',
+    appliedCents: 'CREDIT_LEDGER_APPLIED_CENTS',
+    realCostCents: 'CREDIT_LEDGER_REAL_COST_CENTS',
+    aiUsageLogId: 'CREDIT_LEDGER_AI_USAGE_LOG_ID',
+    createdAt: 'CREDIT_LEDGER_CREATED_AT',
+  },
+}));
+
+vi.mock('@pagespace/db/schema/auth', () => ({
+  users: { id: 'USERS_ID', name: 'USERS_NAME', email: 'USERS_EMAIL' },
+}));
+
+vi.mock('@pagespace/db/operators', () => ({
+  sql: mockSql,
+  eq: mockEq,
+  gte: mockGte,
+  lte: mockLte,
+  and: mockAnd,
+  or: vi.fn((...args: unknown[]) => ({ type: 'or', args })),
+  desc: mockDesc,
+  count: mockCount,
+}));
+
+import {
+  computeMarginPct,
+  getUnitEconomicsSummary,
+  getMarginByPeriod,
+  getMarginByModel,
+  getTopSpendersByMargin,
+  getOutstandingDebtByUser,
+} from '../monitoring-queries';
+
+function resetQueue(...sets: unknown[][]) {
+  resultQueue.length = 0;
+  resultQueue.push(...sets);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resultQueue.length = 0;
+  mockSelect.mockImplementation(() => makeChain());
+});
+
+describe('computeMarginPct', () => {
+  it('returns positive margin when charged exceeds real cost', () => {
+    expect(computeMarginPct(100, 150)).toBeCloseTo(50);
+  });
+
+  it('returns negative margin when charged is below real cost', () => {
+    expect(computeMarginPct(200, 150)).toBeCloseTo(-25);
+  });
+
+  it('returns null when real cost is zero (margin undefined)', () => {
+    expect(computeMarginPct(0, 150)).toBeNull();
+  });
+
+  it('returns null when real cost is negative (defensive)', () => {
+    expect(computeMarginPct(-10, 150)).toBeNull();
+  });
+
+  it('returns 0 when charged equals real cost', () => {
+    expect(computeMarginPct(100, 100)).toBe(0);
+  });
+});
+
+describe('getUnitEconomicsSummary', () => {
+  it('combines usage aggregate and debt aggregate into a margin summary', async () => {
+    resetQueue(
+      [{ realCostCents: 100, chargedCents: 150, appliedCents: 140, requestCount: 3 }],
+      [{ debtCents: 10 }],
+    );
+
+    const result = await getUnitEconomicsSummary();
+
+    expect(result).toEqual({
+      realCostCents: 100,
+      chargedCents: 150,
+      appliedCents: 140,
+      requestCount: 3,
+      debtCents: 10,
+      marginCents: 50,
+      marginPct: 50,
+    });
+  });
+
+  it('filters the usage aggregate to entryType = usage', async () => {
+    resetQueue([{ realCostCents: 0, chargedCents: 0, appliedCents: 0, requestCount: 0 }], [{ debtCents: 0 }]);
+
+    await getUnitEconomicsSummary();
+
+    const eqArgs = mockEq.mock.calls.map((c) => [c[0], c[1]]);
+    expect(eqArgs).toContainEqual(['CREDIT_LEDGER_ENTRY_TYPE', 'usage']);
+    expect(eqArgs).toContainEqual(['CREDIT_LEDGER_ENTRY_TYPE', 'adjustment']);
+  });
+
+  it('handles empty result sets by defaulting to zero', async () => {
+    resetQueue([], []);
+
+    const result = await getUnitEconomicsSummary();
+
+    expect(result.realCostCents).toBe(0);
+    expect(result.chargedCents).toBe(0);
+    expect(result.debtCents).toBe(0);
+    expect(result.marginPct).toBeNull();
+  });
+
+  it('applies date filters on aiUsageLogs.timestamp when provided', async () => {
+    resetQueue([{ realCostCents: 0, chargedCents: 0, appliedCents: 0, requestCount: 0 }], [{ debtCents: 0 }]);
+    const start = new Date('2026-01-01');
+    const end = new Date('2026-02-01');
+
+    await getUnitEconomicsSummary(start, end);
+
+    const gteCols = mockGte.mock.calls.map((c) => c[0]);
+    const lteCols = mockLte.mock.calls.map((c) => c[0]);
+    expect(gteCols).toContain('AI_USAGE_TIMESTAMP');
+    expect(lteCols).toContain('AI_USAGE_TIMESTAMP');
+    // debt aggregate filters on the ledger's own createdAt, independent of usage logs
+    expect(gteCols).toContain('CREDIT_LEDGER_CREATED_AT');
+    expect(lteCols).toContain('CREDIT_LEDGER_CREATED_AT');
+  });
+});
+
+describe('getMarginByPeriod', () => {
+  it('computes margin per period row', async () => {
+    resetQueue([
+      { period: '2026-01-02', realCostCents: 200, chargedCents: 300, appliedCents: 300, requestCount: 5 },
+      { period: '2026-01-01', realCostCents: 100, chargedCents: 100, appliedCents: 100, requestCount: 2 },
+    ]);
+
+    const rows = await getMarginByPeriod();
+
+    expect(rows[0]).toMatchObject({ period: '2026-01-02', marginCents: 100, marginPct: 50 });
+    expect(rows[1]).toMatchObject({ period: '2026-01-01', marginCents: 0, marginPct: 0 });
+  });
+
+  it('rejects an invalid granularity to prevent SQL injection', async () => {
+    await expect(
+      // @ts-expect-error intentional invalid granularity
+      getMarginByPeriod(undefined, undefined, 'day; DROP TABLE'),
+    ).rejects.toThrow();
+  });
+});
+
+describe('getMarginByModel', () => {
+  it('returns per model/provider margin', async () => {
+    resetQueue([
+      { provider: 'anthropic', model: 'claude', realCostCents: 100, chargedCents: 150, appliedCents: 150, requestCount: 4 },
+    ]);
+
+    const rows = await getMarginByModel();
+
+    expect(rows[0]).toMatchObject({ provider: 'anthropic', model: 'claude', marginCents: 50, marginPct: 50 });
+  });
+});
+
+describe('getTopSpendersByMargin', () => {
+  it('returns per user margin ordered by charged spend', async () => {
+    resetQueue([
+      { userId: 'u1', userName: 'Alice', userEmail: 'a@x.com', realCostCents: 100, chargedCents: 150, appliedCents: 150, requestCount: 9 },
+    ]);
+
+    const rows = await getTopSpendersByMargin();
+
+    expect(rows[0]).toMatchObject({ userId: 'u1', userName: 'Alice', marginCents: 50, marginPct: 50 });
+  });
+});
+
+describe('getOutstandingDebtByUser', () => {
+  it('returns per user uncovered debt from adjustment rows', async () => {
+    resetQueue([
+      { userId: 'u1', userName: 'Alice', userEmail: 'a@x.com', debtCents: 25 },
+    ]);
+
+    const rows = await getOutstandingDebtByUser();
+
+    expect(rows[0]).toMatchObject({ userId: 'u1', debtCents: 25 });
+    const eqArgs = mockEq.mock.calls.map((c) => [c[0], c[1]]);
+    expect(eqArgs).toContainEqual(['CREDIT_LEDGER_ENTRY_TYPE', 'adjustment']);
+  });
+});

--- a/apps/web/src/lib/monitoring/monitoring-queries.ts
+++ b/apps/web/src/lib/monitoring/monitoring-queries.ts
@@ -6,6 +6,7 @@ import { db } from '@pagespace/db/db'
 import { sql, eq, and, or, gte, lte, desc, count } from '@pagespace/db/operators'
 import { users } from '@pagespace/db/schema/auth'
 import { apiMetrics, userActivities, aiUsageLogs, systemLogs, errorLogs } from '@pagespace/db/schema/monitoring';
+import { creditLedger } from '@pagespace/db/schema/credits';
 import type { SQL } from '@pagespace/db/operators';
 
 /**
@@ -439,6 +440,273 @@ export async function getPerformanceMetrics(startDate?: Date, endDate?: Date) {
     slowQueries,
     metricTypes,
   };
+}
+
+// ── AI unit economics (real cost vs charged credits vs margin) ────────────────
+//
+// The metering data already exists; these queries only aggregate it:
+//   - creditLedger.realCostCents   — our REAL provider cost, pre-markup (cents)
+//   - creditLedger.amountCents      — full intended charge to the user (signed)
+//   - creditLedger.appliedCents     — actually debited from the balance (signed)
+//   - 'adjustment' rows             — uncovered debt (charge we couldn't collect)
+// Each AI call has exactly one entryType='usage' ledger row, soft-linked to its
+// aiUsageLogs row via aiUsageLogId, so a join reaches provider/model/timestamp.
+// All magnitudes are taken as ABS() because usage/debt rows store negative values.
+
+export type Granularity = 'day' | 'month';
+
+export interface UnitEconomicsSummary {
+  realCostCents: number;
+  chargedCents: number;
+  appliedCents: number;
+  requestCount: number;
+  debtCents: number;
+  marginCents: number;
+  marginPct: number | null;
+}
+
+export interface MarginByPeriodRow {
+  period: string;
+  realCostCents: number;
+  chargedCents: number;
+  appliedCents: number;
+  requestCount: number;
+  marginCents: number;
+  marginPct: number | null;
+}
+
+export interface MarginByModelRow {
+  provider: string;
+  model: string;
+  realCostCents: number;
+  chargedCents: number;
+  appliedCents: number;
+  requestCount: number;
+  marginCents: number;
+  marginPct: number | null;
+}
+
+export interface TopSpenderRow {
+  userId: string;
+  userName: string | null;
+  userEmail: string | null;
+  realCostCents: number;
+  chargedCents: number;
+  appliedCents: number;
+  requestCount: number;
+  marginCents: number;
+  marginPct: number | null;
+}
+
+export interface DebtByUserRow {
+  userId: string;
+  userName: string | null;
+  userEmail: string | null;
+  debtCents: number;
+}
+
+/**
+ * Gross margin as a percentage of real cost: (charged − real) / real × 100.
+ * Returns null when real cost is non-positive, since the percentage is then
+ * undefined (a charge against zero cost is infinite margin, not a number).
+ */
+export function computeMarginPct(realCostCents: number, chargedCents: number): number | null {
+  if (!realCostCents || realCostCents <= 0) return null;
+  return ((chargedCents - realCostCents) / realCostCents) * 100;
+}
+
+// Reusable SQL aggregate expressions over the ledger usage rows.
+const realCostSum = sql<number>`COALESCE(SUM(ABS(${creditLedger.realCostCents})), 0)::int`;
+const chargedSum = sql<number>`COALESCE(SUM(ABS(${creditLedger.amountCents})), 0)::int`;
+const appliedSum = sql<number>`COALESCE(SUM(ABS(${creditLedger.appliedCents})), 0)::int`;
+
+/** Usage-row conditions: entryType='usage' plus optional aiUsageLogs.timestamp range. */
+function usageConditions(startDate?: Date, endDate?: Date): SQL[] {
+  const conditions: SQL[] = [eq(creditLedger.entryType, 'usage')];
+  if (startDate) conditions.push(gte(aiUsageLogs.timestamp, startDate));
+  if (endDate) conditions.push(lte(aiUsageLogs.timestamp, endDate));
+  return conditions;
+}
+
+/**
+ * Total real cost vs charged credits, gross margin, request count, and
+ * uncovered debt across the period.
+ */
+export async function getUnitEconomicsSummary(
+  startDate?: Date,
+  endDate?: Date,
+): Promise<UnitEconomicsSummary> {
+  const usage = await db
+    .select({
+      realCostCents: realCostSum,
+      chargedCents: chargedSum,
+      appliedCents: appliedSum,
+      requestCount: count(),
+    })
+    .from(creditLedger)
+    .innerJoin(aiUsageLogs, eq(creditLedger.aiUsageLogId, aiUsageLogs.id))
+    .where(and(...usageConditions(startDate, endDate)));
+
+  // Debt is summed directly from adjustment rows (no join): an adjustment can
+  // outlive its aiUsageLog after retention purges, and we never want to
+  // under-report outstanding debt. Filter on the ledger's own createdAt.
+  const debtConditions: SQL[] = [eq(creditLedger.entryType, 'adjustment')];
+  if (startDate) debtConditions.push(gte(creditLedger.createdAt, startDate));
+  if (endDate) debtConditions.push(lte(creditLedger.createdAt, endDate));
+
+  const debt = await db
+    .select({ debtCents: chargedSum })
+    .from(creditLedger)
+    .where(and(...debtConditions));
+
+  const realCostCents = usage[0]?.realCostCents ?? 0;
+  const chargedCents = usage[0]?.chargedCents ?? 0;
+  const appliedCents = usage[0]?.appliedCents ?? 0;
+  const requestCount = usage[0]?.requestCount ?? 0;
+  const debtCents = debt[0]?.debtCents ?? 0;
+
+  return {
+    realCostCents,
+    chargedCents,
+    appliedCents,
+    requestCount,
+    debtCents,
+    marginCents: chargedCents - realCostCents,
+    marginPct: computeMarginPct(realCostCents, chargedCents),
+  };
+}
+
+/**
+ * Margin per period (day or month) over the requested window.
+ */
+export async function getMarginByPeriod(
+  startDate?: Date,
+  endDate?: Date,
+  granularity: Granularity = 'day',
+): Promise<MarginByPeriodRow[]> {
+  if (granularity !== 'day' && granularity !== 'month') {
+    throw new Error(`Invalid granularity: ${granularity}`);
+  }
+  // Bound parameter, not string interpolation — DATE_TRUNC's unit is a value.
+  const periodExpr = sql<string>`DATE_TRUNC(${granularity}, ${aiUsageLogs.timestamp})`;
+
+  const rows = await db
+    .select({
+      period: periodExpr,
+      realCostCents: realCostSum,
+      chargedCents: chargedSum,
+      appliedCents: appliedSum,
+      requestCount: count(),
+    })
+    .from(creditLedger)
+    .innerJoin(aiUsageLogs, eq(creditLedger.aiUsageLogId, aiUsageLogs.id))
+    .where(and(...usageConditions(startDate, endDate)))
+    .groupBy(periodExpr)
+    .orderBy(desc(periodExpr))
+    .limit(366);
+
+  return rows.map((r) => ({
+    ...r,
+    marginCents: r.chargedCents - r.realCostCents,
+    marginPct: computeMarginPct(r.realCostCents, r.chargedCents),
+  }));
+}
+
+/**
+ * Margin per provider/model — surfaces which models earn or lose money.
+ */
+export async function getMarginByModel(
+  startDate?: Date,
+  endDate?: Date,
+): Promise<MarginByModelRow[]> {
+  const rows = await db
+    .select({
+      provider: aiUsageLogs.provider,
+      model: aiUsageLogs.model,
+      realCostCents: realCostSum,
+      chargedCents: chargedSum,
+      appliedCents: appliedSum,
+      requestCount: count(),
+    })
+    .from(creditLedger)
+    .innerJoin(aiUsageLogs, eq(creditLedger.aiUsageLogId, aiUsageLogs.id))
+    .where(and(...usageConditions(startDate, endDate)))
+    .groupBy(aiUsageLogs.provider, aiUsageLogs.model)
+    .orderBy(desc(realCostSum))
+    .limit(50);
+
+  return rows.map((r) => ({
+    ...r,
+    marginCents: r.chargedCents - r.realCostCents,
+    marginPct: computeMarginPct(r.realCostCents, r.chargedCents),
+  }));
+}
+
+/**
+ * Top spenders by charged credits, with their real cost and margin.
+ */
+export async function getTopSpendersByMargin(
+  startDate?: Date,
+  endDate?: Date,
+  limit = 10,
+): Promise<TopSpenderRow[]> {
+  const rows = await db
+    .select({
+      userId: creditLedger.userId,
+      userName: users.name,
+      userEmail: users.email,
+      realCostCents: realCostSum,
+      chargedCents: chargedSum,
+      appliedCents: appliedSum,
+      requestCount: count(),
+    })
+    .from(creditLedger)
+    .innerJoin(aiUsageLogs, eq(creditLedger.aiUsageLogId, aiUsageLogs.id))
+    .innerJoin(users, eq(creditLedger.userId, users.id))
+    .where(and(...usageConditions(startDate, endDate)))
+    .groupBy(creditLedger.userId, users.name, users.email)
+    .orderBy(desc(chargedSum))
+    .limit(limit);
+
+  return rows.map((r) => ({
+    ...r,
+    marginCents: r.chargedCents - r.realCostCents,
+    marginPct: computeMarginPct(r.realCostCents, r.chargedCents),
+  }));
+}
+
+/**
+ * Users carrying the most uncovered debt (sum of 'adjustment' rows).
+ */
+export async function getOutstandingDebtByUser(
+  startDate?: Date,
+  endDate?: Date,
+  limit = 10,
+): Promise<DebtByUserRow[]> {
+  const conditions: SQL[] = [eq(creditLedger.entryType, 'adjustment')];
+  if (startDate) conditions.push(gte(creditLedger.createdAt, startDate));
+  if (endDate) conditions.push(lte(creditLedger.createdAt, endDate));
+
+  const rows = await db
+    .select({
+      userId: creditLedger.userId,
+      userName: users.name,
+      userEmail: users.email,
+      debtCents: chargedSum,
+    })
+    .from(creditLedger)
+    .innerJoin(users, eq(creditLedger.userId, users.id))
+    .where(and(...conditions))
+    .groupBy(creditLedger.userId, users.name, users.email)
+    .orderBy(desc(chargedSum))
+    .limit(limit);
+
+  return rows.map((r) => ({
+    userId: r.userId,
+    userName: r.userName,
+    userEmail: r.userEmail,
+    debtCents: r.debtCents,
+  }));
 }
 
 /**

--- a/apps/web/src/lib/monitoring/monitoring-queries.ts
+++ b/apps/web/src/lib/monitoring/monitoring-queries.ts
@@ -516,9 +516,21 @@ export function computeMarginPct(realCostCents: number, chargedCents: number): n
 }
 
 // Reusable SQL aggregate expressions over the ledger usage rows.
-const realCostSum = sql<number>`COALESCE(SUM(ABS(${creditLedger.realCostCents})), 0)::int`;
-const chargedSum = sql<number>`COALESCE(SUM(ABS(${creditLedger.amountCents})), 0)::int`;
+//
+// IMPORTANT (sub-cent accuracy): a single cheap-model call can cost a fraction
+// of a cent. The ledger stores the PRECISE charge in `chargeMillicents`
+// (1/1000 cent) and the precise real cost lives in `aiUsageLogs.cost` (dollars);
+// the whole-cent `amountCents`/`realCostCents` columns are per-row rounded for
+// audit. Summing the rounded columns would round high-volume sub-cent traffic to
+// $0 and report a bogus margin — so we SUM the precise fields and round ONCE at
+// the end. `appliedCents` is exempt: it is the whole-cent amount actually debited
+// (the sub-cent remainder is banked in pendingMillicents), so its sum is exact.
+const realCostSum = sql<number>`ROUND(COALESCE(SUM(${aiUsageLogs.cost}::numeric), 0) * 100)::int`;
+const chargedSum = sql<number>`ROUND(COALESCE(SUM(COALESCE(${creditLedger.chargeMillicents}, ABS(${creditLedger.amountCents}) * 1000)), 0) / 1000.0)::int`;
 const appliedSum = sql<number>`COALESCE(SUM(ABS(${creditLedger.appliedCents})), 0)::int`;
+// Debt comes from 'adjustment' rows, which carry only the whole-cent shortfall in
+// `amountCents` (no chargeMillicents) — so debt is summed from amountCents.
+const debtSum = sql<number>`COALESCE(SUM(ABS(${creditLedger.amountCents})), 0)::int`;
 
 /** Usage-row conditions: entryType='usage' plus optional aiUsageLogs.timestamp range. */
 function usageConditions(startDate?: Date, endDate?: Date): SQL[] {
@@ -555,7 +567,7 @@ export async function getUnitEconomicsSummary(
   if (endDate) debtConditions.push(lte(creditLedger.createdAt, endDate));
 
   const debt = await db
-    .select({ debtCents: chargedSum })
+    .select({ debtCents: debtSum })
     .from(creditLedger)
     .where(and(...debtConditions));
 
@@ -692,13 +704,13 @@ export async function getOutstandingDebtByUser(
       userId: creditLedger.userId,
       userName: users.name,
       userEmail: users.email,
-      debtCents: chargedSum,
+      debtCents: debtSum,
     })
     .from(creditLedger)
     .innerJoin(users, eq(creditLedger.userId, users.id))
     .where(and(...conditions))
     .groupBy(creditLedger.userId, users.name, users.email)
-    .orderBy(desc(chargedSum))
+    .orderBy(desc(debtSum))
     .limit(limit);
 
   return rows.map((r) => ({


### PR DESCRIPTION
## Why
PageSpace is moving AI to a prepaid metered-credit model. Before the app can be advertised, the founder must be able to **see real unit economics**: what each AI call actually costs us vs what we charge in credits, and the margin, per user / model / period. This is Workstream E of the credits cutover plan — the lever for fixing pricing.

The metering data already exists (`aiUsageLogs.cost` real $, `creditLedger.realCostCents` / `amountCents` / `appliedCents` / `adjustment` debt, joinable by `aiUsageLogId`). This PR only adds the aggregation queries + an admin view.

## What
**Margin queries** (`apps/web/src/lib/monitoring/monitoring-queries.ts`):
- `computeMarginPct(real, charged)` — pure, returns `null` when real cost ≤ 0.
- `getUnitEconomicsSummary` — total real cost vs charged vs applied, gross margin $/%, request count, outstanding debt.
- `getMarginByPeriod(day|month)` — margin time series.
- `getMarginByModel` — per provider/model.
- `getTopSpendersByMargin` — users by charged spend, with our cost + margin.
- `getOutstandingDebtByUser` — uncovered debt from `adjustment` rows.

Usage rows joined `creditLedger ⋈ aiUsageLogs` filtered to `entryType='usage'`; magnitudes via `ABS()` (usage/debt stored negative). Debt is summed directly from `adjustment` rows by ledger `createdAt` (no join) so retention purges of `aiUsageLogs` can't under-report debt. `DATE_TRUNC` granularity is a **bound parameter**, not string-interpolated, and is whitelisted.

**Admin API** — `GET /api/admin/unit-economics` (`withAdminAuth`): JSON snapshot (`range`, `granularity`) + `format=csv` export (RFC-4180 escaped) for a monthly cost-vs-revenue snapshot.

**Admin view** — `/admin/unit-economics`: summary cards (real cost / charged / gross margin / debt / requests), margin-by-model table, top spenders, outstanding debt, margin-over-time; CSV export button; range + granularity selectors. Linked from `/admin` overview + nav tab. Admin-gated by the existing admin `layout.tsx` (server `verifyAdminAuth`) **and** the API route's `withAdminAuth` — no custom access control.

## Tests
14 unit tests (`unit-economics-queries.test.ts`): margin math, empty/zero handling, date filters on the right columns, and `entryType` scoping. Mocked DB — no real connection.

## Verification
- `bun run --filter web lint` ✓ (no new warnings)
- `bun run --filter web typecheck` ✓
- `bun run --filter web test src/lib/monitoring/` ✓ (39 passed)
- `bun run --filter web build` ✓

File-disjoint from billing core and AI routes — touches only monitoring queries, the new admin route, and the new API route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)