### PR TITLE
feat(ai): server-side tool execution for OpenAI-compatible completions

### DIFF
--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -67,6 +67,18 @@ vi.mock('@/lib/ai/core', () => ({
   }),
   extractMessageContent: vi.fn().mockReturnValue('Hello'),
   isProviderError: vi.fn((r: unknown) => r != null && typeof r === 'object' && 'error' in r && 'status' in r),
+  pageSpaceTools: {},
+  filterToolsForReadOnly: vi.fn((tools: unknown) => tools),
+  getModelCapabilities: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('@/lib/ai/tools/tool-exposure', () => ({
+  applyToolExposureMode: vi.fn((tools: unknown) => ({ tools, toolDiscoveryPrompt: '' })),
+}));
+
+vi.mock('@/lib/ai/tools/finish-tool', () => ({
+  finishTool: {},
+  FINISH_TOOL_NAME: 'finish',
 }));
 
 vi.mock('@/lib/subscription/usage-service', () => ({

--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -44,6 +44,7 @@ vi.mock('@pagespace/lib/utils/enums', () => ({
 
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
   canUserViewPage: vi.fn().mockResolvedValue(true),
+  canUserEditPage: vi.fn().mockResolvedValue(true),
 }));
 
 vi.mock('@pagespace/lib/logging/logger-config', () => ({
@@ -121,7 +122,7 @@ import { NextResponse } from 'next/server';
 import { POST } from '../route';
 import { authenticateRequestWithOptions, checkMCPPageScope } from '@/lib/auth';
 import { db } from '@pagespace/db/db';
-import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { canUserViewPage, canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 import { chatMessageRepository } from '@/lib/repositories/chat-message-repository';
 import { sanitizeMessagesForModel } from '@/lib/ai/core';
@@ -165,6 +166,7 @@ describe('POST /api/v1/chat/completions', () => {
     vi.mocked(authenticateRequestWithOptions).mockResolvedValue(mcpAuth);
     vi.mocked(checkMCPPageScope).mockResolvedValue(null);
     vi.mocked(canUserViewPage).mockResolvedValue(true);
+    vi.mocked(canUserEditPage).mockResolvedValue(true);
     vi.mocked(db.select).mockReturnValue({
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockResolvedValue([agentPage]),
@@ -247,6 +249,18 @@ describe('POST /api/v1/chat/completions', () => {
       should: 'return 404 Not Found',
       actual: response.status,
       expected: 404,
+    });
+  });
+
+  test('returns 403 when the caller can view but cannot edit the agent page', async () => {
+    vi.mocked(canUserViewPage).mockResolvedValue(true);
+    vi.mocked(canUserEditPage).mockResolvedValue(false);
+    const response = await POST(makeRequest(validBody));
+    assert({
+      given: 'a view-only caller (no edit permission) on an agent that exposes write tools',
+      should: 'return 403 so a view-only user cannot drive server-side tool writes',
+      actual: response.status,
+      expected: 403,
     });
   });
 

--- a/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
+++ b/apps/web/src/app/api/v1/chat/completions/__tests__/route.test.ts
@@ -7,6 +7,7 @@ vi.mock('@/lib/auth', () => ({
   authenticateRequestWithOptions: vi.fn(),
   isAuthError: vi.fn((r: unknown) => r != null && typeof r === 'object' && 'error' in r),
   checkMCPPageScope: vi.fn().mockResolvedValue(null),
+  getAllowedDriveIds: vi.fn(() => []),
 }));
 
 vi.mock('@pagespace/db/db', () => ({

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -5,6 +5,7 @@ import { createId } from '@paralleldrive/cuid2';
 import { db } from '@pagespace/db/db';
 import { eq } from '@pagespace/db/operators';
 import { pages } from '@pagespace/db/schema/core';
+import { users } from '@pagespace/db/schema/auth';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { canUserViewPage, canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { loggers } from '@pagespace/lib/logging/logger-config';
@@ -127,6 +128,15 @@ export async function POST(request: Request): Promise<Response> {
   // Always inject the finish tool so the agentic loop can terminate cleanly.
   filteredTools = { ...filteredTools, ...finishTool } as ToolSet;
 
+  // Load the caller's timezone so time-aware tools (calendar, task triggers)
+  // resolve dates in the user's zone instead of defaulting to UTC, matching
+  // the in-app page chat (apps/web/src/app/api/ai/chat/route.ts:833).
+  const [user] = await db
+    .select({ timezone: users.timezone })
+    .from(users)
+    .where(eq(users.id, authResult.userId));
+  const userTimezone = user?.timezone ?? undefined;
+
   // 8. Build message context and save new user message
   const isThreadMode = incomingConversationId !== undefined;
   const conversationId = isThreadMode ? incomingConversationId : createId();
@@ -166,6 +176,7 @@ export async function POST(request: Request): Promise<Response> {
     experimental_context: {
       userId: authResult.userId,
       conversationId,
+      timezone: userTimezone,
       aiProvider: page.aiProvider ?? undefined,
       aiModel: page.aiModel ?? undefined,
       modelCapabilities: await getModelCapabilities(

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -13,6 +13,7 @@ import {
   authenticateRequestWithOptions,
   isAuthError,
   checkMCPPageScope,
+  getAllowedDriveIds,
 } from '@/lib/auth';
 import {
   createAIProvider,
@@ -185,6 +186,9 @@ export async function POST(request: Request): Promise<Response> {
       ),
       chatSource: { type: 'page' as const, agentPageId: pageId, agentTitle: page.title },
       enabledTools: agentEnabledTools ?? null,
+      // Bind tool execution to the MCP token's drive scope so a scoped token
+      // cannot reach drives outside its scope via the agent's broader ACL.
+      mcpAllowedDriveIds: getAllowedDriveIds(authResult),
     },
     maxRetries: 20,
     onFinish: async ({ text, totalUsage }) => {

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
-import { streamText, convertToModelMessages } from 'ai';
+import { streamText, convertToModelMessages, hasToolCall, stepCountIs } from 'ai';
+import type { ToolSet } from 'ai';
 import { createId } from '@paralleldrive/cuid2';
 import { db } from '@pagespace/db/db';
 import { eq } from '@pagespace/db/operators';
@@ -20,7 +21,12 @@ import {
   extractMessageContent,
   isProviderError,
   convertDbMessageToUIMessage,
+  pageSpaceTools,
+  filterToolsForReadOnly,
+  getModelCapabilities,
 } from '@/lib/ai/core';
+import { applyToolExposureMode } from '@/lib/ai/tools/tool-exposure';
+import { finishTool, FINISH_TOOL_NAME } from '@/lib/ai/tools/finish-tool';
 import { incrementUsage } from '@/lib/subscription/usage-service';
 import { chatMessageRepository } from '@/lib/repositories/chat-message-repository';
 import { validateInferenceRequest } from '@/lib/ai/openai-api/validate-inference-request';
@@ -32,6 +38,9 @@ import { AIMonitoring } from '@pagespace/lib/monitoring/ai-monitoring';
 export const maxDuration = 300;
 
 const AUTH_OPTIONS = { allow: ['mcp'] as const, requireCSRF: false };
+
+// Runtime-toggled tools that must stay directly callable even in search mode.
+const ALWAYS_UPFRONT_TOOLS = new Set(['web_search']);
 
 export async function POST(request: Request): Promise<Response> {
   // 1. Authenticate — MCP tokens only; no session, no CSRF, no browser session ID
@@ -89,6 +98,27 @@ export async function POST(request: Request): Promise<Response> {
   const systemPrompt = page.systemPrompt
     ?? buildSystemPrompt('page', undefined, false);
 
+  // 7b. Build the agent's server-side tool set (mirrors /api/ai/chat).
+  // The OpenAI request shape carries no read-only / web-search toggles, so
+  // read-only defaults to false; web_search falls through the allowlist.
+  const baseTools = filterToolsForReadOnly(pageSpaceTools, false);
+  // Per-agent allowlist: null/undefined = unrestricted; [] = none; [names] = only those.
+  const agentEnabledTools = page.enabledTools as string[] | null;
+  let filteredTools: ToolSet =
+    agentEnabledTools != null
+      ? (Object.fromEntries(
+          Object.entries(baseTools).filter(([name]) => agentEnabledTools.includes(name)),
+        ) as ToolSet)
+      : (baseTools as ToolSet);
+  // Exposure mode: 'upfront' (default) hands every tool over; 'search' defers
+  // non-core tools behind tool_search/execute_tool.
+  const toolExposureMode = (page.toolExposureMode as 'upfront' | 'search' | null) ?? 'upfront';
+  const exposure = applyToolExposureMode(filteredTools, toolExposureMode, ALWAYS_UPFRONT_TOOLS);
+  filteredTools = exposure.tools;
+  const toolDiscoveryPrompt = exposure.toolDiscoveryPrompt;
+  // Always inject the finish tool so the agentic loop can terminate cleanly.
+  filteredTools = { ...filteredTools, ...finishTool } as ToolSet;
+
   // 8. Build message context and save new user message
   const isThreadMode = incomingConversationId !== undefined;
   const conversationId = isThreadMode ? incomingConversationId : createId();
@@ -121,8 +151,23 @@ export async function POST(request: Request): Promise<Response> {
   const sanitized = sanitizeMessagesForModel(inferenceMessages);
   const aiResult = streamText({
     model: providerResult.model,
-    system: systemPrompt,
+    system: systemPrompt + toolDiscoveryPrompt,
     messages: convertToModelMessages(sanitized),
+    tools: filteredTools,
+    stopWhen: [hasToolCall(FINISH_TOOL_NAME), stepCountIs(100)],
+    experimental_context: {
+      userId: authResult.userId,
+      conversationId,
+      aiProvider: page.aiProvider ?? undefined,
+      aiModel: page.aiModel ?? undefined,
+      modelCapabilities: await getModelCapabilities(
+        providerResult.modelName,
+        providerResult.provider,
+      ),
+      chatSource: { type: 'page' as const, agentPageId: pageId, agentTitle: page.title },
+      enabledTools: agentEnabledTools ?? null,
+    },
+    maxRetries: 20,
     onFinish: async ({ text, totalUsage }) => {
       const assistantId = createId();
       await saveMessageToDatabase({

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -6,7 +6,7 @@ import { db } from '@pagespace/db/db';
 import { eq } from '@pagespace/db/operators';
 import { pages } from '@pagespace/db/schema/core';
 import { PageType } from '@pagespace/lib/utils/enums';
-import { canUserViewPage } from '@pagespace/lib/permissions/permissions';
+import { canUserViewPage, canUserEditPage } from '@pagespace/lib/permissions/permissions';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import {
   authenticateRequestWithOptions,
@@ -78,10 +78,18 @@ export async function POST(request: Request): Promise<Response> {
     return NextResponse.json({ error: 'Agent not found' }, { status: 404 });
   }
 
-  // 5. Permission check
+  // 5. Permission check. View is necessary but not sufficient: this endpoint runs
+  // the agent's server-side tools (including write tools) with the agent page as the
+  // actor, so it requires the same edit gate the in-app page chat enforces before
+  // sending a message. A view-only caller must not be able to drive writes.
   const canView = await canUserViewPage(authResult.userId, pageId);
   if (!canView) {
     auditRequest(request, { eventType: 'authz.access.denied', userId: authResult.userId, resourceType: 'openai_inference', resourceId: pageId, details: { reason: 'no_view_permission', method: 'POST' }, riskScore: 0.5 });
+    return NextResponse.json({ error: 'Access denied' }, { status: 403 });
+  }
+  const canEdit = await canUserEditPage(authResult.userId, pageId);
+  if (!canEdit) {
+    auditRequest(request, { eventType: 'authz.access.denied', userId: authResult.userId, resourceType: 'openai_inference', resourceId: pageId, details: { reason: 'no_edit_permission', method: 'POST' }, riskScore: 0.5 });
     return NextResponse.json({ error: 'Access denied' }, { status: 403 });
   }
 

--- a/apps/web/src/lib/ai/core/types.ts
+++ b/apps/web/src/lib/ai/core/types.ts
@@ -40,6 +40,12 @@ export interface ToolExecutionContext {
   // Allowlist of tool names this agent is permitted to execute (null = unrestricted)
   enabledTools?: string[] | null;
 
+  // MCP token drive-scope restriction. Empty/undefined = full access (session auth
+  // or an unscoped MCP token); non-empty = tools may only touch these drive IDs.
+  // Enforced in actor-permissions so a scoped token cannot escalate through an
+  // agent whose own ACL spans drives outside the token scope.
+  mcpAllowedDriveIds?: string[];
+
   // Chat source identification - determines sender identity for channel messages
   chatSource?: {
     type: 'global' | 'page';

--- a/apps/web/src/lib/ai/tools/__tests__/actor-permissions.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/actor-permissions.test.ts
@@ -116,9 +116,19 @@ describe('MCP drive-scope enforcement', () => {
     expect(mockGetAgentAccessLevel).not.toHaveBeenCalled();
   });
 
-  it('canActorEditPage: fails closed when the page drive cannot be resolved', async () => {
+  it('canActorEditPage: denies an unknown id that is neither a page nor an allowed drive', async () => {
     mockDbWhere.mockResolvedValue([]);
     expect(await canActorEditPage(scopedAgentCtx, 'missing-page')).toBe(false);
+    expect(mockGetAgentAccessLevel).not.toHaveBeenCalled();
+  });
+
+  it('canActorEditPage: root-create path — an in-scope drive id with no page row is allowed', async () => {
+    // create_page passes the DRIVE id to canActorEditPage for root-level creates.
+    mockDbWhere.mockResolvedValue([]); // no page row for a drive id
+    mockGetAgentAccessLevel.mockResolvedValue({ canEdit: true });
+    expect(await canActorEditPage(scopedAgentCtx, 'drive-A')).toBe(true);
+    // The scope ceiling passed (drive-A is in scope), so the agent ACL was consulted.
+    expect(mockGetAgentAccessLevel).toHaveBeenCalledWith('agent-1', 'drive-A');
   });
 
   it('canActorEditPage: allows an in-scope page (then defers to the agent ACL)', async () => {

--- a/apps/web/src/lib/ai/tools/__tests__/actor-permissions.test.ts
+++ b/apps/web/src/lib/ai/tools/__tests__/actor-permissions.test.ts
@@ -1,27 +1,47 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockHasAgentDriveMembership, mockCheckDriveAccess } = vi.hoisted(() => ({
+const {
+  mockHasAgentDriveMembership,
+  mockCheckDriveAccess,
+  mockGetUserDriveAccess,
+  mockGetAgentAccessLevel,
+  mockDbWhere,
+} = vi.hoisted(() => ({
   mockHasAgentDriveMembership: vi.fn(),
   mockCheckDriveAccess: vi.fn(),
+  mockGetUserDriveAccess: vi.fn(),
+  mockGetAgentAccessLevel: vi.fn(),
+  mockDbWhere: vi.fn(),
 }));
 
 vi.mock('@pagespace/lib/permissions/permissions', () => ({
   getUserAccessLevel: vi.fn(),
-  getUserDriveAccess: vi.fn(),
+  getUserDriveAccess: mockGetUserDriveAccess,
   canUserEditPage: vi.fn(),
   canUserDeletePage: vi.fn(),
   getUserAccessiblePagesInDriveWithDetails: vi.fn(),
 }));
 vi.mock('@pagespace/lib/permissions/agent-permissions', () => ({
-  getAgentAccessLevel: vi.fn(),
+  getAgentAccessLevel: mockGetAgentAccessLevel,
   getAgentAccessiblePagesInDrive: vi.fn(),
   hasAgentDriveMembership: mockHasAgentDriveMembership,
 }));
 vi.mock('@pagespace/lib/services/drive-member-service', () => ({
   checkDriveAccess: mockCheckDriveAccess,
 }));
+vi.mock('@pagespace/db/db', () => ({
+  db: { select: () => ({ from: () => ({ where: mockDbWhere }) }) },
+}));
+vi.mock('@pagespace/db/operators', () => ({ eq: vi.fn() }));
+vi.mock('@pagespace/db/schema/core', () => ({ pages: { id: 'id', driveId: 'driveId' } }));
 
-import { canActorManageDrive } from '../actor-permissions';
+import {
+  canActorManageDrive,
+  canActorAccessDrive,
+  canActorEditPage,
+  filterDriveIdsByMcpScope,
+  driveOutsideMcpScope,
+} from '../actor-permissions';
 import type { ToolExecutionContext } from '../../core';
 
 const DRIVE = 'drive-1';
@@ -65,5 +85,72 @@ describe('canActorManageDrive', () => {
   it('denies an agent that is not a drive member', async () => {
     mockHasAgentDriveMembership.mockResolvedValue(false);
     expect(await canActorManageDrive(agentCtx, DRIVE)).toBe(false);
+  });
+});
+
+describe('MCP drive-scope enforcement', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // A scoped MCP token acting as an agent that DOES have access to the target.
+  const scopedAgentCtx = {
+    userId: 'user-1',
+    chatSource: { type: 'page', agentPageId: 'agent-1' },
+    mcpAllowedDriveIds: ['drive-A'],
+  } as ToolExecutionContext;
+
+  it('canActorAccessDrive: denies a drive outside the token scope before any ACL check', async () => {
+    expect(await canActorAccessDrive(scopedAgentCtx, 'drive-B')).toBe(false);
+    // Fails closed at the scope ceiling — the agent ACL is never consulted.
+    expect(mockHasAgentDriveMembership).not.toHaveBeenCalled();
+  });
+
+  it('canActorAccessDrive: allows an in-scope drive (then defers to the agent ACL)', async () => {
+    mockHasAgentDriveMembership.mockResolvedValue(true);
+    expect(await canActorAccessDrive(scopedAgentCtx, 'drive-A')).toBe(true);
+    expect(mockHasAgentDriveMembership).toHaveBeenCalledWith('agent-1', 'drive-A');
+  });
+
+  it('canActorEditPage: denies when the page lives in a drive outside the token scope', async () => {
+    mockDbWhere.mockResolvedValue([{ driveId: 'drive-B' }]);
+    expect(await canActorEditPage(scopedAgentCtx, 'page-x')).toBe(false);
+    expect(mockGetAgentAccessLevel).not.toHaveBeenCalled();
+  });
+
+  it('canActorEditPage: fails closed when the page drive cannot be resolved', async () => {
+    mockDbWhere.mockResolvedValue([]);
+    expect(await canActorEditPage(scopedAgentCtx, 'missing-page')).toBe(false);
+  });
+
+  it('canActorEditPage: allows an in-scope page (then defers to the agent ACL)', async () => {
+    mockDbWhere.mockResolvedValue([{ driveId: 'drive-A' }]);
+    mockGetAgentAccessLevel.mockResolvedValue({ canEdit: true });
+    expect(await canActorEditPage(scopedAgentCtx, 'page-y')).toBe(true);
+  });
+
+  it('unscoped caller (no mcpAllowedDriveIds) skips scope checks entirely', async () => {
+    const unscoped = { userId: 'user-1', mcpAllowedDriveIds: [] } as ToolExecutionContext;
+    mockGetUserDriveAccess.mockResolvedValue(true);
+    expect(await canActorAccessDrive(unscoped, 'drive-B')).toBe(true);
+    // No page-drive lookup happens for drive-level checks.
+    expect(mockDbWhere).not.toHaveBeenCalled();
+  });
+});
+
+describe('filterDriveIdsByMcpScope / driveOutsideMcpScope', () => {
+  const scoped = { userId: 'u', mcpAllowedDriveIds: ['a', 'b'] } as ToolExecutionContext;
+  const unscoped = { userId: 'u' } as ToolExecutionContext;
+
+  it('filters a drive list down to the token scope', () => {
+    expect(filterDriveIdsByMcpScope(scoped, ['a', 'c', 'b', 'd'])).toEqual(['a', 'b']);
+  });
+
+  it('returns the list unchanged for an unscoped caller', () => {
+    expect(filterDriveIdsByMcpScope(unscoped, ['a', 'c'])).toEqual(['a', 'c']);
+  });
+
+  it('driveOutsideMcpScope: true for out-of-scope, false for in-scope and unscoped', () => {
+    expect(driveOutsideMcpScope(scoped, 'c')).toBe(true);
+    expect(driveOutsideMcpScope(scoped, 'a')).toBe(false);
+    expect(driveOutsideMcpScope(unscoped, 'c')).toBe(false);
   });
 });

--- a/apps/web/src/lib/ai/tools/activity-tools.ts
+++ b/apps/web/src/lib/ai/tools/activity-tools.ts
@@ -20,6 +20,7 @@ import {
 } from '@pagespace/lib/content/diff-generator';
 import { readPageContent } from '@pagespace/lib/services/page-content-store';
 import { type ToolExecutionContext } from '../core';
+import { filterDriveIdsByMcpScope } from './actor-permissions';
 
 /**
  * Activity tools for AI agents
@@ -395,6 +396,9 @@ When summarizing multiple changes, group them thematically and describe the over
           for (const d of ownedDrives) driveIdSet.add(d.id);
           targetDriveIds = Array.from(driveIdSet);
         }
+
+        // Ceiling a scoped MCP token to its allowed drives (no-op otherwise).
+        targetDriveIds = filterDriveIdsByMcpScope(context as ToolExecutionContext, targetDriveIds);
 
         if (targetDriveIds.length === 0) {
           return {

--- a/apps/web/src/lib/ai/tools/actor-permissions.ts
+++ b/apps/web/src/lib/ai/tools/actor-permissions.ts
@@ -69,13 +69,19 @@ export function filterDriveIdsByMcpScope(
 
 /**
  * Page-level equivalent: resolves the page's drive (only when a scope is active)
- * and fails closed if the drive cannot be determined.
+ * and checks it against the token scope.
+ *
+ * The create_page root path authorizes by passing the DRIVE id to
+ * canActorEditPage ("the drive is the parent of root pages"), so when no page
+ * row matches we fall back to treating the id as a drive id and checking that
+ * against the scope. A genuinely unknown id matches neither and stays
+ * fail-closed (the actor ACL would reject it anyway).
  */
 async function pageOutsideMcpScope(context: ToolExecutionContext, pageId: string): Promise<boolean> {
   if (!hasMcpScope(context)) return false;
   const [row] = await db.select({ driveId: pages.driveId }).from(pages).where(eq(pages.id, pageId));
-  if (!row?.driveId) return true;
-  return !context.mcpAllowedDriveIds!.includes(row.driveId);
+  const driveId = row?.driveId ?? pageId;
+  return !context.mcpAllowedDriveIds!.includes(driveId);
 }
 
 export async function canActorEditPage(

--- a/apps/web/src/lib/ai/tools/actor-permissions.ts
+++ b/apps/web/src/lib/ai/tools/actor-permissions.ts
@@ -25,9 +25,17 @@ export function getAgentPageId(context: ToolExecutionContext): string | undefine
  * Whether the caller carries an MCP drive-scope restriction (a non-empty
  * allowedDriveIds). Empty/undefined means full access — session auth or an
  * unscoped token — and skips all scope checks.
+ *
+ * Exported as `isMcpScoped` for tools that should be blocked entirely for
+ * drive-scoped tokens (e.g. creating a brand-new drive), mirroring the
+ * /api/mcp/drives REST gate.
  */
-function hasMcpScope(context: ToolExecutionContext): boolean {
+export function isMcpScoped(context: ToolExecutionContext): boolean {
   return (context.mcpAllowedDriveIds?.length ?? 0) > 0;
+}
+
+function hasMcpScope(context: ToolExecutionContext): boolean {
+  return isMcpScoped(context);
 }
 
 /**

--- a/apps/web/src/lib/ai/tools/actor-permissions.ts
+++ b/apps/web/src/lib/ai/tools/actor-permissions.ts
@@ -13,15 +13,68 @@ import {
   hasAgentDriveMembership,
 } from '@pagespace/lib/permissions/agent-permissions';
 import { checkDriveAccess } from '@pagespace/lib/services/drive-member-service';
+import { db } from '@pagespace/db/db';
+import { eq } from '@pagespace/db/operators';
+import { pages } from '@pagespace/db/schema/core';
 
 export function getAgentPageId(context: ToolExecutionContext): string | undefined {
   return context.chatSource?.type === 'page' ? context.chatSource.agentPageId : undefined;
+}
+
+/**
+ * Whether the caller carries an MCP drive-scope restriction (a non-empty
+ * allowedDriveIds). Empty/undefined means full access — session auth or an
+ * unscoped token — and skips all scope checks.
+ */
+function hasMcpScope(context: ToolExecutionContext): boolean {
+  return (context.mcpAllowedDriveIds?.length ?? 0) > 0;
+}
+
+/**
+ * True when a scoped MCP caller is trying to reach a drive outside its token
+ * scope. The actor's own ACL (user or agent) is checked separately; this is an
+ * additional ceiling that a scoped token can never exceed, mirroring
+ * checkMCPDriveScope on the REST surface.
+ *
+ * Exported so tools that authorize via primitives OTHER than the canActor*
+ * chokepoint (e.g. activity, calendar, member listing) can apply the same
+ * ceiling without changing their existing permission logic. Deny-only and a
+ * no-op for unscoped callers, so it never affects the in-app product.
+ */
+export function driveOutsideMcpScope(context: ToolExecutionContext, driveId: string): boolean {
+  if (!hasMcpScope(context)) return false;
+  return !context.mcpAllowedDriveIds!.includes(driveId);
+}
+
+/**
+ * Filter a list of drive IDs down to those a scoped MCP token may reach.
+ * Returns the input unchanged for unscoped callers (full access).
+ */
+export function filterDriveIdsByMcpScope(
+  context: ToolExecutionContext,
+  driveIds: string[],
+): string[] {
+  if (!hasMcpScope(context)) return driveIds;
+  const allowed = new Set(context.mcpAllowedDriveIds);
+  return driveIds.filter((id) => allowed.has(id));
+}
+
+/**
+ * Page-level equivalent: resolves the page's drive (only when a scope is active)
+ * and fails closed if the drive cannot be determined.
+ */
+async function pageOutsideMcpScope(context: ToolExecutionContext, pageId: string): Promise<boolean> {
+  if (!hasMcpScope(context)) return false;
+  const [row] = await db.select({ driveId: pages.driveId }).from(pages).where(eq(pages.id, pageId));
+  if (!row?.driveId) return true;
+  return !context.mcpAllowedDriveIds!.includes(row.driveId);
 }
 
 export async function canActorEditPage(
   context: ToolExecutionContext,
   pageId: string,
 ): Promise<boolean> {
+  if (await pageOutsideMcpScope(context, pageId)) return false;
   const agentPageId = getAgentPageId(context);
   if (agentPageId) {
     const perms = await getAgentAccessLevel(agentPageId, pageId);
@@ -34,6 +87,7 @@ export async function canActorDeletePage(
   context: ToolExecutionContext,
   pageId: string,
 ): Promise<boolean> {
+  if (await pageOutsideMcpScope(context, pageId)) return false;
   const agentPageId = getAgentPageId(context);
   if (agentPageId) {
     const perms = await getAgentAccessLevel(agentPageId, pageId);
@@ -46,6 +100,7 @@ export async function canActorViewPage(
   context: ToolExecutionContext,
   pageId: string,
 ): Promise<boolean> {
+  if (await pageOutsideMcpScope(context, pageId)) return false;
   const agentPageId = getAgentPageId(context);
   if (agentPageId) {
     const perms = await getAgentAccessLevel(agentPageId, pageId);
@@ -59,6 +114,7 @@ export async function canActorAccessDrive(
   context: ToolExecutionContext,
   driveId: string,
 ): Promise<boolean> {
+  if (driveOutsideMcpScope(context, driveId)) return false;
   const agentPageId = getAgentPageId(context);
   if (agentPageId) return hasAgentDriveMembership(agentPageId, driveId);
   return getUserDriveAccess(context.userId, driveId);
@@ -79,6 +135,7 @@ export async function canActorManageDrive(
   context: ToolExecutionContext,
   driveId: string,
 ): Promise<boolean> {
+  if (driveOutsideMcpScope(context, driveId)) return false;
   const agentPageId = getAgentPageId(context);
   if (agentPageId) return hasAgentDriveMembership(agentPageId, driveId);
   const access = await checkDriveAccess(driveId, context.userId);
@@ -89,6 +146,7 @@ export async function getActorAccessiblePagesInDrive(
   context: ToolExecutionContext,
   driveId: string,
 ): Promise<PageWithPermissions[]> {
+  if (driveOutsideMcpScope(context, driveId)) return [];
   const agentPageId = getAgentPageId(context);
   if (agentPageId) {
     return getAgentAccessiblePagesInDrive(agentPageId, driveId);

--- a/apps/web/src/lib/ai/tools/agent-communication-tools.ts
+++ b/apps/web/src/lib/ai/tools/agent-communication-tools.ts
@@ -5,7 +5,7 @@ import { generateText, convertToModelMessages, UIMessage } from 'ai';
 import { db } from '@pagespace/db/db'
 import { eq, and, sql } from '@pagespace/db/operators'
 import { pages, chatMessages, drives } from '@pagespace/db/schema/core';
-import { canActorViewPage, canActorAccessDrive } from './actor-permissions';
+import { canActorViewPage, canActorAccessDrive, filterDriveIdsByMcpScope } from './actor-permissions';
 import {
   sanitizeMessagesForModel,
   saveMessageToDatabase,
@@ -251,7 +251,7 @@ export const agentCommunicationTools = {
       
       try {
         // Get all drives the user has access to
-        const userDrives = await db
+        const allUserDrives = await db
           .select({
             id: drives.id,
             name: drives.name,
@@ -259,7 +259,13 @@ export const agentCommunicationTools = {
           })
           .from(drives)
           .where(eq(drives.ownerId, userId)); // Simplified - you might want more complex permission logic
-        
+
+        // Ceiling a scoped MCP token to its allowed drives (no-op otherwise).
+        const allowedIds = new Set(
+          filterDriveIdsByMcpScope(executionContext, allUserDrives.map((d) => d.id)),
+        );
+        const userDrives = allUserDrives.filter((d) => allowedIds.has(d.id));
+
         let totalAgentCount = 0;
         const agentsByDrive = [];
         const allAgents = [];

--- a/apps/web/src/lib/ai/tools/calendar-read-tools.ts
+++ b/apps/web/src/lib/ai/tools/calendar-read-tools.ts
@@ -8,6 +8,7 @@ import { workflowRuns } from '@pagespace/db/schema/workflow-runs';
 import type { CalendarTriggerMetadata } from '@pagespace/db/schema/calendar-triggers';
 import { isUserDriveMember, getDriveIdsForUser } from '@pagespace/lib/permissions/permissions';
 import { type ToolExecutionContext } from '../core';
+import { driveOutsideMcpScope, filterDriveIdsByMcpScope } from './actor-permissions';
 import { normalizeTimezone, getTimezoneOffsetMinutes, formatDateInTimezone, isNaiveISODatetime, parseNaiveDatetimeInTimezone } from '../core/timestamp-utils';
 
 /**
@@ -15,8 +16,15 @@ import { normalizeTimezone, getTimezoneOffsetMinutes, formatDateInTimezone, isNa
  */
 async function canAccessEvent(
   userId: string,
-  event: typeof calendarEvents.$inferSelect
+  event: typeof calendarEvents.$inferSelect,
+  context?: ToolExecutionContext
 ): Promise<boolean> {
+  // A scoped MCP token may never reach a drive-tied event outside its scope,
+  // even one it created (no-op for unscoped callers / personal events).
+  if (context && event.driveId && driveOutsideMcpScope(context, event.driveId)) {
+    return false;
+  }
+
   // Creator always has access
   if (event.createdById === userId) {
     return true;
@@ -238,6 +246,10 @@ export const calendarReadTools = {
             };
           }
 
+          if (driveOutsideMcpScope(ctx as ToolExecutionContext, driveId)) {
+            return { success: false, error: 'This token does not have access to this drive.' };
+          }
+
           const canView = await isUserDriveMember(userId, driveId);
           if (!canView) {
             return {
@@ -324,8 +336,12 @@ export const calendarReadTools = {
           };
         }
 
-        // User context: aggregate events from all sources
-        const driveIds = await getDriveIdsForUser(userId);
+        // User context: aggregate events from all sources. Ceiling a scoped MCP
+        // token to its allowed drives (no-op for unscoped callers).
+        const driveIds = filterDriveIdsByMcpScope(
+          ctx as ToolExecutionContext,
+          await getDriveIdsForUser(userId),
+        );
         const conditions = [];
 
         // Personal events
@@ -398,23 +414,30 @@ export const calendarReadTools = {
           orderBy: [desc(calendarEvents.startAt)],
         });
 
+        // Final ceiling: drop any drive-tied event outside a scoped MCP token's
+        // drives (e.g. reached via the attendee branch). No-op for unscoped
+        // callers; personal events (no driveId) are unaffected.
+        const scopedEvents = events.filter(
+          (e) => !e.driveId || !driveOutsideMcpScope(ctx as ToolExecutionContext, e.driveId),
+        );
+
         const userTzForList = (ctx as ToolExecutionContext)?.timezone;
-        const triggerMapAll = await fetchTriggerInfoForEvents(events);
-        const formattedEvents = events.map((e) => formatEventForResponse(e, userTzForList, triggerMapAll.get(e.id)));
+        const triggerMapAll = await fetchTriggerInfoForEvents(scopedEvents);
+        const formattedEvents = scopedEvents.map((e) => formatEventForResponse(e, userTzForList, triggerMapAll.get(e.id)));
 
         return {
           success: true,
           data: { events: formattedEvents },
-          summary: `Found ${events.length} event${events.length === 1 ? '' : 's'} from ${startDate} to ${endDate}`,
+          summary: `Found ${scopedEvents.length} event${scopedEvents.length === 1 ? '' : 's'} from ${startDate} to ${endDate}`,
           stats: {
-            eventCount: events.length,
+            eventCount: scopedEvents.length,
             dateRange: { start: startDate, end: endDate },
             context: 'user',
             includedDrives: driveIds.length,
             includePersonal,
           },
           nextSteps:
-            events.length > 0
+            scopedEvents.length > 0
               ? [
                   'Use get_calendar_event to see full details of a specific event',
                   'Use create_calendar_event to schedule new meetings',
@@ -488,7 +511,7 @@ export const calendarReadTools = {
         }
 
         // Check access
-        const hasAccess = await canAccessEvent(userId, event);
+        const hasAccess = await canAccessEvent(userId, event, ctx as ToolExecutionContext);
         if (!hasAccess) {
           return {
             success: false,
@@ -608,6 +631,9 @@ export const calendarReadTools = {
 
         // Validate drive access if specified
         if (driveId) {
+          if (driveOutsideMcpScope(ctx as ToolExecutionContext, driveId)) {
+            return { success: false, error: 'This token does not have access to this drive.' };
+          }
           const canView = await isUserDriveMember(userId, driveId);
           if (!canView) {
             return {
@@ -617,8 +643,12 @@ export const calendarReadTools = {
           }
         }
 
-        // Get user's events in the date range
-        const driveIds = driveId ? [driveId] : await getDriveIdsForUser(userId);
+        // Get user's events in the date range. Ceiling a scoped MCP token to its
+        // allowed drives (no-op for unscoped callers).
+        const driveIds = filterDriveIdsByMcpScope(
+          ctx as ToolExecutionContext,
+          driveId ? [driveId] : await getDriveIdsForUser(userId),
+        );
         const conditions = [];
 
         // Personal events (user is creator, no drive)
@@ -662,9 +692,17 @@ export const calendarReadTools = {
             startAt: true,
             endAt: true,
             allDay: true,
+            driveId: true,
           },
           orderBy: [calendarEvents.startAt],
         });
+
+        // Final ceiling: a scoped MCP token must not learn the timing of
+        // out-of-scope drive events via the creator/attendee branches above
+        // (no-op for unscoped callers; personal events have no driveId).
+        const scopedEvents = events.filter(
+          (e) => !e.driveId || !driveOutsideMcpScope(ctx as ToolExecutionContext, e.driveId),
+        );
 
         // Find free slots using user's timezone for working hour boundaries
         const userTz = normalizeTimezone((ctx as ToolExecutionContext)?.timezone);
@@ -672,7 +710,7 @@ export const calendarReadTools = {
         const freeSlots: Array<{ start: string; end: string; durationMinutes: number }> = [];
 
         // Create busy intervals from events
-        const busyIntervals = events.map((e) => ({
+        const busyIntervals = scopedEvents.map((e) => ({
           start: e.startAt.getTime(),
           end: e.endAt.getTime(),
         }));

--- a/apps/web/src/lib/ai/tools/calendar-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/calendar-write-tools.ts
@@ -205,6 +205,9 @@ export const calendarWriteTools = {
             if (instrPage.isTrashed) return { success: false, error: 'Instruction page is in trash.' };
             if (!instrPage.driveId) return { success: false, error: 'Cannot use a personal page as instructions.' };
             if (instrPage.driveId !== driveId) {
+              if (driveOutsideMcpScope(ctx as ToolExecutionContext, instrPage.driveId)) {
+                return { success: false, error: 'This token does not have access to the instruction page drive.' };
+              }
               const canAccessInstrDrive = await isUserDriveMember(userId, instrPage.driveId);
               if (!canAccessInstrDrive) return { success: false, error: 'You do not have access to the instruction page drive.' };
             }

--- a/apps/web/src/lib/ai/tools/calendar-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/calendar-write-tools.ts
@@ -18,6 +18,7 @@ import { getDriveMemberUserIds } from '@pagespace/lib/services/drive-member-serv
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { broadcastCalendarEvent } from '@/lib/websocket/calendar-events';
 import { type ToolExecutionContext } from '../core';
+import { driveOutsideMcpScope } from './actor-permissions';
 import { normalizeTimezone, formatDateInTimezone, parseDateTime } from '../core/timestamp-utils';
 import { maskIdentifier } from '@/lib/logging/mask';
 
@@ -153,6 +154,9 @@ export const calendarWriteTools = {
 
         // Validate drive access if driveId is provided
         if (driveId) {
+          if (driveOutsideMcpScope(ctx as ToolExecutionContext, driveId)) {
+            return { success: false, error: 'This token does not have access to this drive.' };
+          }
           const canAccess = await isUserDriveMember(userId, driveId);
           if (!canAccess) {
             return {
@@ -183,6 +187,9 @@ export const calendarWriteTools = {
           if (agent.isTrashed) return { success: false, error: `Agent "${agent.title}" is in trash.` };
           if (!agent.driveId) return { success: false, error: 'Cannot trigger a personal agent page. Use a drive-based agent.' };
           if (agent.driveId !== driveId) {
+            if (driveOutsideMcpScope(ctx as ToolExecutionContext, agent.driveId)) {
+              return { success: false, error: 'This token does not have access to the drive containing this agent.' };
+            }
             const canAccessAgentDrive = await isUserDriveMember(userId, agent.driveId);
             if (!canAccessAgentDrive) return { success: false, error: 'You do not have access to the drive containing this agent.' };
           }
@@ -454,6 +461,12 @@ export const calendarWriteTools = {
           };
         }
 
+        // A scoped MCP token may only touch events whose drive is in scope,
+        // even for events it created in another drive (no-op for unscoped callers).
+        if (event.driveId && driveOutsideMcpScope(ctx as ToolExecutionContext, event.driveId)) {
+          return { success: false, error: 'This token does not have access to this event’s drive.' };
+        }
+
         // Check edit permission
         const editCheck = await canEditEvent(userId, event);
         if (!editCheck.canEdit) {
@@ -665,6 +678,12 @@ export const calendarWriteTools = {
             success: false,
             error: 'Event not found.',
           };
+        }
+
+        // A scoped MCP token may only touch events whose drive is in scope,
+        // even for events it created in another drive (no-op for unscoped callers).
+        if (event.driveId && driveOutsideMcpScope(ctx as ToolExecutionContext, event.driveId)) {
+          return { success: false, error: 'This token does not have access to this event’s drive.' };
         }
 
         // Check edit permission

--- a/apps/web/src/lib/ai/tools/drive-tools.ts
+++ b/apps/web/src/lib/ai/tools/drive-tools.ts
@@ -11,7 +11,7 @@ import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket';
 import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
 import { listAgentDrives } from '@pagespace/lib/services/drive-agent-service';
 import { type ToolExecutionContext } from '../core';
-import { getAgentPageId, filterDriveIdsByMcpScope } from './actor-permissions';
+import { getAgentPageId, filterDriveIdsByMcpScope, driveOutsideMcpScope, isMcpScoped } from './actor-permissions';
 
 // Helper: Extract AI attribution context with actor info for activity logging
 async function getAiContextWithActor(context: ToolExecutionContext) {
@@ -183,6 +183,12 @@ export const driveTools = {
         throw new Error('User authentication required');
       }
 
+      // A drive-scoped MCP token is bound to specific drives and cannot create
+      // new ones (mirrors the /api/mcp/drives REST gate). No-op for unscoped callers.
+      if (isMcpScoped(context as ToolExecutionContext)) {
+        throw new Error('This token is scoped to specific drives and cannot create new drives');
+      }
+
       try {
         // Validate name
         if (!name || name.trim().length === 0) {
@@ -273,6 +279,10 @@ export const driveTools = {
       const userId = (context as ToolExecutionContext)?.userId;
       if (!userId) {
         throw new Error('User authentication required');
+      }
+
+      if (driveOutsideMcpScope(context as ToolExecutionContext, driveId)) {
+        throw new Error('This token does not have access to this drive');
       }
 
       try {
@@ -387,6 +397,10 @@ This context persists across conversations and helps provide better assistance. 
       const userId = (execContext as ToolExecutionContext)?.userId;
       if (!userId) {
         throw new Error('User authentication required');
+      }
+
+      if (driveOutsideMcpScope(execContext as ToolExecutionContext, driveId)) {
+        throw new Error('This token does not have access to this drive');
       }
 
       try {

--- a/apps/web/src/lib/ai/tools/drive-tools.ts
+++ b/apps/web/src/lib/ai/tools/drive-tools.ts
@@ -11,7 +11,7 @@ import { broadcastDriveEvent, createDriveEventPayload } from '@/lib/websocket';
 import { getDriveRecipientUserIds } from '@pagespace/lib/services/drive-member-service';
 import { listAgentDrives } from '@pagespace/lib/services/drive-agent-service';
 import { type ToolExecutionContext } from '../core';
-import { getAgentPageId } from './actor-permissions';
+import { getAgentPageId, filterDriveIdsByMcpScope } from './actor-permissions';
 
 // Helper: Extract AI attribution context with actor info for activity logging
 async function getAiContextWithActor(context: ToolExecutionContext) {
@@ -53,7 +53,12 @@ export const driveTools = {
       const agentPageId = getAgentPageId(context as ToolExecutionContext);
       if (agentPageId) {
         try {
-          const agentDrives = await listAgentDrives(agentPageId);
+          const allAgentDrives = await listAgentDrives(agentPageId);
+          // Ceiling a scoped MCP token to its allowed drives (no-op otherwise).
+          const scopedIds = new Set(
+            filterDriveIdsByMcpScope(context as ToolExecutionContext, allAgentDrives.map((d) => d.driveId)),
+          );
+          const agentDrives = allAgentDrives.filter((d) => scopedIds.has(d.driveId));
           return {
             success: true,
             drives: agentDrives.map((d) => ({
@@ -127,7 +132,15 @@ export const driveTools = {
 
         // 4. Combine all drives and deduplicate
         const allDrives = [...ownedDrives, ...memberDrives, ...permissionDrives];
-        const uniqueDrives = Array.from(new Map(allDrives.map(d => [d.id, d])).values());
+        const dedupedDrives = Array.from(new Map(allDrives.map(d => [d.id, d])).values());
+        // Ceiling a scoped MCP token to its allowed drives (no-op otherwise).
+        const scopedIds = new Set(
+          filterDriveIdsByMcpScope(
+            context as ToolExecutionContext,
+            dedupedDrives.map(d => d.id).filter((id): id is string => id != null),
+          ),
+        );
+        const uniqueDrives = dedupedDrives.filter(d => d.id != null && scopedIds.has(d.id));
 
         return {
           success: true,

--- a/apps/web/src/lib/ai/tools/member-tools.ts
+++ b/apps/web/src/lib/ai/tools/member-tools.ts
@@ -8,6 +8,7 @@ import { userProfiles } from '@pagespace/db/schema/members';
 import { connections } from '@pagespace/db/schema/social';
 import { checkDriveAccess, listDriveMembers } from '@pagespace/lib/services/drive-member-service';
 import { type ToolExecutionContext } from '../core';
+import { driveOutsideMcpScope } from './actor-permissions';
 
 export const memberTools = {
   list_drive_members: tool({
@@ -18,6 +19,10 @@ export const memberTools = {
     execute: async ({ driveId }, { experimental_context: context }) => {
       const userId = (context as ToolExecutionContext)?.userId;
       if (!userId) throw new Error('User authentication required');
+
+      if (driveOutsideMcpScope(context as ToolExecutionContext, driveId)) {
+        return { success: false, error: 'This token does not have access to this drive' };
+      }
 
       const access = await checkDriveAccess(driveId, userId);
       if (!access.drive) return { success: false, error: 'Drive not found' };

--- a/apps/web/src/lib/ai/tools/page-write-tools.ts
+++ b/apps/web/src/lib/ai/tools/page-write-tools.ts
@@ -1,6 +1,6 @@
 import { tool } from 'ai';
 import { z } from 'zod';
-import { canActorEditPage, canActorDeletePage } from './actor-permissions';
+import { canActorEditPage, canActorDeletePage, driveOutsideMcpScope } from './actor-permissions';
 import { PageType } from '@pagespace/lib/utils/enums';
 import { isAIChatPage, isDocumentPage, isCodePage, getDefaultContent, getCreatablePageTypes } from '@pagespace/lib/content/page-types.config';
 import { parseSheetContent, serializeSheetContent, updateSheetCells, isValidCellAddress, isSheetType } from '@pagespace/lib/sheets/sheet';
@@ -832,6 +832,10 @@ export const pageWriteTools = {
         throw new Error('User authentication required');
       }
 
+      if (driveOutsideMcpScope(context as ToolExecutionContext, id)) {
+        throw new Error('This token does not have access to this drive');
+      }
+
       try {
         if (!confirmDriveName) {
           throw new Error('Drive name confirmation is required for trashing drives (confirmDriveName parameter)');
@@ -913,6 +917,10 @@ export const pageWriteTools = {
       const userId = (context as ToolExecutionContext)?.userId;
       if (!userId) {
         throw new Error('User authentication required');
+      }
+
+      if (driveOutsideMcpScope(context as ToolExecutionContext, id)) {
+        throw new Error('This token does not have access to this drive');
       }
 
       try {


### PR DESCRIPTION
## What

The OpenAI-compatible endpoint `POST /api/v1/chat/completions` called `streamText` with **no tools**. External OpenAI-compatible clients therefore got a talk-only agent — it could not use any of PageSpace's ~51 server-side tools (read/search/create/edit pages, tasks, calendar, etc.), even though the *same* agent uses them in the in-app chat (`/api/ai/chat`).

This wires the existing agentic tool loop into the endpoint so the agent runs its tools **server-side** before producing its final answer.

## How

Mirrors the canonical pattern from `/api/ai/chat/route.ts`:

- **Permission gate** — requires `canUserViewPage` **and** `canUserEditPage` (same as the in-app page chat at `route.ts:223-252`). Since tools now execute with the agent page as the actor (`chatSource.agentPageId`), a view-only caller must not be able to drive writes; a view-only caller gets 403.
- **Build the tool set** — read-only filter → per-agent `enabledTools` allowlist (`null` = unrestricted, `[]` = none, `[names]` = only those) → `toolExposureMode` (`upfront` default / `search`) → inject the `finish` tool.
- **Wire into `streamText`** — pass `tools`, `stopWhen: [hasToolCall('finish'), stepCountIs(100)]`, `maxRetries: 20`, and `experimental_context` (userId, conversationId, provider/model, modelCapabilities, `chatSource.agentPageId`, `enabledTools`).

## No surface change

The SSE adapter (`adapt-to-openai-chunk.ts`) already emits only `start` / `text-delta` / `finish` and drops every tool-related chunk. Tool calls run server-side; the client receives only the final assistant text — no streaming of tool calls needed.

## Scope cuts

- Integration tools and desktop MCP tools are **out of scope** (they need client-supplied `mcpTools` / per-agent integration resolution this headless endpoint doesn't carry).
- Read-only / web-search runtime toggles aren't part of the OpenAI request shape, so read-only defaults to `false` and `web_search` falls through the allowlist like any other tool.

## Testing

- ✅ `typecheck` clean for the route
- ✅ `eslint` clean
- ✅ Unit tests 17/17 pass (route test mocks extended for the new imports + edit-gate regression test)
- ⏳ Live end-to-end (curl with a real MCP token against an agent with read/search tools) not yet run — needs a running stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)