### PR TITLE
feat(canvas): hide Publish control where publishing is unconfigured

### DIFF
--- a/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
@@ -273,6 +273,23 @@ describe('GET /api/pages/[pageId]/publish', () => {
     expect(json).toEqual({ published: false, available: false });
   });
 
+  it('reports available: false when the kill-switch is engaged even if the bucket is configured', async () => {
+    const prev = process.env.CANVAS_PUBLISHING_DISABLED;
+    process.env.CANVAS_PUBLISHING_DISABLED = 'true';
+    try {
+      isPublishConfigured.mockReturnValue(true);
+      findFirstPublished.mockResolvedValue(undefined);
+      const res = await GET(makeReq(), { params });
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      // POST would 503 ("temporarily disabled") here, so the UI must hide the control.
+      expect(json).toEqual({ published: false, available: false });
+    } finally {
+      if (prev === undefined) delete process.env.CANVAS_PUBLISHING_DISABLED;
+      else process.env.CANVAS_PUBLISHING_DISABLED = prev;
+    }
+  });
+
   it('returns { published: true, url, available } when a row exists', async () => {
     findFirstPublished.mockResolvedValue({ driveId: 'drive-1', path: 'welcome' });
     findFirstDrive.mockResolvedValue({ publishSubdomain: 'acme' });

--- a/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
+++ b/apps/web/src/app/api/pages/[pageId]/publish/__tests__/route.test.ts
@@ -255,16 +255,25 @@ describe('GET /api/pages/[pageId]/publish', () => {
     expect(res.status).toBe(403);
   });
 
-  it('returns { published: false } when no row exists', async () => {
+  it('returns { published: false, available: true } when no row exists and publishing is configured', async () => {
     findFirstPublished.mockResolvedValue(undefined);
     const res = await GET(makeReq(), { params });
     expect(res.status).toBe(200);
     const json = await res.json();
-    expect(json).toEqual({ published: false });
+    expect(json).toEqual({ published: false, available: true });
     expect(findFirstDrive).not.toHaveBeenCalled();
   });
 
-  it('returns { published: true, url } when a row exists', async () => {
+  it('reports available: false when the publish bucket is not configured (UI hides the control)', async () => {
+    isPublishConfigured.mockReturnValue(false);
+    findFirstPublished.mockResolvedValue(undefined);
+    const res = await GET(makeReq(), { params });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ published: false, available: false });
+  });
+
+  it('returns { published: true, url, available } when a row exists', async () => {
     findFirstPublished.mockResolvedValue({ driveId: 'drive-1', path: 'welcome' });
     findFirstDrive.mockResolvedValue({ publishSubdomain: 'acme' });
 
@@ -273,6 +282,7 @@ describe('GET /api/pages/[pageId]/publish', () => {
     const json = await res.json();
     expect(json).toEqual({
       published: true,
+      available: true,
       url: 'https://acme.pagespace.site/welcome',
       subdomain: 'acme',
       path: 'welcome',

--- a/apps/web/src/app/api/pages/[pageId]/publish/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/publish/route.ts
@@ -44,11 +44,12 @@ export async function GET(req: Request, { params }: { params: Promise<{ pageId: 
   }
 
   try {
-    // Whether the server can actually publish (dedicated public bucket configured).
-    // The UI uses this to hide the Publish control where publishing is unavailable
-    // (e.g. a deployment that hasn't provisioned PUBLISH_BUCKET) instead of offering
-    // a button that only ever returns 503.
-    const available = isPublishConfigured();
+    // Whether a publish attempt could actually succeed — used by the UI to hide the
+    // Publish control instead of offering a button that only ever returns 503. This
+    // must mirror EVERY 503 fast-path in POST below: the dedicated public bucket must
+    // be configured AND the operational kill-switch must not be engaged.
+    const available =
+      isPublishConfigured() && process.env.CANVAS_PUBLISHING_DISABLED !== 'true';
 
     const row = await db.query.publishedPages.findFirst({
       where: eq(publishedPages.pageId, pageId),

--- a/apps/web/src/app/api/pages/[pageId]/publish/route.ts
+++ b/apps/web/src/app/api/pages/[pageId]/publish/route.ts
@@ -44,13 +44,19 @@ export async function GET(req: Request, { params }: { params: Promise<{ pageId: 
   }
 
   try {
+    // Whether the server can actually publish (dedicated public bucket configured).
+    // The UI uses this to hide the Publish control where publishing is unavailable
+    // (e.g. a deployment that hasn't provisioned PUBLISH_BUCKET) instead of offering
+    // a button that only ever returns 503.
+    const available = isPublishConfigured();
+
     const row = await db.query.publishedPages.findFirst({
       where: eq(publishedPages.pageId, pageId),
       columns: { driveId: true, path: true },
     });
 
     if (!row) {
-      return NextResponse.json({ published: false });
+      return NextResponse.json({ published: false, available });
     }
 
     const drive = await db.query.drives.findFirst({
@@ -62,6 +68,7 @@ export async function GET(req: Request, { params }: { params: Promise<{ pageId: 
 
     return NextResponse.json({
       published: true,
+      available,
       url: `https://${subdomain}.${PUBLISH_HOST}/${row.path}`,
       subdomain,
       path: row.path,

--- a/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPublishControls.tsx
+++ b/apps/web/src/components/layout/middle-content/page-views/canvas/CanvasPublishControls.tsx
@@ -11,6 +11,10 @@ interface CanvasPublishControlsProps {
 interface PublishState {
   published: boolean;
   url: string | null;
+  // Whether the server can publish at all (dedicated public bucket configured).
+  // When false (e.g. a deployment without PUBLISH_BUCKET) the control is hidden
+  // rather than offering a Publish button that only ever 503s.
+  available: boolean;
 }
 
 const readError = async (res: Response): Promise<string> => {
@@ -23,7 +27,7 @@ const readError = async (res: Response): Promise<string> => {
 };
 
 const CanvasPublishControls = ({ pageId }: CanvasPublishControlsProps) => {
-  const [state, setState] = useState<PublishState>({ published: false, url: null });
+  const [state, setState] = useState<PublishState>({ published: false, url: null, available: false });
   const [isLoading, setIsLoading] = useState(true);
   const [isBusy, setIsBusy] = useState(false);
   const [showPreview, setShowPreview] = useState(false);
@@ -35,15 +39,19 @@ const CanvasPublishControls = ({ pageId }: CanvasPublishControlsProps) => {
       try {
         const res = await fetchWithAuth(`/api/pages/${pageId}/publish`);
         if (!res.ok) {
-          if (!cancelled) setState({ published: false, url: null });
+          if (!cancelled) setState({ published: false, url: null, available: false });
           return;
         }
-        const data = (await res.json()) as { published: boolean; url?: string };
+        const data = (await res.json()) as { published: boolean; url?: string; available?: boolean };
         if (!cancelled) {
-          setState({ published: data.published, url: data.published ? data.url ?? null : null });
+          setState({
+            published: data.published,
+            url: data.published ? data.url ?? null : null,
+            available: data.available ?? false,
+          });
         }
       } catch {
-        if (!cancelled) setState({ published: false, url: null });
+        if (!cancelled) setState({ published: false, url: null, available: false });
       } finally {
         if (!cancelled) setIsLoading(false);
       }
@@ -62,7 +70,7 @@ const CanvasPublishControls = ({ pageId }: CanvasPublishControlsProps) => {
         return;
       }
       const data = (await res.json()) as { url: string };
-      setState({ published: true, url: data.url });
+      setState({ published: true, url: data.url, available: true });
       toast.success('Page published');
     } catch {
       toast.error('Failed to publish page');
@@ -79,7 +87,7 @@ const CanvasPublishControls = ({ pageId }: CanvasPublishControlsProps) => {
         toast.error(await readError(res));
         return;
       }
-      setState({ published: false, url: null });
+      setState((prev) => ({ ...prev, published: false, url: null }));
       setShowPreview(false);
       toast.success('Page unpublished');
     } catch {
@@ -101,6 +109,12 @@ const CanvasPublishControls = ({ pageId }: CanvasPublishControlsProps) => {
 
   if (isLoading) {
     return <span className="px-4 py-2 text-sm text-muted-foreground">Loading…</span>;
+  }
+
+  // Publishing isn't configured on this deployment (e.g. no PUBLISH_BUCKET) —
+  // hide the control entirely rather than show a button that only returns 503.
+  if (!state.available) {
+    return null;
   }
 
   if (!state.published || !state.url) {


### PR DESCRIPTION
Follow-up to #1503.

## Problem
The canvas **Publish** button renders for any drive-editor, gated only on edit permission + published status — never on whether the server can actually publish. Where a publish attempt can only 503, the button is a visible dead end:
- `PUBLISH_BUCKET` unset (e.g. VPS prod) → POST 503 `"Publishing is not configured"`.
- `CANVAS_PUBLISHING_DISABLED=true` (operator kill-switch) → POST 503 `"Publishing is temporarily disabled"`.

(Both are harmless — #1503's guards fail fast before any DB write — but the button shouldn't appear where publishing is off.)

## Change
- `GET /api/pages/[pageId]/publish` now returns `available`, mirroring **every** POST 503 fast-path: `isPublishConfigured() && CANVAS_PUBLISHING_DISABLED !== 'true'`.
- `CanvasPublishControls` reads `available` and renders `null` when false — the whole control disappears where publishing isn't available. Where the bucket is set and the kill-switch is off (Fly), it behaves exactly as before.

Net effect: VPS (no bucket) or kill-switch engaged → no Publish UI. Fly (bucket provisioned, kill-switch off) → Publish UI as today.

## Validation
- Publish route tests: 18/18 pass — added GET cases for `available: true` (configured), `available: false` (no bucket), and `available: false` (kill-switch on, bucket configured); updated existing GET equality assertions.
- `apps/web` typecheck: no new errors (pre-existing `@fly/sprites` sandbox errors are unrelated to this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)