### PR TITLE
fix(auth): stop admin login from logging users out of the web app

### DIFF
--- a/apps/admin/src/app/api/admin/users/[userId]/data/__tests__/route.test.ts
+++ b/apps/admin/src/app/api/admin/users/[userId]/data/__tests__/route.test.ts
@@ -100,7 +100,7 @@ const mockValidateSession = vi.mocked(sessionService.validateSession);
 const mockAdminValidation = vi.mocked(validateAdminAccess);
 const mockFindById = vi.mocked(accountRepository.findById);
 
-const FAKE_COOKIE = 'session=ps_sess_faketoken';
+const FAKE_COOKIE = 'admin_session=ps_sess_faketoken';
 
 function mockAdminAuth(adminId = 'admin-123') {
   mockValidateSession.mockResolvedValue({

--- a/apps/admin/src/app/api/admin/users/[userId]/export/__tests__/route.test.ts
+++ b/apps/admin/src/app/api/admin/users/[userId]/export/__tests__/route.test.ts
@@ -44,7 +44,7 @@ import { validateAdminAccess } from '@/lib/auth/admin-role';
 const mockValidateSession = vi.mocked(sessionService.validateSession);
 const mockAdminValidation = vi.mocked(validateAdminAccess);
 
-const FAKE_COOKIE = 'session=ps_sess_faketoken';
+const FAKE_COOKIE = 'admin_session=ps_sess_faketoken';
 
 function mockAdminAuth() {
   mockValidateSession.mockResolvedValue({

--- a/apps/admin/src/app/api/admin/users/[userId]/gift-subscription/__tests__/route.security.test.ts
+++ b/apps/admin/src/app/api/admin/users/[userId]/gift-subscription/__tests__/route.security.test.ts
@@ -177,7 +177,7 @@ describe('/api/admin/users/[userId]/gift-subscription - Security Tests', () => {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'Cookie': `session=${adminSessionToken}`,
+            'Cookie': `admin_session=${adminSessionToken}`,
             'X-CSRF-Token': adminCsrfToken,
           },
           body: JSON.stringify({
@@ -209,7 +209,7 @@ describe('/api/admin/users/[userId]/gift-subscription - Security Tests', () => {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'Cookie': `session=${adminSessionToken}`,
+            'Cookie': `admin_session=${adminSessionToken}`,
             'X-CSRF-Token': adminCsrfToken,
           },
           body: JSON.stringify({
@@ -257,7 +257,7 @@ describe('/api/admin/users/[userId]/gift-subscription - Security Tests', () => {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'Cookie': `session=${adminSessionToken}`,
+            'Cookie': `admin_session=${adminSessionToken}`,
             'X-CSRF-Token': adminCsrfToken,
           },
           body: JSON.stringify({
@@ -320,7 +320,7 @@ describe('/api/admin/users/[userId]/gift-subscription - Security Tests', () => {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'Cookie': `session=${adminSessionToken}`,
+            'Cookie': `admin_session=${adminSessionToken}`,
             // No X-CSRF-Token header
           },
           body: JSON.stringify({
@@ -347,7 +347,7 @@ describe('/api/admin/users/[userId]/gift-subscription - Security Tests', () => {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'Cookie': `session=${adminSessionToken}`,
+            'Cookie': `admin_session=${adminSessionToken}`,
             'X-CSRF-Token': 'invalid-csrf-token',
           },
           body: JSON.stringify({
@@ -388,7 +388,7 @@ describe('/api/admin/users/[userId]/gift-subscription - Security Tests', () => {
         {
           method: 'DELETE',
           headers: {
-            'Cookie': `session=${adminSessionToken}`,
+            'Cookie': `admin_session=${adminSessionToken}`,
             'X-CSRF-Token': adminCsrfToken,
           },
         }
@@ -412,7 +412,7 @@ describe('/api/admin/users/[userId]/gift-subscription - Security Tests', () => {
         {
           method: 'DELETE',
           headers: {
-            'Cookie': `session=${adminSessionToken}`,
+            'Cookie': `admin_session=${adminSessionToken}`,
             'X-CSRF-Token': adminCsrfToken,
           },
         }
@@ -454,7 +454,7 @@ describe('/api/admin/users/[userId]/gift-subscription - Security Tests', () => {
         {
           method: 'DELETE',
           headers: {
-            'Cookie': `session=${adminSessionToken}`,
+            'Cookie': `admin_session=${adminSessionToken}`,
             'X-CSRF-Token': adminCsrfToken,
           },
         }
@@ -508,7 +508,7 @@ describe('/api/admin/users/[userId]/gift-subscription - Security Tests', () => {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'Cookie': `session=${adminSessionToken}`,
+            'Cookie': `admin_session=${adminSessionToken}`,
             'X-CSRF-Token': adminCsrfToken,
           },
           body: JSON.stringify({
@@ -544,7 +544,7 @@ describe('/api/admin/users/[userId]/gift-subscription - Security Tests', () => {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'Cookie': `session=${adminSessionToken}`,
+            'Cookie': `admin_session=${adminSessionToken}`,
             'X-CSRF-Token': adminCsrfToken,
           },
           body: JSON.stringify({

--- a/apps/admin/src/app/api/auth/magic-link/verify/route.ts
+++ b/apps/admin/src/app/api/auth/magic-link/verify/route.ts
@@ -4,7 +4,7 @@ import { eq } from '@pagespace/db/operators';
 import { users } from '@pagespace/db/schema/auth';
 import { sessionService } from '@pagespace/lib/auth/session-service';
 import { verifyMagicLinkToken } from '@pagespace/lib/auth/magic-link-service';
-import { SESSION_DURATION_MS } from '@pagespace/lib/auth/constants';
+import { SESSION_DURATION_MS, ADMIN_SESSION_SERVICE } from '@pagespace/lib/auth/constants';
 import { loggers } from '@pagespace/lib/logging/logger-config';
 import { auditRequest } from '@pagespace/lib/audit/audit-log';
 import { appendSessionCookie } from '@/lib/auth/cookie-config';
@@ -64,13 +64,15 @@ export async function GET(req: Request) {
       return redirectWithError('not_admin');
     }
 
-    await sessionService.revokeAllUserSessions(userId, 'magic_link_login');
+    // Revoke only prior admin-console sessions — never the user's web sessions.
+    await sessionService.revokeAdminUserSessions(userId, 'admin_login');
 
     const sessionToken = await sessionService.createSession({
       userId,
       type: 'user',
       scopes: [],
       expiresInMs: SESSION_DURATION_MS,
+      createdByService: ADMIN_SESSION_SERVICE,
     });
 
     auditRequest(req, {

--- a/apps/admin/src/lib/auth/cookie-config.ts
+++ b/apps/admin/src/lib/auth/cookie-config.ts
@@ -24,13 +24,17 @@ const SESSION_MAX_AGE = 7 * 24 * 60 * 60;
  * Cookie configuration constants
  */
 export const COOKIE_CONFIG = {
+  // Admin uses its own cookie names so the browser keeps the admin and web
+  // sessions side by side. The web app and admin share COOKIE_DOMAIN in
+  // production (and host on localhost in dev), so a shared `session` name would
+  // overwrite the web session on admin login. See cookie-config.ts in apps/web.
   session: {
-    name: 'session',
+    name: 'admin_session',
     maxAge: SESSION_MAX_AGE,
     path: '/',
   },
   loggedIn: {
-    name: 'ps_logged_in',
+    name: 'ps_admin_logged_in',
     value: '1',
     maxAge: SESSION_MAX_AGE,
     path: '/',

--- a/apps/admin/src/middleware.ts
+++ b/apps/admin/src/middleware.ts
@@ -10,7 +10,9 @@ export function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  const sessionCookie = request.cookies.get('session');
+  // Admin's session cookie is named `admin_session` (see lib/auth/cookie-config.ts)
+  // so it never collides with the web app's `session` cookie on the shared domain.
+  const sessionCookie = request.cookies.get('admin_session');
   if (!sessionCookie) {
     if (pathname.startsWith('/api/')) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/apps/web/src/app/api/auth/apple/native/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/apple/native/__tests__/route.test.ts
@@ -43,6 +43,8 @@ vi.mock('@pagespace/lib/auth/session-service', () => ({
       expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
     }),
     revokeAllUserSessions: vi.fn().mockResolvedValue(0),
+    revokeWebUserSessions: vi.fn().mockResolvedValue(0),
+    revokeAdminUserSessions: vi.fn().mockResolvedValue(0),
     revokeSession: vi.fn().mockResolvedValue(undefined),
   },
 }));
@@ -200,7 +202,7 @@ describe('POST /api/auth/apple/native', () => {
         emailVerified: true,
       },
     });
-    vi.mocked(sessionService.revokeAllUserSessions).mockResolvedValue(0);
+    vi.mocked(sessionService.revokeWebUserSessions).mockResolvedValue(0);
     // @ts-expect-error - partial mock data
     vi.mocked(sessionService.validateSession).mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -481,11 +483,11 @@ describe('POST /api/auth/apple/native', () => {
 
   describe('session management', () => {
     it('revokes existing sessions before creating new one', async () => {
-      vi.mocked(sessionService.revokeAllUserSessions).mockResolvedValue(2);
+      vi.mocked(sessionService.revokeWebUserSessions).mockResolvedValue(2);
 
       await POST(createNativeRequest(validPayload));
 
-      expect(sessionService.revokeAllUserSessions).toHaveBeenCalledWith('new-user-id', 'new_login');
+      expect(sessionService.revokeWebUserSessions).toHaveBeenCalledWith('new-user-id', 'new_login');
       expect(loggers.auth.info).toHaveBeenCalledWith(
         'Revoked existing sessions on native Apple OAuth login',
         { userId: 'new-user-id', count: 2, platform: 'ios' }
@@ -493,7 +495,7 @@ describe('POST /api/auth/apple/native', () => {
     });
 
     it('does not log when no sessions were revoked', async () => {
-      vi.mocked(sessionService.revokeAllUserSessions).mockResolvedValue(0);
+      vi.mocked(sessionService.revokeWebUserSessions).mockResolvedValue(0);
 
       await POST(createNativeRequest(validPayload));
 

--- a/apps/web/src/app/api/auth/apple/native/route.ts
+++ b/apps/web/src/app/api/auth/apple/native/route.ts
@@ -157,7 +157,7 @@ export async function POST(req: Request) {
     }
 
     // SESSION FIXATION PREVENTION: Revoke all existing sessions before creating new one
-    const revokedCount = await sessionService.revokeAllUserSessions(user.id, 'new_login');
+    const revokedCount = await sessionService.revokeWebUserSessions(user.id, 'new_login');
     if (revokedCount > 0) {
       loggers.auth.info('Revoked existing sessions on native Apple OAuth login', {
         userId: user.id,

--- a/apps/web/src/app/api/auth/apple/native/route.ts
+++ b/apps/web/src/app/api/auth/apple/native/route.ts
@@ -156,7 +156,8 @@ export async function POST(req: Request) {
       });
     }
 
-    // SESSION FIXATION PREVENTION: Revoke all existing sessions before creating new one
+    // SESSION FIXATION PREVENTION: Revoke existing web sessions before creating a
+    // new one. Admin-console sessions are scoped separately and left intact.
     const revokedCount = await sessionService.revokeWebUserSessions(user.id, 'new_login');
     if (revokedCount > 0) {
       loggers.auth.info('Revoked existing sessions on native Apple OAuth login', {

--- a/apps/web/src/app/api/auth/google/native/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/google/native/__tests__/route.test.ts
@@ -75,6 +75,8 @@ vi.mock('@pagespace/lib/auth/session-service', () => ({
       scopes: ['*'],
     }),
     revokeAllUserSessions: vi.fn().mockResolvedValue(0),
+    revokeWebUserSessions: vi.fn().mockResolvedValue(0),
+    revokeAdminUserSessions: vi.fn().mockResolvedValue(0),
     revokeSession: vi.fn().mockResolvedValue(undefined),
   },
 }));
@@ -251,7 +253,7 @@ describe('POST /api/auth/google/native', () => {
       type: 'user',
       scopes: ['*'],
     } as never);
-    vi.mocked(sessionService.revokeAllUserSessions).mockResolvedValue(0);
+    vi.mocked(sessionService.revokeWebUserSessions).mockResolvedValue(0);
     vi.mocked(generateCSRFToken).mockReturnValue('mock-csrf-token');
 
     // Default device token mock
@@ -582,12 +584,12 @@ describe('POST /api/auth/google/native', () => {
 
   describe('session management', () => {
     it('should revoke existing sessions before creating new one (session fixation prevention)', async () => {
-      vi.mocked(sessionService.revokeAllUserSessions).mockResolvedValue(2);
+      vi.mocked(sessionService.revokeWebUserSessions).mockResolvedValue(2);
 
       const request = createNativeRequest(validNativePayload);
       await POST(request);
 
-      expect(sessionService.revokeAllUserSessions).toHaveBeenCalledWith(
+      expect(sessionService.revokeWebUserSessions).toHaveBeenCalledWith(
         mockNewUser.id,
         'new_login'
       );

--- a/apps/web/src/app/api/auth/google/native/route.ts
+++ b/apps/web/src/app/api/auth/google/native/route.ts
@@ -180,7 +180,7 @@ export async function POST(req: Request) {
     }
 
     // SESSION FIXATION PREVENTION: Revoke all existing sessions before creating new one
-    const revokedCount = await sessionService.revokeAllUserSessions(user.id, 'new_login');
+    const revokedCount = await sessionService.revokeWebUserSessions(user.id, 'new_login');
     if (revokedCount > 0) {
       loggers.auth.info('Revoked existing sessions on native Google OAuth login', {
         userId: user.id,

--- a/apps/web/src/app/api/auth/google/native/route.ts
+++ b/apps/web/src/app/api/auth/google/native/route.ts
@@ -179,7 +179,8 @@ export async function POST(req: Request) {
       });
     }
 
-    // SESSION FIXATION PREVENTION: Revoke all existing sessions before creating new one
+    // SESSION FIXATION PREVENTION: Revoke existing web sessions before creating a
+    // new one. Admin-console sessions are scoped separately and left intact.
     const revokedCount = await sessionService.revokeWebUserSessions(user.id, 'new_login');
     if (revokedCount > 0) {
       loggers.auth.info('Revoked existing sessions on native Google OAuth login', {

--- a/apps/web/src/app/api/auth/magic-link/__tests__/round-trip.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/__tests__/round-trip.test.ts
@@ -68,6 +68,8 @@ vi.mock('@pagespace/lib/auth/session-service', () => ({
       expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
     }),
     revokeAllUserSessions: vi.fn().mockResolvedValue(0),
+    revokeWebUserSessions: vi.fn().mockResolvedValue(0),
+    revokeAdminUserSessions: vi.fn().mockResolvedValue(0),
   },
 }));
 vi.mock('@pagespace/lib/auth/csrf-utils', () => ({

--- a/apps/web/src/app/api/auth/magic-link/verify/__tests__/desktop-verify.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/__tests__/desktop-verify.test.ts
@@ -37,6 +37,8 @@ vi.mock('@pagespace/lib/auth/session-service', () => ({
       expiresAt: new Date(Date.now() + 86400000),
     }),
     revokeAllUserSessions: vi.fn().mockResolvedValue(0),
+    revokeWebUserSessions: vi.fn().mockResolvedValue(0),
+    revokeAdminUserSessions: vi.fn().mockResolvedValue(0),
   },
 }));
 vi.mock('@pagespace/lib/auth/csrf-utils', () => ({

--- a/apps/web/src/app/api/auth/magic-link/verify/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/__tests__/route.test.ts
@@ -32,6 +32,8 @@ vi.mock('@pagespace/lib/auth/session-service', () => ({
       expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
     }),
     revokeAllUserSessions: vi.fn().mockResolvedValue(0),
+    revokeWebUserSessions: vi.fn().mockResolvedValue(0),
+    revokeAdminUserSessions: vi.fn().mockResolvedValue(0),
     revokeSession: vi.fn().mockResolvedValue(undefined),
   },
 }));
@@ -146,7 +148,7 @@ describe('GET /api/auth/magic-link/verify', () => {
       ok: true,
       data: { userId: 'test-user-id', isNewUser: false },
     });
-    vi.mocked(sessionService.revokeAllUserSessions).mockResolvedValue(0);
+    vi.mocked(sessionService.revokeWebUserSessions).mockResolvedValue(0);
     // @ts-expect-error - partial mock data
     vi.mocked(sessionService.validateSession).mockResolvedValue({
       sessionId: 'mock-session-id',
@@ -269,11 +271,11 @@ describe('GET /api/auth/magic-link/verify', () => {
 
   describe('session management', () => {
     it('revokes existing sessions before creating new one', async () => {
-      vi.mocked(sessionService.revokeAllUserSessions).mockResolvedValue(2);
+      vi.mocked(sessionService.revokeWebUserSessions).mockResolvedValue(2);
 
       await GET(createVerifyRequest('valid-token'));
 
-      expect(sessionService.revokeAllUserSessions).toHaveBeenCalledWith(
+      expect(sessionService.revokeWebUserSessions).toHaveBeenCalledWith(
         'test-user-id',
         'magic_link_login'
       );
@@ -284,7 +286,7 @@ describe('GET /api/auth/magic-link/verify', () => {
     });
 
     it('does not log when no sessions were revoked', async () => {
-      vi.mocked(sessionService.revokeAllUserSessions).mockResolvedValue(0);
+      vi.mocked(sessionService.revokeWebUserSessions).mockResolvedValue(0);
 
       await GET(createVerifyRequest('valid-token'));
 

--- a/apps/web/src/app/api/auth/magic-link/verify/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/route.ts
@@ -100,7 +100,7 @@ export async function GET(req: Request) {
     const boundInviteToken = parsedMeta?.inviteToken;
 
     // SESSION FIXATION PREVENTION: Revoke all existing sessions before creating new one
-    const revokedCount = await sessionService.revokeAllUserSessions(userId, 'magic_link_login');
+    const revokedCount = await sessionService.revokeWebUserSessions(userId, 'magic_link_login');
     if (revokedCount > 0) {
       loggers.auth.info('Revoked existing sessions on magic link login', {
         userId,

--- a/apps/web/src/app/api/auth/magic-link/verify/route.ts
+++ b/apps/web/src/app/api/auth/magic-link/verify/route.ts
@@ -99,7 +99,8 @@ export async function GET(req: Request) {
     }
     const boundInviteToken = parsedMeta?.inviteToken;
 
-    // SESSION FIXATION PREVENTION: Revoke all existing sessions before creating new one
+    // SESSION FIXATION PREVENTION: Revoke existing web sessions before creating a
+    // new one. Admin-console sessions are scoped separately and left intact.
     const revokedCount = await sessionService.revokeWebUserSessions(userId, 'magic_link_login');
     if (revokedCount > 0) {
       loggers.auth.info('Revoked existing sessions on magic link login', {

--- a/apps/web/src/app/api/auth/passkey/authenticate/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/passkey/authenticate/__tests__/route.test.ts
@@ -33,6 +33,8 @@ vi.mock('@pagespace/lib/auth/session-service', () => ({
       expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
     }),
     revokeAllUserSessions: vi.fn().mockResolvedValue(0),
+    revokeWebUserSessions: vi.fn().mockResolvedValue(0),
+    revokeAdminUserSessions: vi.fn().mockResolvedValue(0),
     revokeSession: vi.fn().mockResolvedValue(undefined),
   },
 }));
@@ -174,7 +176,7 @@ describe('POST /api/auth/passkey/authenticate', () => {
     it('revokes existing sessions before creating new one', async () => {
       await POST(createRequest());
 
-      expect(sessionService.revokeAllUserSessions).toHaveBeenCalledWith('user-1', 'passkey_login');
+      expect(sessionService.revokeWebUserSessions).toHaveBeenCalledWith('user-1', 'passkey_login');
       expect(sessionService.createSession).toHaveBeenCalledWith(expect.objectContaining({
         userId: 'user-1',
         type: 'user',
@@ -183,7 +185,7 @@ describe('POST /api/auth/passkey/authenticate', () => {
     });
 
     it('logs when existing sessions are revoked', async () => {
-      vi.mocked(sessionService.revokeAllUserSessions).mockResolvedValue(3);
+      vi.mocked(sessionService.revokeWebUserSessions).mockResolvedValue(3);
 
       await POST(createRequest());
 
@@ -194,7 +196,7 @@ describe('POST /api/auth/passkey/authenticate', () => {
     });
 
     it('does not log when no sessions are revoked', async () => {
-      vi.mocked(sessionService.revokeAllUserSessions).mockResolvedValue(0);
+      vi.mocked(sessionService.revokeWebUserSessions).mockResolvedValue(0);
 
       await POST(createRequest());
 

--- a/apps/web/src/app/api/auth/passkey/authenticate/route.ts
+++ b/apps/web/src/app/api/auth/passkey/authenticate/route.ts
@@ -161,8 +161,9 @@ export async function POST(req: Request) {
 
     const { userId } = result.data;
 
-    // Passkey is the strongest auth flow — hard-reset all sessions across devices
-    const revokedCount = await sessionService.revokeAllUserSessions(userId, 'passkey_login');
+    // Passkey is the strongest auth flow — hard-reset web sessions across devices
+    // (admin-console sessions are scoped separately and left intact).
+    const revokedCount = await sessionService.revokeWebUserSessions(userId, 'passkey_login');
     if (revokedCount > 0) {
       loggers.auth.info('Revoked all sessions on passkey login', { userId, count: revokedCount });
     }

--- a/apps/web/src/lib/auth/__tests__/device-auth-helpers.test.ts
+++ b/apps/web/src/lib/auth/__tests__/device-auth-helpers.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('@pagespace/lib/auth/session-service', () => ({
   sessionService: {
     revokeDeviceSessions: vi.fn(),
-    revokeAllUserSessions: vi.fn(),
+    revokeWebUserSessions: vi.fn(),
   },
 }));
 
@@ -32,16 +32,16 @@ describe('device-auth-helpers', () => {
       const count = await revokeSessionsForLogin('user-1', 'device-abc', 'new_login', 'Google OAuth');
 
       expect(sessionService.revokeDeviceSessions).toHaveBeenCalledWith('user-1', 'device-abc', 'new_login');
-      expect(sessionService.revokeAllUserSessions).not.toHaveBeenCalled();
+      expect(sessionService.revokeWebUserSessions).not.toHaveBeenCalled();
       expect(count).toBe(1);
     });
 
-    it('without deviceId falls back to revokeAllUserSessions', async () => {
-      vi.mocked(sessionService.revokeAllUserSessions).mockResolvedValue(2);
+    it('without deviceId falls back to revokeWebUserSessions', async () => {
+      vi.mocked(sessionService.revokeWebUserSessions).mockResolvedValue(2);
 
       const count = await revokeSessionsForLogin('user-1', undefined, 'new_login', 'password');
 
-      expect(sessionService.revokeAllUserSessions).toHaveBeenCalledWith('user-1', 'new_login');
+      expect(sessionService.revokeWebUserSessions).toHaveBeenCalledWith('user-1', 'new_login');
       expect(sessionService.revokeDeviceSessions).not.toHaveBeenCalled();
       expect(count).toBe(2);
     });

--- a/apps/web/src/lib/auth/device-auth-helpers.ts
+++ b/apps/web/src/lib/auth/device-auth-helpers.ts
@@ -17,9 +17,10 @@ export async function revokeSessionsForLogin(
     if (count > 0) loggers.auth.info(`Revoked device sessions on ${provider} login`, { userId, deviceId, count });
     return count;
   }
-  // Fallback: revoke all sessions for backward compatibility with older clients
-  const count = await sessionService.revokeAllUserSessions(userId, reason);
-  if (count > 0) loggers.auth.info(`Revoked all sessions on ${provider} login (no deviceId)`, { userId, count });
+  // Fallback: revoke all WEB sessions for backward compatibility with older clients.
+  // Excludes admin-console sessions so a web login never logs the user out of admin.
+  const count = await sessionService.revokeWebUserSessions(userId, reason);
+  if (count > 0) loggers.auth.info(`Revoked web sessions on ${provider} login (no deviceId)`, { userId, count });
   return count;
 }
 

--- a/packages/lib/src/auth/__tests__/session-repository-logging.test.ts
+++ b/packages/lib/src/auth/__tests__/session-repository-logging.test.ts
@@ -20,6 +20,7 @@ vi.mock('@pagespace/db/schema/auth', () => ({
 }));
 vi.mock('@pagespace/db/operators', () => ({
   eq: vi.fn(),
+  ne: vi.fn(),
   and: vi.fn(),
   or: vi.fn(),
   isNull: vi.fn(),

--- a/packages/lib/src/auth/__tests__/session-service-unit.test.ts
+++ b/packages/lib/src/auth/__tests__/session-service-unit.test.ts
@@ -8,6 +8,8 @@ vi.mock('../session-repository', () => ({
     touchSession: vi.fn(),
     revokeByHash: vi.fn(),
     revokeAllForUser: vi.fn(),
+    revokeWebForUser: vi.fn(),
+    revokeAdminForUser: vi.fn(),
     revokeForUserDevice: vi.fn(),
     deleteExpired: vi.fn(),
   },
@@ -258,6 +260,30 @@ describe('SessionService', () => {
       const count = await service.revokeAllUserSessions('user-1', 'test');
 
       expect(count).toBe(0);
+    });
+  });
+
+  describe('revokeWebUserSessions', () => {
+    it('delegates to revokeWebForUser (excludes admin sessions) and returns the count', async () => {
+      vi.mocked(sessionRepository.revokeWebForUser).mockResolvedValue(2);
+
+      const count = await service.revokeWebUserSessions('user-1', 'magic_link_login');
+
+      expect(count).toBe(2);
+      expect(sessionRepository.revokeWebForUser).toHaveBeenCalledWith('user-1', 'magic_link_login');
+      expect(sessionRepository.revokeAllForUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('revokeAdminUserSessions', () => {
+    it('delegates to revokeAdminForUser (only admin sessions) and returns the count', async () => {
+      vi.mocked(sessionRepository.revokeAdminForUser).mockResolvedValue(1);
+
+      const count = await service.revokeAdminUserSessions('user-1', 'admin_login');
+
+      expect(count).toBe(1);
+      expect(sessionRepository.revokeAdminForUser).toHaveBeenCalledWith('user-1', 'admin_login');
+      expect(sessionRepository.revokeAllForUser).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/lib/src/auth/__tests__/session-service.test.ts
+++ b/packages/lib/src/auth/__tests__/session-service.test.ts
@@ -5,6 +5,7 @@ import { sessions } from '@pagespace/db/schema/sessions';
 import { eq, and, isNull } from 'drizzle-orm';
 import { createId } from '@paralleldrive/cuid2';
 import { sessionService } from '../session-service';
+import { ADMIN_SESSION_SERVICE } from '../constants';
 
 describe('Session Service', () => {
   let testUserId: string;
@@ -261,6 +262,49 @@ describe('Session Service', () => {
 
       const count = await sessionService.revokeAllUserSessions(testUserId, 'test');
       expect(count).toBe(1);
+    });
+  });
+
+  describe('per-app session scoping', () => {
+    async function createWebSession() {
+      return sessionService.createSession({
+        userId: testUserId,
+        type: 'user',
+        scopes: ['*'],
+        expiresInMs: 3600000,
+      });
+    }
+
+    async function createAdminSession() {
+      return sessionService.createSession({
+        userId: testUserId,
+        type: 'user',
+        scopes: [],
+        expiresInMs: 3600000,
+        createdByService: ADMIN_SESSION_SERVICE,
+      });
+    }
+
+    it('revokeWebUserSessions revokes web sessions but leaves admin sessions intact', async () => {
+      const webToken = await createWebSession();
+      const adminToken = await createAdminSession();
+
+      const count = await sessionService.revokeWebUserSessions(testUserId, 'magic_link_login');
+
+      expect(count).toBe(1);
+      expect(await sessionService.validateSession(webToken)).toBeNull();
+      expect(await sessionService.validateSession(adminToken)).not.toBeNull();
+    });
+
+    it('revokeAdminUserSessions revokes admin sessions but leaves web sessions intact', async () => {
+      const webToken = await createWebSession();
+      const adminToken = await createAdminSession();
+
+      const count = await sessionService.revokeAdminUserSessions(testUserId, 'admin_login');
+
+      expect(count).toBe(1);
+      expect(await sessionService.validateSession(adminToken)).toBeNull();
+      expect(await sessionService.validateSession(webToken)).not.toBeNull();
     });
   });
 });

--- a/packages/lib/src/auth/constants.ts
+++ b/packages/lib/src/auth/constants.ts
@@ -10,6 +10,13 @@ import { isOnPrem } from '../deployment-mode';
  */
 export const SESSION_DURATION_MS = 7 * 24 * 60 * 60 * 1000;
 
+/**
+ * Marks sessions minted by the standalone admin console (apps/admin) via the
+ * sessions.createdByService column. Lets login revocation be scoped per-app so
+ * an admin login does not revoke web sessions, and vice versa.
+ */
+export const ADMIN_SESSION_SERVICE = 'admin-console';
+
 
 /**
  * Idle session timeout in milliseconds.

--- a/packages/lib/src/auth/session-repository.ts
+++ b/packages/lib/src/auth/session-repository.ts
@@ -4,9 +4,10 @@
  */
 
 import { db } from '@pagespace/db/db';
-import { eq, and, or, isNull, gt, lt } from '@pagespace/db/operators';
+import { eq, ne, and, or, isNull, gt, lt } from '@pagespace/db/operators';
 import { users } from '@pagespace/db/schema/auth';
 import { sessions } from '@pagespace/db/schema/sessions';
+import { ADMIN_SESSION_SERVICE } from './constants';
 
 export interface SessionUserRecord {
   id: string;
@@ -85,14 +86,49 @@ export const sessionRepository = {
     return result.rowCount ?? 0;
   },
 
+  // Revoke every active session for the user EXCEPT admin-console sessions, so a
+  // web login does not knock the user out of the admin app.
+  revokeWebForUser: async (userId: string, reason: string): Promise<number> => {
+    const result = await db.update(sessions)
+      .set({ revokedAt: new Date(), revokedReason: reason })
+      .where(and(
+        eq(sessions.userId, userId),
+        or(
+          ne(sessions.createdByService, ADMIN_SESSION_SERVICE),
+          isNull(sessions.createdByService),
+        ),
+        isNull(sessions.revokedAt),
+      ));
+    return result.rowCount ?? 0;
+  },
+
+  // Revoke ONLY admin-console sessions for the user, so an admin login does not
+  // knock the user out of the main web app.
+  revokeAdminForUser: async (userId: string, reason: string): Promise<number> => {
+    const result = await db.update(sessions)
+      .set({ revokedAt: new Date(), revokedReason: reason })
+      .where(and(
+        eq(sessions.userId, userId),
+        eq(sessions.createdByService, ADMIN_SESSION_SERVICE),
+        isNull(sessions.revokedAt),
+      ));
+    return result.rowCount ?? 0;
+  },
+
   revokeForUserDevice: async (userId: string, deviceId: string, reason: string): Promise<number> => {
     // Revoke sessions matching this device OR legacy sessions with no device_id (pre-migration).
     // This ensures the first device-aware login after deploy cleans up old NULL sessions.
+    // Exclude admin-console sessions: they always have a NULL device_id and must not be
+    // collaterally revoked by a web/desktop device login.
     const result = await db.update(sessions)
       .set({ revokedAt: new Date(), revokedReason: reason })
       .where(and(
         eq(sessions.userId, userId),
         or(eq(sessions.deviceId, deviceId), isNull(sessions.deviceId)),
+        or(
+          ne(sessions.createdByService, ADMIN_SESSION_SERVICE),
+          isNull(sessions.createdByService),
+        ),
         isNull(sessions.revokedAt),
       ));
     return result.rowCount ?? 0;

--- a/packages/lib/src/auth/session-service.ts
+++ b/packages/lib/src/auth/session-service.ts
@@ -140,6 +140,22 @@ export class SessionService {
   }
 
   /**
+   * Revoke the user's sessions EXCEPT admin-console sessions. Used by web login
+   * flows so signing into the web app does not log the user out of the admin app.
+   */
+  async revokeWebUserSessions(userId: string, reason: string): Promise<number> {
+    return sessionRepository.revokeWebForUser(userId, reason);
+  }
+
+  /**
+   * Revoke ONLY the user's admin-console sessions. Used by the admin login flow
+   * so signing into the admin app does not log the user out of the web app.
+   */
+  async revokeAdminUserSessions(userId: string, reason: string): Promise<number> {
+    return sessionRepository.revokeAdminForUser(userId, reason);
+  }
+
+  /**
    * Revoke sessions for a specific device only, enabling multi-device login.
    * Used by login endpoints when deviceId is available. Falls back to
    * revokeAllUserSessions when deviceId is absent (backward compat).


### PR DESCRIPTION
## Problem

Logging into the admin console logged the user out of the main web app.

`apps/admin` (admin.pagespace.ai) and `apps/web` (pagespace.ai) are separate Next.js apps that share one Postgres `sessions` table. Two compounding bugs broke web auth on admin login:

1. **Cookie collision** — both apps wrote a cookie literally named `session` at path `/`. In production `COOKIE_DOMAIN=.pagespace.ai` scopes both to the parent domain, so admin's login cookie *overwrote* web's in the browser. (Also reproduces locally — cookies are keyed by host, not port, so `localhost:3000` and `localhost:3005` collide.)
2. **Global DB revocation** — admin's magic-link verify called `revokeAllUserSessions(userId)`, marking *every* session for that user revoked, including the web one.

## Fix

Full bidirectional decoupling — admin and web sessions now coexist, and neither app's login disturbs the other's session. Uses the existing `sessions.createdByService` column, so **no DB migration**.

- **Admin gets its own cookies** (`admin_session` / `ps_admin_logged_in`) so the browser keeps both apps' cookies side by side (`apps/admin/src/lib/auth/cookie-config.ts`, `apps/admin/src/middleware.ts`).
- **Admin sessions are tagged** with `createdByService = ADMIN_SESSION_SERVICE` (`'admin-console'`) at creation (`apps/admin/.../magic-link/verify/route.ts`).
- **Scoped revocation** in `packages/lib`:
  - `revokeWebForUser` / `revokeWebUserSessions` — revoke everything *except* admin sessions.
  - `revokeAdminForUser` / `revokeAdminUserSessions` — revoke *only* admin sessions.
  - `revokeForUserDevice` now also excludes admin sessions (they carry a NULL `deviceId` and would otherwise be caught by a desktop device login).
- **Admin login** → `revokeAdminUserSessions`; **web login flows** (magic-link, passkey, Apple, Google, and the shared `device-auth-helpers` fallback that covers callback/login/one-tap) → `revokeWebUserSessions`.

`revokeAllUserSessions` (true global) is retained for any future account-suspension/security use; no login flow calls it anymore.

## Tests

- Updated affected route/helper unit tests to expect the scoped methods.
- Added service-delegation unit tests (`session-service-unit.test.ts`).
- Added **DB-backed integration tests** (`session-service.test.ts`) proving admin sessions survive a web login and web sessions survive an admin login.

Verified locally:
- `@pagespace/lib` + `admin` typecheck clean.
- 188 web auth route tests pass; 41 lib mocked auth tests pass; 16 lib DB integration tests pass against a real Postgres.

## Manual verification

1. Log into web as an admin user → `session` cookie set, `/dashboard` loads.
2. Log into admin → `admin_session` cookie set, web's `session` cookie unchanged.
3. Reload web → still logged in. ✅ (reported bug)
4. Re-log into web → reload admin → admin still logged in. ✅ (mirror direction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)