### PR TITLE
chore(web): pin web runtime to Node 24.16.0-alpine

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.6
 # Install dependencies only when needed
-FROM node:22.17.0-alpine AS deps
+FROM node:24.16.0-alpine AS deps
 WORKDIR /app
 
 COPY --from=oven/bun:1.3.12-alpine /usr/local/bin/bun /usr/local/bin/bun
@@ -31,7 +31,7 @@ COPY tsconfig.json ./
 COPY types ./types
 
 # Rebuild the source code only when needed
-FROM node:22.17.0-alpine AS builder
+FROM node:24.16.0-alpine AS builder
 WORKDIR /app
 
 COPY --from=oven/bun:1.3.12-alpine /usr/local/bin/bun /usr/local/bin/bun
@@ -71,7 +71,7 @@ RUN cd apps/web && NODE_OPTIONS="--max-old-space-size=4096" bun run build
 ENV NODE_ENV=production
 
 # Production image, copy all the files and run next
-FROM node:22.17.0-alpine AS runner
+FROM node:24.16.0-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production


### PR DESCRIPTION
Bumps the **web** Docker image (deps/builder/runner) from `node:22.17.0-alpine` → `node:24.16.0-alpine`.

## Why
The agent code-execution driver (`@fly/sprites`, default-OFF in #1487) is **Node 24+/ESM-only** and loads in-process in the web server, so enabling code execution requires the web runtime on Node 24. This lands that prerequisite **separately** from the dark feature.

## Validation (local)
Full production image build on `node:24.16.0-alpine` succeeds end-to-end:
- `bun install --frozen-lockfile` ✅
- `@pagespace/db` + `@pagespace/lib` build ✅
- `next build` — compiled, **208/208 static pages generated** ✅
- Image runs **Node v24.16.0**, no `EBADENGINE`/engine warnings, `@fly/sprites` present in tree ✅

## Scope / risk
- **Web only.** `processor` (TensorFlow native, highest ABI-rebuild risk) intentionally stays on Node 22; realtime/admin/marketing untouched.
- Web has no native deps + alpine base + Next.js 15 → low risk; the build proved it out.
- Independent of #1487 (which ships dark); merge order doesn't matter, but the feature can't be enabled until this is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Node.js runtime to version 24.16.0 for improved performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->