### PR TITLE
fix(canvas): publish to a dedicated public bucket (not the uploads bucket)

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
@@ -41,10 +41,12 @@ vi.mock('@pagespace/lib/utils/utils', () => ({
 const buildPublishedKey = vi.fn();
 const putPublishedArtifact = vi.fn();
 const deletePublishedArtifact = vi.fn();
+const isPublishConfigured = vi.fn();
 vi.mock('@/lib/canvas/published-storage', () => ({
   buildPublishedKey: (...args: unknown[]) => buildPublishedKey(...args),
   putPublishedArtifact: (...args: unknown[]) => putPublishedArtifact(...args),
   deletePublishedArtifact: (...args: unknown[]) => deletePublishedArtifact(...args),
+  isPublishConfigured: (...args: unknown[]) => isPublishConfigured(...args),
 }));
 
 const renderPublishedPage = vi.fn();
@@ -106,6 +108,7 @@ beforeEach(() => {
   authenticateRequestWithOptions.mockResolvedValue({ userId: 'user-1' });
   canUserEditPage.mockResolvedValue(true);
   validatePublishSubdomain.mockReturnValue({ valid: true });
+  isPublishConfigured.mockReturnValue(true);
   buildPublishedKey.mockImplementation((subdomain: string, path: string) => `published/${subdomain}/${path}/index.html`);
   putPublishedArtifact.mockResolvedValue({ key: 'published/acme/welcome/index.html' });
   renderPublishedPage.mockReturnValue('<html>rendered</html>');
@@ -134,6 +137,17 @@ describe('POST /api/pages/[pageId]/publish', () => {
       if (prev === undefined) delete process.env.CANVAS_PUBLISHING_DISABLED;
       else process.env.CANVAS_PUBLISHING_DISABLED = prev;
     }
+  });
+
+  it('returns 503 and touches nothing when the publish bucket is not configured', async () => {
+    isPublishConfigured.mockReturnValue(false);
+    const res = await POST(makeReq({}), { params });
+    expect(res.status).toBe(503);
+    const json = await res.json();
+    expect(json.error).toMatch(/not configured/i);
+    // fails fast BEFORE any DB reservation or upload
+    expect(onConflictDoUpdate).not.toHaveBeenCalled();
+    expect(putPublishedArtifact).not.toHaveBeenCalled();
   });
 
   it('returns 400 when the page is not a canvas page', async () => {

--- a/apps/web/src/app/api/pages/[pageId]/publish/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/publish/route.ts
@@ -11,7 +11,7 @@ import { eq } from '@pagespace/db/operators';
 import { pages, drives } from '@pagespace/db/schema/core';
 import { publishedPages } from '@pagespace/db/schema/published-pages';
 import { renderPublishedPage } from '@/lib/canvas/render-published';
-import { buildPublishedKey, putPublishedArtifact, deletePublishedArtifact } from '@/lib/canvas/published-storage';
+import { buildPublishedKey, putPublishedArtifact, deletePublishedArtifact, isPublishConfigured } from '@/lib/canvas/published-storage';
 
 const AUTH_OPTIONS = { allow: ['session', 'mcp'] as const, requireCSRF: true };
 
@@ -92,6 +92,14 @@ export async function POST(req: Request, { params }: { params: Promise<{ pageId:
   // Operational kill-switch: lets operators disable publishing without a deploy.
   if (process.env.CANVAS_PUBLISHING_DISABLED === 'true') {
     return NextResponse.json({ error: 'Publishing is temporarily disabled' }, { status: 503 });
+  }
+
+  // Fail fast BEFORE any DB reservation: if the publish bucket isn't configured,
+  // the later upload would throw and leave a published_pages row pointing at a
+  // non-existent object. (Also makes publishing inert anywhere PUBLISH_BUCKET is
+  // unset — e.g. a prod box that hasn't provisioned the public bucket yet.)
+  if (!isPublishConfigured()) {
+    return NextResponse.json({ error: 'Publishing is not configured' }, { status: 503 });
   }
 
   try {

--- a/apps/web/src/lib/canvas/__tests__/published-storage.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/published-storage.test.ts
@@ -10,10 +10,12 @@ const send = vi.fn();
 
 vi.mock('server-only', () => ({}));
 
-vi.mock('@/lib/presigned-url', () => ({
-  getS3Client: vi.fn(() => ({ send })),
-  getS3Bucket: vi.fn(() => 'test-bucket'),
-}));
+// Mock only the S3Client constructor (capture .send); keep the real command
+// classes so `instanceof` checks below still hold.
+vi.mock('@aws-sdk/client-s3', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@aws-sdk/client-s3')>();
+  return { ...actual, S3Client: vi.fn(() => ({ send })) };
+});
 
 describe('buildPublishedKey', () => {
   it('maps the root path to a single index.html with no double slash', () => {
@@ -55,6 +57,7 @@ describe('putPublishedArtifact', () => {
   beforeEach(() => {
     send.mockReset();
     send.mockResolvedValue({});
+    process.env.PUBLISH_BUCKET = 'test-bucket';
   });
 
   it('sends a PutObjectCommand with the right bucket, key, body, and content type', async () => {
@@ -82,6 +85,7 @@ describe('deletePublishedArtifact', () => {
   beforeEach(() => {
     send.mockReset();
     send.mockResolvedValue({});
+    process.env.PUBLISH_BUCKET = 'test-bucket';
   });
 
   it('sends a DeleteObjectCommand with the right bucket and key', async () => {

--- a/apps/web/src/lib/canvas/__tests__/published-storage.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/published-storage.test.ts
@@ -4,6 +4,7 @@ import {
   buildPublishedKey,
   putPublishedArtifact,
   deletePublishedArtifact,
+  isPublishConfigured,
 } from '../published-storage';
 
 const send = vi.fn();
@@ -98,5 +99,29 @@ describe('deletePublishedArtifact', () => {
       Bucket: 'test-bucket',
       Key: 'published/acme/index.html',
     });
+  });
+});
+
+describe('publish bucket configuration', () => {
+  it('isPublishConfigured reflects PUBLISH_BUCKET presence', () => {
+    const prev = process.env.PUBLISH_BUCKET;
+    delete process.env.PUBLISH_BUCKET;
+    expect(isPublishConfigured()).toBe(false);
+    process.env.PUBLISH_BUCKET = 'pagespace-published';
+    expect(isPublishConfigured()).toBe(true);
+    if (prev === undefined) delete process.env.PUBLISH_BUCKET;
+    else process.env.PUBLISH_BUCKET = prev;
+  });
+
+  it('putPublishedArtifact throws when PUBLISH_BUCKET is unset', async () => {
+    const prev = process.env.PUBLISH_BUCKET;
+    send.mockReset();
+    delete process.env.PUBLISH_BUCKET;
+    await expect(
+      putPublishedArtifact({ subdomain: 'acme', path: '', html: '<html></html>' }),
+    ).rejects.toThrow(/PUBLISH_BUCKET/);
+    expect(send).not.toHaveBeenCalled();
+    if (prev === undefined) delete process.env.PUBLISH_BUCKET;
+    else process.env.PUBLISH_BUCKET = prev;
   });
 });

--- a/apps/web/src/lib/canvas/__tests__/published-storage.test.ts
+++ b/apps/web/src/lib/canvas/__tests__/published-storage.test.ts
@@ -105,23 +105,29 @@ describe('deletePublishedArtifact', () => {
 describe('publish bucket configuration', () => {
   it('isPublishConfigured reflects PUBLISH_BUCKET presence', () => {
     const prev = process.env.PUBLISH_BUCKET;
-    delete process.env.PUBLISH_BUCKET;
-    expect(isPublishConfigured()).toBe(false);
-    process.env.PUBLISH_BUCKET = 'pagespace-published';
-    expect(isPublishConfigured()).toBe(true);
-    if (prev === undefined) delete process.env.PUBLISH_BUCKET;
-    else process.env.PUBLISH_BUCKET = prev;
+    try {
+      delete process.env.PUBLISH_BUCKET;
+      expect(isPublishConfigured()).toBe(false);
+      process.env.PUBLISH_BUCKET = 'pagespace-published';
+      expect(isPublishConfigured()).toBe(true);
+    } finally {
+      if (prev === undefined) delete process.env.PUBLISH_BUCKET;
+      else process.env.PUBLISH_BUCKET = prev;
+    }
   });
 
   it('putPublishedArtifact throws when PUBLISH_BUCKET is unset', async () => {
     const prev = process.env.PUBLISH_BUCKET;
-    send.mockReset();
-    delete process.env.PUBLISH_BUCKET;
-    await expect(
-      putPublishedArtifact({ subdomain: 'acme', path: '', html: '<html></html>' }),
-    ).rejects.toThrow(/PUBLISH_BUCKET/);
-    expect(send).not.toHaveBeenCalled();
-    if (prev === undefined) delete process.env.PUBLISH_BUCKET;
-    else process.env.PUBLISH_BUCKET = prev;
+    try {
+      send.mockReset();
+      delete process.env.PUBLISH_BUCKET;
+      await expect(
+        putPublishedArtifact({ subdomain: 'acme', path: '', html: '<html></html>' }),
+      ).rejects.toThrow(/PUBLISH_BUCKET/);
+      expect(send).not.toHaveBeenCalled();
+    } finally {
+      if (prev === undefined) delete process.env.PUBLISH_BUCKET;
+      else process.env.PUBLISH_BUCKET = prev;
+    }
   });
 });

--- a/apps/web/src/lib/canvas/published-storage.ts
+++ b/apps/web/src/lib/canvas/published-storage.ts
@@ -47,6 +47,15 @@ function getPublishBucket(): string {
 }
 
 /**
+ * Whether publish storage is configured. Callers should check this BEFORE any
+ * DB reservation so a missing bucket can't leave a `published_pages` row that
+ * points at a non-existent object.
+ */
+export function isPublishConfigured(): boolean {
+  return Boolean(process.env.PUBLISH_BUCKET);
+}
+
+/**
  * Sanitize a request path into a clean, traversal-safe path segment list.
  * Lowercases, splits on `/`, and drops empty, `.`, and `..` segments so the
  * resulting key can never escape the `published/<subdomain>/` prefix.

--- a/apps/web/src/lib/canvas/published-storage.ts
+++ b/apps/web/src/lib/canvas/published-storage.ts
@@ -1,17 +1,50 @@
 import 'server-only';
 
-import { PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
-import { getS3Client, getS3Bucket } from '@/lib/presigned-url';
+import { S3Client, PutObjectCommand, DeleteObjectCommand } from '@aws-sdk/client-s3';
 
 /**
  * Storage helper for PUBLISHED canvas artifacts.
  *
- * Published pages are written to S3/Tigris under a clean-URL / folder
- * convention: `published/<subdomain>/<cleanPath>/index.html`. The edge serves
+ * Published pages are PUBLIC, so they live in their own dedicated public bucket
+ * (`PUBLISH_BUCKET`, e.g. `pagespace-published`) — intentionally SEPARATE from the
+ * private uploads bucket (`pagespace-files`, served via presigned URLs). We must
+ * never write published artifacts into the uploads bucket: making that bucket
+ * (or a prefix of it) public-read would expose private user files.
+ *
+ * Layout: `published/<subdomain>/<cleanPath>/index.html`. The edge serves
  * `index.html` for the matching request path. The subdomain is assumed to have
  * already been validated/normalized by the caller (see
  * `@pagespace/lib/validators/subdomain`).
  */
+
+let _client: S3Client | null = null;
+
+/** Lazily build the S3 client for the dedicated public publish bucket. */
+function getPublishClient(): S3Client {
+  if (!_client) {
+    _client = new S3Client({
+      region: process.env.PUBLISH_S3_REGION ?? 'auto',
+      endpoint: process.env.PUBLISH_S3_ENDPOINT,
+      credentials:
+        process.env.PUBLISH_S3_ACCESS_KEY_ID && process.env.PUBLISH_S3_SECRET_ACCESS_KEY
+          ? {
+              accessKeyId: process.env.PUBLISH_S3_ACCESS_KEY_ID,
+              secretAccessKey: process.env.PUBLISH_S3_SECRET_ACCESS_KEY,
+            }
+          : undefined,
+    });
+  }
+  return _client;
+}
+
+/** Name of the dedicated public publish bucket. Throws if not configured. */
+function getPublishBucket(): string {
+  const bucket = process.env.PUBLISH_BUCKET;
+  if (!bucket) {
+    throw new Error('PUBLISH_BUCKET is not configured (dedicated public bucket for canvas publishing)');
+  }
+  return bucket;
+}
 
 /**
  * Sanitize a request path into a clean, traversal-safe path segment list.
@@ -40,7 +73,7 @@ export function buildPublishedKey(subdomain: string, path: string): string {
 }
 
 /**
- * Upload a rendered published-page HTML document to storage.
+ * Upload a rendered published-page HTML document to the public publish bucket.
  */
 export async function putPublishedArtifact(params: {
   subdomain: string;
@@ -49,9 +82,9 @@ export async function putPublishedArtifact(params: {
 }): Promise<{ key: string }> {
   const key = buildPublishedKey(params.subdomain, params.path);
 
-  await getS3Client().send(
+  await getPublishClient().send(
     new PutObjectCommand({
-      Bucket: getS3Bucket(),
+      Bucket: getPublishBucket(),
       Key: key,
       Body: params.html,
       ContentType: 'text/html; charset=utf-8',
@@ -65,9 +98,9 @@ export async function putPublishedArtifact(params: {
  * Delete a previously-published artifact by its storage key.
  */
 export async function deletePublishedArtifact(key: string): Promise<void> {
-  await getS3Client().send(
+  await getPublishClient().send(
     new DeleteObjectCommand({
-      Bucket: getS3Bucket(),
+      Bucket: getPublishBucket(),
       Key: key,
     }),
   );


### PR DESCRIPTION
Follow-up to #1493. Two related correctness/security fixes for canvas publishing storage.

## 1. Publish to a dedicated public bucket (not the uploads bucket)
The publish storage helper reused `getS3Client()`/`getS3Bucket()` — the **private uploads bucket** (`pagespace-files`, served via presigned URLs). Publishing serves content **publicly**, so writing there (and the public-read policy it implies) would risk exposing private user uploads. Now repointed to a **dedicated public bucket** via its own client:
- `PUBLISH_BUCKET` (e.g. `pagespace-published`)
- `PUBLISH_S3_ENDPOINT` / `PUBLISH_S3_REGION` / `PUBLISH_S3_ACCESS_KEY_ID` / `PUBLISH_S3_SECRET_ACCESS_KEY`

The bucket `pagespace-published` is already provisioned (Fly Tigris, public). Keys/paths unchanged; only the storage target.

## 2. Fail fast when publish storage is unconfigured (Codex P2)
Because the publish route reserves the `published_pages` row **before** uploading, a missing `PUBLISH_BUCKET` would throw during upload *after* the reservation — leaving a page marked published with no object. Now `isPublishConfigured()` is checked immediately after the kill-switch and returns **503 before any DB write**. This also makes publishing inert anywhere `PUBLISH_BUCKET` is unset (e.g. a prod box that hasn't provisioned the public bucket), independent of the kill-switch flag.

## Ops before enabling
Set the five `PUBLISH_*` vars on the app (`pagespace-web`). Leave them unset where publishing should stay off (e.g. VPS prod) — publishing returns 503 there regardless of the flag.

## Validation
- `apps/web` typecheck clean; full CI green.
- Tests (26): publish route 403/400/503 (kill-switch + unconfigured, no DB/upload) + republish/path-collision/stale-artifact; storage put/delete, traversal-safe keys, `isPublishConfigured`, unconfigured-throw. Env mutations in tests wrapped in try/finally (CodeRabbit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)