### PR TITLE
feat(email): announce metered AI credits to users (template + broadcast script)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,6 @@ skills-lock.json
 
 # MCP server config (contains auth tokens)
 .mcp.json
+
+# Broadcast idempotency ledger (credits announcement email)
+.credits-change-sent.jsonl

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -327,6 +327,21 @@
       "import": "./dist/email-templates/FeedbackNotificationEmail.js",
       "require": "./dist/email-templates/FeedbackNotificationEmail.js"
     },
+    "./email-templates/CreditsChangeEmail": {
+      "types": "./dist/email-templates/CreditsChangeEmail.d.ts",
+      "import": "./dist/email-templates/CreditsChangeEmail.js",
+      "require": "./dist/email-templates/CreditsChangeEmail.js"
+    },
+    "./email-templates/credits-change-content": {
+      "types": "./dist/email-templates/credits-change-content.d.ts",
+      "import": "./dist/email-templates/credits-change-content.js",
+      "require": "./dist/email-templates/credits-change-content.js"
+    },
+    "./email-templates/render-email": {
+      "types": "./dist/email-templates/render-email.d.ts",
+      "import": "./dist/email-templates/render-email.js",
+      "require": "./dist/email-templates/render-email.js"
+    },
     "./auth/secure-compare": {
       "types": "./dist/auth/secure-compare.d.ts",
       "import": "./dist/auth/secure-compare.js",
@@ -911,6 +926,15 @@
       ],
       "email-templates/FeedbackNotificationEmail": [
         "./dist/email-templates/FeedbackNotificationEmail.d.ts"
+      ],
+      "email-templates/CreditsChangeEmail": [
+        "./dist/email-templates/CreditsChangeEmail.d.ts"
+      ],
+      "email-templates/credits-change-content": [
+        "./dist/email-templates/credits-change-content.d.ts"
+      ],
+      "email-templates/render-email": [
+        "./dist/email-templates/render-email.d.ts"
       ],
       "auth/secure-compare": [
         "./dist/auth/secure-compare.d.ts"

--- a/packages/lib/src/email-templates/CreditsChangeEmail.tsx
+++ b/packages/lib/src/email-templates/CreditsChangeEmail.tsx
@@ -1,0 +1,137 @@
+import * as React from 'react';
+import {
+  Body,
+  Button,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Link,
+  Section,
+  Text,
+} from '@react-email/components';
+import { emailStyles, colors, spacing, typography } from './shared-styles';
+import type { TierCreditSummary } from './credits-change-content';
+
+interface CreditsChangeEmailProps {
+  /** Recipient's display name (falls back to a friendly default upstream). */
+  userName: string;
+  /** Per-tier allowance + top-up copy, derived from credit-pricing. */
+  summary: TierCreditSummary;
+  /** Link to the in-app plan/billing screen where credits are managed. */
+  manageUrl: string;
+  /** Optional one-click unsubscribe link for the announcement. */
+  unsubscribeUrl?: string;
+}
+
+const tierBox = {
+  backgroundColor: colors.accent,
+  borderLeft: `4px solid ${colors.accentBorder}`,
+  padding: `${spacing.md} ${spacing.lg}`,
+  margin: `${spacing.lg} 0`,
+  borderRadius: '4px',
+};
+
+const allowanceAmount = {
+  fontSize: typography.h2,
+  fontWeight: typography.bold,
+  color: colors.primary,
+  margin: `0 0 ${spacing.xs} 0`,
+  letterSpacing: '-0.4px',
+};
+
+const allowanceLabel = {
+  fontSize: typography.small,
+  color: colors.mutedText,
+  margin: '0',
+};
+
+const packItem = {
+  fontSize: typography.body,
+  lineHeight: typography.bodyLineHeight,
+  color: colors.text,
+  margin: `0 0 ${spacing.xs} 0`,
+};
+
+export function CreditsChangeEmail({
+  userName,
+  summary,
+  manageUrl,
+  unsubscribeUrl,
+}: CreditsChangeEmailProps) {
+  return (
+    <Html>
+      <Head />
+      <Body style={emailStyles.main}>
+        <Container style={emailStyles.container}>
+          <Section style={emailStyles.header}>
+            <Heading style={emailStyles.headerTitle}>PageSpace</Heading>
+          </Section>
+          <Section style={emailStyles.content}>
+            <Text style={emailStyles.contentHeading}>
+              Your AI usage is moving to monthly credits
+            </Text>
+            <Text style={emailStyles.paragraph}>Hi {userName},</Text>
+            <Text style={emailStyles.paragraph}>
+              We&apos;re changing how AI usage works in PageSpace. Instead of a
+              daily cap on how many times you can call the AI, every plan now
+              comes with a monthly pool of <strong>AI credits</strong> you can
+              spend however you like — and you can top up anytime if you need
+              more.
+            </Text>
+
+            <Section style={tierBox}>
+              <Text style={allowanceLabel}>
+                Your {summary.tierLabel} plan now includes
+              </Text>
+              <Text style={allowanceAmount}>
+                {summary.monthlyAllowanceLabel} of AI credits / month
+              </Text>
+              <Text style={allowanceLabel}>
+                Refreshes at the start of every billing period.
+              </Text>
+            </Section>
+
+            <Text style={emailStyles.paragraph}>
+              <strong>Need more?</strong> Top up your balance anytime with a
+              one-time credit pack:
+            </Text>
+            {summary.topupPacks.map((pack) => (
+              <Text key={pack.id} style={packItem}>
+                • {pack.amountLabel} credits
+              </Text>
+            ))}
+
+            <Text style={emailStyles.paragraph}>
+              Credits only apply to AI features. Your documents, tasks,
+              channels, files, and collaboration are completely unaffected —
+              nothing about how you work with your team is changing.
+            </Text>
+
+            <Section style={emailStyles.buttonContainer}>
+              <Button style={emailStyles.button} href={manageUrl}>
+                View your plan &amp; credits
+              </Button>
+            </Section>
+
+            <Text style={emailStyles.hint}>
+              Questions? Just reply to this email and we&apos;ll help you out.
+            </Text>
+          </Section>
+          <Section style={emailStyles.footer}>
+            <Text style={emailStyles.footerText}>
+              You&apos;re receiving this because you have a PageSpace account.
+            </Text>
+            {unsubscribeUrl ? (
+              <Text style={emailStyles.footerText}>
+                <Link href={unsubscribeUrl} style={emailStyles.link}>
+                  Unsubscribe from product update emails
+                </Link>
+              </Text>
+            ) : null}
+          </Section>
+        </Container>
+      </Body>
+    </Html>
+  );
+}

--- a/packages/lib/src/email-templates/__tests__/CreditsChangeEmail.test.tsx
+++ b/packages/lib/src/email-templates/__tests__/CreditsChangeEmail.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@react-email/components';
+import { CreditsChangeEmail } from '../CreditsChangeEmail';
+import {
+  getTierCreditSummary,
+  formatCents,
+  normalizeTier,
+} from '../credits-change-content';
+import {
+  TIER_MONTHLY_ALLOWANCE_CENTS,
+  CREDIT_PACKS,
+} from '../../billing/credit-pricing';
+import type { SubscriptionTier } from '../../services/subscription-utils';
+
+const TIERS: SubscriptionTier[] = ['free', 'pro', 'founder', 'business'];
+
+describe('formatCents', () => {
+  it('renders whole dollars without trailing cents', () => {
+    expect(formatCents(500)).toBe('$5');
+    expect(formatCents(10000)).toBe('$100');
+  });
+
+  it('preserves sub-dollar precision', () => {
+    expect(formatCents(1550)).toBe('$15.50');
+    expect(formatCents(25)).toBe('$0.25');
+  });
+});
+
+describe('normalizeTier', () => {
+  it('passes through known tiers', () => {
+    expect(normalizeTier('pro')).toBe('pro');
+    expect(normalizeTier('founder')).toBe('founder');
+    expect(normalizeTier('business')).toBe('business');
+    expect(normalizeTier('free')).toBe('free');
+  });
+
+  it('falls back to free for unknown/empty values', () => {
+    expect(normalizeTier('legacy_enterprise')).toBe('free');
+    expect(normalizeTier(null)).toBe('free');
+    expect(normalizeTier(undefined)).toBe('free');
+  });
+});
+
+describe('getTierCreditSummary', () => {
+  it.each(TIERS)('sources the %s allowance straight from credit-pricing', (tier) => {
+    const summary = getTierCreditSummary(tier);
+    expect(summary.monthlyAllowanceCents).toBe(TIER_MONTHLY_ALLOWANCE_CENTS[tier]);
+    expect(summary.monthlyAllowanceLabel).toBe(
+      formatCents(TIER_MONTHLY_ALLOWANCE_CENTS[tier]),
+    );
+  });
+
+  it('exposes every credit pack as a top-up option', () => {
+    const summary = getTierCreditSummary('pro');
+    const packIds = summary.topupPacks.map((p) => p.id).sort();
+    expect(packIds).toEqual(Object.keys(CREDIT_PACKS).sort());
+  });
+});
+
+describe('CreditsChangeEmail', () => {
+  it.each(TIERS)('renders the correct per-tier allowance for %s', async (tier) => {
+    const summary = getTierCreditSummary(tier);
+    const html = await render(
+      CreditsChangeEmail({
+        userName: 'Ada',
+        summary,
+        manageUrl: 'https://app.pagespace.ai/settings/plan',
+        unsubscribeUrl: 'https://app.pagespace.ai/api/notifications/unsubscribe/tok',
+      }),
+    );
+
+    // The per-tier dollar figure must come through verbatim from credit-pricing.
+    expect(html).toContain(summary.monthlyAllowanceLabel);
+    expect(html).toContain(summary.tierLabel);
+    // Top-up packs are listed.
+    for (const pack of summary.topupPacks) {
+      expect(html).toContain(pack.amountLabel);
+    }
+  });
+
+  it('greets the recipient and links to plan management', async () => {
+    const html = await render(
+      CreditsChangeEmail({
+        userName: 'Grace',
+        summary: getTierCreditSummary('free'),
+        manageUrl: 'https://app.pagespace.ai/settings/plan',
+      }),
+    );
+    expect(html).toContain('Grace');
+    expect(html).toContain('https://app.pagespace.ai/settings/plan');
+    // Reassurance that collaboration is unaffected.
+    expect(html.toLowerCase()).toContain('collaboration');
+  });
+
+  it('omits the unsubscribe link when no URL is provided', async () => {
+    const html = await render(
+      CreditsChangeEmail({
+        userName: 'Linus',
+        summary: getTierCreditSummary('business'),
+        manageUrl: 'https://app.pagespace.ai/settings/plan',
+      }),
+    );
+    expect(html).not.toContain('Unsubscribe from product update emails');
+  });
+});

--- a/packages/lib/src/email-templates/credits-change-content.ts
+++ b/packages/lib/src/email-templates/credits-change-content.ts
@@ -1,0 +1,87 @@
+/**
+ * credits-change-content — derives the per-tier copy for the metered-AI-credits
+ * announcement email straight from the billing source of truth
+ * (`../billing/credit-pricing`). Keeping this derivation in one place means the
+ * announcement email, the broadcast script, and the tests all read the SAME
+ * numbers — the dollar figures can never drift from what the gate actually grants.
+ *
+ * This module is pure (no I/O, no React) so it is trivially unit-testable and
+ * safe to import from both the template and the broadcast script.
+ */
+
+import {
+  TIER_MONTHLY_ALLOWANCE_CENTS,
+  CREDIT_PACKS,
+  type CreditPack,
+} from '../billing/credit-pricing';
+import type { SubscriptionTier } from '../services/subscription-utils';
+
+/**
+ * Format whole cents as a customer-facing USD string. Whole-dollar amounts drop
+ * the trailing ".00" for cleaner copy ("$5"); sub-dollar precision is preserved
+ * ("$15.50") so a tuned env override never renders a misleading rounded figure.
+ */
+export function formatCents(cents: number): string {
+  const dollars = cents / 100;
+  return Number.isInteger(dollars) ? `$${dollars}` : `$${dollars.toFixed(2)}`;
+}
+
+/** Human-readable label for each subscription tier. */
+const TIER_LABELS: Record<SubscriptionTier, string> = {
+  free: 'Free',
+  pro: 'Pro',
+  founder: 'Founder',
+  business: 'Business',
+};
+
+export interface TopupPackSummary {
+  /** Stable pack SKU id (matches `CreditPack.id`). */
+  id: string;
+  /** Marketing label from the pack definition, e.g. "$10 credits". */
+  label: string;
+  /** Formatted credit value the pack adds, e.g. "$10". */
+  amountLabel: string;
+}
+
+export interface TierCreditSummary {
+  tier: SubscriptionTier;
+  /** Display name for the tier, e.g. "Pro". */
+  tierLabel: string;
+  /** Raw monthly allowance in cents, straight from credit-pricing. */
+  monthlyAllowanceCents: number;
+  /** Formatted monthly allowance, e.g. "$15". */
+  monthlyAllowanceLabel: string;
+  /** Buy-more top-up packs available to every tier. */
+  topupPacks: TopupPackSummary[];
+}
+
+/**
+ * Coerce an arbitrary stored `users.subscriptionTier` string into a known tier.
+ * Unknown/legacy values fall back to `free` so the email always renders a valid
+ * allowance rather than throwing on a stray value.
+ */
+export function normalizeTier(raw: string | null | undefined): SubscriptionTier {
+  if (raw === 'pro' || raw === 'founder' || raw === 'business') return raw;
+  return 'free';
+}
+
+/** Build the announcement copy data for a single tier from credit-pricing. */
+export function getTierCreditSummary(tier: SubscriptionTier): TierCreditSummary {
+  const monthlyAllowanceCents = TIER_MONTHLY_ALLOWANCE_CENTS[tier];
+
+  const topupPacks: TopupPackSummary[] = Object.values(CREDIT_PACKS).map(
+    (pack: CreditPack) => ({
+      id: pack.id,
+      label: pack.label,
+      amountLabel: formatCents(pack.cents),
+    }),
+  );
+
+  return {
+    tier,
+    tierLabel: TIER_LABELS[tier],
+    monthlyAllowanceCents,
+    monthlyAllowanceLabel: formatCents(monthlyAllowanceCents),
+    topupPacks,
+  };
+}

--- a/packages/lib/src/email-templates/render-email.ts
+++ b/packages/lib/src/email-templates/render-email.ts
@@ -1,0 +1,14 @@
+import { render } from '@react-email/components';
+import type { ReactElement } from 'react';
+
+/**
+ * Render a React Email element to its final HTML string.
+ *
+ * Thin wrapper over `@react-email/components`' `render` so callers outside this
+ * package (e.g. the broadcast scripts at the repo root) can produce email HTML
+ * without depending on `@react-email/components` directly — that dependency only
+ * resolves from within this package.
+ */
+export function renderEmailToHtml(element: ReactElement): Promise<string> {
+  return render(element);
+}

--- a/scripts/send-credits-change-notifications.ts
+++ b/scripts/send-credits-change-notifications.ts
@@ -8,17 +8,26 @@
  * source of truth (`@pagespace/lib/billing/credit-pricing`) so the email can
  * never quote a number that disagrees with what the credit gate actually grants.
  *
- * Idempotent / resumable: every successful send is appended to a local JSONL
- * ledger (default `<repo>/.credits-change-sent.jsonl`, override with
+ * Idempotent / resumable: every successful send is appended (and fsync'd) to a
+ * local JSONL ledger (default `<repo>/.credits-change-sent.jsonl`, override with
  * CREDITS_EMAIL_LOG_PATH or --log). Re-running skips any recipient already in
- * the ledger, so an interrupted run can be resumed without double-sending.
- * Failures are NOT recorded, so they are retried on the next run.
+ * the ledger, so an interrupted run can be resumed without double-sending. The
+ * ledger is opened/validated BEFORE the first send; a per-recipient provider
+ * failure is recorded as retryable (not written), but a ledger-write failure
+ * AFTER a successful send is fatal — the run aborts and names the unrecorded
+ * recipient so it can never be silently re-sent.
+ *
+ * Safety: a live (non --dry-run) send refuses to run if the resolved app base
+ * URL points at localhost, so the broadcast can never email a broken CTA.
  *
  * Usage:
  *   bun scripts/send-credits-change-notifications.ts --dry-run
  *   bun scripts/send-credits-change-notifications.ts --verified-only
  *   bun scripts/send-credits-change-notifications.ts --limit=50
  *   bun scripts/send-credits-change-notifications.ts --log=/tmp/credits-sent.jsonl
+ *
+ * The CTA link uses NEXT_PUBLIC_APP_URL, falling back to WEB_APP_URL (the first
+ * non-localhost value wins).
  *
  * Flags:
  *   --dry-run         Render + report recipients; send nothing, write nothing.
@@ -33,6 +42,7 @@
  */
 
 import { promises as fs } from 'node:fs';
+import type { FileHandle } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { db } from '@pagespace/db/db';
@@ -134,26 +144,71 @@ async function loadSentEmails(logPath: string): Promise<Set<string>> {
   return sent;
 }
 
-/** Append one successful send to the ledger (atomic per-line). */
-async function recordSent(
-  logPath: string,
-  entry: SentLedgerEntry,
-): Promise<void> {
-  await fs.appendFile(logPath, `${JSON.stringify(entry)}\n`, 'utf8');
+/**
+ * Open the ledger for appending, creating its parent directory first. Validating
+ * writability UP FRONT (before any email is sent) turns a bad --log path or a
+ * permission/disk problem into a clean pre-flight failure instead of a
+ * mid-broadcast crash that leaves successful sends unrecorded.
+ */
+async function openLedger(logPath: string): Promise<FileHandle> {
+  await fs.mkdir(path.dirname(logPath), { recursive: true });
+  return fs.open(logPath, 'a');
+}
+
+/**
+ * Append one successful send and fsync it to disk before returning, so the
+ * record is durable the instant `sendEmail` is acknowledged. A failure here is
+ * treated as fatal by the caller: an unrecorded successful send would be
+ * re-sent on the next run, so we must never silently continue past it.
+ */
+async function recordSent(handle: FileHandle, entry: SentLedgerEntry): Promise<void> {
+  await handle.write(`${JSON.stringify(entry)}\n`, null, 'utf8');
+  await handle.sync();
 }
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function appBaseUrl(): string {
-  return process.env.NEXT_PUBLIC_APP_URL?.trim() || 'http://localhost:3000';
+/** True when the URL points at the local machine (unsafe for a broadcast CTA). */
+function isLocalhostUrl(url: string): boolean {
+  try {
+    const { hostname } = new URL(url);
+    return (
+      hostname === 'localhost' ||
+      hostname === '127.0.0.1' ||
+      hostname === '0.0.0.0' ||
+      hostname === '::1' ||
+      hostname === '[::1]'
+    );
+  } catch {
+    // Unparseable → treat as unsafe so we never email a malformed CTA.
+    return true;
+  }
+}
+
+/**
+ * Resolve the public app base URL for the email CTA. Prefers the first
+ * configured NON-localhost candidate so a setup with only the server-side
+ * WEB_APP_URL pointed at production (and a stale localhost NEXT_PUBLIC_APP_URL)
+ * still produces working links. Falls back to whatever is set, else localhost.
+ */
+function resolveBaseUrl(): string {
+  const candidates = [
+    process.env.NEXT_PUBLIC_APP_URL,
+    process.env.WEB_APP_URL,
+  ].map((c) => c?.trim()).filter((c): c is string => Boolean(c));
+
+  const live = candidates.find((c) => !isLocalhostUrl(c));
+  const chosen = live ?? candidates[0] ?? 'http://localhost:3000';
+  return chosen.replace(/\/+$/, '');
 }
 
 async function main(): Promise<void> {
   const opts = parseArgs(process.argv.slice(2));
-  const baseUrl = appBaseUrl();
+  const baseUrl = resolveBaseUrl();
   const manageUrl = `${baseUrl}/settings/plan`;
+  const localhostBase = isLocalhostUrl(baseUrl);
 
   console.log('📢 Metered AI-credits announcement broadcast');
   console.log(`  Mode:          ${opts.dryRun ? 'DRY RUN (no sends)' : 'LIVE SEND'}`);
@@ -161,15 +216,30 @@ async function main(): Promise<void> {
   console.log(`  Ledger:        ${opts.logPath}`);
   console.log(`  Manage URL:    ${manageUrl}`);
   if (opts.limit) console.log(`  Limit:         ${opts.limit}`);
-  if (baseUrl.includes('localhost')) {
-    console.warn('  ⚠️  NEXT_PUBLIC_APP_URL is unset — links point at localhost. Set it before a real send.');
-  }
   console.log('');
+
+  // Never email every user a broken localhost CTA. A dry run may use localhost
+  // (it sends nothing); a live send must resolve a real public URL.
+  if (localhostBase) {
+    if (opts.dryRun) {
+      console.warn('  ⚠️  Base URL resolves to localhost — set NEXT_PUBLIC_APP_URL or WEB_APP_URL before a real send.\n');
+    } else {
+      console.error(
+        '❌ Refusing live send: app base URL resolves to localhost, which would email broken links.\n' +
+          '   Set NEXT_PUBLIC_APP_URL (or WEB_APP_URL) to the public app URL and re-run.',
+      );
+      process.exit(1);
+    }
+  }
 
   const sentEmails = await loadSentEmails(opts.logPath);
   if (sentEmails.size > 0) {
     console.log(`↩️  Resuming: ${sentEmails.size} recipient(s) already recorded in the ledger.\n`);
   }
+
+  // Open (and validate writability of) the ledger BEFORE the first send, so a
+  // bad path or permission error fails fast rather than after emails go out.
+  const ledger: FileHandle | null = opts.dryRun ? null : await openLedger(opts.logPath);
 
   // Pull all users that can receive email. emailVerified gating is opt-in via
   // --verified-only; email validity is always enforced in code below.
@@ -178,7 +248,6 @@ async function main(): Promise<void> {
       id: users.id,
       name: users.name,
       email: users.email,
-      emailVerified: users.emailVerified,
       subscriptionTier: users.subscriptionTier,
     })
     .from(users)
@@ -217,33 +286,62 @@ async function main(): Promise<void> {
       manageUrl,
     });
 
-    try {
-      if (opts.dryRun) {
-        // Render to HTML so the dry run exercises the real template path and
-        // surfaces any rendering error, without contacting the provider.
+    if (opts.dryRun) {
+      // Render to HTML so the dry run exercises the real template path and
+      // surfaces any rendering error, without contacting the provider.
+      try {
         const html = await renderEmailToHtml(component);
         console.log(
           `  [dry-run] → ${email} (${summary.tierLabel}, ${summary.monthlyAllowanceLabel}/mo, ${html.length} bytes)`,
         );
-      } else {
-        await sendEmail({ to: email, subject: EMAIL_SUBJECT, react: component });
-        await recordSent(opts.logPath, {
-          email: emailKey,
-          userId: user.id,
-          sentAt: new Date().toISOString(),
-        });
-        console.log(`  ✓ ${email} (${summary.tierLabel})`);
-        if (opts.delayMs > 0) await sleep(opts.delayMs);
+        sentCount++;
+      } catch (error) {
+        errorCount++;
+        const msg = error instanceof Error ? error.message : String(error);
+        errors.push(`${email}: ${msg}`);
+        console.error(`  ✗ Render failed for ${email}: ${msg}`);
       }
-      sentEmails.add(emailKey);
-      sentCount++;
+      continue;
+    }
+
+    // Live send. A provider failure is per-recipient retryable, but once a send
+    // is accepted the ledger record MUST persist — otherwise a re-run would
+    // double-send. So a ledger-write failure after a successful send is fatal:
+    // we name the unrecorded recipient and abort before sending anyone else.
+    try {
+      await sendEmail({ to: email, subject: EMAIL_SUBJECT, react: component });
     } catch (error) {
       errorCount++;
       const msg = error instanceof Error ? error.message : String(error);
       errors.push(`${email}: ${msg}`);
-      console.error(`  ✗ Failed for ${email}: ${msg}`);
+      console.error(`  ✗ Send failed for ${email}: ${msg}`);
+      continue;
     }
+
+    try {
+      await recordSent(ledger!, {
+        email: emailKey,
+        userId: user.id,
+        sentAt: new Date().toISOString(),
+      });
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      console.error(
+        `\n❌ FATAL: sent to ${email} but failed to record it in the ledger: ${msg}\n` +
+          `   Add this line to ${opts.logPath} before re-running, or that user will be emailed again:\n` +
+          `   ${JSON.stringify({ email: emailKey, userId: user.id })}`,
+      );
+      await ledger!.close();
+      process.exit(1);
+    }
+
+    sentEmails.add(emailKey);
+    sentCount++;
+    console.log(`  ✓ ${email} (${summary.tierLabel})`);
+    if (opts.delayMs > 0) await sleep(opts.delayMs);
   }
+
+  if (ledger) await ledger.close();
 
   console.log('\n📊 Summary:');
   console.log(`  ${opts.dryRun ? 'Would send' : 'Sent'}:        ${sentCount}`);

--- a/scripts/send-credits-change-notifications.ts
+++ b/scripts/send-credits-change-notifications.ts
@@ -1,0 +1,269 @@
+#!/usr/bin/env bun
+/**
+ * Broadcast the "AI usage is moving to metered credits" announcement to users.
+ *
+ * Mirrors scripts/send-tos-notifications.ts but sends a transactional product
+ * announcement (one React Email per recipient) via the shared, rate-limited
+ * `sendEmail` service. Per-tier dollar figures are derived from the billing
+ * source of truth (`@pagespace/lib/billing/credit-pricing`) so the email can
+ * never quote a number that disagrees with what the credit gate actually grants.
+ *
+ * Idempotent / resumable: every successful send is appended to a local JSONL
+ * ledger (default `<repo>/.credits-change-sent.jsonl`, override with
+ * CREDITS_EMAIL_LOG_PATH or --log). Re-running skips any recipient already in
+ * the ledger, so an interrupted run can be resumed without double-sending.
+ * Failures are NOT recorded, so they are retried on the next run.
+ *
+ * Usage:
+ *   bun scripts/send-credits-change-notifications.ts --dry-run
+ *   bun scripts/send-credits-change-notifications.ts --verified-only
+ *   bun scripts/send-credits-change-notifications.ts --limit=50
+ *   bun scripts/send-credits-change-notifications.ts --log=/tmp/credits-sent.jsonl
+ *
+ * Flags:
+ *   --dry-run         Render + report recipients; send nothing, write nothing.
+ *   --verified-only   Only target users whose email is verified.
+ *   --limit=N         Cap the number of (not-yet-sent) recipients this run.
+ *   --delay-ms=N      Pause between real sends (default 120ms) to be gentle on
+ *                     the provider API. Ignored in --dry-run.
+ *   --log=PATH        Override the idempotency ledger path.
+ *
+ * Docker usage:
+ *   docker compose run --rm migrate bun scripts/send-credits-change-notifications.ts --dry-run
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { db } from '@pagespace/db/db';
+import { users } from '@pagespace/db/schema/auth';
+import { isNotNull } from '@pagespace/db/operators';
+import { sendEmail } from '@pagespace/lib/services/email-service';
+import { isValidEmail } from '@pagespace/lib/validators/email';
+import { CreditsChangeEmail } from '@pagespace/lib/email-templates/CreditsChangeEmail';
+import { renderEmailToHtml } from '@pagespace/lib/email-templates/render-email';
+import {
+  getTierCreditSummary,
+  normalizeTier,
+} from '@pagespace/lib/email-templates/credits-change-content';
+
+const EMAIL_SUBJECT = 'Your PageSpace AI usage is moving to monthly credits';
+
+interface CliOptions {
+  dryRun: boolean;
+  verifiedOnly: boolean;
+  limit: number | null;
+  delayMs: number;
+  logPath: string;
+}
+
+interface SentLedgerEntry {
+  email: string;
+  userId: string;
+  sentAt: string;
+}
+
+function defaultLogPath(): string {
+  const fromEnv = process.env.CREDITS_EMAIL_LOG_PATH?.trim();
+  if (fromEnv) return path.resolve(fromEnv);
+  // Resolve relative to the repo root (scripts/..) so the ledger location is
+  // stable regardless of the directory the script is launched from.
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return path.join(here, '..', '.credits-change-sent.jsonl');
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const opts: CliOptions = {
+    dryRun: false,
+    verifiedOnly: false,
+    limit: null,
+    delayMs: 120,
+    logPath: defaultLogPath(),
+  };
+
+  for (const arg of argv) {
+    if (arg === '--dry-run') {
+      opts.dryRun = true;
+    } else if (arg === '--verified-only') {
+      opts.verifiedOnly = true;
+    } else if (arg.startsWith('--limit=')) {
+      const n = Number.parseInt(arg.slice('--limit='.length), 10);
+      if (!Number.isInteger(n) || n <= 0) {
+        throw new Error(`Invalid --limit value: ${arg}`);
+      }
+      opts.limit = n;
+    } else if (arg.startsWith('--delay-ms=')) {
+      const n = Number.parseInt(arg.slice('--delay-ms='.length), 10);
+      if (!Number.isInteger(n) || n < 0) {
+        throw new Error(`Invalid --delay-ms value: ${arg}`);
+      }
+      opts.delayMs = n;
+    } else if (arg.startsWith('--log=')) {
+      const p = arg.slice('--log='.length).trim();
+      if (!p) throw new Error('--log requires a path');
+      opts.logPath = path.resolve(p);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return opts;
+}
+
+/** Load the set of already-emailed addresses (lowercased) from the ledger. */
+async function loadSentEmails(logPath: string): Promise<Set<string>> {
+  const sent = new Set<string>();
+  let raw: string;
+  try {
+    raw = await fs.readFile(logPath, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return sent;
+    throw error;
+  }
+
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const entry = JSON.parse(trimmed) as Partial<SentLedgerEntry>;
+      if (entry.email) sent.add(entry.email.toLowerCase());
+    } catch {
+      console.warn(`  ⚠️  Skipping malformed ledger line: ${trimmed.slice(0, 80)}`);
+    }
+  }
+  return sent;
+}
+
+/** Append one successful send to the ledger (atomic per-line). */
+async function recordSent(
+  logPath: string,
+  entry: SentLedgerEntry,
+): Promise<void> {
+  await fs.appendFile(logPath, `${JSON.stringify(entry)}\n`, 'utf8');
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function appBaseUrl(): string {
+  return process.env.NEXT_PUBLIC_APP_URL?.trim() || 'http://localhost:3000';
+}
+
+async function main(): Promise<void> {
+  const opts = parseArgs(process.argv.slice(2));
+  const baseUrl = appBaseUrl();
+  const manageUrl = `${baseUrl}/settings/plan`;
+
+  console.log('📢 Metered AI-credits announcement broadcast');
+  console.log(`  Mode:          ${opts.dryRun ? 'DRY RUN (no sends)' : 'LIVE SEND'}`);
+  console.log(`  Audience:      ${opts.verifiedOnly ? 'verified emails only' : 'all users with a valid email'}`);
+  console.log(`  Ledger:        ${opts.logPath}`);
+  console.log(`  Manage URL:    ${manageUrl}`);
+  if (opts.limit) console.log(`  Limit:         ${opts.limit}`);
+  if (baseUrl.includes('localhost')) {
+    console.warn('  ⚠️  NEXT_PUBLIC_APP_URL is unset — links point at localhost. Set it before a real send.');
+  }
+  console.log('');
+
+  const sentEmails = await loadSentEmails(opts.logPath);
+  if (sentEmails.size > 0) {
+    console.log(`↩️  Resuming: ${sentEmails.size} recipient(s) already recorded in the ledger.\n`);
+  }
+
+  // Pull all users that can receive email. emailVerified gating is opt-in via
+  // --verified-only; email validity is always enforced in code below.
+  const rows = await db
+    .select({
+      id: users.id,
+      name: users.name,
+      email: users.email,
+      emailVerified: users.emailVerified,
+      subscriptionTier: users.subscriptionTier,
+    })
+    .from(users)
+    .where(opts.verifiedOnly ? isNotNull(users.emailVerified) : undefined);
+
+  console.log(`👥 ${rows.length} user(s) returned from the database.\n`);
+
+  let sentCount = 0;
+  let skippedAlready = 0;
+  let skippedInvalid = 0;
+  let errorCount = 0;
+  const errors: string[] = [];
+
+  for (const user of rows) {
+    if (opts.limit !== null && sentCount >= opts.limit) {
+      console.log(`\n⏹️  Reached --limit=${opts.limit}; stopping.`);
+      break;
+    }
+
+    const email = user.email?.trim();
+    if (!email || !isValidEmail(email)) {
+      skippedInvalid++;
+      continue;
+    }
+
+    const emailKey = email.toLowerCase();
+    if (sentEmails.has(emailKey)) {
+      skippedAlready++;
+      continue;
+    }
+
+    const summary = getTierCreditSummary(normalizeTier(user.subscriptionTier));
+    const component = CreditsChangeEmail({
+      userName: user.name?.trim() || 'there',
+      summary,
+      manageUrl,
+    });
+
+    try {
+      if (opts.dryRun) {
+        // Render to HTML so the dry run exercises the real template path and
+        // surfaces any rendering error, without contacting the provider.
+        const html = await renderEmailToHtml(component);
+        console.log(
+          `  [dry-run] → ${email} (${summary.tierLabel}, ${summary.monthlyAllowanceLabel}/mo, ${html.length} bytes)`,
+        );
+      } else {
+        await sendEmail({ to: email, subject: EMAIL_SUBJECT, react: component });
+        await recordSent(opts.logPath, {
+          email: emailKey,
+          userId: user.id,
+          sentAt: new Date().toISOString(),
+        });
+        console.log(`  ✓ ${email} (${summary.tierLabel})`);
+        if (opts.delayMs > 0) await sleep(opts.delayMs);
+      }
+      sentEmails.add(emailKey);
+      sentCount++;
+    } catch (error) {
+      errorCount++;
+      const msg = error instanceof Error ? error.message : String(error);
+      errors.push(`${email}: ${msg}`);
+      console.error(`  ✗ Failed for ${email}: ${msg}`);
+    }
+  }
+
+  console.log('\n📊 Summary:');
+  console.log(`  ${opts.dryRun ? 'Would send' : 'Sent'}:        ${sentCount}`);
+  console.log(`  Skipped (already sent): ${skippedAlready}`);
+  console.log(`  Skipped (invalid email): ${skippedInvalid}`);
+  console.log(`  Errors:                 ${errorCount}`);
+  errors.forEach((err) => console.error(`    - ${err}`));
+
+  if (opts.dryRun) {
+    console.log('\n✅ Dry run complete — no emails sent, ledger untouched.');
+  } else if (errorCount === 0) {
+    console.log('\n✅ Broadcast complete.');
+  } else {
+    console.log('\n⚠️  Broadcast finished with errors; re-run to retry the failures.');
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error('\n❌ Script failed:', error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Workstream F — Resend announcement to all users

Part of the metered-AI-credits cutover (PR #1484 / `pu/credits-remediation`). A one-time announcement email telling users their AI usage is moving from **daily call limits** to a **monthly pool of prepaid AI credits** (with buy-more top-ups). Wiring + a verified `--dry-run` is the deliverable — **no emails are sent for real**; the live send is scheduled to coincide with the cutover release.

### What's here
- **`CreditsChangeEmail.tsx`** — React Email template matching the existing template visual style (shared `emailStyles`). States the per-tier monthly allowance + top-up packs, and reassures that documents/tasks/channels/files/collaboration are unaffected. Optional unsubscribe link.
- **`credits-change-content.ts`** — pure helper that derives every per-tier dollar figure straight from `billing/credit-pricing` (`TIER_MONTHLY_ALLOWANCE_CENTS` + `CREDIT_PACKS`). Single source of truth, so the email can never quote a number the credit gate doesn't actually grant. Includes `normalizeTier` (unknown/legacy tiers → `free`) and `formatCents`.
- **`render-email.ts`** — thin wrapper over `@react-email/components`' `render` so repo-root scripts can produce email HTML without depending on `@react-email/components` directly (it only resolves inside `packages/lib`).
- **`scripts/send-credits-change-notifications.ts`** — broadcast script mirroring `send-tos-notifications.ts`. Queries all users with a valid email, sends via the shared rate-limited `sendEmail`, and is **idempotent/resumable** via a local JSONL ledger (re-runs skip already-sent recipients; failures are not recorded so they retry next run). Flags: `--dry-run`, `--verified-only`, `--limit=N`, `--delay-ms=N`, `--log=PATH`.
- Package `exports` entries for the three new lib modules; `.gitignore` entry for the ledger file.

### Idempotency design note
The announcement is a one-shot product change, not a `NotificationType`, so reusing `emailNotificationLog` would require adding an enum value + migration (DB schema churn on the shared billing branch). Instead the script tracks sends in a gitignored JSONL ledger — idempotent, resumable, zero schema change, fully file-disjoint from billing core.

### Verification (`--dry-run` against a seeded DB)
- Per-tier numbers render correctly: **free $5 / pro $15 / founder $50 / business $100** — sourced from `credit-pricing.ts`.
- Invalid emails skipped; ledger entries skipped on re-run (idempotency); `--verified-only` excludes unverified users; `--limit` stops early; localhost warning fires when `NEXT_PUBLIC_APP_URL` is unset.
- 15 unit tests (helper logic + render-to-HTML asserting numbers come through verbatim).

### CI
`bun run lint` ✅ · `bun run typecheck` ✅ · `bun run build` ✅ · tests ✅ (the one failure in the full run is a pre-existing local-timezone artifact in `messages/grouping.test.ts` — passes under `TZ=UTC` as CI runs; unrelated to this change).

Scope: file-disjoint from billing core / AI routes / marketing app — touches only `packages/lib/src/email-templates/`, `scripts/`, `packages/lib/package.json` exports, and `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)