### PR TITLE
docs(marketing): move pricing/FAQ/terms copy to metered AI credits

### DIFF
--- a/apps/marketing/src/app/blog/[slug]/data.ts
+++ b/apps/marketing/src/app/blog/[slug]/data.ts
@@ -39,14 +39,14 @@ In practice nothing breaks. Open an AI Chat, pick a model, send a message. The m
 - **Your previously-stored keys are gone from our side.** We've deleted them. Your accounts at OpenAI, Anthropic, Google AI, and the other providers are untouched — those keys still exist with the upstream provider. Revoke them there if you want, but you don't have to.
 - **Provider availability is now a deployment-level concern.** On pagespace.ai cloud, that's whatever PageSpace has enabled. On a self-hosted install, it's whatever your operator has configured via environment variables.
 
-## Standard vs pro tier
+## Standard vs pro models
 
-Every paid plan has a daily AI quota split into two tiers:
+AI usage is metered against a monthly AI-credit allowance, and which models you can reach depends on your plan:
 
-- **Standard** covers smaller and mid-tier models — Gemini Flash, Claude Haiku, GPT mini variants, GLM 4.7, and similar.
-- **Pro** covers frontier flagships — Claude Opus, the GPT-5 family, OpenAI o3, and GLM-5.
+- **Standard** covers smaller and mid-tier models — Gemini Flash, Claude Haiku, GPT mini variants, GLM 4.7, and similar. Available on every plan, including Free.
+- **Pro** covers frontier flagships — Claude Opus, the GPT-5 family, OpenAI o3, and GLM-5. Available on paid plans.
 
-If you regularly hit the pro daily limit, [upgrade to a higher plan](/pricing) for more pro capacity.
+Each call draws credits based on the underlying model's real cost, so frontier models spend faster than lightweight ones. If you run low, buy more credits anytime or wait for your monthly allowance to reset — or [upgrade to a higher plan](/pricing) for a larger monthly allowance.
 
 ## Why we did this
 
@@ -403,7 +403,7 @@ Practical example: create a recurring event, "Weekly Metrics Review," every Mond
 
 Another one. Project deadline is Friday. Create an event, "Pre-deadline check," Thursday at 4pm. Attach a project agent with instructions to review the open tasks and post a status summary. Thursday afternoon, the agent runs a check for you while you're still in meetings.
 
-The trigger system checks drive access, agent page existence, and your daily AI usage limit before executing. If any check fails, nothing runs and nothing breaks.
+The trigger system checks drive access, agent page existence, and your available AI credits before executing. If any check fails, nothing runs and nothing breaks.
 
 The calendar becomes a scheduler for AI work.
 

--- a/apps/marketing/src/app/docs/features/ai/page.tsx
+++ b/apps/marketing/src/app/docs/features/ai/page.tsx
@@ -26,7 +26,7 @@ AI in PageSpace isn't bolted on — it's a behaviour the whole product shares. A
 
 ## How it works
 
-**Providers.** PageSpace routes your conversation to one of several AI providers through a single underlying pipe. Provider credentials are held by the deployment operator — on cloud, that's PageSpace; on a self-hosted install, it's whoever runs the server. The model picker only lists providers the operator has enabled, so anything unconfigured is hidden rather than failing at call time. Calls count against your plan's standard or pro daily AI quota depending on the model you pick.
+**Providers.** PageSpace routes your conversation to one of several AI providers through a single underlying pipe. Provider credentials are held by the deployment operator — on cloud, that's PageSpace; on a self-hosted install, it's whoever runs the server. The model picker only lists providers the operator has enabled, so anything unconfigured is hidden rather than failing at call time. Each call draws from your plan's monthly AI-credit allowance based on the model's real cost; free accounts use standard models, while paid plans add Pro (advanced) models.
 
 **Permissions.** When an agent acts, it acts as **you**. It can only see pages you can see and only change pages you can change. Share a page with a teammate and *their* agents can now see it too, under their account. Revoke access and the agents lose access immediately — there is no AI back-door.
 

--- a/apps/marketing/src/app/docs/getting-started/page.tsx
+++ b/apps/marketing/src/app/docs/getting-started/page.tsx
@@ -1,5 +1,6 @@
 import { DocsMarkdown } from "@/components/DocsContent";
 import { createMetadata } from "@/lib/metadata";
+import { MONTHLY_CREDITS } from "@/lib/credits";
 
 export const metadata = createMetadata({
   title: "Getting Started",
@@ -21,7 +22,7 @@ Sign up at **pagespace.ai** — there are no passwords. Pick one:
 - **Magic link**: enter your email and click the link we send.
 - **Google** or **Apple** OAuth.
 
-No credit card required. The free tier includes 500 MB storage, 50 AI calls per day, and a 20 MB max file size.
+No credit card required. The free tier includes 500 MB storage, ${MONTHLY_CREDITS.free}/month of AI credits, and a 20 MB max file size.
 
 After signup, PageSpace sets you up with a starter **drive** (workspace) so you can jump straight in.
 
@@ -75,7 +76,7 @@ PageSpace routes every model through the Vercel AI SDK across 12 providers. Prov
 | Ollama | Models discovered from a configured Ollama server |
 | LM Studio | Models discovered from a configured LM Studio server |
 
-Open **Settings > AI** to pick a provider and model. The picker only shows providers your deployment has enabled — anything unconfigured is hidden. The provider and model you pick become your account-level default; any individual AI Chat page can override both. Calls count against your plan's standard or pro daily AI quota depending on the model.
+Open **Settings > AI** to pick a provider and model. The picker only shows providers your deployment has enabled — anything unconfigured is hidden. The provider and model you pick become your account-level default; any individual AI Chat page can override both. Each call draws from your plan's monthly AI-credit allowance based on the model's real cost; free accounts use standard models, while paid plans add Pro (advanced) models.
 
 ## 5. Create an AI Agent
 

--- a/apps/marketing/src/app/faq/page.tsx
+++ b/apps/marketing/src/app/faq/page.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { SiteNavbar } from "@/components/SiteNavbar";
 import { SiteFooter } from "@/components/SiteFooter";
 import { pageMetadata } from "@/lib/metadata";
+import { MONTHLY_CREDITS, creditPacksPhrase } from "@/lib/credits";
 import { FAQHashOpener } from "./hash-opener";
 
 export const metadata = pageMetadata.faq;
@@ -56,8 +57,7 @@ const faqs: FAQItem[] = [
   {
     id: "is-there-a-free-plan",
     question: "Is there a free plan?",
-    answer:
-      "Yes. The Free plan includes 500 MB of storage and 50 AI calls per day. No credit card required.",
+    answer: `Yes. The Free plan includes 500 MB of storage and ${MONTHLY_CREDITS.free}/month of AI credits that meter your usage. No credit card required.`,
     category: "Pricing and plans",
   },
   {
@@ -65,19 +65,27 @@ const faqs: FAQItem[] = [
     question: "What do the paid plans include?",
     answer: (
       <>
-        More AI calls and storage. Pro is $15/month, Founder is $50/month,
-        Business is $100/month. All plans include real-time collaboration, AI
-        agents, and the ability to bring your own API key. Full comparison on
-        the {docsLink("/pricing", "Pricing page")}.
+        More AI credits, access to Pro models, and more storage. Each plan
+        includes a monthly AI-credit allowance — {MONTHLY_CREDITS.pro}/month on
+        Pro ($15/month), {MONTHLY_CREDITS.founder}/month on Founder ($50/month),
+        and {MONTHLY_CREDITS.business}/month on Business ($100/month) — and you
+        can buy more credits anytime. All plans include real-time collaboration
+        and AI agents. Full comparison on the{" "}
+        {docsLink("/pricing", "Pricing page")}.
       </>
     ),
     category: "Pricing and plans",
   },
   {
+    id: "how-ai-credits-work",
+    question: "How do AI credits work?",
+    answer: `Every plan includes a monthly allowance of AI credits — ${MONTHLY_CREDITS.free}/month on Free, more on paid plans. Each AI action draws down credits based on what the underlying model actually costs, so a quick reply with a lightweight model costs far less than a long answer from a frontier model. Unused monthly credits don't roll over; your allowance resets at the start of each billing period.`,
+    category: "Pricing and plans",
+  },
+  {
     id: "hit-daily-ai-limit",
-    question: "What happens when I run out of AI calls for the day?",
-    answer:
-      "Everything else keeps working — your documents, tasks, channels, and collaboration are unaffected. AI features pause until your limit resets the next day. Upgrade your plan for higher daily quotas.",
+    question: "What happens when I run out of AI credits?",
+    answer: `Everything else keeps working — your documents, tasks, channels, and collaboration are unaffected. AI features pause until you either buy more credits (top-up packs come in ${creditPacksPhrase()}) or your monthly allowance resets at the start of the next billing period.`,
     category: "Pricing and plans",
   },
 

--- a/apps/marketing/src/app/pricing/page.tsx
+++ b/apps/marketing/src/app/pricing/page.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { SiteNavbar } from "@/components/SiteNavbar";
 import { SiteFooter } from "@/components/SiteFooter";
 import { pageMetadata, APP_URL } from "@/lib/metadata";
+import { MONTHLY_CREDITS } from "@/lib/credits";
 
 export const metadata = pageMetadata.pricing;
 
@@ -17,8 +18,9 @@ interface Plan {
   highlight?: boolean;
   features: {
     storage: string;
-    aiCalls: string;
-    proAiCalls: string;
+    monthlyCredits: string;
+    models: string;
+    buyMore: boolean;
     realtime: boolean;
     hierarchicalAgents: boolean;
     prioritySupport: boolean;
@@ -34,8 +36,9 @@ const plans: Plan[] = [
     ctaVariant: "outline",
     features: {
       storage: "500 MB",
-      aiCalls: "50/day",
-      proAiCalls: "—",
+      monthlyCredits: `${MONTHLY_CREDITS.free}/mo`,
+      models: "Standard",
+      buyMore: true,
       realtime: true,
       hierarchicalAgents: true,
       prioritySupport: false,
@@ -51,8 +54,9 @@ const plans: Plan[] = [
     highlight: true,
     features: {
       storage: "2 GB",
-      aiCalls: "200/day",
-      proAiCalls: "50/day",
+      monthlyCredits: `${MONTHLY_CREDITS.pro}/mo`,
+      models: "Standard + Pro",
+      buyMore: true,
       realtime: true,
       hierarchicalAgents: true,
       prioritySupport: true,
@@ -67,8 +71,9 @@ const plans: Plan[] = [
     ctaVariant: "outline",
     features: {
       storage: "10 GB",
-      aiCalls: "500/day",
-      proAiCalls: "100/day",
+      monthlyCredits: `${MONTHLY_CREDITS.founder}/mo`,
+      models: "Standard + Pro",
+      buyMore: true,
       realtime: true,
       hierarchicalAgents: true,
       prioritySupport: true,
@@ -83,8 +88,9 @@ const plans: Plan[] = [
     ctaVariant: "outline",
     features: {
       storage: "50 GB",
-      aiCalls: "1,000/day",
-      proAiCalls: "500/day",
+      monthlyCredits: `${MONTHLY_CREDITS.business}/mo`,
+      models: "Standard + Pro",
+      buyMore: true,
       realtime: true,
       hierarchicalAgents: true,
       prioritySupport: true,
@@ -105,7 +111,8 @@ export default function PricingPage() {
               Simple, transparent pricing
             </h1>
             <p className="text-lg text-muted-foreground mb-4">
-              Start free with generous limits. Scale as you grow. No hidden fees.
+              Every plan includes a monthly allowance of AI credits that meter
+              your usage. Run low? Buy more anytime. No hidden fees.
             </p>
             <p className="text-sm text-muted-foreground">
               No credit card required for the Free plan.
@@ -150,17 +157,18 @@ export default function PricingPage() {
                       <span className="font-medium">{plan.features.storage}</span>
                     </div>
                     <div className="flex items-center justify-between text-sm">
-                      <span className="text-muted-foreground">Standard AI calls</span>
-                      <span className="font-medium">{plan.features.aiCalls}</span>
+                      <span className="text-muted-foreground">AI credits</span>
+                      <span className="font-medium">{plan.features.monthlyCredits}</span>
                     </div>
                     <div className="flex items-center justify-between text-sm">
-                      <span className="text-muted-foreground">Pro AI calls</span>
-                      <span className="font-medium">{plan.features.proAiCalls}</span>
+                      <span className="text-muted-foreground">Models</span>
+                      <span className="font-medium">{plan.features.models}</span>
                     </div>
                   </div>
 
                   <div className="border-t border-border pt-4 space-y-2">
                     {[
+                      { key: "buyMore", label: "Buy more credits anytime", value: plan.features.buyMore },
                       { key: "realtime", label: "Real-time collaboration", value: plan.features.realtime },
                       { key: "hierarchicalAgents", label: "Hierarchical AI agents", value: plan.features.hierarchicalAgents },
                       { key: "prioritySupport", label: "Priority support", value: plan.features.prioritySupport },
@@ -221,8 +229,9 @@ export default function PricingPage() {
               <tbody>
                 {[
                   { key: "storage", label: "Storage" },
-                  { key: "aiCalls", label: "Standard AI calls" },
-                  { key: "proAiCalls", label: "Pro AI calls" },
+                  { key: "monthlyCredits", label: "Monthly AI credits" },
+                  { key: "models", label: "Model access" },
+                  { key: "buyMore", label: "Buy more credits anytime" },
                   { key: "realtime", label: "Real-time Collaboration" },
                   { key: "hierarchicalAgents", label: "Hierarchical AI Agents" },
                   { key: "prioritySupport", label: "Priority Support" },

--- a/apps/marketing/src/app/privacy/page.tsx
+++ b/apps/marketing/src/app/privacy/page.tsx
@@ -71,7 +71,7 @@ export default function PrivacyPolicy() {
               When you use AI features, we work with external AI providers, each subject to that provider&#39;s own privacy policy. Provider routing is managed by PageSpace at the deployment level — you no longer supply or store provider API keys yourself. Supported providers include:
             </p>
             <ul className="list-disc pl-6 mb-4">
-              <li><strong>PageSpace-hosted (default):</strong> included on every plan, currently backed by GLM inference. Standard and pro models are metered separately against your plan&#39;s daily AI call quotas</li>
+              <li><strong>PageSpace-hosted (default):</strong> included on every plan, currently backed by GLM inference. AI usage is metered against your plan&#39;s monthly AI-credit allowance, with standard and Pro models available depending on your plan</li>
               <li><strong>OpenRouter, Google AI (Gemini), Anthropic (Claude), OpenAI, xAI (Grok), Azure OpenAI, GLM, MiniMax:</strong> routed through provider credentials managed by PageSpace. Availability of any individual provider depends on whether it is configured for your deployment</li>
               <li><strong>Ollama and LM Studio (self-hosted deployments only):</strong> the deployment operator configures the endpoint; prompts and selected context are sent only to that configured server. When the endpoint is a local process, content stays on the machine running it</li>
             </ul>

--- a/apps/marketing/src/app/terms/page.tsx
+++ b/apps/marketing/src/app/terms/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { SiteNavbar } from "@/components/SiteNavbar";
 import { SiteFooter } from "@/components/SiteFooter";
 import { pageMetadata, LEGAL_LAST_UPDATED } from "@/lib/metadata";
+import { MONTHLY_CREDITS } from "@/lib/credits";
 
 export const metadata = pageMetadata.terms;
 
@@ -124,11 +125,14 @@ export default function TermsOfService() {
               PageSpace offers the following subscription plans:
             </p>
             <ul className="list-disc pl-6 mb-4">
-              <li><strong>Free Plan:</strong> 50 AI calls per day, 500MB storage</li>
-              <li><strong>Pro Plan ($15/month):</strong> 200 AI calls per day, 50 Pro AI sessions per month, 2GB storage</li>
-              <li><strong>Founder Plan ($50/month):</strong> 500 AI calls per day, 100 Pro AI sessions per month, 10GB storage, priority support</li>
-              <li><strong>Business Plan ($100/month):</strong> 1,000 AI calls per day, 500 Pro AI sessions per month, 50GB storage, priority support</li>
+              <li><strong>Free Plan:</strong> {MONTHLY_CREDITS.free}/month in AI credits, standard models, 500MB storage</li>
+              <li><strong>Pro Plan ($15/month):</strong> {MONTHLY_CREDITS.pro}/month in AI credits, standard and Pro models, 2GB storage</li>
+              <li><strong>Founder Plan ($50/month):</strong> {MONTHLY_CREDITS.founder}/month in AI credits, standard and Pro models, 10GB storage, priority support</li>
+              <li><strong>Business Plan ($100/month):</strong> {MONTHLY_CREDITS.business}/month in AI credits, standard and Pro models, 50GB storage, priority support</li>
             </ul>
+            <p className="mb-4">
+              Each plan&#39;s monthly AI-credit allowance meters AI usage and resets at the start of each billing period; unused monthly credits do not roll over. Additional credits may be purchased at any time as one-time top-ups, which do not expire at the monthly reset. Model availability differs by plan: free accounts use standard models, while paid plans add access to Pro (advanced) models.
+            </p>
 
             <h3 className="text-xl font-semibold mb-3">11.2 Billing and Payment</h3>
             <ul className="list-disc pl-6 mb-4">
@@ -140,9 +144,9 @@ export default function TermsOfService() {
               <li>No refunds are provided for partial months of service</li>
             </ul>
 
-            <h3 className="text-xl font-semibold mb-3">11.3 Usage Limits</h3>
+            <h3 className="text-xl font-semibold mb-3">11.3 AI Credits and Usage Limits</h3>
             <p className="mb-4">
-              Each subscription plan includes specific usage limits. Exceeding these limits may result in service throttling or temporary suspension until your next billing cycle.
+              AI usage is metered against your plan&#39;s monthly AI-credit allowance. When your available credits are exhausted, AI features pause until you purchase additional credits or your monthly allowance resets at the start of the next billing period; all non-AI features (documents, tasks, channels, and collaboration) remain available. AI-credit prices and allowances may be adjusted with reasonable notice. Storage and file-size limits also apply per plan, and exceeding them may result in service throttling or temporary suspension until your next billing cycle.
             </p>
           </section>
 

--- a/apps/marketing/src/lib/credits.ts
+++ b/apps/marketing/src/lib/credits.ts
@@ -1,0 +1,49 @@
+/**
+ * Marketing-facing AI-credit copy helpers — the SINGLE SOURCE OF TRUTH for any
+ * credit/pricing number shown on the marketing site.
+ *
+ * Every dollar figure here is derived directly from the canonical billing
+ * constants in `@pagespace/lib/billing/credit-pricing`
+ * (`TIER_MONTHLY_ALLOWANCE_CENTS` and `CREDIT_PACKS`) so public pricing copy can
+ * never drift from what the app actually meters. Do NOT hardcode tier dollar
+ * amounts or top-up pack values anywhere else in `apps/marketing` — import from
+ * this module instead. If the allowances change in `credit-pricing.ts`, the
+ * pricing page, FAQ, Terms, docs, schema.org markup, and search index all update
+ * automatically.
+ */
+import {
+  TIER_MONTHLY_ALLOWANCE_CENTS,
+  CREDIT_PACKS,
+} from "@pagespace/lib/billing/credit-pricing";
+import type { SubscriptionTier } from "@pagespace/lib/services/subscription-utils";
+
+/** Format whole cents as a plain dollar string, dropping a trailing ".00". */
+function formatDollars(cents: number): string {
+  const dollars = cents / 100;
+  return Number.isInteger(dollars) ? `$${dollars}` : `$${dollars.toFixed(2)}`;
+}
+
+/** Monthly included AI-credit allowance per tier, as display strings (e.g. "$5"). */
+export const MONTHLY_CREDITS: Record<SubscriptionTier, string> = {
+  free: formatDollars(TIER_MONTHLY_ALLOWANCE_CENTS.free),
+  pro: formatDollars(TIER_MONTHLY_ALLOWANCE_CENTS.pro),
+  founder: formatDollars(TIER_MONTHLY_ALLOWANCE_CENTS.founder),
+  business: formatDollars(TIER_MONTHLY_ALLOWANCE_CENTS.business),
+};
+
+/** "$5/month in AI credits" style phrase for a tier. */
+export function monthlyCreditsPhrase(tier: SubscriptionTier): string {
+  return `${MONTHLY_CREDITS[tier]}/month in AI credits`;
+}
+
+/** Buyable top-up packs as display strings (e.g. "$10"), sorted by value. */
+export const CREDIT_PACKS_DISPLAY: string[] = Object.values(CREDIT_PACKS)
+  .sort((a, b) => a.cents - b.cents)
+  .map((pack) => formatDollars(pack.cents));
+
+/** Top-up packs joined for prose, e.g. "$10, $25, or $50". */
+export function creditPacksPhrase(): string {
+  const packs = CREDIT_PACKS_DISPLAY;
+  if (packs.length <= 1) return packs.join("");
+  return `${packs.slice(0, -1).join(", ")}, or ${packs[packs.length - 1]}`;
+}

--- a/apps/marketing/src/lib/metadata.ts
+++ b/apps/marketing/src/lib/metadata.ts
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { MONTHLY_CREDITS } from "./credits";
 
 const SITE_NAME = "PageSpace";
 export const SITE_URL = process.env.NEXT_PUBLIC_MARKETING_URL || "https://pagespace.ai";
@@ -169,7 +170,7 @@ export const pageMetadata = {
   pricing: createMetadata({
     title: "Pricing",
     description:
-      "Simple, transparent pricing for individuals, teams, and enterprises. Start free with 500MB storage and 50 daily AI calls.",
+      `Simple, transparent pricing for individuals, teams, and enterprises. Start free with 500MB storage and ${MONTHLY_CREDITS.free}/month of AI credits.`,
     path: "/pricing",
     keywords: ["pricing", "plans", "free tier", "subscription"],
   }),

--- a/apps/marketing/src/lib/schema.tsx
+++ b/apps/marketing/src/lib/schema.tsx
@@ -3,6 +3,7 @@
  * @see https://schema.org/
  * @see https://developers.google.com/search/docs/appearance/structured-data
  */
+import { MONTHLY_CREDITS } from "./credits";
 
 // In development, set NEXT_PUBLIC_MARKETING_URL and NEXT_PUBLIC_APP_URL to distinct local origins
 const SITE_URL = process.env.NEXT_PUBLIC_MARKETING_URL || "https://pagespace.ai";
@@ -86,7 +87,7 @@ export const productSchema = {
       name: "Free",
       price: "0",
       priceCurrency: "USD",
-      description: "500MB storage, 50 daily AI calls",
+      description: `500MB storage, ${MONTHLY_CREDITS.free}/month in AI credits, standard models`,
       availability: "https://schema.org/InStock",
     },
     {
@@ -100,7 +101,7 @@ export const productSchema = {
         priceCurrency: "USD",
         billingDuration: "P1M",
       },
-      description: "2GB storage, 200 daily AI calls, 50 Pro AI sessions",
+      description: `2GB storage, ${MONTHLY_CREDITS.pro}/month in AI credits, standard and Pro models`,
       availability: "https://schema.org/InStock",
     },
     {
@@ -114,7 +115,7 @@ export const productSchema = {
         priceCurrency: "USD",
         billingDuration: "P1M",
       },
-      description: "10GB storage, 500 daily AI calls, 100 Pro AI sessions",
+      description: `10GB storage, ${MONTHLY_CREDITS.founder}/month in AI credits, standard and Pro models`,
       availability: "https://schema.org/InStock",
     },
     {
@@ -128,7 +129,7 @@ export const productSchema = {
         priceCurrency: "USD",
         billingDuration: "P1M",
       },
-      description: "50GB storage, 1000 daily AI calls, 500 Pro AI sessions",
+      description: `50GB storage, ${MONTHLY_CREDITS.business}/month in AI credits, standard and Pro models`,
       availability: "https://schema.org/InStock",
     },
   ],

--- a/apps/marketing/src/lib/search-data.ts
+++ b/apps/marketing/src/lib/search-data.ts
@@ -1,4 +1,5 @@
 import { blogPosts } from "@/app/blog/[slug]/data";
+import { MONTHLY_CREDITS } from "@/lib/credits";
 
 export interface SearchEntry {
   title: string;
@@ -116,19 +117,26 @@ const faqEntries: SearchEntry[] = [
   },
   {
     title: "Is there a free plan?",
-    description:
-      "Yes. Free plan includes 500 MB storage and 50 AI calls per day. No credit card required.",
+    description: `Yes. Free plan includes 500 MB storage and ${MONTHLY_CREDITS.free}/month of AI credits. No credit card required.`,
     href: "/faq#is-there-a-free-plan",
     category: "FAQ",
-    keywords: "free plan pricing cost no credit card",
+    keywords: "free plan pricing cost no credit card ai credits",
   },
   {
-    title: "What happens when I run out of AI calls?",
+    title: "How do AI credits work?",
     description:
-      "Documents, tasks, channels, and collaboration keep working. AI pauses until your limit resets the next day.",
+      "Every plan includes a monthly AI-credit allowance. Each AI action draws down credits based on the model's real cost; unused monthly credits reset each billing period.",
+    href: "/faq#how-ai-credits-work",
+    category: "FAQ",
+    keywords: "ai credits metered usage allowance reset monthly billing",
+  },
+  {
+    title: "What happens when I run out of AI credits?",
+    description:
+      "Documents, tasks, channels, and collaboration keep working. AI pauses until you buy more credits or your monthly allowance resets.",
     href: "/faq#hit-daily-ai-limit",
     category: "FAQ",
-    keywords: "daily limit ai calls reset quota",
+    keywords: "out of credits ai limit reset buy more top up quota",
   },
   {
     title: "How do I sign up?",


### PR DESCRIPTION
## Why
PageSpace AI is moving from "N AI calls per day per tier" to prepaid **metered AI credits** (monthly \$ allowance + buyable top-ups). The marketing site still promised "calls per day" everywhere; this rewrites all public copy to the credits story in lockstep with the cutover. Part of Workstream D (marketing-app portion) of the credits cutover, landing inside PR #1484 (`pu/credits-remediation`).

## What changed
Single source of truth: new `apps/marketing/src/lib/credits.ts` derives all dollar figures from `@pagespace/lib/billing/credit-pricing` (`TIER_MONTHLY_ALLOWANCE_CENTS`, `CREDIT_PACKS`) so public copy can't drift from what the app actually meters. No tier dollar amounts are hardcoded elsewhere.

Surfaces rewritten (`apps/marketing/**` only):
- **Pricing page** — replaced `aiCalls`/`proAiCalls` per-day fields with a monthly AI-credit allowance row, an explicit **Model access** row (Standard vs Standard + Pro), and a "Buy more credits anytime" capability; updated hero copy and the full comparison table.
- **FAQ** — free-plan and paid-plan answers now describe credit allowances; added a new "How do AI credits work?" entry; the out-of-credits answer (anchor `#hit-daily-ai-limit` kept stable) now says buy more or wait for the monthly reset.
- **Terms** — subscription-plan list and the usage-limits section (11.3) describe the monthly credit allowance, top-ups, monthly reset, and the kept model-tier distinction.
- **Docs** — `getting-started` and `features/ai` daily-quota mentions → credits + model tiers.
- **Privacy** — provider metering line → credits.
- **schema.org** (`schema.tsx`) offer descriptions and **search index** (`search-data.ts`) + **metadata.ts** pricing description → credits.
- **Blog** — the BYOK post's "Standard vs pro tier" section → credits narrative (keeps the standard/Pro model capability split).

Model-tier capability distinction is **kept** (free = standard models; paid = standard + Pro). Storage and file-size copy left unchanged.

## Numbers (from `credit-pricing.ts`)
Free \$5/mo · Pro \$15/mo · Founder \$50/mo · Business \$100/mo; top-up packs \$10 / \$25 / \$50. These are the current placeholder defaults in `credit-pricing.ts` — ⚠️ they go public the moment this lands, so confirm they're launch-ready.

## Verification
- `bun run typecheck` — green (13/13)
- `bun run lint` — green (13/13)
- `bun run build` — green
- Swept `apps/marketing` for "AI calls per day"/daily-quota copy: none remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)